### PR TITLE
fix: second code-review round across deck, pipeline, graph, store, co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,9 +619,10 @@ remember" at prompt time.
 
 ## Local telemetry — SQLite, on your disk
 
-Every execution is recorded in `.stella/store.db`: the full event stream
-(chain-of-thought deltas included), per-model-call telemetry (tokens in/out, cache
-read hit/miss, cost from the model card's pricing), and the Files-Touched ledger
+Executions are recorded, best-effort, in `.stella/store.db` (the store is never a
+dependency of a turn — a session runs even if it can't be opened): the full event
+stream (chain-of-thought deltas included), per-model-call telemetry (tokens in/out,
+cache read hit/miss, cost from the model card's pricing), and the Files-Touched ledger
 (`file_locks` and `graph_nodes` / `graph_edges` tables exist in the schema as
 reserved seams for the context plane; no shipping command writes them yet). Query it
 with any SQLite client. **Nothing leaves your machine** — the only network traffic

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -278,8 +278,10 @@ Two architectural constraints, enforced together:
    lock-in. Nine providers plus any local server.
 2. **No phone-home:** The only outbound network traffic Stella produces is to
    the model provider the user chose. No telemetry, no update checks, no
-   "anonymous" analytics. Every event is recorded in a local SQLite file
-   (`.stella/store.db`).
+   "anonymous" analytics. Events are recorded, best-effort, to a local SQLite
+   file (`.stella/store.db`) — the store is never a dependency of a turn: a
+   session runs even when it can't be opened, and an individual event write
+   that fails degrades the local record rather than the run.
 
 ### Why it is hard to copy
 

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -27,8 +27,8 @@ use stella_model::credential::ApiKey;
 use stella_model::provider::Provider;
 use stella_pipeline::{
     AutoApproveGate, CmdOutcome, CommandRunner, ContextRecallPort, NoContextRecall, Pipeline,
-    PipelineConfig, PipelinePorts, PipelineStatus, ProviderResolver, RepoStructurePort,
-    StdioApprovalGate,
+    PipelineConfig, PipelinePorts, PipelineStatus, ProviderResolver, RepoStatusPort,
+    RepoStructurePort, StdioApprovalGate,
 };
 use stella_protocol::event::BudgetMode;
 use stella_protocol::{AgentEvent, CompletionMessage, ModelRef, Role, ToolOutput};
@@ -320,6 +320,9 @@ async fn run_pipeline_one_shot(
         let repo_structure = GitRepoStructure {
             root: cfg.workspace_root.clone(),
         };
+        let repo_status = GitRepoStatus {
+            root: cfg.workspace_root.clone(),
+        };
         let command_runner = ShellCommandRunner {
             root: cfg.workspace_root.clone(),
         };
@@ -362,6 +365,7 @@ async fn run_pipeline_one_shot(
             tools: &tools,
             recall,
             repo: &repo_structure,
+            repo_status: &repo_status,
             commands: &command_runner,
             approvals: if is_text {
                 &stdio_gate
@@ -526,6 +530,66 @@ impl RepoStructurePort for GitRepoStructure {
             }
             _ => String::new(),
         }
+    }
+}
+
+/// Untracked-file fingerprints for the pipeline's zero-diff guard. Unlike the
+/// pipeline's `CommandRunner` (whose output is truncated), this captures the
+/// COMPLETE `git ls-files --others` listing and fingerprints each file itself
+/// (in-process, with real filesystem access), so a large untracked set is not
+/// silently clipped and a modification to an already-untracked file is
+/// detectable (its `len:mtime` fingerprint changes).
+struct GitRepoStatus {
+    root: std::path::PathBuf,
+}
+
+#[async_trait::async_trait]
+impl RepoStatusPort for GitRepoStatus {
+    async fn untracked_fingerprints(&self) -> std::collections::HashMap<String, String> {
+        let mut out = std::collections::HashMap::new();
+        // `-z` NUL-delimits paths (robust to spaces/newlines); quotePath off
+        // keeps non-ASCII literal. Full stdout is read — never truncated.
+        let output = tokio::process::Command::new("git")
+            .args([
+                "-c",
+                "core.quotePath=false",
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "-z",
+            ])
+            .current_dir(&self.root)
+            .output()
+            .await;
+        let Ok(listing) = output else {
+            return out;
+        };
+        if !listing.status.success() {
+            return out; // not a git repo, or git unavailable
+        }
+        for rel in String::from_utf8_lossy(&listing.stdout)
+            .split('\0')
+            .filter(|p| !p.is_empty())
+        {
+            // Fingerprint = size:mtime_nanos — changes whenever the file is
+            // written, without reading (and hashing) potentially large
+            // untracked files on every snapshot. Unreadable metadata → a
+            // sentinel so the file still registers as present.
+            let fingerprint = match std::fs::metadata(self.root.join(rel)) {
+                Ok(meta) => {
+                    let mtime = meta
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0);
+                    format!("{}:{mtime}", meta.len())
+                }
+                Err(_) => "unreadable".to_string(),
+            };
+            out.insert(rel.to_string(), fingerprint);
+        }
+        out
     }
 }
 
@@ -898,6 +962,11 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                     // A fresh index may name tables/types the schema gate
                     // should know about this session, not just the next one.
                     populate_schema_index(&registry, &cfg.workspace_root);
+                    // The code graph now exists — expose the `code_graph` tool
+                    // to the rest of this session (it is registered only when
+                    // an index is present, so a session that started without
+                    // one otherwise wouldn't see it until relaunch).
+                    registry.enable_code_graph_if_available(&cfg.workspace_root);
                     // Re-open memory so recall/reflection use the taxonomy
                     // `/init` just wrote — otherwise the cached domains stay
                     // stale until the next launch.

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -209,7 +209,7 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
         // Session-level slash commands are the driver's, never the model's —
         // the deck's popup enqueues them like any prompt (tab switches and
         // the help overlay were already handled TUI-side and never reach us).
-        match run_deck_command(
+        let command = run_deck_command(
             &prompt,
             &in_tx,
             &mut messages,
@@ -218,8 +218,17 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
             &registry,
             cfg,
         )
-        .await
-        {
+        .await;
+        if !matches!(command, DeckCommand::Prompt) {
+            // A handled command emits its answer as `Text`, which flips the
+            // lead to `Running` in the deck's fold — but no turn is in flight.
+            // Return it to `WaitingInput` so the dashboard reflects reality.
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::WaitingInput,
+            });
+        }
+        match command {
             DeckCommand::Prompt => {}
             DeckCommand::Handled => continue 'session,
             DeckCommand::InitCompleted => {
@@ -433,6 +442,10 @@ async fn run_deck_command(
                     // A fresh index may name tables/types the schema gate
                     // should know about this session, not just the next one.
                     agent::populate_schema_index(registry, &cfg.workspace_root);
+                    // Expose the `code_graph` tool for the rest of the session
+                    // now that the index exists (it is registered only when an
+                    // index is present at construction).
+                    registry.enable_code_graph_if_available(&cfg.workspace_root);
                     return DeckCommand::InitCompleted;
                 }
                 Err(e) => say(format!("init failed: {e}")),

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -782,17 +782,32 @@ impl Config {
             if PROVIDERS.iter().any(|p| p.id == id.as_str()) || id == LOCAL_PROVIDER.id {
                 continue;
             }
-            let Ok(p) = custom_provider(id, entry) else {
-                continue;
+            // A malformed provider entry surfaces as a warning line rather than
+            // silently vanishing — the ANSI renderer warns here too, and a
+            // deck user needs to see that their settings.json is broken.
+            let p = match custom_provider(id, entry) {
+                Ok(p) => p,
+                Err(e) => {
+                    lines.push(format!("  ! provider `{id}` is misconfigured: {e}"));
+                    continue;
+                }
             };
             if !printed_header {
                 lines.push("Config-defined providers (settings.json):".to_string());
                 printed_header = true;
             }
+            // Key status must consider the provider's env var (settable via
+            // `api_key_env` or the derived default), not only the settings
+            // literal — otherwise a provider keyed through the environment
+            // wrongly shows ✗ (matching the built-in branch above).
             let settings_key = entry.api_key.as_deref().is_some_and(|k| !k.is_empty());
+            let has_key = settings_key
+                || std::iter::once(&p.env_var)
+                    .chain(p.env_var_aliases)
+                    .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
             lines.push(format!(
                 "  {} {}/{}  {}",
-                if settings_key { "✓" } else { "✗" },
+                if has_key { "✓" } else { "✗" },
                 p.id,
                 if p.default_model.is_empty() {
                     "<model>"

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -282,17 +282,25 @@ impl SessionMemory {
     /// shifts supersedes stale beliefs instead of deleting them, so
     /// "what did we believe at T1" still answers (L-C3).
     ///
-    /// Known limitation: `covers_path` *facts* are versioned (a moved path's
-    /// old fact is superseded), but the File node's `node_domains` tags are
-    /// insert-only — re-running `init` after a path moves from domain A to B
-    /// adds the B tag without removing A. This does NOT break recall
-    /// correctness: the session scopes recall to the *full current taxonomy*,
-    /// so the node still passes the scope filter via B; the only residual is a
-    /// mild domain-overlap ranking boost for A. A correct fix is versioned
-    /// node-domain associations (matching the fact model) — deliberately not a
-    /// wholesale `node_domains` rewrite, which would depend on the unenforced
-    /// invariant that only the taxonomy ever tags File nodes and would silently
-    /// wipe tags from any future source.
+    /// Known limitation (deliberately deferred): `covers_path` *facts* are
+    /// versioned (a moved path's old fact is superseded), but the File node's
+    /// `node_domains` tags are insert-only — re-running `init` after a path
+    /// moves from domain A to B adds the B tag without removing A. This does
+    /// NOT break recall correctness: the session scopes recall to the *full
+    /// current taxonomy*, so the node still passes the scope filter via B; the
+    /// residual is only a domain-overlap ranking boost for A, and only while A
+    /// itself remains a taxonomy domain.
+    ///
+    /// Two fixes were considered and both deferred:
+    /// - Versioned node-domain associations (mirroring the fact model) — the
+    ///   correct design, but a `stella-context` schema change (`node_domains`
+    ///   gains validity columns, and every scope query must filter live rows).
+    ///   Disproportionate to a ranking-edge, and higher-risk right after the
+    ///   store's DuckDB→SQLite migration.
+    /// - Retiring taxonomy-owned tags before re-adding (a `node_domains`
+    ///   rewrite) — rejected as brittle: it relies on the unenforced invariant
+    ///   that only the taxonomy ever tags File nodes, so it would silently wipe
+    ///   a tag written by any future source.
     pub async fn record_taxonomy(&self, taxonomy: &crate::domains::Domains) {
         let domains = taxonomy
             .domains
@@ -364,41 +372,47 @@ impl SessionMemory {
         let stored = self.store.upsert(delta).await.is_ok();
 
         // 2. Append to the mining log and mine for auto-creatable skills.
-        // Track whether the log write actually succeeded so the message below
-        // never claims a fallback that didn't happen.
+        // Count how many lessons actually reached the log so the message below
+        // reports partial persistence accurately (some serialize/append writes
+        // may fail while others succeed).
         let log_path = self
             .workspace_root
             .join(".stella")
             .join("reflections.jsonl");
-        let mut logged = true;
+        let mut logged_count = 0usize;
         for lesson in &lessons {
-            match serde_json::to_string(lesson) {
-                Ok(line) if append_line(&log_path, &line).is_ok() => {}
-                _ => logged = false,
+            if let Ok(line) = serde_json::to_string(lesson)
+                && append_line(&log_path, &line).is_ok()
+            {
+                logged_count += 1;
             }
         }
         self.auto_create_skills(&log_path, quiet);
 
         if !quiet {
+            let n = lessons.len();
             if stored {
                 println!(
-                    "  {} remembered {} lesson(s) from this turn",
-                    "✦".magenta(),
-                    lessons.len()
+                    "  {} remembered {n} lesson(s) from this turn",
+                    "✦".magenta()
                 );
-            } else if logged {
+            } else if logged_count == n {
                 println!(
-                    "  {} could not persist {} lesson(s) to the context store \
+                    "  {} could not persist {n} lesson(s) to the context store \
                      (logged to reflections.jsonl only)",
-                    "!".yellow(),
-                    lessons.len()
+                    "!".yellow()
+                );
+            } else if logged_count > 0 {
+                println!(
+                    "  {} could not persist {n} lesson(s) to the context store; \
+                     {logged_count} of {n} reached reflections.jsonl",
+                    "!".yellow()
                 );
             } else {
                 println!(
-                    "  {} could not persist {} lesson(s) — both the context store \
+                    "  {} could not persist {n} lesson(s) — both the context store \
                      and reflections.jsonl writes failed",
-                    "!".yellow(),
-                    lessons.len()
+                    "!".yellow()
                 );
             }
         }

--- a/stella-cli/src/ocp.rs
+++ b/stella-cli/src/ocp.rs
@@ -81,18 +81,18 @@ impl ContextProvider for MemoryProvider {
         // The store's recall does not honor `query.kinds`, so a kind-filtered
         // query (now routed here because we advertise those kinds) must be
         // filtered before returning — otherwise a `kinds: [Symbol]` request
-        // could surface memory/fact frames. Frames removed here count toward
-        // the truncation metadata alongside the store's own drops.
+        // could surface memory/fact frames. This filtering is NOT truncation:
+        // `ContextQueryResult.truncated`/`dropped_estimate` describe candidates
+        // that matched the request but were cut for budget, so they reflect
+        // only the store's own drops — a non-matching kind was never a
+        // candidate for this query in the first place.
         let mut frames = result.frames;
-        let mut dropped = result.dropped.len();
         if !query.kinds.is_empty() {
-            let before = frames.len();
             frames.retain(|f| query.kinds.contains(&f.kind));
-            dropped += before - frames.len();
         }
         Ok(ContextQueryResult {
-            truncated: dropped > 0,
-            dropped_estimate: u32::try_from(dropped).ok(),
+            truncated: !result.dropped.is_empty(),
+            dropped_estimate: u32::try_from(result.dropped.len()).ok(),
             frames,
         })
     }

--- a/stella-cli/src/stats.rs
+++ b/stella-cli/src/stats.rs
@@ -49,15 +49,24 @@ pub fn run_stats(format: StatsFormat, provider: Option<&str>) -> Result<(), Stri
 
     if rows.is_empty() {
         // An empty store is a state, not an error — but keep stdout valid
-        // for the machine formats.
+        // for the machine formats. If the SQLite store has no rows yet a
+        // pre-migration DuckDB file is present, say so explicitly: "no
+        // executions" would otherwise imply the workspace has no telemetry
+        // when in fact the old telemetry simply isn't read by this version.
+        let legacy_duckdb = workspace_root.join(".stella").join("stella.duckdb");
+        let message = if legacy_duckdb.exists() {
+            legacy_duckdb_message(provider)
+        } else {
+            empty_message(provider)
+        };
         match format {
-            StatsFormat::Table => println!("{}", empty_message(provider)),
+            StatsFormat::Table => println!("{message}"),
             StatsFormat::Json => {
-                eprintln!("{}", empty_message(provider));
+                eprintln!("{message}");
                 println!("[]");
             }
             StatsFormat::Csv => {
-                eprintln!("{}", empty_message(provider));
+                eprintln!("{message}");
                 println!("{}", csv_header());
             }
         }
@@ -85,6 +94,24 @@ fn empty_message(provider: Option<&str>) -> String {
                  generate local telemetry in .stella/store.db."
             .to_string(),
     }
+}
+
+/// Shown when the current SQLite store is empty/absent but a pre-migration
+/// `.stella/stella.duckdb` is present: the telemetry exists, this version just
+/// doesn't read the old format. Explicit so a migrated workspace is never
+/// silently reported as having no history.
+fn legacy_duckdb_message(provider: Option<&str>) -> String {
+    let scope = match provider {
+        Some(p) => format!(" for provider `{p}`"),
+        None => String::new(),
+    };
+    format!(
+        "No executions in the SQLite store{scope}, but a legacy .stella/stella.duckdb was \
+         found. Stella migrated its telemetry store from DuckDB to SQLite (.stella/store.db); \
+         the old DuckDB file is not read by this version and is not migrated automatically. \
+         New runs record to .stella/store.db; the historical DuckDB data is preserved on disk \
+         but not shown here."
+    )
 }
 
 /// The TOTAL row across every displayed row, computed in Rust (weighted,

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -83,11 +83,23 @@ impl Inner {
             .push(handle);
     }
 
+    /// Install the live watcher — but only if `shutdown()` has not already
+    /// run. The flag check and the store happen under the **same** watcher
+    /// lock that `shutdown()` takes to set the flag and clear the slot, so the
+    /// install serializes against shutdown and the mount-vs-shutdown TOCTOU
+    /// window is closed: a watcher created by the background task after a
+    /// concurrent `shutdown()` is dropped here (at end of scope) instead of
+    /// being stored, so it can never leak past shutdown.
     fn set_watcher(&self, watcher: RecommendedWatcher) {
-        *self
+        let mut slot = self
             .watcher
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(watcher);
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.shutdown.load(Ordering::Relaxed) {
+            // `watcher` is dropped at end of scope → stops watching at once.
+            return;
+        }
+        *slot = Some(watcher);
     }
 }
 
@@ -101,9 +113,9 @@ pub struct CodeGraph {
 pub struct NeighborhoodSymbol {
     pub name: String,
     /// The stored kind tag as persisted by the index (`"function"`,
-    /// `"struct"`, `"class"`, `"table"`, …) — see [`SymbolKind::tag`]. An
-    /// owned `String` so this public type round-trips through serde without a
-    /// borrow lifetime.
+    /// `"struct"`, `"class"`, `"table"`, …) — see [`crate::SymbolKind::tag`].
+    /// An owned `String` so this public type round-trips through serde without
+    /// a borrow lifetime.
     pub kind: String,
     pub start_line: u32,
 }
@@ -297,12 +309,21 @@ impl CodeGraph {
     /// closes the event channel, so the debounce loop exits on its own; task
     /// handles are aborted as a backstop.
     pub fn shutdown(&self) {
-        self.inner.shutdown.store(true, Ordering::Relaxed);
-        *self
-            .inner
-            .watcher
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        // Set the shutdown flag *and* clear the watcher slot under one hold of
+        // the watcher lock. `set_watcher` re-checks the flag under this same
+        // lock, so install and shutdown serialize: a watcher installed
+        // concurrently by the mount background task is either cleared here (if
+        // it stored first) or dropped by `set_watcher` (if it runs after us).
+        // Invariant: after this returns, no watcher can be (re)installed.
+        {
+            let mut watcher = self
+                .inner
+                .watcher
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            self.inner.shutdown.store(true, Ordering::Relaxed);
+            *watcher = None;
+        }
         let handles: Vec<JoinHandle<()>> = self
             .inner
             .tasks
@@ -341,5 +362,70 @@ impl Drop for CodeGraph {
         // behavior) could therefore never fire after a successful `mount`,
         // leaking the OS watcher and both loops until process exit.
         self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// A parked `notify` watcher, not armed on any path — enough to exercise
+    /// the install path without depending on OS event delivery.
+    fn make_watcher() -> RecommendedWatcher {
+        notify::recommended_watcher(|_res: notify::Result<notify::Event>| {}).unwrap()
+    }
+
+    fn open_graph() -> (CodeGraph, TempDir, TempDir) {
+        let ws = TempDir::new().unwrap();
+        let dbdir = TempDir::new().unwrap();
+        let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+        (graph, ws, dbdir)
+    }
+
+    fn watcher_is_installed(graph: &CodeGraph) -> bool {
+        graph
+            .inner
+            .watcher
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+    }
+
+    /// Reproduces the mount-vs-shutdown race deterministically: `shutdown()`
+    /// runs first (flag set, slot cleared), then the racing mount task — having
+    /// already passed its pre-install shutdown check — tries to install its
+    /// watcher. The guarded `set_watcher` must drop it, not store it, so the
+    /// OS watcher cannot leak past shutdown.
+    #[test]
+    fn set_watcher_after_shutdown_drops_the_watcher() {
+        let (graph, _ws, _dbdir) = open_graph();
+
+        graph.shutdown();
+        graph.inner.set_watcher(make_watcher());
+
+        assert!(
+            !watcher_is_installed(&graph),
+            "a watcher installed after shutdown must be dropped, not retained"
+        );
+    }
+
+    /// Control: with no shutdown, the normal install path stores the watcher.
+    #[test]
+    fn set_watcher_before_shutdown_stores_the_watcher() {
+        let (graph, _ws, _dbdir) = open_graph();
+
+        graph.inner.set_watcher(make_watcher());
+        assert!(
+            watcher_is_installed(&graph),
+            "a watcher installed before shutdown must be retained"
+        );
+
+        // And a subsequent shutdown clears it back out.
+        graph.shutdown();
+        assert!(
+            !watcher_is_installed(&graph),
+            "shutdown must clear an already-installed watcher"
+        );
     }
 }

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -61,8 +61,8 @@ pub use pipeline::{
 };
 pub use ports::{
     AlwaysAbortGate, ApprovalGate, AutoApproveGate, CmdOutcome, CommandRunner, ContextRecallPort,
-    NoContextRecall, NoRepoStructure, ProviderResolver, RecalledFrame, RepoStructurePort,
-    ScopeDecision, StdioApprovalGate,
+    NoContextRecall, NoRepoStatus, NoRepoStructure, ProviderResolver, RecalledFrame,
+    RepoStatusPort, RepoStructurePort, ScopeDecision, StdioApprovalGate,
 };
 pub use triage::TaskClass;
 pub use verify::{FlipOracle, FlipState, LadderDecision, LadderInputs};

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -34,7 +34,7 @@
 //! need `&mut Router`). That feedback is the responsibility of the glue that
 //! owns the `Router` — documented here so the boundary is explicit.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::time::Duration;
 
 use stella_core::hooks::{HookRunner, Hooks};
@@ -54,7 +54,7 @@ use crate::candidate::{
 use crate::plan::{PlanStep, build_planner_prompt, parse_plan, plan_repair_prompt};
 use crate::ports::{
     ApprovalGate, CommandRunner, ContextRecallPort, ProviderResolver, RecalledFrame,
-    RepoStructurePort, ScopeDecision,
+    RepoStatusPort, RepoStructurePort, ScopeDecision,
 };
 use crate::scope::{ScopeEstimate, apply_trim, build_proposal, needs_scope_review};
 use crate::triage::{TaskClass, classify_triage_response, resolve_task_class, triage_prompt};
@@ -86,6 +86,9 @@ pub struct PipelinePorts<'a> {
     pub recall: &'a dyn ContextRecallPort,
     /// Repo-structure summary for the planner's split context (L-E6).
     pub repo: &'a dyn RepoStructurePort,
+    /// Untracked-file snapshots for the zero-diff guard (`git diff` can't see
+    /// untracked files; this makes new/modified untracked files visible).
+    pub repo_status: &'a dyn RepoStatusPort,
     /// Runs the verification ladder's test and diff commands (L-E11).
     pub commands: &'a dyn CommandRunner,
     /// The interactive scope-review gate (L-E5).
@@ -289,6 +292,7 @@ pub struct Pipeline<'a> {
     tools: &'a dyn stella_core::ToolExecutor,
     recall: &'a dyn ContextRecallPort,
     repo: &'a dyn RepoStructurePort,
+    repo_status: &'a dyn RepoStatusPort,
     commands: &'a dyn CommandRunner,
     approvals: &'a dyn ApprovalGate,
     sleeper: &'a dyn Sleeper,
@@ -310,6 +314,7 @@ impl<'a> Pipeline<'a> {
             tools: ports.tools,
             recall: ports.recall,
             repo: ports.repo,
+            repo_status: ports.repo_status,
             commands: ports.commands,
             approvals: ports.approvals,
             sleeper: ports.sleeper,
@@ -644,11 +649,12 @@ impl<'a> Pipeline<'a> {
             oracle.observe(cmd, pre.passed());
         }
 
-        // Snapshot untracked files BEFORE executing so `gather_diff` can tell
-        // files this turn created from pre-existing dirty state — otherwise a
-        // stale untracked file would be attributed to (and verified against)
-        // this turn.
-        let untracked_before = self.list_untracked().await;
+        // Snapshot untracked files (with content fingerprints) BEFORE
+        // executing so `gather_diff` can tell files this turn created OR
+        // modified from pre-existing dirty state — a stale untracked file with
+        // an unchanged fingerprint is not this turn's work, but one the turn
+        // edited (fingerprint changed) is.
+        let untracked_before = self.repo_status.untracked_fingerprints().await;
 
         // Execute: one turn for simple/single-task; one turn per plan step for
         // multi-step (each step guides a fresh engine turn).
@@ -877,7 +883,7 @@ impl<'a> Pipeline<'a> {
         file_changes: &mut u32,
         final_text: &mut String,
         total: &mut f64,
-        untracked_before: &HashSet<String>,
+        untracked_before: &HashMap<String, String>,
     ) -> Result<(u32, String), String> {
         messages.push(CompletionMessage::user(revision_prompt(reason)));
         self.emit(AgentEvent::Stage {
@@ -1036,37 +1042,13 @@ impl<'a> Pipeline<'a> {
         outcome
     }
 
-    /// The git-ignored-aware set of untracked files, root-relative. Empty
-    /// unless the configured diff command is git's (untracked accounting only
-    /// makes sense there). `-c core.quotePath=false` keeps non-ASCII paths
-    /// literal so the set matches what a later `gather_diff` sees.
-    async fn list_untracked(&self) -> HashSet<String> {
-        let is_git = self
-            .config
-            .diff_command
-            .as_deref()
-            .is_some_and(|c| c.trim_start().starts_with("git diff"));
-        if !is_git {
-            return HashSet::new();
-        }
-        let out = self
-            .commands
-            .run("git -c core.quotePath=false ls-files --others --exclude-standard")
-            .await;
-        out.stdout_tail
-            .lines()
-            .map(str::trim)
-            .filter(|l| !l.is_empty())
-            .map(String::from)
-            .collect()
-    }
-
-    /// The real added-line count of a new untracked file, via a no-index diff
+    /// The real added-line count of an untracked file, via a no-index diff
     /// numstat (`<added>\t<deleted>\t<path>`). A binary file numstats as `-`
     /// and counts as one changed line (a change the ladder must see, but
     /// unmeasurable in lines). Counting real lines — not a flat 1 per file —
-    /// is what keeps a large new file from slipping under the diff budget and
-    /// taking `SubmitFast`.
+    /// is what keeps a large untracked file from slipping under the diff budget
+    /// and taking `SubmitFast`. A single file's numstat is one line, so this is
+    /// safe against the CommandRunner's output truncation.
     async fn untracked_added_lines(&self, path: &str) -> u32 {
         let out = self
             .commands
@@ -1086,13 +1068,15 @@ impl<'a> Pipeline<'a> {
     /// Run the diff command and return `(changed_line_count, raw_diff)`.
     ///
     /// `git diff` cannot see untracked files, so a turn whose entire change is
-    /// a NEW file would read as "no diff" — skipping verification via the
-    /// zero-diff guard and showing the judge an empty diff. When the configured
-    /// command is git's, files that became untracked *this turn* (i.e. not in
-    /// `untracked_before`) are appended with their real added-line counts, so
-    /// pre-existing dirty state is never attributed to the turn and a large new
-    /// file cannot slip under the diff-size budget.
-    async fn gather_diff(&self, untracked_before: &HashSet<String>) -> (u32, String) {
+    /// a NEW (or edited-untracked) file would read as "no diff" — skipping
+    /// verification via the zero-diff guard and showing the judge an empty
+    /// diff. When the configured command is git's, untracked files that were
+    /// **created or modified this turn** — present now with either no
+    /// `untracked_before` entry or a changed fingerprint — are appended with
+    /// their real added-line counts. Untouched dirty files (same fingerprint)
+    /// are excluded, so pre-existing state is never attributed to the turn, and
+    /// a large untracked file cannot slip under the diff-size budget.
+    async fn gather_diff(&self, untracked_before: &HashMap<String, String>) -> (u32, String) {
         let Some(cmd) = &self.config.diff_command else {
             return (0, String::new());
         };
@@ -1100,17 +1084,19 @@ impl<'a> Pipeline<'a> {
         let mut lines = count_diff_lines(&out.stdout_tail);
         let mut text = out.stdout_tail;
         if cmd.trim_start().starts_with("git diff") {
-            let mut fresh: Vec<String> = self
-                .list_untracked()
-                .await
-                .into_iter()
-                .filter(|p| !untracked_before.contains(p))
+            let after = self.repo_status.untracked_fingerprints().await;
+            // Created (absent before) OR modified (fingerprint changed) this
+            // turn — never an untouched dirty file.
+            let mut fresh: Vec<&str> = after
+                .iter()
+                .filter(|(path, fp)| untracked_before.get(*path) != Some(*fp))
+                .map(|(path, _)| path.as_str())
                 .collect();
             fresh.sort(); // deterministic order for the appended evidence
             for path in fresh {
-                let added = self.untracked_added_lines(&path).await;
+                let added = self.untracked_added_lines(path).await;
                 lines += added;
-                text.push_str(&format!("\n+ new file (untracked): {path} (+{added} lines)"));
+                text.push_str(&format!("\n+ untracked change: {path} (+{added} lines)"));
             }
         }
         (lines, text)
@@ -1265,9 +1251,34 @@ mod tests {
     use tokio::sync::Mutex as TokioMutex;
     use tokio::sync::mpsc;
 
-    use crate::ports::{AutoApproveGate, CmdOutcome, NoContextRecall, NoRepoStructure};
+    use crate::ports::{
+        AutoApproveGate, CmdOutcome, NoContextRecall, NoRepoStatus, NoRepoStructure,
+    };
 
     // ---- test doubles ---------------------------------------------------
+
+    /// A [`RepoStatusPort`] returning a fixed untracked `path -> fingerprint`
+    /// map — the "after execute" snapshot `gather_diff` diffs against a
+    /// caller-supplied before-snapshot.
+    struct FakeRepoStatus {
+        files: HashMap<String, String>,
+    }
+    impl FakeRepoStatus {
+        fn new(files: Vec<(&str, &str)>) -> Self {
+            Self {
+                files: files
+                    .into_iter()
+                    .map(|(p, fp)| (p.to_string(), fp.to_string()))
+                    .collect(),
+            }
+        }
+    }
+    #[async_trait]
+    impl RepoStatusPort for FakeRepoStatus {
+        async fn untracked_fingerprints(&self) -> HashMap<String, String> {
+            self.files.clone()
+        }
+    }
 
     /// A scripted provider serving triage, plan, worker, and judge calls from
     /// one ordered queue (the resolver hands the same provider to every role).
@@ -1477,6 +1488,7 @@ mod tests {
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
         let approvals = AutoApproveGate;
         let sleeper = NoopSleeper;
         let router = router();
@@ -1494,6 +1506,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1549,6 +1562,7 @@ mod tests {
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
         let approvals = AutoApproveGate;
         let sleeper = NoopSleeper;
         let router = router();
@@ -1566,6 +1580,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1609,6 +1624,7 @@ mod tests {
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
         let approvals = AutoApproveGate;
         let sleeper = NoopSleeper;
         let router = router();
@@ -1621,6 +1637,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1665,6 +1682,7 @@ mod tests {
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
         let approvals = FixedGate(ScopeDecision::Approve);
         let sleeper = NoopSleeper;
         let router = router();
@@ -1682,6 +1700,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1717,6 +1736,7 @@ mod tests {
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
+        let repo_status = NoRepoStatus;
         let approvals = FixedGate(ScopeDecision::Abort);
         let sleeper = NoopSleeper;
         let router = router();
@@ -1729,6 +1749,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1776,9 +1797,11 @@ mod tests {
     async fn gather_diff_counts_real_new_file_lines_and_excludes_pre_existing() {
         let provider = ScriptedProvider::new(vec![]);
         let resolver = OneProvider(&provider);
-        // Empty tracked diff; one big new file the ScriptedRunner reports as
-        // untracked with 5000 added lines.
+        // Empty tracked diff; the ScriptedRunner reports src/huge.rs's no-index
+        // numstat as 5000 added lines. The repo status reports it as untracked
+        // with fingerprint "v2".
         let runner = ScriptedRunner::new(vec![], "").with_untracked(vec![("src/huge.rs", 5000)]);
+        let repo_status = FakeRepoStatus::new(vec![("src/huge.rs", "v2")]);
         let tools = EmptyTools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
@@ -1793,6 +1816,7 @@ mod tests {
                 tools: &tools,
                 recall: &recall,
                 repo: &repo,
+                repo_status: &repo_status,
                 commands: &runner,
                 approvals: &approvals,
                 sleeper: &sleeper,
@@ -1803,14 +1827,24 @@ mod tests {
         );
 
         // No baseline → the file is this turn's; its real 5000 lines count.
-        let (lines, text) = pipeline.gather_diff(&HashSet::new()).await;
+        let (lines, text) = pipeline.gather_diff(&HashMap::new()).await;
         assert_eq!(lines, 5000, "a new file counts its real added lines, not 1");
         assert!(text.contains("src/huge.rs"), "diff text names the new file");
 
-        // Already untracked before the turn → not attributed to it.
-        let before: HashSet<String> = std::iter::once("src/huge.rs".to_string()).collect();
-        let (lines2, _) = pipeline.gather_diff(&before).await;
+        // Present before at the SAME fingerprint → untouched dirty state, not
+        // attributed to the turn.
+        let unchanged: HashMap<String, String> =
+            std::iter::once(("src/huge.rs".to_string(), "v2".to_string())).collect();
+        let (lines2, _) = pipeline.gather_diff(&unchanged).await;
         assert_eq!(lines2, 0, "a pre-existing untracked file is not this turn's change");
+
+        // Present before but at a DIFFERENT fingerprint → the turn edited an
+        // already-untracked file; it must be visible (the P1 regression).
+        let modified: HashMap<String, String> =
+            std::iter::once(("src/huge.rs".to_string(), "v1".to_string())).collect();
+        let (lines3, text3) = pipeline.gather_diff(&modified).await;
+        assert_eq!(lines3, 5000, "an edit to an already-untracked file is counted");
+        assert!(text3.contains("src/huge.rs"));
     }
 
     #[test]

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -88,6 +88,26 @@ pub trait RepoStructurePort: Send + Sync {
     async fn structure_summary(&self) -> String;
 }
 
+/// A snapshot of the working tree's untracked (git-ignored-aware) files, each
+/// with a content fingerprint. The verification ladder diffs a before-turn and
+/// after-turn snapshot to find files the turn **created or modified**, since
+/// `git diff` alone is blind to untracked files.
+///
+/// Distinct from [`CommandRunner`] on purpose: the listing must be COMPLETE —
+/// `CommandRunner` output is middle-out truncated (L-S3), so a large untracked
+/// set would lose files and corrupt the diff-size accounting — and it must
+/// carry per-file fingerprints so a modification (not just a creation) to an
+/// already-untracked file is visible. A caller without a git working tree
+/// supplies [`NoRepoStatus`].
+#[async_trait]
+pub trait RepoStatusPort: Send + Sync {
+    /// Untracked files as `path -> fingerprint`, where the fingerprint changes
+    /// whenever the file's content does (e.g. `len:mtime_nanos`). Complete and
+    /// never truncated. Empty when the workspace is not a git repo or on any
+    /// failure — the guard then rests on the tracked `git diff` alone.
+    async fn untracked_fingerprints(&self) -> std::collections::HashMap<String, String>;
+}
+
 /// The outcome of running one shell command through [`CommandRunner`]. Output
 /// is pre-truncated by the runner (middle-out, L-S3) into head+tail tails —
 /// the pipeline never needs the full stream, only exit status and enough
@@ -183,6 +203,18 @@ pub struct NoRepoStructure;
 impl RepoStructurePort for NoRepoStructure {
     async fn structure_summary(&self) -> String {
         String::new()
+    }
+}
+
+/// A [`RepoStatusPort`] that reports no untracked files — for callers with no
+/// git working tree (the zero-diff guard then uses the tracked diff alone).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoRepoStatus;
+
+#[async_trait]
+impl RepoStatusPort for NoRepoStatus {
+    async fn untracked_fingerprints(&self) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::new()
     }
 }
 

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -65,6 +65,18 @@ impl From<rusqlite::Error> for StoreError {
 
 type Result<T> = std::result::Result<T, StoreError>;
 
+/// Reject graph `properties` that are not a valid JSON document before they
+/// reach a plain SQLite `TEXT` column. Under the previous DuckDB backend the
+/// column was JSON-typed and refused malformed input at the DB boundary;
+/// SQLite silently persists arbitrary bytes, so unparseable data would only
+/// surface later, when a JSON-expecting reader chokes on it. The empty
+/// default `"{}"` is valid JSON and passes.
+fn validate_json_properties(properties: &str) -> Result<()> {
+    serde_json::from_str::<serde_json::Value>(properties)
+        .map(|_| ())
+        .map_err(|e| StoreError(format!("graph properties are not valid JSON: {e}")))
+}
+
 /// One StepUsage-shaped telemetry record (mirrors the event, plus the
 /// derived cache-miss column so analytics never re-derive it).
 #[derive(Debug, Clone, PartialEq)]
@@ -421,7 +433,14 @@ impl Store {
     }
 
     /// Upsert a graph node — the context plane's write seam.
+    ///
+    /// `properties` must be a valid JSON document. The old DuckDB backend
+    /// stored it in a JSON-typed column that rejected malformed input at the
+    /// DB boundary; SQLite's `TEXT` column would silently accept arbitrary
+    /// bytes, so the JSON-validity invariant is re-asserted here before the
+    /// INSERT rather than let unparseable data reach JSON-expecting readers.
     pub fn upsert_graph_node(&self, id: &str, label: &str, properties: &str) -> Result<()> {
+        validate_json_properties(properties)?;
         self.lock().execute(
             "INSERT INTO graph_nodes (id, label, properties) VALUES (?, ?, ?) \
              ON CONFLICT (id) DO UPDATE SET label = excluded.label, \
@@ -432,6 +451,9 @@ impl Store {
     }
 
     /// Insert a graph edge.
+    ///
+    /// `properties` must be a valid JSON document — see [`Store::upsert_graph_node`]
+    /// for why the invariant is enforced here rather than by the column type.
     pub fn insert_graph_edge(
         &self,
         src: &str,
@@ -439,6 +461,7 @@ impl Store {
         edge_type: &str,
         properties: &str,
     ) -> Result<()> {
+        validate_json_properties(properties)?;
         self.lock().execute(
             "INSERT INTO graph_edges (src, dst, edge_type, properties) VALUES (?, ?, ?, ?)",
             params![src, dst, edge_type, properties],
@@ -804,6 +827,66 @@ mod tests {
             "upsert, not duplicate"
         );
         assert_eq!(store.count("graph_edges").unwrap(), 1);
+    }
+
+    #[test]
+    fn graph_seam_rejects_non_json_properties_and_persists_valid_ones() {
+        let store = Store::in_memory().unwrap();
+
+        // Malformed JSON is refused at the seam by BOTH write methods — the
+        // invariant the JSON-typed DuckDB column used to enforce — so nothing
+        // unparseable lands in the plain SQLite TEXT column.
+        assert!(
+            store
+                .upsert_graph_node("doc:readme", "Document", "not json")
+                .is_err(),
+            "node upsert must reject non-JSON properties"
+        );
+        assert!(
+            store
+                .insert_graph_edge("doc:readme", "sym:main", "mentions", "{oops")
+                .is_err(),
+            "edge insert must reject non-JSON properties"
+        );
+        assert_eq!(
+            store.count("graph_nodes").unwrap(),
+            0,
+            "a rejected node must not be written"
+        );
+        assert_eq!(
+            store.count("graph_edges").unwrap(),
+            0,
+            "a rejected edge must not be written"
+        );
+
+        // Valid JSON — including the empty default and a caller-supplied
+        // object — is accepted and round-trips out of the column intact.
+        store
+            .upsert_graph_node("doc:readme", "Document", r#"{"path":"README.md"}"#)
+            .unwrap();
+        store
+            .insert_graph_edge("doc:readme", "sym:main", "mentions", "{}")
+            .unwrap();
+        assert_eq!(store.count("graph_nodes").unwrap(), 1);
+        assert_eq!(store.count("graph_edges").unwrap(), 1);
+
+        let conn = store.lock();
+        let node_props: String = conn
+            .query_row(
+                "SELECT properties FROM graph_nodes WHERE id = ?",
+                params!["doc:readme"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(node_props, r#"{"path":"README.md"}"#);
+        let edge_props: String = conn
+            .query_row(
+                "SELECT properties FROM graph_edges WHERE src = ? AND dst = ?",
+                params!["doc:readme", "sym:main"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(edge_props, "{}");
     }
 
     /// Test-only shorthand: a telemetry row with just the analytics-relevant

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -48,6 +48,12 @@ impl FileOp {
 /// "Files Touched" panel and persisted as telemetry.
 pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
+    /// Tools enabled AFTER construction — currently just `code_graph`, once a
+    /// mid-session `stella init` / `/init` builds the index. Kept in a
+    /// separate interior-mutable overlay so the primary `tools` map stays
+    /// immutable and lock-free; the overlay is consulted as a fallback in the
+    /// three read paths (`schemas`, dispatch, name listing).
+    late_tools: std::sync::RwLock<HashMap<String, Arc<dyn Tool>>>,
     root: PathBuf,
     touched: std::sync::Mutex<Vec<(String, Vec<FileOp>)>>,
     schema_index: std::sync::Mutex<SchemaIndex>,
@@ -147,15 +153,39 @@ impl ToolRegistry {
         }
         Self {
             tools,
+            late_tools: std::sync::RwLock::new(HashMap::new()),
             root,
             touched: std::sync::Mutex::new(Vec::new()),
             schema_index: std::sync::Mutex::new(SchemaIndex::default()),
         }
     }
 
-    /// All tool schemas, for advertising to the model.
+    /// Enable the `code_graph` query tool if `stella init` has since built the
+    /// index and it isn't already registered. Idempotent, cheap, and safe to
+    /// call every turn. Lets a mid-session `/init` expose `code_graph` to
+    /// subsequent turns without rebuilding the whole registry (and its MCP
+    /// wrapper) — the overlay is shared through every `&ToolRegistry` /
+    /// `Arc<ToolRegistry>` reference the session already holds.
+    pub fn enable_code_graph_if_available(&self, root: &std::path::Path) {
+        if !crate::graph::graph_available(root) {
+            return;
+        }
+        let tool: Arc<dyn Tool> = Arc::new(crate::graph::CodeGraphQuery);
+        let name = tool.schema().name;
+        if self.tools.contains_key(&name) {
+            return; // already registered at construction
+        }
+        let mut late = self.late_tools.write().unwrap_or_else(|p| p.into_inner());
+        late.entry(name).or_insert(tool);
+    }
+
+    /// All tool schemas, for advertising to the model — primary tools plus any
+    /// late-enabled overlay tools.
     pub fn schemas(&self) -> Vec<ToolSchema> {
-        self.tools.values().map(|t| t.schema()).collect()
+        let mut schemas: Vec<ToolSchema> = self.tools.values().map(|t| t.schema()).collect();
+        let late = self.late_tools.read().unwrap_or_else(|p| p.into_inner());
+        schemas.extend(late.values().map(|t| t.schema()));
+        schemas
     }
 
     /// Execute a tool by name. Returns an error `ToolOutput` if the name is
@@ -216,7 +246,17 @@ impl ToolRegistry {
             }
         }
 
-        let output = match self.tools.get(name) {
+        // Resolve from the primary map, falling back to the late-enabled
+        // overlay. Clone the `Arc` out so the overlay's read lock is released
+        // before the `.await` (a lock guard must not cross an await point).
+        let tool = self.tools.get(name).cloned().or_else(|| {
+            self.late_tools
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .get(name)
+                .cloned()
+        });
+        let output = match tool {
             Some(tool) => tool.execute(input, &self.root).await,
             None => ToolOutput::Error {
                 message: format!(
@@ -312,7 +352,13 @@ impl ToolRegistry {
     /// Comma-separated sorted list of registered tool names, for error
     /// messages.
     pub fn available_names(&self) -> String {
-        let mut names: Vec<&str> = self.tools.keys().map(|s| s.as_str()).collect();
+        let late = self.late_tools.read().unwrap_or_else(|p| p.into_inner());
+        let mut names: Vec<String> = self
+            .tools
+            .keys()
+            .cloned()
+            .chain(late.keys().cloned())
+            .collect();
         names.sort();
         names.join(", ")
     }
@@ -414,6 +460,41 @@ mod tests {
                 "{absent} must be absent"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn code_graph_tool_is_enabled_after_a_mid_session_index_build() {
+        // A session that starts without a code-graph index doesn't advertise
+        // `code_graph`; once `stella init` / `/init` builds the index,
+        // `enable_code_graph_if_available` must expose it for the rest of the
+        // session (schema advertised AND dispatchable) without a rebuild.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let reg = ToolRegistry::with_issue_backend(root.clone(), None);
+        let has_code_graph = |r: &ToolRegistry| r.schemas().iter().any(|s| s.name == "code_graph");
+
+        assert!(!has_code_graph(&reg), "no index → not advertised");
+        reg.enable_code_graph_if_available(&root); // no index yet: a no-op
+        assert!(!has_code_graph(&reg));
+
+        // Build a minimal index, exactly what `stella init` does.
+        std::fs::write(root.join("lib.rs"), "pub fn f() {}\n").unwrap();
+        let db = root.join(".stella").join("codegraph.db");
+        std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+        let graph = stella_graph::CodeGraph::open(&root, &db).unwrap();
+        graph.index_all().unwrap();
+        graph.shutdown();
+
+        reg.enable_code_graph_if_available(&root);
+        assert!(has_code_graph(&reg), "index built → now advertised");
+        // And it actually dispatches through the overlay.
+        let out = reg
+            .execute(
+                "code_graph",
+                &serde_json::json!({"op": "definitions", "target": "f"}),
+            )
+            .await;
+        assert!(!out.is_error(), "code_graph must dispatch: {out:?}");
     }
 
     #[test]

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -306,9 +306,10 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
     match handle_slash_popup_key(key, matches, &mut ui.composer, &mut ui.slash_selected)? {
         SlashPopupOutcome::Handled => Some(DeckAction::Handled),
         SlashPopupOutcome::Submit(text) => Some(match text.as_str() {
-            // Views the deck itself owns: act locally, never round-trip.
-            // `/diff` opens the diff viewer; `/files` shows the file tree, so
-            // it must also *close* a diff left open from a prior view.
+            // Only the tab-switch commands are deck-local (they change view
+            // state the driver has no say over). `/diff` opens the diff
+            // viewer; `/files` shows the file tree, so it must also *close* a
+            // diff left open from a prior view.
             "/files" | "/diff" => {
                 ui.set_tab(DeckTab::Files);
                 ui.files_diff_open = text == "/diff";
@@ -318,10 +319,9 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
                 ui.set_tab(DeckTab::Graph);
                 DeckAction::Handled
             }
-            "/help" => {
-                ui.help_open = true;
-                DeckAction::Handled
-            }
+            // Everything else — including `/help` — is enqueued for the
+            // driver, which owns the session vocabulary and answers into the
+            // transcript (a transient overlay would leave no record).
             _ => DeckAction::Send(WorkspaceInput::Enqueue { text }),
         }),
     }


### PR DESCRIPTION
…nfig

Deck / CLI
- Emit WaitingInput after a handled slash command so the lead doesn't stay stuck at Running (its Text answer had set Running with no turn in flight).
- /help now routes to the driver (answers into the transcript) like /clear and /models; only the tab commands (/files,/diff,/graph) stay deck-local.
- /models (plain, for the deck) now lists config-defined providers and warns on a misconfigured one, and its key check honors the provider env var — matching the ANSI `stella models` renderer.
- /init now exposes the code_graph tool for the rest of the session: the tool registry gained a small interior-mutable overlay so a mid-session index build registers code_graph without rebuilding the registry + MCP wrapper. (+ test)

Pipeline — untracked-file verification (P1)
- Introduce a RepoStatusPort: a COMPLETE, non-truncated untracked-file listing with per-file fingerprints (unlike the truncating CommandRunner).
- gather_diff now counts a file as this turn's when it's newly untracked OR its fingerprint changed — so an edit to an already-untracked file is no longer invisible to verification. Production impl GitRepoStatus reads the full `git ls-files -z` and fingerprints by len:mtime. (+ test incl. the modified-untracked case)

Context / memory
- MemoryProvider stops counting kind-filter removals as budget truncation (dropped_estimate reflects only real budget drops, per the OCP contract).
- reflect_and_record reports partial JSONL persistence accurately (per-lesson count, not an all-or-nothing bool).
- Stale node-domain-on-path-move documented as a deliberate deferral (both candidate fixes weighed; correct fix is a context-store schema change).

stella-graph (subagent)
- Fixed the mount-vs-shutdown watcher race: set_watcher re-checks shutdown under the watcher mutex, so a late watcher is dropped, not leaked. (+ tests)
- Fixed the broken SymbolKind::tag intra-doc link.

stella-store (subagent)
- Restored the JSON-validity invariant lost in the DuckDB→SQLite migration: graph node/edge writes validate `properties` as JSON before persisting. (+ test)

stats / docs
- `stella stats` detects a pre-migration .stella/stella.duckdb and explains it rather than silently reporting an empty workspace.
- README + defensibility paper qualify telemetry as best-effort (the store is never a dependency of a turn).

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes untracked-file verification and a `stella-graph` shutdown race, improves deck commands, and exposes `code_graph` after a mid-session `/init`. Also restores JSON validation in the store and clarifies `stella stats` messaging.

- **New Features**
  - Enable `code_graph` for the rest of the session after `/init` without restarting (registry overlay; advertised and dispatchable).
  - Deck `/models` lists config-defined providers, warns on misconfig, and respects env-var keys.

- **Bug Fixes**
  - Verification: new `RepoStatusPort` with full, fingerprinted snapshots; `gather_diff` now counts untracked files created or modified this turn, fixing missed edits to already-untracked files.
  - `stella-graph`: fix mount/shutdown watcher race; late watcher is dropped under lock (tests added).
  - `stella-store`: validate graph `properties` as JSON before writes (tests added).
  - Deck UX: emit `WaitingInput` after handled slash commands; route `/help` to the driver; only `/files`, `/diff`, `/graph` stay local.
  - Memory/telemetry: correct truncation metadata for kind-filtered recall; accurate partial JSONL reporting; `stella stats` explains legacy `.stella/stella.duckdb`; docs state telemetry is best-effort.

<sup>Written for commit 3409085fc7b3bf14bd0297a382fca72c6e522194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
