### PR TITLE
ci(release): auto-version + release on every main merge, with AI release notes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,99 @@
+name: auto-tag
+
+# Every merge to main cuts a release. This job computes the next semantic
+# version from the latest tag and the merge commit's message, creates the tag,
+# and kicks off `release.yml` (build + GitHub Release + Homebrew) for it.
+#
+#   (default)            patch bump    0.1.3 -> 0.1.4
+#   'release.minor: …'   minor bump    0.1.3 -> 0.2.0   (patch reset to 0)
+#   'release:major …'    major bump    0.1.3 -> 1.0.0   (minor + patch reset)
+#
+# Put the prefix at the start of the PR title — a squash-merge uses the PR
+# title as the commit subject. `release.minor`/`release:minor` and
+# `release:major`/`release.major` are both accepted. Add `[skip release]` to
+# the title to land a change without cutting a release (docs/chore merges).
+#
+# No commit is pushed back to main — the tag is the source of truth, so this
+# never fights branch protection. release.yml injects the tag's version into
+# the build so `stella --version` is correct.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  # Serialize so rapid merges compute their version off the previous tag.
+  group: auto-tag
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push the tag
+  actions: write # dispatch release.yml
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compute next version and create the tag
+        id: ver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          msg="$(git log -1 --pretty=%B)"
+          printf 'HEAD commit message:\n%s\n\n' "$msg"
+
+          if printf '%s' "$msg" | grep -qiE '\[skip (release|ci)\]'; then
+            echo "skip marker present — not cutting a release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Base off the newest v-prefixed tag; if there is none yet, off the
+          # workspace version in Cargo.toml.
+          last="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
+          if [ -z "$last" ]; then
+            base="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)"
+            base="${base:-0.0.0}"
+          else
+            base="${last#v}"
+          fi
+          IFS=. read -r major minor patch <<< "$base"
+          major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
+
+          if printf '%s' "$msg" | grep -qiE '(^|[^[:alnum:]])release[.:]major'; then
+            major=$((major + 1)); minor=0; patch=0; kind="major"
+          elif printf '%s' "$msg" | grep -qiE '(^|[^[:alnum:]])release[.:]minor'; then
+            minor=$((minor + 1)); patch=0; kind="minor"
+          else
+            patch=$((patch + 1)); kind="patch"
+          fi
+          version="${major}.${minor}.${patch}"
+          tag="v${version}"
+          echo "Next release: ${tag} (${kind} bump from ${base})"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "::error::tag ${tag} already exists — aborting to avoid clobbering a release."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "stella ${version}"
+          git push origin "${tag}"
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger the release build for the new tag
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # A tag pushed with GITHUB_TOKEN does not itself trigger `on: push:
+        # tags`, so dispatch release.yml explicitly at the tag ref.
+        run: gh workflow run release.yml --ref "${{ steps.ver.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,16 +71,33 @@ jobs:
         if: ${{ matrix.cross }}
         run: cargo install cross --locked
 
