### PR TITLE
feat(bench): Off-grid division tooling + verified local-model guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ and the harness to prove it ships in this repo.
 |---|---|---|
 | 🥇 **Heavyweight** | Frontier model, $2/task cap | Highest resolve rate |
 | 🪶 **Featherweight** | Any model, any cap | Lowest **$ per resolved task** |
-| 🔌 **Off-grid** | Local models only (`--base-url`, zero API keys) | Resolve rate at $0 marginal cost |
+| 🔌 **Off-grid** | Local models only (`--base-url`, zero API keys) — [the guide](docs/off-grid.md) | Resolve rate at $0 marginal cost |
 | ⚔️ **Cross-harness** | Same model, Stella vs. any other agent CLI | Biggest head-to-head gap |
 
 ### Enter

--- a/bench/README.md
+++ b/bench/README.md
@@ -102,6 +102,8 @@ Run `python3 bench/run_swebench.py --help` for the full list. Key options:
 | `--instance-id ID` | — | Only this instance id (repeatable). |
 | `--model M` | `anthropic/claude-fable-5` | Passed to `stella --model`. |
 | `--budget USD` | `2.0` | Per-instance USD cap (`stella --budget`). |
+| `--base-url URL` | — | Passed to `stella --base-url`; required for `local/<model>` (Ollama, vLLM, LM Studio, llama.cpp — see [docs/off-grid.md](../docs/off-grid.md)). |
+| `--division D` | auto | Arena division stamped into `summary.json` (`heavyweight`, `featherweight`, `off-grid`, `cross-harness`). `local/<model>` runs auto-stamp `off-grid`. |
 | `--timeout SEC` | `1800` | Per-instance timeout. |
 | `--stella-bin PATH` | auto | `stella` on PATH, else `./target/release/stella`. |
 | `--run-id ID` | auto | Run identifier (default: model + timestamp). |

--- a/bench/run_swebench.py
+++ b/bench/run_swebench.py
@@ -263,8 +263,27 @@ def collect_patch(workdir: str, exclude_paths: List[str]) -> str:
 # --------------------------------------------------------------------------- #
 # Per-instance execution
 # --------------------------------------------------------------------------- #
