### PR TITLE
ci(release): publish Homebrew formula to the tap + remove leaked .env.local

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,0 @@
-ZAI_API_KEY=e1150a1569aa46699a05e0145bf267d6.C8eeFiRQtLf9k2E6
-STELLA_BASE_URL=https://api.z.ai/api/coding/paas/v4
-STELLA_MODEL=zai/glm-5.2
-STELLA_BINARY=/Users/macanderson/Workspaces/stella-cli/target/release/stella
-ZAI_GLM_CODING_PLAN=1

--- a/.github/homebrew/stella.rb.tmpl
+++ b/.github/homebrew/stella.rb.tmpl
@@ -1,0 +1,48 @@
+# Homebrew formula template for the Stella CLI.
+#
+# This is NOT a hand-maintained formula — the `release` workflow renders it on
+# every tag push by substituting the @VERSION@ / @SHA_*@ placeholders below with
+# the real version and per-target SHA-256 sums of the prebuilt tarballs, then
+# commits the result to the tap repo (oxageninc/homebrew-stella) as
+# Formula/stella.rb. See .github/workflows/release.yml (the `homebrew` job).
+#
+# Unlike packaging/homebrew/stella.rb (which builds from source with cargo),
+# this installs the prebuilt binary directly — no Rust toolchain required.
+class Stella < Formula
+  desc "Fast, BYOK, model-agnostic terminal coding agent"
+  homepage "https://github.com/oxageninc/stella-cli"
+  version "@VERSION@"
+  license "MIT OR Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/oxageninc/stella-cli/releases/download/v@VERSION@/stella-@VERSION@-aarch64-apple-darwin.tar.gz"
+      sha256 "@SHA_AARCH64_DARWIN@"
+    end
+    on_intel do
+      url "https://github.com/oxageninc/stella-cli/releases/download/v@VERSION@/stella-@VERSION@-x86_64-apple-darwin.tar.gz"
+      sha256 "@SHA_X86_64_DARWIN@"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/oxageninc/stella-cli/releases/download/v@VERSION@/stella-@VERSION@-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "@SHA_AARCH64_LINUX@"
+    end
+    on_intel do
+      url "https://github.com/oxageninc/stella-cli/releases/download/v@VERSION@/stella-@VERSION@-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "@SHA_X86_64_LINUX@"
+    end
+  end
+
+  # Each tarball unpacks to a single stella-<version>-<target>/ directory that
+  # Homebrew descends into automatically, so the binary is at the CWD root.
+  def install
+    bin.install "stella"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/stella --version")
+  end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,4 +229,4 @@ jobs:
             exit 0
           fi
           git commit -m "stella ${version}"
-          git push origin HEAD:main
+          git push origin HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,3 +147,86 @@ jobs:
             artifacts/SHA256SUMS
           fail_on_unmatched_files: true
           generate_release_notes: true
