### PR TITLE
fix: repair the broken #79 merge — main does not build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,6 +3387,7 @@ dependencies = [
  "stella-protocol",
  "stella-store",
  "stella-tools",
+ "stella-tui",
  "tempfile",
  "tokio",
  "toml",

--- a/README.md
+++ b/README.md
@@ -288,15 +288,10 @@ flowchart TD
 > crates that aren't wired into the CLI yet — they're the next layers, and some
 > of the best places to contribute:
 >
-> - **`stella-pipeline`** — the triage → enhance → route → execute → verify →
->   judge → revise orchestration plane (the CLI currently drives the engine directly).
 > - **`stella-fleet`** — multi-agent fan-out: DAG planner, worktree isolation,
 >   lineage + spend ledger.
-> - **`stella-tui`** — a pure-fold ratatui REPL (HUD, panels, diff viewer). The
->   shipping shell today is `stella-cli`'s simpler line REPL.
 > - **`stella-media`** — multimodal generation behind a `MediaProvider` port.
 > - **`stella-graph` retrieval & the fuller context plane** — the code graph is
->   indexed on `stella init` but not yet queried at runtime; bi-temporal facts and
 >   indexed on `stella init` and feeds the schema conflict gate at session start,
 >   but broader runtime retrieval is not yet queried; bi-temporal facts and
 >   episodic memory are implemented and tested but the CLI currently uses only the
@@ -515,9 +510,6 @@ stella stats     # cost, tokens, and $/resolved task per provider/model from
 ### Global flags
 
 `--model provider/id` · `--api-key` · `--base-url` · `--budget <usd>` ·
-`--output-format text|json|stream-json` (all also as `STELLA_*` env vars). The
-`json` / `stream-json` formats are for headless one-shot `stella run`; the
-interactive `chat` / `goal` / `monitor` modes always render human-readable output.
 `--output-format text|json|stream-json` (also as `STELLA_MODEL`,
 `STELLA_BASE_URL`, `STELLA_BUDGET`, and `STELLA_OUTPUT_FORMAT`; API keys come
 from provider-specific env vars or `~/.config/stella/credentials.toml`). The
@@ -605,17 +597,11 @@ targets — see the architecture status note above).
 | `stella-mcp` | ✅ | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry; per-call timeouts isolate dead servers |
 | `stella-protocol` | ✅ | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports |
 | `stella-context` | ◑ | The context plane. Reflection-memory recall + embedding index are wired; the bi-temporal property graph and episodic memory are built and tested but not yet consulted at runtime |
-| `stella-graph` | 🧪 | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python). Indexed on `stella init`; runtime retrieval not yet wired |
-| `stella-pipeline` | 🧪 | The orchestration plane above the engine: triage → enhance → route → execute → verify → judge → revise |
-| `stella-fleet` | 🧪 | The multi-agent fleet: DAG planner + wave scheduling, git-worktree isolation per task, SQLite lineage + per-task spend ledger |
-| `stella-media` | 🧪 | Multimodal generation (image/SVG/video) behind one `MediaProvider` port — BYOK, artifact discipline, cost-gated |
-| `stella-tui` | 🧪 | Event-log REPL — a pure `SessionModel` fold + a thin crossterm shell (renders deterministically from events) |
-| `ocp-types` · `ocp-host` · `ocp-conformance` | ✅ | Open Context Protocol — wire types (zero deps beyond `serde`), host runtime (discover/negotiate/route/gate), and the public conformance suite |
 | `stella-graph` | ◑ | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python/SQL). Indexed on `stella init`; the schema gate reads it at session start, broader runtime retrieval not yet wired |
 | `stella-pipeline` | ✅ | The orchestration plane above the engine — the default `stella run` path: triage → plan (split context) → scope review → execute → verify → judge, with bounded revision (`--no-pipeline` opts out) |
 | `stella-fleet` | 🧪 | The multi-agent fleet: DAG planner + wave scheduling, git-worktree isolation per task, SQLite lineage + per-task spend ledger |
 | `stella-media` | 🧪 | Multimodal generation (image/SVG/video) behind one `MediaProvider` port — BYOK, artifact discipline, cost-gated |
