### PR TITLE
Migrate stella-store from DuckDB to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,6 @@ Thumbs.db
 .env.local
 .env.*.local
 !.env.example
-*.duckdb
-*.duckdb.*
 
 # Stella-specific
 .stella/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Sixteen crates. The one-sentence rule of thumb:
 | Change CLI commands, flags, or agent wiring | `stella-cli` | This is the shipping binary. |
 | Change REPL rendering / panels / keybindings | `stella-tui` | Pure-fold ratatui REPL. Not yet the default shell. |
 | Touch shared types crossing a crate boundary | `stella-protocol` | **Zero logic, zero I/O — types only.** |
-| Persistence: executions, events, telemetry (DuckDB) | `stella-store` | |
+| Persistence: executions, events, telemetry (SQLite) | `stella-store` | |
 | Retrieval: graph, embeddings, episodic memory | `stella-context` | |
 | Tree-sitter code indexing | `stella-graph` | |
 | Triage → … → judge orchestration plane | `stella-pipeline` | |
@@ -172,7 +172,7 @@ editing Stella's own code should know what lives where:
 | `.stella/mcp.toml` | MCP server config — extra tools merged into the registry at session start. |
 | `.stella/domains.toml` | Domain taxonomy for memory/reflection tagging, inferred by `stella init`. |
 | `.stella/reflections.jsonl` | Per-turn reflection mining log (one JSON object per line). |
-| `.stella/stella.duckdb` | Local DuckDB telemetry (executions, events, cost/tokens). No phone-home. |
+| `.stella/store.db` | Local SQLite telemetry (executions, events, cost/tokens). No phone-home. |
 | `.stella/codegraph.db` | Tree-sitter code-graph index, built on `stella init`. |
 
 ---
@@ -232,9 +232,6 @@ seconds; `cargo test --workspace` rebuilds everything.
 
 ## Gotchas
 
-- **Bundled DuckDB** (`stella-store`) is a heavy C++ compile on a cold cache.
-  First `cargo build --workspace` takes minutes; use `cargo build -p <crate>`
-  to avoid it when you're not touching store.
 - **`Cargo.lock` is tracked.** Stella ships a binary and `install.sh` builds
   with `--locked`, so the lockfile must be committed and reproducible.
 - **The `dcp-types/` crate** is a prototype. If you see it in the workspace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ out to them at runtime).
 git clone https://github.com/oxageninc/stella.git
 cd stella
 
