### PR TITLE
fix(zai): don't misreport an insufficient-balance 429 as a rate limit

### DIFF
--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -176,6 +176,78 @@ fn classify_zai_stream_error(err: &ZaiStreamError) -> ProviderError {
     }
 }
 
+/// The `error` object Z.ai returns in a *non-streamed* HTTP error body:
+/// `{"error":{"code":"1113","message":"Insufficient balance ..."}}`. Distinct
+/// from [`ZaiStreamError`] (the in-band SSE frame) — this is the top-level
+/// envelope on a plain JSON 4xx response.
+#[derive(Deserialize, Debug)]
+struct ZaiErrorEnvelope {
+    error: ZaiErrorBody,
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct ZaiErrorBody {
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    code: Option<Value>,
+}
+
+/// Classify an HTTP 429 by its body. Z.ai returns 429 both for real rate
+/// limiting AND for account-balance/quota exhaustion (code 1113,
+/// "Insufficient balance or no resource package. Please recharge") — the
+/// latter is **terminal**: no amount of backoff refills an empty account, so
+/// retrying it just delays a clear error and, worse, reports it as a rate
+/// limit. Billing/quota text ⇒ [`ProviderError::Terminal`]; anything else ⇒
+/// retryable [`ProviderError::RateLimited`], honoring a `Retry-After` hint
+/// when the server sent one. The provider's own message is always carried
+/// through so the real reason is visible instead of a hard-coded string.
+fn classify_zai_429(body: &str, retry_after_ms: Option<u64>) -> ProviderError {
+    let detail = serde_json::from_str::<ZaiErrorEnvelope>(body)
+        .ok()
+        .map(|e| e.error.message)
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| body.trim().to_string());
+    let haystack = detail.to_lowercase();
+    let message = if detail.is_empty() {
+        "Z.ai HTTP 429".to_string()
+    } else {
+        format!("Z.ai HTTP 429: {detail}")
+    };
+    // Balance/quota exhaustion — never self-clears, so terminal not retryable.
+    if haystack.contains("balance")
+        || haystack.contains("recharge")
+        || haystack.contains("resource package")
+        || haystack.contains("insufficient")
+        || haystack.contains("quota")
+        || haystack.contains("arrears")
+    {
+        ProviderError::Terminal(message)
+    } else {
+        ProviderError::RateLimited {
+            message,
+            retry_after_ms,
+        }
+    }
+}
+
+/// Parse a `Retry-After` response header into milliseconds. Z.ai (like most
+/// OpenAI-compatible gateways) sends it as an integer number of seconds; the
+/// alternative HTTP-date form is tolerated by being ignored — the caller
+/// falls back to computed backoff. `None` when the header is absent or not a
+/// bare integer.
+fn parse_retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(|secs| secs.saturating_mul(1_000))
+}
+
 #[derive(Deserialize, Debug)]
 struct ZaiStreamChoice {
     #[serde(default)]
@@ -317,10 +389,20 @@ impl Provider for ZaiProvider {
             return Err(ProviderError::Auth("Z.ai rejected the API key".into()));
         }
         if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Err(ProviderError::RateLimited {
-                message: "Z.ai rate limit".into(),
-                retry_after_ms: None,
-            });
+            // Z.ai overloads HTTP 429: besides genuine throttling it also
+            // returns 429 for BILLING problems — an account with no credit
+            // answers with `{"error":{"code":"1113","message":"Insufficient
+            // balance or no resource package. Please recharge."}}`. Blindly
+            // mapping every 429 to a retryable `RateLimited` both mislabels
+            // that as a rate limit (the user sees "provider rate limited" on
+            // their very first call, which can't be a real throttle) AND burns
+            // three pointless retries on a condition backoff will never clear.
+            // Read the body and classify: a real throttle stays retryable, a
+            // billing/quota failure is terminal, and either way Z.ai's own
+            // message is surfaced instead of a hard-coded string.
+            let retry_after_ms = parse_retry_after_ms(response.headers());
+            let body = response.text().await.unwrap_or_default();
+            return Err(classify_zai_429(&body, retry_after_ms));
         }
         // 5xx (incl. 529 overloaded) is a transient server-side failure — map
         // to a retryable Transport error, not the terminal bucket below.