+      # Stamp the release version (from the tag) into the workspace manifest so
+      # the compiled binary reports it — `stella --version` == the release tag.
+      # No commit lands on main; this edit is ephemeral to the build runner.
+      # `--locked` is dropped because bumping the workspace-member version would
+      # otherwise be rejected as a stale lockfile; registry deps stay pinned by
+      # the existing Cargo.lock (cargo only rewrites the workspace entries).
+      - name: Stamp release version
+        if: ${{ github.ref_type == 'tag' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          sed -i.bak -E "0,/^version = \"[^\"]*\"/s//version = \"${version}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+          echo "workspace version set to ${version}"
+          grep -m1 '^version = ' Cargo.toml
+
       - name: Build stella
         shell: bash
         run: |
           set -euo pipefail
           if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --locked \
+            cross build --release \
               --target ${{ matrix.target }} \
               --package stella-cli --bin stella
           else
-            cargo build --release --locked \
+            cargo build --release \
               --target ${{ matrix.target }} \
               --package stella-cli --bin stella
           fi
@@ -123,6 +140,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Full history + tags so the notes step can diff against the prior tag.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -139,6 +162,51 @@ jobs:
           echo "----- SHA256SUMS -----"
           cat SHA256SUMS
 
+      # Draft the release notes from the diff since the previous tag using the
+      # AI Gateway. Falls back to a plain commit list if the key is unset or the
+      # call fails, so a release is never blocked on note generation.
+      - name: Generate release notes
+        shell: bash
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL || 'anthropic/claude-sonnet-5' }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          prev="$(git tag -l 'v*' --sort=-v:refname | grep -vx "${tag}" | head -n1 || true)"
+          echo "notes range: ${prev:-<start>}..${tag}"
+
+          commits="$(git log --no-merges --pretty='- %s' ${prev:+${prev}..HEAD} | head -n 300)"
+          {
+            echo "## Commits"; echo "$commits";
+            echo; echo "## Files changed";
+            git diff --stat ${prev:+${prev}..HEAD} | tail -n 80;
+          } > ctx.txt
+          git diff ${prev:+${prev}..HEAD} 2>/dev/null | head -c 120000 > diff.txt || true
+
+          notes=""
+          if [ -n "${AI_GATEWAY_API_KEY:-}" ]; then
+            prompt="$(printf 'Write the GitHub release notes for the "stella" coding-agent CLI %s, in clean Markdown. Start with a one-line summary, then grouped bullet sections (Features, Fixes, Performance, Docs, Internal) — omit any empty section. Be concrete and user-facing; no preamble, no headings above the summary. Base it strictly on the commits and diff below.\n\n%s\n\n## Diff (truncated)\n```diff\n%s\n```\n' "$version" "$(cat ctx.txt)" "$(cat diff.txt)")"
+            payload="$(jq -n --arg m "$RELEASE_NOTES_MODEL" --arg c "$prompt" '{model:$m,messages:[{role:"user",content:$c}],temperature:0.2}')"
+            resp="$(curl -sS --max-time 150 \
+              -H "Authorization: Bearer ${AI_GATEWAY_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$payload" \
+              https://ai-gateway.vercel.sh/v1/chat/completions || true)"
+            notes="$(printf '%s' "$resp" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+            [ -z "$notes" ] && echo "::warning::AI note generation returned nothing; using the commit list."
+          else
+            echo "::warning::AI_GATEWAY_API_KEY not available; using the commit list."
+          fi
+          [ -z "$notes" ] && notes="$(printf '## What changed\n\n%s' "$commits")"
+
+          {
+            printf '%s\n\n' "$notes"
+            [ -n "$prev" ] && printf '**Full changelog**: https://github.com/%s/compare/%s...%s\n' "$GITHUB_REPOSITORY" "$prev" "$tag"
+          } > notes.md
+          echo "----- notes.md -----"; cat notes.md
+
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -146,7 +214,7 @@ jobs:
             artifacts/stella-*.tar.gz
             artifacts/SHA256SUMS
           fail_on_unmatched_files: true
-          generate_release_notes: true
+          body_path: notes.md
 
   # Renders .github/homebrew/stella.rb.tmpl with the real version + per-target
   # SHA-256 sums and commits it as Formula/stella.rb to the tap repo


### PR DESCRIPTION
## What this does

Every merge to `main` cuts a released `stella` binary and updates Homebrew — no manual tagging.

### Versioning (from the merge commit / PR title)
| PR title prefix | Bump | Example |
|---|---|---|
| *(none)* | patch | `0.1.3 → 0.1.4` |
| `release.minor:` or `release:minor` | minor (patch → 0) | `0.1.3 → 0.2.0` |
| `release:major` or `release.major:` | major (minor+patch → 0) | `0.1.3 → 1.0.0` |

Squash-merge uses the PR title as the commit subject, so the prefix goes in the **PR title**. Add `[skip release]` to land a change without a release.

### How it works
1. **`auto-tag.yml`** (on push to `main`): computes the next `vX.Y.Z` from the latest tag + commit message, creates & pushes the **tag**, then dispatches `release.yml` at that tag.
   - The **tag is the source of truth** — nothing is committed back to `main`, so this does **not** conflict with the branch protection we just added.
   - It dispatches `release.yml` explicitly because a tag pushed with `GITHUB_TOKEN` doesn't self-trigger `on: push: tags`.
2. **`release.yml`** (unchanged trigger; now enhanced):
   - **Stamps the tag's version** into `Cargo.toml` before building so `stella --version` matches the release. (Drops `--locked` for that build only; registry deps stay pinned by `Cargo.lock` — only the workspace-member versions change.)
   - **Generates release notes from the diff** since the previous tag via the AI Gateway (`secrets.AI_GATEWAY_API_KEY`, model overridable via `vars.RELEASE_NOTES_MODEL`), falling back to a commit list if the key/call is unavailable — a release is never blocked on it.
   - Builds all 4 targets, publishes the GitHub Release (**all releases are tags**), and pushes the Homebrew formula to `oxageninc/homebrew-stella` (unchanged) — so `brew upgrade stella` works after each merge.

### Notes / decisions
- **Compute cost:** every merge triggers the full LTO 4-target build (~up to 90 min). Use `[skip release]` for docs/chore merges you don't want released.
- **Secrets:** relies on the org `AI_GATEWAY_API_KEY` (release notes) and the existing `HOMEBREW_TAP_TOKEN` (tap). If `AI_GATEWAY_API_KEY` isn't granted to this repo, notes fall back to the commit list automatically.
- **⚠️ Merging this PR cuts the first automated release (`v0.1.1`).** That's intended as the live smoke test; add `[skip release]` to the squash commit if you'd rather defer to the next merge.

Config-only (workflow YAML); Rust build/CI unaffected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-releases on every merge to `main`: computes the next semver, tags it, builds all targets, publishes a GitHub Release with notes, and updates Homebrew. No manual tagging.

- **New Features**
  - Added `auto-tag.yml` to compute and push the next `vX.Y.Z` from the latest tag + merge message, serialize runs to avoid races, skip on `[skip release]` or `[skip ci]`, then trigger `release.yml` for that tag. The tag is the source of truth; nothing is committed to `main`.
  - Updated `release.yml` to stamp the tag version into `Cargo.toml` so `stella --version` matches, generate release notes from the diff via `AI_GATEWAY_API_KEY` with a commit-list fallback, and publish artifacts + Homebrew.

- **Migration**
  - Title rules: default patch; `release.minor:`/`release:minor` for minor; `release:major`/`release.major:` for major. Add `[skip release]` or `[skip ci]` to skip a release.
  - Secrets: ensure `AI_GATEWAY_API_KEY` (optional) and `HOMEBREW_TAP_TOKEN`; notes fall back if the key is missing.
  - Merging this PR will cut the first automated release (`v0.1.1`); use `[skip release]` to defer.

<sup>Written for commit 82344af53a7318796eb8f6649150e625320b6696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
