### PR TITLE
feat(stella-tools): manifest validation API + stella tools --validate

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -28,6 +28,7 @@ use stella_protocol::{AgentEvent, CompletionMessage, ModelRef, Role, ToolOutput}
 use stella_store::{Store, TelemetryRow};
 use stella_tools::ToolRegistry;
 use stella_tools::custom::{self, CustomTool, CustomToolSet};
+use stella_tools::validate;
 use tokio::sync::mpsc;
 
 use crate::OutputFormat;
@@ -643,6 +644,12 @@ fn discover_custom_tools(cfg: &Config, print_diagnostics: bool) -> Vec<CustomToo
                 diagnostic.reason
             );
         }
+        if !report.diagnostics.is_empty() {
+            eprintln!(
+                "  {}",
+                "run `stella tools --validate` to check every custom tool manifest".dimmed()
+            );
+        }
     }
     report.tools
 }
@@ -724,6 +731,92 @@ pub fn run_tools_listing() -> Result<(), String> {
             .dimmed()
     );
     Ok(())
+}
+
+/// `stella tools --validate [DIR]` — the strict pre-flight for custom tool
+/// manifests. Where discovery (and the plain listing above) stays lenient,
+/// this checks every `*.toml` in `dir` (or, by default, the same directories
+/// discovery scans) and reports errors, warnings, and infos per file — see
+/// `stella_tools::validate`. Returns `Err` when any manifest has errors, so
+/// the process exits non-zero and a broken manifest is caught *before* a run
+/// consumes model budget.
+pub fn run_tools_validation(dir: Option<&std::path::Path>) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    tui::section_header("Custom tool manifests — validation");
+
+    let report = match dir {
+        Some(dir) => {
+            if !dir.is_dir() {
+                return Err(format!(
+                    "`{}` is not a directory — pass a directory of *.toml manifests, or omit \
+                     the value to check .stella/tools/ and ~/.config/stella/tools/",
+                    dir.display()
+                ));
+            }
+            println!("  {} {}", "checking:".dimmed(), dir.display());
+            validate::validate_dir(dir, &workspace_root)
+        }
+        None => {
+            println!(
+                "  {} {}",
+                "checking:".dimmed(),
+                ".stella/tools/, ~/.config/stella/tools/".dimmed()
+            );
+            validate::validate_default(&workspace_root)
+        }
+    };
+
+    if report.manifests.is_empty() {
+        println!(
+            "  {}",
+            "no manifests found — drop a <name>.toml in .stella/tools/ to add a custom tool"
+                .dimmed()
+        );
+        return Ok(());
+    }
+
+    println!();
+    for manifest in &report.manifests {
+        let mark = if manifest.has_errors() {
+            "✗".red()
+        } else {
+            "✓".green()
+        };
+        let name = manifest
+            .name
+            .as_deref()
+            .map(|n| format!(" ({n})"))
+            .unwrap_or_default();
+        println!("  {mark} {}{}", manifest.path.display(), name.bright_blue());
+        for issue in &manifest.issues {
+            let (label, message) = match issue.severity {
+                validate::Severity::Error => ("error:".red().bold(), issue.message.red()),
+                validate::Severity::Warning => ("warning:".yellow().bold(), issue.message.normal()),
+                validate::Severity::Info => ("info:".dimmed(), issue.message.dimmed()),
+            };
+            println!("      {label} {message}");
+        }
+    }
+
+    let failed = report.manifests.iter().filter(|m| m.has_errors()).count();
+    let ok = report.manifests.len() - failed;
+    println!(
+        "\n  {} manifest(s) checked: {} ok, {} with errors, {} warning(s)",
+        report.manifests.len(),
+        ok,
+        failed,
+        report.warning_count()
+    );
+
+    if failed > 0 {
+        Err(format!(
+            "{failed} of {} custom tool manifest(s) failed validation",
+            report.manifests.len()
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 /// Construct the turn/session budget guard from `--budget`. No limit at

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -115,7 +115,16 @@ enum Command {
 
     /// List every tool available to the agent this session — built-ins,
     /// developer custom tools (.stella/tools/), and manifest diagnostics
-    Tools,
+    Tools {
+        /// Validate custom tool manifests instead of listing: parse every
+        /// <name>.toml, check names, required fields, timeouts, and
+        /// collisions with built-ins and other manifests, then exit
+        /// non-zero if any manifest has errors. Pass a directory to check
+        /// (defaults to the dirs discovery scans: .stella/tools/ and
+        /// ~/.config/stella/tools/).
+        #[arg(long, value_name = "DIR")]
+        validate: Option<Option<std::path::PathBuf>>,
+    },
 
     /// List configured providers and available models
     Models,
@@ -156,13 +165,18 @@ fn main() -> ExitCode {
 
 fn run(cli: Cli) -> Result<(), String> {
     // Models and Version don't need a configured provider/key.
-    match cli.command {
+    match &cli.command {
         Some(Command::Models) => {
             config::Config::print_available_models();
             return Ok(());
         }
-        Some(Command::Tools) => {
-            return agent::run_tools_listing();
+        Some(Command::Tools { validate }) => {
+            return match validate {
+                // `--validate` (dir optional) is the strict pre-flight path;
+                // a plain `stella tools` stays the lenient listing.
+                Some(dir) => agent::run_tools_validation(dir.as_deref()),
+                None => agent::run_tools_listing(),
+            };
         }
         Some(Command::Version) => {
             println!("stella v{}", env!("CARGO_PKG_VERSION"));
@@ -225,7 +239,7 @@ fn run(cli: Cli) -> Result<(), String> {
         // Models/Version (and Tools) short-circuit in the first match at the
         // top of `run` before a provider is resolved; Init is handled by the
         // caller. Reaching any of them here is impossible.
-        Command::Init | Command::Tools | Command::Models | Command::Version => {
+        Command::Init | Command::Tools { .. } | Command::Models | Command::Version => {
             unreachable!("handled before provider resolution")
         }
         Command::Config => {

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -123,10 +123,12 @@ pub const RESERVED_NAMES: &[&str] = &[
     "install_skill",
 ];
 
-/// Timeout applied when a manifest omits `timeout_ms`.
-const DEFAULT_TIMEOUT_MS: u64 = 30_000;
-/// Hard ceiling on `timeout_ms`; a manifest cannot ask for more.
-const MAX_TIMEOUT_MS: u64 = 600_000;
+/// Timeout applied when a manifest omits `timeout_ms`. Public so
+/// [`crate::validate`] can explain the defaulting it mirrors.
+pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+/// Hard ceiling on `timeout_ms`; a manifest cannot ask for more. Public so
+/// [`crate::validate`] can warn about the clamp it mirrors.
+pub const MAX_TIMEOUT_MS: u64 = 600_000;
 /// Byte cap on captured stdout/stderr before middle-out truncation kicks in.
 /// Matches [`crate::bash`] so custom and native exec behave the same.
 const MAX_OUTPUT_BYTES: usize = 100_000;

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -21,6 +21,7 @@ pub mod project;
 pub mod read;
 pub mod registry;
 pub mod screenshot;
+pub mod validate;
 pub mod verify;
 pub mod write;
 

--- a/stella-tools/src/validate.rs
+++ b/stella-tools/src/validate.rs
@@ -1,0 +1,713 @@
+//! `validate` — the **strict** counterpart to [`crate::custom`] discovery,
+//! backing `stella tools --validate`.
+//!
+//! Discovery ([`crate::custom::discover`]) is deliberately lenient: a broken
+//! manifest becomes a diagnostic and the session runs on, and a sloppy-but-
+//! loadable one is silently normalized (timeouts defaulted and clamped,
+//! duplicate names dropped). That is the right behavior mid-session, but it
+//! means a developer only learns about a mistake when a run fails after it
+//! has already consumed model budget.
+//!
+//! This module is the pre-flight check: it scans the same directories, reuses
+//! [`crate::custom::parse_manifest`]'s exact error messages, and additionally
+//! surfaces everything discovery normalizes without a word:
+//!
+//! - **Errors** (the manifest will not load): unreadable file, invalid TOML /
+//!   missing fields, invalid or reserved tool name, empty description, empty
+//!   `command`, non-table `input_schema`.
+//! - **Warnings** (the manifest loads but will not behave as written):
+//!   `timeout_ms` above the 10-minute cap (clamped at runtime), a tool name
+//!   already claimed by an earlier manifest (that one wins, this one is
+//!   ignored), and a `command[0]` that does not exist or is not executable —
+//!   a warning rather than an error because the script may legitimately be
+//!   provisioned later (checked out, installed, built) before the tool runs.
+//! - **Info**: `timeout_ms` omitted or `0`, which silently becomes the 30s
+//!   default.
+//!
+//! Validation never mutates discovery's behavior — `discover` stays the
+//! lenient path, this is the strict one.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::custom::{self, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS};
+
+/// How bad a [`ValidationIssue`] is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// The manifest will not load at all — discovery would skip the tool.
+    Error,
+    /// The manifest loads, but not the way it is written (clamped timeout,
+    /// shadowed name, missing script).
+    Warning,
+    /// Worth knowing, nothing to fix (e.g. an implicit default applied).
+    Info,
+}
+
+/// One finding about one manifest, printable as-is.
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    pub severity: Severity,
+    pub message: String,
+}
+
+/// Everything validation found out about a single manifest file.
+#[derive(Debug, Clone)]
+pub struct ManifestReport {
+    /// The manifest file the findings are about.
+    pub path: PathBuf,
+    /// The declared tool name, when the file parses far enough to have one —
+    /// present even for manifests that fail full validation (e.g. a missing
+    /// `description`), so reports can name the tool the developer meant.
+    pub name: Option<String>,
+    /// Findings, most severe first is *not* guaranteed — they are emitted in
+    /// check order (parse, duplicate, timeout, command).
+    pub issues: Vec<ValidationIssue>,
+}
+
+impl ManifestReport {
+    fn push(&mut self, severity: Severity, message: String) {
+        self.issues.push(ValidationIssue { severity, message });
+    }
+
+    /// `true` iff this manifest would fail to load at discovery.
+    pub fn has_errors(&self) -> bool {
+        self.issues.iter().any(|i| i.severity == Severity::Error)
+    }
+}
+
+/// The result of validating a set of tool directories: one entry per `*.toml`
+/// file found, in scan order (workspace before user-global, files sorted).
+#[derive(Debug, Clone, Default)]
+pub struct ValidationReport {
+    pub manifests: Vec<ManifestReport>,
+}
+
+impl ValidationReport {
+    /// Total error-severity findings across all manifests.
+    pub fn error_count(&self) -> usize {
+        self.count(Severity::Error)
+    }
+
+    /// Total warning-severity findings across all manifests.
+    pub fn warning_count(&self) -> usize {
+        self.count(Severity::Warning)
+    }
+
+    /// `true` iff at least one manifest would fail to load.
+    pub fn has_errors(&self) -> bool {
+        self.manifests.iter().any(ManifestReport::has_errors)
+    }
+
+    fn count(&self, severity: Severity) -> usize {
+        self.manifests
+            .iter()
+            .flat_map(|m| &m.issues)
+            .filter(|i| i.severity == severity)
+            .count()
+    }
+}
+
+/// Validate the default discovery locations for `workspace_root`: the
+/// workspace `.stella/tools/` then the user-global `~/.config/stella/tools/`
+/// (read from `$HOME`), exactly the directories and order
+/// [`crate::custom::discover`] scans — so duplicate-name findings mirror the
+/// real workspace-wins shadowing. Thin env-reading wrapper over
+/// [`validate_default_in`], mirroring `discover`/`discover_in`.
+pub fn validate_default(workspace_root: &Path) -> ValidationReport {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    validate_default_in(workspace_root, home.as_deref())
+}
+
+/// [`validate_default`] with the home directory injected (tests pass a
+/// tempdir instead of mutating the process env). A `None` home skips the
+/// user-global scan, like [`crate::custom::discover_in`].
+pub fn validate_default_in(workspace_root: &Path, home: Option<&Path>) -> ValidationReport {
+    let mut dirs: Vec<PathBuf> = vec![workspace_root.join(".stella").join("tools")];
+    if let Some(home) = home {
+        dirs.push(home.join(".config").join("stella").join("tools"));
+    }
+    validate_dirs(&dirs, workspace_root)
+}
+
+/// Validate every `*.toml` manifest in one explicit directory.
+/// `workspace_root` is where the tools would *run* (custom tools always spawn
+/// with the workspace root as cwd — see [`crate::custom`]), so relative
+/// `command[0]` paths are checked against it, not against `dir`. An absent
+/// `dir` yields an empty report; callers that require the directory to exist
+/// should check first.
+pub fn validate_dir(dir: &Path, workspace_root: &Path) -> ValidationReport {
+    validate_dirs(std::slice::from_ref(&dir.to_path_buf()), workspace_root)
+}
+
+/// Scan `dirs` in order (earlier dirs win name collisions, matching
+/// discovery) and validate every manifest found.
+fn validate_dirs(dirs: &[PathBuf], workspace_root: &Path) -> ValidationReport {
+    let mut report = ValidationReport::default();
+    // name → first manifest that claimed it; discovery order means that
+    // manifest is the one a session would actually load.
+    let mut seen: HashMap<String, PathBuf> = HashMap::new();
+
+    for dir in dirs {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => continue, // no such directory → nothing to validate
+        };
+        let mut paths: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("toml"))
+            .collect();
+        paths.sort();
+
+        for path in paths {
+            report
+                .manifests
+                .push(validate_file(&path, workspace_root, &mut seen));
+        }
+    }
+    report
+}
+
+/// Validate one manifest file. `seen` carries name→path across files so
+/// duplicates are reported on the manifest that would be ignored.
+fn validate_file(
+    path: &Path,
+    workspace_root: &Path,
+    seen: &mut HashMap<String, PathBuf>,
+) -> ManifestReport {
+    let mut out = ManifestReport {
+        path: path.to_path_buf(),
+        name: None,
+        issues: Vec::new(),
+    };
+
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) => {
+            // Same wording discovery uses for an unreadable manifest.
+            out.push(Severity::Error, format!("could not read manifest: {e}"));
+            return out;
+        }
+    };
+
+    // Lenient pre-parse: even a manifest that fails full validation (say, a
+    // missing `description`) usually still parses as TOML, so we can report
+    // it under the tool name the developer intended and read the raw
+    // `timeout_ms` before parse_manifest normalizes it away.
+    let lenient: Option<toml::Value> = toml::from_str(&text).ok();
+    out.name = lenient
+        .as_ref()
+        .and_then(|v| v.get("name"))
+        .and_then(toml::Value::as_str)
+        .map(str::to_string);
+
+    let tool = match custom::parse_manifest(&text, path) {
+        Ok(tool) => tool,
+        Err(reason) => {
+            // parse_manifest's message is already precise and printable.
+            out.push(Severity::Error, reason);
+            return out;
+        }
+    };
+    out.name = Some(tool.name.clone());
+
+    // Duplicate names: discovery keeps the first definition and silently
+    // drops this one, so the finding goes on the loser.
+    if let Some(first) = seen.get(&tool.name) {
+        let relation = if first.parent() == path.parent() {
+            "another manifest in the same directory"
+        } else {
+            "a workspace manifest that shadows this user-global one"
+        };
+        out.push(
+            Severity::Warning,
+            format!(
+                "tool name `{}` is already defined by {relation} ({}) — at discovery that \
+                 definition wins and this manifest is ignored",
+                tool.name,
+                first.display()
+            ),
+        );
+    } else {
+        seen.insert(tool.name.clone(), path.to_path_buf());
+    }
+
+    // Timeout semantics discovery silently normalizes (custom.rs applies the
+    // default for None/0 and clamps to the cap).
+    let raw_timeout = lenient
+        .as_ref()
+        .and_then(|v| v.get("timeout_ms"))
+        .and_then(toml::Value::as_integer)
+        .and_then(|t| u64::try_from(t).ok());
+    match raw_timeout {
+        None => out.push(
+            Severity::Info,
+            format!("timeout_ms is not set — the default of {DEFAULT_TIMEOUT_MS} ms (30s) applies"),
+        ),
+        Some(0) => out.push(
+            Severity::Info,
+            format!(
+                "timeout_ms = 0 is treated as unset — the default of {DEFAULT_TIMEOUT_MS} ms \
+                 (30s) applies"
+            ),
+        ),
+        Some(t) if t > MAX_TIMEOUT_MS => out.push(
+            Severity::Warning,
+            format!(
+                "timeout_ms = {t} exceeds the hard cap of {MAX_TIMEOUT_MS} ms (10 minutes) — it \
+                 will be clamped to {MAX_TIMEOUT_MS} ms at runtime"
+            ),
+        ),
+        Some(_) => {}
+    }
+
+    // command[0] resolvability. A warning, not an error: the script may be
+    // provisioned later (generated, installed, built) before the tool runs.
+    if let Some(message) = command_issue(&tool.command[0], workspace_root) {
+        out.push(Severity::Warning, message);
+    }
+
+    out
+}
+
+/// Check whether `cmd0` would spawn, mirroring [`crate::custom`]'s runtime
+/// semantics: the child runs with the **workspace root** as cwd, so a path
+/// containing `/` resolves against it, while a bare name goes through `$PATH`.
+/// Returns a printable finding, or `None` when the command looks runnable.
+fn command_issue(cmd0: &str, workspace_root: &Path) -> Option<String> {
+    if cmd0.contains('/') {
+        let resolved = if Path::new(cmd0).is_absolute() {
+            PathBuf::from(cmd0)
+        } else {
+            workspace_root.join(cmd0)
+        };
+        if !resolved.exists() {
+            return Some(format!(
+                "command[0] `{cmd0}` does not exist (resolves to {} — custom tools run from the \
+                 workspace root); the tool will fail to spawn unless it is provisioned before use",
+                resolved.display()
+            ));
+        }
+        if resolved.is_dir() {
+            return Some(format!(
+                "command[0] `{cmd0}` is a directory, not an executable ({})",
+                resolved.display()
+            ));
+        }
+        if !is_executable(&resolved) {
+            return Some(format!(
+                "command[0] `{cmd0}` is not executable — try `chmod +x {}`",
+                resolved.display()
+            ));
+        }
+        None
+    } else if find_on_path(cmd0) {
+        None
+    } else {
+        Some(format!(
+            "command[0] `{cmd0}` was not found on PATH; the tool will fail to spawn unless it \
+             is installed before use"
+        ))
+    }
+}
+
+/// `true` iff `path` has any execute bit set (owner/group/other). On
+/// non-unix targets there is no execute bit to inspect, so existence wins.
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    true
+}
+
+/// `true` iff a bare command name resolves to an executable file via `$PATH`
+/// (the lookup the OS would do at spawn time).
+fn find_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| {
+        if dir.as_os_str().is_empty() {
+            return false;
+        }
+        let candidate = dir.join(name);
+        candidate.is_file() && is_executable(&candidate)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn write_manifest(dir: &Path, file: &str, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(file), body).unwrap();
+    }
+
+    fn ws_tools(root: &Path) -> PathBuf {
+        root.join(".stella").join("tools")
+    }
+
+    fn global_tools(home: &Path) -> PathBuf {
+        home.join(".config").join("stella").join("tools")
+    }
+
+    /// Drop an executable script at `root/name` so command[0] checks pass.
+    fn write_script(root: &Path, name: &str) {
+        let path = root.join(name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+    }
+
+    fn issues_with(report: &ManifestReport, severity: Severity) -> Vec<&str> {
+        report
+            .issues
+            .iter()
+            .filter(|i| i.severity == severity)
+            .map(|i| i.message.as_str())
+            .collect()
+    }
+
+    // ---- witness: clean pass ----------------------------------------------
+
+    #[test]
+    fn valid_manifest_passes_clean() {
+        let ws = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "scripts/ok.sh");
+        write_manifest(
+            &ws_tools(ws.path()),
+            "ok.toml",
+            "name = \"ok_tool\"\ndescription = \"d\"\ncommand = [\"./scripts/ok.sh\"]\n\
+             timeout_ms = 60000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        assert_eq!(report.manifests.len(), 1);
+        let m = &report.manifests[0];
+        assert_eq!(m.name.as_deref(), Some("ok_tool"));
+        assert!(m.issues.is_empty(), "expected no findings: {:?}", m.issues);
+        assert!(!report.has_errors());
+        assert_eq!(report.error_count(), 0);
+        assert_eq!(report.warning_count(), 0);
+    }
+
+    // ---- witness: malformed TOML -------------------------------------------
+
+    #[test]
+    fn malformed_toml_is_an_error_with_a_precise_message() {
+        let ws = tempfile::tempdir().unwrap();
+        write_manifest(&ws_tools(ws.path()), "bad.toml", "this is not = toml [[[");
+
+        let report = validate_default_in(ws.path(), None);
+        assert_eq!(report.manifests.len(), 1);
+        let m = &report.manifests[0];
+        assert!(m.path.ends_with("bad.toml"));
+        assert!(m.has_errors());
+        let errors = issues_with(m, Severity::Error);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("invalid TOML"), "got: {}", errors[0]);
+    }
+
+    #[test]
+    fn missing_required_field_reports_the_field_and_keeps_the_tool_name() {
+        let ws = tempfile::tempdir().unwrap();
+        // Valid TOML, but no `description` — parse_manifest rejects it while
+        // the lenient pre-parse can still recover the intended name.
+        write_manifest(
+            &ws_tools(ws.path()),
+            "nodesc.toml",
+            "name = \"my_tool\"\ncommand = [\"./x.sh\"]",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        let m = &report.manifests[0];
+        assert_eq!(m.name.as_deref(), Some("my_tool"));
+        assert!(m.has_errors());
+        assert!(
+            issues_with(m, Severity::Error)[0].contains("description"),
+            "{:?}",
+            m.issues
+        );
+    }
+
+    // ---- witness: reserved name ---------------------------------------------
+
+    #[test]
+    fn reserved_name_is_an_error() {
+        let ws = tempfile::tempdir().unwrap();
+        write_manifest(
+            &ws_tools(ws.path()),
+            "bash.toml",
+            "name = \"bash\"\ndescription = \"d\"\ncommand = [\"/bin/true\"]",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        let m = &report.manifests[0];
+        assert!(m.has_errors());
+        assert!(
+            issues_with(m, Severity::Error)[0].contains("reserved"),
+            "{:?}",
+            m.issues
+        );
+    }
+
+    // ---- witness: duplicate names -------------------------------------------
+
+    #[test]
+    fn same_dir_duplicate_is_a_warning_on_the_losing_manifest() {
+        let ws = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "a.sh");
+        let dir = ws_tools(ws.path());
+        // Files scan in sorted order: 01_first.toml wins, 02_second.toml loses.
+        write_manifest(
+            &dir,
+            "01_first.toml",
+            "name = \"dup\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\ntimeout_ms = 1000",
+        );
+        write_manifest(
+            &dir,
+            "02_second.toml",
+            "name = \"dup\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\ntimeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        assert_eq!(report.manifests.len(), 2);
+        assert!(report.manifests[0].issues.is_empty());
+        let loser = &report.manifests[1];
+        assert!(!loser.has_errors(), "duplicate is a warning, not an error");
+        let warnings = issues_with(loser, Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("already defined"), "{}", warnings[0]);
+        assert!(warnings[0].contains("same directory"), "{}", warnings[0]);
+        assert!(warnings[0].contains("01_first.toml"), "{}", warnings[0]);
+    }
+
+    #[test]
+    fn workspace_shadowing_a_global_manifest_is_a_warning_on_the_global_one() {
+        let ws = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "w.sh");
+        write_manifest(
+            &ws_tools(ws.path()),
+            "dup.toml",
+            "name = \"dup\"\ndescription = \"ws\"\ncommand = [\"./w.sh\"]\ntimeout_ms = 1000",
+        );
+        write_manifest(
+            &global_tools(home.path()),
+            "dup.toml",
+            "name = \"dup\"\ndescription = \"global\"\ncommand = [\"./w.sh\"]\ntimeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), Some(home.path()));
+        assert_eq!(report.manifests.len(), 2);
+        // Workspace manifest scanned first — it wins, no findings.
+        assert!(report.manifests[0].path.starts_with(ws.path()));
+        assert!(report.manifests[0].issues.is_empty());
+        // Global manifest is shadowed.
+        let global = &report.manifests[1];
+        assert!(global.path.starts_with(home.path()));
+        let warnings = issues_with(global, Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("shadows"), "{}", warnings[0]);
+    }
+
+    // ---- witness: timeout normalization ---------------------------------------
+
+    #[test]
+    fn over_cap_timeout_warns_about_clamping() {
+        let ws = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "a.sh");
+        write_manifest(
+            &ws_tools(ws.path()),
+            "slow.toml",
+            "name = \"slow_tool\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\n\
+             timeout_ms = 99999999",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        let m = &report.manifests[0];
+        assert!(!m.has_errors(), "clamp is a warning: {:?}", m.issues);
+        let warnings = issues_with(m, Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("clamped"), "{}", warnings[0]);
+        assert!(warnings[0].contains("600000"), "{}", warnings[0]);
+    }
+
+    #[test]
+    fn omitted_and_zero_timeouts_are_info_about_the_default() {
+        let ws = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "a.sh");
+        let dir = ws_tools(ws.path());
+        write_manifest(
+            &dir,
+            "omitted.toml",
+            "name = \"om_tool\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]",
+        );
+        write_manifest(
+            &dir,
+            "zero.toml",
+            "name = \"zero_tool\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\ntimeout_ms = 0",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        assert!(!report.has_errors());
+        assert_eq!(report.warning_count(), 0);
+        for m in &report.manifests {
+            let infos = issues_with(m, Severity::Info);
+            assert_eq!(infos.len(), 1, "{:?}", m.issues);
+            assert!(infos[0].contains("30"), "{}", infos[0]);
+        }
+    }
+
+    // ---- witness: command[0] checks --------------------------------------------
+
+    #[test]
+    fn missing_relative_command_is_a_warning_naming_the_resolved_path() {
+        let ws = tempfile::tempdir().unwrap();
+        write_manifest(
+            &ws_tools(ws.path()),
+            "ghost.toml",
+            "name = \"ghost_tool\"\ndescription = \"d\"\ncommand = [\"./no/such.sh\"]\n\
+             timeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        let m = &report.manifests[0];
+        assert!(!m.has_errors(), "missing script is a warning, not an error");
+        let warnings = issues_with(m, Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("./no/such.sh"), "{}", warnings[0]);
+        assert!(warnings[0].contains("does not exist"), "{}", warnings[0]);
+        assert!(
+            warnings[0].contains(&ws.path().display().to_string()),
+            "resolved path should name the workspace root: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn non_executable_command_is_a_warning() {
+        let ws = tempfile::tempdir().unwrap();
+        let script = ws.path().join("noexec.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o644); // rw-, no execute bit
+        std::fs::set_permissions(&script, perms).unwrap();
+        write_manifest(
+            &ws_tools(ws.path()),
+            "noexec.toml",
+            "name = \"noexec_tool\"\ndescription = \"d\"\ncommand = [\"./noexec.sh\"]\n\
+             timeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        let warnings = issues_with(&report.manifests[0], Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("not executable"), "{}", warnings[0]);
+    }
+
+    #[test]
+    fn bare_command_on_path_passes_and_unknown_bare_command_warns() {
+        let ws = tempfile::tempdir().unwrap();
+        let dir = ws_tools(ws.path());
+        write_manifest(
+            &dir,
+            "onpath.toml",
+            "name = \"onpath_tool\"\ndescription = \"d\"\ncommand = [\"sh\", \"-c\", \"true\"]\n\
+             timeout_ms = 1000",
+        );
+        write_manifest(
+            &dir,
+            "offpath.toml",
+            "name = \"offpath_tool\"\ndescription = \"d\"\n\
+             command = [\"stella_no_such_binary_xyz\"]\ntimeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        assert_eq!(report.manifests.len(), 2);
+        let by_name = |n: &str| {
+            report
+                .manifests
+                .iter()
+                .find(|m| m.name.as_deref() == Some(n))
+                .unwrap()
+        };
+        let off = by_name("offpath_tool");
+        let warnings = issues_with(off, Severity::Warning);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("not found on PATH"), "{}", warnings[0]);
+        assert!(issues_with(by_name("onpath_tool"), Severity::Warning).is_empty());
+    }
+
+    // ---- shape of the report ----------------------------------------------------
+
+    #[test]
+    fn absent_directories_yield_an_empty_report() {
+        let ws = tempfile::tempdir().unwrap();
+        let report = validate_default_in(ws.path(), None);
+        assert!(report.manifests.is_empty());
+        assert!(!report.has_errors());
+
+        let report = validate_dir(&ws.path().join("nope"), ws.path());
+        assert!(report.manifests.is_empty());
+    }
+
+    #[test]
+    fn validate_dir_checks_an_explicit_directory_against_the_workspace_root() {
+        let ws = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "run.sh");
+        write_manifest(
+            elsewhere.path(),
+            "tool.toml",
+            "name = \"else_tool\"\ndescription = \"d\"\ncommand = [\"./run.sh\"]\n\
+             timeout_ms = 1000",
+        );
+
+        // command[0] resolves against the workspace root, not the manifest dir.
+        let report = validate_dir(elsewhere.path(), ws.path());
+        assert_eq!(report.manifests.len(), 1);
+        assert!(
+            report.manifests[0].issues.is_empty(),
+            "{:?}",
+            report.manifests[0].issues
+        );
+    }
+
+    #[test]
+    fn mixed_directory_summarizes_errors_and_warnings() {
+        let ws = tempfile::tempdir().unwrap();
+        write_script(ws.path(), "a.sh");
+        let dir = ws_tools(ws.path());
+        write_manifest(
+            &dir,
+            "good.toml",
+            "name = \"good_tool\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\ntimeout_ms = 1000",
+        );
+        write_manifest(&dir, "broken.toml", "not toml at all [[[");
+        write_manifest(
+            &dir,
+            "shadow.toml",
+            "name = \"good_tool\"\ndescription = \"d\"\ncommand = [\"./a.sh\"]\ntimeout_ms = 1000",
+        );
+
+        let report = validate_default_in(ws.path(), None);
+        assert_eq!(report.manifests.len(), 3);
+        assert!(report.has_errors());
+        assert_eq!(report.error_count(), 1);
+        assert_eq!(report.warning_count(), 1);
+        let failed = report.manifests.iter().filter(|m| m.has_errors()).count();
+        assert_eq!(failed, 1);
+    }
+}


### PR DESCRIPTION
Closes #21. Custom-tool manifest mistakes now surface before a run consumes budget, not mid-session:

- stella-tools gains a validate module: validate_dir / validate_default return a structured ValidationReport (per-manifest errors, warnings, info). Errors reuse parse_manifest's precise messages (invalid TOML, bad/reserved names, empty description/command, bad input_schema); warnings cover timeout clamping to the 10-minute cap, duplicate names across manifests (including workspace-shadows-global), and a command[0] that does not exist from the workspace root; omitted timeout_ms is surfaced as info with the 30s default.
- stella tools --validate [DIR] prints a per-file report and exits non-zero when any manifest has errors (verified: exit 1 on a broken manifest, exit 0 on a clean dir); plain stella tools stays the lenient listing, and session-start diagnostics now point at --validate as the pre-flight.

Witness tests: 15 new cases over tempdir fixtures covering every rule, plus the CLI wiring.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict custom-tool manifest validator and a CLI entry point so errors are caught before a run consumes budget (implements #21). Use `stella tools --validate [DIR]` to scan manifests, print errors/warnings/info, and exit non‑zero on errors.

- **New Features**
  - `stella-tools::validate` exposes `validate_default` and `validate_dir`, returning a structured `ValidationReport`.
  - Checks include: parse errors (bad TOML, missing fields, invalid/reserved names), duplicate tool names (workspace wins over user-global), `timeout_ms` defaulting/clamping, and `command[0]` existence/exec checks relative to the workspace root or `$PATH`.
  - `stella-cli`: `stella tools --validate [DIR]` validates `.stella/tools/` and `~/.config/stella/tools/` by default, or a provided directory; exits non‑zero if any manifest has errors. A plain `stella tools` remains a lenient listing; discovery diagnostics now point to `--validate`.
  - Exposes `DEFAULT_TIMEOUT_MS` and `MAX_TIMEOUT_MS` from `stella-tools::custom` for clearer messages.

- **Migration**
  - Run `stella tools --validate` locally or in CI to catch broken manifests early; treat a non‑zero exit as a failure.
  - Use `stella tools --validate <dir>` to validate a specific directory when needed.

<sup>Written for commit cef259a42179bee7b94b7aba2ae456e12721c420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
