### PR TITLE
feat(stella-graph): ORM pattern detection (Diesel, Django, SQLAlchemy)

### DIFF
--- a/stella-graph/src/parse.rs
+++ b/stella-graph/src/parse.rs
@@ -109,7 +109,17 @@ pub(crate) fn parse_file(grammars: &Grammars, lang: Language, source: &str) -> O
     let root = tree.root_node();
     let src = source.as_bytes();
 
-    let symbols = extract_symbols(&pack.symbols, root, src);
+    let mut symbols = extract_symbols(&pack.symbols, root, src);
+
+    // ORM pattern detection: scan the AST for table-like definitions
+    // (Diesel `table!` macros, Django/SQLAlchemy model classes) and add
+    // them as Table symbols. SQL DDL is the ground truth; these are hints.
+    match lang {
+        Language::Rust => symbols.extend(extract_rust_orm_tables(root, src)),
+        Language::Python => symbols.extend(extract_python_orm_tables(root, src)),
+        _ => {}
+    }
+
     let imports = match lang {
         Language::Rust => extract_rust_imports(&pack.imports, root, src),
         Language::Python => extract_python_imports(&pack.imports, root, src),
@@ -335,6 +345,145 @@ fn py_module_name(node: Node, src: &[u8]) -> Option<String> {
         node
     };
     target.utf8_text(src).ok().map(|s| s.to_string())
+}
+
+/// Detect Diesel `table!` macro invocations and extract them as Table symbols.
+/// The macro looks like: `diesel::table! { users (id) { ... } }` or `table! { ... }`.
+/// We extract the first identifier inside the token_tree as the table name.
+fn extract_rust_orm_tables(root: Node, src: &[u8]) -> Vec<Symbol> {
+    let mut out = Vec::new();
+
+    fn walk(node: Node, src: &[u8], out: &mut Vec<Symbol>) {
+        if node.kind() == "macro_invocation"
+            && let Some(macro_id) = node.child_by_field_name("macro")
+            && let Ok(name) = macro_id.utf8_text(src)
+        {
+            let name_lower = name.to_ascii_lowercase();
+            if name_lower.ends_with("table") {
+                let mut tc = node.walk();
+                for child in node.children(&mut tc) {
+                    if child.kind() == "token_tree" {
+                        let mut inner_tc = child.walk();
+                        for inner in child.children(&mut inner_tc) {
+                            if inner.kind() == "identifier"
+                                && let Ok(table_name) = inner.utf8_text(src)
+                                && !table_name.is_empty()
+                            {
+                                out.push(Symbol {
+                                    name: table_name.to_string(),
+                                    kind: SymbolKind::Table,
+                                    start_line: node.start_position().row as u32 + 1,
+                                    end_line: node.end_position().row as u32 + 1,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            walk(child, src, out);
+        }
+    }
+
+    walk(root, src, &mut out);
+    out
+}
+
+/// Detect Django/SQLAlchemy model classes and extract them as Table symbols.
+/// Django: `class Payment(models.Model):` — superclass contains `Model`.
+/// SQLAlchemy: `class Payment(Base):` with `__tablename__ = "payments"`.
+fn extract_python_orm_tables(root: Node, src: &[u8]) -> Vec<Symbol> {
+    let mut out = Vec::new();
+
+    fn walk(node: Node, src: &[u8], out: &mut Vec<Symbol>) {
+        if node.kind() == "class_definition" {
+            let is_model = check_python_orm_superclass(node, src)
+                || check_python_tablename(node, src);
+            if is_model
+                && let Some(name_node) = node.child_by_field_name("name")
+                && let Ok(name) = name_node.utf8_text(src)
+            {
+                let table_name = python_class_to_table_name(name);
+                out.push(Symbol {
+                    name: table_name,
+                    kind: SymbolKind::Table,
+                    start_line: node.start_position().row as u32 + 1,
+                    end_line: node.end_position().row as u32 + 1,
+                });
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            walk(child, src, out);
+        }
+    }
+
+    walk(root, src, &mut out);
+    out
+}
+
+/// Check if a Python class inherits from a known ORM base class.
+fn check_python_orm_superclass(class_node: Node, src: &[u8]) -> bool {
+    let Some(superclasses) = class_node.child_by_field_name("superclasses") else {
+        return false;
+    };
+    let mut cursor = superclasses.walk();
+    for arg in superclasses.children(&mut cursor) {
+        if let Ok(text) = arg.utf8_text(src) {
+            let text = text.trim();
+            // Django: models.Model, db.Model
+            // SQLAlchemy: Base, declarative_base, Model
+            if text.ends_with("Model")
+                || text.ends_with(".Base")
+                || text == "Base"
+                || text.ends_with("declarative_base()")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check if a Python class body contains `__tablename__ = "..."`.
+fn check_python_tablename(class_node: Node, src: &[u8]) -> bool {
+    let body = match class_node.child_by_field_name("body") {
+        Some(b) => b,
+        None => return false,
+    };
+    let mut cursor = body.walk();
+    for child in body.children(&mut cursor) {
+        if child.kind() == "assignment"
+            && let Some(left) = child.child_by_field_name("left")
+            && let Ok(text) = left.utf8_text(src)
+            && text == "__tablename__"
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Naive Django-style class→table conversion: CamelCase → snake_case + plural.
+/// `Payment` → `payments`, `UserProfile` → `user_profiles`.
+fn python_class_to_table_name(name: &str) -> String {
+    let mut snake = String::new();
+    for (i, ch) in name.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            snake.push('_');
+        }
+        snake.push(ch.to_ascii_lowercase());
+    }
+    // Naive pluralization
+    if snake.ends_with('s') {
+        format!("{snake}es")
+    } else {
+        format!("{snake}s")
+    }
 }
 
 #[cfg(test)]
@@ -594,6 +743,76 @@ CREATE TABLE warehouse.analytics.events (id BIGINT);
                 && s.name != "analytics"),
             "schema qualifiers leaked into the symbol index: {:?}",
             parsed.symbols.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn diesel_table_macro_detected_as_table() {
+        let src = "\
+diesel::table! {
+    users (id) {
+        id -> Int4,
+        email -> Varchar,
+        created_at -> Timestamptz,
+    }
+}
+
+pub struct User {
+    id: i32,
+    email: String,
+}
+";
+        let parsed = parse(Language::Rust, src);
+        assert!(
+            parsed.symbols.iter().any(|s| {
+                s.name == "users" && s.kind == SymbolKind::Table
+            }),
+            "Diesel table! not detected: {:?}",
+            parsed.symbols
+        );
+        assert_eq!(kinds(&parsed, "User"), vec![SymbolKind::Struct]);
+    }
+
+    #[test]
+    fn django_model_detected_as_table() {
+        let src = "\
+from django.db import models
+
+class Payment(models.Model):
+    amount = models.DecimalField()
+    status = models.CharField(max_length=20)
+
+class Helper:
+    pass
+";
+        let parsed = parse(Language::Python, src);
+        assert!(
+            parsed.symbols
+                .iter()
+                .any(|s| s.name == "payments" && s.kind == SymbolKind::Table),
+            "Django model not detected: {:?}",
+            parsed.symbols
+        );
+        assert_eq!(kinds(&parsed, "Helper"), vec![SymbolKind::Class]);
+    }
+
+    #[test]
+    fn sqlalchemy_tablename_detected_as_table() {
+        let src = "\
+from sqlalchemy.orm import declarative_base
+Base = declarative_base()
+
+class Order(Base):
+    __tablename__ = \"orders\"
+    id = Column(Integer, primary_key=True)
+";
+        let parsed = parse(Language::Python, src);
+        assert!(
+            parsed.symbols
+                .iter()
+                .any(|s| s.kind == SymbolKind::Table),
+            "SQLAlchemy model not detected: {:?}",
+            parsed.symbols
         );
     }
 }

--- a/stella-graph/src/parse.rs
+++ b/stella-graph/src/parse.rs
@@ -359,7 +359,7 @@ fn extract_rust_orm_tables(root: Node, src: &[u8]) -> Vec<Symbol> {
             && let Ok(name) = macro_id.utf8_text(src)
         {
             let name_lower = name.to_ascii_lowercase();
-            if name_lower.ends_with("table") {
+            if name_lower == "table" || name_lower.ends_with("::table") {
                 let mut tc = node.walk();
                 for child in node.children(&mut tc) {
                     if child.kind() == "token_tree" {
@@ -400,13 +400,13 @@ fn extract_python_orm_tables(root: Node, src: &[u8]) -> Vec<Symbol> {
 
     fn walk(node: Node, src: &[u8], out: &mut Vec<Symbol>) {
         if node.kind() == "class_definition" {
-            let is_model = check_python_orm_superclass(node, src)
-                || check_python_tablename(node, src);
+            let tablename = python_tablename_value(node, src);
+            let is_model = tablename.is_some() || check_python_orm_superclass(node, src);
             if is_model
                 && let Some(name_node) = node.child_by_field_name("name")
                 && let Ok(name) = name_node.utf8_text(src)
             {
-                let table_name = python_class_to_table_name(name);
+                let table_name = tablename.unwrap_or_else(|| python_class_to_table_name(name));
                 out.push(Symbol {
                     name: table_name,
                     kind: SymbolKind::Table,
@@ -427,6 +427,10 @@ fn extract_python_orm_tables(root: Node, src: &[u8]) -> Vec<Symbol> {
 }
 
 /// Check if a Python class inherits from a known ORM base class.
+/// Matches the base expression's innermost identifier exactly (`Model`,
+/// `models.Model`, `Base`, `sqlalchemy.orm.Base`, `declarative_base()`) so
+/// unrelated types that merely end in the same substring — `ViewModel`,
+/// `DatabaseModel` — are not mistaken for ORM bases.
 fn check_python_orm_superclass(class_node: Node, src: &[u8]) -> bool {
     let Some(superclasses) = class_node.child_by_field_name("superclasses") else {
         return false;
@@ -434,14 +438,8 @@ fn check_python_orm_superclass(class_node: Node, src: &[u8]) -> bool {
     let mut cursor = superclasses.walk();
     for arg in superclasses.children(&mut cursor) {
         if let Ok(text) = arg.utf8_text(src) {
-            let text = text.trim();
-            // Django: models.Model, db.Model
-            // SQLAlchemy: Base, declarative_base, Model
-            if text.ends_with("Model")
-                || text.ends_with(".Base")
-                || text == "Base"
-                || text.ends_with("declarative_base()")
-            {
+            let ident = python_base_identifier(text.trim());
+            if ident == "Model" || ident == "Base" || ident == "declarative_base" {
                 return true;
             }
         }
@@ -449,23 +447,56 @@ fn check_python_orm_superclass(class_node: Node, src: &[u8]) -> bool {
     false
 }
 
-/// Check if a Python class body contains `__tablename__ = "..."`.
-fn check_python_tablename(class_node: Node, src: &[u8]) -> bool {
-    let body = match class_node.child_by_field_name("body") {
-        Some(b) => b,
-        None => return false,
-    };
+/// The innermost identifier of a (possibly qualified, possibly called) base
+/// class expression: `models.Model` -> `Model`, `declarative_base()` ->
+/// `declarative_base`.
+fn python_base_identifier(text: &str) -> &str {
+    let text = text.strip_suffix("()").unwrap_or(text);
+    text.rsplit('.').next().unwrap_or(text)
+}
+
+/// Extract the string value of `__tablename__ = "..."` from a Python class
+/// body, if present.
+fn python_tablename_value(class_node: Node, src: &[u8]) -> Option<String> {
+    let body = class_node.child_by_field_name("body")?;
     let mut cursor = body.walk();
-    for child in body.children(&mut cursor) {
-        if child.kind() == "assignment"
-            && let Some(left) = child.child_by_field_name("left")
+    for stmt in body.children(&mut cursor) {
+        // Class-body statements are wrapped in `expression_statement`; the
+        // `assignment` itself is an unnamed child of that wrapper.
+        let assignment = if stmt.kind() == "assignment" {
+            Some(stmt)
+        } else if stmt.kind() == "expression_statement" {
+            let mut inner = stmt.walk();
+            stmt.children(&mut inner).find(|c| c.kind() == "assignment")
+        } else {
+            None
+        };
+        let Some(assignment) = assignment else {
+            continue;
+        };
+        if let Some(left) = assignment.child_by_field_name("left")
             && let Ok(text) = left.utf8_text(src)
             && text == "__tablename__"
+            && let Some(right) = assignment.child_by_field_name("right")
         {
-            return true;
+            return python_string_literal_value(right, src);
         }
     }
-    false
+    None
+}
+
+/// The inner text of a Python string literal node, quotes stripped.
+fn python_string_literal_value(node: Node, src: &[u8]) -> Option<String> {
+    if node.kind() != "string" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return child.utf8_text(src).ok().map(|s| s.to_string());
+        }
+    }
+    None
 }
 
 /// Naive Django-style class→table conversion: CamelCase → snake_case + plural.
@@ -812,6 +843,66 @@ class Order(Base):
                 .iter()
                 .any(|s| s.kind == SymbolKind::Table),
             "SQLAlchemy model not detected: {:?}",
+            parsed.symbols
+        );
+    }
+
+    #[test]
+    fn sqlalchemy_explicit_tablename_overrides_class_name_convention() {
+        // `__tablename__` deliberately does not match the naive
+        // CamelCase->snake_case->pluralize conversion of the class name, so
+        // this only passes if the literal value is read rather than derived.
+        let src = "\
+from sqlalchemy.orm import declarative_base
+Base = declarative_base()
+
+class Order(Base):
+    __tablename__ = \"customer_orders\"
+    id = Column(Integer, primary_key=True)
+";
+        let parsed = parse(Language::Python, src);
+        assert!(
+            parsed
+                .symbols
+                .iter()
+                .any(|s| s.name == "customer_orders" && s.kind == SymbolKind::Table),
+            "explicit __tablename__ value not used: {:?}",
+            parsed.symbols
+        );
+        assert!(
+            !parsed.symbols.iter().any(|s| s.name == "orders"),
+            "table name should not fall back to class-name convention: {:?}",
+            parsed.symbols
+        );
+    }
+
+    #[test]
+    fn python_unrelated_view_model_not_detected_as_table() {
+        let src = "\
+class OrderViewModel(ViewModel):
+    total = 0
+";
+        let parsed = parse(Language::Python, src);
+        assert!(
+            !parsed.symbols.iter().any(|s| s.kind == SymbolKind::Table),
+            "unrelated ViewModel base should not be indexed as a table: {:?}",
+            parsed.symbols
+        );
+    }
+
+    #[test]
+    fn rust_unrelated_table_suffixed_macro_not_detected() {
+        let src = "\
+render_table! {
+    users (id) {
+        id -> Int4,
+    }
+}
+";
+        let parsed = parse(Language::Rust, src);
+        assert!(
+            !parsed.symbols.iter().any(|s| s.kind == SymbolKind::Table),
+            "unrelated render_table! macro should not be indexed as a table: {:?}",
             parsed.symbols
         );
     }


### PR DESCRIPTION

## Summary

Phase 3 of the schema-aware code graph: detect ORM model definitions in Rust and Python source and emit them as `Table` symbols, making schema retrievable from code files alongside SQL migrations.

- **Diesel (Rust)**: `table!` macro → extracts table name from the first identifier in the token tree
- **Django (Python)**: classes inheriting from `models.Model` → infers table name via CamelCase → snake_case plural
- **SQLAlchemy (Python)**: classes with `__tablename__` assignment → detected as ORM models

SQL DDL (Phase 1) remains the ground truth. ORM models are hints layered on top — when both define the same table, the pre-write gate (Phase 2) uses the canonical DDL name.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 44 suites pass
- [x] New test: `diesel_table_macro_detected_as_table`
- [x] New test: `django_model_detected_as_table`
- [x] New test: `sqlalchemy_tablename_detected_as_table`

## What's next

Phase 4: Semantic edges (function → table query/mutation links via SQL string literal detection in function bodies)

Design doc: `docs/design/schema-graph.md`

💘 Generated with Crush

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects ORM models in Rust and Python and emits them as `Table` symbols so schema can be discovered from code files, not just SQL migrations. SQL DDL stays the source of truth; ORM detections are hints.

- **New Features**
  - Rust (`Diesel`): detect `table!` and `diesel::table!`; use the first identifier in the token tree as the table name.
  - Python (`Django`): detect classes inheriting `models.Model`; infer table name by CamelCase → snake_case plural.
  - Python (`SQLAlchemy`): detect classes with `__tablename__` and emit them as tables.

- **Bug Fixes**
  - Rust (`Diesel`): ignore non-ORM macros like `render_table!`; only `table!` and `*::table!` are treated as tables.
  - Python (`SQLAlchemy`): use the literal `__tablename__` value and prefer it over class-name conventions.
  - Python (Django/SQLAlchemy): match base classes by exact identifier (`Model`, `Base`, `declarative_base`) to avoid false positives (e.g., `ViewModel`).

<sup>Written for commit 8eb2ae295bfd681dda6c176673c972f684e57915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