-| `stella-tui` | 🧪 | Event-log REPL — a pure `SessionModel` fold + a thin crossterm shell (renders deterministically from events) |
+| `stella-tui` | ✅ | The Command Deck — a pure event-fold core (`SessionModel`/`WorkspaceModel`) + thin crossterm shell; the default `stella chat` surface on a TTY (`--plain` opts out) |
 | `ocp-types` · `ocp-host` · `ocp-conformance` | ◑ | Open Context Protocol — wire types (zero deps beyond `serde`, in the binary), host runtime (discover/negotiate/route/gate), and the public conformance suite; only `ocp-types` is wired into the shipping CLI today |
 
 ## Development

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -30,11 +30,8 @@ stella-store = { path = "../stella-store" }
 stella-mcp = { path = "../stella-mcp" }
 stella-context = { path = "../stella-context" }
 stella-graph = { path = "../stella-graph" }
-<<<<<<< HEAD
-stella-tui = { path = "../stella-tui" }
-=======
 stella-pipeline = { path = "../stella-pipeline" }
->>>>>>> 41325e9a4a9d778b2906cd2be26473dc260bd7b7
+stella-tui = { path = "../stella-tui" }
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -116,7 +116,6 @@ const MEMORY_PROMPT_BUDGET_CHARS: usize = 16_000;
 /// Assemble the session's system prompt from a `base` instruction set plus
 /// the workspace's saved memories. Memories are loaded ONCE per session and
 /// concatenated in filename order so the resulting prefix is byte-stable
-<<<<<<< HEAD
 /// across every model call — that stability is what lets the whole prompt
 /// (instructions + memories) ride the provider's prompt cache instead of
 /// being re-billed. Memories saved mid-session deliberately do NOT appear
@@ -124,11 +123,7 @@ const MEMORY_PROMPT_BUDGET_CHARS: usize = 16_000;
 /// prefix on every save. This coexists with `SessionMemory`'s per-turn
 /// recall block (memory.rs) — the baked prefix carries durable lessons, the
 /// recall block carries turn-relevant memories and skills.
