### PR TITLE
chore(security): Dependabot + dependency-review + OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Automated dependency + security updates.
+# https://docs.github.com/code-security/dependabot
+version: 2
+updates:
+  # Rust workspace.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo:
+        update-types: [minor, patch]
+
+  # GitHub Actions pinned in workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Python benchmark harness + Harbor adapter.
+  - package-ecosystem: pip
+    directory: /bench
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /bench/harbor_adapter
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# Block PRs that introduce dependencies with known vulnerabilities or
+# disallowed licenses. Free on public repos (uses the dependency graph).
+name: dependency-review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+# OpenSSF Scorecard — measures the repo's security posture (branch protection,
+# pinned actions, token permissions, etc.) and publishes results to the
+# Security tab. The de-facto supply-chain health check for popular OSS repos.
+# https://github.com/ossf/scorecard-action
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the OpenSSF API
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds the remaining standard OSS supply-chain governance on top of Stella's existing CI (`fmt + clippy + test`, `cargo-deny + cargo-audit`) and existing SECURITY.md / CODEOWNERS.

- **Dependabot**: weekly `cargo` + `github-actions` + `pip` (`bench/`, `bench/harbor_adapter/`) updates, grouped.
- **dependency-review**: blocks PRs adding high-severity vulnerable deps.
- **OpenSSF Scorecard**: security-posture score to the Security tab.

Config-only — no crate/source changes; `fmt/clippy/test` unaffected. (Also enabled out-of-band: Dependabot alerts + security auto-fixes, private vulnerability reporting, CodeQL default setup, and branch protection on `main`.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Dependabot`, `dependency-review`, and `OpenSSF Scorecard` to strengthen supply-chain security and surface issues early. Config-only; no crate/source changes.

- **New Features**
  - `Dependabot`: weekly updates for `cargo`, `github-actions`, and `pip` in `bench/` and `bench/harbor_adapter/`; groups minor/patch updates.
  - `dependency-review`: blocks PRs that add high-severity vulnerable dependencies; comments on failure.
  - `OpenSSF Scorecard`: runs weekly and on `main` pushes; uploads SARIF and publishes results to the Security tab.

<sup>Written for commit e36c97ea8bb9887b592d86ae7eb57b7c493967b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