-cargo build --workspace          # first build compiles bundled DuckDB — go get coffee
+cargo build --workspace          # first build compiles bundled SQLite — quick
 cargo test  --workspace          # the full suite
 cargo run -p stella-cli -- models   # smoke-check your build
 ```
@@ -85,7 +85,7 @@ Sixteen crates sounds like a lot; the rule of thumb is one sentence each:
 | Change a CLI command, flag, or the agent wiring | `stella-cli` |
 | Change the REPL rendering / panels / keybindings | `stella-tui` |
 | Touch shared types crossing a crate boundary | `stella-protocol` (zero logic, zero I/O — types only) |
-| Persistence: executions, events, telemetry (DuckDB) | `stella-store` |
+| Persistence: executions, events, telemetry (SQLite) | `stella-store` |
 | Retrieval: graph, embeddings, episodic memory | `stella-context` |
 | Tree-sitter code indexing | `stella-graph` |
 | The triage → … → judge orchestration plane | `stella-pipeline` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,12 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "const-random",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -47,15 +28,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "anpa"
@@ -129,184 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "arrow"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-array"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
-dependencies = [
- "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.17.1",
- "num-complex",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "comfy-table",
- "half",
- "lexical-core",
- "num-traits",
- "ryu",
-]
-
-[[package]]
-name = "arrow-data"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
-]
-
-[[package]]
-name = "arrow-row"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "arrow-select"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-string"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num-traits",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,15 +119,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -406,18 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "bitvec"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,30 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,28 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,12 +256,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -552,8 +273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -578,17 +297,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
 ]
 
 [[package]]
@@ -653,17 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comfy-table"
-version = "7.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
-dependencies = [
- "crossterm 0.28.1",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,26 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,12 +388,6 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -737,32 +408,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.13.0",
- "crossterm_winapi",
- "parking_lot",
- "rustix 0.38.44",
- "winapi",
-]
 
 [[package]]
 name = "crossterm"
@@ -776,7 +425,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -790,12 +439,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -935,17 +578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,24 +673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "duckdb"
-version = "1.10504.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
-dependencies = [
- "arrow",
- "cast",
- "comfy-table",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink 0.10.0",
- "libduckdb-sys",
- "num-integer",
- "rust_decimal",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,16 +749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,27 +767,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1214,12 +801,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1378,42 +959,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
+ "ahash",
 ]
 
 [[package]]
@@ -1424,7 +975,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1435,7 +986,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1445,15 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1596,30 +1138,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1820,16 +1338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,84 +1392,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lexical-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libduckdb-sys"
-version = "1.10504.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
-dependencies = [
- "cc",
- "flate2",
- "pkg-config",
- "reqwest",
- "serde",
- "serde_json",
- "tar",
- "vcpkg",
- "zip",
-]
 
 [[package]]
 name = "libm"
@@ -1988,12 +1422,6 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.0",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2087,16 +1515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,25 +1586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,22 +1603,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2522,15 +1911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,32 +1930,12 @@ dependencies = [
  "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.5",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2662,19 +2022,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2684,7 +2036,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2697,16 +2049,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2724,9 +2066,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -2802,7 +2141,7 @@ dependencies = [
  "lru",
  "palette",
  "serde",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -2816,7 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core",
 ]
@@ -2866,7 +2205,7 @@ dependencies = [
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum 0.28.0",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -2911,15 +2250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,7 +2257,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2976,35 +2305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "roxmltree"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,26 +2343,9 @@ dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.7",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3082,19 +2365,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3102,7 +2372,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3179,12 +2449,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -3315,18 +2579,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3553,7 +2805,7 @@ dependencies = [
 name = "stella-store"
 version = "0.1.0"
 dependencies = [
- "duckdb",
+ "rusqlite",
  "serde",
  "serde_json",
  "stella-protocol",
@@ -3582,7 +2834,7 @@ dependencies = [
 name = "stella-tui"
 version = "0.1.0"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
  "proptest",
  "ratatui",
  "ratatui-comfy-tabs",
@@ -3611,32 +2863,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "strum_macros",
 ]
 
 [[package]]
@@ -3729,23 +2960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,7 +2968,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3766,7 +2980,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -3896,15 +3110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,18 +3206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
 ]
 
 [[package]]
@@ -4345,7 +3538,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -4817,9 +4009,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wiremock"
@@ -4855,25 +4044,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
-]
 
 [[package]]
 name = "yoke"
@@ -4979,39 +4149,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 tree-sitter-sequel = "0.3"
 
-duckdb = { version = "1.3", features = ["bundled"] }
 ratatui-comfy-tabs = "0.5.12"
 tachyonfx = "0.25.1"
 sysinfo = "0.38.4"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/rust-1.90%2B-FFAC26?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.90+">
   <img src="https://img.shields.io/badge/providers-9%20%2B%20local-FFAC26?style=flat-square" alt="9 providers + local">
   <img src="https://img.shields.io/badge/phone--home-none-1f7a3d?style=flat-square" alt="No phone-home">
-  <img src="https://img.shields.io/badge/telemetry-local%20DuckDB-1f7a3d?style=flat-square" alt="Local DuckDB telemetry">
+  <img src="https://img.shields.io/badge/telemetry-local%20SQLite-1f7a3d?style=flat-square" alt="Local SQLite telemetry">
   <a href="#the-arena"><img src="https://img.shields.io/badge/%E2%9A%94_arena-open_challenge-E5484D?style=flat-square" alt="Arena — open challenge"></a>
   <a href="https://github.com/sponsors/macanderson"><img src="https://img.shields.io/badge/%E2%99%A5_sponsor-stella-EA4AAA?style=flat-square" alt="Sponsor Stella"></a>
 </p>
@@ -54,7 +54,7 @@ of the shipping `stella` CLI today, not a roadmap item:
 | 🔑 **Models** | Locked to one vendor / one account | **BYOK, 9 providers + any local server** — auto-detected, pinnable per run | Part 14 |
 | 🧵 **Orchestration** | Sprawling multi-agent swarms that lose the plot | One **deterministic single-thread engine** — no coordinator tax | Part 9 |
 | 💾 **Memory** | Re-read the world every session | **Prompt-cache-native** lessons in a byte-stable prompt (~0.1× input price) | Parts 6 & 11 |
-| 📡 **Telemetry** | Phone home to a SaaS backend | **Zero phone-home.** Every event in a local `DuckDB` file — your data, your disk | Part 13 |
+| 📡 **Telemetry** | Phone home to a SaaS backend | **Zero phone-home.** Every event in a local `SQLite` file — your data, your disk | Part 13 |
 | 💰 **Cost** | Runs until you notice the bill | A **hard `--budget`** that aborts cleanly, never mid-tool | Part 1 |
 
 <div align="center">
@@ -88,7 +88,7 @@ and the harness to prove it ships in this repo.
 ```text
    STELLA ────────────────────⚔────────────────────  THE BIG BOYS
    your keys · 9 providers + local  │  one vendor, their account
-   telemetry on your disk (DuckDB)  │  telemetry in their cloud
+   telemetry on your disk (SQLite)  │  telemetry in their cloud
    WITNESS CONFIRMED                │  "looks done to me"
    hard --budget, aborts cleanly    │  runs until you notice the bill
    $ per resolved task              │  $ per vibe
@@ -104,7 +104,7 @@ and the harness to prove it ships in this repo.
 3. **Official scoring only.** SWE-bench Verified's Docker evaluator, unmodified.
    No self-graded homework.
 4. **Publish everything.** `predictions.jsonl`, `summary.json`, per-instance
-   logs, and the token/cost numbers straight out of your local DuckDB telemetry.
+   logs, and the token/cost numbers straight out of your local SQLite telemetry.
    If it can't be reproduced, it didn't happen.
 
 ### Pick your division