-pub(crate) fn build_system_prompt(workspace_root: &std::path::Path) -> String {
-=======
-/// across every model call — that stability preserves prompt-cache hits.
 fn assemble_system_prompt(base: &str, workspace_root: &std::path::Path) -> String {
->>>>>>> 41325e9a4a9d778b2906cd2be26473dc260bd7b7
     let dir = workspace_root.join(".stella/memories");
     let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
         .map(|entries| {
@@ -187,8 +182,9 @@ Workspace memories (lessons from previous sessions — apply them):
     prompt
 }
 
-/// Shortcut: the raw step-loop system prompt plus workspace memories.
-fn build_system_prompt(workspace_root: &std::path::Path) -> String {
+/// Shortcut: the raw step-loop system prompt plus workspace memories
+/// (`pub(crate)`: the Command Deck session assembles the same prompt).
+pub(crate) fn build_system_prompt(workspace_root: &std::path::Path) -> String {
     assemble_system_prompt(SYSTEM_PROMPT, workspace_root)
 }
 
@@ -960,7 +956,7 @@ fn build_code_graph(workspace_root: &std::path::Path) {
 /// index with all known table/type/view names. Best-effort: if the graph
 /// can't open (no `.stella/codegraph.db`), the schema gate runs with an
 /// empty index — it just won't catch conflicts until `stella init` runs.
-fn populate_schema_index(registry: &ToolRegistry, workspace_root: &std::path::Path) {
+pub(crate) fn populate_schema_index(registry: &ToolRegistry, workspace_root: &std::path::Path) {
     let db_path = workspace_root.join(".stella").join("codegraph.db");
     if !db_path.exists() {
         return;

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -233,6 +233,15 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
                         | Some(WorkspaceInput::ToAgent {
                             input: UserInput::Prompt { text }, ..
                         }) => queue.push_back(text),
+                        // The deck's queue editor mutates its own view of the
+                        // backlog and mirrors each edit here so the dispatch
+                        // queue never drifts from what the user is looking at.
+                        Some(WorkspaceInput::QueueRemove { index }) => {
+                            if index < queue.len() {
+                                queue.remove(index);
+                            }
+                        }
+                        Some(WorkspaceInput::QueueClear) => queue.clear(),
                         Some(WorkspaceInput::ToAgent {
                             input: UserInput::AskUserAnswer { answer, .. }, ..
                         }) => {
@@ -499,7 +508,10 @@ impl ToolExecutor for FileChangeTap<'_> {
     }
 
     async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
-        let path = input.get("path").and_then(Value::as_str).map(str::to_string);
+        let path = input
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_string);
         // Pre-state, captured before the mutation: existence decides
         // Created-vs-Modified for write_file; content is delete_file's diff.
         let pre = match (name, &path) {
@@ -518,11 +530,9 @@ impl ToolExecutor for FileChangeTap<'_> {
         if let Some(path) = path
             && let Some((kind, diff)) = file_change_of(name, input, pre)
         {
-            let _ = self.events.send(AgentEvent::FileChange {
-                path,
-                kind,
-                diff,
-            });
+            let _ = self
+                .events
+                .send(AgentEvent::FileChange { path, kind, diff });
         }
         output
     }
@@ -556,10 +566,7 @@ fn file_change_of(
         }
         "delete_file" => {
             let old = pre.and_then(|(_, content)| content);
-            Some((
-                FileChangeKind::Deleted,
-                old.map(|c| pseudo_diff(&c, "")),
-            ))
+            Some((FileChangeKind::Deleted, old.map(|c| pseudo_diff(&c, ""))))
         }
         _ => None,
     }
@@ -571,8 +578,7 @@ fn file_change_of(
 fn pseudo_diff(old: &str, new: &str) -> String {
     let mut out = String::new();
     let mut side = |content: &str, prefix: char| {
-        let mut lines = 0usize;
-        for line in content.lines() {
+        for (lines, line) in content.lines().enumerate() {
             if lines == PSEUDO_DIFF_MAX_LINES {
                 out.push_str(&format!(
                     " … ({} more lines)\n",
@@ -583,7 +589,6 @@ fn pseudo_diff(old: &str, new: &str) -> String {
             out.push(prefix);
             out.push_str(line);
             out.push('\n');
-            lines += 1;
         }
     };
     side(old, '-');
@@ -757,11 +762,11 @@ mod tests {
     }
 
     /// Drive [`DeckAskUserIo::prompt`] with a scripted answer and inspect the
-    /// Inbound stream it produces.
-    async fn run_prompt(
-        options: &[&str],
-        answer: &str,
-    ) -> (Result<String, String>, Vec<Inbound>) {
+    /// Inbound stream it produces. The answer is sent only AFTER the AskUser
+    /// card appears: `prompt` drains stale answers before presenting (the
+    /// cancelled-turn contract), so a pre-sent answer would be swallowed and
+    /// the await would hang.
+    async fn run_prompt(options: &[&str], answer: &str) -> (Result<String, String>, Vec<Inbound>) {
         let (in_tx, mut in_rx) = mpsc::unbounded_channel();
         let (ans_tx, ans_rx) = mpsc::unbounded_channel();
         let io = DeckAskUserIo {
@@ -769,10 +774,12 @@ mod tests {
             inbound: in_tx,
             answers: Arc::new(tokio::sync::Mutex::new(ans_rx)),
         };
-        ans_tx.send(answer.to_string()).unwrap();
         let opts: Vec<String> = options.iter().map(|s| s.to_string()).collect();
-        let result = io.prompt("which one?", &opts).await;
+        let asking = tokio::spawn(async move { io.prompt("which one?", &opts).await });
         let mut seen = Vec::new();
+        seen.push(in_rx.recv().await.expect("the AskUser card is presented"));
+        ans_tx.send(answer.to_string()).unwrap();
+        let result = asking.await.expect("the prompt task settles");
         while let Ok(inbound) = in_rx.try_recv() {
             seen.push(inbound);
         }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -49,7 +49,7 @@ pub enum OutputFormat {
 #[derive(Parser)]
 #[command(
     name = "stella",
-    version = version_string(),
+    version = version_static(),
     about = "A fast, BYOK, model-agnostic terminal coding agent"
 )]
 struct Cli {
@@ -177,15 +177,19 @@ fn version_string() -> String {
     }
 }
 
+/// clap's `version` attribute needs a `'static` string, but the dev stamp is
+/// assembled at runtime — leak it once at parse time (a few bytes, once per
+/// process).
+fn version_static() -> &'static str {
+    version_string().leak()
+}
+
 /// Whether `chat` should launch the Command Deck: an explicit `--plain` or
 /// STELLA_PLAIN=1 opts out, and both stdin and stdout must be real terminals
 /// (raw mode + the alternate screen are meaningless on a pipe).
 fn use_deck(plain_flag: bool) -> bool {
     let plain_env = std::env::var_os("STELLA_PLAIN").is_some_and(|v| !v.is_empty() && v != "0");
-    !plain_flag
-        && !plain_env
-        && std::io::stdin().is_terminal()
-        && std::io::stdout().is_terminal()
+    !plain_flag && !plain_env && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
 }
 
 /// `--budget` must be a positive, finite dollar amount — a NaN or negative

--- a/stella-graph/src/parse.rs
+++ b/stella-graph/src/parse.rs
@@ -795,9 +795,10 @@ pub struct User {
 ";
         let parsed = parse(Language::Rust, src);
         assert!(
-            parsed.symbols.iter().any(|s| {
-                s.name == "users" && s.kind == SymbolKind::Table
-            }),
+            parsed
+                .symbols
+                .iter()
+                .any(|s| { s.name == "users" && s.kind == SymbolKind::Table }),
             "Diesel table! not detected: {:?}",
             parsed.symbols
         );
@@ -818,7 +819,8 @@ class Helper:
 ";
         let parsed = parse(Language::Python, src);
         assert!(
-            parsed.symbols
+            parsed
+                .symbols
                 .iter()
                 .any(|s| s.name == "payments" && s.kind == SymbolKind::Table),
             "Django model not detected: {:?}",
@@ -839,9 +841,7 @@ class Order(Base):
 ";
         let parsed = parse(Language::Python, src);
         assert!(
-            parsed.symbols
-                .iter()
-                .any(|s| s.kind == SymbolKind::Table),
+            parsed.symbols.iter().any(|s| s.kind == SymbolKind::Table),
             "SQLAlchemy model not detected: {:?}",
             parsed.symbols
         );

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -954,7 +954,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
     fn prompt_started_pops_the_front_of_the_queue_and_leaves_a_trace() {
         let mut w = WorkspaceModel::new();
         w.apply_inbound(&reg("lead"));
@@ -967,7 +966,10 @@ mod tests {
             text: "first".into(),
         });
         assert_eq!(w.queue.pending(), 1);
-        assert_eq!(w.queue.items.front().map(|q| q.text.as_str()), Some("second"));
+        assert_eq!(
+            w.queue.items.front().map(|q| q.text.as_str()),
+            Some("second")
+        );
         let row = w.trace.rows.back().expect("a trace row was recorded");
         assert_eq!(row.agent, "lead");
         assert!(row.summary.contains("first"), "{}", row.summary);
@@ -984,7 +986,9 @@ mod tests {
             text: "driver-side prompt".into(),
         });
         assert_eq!(w.queue.pending(), 1);
-=======
+    }
+
+    #[test]
     fn prompt_queue_edits_like_a_list() {
         let mut q = PromptQueue::default();
         q.enqueue("a".into(), 1);
@@ -996,7 +1000,6 @@ mod tests {
         assert_eq!(q.remove(9), None, "out of range is a no-op");
         q.clear();
         assert_eq!(q.pending(), 0);
->>>>>>> 41325e9a4a9d778b2906cd2be26473dc260bd7b7
     }
 
     #[test]

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -142,8 +142,7 @@ fn render_activity_strip(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &
         String::new()
     };
     let right_w = right_text.chars().count() as u16;
-    let cols =
-        Layout::horizontal([Constraint::Min(1), Constraint::Length(right_w)]).split(area);
+    let cols = Layout::horizontal([Constraint::Min(1), Constraint::Length(right_w)]).split(area);
 
     let mut spans: Vec<Span<'static>> = vec![Span::raw(" ")];
     let running = model
@@ -456,7 +455,10 @@ mod tests {
         let mut idle = WorkspaceModel::new();
         assert!(!activity_strip_active(&idle));
         idle.queue.enqueue("later".into(), 1);
-        assert!(activity_strip_active(&idle), "queued prompts keep it visible");
+        assert!(
+            activity_strip_active(&idle),
+            "queued prompts keep it visible"
+        );
         assert!(activity_strip_active(&running_model_with_queue()));
     }
 

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -299,7 +299,6 @@ impl CappedOutput {
     }
 }
 
-
 /// Run the command deck to completion. [`Inbound`] envelopes stream in over
 /// `inbound`; the user's [`WorkspaceInput`]s stream out over `submissions`.
 /// Returns when the inbound stream closes or the user quits, having always

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -332,11 +332,9 @@ fn handle_queue_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
             ui.queue_sel = (ui.queue_sel + 1).min(count - 1);
             DeckAction::Handled
         }
-        KeyCode::Char('x') if ctrl => {
-            DeckAction::Send(WorkspaceInput::QueueRemove {
-                index: ui.queue_sel,
-            })
-        }
+        KeyCode::Char('x') if ctrl => DeckAction::Send(WorkspaceInput::QueueRemove {
+            index: ui.queue_sel,
+        }),
         KeyCode::Enter => {
             // Pull the prompt out of the queue and into the composer to edit —
             // it is *removed*, not duplicated; re-submitting re-enqueues it.
@@ -943,7 +941,10 @@ mod tests {
         let mut ui = ready_ui();
         handle_deck_key(ctrl('t'), &model, &mut ui);
         // First press only arms the confirm.
-        assert_eq!(handle_deck_key(ctrl('d'), &model, &mut ui), DeckAction::Handled);
+        assert_eq!(
+            handle_deck_key(ctrl('d'), &model, &mut ui),
+            DeckAction::Handled
+        );
         assert!(ui.queue_confirm_clear);
         // Any other key disarms it.
         handle_deck_key(key(KeyCode::Down), &model, &mut ui);

--- a/stella-tui/src/fx.rs
+++ b/stella-tui/src/fx.rs
@@ -103,8 +103,15 @@ pub fn garble_line(phase: u64, width: usize) -> Line<'static> {
             // A gradient that ping-pongs dark→bright→dark across the width.
             let steps = ramp.len() * 2 - 2;
             let slot = (col * steps) / width.max(1);
-            let idx = if slot < ramp.len() { slot } else { steps - slot };
-            Span::styled(ch.to_string(), Style::default().fg(ramp[idx.min(ramp.len() - 1)]))
+            let idx = if slot < ramp.len() {
+                slot
+            } else {
+                steps - slot
+            };
+            Span::styled(
+                ch.to_string(),
+                Style::default().fg(ramp[idx.min(ramp.len() - 1)]),
+            )
         })
         .collect::<Vec<_>>();
     Line::from(spans)

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -358,10 +358,7 @@ fn render_diff(
     .split(area);
     let w = area.width as usize;
     Paragraph::new(diff::header_line(path, w)).render(bands[0], buf);
-    let visible: Vec<Line<'static>> = lines
-        .get(window)
-        .map(<[Line]>::to_vec)
-        .unwrap_or_default();
+    let visible: Vec<Line<'static>> = lines.get(window).map(<[Line]>::to_vec).unwrap_or_default();
     Paragraph::new(Text::from(visible)).render(bands[1], buf);
     Paragraph::new(diff::footer_line(added, removed, w)).render(bands[2], buf);
 }
@@ -759,7 +756,9 @@ fn collapsed_thinking_line(text: &str) -> Line<'static> {
         ),
         Span::styled(
             tail,
-            Style::new().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            Style::new()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
         ),
     ])
 }
@@ -979,11 +978,7 @@ mod tests {
         model.apply(&AgentEvent::Reasoning { delta: long });
         let lines = transcript_lines(&model, false);
         assert_eq!(lines.len(), 1);
-        let text: String = lines[0]
-            .spans
-            .iter()
-            .map(|s| s.content.clone())
-            .collect();
+        let text: String = lines[0].spans.iter().map(|s| s.content.clone()).collect();
         assert!(text.ends_with("THE-TAIL"), "keeps the tail: {text}");
         assert!(text.contains('…'), "marks the elision: {text}");
     }


### PR DESCRIPTION
## Why

PR #79 was merged with **unresolved conflict markers committed** to `stella-cli/Cargo.toml`, `stella-cli/src/agent.rs`, and `stella-tui/src/deck.rs`. `origin/main` currently cannot parse its own manifests (`cargo build` fails at Cargo.toml line 33), and once the markers are resolved the auto-merged code still fails to compile, two tests deadlock forever, and the fmt/clippy CI gates fail. **This PR unbreaks main and nothing else** — the feature work that surfaced it lands separately.

## What broke, and the resolution

| File | Damage | Resolution |
|---|---|---|
| `stella-cli/Cargo.toml` | markers: `stella-tui` (HEAD) vs `stella-pipeline` | keep **both** — the deck and the default `stella run` pipeline are both real |
| `stella-cli/src/agent.rs` | markers: `build_system_prompt` vs `assemble_system_prompt(base, …)` refactor | keep the refactor (its body reads `base`) with #79's fuller doc; make `build_system_prompt` + `populate_schema_index` `pub(crate)` (the deck calls both — E0603) |
| `stella-tui/src/deck.rs` | markers: two test sets | keep all three tests — both sides were real coverage |
| `stella-cli/src/command_deck.rs` | E0004: dispatcher predates `QueueRemove`/`QueueClear` | mirror the deck's queue edits into the dispatch queue |
| `stella-cli/src/main.rs` | E0277: `version = version_string` (String) on clap 4.6 | leak the dev stamp once → `'static` |
| `command_deck` tests | `deck_ask_io_*` hang forever: `prompt` drains stale answers **before** presenting the card, swallowing the tests' pre-sent answers | answer only after the card appears |
| `README.md` | both sides' status note / flags paragraph / workspace-table rows kept — duplicated & contradictory | dedupe to the accurate set; `stella-tui` → ✅ (the deck #79 itself shipped) |
| `stella-graph`, `stella-tui` (5 files) | committed rustfmt violations — `cargo fmt --check` fails on main | `cargo fmt --all` |
| `Cargo.lock` | stale against the broken manifest | regenerated |

## Gate

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` — **1151 passed, 0 failed** (44 suites)

> Marked draft only for your once-over — this is merge-ready and everything else is blocked behind it. A follow-up PR (wiring stella-fleet, the code-graph tool, generate_image, and the episodic/bi-temporal context plane) stacks on top.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the broken merge from #79 so `main` builds and CI is green again. Resolves conflict markers, restores compile and tests, and keeps both `stella-pipeline` and `stella-tui`.

- **Bug Fixes**
  - Manifests: resolved conflicts in `stella-cli/Cargo.toml`; kept `stella-pipeline` and `stella-tui`; regenerated `Cargo.lock`.
  - Agent API: kept `assemble_system_prompt(base, …)` refactor and fuller docs; made `build_system_prompt` and `populate_schema_index` `pub(crate)` for the deck.
  - Command Deck: mirrored `QueueRemove`/`QueueClear` into the dispatcher queue to stay in sync; fixed `AskUser` tests to answer after the card appears to avoid hangs.
  - CLI: added `version_static` that leaks `version_string` once to satisfy clap’s `'static` requirement.
  - Tests/formatting: preserved all three queue tests; fixed fmt/clippy issues across `stella-graph` and `stella-tui`.
  - Docs: deduped README; updated status table and flags; marked `stella-tui` ✅ as the default TTY chat surface.

Gate: `cargo fmt --all --check` ✓ · `cargo clippy --workspace --all-targets -D warnings` ✓ · `cargo test --workspace` ✓ (1151 passed).

<sup>Written for commit 99f69cafcc8c917c355bed63db0a3a2d4484b000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
