### PR TITLE
feat(stella-store): per-provider usage/cost analytics + stella stats …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,7 @@ name = "stella-store"
 version = "0.1.0"
 dependencies = [
  "duckdb",
+ "serde",
  "serde_json",
  "stella-protocol",
 ]

--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ stella monitor main          # drive a branch/PR's CI to green as a judged goal
 ```bash
 stella init      # infer this workspace's domain taxonomy (.stella/domains.toml)
 stella tools     # list every tool available to the agent this session
+stella stats     # cost, tokens, and $/resolved task per provider/model from
+                 # local telemetry (--format table|json|csv, --provider <id>)
 ```
 
 ### Global flags

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -22,6 +22,7 @@ mod config;
 mod domains;
 mod interactive;
 mod memory;
+mod stats;
 mod tui;
 
 use std::process::ExitCode;
@@ -120,6 +121,19 @@ enum Command {
     /// List configured providers and available models
     Models,
 
+    /// Summarize cost, tokens, and resolve rate per provider/model from
+    /// local telemetry (.stella/stella.duckdb) — $/resolved-task receipts
+    Stats {
+        /// Output format: table (aligned, with TOTAL row), json, or csv
+        #[arg(long, value_enum, default_value = "table")]
+        format: stats::StatsFormat,
+
+        /// Only show executions for this provider id (e.g. zai, anthropic,
+        /// local)
+        #[arg(long)]
+        provider: Option<String>,
+    },
+
     /// Show current configuration
     Config,
 
@@ -155,7 +169,7 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<(), String> {
-    // Models and Version don't need a configured provider/key.
+    // Models, Stats, and Version don't need a configured provider/key.
     match cli.command {
         Some(Command::Models) => {
             config::Config::print_available_models();
@@ -163,6 +177,10 @@ fn run(cli: Cli) -> Result<(), String> {
         }
         Some(Command::Tools) => {
             return agent::run_tools_listing();
+        }
+        Some(Command::Stats { format, provider }) => {
+            // Reads local telemetry only — works with zero API keys.
+            return stats::run_stats(format, provider.as_deref());
         }
         Some(Command::Version) => {
             println!("stella v{}", env!("CARGO_PKG_VERSION"));
@@ -222,10 +240,14 @@ fn run(cli: Cli) -> Result<(), String> {
         Command::Chat => {
             rt()?.block_on(agent::run_interactive(&cfg, cli.budget))?;
         }
-        // Models/Version (and Tools) short-circuit in the first match at the
-        // top of `run` before a provider is resolved; Init is handled by the
-        // caller. Reaching any of them here is impossible.
-        Command::Init | Command::Tools | Command::Models | Command::Version => {
+        // Models/Stats/Version (and Tools) short-circuit in the first match
+        // at the top of `run` before a provider is resolved; Init is handled
+        // by the caller. Reaching any of them here is impossible.
+        Command::Init
+        | Command::Tools
+        | Command::Models
+        | Command::Stats { .. }
+        | Command::Version => {
             unreachable!("handled before provider resolution")
         }
         Command::Config => {

--- a/stella-cli/src/stats.rs
+++ b/stella-cli/src/stats.rs
@@ -1,0 +1,364 @@
+//! `stella stats` — cost/$-per-resolved-task analytics straight from the
+//! workspace's local DuckDB telemetry (`.stella/stella.duckdb`).
+//!
+//! Reads what `stella-store` recorded — nothing else. Works with zero API
+//! keys configured (no provider is ever resolved), never writes: if the
+//! database file doesn't exist yet it says so instead of creating one.
+//!
+//! Formats: an aligned table for humans (with a TOTAL row), and json/csv
+//! for machine-readable receipts (Arena submissions want these). Field
+//! order in json/csv follows `UsageStatsRow`'s declaration order — a
+//! stable contract.
+
+use clap::ValueEnum;
+use stella_store::{Store, UsageStatsRow};
+
+/// Output format for `stella stats`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum StatsFormat {
+    /// Aligned human-readable columns with a TOTAL row (default).
+    Table,
+    /// Pretty-printed JSON array of per-(provider, model) rows.
+    Json,
+    /// RFC-4180-style CSV with a header row.
+    Csv,
+}
+
+/// Entry point for `stella stats`. `provider` filters rows to one provider
+/// id (e.g. `zai`, `anthropic`, `local`); `None` shows everything.
+pub fn run_stats(format: StatsFormat, provider: Option<&str>) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+
+    // Stats is read-only: opening the store would create `.stella/` as a
+    // side effect, so bail out politely when there's nothing to read.
+    let db_path = workspace_root.join(".stella").join("stella.duckdb");
+    let rows = if db_path.exists() {
+        let store =
+            Store::open(&workspace_root).map_err(|e| format!("cannot open local store: {e}"))?;
+        let mut rows = store
+            .usage_stats()
+            .map_err(|e| format!("cannot read usage stats: {e}"))?;
+        if let Some(p) = provider {
+            rows.retain(|r| r.provider == p);
+        }
+        rows
+    } else {
+        Vec::new()
+    };
+
+    if rows.is_empty() {
+        // An empty store is a state, not an error — but keep stdout valid
+        // for the machine formats.
+        match format {
+            StatsFormat::Table => println!("{}", empty_message(provider)),
+            StatsFormat::Json => {
+                eprintln!("{}", empty_message(provider));
+                println!("[]");
+            }
+            StatsFormat::Csv => {
+                eprintln!("{}", empty_message(provider));
+                println!("{}", csv_header());
+            }
+        }
+        return Ok(());
+    }
+
+    match format {
+        StatsFormat::Table => print!("{}", render_table(&rows)),
+        StatsFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&rows).map_err(|e| format!("serialize: {e}"))?
+        ),
+        StatsFormat::Csv => print!("{}", render_csv(&rows)),
+    }
+    Ok(())
+}
+
+fn empty_message(provider: Option<&str>) -> String {
+    match provider {
+        Some(p) => format!(
+            "No executions recorded for provider `{p}` yet — run `stella run \"...\"` (or \
+             chat/goal) to generate local telemetry."
+        ),
+        None => "No executions recorded yet — run `stella run \"...\"` (or chat/goal) to \
+                 generate local telemetry in .stella/stella.duckdb."
+            .to_string(),
+    }
+}
+
+/// The TOTAL row across every displayed row, computed in Rust (weighted,
+/// not an average of averages): rates and $/resolved are re-derived from
+/// the summed counts, and $/resolved stays `-` when nothing resolved.
+fn totals(rows: &[UsageStatsRow]) -> UsageStatsRow {
+    let runs: i64 = rows.iter().map(|r| r.runs).sum();
+    let resolved: i64 = rows.iter().map(|r| r.resolved).sum();
+    let total_cost_usd: f64 = rows.iter().map(|r| r.total_cost_usd).sum();
+    let total_duration_ms: f64 = rows.iter().map(|r| r.avg_duration_ms * r.runs as f64).sum();
+    UsageStatsRow {
+        provider: "TOTAL".into(),
+        model: "-".into(),
+        division: "-".into(),
+        runs,
+        resolved,
+        resolve_rate: if runs > 0 {
+            resolved as f64 / runs as f64
+        } else {
+            0.0
+        },
+        total_cost_usd,
+        cost_per_resolved_usd: (resolved > 0).then(|| total_cost_usd / resolved as f64),
+        input_tokens: rows.iter().map(|r| r.input_tokens).sum(),
+        output_tokens: rows.iter().map(|r| r.output_tokens).sum(),
+        cache_read_tokens: rows.iter().map(|r| r.cache_read_tokens).sum(),
+        cache_write_tokens: rows.iter().map(|r| r.cache_write_tokens).sum(),
+        avg_duration_ms: if runs > 0 {
+            total_duration_ms / runs as f64
+        } else {
+            0.0
+        },
+    }
+}
+
+/// Column headers, in `UsageStatsRow` field order.
+const TABLE_HEADERS: [&str; 13] = [
+    "PROVIDER",
+    "MODEL",
+    "DIVISION",
+    "RUNS",
+    "RESOLVED",
+    "RATE",
+    "COST ($)",
+    "$/RESOLVED",
+    "IN TOK",
+    "OUT TOK",
+    "CACHE RD",
+    "CACHE WR",
+    "AVG MS",
+];
+
+/// The first three columns are strings (left-aligned); the rest are
+/// numbers (right-aligned).
+const STRING_COLS: usize = 3;
+
+fn table_cells(row: &UsageStatsRow) -> [String; 13] {
+    [
+        row.provider.clone(),
+        row.model.clone(),
+        row.division.clone(),
+        row.runs.to_string(),
+        row.resolved.to_string(),
+        format!("{:.1}%", row.resolve_rate * 100.0),
+        format!("{:.4}", row.total_cost_usd),
+        match row.cost_per_resolved_usd {
+            Some(v) => format!("{v:.4}"),
+            None => "-".into(),
+        },
+        row.input_tokens.to_string(),
+        row.output_tokens.to_string(),
+        row.cache_read_tokens.to_string(),
+        row.cache_write_tokens.to_string(),
+        format!("{:.0}", row.avg_duration_ms),
+    ]
+}
+
+/// Render the aligned table with a separator line before the TOTAL row.
+fn render_table(rows: &[UsageStatsRow]) -> String {
+    let body: Vec<[String; 13]> = rows.iter().map(table_cells).collect();
+    let total = table_cells(&totals(rows));
+
+    let mut widths: Vec<usize> = TABLE_HEADERS.iter().map(|h| h.len()).collect();
+    for cells in body.iter().chain(std::iter::once(&total)) {
+        for (w, cell) in widths.iter_mut().zip(cells.iter()) {
+            *w = (*w).max(cell.len());
+        }
+    }
+
+    let render_line = |cells: &[String]| -> String {
+        let cols: Vec<String> = cells
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| {
+                if i < STRING_COLS {
+                    format!("{cell:<width$}", width = widths[i])
+                } else {
+                    format!("{cell:>width$}", width = widths[i])
+                }
+            })
+            .collect();
+        // Two-space gutter; trim so left-aligned last cells never leave
+        // trailing whitespace.
+        cols.join("  ").trim_end().to_string()
+    };
+
+    let mut out = String::new();
+    let headers: Vec<String> = TABLE_HEADERS.iter().map(|h| h.to_string()).collect();
+    out.push_str(&render_line(&headers));
+    out.push('\n');
+    for cells in &body {
+        out.push_str(&render_line(cells));
+        out.push('\n');
+    }
+    let rule_width = widths.iter().sum::<usize>() + 2 * (widths.len() - 1);
+    out.push_str(&"-".repeat(rule_width));
+    out.push('\n');
+    out.push_str(&render_line(&total));
+    out.push('\n');
+    out
+}
+
+/// CSV header, matching `UsageStatsRow`'s serialized field order exactly.
+fn csv_header() -> &'static str {
+    "provider,model,division,runs,resolved,resolve_rate,total_cost_usd,cost_per_resolved_usd,\
+     input_tokens,output_tokens,cache_read_tokens,cache_write_tokens,avg_duration_ms"
+}
+
+/// Quote a CSV field when it contains a comma, quote, or line break;
+/// embedded quotes are doubled (RFC 4180).
+fn csv_escape(field: &str) -> String {
+    if field.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+
+fn csv_row(row: &UsageStatsRow) -> String {
+    format!(
+        "{},{},{},{},{},{:.4},{:.6},{},{},{},{},{},{:.1}",
+        csv_escape(&row.provider),
+        csv_escape(&row.model),
+        csv_escape(&row.division),
+        row.runs,
+        row.resolved,
+        row.resolve_rate,
+        row.total_cost_usd,
+        match row.cost_per_resolved_usd {
+            Some(v) => format!("{v:.6}"),
+            None => String::new(),
+        },
+        row.input_tokens,
+        row.output_tokens,
+        row.cache_read_tokens,
+        row.cache_write_tokens,
+        row.avg_duration_ms,
+    )
+}
+
+fn render_csv(rows: &[UsageStatsRow]) -> String {
+    let mut out = String::from(csv_header());
+    out.push('\n');
+    for row in rows {
+        out.push_str(&csv_row(row));
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(provider: &str, model: &str) -> UsageStatsRow {
+        UsageStatsRow {
+            provider: provider.into(),
+            model: model.into(),
+            division: UsageStatsRow::division_for_provider(provider).into(),
+            runs: 4,
+            resolved: 2,
+            resolve_rate: 0.5,
+            total_cost_usd: 0.03,
+            cost_per_resolved_usd: Some(0.015),
+            input_tokens: 6000,
+            output_tokens: 600,
+            cache_read_tokens: 2000,
+            cache_write_tokens: 10,
+            avg_duration_ms: 750.0,
+        }
+    }
+
+    #[test]
+    fn csv_escapes_quotes_and_commas() {
+        assert_eq!(csv_escape("plain"), "plain");
+        assert_eq!(csv_escape("a,b"), "\"a,b\"");
+        assert_eq!(csv_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(csv_escape("line\nbreak"), "\"line\nbreak\"");
+    }
+
+    #[test]
+    fn csv_row_matches_header_order_and_blanks_unresolved() {
+        let mut r = row("zai", "glm-5.2");
+        assert_eq!(
+            csv_header().split(',').count(),
+            csv_row(&r).split(',').count()
+        );
+        assert_eq!(
+            csv_row(&r),
+            "zai,glm-5.2,-,4,2,0.5000,0.030000,0.015000,6000,600,2000,10,750.0"
+        );
+
+        // resolved = 0 → the $/resolved field is EMPTY, never 0 or NaN.
+        r.resolved = 0;
+        r.resolve_rate = 0.0;
+        r.cost_per_resolved_usd = None;
+        assert_eq!(
+            csv_row(&r),
+            "zai,glm-5.2,-,4,0,0.0000,0.030000,,6000,600,2000,10,750.0"
+        );
+
+        // Fields with commas round-trip quoted.
+        r.model = "weird,model".into();
+        assert!(csv_row(&r).starts_with("zai,\"weird,model\",-,"));
+    }
+
+    #[test]
+    fn totals_row_is_weighted_not_average_of_averages() {
+        let mut a = row("zai", "glm-5.2");
+        let mut b = row("anthropic", "claude-fable-5");
+        b.runs = 1;
+        b.resolved = 0;
+        b.resolve_rate = 0.0;
+        b.total_cost_usd = 0.05;
+        b.cost_per_resolved_usd = None;
+        b.avg_duration_ms = 100.0;
+        a.avg_duration_ms = 750.0;
+
+        let t = totals(&[a, b]);
+        assert_eq!(t.provider, "TOTAL");
+        assert_eq!(t.runs, 5);
+        assert_eq!(t.resolved, 2);
+        assert!((t.resolve_rate - 0.4).abs() < 1e-12);
+        assert!((t.total_cost_usd - 0.08).abs() < 1e-12);
+        assert!((t.cost_per_resolved_usd.unwrap() - 0.04).abs() < 1e-12);
+        // (750*4 + 100*1) / 5 = 620 — weighted by runs.
+        assert!((t.avg_duration_ms - 620.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn totals_with_nothing_resolved_has_no_cost_per_resolved() {
+        let mut a = row("anthropic", "claude-fable-5");
+        a.resolved = 0;
+        a.cost_per_resolved_usd = None;
+        let t = totals(&[a]);
+        assert_eq!(t.cost_per_resolved_usd, None);
+    }
+
+    #[test]
+    fn table_aligns_columns_and_appends_total() {
+        let out = render_table(&[row("zai", "glm-5.2"), row("local", "llama-3.3")]);
+        let lines: Vec<&str> = out.lines().collect();
+        // header + 2 rows + rule + TOTAL
+        assert_eq!(lines.len(), 5);
+        assert!(lines[0].starts_with("PROVIDER"));
+        assert!(lines[1].contains("50.0%"));
+        assert!(lines[1].contains("0.0300"));
+        assert!(lines[1].contains("0.0150"));
+        assert!(lines[2].contains("off-grid"));
+        assert!(lines[3].chars().all(|c| c == '-'));
+        assert!(lines[4].starts_with("TOTAL"));
+        // Every RATE cell ends at the same column — alignment witness.
+        let col = lines[0].find("RATE").unwrap() + "RATE".len();
+        assert!(lines[1][..col].ends_with("50.0%"));
+        assert!(lines[2][..col].ends_with("50.0%"));
+    }
+}

--- a/stella-store/Cargo.toml
+++ b/stella-store/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
 duckdb = { version = "1.3", features = ["bundled"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -38,6 +38,7 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use duckdb::{Connection, params};
+use serde::Serialize;
 use stella_protocol::AgentEvent;
 
 /// Wrapper error: everything the store can fail with, rendered.
@@ -75,6 +76,51 @@ pub struct TelemetryRow {
     pub duration_ms: u64,
     pub retries: u32,
     pub tool_calls: u64,
+}
+
+/// One aggregated analytics row per (provider, model): the numbers behind
+/// "$-per-resolved-task" receipts, straight from local telemetry.
+///
+/// Field order is the serialization contract for `stella stats --format
+/// json|csv` — append new fields at the end, never reorder.
+///
+/// `division` is the Arena division *derivable from stored data alone*:
+/// provider `local` runs are provably Off-grid (`"off-grid"`); every other
+/// provider gets `"-"`. Heavyweight/Featherweight are claims about model
+/// class and per-task caps that the store does not record, so they are
+/// never inferred here.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct UsageStatsRow {
+    pub provider: String,
+    pub model: String,
+    /// Arena division: `"off-grid"` for provider `local`, else `"-"`.
+    pub division: String,
+    /// Executions recorded (any outcome, including still-open ones).
+    pub runs: i64,
+    /// Executions with outcome `completed` — the "resolved" count.
+    pub resolved: i64,
+    /// `resolved / runs` (a group always has ≥ 1 run).
+    pub resolve_rate: f64,
+    /// Sum of `executions.cost_usd` — the authoritative per-run total.
+    pub total_cost_usd: f64,
+    /// `total_cost_usd / resolved`; `None` when nothing resolved — a
+    /// division by zero is never papered over with a fake number.
+    pub cost_per_resolved_usd: Option<f64>,
+    /// Token sums from `telemetry` (zero when a run recorded none).
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    /// Mean model-call wall time per run: `sum(duration_ms) / runs`.
+    pub avg_duration_ms: f64,
+}
+
+impl UsageStatsRow {
+    /// Arena division derivable from the provider id alone (see the struct
+    /// docs for why only Off-grid is ever inferred).
+    pub fn division_for_provider(provider: &str) -> &'static str {
+        if provider == "local" { "off-grid" } else { "-" }
+    }
 }
 
 pub struct Store {
@@ -350,6 +396,88 @@ impl Store {
                 })?;
         Ok(count)
     }
+
+    /// Aggregate usage/cost analytics per (provider, model) — the data
+    /// behind `stella stats` and every Arena "$-per-resolved-task" receipt.
+    ///
+    /// Semantics:
+    /// - One output row per distinct `executions.(provider, model)` pair;
+    ///   telemetry is attributed to its execution's provider/model.
+    /// - `runs` counts every execution; `resolved` counts
+    ///   `outcome = 'completed'` (aborted and still-open runs are not
+    ///   resolved).
+    /// - Cost comes from `executions.cost_usd` (the per-run total written
+    ///   at finish); token and duration sums come from `telemetry`,
+    ///   pre-aggregated per execution before the join so a multi-step run
+    ///   can never fan out the executions side.
+    /// - `cost_per_resolved_usd` is `None` when `resolved = 0`.
+    /// - Rows are ordered by total cost descending (ties broken by
+    ///   provider, then model, so output is deterministic).
+    ///
+    /// Division mapping: only provider `local` maps to an Arena division
+    /// (`off-grid`); all other rows carry `"-"` — see [`UsageStatsRow`].
+    pub fn usage_stats(&self) -> Result<Vec<UsageStatsRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT e.provider,
+                    e.model,
+                    count(*) AS runs,
+                    count(*) FILTER (WHERE e.outcome = 'completed') AS resolved,
+                    coalesce(sum(e.cost_usd), 0) AS total_cost_usd,
+                    CAST(coalesce(sum(t.input_tokens), 0) AS BIGINT) AS input_tokens,
+                    CAST(coalesce(sum(t.output_tokens), 0) AS BIGINT) AS output_tokens,
+                    CAST(coalesce(sum(t.cache_read_tokens), 0) AS BIGINT) AS cache_read_tokens,
+                    CAST(coalesce(sum(t.cache_write_tokens), 0) AS BIGINT) AS cache_write_tokens,
+                    CAST(coalesce(sum(t.duration_ms), 0) AS BIGINT) AS total_duration_ms
+             FROM executions e
+             LEFT JOIN (
+               SELECT execution_id,
+                      sum(input_tokens) AS input_tokens,
+                      sum(output_tokens) AS output_tokens,
+                      sum(cache_read_tokens) AS cache_read_tokens,
+                      sum(cache_write_tokens) AS cache_write_tokens,
+                      sum(duration_ms) AS duration_ms
+               FROM telemetry
+               GROUP BY execution_id
+             ) t ON t.execution_id = e.id
+             GROUP BY e.provider, e.model
+             ORDER BY total_cost_usd DESC, e.provider ASC, e.model ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let provider: String = row.get(0)?;
+            let model: String = row.get(1)?;
+            let runs: i64 = row.get(2)?;
+            let resolved: i64 = row.get(3)?;
+            let total_cost_usd: f64 = row.get(4)?;
+            let input_tokens: i64 = row.get(5)?;
+            let output_tokens: i64 = row.get(6)?;
+            let cache_read_tokens: i64 = row.get(7)?;
+            let cache_write_tokens: i64 = row.get(8)?;
+            let total_duration_ms: i64 = row.get(9)?;
+            let division = UsageStatsRow::division_for_provider(&provider).to_string();
+            Ok(UsageStatsRow {
+                provider,
+                model,
+                division,
+                runs,
+                resolved,
+                // A GROUP BY group always holds ≥ 1 execution row.
+                resolve_rate: resolved as f64 / runs as f64,
+                total_cost_usd,
+                cost_per_resolved_usd: (resolved > 0).then(|| total_cost_usd / resolved as f64),
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
+                avg_duration_ms: total_duration_ms as f64 / runs as f64,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
 }
 
 #[cfg(test)]
@@ -451,6 +579,189 @@ mod tests {
             "upsert, not duplicate"
         );
         assert_eq!(store.count("graph_edges").unwrap(), 1);
+    }
+
+    /// Test-only shorthand: a telemetry row with just the analytics-relevant
+    /// fields set.
+    fn telemetry(
+        step: u64,
+        provider: &str,
+        model: &str,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        cache_write: u64,
+        cost: f64,
+        duration_ms: u64,
+    ) -> TelemetryRow {
+        TelemetryRow {
+            step,
+            provider: provider.into(),
+            model: model.into(),
+            input_tokens: input,
+            output_tokens: output,
+            cache_read_tokens: cache_read,
+            cache_miss_tokens: input.saturating_sub(cache_read),
+            cache_write_tokens: cache_write,
+            cost_usd: cost,
+            duration_ms,
+            retries: 0,
+            tool_calls: 0,
+        }
+    }
+
+    /// Fixture: three providers with mixed outcomes.
+    /// - anthropic: 1 aborted run, cost 0.05 → resolved = 0.
+    /// - zai: 2 completed (0.02 + 0.01), 1 aborted, 1 never finished.
+    /// - local: 1 completed at $0 → the Off-grid division.
+    fn seeded_store() -> Store {
+        let store = Store::in_memory().unwrap();
+
+        let a = store
+            .begin_execution("run", "p1", "anthropic", "claude-fable-5")
+            .unwrap();
+        store.finish_execution(a, "aborted", 0.05).unwrap();
+
+        let z1 = store
+            .begin_execution("run", "p2", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_telemetry(
+                z1,
+                &telemetry(0, "zai", "glm-5.2", 1000, 100, 500, 10, 0.01, 1000),
+            )
+            .unwrap();
+        store
+            .record_telemetry(
+                z1,
+                &telemetry(1, "zai", "glm-5.2", 2000, 200, 500, 0, 0.01, 500),
+            )
+            .unwrap();
+        store.finish_execution(z1, "completed", 0.02).unwrap();
+
+        let z2 = store
+            .begin_execution("run", "p3", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_telemetry(
+                z2,
+                &telemetry(0, "zai", "glm-5.2", 3000, 300, 1000, 0, 0.01, 1500),
+            )
+            .unwrap();
+        store.finish_execution(z2, "completed", 0.01).unwrap();
+
+        // Aborted with no telemetry (LEFT JOIN's zero path) and a run that
+        // never finished (outcome NULL) — both count as runs, not resolved.
+        let z3 = store
+            .begin_execution("run", "p4", "zai", "glm-5.2")
+            .unwrap();
+        store.finish_execution(z3, "aborted", 0.0).unwrap();
+        store
+            .begin_execution("run", "p5", "zai", "glm-5.2")
+            .unwrap();
+
+        let l = store
+            .begin_execution("run", "p6", "local", "llama-3.3")
+            .unwrap();
+        store
+            .record_telemetry(
+                l,
+                &telemetry(0, "local", "llama-3.3", 500, 50, 0, 0, 0.0, 2000),
+            )
+            .unwrap();
+        store.finish_execution(l, "completed", 0.0).unwrap();
+
+        store
+    }
+
+    #[test]
+    fn usage_stats_aggregates_per_provider_model() {
+        let store = seeded_store();
+        let rows = store.usage_stats().unwrap();
+        assert_eq!(rows.len(), 3);
+
+        // Ordered by total cost desc: anthropic 0.05, zai 0.03, local 0.0.
+        assert_eq!(
+            rows.iter().map(|r| r.provider.as_str()).collect::<Vec<_>>(),
+            ["anthropic", "zai", "local"]
+        );
+
+        let zai = &rows[1];
+        assert_eq!(zai.model, "glm-5.2");
+        assert_eq!(zai.division, "-");
+        assert_eq!(zai.runs, 4);
+        assert_eq!(zai.resolved, 2);
+        assert!((zai.resolve_rate - 0.5).abs() < 1e-12);
+        assert!((zai.total_cost_usd - 0.03).abs() < 1e-12);
+        assert!((zai.cost_per_resolved_usd.unwrap() - 0.015).abs() < 1e-12);
+        assert_eq!(zai.input_tokens, 6000);
+        assert_eq!(zai.output_tokens, 600);
+        assert_eq!(zai.cache_read_tokens, 2000);
+        assert_eq!(zai.cache_write_tokens, 10);
+        assert!((zai.avg_duration_ms - 750.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn usage_stats_never_divides_by_zero_resolved() {
+        let store = seeded_store();
+        let rows = store.usage_stats().unwrap();
+        let anthropic = &rows[0];
+        assert_eq!(anthropic.runs, 1);
+        assert_eq!(anthropic.resolved, 0);
+        assert_eq!(anthropic.resolve_rate, 0.0);
+        assert!((anthropic.total_cost_usd - 0.05).abs() < 1e-12);
+        assert_eq!(
+            anthropic.cost_per_resolved_usd, None,
+            "resolved = 0 must yield None, never a fake number"
+        );
+        // No telemetry rows at all → token/duration sums are zero.
+        assert_eq!(anthropic.input_tokens, 0);
+        assert_eq!(anthropic.avg_duration_ms, 0.0);
+    }
+
+    #[test]
+    fn usage_stats_maps_local_provider_to_off_grid_division() {
+        let store = seeded_store();
+        let rows = store.usage_stats().unwrap();
+        let local = &rows[2];
+        assert_eq!(local.provider, "local");
+        assert_eq!(local.division, "off-grid");
+        assert_eq!(local.resolve_rate, 1.0);
+        assert_eq!(local.cost_per_resolved_usd, Some(0.0));
+        assert_eq!(UsageStatsRow::division_for_provider("local"), "off-grid");
+        assert_eq!(UsageStatsRow::division_for_provider("anthropic"), "-");
+        assert_eq!(UsageStatsRow::division_for_provider("openrouter"), "-");
+    }
+
+    #[test]
+    fn usage_stats_empty_store_returns_no_rows() {
+        let store = Store::in_memory().unwrap();
+        assert!(store.usage_stats().unwrap().is_empty());
+    }
+
+    #[test]
+    fn usage_stats_row_serializes_with_stable_field_order() {
+        let row = UsageStatsRow {
+            provider: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            division: "-".into(),
+            runs: 1,
+            resolved: 0,
+            resolve_rate: 0.0,
+            total_cost_usd: 0.05,
+            cost_per_resolved_usd: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            avg_duration_ms: 0.0,
+        };
+        // Exact string: field ORDER is the machine contract for json/csv
+        // receipts, and resolved = 0 must serialize as null (not 0 or NaN).
+        assert_eq!(
+            serde_json::to_string(&row).unwrap(),
+            r#"{"provider":"anthropic","model":"claude-fable-5","division":"-","runs":1,"resolved":0,"resolve_rate":0.0,"total_cost_usd":0.05,"cost_per_resolved_usd":null,"input_tokens":0,"output_tokens":0,"cache_read_tokens":0,"cache_write_tokens":0,"avg_duration_ms":0.0}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
…command

Closes #22. Every execution's tokens/cost/outcome already lands in local DuckDB; this makes the numbers behind Arena claims first-class:

- Store::usage_stats aggregates per (provider, model): runs, resolved (outcome = 'completed'), resolve rate, total cost (executions), input/output/cache tokens and duration (telemetry, pre-aggregated per execution before the join so multi-step runs can't fan out), and cost_per_resolved_usd — None when resolved = 0, never a faked number. Ordered by cost desc with deterministic tie-breaks. Provider "local" maps to the Arena "off-grid" division; other rows carry "-" (the schema records no model-class divisions, so none are invented).
- stella stats [--format table|json|csv] [--provider <id>] prints the receipt-ready summary from local telemetry with zero API keys needed; CSV is manually quoted (no new dependency), JSON uses serde with stable field order.

Witness tests: aggregation across two providers with mixed outcomes, the resolved=0 division guard, off-grid mapping, empty store, and serialization field-order stability.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-provider/model usage and cost analytics to `stella-store` and a new `stella stats` CLI for receipt-ready summaries from local telemetry. Closes #22 and enables $/resolved-task reporting without API keys.

- **New Features**
  - `Store::usage_stats` aggregates per (provider, model): runs, resolved (completed), resolve rate, total cost, token sums (input/output/cache), and avg duration; computes $/resolved only when resolved > 0; orders by cost desc with provider/model tie-breaks; maps provider `local` to division "off-grid" (others `"-"`); pre-aggregates telemetry per execution to avoid fan-out.
  - `stella stats [--format table|json|csv] [--provider <id>]` reads `.stella/stella.duckdb` without creating it; table adds a weighted TOTAL row; JSON/CSV use stable field order; CSV uses RFC-4180 quoting; helpful empty output for no data.

- **Dependencies**
  - Added `serde` to `stella-store` for stable JSON serialization.

<sup>Written for commit 1a89a5bd8ff1f5b578dd04f3a13df02c17dc05bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
