### PR TITLE
feat(stella-core): calibrate token estimates against observed StepUsa…

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -18,7 +18,8 @@ use colored::Colorize;
 use stella_core::ports::{SystemClock, ToolExecutor};
 use stella_core::router::{CircuitBreaker, ProviderProfile};
 use stella_core::{
-    BudgetGuard, Engine, EngineConfig, GoalConfig, GoalOutcome, RoleTable, Router, TurnOutcome,
+    BudgetGuard, CalibrationMap, Engine, EngineConfig, GoalConfig, GoalOutcome, RoleTable, Router,
+    TurnOutcome,
 };
 use stella_mcp::{McpConfig, McpToolSet};
 use stella_model::credential::ApiKey;
@@ -155,6 +156,7 @@ pub async fn run_one_shot(
     let custom_tools = discover_custom_tools(cfg, format == OutputFormat::Text);
     let mut budget = build_budget_guard(budget_limit);
     let store = open_store(&cfg.workspace_root);
+    let calibration = seed_calibration(&store, cfg);
 
     if format == OutputFormat::Text {
         tui::section_header("Stella");
@@ -180,6 +182,7 @@ pub async fn run_one_shot(
         &registry,
         &mut messages,
         &mut budget,
+        &calibration,
         cfg,
         format,
         &store,
@@ -230,6 +233,7 @@ pub async fn run_goal_cmd(
     let custom_tools = discover_custom_tools(cfg, true);
     let mut budget = build_budget_guard(budget_limit);
     let store = open_store(&cfg.workspace_root);
+    let calibration = seed_calibration(&store, cfg);
 
     tui::section_header("Stella — goal mode");
     println!("  {}\n", goal.dimmed());
@@ -249,6 +253,7 @@ pub async fn run_goal_cmd(
         &registry,
         &mut messages,
         &mut budget,
+        &calibration,
         cfg,
         &store,
         goal,
@@ -282,6 +287,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     let custom_tools = discover_custom_tools(cfg, true);
     let mut budget = build_budget_guard(budget_limit);
     let store = open_store(&cfg.workspace_root);
+    // Session-scoped like `budget`: seeded once from prior sessions'
+    // telemetry, then sharpened by every turn in this REPL.
+    let calibration = seed_calibration(&store, cfg);
 
     tui::welcome_banner(
         cfg.provider.id,
@@ -400,6 +408,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 &registry,
                 &mut messages,
                 &mut budget,
+                &calibration,
                 cfg,
                 &store,
                 goal,
@@ -433,6 +442,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             &registry,
             &mut messages,
             &mut budget,
+            &calibration,
             cfg,
             OutputFormat::Text,
             &store,
@@ -753,6 +763,27 @@ fn open_store(workspace_root: &std::path::Path) -> Option<Arc<Store>> {
     }
 }
 
+/// How many recent drift samples to replay into a fresh session's
+/// calibration. With the estimator's EWMA weight (0.3) anything past ~20
+/// samples has negligible influence, and 20 rows is a trivial query.
+const DRIFT_SEED_SAMPLES: usize = 20;
+
+/// Build the session's token-drift calibration, seeded from prior sessions'
+/// telemetry for the resolved provider/model (`Store::drift_samples`) so the
+/// estimator starts already corrected instead of re-learning each session.
+/// Best-effort like all persistence: no store (or a failed query) just means
+/// starting uncalibrated — factor 1.0, the pre-drift behavior.
+fn seed_calibration(store: &Option<Arc<Store>>, cfg: &Config) -> CalibrationMap {
+    let calibration = CalibrationMap::new();
+    if let Some(store) = store
+        && let Ok(samples) = store.drift_samples(cfg.provider.id, &cfg.model_id, DRIFT_SEED_SAMPLES)
+        && !samples.is_empty()
+    {
+        calibration.seed(&cfg.model_id, &samples);
+    }
+    calibration
+}
+
 /// Begin an execution record; a failure degrades to "no persistence for this
 /// execution" rather than blocking the work.
 fn begin_execution(
@@ -787,6 +818,7 @@ async fn run_turn(
     registry: &ToolRegistry,
     messages: &mut Vec<CompletionMessage>,
     budget: &mut BudgetGuard,
+    calibration: &CalibrationMap,
     cfg: &Config,
     format: OutputFormat,
     store: &Option<Arc<Store>>,
@@ -821,7 +853,8 @@ async fn run_turn(
             default_ask_io(format == OutputFormat::Text),
         )
         .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
-        let engine = Engine::new(provider, &tools, EngineConfig::default());
+        let engine =
+            Engine::new(provider, &tools, EngineConfig::default()).with_calibration(calibration);
         engine.run_turn(messages, budget, &tx).await
     };
     // Dropping the last sender closes the channel, ending the renderer's
@@ -925,6 +958,7 @@ fn spawn_renderer(
                     input_tokens,
                     output_tokens,
                     cached_input_tokens,
+                    estimated_input_tokens,
                     cost_usd,
                     duration_ms,
                     retries,
@@ -938,6 +972,7 @@ fn spawn_renderer(
                             provider: provider_id.clone(),
                             model: model.clone(),
                             input_tokens: *input_tokens,
+                            estimated_input_tokens: *estimated_input_tokens,
                             output_tokens: *output_tokens,
                             cache_read_tokens: *cached_input_tokens,
                             cache_miss_tokens: input_tokens.saturating_sub(*cached_input_tokens),
@@ -1021,6 +1056,7 @@ async fn run_goal_turn(
     registry: &ToolRegistry,
     messages: &mut Vec<CompletionMessage>,
     budget: &mut BudgetGuard,
+    calibration: &CalibrationMap,
     cfg: &Config,
     store: &Option<Arc<Store>>,
     goal: &str,
@@ -1064,7 +1100,8 @@ async fn run_goal_turn(
         );
         let tools = InteractiveToolSet::new(&customs, tx.clone(), default_ask_io(true))
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
-        let engine = Engine::new(provider, &tools, EngineConfig::default());
+        let engine =
+            Engine::new(provider, &tools, EngineConfig::default()).with_calibration(calibration);
         engine
             .run_goal(judge, goal, messages, budget, &tx, &GoalConfig::default())
             .await

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -376,6 +376,9 @@ pub fn render_event(event: &AgentEvent) {
             duration_ms,
             retries,
             tool_calls,
+            // `estimated_input_tokens` is calibration feedback for the
+            // estimator (stella-core), not HUD material.
+            ..
         } => {
             // One dimmed telemetry line per committed model call: the live
             // HUD a metering consumer would reconstruct from this event.

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -65,6 +65,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::budget::{BudgetGuard, BudgetOutcome};
 use crate::compaction::compact;
+use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
 use crate::hooks::{HookPayload, HookRunner, Hooks, run_hooks};
 use crate::loop_detect::{LoopDetectionConfig, detect_loop};
 use crate::ports::ToolExecutor;
@@ -81,7 +82,10 @@ pub struct EngineConfig {
     pub retry_policy: RetryPolicy,
     pub loop_detection: LoopDetectionConfig,
     /// Compaction fires once the estimated conversation size exceeds this
-    /// many tokens (`crate::estimator`).
+    /// many tokens (`crate::estimator`). When calibration is attached
+    /// ([`Engine::with_calibration`]) the comparison uses the
+    /// drift-corrected estimate, so this budget is honored in the model's
+    /// own observed tokens rather than raw heuristic tokens.
     pub compaction_budget_tokens: u64,
     /// Hard backstop on step count, independent of loop detection — belt
     /// and suspenders, never the *primary* stuck-loop defense (that's
@@ -150,6 +154,14 @@ pub struct Engine<'a> {
     /// so `new`/`with_sleeper` keep their existing signatures. When `None`,
     /// no hook is ever consulted and the turn path adds zero work.
     hooks: Option<HooksHandle<'a>>,
+    /// Token-drift calibration (`crate::estimator::CalibrationMap`), off by
+    /// default. Attached via [`Engine::with_calibration`]; the caller owns
+    /// the map across turns (and seeds it from persisted telemetry at
+    /// session start), the engine feeds it every committed step's
+    /// (estimated, actual) pair and reads the correction back into the
+    /// compaction decision. When `None` the turn path is exactly the
+    /// uncalibrated engine.
+    pub(crate) calibration: Option<&'a CalibrationMap>,
 }
 
 /// Upper bound on tool calls from one step executing concurrently. Tools
@@ -183,6 +195,7 @@ impl<'a> Engine<'a> {
             sleeper,
             config,
             hooks: None,
+            calibration: None,
         }
     }
 
@@ -195,6 +208,16 @@ impl<'a> Engine<'a> {
     /// anything (the config alone spawns nothing).
     pub fn with_hooks(mut self, hooks: &'a Hooks, runner: &'a dyn HookRunner) -> Self {
         self.hooks = Some(HooksHandle { hooks, runner });
+        self
+    }
+
+    /// Attach token-drift calibration, opt-in and by reference for the same
+    /// reason `run_turn` borrows `messages`: the caller (CLI session, REPL,
+    /// fleet worker) owns state that outlives any single turn — engines are
+    /// constructed per turn, calibration accumulates per session. An engine
+    /// built without this estimates exactly as before.
+    pub fn with_calibration(mut self, calibration: &'a CalibrationMap) -> Self {
+        self.calibration = Some(calibration);
         self
     }
 
@@ -243,12 +266,36 @@ impl<'a> Engine<'a> {
         });
 
         let mut total_cost_usd = 0.0f64;
+        // The model string of the last committed step, for reading the
+        // per-model drift correction. `None` until the first result lands —
+        // `CalibrationMap::factor` then falls back to the session's single
+        // seeded entry.
+        let mut calibration_model: Option<String> = None;
 
         for step in 0..self.config.max_steps {
             // ---- Compaction (before every model call, per the running
             // ---- estimate; L-E3 dedup+evict, stable system prefix — the
             // ---- system message is index 0 and compact() never touches it).
-            if let Some(report) = compact(messages, self.config.compaction_budget_tokens) {
+            //
+            // Drift correction enters here: `compact` compares the RAW
+            // estimate against the budget it is given, so dividing the
+            // configured budget by the correction factor is exactly
+            // comparing the CALIBRATED estimate (raw × factor) against the
+            // configured budget — including the eviction loop's stopping
+            // condition — without threading a factor through compaction's
+            // incremental bookkeeping. A factor > 1 (we under-estimate this
+            // model's tokenizer) shrinks the effective budget and compacts
+            // earlier; the factor's clamp (`crate::estimator`) bounds how
+            // far either way a noisy sample can move this.
+            let compaction_budget = match self.calibration {
+                Some(calibration) => {
+                    (self.config.compaction_budget_tokens as f64
+                        / calibration.factor(calibration_model.as_deref()))
+                        as u64
+                }
+                None => self.config.compaction_budget_tokens,
+            };
+            if let Some(report) = compact(messages, compaction_budget) {
                 let _ = events.send(AgentEvent::Compaction {
                     before_tokens: report.before_tokens,
                     after_tokens: report.after_tokens,
@@ -298,6 +345,12 @@ impl<'a> Engine<'a> {
                 .filter(|s| s.read_only)
                 .map(|s| s.name.clone())
                 .collect();
+            // The raw (uncalibrated) estimate of exactly what this step
+            // sends — recorded against the provider's reported usage below.
+            // Raw, not calibrated: the drift ratio is actual/raw, and
+            // recording a corrected estimate would compound corrections on
+            // every feedback pass.
+            let estimated_input_tokens = estimate_conversation_tokens(messages);
             let messages_snapshot = messages.clone();
             let req_config = &self.config;
             let attempt: RetryAttemptFn = Box::new(move || {
@@ -343,6 +396,21 @@ impl<'a> Engine<'a> {
                 });
             }
 
+            // ---- Drift feedback for the call that just committed: the
+            // ---- provider's reported input tokens (total, cached included
+            // ---- — cached tokens were still real prompt tokens) against
+            // ---- the raw estimate, keyed by the model that actually
+            // ---- served the call. `record` ignores zero-sided pairs, so a
+            // ---- provider omitting usage never poisons the state.
+            if let Some(calibration) = self.calibration {
+                calibration.record(
+                    &result.model,
+                    estimated_input_tokens,
+                    result.usage.input_tokens,
+                );
+            }
+            calibration_model = Some(result.model.clone());
+
             // ---- Telemetry for the call that just committed: exactly one
             // ---- StepUsage per landed step — the metering record.
             let _ = events.send(AgentEvent::StepUsage {
@@ -351,6 +419,7 @@ impl<'a> Engine<'a> {
                 input_tokens: result.usage.input_tokens,
                 output_tokens: result.usage.output_tokens,
                 cached_input_tokens: result.usage.cached_input_tokens,
+                estimated_input_tokens,
                 cost_usd: result.cost_usd,
                 duration_ms: call_duration_ms,
                 retries: retries.len() as u32,
@@ -1450,6 +1519,177 @@ mod tests {
         );
         assert_eq!(usages[0], (0, 1000, 800, 1, 1, 0.0001));
         assert_eq!(usages[1], (1, 1000, 800, 0, 0, 0.0001));
+    }
+
+    // ---- Token-drift calibration -------------------------------------------
+
+    use crate::estimator::CalibrationMap;
+
+    /// A conversation with one old, evictable tool output — the shape
+    /// compaction acts on (the LAST tool message is protected).
+    fn compactable_history() -> Vec<CompletionMessage> {
+        let tool_msg = |call_id: &str, content: String| CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: call_id.into(),
+                output: ToolOutput::Ok { content },
+            }],
+        };
+        let assistant_with_call = |call_id: &str| CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: call_id.into(),
+                name: "bash".into(),
+                input: serde_json::json!({"cmd": call_id}),
+            }],
+            tool_results: vec![],
+        };
+        vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("do things"),
+            assistant_with_call("c1"),
+            tool_msg("c1", "old ".repeat(1000)),
+            assistant_with_call("c2"),
+            tool_msg("c2", "new ".repeat(1000)),
+        ]
+    }
+
+    /// Witness for the feedback loop's read side: the SAME conversation
+    /// under the SAME configured budget compacts only when calibration says
+    /// the raw estimate runs low against this model's tokenizer — the
+    /// compaction decision demonstrably consumes the calibrated estimate,
+    /// not the raw one.
+    #[tokio::test]
+    async fn calibrated_estimate_changes_the_compaction_decision() {
+        let run = |calibrate: bool| async move {
+            let provider = ScriptedProvider {
+                id: "scripted".into(),
+                script: TokioMutex::new(vec![Ok(text_result("done"))]),
+                calls: Arc::new(AtomicU32::new(0)),
+            };
+            let tools = CountingTools {
+                calls: Arc::new(AtomicU32::new(0)),
+            };
+            let sleeper = NoopSleeper;
+            let mut messages = compactable_history();
+            // A budget the RAW estimate just fits under: uncalibrated, no
+            // compaction can fire.
+            let raw = crate::estimator::estimate_conversation_tokens(&messages);
+            let config = EngineConfig {
+                compaction_budget_tokens: raw + 10,
+                ..EngineConfig::default()
+            };
+            // Observed drift: this model's tokenizer reports 2× the char
+            // heuristic (three samples — the minimum for the factor to
+            // apply). Calibrated, the same conversation reads as ~2×(budget)
+            // and must compact.
+            let calibration = CalibrationMap::new();
+            if calibrate {
+                calibration.seed("scripted", &[(1000, 2000), (1000, 2000), (1000, 2000)]);
+            }
+            let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper)
+                .with_calibration(&calibration);
+            let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+            let (tx, mut rx) = mpsc::unbounded_channel();
+            let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+            assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+            drain_events(&mut rx)
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Compaction { .. }))
+        };
+
+        assert!(
+            !run(false).await,
+            "uncalibrated, the conversation fits the budget — no compaction"
+        );
+        assert!(
+            run(true).await,
+            "with observed 2× drift the calibrated estimate exceeds the budget — \
+             compaction must fire before the model call"
+        );
+    }
+
+    /// Witness for the feedback loop's write side: every committed step
+    /// records its (estimated, actual) pair into the attached calibration —
+    /// keyed by the model that served it — and emits the raw estimate on
+    /// `StepUsage` for persistence.
+    #[tokio::test]
+    async fn each_committed_step_feeds_the_calibration_and_reports_its_estimate() {
+        let with_real_usage = |result: CompletionResultAlias| {
+            let mut result = result;
+            result.usage = CompletionUsage {
+                input_tokens: 4_000,
+                output_tokens: 50,
+                cached_input_tokens: 0,
+            };
+            // Vary each call's input: `tool_call_result` reuses one command,
+            // and three byte-identical bash calls are exactly what
+            // `loop_detect` exists to abort — this test is about the
+            // calibration feed, not the loop breaker.
+            if let Some(call) = result.tool_calls.first_mut() {
+                call.input = serde_json::json!({ "cmd": format!("echo {}", call.call_id) });
+            }
+            result
+        };
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![
+                Ok(with_real_usage(tool_call_result("call_1", "bash"))),
+                Ok(with_real_usage(tool_call_result("call_2", "bash"))),
+                Ok(with_real_usage(tool_call_result("call_3", "bash"))),
+                Ok(with_real_usage(text_result("done"))),
+            ]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let calibration = CalibrationMap::new();
+        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+            .with_calibration(&calibration);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("hi"),
+        ];
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+        // Every StepUsage carries the raw pre-call estimate (> 0: the
+        // conversation is never empty).
+        let estimates: Vec<u64> = drain_events(&mut rx)
+            .iter()
+            .filter_map(|e| match e {
+                AgentEvent::StepUsage {
+                    estimated_input_tokens,
+                    ..
+                } => Some(*estimated_input_tokens),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(estimates.len(), 4);
+        assert!(estimates.iter().all(|&e| e > 0), "{estimates:?}");
+
+        // Four samples of a model reporting far more tokens than the tiny
+        // history estimates: the correction engaged (past min-samples),
+        // pushed up, and stayed inside its clamp — a noisy run can shift
+        // budgeting by at most 2× in either direction.
+        let factor = calibration.factor(Some("scripted"));
+        assert!(
+            factor > 1.0 && factor <= 2.0,
+            "factor must be engaged and bounded, got {factor}"
+        );
+        assert_eq!(
+            calibration.factor(Some("some-other-model")),
+            1.0,
+            "drift is keyed by the model that served the call"
+        );
     }
 
     // ---- Lifecycle hooks wired into the turn path -------------------------

--- a/stella-core/src/estimator.rs
+++ b/stella-core/src/estimator.rs
@@ -1,9 +1,16 @@
 //! Token estimation for compaction decisions. The estimator returns a
 //! deliberately conservative (over-)estimate — over-estimating triggers
 //! compaction earlier, the safe direction. Provider-reported usage flows
-//! through `AgentEvent::StepUsage` for telemetry; feeding it back to
-//! correct estimator drift per provider (`07-model-matrix.md` §4.3) is
-//! planned but NOT implemented yet — do not rely on drift correction.
+//! through `AgentEvent::StepUsage` for telemetry AND back into the
+//! estimator: [`Calibration`] tracks the observed actual/estimated
+//! input-token ratio per model (`07-model-matrix.md` §4.3) and corrects the
+//! heuristic with a bounded factor, so the estimate converges on what the
+//! provider's tokenizer actually reports over a session. The uncalibrated
+//! functions remain the char-heuristic baseline; the correction is applied
+//! on top, never by mutating the heuristic's constants.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 use stella_protocol::CompletionMessage;
 
@@ -38,6 +45,190 @@ pub fn estimate_message_tokens(message: &CompletionMessage) -> u64 {
 /// Estimate the total token cost of a conversation.
 pub fn estimate_conversation_tokens(messages: &[CompletionMessage]) -> u64 {
     messages.iter().map(estimate_message_tokens).sum()
+}
+
+/// EWMA smoothing weight for new drift samples. 0.3 converges within a
+/// handful of steps (visible improvement inside one session) while a single
+/// noisy sample moves the state by at most 30%.
+const CALIBRATION_ALPHA: f64 = 0.3;
+
+/// Samples required before a correction is applied at all — below this the
+/// factor is exactly 1.0, so one or two flukes can never steer budgeting.
+const CALIBRATION_MIN_SAMPLES: u32 = 3;
+
+/// Bounds on the applied correction factor. The lower bound matters most:
+/// the raw estimator is deliberately biased HIGH (see [`CHARS_PER_TOKEN`]),
+/// and a factor below 1.0 spends that safety margin — capping it at 0.5
+/// means calibration can at most halve the conservative estimate, so the
+/// calibrated number stays an early-compaction bias, never an invitation to
+/// silent provider truncation. The upper bound keeps a run of pathological
+/// samples (a tokenizer bug, a provider mis-reporting usage) from doubling
+/// every estimate and thrashing compaction.
+const CALIBRATION_MIN_FACTOR: f64 = 0.5;
+const CALIBRATION_MAX_FACTOR: f64 = 2.0;
+
+/// One raw sample may not move the EWMA state by more than this ratio band
+/// (2× the applied-factor bounds): a single absurd sample (estimated 10,
+/// actual 50 000) is truncated before it enters the average, so recovery
+/// takes a few ordinary samples instead of dozens.
+const CALIBRATION_SAMPLE_MIN_RATIO: f64 = CALIBRATION_MIN_FACTOR / 2.0;
+const CALIBRATION_SAMPLE_MAX_RATIO: f64 = CALIBRATION_MAX_FACTOR * 2.0;
+
+/// Drift correction for one provider/model: an EWMA of the observed
+/// actual/estimated input-token ratio, fed by `(estimated, actual)` pairs
+/// from committed steps (`AgentEvent::StepUsage`) and applied as a bounded
+/// multiplicative factor on the char-heuristic estimate.
+///
+/// The ratio also absorbs systematic per-request overhead the heuristic
+/// cannot see (tool schemas, provider framing): those inflate `actual`
+/// uniformly, so they surface as a stable ratio rather than noise.
+///
+/// Pure state — no I/O, no clock. Persistence of samples across sessions is
+/// `stella-store`'s job; replay them through [`Calibration::record`] (oldest
+/// first, so the EWMA weights the most recent session highest) to rebuild
+/// the state.
+#[derive(Debug, Clone)]
+pub struct Calibration {
+    ratio_ewma: f64,
+    samples: u32,
+}
+
+impl Default for Calibration {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Calibration {
+    /// Fresh, uncorrected state: factor 1.0 until enough samples arrive.
+    pub fn new() -> Self {
+        Self {
+            ratio_ewma: 1.0,
+            samples: 0,
+        }
+    }
+
+    /// Feed one observed pair: the raw (uncalibrated) pre-call estimate and
+    /// the provider-reported actual input tokens (total, cached included).
+    /// Zero on either side carries no signal (scripted tests, providers that
+    /// omit usage) and is ignored rather than recorded as ratio 0/∞.
+    pub fn record(&mut self, estimated: u64, actual: u64) {
+        if estimated == 0 || actual == 0 {
+            return;
+        }
+        let ratio = (actual as f64 / estimated as f64)
+            .clamp(CALIBRATION_SAMPLE_MIN_RATIO, CALIBRATION_SAMPLE_MAX_RATIO);
+        if self.samples == 0 {
+            self.ratio_ewma = ratio;
+        } else {
+            self.ratio_ewma =
+                CALIBRATION_ALPHA * ratio + (1.0 - CALIBRATION_ALPHA) * self.ratio_ewma;
+        }
+        self.samples += 1;
+    }
+
+    /// How many samples have been recorded.
+    pub fn samples(&self) -> u32 {
+        self.samples
+    }
+
+    /// The correction factor to multiply a raw estimate by: exactly 1.0
+    /// below [`CALIBRATION_MIN_SAMPLES`], otherwise the EWMA ratio clamped
+    /// to [[`CALIBRATION_MIN_FACTOR`], [`CALIBRATION_MAX_FACTOR`]] — see the
+    /// bounds' doc for why that keeps the safe over-estimate direction.
+    pub fn factor(&self) -> f64 {
+        if self.samples < CALIBRATION_MIN_SAMPLES {
+            return 1.0;
+        }
+        self.ratio_ewma
+            .clamp(CALIBRATION_MIN_FACTOR, CALIBRATION_MAX_FACTOR)
+    }
+
+    /// [`estimate_message_tokens`] corrected by the current factor.
+    pub fn calibrated_message_tokens(&self, message: &CompletionMessage) -> u64 {
+        (estimate_message_tokens(message) as f64 * self.factor()).ceil() as u64
+    }
+
+    /// [`estimate_conversation_tokens`] corrected by the current factor.
+    pub fn calibrated_conversation_tokens(&self, messages: &[CompletionMessage]) -> u64 {
+        (estimate_conversation_tokens(messages) as f64 * self.factor()).ceil() as u64
+    }
+}
+
+/// Per-model calibration state, keyed by the model string the provider
+/// reports on each result (tokenizers differ per model, so their drift must
+/// never blend). The provider dimension is handled where samples are
+/// persisted and re-loaded: `stella-store` keys telemetry by
+/// `(provider, model)` and a session seeds only its own resolved pair, so
+/// one map never mixes same-named models from different providers.
+///
+/// Interior-mutable (a `Mutex` never held across an await) because the
+/// engine drives turns through `&self` — the caller owns the map across
+/// turns and hands the engine a shared reference, mirroring how
+/// `BudgetGuard` outlives individual turns.
+#[derive(Debug, Default)]
+pub struct CalibrationMap {
+    inner: Mutex<HashMap<String, Calibration>>,
+}
+
+impl CalibrationMap {
+    /// An empty map: every model reads factor 1.0 until samples arrive.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replay persisted `(estimated, actual)` pairs — oldest first — into
+    /// `model`'s state, so a new session starts where the last one left off.
+    pub fn seed(&self, model: &str, samples: &[(u64, u64)]) {
+        let mut inner = self.lock();
+        let calibration = inner.entry(model.to_string()).or_default();
+        for &(estimated, actual) in samples {
+            calibration.record(estimated, actual);
+        }
+    }
+
+    /// Feed one observed pair into `model`'s state.
+    pub fn record(&self, model: &str, estimated: u64, actual: u64) {
+        self.lock()
+            .entry(model.to_string())
+            .or_default()
+            .record(estimated, actual);
+    }
+
+    /// The correction factor for `model`. `None` (the driver hasn't seen a
+    /// result yet, so no model string exists) falls back to the map's single
+    /// entry when there is exactly one — the session-seeded state — and to
+    /// 1.0 otherwise; an ambiguous multi-model map never guesses.
+    pub fn factor(&self, model: Option<&str>) -> f64 {
+        let inner = self.lock();
+        match model {
+            Some(model) => inner.get(model).map(Calibration::factor).unwrap_or(1.0),
+            None if inner.len() == 1 => inner
+                .values()
+                .next()
+                .map(Calibration::factor)
+                .unwrap_or(1.0),
+            None => 1.0,
+        }
+    }
+
+    /// [`estimate_conversation_tokens`] corrected by `model`'s factor (same
+    /// `None` fallback as [`CalibrationMap::factor`]).
+    pub fn calibrated_conversation_tokens(
+        &self,
+        model: Option<&str>,
+        messages: &[CompletionMessage],
+    ) -> u64 {
+        (estimate_conversation_tokens(messages) as f64 * self.factor(model)).ceil() as u64
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, Calibration>> {
+        // Poisoning means a panic mid-record; the state is a plain f64+u32
+        // pair that cannot be left torn — keep calibrating.
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 #[cfg(test)]
@@ -96,5 +287,159 @@ mod tests {
         let total = estimate_conversation_tokens(&messages);
         let sum: u64 = messages.iter().map(estimate_message_tokens).sum();
         assert_eq!(total, sum);
+    }
+
+    // ---- Calibration -------------------------------------------------------
+
+    #[test]
+    fn factor_is_identity_below_the_minimum_sample_count() {
+        let mut cal = Calibration::new();
+        assert_eq!(cal.factor(), 1.0);
+        cal.record(1000, 1500);
+        cal.record(1000, 1500);
+        assert_eq!(
+            cal.factor(),
+            1.0,
+            "two samples must not steer budgeting yet (min is {CALIBRATION_MIN_SAMPLES})"
+        );
+        cal.record(1000, 1500);
+        assert!(
+            (cal.factor() - 1.5).abs() < 1e-9,
+            "at the minimum count the correction applies: {}",
+            cal.factor()
+        );
+    }
+
+    #[test]
+    fn calibration_converges_and_the_estimate_error_shrinks() {
+        // A provider whose tokenizer consistently runs 40% over the char
+        // heuristic: the calibrated estimate's error against `actual` must
+        // shrink monotonically-ish over a session and land near zero.
+        let mut cal = Calibration::new();
+        let estimated = 10_000u64;
+        let actual = 14_000u64;
+        let initial_error = estimated.abs_diff(actual);
+        let mut last_error = u64::MAX;
+        for step in 0..10 {
+            let calibrated = (estimated as f64 * cal.factor()).ceil() as u64;
+            let error = calibrated.abs_diff(actual);
+            if step >= 3 {
+                assert!(
+                    error <= last_error,
+                    "error must not grow once corrections apply: step {step}, {error} > {last_error}"
+                );
+                last_error = error;
+            }
+            cal.record(estimated, actual);
+        }
+        let final_error = ((estimated as f64 * cal.factor()).ceil() as u64).abs_diff(actual);
+        assert!(
+            final_error < initial_error / 10,
+            "after 10 steady samples the error must be <10% of the raw drift: \
+             {final_error} vs initial {initial_error}"
+        );
+    }
+
+    #[test]
+    fn factor_is_clamped_so_wild_ratios_cannot_destabilize_budgets() {
+        let mut low = Calibration::new();
+        let mut high = Calibration::new();
+        for _ in 0..20 {
+            low.record(100_000, 1); // absurd under-run
+            high.record(1, 100_000); // absurd over-run
+        }
+        assert_eq!(
+            low.factor(),
+            CALIBRATION_MIN_FACTOR,
+            "the correction may at most halve the conservative estimate"
+        );
+        assert_eq!(
+            high.factor(),
+            CALIBRATION_MAX_FACTOR,
+            "the correction may at most double the estimate"
+        );
+    }
+
+    #[test]
+    fn one_noisy_sample_is_bounded_before_it_enters_the_average() {
+        let mut cal = Calibration::new();
+        for _ in 0..5 {
+            cal.record(1000, 1000); // steady, perfectly calibrated
+        }
+        cal.record(1, 1_000_000); // one absurd spike
+        // The spike enters as at most CALIBRATION_SAMPLE_MAX_RATIO with
+        // weight alpha: 0.3·4.0 + 0.7·1.0 = 1.9 — never the raw 1e6 ratio.
+        assert!(
+            cal.factor() <= 1.9 + 1e-9,
+            "a single spike must move the factor by a bounded step, got {}",
+            cal.factor()
+        );
+        // …and a couple of ordinary samples pull it back down.
+        cal.record(1000, 1000);
+        cal.record(1000, 1000);
+        cal.record(1000, 1000);
+        assert!(
+            cal.factor() < 1.35,
+            "recovery must be quick: {}",
+            cal.factor()
+        );
+    }
+
+    #[test]
+    fn zero_sided_samples_carry_no_signal_and_are_ignored() {
+        let mut cal = Calibration::new();
+        for _ in 0..10 {
+            cal.record(0, 5_000); // no estimate recorded (legacy rows)
+            cal.record(5_000, 0); // provider omitted usage
+        }
+        assert_eq!(cal.samples(), 0);
+        assert_eq!(cal.factor(), 1.0);
+    }
+
+    #[test]
+    fn calibrated_estimates_scale_the_raw_heuristic() {
+        let mut cal = Calibration::new();
+        for _ in 0..5 {
+            cal.record(1000, 2000);
+        }
+        let msg = CompletionMessage::user("a".repeat(3500));
+        let raw = estimate_message_tokens(&msg);
+        assert_eq!(cal.calibrated_message_tokens(&msg), raw * 2);
+        let convo = vec![CompletionMessage::system("sys"), msg];
+        assert_eq!(
+            cal.calibrated_conversation_tokens(&convo),
+            (estimate_conversation_tokens(&convo) as f64 * 2.0).ceil() as u64
+        );
+    }
+
+    #[test]
+    fn map_keys_models_independently_and_seeds_replay_history() {
+        let map = CalibrationMap::new();
+        map.seed("glm-5.2", &[(1000, 1500), (1000, 1500), (1000, 1500)]);
+        map.record("claude-fable-5", 1000, 800);
+        assert!((map.factor(Some("glm-5.2")) - 1.5).abs() < 1e-9);
+        assert_eq!(
+            map.factor(Some("claude-fable-5")),
+            1.0,
+            "one sample is below the minimum — and glm's drift must not leak in"
+        );
+        assert_eq!(map.factor(Some("never-seen")), 1.0);
+    }
+
+    #[test]
+    fn map_falls_back_to_its_single_entry_before_any_model_is_known() {
+        let map = CalibrationMap::new();
+        assert_eq!(map.factor(None), 1.0, "empty map: no correction");
+        map.seed("glm-5.2", &[(1000, 1400), (1000, 1400), (1000, 1400)]);
+        assert!(
+            (map.factor(None) - 1.4).abs() < 1e-9,
+            "a single seeded entry serves the first pre-call read of a session"
+        );
+        map.seed("other-model", &[(1000, 1400), (1000, 1400), (1000, 1400)]);
+        assert_eq!(
+            map.factor(None),
+            1.0,
+            "two entries and no model named: never guess"
+        );
     }
 }

--- a/stella-core/src/goal.rs
+++ b/stella-core/src/goal.rs
@@ -236,7 +236,7 @@ impl Engine<'_> {
             )),
         ];
         let read_only = ReadOnlyTools::new(self.tools);
-        let judge_engine = Engine::with_sleeper(
+        let mut judge_engine = Engine::with_sleeper(
             judge,
             &read_only,
             EngineConfig {
@@ -249,6 +249,11 @@ impl Engine<'_> {
             },
             self.sleeper,
         );
+        // Share the session's drift calibration: the map is keyed per model
+        // (`crate::estimator::CalibrationMap`), so a cross-family judge
+        // learns its own model's drift without ever blending into the
+        // worker's.
+        judge_engine.calibration = self.calibration;
 
         match judge_engine
             .run_turn(&mut judge_messages, budget, events)

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod skills;
 
 pub use budget::{BudgetGuard, BudgetOutcome};
 pub use driver::{Engine, EngineConfig, TurnOutcome};
+pub use estimator::{Calibration, CalibrationMap};
 pub use goal::{GoalConfig, GoalOutcome};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};
 pub use loop_detect::{LoopDetectionConfig, LoopVerdict, detect_loop};

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -103,6 +103,16 @@ pub enum AgentEvent {
         input_tokens: u64,
         output_tokens: u64,
         cached_input_tokens: u64,
+        /// The engine's RAW (uncalibrated) pre-call estimate of the input it
+        /// sent — paired with `input_tokens` this is one drift sample, the
+        /// feedback that calibrates future estimates per model
+        /// (`stella-core::estimator::Calibration`). Raw by contract:
+        /// consumers rebuild the correction from these pairs, and a
+        /// corrected estimate here would compound the correction on every
+        /// round trip. `0` means no estimate was taken (pre-drift emitters —
+        /// hence `serde(default)`, so old streams still parse).
+        #[serde(default)]
+        estimated_input_tokens: u64,
         cost_usd: f64,
         duration_ms: u64,
         retries: u32,
@@ -535,6 +545,7 @@ mod tests {
             input_tokens: 12_000,
             output_tokens: 450,
             cached_input_tokens: 9_000,
+            estimated_input_tokens: 11_200,
             cost_usd: 0.0042,
             duration_ms: 1_830,
             retries: 1,
@@ -547,14 +558,39 @@ mod tests {
             AgentEvent::StepUsage {
                 step,
                 cached_input_tokens,
+                estimated_input_tokens,
                 retries,
                 tool_calls,
                 ..
             } => {
                 assert_eq!(step, 3);
                 assert_eq!(cached_input_tokens, 9_000);
+                assert_eq!(estimated_input_tokens, 11_200);
                 assert_eq!(retries, 1);
                 assert_eq!(tool_calls, 4);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_usage_from_a_pre_drift_stream_still_parses() {
+        // Backward compatibility: a `step_usage` line serialized before
+        // `estimated_input_tokens` existed must deserialize with the field
+        // defaulting to 0 ("no estimate was taken") — the stream-json wire
+        // format is versioned by being additive-only.
+        let legacy = r#"{"type":"step_usage","step":3,"model":"glm-5.2","input_tokens":12000,
+            "output_tokens":450,"cached_input_tokens":9000,"cost_usd":0.0042,
+            "duration_ms":1830,"retries":1,"tool_calls":4}"#;
+        let back: AgentEvent = serde_json::from_str(legacy).unwrap();
+        match back {
+            AgentEvent::StepUsage {
+                estimated_input_tokens,
+                input_tokens,
+                ..
+            } => {
+                assert_eq!(estimated_input_tokens, 0);
+                assert_eq!(input_tokens, 12_000);
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -10,9 +10,11 @@
 //!   row per event in order, including `Reasoning` deltas — the full chain
 //!   of thought is replayable against its execution.
 //! - **telemetry** — one row per committed model call (from `StepUsage`):
-//!   provider, model, tokens in/out, cache read hits, cache misses, cache
-//!   writes, cost (computed from the model card's pricing × token counts
-//!   in the adapter), duration, retries, tool-call count.
+//!   provider, model, tokens in/out, the engine's pre-call input estimate
+//!   (the drift sample [`Store::drift_samples`] serves back to calibrate
+//!   future estimates), cache read hits, cache misses, cache writes, cost
+//!   (computed from the model card's pricing × token counts in the
+//!   adapter), duration, retries, tool-call count.
 //! - **files_touched** — the CRUD ledger per execution.
 //! - **file_locks** — schema + API for cooperative file claims in multi-agent
 //!   work. Reserved: no shipping command acquires locks yet.
@@ -67,6 +69,10 @@ pub struct TelemetryRow {
     pub provider: String,
     pub model: String,
     pub input_tokens: u64,
+    /// The engine's raw pre-call estimate of `input_tokens` — paired they
+    /// are one drift sample ([`Store::drift_samples`]); 0 means no estimate
+    /// was taken (rows persisted before drift correction existed).
+    pub estimated_input_tokens: u64,
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
     pub cache_miss_tokens: u64,
@@ -133,6 +139,7 @@ impl Store {
                provider TEXT NOT NULL,
                model TEXT NOT NULL,
                input_tokens BIGINT NOT NULL,
+               estimated_input_tokens BIGINT NOT NULL DEFAULT 0,
                output_tokens BIGINT NOT NULL,
                cache_read_tokens BIGINT NOT NULL,
                cache_miss_tokens BIGINT NOT NULL,
@@ -163,6 +170,16 @@ impl Store {
                edge_type TEXT NOT NULL,
                properties JSON NOT NULL DEFAULT '{}'
              );",
+        )?;
+        // Additive migration for databases created before drift correction
+        // landed: `CREATE TABLE IF NOT EXISTS` above is a no-op on them, so
+        // the column arrives via ALTER. Old rows default to 0 = "no estimate
+        // was taken", which `drift_samples` excludes as signal-free. (No NOT
+        // NULL here — DuckDB can't retrofit the constraint onto a non-empty
+        // table; the DEFAULT keeps new writes non-null in practice.)
+        conn.execute_batch(
+            "ALTER TABLE telemetry ADD COLUMN IF NOT EXISTS \
+             estimated_input_tokens BIGINT DEFAULT 0;",
         )?;
         Ok(())
     }
@@ -217,14 +234,16 @@ impl Store {
     pub fn record_telemetry(&self, execution_id: i64, row: &TelemetryRow) -> Result<()> {
         self.lock().execute(
             "INSERT INTO telemetry (execution_id, step, provider, model, input_tokens, \
-             output_tokens, cache_read_tokens, cache_miss_tokens, cache_write_tokens, cost_usd, \
-             duration_ms, retries, tool_calls) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens, \
+             cache_write_tokens, cost_usd, duration_ms, retries, tool_calls) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
                 row.step as i64,
                 row.provider,
                 row.model,
                 row.input_tokens as i64,
+                row.estimated_input_tokens as i64,
                 row.output_tokens as i64,
                 row.cache_read_tokens as i64,
                 row.cache_miss_tokens as i64,
@@ -236,6 +255,47 @@ impl Store {
             ],
         )?;
         Ok(())
+    }
+
+    /// The most recent `limit` (estimated, actual) input-token pairs for one
+    /// provider/model — the drift samples that seed a new session's
+    /// `Calibration` (`stella-core::estimator`) from prior sessions'
+    /// telemetry. Returned OLDEST FIRST, so replaying them through an EWMA
+    /// in order weights the most recent step highest. Rows without a
+    /// recorded estimate (`estimated_input_tokens` 0 or NULL: pre-drift
+    /// sessions, migrated databases) or without reported usage carry no
+    /// drift signal and are excluded. Keyed by (provider, model), never
+    /// model alone — the same slug on two providers is two tokenizers.
+    pub fn drift_samples(
+        &self,
+        provider: &str,
+        model: &str,
+        limit: usize,
+    ) -> Result<Vec<(u64, u64)>> {
+        let conn = self.lock();
+        // execution ids come from a monotonic sequence and steps count up
+        // within one execution, so (execution_id, step) is insertion order —
+        // unlike ts, whose second-level granularity ties within a turn.
+        let mut stmt = conn.prepare(
+            "SELECT estimated_input_tokens, input_tokens FROM (
+               SELECT estimated_input_tokens, input_tokens, execution_id, step
+               FROM telemetry
+               WHERE provider = ? AND model = ?
+                 AND estimated_input_tokens > 0 AND input_tokens > 0
+               ORDER BY execution_id DESC, step DESC
+               LIMIT ?
+             ) ORDER BY execution_id ASC, step ASC",
+        )?;
+        let rows = stmt.query_map(params![provider, model, limit as i64], |row| {
+            let estimated: i64 = row.get(0)?;
+            let actual: i64 = row.get(1)?;
+            Ok((estimated as u64, actual as u64))
+        })?;
+        let mut samples = Vec::new();
+        for row in rows {
+            samples.push(row?);
+        }
+        Ok(samples)
     }
 
     /// Persist the CRUD ledger for an execution.
@@ -392,6 +452,7 @@ mod tests {
                     provider: "zai".into(),
                     model: "glm-5.2".into(),
                     input_tokens: 12_000,
+                    estimated_input_tokens: 11_000,
                     output_tokens: 400,
                     cache_read_tokens: 9_000,
                     cache_miss_tokens: 3_000,
@@ -411,6 +472,158 @@ mod tests {
         assert_eq!(store.count("telemetry").unwrap(), 1);
         assert_eq!(store.count("files_touched").unwrap(), 1);
         assert_eq!(store.count("executions").unwrap(), 1);
+    }
+
+    /// A telemetry row shaped for drift tests — only the sample-relevant
+    /// fields vary.
+    fn drift_row(
+        step: u64,
+        provider: &str,
+        model: &str,
+        estimated: u64,
+        actual: u64,
+    ) -> TelemetryRow {
+        TelemetryRow {
+            step,
+            provider: provider.into(),
+            model: model.into(),
+            input_tokens: actual,
+            estimated_input_tokens: estimated,
+            output_tokens: 100,
+            cache_read_tokens: 0,
+            cache_miss_tokens: actual,
+            cache_write_tokens: 0,
+            cost_usd: 0.001,
+            duration_ms: 500,
+            retries: 0,
+            tool_calls: 1,
+        }
+    }
+
+    #[test]
+    fn drift_samples_roundtrip_the_estimated_column_oldest_first() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        store
+            .record_telemetry(id, &drift_row(0, "zai", "glm-5.2", 1_000, 1_400))
+            .unwrap();
+        store
+            .record_telemetry(id, &drift_row(1, "zai", "glm-5.2", 2_000, 2_900))
+            .unwrap();
+
+        let samples = store.drift_samples("zai", "glm-5.2", 10).unwrap();
+        assert_eq!(
+            samples,
+            vec![(1_000, 1_400), (2_000, 2_900)],
+            "oldest first — EWMA replay order"
+        );
+    }
+
+    #[test]
+    fn drift_samples_are_keyed_by_provider_and_model_and_skip_signal_free_rows() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        store
+            .record_telemetry(id, &drift_row(0, "zai", "glm-5.2", 1_000, 1_400))
+            .unwrap();
+        // Same model slug on a DIFFERENT provider: a different tokenizer,
+        // never the same calibration.
+        store
+            .record_telemetry(id, &drift_row(1, "other", "glm-5.2", 1_000, 9_000))
+            .unwrap();
+        // Different model, same provider.
+        store
+            .record_telemetry(id, &drift_row(2, "zai", "glm-4", 1_000, 9_000))
+            .unwrap();
+        // No estimate recorded (pre-drift row) and no reported usage: both
+        // signal-free.
+        store
+            .record_telemetry(id, &drift_row(3, "zai", "glm-5.2", 0, 1_400))
+            .unwrap();
+        store
+            .record_telemetry(id, &drift_row(4, "zai", "glm-5.2", 1_000, 0))
+            .unwrap();
+
+        let samples = store.drift_samples("zai", "glm-5.2", 10).unwrap();
+        assert_eq!(samples, vec![(1_000, 1_400)]);
+    }
+
+    #[test]
+    fn drift_samples_limit_keeps_the_most_recent_rows() {
+        let store = Store::in_memory().unwrap();
+        // Across two executions, so the ordering key spans sessions.
+        let first = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        for step in 0..3u64 {
+            store
+                .record_telemetry(first, &drift_row(step, "zai", "glm-5.2", 100 + step, 200))
+                .unwrap();
+        }
+        let second = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        for step in 0..3u64 {
+            store
+                .record_telemetry(second, &drift_row(step, "zai", "glm-5.2", 500 + step, 600))
+                .unwrap();
+        }
+
+        let samples = store.drift_samples("zai", "glm-5.2", 4).unwrap();
+        assert_eq!(
+            samples,
+            vec![(102, 200), (500, 600), (501, 600), (502, 600)],
+            "the limit trims the OLDEST rows and keeps replay order"
+        );
+    }
+
+    #[test]
+    fn migrate_adds_the_estimated_column_to_a_pre_drift_database() {
+        let root = std::env::temp_dir().join(format!(
+            "stella_store_migrate_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(root.join(".stella")).unwrap();
+        // Simulate a database created before drift correction: the telemetry
+        // table exists WITHOUT estimated_input_tokens and already has a row.
+        {
+            let conn = Connection::open(root.join(".stella/stella.duckdb")).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE telemetry (
+                   execution_id BIGINT NOT NULL,
+                   step BIGINT NOT NULL,
+                   ts TIMESTAMP NOT NULL DEFAULT current_timestamp,
+                   provider TEXT NOT NULL,
+                   model TEXT NOT NULL,
+                   input_tokens BIGINT NOT NULL,
+                   output_tokens BIGINT NOT NULL,
+                   cache_read_tokens BIGINT NOT NULL,
+                   cache_miss_tokens BIGINT NOT NULL,
+                   cache_write_tokens BIGINT NOT NULL DEFAULT 0,
+                   cost_usd DOUBLE NOT NULL,
+                   duration_ms BIGINT NOT NULL,
+                   retries INTEGER NOT NULL,
+                   tool_calls BIGINT NOT NULL
+                 );
+                 INSERT INTO telemetry (execution_id, step, provider, model, input_tokens,
+                   output_tokens, cache_read_tokens, cache_miss_tokens, cost_usd, duration_ms,
+                   retries, tool_calls)
+                 VALUES (1, 0, 'zai', 'glm-5.2', 1400, 100, 0, 1400, 0.001, 500, 0, 1);",
+            )
+            .unwrap();
+        }
+        // Store::open runs migrate() against the old schema…
+        let store = Store::open(&root).unwrap();
+        // …after which new-schema writes and reads work,
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        store
+            .record_telemetry(id, &drift_row(0, "zai", "glm-5.2", 1_000, 1_400))
+            .unwrap();
+        // and the legacy row (estimated defaulted, no signal) is excluded.
+        assert_eq!(store.count("telemetry").unwrap(), 2);
+        assert_eq!(
+            store.drift_samples("zai", "glm-5.2", 10).unwrap(),
+            vec![(1_000, 1_400)]
+        );
+        drop(store);
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
…ge drift

Closes #15. The estimator's documented stub — per-provider drift correction — is now implemented end to end:

- estimator::Calibration: an EWMA (alpha 0.3) of the observed actual/estimated input-token ratio, per model. Inactive below 3 samples; each raw sample is truncated to [0.25, 4.0] before entering the average; the applied factor is clamped to [0.5, 2.0] so calibration can at most halve the deliberately conservative estimate (the safe over-estimate direction survives) and a pathological run can never thrash compaction. CalibrationMap keys the state per model string — the same slug on two providers is two tokenizers.
- Driver feedback loop: before each completion the engine takes the raw conversation estimate; when usage lands it records the (estimated, actual) pair and scales the compaction budget by the model's factor — the raw estimate itself is never rewritten, so the correction cannot compound.
- Persistence: StepUsage gains estimated_input_tokens (serde(default) — old stream-json still parses, with a witness test), the telemetry table gains the column via an additive ALTER TABLE IF NOT EXISTS migration, and Store::drift_samples serves the most recent pairs oldest-first. Sessions seed their CalibrationMap from the store, so calibration carries across sessions per provider/model.

Witness tests: convergence, clamping, min-samples, seed-replay ordering, calibrated compaction firing where uncalibrated does not, per-step calibration feed + raw estimate on StepUsage, legacy-stream parse, store column round-trip and drift_samples filtering.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calibrates token estimates against provider-reported usage so compaction honors real model tokens. Adds a per-model correction that learns from telemetry and persists across sessions.

- **New Features**
  - `stella-core`: Per-model EWMA calibration (alpha 0.3; active after 3 samples; clamped 0.5–2.0). Attach via `Engine::with_calibration`.
  - Engine scales the compaction budget by the model’s factor and records (estimated, actual) after each committed step.
  - `stella-cli`: Sessions seed calibration from the last 20 drift samples; the judge shares the same map.

- **Migration**
  - `stella-protocol`: `StepUsage` adds `estimated_input_tokens` (serde default keeps older streams valid).
  - `stella-store`: Added `estimated_input_tokens` column (additive ALTER) and `drift_samples(provider, model, limit)` returning oldest‑first pairs.
  - No user action needed; existing databases migrate on open.

<sup>Written for commit 7fb2924d8eefaf427310d26128e25109fd9c2040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
