### PR TITLE
feat: multi-provider adapters (Gemini/Vertex/Bedrock) + STELLA logomark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,7 +464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -576,6 +585,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -621,6 +639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +675,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -861,6 +900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1023,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -2139,6 +2197,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,10 +2301,12 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
+ "hmac",
  "reqwest",
  "rpassword",
  "serde",
  "serde_json",
+ "sha2",
  "stella-protocol",
  "thiserror",
  "tokio",
@@ -2615,6 +2686,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ rand = "0.9"
 proptest = "1"
 toml = "0.9"
 rpassword = "7"
+hmac = "0.12"
+sha2 = "0.10"
 
 [profile.release]
 lto = true

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use stella_core::{BudgetGuard, Engine, EngineConfig, TurnOutcome};
+use stella_model::credential::ApiKey;
 use stella_model::provider::Provider;
 use stella_protocol::event::BudgetMode;
 use stella_protocol::{AgentEvent, CompletionMessage, ToolOutput};
@@ -211,12 +212,22 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
 
     loop {
-        // Read user input
+        // The rocket-vs-UFO duel animates one line above the prompt while
+        // the REPL waits for input (TTY only; STELLA_FUN=0 opts out), and is
+        // stopped the moment a line arrives so nothing ever animates while a
+        // turn's event stream is printing — see tui.rs's module doc for why
+        // that boundary matters.
+        let duel = tui::PromptDuel::start();
+
         print!("{} ", ">".bright_cyan().bold());
         std::io::stdout().flush().map_err(|e| e.to_string())?;
 
         let mut input = String::new();
-        match std::io::stdin().read_line(&mut input) {
+        let read = std::io::stdin().read_line(&mut input);
+        if let Some(duel) = duel {
+            duel.stop();
+        }
+        match read {
             Ok(0) => break, // EOF (Ctrl+D)
             Ok(_) => {}
             Err(e) => return Err(format!("read error: {e}")),
@@ -603,45 +614,128 @@ fn spawn_renderer(
     })
 }
 
-/// Build the provider adapter from config. Consults the catalog first so an
+/// Build the provider adapter from config. Consults the catalog first
+/// (provider-scoped, since the same slug legitimately exists on several
+/// providers — `gemini-3-pro` on both `gemini` and `vertex`) so an
 /// unrecognized model slug is a hard, immediate, named error — never a
 /// silent construction of a provider that will simply fail its first live
-/// call (`07-model-matrix.md` §3, L-M1/L-M2: this hard-error rule existed in
-/// `stella_model::catalog` since Phase 0 but was never actually called from
-/// the request path, so it was unenforced in practice).
+/// call (`07-model-matrix.md` §3, L-M1/L-M2). The one exemption is `local`:
+/// a local server's models are whatever the user pulled into it — there is
+/// no curated catalog to check against, and the anti-phantom-slug rule
+/// exists to catch drift in OUR seed data, not to veto the user's own
+/// endpoint.
 ///
-/// OpenAI gets its own arm ahead of the `openai_compatible` bool: real
-/// OpenAI speaks the Responses API (`stella_model::openai`), a wire shape
-/// (and tool-call dialect, see `catalog.rs`'s `ToolDialect::OpenaiResponses`)
-/// genuinely distinct from the Chat Completions shape every other
-/// `openai_compatible` row (Z.ai, xAI, DeepSeek, Gemini's OpenAI-compat
-/// shim, OpenRouter) actually speaks — see `openai.rs`'s module doc for why
-/// reusing `ZaiProvider` for OpenAI was wrong even though it happened to
-/// work.
+/// Each wire dialect gets its own arm: OpenAI (Responses API), Anthropic
+/// (Messages), Gemini direct + Vertex (generateContent), Bedrock (Converse,
+/// SigV4). Everything else — Z.ai, xAI, DeepSeek, OpenRouter, local — is
+/// genuinely the same Chat Completions shape behind different base URLs,
+/// served by the shared adapter re-identified per provider so its
+/// `Provider::id()` and error messages name the surface actually being
+/// called (an xAI 401 must never read "Z.ai rejected the API key").
 fn build_provider(cfg: &Config) -> Result<Box<dyn Provider>, String> {
-    stella_model::catalog::Catalog::seed()
-        .resolve(&cfg.model_id)
-        .map_err(|e| e.to_string())?;
+    if cfg.provider.id != "local" {
+        stella_model::catalog::Catalog::seed()
+            .resolve_for(cfg.provider.id, &cfg.model_id)
+            .map_err(|e| e.to_string())?;
+    }
 
     let api_key = cfg.api_key.clone();
+    let base_url = cfg.effective_base_url().to_string();
 
-    if cfg.provider.id == "openai" {
-        let provider = stella_model::openai::OpenAiProvider::new(api_key, cfg.model_id.clone())
-            .with_base_url(cfg.provider.base_url.to_string());
-        Ok(Box::new(provider))
-    } else if cfg.provider.openai_compatible {
-        // Z.ai, xAI, DeepSeek, Gemini (OpenAI-compat shim), OpenRouter all
-        // use the same Chat Completions adapter shape — only the base URL
-        // differs.
-        let provider = stella_model::zai::ZaiProvider::new(api_key, cfg.model_id.clone())
-            .with_base_url(cfg.provider.base_url.to_string());
-        Ok(Box::new(provider))
-    } else {
-        // Anthropic Messages API
-        let provider =
-            stella_model::anthropic::AnthropicProvider::new(api_key, cfg.model_id.clone())
-                .with_base_url(cfg.provider.base_url.to_string());
-        Ok(Box::new(provider))
+    match cfg.provider.id {
+        "openai" => {
+            let provider = stella_model::openai::OpenAiProvider::new(api_key, cfg.model_id.clone())
+                .with_base_url(base_url);
+            Ok(Box::new(provider))
+        }
+        "anthropic" => {
+            let provider =
+                stella_model::anthropic::AnthropicProvider::new(api_key, cfg.model_id.clone())
+                    .with_base_url(base_url);
+            Ok(Box::new(provider))
+        }
+        "gemini" => {
+            let provider = stella_model::gemini::GeminiProvider::new(api_key, cfg.model_id.clone())
+                .with_base_url(base_url);
+            Ok(Box::new(provider))
+        }
+        "vertex" => {
+            // The access token is cfg.api_key (VERTEX_ACCESS_TOKEN via the
+            // credential chain); project and location are Vertex-specific
+            // addressing, resolved here with named errors rather than
+            // burying a doomed request.
+            let project = std::env::var("VERTEX_PROJECT_ID")
+                .or_else(|_| std::env::var("GOOGLE_CLOUD_PROJECT"))
+                .ok()
+                .filter(|v| !v.is_empty())
+                .ok_or_else(|| {
+                    "Vertex AI needs a project id — set VERTEX_PROJECT_ID (or \
+                     GOOGLE_CLOUD_PROJECT)"
+                        .to_string()
+                })?;
+            let location = std::env::var("VERTEX_LOCATION")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "global".to_string());
+            let mut provider = stella_model::vertex::VertexProvider::new(
+                api_key,
+                cfg.model_id.clone(),
+                project,
+                location,
+            );
+            if let Some(override_url) = &cfg.base_url_override {
+                provider = provider.with_base_url(override_url.clone());
+            }
+            Ok(Box::new(provider))
+        }
+        "bedrock" => {
+            // cfg.api_key is AWS_ACCESS_KEY_ID via the credential chain;
+            // the rest of the standard AWS env set is read here. Secret
+            // resolution failure is a named error pointing at the exact
+            // var, not a doomed unsigned request.
+            let secret = std::env::var("AWS_SECRET_ACCESS_KEY")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .ok_or_else(|| {
+                    "Bedrock needs AWS_SECRET_ACCESS_KEY alongside AWS_ACCESS_KEY_ID".to_string()
+                })?;
+            let session_token = std::env::var("AWS_SESSION_TOKEN")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(ApiKey::new);
+            let region = std::env::var("AWS_REGION")
+                .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+                .ok()
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "us-east-1".to_string());
+            let mut provider = stella_model::bedrock::BedrockProvider::new(
+                api_key,
+                ApiKey::new(secret),
+                session_token,
+                region,
+                cfg.model_id.clone(),
+            );
+            if let Some(override_url) = &cfg.base_url_override {
+                provider = provider.with_base_url(override_url.clone());
+            }
+            Ok(Box::new(provider))
+        }
+        // Z.ai, xAI, DeepSeek, OpenRouter, local — the shared Chat
+        // Completions adapter, re-identified per provider.
+        other => {
+            let label = match other {
+                "zai" => "Z.ai",
+                "xai" => "xAI",
+                "deepseek" => "DeepSeek",
+                "openrouter" => "OpenRouter",
+                "local" => "the local endpoint",
+                _ => cfg.provider.display_name,
+            };
+            let provider = stella_model::zai::ZaiProvider::new(api_key, cfg.model_id.clone())
+                .with_base_url(base_url)
+                .with_identity(other, label);
+            Ok(Box::new(provider))
+        }
     }
 }
 

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -9,97 +9,138 @@
 use std::env;
 
 use colored::Colorize;
-use stella_model::credential::{ApiKey, CredentialsFile};
+use stella_model::credential::{ApiKey, CredentialError, CredentialsFile};
 
 /// One provider's config: id, env var name, display name, default model.
 #[derive(Debug, Clone)]
 pub struct ProviderConfig {
     pub id: &'static str,
     pub env_var: &'static str,
+    /// Alternate env var names accepted for this provider's credential,
+    /// tried after `env_var` and before the credentials file (spec §2:
+    /// `GEMINI_API_KEY` alias `GOOGLE_API_KEY`).
+    pub env_var_aliases: &'static [&'static str],
     pub display_name: &'static str,
     pub default_model: &'static str,
     pub base_url: &'static str,
-    /// Whether this provider speaks the OpenAI-*compatible* chat/completions
-    /// dialect (true for Z.ai, xAI, DeepSeek, Gemini's OpenAI-compat shim,
-    /// OpenRouter, any generic OpenAI-compatible gateway). False for
-    /// Anthropic (Messages API). Real OpenAI (`id == "openai"`) is `true`
-    /// here too for backwards compatibility with anything still matching on
-    /// this flag, but `build_provider` (`agent.rs`) special-cases
-    /// `id == "openai"` ahead of this flag and routes it through the real
-    /// Responses API adapter (`stella_model::openai`) instead — OpenAI's own
-    /// API is not the same wire shape as the "OpenAI-compatible" gateways
-    /// this flag is actually describing.
-    pub openai_compatible: bool,
 }
 
-/// All supported providers, in preference order.
+/// All supported providers, in preference order. Order matters twice over:
+/// auto-detection picks the first row with a resolvable credential, which is
+/// why Bedrock (keyed on the generic `AWS_ACCESS_KEY_ID` that plenty of
+/// non-Bedrock users have exported) sits last — it must only ever be
+/// auto-picked when nothing else is configured; `--model bedrock/…` pins it
+/// explicitly regardless.
 pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         id: "zai",
         env_var: "ZAI_API_KEY",
+        env_var_aliases: &[],
         display_name: "Z.ai (GLM 5.2)",
         default_model: "glm-5.2",
         base_url: "https://api.z.ai/api/paas/v4",
-        openai_compatible: true,
     },
     ProviderConfig {
         id: "anthropic",
         env_var: "ANTHROPIC_API_KEY",
+        env_var_aliases: &[],
         display_name: "Anthropic (Claude)",
         default_model: "claude-fable-5",
         base_url: "https://api.anthropic.com",
-        openai_compatible: false,
     },
     ProviderConfig {
         id: "openai",
         env_var: "OPENAI_API_KEY",
+        env_var_aliases: &[],
         display_name: "OpenAI (GPT)",
         default_model: "gpt-5.5",
         base_url: "https://api.openai.com/v1",
-        openai_compatible: true,
     },
     ProviderConfig {
         id: "xai",
         env_var: "XAI_API_KEY",
+        env_var_aliases: &[],
         display_name: "xAI (Grok)",
         default_model: "grok-4",
         base_url: "https://api.x.ai/v1",
-        openai_compatible: true,
     },
     ProviderConfig {
         id: "deepseek",
         env_var: "DEEPSEEK_API_KEY",
+        env_var_aliases: &[],
         display_name: "DeepSeek",
         default_model: "deepseek-chat",
         base_url: "https://api.deepseek.com/v1",
-        openai_compatible: true,
     },
     ProviderConfig {
         id: "gemini",
         env_var: "GEMINI_API_KEY",
+        // Spec §2: "GEMINI_API_KEY (alias GOOGLE_API_KEY)" — the name most
+        // Google tooling exports.
+        env_var_aliases: &["GOOGLE_API_KEY"],
         display_name: "Google Gemini",
         default_model: "gemini-3-pro",
-        // NOTE: this is Google's OpenAI-compatibility shim
-        // (`/v1beta/openai/...`), not Gemini's native `generateContent`
-        // wire shape — the two are NOT interchangeable and the base URL
-        // must include the `/openai` segment or every request 404s. A
-        // native "Gemini direct" adapter (07-model-matrix.md §2: thinking
-        // support, Imagen/Veo, native multimodal) is real follow-up work,
-        // deferred because it can't be verified without a live
-        // GEMINI_API_KEY in this environment (same reasoning as Bedrock/
-        // Vertex/local-GGUF — see the Phase 2 PR description).
-        base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
-        openai_compatible: true,
+        // Gemini's native generateContent surface
+        // (`stella_model::gemini::GeminiProvider`). This row previously
+        // pointed at Google's OpenAI-compatibility shim
+        // (`…/v1beta/openai`) served by the generic Chat Completions
+        // adapter as a stand-in until the native adapter existed.
+        base_url: "https://generativelanguage.googleapis.com/v1beta",
     },
     ProviderConfig {
         id: "openrouter",
         env_var: "OPENROUTER_API_KEY",
+        env_var_aliases: &[],
         display_name: "OpenRouter",
         default_model: "auto",
         base_url: "https://openrouter.ai/api/v1",
-        openai_compatible: true,
+    },
+    ProviderConfig {
+        id: "vertex",
+        // Deliberately Vertex-specific (not a generic Google var) so
+        // auto-detection is an explicit opt-in; documented as
+        // `export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)`.
+        // Also requires VERTEX_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) and
+        // honors VERTEX_LOCATION — resolved in `build_provider`.
+        env_var: "VERTEX_ACCESS_TOKEN",
+        env_var_aliases: &[],
+        display_name: "Google Vertex AI",
+        default_model: "gemini-3-pro",
+        // Display anchor: the real endpoint is project/location-scoped and
+        // built per request by the adapter.
+        base_url: "https://aiplatform.googleapis.com",
+    },
+    ProviderConfig {
+        id: "bedrock",
+        // The standard AWS chain vars; AWS_SECRET_ACCESS_KEY (and optional
+        // AWS_SESSION_TOKEN / AWS_REGION) are resolved in `build_provider`.
+        // Last in preference order on purpose — see the doc comment above.
+        env_var: "AWS_ACCESS_KEY_ID",
+        env_var_aliases: &[],
+        display_name: "Amazon Bedrock",
+        default_model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        // Display anchor: the real host is region-scoped
+        // (`bedrock-runtime.<AWS_REGION>.amazonaws.com`), built per request
+        // by the adapter.
+        base_url: "https://bedrock-runtime.<AWS_REGION>.amazonaws.com",
     },
 ];
+
+/// The `local` pseudo-provider: any OpenAI-compatible endpoint the user
+/// points `--base-url` at (Ollama, vLLM, LM Studio, llama.cpp server —
+/// `07-model-matrix.md` §2). Not in [`PROVIDERS`]: it is never auto-detected
+/// (there is no ambient signal a local server exists), has no default model
+/// (the server's models are whatever the user pulled), and its API key is
+/// optional (`LOCAL_API_KEY`, defaulting to a placeholder — most local
+/// servers ignore auth entirely).
+pub static LOCAL_PROVIDER: ProviderConfig = ProviderConfig {
+    id: "local",
+    env_var: "LOCAL_API_KEY",
+    env_var_aliases: &[],
+    display_name: "Local (OpenAI-compatible)",
+    default_model: "",
+    base_url: "",
+};
 
 /// Resolved configuration: which provider, which model, which API key.
 ///