+
+  # Renders .github/homebrew/stella.rb.tmpl with the real version + per-target
+  # SHA-256 sums and commits it as Formula/stella.rb to the tap repo
+  # (oxageninc/homebrew-stella). Runs only after the GitHub Release exists, so
+  # the formula's release-asset URLs resolve. Requires the HOMEBREW_TAP_TOKEN
+  # secret (see the one-time setup in RELEASING.md); skips gracefully without it
+  # so a release is never blocked on the tap being wired.
+  homebrew:
+    name: publish Homebrew formula
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout (for the formula template)
+        uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: stella-*
+          merge-multiple: true
+
+      - name: Render formula and push to tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN is not set — skipping Homebrew tap publish."
+            echo "One-time setup (create the tap repo + add the secret) is documented in RELEASING.md."
+            exit 0
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+
+          # SHA-256 of a given target's release tarball (same bytes uploaded to
+          # the GitHub Release in the `release` job).
+          sha_for() {
+            local target="$1"
+            local f="artifacts/stella-${version}-${target}.tar.gz"
+            if [ ! -f "$f" ]; then
+              echo "::error::expected release asset not found: ${f}" >&2
+              exit 1
+            fi
+            sha256sum "$f" | awk '{ print $1 }'
+          }
+
+          sha_aarch64_darwin="$(sha_for aarch64-apple-darwin)"
+          sha_x86_64_darwin="$(sha_for x86_64-apple-darwin)"
+          sha_aarch64_linux="$(sha_for aarch64-unknown-linux-gnu)"
+          sha_x86_64_linux="$(sha_for x86_64-unknown-linux-gnu)"
+
+          mkdir -p rendered
+          sed \
+            -e "s/@VERSION@/${version}/g" \
+            -e "s/@SHA_AARCH64_DARWIN@/${sha_aarch64_darwin}/g" \
+            -e "s/@SHA_X86_64_DARWIN@/${sha_x86_64_darwin}/g" \
+            -e "s/@SHA_AARCH64_LINUX@/${sha_aarch64_linux}/g" \
+            -e "s/@SHA_X86_64_LINUX@/${sha_x86_64_linux}/g" \
+            .github/homebrew/stella.rb.tmpl > rendered/stella.rb
+
+          echo "----- rendered Formula/stella.rb -----"
+          cat rendered/stella.rb
+
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/oxageninc/homebrew-stella.git" tap
+
+          mkdir -p tap/Formula
+          cp rendered/stella.rb tap/Formula/stella.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/stella.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for ${version}; nothing to commit."
+            exit 0
+          fi
+          git commit -m "stella ${version}"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ curl -fsSL https://raw.githubusercontent.com/oxageninc/stella-cli/main/install.s
 stella --version
 ```
 
-**Homebrew** — the formula in `packaging/homebrew/stella.rb` builds from source
-(`brew install --build-from-source ./packaging/homebrew/stella.rb`).
+**Homebrew** — installs the prebuilt binary from the tap (no Rust toolchain
+needed); the release workflow keeps the formula in sync on every tag:
+
+```bash
+brew install oxageninc/stella/stella
+# equivalently: brew tap oxageninc/stella && brew install stella
+```
+
+To build from source instead, use the local formula in
+`packaging/homebrew/stella.rb` (`brew install --build-from-source ./packaging/homebrew/stella.rb`).
 
 **From cargo** (requires Rust 1.90+ via [rustup](https://rustup.rs) and git):
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,14 @@
 # Releasing Stella
 
 Stella ships prebuilt binaries, a Homebrew formula, and a `curl | sh`
-installer via [`dist`](https://axodotdev.github.io/cargo-dist) (cargo-dist).
-Everything is driven by pushing a version tag — the
+installer. Everything is driven by pushing a version tag — the
 [`Release`](.github/workflows/release.yml) workflow does the rest.
 
-The `dist` configuration lives in the root `Cargo.toml` under
-`[workspace.metadata.dist]`; only the `stella` binary (from `stella-cli`) is
-distributed — the workspace's fixture binaries opt out with
-`[package.metadata.dist] dist = false`.
+The workflow is a **hand-rolled build matrix** (it does not require cargo-dist
+on the runner). The `[workspace.metadata.dist]` block in the root `Cargo.toml`
+is retained for a possible future migration to
+[`dist`](https://axodotdev.github.io/cargo-dist) but is **not** the active
+pipeline today; the source of truth is `.github/workflows/release.yml`.
 
 ## One-time setup
 
@@ -31,20 +31,15 @@ This has to exist and be writable before the first release:
 
 The prebuilt tarballs, checksums, and the `curl | sh` installer are published
 to this repo's GitHub Releases and need no extra secrets — only the Homebrew
-tap push does.
+tap push does. If `HOMEBREW_TAP_TOKEN` is absent, the release still succeeds and
+the `homebrew` job skips with a warning.
 
 ## Cut a release
 
 1. Bump the version if needed — `version` in `[workspace.package]` of the root
    `Cargo.toml` (all crates inherit it) — and commit.
 
-2. (Optional) Preview exactly what will be built without compiling anything:
-
-   ```bash
-   dist plan
-   ```
-
-3. Tag and push. The tag must be `v<major>.<minor>.<patch>` matching the
+2. Tag and push. The tag must be `v<major>.<minor>.<patch>` matching the
    workspace version:
 
    ```bash
@@ -56,14 +51,16 @@ That push starts the `Release` workflow, which:
 
 - builds `stella` for macOS (`aarch64`, `x86_64`) and Linux (`aarch64`,
   `x86_64`),
-- packs each as a `.tar.xz` with the licenses + README and a SHA-256 checksum,
-- creates a GitHub Release with those artifacts, a `sha256.sum`, and the
-  `stella-cli-installer.sh` shell installer,
-- generates `Formula/stella.rb` and commits it to the Homebrew tap.
+- packs each as a `stella-<version>-<target>.tar.gz` with the licenses +
+  README,
+- creates a GitHub Release with those tarballs and a `SHA256SUMS`,
+- renders `Formula/stella.rb` from `.github/homebrew/stella.rb.tmpl` (real
+  version + per-target SHA-256 sums) and commits it to the Homebrew tap
+  (skipped if `HOMEBREW_TAP_TOKEN` is not configured).
 
 ## After the release — how users install
 
-Homebrew (prebuilt bottle-style formula, no compile):
+Homebrew (prebuilt binary, no Rust toolchain):
 
 ```bash
 brew install oxageninc/stella/stella
@@ -73,21 +70,21 @@ brew install oxageninc/stella/stella
 Shell installer (macOS/Linux, no Homebrew):
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/oxageninc/stella-cli/releases/latest/download/stella-cli-installer.sh | sh
+curl -fsSL https://raw.githubusercontent.com/oxageninc/stella-cli/main/install.sh | sh
 ```
 
-Upgrades are `brew upgrade stella` or re-running the installer.
+The installer detects the platform, downloads the matching tarball from the
+GitHub Release, verifies it against `SHA256SUMS`, and falls back to
+`cargo install` where no prebuilt binary matches. Upgrades are
+`brew upgrade stella` or re-running the installer.
 