@@ -264,7 +264,7 @@ flowchart TD
     CORE -->|Provider port| MODEL["stella-model — adapters<br/>anthropic · openai · gemini · vertex · bedrock · zai<br/>(+ any OpenAI-compatible: xai · deepseek · openrouter · local)"]
     CORE -->|ToolExecutor port| TOOLS["stella-tools<br/>CRUD · bash · grep · glob · build · test · verify_done · issues · CI"]
     MCP["stella-mcp<br/>external MCP servers"] -.->|merges tools into registry| TOOLS
-    CORE -->|emits AgentEvent stream| STORE["stella-store<br/>DuckDB: executions · events · telemetry"]
+    CORE -->|emits AgentEvent stream| STORE["stella-store<br/>SQLite: executions · events · telemetry"]
     U -->|"recall · episodes · bi-temporal facts"| CTX["stella-context — context plane<br/>recall · embeddings · memory"]
     GRAPH["stella-graph — tree-sitter code index"] -->|"indexed on `stella init` · queried via `code_graph` + `stella graph`"| DB[("SQLite code graph<br/>.stella/codegraph.db")]
     MODEL -.->|versioned serde| PROTO["stella-protocol — shared types + Provider/tool ports"]
@@ -617,14 +617,14 @@ fans out through the **OCP host** to the memory store *and* the code graph, fuse
 by score under one frame/token budget — the graph's symbols join "what do we
 remember" at prompt time.
 
-## Local telemetry — DuckDB, on your disk
+## Local telemetry — SQLite, on your disk
 
-Every execution is recorded in `.stella/stella.duckdb`: the full event stream
+Every execution is recorded in `.stella/store.db`: the full event stream
 (chain-of-thought deltas included), per-model-call telemetry (tokens in/out, cache
 read hit/miss, cost from the model card's pricing), and the Files-Touched ledger
 (`file_locks` and `graph_nodes` / `graph_edges` tables exist in the schema as
 reserved seams for the context plane; no shipping command writes them yet). Query it
-with any DuckDB client. **Nothing leaves your machine** — the only network traffic
+with any SQLite client. **Nothing leaves your machine** — the only network traffic
 Stella produces is to the model provider you chose.
 
 <div align="center">
@@ -657,7 +657,7 @@ targets — see the architecture status note above).
 | `stella-core` | ✅ | The step-driver engine (no I/O): parallel tools, goal loop, budget, retry, compaction, loop detection, router |
 | `stella-tools` | ✅ | The built-in tools (CRUD, `bash`, `grep`/`glob`, build/test, `verify_done`, issues, CI) — workspace-root-pinned |
 | `stella-model` | ✅ | The `Provider` port's adapters: anthropic, openai, gemini, vertex, bedrock, zai (SSE, tool-call dialects, SigV4, pricing) |
-| `stella-store` | ✅ | DuckDB persistence — executions, events (full CoT), telemetry, files-touched |
+| `stella-store` | ✅ | SQLite persistence — executions, events (full CoT), telemetry, files-touched |
 | `stella-mcp` | ✅ | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry; per-call timeouts isolate dead servers |
 | `stella-protocol` | ✅ | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports |
 | `stella-context` | ✅ | The context plane: reflection-memory recall + embedding index, an episode recorded for every working turn, and bi-temporal `covers_path` facts written at `stella init` — all recalled through one fused, budgeted pipeline |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,8 +73,9 @@ scripts/release.sh patch             # 0.1.15 -> 0.1.16  (also: minor, major)
 It refuses to run unless your checkout is clean and matches `origin/main`, and
 it never leaves your tree modified. macOS targets build natively; the Linux
 targets cross-compile via [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild)
-(Zig as the C/C++ cross-linker — no Docker, and it compiles DuckDB's bundled
-C++ cleanly, unlike the old `cross` image). `zig` and `cargo-zigbuild` are
+(Zig as the C/C++ cross-linker — no Docker, and it compiles the workspace's
+bundled C deps (SQLite, tree-sitter grammars) cleanly, unlike the old `cross`
+image). `zig` and `cargo-zigbuild` are
 auto-installed if missing. All release assets are uploaded in one call, which
 matters because this repo has **immutable releases** enabled — a published
 release's assets can't be added or changed afterward, so an incomplete release

--- a/docs/off-grid.md
+++ b/docs/off-grid.md
@@ -68,7 +68,7 @@ Notes that matter for benchmarking:
   data, is the authority on which models exist.
 - Cost is metered at $0 (no pricing card), so `--budget` is not a useful cap
   off-grid; use the harness `--timeout` instead.
-- Local runs land in the same DuckDB telemetry as hosted runs; `stella stats`
+- Local runs land in the same SQLite telemetry as hosted runs; `stella stats`
   reports them under the `off-grid` division.
 
 ## 2 · Run the benchmark
@@ -127,7 +127,7 @@ division **Off-grid** and the standard receipts:
   per-instance logs from the run directory;
 - the official evaluator's output;
 - `stella stats --format csv` for the token/latency numbers straight out of
