### PR TITLE
chore:adding bench results

### DIFF
--- a/bench/results/glm52-smoke/logs/astropy__astropy-12907.log
+++ b/bench/results/glm52-smoke/logs/astropy__astropy-12907.log
@@ -1,0 +1,26 @@
+# stella swebench log for astropy__astropy-12907
+$ git clone --quiet https://github.com/astropy/astropy.git /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-astropy__astropy-12907-3eefq6kg/repo
+
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-astropy__astropy-12907-3eefq6kg/repo checkout -f d16bfe05a744909de4b27f5875fe0d4ed41ce607
+Note: switching to 'd16bfe05a744909de4b27f5875fe0d4ed41ce607'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at d16bfe05a7 Merge pull request #12900 from Cadair/custom_compound_model
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-astropy__astropy-12907-3eefq6kg/repo reset --hard d16bfe05a744909de4b27f5875fe0d4ed41ce607
+HEAD is now at d16bfe05a7 Merge pull request #12900 from Cadair/custom_compound_model
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-astropy__astropy-12907-3eefq6kg/repo clean -fdx
+

--- a/bench/results/stella-anthropic-claude-fable-5-20260711-202536/logs/octocat__Hello-World-1.log
+++ b/bench/results/stella-anthropic-claude-fable-5-20260711-202536/logs/octocat__Hello-World-1.log
@@ -1,0 +1,28 @@
+# stella swebench log for octocat__Hello-World-1
+$ git clone --quiet https://github.com/octocat/Hello-World.git /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Hello-World-1-hghy400m/repo
+
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Hello-World-1-hghy400m/repo checkout -f 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d
+Note: switching to '7fd1a60b01f91b314f59955a4e4d4e80d8edf11d'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at 7fd1a60 Merge pull request #6 from Spaceghost/patch-1
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Hello-World-1-hghy400m/repo reset --hard 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d
+HEAD is now at 7fd1a60 Merge pull request #6 from Spaceghost/patch-1
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Hello-World-1-hghy400m/repo clean -fdx
+
+$ /Users/macanderson/.cargo/bin/stella --model anthropic/claude-fable-5 --budget 2.0 run The README file only contains the text 'Hello World!'. Update it so the greeting also welcomes contributors on a second line reading 'Welcome, contributors.'
+[1;31mstella:[0m could not resolve a credential for Anthropic (Claude): credential for `ANTHROPIC_API_KEY` is empty

--- a/bench/results/stella-anthropic-claude-fable-5-20260711-202536/logs/octocat__Spoon-Knife-1.log
+++ b/bench/results/stella-anthropic-claude-fable-5-20260711-202536/logs/octocat__Spoon-Knife-1.log
@@ -1,0 +1,28 @@
+# stella swebench log for octocat__Spoon-Knife-1
+$ git clone --quiet https://github.com/octocat/Spoon-Knife.git /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Spoon-Knife-1-6r6efc_2/repo
+
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Spoon-Knife-1-6r6efc_2/repo checkout -f d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9
+Note: switching to 'd0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at d0dd1f6 Pointing to the guide for forking
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Spoon-Knife-1-6r6efc_2/repo reset --hard d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9
+HEAD is now at d0dd1f6 Pointing to the guide for forking
+$ git -C /var/folders/4m/m985rkjn53q1ks2vdkcb1mzc0000gn/T/stella-swebench-octocat__Spoon-Knife-1-6r6efc_2/repo clean -fdx
+
+$ /Users/macanderson/.cargo/bin/stella --model anthropic/claude-fable-5 --budget 2.0 run index.html is missing a page <title>. Add a <title>Spoon-Knife</title> element inside the document <head> so the page has a descriptive browser tab title.
+[1;31mstella:[0m could not resolve a credential for Anthropic (Claude): credential for `ANTHROPIC_API_KEY` is empty

--- a/bench/results/stella-anthropic-claude-fable-5-20260711-202536/predictions.jsonl
+++ b/bench/results/stella-anthropic-claude-fable-5-20260711-202536/predictions.jsonl
@@ -1,0 +1,2 @@
+{"instance_id": "octocat__Hello-World-1", "model_name_or_path": "anthropic/claude-fable-5", "model_patch": ""}
+{"instance_id": "octocat__Spoon-Knife-1", "model_name_or_path": "anthropic/claude-fable-5", "model_patch": ""}

--- a/bench/results/stella-anthropic-claude-fable-5-20260711-202536/summary.json
+++ b/bench/results/stella-anthropic-claude-fable-5-20260711-202536/summary.json
@@ -1,0 +1,13 @@
+{
+  "run_id": "stella-anthropic-claude-fable-5-20260711-202536",
+  "model_name_or_path": "anthropic/claude-fable-5",
+  "dataset": "bench/instances.sample.jsonl",
+  "total_selected": 2,
+  "attempted": 2,
+  "succeeded": 0,
+  "empty": 2,
+  "failed": 0,
+  "stella_errors": 2,
+  "predictions_written": 2,
+  "predictions_path": "bench/results/stella-anthropic-claude-fable-5-20260711-202536/predictions.jsonl"
+}


### PR DESCRIPTION
# Finish Roadmap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds benchmark artifacts under bench/results for two runs: `glm52-smoke` (astropy__astropy-12907) and `anthropic/claude-fable-5` (octocat samples), including logs, predictions, and a run summary.
The Anthropic run failed due to missing `ANTHROPIC_API_KEY`, resulting in empty predictions and 2 `stella_errors` recorded in `summary.json`.

<sup>Written for commit ca3893d63cc19a41fe7692aea159a3cf6aa54203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella-cli/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