-## Updating the dist toolchain
+## Formula templates
 
-The pinned `dist` version is `cargo-dist-version` in
-`[workspace.metadata.dist]`. To move to a newer `dist`, install it and re-run
-init so the workflow is regenerated against the new version:
+Two formulas live in the repo, for two different purposes:
 
-```bash
-brew upgrade cargo-dist            # or: cargo install cargo-dist
-dist init --yes --hosting github   # regenerates .github/workflows/release.yml
-```
-
-Commit the regenerated workflow and the bumped `cargo-dist-version` together.
+- `.github/homebrew/stella.rb.tmpl` — the **template** the release workflow
+  renders and pushes to the tap as `Formula/stella.rb`. Installs the prebuilt
+  binary per platform. Edit this to change what lands in the tap.
+- `packaging/homebrew/stella.rb` — a **build-from-source** formula for local
+  use (`brew install --build-from-source ./packaging/homebrew/stella.rb`); it
+  compiles with cargo and needs no per-release sha maintenance.


### PR DESCRIPTION
## Summary

Wires the Homebrew tap publish into the release pipeline (the tap was documented in `RELEASING.md` + `[workspace.metadata.dist]` but never actually produced), and removes a leaked credential from the repo.

### 🔴 Security (commit 1) — act on this first
`.env.local` was **committed to this public repo** with a live `ZAI_API_KEY` and BYOK config. It's already in `.gitignore`, so it should never have been tracked. This untracks it from HEAD.

> ⚠️ Untracking does **not** scrub git history — the key is already public. **Rotate/revoke `ZAI_API_KEY` at the provider now** and treat it as compromised. History scrubbing (BFG/`git filter-repo`) is optional once the key is dead.

### Homebrew tap publish (commit 2)
- **New `homebrew` job** in `release.yml` (`needs: release`, tag-only): renders `.github/homebrew/stella.rb.tmpl` with the real version + per-target SHA-256 sums of the prebuilt `.tar.gz` assets, then commits `Formula/stella.rb` to `oxageninc/homebrew-stella`. **Skips gracefully when `HOMEBREW_TAP_TOKEN` is unset**, so a release is never blocked on the tap being wired.
- **New `.github/homebrew/stella.rb.tmpl`** — a prebuilt (no Rust toolchain) formula selecting the right tarball per macOS/Linux × arm/intel. Runs after the Release exists so its `releases/download/...` URLs resolve.
- **Docs reconciled to reality**: `RELEASING.md` and `README.md` described a cargo-dist flow (`.tar.xz`, `stella-cli-installer.sh`, `dist plan`) the hand-rolled workflow doesn't produce. Now they describe the actual `.tar.gz` + `SHA256SUMS` + `install.sh` pipeline, and point Homebrew at the tap (`brew install oxageninc/stella/stella`).

### Still required before the first Homebrew release (out-of-band, human-only)
1. Tap repo `oxageninc/homebrew-stella` must exist (being created alongside this PR).
2. Mint a PAT with **contents: write** on the tap repo.
3. Add it as the `HOMEBREW_TAP_TOKEN` secret on `oxageninc/stella-cli`.

Until step 2–3 are done, releases still succeed; the `homebrew` job just warns and skips.

## Verification
- `actionlint .github/workflows/release.yml` → clean.
- YAML parses; job graph is `build → release → homebrew`.
- Formula template placeholders (`@VERSION@`, `@SHA_*@`) are substituted by the `sed` in the job; each tarball unpacks to a single `stella-<version>-<target>/` dir that Homebrew descends into, so `bin.install "stella"` is correct.

Note: a full end-to-end proof requires an actual tag push + the tap secret, which is gated on the one-time setup above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the Homebrew formula to the `oxageninc/homebrew-stella` tap on tag releases and removes a leaked `.env.local` containing a live `ZAI_API_KEY`. Rotate/revoke the exposed key; removing from HEAD does not scrub history.

- **New Features**
  - Adds a `homebrew` job in `.github/workflows/release.yml` to render `.github/homebrew/stella.rb.tmpl` with the real version and per-target SHA-256 sums, then push `Formula/stella.rb` to `oxageninc/homebrew-stella` (skips if `HOMEBREW_TAP_TOKEN` is unset).
  - Introduces a prebuilt-binary formula template that selects the correct tarball for macOS/Linux on arm/intel.
  - Updates `README.md` and `RELEASING.md` to document the `.tar.gz` + `SHA256SUMS` + `install.sh` pipeline and `brew install oxageninc/stella/stella`.

- **Migration**
  - Ensure `oxageninc/homebrew-stella` exists.
  - Create a PAT with `contents: write` and add it as `HOMEBREW_TAP_TOKEN` on `oxageninc/stella-cli`.
  - Until set, releases still succeed and the `homebrew` job skips.

<sup>Written for commit abd61a6cddee8b4c1c69a2357b5211d2a7ed7dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella-cli/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
