### PR TITLE
stella-cli: fix duplicate-provider regression + gate per-turn reflection

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -34,7 +34,7 @@ use crate::OutputFormat;
 use crate::config::Config;
 use crate::domains::{heuristic_domains, infer_domains};
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
-use crate::memory::{SessionMemory, inject_recall_block};
+use crate::memory::{SessionMemory, inject_recall_block, turn_warrants_reflection};
 use crate::tui;
 
 const SYSTEM_PROMPT: &str = r#"You are Stella, a fast terminal coding agent. You help the user with software engineering tasks by reading files, writing code, running commands, and searching the codebase.
@@ -183,8 +183,11 @@ pub async fn run_one_shot(
     .await;
     // …and reflect on the completed turn, recording domain-tagged lessons
     // (recurring ones auto-promote to SKILL.md files). Best-effort: never
-    // fails or slows the turn that just ran.
+    // fails or slows the turn that just ran. Gated on `turn_warrants_reflection`
+    // so a tool-free turn never spends a model call to mine lessons it can't
+    // have produced (the whole one-shot transcript IS this turn).
     if outcome.is_ok()
+        && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
         m.reflect_and_record(&*provider, &messages, format != OutputFormat::Text)
@@ -246,6 +249,7 @@ pub async fn run_goal_cmd(
     )
     .await;
     if outcome.is_ok()
+        && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
         m.reflect_and_record(&*provider, &messages, false).await;
@@ -376,6 +380,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 let block = m.recall_block(goal).await;
                 inject_recall_block(&mut messages, block);
             }
+            // Everything the goal loop appends past here is this turn's work,
+            // gating reflection on it (see `turn_warrants_reflection`).
+            let turn_start = messages.len();
             if let Err(e) = run_goal_turn(
                 &*provider,
                 base_tools,
@@ -390,7 +397,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             .await
             {
                 eprintln!("  {} {}\n", "Error:".red().bold(), e);
-            } else if let Some(m) = &mut memory {
+            } else if turn_warrants_reflection(&messages[turn_start..])
+                && let Some(m) = &mut memory
+            {
                 m.reflect_and_record(&*provider, &messages, false).await;
             }
             continue;
@@ -404,6 +413,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             inject_recall_block(&mut messages, block);
         }
 
+        // Everything `run_turn` appends past here is this turn's work; the
+        // reflection gate reads only that slice (see `turn_warrants_reflection`).
+        let turn_start = messages.len();
         if let Err(e) = run_turn(
             &*provider,
             base_tools,
@@ -420,7 +432,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         .await
         {
             eprintln!("  {} {}\n", "Error:".red().bold(), e);
-        } else if let Some(m) = &mut memory {
+        } else if turn_warrants_reflection(&messages[turn_start..])
+            && let Some(m) = &mut memory
+        {
             m.reflect_and_record(&*provider, &messages, false).await;
         }
     }

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -124,36 +124,6 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         // by the adapter.
         base_url: "https://bedrock-runtime.<AWS_REGION>.amazonaws.com",
     },
-    // Vertex and Bedrock are appended LAST so auto-detection (the no-`--model`
-    // path picks the first provider with a resolvable credential) never
-    // prefers them over an explicitly-configured provider — AWS_ACCESS_KEY_ID
-    // in particular is commonly present in a shell for unrelated reasons.
-    // Both speak a native, non-OpenAI wire shape, so `build_provider`
-    // (agent.rs) routes them to their own adapters rather than the generic
-    // Chat Completions client.
-    ProviderConfig {
-        id: "vertex",
-        env_var: "VERTEX_ACCESS_TOKEN",
-        env_var_aliases: &[],
-        display_name: "Google Vertex AI",
-        default_model: "gemini-3-pro",
-        // Native generateContent, project/location-scoped. The VertexProvider
-        // adapter builds its own addressing from VERTEX_PROJECT_ID /
-        // VERTEX_LOCATION, so this base_url is shown in `stella models` for
-        // reference only — build_provider does not pass it to the adapter.
-        base_url: "https://aiplatform.googleapis.com",
-    },
-    ProviderConfig {
-        id: "bedrock",
-        env_var: "AWS_ACCESS_KEY_ID",
-        env_var_aliases: &[],
-        display_name: "Amazon Bedrock",
-        default_model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        // Region-templated at request time by the BedrockProvider adapter
-        // (bedrock-runtime.<AWS_REGION>.amazonaws.com); shown here for
-        // reference only.
-        base_url: "https://bedrock-runtime.us-east-1.amazonaws.com",
-    },
 ];
 
 /// The `local` pseudo-provider: any OpenAI-compatible endpoint the user
@@ -384,35 +354,13 @@ impl Config {
         })
     }
 