@@ -583,11 +665,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn complete_maps_429_to_rate_limited_and_it_is_retryable() {
+    async fn complete_maps_a_real_throttle_429_to_retryable_rate_limited() {
         let server = MockServer::start().await;
+        // A genuine throttle body (no billing/quota keywords) stays a
+        // retryable RateLimited — the normal, correct 429 path.
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
-            .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .set_body_string(r#"{"error":{"code":"1302","message":"API rate limit reached"}}"#),
+            )
             .mount(&server)
             .await;
 
@@ -605,6 +692,81 @@ mod tests {
         let err = provider.complete(req).await.unwrap_err();
         assert!(matches!(err, ProviderError::RateLimited { .. }));
         assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn complete_maps_insufficient_balance_429_to_terminal_not_rate_limited() {
+        let server = MockServer::start().await;
+        // The exact body a live, empty-balance Z.ai account returns for its
+        // very first request. HTTP 429, but NOT a rate limit — a billing
+        // failure that no retry can clear. It must classify as terminal, be
+        // NON-retryable, and surface Z.ai's own message rather than a
+        // hard-coded "rate limit" string.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_string(
+                r#"{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(
+            matches!(err, ProviderError::Terminal(_)),
+            "insufficient-balance 429 must be terminal, got {err:?}"
+        );
+        assert!(
+            !err.is_retryable(),
+            "a billing failure must never be retried"
+        );
+        assert!(
+            err.to_string().contains("Insufficient balance"),
+            "the real Z.ai message must be surfaced, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_honors_retry_after_header_on_a_throttle_429() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "2")
+                    .set_body_string("too many requests"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        match err {
+            ProviderError::RateLimited { retry_after_ms, .. } => {
+                assert_eq!(retry_after_ms, Some(2_000), "Retry-After: 2s → 2000ms");
+            }
+            other => panic!("expected RateLimited with a retry hint, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Fixes Stella reporting **"provider rate limited" on the very first Z.ai request** when the real problem is an **empty account balance**.

## Root cause (reproduced against the live API)

The exact request Stella makes returns **HTTP 429** with this body when the Z.ai account has no credit:

```json
{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}
```

Z.ai overloads `429` for billing as well as throttling. `stella-model/src/zai.rs` mapped **every** 429 to a retryable `RateLimited`, threw away the body, and hard-coded the message `"Z.ai rate limit"`. Two bad consequences:

1. A billing failure is mislabeled as a rate limit — impossible on a first-ever call, which is exactly what the user observed.
2. `RateLimited` is retryable, so the step-driver silently retried three more times against a condition backoff can never clear, then surfaced the misleading message.

## Fix

On a 429, read and classify the body:

- **Balance/quota exhaustion** (`balance`/`recharge`/`insufficient`/`quota`/`resource package`/`arrears`) → `ProviderError::Terminal` — **non-retryable**, so the user gets Z.ai's real message immediately.
- **Anything else** → retryable `RateLimited`, now honoring a `Retry-After` header when present.

Either way the provider's own message is carried through instead of a fixed string. This mirrors the existing `classify_zai_stream_error` logic, which the hard-coded 429 shortcut was bypassing.

## Tests

- `complete_maps_insufficient_balance_429_to_terminal_not_rate_limited` — the real 1113 body → terminal, non-retryable, message preserved.
- `complete_maps_a_real_throttle_429_to_retryable_rate_limited` — genuine throttle stays retryable.
- `complete_honors_retry_after_header_on_a_throttle_429` — `Retry-After: 2` → `2000ms`.

All 73 `stella-model` tests pass; clippy clean.

## Note (out of scope)

The reporting user's underlying blocker is that **the Z.ai account itself has no balance** — this PR makes that reason visible, it doesn't add credit. Separately, Stella does **not** load `.env.local` (no `dotenv` dependency), so a key placed there is ignored unless exported or in `~/.config/stella/credentials.toml`; flagging for a possible follow-up.
