### PR TITLE
build(release): fix formula-guard false positive + restore Cargo.lock [skip release]

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,7 +99,11 @@ bold ""
 # The one `^version = ` line is [workspace.package].version. (The CI workflow's
 # `sed "0,/re/"` is GNU-only and silently no-ops on macOS — perl is portable.)
 cp Cargo.toml .Cargo.toml.relbak
-restore_manifest() { [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true; }
+cp Cargo.lock .Cargo.lock.relbak   # cargo rewrites workspace-member versions in the lock during the stamped build
+restore_manifest() {
+  [ -f .Cargo.toml.relbak ] && mv .Cargo.toml.relbak Cargo.toml || true
+  [ -f .Cargo.lock.relbak ] && mv .Cargo.lock.relbak Cargo.lock || true
+}
 trap 'restore_manifest' EXIT
 perl -pi -e "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
 grep -m1 '^version = ' Cargo.toml | grep -q "\"${VERSION}\"" || die "version stamp failed"
@@ -162,7 +166,9 @@ sed \
   -e "s/@SHA_AARCH64_LINUX@/$(sha_of aarch64-unknown-linux-gnu)/g" \
   -e "s/@SHA_X86_64_LINUX@/$(sha_of x86_64-unknown-linux-gnu)/g" \
   "$TMPL" > "$rendered"
-grep -q '@SHA\|@VERSION' "$rendered" && die "formula still has unrendered placeholders"
+# Match only real placeholder tokens: the template's own comment contains the
+# literal "@SHA_*@", which a bare '@SHA' grep false-positives on.
+grep -qE '@(VERSION|SHA_[A-Z0-9_]+)@' "$rendered" && die "formula still has unrendered placeholders"
 
 tap="$(mktemp -d)/tap"
 gh repo clone "$TAP_REPO" "$tap" -- --depth 1 --quiet


### PR DESCRIPTION
Two `scripts/release.sh` bugs found while cutting v0.2.0 (the release itself shipped; the formula was rendered and pushed to the tap manually):

1. **Placeholder guard false positive** — `grep -q '@SHA\|@VERSION'` matches the template's own comment text (`@SHA_*@`), so a fully rendered formula is rejected and the script dies after the GitHub Release exists but before the tap push. Now matches only real tokens: `@(VERSION|SHA_[A-Z0-9_]+)@`.
2. **Dirty tree after a run** — the stamped build rewrites workspace-member versions in `Cargo.lock`, but the exit trap only restored `Cargo.toml`. Both are backed up and restored now.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release script to stop false positives in the Homebrew formula placeholder check and ensures the working tree stays clean by restoring `Cargo.lock` on exit. Prevents the release from aborting after publishing the GitHub Release and avoids a dirty repo.

- **Bug Fixes**
  - Placeholder guard: replaced `grep -q '@SHA\|@VERSION'` with `grep -qE '@(VERSION|SHA_[A-Z0-9_]+)@'` to ignore the template’s comment and only flag real tokens.
  - Clean tree: now backs up and restores `Cargo.lock` alongside `Cargo.toml` in the exit trap since the stamped build mutates the lockfile.

<sup>Written for commit f35f86626337d677f76d221dc687c25fd37c75e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