@@ -113,17 +154,32 @@ pub struct Config {
     pub model_id: String,
     pub api_key: ApiKey,
     pub workspace_root: std::path::PathBuf,
+    /// `--base-url`: required for the `local` provider (it IS the server
+    /// address), an optional proxy/override for every other provider.
+    pub base_url_override: Option<String>,
 }
 
 impl Config {
+    /// The base URL requests actually go to: `--base-url` when given,
+    /// otherwise the provider's default. (Vertex and Bedrock build
+    /// region/project-scoped URLs in their adapters and only consume the
+    /// override half of this.)
+    pub fn effective_base_url(&self) -> &str {
+        self.base_url_override
+            .as_deref()
+            .unwrap_or(self.provider.base_url)
+    }
+
     /// Load config: resolve provider from `--model` flag or the first one
     /// with a resolvable credential, then run the full chain (CLI flag ->
-    /// env var -> credentials file -> interactive prompt) for it.
+    /// env var (+aliases) -> credentials file -> interactive prompt) for it.
     /// `api_key_override` is `--api-key`, threaded straight into the chain's
-    /// first (highest-precedence) step. Errors if no key is found at all.
+    /// first (highest-precedence) step; `base_url_override` is `--base-url`.
+    /// Errors if no key is found at all.
     pub fn load(
         model_override: Option<&str>,
         api_key_override: Option<&str>,
+        base_url_override: Option<&str>,
     ) -> Result<Self, String> {
         let workspace_root =
             env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
@@ -152,6 +208,7 @@ impl Config {
                         provider,
                         model_id_override(model_spec),
                         api_key_override,
+                        base_url_override,
                         &mut credentials_file,
                         &workspace_root,
                         true,
@@ -159,12 +216,41 @@ impl Config {
                 }
             };
 
+            // `local/<model>`: any OpenAI-compatible endpoint the user
+            // points --base-url at. Never auto-detected, key optional —
+            // see LOCAL_PROVIDER's doc comment.
+            if provider_id == LOCAL_PROVIDER.id {
+                let base_url = base_url_override.map(str::to_string).ok_or_else(|| {
+                    "the local provider needs --base-url (e.g. stella --model local/llama3.3 \
+                     --base-url http://localhost:11434/v1)"
+                        .to_string()
+                })?;
+                let api_key = api_key_override
+                    .map(str::to_string)
+                    .or_else(|| {
+                        env::var(LOCAL_PROVIDER.env_var)
+                            .ok()
+                            .filter(|v| !v.is_empty())
+                    })
+                    // Most local servers ignore auth; OpenAI-compatible
+                    // clients still send *something* as the bearer token.
+                    .unwrap_or_else(|| "local".to_string());
+                return Ok(Self {
+                    provider: LOCAL_PROVIDER.clone(),
+                    model_id,
+                    api_key,
+                    workspace_root,
+                    base_url_override: Some(base_url),
+                });
+            }
+
             let provider = PROVIDERS
                 .iter()
                 .find(|p| p.id == provider_id)
                 .ok_or_else(|| {
                     format!("unknown provider `{provider_id}` — available: {}", {
-                        let v: Vec<&str> = PROVIDERS.iter().map(|p| p.id).collect();
+                        let mut v: Vec<&str> = PROVIDERS.iter().map(|p| p.id).collect();
+                        v.push(LOCAL_PROVIDER.id);
                         v.join(", ")
                     })
                 })?;
@@ -173,6 +259,7 @@ impl Config {
                 provider,
                 model_id,
                 api_key_override,
+                base_url_override,
                 &mut credentials_file,
                 &workspace_root,
                 true,
@@ -180,22 +267,16 @@ impl Config {
         }
 
         // No --model: pick the first provider with a resolvable credential
-        // (env var or credentials file — never prompts here, since prompting
-        // needs a specific provider in mind and the user hasn't named one).
+        // (env var/aliases or credentials file — never prompts here, since
+        // prompting needs a specific provider in mind and the user hasn't
+        // named one).
         for provider in PROVIDERS {
-            if ApiKey::resolve(
-                provider.id,
-                provider.env_var,
-                api_key_override,
-                Some(&credentials_file),
-                false,
-            )
-            .is_ok()
-            {
+            if resolve_provider_key(provider, api_key_override, &credentials_file, false).is_ok() {
                 return Self::resolve(
                     provider,
                     provider.default_model.to_string(),
                     api_key_override,
+                    base_url_override,
                     &mut credentials_file,
                     &workspace_root,
                     false,
@@ -220,23 +301,19 @@ impl Config {
         provider: &ProviderConfig,
         model_id: String,
         api_key_override: Option<&str>,
+        base_url_override: Option<&str>,
         credentials_file: &mut CredentialsFile,
         workspace_root: &std::path::Path,
         interactive: bool,
     ) -> Result<Self, String> {
-        let (key, source) = ApiKey::resolve(
-            provider.id,
-            provider.env_var,
-            api_key_override,
-            Some(credentials_file),
-            interactive,
-        )
-        .map_err(|e| {
-            format!(
-                "could not resolve a credential for {}: {e}",
-                provider.display_name
-            )
-        })?;
+        let (key, source) =
+            resolve_provider_key(provider, api_key_override, credentials_file, interactive)
+                .map_err(|e| {
+                    format!(
+                        "could not resolve a credential for {}: {e}",
+                        provider.display_name
+                    )
+                })?;
 
         // "Interactive prompt on first use" (01-product-spec.md §4) implies
         // exactly that — first use. Persist so next invocation resolves via
@@ -259,6 +336,7 @@ impl Config {
             model_id,
             api_key: key,
             workspace_root: workspace_root.to_path_buf(),
+            base_url_override: base_url_override.map(str::to_string),
         })
     }
 
@@ -268,7 +346,10 @@ impl Config {
             "Stella — Available Providers & Models".cyan().bold()
         );
         for p in PROVIDERS {
-            let key_status = if env::var(p.env_var).map(|v| !v.is_empty()).unwrap_or(false) {
+            let has_key = std::iter::once(&p.env_var)
+                .chain(p.env_var_aliases)
+                .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
+            let key_status = if has_key {
                 "✓ configured".green()
             } else {
                 "✗ no key".dimmed()
@@ -284,6 +365,10 @@ impl Config {
         }
         println!("\n  Use --model provider/model_id to pin a specific model.");
         println!("  Example: stella --model zai/glm-5.2 run 'fix the failing test'");
+        println!(
+            "  Local endpoints (Ollama, vLLM, LM Studio): stella --model local/<model> \
+             --base-url http://localhost:11434/v1"
+        );
     }
 
     pub fn print_config(&self) {
@@ -295,16 +380,16 @@ impl Config {
             self.model_id.bright_white()
         );
         println!("  API Key:    {}", self.api_key.redacted_preview().dimmed());
-        println!("  Base URL:   {}", self.provider.base_url.dimmed());
+        println!("  Base URL:   {}", self.effective_base_url().dimmed());
         println!("  Workspace:  {}", self.workspace_root.display());
         println!(
             "  Dialect:    {}",
-            if self.provider.id == "openai" {
-                "OpenAI Responses"
-            } else if self.provider.openai_compatible {
-                "OpenAI-compatible"
-            } else {
-                "Anthropic Messages"
+            match self.provider.id {
+                "openai" => "OpenAI Responses",
+                "anthropic" => "Anthropic Messages",
+                "gemini" | "vertex" => "Gemini generateContent",
+                "bedrock" => "Bedrock Converse",
+                _ => "OpenAI-compatible",
             }
         );
     }
@@ -318,7 +403,10 @@ impl Config {
             "Stella — Available Providers & Models".cyan().bold()
         );
         for p in PROVIDERS {
-            let key_status = if env::var(p.env_var).map(|v| !v.is_empty()).unwrap_or(false) {
+            let has_key = std::iter::once(&p.env_var)
+                .chain(p.env_var_aliases)
+                .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
+            let key_status = if has_key {
                 "✓ configured".green()
             } else {
                 "✗ no key".dimmed()
@@ -334,11 +422,74 @@ impl Config {
         }
         println!("\n  Use --model provider/model_id to pin a specific model.");
         println!("  Example: stella --model zai/glm-5.2 run 'fix the failing test'");
+        println!(
+            "  Local endpoints (Ollama, vLLM, LM Studio): stella --model local/<model> \
+             --base-url http://localhost:11434/v1"
+        );
     }
 }
 
 fn model_id_override(slug: &str) -> String {
     slug.to_string()
+}
+
+/// The provider-aware credential chain: CLI flag -> primary env var ->
+/// alias env vars -> credentials file -> interactive prompt. Wraps
+/// `ApiKey::resolve` (which owns everything except aliases) so alias env
+/// vars slot in at exactly env-var precedence — after the primary var,
+/// before the credentials file.
+fn resolve_provider_key(
+    provider: &ProviderConfig,
+    api_key_override: Option<&str>,
+    credentials_file: &CredentialsFile,
+    interactive: bool,
+) -> Result<(ApiKey, stella_model::credential::CredentialSource), CredentialError> {
+    use stella_model::credential::CredentialSource;
+
+    let first_pass = ApiKey::resolve(
+        provider.id,
+        provider.env_var,
+        api_key_override,
+        Some(credentials_file),
+        false,
+    );
+    match first_pass {
+        // Flag or primary env var hit: nothing outranks those.
+        Ok((key, source @ (CredentialSource::CliFlag | CredentialSource::EnvVar))) => {
+            Ok((key, source))
+        }
+        // The chain fell through to the credentials file — but an alias env
+        // var still outranks the file.
+        Ok((key, source)) => {
+            for alias in provider.env_var_aliases {
+                if let Ok(alias_key) = ApiKey::from_env(alias) {
+                    return Ok((alias_key, CredentialSource::EnvVar));
+                }
+            }
+            Ok((key, source))
+        }
+        Err(CredentialError::NotFound { .. }) => {
+            for alias in provider.env_var_aliases {
+                match ApiKey::from_env(alias) {
+                    Ok(key) => return Ok((key, CredentialSource::EnvVar)),
+                    // An explicitly-set-but-empty alias is a user mistake
+                    // worth surfacing, same posture as the primary var.
+                    Err(err @ CredentialError::Empty { .. }) => return Err(err),
+                    Err(_) => {}
+                }
+            }
+            // Nothing anywhere — rerun the full chain with the caller's
+            // interactivity so the prompt step can fire when allowed.
+            ApiKey::resolve(
+                provider.id,
+                provider.env_var,
+                api_key_override,
+                Some(credentials_file),
+                interactive,
+            )
+        }
+        Err(other) => Err(other),
+    }
 }
 
 #[cfg(test)]
@@ -351,22 +502,28 @@ mod tests {
     /// catalog check (`agent.rs`) would hard-error on first use of a
     /// provider whose default was never added to the seed — exactly what
     /// happened for 5 of these 7 rows before the catalog was completed.
+    /// Uses the provider-scoped resolver, same as `build_provider`, so a
+    /// default that only exists under a *different* provider's row still
+    /// fails here.
     #[test]
     fn every_provider_default_model_resolves_against_the_catalog_seed() {
         let catalog = stella_model::catalog::Catalog::seed();
         for provider in PROVIDERS {
-            catalog.resolve(provider.default_model).unwrap_or_else(|e| {
-                panic!(
-                    "provider `{}`'s default_model `{}` is not in the catalog seed: {e}",
-                    provider.id, provider.default_model
-                )
-            });
+            catalog
+                .resolve_for(provider.id, provider.default_model)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "provider `{}`'s default_model `{}` is not in the catalog seed: {e}",
+                        provider.id, provider.default_model
+                    )
+                });
         }
     }
 
     #[test]
     fn provider_ids_are_unique() {
         let mut ids: Vec<&str> = PROVIDERS.iter().map(|p| p.id).collect();
+        ids.push(LOCAL_PROVIDER.id);
         let before = ids.len();
         ids.sort_unstable();
         ids.dedup();
@@ -387,5 +544,58 @@ mod tests {
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains(secret), "Config Debug leaked the key: {dbg}");
         assert!(dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn alias_env_var_resolves_when_the_primary_is_unset() {
+        // Synthetic provider with unique var names so parallel tests can't
+        // race on shared env state (the convention credential.rs's own
+        // tests follow).
+        let provider = ProviderConfig {
+            id: "alias-test",
+            env_var: "STELLA_TEST_ALIAS_PRIMARY_KEY",
+            env_var_aliases: &["STELLA_TEST_ALIAS_SECONDARY_KEY"],
+            display_name: "Alias Test",
+            default_model: "m",
+            base_url: "",
+        };
+        // SAFETY: test-only env mutation, unique var names per test.
+        unsafe {
+            std::env::remove_var("STELLA_TEST_ALIAS_PRIMARY_KEY");
+            std::env::set_var("STELLA_TEST_ALIAS_SECONDARY_KEY", "sk-from-alias");
+        }
+        let file = CredentialsFile::load(std::env::temp_dir().join(format!(
+            "oxagen-test-alias-credentials-{}.toml",
+            std::process::id()
+        )))
+        .unwrap();
+
+        let (key, source) = resolve_provider_key(&provider, None, &file, false).unwrap();
+        assert_eq!(key.reveal(), "sk-from-alias");
+        assert_eq!(source, stella_model::credential::CredentialSource::EnvVar);
+
+        unsafe {
+            std::env::remove_var("STELLA_TEST_ALIAS_SECONDARY_KEY");
+        }
+    }
+
+    #[test]
+    fn local_provider_requires_base_url_and_defaults_its_key() {
+        let err = Config::load(Some("local/llama3.3"), None, None).unwrap_err();
+        assert!(err.contains("--base-url"), "{err}");
+
+        let cfg = Config::load(
+            Some("local/llama3.3"),
+            None,
+            Some("http://localhost:11434/v1"),
+        )
+        .expect("local provider with --base-url should resolve");
+        assert_eq!(cfg.provider.id, "local");
+        assert_eq!(cfg.model_id, "llama3.3");
+        assert_eq!(cfg.effective_base_url(), "http://localhost:11434/v1");
+        // No LOCAL_API_KEY set: the placeholder key is used (local servers
+        // generally ignore auth, but the OpenAI-compatible client always
+        // sends a bearer token).
+        assert_eq!(cfg.api_key.reveal(), "local");
     }
 }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -1,9 +1,10 @@
 //! `stella` — a fast, BYOK, model-agnostic terminal coding agent.
 //!
 //! Built on the `stella-*` crate stack: `stella-model` for provider
-//! abstraction (Z.ai/GLM 5.2, Anthropic, OpenAI, xAI, DeepSeek, Gemini —
-//! any OpenAI-compatible endpoint), `stella-tools` for the built-in tool
-//! set, and `stella-protocol` for the shared types.
+//! abstraction (Z.ai/GLM 5.2, Anthropic, OpenAI, xAI, DeepSeek, Gemini
+//! direct, Vertex AI, Amazon Bedrock, OpenRouter — plus any local
+//! OpenAI-compatible endpoint via `--base-url`), `stella-tools` for the
+//! built-in tool set, and `stella-protocol` for the shared types.
 //!
 //! Design goals (per docs/specs/oxagen-rust-cli/01-product-spec.md):
 //! - No phone-home requirement — works with zero network calls other than
@@ -42,6 +43,13 @@ struct Cli {
     /// value is visible in shell history and `ps`.
     #[arg(long)]
     api_key: Option<String>,
+
+    /// Base URL override. Required with --model local/<model> to point at a
+    /// local OpenAI-compatible server (Ollama, vLLM, LM Studio, llama.cpp
+    /// server — e.g. http://localhost:11434/v1); optional for every other
+    /// provider to route through a proxy.
+    #[arg(long, env = "STELLA_BASE_URL")]
+    base_url: Option<String>,
 
     /// Output format: text (default, interactive) or json (headless)
     #[arg(long, env = "STELLA_OUTPUT_FORMAT", default_value = "text")]
@@ -133,7 +141,11 @@ fn run(cli: Cli) -> Result<(), String> {
     }
 
     // Run/Chat/Config need a resolved config (which requires an API key).
-    let cfg = config::Config::load(cli.model.as_deref(), cli.api_key.as_deref())?;
+    let cfg = config::Config::load(
+        cli.model.as_deref(),
+        cli.api_key.as_deref(),
+        cli.base_url.as_deref(),
+    )?;
 
     match cli.command.unwrap_or(Command::Chat) {
         Command::Run { prompt } => {

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -16,8 +16,18 @@
 //! concurrent task racing the event-draining task below, both writing to the
 //! terminal — real interleaving risk for a cosmetic win. `Stage::Execute`
 //! below gives one clean, immediate "thinking" line instead.
+//!
+//! The [`PromptDuel`] animation (a rocket dueling a UFO one line above the
+//! prompt, ported from the TS CLI's `SpaceInvaders` rail) does NOT violate
+//! that rationale: it runs only while the REPL is blocked on `read_line` —
+//! no turn in flight, no event stream to race — and is stopped before the
+//! turn starts. The only concurrent writer while it animates is the
+//! terminal's own echo of the user's keystrokes, which lives on a different
+//! row than the one the animator repaints.
 
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use colored::Colorize;
@@ -283,16 +293,22 @@ pub fn cost_summary(cost_usd: f64, model: &str, elapsed: Duration) {
     );
 }
 
-/// Print the welcome banner.
+/// Print the welcome banner: the STELLA block-letter logomark swept with the
+/// stellar gradient, then the session info line. (The previous banner was a
+/// hand-pasted figlet that had drifted into garbage — it did not actually
+/// spell "Stella" — which is exactly why the wordmark below is *composed*
+/// from per-letter glyph data, the same defense the TS CLI's `banner.tsx`
+/// uses: composition can't misspell.)
 pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
-    let stella = r#"
-   ____  _     _     _ __        __
-  / ___|| |__ (_)___| |\ \      / /_ _ _ __ ___
-  \___ \| '_ \| / __| __\ \ /\ / / _` | '__/ _ \
-   ___) | | | | \__ \ |_ \ V  V / (_| | | |  __/
-  |____/|_| |_|_|___/_|__\_/\_/ \__,_|_|  \___|
-"#;
-    println!("{}", stella.color(accent()));
+    println!();
+    for line in wordmark_lines() {
+        println!("  {line}");
+    }
+    println!(
+        "\n  {} {}",
+        "✦".bright_magenta(),
+        "a fast, BYOK, model-agnostic coding agent".dimmed()
+    );
     println!(
         "  {} {} · {} · {}",
         "◆".cyan(),
@@ -439,6 +455,299 @@ pub fn render_event(event: &AgentEvent) {
     }
 }
 
+// ── STELLA logomark ─────────────────────────────────────────────────────────
+//
+// 5-row block glyphs, kept as literals so the wordmark renders identically
+// across terminals (no figlet dependency) — the same composition scheme as
+// the TS CLI's `apps/cli/src/tui/banner.tsx`. Each glyph is a fixed-width
+// column of 5 rows; the word is composed by joining glyph rows with one
+// space so letters never touch.
+
+const GLYPH_ROWS: usize = 5;
+
+fn glyph(ch: char) -> Option<[&'static str; GLYPH_ROWS]> {
+    match ch {
+        'S' => Some(["███████", "██     ", "███████", "     ██", "███████"]),
+        'T' => Some(["███████", "   ██  ", "   ██  ", "   ██  ", "   ██  "]),
+        'E' => Some(["███████", "██     ", "█████  ", "██     ", "███████"]),
+        'L' => Some(["██     ", "██     ", "██     ", "██     ", "███████"]),
+        'A' => Some([" █████ ", "██   ██", "███████", "██   ██", "██   ██"]),
+        _ => None,
+    }
+}
+
+/// Compose a word into its 5-row block-letter form. Unknown chars are
+/// skipped, so the output can never contain a garbled letter.
+fn compose_wordmark(text: &str) -> Vec<String> {
+    let letters: Vec<[&'static str; GLYPH_ROWS]> = text
+        .chars()
+        .flat_map(|c| glyph(c.to_ascii_uppercase()))
+        .collect();
+    (0..GLYPH_ROWS)
+        .map(|row| letters.iter().map(|g| g[row]).collect::<Vec<_>>().join(" "))
+        .collect()
+}
+
+// Stellar gradient — violet → magenta → pink → cyan, swept left-to-right
+// across the wordmark (the night-sky counterpart of the TS banner's sunset).
+const STELLAR_STOPS: [(u8, u8, u8); 4] = [
+    (0x8B, 0x5C, 0xF6), // violet
+    (0xD9, 0x46, 0xEF), // magenta
+    (0xEC, 0x48, 0x99), // pink
+    (0x22, 0xD3, 0xEE), // cyan
+];
+
+/// Color at horizontal position `t` ∈ [0,1] along the stellar gradient.
+fn stellar_color_at(t: f64) -> (u8, u8, u8) {
+    let clamped = t.clamp(0.0, 1.0);
+    let segments = (STELLAR_STOPS.len() - 1) as f64;
+    let scaled = clamped * segments;
+    let idx = (scaled.floor() as usize).min(STELLAR_STOPS.len() - 2);
+    let local = scaled - idx as f64;
+    let from = STELLAR_STOPS[idx];
+    let to = STELLAR_STOPS[idx + 1];
+    let mix = |a: u8, b: u8| -> u8 { (a as f64 + (b as f64 - a as f64) * local).round() as u8 };
+    (mix(from.0, to.0), mix(from.1, to.1), mix(from.2, to.2))
+}
+
+/// The STELLA wordmark, each row colored column-by-column along the
+/// gradient. Returns display-ready strings (ANSI truecolor when the terminal
+/// supports it — `colored` handles the no-color fallback itself).
+fn wordmark_lines() -> Vec<String> {
+    let rows = compose_wordmark("STELLA");
+    let width = rows.first().map(|r| r.chars().count()).unwrap_or(1).max(2);
+    rows.iter()
+        .map(|row| {
+            row.chars()
+                .enumerate()
+                .map(|(i, ch)| {
+                    if ch == ' ' {
+                        ch.to_string()
+                    } else {
+                        let (r, g, b) = stellar_color_at(i as f64 / (width - 1) as f64);
+                        ch.to_string().truecolor(r, g, b).to_string()
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect()
+}
+
+// ── Fun: a rocket duels a UFO one line above the prompt ─────────────────────
+//
+// A straight port of the TS CLI's `renderInvadersLane` (apps/cli/src/repl/
+// components.tsx) — same sprites, same constants, same deterministic
+// physics, so the two CLIs share one signature animation. Sprites are
+// monochrome geometric glyphs (no color emoji) so they read the same in any
+// terminal theme. The rocket idles on a flickering thrust flame and snaps
+// into a recoil frame the instant it fires; the UFO patrols a weaving beat
+// and pulses its running light, mostly taking the hit and blooming into a
+// brief explosion, occasionally weaving clear for a near-miss flyby.
+
+const ROCKET: [&str; 2] = ["}=>", "-=>"];
+const ROCKET_RECOIL: &str = "{=>";
+const ROCKET_IDLE: &str = "|=>";
+const ROCKET_LEN: usize = 3;
+const UFO: [&str; 2] = ["<●>", "<○>"];
+const UFO_LEN: usize = 3;
+const EXPLOSION: [&str; 2] = ["✳✳✳", " ✸ "]; // flash, then dissipate to a spark
+const BOLT_HEAD: char = '•';
+const BOLT_TRAIL: char = '·';
+const BOLT_SPEED: usize = 3; // cells advanced per tick — a snappy tracer
+
+/// Write `sprite` into the fixed-width lane at `at`, clipping at both edges.
+fn place_sprite(lane: &mut [char], at: isize, sprite: &str) {
+    for (i, ch) in sprite.chars().enumerate() {
+        let idx = at + i as isize;
+        if idx >= 0 && (idx as usize) < lane.len() {
+            lane[idx as usize] = ch;
+        }
+    }
+}
+
+/// Bounces `n` back and forth across [0, span] — the UFO's weaving patrol.
+fn triangle_wave(n: u64, span: usize) -> usize {
+    if span == 0 {
+        return 0;
+    }
+    let period = (span * 2) as u64;
+    let m = (n % period) as usize;
+    if m <= span { m } else { period as usize - m }
+}
+
+/// Whether half-open ranges [a, a+a_len) and [b, b+b_len) intersect.
+fn overlaps(a: usize, a_len: usize, b: usize, b_len: usize) -> bool {
+    a < b + b_len && b < a + a_len
+}
+
+/// Pure renderer for one row of the rocket-vs-UFO duel, at a fixed `width`.
+/// When `active` the rocket fires on a steady cadence while the UFO weaves a
+/// patrol near the far end of the lane; most bolts land and bloom into a
+/// brief explosion before the UFO reforms, but the weave occasionally
+/// carries it clear of the shot for a near-miss flyby instead. Kept pure
+/// (no timers, no I/O) so every frame is deterministic and unit-testable.
+pub fn render_invaders_lane(tick: u64, width: usize, active: bool) -> String {
+    let w = width.clamp(14, 30);
+    let mut lane: Vec<char> = vec![' '; w];
+    let muzzle = ROCKET_LEN; // column right after the rocket's nose
+
+    if !active {
+        place_sprite(&mut lane, 0, ROCKET_IDLE);
+        place_sprite(&mut lane, (w - UFO_LEN) as isize, UFO[0]);
+        return lane.into_iter().collect();
+    }
+
+    // The UFO patrols a weave zone near the far end, well clear of the rocket.
+    let ufo_right = w - UFO_LEN;
+    let ufo_left = (muzzle + 3).max(ufo_right.saturating_sub(5));
+    let weave_span = (ufo_right - ufo_left).max(1);
+    let ufo_at = |t: u64| -> usize { ufo_left + triangle_wave(t, weave_span) };
+
+    // The rocket fires every `cycle` ticks: a recoil/muzzle-flash tick spawns
+    // the bolt, which streaks out at BOLT_SPEED cells/tick until it lands a
+    // hit or clears the lane, followed by a short beat before it reloads.
+    let flight_ticks = (w - muzzle).div_ceil(BOLT_SPEED) as u64;
+    let cycle = flight_ticks + 2;
+    let cycle_pos = tick % cycle;
+    let volley_start = tick - cycle_pos;
+
+    // Whether (and when) this volley's bolt connects is a pure function of
+    // the volley's start tick, so hits and near-misses fall out of the
+    // rocket/UFO phase relationship instead of a coin flip.
+    let mut hit_frame: Option<u64> = None;
+    for f in 0..flight_ticks {
+        let bolt_at = muzzle + f as usize * BOLT_SPEED;
+        if overlaps(bolt_at, 1, ufo_at(volley_start + f), UFO_LEN) {
+            hit_frame = Some(f);
+            break;
+        }
+    }
+
+    place_sprite(
+        &mut lane,
+        0,
+        if cycle_pos == 0 {
+            ROCKET_RECOIL
+        } else {
+            ROCKET[(tick % 2) as usize]
+        },
+    );
+
+    if let Some(hit) = hit_frame
+        && cycle_pos >= hit
+    {
+        // The bolt has landed — flash the impact, then let the UFO reform
+        // and resume its patrol for the rest of the beat before the next
+        // volley.
+        let since_hit = (cycle_pos - hit) as usize;
+        if since_hit < EXPLOSION.len() {
+            place_sprite(
+                &mut lane,
+                ufo_at(volley_start + hit) as isize,
+                EXPLOSION[since_hit],
+            );
+        } else {
+            place_sprite(&mut lane, ufo_at(tick) as isize, UFO[(tick % 2) as usize]);
+        }
+        return lane.into_iter().collect();
+    }
+
+    if cycle_pos < flight_ticks {
+        // Still in flight (a miss this volley, or a hit not yet reached) —
+        // the bolt leaves a fading trail behind its head as it streaks.
+        let bolt_at = muzzle + cycle_pos as usize * BOLT_SPEED;
+        if bolt_at > muzzle {
+            lane[bolt_at - 1] = BOLT_TRAIL;
+        }
+        if bolt_at < w {
+            lane[bolt_at] = BOLT_HEAD;
+        }
+    }
+    place_sprite(&mut lane, ufo_at(tick) as isize, UFO[(tick % 2) as usize]);
+    lane.into_iter().collect()
+}
+
+/// Default lane width — matches the TS `SpaceInvaders` component.
+const DUEL_WIDTH: usize = 24;
+/// Frame period — matches the TS component's 140ms interval.
+const DUEL_FRAME: Duration = Duration::from_millis(140);
+
+/// The animated duel one line above the prompt input. `start()` prints the
+/// opening frame on its own line (call it right before printing the prompt
+/// marker, so the lane sits exactly one row above the input), then a
+/// background thread repaints that row in place every ~140ms while the REPL
+/// is blocked reading input. `stop()` freezes the duel on its last frame —
+/// it stays behind in scrollback, the same way the TS rail goes still the
+/// moment its turn ends.
+///
+/// Repainting uses save-cursor / up-one-row / clear-line / restore in a
+/// single buffered write, so the user's in-progress typing on the row below
+/// is never touched. The only race is the beat between the user pressing
+/// Enter (which scrolls the prompt row up) and the caller invoking `stop()`;
+/// callers keep that window sub-millisecond by stopping immediately after
+/// `read_line` returns, against a 140ms frame period.
+pub struct PromptDuel {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl PromptDuel {
+    /// Start the duel if this session wants it: stdout must be a real
+    /// terminal (cursor-movement escapes would corrupt a pipe), and the fun
+    /// switch must not be off (`STELLA_FUN=0`, or the TS CLI's legacy
+    /// `STELLA_CLI_FUN=0`). Returns `None` — and prints nothing — otherwise.
+    pub fn start() -> Option<Self> {
+        let fun_off = |var: &str| std::env::var(var).map(|v| v == "0").unwrap_or(false);
+        if !io::stdout().is_terminal() || fun_off("STELLA_FUN") || fun_off("STELLA_CLI_FUN") {
+            return None;
+        }
+
+        println!(
+            "  {} {}",
+            "▸".dimmed(),
+            render_invaders_lane(0, DUEL_WIDTH, true).cyan()
+        );
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            let mut tick: u64 = 0;
+            loop {
+                std::thread::sleep(DUEL_FRAME);
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                tick += 1;
+                let frame = format!(
+                    // save cursor → up one row → col 1 → clear row → lane →
+                    // restore cursor, as one write so a keystroke echo can't
+                    // interleave mid-escape.
+                    "\x1b7\x1b[1A\r\x1b[2K  {} {}\x1b8",
+                    "▸".dimmed(),
+                    render_invaders_lane(tick, DUEL_WIDTH, true).cyan()
+                );
+                let mut out = io::stdout();
+                let _ = out.write_all(frame.as_bytes());
+                let _ = out.flush();
+            }
+        });
+
+        Some(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    /// Stop animating and wait for the painter thread to exit, leaving the
+    /// last frame in scrollback.
+    pub fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -483,5 +792,139 @@ mod tests {
             false,
             Duration::from_millis(3),
         );
+    }
+
+    // ── wordmark ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn wordmark_composes_six_letters_into_five_equal_width_rows() {
+        let rows = compose_wordmark("STELLA");
+        assert_eq!(rows.len(), GLYPH_ROWS);
+        let width = rows[0].chars().count();
+        // 6 glyphs × 7 columns + 5 separator spaces.
+        assert_eq!(width, 6 * 7 + 5);
+        for row in &rows {
+            assert_eq!(row.chars().count(), width, "ragged wordmark row");
+            assert!(row.chars().all(|c| c == '█' || c == ' '));
+        }
+    }
+
+    #[test]
+    fn wordmark_skips_unknown_characters_instead_of_garbling() {
+        // The old banner shipped a hand-pasted figlet that silently drifted
+        // into not spelling "Stella" — composition skips anything it has no
+        // glyph for, so a typo shrinks the mark instead of corrupting it.
+        assert_eq!(compose_wordmark("S?T"), compose_wordmark("ST"));
+    }
+
+    #[test]
+    fn stellar_gradient_hits_its_endpoint_stops_exactly() {
+        assert_eq!(stellar_color_at(0.0), STELLAR_STOPS[0]);
+        assert_eq!(stellar_color_at(1.0), STELLAR_STOPS[3]);
+        // Out-of-range positions clamp instead of extrapolating.
+        assert_eq!(stellar_color_at(-1.0), STELLAR_STOPS[0]);
+        assert_eq!(stellar_color_at(2.0), STELLAR_STOPS[3]);
+    }
+
+    // ── invaders lane ──────────────────────────────────────────────────────
+    //
+    // Fixtures are ported verbatim from the TS suite
+    // (apps/cli/src/repl/__tests__/components.test.tsx) so the two CLIs'
+    // animations can never drift apart silently: at W=24 the first volley's
+    // bolt connects on tick 6, and the 9th volley (ticks 72–80) is the
+    // deterministic near-miss.
+
+    const W: usize = 24;
+
+    #[test]
+    fn stands_down_when_idle_rocket_parked_ufo_calm() {
+        let lane = render_invaders_lane(0, W, false);
+        assert_eq!(lane.chars().count(), W); // fixed width — no layout jitter
+        assert!(lane.starts_with("|=>")); // powered-down rocket, thrust off
+        assert!(lane.trim_end().ends_with("<●>")); // UFO holding position
+        assert!(!lane.contains('•')); // no bolt in flight while still
+    }
+
+    #[test]
+    fn fires_when_active_bolt_streaks_toward_the_ufo() {
+        // Tick 2 is mid-flight (well before the tick-6 hit for this width),
+        // so rocket, bolt, and UFO are all on the lane at once.
+        let lane = render_invaders_lane(2, W, true);
+        assert_eq!(lane.chars().count(), W);
+        let chars: Vec<char> = lane.chars().collect();
+        assert!(matches!(chars[0], '{' | '}' | '-')); // a rocket frame at the nose
+        let nose = 2; // first char after the rocket sprite
+        let bolt = chars
+            .iter()
+            .position(|&c| c == '•')
+            .expect("bolt in flight");
+        let ufo = chars
+            .iter()
+            .position(|&c| c == '●' || c == '○')
+            .expect("ufo on lane");
+        assert!(bolt > nose);
+        assert!(ufo > bolt); // the UFO is still further out ahead of the bolt
+    }
+
+    #[test]
+    fn advances_the_bolt_frame_over_frame() {
+        let bolt_at = |tick: u64| -> usize {
+            render_invaders_lane(tick, W, true)
+                .chars()
+                .position(|c| c == '•')
+                .expect("bolt in flight")
+        };
+        // Ticks 0-2 are the opening flight of the first volley at this width
+        // — the bolt moves BOLT_SPEED (3) cells closer to the UFO each tick.
+        assert_eq!(bolt_at(0), 3);
+        assert_eq!(bolt_at(1), 6);
+        assert_eq!(bolt_at(2), 9);
+    }
+
+    #[test]
+    fn blooms_into_an_explosion_on_a_hit_then_reforms_the_ufo() {
+        // Verified fixture: at W=24 the first volley's bolt connects on tick 6.
+        let impact = render_invaders_lane(6, W, true);
+        assert!(impact.contains('✳') || impact.contains('✸'));
+        assert!(!impact.contains('•')); // the bolt is spent on impact
+        assert!(!impact.contains('●') && !impact.contains('○')); // explosion replaces the UFO
+
+        let dissipating = render_invaders_lane(7, W, true);
+        assert!(dissipating.contains('✳') || dissipating.contains('✸'));
+
+        // Later in the same beat (before the next volley reloads) the UFO reforms.
+        let reformed = render_invaders_lane(8, W, true);
+        assert!(reformed.contains('●') || reformed.contains('○'));
+        assert!(!reformed.contains('✳') && !reformed.contains('✸'));
+    }
+
+    #[test]
+    fn occasionally_the_weave_carries_the_ufo_clear_for_a_near_miss() {
+        // Verified fixture: at W=24 (fire cycle 9, weave period 10 — coprime,
+        // so the phase drifts volley to volley) the 9th volley (ticks 72-80)
+        // never lines up — the bolt streaks past and the UFO is untouched.
+        let frames: Vec<String> = (72..81).map(|t| render_invaders_lane(t, W, true)).collect();
+        assert!(!frames.iter().any(|f| f.contains('✳') || f.contains('✸')));
+        assert!(frames.iter().any(|f| f.contains('•'))); // the rocket still fired
+        assert!(
+            frames.iter().all(|f| f.contains('●') || f.contains('○')) // the UFO survives throughout
+        );
+    }
+
+    #[test]
+    fn is_deterministic_and_fixed_width_across_a_long_run() {
+        for tick in 0..200 {
+            let a = render_invaders_lane(tick, W, true);
+            let b = render_invaders_lane(tick, W, true);
+            assert_eq!(a, b, "tick {tick} not deterministic");
+            assert_eq!(a.chars().count(), W, "tick {tick} broke the lane width");
+        }
+    }
+
+    #[test]
+    fn clamps_degenerate_widths_instead_of_panicking() {
+        // Below the 14-cell minimum and above the 30-cell maximum both clamp.
+        assert_eq!(render_invaders_lane(5, 1, true).chars().count(), 14);
+        assert_eq!(render_invaders_lane(5, 500, true).chars().count(), 30);
     }
 }

--- a/stella-model/Cargo.toml
+++ b/stella-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stella-model"
-description = "Provider trait + adapters (Phase 0 spike: Z.ai/GLM 5.2, Anthropic). Owns per-vendor SSE parsing, tool-call dialect translation, credential resolution, and model-catalog lookups."
+description = "Provider trait + adapters (Z.ai/GLM 5.2, Anthropic, OpenAI, Gemini direct, Vertex, Bedrock, OpenAI-compatible gateways). Owns per-vendor SSE parsing, tool-call dialect translation, request signing, credential resolution, and model-catalog lookups."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -19,6 +19,8 @@ reqwest.workspace = true
 futures-util.workspace = true
 toml.workspace = true
 rpassword.workspace = true
+hmac.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -1,0 +1,1008 @@
+//! Amazon Bedrock adapter — the Converse API
+//! (`07-model-matrix.md` §2: "Bedrock | AWS chain | Converse/ConverseStream |
+//! catalog-driven … Model Garden by ARN"). Two deliberate v1 scopings, both
+//! consistent with postures already recorded elsewhere in this crate:
+//!
+//! - **Non-streaming `Converse`, not `ConverseStream`.** The streaming
+//!   variant speaks `application/vnd.amazon.eventstream` — a binary framing
+//!   with per-message CRC32 prologues, not SSE — an entirely separate
+//!   transport decoder. `Provider::complete` aggregates internally either
+//!   way (no caller renders partial tokens yet), so `Converse` returns an
+//!   identical `CompletionResult`; the event-stream decoder lands when the
+//!   TUI actually streams partial output.
+//! - **Explicit credentials, not the full AWS chain.** The adapter takes
+//!   access key / secret / optional session token directly; `stella-cli`
+//!   resolves them from the standard `AWS_ACCESS_KEY_ID` /
+//!   `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env vars. Profile files,
+//!   SSO, and IMDS are the "provider-native config" step the credential
+//!   chain doc (`credential.rs`) already records as deferred alongside this
+//!   adapter.
+//!
+//! Requests are signed with SigV4 implemented in [`sigv4`] below — pure
+//! functions over explicit inputs, pinned by golden vectors generated from
+//! botocore's reference implementation (see `sigv4::tests`), because
+//! request signing is exactly the kind of code that "looks right" while
+//! producing signatures a real endpoint rejects.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use stella_protocol::{
+    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
+    ProviderError, ToolCall,
+};
+
+use crate::credential::ApiKey;
+use crate::provider::Provider;
+
+pub struct BedrockProvider {
+    client: reqwest::Client,
+    access_key: ApiKey,
+    secret_key: ApiKey,
+    session_token: Option<ApiKey>,
+    region: String,
+    model: String,
+    base_url_override: Option<String>,
+}
+
+impl BedrockProvider {
+    /// Build an adapter for `model` (a catalog-resolved Bedrock model id or
+    /// inference-profile id, e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`)
+    /// in `region`.
+    pub fn new(
+        access_key: ApiKey,
+        secret_key: ApiKey,
+        session_token: Option<ApiKey>,
+        region: impl Into<String>,
+        model: impl Into<String>,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            access_key,
+            secret_key,
+            session_token,
+            region: region.into(),
+            model: model.into(),
+            base_url_override: None,
+        }
+    }
+
+    /// Override the scheme+host — used by conformance tests against a mock
+    /// server, and by anyone routing through a private proxy. Signing is
+    /// unaffected beyond the `host` header (a mock server never verifies
+    /// signatures; a proxy forwards them).
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url_override = Some(base_url.into());
+        self
+    }
+
+    /// The wire path for this model's Converse call. Bedrock model ids
+    /// routinely contain `:` (version suffixes) and ARNs contain `/` — both
+    /// must be percent-encoded in the request path, exactly as the AWS SDKs
+    /// send them, and the canonical URI signs the same encoded form.
+    fn wire_path(&self) -> String {
+        format!("/model/{}/converse", sigv4::uri_encode(&self.model))
+    }
+
+    fn base_url(&self) -> String {
+        match &self.base_url_override {
+            Some(base) => base.clone(),
+            None => format!("https://bedrock-runtime.{}.amazonaws.com", self.region),
+        }
+    }
+}
+
+// ── Wire types (Bedrock Converse API) ────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConverseRequest {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    system: Vec<BedrockTextBlock>,
+    messages: Vec<BedrockMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inference_config: Option<BedrockInferenceConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_config: Option<BedrockToolConfig>,
+}
+
+#[derive(Serialize, Debug)]
+struct BedrockTextBlock {
+    text: String,
+}
+
+#[derive(Serialize, Debug)]
+struct BedrockMessage {
+    role: &'static str,
+    content: Vec<BedrockContentBlock>,
+}
+
+/// One content block. Exactly one field is set per block (the wire treats
+/// them as a union) — same shape convention as `gemini.rs`'s outbound part.
+#[derive(Serialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct BedrockContentBlock {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_use: Option<BedrockToolUse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_result: Option<BedrockToolResult>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct BedrockToolUse {
+    tool_use_id: String,
+    name: String,
+    #[serde(default)]
+    input: Value,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct BedrockToolResult {
+    tool_use_id: String,
+    content: Vec<BedrockTextBlock>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockInferenceConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+}
+
+#[derive(Serialize)]
+struct BedrockToolConfig {
+    tools: Vec<BedrockToolEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockToolEntry {
+    tool_spec: BedrockToolSpec,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BedrockToolSpec {
+    name: String,
+    description: String,
+    input_schema: BedrockInputSchema,
+}
+
+#[derive(Serialize)]
+struct BedrockInputSchema {
+    json: Value,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ConverseResponse {
+    #[serde(default)]
+    output: Option<ConverseOutput>,
+    #[serde(default)]
+    usage: Option<BedrockUsage>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ConverseOutput {
+    #[serde(default)]
+    message: Option<ConverseOutputMessage>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ConverseOutputMessage {
+    #[serde(default)]
+    content: Vec<InboundContentBlock>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct InboundContentBlock {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    tool_use: Option<BedrockToolUse>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct BedrockUsage {
+    #[serde(default)]
+    input_tokens: u64,
+    #[serde(default)]
+    output_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+}
+
+/// Translate the engine's one message list into Converse `system` +
+/// `messages`. Dialect rules: system turns hoist into the dedicated
+/// `system` array; an assistant's tool calls are `toolUse` blocks on its
+/// own message; tool results are `toolResult` blocks on a **user**-role
+/// message (Converse's framing for "the environment answered"), each
+/// correlated by `toolUseId` and carrying `status: "error"` for failed
+/// tools instead of the text-prefix convention the OpenAI dialects use.
+fn to_bedrock_messages(
+    messages: &[CompletionMessage],
+) -> (Vec<BedrockTextBlock>, Vec<BedrockMessage>) {
+    let mut system = Vec::new();
+    let mut out: Vec<BedrockMessage> = Vec::new();
+    for message in messages {
+        match message.role {
+            MessageRole::System => system.push(BedrockTextBlock {
+                text: message.content.clone(),
+            }),
+            MessageRole::User => out.push(BedrockMessage {
+                role: "user",
+                content: vec![BedrockContentBlock {
+                    text: Some(message.content.clone()),
+                    ..Default::default()
+                }],
+            }),
+            MessageRole::Assistant => {
+                let mut content = Vec::new();
+                if !message.content.is_empty() {
+                    content.push(BedrockContentBlock {
+                        text: Some(message.content.clone()),
+                        ..Default::default()
+                    });
+                }
+                for call in &message.tool_calls {
+                    content.push(BedrockContentBlock {
+                        tool_use: Some(BedrockToolUse {
+                            tool_use_id: call.call_id.clone(),
+                            name: call.name.clone(),
+                            input: call.input.clone(),
+                        }),
+                        ..Default::default()
+                    });
+                }
+                if !content.is_empty() {
+                    out.push(BedrockMessage {
+                        role: "assistant",
+                        content,
+                    });
+                }
+            }
+            MessageRole::Tool => {
+                let content: Vec<BedrockContentBlock> = message
+                    .tool_results
+                    .iter()
+                    .map(|result| {
+                        let (text, status) = match &result.output {
+                            stella_protocol::ToolOutput::Ok { content } => (content.clone(), None),
+                            stella_protocol::ToolOutput::Error { message } => {
+                                (message.clone(), Some("error"))
+                            }
+                        };
+                        BedrockContentBlock {
+                            tool_result: Some(BedrockToolResult {
+                                tool_use_id: result.call_id.clone(),
+                                content: vec![BedrockTextBlock { text }],
+                                status,
+                            }),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+                if !content.is_empty() {
+                    out.push(BedrockMessage {
+                        role: "user",
+                        content,
+                    });
+                }
+            }
+        }
+    }
+    (system, out)
+}
+
+fn to_bedrock_tool_config(
+    tools: &[stella_protocol::tool::ToolSchema],
+) -> Option<BedrockToolConfig> {
+    if tools.is_empty() {
+        return None;
+    }
+    Some(BedrockToolConfig {
+        tools: tools
+            .iter()
+            .map(|tool| BedrockToolEntry {
+                tool_spec: BedrockToolSpec {
+                    name: tool.name.clone(),
+                    description: tool.description.clone(),
+                    input_schema: BedrockInputSchema {
+                        json: tool.input_schema.clone(),
+                    },
+                },
+            })
+            .collect(),
+    })
+}
+
+#[async_trait]
+impl Provider for BedrockProvider {
+    fn id(&self) -> &str {
+        "bedrock"
+    }
+
+    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        let (system, messages) = to_bedrock_messages(&req.messages);
+        let inference_config = if req.max_output_tokens.is_none() && req.temperature.is_none() {
+            None
+        } else {
+            Some(BedrockInferenceConfig {
+                max_tokens: req.max_output_tokens,
+                temperature: req.temperature,
+            })
+        };
+        let body = ConverseRequest {
+            system,
+            messages,
+            inference_config,
+            tool_config: to_bedrock_tool_config(&req.tools),
+        };
+        let payload =
+            serde_json::to_vec(&body).map_err(|e| ProviderError::Malformed(e.to_string()))?;
+
+        let base_url = self.base_url();
+        let wire_path = self.wire_path();
+        let url = format!("{base_url}{wire_path}");
+        let host = sigv4::host_from_url(&url)
+            .ok_or_else(|| ProviderError::Transport(format!("unparseable Bedrock URL: {url}")))?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| ProviderError::Transport(e.to_string()))?
+            .as_secs();
+        let amz_date = sigv4::format_amz_date(now as i64);
+
+        let signing = sigv4::sign(&sigv4::SigningInput {
+            method: "POST",
+            wire_path: &wire_path,
+            canonical_query: "",
+            host: &host,
+            content_type: "application/json",
+            payload: &payload,
+            region: &self.region,
+            service: "bedrock",
+            access_key: self.access_key.reveal(),
+            secret_key: self.secret_key.reveal(),
+            session_token: self.session_token.as_ref().map(|t| t.reveal()),
+            amz_date: &amz_date,
+        });
+
+        let mut request = self
+            .client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("x-amz-date", &amz_date)
+            .header("authorization", signing.authorization)
+            .body(payload);
+        if let Some(token) = &self.session_token {
+            request = request.header("x-amz-security-token", token.reveal());
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| ProviderError::Transport(e.to_string()))?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(ProviderError::Auth(format!(
+                "Bedrock rejected the AWS credentials (HTTP {status})"
+            )));
+        }
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ProviderError::RateLimited {
+                message: "Bedrock throttled the request".into(),
+                retry_after_ms: None,
+            });
+        }
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(ProviderError::Terminal(format!(
+                "Bedrock HTTP {status}: {text}"
+            )));
+        }
+
+        let parsed: ConverseResponse = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Malformed(e.to_string()))?;
+
+        let mut text = String::new();
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        if let Some(message) = parsed.output.and_then(|o| o.message) {
+            for block in message.content {
+                if let Some(t) = block.text {
+                    text.push_str(&t);
+                }
+                if let Some(tool_use) = block.tool_use {
+                    tool_calls.push(ToolCall {
+                        call_id: tool_use.tool_use_id,
+                        name: tool_use.name,
+                        input: tool_use.input,
+                    });
+                }
+            }
+        }
+        let usage = parsed.usage.unwrap_or_default();
+
+        Ok(CompletionResult {
+            text,
+            tool_calls,
+            usage: CompletionUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cached_input_tokens: usage.cache_read_input_tokens,
+            },
+            model: self.model.clone(),
+            cost_usd: 0.0,
+        })
+    }
+}
+
+/// AWS Signature Version 4 over explicit inputs — no ambient clock, no
+/// ambient env — so every step is unit-testable and the composed result can
+/// be pinned against botocore-generated golden vectors. Only what Converse
+/// needs is implemented (POST, empty query string, four signed headers);
+/// growing it further should extend the golden-vector suite in lockstep.
+pub(crate) mod sigv4 {
+    use hmac::{Hmac, Mac};
+    use sha2::{Digest, Sha256};
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    pub(crate) struct SigningInput<'a> {
+        pub method: &'a str,
+        /// The request path exactly as sent on the wire (already
+        /// percent-encoded once — see [`uri_encode`]). Per the SigV4 spec,
+        /// every service except S3 signs a canonical URI whose segments are
+        /// URI-encoded *twice*; [`sign`] derives that second encoding from
+        /// this wire form (`%3A` → `%253A`), matching botocore — the
+        /// golden-vector tests pin this exact behavior, which a plausible
+        /// "sign what you send" implementation gets wrong.
+        pub wire_path: &'a str,
+        pub canonical_query: &'a str,
+        pub host: &'a str,
+        pub content_type: &'a str,
+        pub payload: &'a [u8],
+        pub region: &'a str,
+        pub service: &'a str,
+        pub access_key: &'a str,
+        pub secret_key: &'a str,
+        pub session_token: Option<&'a str>,
+        /// `YYYYMMDD'T'HHMMSS'Z'` — from [`format_amz_date`] in production,
+        /// fixed in tests.
+        pub amz_date: &'a str,
+    }
+
+    pub(crate) struct SigningOutput {
+        pub authorization: String,
+    }
+
+    /// Percent-encode one URI path segment per RFC 3986: unreserved
+    /// characters (`A-Z a-z 0-9 - . _ ~`) pass through, everything else —
+    /// including `:` in Bedrock version suffixes and `/` in ARNs — becomes
+    /// uppercase `%XX`.
+    pub(crate) fn uri_encode(segment: &str) -> String {
+        let mut out = String::with_capacity(segment.len());
+        for byte in segment.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                    out.push(byte as char)
+                }
+                other => out.push_str(&format!("%{other:02X}")),
+            }
+        }
+        out
+    }
+
+    /// The canonical URI derived from a wire path: the SigV4 second
+    /// encoding pass for non-S3 services. `/` passes through (it separates
+    /// segments), unreserved bytes pass through, and everything else —
+    /// including the `%` of existing escapes — is re-encoded.
+    fn canonical_uri_from_wire_path(wire_path: &str) -> String {
+        let mut out = String::with_capacity(wire_path.len());
+        for byte in wire_path.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                    out.push(byte as char)
+                }
+                other => out.push_str(&format!("%{other:02X}")),
+            }
+        }
+        out
+    }
+
+    /// `host[:port]` from a URL, the exact value reqwest will send as the
+    /// `Host` header (port included only when non-default) — the canonical
+    /// headers must sign precisely what goes on the wire.
+    pub(crate) fn host_from_url(url: &str) -> Option<String> {
+        let parsed: reqwest::Url = url.parse().ok()?;
+        let host = parsed.host_str()?;
+        match parsed.port() {
+            Some(port) => Some(format!("{host}:{port}")),
+            None => Some(host.to_string()),
+        }
+    }
+
+    /// Format seconds-since-epoch as SigV4's `YYYYMMDD'T'HHMMSS'Z'`.
+    /// Implemented directly (days-to-civil-date, Howard Hinnant's
+    /// algorithm) rather than pulling a date crate for one format.
+    pub(crate) fn format_amz_date(epoch_secs: i64) -> String {
+        let days = epoch_secs.div_euclid(86_400);
+        let secs_of_day = epoch_secs.rem_euclid(86_400);
+        let (year, month, day) = civil_from_days(days);
+        let hour = secs_of_day / 3_600;
+        let minute = (secs_of_day % 3_600) / 60;
+        let second = secs_of_day % 60;
+        format!("{year:04}{month:02}{day:02}T{hour:02}{minute:02}{second:02}Z")
+    }
+
+    /// Days since 1970-01-01 → (year, month, day) in the proleptic
+    /// Gregorian calendar.
+    fn civil_from_days(days: i64) -> (i64, u32, u32) {
+        let z = days + 719_468;
+        let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+        let doe = (z - era * 146_097) as u64;
+        let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+        let year = yoe as i64 + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+        let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+        (if month <= 2 { year + 1 } else { year }, month, day)
+    }
+
+    fn sha256_hex(data: &[u8]) -> String {
+        hex(&Sha256::digest(data))
+    }
+
+    fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+        mac.update(data);
+        mac.finalize().into_bytes().to_vec()
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// Derive the per-day signing key: the documented
+    /// `HMAC(HMAC(HMAC(HMAC("AWS4"+secret, date), region), service), "aws4_request")`
+    /// chain.
+    pub(crate) fn derive_signing_key(
+        secret_key: &str,
+        date: &str,
+        region: &str,
+        service: &str,
+    ) -> Vec<u8> {
+        let k_date = hmac_sha256(format!("AWS4{secret_key}").as_bytes(), date.as_bytes());
+        let k_region = hmac_sha256(&k_date, region.as_bytes());
+        let k_service = hmac_sha256(&k_region, service.as_bytes());
+        hmac_sha256(&k_service, b"aws4_request")
+    }
+
+    pub(crate) fn sign(input: &SigningInput<'_>) -> SigningOutput {
+        let date = &input.amz_date[..8];
+        let payload_hash = sha256_hex(input.payload);
+        let canonical_uri = canonical_uri_from_wire_path(input.wire_path);
+
+        // Canonical headers: lowercase names, trimmed values, sorted by
+        // name, one per line. The fixed set Converse needs sorts as
+        // content-type < host < x-amz-date < x-amz-security-token.
+        let mut canonical_headers = format!(
+            "content-type:{}\nhost:{}\nx-amz-date:{}\n",
+            input.content_type, input.host, input.amz_date
+        );
+        let mut signed_headers = "content-type;host;x-amz-date".to_string();
+        if let Some(token) = input.session_token {
+            canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
+            signed_headers.push_str(";x-amz-security-token");
+        }
+
+        let canonical_request = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}",
+            input.method,
+            canonical_uri,
+            input.canonical_query,
+            canonical_headers,
+            signed_headers,
+            payload_hash
+        );
+
+        let scope = format!("{date}/{}/{}/aws4_request", input.region, input.service);
+        let string_to_sign = format!(
+            "AWS4-HMAC-SHA256\n{}\n{scope}\n{}",
+            input.amz_date,
+            sha256_hex(canonical_request.as_bytes())
+        );
+
+        let signing_key = derive_signing_key(input.secret_key, date, input.region, input.service);
+        let signature = hex(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+
+        SigningOutput {
+            authorization: format!(
+                "AWS4-HMAC-SHA256 Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+                input.access_key
+            ),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn uri_encode_passes_unreserved_and_encodes_the_rest_uppercase() {
+            assert_eq!(
+                uri_encode("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+                "us.anthropic.claude-sonnet-4-5-20250929-v1%3A0"
+            );
+            assert_eq!(uri_encode("a/b c~d_e"), "a%2Fb%20c~d_e");
+        }
+
+        #[test]
+        fn format_amz_date_handles_epoch_and_a_known_recent_instant() {
+            assert_eq!(format_amz_date(0), "19700101T000000Z");
+            // 2026-07-11 12:34:56 UTC — cross-checked with
+            // `date -u -r 1783773296 +%Y%m%dT%H%M%SZ`.
+            assert_eq!(format_amz_date(1_783_773_296), "20260711T123456Z");
+        }
+
+        #[test]
+        fn derive_signing_key_matches_the_documented_aws_example() {
+            // The worked example from AWS's SigV4 documentation
+            // ("Deriving a signing key"): secret wJalr…, 20120215,
+            // us-east-1, iam.
+            let key = derive_signing_key(
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "20120215",
+                "us-east-1",
+                "iam",
+            );
+            assert_eq!(
+                hex(&key),
+                "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+            );
+        }
+
+        #[test]
+        fn host_from_url_includes_non_default_ports_and_drops_default_ones() {
+            assert_eq!(
+                host_from_url("https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse"),
+                Some("bedrock-runtime.us-east-1.amazonaws.com".to_string())
+            );
+            assert_eq!(
+                host_from_url("http://127.0.0.1:9099/model/x/converse"),
+                Some("127.0.0.1:9099".to_string())
+            );
+        }
+
+        #[test]
+        fn canonical_uri_re_encodes_the_wire_paths_existing_escapes() {
+            // The SigV4 double-encoding rule for non-S3 services: the `%3A`
+            // sent on the wire signs as `%253A`. Botocore does this; a
+            // "sign what you send" implementation fails against the real
+            // endpoint with SignatureDoesNotMatch.
+            assert_eq!(
+                canonical_uri_from_wire_path(
+                    "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse"
+                ),
+                "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%253A0/converse"
+            );
+        }
+
+        /// Golden vector generated with botocore 1.43.46's `SigV4Auth` (the
+        /// AWS reference implementation) for this exact request shape, with
+        /// the clock frozen to `20260711T123456Z` — the generator script and
+        /// its output are archived under `verifications/` for the PR. Pins
+        /// the full composition: canonical request (double-encoded model id
+        /// in the path), string to sign, key derivation, and header
+        /// formatting.
+        #[test]
+        fn sign_matches_botocore_golden_vector_without_session_token() {
+            let output = sign(&SigningInput {
+                method: "POST",
+                wire_path: "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+                canonical_query: "",
+                host: "bedrock-runtime.us-east-1.amazonaws.com",
+                content_type: "application/json",
+                payload: br#"{"messages":[{"role":"user","content":[{"text":"hi"}]}]}"#,
+                region: "us-east-1",
+                service: "bedrock",
+                access_key: "AKIDEXAMPLE",
+                secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                session_token: None,
+                amz_date: "20260711T123456Z",
+            });
+            assert_eq!(
+                output.authorization,
+                "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260711/us-east-1/bedrock/aws4_request, \
+                 SignedHeaders=content-type;host;x-amz-date, \
+                 Signature=ae768b88a6982fa3a8811e2286c4360bf143e55da1d1aac37851bbf7a0b78773"
+            );
+        }
+
+        /// Same request signed with a session token — the token joins both
+        /// the canonical headers and the signed-headers list.
+        #[test]
+        fn sign_matches_botocore_golden_vector_with_session_token() {
+            let output = sign(&SigningInput {
+                method: "POST",
+                wire_path: "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+                canonical_query: "",
+                host: "bedrock-runtime.us-east-1.amazonaws.com",
+                content_type: "application/json",
+                payload: br#"{"messages":[{"role":"user","content":[{"text":"hi"}]}]}"#,
+                region: "us-east-1",
+                service: "bedrock",
+                access_key: "AKIDEXAMPLE",
+                secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                session_token: Some("IQoJb3JpZ2luX2VjEXAMPLETOKEN"),
+                amz_date: "20260711T123456Z",
+            });
+            assert_eq!(
+                output.authorization,
+                "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260711/us-east-1/bedrock/aws4_request, \
+                 SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, \
+                 Signature=97c2b7044a3c4687c95e5e23e82d9d895c638ad815ab2d13743d6ad1e1d7b4ac"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::tool::ToolSchema;
+    use stella_protocol::{ToolOutput, ToolResult};
+    use wiremock::matchers::{header_regex, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_provider(server_uri: &str) -> BedrockProvider {
+        BedrockProvider::new(
+            ApiKey::new("AKIDEXAMPLE"),
+            ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
+            None,
+            "us-east-1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        )
+        .with_base_url(server_uri.to_string())
+    }
+
+    #[test]
+    fn to_bedrock_messages_hoists_system_and_frames_tool_round_trips() {
+        let messages = vec![
+            CompletionMessage::system("You are a coding agent."),
+            CompletionMessage::user("read a.rs"),
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: "tooluse_abc".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({"path": "a.rs"}),
+                }],
+                tool_results: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    call_id: "tooluse_abc".into(),
+                    output: ToolOutput::Ok {
+                        content: "fn main(){}".into(),
+                    },
+                }],
+            },
+        ];
+        let (system, mapped) = to_bedrock_messages(&messages);
+        assert_eq!(system.len(), 1);
+        assert_eq!(mapped.len(), 3);
+        assert_eq!(mapped[1].role, "assistant");
+        let tool_use = mapped[1].content[0].tool_use.as_ref().unwrap();
+        assert_eq!(tool_use.tool_use_id, "tooluse_abc");
+        // Converse frames tool results as a user-role message.
+        assert_eq!(mapped[2].role, "user");
+        let tool_result = mapped[2].content[0].tool_result.as_ref().unwrap();
+        assert_eq!(tool_result.tool_use_id, "tooluse_abc");
+        assert_eq!(tool_result.content[0].text, "fn main(){}");
+        assert_eq!(tool_result.status, None);
+    }
+
+    #[test]
+    fn failed_tool_results_carry_error_status_not_a_text_prefix() {
+        let messages = vec![CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "tooluse_1".into(),
+                output: ToolOutput::Error {
+                    message: "no such file".into(),
+                },
+            }],
+        }];
+        let (_, mapped) = to_bedrock_messages(&messages);
+        let tool_result = mapped[0].content[0].tool_result.as_ref().unwrap();
+        assert_eq!(tool_result.status, Some("error"));
+        assert_eq!(tool_result.content[0].text, "no such file");
+    }
+
+    #[tokio::test]
+    async fn complete_posts_a_signed_converse_request_and_parses_text() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+            ))
+            .and(header_regex(
+                "authorization",
+                r"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/\d{8}/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=[0-9a-f]{64}$",
+            ))
+            .and(header_regex("x-amz-date", r"^\d{8}T\d{6}Z$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"message": {"role": "assistant", "content": [{"text": "Hello from Bedrock"}]}},
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 9, "outputTokens": 5, "cacheReadInputTokens": 3}
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: Some(1024),
+            temperature: Some(0.0),
+            effort: None,
+            tools: vec![],
+        };
+
+        let result = provider
+            .complete(req)
+            .await
+            .expect("completion should succeed");
+        assert_eq!(result.text, "Hello from Bedrock");
+        assert_eq!(result.usage.input_tokens, 9);
+        assert_eq!(result.usage.output_tokens, 5);
+        assert_eq!(result.usage.cached_input_tokens, 3);
+    }
+
+    #[tokio::test]
+    async fn complete_parses_tool_use_blocks_into_tool_calls() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"message": {"role": "assistant", "content": [
+                    {"text": "Let me read that."},
+                    {"toolUse": {"toolUseId": "tooluse_xyz", "name": "read_file", "input": {"path": "src/lib.rs"}}}
+                ]}},
+                "stopReason": "tool_use",
+                "usage": {"inputTokens": 30, "outputTokens": 12}
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("read src/lib.rs")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![ToolSchema {
+                name: "read_file".into(),
+                description: "Read a file".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+            }],
+        };
+
+        let result = provider.complete(req).await.expect("should succeed");
+        assert_eq!(result.text, "Let me read that.");
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].call_id, "tooluse_xyz");
+        assert_eq!(result.tool_calls[0].name, "read_file");
+        assert_eq!(
+            result.tool_calls[0].input,
+            serde_json::json!({"path": "src/lib.rs"})
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_maps_403_to_auth_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(403).set_body_string(
+                "{\"message\":\"The security token included in the request is invalid.\"}",
+            ))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Auth(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn complete_maps_429_throttling_to_rate_limited() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(429).set_body_string("{\"message\":\"Too many requests\"}"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(matches!(err, ProviderError::RateLimited { .. }));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn complete_sends_the_session_token_header_when_configured() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header_regex(
+                "x-amz-security-token",
+                r"^IQoJb3JpZ2luX2VjEXAMPLETOKEN$",
+            ))
+            .and(header_regex(
+                "authorization",
+                r"SignedHeaders=content-type;host;x-amz-date;x-amz-security-token,",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+                "usage": {"inputTokens": 1, "outputTokens": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = BedrockProvider::new(
+            ApiKey::new("AKIDEXAMPLE"),
+            ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
+            Some(ApiKey::new("IQoJb3JpZ2luX2VjEXAMPLETOKEN")),
+            "us-east-1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        )
+        .with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let result = provider.complete(req).await.expect("should succeed");
+        assert_eq!(result.text, "ok");
+    }
+}

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -60,6 +60,20 @@ pub enum ToolDialect {
     /// adapter exists; `OpenaiJson` stays the dialect name for everything
     /// that actually speaks the Chat Completions wire shape.
     OpenaiResponses,
+    /// Google's native `generateContent` dialect
+    /// (`stella_model::gemini::GeminiProvider` and
+    /// `stella_model::vertex::VertexProvider` — identical wire shape,
+    /// different auth/addressing): `functionCall`/`functionResponse` parts
+    /// correlated by function *name* (no wire call ids), args arriving as
+    /// complete JSON objects rather than streamed string fragments, and
+    /// Gemini 3 thought signatures riding on call parts
+    /// (`07-model-matrix.md` §4 `gemini-functions`).
+    GeminiFunctions,
+    /// Amazon Bedrock's Converse dialect
+    /// (`stella_model::bedrock::BedrockProvider`): `toolUse`/`toolResult`
+    /// content blocks correlated by `toolUseId`, tool results framed on a
+    /// user-role message with an explicit `status` field for failures.
+    BedrockConverse,
 }
 
 /// One catalog row — provider-native slug, verified against the provider's
@@ -167,16 +181,46 @@ impl Catalog {
                     provider: "gemini",
                     family: "gemini",
                     context_window: 1_000_000,
-                    // Routed through Google's OpenAI-compatibility shim
-                    // today (config.rs base_url has the `/openai` suffix);
-                    // a native Gemini adapter would use its own
-                    // GeminiFunctions dialect once built (deferred — see
-                    // config.rs and the Phase 2 PR description).
-                    tool_dialect: ToolDialect::OpenaiJson,
+                    // The native Gemini-direct adapter
+                    // (stella_model::gemini) — this row used to be
+                    // OpenaiJson while requests routed through Google's
+                    // OpenAI-compatibility shim as a stand-in.
+                    tool_dialect: ToolDialect::GeminiFunctions,
                     pricing: Pricing {
                         input_usd_per_mtok: 1.25,
                         output_usd_per_mtok: 10.00,
                         cached_input_usd_per_mtok: 0.31,
+                    },
+                },
+                CatalogEntry {
+                    // The same Google model surfaced through Vertex AI —
+                    // one model genuinely existing on two providers is why
+                    // uniqueness (and `resolve_for`) is keyed on
+                    // (provider, id), not id alone.
+                    id: "gemini-3-pro",
+                    provider: "vertex",
+                    family: "gemini",
+                    context_window: 1_000_000,
+                    tool_dialect: ToolDialect::GeminiFunctions,
+                    pricing: Pricing {
+                        input_usd_per_mtok: 1.25,
+                        output_usd_per_mtok: 10.00,
+                        cached_input_usd_per_mtok: 0.31,
+                    },
+                },
+                CatalogEntry {
+                    // A cross-region inference profile, not a bare model id
+                    // — Bedrock rejects on-demand invocation of newer
+                    // Anthropic models without one.
+                    id: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                    provider: "bedrock",
+                    family: "claude",
+                    context_window: 200_000,
+                    tool_dialect: ToolDialect::BedrockConverse,
+                    pricing: Pricing {
+                        input_usd_per_mtok: 3.00,
+                        output_usd_per_mtok: 15.00,
+                        cached_input_usd_per_mtok: 0.30,
                     },
                 },
                 CatalogEntry {
@@ -211,13 +255,30 @@ impl Catalog {
 
     /// Resolve a slug against the catalog. Returns `ProviderError::UnknownModel`
     /// (never a fallback to a default model) when the slug isn't present —
-    /// the loud, named error the spec requires.
+    /// the loud, named error the spec requires. When the same slug exists on
+    /// several providers (e.g. `gemini-3-pro` on both `gemini` and
+    /// `vertex`), the first row wins; use [`Catalog::resolve_for`] when the
+    /// provider is known.
     pub fn resolve(&self, slug: &str) -> Result<&CatalogEntry, ProviderError> {
         self.entries
             .iter()
             .find(|entry| entry.id == slug)
             .ok_or_else(|| ProviderError::UnknownModel {
                 slug: slug.to_string(),
+            })
+    }
+
+    /// Resolve a slug for a specific provider — the form `build_provider`
+    /// uses, since the same model genuinely exists on more than one
+    /// provider (Gemini on `gemini` and `vertex`; most things on
+    /// `openrouter`) and a slug that exists on provider A must still be a
+    /// hard error when requested from provider B.
+    pub fn resolve_for(&self, provider: &str, slug: &str) -> Result<&CatalogEntry, ProviderError> {
+        self.entries
+            .iter()
+            .find(|entry| entry.provider == provider && entry.id == slug)
+            .ok_or_else(|| ProviderError::UnknownModel {
+                slug: format!("{provider}/{slug}"),
             })
     }
 
@@ -249,16 +310,23 @@ mod tests {
     }
 
     #[test]
-    fn seed_catalog_has_no_duplicate_ids() {
+    fn seed_catalog_has_no_duplicate_provider_id_pairs() {
+        // Keyed on (provider, id), not id alone: the same model genuinely
+        // exists on more than one provider (gemini-3-pro on gemini and
+        // vertex), which is exactly why resolve_for exists.
         let catalog = Catalog::seed();
-        let mut ids: Vec<&str> = catalog.entries().iter().map(|e| e.id).collect();
-        let before = ids.len();
-        ids.sort_unstable();
-        ids.dedup();
+        let mut pairs: Vec<(&str, &str)> = catalog
+            .entries()
+            .iter()
+            .map(|e| (e.provider, e.id))
+            .collect();
+        let before = pairs.len();
+        pairs.sort_unstable();
+        pairs.dedup();
         assert_eq!(
-            ids.len(),
+            pairs.len(),
             before,
-            "catalog seed must not contain duplicate slugs"
+            "catalog seed must not contain duplicate (provider, slug) pairs"
         );
     }
 
@@ -322,12 +390,32 @@ mod tests {
     }
 
     #[test]
+    fn resolve_for_scopes_the_slug_to_the_named_provider() {
+        let catalog = Catalog::seed();
+        let entry = catalog
+            .resolve_for("vertex", "gemini-3-pro")
+            .expect("vertex row is seeded");
+        assert_eq!(entry.provider, "vertex");
+        assert_eq!(entry.tool_dialect, ToolDialect::GeminiFunctions);
+
+        // A slug that exists — but on a different provider — is still a
+        // hard error for the provider actually requested.
+        let err = catalog.resolve_for("bedrock", "gemini-3-pro").unwrap_err();
+        match err {
+            ProviderError::UnknownModel { slug } => {
+                assert_eq!(slug, "bedrock/gemini-3-pro")
+            }
+            other => panic!("expected UnknownModel, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn seed_covers_every_provider_stella_cli_can_select() {
-        // stella-cli/src/config.rs::PROVIDERS lists 7 providers; this test
-        // doesn't import that crate (stella-cli depends on stella-model,
-        // not the reverse) but pins the provider id set here so the two
-        // can't silently drift apart again — the actual cross-check lives
-        // in stella-cli's own test suite (config::tests).
+        // stella-cli/src/config.rs::PROVIDERS lists these providers; this
+        // test doesn't import that crate (stella-cli depends on
+        // stella-model, not the reverse) but pins the provider id set here
+        // so the two can't silently drift apart again — the actual
+        // cross-check lives in stella-cli's own test suite (config::tests).
         let catalog = Catalog::seed();
         for provider in [
             "zai",
@@ -337,6 +425,8 @@ mod tests {
             "deepseek",
             "gemini",
             "openrouter",
+            "vertex",
+            "bedrock",
         ] {
             assert!(
                 catalog.entries().iter().any(|e| e.provider == provider),

--- a/stella-model/src/credential.rs
+++ b/stella-model/src/credential.rs
@@ -3,9 +3,10 @@
 //! (`docs/specs/oxagen-rust-cli/02-architecture.md` §8).
 //!
 //! Resolution order per `01-product-spec.md` §4: CLI flag -> env var ->
-//! provider-native config (`~/.config/stella/credentials.toml` here; AWS
-//! profile / ADC file are Bedrock/Vertex concerns, deferred alongside those
-//! adapters) -> interactive prompt on first use, which never silently fails
+//! provider-native config (`~/.config/stella/credentials.toml` here; the AWS
+//! profile file and Google ADC file remain deferred — the Bedrock/Vertex
+//! adapters take ready credentials from env vars for now, see their module
+//! docs) -> interactive prompt on first use, which never silently fails
 //! with an opaque provider error.
 
 use std::collections::BTreeMap;

--- a/stella-model/src/gemini.rs
+++ b/stella-model/src/gemini.rs
@@ -1,0 +1,808 @@
+//! Gemini direct adapter — Google's native `generativelanguage.googleapis.com`
+//! generateContent API (`gemini-functions` dialect, `07-model-matrix.md` §2/§4),
+//! replacing the OpenAI-compatibility shim `stella-cli` previously pointed
+//! `ZaiProvider` at. The shim works for plain chat but is not the wire shape
+//! the spec calls for and drops everything Gemini-specific: thinking level,
+//! thought-signature round-trips (required for Gemini 3 function calling),
+//! cached-token accounting, and the native media endpoints (Imagen/Veo)
+//! that later phases hang off this same adapter family.
+//!
+//! The wire types and stream aggregation here are shared with
+//! `vertex.rs` — Vertex AI speaks the identical `generateContent` response
+//! shape behind different auth (OAuth bearer vs. API key) and a
+//! project/location-scoped URL, so the two adapters differ only in those
+//! seams (`07-model-matrix.md` §2: "casual Gemini use → direct adapter",
+//! Vertex is the enterprise path).
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use stella_protocol::{
+    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
+    ProviderError, ReasoningEffort, ToolCall,
+};
+
+use crate::credential::ApiKey;
+use crate::provider::Provider;
+use crate::sse::SseDecoder;
+
+const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+
+/// Separator between the synthesized call ordinal and a Gemini thought
+/// signature inside a `ToolCall::call_id`. Gemini's wire has no call ids at
+/// all — calls correlate to responses by function *name* and order — but the
+/// engine's internal protocol requires one, so this adapter mints
+/// `call_0`, `call_1`, …. Gemini 3 additionally attaches a `thoughtSignature`
+/// to streamed `functionCall` parts and *requires* it to be echoed back on
+/// the matching part in conversation history (omitting it degrades or
+/// rejects the next turn). `CompletionMessage`/`ToolCall` have no slot for a
+/// provider-private blob, so the signature rides inside the minted call id
+/// after this separator (`call_0#<sig>`) and is split back out when history
+/// is re-framed for the wire. `#` cannot appear in the base64 signature, so
+/// the split is unambiguous.
+const SIGNATURE_SEPARATOR: char = '#';
+
+pub struct GeminiProvider {
+    client: reqwest::Client,
+    api_key: ApiKey,
+    base_url: String,
+    model: String,
+}
+
+impl GeminiProvider {
+    /// Build an adapter for `model` (a catalog-resolved slug, e.g.
+    /// `gemini-3-pro` — never a literal chosen at the call site).
+    pub fn new(api_key: ApiKey, model: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: model.into(),
+        }
+    }
+
+    /// Override the base URL — used by conformance tests against a mock
+    /// server, and by anyone routing through a private proxy.
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+// ── Wire types (Gemini generateContent API) ──────────────────────────────
+//
+// `pub(crate)` where `vertex.rs` shares them: the request/response envelope
+// is identical between the two Google surfaces; only auth and URL differ.
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) system_instruction: Option<GeminiSystemInstruction>,
+    pub(crate) contents: Vec<GeminiContent>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tools: Vec<GeminiToolDecls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) generation_config: Option<GeminiGenerationConfig>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct GeminiSystemInstruction {
+    pub(crate) parts: Vec<GeminiTextPart>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct GeminiTextPart {
+    pub(crate) text: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiContent {
+    pub(crate) role: &'static str,
+    pub(crate) parts: Vec<GeminiOutboundPart>,
+}
+
+/// One outbound content part. Exactly one of the value fields is set per
+/// part (the wire treats them as a union); `thought_signature` may accompany
+/// a `function_call` part when replaying Gemini 3 history — see
+/// [`SIGNATURE_SEPARATOR`].
+#[derive(Serialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiOutboundPart {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) function_call: Option<GeminiFunctionCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) function_response: Option<GeminiFunctionResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) thought_signature: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct GeminiFunctionCall {
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) args: Value,
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct GeminiFunctionResponse {
+    pub(crate) name: String,
+    /// The wire requires a JSON *object*, not a bare string — tool output is
+    /// wrapped as `{"output": …}` / `{"error": …}` per Google's own
+    /// function-calling convention.
+    pub(crate) response: Value,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiToolDecls {
+    pub(crate) function_declarations: Vec<GeminiFunctionDecl>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct GeminiFunctionDecl {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) parameters: Value,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiGenerationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) thinking_config: Option<GeminiThinkingConfig>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiThinkingConfig {
+    pub(crate) thinking_level: &'static str,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiStreamChunk {
+    #[serde(default)]
+    pub(crate) candidates: Vec<GeminiCandidate>,
+    #[serde(default)]
+    pub(crate) usage_metadata: Option<GeminiUsageMetadata>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct GeminiCandidate {
+    #[serde(default)]
+    pub(crate) content: Option<GeminiCandidateContent>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct GeminiCandidateContent {
+    #[serde(default)]
+    pub(crate) parts: Vec<GeminiInboundPart>,
+}
+
+/// One streamed content part. `thought: true` marks a thought-summary text
+/// part (model reasoning surfaced for display) — never aggregated into the
+/// user-visible answer text.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiInboundPart {
+    #[serde(default)]
+    pub(crate) text: Option<String>,
+    #[serde(default)]
+    pub(crate) thought: bool,
+    #[serde(default)]
+    pub(crate) function_call: Option<GeminiFunctionCall>,
+    #[serde(default)]
+    pub(crate) thought_signature: Option<String>,
+}
+
+/// Cumulative usage — each chunk reports the running totals, so the last
+/// assignment wins. `candidates_token_count` excludes thinking tokens; the
+/// engine's one `output_tokens` figure includes them (they are billed
+/// output), per the "normalization lives in the adapter" rule
+/// (`07-model-matrix.md` §6).
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GeminiUsageMetadata {
+    #[serde(default)]
+    pub(crate) prompt_token_count: u64,
+    #[serde(default)]
+    pub(crate) candidates_token_count: u64,
+    #[serde(default)]
+    pub(crate) thoughts_token_count: u64,
+    #[serde(default)]
+    pub(crate) cached_content_token_count: u64,
+}
+
+/// Map the engine's one `ReasoningEffort` enum to Gemini's
+/// `thinkingConfig.thinkingLevel`, which only accepts `"low"`/`"high"`
+/// (Gemini 3; there is no medium tier). Same collapse posture as
+/// `openai.rs::map_reasoning_effort`: never drop the hint, never panic on a
+/// variant the provider doesn't model.
+pub(crate) fn map_thinking_level(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium
+        | ReasoningEffort::High
+        | ReasoningEffort::Xhigh
+        | ReasoningEffort::Max => "high",
+    }
+}
+
+/// Split a minted call id back into `(wire ordinal, thought signature)` —
+/// the inverse of what [`aggregate_gemini_stream`] minted.
+fn split_call_id(call_id: &str) -> (&str, Option<&str>) {
+    match call_id.split_once(SIGNATURE_SEPARATOR) {
+        Some((ordinal, signature)) if !signature.is_empty() => (ordinal, Some(signature)),
+        _ => (call_id, None),
+    }
+}
+
+/// Translate the engine's one message list into Gemini `contents` +
+/// `systemInstruction`. Dialect rules (`gemini-functions`):
+/// - system turns hoist into `systemInstruction` (joined, like `openai.rs`)
+/// - assistant → `role: "model"`, its tool calls become `functionCall`
+///   parts (with any Gemini 3 thought signature restored — see
+///   [`SIGNATURE_SEPARATOR`])
+/// - tool results → a `role: "user"` content whose parts are
+///   `functionResponse` objects. Gemini correlates a response to its call by
+///   function *name* (there are no wire call ids), so the name is recovered
+///   from the assistant `tool_calls` earlier in this same message list that
+///   minted the `call_id`.
+pub(crate) fn to_gemini_request_parts(
+    messages: &[CompletionMessage],
+) -> (Option<GeminiSystemInstruction>, Vec<GeminiContent>) {
+    let mut system: Vec<String> = Vec::new();
+    let mut contents: Vec<GeminiContent> = Vec::new();
+    // call_id -> function name, harvested from assistant turns in order so
+    // a later Tool message can name the call it answers.
+    let mut call_names: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    for message in messages {
+        match message.role {
+            MessageRole::System => system.push(message.content.clone()),
+            MessageRole::User => contents.push(GeminiContent {
+                role: "user",
+                parts: vec![GeminiOutboundPart {
+                    text: Some(message.content.clone()),
+                    ..Default::default()
+                }],
+            }),
+            MessageRole::Assistant => {
+                let mut parts = Vec::new();
+                if !message.content.is_empty() {
+                    parts.push(GeminiOutboundPart {
+                        text: Some(message.content.clone()),
+                        ..Default::default()
+                    });
+                }
+                for call in &message.tool_calls {
+                    call_names.insert(call.call_id.clone(), call.name.clone());
+                    let (_, signature) = split_call_id(&call.call_id);
+                    parts.push(GeminiOutboundPart {
+                        function_call: Some(GeminiFunctionCall {
+                            name: call.name.clone(),
+                            args: call.input.clone(),
+                        }),
+                        thought_signature: signature.map(str::to_string),
+                        ..Default::default()
+                    });
+                }
+                if !parts.is_empty() {
+                    contents.push(GeminiContent {
+                        role: "model",
+                        parts,
+                    });
+                }
+            }
+            MessageRole::Tool => {
+                let parts: Vec<GeminiOutboundPart> = message
+                    .tool_results
+                    .iter()
+                    .map(|result| {
+                        let name = call_names
+                            .get(&result.call_id)
+                            .cloned()
+                            .unwrap_or_else(|| result.call_id.clone());
+                        let response = match &result.output {
+                            stella_protocol::ToolOutput::Ok { content } => {
+                                serde_json::json!({ "output": content })
+                            }
+                            stella_protocol::ToolOutput::Error { message } => {
+                                serde_json::json!({ "error": message })
+                            }
+                        };
+                        GeminiOutboundPart {
+                            function_response: Some(GeminiFunctionResponse { name, response }),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+                if !parts.is_empty() {
+                    contents.push(GeminiContent {
+                        role: "user",
+                        parts,
+                    });
+                }
+            }
+        }
+    }
+
+    let system_instruction = if system.is_empty() {
+        None
+    } else {
+        Some(GeminiSystemInstruction {
+            parts: vec![GeminiTextPart {
+                text: system.join("\n\n"),
+            }],
+        })
+    };
+    (system_instruction, contents)
+}
+
+pub(crate) fn to_gemini_tools(tools: &[stella_protocol::tool::ToolSchema]) -> Vec<GeminiToolDecls> {
+    if tools.is_empty() {
+        return Vec::new();
+    }
+    vec![GeminiToolDecls {
+        function_declarations: tools
+            .iter()
+            .map(|tool| GeminiFunctionDecl {
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                parameters: tool.input_schema.clone(),
+            })
+            .collect(),
+    }]
+}
+
+pub(crate) fn build_generation_config(req: &CompletionRequest) -> Option<GeminiGenerationConfig> {
+    if req.max_output_tokens.is_none() && req.temperature.is_none() && req.effort.is_none() {
+        return None;
+    }
+    Some(GeminiGenerationConfig {
+        max_output_tokens: req.max_output_tokens,
+        temperature: req.temperature,
+        thinking_config: req.effort.map(|effort| GeminiThinkingConfig {
+            thinking_level: map_thinking_level(effort),
+        }),
+    })
+}
+
+/// Classify a non-success generateContent status. Shared with `vertex.rs`
+/// (identical error envelope); `label` names the actual surface in the
+/// message so a Vertex failure never reads as a Gemini one.
+pub(crate) async fn classify_google_error(
+    label: &str,
+    response: reqwest::Response,
+) -> ProviderError {
+    let status = response.status();
+    let retry_after_ms = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|s| s.saturating_mul(1000));
+    let body = response.text().await.unwrap_or_default();
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return ProviderError::Auth(format!("{label} rejected the credential (HTTP {status})"));
+    }
+    // Google reports an invalid API key as HTTP 400 with reason
+    // API_KEY_INVALID, not a 401 — surface it as the auth failure it is so
+    // the user is told to fix the key rather than shown a generic terminal
+    // error (and so the step-driver never retries it).
+    if status == reqwest::StatusCode::BAD_REQUEST && body.contains("API_KEY_INVALID") {
+        return ProviderError::Auth(format!("{label} rejected the API key: {body}"));
+    }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return ProviderError::RateLimited {
+            message: format!("{label} rate limit"),
+            retry_after_ms,
+        };
+    }
+    ProviderError::Terminal(format!("{label} HTTP {status}: {body}"))
+}
+
+#[async_trait]
+impl Provider for GeminiProvider {
+    fn id(&self) -> &str {
+        "gemini"
+    }
+
+    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        let (system_instruction, contents) = to_gemini_request_parts(&req.messages);
+        let body = GeminiRequest {
+            system_instruction,
+            contents,
+            tools: to_gemini_tools(&req.tools),
+            generation_config: build_generation_config(&req),
+        };
+
+        let response = self
+            .client
+            .post(format!(
+                "{}/models/{}:streamGenerateContent?alt=sse",
+                self.base_url, self.model
+            ))
+            .header("x-goog-api-key", self.api_key.reveal())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Transport(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(classify_google_error("Gemini", response).await);
+        }
+
+        let (text, tool_calls, usage) = aggregate_gemini_stream(response).await?;
+        Ok(CompletionResult {
+            text,
+            tool_calls,
+            usage,
+            model: self.model.clone(),
+            cost_usd: 0.0,
+        })
+    }
+}
+
+/// Aggregate a `streamGenerateContent?alt=sse` response. Unlike the OpenAI
+/// dialects there is no fragment reassembly: each `functionCall` part
+/// arrives whole (args already a JSON object), and text parts are plain
+/// deltas. Thought-summary parts (`thought: true`) are excluded from the
+/// answer text; a part's `thoughtSignature` is preserved by riding inside
+/// the minted call id (see [`SIGNATURE_SEPARATOR`]).
+pub(crate) async fn aggregate_gemini_stream(
+    response: reqwest::Response,
+) -> Result<(String, Vec<ToolCall>, CompletionUsage), ProviderError> {
+    use futures_util::StreamExt;
+
+    let mut decoder = SseDecoder::new();
+    let mut text = String::new();
+    let mut usage = CompletionUsage::default();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| ProviderError::Transport(e.to_string()))?;
+        let chunk_str =
+            std::str::from_utf8(&chunk).map_err(|e| ProviderError::Malformed(e.to_string()))?;
+        decoder.push(chunk_str);
+        for event in decoder.poll() {
+            let data = event.data.trim();
+            if data.is_empty() || data == "[DONE]" {
+                continue;
+            }
+            let parsed: GeminiStreamChunk = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue, // tolerate keep-alive/ping frames
+            };
+            if let Some(u) = parsed.usage_metadata {
+                usage.input_tokens = u.prompt_token_count;
+                usage.output_tokens = u.candidates_token_count + u.thoughts_token_count;
+                usage.cached_input_tokens = u.cached_content_token_count;
+            }
+            for candidate in parsed.candidates {
+                let Some(content) = candidate.content else {
+                    continue;
+                };
+                for part in content.parts {
+                    if let Some(call) = part.function_call {
+                        let ordinal = tool_calls.len();
+                        let call_id = match &part.thought_signature {
+                            Some(sig) => format!("call_{ordinal}{SIGNATURE_SEPARATOR}{sig}"),
+                            None => format!("call_{ordinal}"),
+                        };
+                        tool_calls.push(ToolCall {
+                            call_id,
+                            name: call.name,
+                            input: call.args,
+                        });
+                    } else if let Some(t) = part.text
+                        && !part.thought
+                    {
+                        text.push_str(&t);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((text, tool_calls, usage))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::tool::ToolSchema;
+    use stella_protocol::{ToolOutput, ToolResult};
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn to_gemini_request_parts_hoists_system_and_maps_roles() {
+        let messages = vec![
+            CompletionMessage::system("You are a coding agent."),
+            CompletionMessage::user("Fix the bug."),
+        ];
+        let (system, contents) = to_gemini_request_parts(&messages);
+        assert_eq!(
+            system.unwrap().parts[0].text,
+            "You are a coding agent.".to_string()
+        );
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0].role, "user");
+    }
+
+    #[test]
+    fn tool_results_become_function_response_parts_named_via_the_calling_turn() {
+        // Gemini has no wire call ids: a functionResponse names the function
+        // it answers. The adapter must recover that name from the assistant
+        // turn that minted the call_id.
+        let messages = vec![
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: "call_0".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({"path": "a.rs"}),
+                }],
+                tool_results: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    call_id: "call_0".into(),
+                    output: ToolOutput::Ok {
+                        content: "fn main(){}".into(),
+                    },
+                }],
+            },
+        ];
+        let (_, contents) = to_gemini_request_parts(&messages);
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0].role, "model");
+        let call = contents[0].parts[0].function_call.as_ref().unwrap();
+        assert_eq!(call.name, "read_file");
+        assert_eq!(contents[1].role, "user");
+        let response = contents[1].parts[0].function_response.as_ref().unwrap();
+        assert_eq!(response.name, "read_file");
+        assert_eq!(
+            response.response,
+            serde_json::json!({"output": "fn main(){}"})
+        );
+    }
+
+    #[test]
+    fn error_results_are_framed_as_error_objects() {
+        let messages = vec![CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "call_1".into(),
+                output: ToolOutput::Error {
+                    message: "no such file".into(),
+                },
+            }],
+        }];
+        let (_, contents) = to_gemini_request_parts(&messages);
+        let response = contents[0].parts[0].function_response.as_ref().unwrap();
+        assert_eq!(
+            response.response,
+            serde_json::json!({"error": "no such file"})
+        );
+    }
+
+    #[test]
+    fn thought_signatures_round_trip_through_the_minted_call_id() {
+        // Gemini 3 attaches a thoughtSignature to a functionCall part and
+        // requires it echoed back on the matching history part. The engine's
+        // ToolCall has no slot for it, so it rides inside the minted call_id
+        // — this test pins the full mint → history-replay round trip.
+        let messages = vec![CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: "call_0#c2lnbmF0dXJl".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"command": "ls"}),
+            }],
+            tool_results: vec![],
+        }];
+        let (_, contents) = to_gemini_request_parts(&messages);
+        let part = &contents[0].parts[0];
+        assert_eq!(part.thought_signature.as_deref(), Some("c2lnbmF0dXJl"));
+        let call = part.function_call.as_ref().unwrap();
+        assert_eq!(call.name, "bash");
+    }
+
+    #[test]
+    fn thinking_level_maps_low_directly_and_everything_else_to_high() {
+        assert_eq!(map_thinking_level(ReasoningEffort::Low), "low");
+        assert_eq!(map_thinking_level(ReasoningEffort::Medium), "high");
+        assert_eq!(map_thinking_level(ReasoningEffort::High), "high");
+        assert_eq!(map_thinking_level(ReasoningEffort::Xhigh), "high");
+        assert_eq!(map_thinking_level(ReasoningEffort::Max), "high");
+    }
+
+    #[tokio::test]
+    async fn complete_streams_and_aggregates_text_excluding_thought_parts() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"planning...\",\"thought\":true}]}}]}\n\n",
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hel\"}]}}]}\n\n",
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"lo!\"}]}}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":3,\"thoughtsTokenCount\":5,\"cachedContentTokenCount\":2}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/models/gemini-3-pro:streamGenerateContent"))
+            .and(query_param("alt", "sse"))
+            .and(header("x-goog-api-key", "test-gemini-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = GeminiProvider::new(ApiKey::new("test-gemini-key"), "gemini-3-pro")
+            .with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![
+                CompletionMessage::system("system"),
+                CompletionMessage::user("say hello"),
+            ],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let result = provider
+            .complete(req)
+            .await
+            .expect("completion should succeed");
+        assert_eq!(result.text, "Hello!");
+        assert_eq!(result.usage.input_tokens, 10);
+        // candidates (3) + thoughts (5): thinking tokens are billed output.
+        assert_eq!(result.usage.output_tokens, 8);
+        assert_eq!(result.usage.cached_input_tokens, 2);
+        assert_eq!(result.model, "gemini-3-pro");
+    }
+
+    #[tokio::test]
+    async fn complete_mints_call_ids_and_captures_thought_signatures() {
+        let server = MockServer::start().await;
+        // Two parallel functionCall parts in one turn — Gemini sends args as
+        // complete JSON objects (no fragment reassembly) and a Gemini 3
+        // thoughtSignature on the first part of the group.
+        let sse_body = concat!(
+            "data: {\"candidates\":[{\"content\":{\"parts\":[",
+            "{\"functionCall\":{\"name\":\"read_file\",\"args\":{\"path\":\"src/lib.rs\"}},\"thoughtSignature\":\"c2ln\"},",
+            "{\"functionCall\":{\"name\":\"bash\",\"args\":{\"command\":\"ls\"}}}",
+            "]}}],\"usageMetadata\":{\"promptTokenCount\":20,\"candidatesTokenCount\":12}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/models/gemini-3-pro:streamGenerateContent"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = GeminiProvider::new(ApiKey::new("test-key"), "gemini-3-pro")
+            .with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("read src/lib.rs and list files")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![ToolSchema {
+                name: "read_file".into(),
+                description: "Read a file".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+            }],
+        };
+
+        let result = provider.complete(req).await.expect("should succeed");
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].call_id, "call_0#c2ln");
+        assert_eq!(result.tool_calls[0].name, "read_file");
+        assert_eq!(
+            result.tool_calls[0].input,
+            serde_json::json!({"path": "src/lib.rs"})
+        );
+        assert_eq!(result.tool_calls[1].call_id, "call_1");
+        assert_eq!(result.tool_calls[1].name, "bash");
+    }
+
+    #[tokio::test]
+    async fn complete_maps_403_to_auth_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            GeminiProvider::new(ApiKey::new("bad-key"), "gemini-3-pro").with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Auth(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn complete_maps_400_api_key_invalid_to_auth_not_terminal() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(
+                "{\"error\":{\"code\":400,\"status\":\"INVALID_ARGUMENT\",\"details\":[{\"reason\":\"API_KEY_INVALID\"}]}}",
+            ))
+            .mount(&server)
+            .await;
+
+        let provider =
+            GeminiProvider::new(ApiKey::new("bad-key"), "gemini-3-pro").with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Auth(_)));
+    }
+
+    #[tokio::test]
+    async fn complete_maps_429_to_rate_limited_with_retry_after() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "3")
+                    .set_body_string("quota exceeded"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider =
+            GeminiProvider::new(ApiKey::new("key"), "gemini-3-pro").with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(err.is_retryable());
+        match err {
+            ProviderError::RateLimited { retry_after_ms, .. } => {
+                assert_eq!(retry_after_ms, Some(3000));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+}

--- a/stella-model/src/lib.rs
+++ b/stella-model/src/lib.rs
@@ -1,13 +1,18 @@
 //! `stella-model` — the `Provider` trait plus its concrete adapters: Z.ai
-//! (GLM 5.2, OpenAI-compatible chat), Anthropic (Messages API), and OpenAI
-//! (Responses API).
+//! (GLM 5.2, OpenAI-compatible chat), Anthropic (Messages API), OpenAI
+//! (Responses API), Gemini direct (native generateContent), Vertex AI
+//! (generateContent, enterprise auth), and Amazon Bedrock (Converse,
+//! SigV4-signed).
 pub mod anthropic;
+pub mod bedrock;
 pub mod catalog;
 pub mod credential;
+pub mod gemini;
 pub(crate) mod http;
 pub mod openai;
 pub mod provider;
 pub mod sse;
+pub mod vertex;
 pub mod zai;
 
 pub use catalog::{Catalog, CatalogEntry, Pricing, ToolDialect};

--- a/stella-model/src/vertex.rs
+++ b/stella-model/src/vertex.rs
@@ -1,0 +1,226 @@
+//! Vertex AI adapter — Google's enterprise surface for the same
+//! `generateContent` wire shape `gemini.rs` speaks (`07-model-matrix.md` §2:
+//! "Vertex | ADC | generateContent | catalog-driven … Enterprise path;
+//! casual Gemini use → direct adapter"). The request/response envelope,
+//! tool-call dialect (`gemini-functions`), and stream aggregation are all
+//! shared with `gemini.rs`; what differs is auth and addressing:
+//!
+//! - **Auth**: an OAuth2 bearer token, not an API key. The full ADC chain
+//!   (service-account JWT signing, metadata-server exchange) is deliberately
+//!   out of scope for this first cut — the adapter takes a ready token,
+//!   which `stella-cli` resolves from `VERTEX_ACCESS_TOKEN` (documented as
+//!   `export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)`), the
+//!   same "ready credential in, provider-native acquisition later" posture
+//!   the credential chain doc already records for Bedrock/Vertex.
+//! - **Addressing**: requests are project- and location-scoped:
+//!   `{base}/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:streamGenerateContent`,
+//!   where the base host is `aiplatform.googleapis.com` for the `global`
+//!   location and `{location}-aiplatform.googleapis.com` for a pinned
+//!   region.
+
+use async_trait::async_trait;
+use stella_protocol::{CompletionRequest, CompletionResult, ProviderError};
+
+use crate::credential::ApiKey;
+use crate::gemini::{
+    GeminiRequest, aggregate_gemini_stream, build_generation_config, classify_google_error,
+    to_gemini_request_parts, to_gemini_tools,
+};
+use crate::provider::Provider;
+
+pub struct VertexProvider {
+    client: reqwest::Client,
+    access_token: ApiKey,
+    model: String,
+    project: String,
+    location: String,
+    base_url_override: Option<String>,
+}
+
+impl VertexProvider {
+    /// Build an adapter for `model` in `project`/`location`. `location`
+    /// `"global"` selects the global endpoint; anything else selects the
+    /// matching regional host.
+    pub fn new(
+        access_token: ApiKey,
+        model: impl Into<String>,
+        project: impl Into<String>,
+        location: impl Into<String>,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            access_token,
+            model: model.into(),
+            project: project.into(),
+            location: location.into(),
+            base_url_override: None,
+        }
+    }
+
+    /// Override the scheme+host — used by conformance tests against a mock
+    /// server, and by anyone routing through a private proxy. The
+    /// project/location path structure is preserved either way.
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url_override = Some(base_url.into());
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        let base = match &self.base_url_override {
+            Some(base) => base.clone(),
+            None if self.location == "global" => "https://aiplatform.googleapis.com".to_string(),
+            None => format!("https://{}-aiplatform.googleapis.com", self.location),
+        };
+        format!(
+            "{base}/v1/projects/{}/locations/{}/publishers/google/models/{}:streamGenerateContent?alt=sse",
+            self.project, self.location, self.model
+        )
+    }
+}
+
+#[async_trait]
+impl Provider for VertexProvider {
+    fn id(&self) -> &str {
+        "vertex"
+    }
+
+    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        let (system_instruction, contents) = to_gemini_request_parts(&req.messages);
+        let body = GeminiRequest {
+            system_instruction,
+            contents,
+            tools: to_gemini_tools(&req.tools),
+            generation_config: build_generation_config(&req),
+        };
+
+        let response = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(self.access_token.reveal())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Transport(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(classify_google_error("Vertex AI", response).await);
+        }
+
+        let (text, tool_calls, usage) = aggregate_gemini_stream(response).await?;
+        Ok(CompletionResult {
+            text,
+            tool_calls,
+            usage,
+            model: self.model.clone(),
+            cost_usd: 0.0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::CompletionMessage;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn endpoint_uses_the_global_host_for_the_global_location() {
+        let provider =
+            VertexProvider::new(ApiKey::new("token"), "gemini-3-pro", "my-project", "global");
+        assert_eq!(
+            provider.endpoint(),
+            "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google/models/gemini-3-pro:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn endpoint_uses_the_regional_host_for_a_pinned_region() {
+        let provider = VertexProvider::new(
+            ApiKey::new("token"),
+            "gemini-3-pro",
+            "my-project",
+            "us-central1",
+        );
+        assert_eq!(
+            provider.endpoint(),
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-3-pro:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_sends_a_bearer_token_to_the_project_scoped_path() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hi from Vertex\"}]}}],",
+            "\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":4}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path(
+                "/v1/projects/my-project/locations/global/publishers/google/models/gemini-3-pro:streamGenerateContent",
+            ))
+            .and(query_param("alt", "sse"))
+            .and(header("authorization", "Bearer ya29.test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = VertexProvider::new(
+            ApiKey::new("ya29.test-token"),
+            "gemini-3-pro",
+            "my-project",
+            "global",
+        )
+        .with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let result = provider
+            .complete(req)
+            .await
+            .expect("completion should succeed");
+        assert_eq!(result.text, "Hi from Vertex");
+        assert_eq!(result.usage.input_tokens, 7);
+        assert_eq!(result.usage.output_tokens, 4);
+    }
+
+    #[tokio::test]
+    async fn complete_maps_401_to_auth_error_naming_vertex_not_gemini() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthenticated"))
+            .mount(&server)
+            .await;
+
+        let provider = VertexProvider::new(
+            ApiKey::new("expired-token"),
+            "gemini-3-pro",
+            "my-project",
+            "global",
+        )
+        .with_base_url(server.uri());
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        match &err {
+            ProviderError::Auth(message) => {
+                assert!(message.contains("Vertex AI"), "{message}");
+            }
+            other => panic!("expected Auth, got {other:?}"),
+        }
+        assert!(!err.is_retryable());
+    }
+}

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -35,6 +35,8 @@ pub struct ZaiProvider {
     /// slug isn't in the catalog — `build_provider` (`agent.rs`) rejects that
     /// case up front, so in practice this is always `Some` for a live call.
     pricing: Option<Pricing>,
+    id: String,
+    label: String,
 }
 
 impl ZaiProvider {
@@ -47,11 +49,26 @@ impl ZaiProvider {
             base_url: DEFAULT_BASE_URL.to_string(),
             model,
             pricing,
+            id: "zai".to_string(),
+            label: "Z.ai".to_string(),
         }
     }
 
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        self
+    }
+
+    /// Re-identify this adapter for another OpenAI-*compatible* provider it
+    /// is serving (xAI, DeepSeek, OpenRouter, a local endpoint): `id` is
+    /// what `Provider::id()` reports and `label` is the human name used in
+    /// error messages. Without this, every gateway routed through the
+    /// shared Chat Completions adapter misreported itself as Z.ai — an
+    /// xAI 401 read "Z.ai rejected the API key", pointing the user at the
+    /// wrong credential.
+    pub fn with_identity(mut self, id: impl Into<String>, label: impl Into<String>) -> Self {
+        self.id = id.into();
+        self.label = label.into();
         self
     }
 }
