### PR TITLE
docs(readme): link arena as the Cross-harness division runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ The full harness docs live in [`bench/`](bench/README.md), and a
 head-to-head runs against other agents lives in
 [`bench/harbor_adapter/`](bench/harbor_adapter/README.md).
 
+For the **Cross-harness** division, [`arena`](https://github.com/oxageninc/arena)
+is a standalone, open-source runner that pits Stella against Claude Code, Gemini
+CLI, Oxagen, and any agent you bolt on — same model, same budget, held-out tests
+the agent can't see or author, and paired statistics (Wilson intervals, exact
+McNemar, bootstrap CIs), with every run's manifest, transcripts, and diffs kept
+as receipts.
+
 ### The leaderboard
 
 | # | Pilot | Match-up | Model | Division | Resolved | $/resolved | Receipts |


### PR DESCRIPTION
The Arena section describes a Cross-harness division (Stella vs. other agent CLIs) but pointed to no tool for it. That runner now exists publicly at github.com/oxageninc/arena — same model/budget, held-out verification, paired stats, full receipts. Stella's own SWE-bench harness (bench/) is unchanged.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linked the Cross-harness division in the README to `arena`, a standalone runner that pits Stella against other agent CLIs with the same model and budget. It uses held-out tests, paired stats, and stores manifests/transcripts/diffs as receipts; Stella’s `bench/` harness is unchanged.

<sup>Written for commit 97b778c5ee1ebf66838414f9aab7d31483777412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
