### PR TITLE
fix: slash menu, /init command, and wiring fixes across code-graph, context recall, fleet & pipeline

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -894,9 +894,15 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             println!();
             let mut emit = |line: String| println!("  {line}");
             match init_workspace(Some(&*provider), &cfg.workspace_root, &mut emit).await {
-                // A fresh index may name tables/types the schema gate should
-                // know about this session, not just the next one.
-                Ok(_) => populate_schema_index(&registry, &cfg.workspace_root),
+                Ok(_) => {
+                    // A fresh index may name tables/types the schema gate
+                    // should know about this session, not just the next one.
+                    populate_schema_index(&registry, &cfg.workspace_root);
+                    // Re-open memory so recall/reflection use the taxonomy
+                    // `/init` just wrote — otherwise the cached domains stay
+                    // stale until the next launch.
+                    memory = SessionMemory::open(&cfg.workspace_root, true);
+                }
                 Err(e) => println!("  {} init failed: {e}", "✗".red()),
             }
             println!();
@@ -1192,7 +1198,7 @@ pub(crate) fn graph_snapshot(
         });
         nodes.push(GraphNode {
             label: symbol.name.clone(),
-            kind: symbol.kind.to_string(),
+            kind: symbol.kind.clone(),
             location: Some(format!("{}:{}", hood.file, symbol.start_line)),
         });
     }

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -41,7 +41,7 @@ use tokio::sync::mpsc;
 
 use crate::OutputFormat;
 use crate::config::Config;
-use crate::domains::{heuristic_domains, infer_domains};
+use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
 use crate::memory::{SessionMemory, inject_recall_block, turn_warrants_reflection};
 use crate::tui;
@@ -55,6 +55,7 @@ You have these tools available:
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
 - bash: Run a shell command in the workspace root (with timeout)
+- code_graph: Query the workspace's indexed code graph — where a symbol is defined or referenced, what a file imports, which files import it, or a file's neighborhood. Appears only when `.stella/codegraph.db` exists (run `stella init` to build it).
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
 - build_project: Build with the workspace's own toolchain (cargo/npm/go/make)
@@ -67,6 +68,7 @@ You have these tools available:
 Some tools have prerequisites: issue tracking (create_issue/update_issue/close_issue/search_issues/start_work_on_issue) appears only when configured; ci_status requires the gh CLI. Use them when present.
 
 Rules:
+- For "where is X defined", "who calls/references X", or "what depends on this file" questions, reach for code_graph FIRST when it is available — it is precise and cheap. Fall back to grep/glob only when the graph can't answer (free-text search, a symbol the index doesn't carry, or no index yet).
 - Always read a file before editing it — never edit blind.
 - Make minimal, surgical edits. Use edit_file, not write_file, for changes to existing files.
 - After changing behavior, use run_tests to check the suite, and verify_done to prove the change with a witness test rather than trusting a green suite.
@@ -85,6 +87,7 @@ You have these tools available:
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
 - bash: Run a shell command in the workspace root (with timeout)
+- code_graph: Query the workspace's indexed code graph — where a symbol is defined or referenced, what a file imports, which files import it, or a file's neighborhood. Appears only when `.stella/codegraph.db` exists (run `stella init` to build it). For symbol and dependency questions it is precise and cheaper than grep.
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
 - build_project: Build with the workspace's own toolchain (cargo/npm/go/make)
