### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
   </picture>
 </p>
 
-<p align="center"><strong>A fast, BYOK, model-agnostic terminal coding agent, built in Rust — that refuses to call a task done until a test proves it.</strong></p>
-
-<p align="center"><em>For everyone who is sick of token waste and average agent runners.</em></p>
-
+<p align="center"><strong>A fast, Gragh RAG with embeddings, BYOK, model-agnostic terminal coding agent, built in Rust.</strong></p>
 <p align="center">
   <a href="https://github.com/oxageninc/stella/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/oxageninc/stella/ci.yml?branch=main&style=flat-square&logo=github&label=ci" alt="CI status"></a>
   <a href="https://github.com/oxageninc/stella/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/oxageninc/stella/release.yml?style=flat-square&logo=github&label=release" alt="Release status"></a>


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README tagline to highlight RAG with embeddings and BYOK, and removed the extra marketing line.
Docs-only change; no code impact.

<sup>Written for commit 5222594bbe589e85247ba3f177db1cba94846d42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