@@ -291,7 +308,7 @@ fn to_zai_tools(tools: &[stella_protocol::tool::ToolSchema]) -> Vec<ZaiToolSchem
 #[async_trait]
 impl Provider for ZaiProvider {
     fn id(&self) -> &str {
-        "zai"
+        &self.id
     }
 
     async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
@@ -314,11 +331,14 @@ impl Provider for ZaiProvider {
             .map_err(|e| ProviderError::Transport(e.to_string()))?;
 
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            return Err(ProviderError::Auth("Z.ai rejected the API key".into()));
+            return Err(ProviderError::Auth(format!(
+                "{} rejected the API key",
+                self.label
+            )));
         }
         if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(ProviderError::RateLimited {
-                message: "Z.ai rate limit".into(),
+                message: format!("{} rate limit", self.label),
                 retry_after_ms: None,
             });
         }
@@ -335,7 +355,8 @@ impl Provider for ZaiProvider {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
             return Err(ProviderError::Terminal(format!(
-                "Z.ai HTTP {status}: {text}"
+                "{} HTTP {status}: {text}",
+                self.label
             )));
         }
 
@@ -580,6 +601,38 @@ mod tests {
         assert_eq!(call.call_id, "call_1");
         assert_eq!(call.name, "read_file");
         assert_eq!(call.input, serde_json::json!({"path": "src/lib.rs"}));
+    }
+
+    #[tokio::test]
+    async fn with_identity_renames_the_provider_in_id_and_error_messages() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let provider = ZaiProvider::new(ApiKey::new("bad-key"), "grok-4")
+            .with_base_url(server.uri())
+            .with_identity("xai", "xAI");
+        assert_eq!(provider.id(), "xai");
+
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        match &err {
+            ProviderError::Auth(message) => {
+                assert!(message.contains("xAI"), "{message}");
+                assert!(!message.contains("Z.ai"), "{message}");
+            }
+            other => panic!("expected Auth, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Ports the two Stella capability waves that landed in the private monorepo **after** the `v0.1.0` eject was cut, and were never carried into this repo:

- **Multi-provider adapters (#939)** — native **Gemini** (`streamGenerateContent`, `gemini-functions` dialect), **Vertex AI** (same wire, bearer token + project/location URL), and **Bedrock** (non-streaming Converse + hand-rolled SigV4). Plus the CLI/catalog wiring that makes them selectable: `--base-url` + `local/<model>` pseudo-provider, `GOOGLE_API_KEY` alias, Bedrock last in credential auto-detect, and provider-scoped `catalog.resolve_for(provider, slug)` (the same model id legitimately exists on two providers — `gemini-3-pro` on both `gemini` and `vertex`).
- **STELLA logomark + PromptDuel (#941)** — the gradient block-glyph wordmark replaces the old figlet banner (which didn't even spell "Stella"), and a deterministic rocket-vs-UFO duel animates one line above the prompt while the REPL waits for input (TTY only; `STELLA_FUN=0` opts out).

### Why this was a separate port

The `v0.1.0` eject snapshotted the crates from a rename branch cut **before** #939/#941 merged, so this repo shipped without the multi-provider adapters or the logomark. The monorepo's own attempt to reconcile the rename with those PRs was reverted (it committed conflict markers via a stale `git rerere` cache), so the fix belongs here, layered onto the already-hardened eject.

### What was reconciled

Both waves overlap the hardening that shipped in `v0.1.0` (per-model `Pricing`, the redacting `ApiKey` newtype, incremental UTF-8 SSE decoding). Each conflicting file was 3-way merged to keep **both** sides:

- `stella-model/src/catalog.rs` — the `gemini-3-pro` row flips to the native `GeminiFunctions` dialect and gains `vertex`/`bedrock` sibling rows, each carrying a real `Pricing` block (so the "every priced model has non-zero pricing" invariant still holds).
- `stella-model/src/{gemini,vertex,bedrock}.rs` — new adapters.
- `stella-model/src/zai.rs` — `with_identity` (gateways stop misreporting as Z.ai) alongside the catalog-resolved pricing.
- `stella-cli/src/config.rs` — provider-aware `resolve_provider_key` (env-var aliases) wrapping the `ApiKey` credential chain; `effective_base_url` in the config display. Dropped the obsolete free-fn `redact_key` in favour of `ApiKey::redacted_preview`.
- `stella-cli/src/agent.rs` — `build_provider` dispatches per wire dialect (OpenAI Responses / Anthropic Messages / Gemini+Vertex generateContent / Bedrock Converse / OpenAI-compatible), plus the `PromptDuel` hook.
- `stella-cli/src/tui.rs` — logomark + duel implementation, both test suites merged.

### New dependencies

`hmac` + `sha2` (Bedrock SigV4 signing).

### Scope isolation

This ports **only** #939 + #941. An earlier cut accidentally swept in `main.rs`/`tui.rs` changes from #938/#947 (the `Init`/`Tools` subcommands, `OutputFormat` enum, and the `domains`/`memory`/`interactive` modules that depend on the phase-3/4/5 crates not present in this repo). Each file was re-merged against the exact PR merge commits so the diff is #939 + #941 and nothing else — the phase-3/4/5 crates are a separate port.

## Test plan

- [x] `cargo fmt --check` — clean (verified locally; parses, all modules resolve)
-  `cargo clippy --workspace --all-targets -- -D warnings` — **CI** (local host was too contended to compile duckdb)
-  `cargo test --workspace` — **CI**
-  `cargo build --workspace --release` — **CI**