-def build_stella_cmd(stella_bin: str, model: str, budget: float, prompt: str) -> List[str]:
-    return [stella_bin, "--model", model, "--budget", str(budget), "run", prompt]
+def build_stella_cmd(
+    stella_bin: str, model: str, budget: float, prompt: str, base_url: Optional[str] = None
+) -> List[str]:
+    cmd = [stella_bin, "--model", model, "--budget", str(budget)]
+    if base_url:
+        cmd.extend(["--base-url", base_url])
+    cmd.extend(["run", prompt])
+    return cmd
+
+
+def detect_division(model: str, base_url: Optional[str]) -> Optional[str]:
+    """The Arena division a run's receipts belong to, when derivable.
+
+    Only Off-grid is mechanically detectable: the `local/<model>` pseudo-
+    provider (any OpenAI-compatible server via --base-url, zero API keys,
+    $0 marginal cost). Heavyweight/Featherweight are model-class claims the
+    harness cannot infer — pass --division explicitly for those.
+    """
+    if model.startswith("local/") and base_url:
+        return "off-grid"
+    return None
 
 
 def describe_plan(
@@ -272,6 +291,7 @@ def describe_plan(
     stella_bin: Optional[str],
     model: str,
     budget: float,
+    base_url: Optional[str],
     timeout: int,
     logs_dir: Path,
     repo_cache: Optional[str],
@@ -287,7 +307,9 @@ def describe_plan(
         if repo_cache
         else f"git clone {clone_url(repo)}"
     )
-    cmd = build_stella_cmd(stella_bin or "<stella-bin>", model, budget, "<problem_statement>")
+    cmd = build_stella_cmd(
+        stella_bin or "<stella-bin>", model, budget, "<problem_statement>", base_url
+    )
     print(f"--- instance: {iid}")
     print(f"    repo         : {repo}")
     print(f"    base_commit  : {base}")
@@ -305,6 +327,7 @@ def run_instance(
     stella_bin: str,
     model: str,
     budget: float,
+    base_url: Optional[str],
     timeout: int,
     logs_dir: Path,
     repo_cache: Optional[str],
@@ -341,7 +364,7 @@ def run_instance(
                     "prediction": None}
 
         # 2) run stella
-        cmd = build_stella_cmd(stella_bin, model, budget, prompt)
+        cmd = build_stella_cmd(stella_bin, model, budget, prompt, base_url)
         env = os.environ.copy()
         env.setdefault("STELLA_BUDGET", str(budget))
         try:
@@ -420,6 +443,21 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     run = p.add_argument_group("stella invocation")
     run.add_argument("--model", default=DEFAULT_MODEL, help="Provider/model passed to `stella --model`.")
     run.add_argument("--budget", type=float, default=DEFAULT_BUDGET, help="USD budget cap per instance (`stella --budget`).")
+    run.add_argument(
+        "--base-url",
+        default=None,
+        help="Endpoint passed to `stella --base-url` — required for the local/"
+        "<model> pseudo-provider (Ollama, vLLM, LM Studio, llama.cpp server); "
+        "an optional override for hosted providers.",
+    )
+    run.add_argument(
+        "--division",
+        choices=["heavyweight", "featherweight", "off-grid", "cross-harness"],
+        default=None,
+        help="Arena division to stamp into summary.json for the results track. "
+        "Default: auto — `local/<model>` runs are stamped off-grid, hosted "
+        "runs carry no division.",
+    )
     run.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Per-instance timeout in seconds.")
     run.add_argument(
         "--stella-bin",
@@ -469,6 +507,12 @@ def validate_instances(instances: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv)
 
+    if args.model.startswith("local/") and not args.base_url:
+        log("error: --model local/<model> needs --base-url "
+            "(e.g. --base-url http://localhost:11434/v1) — see docs/off-grid.md")
+        return 2
+    division = args.division or detect_division(args.model, args.base_url)
+
     run_id = args.run_id or default_run_id(args.model)
     out_base = Path(args.output_dir) / run_id
     logs_dir = out_base / "logs"
@@ -499,12 +543,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"         stella-bin : {stella_bin or '<not found; set --stella-bin>'}")
         print(f"         model      : {args.model}")
         print(f"         budget     : ${args.budget} per instance")
+        print(f"         base-url   : {args.base_url or '<provider default>'}")
+        print(f"         division   : {division or '<none>'}")
         print(f"         instances  : {len(instances)}")
         print()
         for inst in instances:
             describe_plan(
-                inst, stella_bin, args.model, args.budget, args.timeout,
-                logs_dir, args.repo_cache,
+                inst, stella_bin, args.model, args.budget, args.base_url,
+                args.timeout, logs_dir, args.repo_cache,
             )
         print()
         print("DRY RUN complete: no repos cloned, no stella invocations, no files written.")
@@ -537,6 +583,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 stella_bin=stella_bin,
                 model=args.model,
                 budget=args.budget,
+                base_url=args.base_url,
                 timeout=args.timeout,
                 logs_dir=logs_dir,
                 repo_cache=args.repo_cache,
@@ -560,6 +607,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     summary = {
         "run_id": run_id,
         "model_name_or_path": args.model,
+        # The Arena results track: off-grid is auto-stamped for local/<model>
+        # runs; heavyweight/featherweight are explicit claims (--division).
+        "division": division,
+        "base_url": args.base_url,
         "dataset": args.instances or f"{args.dataset_name}:{args.split}",
         "total_selected": total,
         **counts,

--- a/docs/off-grid.md
+++ b/docs/off-grid.md
@@ -1,0 +1,135 @@
+# Off-grid: run and benchmark Stella on local models
+
+The **Off-grid** Arena division is Stella on local models only: any
+OpenAI-compatible server via `--base-url`, zero API keys, **$0 marginal cost**.
+This is the one documented flow from "server running" to "recorded, receipt-ready
+benchmark" — every command here was verified end to end against a live local
+server before landing.
+
+Stella's `local/<model>` pseudo-provider speaks the OpenAI Chat Completions
+dialect, which all four common local stacks serve. No API key is needed
+(`LOCAL_API_KEY` exists for gateways that demand one; a placeholder is sent
+otherwise).
+
+## 1 · Point Stella at your server
+
+### Ollama
+
+```bash
+ollama pull qwen2.5-coder:7b
+stella --model local/qwen2.5-coder:7b \
+       --base-url http://localhost:11434/v1 \
+       run "fix the failing test"
+```
+
+### vLLM
+
+```bash
+vllm serve Qwen/Qwen2.5-Coder-7B-Instruct --port 8000
+stella --model local/Qwen/Qwen2.5-Coder-7B-Instruct \
+       --base-url http://localhost:8000/v1 \
+       run "fix the failing test"
+```
+
+### LM Studio
+
+Load a model in the LM Studio UI, enable the local server (default port 1234),
+then use the model id the server lists (`curl http://localhost:1234/v1/models`):
+
+```bash
+stella --model local/<model-id> --base-url http://localhost:1234/v1 chat
+```
+
+### llama.cpp (server mode)
+
+```bash
+llama-server -m qwen2.5-coder-7b-instruct-q5_k_m.gguf --port 8080
+stella --model local/<any-name> --base-url http://localhost:8080/v1 chat
+```
+
+(`llama-server` serves whatever model it was started with; the slug after
+`local/` is used for display and telemetry keys.)
+
+**Sanity check first** — a one-shot that proves the wiring before you spend a
+benchmark's wall-clock on it:
+
+```bash
+stella --model local/qwen2.5-coder:7b --base-url http://localhost:11434/v1 \
+       run "Reply with exactly one word: ready"
+# → ready · $0.0000
+```
+
+Notes that matter for benchmarking:
+
+- The model slug after `local/` must be exactly what the server reports in
+  `GET /v1/models` (for Ollama, the tag: `qwen2.5-coder:7b`, not
+  `qwen2.5-coder`).
+- The catalog check is bypassed for `local/` — your server, not Stella's seed
+  data, is the authority on which models exist.
+- Cost is metered at $0 (no pricing card), so `--budget` is not a useful cap
+  off-grid; use the harness `--timeout` instead.
+- Local runs land in the same DuckDB telemetry as hosted runs; `stella stats`
+  reports them under the `off-grid` division.
+
+## 2 · Run the benchmark
+
+`bench/run_swebench.py` accepts `--base-url` and stamps the division into the
+run's receipts. A `local/<model>` run without `--base-url` fails fast, before
+any instance is attempted.
+
+```bash
+cargo build --release -p stella-cli
+
+# Validate the wiring — spends nothing, prints the exact plan:
+python3 bench/run_swebench.py \
+  --instances bench/instances.sample.jsonl \
+  --model local/qwen2.5-coder:7b \
+  --base-url http://localhost:11434/v1 \
+  --stella-bin target/release/stella \
+  --dry-run
+
+# The real run (SWE-bench Verified via HuggingFace; drop --limit to go full):
+python3 bench/run_swebench.py \
+  --model local/qwen2.5-coder:7b \
+  --base-url http://localhost:11434/v1 \
+  --stella-bin target/release/stella \
+  --timeout 3600 \
+  --limit 50
+```
+
+`summary.json` records the division alongside the results:
+
+```json
+{
+  "run_id": "stella-local-qwen2.5-coder-...",
+  "model_name_or_path": "local/qwen2.5-coder:7b",
+  "division": "off-grid",
+  "base_url": "http://localhost:11434/v1",
+  ...
+}
+```
+
+Off-grid is auto-detected from `local/<model>` + `--base-url`; the other
+divisions are explicit claims (`--division heavyweight|featherweight`), because
+the harness can't infer a model's class.
+
+Score the predictions with the **official SWE-bench Docker evaluator,
+unmodified** (see `bench/README.md`) — self-graded results don't count in any
+division.
+
+## 3 · Record it — the results track
+
+Submit through the Arena run issue template
+([new issue → Arena run](../../../issues/new?template=arena_run.yml)) with
+division **Off-grid** and the standard receipts:
+
+- `predictions.jsonl`, `summary.json` (with the `off-grid` division stamp),
+  per-instance logs from the run directory;
+- the official evaluator's output;
+- `stella stats --format csv` for the token/latency numbers straight out of
+  local DuckDB — the "resolve rate at $0 marginal cost" claim is the number
+  that decides this division.
+
+Reproducibility bar: name the exact server (Ollama/vLLM/LM Studio/llama.cpp +
+version), the model file or tag (with quantization), and the hardware. A local
+run nobody can re-run is not a result.


### PR DESCRIPTION
Closes #23. The Off-grid division (local models, --base-url, zero API keys, $0 marginal cost) was defined in the README but had no tooling or documented flow. Now:

- bench/run_swebench.py accepts --base-url (threaded into the stella invocation; a local/<model> run without it fails fast before any instance is attempted) and --division, and stamps division + base_url into summary.json — off-grid is auto-detected from local/<model>, while heavyweight/featherweight stay explicit claims the harness refuses to infer.
- docs/off-grid.md: the one documented flow from server to recorded benchmark — Ollama / vLLM / LM Studio / llama.cpp setup, the sanity one-shot, the dry-run + real benchmark commands, the receipt shape, and the results-track submission bar (official evaluator, exact server/model/quant/hardware named).
- README division table and bench/README.md flag table link the guide.

Verified end to end before landing: a live one-shot through a local Ollama qwen2.5-coder:7b ($0.0000, 15.9s) and both harness dry-run paths (missing --base-url fails fast; with it, division: off-grid is stamped).

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Off-grid support for local-model runs with `--base-url` and a verified guide for running Stella against OpenAI-compatible local servers. Auto-detects Off-grid for `local/<model>`, and records `division` and `base_url` in `summary.json`.

- **New Features**
  - `bench/run_swebench.py`: adds `--base-url` and `--division`; threads `--base-url` to `stella`; fails fast if `local/<model>` without `--base-url`; dry-run prints `base-url` and `division`; writes `division` and `base_url` to `summary.json`; Off-grid auto-detected for `local/<model>`.
  - `docs/off-grid.md`: end-to-end local setup and benchmark guide (Ollama, vLLM, LM Studio, llama.cpp), sanity check, dry-run/real commands, receipts. Linked from `README.md` and `bench/README.md`.

- **Migration**
  - Use `--model local/<model>` with `--base-url http://<host>:<port>/v1` for local servers.
  - Only set `--division` when claiming `heavyweight` or `featherweight`; leave unset for Off-grid (auto).

<sup>Written for commit 9febfca0145b430532476724463ff0c7ba948f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
