### PR TITLE
test(stella-graph): deterministic live-index coverage via injected wa…

### DIFF
--- a/stella-graph/Cargo.toml
+++ b/stella-graph/Cargo.toml
@@ -26,3 +26,7 @@ tree-sitter-javascript.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# `test-util` enables tokio's paused clock (`start_paused`), which makes the
+# live-index pipeline tests deterministic: the debounce window auto-advances
+# only while every task is idle, so a burst can never be split by scheduling.
+tokio = { workspace = true, features = ["test-util"] }

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -159,6 +159,20 @@ impl CodeGraph {
         &self.inner.root
     }
 
+    /// Test seam: start the live-index pipeline (debounce → transactional
+    /// apply) **without** an OS filesystem watcher, returning a
+    /// [`crate::WatchInjector`] that feeds synthetic events straight into the
+    /// pipeline channel. Deterministic live-index tests write real files into
+    /// the workspace, inject the paths, and await the injector's applied-batch
+    /// signal — no dependence on OS event delivery timing.
+    ///
+    /// Hidden from docs: test-facing only, `pub` so integration tests in
+    /// `tests/` can reach it. Must be called from within a tokio runtime.
+    #[doc(hidden)]
+    pub fn watch_pipeline_for_tests(&self, debounce: std::time::Duration) -> watch::WatchInjector {
+        watch::spawn_injectable(self.inner.clone(), debounce)
+    }
+
     /// Run a full incremental index pass now (walk, re-parse only changed
     /// files, prune deleted). One transaction (L-L1). Synchronous — callers
     /// in an async context should wrap it in `spawn_blocking`.

--- a/stella-graph/src/lib.rs
+++ b/stella-graph/src/lib.rs
@@ -59,6 +59,8 @@ pub use import::{ImportEdge, ImportKind};
 pub use lang::Language;
 pub use store::IndexStats;
 pub use symbol::{Symbol, SymbolKind};
+#[doc(hidden)]
+pub use watch::WatchInjector;
 
 // Re-export the OCP wire types this provider produces so downstream callers
 // need not also depend on `ocp-types` directly for the return shapes.

--- a/stella-graph/src/watch.rs
+++ b/stella-graph/src/watch.rs
@@ -7,9 +7,19 @@
 //! The watcher only *feeds paths*; the actual re-index is one transactional
 //! [`crate::store::apply_changes`] batch (L-L1), run on the blocking pool so
 //! it never stalls async workers.
+//!
+//! # Structure: event source vs. pipeline
+//!
+//! Event *delivery* (the `notify` OS watcher) is deliberately decoupled from
+//! the *pipeline* (channel → debounce → transactional apply). [`spawn`] wires
+//! the real watcher to [`start_pipeline`]; tests drive the identical pipeline
+//! through a [`WatchInjector`] instead, so live-index behavior is covered
+//! without depending on OS event timing (FSEvents coalescing, inotify
+//! batching). Both entry points share [`is_watch_relevant`], so the
+//! language/ignore filtering under test is the production filter.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -20,11 +30,46 @@ use tokio::sync::mpsc;
 use crate::error::GraphError;
 use crate::graph::Inner;
 use crate::lang::Language;
+use crate::store::IndexStats;
 use crate::walk;
 
 /// Debounce window: filesystem bursts within this interval coalesce into one
 /// re-index batch.
 pub(crate) const DEBOUNCE: Duration = Duration::from_millis(200);
+
+/// Failsafe bound on [`WatchInjector::applied_past`]. Assertions never depend
+/// on it — it only turns a wedged pipeline into a fast test failure instead
+/// of a hang (and under a paused tokio clock it is skipped instantly).
+const APPLIED_FAILSAFE: Duration = Duration::from_secs(60);
+
+/// The applied-batch feed: a monotonically increasing batch sequence number
+/// plus the stats of the most recently applied batch.
+type BatchTick = (u64, IndexStats);
+
+/// Whether a watcher-delivered path is worth re-indexing: a source file we
+/// recognize, not inside an ignored directory. The single relevance filter
+/// shared by the real `notify` callback and [`WatchInjector::inject`].
+fn is_watch_relevant(root: &Path, path: &Path) -> bool {
+    Language::from_path(path).is_some() && !walk::rel_is_ignored(root, path)
+}
+
+/// Spawn the consumption side of live indexing: an unbounded path channel
+/// whose receiver runs [`debounce_loop`]. Returns the sender that feeds it
+/// and a receiver of [`BatchTick`]s, published after every applied batch —
+/// the deterministic completion signal (no wall-clock polling).
+fn start_pipeline(
+    inner: Arc<Inner>,
+    debounce: Duration,
+) -> (
+    mpsc::UnboundedSender<PathBuf>,
+    tokio::sync::watch::Receiver<BatchTick>,
+) {
+    let (tx, rx) = mpsc::unbounded_channel::<PathBuf>();
+    let (tick_tx, tick_rx) = tokio::sync::watch::channel((0, IndexStats::default()));
+    let handle = tokio::spawn(debounce_loop(inner.clone(), rx, debounce, tick_tx));
+    inner.push_task(handle);
+    (tx, tick_rx)
+}
 
 /// Arm a recursive watcher on the workspace root and spawn the debounce loop.
 /// Returns the watcher handle, which the caller must keep alive — dropping it
