### PR TITLE
build(release): survive minor version stamping + drop broken duplicate stamp step [skip release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,23 +89,6 @@ jobs:
           grep -m1 '^version = ' Cargo.toml | grep -q "\"${version}\"" \
             || { echo "::error::version stamp did not take"; exit 1; }
 
-      # Stamp the release version (from the tag) into the workspace manifest so
-      # the compiled binary reports it — `stella --version` == the release tag.
-      # No commit lands on main; this edit is ephemeral to the build runner.
-      # `--locked` is dropped because bumping the workspace-member version would
-      # otherwise be rejected as a stale lockfile; registry deps stay pinned by
-      # the existing Cargo.lock (cargo only rewrites the workspace entries).
-      - name: Stamp release version
-        if: ${{ github.ref_type == 'tag' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          sed -i.bak -E "0,/^version = \"[^\"]*\"/s//version = \"${version}\"/" Cargo.toml
-          rm -f Cargo.toml.bak
-          echo "workspace version set to ${version}"
-          grep -m1 '^version = ' Cargo.toml
-
       - name: Build stella
         shell: bash
         run: |

--- a/ocp-conformance/Cargo.toml
+++ b/ocp-conformance/Cargo.toml
@@ -22,8 +22,10 @@ publish = true
 dist = false
 
 [dependencies]
-ocp-types = { path = "../ocp-types", version = "0.1.0" }
-ocp-host = { path = "../ocp-host", version = "0.1.0" }
+# Floor requirements — see the note in ocp-host/Cargo.toml: caret reqs break
+# the release version stamp at the first minor bump.
+ocp-types = { path = "../ocp-types", version = ">=0.1.0" }
+ocp-host = { path = "../ocp-host", version = ">=0.1.0" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/ocp-host/Cargo.toml
+++ b/ocp-host/Cargo.toml
@@ -16,7 +16,12 @@ categories = ["asynchronous", "network-programming", "api-bindings"]
 publish = true
 
 [dependencies]
-ocp-types = { path = "../ocp-types", version = "0.1.0" }
+# Floor requirement (not caret): the release pipeline stamps every workspace
+# member to the release version at build time, so a caret req like "0.1.0"
+# stops matching at the first minor bump (path deps must satisfy `version`
+# too). ">=" keeps the stamped build resolving at any version and remains a
+# valid crates.io requirement for the independent OCP publish (PUBLISHING.md).
+ocp-types = { path = "../ocp-types", version = ">=0.1.0" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Found while cutting v0.2.0: the release version stamp breaks at the first minor bump.

1. **Caret pins on internal path deps**: `ocp-host` → `ocp-types` and `ocp-conformance` → `ocp-types`/`ocp-host` used `version = "0.1.0"`. The release pipeline (both `scripts/release.sh` and `release.yml`) stamps the workspace to the tag version at build time, and cargo requires path deps to satisfy `version` too — so stamping `0.2.0` failed resolution: `failed to select a version for the requirement ocp-types = "^0.1.0"`. Switched to floor requirements (`>=0.1.0`) with a comment; still valid for the future independent crates.io publish per PUBLISHING.md. Verified: `cargo metadata` resolves cleanly with the workspace stamped to 0.2.0.
2. **release.yml had two "Stamp release version" steps** — the second used `sed -E "0,/re/"`, a GNU-only address form that fails on macOS runners' BSD sed (the exact hazard the first step's comment warns about). Removed the duplicate; the portable perl step remains and self-validates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release version stamping so minor bumps (e.g., v0.2.x) build cleanly, and remove a duplicate non‑portable stamp step from the workflow.

- Bug Fixes
  - Switch internal path deps to floor requirements: `ocp-host` depends on `ocp-types >=0.1.0`; `ocp-conformance` depends on `ocp-types >=0.1.0` and `ocp-host >=0.1.0`. This keeps stamped builds resolving, since cargo requires path deps to match `version`.
  - Remove the duplicate "Stamp release version" step in `.github/workflows/release.yml` that used GNU `sed` and failed on macOS; the portable Perl-based step remains.

<sup>Written for commit a38adc130a61be1c6533d9b8f0e453b518b9d50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
