### PR TITLE
fix(stella-cli): unbreak main — reconcile stella stats with tools --validate

### DIFF
--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -22,8 +22,8 @@ mod config;
 mod domains;
 mod interactive;
 mod memory;
-mod stats;
 mod settings;
+mod stats;
 mod tui;
 
 use std::process::ExitCode;
@@ -195,7 +195,10 @@ fn run(cli: Cli) -> Result<(), String> {
         }
         Some(Command::Stats { format, provider }) => {
             // Reads local telemetry only — works with zero API keys.
-            return stats::run_stats(format, provider.as_deref());
+            // `*format`: this match borrows `&cli.command` (the Tools arm
+            // needs `validate` by ref), so `format` binds as `&StatsFormat`;
+            // it is `Copy`, so deref rather than move.
+            return stats::run_stats(*format, provider.as_deref());
         }
         Some(Command::Version) => {
             println!("stella v{}", env!("CARGO_PKG_VERSION"));
@@ -258,7 +261,11 @@ fn run(cli: Cli) -> Result<(), String> {
         // Models/Version (and Tools) short-circuit in the first match at the
         // top of `run` before a provider is resolved; Init is handled by the
         // caller. Reaching any of them here is impossible.
-        Command::Init | Command::Tools { .. } | Command::Models | Command::Version => {
+        Command::Init
+        | Command::Tools { .. }
+        | Command::Stats { .. }
+        | Command::Models
+        | Command::Version => {
             unreachable!("handled before provider resolution")
         }
         Command::Config => {


### PR DESCRIPTION
## What & why

**`main` is currently red — this fixes it.** PR #50 (`tools --validate`) merged after PR #48 (`stella stats`) and changed `run` to `match &cli.command` (the Tools arm borrows `validate`). The merge was textually clean but the combined tree does not compile:

- **E0308** at the `Stats` arm — `format` now binds as `&StatsFormat`, but `stats::run_stats` takes it by value → `*format` (`StatsFormat` is `Copy`).
- **E0004** at the `unreachable!` provider-resolution arm — the merge kept #50's `Command::Tools { .. }` line, dropping `Command::Stats { .. }`, so that match is non-exhaustive → restore it.

This is the classic clean-merge-but-broken-build interleave: neither #48 nor #50 was wrong alone; they only conflict once both are on `main`.

## The witness

-  No witness needed — because: this restores compilation. On current `main`, `cargo build -p stella-cli` fails with E0308/E0004; on this branch it builds. The failing→passing transition is the build itself.

## The gate

- [x] `cargo build --locked` (was failing on `main`, green here)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p stella-cli` (61 passed)
- [x] Commits signed off for DCO (`git commit -s`)

## Anything reviewers should know?

Please merge promptly — every branch cut from current `main` inherits a non-compiling tree until this lands. No behavior change; purely the integration fix between two already-merged features.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken build on `main` for `stella-cli` by aligning the `stella stats` path with the `tools --validate` change. The app compiles again with no behavior changes.

- **Bug Fixes**
  - In `run`, pass `*format` to `stats::run_stats` since the match is on `&cli.command`.
  - Restore `Command::Stats { .. }` in the final provider-resolution match to keep it exhaustive.

<sup>Written for commit cb331cffbe0fc324568d355d6a4c3477f738aada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
