### PR TITLE
docs(readme): align README with the shipped binary [skip release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,15 +288,14 @@ flowchart TD
 > crates that aren't wired into the CLI yet — they're the next layers, and some
 > of the best places to contribute:
 >
-> - **`stella-pipeline`** — the triage → enhance → route → execute → verify →
->   judge → revise orchestration plane (the CLI currently drives the engine directly).
 > - **`stella-fleet`** — multi-agent fan-out: DAG planner, worktree isolation,
 >   lineage + spend ledger.
 > - **`stella-tui`** — a pure-fold ratatui REPL (HUD, panels, diff viewer). The
 >   shipping shell today is `stella-cli`'s simpler line REPL.
 > - **`stella-media`** — multimodal generation behind a `MediaProvider` port.
 > - **`stella-graph` retrieval & the fuller context plane** — the code graph is
->   indexed on `stella init` but not yet queried at runtime; bi-temporal facts and
+>   indexed on `stella init` and feeds the schema conflict gate at session start,
+>   but broader runtime retrieval is not yet queried; bi-temporal facts and
 >   episodic memory are implemented and tested but the CLI currently uses only the
 >   reflection-memory recall path.
 >
@@ -513,9 +512,13 @@ stella stats     # cost, tokens, and $/resolved task per provider/model from
 ### Global flags
 
 `--model provider/id` · `--api-key` · `--base-url` · `--budget <usd>` ·
-`--output-format text|json|stream-json` (all also as `STELLA_*` env vars). The
+`--output-format text|json|stream-json` (also as `STELLA_MODEL`,
+`STELLA_BASE_URL`, `STELLA_BUDGET`, and `STELLA_OUTPUT_FORMAT`; API keys come
+from provider-specific env vars or `~/.config/stella/credentials.toml`). The
 `json` / `stream-json` formats are for headless one-shot `stella run`; the
-interactive `chat` / `goal` / `monitor` modes always render human-readable output.
+interactive `chat` / `goal` / `monitor` modes always render human-readable
+output. `stella run` executes through the staged pipeline by default; pass
+`--no-pipeline` to fall back to the raw step-loop.
 
 <div align="center">
 
@@ -556,8 +559,9 @@ considers them at prompt-cache-hit prices (~0.1× input). New memories take effe
 
 Every execution is recorded in `.stella/stella.duckdb`: the full event stream
 (chain-of-thought deltas included), per-model-call telemetry (tokens in/out, cache
-read hit/miss, cost from the model card's pricing), the Files-Touched ledger, plus
-`file_locks` and `graph_nodes` / `graph_edges` tables for the context plane. Query it
+read hit/miss, cost from the model card's pricing), and the Files-Touched ledger
+(`file_locks` and `graph_nodes` / `graph_edges` tables exist in the schema as
+reserved seams for the context plane; no shipping command writes them yet). Query it
 with any DuckDB client. **Nothing leaves your machine** — the only network traffic
 Stella produces is to the model provider you chose.
 
@@ -595,12 +599,12 @@ targets — see the architecture status note above).
 | `stella-mcp` | ✅ | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry; per-call timeouts isolate dead servers |
 | `stella-protocol` | ✅ | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports |
 | `stella-context` | ◑ | The context plane. Reflection-memory recall + embedding index are wired; the bi-temporal property graph and episodic memory are built and tested but not yet consulted at runtime |
-| `stella-graph` | 🧪 | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python). Indexed on `stella init`; runtime retrieval not yet wired |
-| `stella-pipeline` | 🧪 | The orchestration plane above the engine: triage → enhance → route → execute → verify → judge → revise |
+| `stella-graph` | ◑ | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python/SQL). Indexed on `stella init`; the schema gate reads it at session start, broader runtime retrieval not yet wired |
+| `stella-pipeline` | ✅ | The orchestration plane above the engine — the default `stella run` path: triage → plan (split context) → scope review → execute → verify → judge, with bounded revision (`--no-pipeline` opts out) |
 | `stella-fleet` | 🧪 | The multi-agent fleet: DAG planner + wave scheduling, git-worktree isolation per task, SQLite lineage + per-task spend ledger |
 | `stella-media` | 🧪 | Multimodal generation (image/SVG/video) behind one `MediaProvider` port — BYOK, artifact discipline, cost-gated |
 | `stella-tui` | 🧪 | Event-log REPL — a pure `SessionModel` fold + a thin crossterm shell (renders deterministically from events) |
-| `ocp-types` · `ocp-host` · `ocp-conformance` | ✅ | Open Context Protocol — wire types (zero deps beyond `serde`), host runtime (discover/negotiate/route/gate), and the public conformance suite |
+| `ocp-types` · `ocp-host` · `ocp-conformance` | ◑ | Open Context Protocol — wire types (zero deps beyond `serde`, in the binary), host runtime (discover/negotiate/route/gate), and the public conformance suite; only `ocp-types` is wired into the shipping CLI today |
 
 ## Development
 


### PR DESCRIPTION
Pre-release accuracy pass from the release-readiness review (no code changes):

- **stella-pipeline** is the default `stella run` execution path since #68 — the README still said "the CLI currently drives the engine directly" and the workspace table marked it 🧪 not-yet-wired. Now marked ✅ with the real stage names (triage → plan → scope review → execute → verify → judge, bounded revision) and `--no-pipeline` documented.
- **ocp row** claimed ✅ ("wired into the shipping CLI today") for all three OCP crates; only `ocp-types` is in the binary. Downgraded to ◑ with an explicit note, matching the README's own OCP paragraph.
- **Global flags** claimed all flags exist "as `STELLA_*` env vars" — `STELLA_API_KEY` doesn't exist anywhere in the codebase. Now lists the four real ones and points keys at provider env vars / credentials.toml.
- **Telemetry** implied `file_locks`/`graph_nodes`/`graph_edges` are recorded; they're reserved schema seams no shipping command writes. Reworded.
- **stella-graph** status updated: schema-gate seeding at session start is wired (#72), broader retrieval isn't.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the README with the currently shipped CLI and binary. Fixes pipeline defaults, OCP wiring, env vars, telemetry notes, and `stella-graph` status.

- **Bug Fixes**
  - `stella-pipeline` is the default `stella run` path; docs show real stages and `--no-pipeline`.
  - OCP row reflects that only `ocp-types` is in the binary; `ocp-host` and `ocp-conformance` are not.
  - Global flags list the real env vars: `STELLA_MODEL`, `STELLA_BASE_URL`, `STELLA_BUDGET`, `STELLA_OUTPUT_FORMAT`; API keys come from provider env vars or `~/.config/stella/credentials.toml`.
  - Telemetry clarifies `file_locks`, `graph_nodes`, `graph_edges` are schema seams, not written by shipping commands.
  - `stella-graph` notes: index feeds the schema gate at session start; broader runtime retrieval not wired.

<sup>Written for commit 7bab1415f7328a7e155d5957957cbabbd9c66142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