@@ -36,7 +81,11 @@ pub(crate) fn spawn(
     debounce: Duration,
 ) -> Result<RecommendedWatcher, GraphError> {
     let root = inner.root.clone();
-    let (tx, rx) = mpsc::unbounded_channel::<PathBuf>();
+    // The tick receiver is dropped: production has no consumer for the
+    // completion signal (the loop publishes via `send_modify`, which never
+    // fails without receivers). If watcher creation fails below, `tx` is
+    // dropped with the closure and the pipeline task exits on channel close.
+    let (tx, _ticks) = start_pipeline(inner, debounce);
 
     let event_root = root.clone();
     let mut watcher = notify::recommended_watcher(move |result: notify::Result<Event>| {
@@ -45,7 +94,7 @@ pub(crate) fn spawn(
         };
         for path in event.paths {
             // Only source files we index, and never inside ignored dirs.
-            if Language::from_path(&path).is_some() && !walk::rel_is_ignored(&event_root, &path) {
+            if is_watch_relevant(&event_root, &path) {
                 let _ = tx.send(path);
             }
         }
@@ -56,18 +105,68 @@ pub(crate) fn spawn(
         .watch(&root, RecursiveMode::Recursive)
         .map_err(|e| GraphError::Watch(e.to_string()))?;
 
-    let handle = tokio::spawn(debounce_loop(inner.clone(), rx, debounce));
-    inner.push_task(handle);
-
     Ok(watcher)
 }
 
-/// Collect a burst of changed paths, then apply them in one batch. Exits when
-/// the channel closes (watcher dropped) or shutdown is requested.
+/// Start the live-index pipeline **without** an OS watcher and return the
+/// injector that stands in for it. See [`WatchInjector`]. Must be called from
+/// within a tokio runtime, like [`spawn`].
+pub(crate) fn spawn_injectable(inner: Arc<Inner>, debounce: Duration) -> WatchInjector {
+    let root = inner.root.clone();
+    let (tx, ticks) = start_pipeline(inner, debounce);
+    WatchInjector { root, tx, ticks }
+}
+
+/// Test seam: stands in for the OS watcher, feeding synthetic events into the
+/// **real** debounce → transactional-apply pipeline. Injection replaces event
+/// *delivery* only — injected paths are read from disk by
+/// [`crate::store::apply_changes`] exactly as in production, so tests write
+/// real files into the workspace and then inject their paths instead of
+/// waiting on environment-dependent fs-event timing.
+#[doc(hidden)]
+pub struct WatchInjector {
+    root: PathBuf,
+    tx: mpsc::UnboundedSender<PathBuf>,
+    ticks: tokio::sync::watch::Receiver<BatchTick>,
+}
+
+impl WatchInjector {
+    /// Inject `path` as if the OS watcher had delivered an event for it,
+    /// applying the same relevance filter as the real `notify` callback.
+    /// Returns whether the path passed the filter and was enqueued.
+    pub fn inject(&self, path: &Path) -> bool {
+        if !is_watch_relevant(&self.root, path) {
+            return false;
+        }
+        self.tx.send(path.to_path_buf()).is_ok()
+    }
+
+    /// Sequence number of the most recently applied batch (0 = none yet).
+    pub fn batches_applied(&self) -> u64 {
+        self.ticks.borrow().0
+    }
+
+    /// Wait until a batch with sequence number strictly greater than `seen`
+    /// has been applied; returns that batch's `(seq, stats)`. `None` means
+    /// the pipeline shut down or the failsafe elapsed — never a normal
+    /// outcome for a healthy pipeline.
+    pub async fn applied_past(&mut self, seen: u64) -> Option<BatchTick> {
+        let wait = self.ticks.wait_for(|(seq, _)| *seq > seen);
+        match tokio::time::timeout(APPLIED_FAILSAFE, wait).await {
+            Ok(Ok(tick)) => Some(tick.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Collect a burst of changed paths, then apply them in one batch and publish
+/// a [`BatchTick`]. Exits when the channel closes (watcher or injector
+/// dropped) or shutdown is requested.
 async fn debounce_loop(
     inner: Arc<Inner>,
     mut rx: mpsc::UnboundedReceiver<PathBuf>,
     debounce: Duration,
+    ticks: tokio::sync::watch::Sender<BatchTick>,
 ) {
     loop {
         let first = match rx.recv().await {
@@ -95,7 +194,18 @@ async fn debounce_loop(
         let paths: Vec<PathBuf> = pending.into_iter().collect();
         let batch_inner = inner.clone();
         // SQLite work is blocking + CPU-bound (re-parse) → off the async pool.
-        let _ =
+        let outcome =
             tokio::task::spawn_blocking(move || batch_inner.apply_changes_blocking(&paths)).await;
+        // A tick means "batch attempt finished", success or not (L-L1: one
+        // bad batch must not wedge consumers awaiting the signal). Failures
+        // publish default stats.
+        let stats = match outcome {
+            Ok(Ok(stats)) => stats,
+            _ => IndexStats::default(),
+        };
+        ticks.send_modify(|(seq, last)| {
+            *seq += 1;
+            *last = stats;
+        });
     }
 }

--- a/stella-graph/tests/live_index.rs
+++ b/stella-graph/tests/live_index.rs
@@ -1,0 +1,237 @@
+//! Deterministic live-indexing coverage: drives the REAL debounce →
+//! `apply_changes` pipeline by injecting paths directly into the watch
+//! channel (`CodeGraph::watch_pipeline_for_tests`), replacing OS event
+//! *delivery* only — every injected path is a real file (or a real deletion)
+//! in the tempdir workspace, read from disk by the production code path.
+//!
+//! Two things make these tests timing-independent:
+//!
+//! 1. `#[tokio::test(start_paused = true)]`: tokio's paused clock only
+//!    auto-advances while **every** task is idle, so the debounce window can
+//!    never elapse between two consecutive `inject` calls — a burst cannot be
+//!    split by scheduling, and no wall-clock time is spent waiting it out.
+//! 2. The injector's applied-batch signal (`applied_past`): assertions run
+//!    after an awaited completion event, never after a sleep/poll. Its
+//!    internal timeout is a failsafe against a wedged pipeline, not something
+//!    any assertion depends on.
+//!
+//! The real-FS smoke test (notify watcher end to end) stays in `watcher.rs`,
+//! opt-in via `--ignored`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use stella_graph::{CodeGraph, WatchInjector};
+use tempfile::TempDir;
+
+/// A fixture workspace + store (db kept in a separate tempdir so it is never
+/// indexed), opened and fully indexed synchronously, with the live pipeline
+/// running and an injector standing in for the OS watcher.
+struct Live {
+    _ws: TempDir,
+    _dbdir: TempDir,
+    /// Canonicalized workspace root — the same form the real watcher's
+    /// events use (it watches `graph.root()`, so e.g. on macOS events carry
+    /// `/private/var/...`, not the tempdir's `/var/...` alias).
+    root: PathBuf,
+    graph: CodeGraph,
+    injector: WatchInjector,
+}
+
+impl Live {
+    fn build(files: &[(&str, &str)]) -> Live {
+        let ws = TempDir::new().unwrap();
+        let dbdir = TempDir::new().unwrap();
+        for (rel, content) in files {
+            let path = ws.path().join(rel);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, content).unwrap();
+        }
+        let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+        graph.index_all().unwrap();
+        // Production debounce width: free under the paused clock.
+        let injector = graph.watch_pipeline_for_tests(Duration::from_millis(200));
+        Live {
+            _ws: ws,
+            _dbdir: dbdir,
+            root: graph.root().to_path_buf(),
+            graph,
+            injector,
+        }
+    }
+
+    /// Absolute path of a workspace-relative file, in canonical root form.
+    fn abs(&self, rel: &str) -> PathBuf {
+        self.root.join(rel)
+    }
+
+    fn write(&self, rel: &str, content: &str) -> PathBuf {
+        let path = self.abs(rel);
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn has_def(&self, name: &str) -> bool {
+        !self.graph.definitions(name).unwrap().is_empty()
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn injected_create_indexes_new_file() {
+    let mut fx = Live::build(&[("a.rs", "pub fn alpha() {}\n")]);
+    assert_eq!(fx.graph.file_count().unwrap(), 1);
+
+    let new = fx.write("b.rs", "pub struct Fresh;\n");
+    assert!(fx.injector.inject(&new));
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(stats.files_parsed, 1);
+
+    assert_eq!(fx.graph.file_count().unwrap(), 2);
+    let defs = fx.graph.definitions("Fresh").unwrap();
+    assert!(!defs.is_empty(), "new file's symbols should be visible");
+    // The live-indexed symbol carries the same citation label a full index
+    // would produce.
+    assert!(
+        defs[0]
+            .citation_label
+            .as_deref()
+            .unwrap()
+            .starts_with("struct Fresh (")
+    );
+
+    fx.graph.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn injected_modify_replaces_symbols() {
+    let mut fx = Live::build(&[("a.rs", "pub fn old_sym() {}\n")]);
+    assert!(fx.has_def("old_sym"));
+
+    let path = fx.write("a.rs", "pub fn new_sym() {}\n");
+    assert!(fx.injector.inject(&path));
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(stats.files_parsed, 1);
+
+    assert!(
+        !fx.has_def("old_sym"),
+        "stale symbols must be replaced, not accumulated"
+    );
+    assert!(fx.has_def("new_sym"));
+    assert_eq!(fx.graph.file_count().unwrap(), 1, "same file, re-indexed");
+
+    fx.graph.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn sha_identical_write_is_skipped() {
+    let content = "pub fn stable() {}\n";
+    let mut fx = Live::build(&[("a.rs", content)]);
+
+    // Byte-identical rewrite: the batch runs, but the parse is skipped (L-C2).
+    let path = fx.write("a.rs", content);
+    assert!(fx.injector.inject(&path));
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(stats.files_skipped_unchanged, 1);
+    assert_eq!(
+        stats.files_parsed, 0,
+        "identical content is never re-parsed"
+    );
+
+    // And the graph is untouched, not wrongly pruned or duplicated.
+    assert_eq!(fx.graph.definitions("stable").unwrap().len(), 1);
+
+    fx.graph.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn injected_delete_prunes_file_and_symbols() {
+    let mut fx = Live::build(&[
+        ("keep.rs", "pub fn kept() {}\n"),
+        ("gone.rs", "pub struct Doomed;\npub fn doomed_fn() {}\n"),
+    ]);
+    assert_eq!(fx.graph.file_count().unwrap(), 2);
+
+    let path = fx.abs("gone.rs");
+    fs::remove_file(&path).unwrap();
+    assert!(fx.injector.inject(&path));
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(stats.files_pruned, 1);
+
+    assert_eq!(fx.graph.file_count().unwrap(), 1);
+    // Symbol rows go with the file row (ON DELETE CASCADE).
+    assert!(!fx.has_def("Doomed"));
+    assert!(!fx.has_def("doomed_fn"));
+    assert!(fx.has_def("kept"), "unrelated files stay indexed");
+
+    fx.graph.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn burst_applies_as_one_batch() {
+    let mut fx = Live::build(&[("a.rs", "pub fn alpha() {}\n")]);
+
+    // A save-storm: two new files plus a deletion, all injected within one
+    // debounce window (guaranteed: the paused clock cannot advance while the
+    // test task is still running between injections).
+    let b = fx.write("b.rs", "pub fn beta() {}\n");
+    let c = fx.write("c.rs", "pub fn gamma() {}\n");
+    let a = fx.abs("a.rs");
+    fs::remove_file(&a).unwrap();
+    assert!(fx.injector.inject(&b));
+    assert!(fx.injector.inject(&c));
+    assert!(fx.injector.inject(&a));
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1, "the whole burst must coalesce into a single batch");
+    assert_eq!(fx.injector.batches_applied(), 1);
+    assert_eq!(stats.files_parsed, 2);
+    assert_eq!(stats.files_pruned, 1);
+
+    assert!(fx.has_def("beta"));
+    assert!(fx.has_def("gamma"));
+    assert!(!fx.has_def("alpha"));
+    assert_eq!(fx.graph.file_count().unwrap(), 2);
+
+    // A change injected *after* the batch signal starts a new batch.
+    let d = fx.write("d.rs", "pub fn delta() {}\n");
+    assert!(fx.injector.inject(&d));
+    let (seq, _) = fx.injector.applied_past(1).await.unwrap();
+    assert_eq!(seq, 2);
+    assert!(fx.has_def("delta"));
+
+    fx.graph.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn irrelevant_paths_are_filtered_at_injection() {
+    let fx = Live::build(&[("a.rs", "pub fn alpha() {}\n")]);
+
+    // Same filter as the real notify callback: non-source extensions,
+    // ignored directories, and paths outside the workspace root never enter
+    // the pipeline.
+    let readme = fx.write("README.md", "# not source\n");
+    assert!(!fx.injector.inject(&readme));
+
+    fs::create_dir_all(fx.abs("node_modules")).unwrap();
+    let vendored = fx.write("node_modules/dep.js", "export const x = 1;\n");
+    assert!(!fx.injector.inject(&vendored));
+
+    let outside = std::env::temp_dir().join("stella-live-index-outside.rs");
+    assert!(!fx.injector.inject(&outside));
+
+    assert_eq!(fx.injector.batches_applied(), 0, "nothing was enqueued");
+    assert_eq!(fx.graph.file_count().unwrap(), 1);
+
+    fx.graph.shutdown();
+}

--- a/stella-graph/tests/watcher.rs
+++ b/stella-graph/tests/watcher.rs
@@ -1,11 +1,14 @@
-//! Watcher smoke test — mount, then create a file and see it indexed live.
+//! Watcher smoke test — mount, then create a file and see it indexed live
+//! through the real OS event source (`notify`).
 //!
-//! `#[ignore]`d by default: filesystem-event delivery timing is
+//! `#[ignore]`d by default: filesystem-event *delivery* timing is
 //! environment-dependent (CI containers, network filesystems, and macOS
-//! FSEvents coalescing all vary), so this would be a flaky gate. The
-//! *deterministic* guarantees — catch-up at mount and transactional
-//! re-index — are covered by `store.rs` and `languages.rs`. Run it locally
-//! with `cargo test -p stella-graph -- --ignored`.
+//! FSEvents coalescing all vary), so this would be a flaky gate. It stays as
+//! an opt-in end-to-end smoke of the `notify` wiring only — the live-index
+//! pipeline itself (debounce → transactional apply, add/modify/delete,
+//! batching) is covered deterministically in `live_index.rs` by injecting
+//! events below the OS watcher. Run this one locally with
+//! `cargo test -p stella-graph -- --ignored`.
 
 use std::fs;
 use std::time::{Duration, Instant};
@@ -25,7 +28,7 @@ async fn poll_until(deadline: Duration, mut cond: impl FnMut() -> bool) -> bool 
 }
 
 #[tokio::test]
-#[ignore = "fs-event timing is environment-dependent; deterministic paths are covered elsewhere"]
+#[ignore = "real fs-event delivery is environment-dependent; deterministic live-index coverage lives in live_index.rs"]
 async fn watcher_indexes_a_newly_created_file() {
     let ws = TempDir::new().unwrap();
     let dbdir = TempDir::new().unwrap();


### PR DESCRIPTION
…tch events

Closes #20. The live-index pipeline (channel -> debounce -> transactional apply_changes) is decoupled from OS event delivery: spawn wires the notify watcher to the same start_pipeline a new test-only WatchInjector drives directly, sharing the production relevance filter (language + ignore rules). The pipeline publishes an applied-batch sequence + IndexStats tick after every batch — a deterministic completion signal, so tests await an event instead of polling wall-clock time; tokio's paused clock (start_paused) guarantees a burst can never be split by the debounce window.

New tests/live_index.rs covers: create indexes a new file (symbols + citation labels), modify replaces stale symbols, SHA-identical writes are never re-parsed (L-C2), delete prunes file + symbols via cascade, and a save-storm burst coalesces into exactly one batch. Verified 10/10 consecutive runs at ~0.12s each. The real-FS notify smoke test stays opt-in (--ignored) as an end-to-end wiring check only.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make live indexing deterministic and testable by decoupling the debounce → apply pipeline from OS events and emitting completion ticks. Adds a test-only `WatchInjector` to drive the same pipeline directly and covers create/modify/delete and burst coalescing; closes #20.

- **Refactors**
  - Split event delivery from the pipeline via `start_pipeline` (channel → debounce → transactional `apply_changes`).
  - Share one relevance filter (`is_watch_relevant`) for both `notify` and injected events.
  - Publish a batch tick after every apply (monotonic seq + `IndexStats`); `spawn` now feeds this pipeline.

- **New Features**
  - Expose `CodeGraph::watch_pipeline_for_tests` and doc-hidden `stella-graph::WatchInjector` to inject paths and await batch completion.
  - Add deterministic tests in `tests/live_index.rs` using tokio’s paused clock: create, modify, identical-write skip, delete, and burst coalescing. Real `notify` smoke test stays `--ignored`.
  - Dev-only dependency: `tokio` with `test-util` for `start_paused`.

<sup>Written for commit 1c0eeb4f35ac099eed8e49948535883cc578c977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
