### PR TITLE
fix(config): drop duplicate vertex/bedrock providers (unbreak `cargo test`)

### DIFF
--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -95,6 +95,13 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         default_model: "auto",
         base_url: "https://openrouter.ai/api/v1",
     },
+    // Vertex and Bedrock are appended LAST so auto-detection (the no-`--model`
+    // path picks the first provider with a resolvable credential) never
+    // prefers them over an explicitly-configured provider — AWS_ACCESS_KEY_ID
+    // in particular is commonly present in a shell for unrelated reasons.
+    // Both speak a native, non-OpenAI wire shape, so `build_provider`
+    // (agent.rs) routes them to their own adapters rather than the generic
+    // Chat Completions client.
     ProviderConfig {
         id: "vertex",
         // Deliberately Vertex-specific (not a generic Google var) so
@@ -123,36 +130,6 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         // (`bedrock-runtime.<AWS_REGION>.amazonaws.com`), built per request
         // by the adapter.
         base_url: "https://bedrock-runtime.<AWS_REGION>.amazonaws.com",
-    },
-    // Vertex and Bedrock are appended LAST so auto-detection (the no-`--model`
-    // path picks the first provider with a resolvable credential) never
-    // prefers them over an explicitly-configured provider — AWS_ACCESS_KEY_ID
-    // in particular is commonly present in a shell for unrelated reasons.
-    // Both speak a native, non-OpenAI wire shape, so `build_provider`
-    // (agent.rs) routes them to their own adapters rather than the generic
-    // Chat Completions client.
-    ProviderConfig {
-        id: "vertex",
-        env_var: "VERTEX_ACCESS_TOKEN",
-        env_var_aliases: &[],
-        display_name: "Google Vertex AI",
-        default_model: "gemini-3-pro",
-        // Native generateContent, project/location-scoped. The VertexProvider
-        // adapter builds its own addressing from VERTEX_PROJECT_ID /
-        // VERTEX_LOCATION, so this base_url is shown in `stella models` for
-        // reference only — build_provider does not pass it to the adapter.
-        base_url: "https://aiplatform.googleapis.com",
-    },
-    ProviderConfig {
-        id: "bedrock",
-        env_var: "AWS_ACCESS_KEY_ID",
-        env_var_aliases: &[],
-        display_name: "Amazon Bedrock",
-        default_model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        // Region-templated at request time by the BedrockProvider adapter
-        // (bedrock-runtime.<AWS_REGION>.amazonaws.com); shown here for
-        // reference only.
-        base_url: "https://bedrock-runtime.us-east-1.amazonaws.com",
     },
 ];
 


### PR DESCRIPTION
## What

Current main (`8654235`) **builds**, but `cargo test --workspace` fails
`config::tests::provider_ids_are_unique`: `PROVIDERS` lists `vertex` and
`bedrock` **twice** (12 rows, 10 unique).

Two branches each appended the Phase-2 native-adapter rows and a textual merge
concatenated both copies — the "appended LAST" comment block ended up wedged
between the two pairs. This slips past `cargo build` (duplicate rows are legal
Rust); only `cargo test` catches it.

## Fix

`stella-cli/src/config.rs` only (−30/+7): keep one richly-documented `vertex`
and `bedrock` entry each, introduced by the "appended LAST" comment block; drop
the second, near-identical pair. **No behavior change** — the duplicates had
identical ids and adapter routing; only the dead rows and the failing
uniqueness invariant are removed.

The sibling defects from the same merge (duplicated `tui.rs` render arms; the
stale `gemini→zai` routing test in `agent.rs`) were already fixed by #8/#9 — the
provider dup was the lone survivor.

## Verification (on top of `8654235`)

- `cargo test --workspace` → **929 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `stella models` lists each provider exactly once

## Note (out of scope — flagging, not fixing here)

`8654235`'s message says it added `.claude/` to `.gitignore`, but the committed
`.gitignore` is only `/target`, `.stella/`, `*.duckdb` — **`.claude/` is not
actually ignored**. Nothing under `.claude/` is tracked today, but the next
`git add -A` will re-sweep the worktree gitlinks back in and re-break
`cargo install --git`, the exact failure `8654235` set out to prevent. Worth a
one-line follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove duplicate `vertex` and `bedrock` provider entries to fix the provider ID uniqueness test and restore `cargo test --workspace`. No behavior change; one documented entry for each provider remains.

- **Bug Fixes**
  - Removed the extra `vertex`/`bedrock` rows caused by a merge; kept the final, documented pair.
  - Verified: 929 tests pass; clippy clean; `stella models` shows each provider once.

<sup>Written for commit 32d50d168f16265247a195224598fd5f024cd871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella-cli/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