@@ -98,7 +101,7 @@ Some tools have prerequisites: issue tracking (create_issue/update_issue/close_i
 
 Methodology (always follow in order):
 1. REPRODUCE: Run the failing test or reproduce the bug before touching any file. Never edit blind, you must see the actual error first.
-2. LOCALIZE: Trace the error to its root cause. Read the failing code path. Use grep and glob to navigate precisely.
+2. LOCALIZE: Trace the error to its root cause. Read the failing code path. When code_graph is available, use it FIRST to find definitions, references, and import edges — it is precise and cheap; fall back to grep and glob for free-text search or when the graph has no answer.
 3. MINIMAL FIX: Make the smallest change that resolves the issue. No refactoring. No style changes. No "while I'm here" edits. One logical change.
 4. VERIFY: Run the target test. If it passes, use verify_done to witness the change. If it fails, read the error and adjust.
 
@@ -231,16 +234,20 @@ fn build_pipeline_system_prompt(workspace_root: &std::path::Path) -> String {
 }
 
 /// Run a one-shot prompt. `use_pipeline` selects the staged pipeline (the
-/// default) vs the raw step-loop (`--no-pipeline`).
+/// default) vs the raw step-loop (`--no-pipeline`). `test_command`, when
+/// given, arms the pipeline's deterministic verification ladder (the
+/// fail→pass flip oracle); without it, verification falls back to the model
+/// judge on every iteration.
 pub async fn run_one_shot(
     cfg: &Config,
     prompt: &str,
     budget_limit: Option<f64>,
     format: OutputFormat,
     use_pipeline: bool,
+    test_command: Option<&str>,
 ) -> Result<(), String> {
     if use_pipeline {
-        run_pipeline_one_shot(cfg, prompt, budget_limit, format).await
+        run_pipeline_one_shot(cfg, prompt, budget_limit, format, test_command).await
     } else {
         run_raw_one_shot(cfg, prompt, budget_limit, format).await
     }
@@ -254,6 +261,7 @@ async fn run_pipeline_one_shot(
     prompt: &str,
     budget_limit: Option<f64>,
     format: OutputFormat,
+    test_command: Option<&str>,
 ) -> Result<(), String> {
     let provider = build_provider(cfg)?;
     let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
@@ -330,6 +338,11 @@ async fn run_pipeline_one_shot(
             engine: engine_config_for(cfg),
             headless: !is_text,
             headless_bypass_scope_review: !is_text,
+            // `--test-command` arms the deterministic verify ladder: the
+            // fail→pass flip oracle and SubmitFast/Revise decisions all key
+            // off it. Left unset, every verification escalates to the model
+            // judge.
+            test_command: test_command.map(str::to_string),
             ..Default::default()
         };
 
@@ -877,6 +890,18 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             println!();
             continue;
         }
+        if input == "/init" {
+            println!();
+            let mut emit = |line: String| println!("  {line}");
+            match init_workspace(Some(&*provider), &cfg.workspace_root, &mut emit).await {
+                // A fresh index may name tables/types the schema gate should
+                // know about this session, not just the next one.
+                Ok(_) => populate_schema_index(&registry, &cfg.workspace_root),
+                Err(e) => println!("  {} init failed: {e}", "✗".red()),
+            }
+            println!();
+            continue;
+        }
         if let Some(title) = input.strip_prefix("/rename ") {
             tui::rename_tab(title.trim());
             println!(
@@ -1051,25 +1076,24 @@ pub(crate) async fn record_turn_episode(
 ///
 /// Idempotent and best-effort: a failure degrades to a warning (init still
 /// succeeds, offline included) — the graph can always be rebuilt on a later
-/// `init` once a toolchain/parser is available.
-fn build_code_graph(workspace_root: &std::path::Path) {
+/// `init` once a toolchain/parser is available. Progress goes to `emit`
+/// (plain text, no ANSI) so both the CLI and the deck transcript can show it.
+fn build_code_graph(workspace_root: &std::path::Path, emit: &mut dyn FnMut(String)) {
     let dot_stella = workspace_root.join(".stella");
     if let Err(e) = std::fs::create_dir_all(&dot_stella) {
-        eprintln!(
-            "  {} could not create .stella for the code graph: {e} — skipped",
-            "!".yellow()
-        );
+        emit(format!(
+            "! could not create .stella for the code graph: {e} — skipped"
+        ));
         return;
     }
     let db_path = dot_stella.join("codegraph.db");
-    println!("  {} indexing code graph…", "◈".cyan());
+    emit("◈ indexing code graph…".to_string());
     match stella_graph::CodeGraph::open(workspace_root, &db_path) {
         Ok(graph) => match graph.index_all() {
             Ok(stats) => {
-                println!(
-                    "  {} code graph: {} symbols, {} imports across {} file{} \
+                emit(format!(
+                    "✓ code graph: {} symbols, {} imports across {} file{} \
                      ({} parsed, {} unchanged)",
-                    "✓".green(),
                     stats.symbols,
                     stats.imports,
                     stats.files_parsed + stats.files_skipped_unchanged,
@@ -1080,23 +1104,127 @@ fn build_code_graph(workspace_root: &std::path::Path) {
                     },
                     stats.files_parsed,
                     stats.files_skipped_unchanged,
-                );
+                ));
                 graph.shutdown();
             }
             Err(e) => {
-                eprintln!(
-                    "  {} code-graph indexing failed: {e} — run `stella init` again to retry",
-                    "!".yellow()
-                );
+                emit(format!(
+                    "! code-graph indexing failed: {e} — run `stella init` again to retry"
+                ));
             }
         },
         Err(e) => {
-            eprintln!(
-                "  {} code-graph store unavailable: {e} — skipped",
-                "!".yellow()
-            );
+            emit(format!("! code-graph store unavailable: {e} — skipped"));
         }
     }
+}
+
+/// The shared init flow behind `stella init` and the `/init` chat command:
+/// infer the domain taxonomy (model-assisted when a provider is available,
+/// directory heuristic otherwise), build the code-graph index, persist
+/// `.stella/domains.toml`, and record the taxonomy into the context plane.
+/// Progress lines stream to `emit` — the CLI prints them, the deck forwards
+/// them into the transcript — so both surfaces share one implementation.
+pub(crate) async fn init_workspace(
+    provider: Option<&dyn Provider>,
+    workspace_root: &std::path::Path,
+    emit: &mut dyn FnMut(String),
+) -> Result<Domains, String> {
+    let domains = match provider {
+        Some(p) => infer_domains(p, workspace_root).await,
+        None => heuristic_domains(workspace_root),
+    };
+
+    // The code graph needs no provider — build it regardless of how the
+    // domains were inferred, so the index exists even fully offline.
+    build_code_graph(workspace_root, emit);
+
+    let path = domains.save(workspace_root)?;
+
+    // Persist the taxonomy into the context plane too: domain descriptions
+    // plus bi-temporal `covers_path` facts, so recall can fuse on them and a
+    // re-run after the taxonomy shifts supersedes (never deletes) the old
+    // beliefs. Best-effort — a store that won't open already warned.
+    if let Some(m) = SessionMemory::open(workspace_root, false) {
+        m.record_taxonomy(&domains).await;
+    }
+
+    emit(format!(
+        "✓ {} domains ({}) → {}",
+        domains.domains.len(),
+        domains.inferred_by,
+        path.display()
+    ));
+    Ok(domains)
+}
+
+/// Query the code graph (if `stella init` has built it) for the
+/// best-connected file's neighborhood, converted to the deck's Graph-tab
+/// snapshot. `None` when there is no index, it is empty, or any read fails —
+/// the tab then shows its "run stella init" hint instead of an empty graph.
+pub(crate) fn graph_snapshot(
+    workspace_root: &std::path::Path,
+) -> Option<stella_tui::GraphSnapshot> {
+    use stella_tui::{GraphEdge, GraphNode, GraphSnapshot};
+
+    let db_path = workspace_root.join(".stella").join("codegraph.db");
+    if !db_path.exists() {
+        return None;
+    }
+    let graph = stella_graph::CodeGraph::open(workspace_root, &db_path).ok()?;
+    let focus = graph.busiest_file().ok()??;
+    let hood = graph
+        .file_neighborhood(std::path::Path::new(&focus))
+        .ok()?;
+    graph.shutdown();
+
+    let mut nodes = vec![GraphNode {
+        label: hood.file.clone(),
+        kind: "file".to_string(),
+        location: Some(hood.file.clone()),
+    }];
+    let mut edges = Vec::new();
+    for symbol in &hood.symbols {
+        edges.push(GraphEdge {
+            from: 0,
+            to: nodes.len(),
+            kind: "defines".to_string(),
+        });
+        nodes.push(GraphNode {
+            label: symbol.name.clone(),
+            kind: symbol.kind.to_string(),
+            location: Some(format!("{}:{}", hood.file, symbol.start_line)),
+        });
+    }
+    for import in &hood.imports {
+        edges.push(GraphEdge {
+            from: 0,
+            to: nodes.len(),
+            kind: "imports".to_string(),
+        });
+        nodes.push(GraphNode {
+            label: import.clone(),
+            kind: "module".to_string(),
+            location: None,
+        });
+    }
+    for importer in &hood.importers {
+        edges.push(GraphEdge {
+            from: nodes.len(),
+            to: 0,
+            kind: "imports".to_string(),
+        });
+        nodes.push(GraphNode {
+            label: importer.clone(),
+            kind: "file".to_string(),
+            location: Some(importer.clone()),
+        });
+    }
+    Some(GraphSnapshot {
+        focus: hood.file,
+        nodes,
+        edges,
+    })
 }
 
 /// Open the code graph (read-only) and populate the tool registry's schema
@@ -1121,8 +1249,8 @@ pub(crate) fn populate_schema_index(registry: &ToolRegistry, workspace_root: &st
 /// index, and write `.stella/domains.toml` (see `crate::domains`). Domain
 /// inference is model-assisted when a provider resolves, with a deterministic
 /// directory heuristic fallback, so init always succeeds — offline included.
-/// The code graph (`.stella/context.db`) is built unconditionally: it needs no
-/// provider, only the on-disk source tree.
+/// The code graph (`.stella/codegraph.db`) is built unconditionally: it needs
+/// no provider, only the on-disk source tree.
 pub async fn run_init(
     model_override: Option<&str>,
     api_key_override: Option<&str>,
@@ -1133,7 +1261,7 @@ pub async fn run_init(
 
     tui::section_header("Stella init");
 
-    let domains = match Config::load(model_override, api_key_override, base_url_override) {
+    let provider = match Config::load(model_override, api_key_override, base_url_override) {
         Ok(cfg) => {
             let provider = build_provider(&cfg)?;
             println!(
@@ -1142,7 +1270,7 @@ pub async fn run_init(
                 cfg.provider.id,
                 cfg.model_id
             );
-            infer_domains(&*provider, &workspace_root).await
+            Some(provider)
         }
         Err(_) => {
             println!(
@@ -1150,31 +1278,13 @@ pub async fn run_init(
                  (re-run `stella init` with a key for a better taxonomy)",
                 "!".yellow()
             );
-            heuristic_domains(&workspace_root)
+            None
         }
     };
 
-    // The code graph needs no provider — build it regardless of how the
-    // domains were inferred, so the index exists even fully offline.
-    build_code_graph(&workspace_root);
+    let mut emit = |line: String| println!("  {line}");
+    let domains = init_workspace(provider.as_deref(), &workspace_root, &mut emit).await?;
 
-    let path = domains.save(&workspace_root)?;
-
-    // Persist the taxonomy into the context plane too: domain descriptions
-    // plus bi-temporal `covers_path` facts, so recall can fuse on them and a
-    // re-run after the taxonomy shifts supersedes (never deletes) the old
-    // beliefs. Best-effort — a store that won't open already warned.
-    if let Some(m) = SessionMemory::open(&workspace_root, false) {
-        m.record_taxonomy(&domains).await;
-    }
-
-    println!(
-        "  {} {} domains ({}) → {}",
-        "✓".green(),
-        domains.domains.len(),
-        domains.inferred_by,
-        path.display()
-    );
     for domain in &domains.domains {
         println!(
             "    {} {} — {} [{}]",
@@ -2163,6 +2273,10 @@ fn print_help() {
     println!(
         "  {}  Change the accent color (multi-window)",
         "/color <name>".bright_blue()
+    );
+    println!(
+        "  {}          Index the workspace: domain taxonomy + code graph",
+        "/init".bright_blue()
     );
     println!("  {}          Show this help", "/help".bright_blue());
     println!("  {}          Exit Stella", "/exit".bright_blue());

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -53,7 +53,7 @@ use stella_tools::ToolRegistry;
 use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentStatus, DeckOptions, Inbound, UserInput, WorkspaceInput, run_deck,
+    AgentMeta, AgentStatus, DeckOptions, Inbound, SlashCommand, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -165,6 +165,13 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
 
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
+        slash_commands: vec![
+            SlashCommand::new("/help", "show help"),
+            SlashCommand::new("/clear", "clear the transcript"),
+            SlashCommand::new("/models", "list models"),
+            SlashCommand::new("/diff", "open the diff viewer"),
+            SlashCommand::new("/files", "focus the files panel"),
+        ],
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -130,7 +130,7 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
     let system_prompt =
         agent::with_session_hook_context(agent::build_system_prompt(&cfg.workspace_root), cfg)
             .await;
-    let mut messages = vec![CompletionMessage::system(system_prompt)];
+    let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
     // `warn: false`: past this point diagnostics would land on the alternate
     // screen; a memory-less session degrades silently here.
     let mut memory = SessionMemory::open(&cfg.workspace_root, false);
@@ -166,12 +166,15 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
         slash_commands: vec![
-            SlashCommand::new("/help", "show help"),
-            SlashCommand::new("/clear", "clear the transcript"),
-            SlashCommand::new("/models", "list models"),
+            SlashCommand::new("/help", "show commands"),
+            SlashCommand::new("/clear", "reset the conversation"),
+            SlashCommand::new("/models", "list providers & models"),
+            SlashCommand::new("/init", "index the workspace: domains + code graph"),
+            SlashCommand::new("/files", "open the Files tab"),
             SlashCommand::new("/diff", "open the diff viewer"),
-            SlashCommand::new("/files", "focus the files panel"),
+            SlashCommand::new("/graph", "open the code-graph tab"),
         ],
+        initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering
@@ -202,6 +205,13 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
             agent: LEAD.to_string(),
             text: prompt.clone(),
         });
+
+        // Session-level slash commands are the driver's, never the model's —
+        // the deck's popup enqueues them like any prompt (tab switches and
+        // the help overlay were already handled TUI-side and never reach us).
+        if run_deck_command(&prompt, &in_tx, &mut messages, &system_prompt, &*provider, &registry, cfg).await {
+            continue 'session;
+        }
 
         // Per-turn conversation bookkeeping, mirroring `run_interactive`:
         // refresh the volatile recall block, then append the user prompt.
@@ -338,6 +348,74 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
         Ok(Err(e)) => Err(format!("deck terminal error: {e}")),
         Err(e) => Err(format!("deck task failed: {e}")),
     }
+}
+
+/// Handle a session-level slash command, returning `true` when `prompt` was
+/// one (the caller skips the model turn). Output goes into the lead agent's
+/// transcript as `Text` events — the deck renders exclusively from events, so
+/// printing to stdout (which the alternate screen owns) is never an option.
+///
+/// Vocabulary: `/help`, `/clear`, `/models`, `/init`. `/files`, `/diff`,
+/// `/graph` are deck-local (tab switches) and consumed TUI-side; an unknown
+/// single-word `/command` gets a hint rather than a wasted model call.
+async fn run_deck_command(
+    prompt: &str,
+    in_tx: &UnboundedSender<Inbound>,
+    messages: &mut Vec<CompletionMessage>,
+    system_prompt: &str,
+    provider: &dyn Provider,
+    registry: &ToolRegistry,
+    cfg: &Config,
+) -> bool {
+    let word = prompt.split_whitespace().next().unwrap_or("");
+    if !word.starts_with('/') {
+        return false;
+    }
+    let say = |text: String| {
+        let _ = in_tx.send(Inbound::Event {
+            agent: LEAD.to_string(),
+            event: AgentEvent::Text { delta: text },
+        });
+    };
+    match word {
+        "/help" => {
+            say("commands: /help · /clear (reset conversation) · /models (list providers) · \
+                 /init (index the workspace: domains + code graph) · /files · /diff · /graph \
+                 (switch tabs) — anything else is a prompt. ctrl+t queue · ? overlay help"
+                .to_string());
+        }
+        "/clear" => {
+            messages.clear();
+            messages.push(CompletionMessage::system(system_prompt.to_string()));
+            say("conversation cleared".to_string());
+        }
+        "/models" => {
+            say(Config::available_models_plain());
+        }
+        "/init" => {
+            let mut emit = |line: String| say(line);
+            match agent::init_workspace(Some(provider), &cfg.workspace_root, &mut emit).await {
+                // A fresh index may name tables/types the schema gate should
+                // know about this session, not just the next one.
+                Ok(_) => agent::populate_schema_index(registry, &cfg.workspace_root),
+                Err(e) => say(format!("init failed: {e}")),
+            }
+        }
+        // Deck-local tab commands are normally consumed TUI-side, but a queued
+        // one reaches here — accept it as handled (a no-op) rather than
+        // calling it "unknown".
+        "/files" | "/diff" | "/graph" => {}
+        // A single unknown /word is a typo'd command, not a prompt — say so
+        // instead of spending a model call. Multi-word text starting with a
+        // path-like token (e.g. `/src/main.rs explain`) stays a prompt.
+        _ if prompt.split_whitespace().count() == 1 => {
+            say(format!(
+                "unknown command `{word}` — try /help, /clear, /models, /init, /files, /diff, /graph"
+            ));
+        }
+        _ => return false,
+    }
+    true
 }
 
 /// One engine turn for the lead agent: the deck-mode analogue of

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -209,8 +209,29 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
         // Session-level slash commands are the driver's, never the model's —
         // the deck's popup enqueues them like any prompt (tab switches and
         // the help overlay were already handled TUI-side and never reach us).
-        if run_deck_command(&prompt, &in_tx, &mut messages, &system_prompt, &*provider, &registry, cfg).await {
-            continue 'session;
+        match run_deck_command(
+            &prompt,
+            &in_tx,
+            &mut messages,
+            &system_prompt,
+            &*provider,
+            &registry,
+            cfg,
+        )
+        .await
+        {
+            DeckCommand::Prompt => {}
+            DeckCommand::Handled => continue 'session,
+            DeckCommand::InitCompleted => {
+                // `/init` changed the taxonomy and rebuilt the index. Re-open
+                // memory so recall/reflection use the new domains this session
+                // (not just the next), and push a fresh Graph-tab snapshot.
+                memory = SessionMemory::open(&cfg.workspace_root, false);
+                if let Some(snapshot) = agent::graph_snapshot(&cfg.workspace_root) {
+                    let _ = in_tx.send(Inbound::GraphSnapshot(snapshot));
+                }
+                continue 'session;
+            }
         }
 
         // Per-turn conversation bookkeeping, mirroring `run_interactive`:
@@ -350,14 +371,27 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
     }
 }
 
-/// Handle a session-level slash command, returning `true` when `prompt` was
-/// one (the caller skips the model turn). Output goes into the lead agent's
+/// The disposition of a would-be slash command.
+enum DeckCommand {
+    /// Not a command — run the model turn as usual.
+    Prompt,
+    /// Handled as a command; skip the model turn.
+    Handled,
+    /// `/init` finished successfully; skip the turn AND refresh the session's
+    /// derived state (memory domains, Graph tab) which the new taxonomy/index
+    /// changed.
+    InitCompleted,
+}
+
+/// Handle a session-level slash command. Output goes into the lead agent's
 /// transcript as `Text` events — the deck renders exclusively from events, so
 /// printing to stdout (which the alternate screen owns) is never an option.
 ///
 /// Vocabulary: `/help`, `/clear`, `/models`, `/init`. `/files`, `/diff`,
 /// `/graph` are deck-local (tab switches) and consumed TUI-side; an unknown
-/// single-word `/command` gets a hint rather than a wasted model call.
+/// bare `/command` gets a hint rather than a wasted model call. Every command
+/// is no-argument, so the *whole* trimmed input is matched — `/init do the
+/// thing` is a model prompt, not a silent reindex that discards the rest.
 async fn run_deck_command(
     prompt: &str,
     in_tx: &UnboundedSender<Inbound>,
@@ -366,10 +400,10 @@ async fn run_deck_command(
     provider: &dyn Provider,
     registry: &ToolRegistry,
     cfg: &Config,
-) -> bool {
-    let word = prompt.split_whitespace().next().unwrap_or("");
-    if !word.starts_with('/') {
-        return false;
+) -> DeckCommand {
+    let trimmed = prompt.trim();
+    if !trimmed.starts_with('/') {
+        return DeckCommand::Prompt;
     }
     let say = |text: String| {
         let _ = in_tx.send(Inbound::Event {
@@ -377,7 +411,7 @@ async fn run_deck_command(
             event: AgentEvent::Text { delta: text },
         });
     };
-    match word {
+    match trimmed {
         "/help" => {
             say("commands: /help · /clear (reset conversation) · /models (list providers) · \
                  /init (index the workspace: domains + code graph) · /files · /diff · /graph \
@@ -395,9 +429,12 @@ async fn run_deck_command(
         "/init" => {
             let mut emit = |line: String| say(line);
             match agent::init_workspace(Some(provider), &cfg.workspace_root, &mut emit).await {
-                // A fresh index may name tables/types the schema gate should
-                // know about this session, not just the next one.
-                Ok(_) => agent::populate_schema_index(registry, &cfg.workspace_root),
+                Ok(_) => {
+                    // A fresh index may name tables/types the schema gate
+                    // should know about this session, not just the next one.
+                    agent::populate_schema_index(registry, &cfg.workspace_root);
+                    return DeckCommand::InitCompleted;
+                }
                 Err(e) => say(format!("init failed: {e}")),
             }
         }
@@ -405,17 +442,17 @@ async fn run_deck_command(
         // one reaches here — accept it as handled (a no-op) rather than
         // calling it "unknown".
         "/files" | "/diff" | "/graph" => {}
-        // A single unknown /word is a typo'd command, not a prompt — say so
-        // instead of spending a model call. Multi-word text starting with a
-        // path-like token (e.g. `/src/main.rs explain`) stays a prompt.
-        _ if prompt.split_whitespace().count() == 1 => {
+        // A bare unknown /word is a typo'd command, not a prompt — say so
+        // instead of spending a model call. Anything with arguments (e.g.
+        // `/src/main.rs explain`) falls through and stays a prompt.
+        _ if !trimmed.contains(char::is_whitespace) => {
             say(format!(
-                "unknown command `{word}` — try /help, /clear, /models, /init, /files, /diff, /graph"
+                "unknown command `{trimmed}` — try /help, /clear, /models, /init, /files, /diff, /graph"
             ));
         }
-        _ => return false,
+        _ => return DeckCommand::Prompt,
     }
-    true
+    DeckCommand::Handled
 }
 
 /// One engine turn for the lead agent: the deck-mode analogue of

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -735,16 +735,28 @@ impl Config {
 }
 
 impl Config {
-    /// The provider/model table as plain text (no ANSI): one line per
-    /// built-in provider with its key status. The Command Deck renders this
-    /// into the transcript for `/models` — stdout printing would corrupt the
-    /// alternate screen, so the deck needs a string, not a print.
+    /// The provider/model table as plain text (no ANSI): the built-in
+    /// providers with their key status, then any config-defined providers
+    /// from `.stella/settings.json` — the same two sections the ANSI
+    /// `print_available_models` renders, so `/models` in the deck lists
+    /// exactly what `stella models` does. The Command Deck renders this into
+    /// the transcript; stdout printing would corrupt the alternate screen, so
+    /// the deck needs a string, not a print.
     pub fn available_models_plain() -> String {
-        let settings = env::current_dir()
+        // Surface a settings load/parse failure rather than silently reporting
+        // built-in defaults (which would hide a malformed config and wrong key
+        // status), then continue with defaults so the listing still renders.
+        let (settings, load_error) = match env::current_dir()
             .map_err(|e| e.to_string())
             .and_then(|ws| crate::settings::Settings::load(&ws))
-            .unwrap_or_default();
+        {
+            Ok(s) => (s, None),
+            Err(e) => (crate::settings::Settings::default(), Some(e)),
+        };
         let mut lines = vec!["Available providers & models:".to_string()];
+        if let Some(e) = &load_error {
+            lines.push(format!("  ! settings could not be read: {e}"));
+        }
         for p in PROVIDERS {
             let p = effective_builtin(p, &settings);
             let settings_key = settings
@@ -761,6 +773,32 @@ impl Config {
                 if has_key { "✓" } else { "✗" },
                 p.id,
                 p.default_model,
+                p.display_name,
+            ));
+        }
+        // Config-defined (non-built-in) providers, mirroring the ANSI table.
+        let mut printed_header = false;
+        for (id, entry) in &settings.providers {
+            if PROVIDERS.iter().any(|p| p.id == id.as_str()) || id == LOCAL_PROVIDER.id {
+                continue;
+            }
+            let Ok(p) = custom_provider(id, entry) else {
+                continue;
+            };
+            if !printed_header {
+                lines.push("Config-defined providers (settings.json):".to_string());
+                printed_header = true;
+            }
+            let settings_key = entry.api_key.as_deref().is_some_and(|k| !k.is_empty());
+            lines.push(format!(
+                "  {} {}/{}  {}",
+                if settings_key { "✓" } else { "✗" },
+                p.id,
+                if p.default_model.is_empty() {
+                    "<model>"
+                } else {
+                    p.default_model
+                },
                 p.display_name,
             ));
         }

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -735,6 +735,39 @@ impl Config {
 }
 
 impl Config {
+    /// The provider/model table as plain text (no ANSI): one line per
+    /// built-in provider with its key status. The Command Deck renders this
+    /// into the transcript for `/models` — stdout printing would corrupt the
+    /// alternate screen, so the deck needs a string, not a print.
+    pub fn available_models_plain() -> String {
+        let settings = env::current_dir()
+            .map_err(|e| e.to_string())
+            .and_then(|ws| crate::settings::Settings::load(&ws))
+            .unwrap_or_default();
+        let mut lines = vec!["Available providers & models:".to_string()];
+        for p in PROVIDERS {
+            let p = effective_builtin(p, &settings);
+            let settings_key = settings
+                .providers
+                .get(p.id)
+                .and_then(|e| e.api_key.as_deref())
+                .is_some_and(|k| !k.is_empty());
+            let has_key = settings_key
+                || std::iter::once(&p.env_var)
+                    .chain(p.env_var_aliases)
+                    .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
+            lines.push(format!(
+                "  {} {}/{}  {}",
+                if has_key { "✓" } else { "✗" },
+                p.id,
+                p.default_model,
+                p.display_name,
+            ));
+        }
+        lines.push("Pin one with --model provider/model_id on the next launch.".to_string());
+        lines.join("\n")
+    }
+
     /// Print all available providers/models without needing a resolved
     /// config: the built-in table (with any settings.json overrides
     /// applied), then the config-defined providers. A malformed settings

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -85,14 +85,24 @@ pub async fn run_fleet(
     let ledger = Ledger::open(&dot_stella.join("fleet.db"))
         .map_err(|e| format!("could not open the fleet ledger: {e}"))?;
 
-    let run_id = format!("fleet-{}", crate::memory::unix_now_secs());
+    // Millisecond + pid: two runs in the same second (scripted/CI) must not
+    // share a ledger run id — `record_run` is INSERT OR REPLACE, so a
+    // collision would merge both runs' accounting under one row.
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let run_id = format!("fleet-{now_ms}-{}", std::process::id());
     let worker = EngineWorker {
         cfg: cfg.clone(),
         budget_limit,
     };
     let fleet = Fleet::new(
         worker,
-        WorktreeManager::new(SystemGitCli, root.clone()),
+        // The run id scopes every worktree/branch slug: task ids repeat
+        // across runs (`t1`, `t2`, …) and worktrees are kept for review, so
+        // an unscoped second run would collide on `git worktree add`.
+        WorktreeManager::new(SystemGitCli, root.clone()).with_run_scope(&run_id),
         ledger,
         agent::build_budget_guard(budget_limit),
         SystemClock::new(),
@@ -347,18 +357,19 @@ fn render_report(plan: &Plan, report: &FleetRunReport, dot_stella: &Path) {
             println!("      {}", handle.outcome.summary.dimmed());
         }
     }
-    let not_run: Vec<&str> = plan
-        .tasks
-        .iter()
-        .filter(|t| !report.completed.contains(&t.id))
-        .filter(|t| !report.handles.iter().any(|h| h.task_id == t.id))
-        .map(|t| t.id.as_str())
-        .collect();
-    if !not_run.is_empty() {
+    for (task_id, reason) in &report.dispatch_failures {
         println!(
-            "  {} not launched: {}",
+            "  {} {} — dispatch failed: {}",
+            "✗".red(),
+            task_id.bold(),
+            reason.dimmed()
+        );
+    }
+    if !report.skipped.is_empty() {
+        println!(
+            "  {} skipped (dependency failed or budget stop): {}",
             "○".yellow(),
-            not_run.join(", ").dimmed()
+            report.skipped.join(", ").dimmed()
         );
     }
     println!(

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -87,11 +87,13 @@ pub async fn run_fleet(
 
     // Millisecond + pid: two runs in the same second (scripted/CI) must not
     // share a ledger run id — `record_run` is INSERT OR REPLACE, so a
-    // collision would merge both runs' accounting under one row.
+    // collision would merge both runs' accounting under one row. A pre-epoch
+    // clock is a hard error rather than a silent fallback to a constant (which
+    // would reintroduce the very collision this guards against).
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+        .map_err(|_| "system clock is before the Unix epoch — cannot mint a unique fleet run id")?
+        .as_millis();
     let run_id = format!("fleet-{now_ms}-{}", std::process::id());
     let worker = EngineWorker {
         cfg: cfg.clone(),

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -110,6 +110,14 @@ enum Command {
         /// falls back to the direct Engine::run_turn path.
         #[arg(long)]
         no_pipeline: bool,
+
+        /// Test command the pipeline's verify stage runs deterministically
+        /// (e.g. "cargo test -p my-crate"). Arms the fail→pass flip oracle:
+        /// a change that flips a failing test to passing can submit without
+        /// a model-judge call. Omitted, verification always escalates to the
+        /// judge.
+        #[arg(long, value_name = "CMD")]
+        test_command: Option<String>,
     },
 
     /// Work in judged rounds until a judge model confirms the goal is met
@@ -408,6 +416,7 @@ fn run(cli: Cli) -> Result<(), String> {
         Command::Run {
             prompt,
             no_pipeline,
+            test_command,
         } => {
             rt()?.block_on(agent::run_one_shot(
                 &cfg,
@@ -415,6 +424,7 @@ fn run(cli: Cli) -> Result<(), String> {
                 cli.budget,
                 cli.output_format,
                 !no_pipeline,
+                test_command.as_deref(),
             ))?;
         }
         Command::Goal { goal } => {

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -281,6 +281,18 @@ impl SessionMemory {
     /// bi-temporal `covers_path` fact. Re-running `init` after the taxonomy
     /// shifts supersedes stale beliefs instead of deleting them, so
     /// "what did we believe at T1" still answers (L-C3).
+    ///
+    /// Known limitation: `covers_path` *facts* are versioned (a moved path's
+    /// old fact is superseded), but the File node's `node_domains` tags are
+    /// insert-only — re-running `init` after a path moves from domain A to B
+    /// adds the B tag without removing A. This does NOT break recall
+    /// correctness: the session scopes recall to the *full current taxonomy*,
+    /// so the node still passes the scope filter via B; the only residual is a
+    /// mild domain-overlap ranking boost for A. A correct fix is versioned
+    /// node-domain associations (matching the fact model) — deliberately not a
+    /// wholesale `node_domains` rewrite, which would depend on the unenforced
+    /// invariant that only the taxonomy ever tags File nodes and would silently
+    /// wipe tags from any future source.
     pub async fn record_taxonomy(&self, taxonomy: &crate::domains::Domains) {
         let domains = taxonomy
             .domains
@@ -352,13 +364,17 @@ impl SessionMemory {
         let stored = self.store.upsert(delta).await.is_ok();
 
         // 2. Append to the mining log and mine for auto-creatable skills.
+        // Track whether the log write actually succeeded so the message below
+        // never claims a fallback that didn't happen.
         let log_path = self
             .workspace_root
             .join(".stella")
             .join("reflections.jsonl");
+        let mut logged = true;
         for lesson in &lessons {
-            if let Ok(line) = serde_json::to_string(lesson) {
-                let _ = append_line(&log_path, &line);
+            match serde_json::to_string(lesson) {
+                Ok(line) if append_line(&log_path, &line).is_ok() => {}
+                _ => logged = false,
             }
         }
         self.auto_create_skills(&log_path, quiet);
@@ -370,10 +386,17 @@ impl SessionMemory {
                     "✦".magenta(),
                     lessons.len()
                 );
-            } else {
+            } else if logged {
                 println!(
                     "  {} could not persist {} lesson(s) to the context store \
                      (logged to reflections.jsonl only)",
+                    "!".yellow(),
+                    lessons.len()
+                );
+            } else {
+                println!(
+                    "  {} could not persist {} lesson(s) — both the context store \
+                     and reflections.jsonl writes failed",
                     "!".yellow(),
                     lessons.len()
                 );

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -295,10 +295,16 @@ impl SessionMemory {
             .iter()
             .flat_map(|d| {
                 d.paths.iter().map(|path| {
+                    // Tag the nodes themselves, not just the edge — node-level
+                    // tags are what `recall_scoped`'s domain filter and
+                    // overlap boost read (`node_domains` rows come from the
+                    // subject/object inputs, never from the fact's own tags).
                     let subject = NodeInput::new(NodeKind::Concept, &d.name)
-                        .with_uri(format!("domain://{}", d.name));
-                    let object =
-                        NodeInput::new(NodeKind::File, path).with_uri(format!("file://{path}"));
+                        .with_uri(format!("domain://{}", d.name))
+                        .with_domains([d.name.clone()]);
+                    let object = NodeInput::new(NodeKind::File, path)
+                        .with_uri(format!("file://{path}"))
+                        .with_domains([d.name.clone()]);
                     let mut fact = FactAssertion::new(subject, "covers_path", object)
                         .with_domains([d.name.clone()]);
                     // A domain legitimately covers several paths at once.
@@ -332,7 +338,10 @@ impl SessionMemory {
             return 0;
         }
 
-        // 1. Store as recallable, domain-tagged reflection memories.
+        // 1. Store as recallable, domain-tagged reflection memories. Still
+        // best-effort (a failed reflection never fails the turn), but the
+        // outcome is kept so the "remembered" line below can't claim success
+        // for lessons that never landed in the store.
         let delta = ContextDelta {
             memories: lessons
                 .iter()
@@ -340,7 +349,7 @@ impl SessionMemory {
                 .collect(),
             ..Default::default()
         };
-        let _ = self.store.upsert(delta).await;
+        let stored = self.store.upsert(delta).await.is_ok();
 
         // 2. Append to the mining log and mine for auto-creatable skills.
         let log_path = self
@@ -355,13 +364,22 @@ impl SessionMemory {
         self.auto_create_skills(&log_path, quiet);
 
         if !quiet {
-            println!(
-                "  {} remembered {} lesson(s) from this turn",
-                "✦".magenta(),
-                lessons.len()
-            );
+            if stored {
+                println!(
+                    "  {} remembered {} lesson(s) from this turn",
+                    "✦".magenta(),
+                    lessons.len()
+                );
+            } else {
+                println!(
+                    "  {} could not persist {} lesson(s) to the context store \
+                     (logged to reflections.jsonl only)",
+                    "!".yellow(),
+                    lessons.len()
+                );
+            }
         }
-        lessons.len()
+        if stored { lessons.len() } else { 0 }
     }
 
     /// Mine the whole reflection log for recurring lessons and auto-create

--- a/stella-cli/src/ocp.rs
+++ b/stella-cli/src/ocp.rs
@@ -149,17 +149,36 @@ pub fn session_host(
     workspace_root: PathBuf,
 ) -> Host {
     let mut host = Host::with_timeout(std::time::Duration::from_millis(RECALL_TIMEOUT_MS));
+    // Both providers advertise the frame kinds they serve. Empty `kinds`
+    // passes only kind-UNfiltered queries through `capability_matches` — a
+    // caller that ever sets `ContextQuery.kinds` would silently route to
+    // zero providers if these stayed empty.
+    // The wire strings mirror each provider's `to_frame_kind` mapping (the
+    // memory store serves every kind it mints; the graph serves symbols,
+    // snippets, and graph frames).
     host.register(Box::new(MemoryProvider {
         store,
         domains,
         info: local_info("workspace-memory"),
-        caps: Capabilities::default(),
+        caps: Capabilities {
+            query: ocp_types::capability::QueryCapability {
+                kinds: ["memory", "episode", "fact", "snippet", "symbol", "doc"]
+                    .map(String::from)
+                    .to_vec(),
+                filters: Vec::new(),
+            },
+            ..Capabilities::default()
+        },
     }));
     host.register(Box::new(GraphProvider {
         workspace_root,
         info: local_info("code-graph"),
         caps: Capabilities {
             graph: true,
+            query: ocp_types::capability::QueryCapability {
+                kinds: ["symbol", "snippet", "graph"].map(String::from).to_vec(),
+                filters: Vec::new(),
+            },
             ..Capabilities::default()
         },
     }));

--- a/stella-cli/src/ocp.rs
+++ b/stella-cli/src/ocp.rs
@@ -78,10 +78,22 @@ impl ContextProvider for MemoryProvider {
                 id: "workspace-memory".to_string(),
                 message: e.to_string(),
             })?;
+        // The store's recall does not honor `query.kinds`, so a kind-filtered
+        // query (now routed here because we advertise those kinds) must be
+        // filtered before returning — otherwise a `kinds: [Symbol]` request
+        // could surface memory/fact frames. Frames removed here count toward
+        // the truncation metadata alongside the store's own drops.
+        let mut frames = result.frames;
+        let mut dropped = result.dropped.len();
+        if !query.kinds.is_empty() {
+            let before = frames.len();
+            frames.retain(|f| query.kinds.contains(&f.kind));
+            dropped += before - frames.len();
+        }
         Ok(ContextQueryResult {
-            truncated: !result.dropped.is_empty(),
-            dropped_estimate: u32::try_from(result.dropped.len()).ok(),
-            frames: result.frames,
+            truncated: dropped > 0,
+            dropped_estimate: u32::try_from(dropped).ok(),
+            frames,
         })
     }
 }

--- a/stella-context/src/provider.rs
+++ b/stella-context/src/provider.rs
@@ -46,6 +46,9 @@ fn store_kinds() -> Vec<String> {
         NodeKind::Person,
         NodeKind::Artifact,
         NodeKind::Task,
+        // The kind the store exists for — omitting it routed kind-filtered
+        // memory queries away from the one provider that stores memories.
+        NodeKind::Memory,
     ]
     .iter()
     .map(|k| k.to_frame_kind())

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -21,7 +21,7 @@ use ocp_types::{ContextFrame, ContextQuery, Provenance};
 use crate::error::ContextError;
 use crate::store::{
     ContextStore, NodeRow, domains_for_node, live_nodes, neighbors, node_ids_for_uris,
-    node_ids_in_domains, node_ids_tagged, vectors_for_fingerprint,
+    node_ids_excluded_by_scope, vectors_for_fingerprint,
 };
 
 /// Provenance `kind` marking a frame's domain tag, so a citation view can show
@@ -143,15 +143,16 @@ impl ContextStore {
             let mut nodes = live_nodes(&conn)?;
             let mut vectors = vectors_for_fingerprint(&conn, &fp_id)?;
             let anchor_ids = node_ids_for_uris(&conn, &q.anchors)?;
-            if let Some(allowed) = node_ids_in_domains(&conn, domains)? {
-                // Scope excludes only nodes whose tags are all out of scope;
-                // untagged nodes pass (the overlap boost in 3b still ranks
-                // in-scope tags above them). Dropping untagged nodes here
-                // silenced recall completely after `stella init`: reflections
-                // and episodes are commonly written with no domain tag.
-                let tagged = node_ids_tagged(&conn)?;
-                nodes.retain(|n| !tagged.contains(&n.id) || allowed.contains(&n.id));
-                vectors.retain(|(id, _)| !tagged.contains(id) || allowed.contains(id));
+            // Scope excludes only nodes whose tags are all out of scope;
+            // untagged nodes pass (the overlap boost in 3b still ranks
+            // in-scope tags above them). Dropping untagged nodes here silenced
+            // recall completely after `stella init`: reflections and episodes
+            // are commonly written with no domain tag. The exclusion set is an
+            // empty no-op when `domains` is empty.
+            let excluded = node_ids_excluded_by_scope(&conn, domains)?;
+            if !excluded.is_empty() {
+                nodes.retain(|n| !excluded.contains(&n.id));
+                vectors.retain(|(id, _)| !excluded.contains(id));
             }
             let mut domains_by_id: HashMap<i64, Vec<String>> = HashMap::new();
             for n in &nodes {

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -21,7 +21,7 @@ use ocp_types::{ContextFrame, ContextQuery, Provenance};
 use crate::error::ContextError;
 use crate::store::{
     ContextStore, NodeRow, domains_for_node, live_nodes, neighbors, node_ids_for_uris,
-    node_ids_in_domains, vectors_for_fingerprint,
+    node_ids_in_domains, node_ids_tagged, vectors_for_fingerprint,
 };
 
 /// Provenance `kind` marking a frame's domain tag, so a citation view can show
@@ -102,11 +102,14 @@ impl ContextStore {
 
     /// Hybrid retrieval scoped to `domains` (scope update): fuse → dedup →
     /// diversify → budget-pack → coverage gate. When `domains` is non-empty it
-    /// **filters** candidates to nodes tagged with at least one of them AND
+    /// **filters out** nodes tagged exclusively with out-of-scope domains AND
     /// **boosts** relevance by domain overlap (a frame sharing more of the
-    /// query's domains ranks higher). An empty `domains` slice behaves exactly
-    /// like [`Self::recall`]. Every returned frame carries its domains in
-    /// provenance so a citation view can show them.
+    /// query's domains ranks higher). Untagged nodes always stay candidates:
+    /// most memories carry no domain tag, and a scope that dropped them would
+    /// return nothing the moment a workspace taxonomy exists. An empty
+    /// `domains` slice behaves exactly like [`Self::recall`]. Every returned
+    /// frame carries its domains in provenance so a citation view can show
+    /// them.
     pub async fn recall_scoped(
         &self,
         q: &ContextQuery,
@@ -141,8 +144,14 @@ impl ContextStore {
             let mut vectors = vectors_for_fingerprint(&conn, &fp_id)?;
             let anchor_ids = node_ids_for_uris(&conn, &q.anchors)?;
             if let Some(allowed) = node_ids_in_domains(&conn, domains)? {
-                nodes.retain(|n| allowed.contains(&n.id));
-                vectors.retain(|(id, _)| allowed.contains(id));
+                // Scope excludes only nodes whose tags are all out of scope;
+                // untagged nodes pass (the overlap boost in 3b still ranks
+                // in-scope tags above them). Dropping untagged nodes here
+                // silenced recall completely after `stella init`: reflections
+                // and episodes are commonly written with no domain tag.
+                let tagged = node_ids_tagged(&conn)?;
+                nodes.retain(|n| !tagged.contains(&n.id) || allowed.contains(&n.id));
+                vectors.retain(|(id, _)| !tagged.contains(id) || allowed.contains(id));
             }
             let mut domains_by_id: HashMap<i64, Vec<String>> = HashMap::new();
             for n in &nodes {

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -1107,6 +1107,27 @@ pub(crate) fn node_ids_in_domains(
     Ok(Some(set))
 }
 
+/// Live node ids carrying ANY domain tag at all. `recall_scoped` needs this to
+/// tell "tagged with an out-of-scope domain" (excluded) apart from "never
+/// tagged" (kept): most memories — reflections whose lessons name no domain,
+/// episodes from turns that touched no taxonomy-covered file — are untagged,
+/// and a scope filter that dropped them would silence recall entirely the
+/// moment `stella init` writes a taxonomy.
+pub(crate) fn node_ids_tagged(
+    conn: &Connection,
+) -> Result<std::collections::HashSet<i64>, ContextError> {
+    let mut set = std::collections::HashSet::new();
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT nd.node_id FROM node_domains nd
+         JOIN node n ON n.id = nd.node_id
+         WHERE n.superseded_at IS NULL",
+    )?;
+    for r in stmt.query_map([], |r| r.get::<_, i64>(0))? {
+        set.insert(r?);
+    }
+    Ok(set)
+}
+
 /// All defined domains as `(name, description)`, for status/inspection.
 pub(crate) fn list_domains(
     conn: &Connection,
@@ -1429,6 +1450,68 @@ mod tests {
             "after warm, retrieval is vector-grounded"
         );
         assert!(!result.frames.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scoped_recall_keeps_untagged_nodes_and_drops_out_of_scope_ones() {
+        // Regression: the post-`stella init` failure mode. A workspace
+        // taxonomy makes every recall domain-scoped; most memories are
+        // written untagged (reflections with no domain, episodes touching no
+        // covered file). The scope must keep those and exclude only nodes
+        // tagged exclusively out of scope — the old hard filter returned
+        // zero frames forever once a taxonomy existed.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("context.db");
+        let store = ContextStore::open_with(
+            &path,
+            Arc::new(crate::embed::HashEmbedder::default()),
+            Arc::new(SystemClock),
+        )
+        .unwrap();
+        store
+            .upsert(
+                crate::writeback::ContextDelta::new()
+                    .with_node(
+                        NodeInput::new(NodeKind::Concept, "untagged-lesson")
+                            .with_content("prefer rg over grep in shell commands"),
+                    )
+                    .with_node(
+                        NodeInput::new(NodeKind::Concept, "in-scope")
+                            .with_content("billing retries use exponential backoff")
+                            .with_domains(["billing".to_string()]),
+                    )
+                    .with_node(
+                        NodeInput::new(NodeKind::Concept, "out-of-scope")
+                            .with_content("frontend uses tailwind for styling")
+                            .with_domains(["frontend".to_string()]),
+                    ),
+            )
+            .await
+            .unwrap();
+
+        let q = ocp_types::ContextQuery {
+            goal: "recall everything".into(),
+            query_text: Some("prefer rg over grep billing retries".into()),
+            embedding: None,
+            kinds: vec![],
+            anchors: vec![],
+            max_frames: 10,
+            max_tokens: 4000,
+            as_of: None,
+        };
+        let result = store
+            .recall_scoped(&q, &["billing".to_string()])
+            .await
+            .unwrap();
+        let titles: Vec<&str> = result.frames.iter().map(|f| f.title.as_str()).collect();
+        assert!(
+            titles.contains(&"untagged-lesson"),
+            "untagged nodes must survive a domain scope: {titles:?}"
+        );
+        assert!(
+            !titles.contains(&"out-of-scope"),
+            "nodes tagged exclusively out of scope must be excluded: {titles:?}"
+        );
     }
 
     #[tokio::test]

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -1082,47 +1082,43 @@ pub(crate) fn domains_for_node(
     Ok(out)
 }
 
-/// Live node ids tagged with ANY of the given domains — the domain-filter
-/// candidate set for `recall_scoped`. An empty `domains` slice returns `None`
-/// (meaning "no filter"), distinct from an empty set ("filter matched nothing").
-pub(crate) fn node_ids_in_domains(
-    conn: &Connection,
-    domains: &[String],
-) -> Result<Option<std::collections::HashSet<i64>>, ContextError> {
-    if domains.is_empty() {
-        return Ok(None);
-    }
-    let mut set = std::collections::HashSet::new();
-    let mut stmt = conn.prepare(
-        "SELECT nd.node_id FROM node_domains nd
-         JOIN domain d ON d.id = nd.domain_id
-         JOIN node n ON n.id = nd.node_id
-         WHERE d.name = ?1 AND n.superseded_at IS NULL",
-    )?;
-    for name in domains {
-        for r in stmt.query_map(params![name], |r| r.get::<_, i64>(0))? {
-            set.insert(r?);
-        }
-    }
-    Ok(Some(set))
-}
-
-/// Live node ids carrying ANY domain tag at all. `recall_scoped` needs this to
-/// tell "tagged with an out-of-scope domain" (excluded) apart from "never
-/// tagged" (kept): most memories — reflections whose lessons name no domain,
+/// Live node ids that carry a domain tag but NONE in `scope` — exactly the
+/// set a scoped recall must exclude. Untagged nodes are never returned (they
+/// stay candidates): most memories — reflections whose lessons name no domain,
 /// episodes from turns that touched no taxonomy-covered file — are untagged,
 /// and a scope filter that dropped them would silence recall entirely the
-/// moment `stella init` writes a taxonomy.
-pub(crate) fn node_ids_tagged(
+/// moment `stella init` writes a taxonomy. An empty `scope` returns an empty
+/// set (nothing is out of scope).
+///
+/// The out-of-scope test runs in one SQL statement (an anti-join against the
+/// in-scope tag set) rather than materializing every tagged id in memory and
+/// differencing in Rust — a large initialized workspace can carry many tags
+/// unrelated to the active scope.
+pub(crate) fn node_ids_excluded_by_scope(
     conn: &Connection,
+    scope: &[String],
 ) -> Result<std::collections::HashSet<i64>, ContextError> {
-    let mut set = std::collections::HashSet::new();
-    let mut stmt = conn.prepare(
+    if scope.is_empty() {
+        return Ok(std::collections::HashSet::new());
+    }
+    let placeholders = std::iter::repeat_n("?", scope.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
         "SELECT DISTINCT nd.node_id FROM node_domains nd
          JOIN node n ON n.id = nd.node_id
-         WHERE n.superseded_at IS NULL",
-    )?;
-    for r in stmt.query_map([], |r| r.get::<_, i64>(0))? {
+         WHERE n.superseded_at IS NULL
+           AND nd.node_id NOT IN (
+             SELECT nd2.node_id FROM node_domains nd2
+             JOIN domain d ON d.id = nd2.domain_id
+             WHERE d.name IN ({placeholders})
+           )"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut set = std::collections::HashSet::new();
+    for r in stmt.query_map(rusqlite::params_from_iter(scope.iter()), |r| {
+        r.get::<_, i64>(0)
+    })? {
         set.insert(r?);
     }
     Ok(set)

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -373,6 +373,10 @@ where
             .filter(|t| !attempted.contains(&t.id))
             .map(|t| t.id.clone())
             .collect();
+        // Dispatch failures accrue in wave-completion order, which varies run
+        // to run; sort by task id so the report reads identically for the same
+        // plan (matching the deterministic `handles` ordering).
+        report.dispatch_failures.sort_by(|a, b| a.0.cmp(&b.0));
         report.completed = succeeded;
         Ok(report)
     }
@@ -467,6 +471,28 @@ mod tests {
                 success: true,
                 seen_roots: Arc::new(StdMutex::new(Vec::new())),
             }
+        }
+        /// A worker whose every task reports failure — for wave-scheduling
+        /// tests that a failed prerequisite must not unblock dependents.
+        fn failing(cost_usd: f64) -> Self {
+            Self {
+                success: false,
+                ..Self::new(cost_usd)
+            }
+        }
+    }
+
+    /// A `GitCli` that fails every `git worktree` invocation (add/remove) with
+    /// a non-zero exit — the shape of a real "worktree already exists" or
+    /// permission failure, so `WorktreeManager::create` returns an error.
+    struct FailGit;
+    #[async_trait]
+    impl GitCli for FailGit {
+        async fn run(&self, _repo: &Path, args: &[&str]) -> Result<GitOutput, GitError> {
+            if args.first() == Some(&"worktree") {
+                return Ok(GitOutput::failed(128, "fatal: worktree add failed"));
+            }
+            Ok(GitOutput::ok(""))
         }
     }
     #[async_trait]
@@ -653,5 +679,64 @@ mod tests {
         let report = f.run_plan(&plan).await.unwrap();
         assert!(!report.budget_aborted);
         assert_eq!(report.completed.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn a_failed_prerequisite_skips_its_dependents() {
+        // a (fails) -> b -> c. a's failure must NOT unblock b, and c (behind
+        // b) is skipped in turn — dependents of a failure never run, so no
+        // budget is spent on doomed turns.
+        let plan = Plan::new(vec![
+            Task::new("a", "a", "p"),
+            Task::new("b", "b", "p").depends_on(["a"]),
+            Task::new("c", "c", "p").depends_on(["b"]),
+        ]);
+        let f = fleet(
+            FakeWorker::failing(0.10),
+            OkGit::new(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            FleetConfig::new("run1", "HEAD"),
+        );
+
+        let report = f.run_plan(&plan).await.unwrap();
+        assert!(!report.all_succeeded(), "a failed → the run did not succeed");
+        assert!(
+            !report.completed.contains("a"),
+            "a failed, so it is not in the succeeded set"
+        );
+        // Only a was ever dispatched; b and c were skipped, not attempted.
+        assert_eq!(report.handles.len(), 1);
+        assert_eq!(report.handles[0].task_id, "a");
+        let mut skipped = report.skipped.clone();
+        skipped.sort();
+        assert_eq!(skipped, vec!["b".to_string(), "c".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn a_git_worktree_failure_is_a_recorded_dispatch_failure() {
+        // Two independent isolated tasks in one wave; git worktree add fails
+        // for both. Each is a recorded dispatch failure (not an early return
+        // that discards the wave), the run did not succeed, and the failures
+        // are reported in deterministic task-id order.
+        let plan = Plan::new(vec![Task::new("t1", "t1", "p"), Task::new("t2", "t2", "p")]);
+        let f = Fleet::new(
+            FakeWorker::new(0.10),
+            WorktreeManager::new(FailGit, "/repo"),
+            Ledger::open_in_memory().unwrap(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            SeqClock::new(),
+            FleetConfig::new("run1", "HEAD").with_max_concurrency(2),
+        )
+        .unwrap();
+
+        let report = f.run_plan(&plan).await.unwrap();
+        assert!(!report.all_succeeded(), "dispatch failures fail the run");
+        assert!(report.handles.is_empty(), "no task produced a handle");
+        let failed: Vec<&str> = report
+            .dispatch_failures
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect();
+        assert_eq!(failed, vec!["t1", "t2"], "both failures recorded, sorted");
     }
 }

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -105,8 +105,16 @@ pub struct TaskHandle {
 pub struct FleetRunReport {
     /// Every dispatched task's handle, in a deterministic (task-id) order.
     pub handles: Vec<TaskHandle>,
-    /// Task ids that completed.
+    /// Task ids whose worker reported success — the set that unblocked
+    /// dependents.
     pub completed: HashSet<TaskId>,
+    /// Tasks whose dispatch itself errored (worktree creation, ledger I/O)
+    /// before a worker could produce a handle, with the reason. Counted as
+    /// failures.
+    pub dispatch_failures: Vec<(TaskId, String)>,
+    /// Tasks never attempted because a dependency failed (or the run stopped
+    /// on budget before their wave).
+    pub skipped: Vec<TaskId>,
     /// `true` if the run stopped early because the parent budget was enforced
     /// and a child pushed it over — the remaining waves were not launched.
     pub budget_aborted: bool,
@@ -118,9 +126,12 @@ impl FleetRunReport {
         self.handles.iter().map(|h| h.outcome.cost_usd).sum()
     }
 
-    /// Whether every dispatched task's worker reported success.
+    /// Whether every task ran and reported success — dispatch failures and
+    /// dependency-skipped tasks count against this.
     pub fn all_succeeded(&self) -> bool {
-        self.handles.iter().all(|h| h.outcome.success)
+        self.dispatch_failures.is_empty()
+            && self.skipped.is_empty()
+            && self.handles.iter().all(|h| h.outcome.success)
     }
 }
 
@@ -268,12 +279,14 @@ where
     }
 
     /// Dispatch a wave of dependency-ready tasks concurrently, bounded by
-    /// `max_concurrency`. Results come back in completion order; the caller
-    /// (`run_plan`) reorders deterministically.
-    pub async fn run_wave(&self, tasks: &[&Task]) -> Vec<Result<TaskHandle, FleetError>> {
+    /// `max_concurrency`. Results come back in completion order, each tagged
+    /// with its task id (a dispatch `Err` — e.g. a failed `worktree add` —
+    /// doesn't carry a handle, and the caller must still know WHICH task it
+    /// lost); the caller (`run_plan`) reorders deterministically.
+    pub async fn run_wave(&self, tasks: &[&Task]) -> Vec<(TaskId, Result<TaskHandle, FleetError>)> {
         let concurrency = self.config.max_concurrency.max(1);
         stream::iter(tasks.iter().copied())
-            .map(|task| self.dispatch(task))
+            .map(|task| async move { (task.id.clone(), self.dispatch(task).await) })
             .buffer_unordered(concurrency)
             .collect()
             .await
@@ -304,24 +317,44 @@ where
         }
 
         let mut report = FleetRunReport::default();
-        let mut completed: HashSet<TaskId> = HashSet::new();
+        // `succeeded` gates dependents: a failed (or dispatch-errored) task
+        // must NOT unblock the tasks that depend on it — running them against
+        // work that never landed just burns budget on doomed turns. They are
+        // reported as `skipped` instead. `attempted` keeps a failed task from
+        // being re-offered by `ready_tasks` (it is never in `succeeded`).
+        let mut succeeded: HashSet<TaskId> = HashSet::new();
+        let mut attempted: HashSet<TaskId> = HashSet::new();
 
         loop {
-            let ready = plan.ready_tasks(&completed);
+            let ready: Vec<&Task> = plan
+                .ready_tasks(&succeeded)
+                .into_iter()
+                .filter(|t| !attempted.contains(&t.id))
+                .collect();
             if ready.is_empty() {
                 break;
             }
 
+            // A dispatch error (worktree creation, ledger I/O) is recorded as
+            // that task's failure — never an early return that would throw
+            // away the settled siblings' handles (their spend, commits, and
+            // worktrees would otherwise vanish from the report).
             let mut handles: Vec<TaskHandle> = Vec::with_capacity(ready.len());
-            for result in self.run_wave(&ready).await {
-                handles.push(result?);
+            for (task_id, result) in self.run_wave(&ready).await {
+                attempted.insert(task_id.clone());
+                match result {
+                    Ok(handle) => handles.push(handle),
+                    Err(e) => report.dispatch_failures.push((task_id, e.to_string())),
+                }
             }
             // Deterministic order regardless of completion timing.
             handles.sort_by(|a, b| a.task_id.cmp(&b.task_id));
 
             let mut wave_tripped_budget = false;
             for handle in handles {
-                completed.insert(handle.task_id.clone());
+                if handle.outcome.success {
+                    succeeded.insert(handle.task_id.clone());
+                }
                 if matches!(handle.budget, BudgetOutcome::AbortTurn { .. }) {
                     wave_tripped_budget = true;
                 }
@@ -334,7 +367,13 @@ where
             }
         }
 
-        report.completed = completed;
+        report.skipped = plan
+            .tasks
+            .iter()
+            .filter(|t| !attempted.contains(&t.id))
+            .map(|t| t.id.clone())
+            .collect();
+        report.completed = succeeded;
         Ok(report)
     }
 

--- a/stella-fleet/src/git.rs
+++ b/stella-fleet/src/git.rs
@@ -194,27 +194,31 @@ fn slugify(task_id: &str) -> String {
     }
 }
 
-/// A short, stable, deterministic hash of `s` as 8 lowercase hex chars.
+/// A stable, deterministic hash of `s` as 16 lowercase hex chars (the full
+/// 64-bit digest).
 ///
 /// [`slugify`] is lossy — `fix/the thing`, `fix the thing`, and `fix-the-thing`
 /// all map to `fix-the-thing`. `Plan::validate` guarantees unique task *ids*
 /// but not unique *slugs*, so two distinct tasks could otherwise collide on the
-/// same worktree directory and branch. Appending this hash of the full task id
-/// makes the slug injective. FNV-1a (not the stdlib's randomizable `Hasher`) so
-/// the result is identical across processes and Rust versions — a later wave
-/// must be able to recompute the exact branch name for the same task id.
+/// same worktree directory and branch. Appending this hash of the full
+/// `run_scope`+task id makes the slug **collision-resistant** (a 64-bit digest,
+/// not truncated to 32 bits as before — the birthday bound at 16 hex chars is
+/// far past any realistic per-run task count). FNV-1a (not the stdlib's
+/// randomizable `Hasher`) so the result is identical across processes and Rust
+/// versions — a later wave must recompute the exact branch name for the same
+/// scope+task id.
 fn short_hash(s: &str) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for b in s.as_bytes() {
         hash ^= u64::from(*b);
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    format!("{:08x}", hash as u32)
+    format!("{hash:016x}")
 }
 
 /// The worktree directory + branch slug for `task_id` within `run_scope`: a
 /// human-readable [`slugify`] stem plus a [`short_hash`] suffix that keeps it
-/// collision-free even when two task ids slugify to the same stem. The run
+/// collision-resistant even when two task ids slugify to the same stem. The run
 /// scope enters the hash so re-running a plan with the same task ids (`t1`,
 /// `t2`, … — every positional invocation) gets fresh directories/branches
 /// instead of colliding with last run's kept-for-review worktrees.

--- a/stella-fleet/src/git.rs
+++ b/stella-fleet/src/git.rs
@@ -212,11 +212,18 @@ fn short_hash(s: &str) -> String {
     format!("{:08x}", hash as u32)
 }
 
-/// The worktree directory + branch slug for `task_id`: a human-readable
-/// [`slugify`] stem plus a [`short_hash`] suffix that keeps it collision-free
-/// even when two task ids slugify to the same stem.
-fn worktree_slug(task_id: &str) -> String {
-    format!("{}-{}", slugify(task_id), short_hash(task_id))
+/// The worktree directory + branch slug for `task_id` within `run_scope`: a
+/// human-readable [`slugify`] stem plus a [`short_hash`] suffix that keeps it
+/// collision-free even when two task ids slugify to the same stem. The run
+/// scope enters the hash so re-running a plan with the same task ids (`t1`,
+/// `t2`, … — every positional invocation) gets fresh directories/branches
+/// instead of colliding with last run's kept-for-review worktrees.
+fn worktree_slug(run_scope: &str, task_id: &str) -> String {
+    format!(
+        "{}-{}",
+        slugify(task_id),
+        short_hash(&format!("{run_scope}\u{1f}{task_id}"))
+    )
 }
 
 /// Manages the lifecycle of isolated task worktrees over a [`GitCli`].
@@ -225,12 +232,13 @@ pub struct WorktreeManager<G: GitCli> {
     repo_root: PathBuf,
     worktrees_root: PathBuf,
     branch_prefix: String,
+    run_scope: String,
 }
 
 impl<G: GitCli> WorktreeManager<G> {
     /// A manager rooted at `repo_root`, placing worktrees under
     /// `<repo_root>/.stella/worktrees/` (`02-architecture.md` §6, alongside
-    /// `ledger.db`) with branches named `fleet/<task-slug>`.
+    /// the fleet ledger) with branches named `fleet/<task-slug>`.
     pub fn new(git: G, repo_root: impl Into<PathBuf>) -> Self {
         let repo_root = repo_root.into();
         let worktrees_root = repo_root.join(".stella").join("worktrees");
@@ -239,12 +247,21 @@ impl<G: GitCli> WorktreeManager<G> {
             repo_root,
             worktrees_root,
             branch_prefix: "fleet/".to_string(),
+            run_scope: String::new(),
         }
     }
 
     /// Override where worktree checkouts are placed (builder style).
     pub fn with_worktrees_root(mut self, root: impl Into<PathBuf>) -> Self {
         self.worktrees_root = root.into();
+        self
+    }
+
+    /// Scope worktree/branch names to one run (builder style): the scope is
+    /// hashed into every slug, so two runs sharing task ids never collide on
+    /// a directory or branch left behind by the earlier run.
+    pub fn with_run_scope(mut self, scope: impl Into<String>) -> Self {
+        self.run_scope = scope.into();
         self
     }
 
@@ -261,7 +278,7 @@ impl<G: GitCli> WorktreeManager<G> {
     /// human-readable stem plus a stable hash suffix so two task ids that
     /// slugify to the same stem never collide on the same directory/branch.
     pub async fn create(&self, task_id: &str, base_ref: &str) -> Result<Worktree, WorktreeError> {
-        let slug = worktree_slug(task_id);
+        let slug = worktree_slug(&self.run_scope, task_id);
         let dir = self.worktrees_root.join(&slug);
         let branch = format!("{}{slug}", self.branch_prefix);
         let dir_str = path_arg(&dir)?;
@@ -527,15 +544,27 @@ mod tests {
         // `slugify` alone maps these three distinct task ids to the same stem;
         // the hash suffix must keep the full slugs distinct so their worktrees
         // and branches never collide.
-        let a = worktree_slug("fix/the thing");
-        let b = worktree_slug("fix the thing");
-        let c = worktree_slug("fix-the-thing");
+        let a = worktree_slug("run", "fix/the thing");
+        let b = worktree_slug("run", "fix the thing");
+        let c = worktree_slug("run", "fix-the-thing");
         assert!(a.starts_with("fix-the-thing-"));
         assert_ne!(a, b);
         assert_ne!(b, c);
         assert_ne!(a, c);
         // Deterministic across calls.
-        assert_eq!(a, worktree_slug("fix/the thing"));
+        assert_eq!(a, worktree_slug("run", "fix/the thing"));
+    }
+
+    #[test]
+    fn worktree_slug_differs_across_runs_for_the_same_task_id() {
+        // Re-running a plan reuses task ids (`t1`, `t2`, …) and the previous
+        // run's worktrees/branches are kept for review — the run scope must
+        // make the second run's slugs fresh, or `git worktree add` fails the
+        // whole run with "already exists".
+        let first = worktree_slug("fleet-1", "t1");
+        let second = worktree_slug("fleet-2", "t1");
+        assert_ne!(first, second);
+        assert!(first.starts_with("t1-") && second.starts_with("t1-"));
     }
 
     #[tokio::test]

--- a/stella-fleet/src/ledger.rs
+++ b/stella-fleet/src/ledger.rs
@@ -92,8 +92,8 @@ pub struct Ledger {
 }
 
 impl Ledger {
-    /// Open (creating if absent) the ledger at `path` — canonically
-    /// `<workspace>/.stella/ledger.db` (`02-architecture.md` §6). Enables WAL
+    /// Open (creating if absent) the ledger at `path` — the CLI opens
+    /// `<workspace>/.stella/fleet.db` (`02-architecture.md` §6). Enables WAL
     /// and foreign keys, then applies the schema.
     pub fn open(path: &Path) -> Result<Self, LedgerError> {
         let conn = Connection::open(path)?;

--- a/stella-fleet/src/ledger.rs
+++ b/stella-fleet/src/ledger.rs
@@ -1,5 +1,5 @@
 //! The commit ledger (`02-architecture.md` §2 "commit ledger (SQLite)", §6
-//! "`ledger.db` — SQLite: fleet commit ledger"). One embedded SQLite file
+//! "`fleet.db` — SQLite: fleet commit ledger"). One embedded SQLite file
 //! (`rusqlite`, bundled — `02-architecture.md` §1.6 "one storage engine")
 //! recording, for every fleet run: its tasks, each dispatch attempt, the
 //! commits an attempt produced, the parent→child lineage, and per-task USD

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -97,17 +97,20 @@ pub struct CodeGraph {
 }
 
 /// One symbol in a [`FileNeighborhood`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NeighborhoodSymbol {
     pub name: String,
-    /// The stored kind tag (`"fn"`, `"struct"`, `"class"`, `"table"`, …).
-    pub kind: &'static str,
+    /// The stored kind tag as persisted by the index (`"function"`,
+    /// `"struct"`, `"class"`, `"table"`, …) — see [`SymbolKind::tag`]. An
+    /// owned `String` so this public type round-trips through serde without a
+    /// borrow lifetime.
+    pub kind: String,
     pub start_line: u32,
 }
 
 /// The structured neighborhood of one file: its symbols and its import
 /// edges in both directions. Root-relative forward-slash paths throughout.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FileNeighborhood {
     pub file: String,
     pub symbols: Vec<NeighborhoodSymbol>,
@@ -262,7 +265,7 @@ impl CodeGraph {
             .into_iter()
             .map(|row| NeighborhoodSymbol {
                 name: row.name,
-                kind: row.kind.tag(),
+                kind: row.kind.tag().to_string(),
                 start_line: row.start_line,
             })
             .collect();

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -96,6 +96,28 @@ pub struct CodeGraph {
     inner: std::sync::Arc<Inner>,
 }
 
+/// One symbol in a [`FileNeighborhood`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NeighborhoodSymbol {
+    pub name: String,
+    /// The stored kind tag (`"fn"`, `"struct"`, `"class"`, `"table"`, …).
+    pub kind: &'static str,
+    pub start_line: u32,
+}
+
+/// The structured neighborhood of one file: its symbols and its import
+/// edges in both directions. Root-relative forward-slash paths throughout.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileNeighborhood {
+    pub file: String,
+    pub symbols: Vec<NeighborhoodSymbol>,
+    /// What this file imports: resolved paths where resolution succeeded,
+    /// raw specifiers (e.g. Rust `use` paths) otherwise.
+    pub imports: Vec<String>,
+    /// Files whose imports resolve to this file.
+    pub importers: Vec<String>,
+}
+
 impl CodeGraph {
     /// Open (or create) the store at `db_path` for the workspace at `root`,
     /// **without** starting background work. Use this for one-shot indexing,
@@ -216,12 +238,45 @@ impl CodeGraph {
     }
 
     /// The OCP-provider query entrypoint: budgeted, provenance-carrying frames
-    /// (`06-context-protocol.md` §3.3), in-process shape. Built and tested as
-    /// the retrieval surface a context plane would call; not yet consumed at
-    /// runtime — the index is written on `stella init` but the CLI does not yet
-    /// query it.
+    /// (`06-context-protocol.md` §3.3), in-process shape. Consumed at runtime
+    /// by the CLI's OCP host (`stella-cli/src/ocp.rs`, `GraphProvider`), which
+    /// fans recall out to this alongside the memory store on every turn.
     pub fn query(&self, q: &ContextQuery) -> Result<Vec<ContextFrame>, GraphError> {
         frames::query(&self.inner.read_guard(), &self.inner.root, q)
+    }
+
+    /// The best-connected file in the index (most symbols + import edges) —
+    /// a UI's default focus when the caller hasn't picked a file. `None` on
+    /// an empty index.
+    pub fn busiest_file(&self) -> Result<Option<String>, GraphError> {
+        store::busiest_file(&self.inner.read_guard())
+    }
+
+    /// The structured neighborhood of `file` — its symbols and import edges
+    /// in both directions — for UI consumers (the deck's Graph tab). The
+    /// frame methods above render prose for the model; this keeps the shape.
+    pub fn file_neighborhood(&self, file: &Path) -> Result<FileNeighborhood, GraphError> {
+        let rel = self.resolve_rel(file);
+        let conn = self.inner.read_guard();
+        let symbols = store::symbols_in_file(&conn, &rel)?
+            .into_iter()
+            .map(|row| NeighborhoodSymbol {
+                name: row.name,
+                kind: row.kind.tag(),
+                start_line: row.start_line,
+            })
+            .collect();
+        let imports = store::imports_from(&conn, &rel)?
+            .into_iter()
+            .map(|row| row.to_path.unwrap_or(row.specifier))
+            .collect();
+        let importers = store::importers_of(&conn, &rel)?;
+        Ok(FileNeighborhood {
+            file: rel,
+            symbols,
+            imports,
+            importers,
+        })
     }
 
     /// All known table, type, and view names (lowercased) from the index.
@@ -275,11 +330,13 @@ impl CodeGraph {
 
 impl Drop for CodeGraph {
     fn drop(&mut self) {
-        // Best-effort teardown if the caller never called `shutdown`. Only the
-        // last handle (Arc strong-count 1) tears down, so cloned background
-        // holders don't stop the watcher early.
-        if std::sync::Arc::strong_count(&self.inner) == 1 {
-            self.shutdown();
-        }
+        // Best-effort teardown if the caller never called `shutdown`.
+        // Unconditional: `CodeGraph` is not `Clone`, so this drop IS the last
+        // public handle going away — the remaining `Arc` holders are the
+        // background catch-up task and debounce loop, which hold clones for
+        // their whole lives. Gating on strong-count == 1 (the previous
+        // behavior) could therefore never fire after a successful `mount`,
+        // leaking the OS watcher and both loops until process exit.
+        self.shutdown();
     }
 }

--- a/stella-graph/src/lib.rs
+++ b/stella-graph/src/lib.rs
@@ -30,7 +30,7 @@
 //! use stella_graph::CodeGraph;
 //!
 //! # fn main() -> Result<(), stella_graph::GraphError> {
-//! let graph = CodeGraph::open(Path::new("."), Path::new("./.stella/context.db"))?;
+//! let graph = CodeGraph::open(Path::new("."), Path::new("./.stella/codegraph.db"))?;
 //! graph.index_all()?;
 //! for frame in graph.definitions("run_turn")? {
 //!     // Cite by the human label, never the raw id (L-C4).
@@ -54,7 +54,7 @@ mod watch;
 
 pub use error::GraphError;
 pub use frames::PROVIDER_ID;
-pub use graph::CodeGraph;
+pub use graph::{CodeGraph, FileNeighborhood, NeighborhoodSymbol};
 pub use import::{ImportEdge, ImportKind};
 pub use lang::Language;
 pub use store::IndexStats;

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -377,6 +377,25 @@ pub(crate) fn file_count(conn: &Connection) -> Result<usize, GraphError> {
     Ok(count as usize)
 }
 
+/// The best-connected file in the index: most symbols plus import edges in
+/// both directions. UI consumers use it as a default focus when the caller
+/// hasn't picked a file yet. `None` on an empty index.
+pub(crate) fn busiest_file(conn: &Connection) -> Result<Option<String>, GraphError> {
+    let path = conn
+        .query_row(
+            "SELECT f.path,
+                    (SELECT COUNT(*) FROM code_graph_symbols s WHERE s.file_id = f.id)
+                  + (SELECT COUNT(*) FROM code_graph_imports i WHERE i.from_file_id = f.id)
+                  + (SELECT COUNT(*) FROM code_graph_imports i2 WHERE i2.to_path = f.path)
+                    AS degree
+             FROM code_graph_files f ORDER BY degree DESC, f.path LIMIT 1",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(path)
+}
+
 /// All distinct symbol names of the given kind tag (e.g. `"table"`,
 /// `"schema_enum"`, `"view"`). Used by the schema gate to populate the
 /// known-schema index at session start.

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -502,6 +502,34 @@ mod tests {
     }
 
     #[test]
+    fn busiest_file_picks_the_most_connected_file() {
+        let ws = tempdir().unwrap();
+        let dbdir = tempdir().unwrap();
+        let root = canon(&ws);
+        let db = dbdir.path().join("context.db");
+        // `hub.rs` carries three symbols; `leaf.rs` carries one. The busiest
+        // file is the one with the highest symbol+import degree.
+        fs::write(
+            root.join("hub.rs"),
+            "pub fn a() {}\npub fn b() {}\npub struct C;\n",
+        )
+        .unwrap();
+        fs::write(root.join("leaf.rs"), "pub fn d() {}\n").unwrap();
+        let grammars = Grammars::load().unwrap();
+        let mut conn = open(&db).unwrap();
+        index_tree(&mut conn, &root, &grammars).unwrap();
+
+        assert_eq!(busiest_file(&conn).unwrap().as_deref(), Some("hub.rs"));
+    }
+
+    #[test]
+    fn busiest_file_is_none_on_an_empty_index() {
+        let dbdir = tempdir().unwrap();
+        let conn = open(&dbdir.path().join("context.db")).unwrap();
+        assert_eq!(busiest_file(&conn).unwrap(), None);
+    }
+
+    #[test]
     fn kill_during_indexing_leaves_a_consistent_store() {
         let ws = tempdir().unwrap();
         let dbdir = tempdir().unwrap();

--- a/stella-graph/tests/frames.rs
+++ b/stella-graph/tests/frames.rs
@@ -135,3 +135,16 @@ fn busiest_file_names_the_most_connected_file() {
     // The one-file fixture makes driver.rs the only (thus busiest) candidate.
     assert_eq!(graph.busiest_file().unwrap().as_deref(), Some("driver.rs"));
 }
+
+#[test]
+fn file_neighborhood_round_trips_through_serde() {
+    // The type crosses the crate boundary (the deck consumes it), so it must
+    // survive a serde round-trip like every other public wire type.
+    let (_ws, _db, graph) = fixture();
+    let hood = graph
+        .file_neighborhood(std::path::Path::new("driver.rs"))
+        .unwrap();
+    let json = serde_json::to_string(&hood).unwrap();
+    let back: stella_graph::FileNeighborhood = serde_json::from_str(&json).unwrap();
+    assert_eq!(hood, back);
+}

--- a/stella-graph/tests/frames.rs
+++ b/stella-graph/tests/frames.rs
@@ -110,3 +110,28 @@ fn kind_filter_limits_returned_frames() {
         "kind filter must exclude non-matching frames"
     );
 }
+
+#[test]
+fn file_neighborhood_returns_the_files_symbols() {
+    // The structured neighborhood the deck's Graph tab renders (as opposed to
+    // the prose frames above): the file's own symbols, with kinds and lines.
+    let (_ws, _db, graph) = fixture();
+    let hood = graph
+        .file_neighborhood(std::path::Path::new("driver.rs"))
+        .unwrap();
+    assert_eq!(hood.file, "driver.rs");
+    let names: Vec<&str> = hood.symbols.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"run_turn"), "symbols: {names:?}");
+    assert!(names.contains(&"Engine"), "symbols: {names:?}");
+    assert!(
+        hood.symbols.iter().any(|s| s.kind == "function"),
+        "a function symbol should carry the persisted `function` kind tag"
+    );
+}
+
+#[test]
+fn busiest_file_names_the_most_connected_file() {
+    let (_ws, _db, graph) = fixture();
+    // The one-file fixture makes driver.rs the only (thus busiest) candidate.
+    assert_eq!(graph.busiest_file().unwrap().as_deref(), Some("driver.rs"));
+}

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -985,8 +985,10 @@ impl<'a> Pipeline<'a> {
         Ok(outcome.value)
     }
 
-    /// Run one engine turn on a private channel, then forward every event to
-    /// the consumer **except** the engine's `Stage`/`Complete` (the pipeline
+    /// Run one engine turn, forwarding every event to the consumer **live**
+    /// (a concurrent drain task, not a post-hoc flush — an execute turn can
+    /// run tool loops for minutes, and buffering froze the renderer for the
+    /// whole turn) **except** the engine's `Stage`/`Complete` (the pipeline
     /// owns those), tallying `FileChange`s into `file_changes` for the
     /// zero-diff guard.
     async fn run_engine_turn(
@@ -997,35 +999,62 @@ impl<'a> Pipeline<'a> {
         file_changes: &mut u32,
     ) -> TurnOutcome {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let outcome = engine.run_turn(messages, budget, &tx).await;
-        drop(tx); // close the channel so the drain below terminates
-        while let Ok(event) = rx.try_recv() {
-            let forward = match &event {
-                // The pipeline is the sole authority for stage boundaries and
-                // the terminal Complete — drop the engine's per-turn copies.
-                AgentEvent::Stage { .. } | AgentEvent::Complete { .. } => false,
-                AgentEvent::FileChange { .. } => {
-                    *file_changes += 1;
-                    true
+        let consumer = self.events.clone();
+        let forwarder = tokio::spawn(async move {
+            let mut seen_file_changes: u32 = 0;
+            while let Some(event) = rx.recv().await {
+                let forward = match &event {
+                    // The pipeline is the sole authority for stage boundaries
+                    // and the terminal Complete — drop the engine's per-turn
+                    // copies.
+                    AgentEvent::Stage { .. } | AgentEvent::Complete { .. } => false,
+                    AgentEvent::FileChange { .. } => {
+                        seen_file_changes += 1;
+                        true
+                    }
+                    _ => true,
+                };
+                if forward {
+                    let _ = consumer.send(event);
                 }
-                _ => true,
-            };
-            if forward {
-                let _ = self.events.send(event);
             }
-        }
+            seen_file_changes
+        });
+        let outcome = engine.run_turn(messages, budget, &tx).await;
+        drop(tx); // close the channel so the forwarder terminates
+        *file_changes += forwarder.await.unwrap_or(0);
         outcome
     }
 
     /// Run the diff command and return `(changed_line_count, raw_diff)`.
+    ///
+    /// `git diff` cannot see untracked files, so a turn whose entire change
+    /// is a NEW file would read as "no diff" — skipping verification via the
+    /// zero-diff guard and showing the judge an empty diff. When the
+    /// configured command is git's, untracked files are listed explicitly
+    /// and appended as named entries, each counting as a changed line.
     async fn gather_diff(&self) -> (u32, String) {
-        match &self.config.diff_command {
-            Some(cmd) => {
-                let out = self.commands.run(cmd).await;
-                (count_diff_lines(&out.stdout_tail), out.stdout_tail)
+        let Some(cmd) = &self.config.diff_command else {
+            return (0, String::new());
+        };
+        let out = self.commands.run(cmd).await;
+        let mut lines = count_diff_lines(&out.stdout_tail);
+        let mut text = out.stdout_tail;
+        if cmd.trim_start().starts_with("git diff") {
+            let untracked = self
+                .commands
+                .run("git ls-files --others --exclude-standard")
+                .await;
+            for path in untracked
+                .stdout_tail
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+            {
+                lines += 1;
+                text.push_str(&format!("\n+ new file (untracked): {path}"));
             }
-            None => (0, String::new()),
         }
+        (lines, text)
     }
 
     fn record_and_tick(&self, budget: &mut BudgetGuard, cost_usd: f64) -> BudgetOutcome {
@@ -1230,6 +1259,15 @@ mod tests {
                 return CmdOutcome {
                     exit_code: 0,
                     stdout_tail: self.diff.clone(),
+                    stderr_tail: String::new(),
+                };
+            }
+            // The untracked-files listing `gather_diff` issues alongside a
+            // git diff — an empty workspace answer, never a test result.
+            if cmd.contains("ls-files") {
+                return CmdOutcome {
+                    exit_code: 0,
+                    stdout_tail: String::new(),
                     stderr_tail: String::new(),
                 };
             }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -34,6 +34,7 @@
 //! need `&mut Router`). That feedback is the responsibility of the glue that
 //! owns the `Router` — documented here so the boundary is explicit.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use stella_core::hooks::{HookRunner, Hooks};
@@ -643,6 +644,12 @@ impl<'a> Pipeline<'a> {
             oracle.observe(cmd, pre.passed());
         }
 
+        // Snapshot untracked files BEFORE executing so `gather_diff` can tell
+        // files this turn created from pre-existing dirty state — otherwise a
+        // stale untracked file would be attributed to (and verified against)
+        // this turn.
+        let untracked_before = self.list_untracked().await;
+
         // Execute: one turn for simple/single-task; one turn per plan step for
         // multi-step (each step guides a fresh engine turn).
         self.emit(AgentEvent::Stage {
@@ -690,7 +697,7 @@ impl<'a> Pipeline<'a> {
         // simple lookup, only if the turn unexpectedly touched files (the
         // zero-diff guard, L-E2). "Touched files" = FileChange events observed
         // OR a non-empty diff.
-        let (mut diff_lines, mut diff_text) = self.gather_diff().await;
+        let (mut diff_lines, mut diff_text) = self.gather_diff(&untracked_before).await;
         let files_touched = file_changes > 0 || !diff_text.trim().is_empty();
         let should_verify = task_class.verifies_unconditionally()
             || (task_class == TaskClass::SimpleLookup && files_touched);
@@ -777,6 +784,7 @@ impl<'a> Pipeline<'a> {
                             &mut file_changes,
                             &mut final_text,
                             total,
+                            &untracked_before,
                         )
                         .await
                     {
@@ -838,6 +846,7 @@ impl<'a> Pipeline<'a> {
                             &mut file_changes,
                             &mut final_text,
                             total,
+                            &untracked_before,
                         )
                         .await
                     {
@@ -868,6 +877,7 @@ impl<'a> Pipeline<'a> {
         file_changes: &mut u32,
         final_text: &mut String,
         total: &mut f64,
+        untracked_before: &HashSet<String>,
     ) -> Result<(u32, String), String> {
         messages.push(CompletionMessage::user(revision_prompt(reason)));
         self.emit(AgentEvent::Stage {
@@ -883,7 +893,7 @@ impl<'a> Pipeline<'a> {
             }
             TurnOutcome::Aborted { reason } => return Err(reason),
         }
-        let (dl, dt) = self.gather_diff().await;
+        let (dl, dt) = self.gather_diff(untracked_before).await;
         self.emit(AgentEvent::Stage {
             name: StageKind::Verify,
         });
@@ -1026,14 +1036,63 @@ impl<'a> Pipeline<'a> {
         outcome
     }
 
+    /// The git-ignored-aware set of untracked files, root-relative. Empty
+    /// unless the configured diff command is git's (untracked accounting only
+    /// makes sense there). `-c core.quotePath=false` keeps non-ASCII paths
+    /// literal so the set matches what a later `gather_diff` sees.
+    async fn list_untracked(&self) -> HashSet<String> {
+        let is_git = self
+            .config
+            .diff_command
+            .as_deref()
+            .is_some_and(|c| c.trim_start().starts_with("git diff"));
+        if !is_git {
+            return HashSet::new();
+        }
+        let out = self
+            .commands
+            .run("git -c core.quotePath=false ls-files --others --exclude-standard")
+            .await;
+        out.stdout_tail
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect()
+    }
+
+    /// The real added-line count of a new untracked file, via a no-index diff
+    /// numstat (`<added>\t<deleted>\t<path>`). A binary file numstats as `-`
+    /// and counts as one changed line (a change the ladder must see, but
+    /// unmeasurable in lines). Counting real lines — not a flat 1 per file —
+    /// is what keeps a large new file from slipping under the diff budget and
+    /// taking `SubmitFast`.
+    async fn untracked_added_lines(&self, path: &str) -> u32 {
+        let out = self
+            .commands
+            .run(&format!(
+                "git diff --no-index --numstat -- /dev/null {}",
+                shell_single_quote(path)
+            ))
+            .await;
+        out.stdout_tail
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .and_then(|l| l.split('\t').next())
+            .and_then(|added| added.trim().parse::<u32>().ok())
+            .unwrap_or(1)
+    }
+
     /// Run the diff command and return `(changed_line_count, raw_diff)`.
     ///
-    /// `git diff` cannot see untracked files, so a turn whose entire change
-    /// is a NEW file would read as "no diff" — skipping verification via the
-    /// zero-diff guard and showing the judge an empty diff. When the
-    /// configured command is git's, untracked files are listed explicitly
-    /// and appended as named entries, each counting as a changed line.
-    async fn gather_diff(&self) -> (u32, String) {
+    /// `git diff` cannot see untracked files, so a turn whose entire change is
+    /// a NEW file would read as "no diff" — skipping verification via the
+    /// zero-diff guard and showing the judge an empty diff. When the configured
+    /// command is git's, files that became untracked *this turn* (i.e. not in
+    /// `untracked_before`) are appended with their real added-line counts, so
+    /// pre-existing dirty state is never attributed to the turn and a large new
+    /// file cannot slip under the diff-size budget.
+    async fn gather_diff(&self, untracked_before: &HashSet<String>) -> (u32, String) {
         let Some(cmd) = &self.config.diff_command else {
             return (0, String::new());
         };
@@ -1041,17 +1100,17 @@ impl<'a> Pipeline<'a> {
         let mut lines = count_diff_lines(&out.stdout_tail);
         let mut text = out.stdout_tail;
         if cmd.trim_start().starts_with("git diff") {
-            let untracked = self
-                .commands
-                .run("git ls-files --others --exclude-standard")
-                .await;
-            for path in untracked
-                .stdout_tail
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-            {
-                lines += 1;
-                text.push_str(&format!("\n+ new file (untracked): {path}"));
+            let mut fresh: Vec<String> = self
+                .list_untracked()
+                .await
+                .into_iter()
+                .filter(|p| !untracked_before.contains(p))
+                .collect();
+            fresh.sort(); // deterministic order for the appended evidence
+            for path in fresh {
+                let added = self.untracked_added_lines(&path).await;
+                lines += added;
+                text.push_str(&format!("\n+ new file (untracked): {path} (+{added} lines)"));
             }
         }
         (lines, text)
@@ -1183,6 +1242,13 @@ fn count_diff_lines(diff: &str) -> u32 {
         .count() as u32
 }
 
+/// POSIX single-quote a shell argument so an untracked file path (which the
+/// user, not the pipeline, named) can never break out of the `git diff`
+/// command string. Embedded single quotes become the standard `'\''`.
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1238,36 +1304,68 @@ mod tests {
         }
     }
 
-    /// A command runner: `diff` returns a fixed diff; anything else pops the
-    /// next queued test result (`true` = pass) or defaults to pass.
+    /// A command runner: the git diff command returns a fixed diff; `ls-files`
+    /// reports the scripted untracked set; a `--no-index --numstat` reports
+    /// that file's scripted added-line count; anything else pops the next
+    /// queued test result (`true` = pass) or defaults to pass.
     struct ScriptedRunner {
         test_results: std::sync::Mutex<VecDeque<bool>>,
         diff: String,
+        /// Untracked files this workspace reports, as `(path, added_lines)`.
+        untracked: Vec<(String, u32)>,
     }
     impl ScriptedRunner {
         fn new(test_results: Vec<bool>, diff: &str) -> Self {
             Self {
                 test_results: std::sync::Mutex::new(test_results.into_iter().collect()),
                 diff: diff.to_string(),
+                untracked: Vec::new(),
             }
+        }
+        fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
+            self.untracked = untracked
+                .into_iter()
+                .map(|(p, n)| (p.to_string(), n))
+                .collect();
+            self
         }
     }
     #[async_trait]
     impl CommandRunner for ScriptedRunner {
         async fn run(&self, cmd: &str) -> CmdOutcome {
+            // Order matters: the no-index numstat and ls-files probes both
+            // contain "diff"/"git", so match them before the generic diff.
+            if cmd.contains("ls-files") {
+                let listing = self
+                    .untracked
+                    .iter()
+                    .map(|(p, _)| p.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return CmdOutcome {
+                    exit_code: 0,
+                    stdout_tail: listing,
+                    stderr_tail: String::new(),
+                };
+            }
+            if cmd.contains("--no-index") && cmd.contains("--numstat") {
+                // Report `<added>\t0\t<path>` for the file named in the cmd.
+                let numstat = self
+                    .untracked
+                    .iter()
+                    .find(|(p, _)| cmd.contains(p.as_str()))
+                    .map(|(p, n)| format!("{n}\t0\t{p}"))
+                    .unwrap_or_default();
+                return CmdOutcome {
+                    exit_code: if numstat.is_empty() { 0 } else { 1 },
+                    stdout_tail: numstat,
+                    stderr_tail: String::new(),
+                };
+            }
             if cmd.contains("diff") {
                 return CmdOutcome {
                     exit_code: 0,
                     stdout_tail: self.diff.clone(),
-                    stderr_tail: String::new(),
-                };
-            }
-            // The untracked-files listing `gather_diff` issues alongside a
-            // git diff — an empty workspace answer, never a test result.
-            if cmd.contains("ls-files") {
-                return CmdOutcome {
-                    exit_code: 0,
-                    stdout_tail: String::new(),
                     stderr_tail: String::new(),
                 };
             }
@@ -1660,6 +1758,59 @@ mod tests {
     fn count_diff_lines_ignores_headers() {
         let diff = "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n context";
         assert_eq!(count_diff_lines(diff), 2);
+    }
+
+    #[test]
+    fn shell_single_quote_neutralizes_metacharacters() {
+        assert_eq!(shell_single_quote("a b"), "'a b'");
+        // An embedded quote can't break out — the classic '\'' escape.
+        assert_eq!(shell_single_quote("a'b"), r"'a'\''b'");
+        assert_eq!(shell_single_quote("x; rm -rf ~"), "'x; rm -rf ~'");
+    }
+
+    /// P1/P2 regression: a large NEW file must contribute its real added-line
+    /// count (not a flat 1, which slipped a 10k-line file under the diff
+    /// budget), and a file already untracked before the turn must not be
+    /// attributed to it.
+    #[tokio::test]
+    async fn gather_diff_counts_real_new_file_lines_and_excludes_pre_existing() {
+        let provider = ScriptedProvider::new(vec![]);
+        let resolver = OneProvider(&provider);
+        // Empty tracked diff; one big new file the ScriptedRunner reports as
+        // untracked with 5000 added lines.
+        let runner = ScriptedRunner::new(vec![], "").with_untracked(vec![("src/huge.rs", 5000)]);
+        let tools = EmptyTools;
+        let recall = NoContextRecall;
+        let repo = NoRepoStructure;
+        let approvals = AutoApproveGate;
+        let sleeper = NoopSleeper;
+        let router = router();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let pipeline = Pipeline::new(
+            PipelinePorts {
+                router: &router,
+                providers: &resolver,
+                tools: &tools,
+                recall: &recall,
+                repo: &repo,
+                commands: &runner,
+                approvals: &approvals,
+                sleeper: &sleeper,
+                hooks: None,
+            },
+            tx,
+            PipelineConfig::default(),
+        );
+
+        // No baseline → the file is this turn's; its real 5000 lines count.
+        let (lines, text) = pipeline.gather_diff(&HashSet::new()).await;
+        assert_eq!(lines, 5000, "a new file counts its real added lines, not 1");
+        assert!(text.contains("src/huge.rs"), "diff text names the new file");
+
+        // Already untracked before the turn → not attributed to it.
+        let before: HashSet<String> = std::iter::once("src/huge.rs".to_string()).collect();
+        let (lines2, _) = pipeline.gather_diff(&before).await;
+        assert_eq!(lines2, 0, "a pre-existing untracked file is not this turn's change");
     }
 
     #[test]

--- a/stella-tools/src/graph.rs
+++ b/stella-tools/src/graph.rs
@@ -119,6 +119,21 @@ pub fn run_query(root: &Path, op: &str, target: &str) -> ToolOutput {
     graph.shutdown();
 
     match result {
+        // Importer edges only exist where import resolution succeeds
+        // (relative TS/JS and Python paths). Rust `use` paths and bare
+        // package specifiers are indexed unresolved, so an empty importers
+        // answer for such a file is a capability gap, not a stale index —
+        // saying "re-index" would send the agent down a useless `stella
+        // init` retry.
+        Ok(frames) if frames.is_empty() && op == "importers" && !target.ends_with(".py") => {
+            ToolOutput::Ok {
+                content: format!(
+                    "no importers found for `{target}` — importer edges exist only where \
+                     import resolution succeeds (relative TS/JS/Python imports); Rust `use` \
+                     paths are indexed unresolved. Try `references` on the module name instead."
+                ),
+            }
+        }
         Ok(frames) if frames.is_empty() => ToolOutput::Ok {
             content: format!(
                 "no {op} found for `{target}` (index may be stale — `stella init` re-indexes)"

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -233,6 +233,10 @@ impl WorkspaceModel {
                     summary: format!("▶ {}", snip(text)),
                 });
             }
+            // The graph snapshot is an out-of-band read-model, not part of the
+            // event-log fold — the view state owns it, applied in
+            // `ingest_inbound`, so the model deliberately ignores it here.
+            Inbound::GraphSnapshot(_) => {}
         }
     }
 

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -291,10 +291,32 @@ fn slash_matches(ui: &DeckUi) -> Vec<String> {
 /// Returns `None` for keys the popup doesn't claim. Shared with the
 /// single-session REPL (`crate::ui`) via `crate::composer` so both surfaces
 /// stay consistent by construction.
+///
+/// Deck-local commands (tab switches, the help overlay) are intercepted here
+/// and act on the UI directly; everything else is enqueued for the driver,
+/// which owns the session-level vocabulary (`/clear`, `/models`, `/init`, …).
 fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Option<DeckAction> {
     match handle_slash_popup_key(key, matches, &mut ui.composer, &mut ui.slash_selected)? {
         SlashPopupOutcome::Handled => Some(DeckAction::Handled),
-        SlashPopupOutcome::Submit(text) => Some(DeckAction::Send(WorkspaceInput::Enqueue { text })),
+        SlashPopupOutcome::Submit(text) => Some(match text.as_str() {
+            // Views the deck itself owns: act locally, never round-trip.
+            "/files" | "/diff" => {
+                ui.set_tab(DeckTab::Files);
+                if text == "/diff" {
+                    ui.files_diff_open = true;
+                }
+                DeckAction::Handled
+            }
+            "/graph" => {
+                ui.set_tab(DeckTab::Graph);
+                DeckAction::Handled
+            }
+            "/help" => {
+                ui.help_open = true;
+                DeckAction::Handled
+            }
+            _ => DeckAction::Send(WorkspaceInput::Enqueue { text }),
+        }),
     }
 }
 

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -146,6 +146,13 @@ pub enum DeckAction {
 
 /// Fold one inbound envelope and keep the ephemeral UI in range.
 pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) {
+    // A refreshed graph snapshot is out-of-band view state (the Graph tab),
+    // not a model fold — apply it straight to the UI. Everything else folds
+    // into the model, then selections are re-clamped.
+    if let Inbound::GraphSnapshot(snapshot) = inbound {
+        ui.graph = Some(snapshot.clone());
+        return;
+    }
     model.apply_inbound(inbound);
     clamp(model, ui);
 }
@@ -300,11 +307,11 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
         SlashPopupOutcome::Handled => Some(DeckAction::Handled),
         SlashPopupOutcome::Submit(text) => Some(match text.as_str() {
             // Views the deck itself owns: act locally, never round-trip.
+            // `/diff` opens the diff viewer; `/files` shows the file tree, so
+            // it must also *close* a diff left open from a prior view.
             "/files" | "/diff" => {
                 ui.set_tab(DeckTab::Files);
-                if text == "/diff" {
-                    ui.files_diff_open = true;
-                }
+                ui.files_diff_open = text == "/diff";
                 DeckAction::Handled
             }
             "/graph" => {
@@ -1013,5 +1020,52 @@ mod tests {
                 text: "/models".into()
             })
         );
+    }
+
+    #[test]
+    fn slash_files_switches_to_files_and_closes_an_open_diff() {
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.slash_commands = vec![SlashCommand::new("/files", "files")];
+        ui.files_diff_open = true; // a diff was left open from a prior view
+        for c in "/files".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled, "/files is consumed locally");
+        assert_eq!(ui.tab, DeckTab::Files);
+        assert!(!ui.files_diff_open, "/files shows the tree, not a diff");
+    }
+
+    #[test]
+    fn slash_diff_switches_to_files_and_opens_the_diff() {
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.slash_commands = vec![SlashCommand::new("/diff", "diff")];
+        for c in "/diff".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.tab, DeckTab::Files);
+        assert!(ui.files_diff_open, "/diff opens the viewer");
+    }
+
+    #[test]
+    fn a_refreshed_graph_snapshot_updates_the_view_out_of_band() {
+        use crate::graph::{GraphNode, GraphSnapshot};
+        let mut model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        assert!(ui.graph.is_none());
+        let snapshot = GraphSnapshot {
+            focus: "src/lib.rs".into(),
+            nodes: vec![GraphNode {
+                label: "src/lib.rs".into(),
+                kind: "file".into(),
+                location: Some("src/lib.rs".into()),
+            }],
+            edges: vec![],
+        };
+        ingest_inbound(&Inbound::GraphSnapshot(snapshot.clone()), &mut model, &mut ui);
+        assert_eq!(ui.graph.as_ref(), Some(&snapshot));
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -12,6 +12,7 @@
 
 use stella_protocol::AgentEvent;
 
+use crate::graph::GraphSnapshot;
 use crate::input::UserInput;
 
 /// Stable identifier for one agent/run within the workspace. Human-meaningful
@@ -121,6 +122,15 @@ pub enum Inbound {
     /// bar's "queued" count goes down the moment work actually starts, and a
     /// trace row records which agent picked the prompt up.
     PromptStarted { agent: AgentId, text: String },
+    /// A refreshed code-graph snapshot for the Graph tab. Unlike the other
+    /// variants this is **not** a folded event — the graph is an out-of-band
+    /// read-model (see `COMMAND_DECK_DESIGN.md` → "The purity boundary"). It
+    /// rides the inbound channel only because that is the driver→deck path;
+    /// [`crate::deck_ui::ingest_inbound`] applies it straight to the view
+    /// state (`DeckUi::graph`) and the model fold ignores it. The driver
+    /// sends one after `/init` rebuilds the index so the tab reflects it
+    /// without a restart.
+    GraphSnapshot(GraphSnapshot),
 }
 
 /// What the deck sends back to the caller / engine. The single-session


### PR DESCRIPTION
## Summary

Started as the "/" slash-menu fix and grew into a wiring/correctness pass across the subsystems that were built but not fully connected: the code graph, context recall, fleet, and pipeline. Adds `/init` as a chat command so the code graph can be (re)built without leaving the session.

## `/init` in chat
- `stella init`'s body is now a shared `init_workspace` core (domain taxonomy + code-graph index + taxonomy write-back), reused by the CLI subcommand, the plain REPL `/init`, and the Command Deck `/init`.
- The deck driver now handles session-level slash commands (`/help`, `/clear`, `/models`, `/init`) as transcript events; `/files`, `/diff`, `/graph` switch tabs TUI-side. New `Config::available_models_plain` renders `/models` without ANSI (the deck owns the alternate screen).

## Code graph
- **Deck Graph tab was demo-only** — `DeckOptions.initial_graph` is now populated from the real index via new `CodeGraph::busiest_file` / `file_neighborhood` (+ `FileNeighborhood`) and an `agent::graph_snapshot` converter.
- **`CodeGraph` Drop leak** — teardown gated on `Arc` strong-count == 1 could never fire after a successful `mount` (background tasks hold clones); now unconditional.
- `code_graph` no longer tells the agent to "re-index" when an empty `importers` result is actually a resolution-capability gap (Rust `use` paths are indexed unresolved).
- Doc fixes: `codegraph.db` (not `context.db`); `query` is consumed at runtime.

## Context / recall — the post-`stella init` regression
- Domain-scoped recall kept **only** domain-tagged nodes, so once a taxonomy existed every untagged memory (most reflections/episodes) became unrecallable — recall returned nothing. Now untagged nodes stay candidates; only nodes tagged exclusively out of scope are excluded. Regression test added.
- `record_taxonomy` tags the subject/object nodes (not just the edge) so scoping/boost sees them.
- `reflect_and_record` no longer claims "remembered N lessons" when the store write failed.
- Both OCP providers advertise the frame kinds they serve; `Memory` added to `store_kinds` so kind-filtered routing can't skip the memory store.

## Fleet
- **Re-run collision** — worktree/branch slugs are now scoped to the run id, so re-running a plan (task ids repeat as `t1`, `t2`, …; worktrees kept for review) no longer fails `git worktree add` and aborts the whole run.
- **Failed deps unblocked dependents** — wave scheduling is now success-gated; a failed/dispatch-errored task no longer unblocks its dependents (reported as skipped), so budget isn't burned on doomed turns.
- A single dispatch error no longer discards the whole wave's settled handles; the report carries `dispatch_failures` + `skipped`.
- `run_id` is ms+pid (not unix-seconds) so same-second runs don't merge in the ledger. Doc fix: `fleet.db` (not `ledger.db`).

## Pipeline
- **Frozen output** — the default `stella run` buffered every engine event until turn end; now a concurrent forwarder streams them live.
- `gather_diff` appends untracked files (git diff can't see them) so a new-file-only change isn't verified against an empty diff.
- `--test-command` wired so the deterministic verify ladder (fail→pass flip oracle) is reachable from the CLI.

## Agent steering
- Both system prompts now list `code_graph` and instruct: prefer it over grep/glob for definition/reference/dependency questions; fall back only when the graph can't answer.

## Embeddings
- Confirmed generated end-to-end (`HashEmbedder` in `open_and_warm`, the one production construction site) for episodes and reflections, and used at read time via cosine scoring. The recall regression above is what made them actually useful post-init — previously every untagged node's vector was filtered out before scoring. (Note: `HashEmbedder` is a hashing stand-in; a semantic ONNX/API embedder remains a separate follow-up.)

## Testing
- `cargo build` clean; `cargo clippy` clean on all touched crates.
- Full test suites pass for stella-cli, stella-graph, stella-context, stella-fleet, stella-pipeline, stella-tui, stella-tools.
- New tests: scoped-recall-keeps-untagged-nodes, `busiest_file`, `file_neighborhood`.
- End-to-end: `stella init` builds `.stella/codegraph.db` (verified) and `stella graph definitions <sym>` queries it.