+    /// Print the provider/model table for an interactive session. The listing
+    /// depends only on `PROVIDERS` and the ambient environment, never on
+    /// `self`, so it delegates to the static [`Config::print_available_models`]
+    /// — one renderer backs both the `/models` REPL command and the top-level
+    /// `stella models` subcommand, and they can never drift apart.
     pub fn print_models(&self) {
-        println!(
-            "{}\n",
-            "Stella — Available Providers & Models".cyan().bold()
-        );
-        for p in PROVIDERS {
-            let has_key = std::iter::once(&p.env_var)
-                .chain(p.env_var_aliases)
-                .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
-            let key_status = if has_key {
-                "✓ configured".green()
-            } else {
-                "✗ no key".dimmed()
-            };
-            println!(
-                "  {} {}/{}  {}  [{}]",
-                key_status,
-                p.id.bright_blue(),
-                p.default_model.bright_white(),
-                p.display_name,
-                p.base_url.dimmed(),
-            );
-        }
-        println!("\n  Use --model provider/model_id to pin a specific model.");
-        println!("  Example: stella --model zai/glm-5.2 run 'fix the failing test'");
-        println!(
-            "  Local endpoints (Ollama, vLLM, LM Studio): stella --model local/<model> \
-             --base-url http://localhost:11434/v1"
-        );
+        Self::print_available_models();
     }
 
     pub fn print_config(&self) {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -203,11 +203,7 @@ fn run(cli: Cli) -> Result<(), String> {
             ))?;
         }
         Command::Goal { goal } => {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("failed to start runtime: {e}"))?;
-            rt.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget))?;
+            rt()?.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget))?;
         }
         Command::Monitor { target } => {
             let target = target.unwrap_or_else(|| "main".to_string());
@@ -219,11 +215,7 @@ fn run(cli: Cli) -> Result<(), String> {
                  code, commit and push the fix, then re-check. The goal is met only when the \
                  latest CI run for `{target}` has completed with every check successful."
             );
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("failed to start runtime: {e}"))?;
-            rt.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget))?;
+            rt()?.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget))?;
         }
         Command::Chat => {
             rt()?.block_on(agent::run_interactive(&cfg, cli.budget))?;

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -359,6 +359,28 @@ pub fn inject_recall_block(messages: &mut Vec<CompletionMessage>, block: Option<
     }
 }
 
+/// Whether a completed turn is even worth a post-turn reflection model call.
+///
+/// Reflection ([`SessionMemory::reflect_and_record`]) mines lessons from WORK
+/// — tool calls, file edits, multi-step problem solving. A turn that invoked
+/// no tools produced no observable agent behavior to critique, and the
+/// reflection prompt itself notes that "most turns have nothing worth
+/// recording." Gating on tool use deterministically skips a model call (and
+/// its latency and dollars) that would almost always return `[]`: the biggest
+/// per-turn saving available, and the skipped turns are exactly the trivial
+/// ones (greetings, quick questions, refusals). The trade is that a durable
+/// preference revealed in pure conversation, with no tool call, is not
+/// mined — an intentional bias toward determinism and cost over a rare,
+/// speculative capture.
+///
+/// `turn_messages` must be ONLY the messages added during the turn being
+/// judged (in the accumulating REPL transcript, the slice past the pre-turn
+/// length) — otherwise a tool call from an earlier turn would keep
+/// re-triggering reflection on every later tool-free turn.
+pub fn turn_warrants_reflection(turn_messages: &[CompletionMessage]) -> bool {
+    turn_messages.iter().any(|m| !m.tool_calls.is_empty())
+}
+
 /// One cheap reflection call (triage-tier discipline: single attempt, any
 /// failure -> empty). The model critiques the completed turn and returns
 /// 0-3 short forward-looking lessons tagged with domains FROM THE SUPPLIED
@@ -546,5 +568,30 @@ mod tests {
         assert!(parse_lessons("no json here", &[]).is_empty());
         assert!(parse_lessons("[]", &[]).is_empty());
         assert!(parse_lessons("[{\"lesson\": \"   \"}]", &[]).is_empty());
+    }
+
+    #[test]
+    fn reflection_gate_fires_on_tool_use_and_skips_tool_free_turns() {
+        use stella_protocol::ToolCall;
+
+        // A pure conversational turn — no tool calls — is not worth a
+        // reflection model call (the common, cheap-to-skip case).
+        let chat_only = vec![
+            msg(MessageRole::User, "what does this crate do?"),
+            msg(MessageRole::Assistant, "it is a terminal coding agent"),
+        ];
+        assert!(!turn_warrants_reflection(&chat_only));
+
+        // A turn where the assistant called a tool DID work worth mining.
+        let mut worked = msg(MessageRole::Assistant, "reading the file first");
+        worked.tool_calls = vec![ToolCall {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            input: serde_json::json!({ "path": "src/main.rs" }),
+        }];
+        assert!(turn_warrants_reflection(&[worked]));
+
+        // An empty turn slice (nothing happened) is trivially skippable.
+        assert!(!turn_warrants_reflection(&[]));
     }
 }


### PR DESCRIPTION
See commit for full breakdown. `stella models` verified to list each provider once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate `vertex` and `bedrock` providers and gates post-turn reflection to only run when a turn used tools. This removes duplicate listings/routers and skips a frequent, unnecessary model call to cut latency and cost.

- **Bug Fixes**
  - Removed duplicate `vertex` and `bedrock` entries from `PROVIDERS`; `stella models` now lists each provider once.
  - Goal loop judge no longer builds duplicate provider profiles.

- **Refactors**
  - Added `turn_warrants_reflection` and sliced per-turn messages so reflection triggers only on tool use across one-shot, goal, and REPL flows.
  - Delegated `print_models` to the static `print_available_models` to avoid drift.
  - Reused the shared `rt` Tokio runtime builder in Goal/Monitor.

<sup>Written for commit 126fec7beee94782782d609d26878872b8f011db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella-cli/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