-  local DuckDB — the "resolve rate at $0 marginal cost" claim is the number
+  local SQLite — the "resolve rate at $0 marginal cost" claim is the number
   that decides this division.
 
 Reproducibility bar: name the exact server (Ollama/vLLM/LM Studio/llama.cpp +

--- a/docs/papers/deterministic-engine.md
+++ b/docs/papers/deterministic-engine.md
@@ -234,7 +234,7 @@ makes it **verifiable.**
 
 A single-thread engine produces a **reproducible execution trace.** Every
 event (model call, tool execution, compaction, budget check) is recorded in
-the DuckDB event stream. A failed run can be replayed: the same inputs produce
+the SQLite event stream. A failed run can be replayed: the same inputs produce
 the same trace (modulo model nondeterminism, which is the model's
 nondeterminism, not the engine's). This makes debugging tractable and makes
 the Arena benchmarking meaningful — the harness is the variable, not the

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -92,7 +92,7 @@ We identify seven such properties in Stella's design.
 | I | Ports, not concretions | The engine (`stella-core`) never imports a provider SDK, filesystem API, or terminal library | Crate-level dependency boundary; `Provider` trait (`stella-protocol`) and `ToolExecutor` trait (`stella-core::ports`) |
 | II | No I/O in the engine | All decision logic is synchronous functions over owned data | Architectural discipline; property-tested in `stella-core` |
 | III | Witness-test contract | A task is done only when a test fails on old code and passes on new | `verify_done` tool (`stella-tools::verify`) |
-| IV | BYOK + no phone-home | The only outbound network traffic is to the user's chosen provider; all telemetry is local | Architectural invariant; local DuckDB (`stella-store`) |
+| IV | BYOK + no phone-home | The only outbound network traffic is to the user's chosen provider; all telemetry is local | Architectural invariant; local SQLite (`stella-store`) |
 | V | Prompt-cache-native memory | Lessons load into a byte-stable system prompt prefix at ~0.1x input price | `build_system_prompt` (`stella-cli::agent`); L-E8 cache discipline |
 | VI | Budget at safe boundaries | The budget guard consults only between model calls, never interrupts a tool | `run_turn` budget check (`stella-core::driver`); property-tested |
 | VII | Open Context Protocol | Retrieval is a typed, budgeted, provenance-carrying, consent-gated, conformance-verified protocol | `ocp-types`, `ocp-host`, `ocp-conformance` |
@@ -278,8 +278,8 @@ Two architectural constraints, enforced together:
    lock-in. Nine providers plus any local server.
 2. **No phone-home:** The only outbound network traffic Stella produces is to
    the model provider the user chose. No telemetry, no update checks, no
-   "anonymous" analytics. Every event is recorded in a local DuckDB file
-   (`.stella/stella.duckdb`).
+   "anonymous" analytics. Every event is recorded in a local SQLite file
+   (`.stella/store.db`).
 
 ### Why it is hard to copy
 
@@ -311,7 +311,7 @@ rejection is often not negotiable. Stella passes the gate by design. Agents
 that require cloud connectivity, even optionally, do not.
 
 For individual developers, the trust perimeter means **your code stays on your
-machine.** The telemetry file is local DuckDB — query it, delete it, back it
+machine.** The telemetry file is local SQLite — query it, delete it, back it
 up, share it. Nobody sees it unless you choose to share it.
 
 ---
@@ -522,7 +522,7 @@ Stella on:
 - **BYOK**: Claude Code is locked to Anthropic models. Stella supports nine
   providers plus local.
 - **No phone-home**: Claude Code is a client of Anthropic's platform; usage is
-  metered server-side. Stella's telemetry is local DuckDB.
+  metered server-side. Stella's telemetry is local SQLite.
 - **Ports**: Claude Code's engine is not separable from its provider
   integration. Stella's engine is SDK-free.
 - **Witness-test**: Claude Code does not have a verify_done-equivalent. It

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -1451,7 +1451,7 @@ pub(crate) fn build_budget_guard(budget_limit: Option<f64>) -> BudgetGuard {
     }
 }
 
-/// Open the workspace DuckDB store (`.stella/stella.duckdb`). Persistence is
+/// Open the workspace SQLite store (`.stella/store.db`). Persistence is
 /// observability, not a work dependency: a store that won't open warns once
 /// and the session runs on without it — never a startup failure.
 pub(crate) fn open_store(workspace_root: &std::path::Path) -> Option<Arc<Store>> {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -192,7 +192,7 @@ enum Command {
     Models,
 
     /// Summarize cost, tokens, and resolve rate per provider/model from
-    /// local telemetry (.stella/stella.duckdb) — $/resolved-task receipts
+    /// local telemetry (.stella/store.db) — $/resolved-task receipts
     Stats {
         /// Output format: table (aligned, with TOTAL row), json, or csv
         #[arg(long, value_enum, default_value = "table")]

--- a/stella-cli/src/stats.rs
+++ b/stella-cli/src/stats.rs
@@ -1,5 +1,5 @@
 //! `stella stats` — cost/$-per-resolved-task analytics straight from the
-//! workspace's local DuckDB telemetry (`.stella/stella.duckdb`).
+//! workspace's local SQLite telemetry (`.stella/store.db`).
 //!
 //! Reads what `stella-store` recorded — nothing else. Works with zero API
 //! keys configured (no provider is ever resolved), never writes: if the
@@ -32,7 +32,7 @@ pub fn run_stats(format: StatsFormat, provider: Option<&str>) -> Result<(), Stri
 
     // Stats is read-only: opening the store would create `.stella/` as a
     // side effect, so bail out politely when there's nothing to read.
-    let db_path = workspace_root.join(".stella").join("stella.duckdb");
+    let db_path = workspace_root.join(".stella").join("store.db");
     let rows = if db_path.exists() {
         let store =
             Store::open(&workspace_root).map_err(|e| format!("cannot open local store: {e}"))?;
@@ -82,7 +82,7 @@ fn empty_message(provider: Option<&str>) -> String {
              chat/goal) to generate local telemetry."
         ),
         None => "No executions recorded yet — run `stella run \"...\"` (or chat/goal) to \
-                 generate local telemetry in .stella/stella.duckdb."
+                 generate local telemetry in .stella/store.db."
             .to_string(),
     }
 }

--- a/stella-store/Cargo.toml
+++ b/stella-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stella-store"
-description = "Local DuckDB persistence: executions, full event streams (chain of thought), telemetry, file locks, and graph nodes/edges. One writer per session; readers are free."
+description = "Local SQLite persistence: executions, full event streams (chain of thought), telemetry, file locks, and graph nodes/edges. One writer per session; readers are free."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -10,7 +10,7 @@ publish.workspace = true
 
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
-duckdb.workspace = true
+rusqlite.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -1,5 +1,5 @@
-//! `stella-store` — the session's local DuckDB database at
-//! `.stella/stella.duckdb`: durable state, full execution records, and
+//! `stella-store` — the session's local SQLite database at
+//! `.stella/store.db`: durable state, full execution records, and
 //! analytics-grade telemetry, all on the user's disk (no server, no
 //! account — the local-first non-negotiable).
 //!
@@ -24,11 +24,14 @@
 //!
 //! # Concurrency
 //!
-//! DuckDB is single-writer per database file. One `Store` per session
-//! process is the contract; internally a `Mutex<Connection>` serializes
-//! writers across in-process parallel agents. Multi-PROCESS fleets need a
-//! lock-holder (or one store per worker + merge) — documented limitation,
-//! not a silent one.
+//! One embedded SQLite file (`rusqlite`, bundled — the workspace's "one
+//! storage engine" invariant; every other embedded store in this workspace
+//! is SQLite too). WAL journaling is enabled at open, so a read-only caller
+//! (`stella stats`) is never blocked by a live session's writes. SQLite
+//! still serializes writers per file; one `Store` per session process is the
+//! contract, and internally a `Mutex<Connection>` serializes writers across
+//! in-process parallel agents. Multi-PROCESS fleets need a lock-holder (or
+//! one store per worker + merge) — documented limitation, not a silent one.
 //!
 //! # Graceful degradation
 //!
@@ -39,7 +42,7 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use duckdb::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use stella_protocol::AgentEvent;
 
@@ -54,8 +57,8 @@ impl std::fmt::Display for StoreError {
 }
 impl std::error::Error for StoreError {}
 
-impl From<duckdb::Error> for StoreError {
-    fn from(e: duckdb::Error) -> Self {
+impl From<rusqlite::Error> for StoreError {
+    fn from(e: rusqlite::Error) -> Self {
         StoreError(e.to_string())
     }
 }
@@ -134,23 +137,26 @@ pub struct Store {
 }
 
 impl Store {
-    /// Open (creating if needed) the workspace database at
-    /// `.stella/stella.duckdb` and apply the schema.
+    /// Open (creating if needed) the workspace database at `.stella/store.db`
+    /// and apply the schema.
     pub fn open(workspace_root: &Path) -> Result<Self> {
         let dir = workspace_root.join(".stella");
         std::fs::create_dir_all(&dir).map_err(|e| StoreError(e.to_string()))?;
-        let conn = Connection::open(dir.join("stella.duckdb"))?;
-        let store = Self {
-            conn: Mutex::new(conn),
-        };
-        store.migrate()?;
-        Ok(store)
+        Self::init(Connection::open(dir.join("store.db"))?)
     }
 
     /// In-memory store — tests and ephemeral runs.
     pub fn in_memory() -> Result<Self> {
+        Self::init(Connection::open_in_memory()?)
+    }
+
+    fn init(conn: Connection) -> Result<Self> {
+        // execute_batch tolerates the row PRAGMA journal_mode returns (a
+        // plain pragma_update errors on it). WAL means a read-only caller
+        // (`stella stats`) is never blocked by a live session's writes.
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
         let store = Self {
-            conn: Mutex::new(Connection::open_in_memory()?),
+            conn: Mutex::new(conn),
         };
         store.migrate()?;
         Ok(store)
@@ -159,74 +165,82 @@ impl Store {
     fn migrate(&self) -> Result<()> {
         let conn = self.lock();
         conn.execute_batch(
-            "CREATE SEQUENCE IF NOT EXISTS execution_seq;
-             CREATE TABLE IF NOT EXISTS executions (
-               id BIGINT PRIMARY KEY DEFAULT nextval('execution_seq'),
+            "CREATE TABLE IF NOT EXISTS executions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
                kind TEXT NOT NULL,
                prompt TEXT NOT NULL,
                provider TEXT NOT NULL,
                model TEXT NOT NULL,
-               started_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-               finished_at TIMESTAMP,
+               started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+               finished_at TEXT,
                outcome TEXT,
-               cost_usd DOUBLE NOT NULL DEFAULT 0
+               cost_usd REAL NOT NULL DEFAULT 0
              );
              CREATE TABLE IF NOT EXISTS events (
-               execution_id BIGINT NOT NULL,
-               seq BIGINT NOT NULL,
-               ts TIMESTAMP NOT NULL DEFAULT current_timestamp,
+               execution_id INTEGER NOT NULL,
+               seq INTEGER NOT NULL,
+               ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                event_type TEXT NOT NULL,
-               payload JSON NOT NULL
+               payload TEXT NOT NULL
              );
              CREATE TABLE IF NOT EXISTS telemetry (
-               execution_id BIGINT NOT NULL,
-               step BIGINT NOT NULL,
-               ts TIMESTAMP NOT NULL DEFAULT current_timestamp,
+               execution_id INTEGER NOT NULL,
+               step INTEGER NOT NULL,
+               ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                provider TEXT NOT NULL,
                model TEXT NOT NULL,
-               input_tokens BIGINT NOT NULL,
-               estimated_input_tokens BIGINT NOT NULL DEFAULT 0,
-               output_tokens BIGINT NOT NULL,
-               cache_read_tokens BIGINT NOT NULL,
-               cache_miss_tokens BIGINT NOT NULL,
-               cache_write_tokens BIGINT NOT NULL DEFAULT 0,
-               cost_usd DOUBLE NOT NULL,
-               duration_ms BIGINT NOT NULL,
+               input_tokens INTEGER NOT NULL,
+               estimated_input_tokens INTEGER NOT NULL DEFAULT 0,
+               output_tokens INTEGER NOT NULL,
+               cache_read_tokens INTEGER NOT NULL,
+               cache_miss_tokens INTEGER NOT NULL,
+               cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+               cost_usd REAL NOT NULL,
+               duration_ms INTEGER NOT NULL,
                retries INTEGER NOT NULL,
-               tool_calls BIGINT NOT NULL
+               tool_calls INTEGER NOT NULL
              );
              CREATE TABLE IF NOT EXISTS files_touched (
-               execution_id BIGINT NOT NULL,
+               execution_id INTEGER NOT NULL,
                path TEXT NOT NULL,
                ops TEXT NOT NULL
              );
              CREATE TABLE IF NOT EXISTS file_locks (
                path TEXT PRIMARY KEY,
                holder TEXT NOT NULL,
-               acquired_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+               acquired_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
              );
              CREATE TABLE IF NOT EXISTS graph_nodes (
                id TEXT PRIMARY KEY,
                label TEXT NOT NULL,
-               properties JSON NOT NULL DEFAULT '{}'
+               properties TEXT NOT NULL DEFAULT '{}'
              );
              CREATE TABLE IF NOT EXISTS graph_edges (
                src TEXT NOT NULL,
                dst TEXT NOT NULL,
                edge_type TEXT NOT NULL,
-               properties JSON NOT NULL DEFAULT '{}'
+               properties TEXT NOT NULL DEFAULT '{}'
              );",
         )?;
         // Additive migration for databases created before drift correction
         // landed: `CREATE TABLE IF NOT EXISTS` above is a no-op on them, so
-        // the column arrives via ALTER. Old rows default to 0 = "no estimate
-        // was taken", which `drift_samples` excludes as signal-free. (No NOT
-        // NULL here — DuckDB can't retrofit the constraint onto a non-empty
-        // table; the DEFAULT keeps new writes non-null in practice.)
-        conn.execute_batch(
-            "ALTER TABLE telemetry ADD COLUMN IF NOT EXISTS \
-             estimated_input_tokens BIGINT DEFAULT 0;",
+        // the column arrives via ALTER when it's missing. Old rows default to
+        // 0 = "no estimate was taken", which `drift_samples` excludes as
+        // signal-free. Unlike DuckDB, SQLite allows a NOT NULL column with a
+        // DEFAULT to be added to a non-empty table — the default backfills
+        // existing rows, so the constraint holds from the moment it lands.
+        let has_estimated_column: i64 = conn.query_row(
+            "SELECT count(*) FROM pragma_table_info('telemetry') \
+             WHERE name = 'estimated_input_tokens'",
+            [],
+            |row| row.get(0),
         )?;
+        if has_estimated_column == 0 {
+            conn.execute_batch(
+                "ALTER TABLE telemetry ADD COLUMN estimated_input_tokens \
+                 INTEGER NOT NULL DEFAULT 0;",
+            )?;
+        }
         Ok(())
     }
 
@@ -248,13 +262,11 @@ impl Store {
         model: &str,
     ) -> Result<i64> {
         let conn = self.lock();
-        let id: i64 = conn.query_row(
-            "INSERT INTO executions (kind, prompt, provider, model) VALUES (?, ?, ?, ?) \
-             RETURNING id",
+        conn.execute(
+            "INSERT INTO executions (kind, prompt, provider, model) VALUES (?, ?, ?, ?)",
             params![kind, prompt, provider, model],
-            |row| row.get(0),
         )?;
-        Ok(id)
+        Ok(conn.last_insert_rowid())
     }
 
     /// Append one event to the execution's stream. `seq` is the caller's
@@ -319,7 +331,7 @@ impl Store {
         limit: usize,
     ) -> Result<Vec<(u64, u64)>> {
         let conn = self.lock();
-        // execution ids come from a monotonic sequence and steps count up
+        // execution ids come from an AUTOINCREMENT counter and steps count up
         // within one execution, so (execution_id, step) is insertion order —
         // unlike ts, whose second-level granularity ties within a turn.
         let mut stmt = conn.prepare(
@@ -363,7 +375,7 @@ impl Store {
     /// Close an execution record.
     pub fn finish_execution(&self, execution_id: i64, outcome: &str, cost_usd: f64) -> Result<()> {
         self.lock().execute(
-            "UPDATE executions SET finished_at = current_timestamp, outcome = ?, cost_usd = ? \
+            "UPDATE executions SET finished_at = CURRENT_TIMESTAMP, outcome = ?, cost_usd = ? \
              WHERE id = ?",
             params![outcome, cost_usd, execution_id],
         )?;
@@ -376,17 +388,17 @@ impl Store {
     pub fn acquire_file_lock(&self, path: &str, holder: &str) -> Result<bool> {
         let conn = self.lock();
         // Only "no such lock row" means unclaimed. A genuine query error must
-        // propagate — `.ok()` would misread it as unclaimed and drive a
-        // spurious INSERT (then a PK conflict), corrupting lock state.
-        let existing: Option<String> = match conn.query_row(
-            "SELECT holder FROM file_locks WHERE path = ?",
-            params![path],
-            |row| row.get(0),
-        ) {
-            Ok(holder) => Some(holder),
-            Err(duckdb::Error::QueryReturnedNoRows) => None,
-            Err(e) => return Err(e.into()),
-        };
+        // propagate — `.optional()` maps just the no-rows case to `None`;
+        // every other error still propagates via `?`. Swallowing a real error
+        // as "unclaimed" would drive a spurious INSERT (then a PK conflict),
+        // corrupting lock state.
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT holder FROM file_locks WHERE path = ?",
+                params![path],
+                |row| row.get(0),
+            )
+            .optional()?;
         match existing {
             Some(current) => Ok(current == holder),
             None => {
@@ -484,11 +496,11 @@ impl Store {
                     count(*) AS runs,
                     count(*) FILTER (WHERE e.outcome = 'completed') AS resolved,
                     coalesce(sum(e.cost_usd), 0) AS total_cost_usd,
-                    CAST(coalesce(sum(t.input_tokens), 0) AS BIGINT) AS input_tokens,
-                    CAST(coalesce(sum(t.output_tokens), 0) AS BIGINT) AS output_tokens,
-                    CAST(coalesce(sum(t.cache_read_tokens), 0) AS BIGINT) AS cache_read_tokens,
-                    CAST(coalesce(sum(t.cache_write_tokens), 0) AS BIGINT) AS cache_write_tokens,
-                    CAST(coalesce(sum(t.duration_ms), 0) AS BIGINT) AS total_duration_ms
+                    CAST(coalesce(sum(t.input_tokens), 0) AS INTEGER) AS input_tokens,
+                    CAST(coalesce(sum(t.output_tokens), 0) AS INTEGER) AS output_tokens,
+                    CAST(coalesce(sum(t.cache_read_tokens), 0) AS INTEGER) AS cache_read_tokens,
+                    CAST(coalesce(sum(t.cache_write_tokens), 0) AS INTEGER) AS cache_write_tokens,
+                    CAST(coalesce(sum(t.duration_ms), 0) AS INTEGER) AS total_duration_ms
              FROM executions e
              LEFT JOIN (
                SELECT execution_id,
@@ -712,23 +724,23 @@ mod tests {
         // Simulate a database created before drift correction: the telemetry
         // table exists WITHOUT estimated_input_tokens and already has a row.
         {
-            let conn = Connection::open(root.join(".stella/stella.duckdb")).unwrap();
+            let conn = Connection::open(root.join(".stella/store.db")).unwrap();
             conn.execute_batch(
                 "CREATE TABLE telemetry (
-                   execution_id BIGINT NOT NULL,
-                   step BIGINT NOT NULL,
-                   ts TIMESTAMP NOT NULL DEFAULT current_timestamp,
+                   execution_id INTEGER NOT NULL,
+                   step INTEGER NOT NULL,
+                   ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                    provider TEXT NOT NULL,
                    model TEXT NOT NULL,
-                   input_tokens BIGINT NOT NULL,
-                   output_tokens BIGINT NOT NULL,
-                   cache_read_tokens BIGINT NOT NULL,
-                   cache_miss_tokens BIGINT NOT NULL,
-                   cache_write_tokens BIGINT NOT NULL DEFAULT 0,
-                   cost_usd DOUBLE NOT NULL,
-                   duration_ms BIGINT NOT NULL,
+                   input_tokens INTEGER NOT NULL,
+                   output_tokens INTEGER NOT NULL,
+                   cache_read_tokens INTEGER NOT NULL,
+                   cache_miss_tokens INTEGER NOT NULL,
+                   cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                   cost_usd REAL NOT NULL,
+                   duration_ms INTEGER NOT NULL,
                    retries INTEGER NOT NULL,
-                   tool_calls BIGINT NOT NULL
+                   tool_calls INTEGER NOT NULL
                  );
                  INSERT INTO telemetry (execution_id, step, provider, model, input_tokens,
                    output_tokens, cache_read_tokens, cache_miss_tokens, cost_usd, duration_ms,


### PR DESCRIPTION
## What & why

`stella-store` was the workspace's only DuckDB consumer; `stella-context`, `stella-fleet`, and `stella-graph` all already use `rusqlite`. The inherited architecture spec (`02-architecture.md` §1.6/§6, referenced by doc comments across the sibling crates) explicitly calls for **one storage engine — no DuckDB, no second embedded database, ever, without an ADR** — and no such ADR exists for `stella-store`'s DuckDB usage. Its lessons-learned doc also records a real DuckDB incident: native-lib mutex locks causing hard aborts on Ctrl-C.

`stella-store`'s actual query load — small, single-user local telemetry plus a handful of `GROUP BY` aggregations behind `stella stats` — doesn't need DuckDB's columnar/OLAP engine. Two of its six DuckDB tables (`file_locks`, `graph_nodes`/`graph_edges`) aren't even written by any shipping command yet. Migrating removes a second bundled native dependency (faster clean builds — no more DuckDB C++ compile) and its whole associated CVE/signal-handling surface, with no functional loss.

Not a closing PR for an issue — surfaced via a code discussion, not a filed bug.

### What changed

- `stella-store`: DuckDB → `rusqlite`. New schema at `.stella/store.db` (was `.stella/stella.duckdb`): DuckDB `SEQUENCE`/`BIGINT`/`DOUBLE`/`JSON` become SQLite `AUTOINCREMENT`/`INTEGER`/`REAL`/`TEXT`; `PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;` enabled at open, matching `stella-fleet`'s established convention. The additive `estimated_input_tokens` migration now checks `pragma_table_info` instead of relying on DuckDB's `ADD COLUMN IF NOT EXISTS` (not valid SQLite syntax).
- `Cargo.toml` / `stella-store/Cargo.toml`: drop the `duckdb` dependency entirely (nothing else in the workspace used it); `stella-store` now depends on the already-shared `rusqlite.workspace = true`.
- `stella-cli`: updated the two doc-comment/path references to the store (`.stella/stella.duckdb` → `.stella/store.db`).
- Docs: every README/AGENTS.md/CONTRIBUTING.md/RELEASING.md/`docs/**` reference to "DuckDB" or the old file path updated to reflect SQLite.
- `.gitignore`: dropped the now-redundant `*.duckdb`/`*.duckdb.*` patterns (`.stella/` already ignores the whole directory).
- `Cargo.lock`: regenerated — removes DuckDB's entire transitive dependency tree (~900 lines).

## The witness

-  This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a storage-engine swap behind an unchanged public API (`Store::open`, `begin_execution`, `record_telemetry`, `usage_stats`, etc. — same signatures, same semantics). `stella-store`'s existing 14-test suite (schema migration, drift samples, file locks, graph upserts, usage-stats aggregation, on-disk persistence across reopen) already exercises every behavior and passes unmodified against the new SQLite backend — it's the regression net a witness test would otherwise provide.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all suites green, including `stella-store`'s 14 tests)
- [x] Docs updated where behavior/flags changed (README, AGENTS.md, CONTRIBUTING.md, RELEASING.md, docs/off-grid.md, docs/papers/*)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core` (this PR doesn't touch `stella-core`)
- [x] No new outbound network calls
- [x] No new cross-boundary types (storage-layer internals only; `TelemetryRow`/`UsageStatsRow` are unchanged)
-  No new deps without justification — `rusqlite` isn't new to the workspace (already used by 3 other crates); `duckdb` is removed, net dependency count goes down

## Anything reviewers should know?

- File rename: existing users' `.stella/stella.duckdb` files are left in place untouched but are no longer read — a fresh `.stella/store.db` is created on next run. Telemetry is explicitly documented as observability, not durable state (`Store::open` never blocks the CLI on failure), so no migration/import path was built for old DuckDB data; flag if that tradeoff should be revisited before release.
- Chose `.stella/store.db` to match the sibling crates' naming convention (`context.db`, `fleet.db`, `codegraph.db`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `stella-store` from DuckDB to SQLite via `rusqlite` to unify on one storage engine and drop a heavy native dependency. The database now lives at `.stella/store.db`; the public API is unchanged.

- **Refactors**
  - `stella-store`: DuckDB → `rusqlite` with `AUTOINCREMENT/INTEGER/REAL/TEXT` schema; `PRAGMA journal_mode=WAL` and `PRAGMA foreign_keys=ON` at open (readers aren’t blocked by live writes); additive `estimated_input_tokens` migration via `pragma_table_info` with `NOT NULL DEFAULT 0`.
  - `stella-cli`: update telemetry path and comments; `stella stats` reads `.stella/store.db` and avoids creating `.stella/` when absent.
  - Docs: replace all “DuckDB” references and old paths; clean `.gitignore`; regenerate `Cargo.lock` (DuckDB tree removed).

- **Migration**
  - Existing `.stella/stella.duckdb` is not imported; a fresh `.stella/store.db` is created on next run.
  - Telemetry remains optional observability; runs never fail if the store can’t open.

<sup>Written for commit ccb4670eb5642e95e8cecebeda84b09bc526b519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
