### PR TITLE
fix: surface truncated streamed tool-call args as terminal errors (anthropic, zai)

### DIFF
--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -125,7 +125,15 @@ enum AnthropicStreamEvent {
         delta: AnthropicDelta,
     },
     #[serde(rename = "message_delta")]
-    MessageDelta { usage: Option<AnthropicUsage> },
+    MessageDelta {
+        /// Carries `stop_reason` — `"max_tokens"` when the model was cut off
+        /// at the output-token limit. Tracked so a tool call whose argument
+        /// JSON was truncated mid-stream surfaces an actionable error instead
+        /// of a silent `Null` (see [`crate::http::truncated_tool_input_error`]).
+        #[serde(default)]
+        delta: AnthropicMessageDeltaBody,
+        usage: Option<AnthropicUsage>,
+    },
     /// A mid-stream error event. The Messages API can send
     /// `event: error` / `data: {"type":"error","error":{...}}` after already
     /// streaming content — modeled explicitly so it aborts the turn with a
@@ -135,6 +143,16 @@ enum AnthropicStreamEvent {
     Error { error: AnthropicStreamError },
     #[serde(other)]
     Other,
+}
+
+/// The `delta` object of a `message_delta` event. Only `stop_reason` is
+/// modeled — it is how the Messages API signals *why* generation ended, and
+/// `"max_tokens"` specifically means the output was cut off at the token
+/// limit (potentially mid-tool-call).
+#[derive(Deserialize, Debug, Default)]
+struct AnthropicMessageDeltaBody {
+    #[serde(default)]
+    stop_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -393,6 +411,15 @@ async fn aggregate_anthropic_stream(
     let mut text = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_uses: BTreeMap<usize, ToolUseAccumulator> = BTreeMap::new();
+    // Why generation ended, from the `message_delta` event. `"max_tokens"`
+    // means the stream was cut off at the output-token limit — the signal a
+    // truncated tool-call payload needs to be reported as such rather than
+    // silently nulled.
+    let mut stop_reason: Option<String> = None;
+    // The highest content-block index that started. Blocks stream
+    // sequentially, so only this block can have been cut off by the token
+    // limit — a later block starting proves every earlier one closed.
+    let mut last_block_index: Option<usize> = None;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = http::next_with_timeout(&mut stream, http::STREAM_IDLE_TIMEOUT).await? {
@@ -418,16 +445,19 @@ async fn aggregate_anthropic_stream(
                 }
                 Ok(AnthropicStreamEvent::ContentBlockStart {
                     index,
-                    content_block: AnthropicStartBlock::ToolUse { id, name },
+                    content_block,
                 }) => {
-                    tool_uses.insert(
-                        index,
-                        ToolUseAccumulator {
-                            id,
-                            name,
-                            input_json: String::new(),
-                        },
-                    );
+                    last_block_index = Some(index);
+                    if let AnthropicStartBlock::ToolUse { id, name } = content_block {
+                        tool_uses.insert(
+                            index,
+                            ToolUseAccumulator {
+                                id,
+                                name,
+                                input_json: String::new(),
+                            },
+                        );
+                    }
                 }
                 Ok(AnthropicStreamEvent::ContentBlockDelta { index, delta }) => match delta {
                     AnthropicDelta::TextDelta { text: delta } => text.push_str(&delta),
@@ -438,14 +468,19 @@ async fn aggregate_anthropic_stream(
                     }
                     AnthropicDelta::Other => {}
                 },
-                Ok(AnthropicStreamEvent::MessageDelta { usage: Some(u) }) => {
-                    if u.input_tokens > 0 {
-                        usage.input_tokens = u.input_tokens + u.cache_read_input_tokens;
+                Ok(AnthropicStreamEvent::MessageDelta { delta, usage: u }) => {
+                    if let Some(reason) = delta.stop_reason {
+                        stop_reason = Some(reason);
                     }
-                    if u.cache_read_input_tokens > 0 {
-                        usage.cached_input_tokens = u.cache_read_input_tokens;
+                    if let Some(u) = u {
+                        if u.input_tokens > 0 {
+                            usage.input_tokens = u.input_tokens + u.cache_read_input_tokens;
+                        }
+                        if u.cache_read_input_tokens > 0 {
+                            usage.cached_input_tokens = u.cache_read_input_tokens;
+                        }
+                        usage.output_tokens = u.output_tokens;
                     }
-                    usage.output_tokens = u.output_tokens;
                 }
                 Ok(_) => {}
                 Err(_) => {
@@ -456,21 +491,70 @@ async fn aggregate_anthropic_stream(
         }
     }
 
-    let tool_calls = tool_uses
-        .into_values()
-        .map(|acc| {
-            let input = if acc.input_json.is_empty() {
-                serde_json::json!({})
-            } else {
-                serde_json::from_str(&acc.input_json).unwrap_or(serde_json::Value::Null)
-            };
-            ToolCall {
-                call_id: acc.id,
-                name: acc.name,
-                input,
+    // The one content block the token limit could have cut: the last block
+    // started, and only when the stream actually stopped at `max_tokens`.
+    // Pinning truncation to that block keeps the blame on the call that was
+    // cut — an *earlier* call whose JSON is broken is the model's own
+    // malformed output and still gets the repair sentinel below.
+    let truncated_index = if stop_reason.as_deref() == Some("max_tokens") {
+        last_block_index
+    } else {
+        None
+    };
+
+    let mut tool_calls = Vec::with_capacity(tool_uses.len());
+    for (index, acc) in tool_uses {
+        let truncated = Some(index) == truncated_index;
+        let input = if acc.input_json.is_empty() {
+            if truncated {
+                // The limit landed after this call's `content_block_start`
+                // but before its first `input_json_delta`: executing it with
+                // `{}` would fail on missing parameters and re-enter the same
+                // unwinnable retry-retruncate loop as a mid-payload cut.
+                return Err(http::truncated_tool_input_error(
+                    "Anthropic",
+                    &acc.name,
+                    "",
+                    "stop_reason=max_tokens",
+                ));
             }
-        })
-        .collect();
+            // A no-argument tool call arrives with no `input_json_delta` at
+            // all: that is an empty object, never null.
+            serde_json::json!({})
+        } else {
+            match serde_json::from_str(&acc.input_json) {
+                Ok(value) => value,
+                // The fragments were concatenated byte-exactly (the SSE
+                // decoder's own tests prove arbitrary chunk boundaries
+                // reassemble losslessly), so an unparseable buffer on the
+                // block the token limit cut means the arguments never
+                // finished streaming. Terminal and turn-aborting — mirroring
+                // openai.rs's `response.incomplete` handling — because
+                // retrying the identical request re-truncates identically:
+                // the old silent `Null` here sent the driver's repair loop
+                // into exactly that "stuck-loop".
+                Err(_) if truncated => {
+                    return Err(http::truncated_tool_input_error(
+                        "Anthropic",
+                        &acc.name,
+                        &acc.input_json,
+                        "stop_reason=max_tokens",
+                    ));
+                }
+                // Broken JSON on a block that *finished* is the model's own
+                // malformed output: fall back to the `Value::Null` sentinel
+                // `driver.rs::execute_with_repair` consumes (the documented
+                // adapter contract), so the repair loop asks the model to
+                // re-emit just this call instead of aborting the turn.
+                Err(_) => serde_json::Value::Null,
+            }
+        };
+        tool_calls.push(ToolCall {
+            call_id: acc.id,
+            name: acc.name,
+            input,
+        });
+    }
 
     Ok((text, tool_calls, usage))
 }
@@ -481,6 +565,257 @@ mod tests {
     use stella_protocol::MessageRole;
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The reported failure's happy path: a multi-kilobyte `write_file` tool
+    /// call whose argument JSON is split across HUNDREDS of `input_json_delta`
+    /// fragments (and thus many SSE events / network chunks) must reassemble
+    /// to the exact JSON object — never a truncated buffer or `null`. Proves
+    /// the assembly itself is sound for large payloads; the null only ever
+    /// came from genuine truncation, handled by the test below.
+    #[tokio::test]
+    async fn complete_reassembles_a_large_multi_fragment_tool_call() {
+        let server = MockServer::start().await;
+        // A realistic large `write_file` content field: several KB, with the
+        // newlines, quotes and backslashes a real README carries.
+        let mut content = String::new();
+        for i in 0..200 {
+            content.push_str(&format!(
+                "## Section {i}\n\nSome \"quoted\" text with a backslash \\ and a tab\there.\n\n"
+            ));
+        }
+        let full_input = serde_json::json!({"path": "README.md", "content": content});
+        let full_input_json = serde_json::to_string(&full_input).unwrap();
+
+        // Fragment the JSON at arbitrary byte-ish boundaries (chars), exactly
+        // as Anthropic streams `partial_json` — including splits mid-escape.
+        let chars: Vec<char> = full_input_json.chars().collect();
+        let mut body = String::from(
+            "event: message_start\n\
+             data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":40,\"output_tokens\":0}}}\n\n\
+             event: content_block_start\n\
+             data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"write_file\"}}\n\n",
+        );
+        for piece in chars.chunks(29) {
+            let frag: String = piece.iter().collect();
+            let escaped = serde_json::to_string(&frag).unwrap();
+            body.push_str("event: content_block_delta\n");
+            body.push_str(&format!(
+                "data: {{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{{\"type\":\"input_json_delta\",\"partial_json\":{escaped}}}}}\n\n"
+            ));
+        }
+        body.push_str(
+            "event: message_delta\n\
+             data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":15}}\n\n",
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("write the readme")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![stella_protocol::tool::ToolSchema {
+                name: "write_file".into(),
+                description: "Write a file".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+                read_only: false,
+            }],
+        };
+
+        let result = provider.complete(req).await.expect("should succeed");
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(
+            result.tool_calls[0].input, full_input,
+            "large multi-fragment tool input must reassemble to the exact JSON, not null"
+        );
+    }
+
+    /// The reported bug's failure path: the model starts a large `write_file`
+    /// tool call but the stream stops at the output-token limit MID-JSON —
+    /// `partial_json` is an unterminated fragment and `message_delta` carries
+    /// `stop_reason: "max_tokens"`. The adapter must NOT silently emit a
+    /// tool call with `null` input (which the driver's repair loop can never
+    /// fix, producing the observed "stuck-loop"); it must surface a clear,
+    /// non-retryable Terminal error naming the truncation and carrying a raw
+    /// snippet of what was accumulated.
+    #[tokio::test]
+    async fn complete_surfaces_a_truncated_tool_call_instead_of_silent_null() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"write_file\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README.md\\\",\\\"content\\\":\\\"# Title\\\\nlots of\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("write the readme")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![stella_protocol::tool::ToolSchema {
+                name: "write_file".into(),
+                description: "Write a file".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+                read_only: false,
+            }],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        // A truncated-at-max_tokens tool call is a terminal, non-retryable
+        // failure — retrying with the same output budget re-truncates.
+        assert!(
+            matches!(err, ProviderError::Terminal(_)),
+            "expected Terminal, got {err:?}"
+        );
+        assert!(!err.is_retryable());
+        let msg = err.to_string();
+        assert!(msg.contains("write_file"), "names the tool: {msg}");
+        assert!(msg.contains("max_tokens"), "names the cause: {msg}");
+        // The raw accumulated snippet must be surfaced, never dropped to null.
+        assert!(msg.contains("README.md"), "carries a raw snippet: {msg}");
+    }
+
+    /// Broken JSON on a call that *finished* streaming (the stream did not
+    /// stop at `max_tokens`) is the model's own malformed output — the
+    /// adapter must keep the `Value::Null` repair sentinel the driver's
+    /// documented repair loop consumes, not abort the turn.
+    #[tokio::test]
+    async fn malformed_but_complete_tool_json_falls_back_to_the_null_repair_sentinel() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"edit_file\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\": not json,}\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":40}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        let result = provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("edit the file")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+            })
+            .await
+            .expect("a repairable malformed call must not abort the turn");
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].input, serde_json::Value::Null);
+    }
+
+    /// `max_tokens` landing between a tool call's `content_block_start` and
+    /// its first `input_json_delta` must surface the same terminal truncation
+    /// error as a mid-payload cut — never a silent `{}` that executes with
+    /// missing parameters and re-enters the retry-retruncate loop.
+    #[tokio::test]
+    async fn a_tool_call_with_no_arguments_cut_at_max_tokens_is_terminal() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"write_file\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        let err = provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("write the readme")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ProviderError::Terminal(_)),
+            "expected Terminal, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("write_file"), "names the tool: {msg}");
+        assert!(msg.contains("max_tokens"), "names the cause: {msg}");
+    }
+
+    /// With parallel tool calls, the truncation error must blame the call the
+    /// token limit actually cut (the last block started) — an earlier call
+    /// whose complete-but-broken JSON is the model's own output must not be
+    /// misreported as truncated.
+    #[tokio::test]
+    async fn truncation_is_blamed_on_the_call_that_was_cut_not_an_earlier_broken_one() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"edit_file\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\": broken,}\"}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_2\",\"name\":\"write_file\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        let err = provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("do both")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+            })
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("write_file"),
+            "blames the truncated call: {msg}"
+        );
+        assert!(
+            !msg.contains("edit_file"),
+            "must not blame the earlier repairable call: {msg}"
+        );
+    }
 
     #[test]
     fn to_anthropic_messages_hoists_system_and_maps_roles() {

--- a/stella-model/src/http.rs
+++ b/stella-model/src/http.rs
@@ -57,6 +57,42 @@ where
     }
 }
 
+/// Longest raw-snippet prefix (in characters) echoed back in a truncated
+/// tool-input error — enough to identify the call without dumping a
+/// multi-kilobyte partial payload into the log.
+const TOOL_INPUT_SNIPPET_CHARS: usize = 200;
+
+/// Build the terminal error for a streamed tool call whose argument JSON was
+/// cut off at the output-token limit before it finished. Shared by every
+/// adapter that assembles tool calls from stream fragments: `provider` names
+/// the concrete backend, `limit_signal` the wire-level evidence
+/// (`stop_reason=max_tokens`, `finish_reason=length`). Non-retryable:
+/// re-issuing the identical request re-truncates identically (the very
+/// "stuck-loop" this error replaces), so the actionable fix — a larger
+/// `max_output_tokens` or a smaller payload — is surfaced in the message
+/// along with a bounded snippet of the RAW accumulated string.
+pub(crate) fn truncated_tool_input_error(
+    provider: &str,
+    name: &str,
+    raw: &str,
+    limit_signal: &str,
+) -> ProviderError {
+    let total_chars = raw.chars().count();
+    let snippet: String = raw.chars().take(TOOL_INPUT_SNIPPET_CHARS).collect();
+    let ellipsis = if total_chars > TOOL_INPUT_SNIPPET_CHARS {
+        "…"
+    } else {
+        ""
+    };
+    ProviderError::Terminal(format!(
+        "{provider} tool call `{name}` was cut off at the output-token limit \
+         ({limit_signal}) before its arguments finished streaming — the \
+         accumulated JSON is incomplete and cannot be parsed ({total_chars} chars: \
+         `{snippet}{ellipsis}`). Raise max_output_tokens or have the model emit a \
+         smaller payload, then retry."
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/stella-model/src/sse.rs
+++ b/stella-model/src/sse.rs
@@ -294,6 +294,44 @@ mod tests {
     }
 
     #[test]
+    fn large_multi_fragment_tool_payload_reassembles_when_fed_one_byte_at_a_time() {
+        // Build a large tool-call JSON, fragment it into many SSE events, and
+        // feed the whole wire stream ONE BYTE AT A TIME — the worst possible
+        // chunk boundary alignment. Then reassemble the `partial_json`
+        // fragments and assert the JSON round-trips. This exercises the SSE
+        // decoder's boundary handling far past what a loopback mock server
+        // (which delivers large chunks) can.
+        let mut content = String::new();
+        for i in 0..300 {
+            content.push_str(&format!("line {i}: \"quoted\" \\ and more\n"));
+        }
+        let full = serde_json::json!({"path": "README.md", "content": content});
+        let full_json = serde_json::to_string(&full).unwrap();
+
+        let chars: Vec<char> = full_json.chars().collect();
+        let mut wire = String::new();
+        for piece in chars.chunks(13) {
+            let frag: String = piece.iter().collect();
+            let escaped = serde_json::to_string(&frag).unwrap();
+            wire.push_str(&format!(
+                "event: content_block_delta\ndata: {{\"partial_json\":{escaped}}}\n\n"
+            ));
+        }
+
+        let mut decoder = SseDecoder::new();
+        let mut assembled = String::new();
+        for b in wire.as_bytes() {
+            decoder.push_bytes(&[*b]).expect("valid utf8");
+            for ev in decoder.poll() {
+                let v: serde_json::Value = serde_json::from_str(&ev.data).unwrap();
+                assembled.push_str(v["partial_json"].as_str().unwrap());
+            }
+        }
+        let reparsed: serde_json::Value = serde_json::from_str(&assembled).unwrap();
+        assert_eq!(reparsed, full);
+    }
+
+    #[test]
     fn sse_decoder_push_bytes_survives_a_multibyte_split_across_chunks() {
         // The end-to-end fix: an SSE data line carrying a multi-byte char
         // split across two network chunks must parse cleanly.

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -284,6 +284,12 @@ fn parse_retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
 struct ZaiStreamChoice {
     #[serde(default)]
     delta: ZaiStreamDelta,
+    /// Why generation ended for this choice. `"length"` is the OpenAI-
+    /// compatible signal that the output was cut off at `max_tokens` — the
+    /// truncation marker a partially-streamed tool call needs so it can be
+    /// reported rather than silently nulled.
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -494,6 +500,10 @@ async fn aggregate_zai_stream(
     let mut text = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_calls: BTreeMap<usize, ToolCallAccumulator> = BTreeMap::new();
+    // Set once any choice reports `finish_reason: "length"` — the output was
+    // cut off at the token limit, so a tool call whose argument JSON didn't
+    // finish streaming is truncated, not merely malformed.
+    let mut truncated_at_token_limit = false;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = http::next_with_timeout(&mut stream, http::STREAM_IDLE_TIMEOUT).await? {
@@ -519,6 +529,9 @@ async fn aggregate_zai_stream(
                 usage.output_tokens = u.completion_tokens;
             }
             for choice in parsed.choices {
+                if choice.finish_reason.as_deref() == Some("length") {
+                    truncated_at_token_limit = true;
+                }
                 if let Some(content) = choice.delta.content {
                     text.push_str(&content);
                 }
@@ -540,21 +553,63 @@ async fn aggregate_zai_stream(
         }
     }
 
+    // OpenAI-style tool calls stream sequentially by index, so when the
+    // stream reports `finish_reason: "length"` only the highest-index call
+    // can be the one the token limit cut. Pinning truncation there keeps the
+    // blame on the right call — an earlier call whose JSON is broken is the
+    // model's own malformed output and still gets the repair sentinel below.
+    let truncated_index = if truncated_at_token_limit {
+        tool_calls.keys().next_back().copied()
+    } else {
+        None
+    };
+
     let mut calls = Vec::with_capacity(tool_calls.len());
-    for acc in tool_calls.into_values() {
+    for (index, acc) in tool_calls {
+        let truncated = Some(index) == truncated_index;
         let trimmed = acc.arguments.trim();
-        // A no-argument tool call arrives as `arguments: ""`; that is an empty
-        // object, not null — a downstream tool deserializing its input as an
-        // object must not be handed `null`. A *non-empty* body that fails to
-        // parse is the model's own broken JSON (GLM emits these): fall back to
-        // the `Value::Null` sentinel `driver.rs::execute_with_repair` checks
-        // for, so the repair loop — documented as tuned to GLM's failure shapes
-        // — can ask the model to retry, rather than erroring out the whole turn
-        // before any `ToolCall` is produced. Mirrors openai.rs / anthropic.rs.
         let input = if trimmed.is_empty() {
+            if truncated {
+                // The limit landed after the call's id/name but before any
+                // argument fragment: executing it with `{}` would fail on
+                // missing parameters and re-enter the same unwinnable
+                // retry-retruncate loop as a mid-payload cut.
+                return Err(http::truncated_tool_input_error(
+                    label,
+                    &acc.name,
+                    "",
+                    "finish_reason=length",
+                ));
+            }
+            // A no-argument tool call arrives as `arguments: ""`; that is an
+            // empty object, not null — a downstream tool deserializing its
+            // input as an object must not be handed `null`.
             Value::Object(serde_json::Map::new())
         } else {
-            serde_json::from_str(trimmed).unwrap_or(Value::Null)
+            match serde_json::from_str(trimmed) {
+                Ok(value) => value,
+                // The stream stopped at the token limit MID-arguments: the
+                // JSON is truncated, not the model's own broken syntax.
+                // Terminal and turn-aborting — mirroring openai.rs's
+                // `response.incomplete` handling — because retrying the
+                // identical request re-truncates identically (the reported
+                // "stuck-loop" defect).
+                Err(_) if truncated => {
+                    return Err(http::truncated_tool_input_error(
+                        label,
+                        &acc.name,
+                        trimmed,
+                        "finish_reason=length",
+                    ));
+                }
+                // A *non-empty* body that fails to parse without being the
+                // truncated call is the model's own broken JSON (GLM emits
+                // these): fall back to the `Value::Null` sentinel
+                // `driver.rs::execute_with_repair` checks for, so the repair
+                // loop — documented as tuned to GLM's failure shapes — can
+                // ask the model to retry. Mirrors anthropic.rs.
+                Err(_) => Value::Null,
+            }
         };
         calls.push(ToolCall {
             call_id: acc.id,
@@ -763,6 +818,138 @@ mod tests {
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "bash");
         assert_eq!(result.tool_calls[0].input, Value::Null);
+    }
+
+    #[tokio::test]
+    async fn complete_surfaces_a_tool_call_truncated_at_the_token_limit_not_null() {
+        let server = MockServer::start().await;
+        // GLM streams a large tool call, but the output is cut off at the token
+        // limit MID-arguments: the final chunk carries `finish_reason: "length"`
+        // and the accumulated `arguments` is an unterminated JSON fragment.
+        // Unlike the malformed-but-complete case (which becomes the repair
+        // sentinel), a truncation is a terminal, actionable failure that must
+        // surface with a raw snippet — never a silent null the repair loop
+        // spins on forever (the reported "stuck-loop").
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"write_file\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"README.md\\\",\\\"content\\\":\\\"# Title\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("write the readme")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![ToolSchema {
+                name: "write_file".into(),
+                description: "Write a file".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+                read_only: false,
+            }],
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(
+            matches!(err, ProviderError::Terminal(_)),
+            "a truncated tool call must be terminal, got {err:?}"
+        );
+        assert!(!err.is_retryable(), "re-issuing the request re-truncates");
+        let msg = err.to_string();
+        assert!(msg.contains("write_file"), "names the tool: {msg}");
+        assert!(
+            msg.contains("finish_reason=length"),
+            "names the cause: {msg}"
+        );
+        assert!(msg.contains("README.md"), "carries a raw snippet: {msg}");
+    }
+
+    /// With parallel tool calls and a `finish_reason: "length"` cut, the
+    /// truncation error must blame the call that was actually cut (the
+    /// highest index — the one still streaming) — an earlier call whose
+    /// complete-but-broken JSON is GLM's own output must not be misreported
+    /// as truncated.
+    #[tokio::test]
+    async fn truncation_is_blamed_on_the_last_call_not_an_earlier_broken_one() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"bash\",\"arguments\":\"{not valid json\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_2\",\"function\":{\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"README\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        let err = provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("do both")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+            })
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("write_file"),
+            "blames the truncated call: {msg}"
+        );
+        assert!(
+            !msg.contains("bash"),
+            "must not blame the earlier repairable call: {msg}"
+        );
+    }
+
+    /// `finish_reason: "length"` landing after a call's id/name but before
+    /// any argument fragment must surface the terminal truncation error —
+    /// never a silent `{}` that executes with missing parameters.
+    #[tokio::test]
+    async fn a_tool_call_with_no_arguments_cut_at_the_token_limit_is_terminal() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"write_file\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        let err = provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("write the readme")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ProviderError::Terminal(_)),
+            "expected Terminal, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("write_file"), "names the tool: {msg}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why

Large streamed tool calls (e.g. `write_file` with a whole README) that hit the output-token limit mid-arguments were silently coerced to `Value::Null` by the anthropic and zai adapters — the stream's `stop_reason`/`finish_reason` was ignored. The driver's malformed-call repair loop then re-requested the identical oversized call, it re-truncated identically, and after 3 rounds the loop detector aborted the turn with a misleading **"stuck-loop detected"**.

Both adapters now model the stop/finish reason and pin truncation to the one call the limit actually cut (anthropic: the last content block started; zai: the highest tool-call index). That call surfaces a **non-retryable `Terminal` error** naming the tool, pointing at `max_output_tokens`, and carrying a 200-char snippet of the raw accumulated JSON — including when the cut lands before any argument fragment arrived (previously a silent `{}` that executed with missing parameters and re-entered the same loop). Aborting the turn on truncation mirrors `openai.rs`'s existing `response.incomplete` handling.

Crucially, malformed-but-**complete** argument JSON keeps the documented `Value::Null` repair sentinel in **both** adapters (anthropic previously lost it in an intermediate cut of this fix), so `driver.rs::execute_with_repair` still self-heals GLM's broken-syntax shapes without aborting the turn. The shared error builder lives in `http.rs`.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here):
  - `anthropic::complete_surfaces_a_truncated_tool_call_instead_of_silent_null`
  - `anthropic::malformed_but_complete_tool_json_falls_back_to_the_null_repair_sentinel`
  - `anthropic::a_tool_call_with_no_arguments_cut_at_max_tokens_is_terminal`
  - `anthropic::truncation_is_blamed_on_the_call_that_was_cut_not_an_earlier_broken_one`
  - `zai::complete_surfaces_a_tool_call_truncated_at_the_token_limit_not_null` (+ last-index blame and empty-args variants)
  - `sse::large_multi_fragment_tool_payload_reassembles_when_fed_one_byte_at_a_time` — proves the SSE decoder was *not* the culprit

## The gate

- [x] `cargo fmt --check` (all files touched here; pre-existing drift in untouched files matches `main`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1219 passed, 0 failed
- [x] Behavior documented in adapter doc comments
- [x] Commits signed off for DCO

## Ground-rule check

- [x] No I/O added to `stella-core` (untouched); no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- **Design call:** a truncated tool call aborts the whole turn (discarding streamed text and valid parallel calls) rather than salvaging partial progress — consistent with `openai.rs`'s `response.incomplete` handling; the failure is a configuration problem (`max_output_tokens` too low) and the message says exactly that.
- **Attribution heuristic:** only the last block/highest index can be truncation's victim, since blocks/calls stream sequentially. A no-arg tool call that is the final block when `max_tokens` lands is indistinguishable from a truncated one and errs toward the terminal error (rare, and the alternative re-creates the stuck loop).
- The diff was written by subagents, then adversarially reviewed by a 22-agent workflow review; all confirmed findings are addressed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort turns when a streamed tool call is cut off at the output‑token limit in the Anthropic and Zai adapters, returning a clear, non‑retryable Terminal error with the tool name and a raw argument snippet. This stops the silent `null`/`{}` inputs that sent the driver’s repair loop into a stuck cycle.

- **Bug Fixes**
  - Detect truncation via `stop_reason=max_tokens` (Anthropic) and `finish_reason=length` (Zai), and attribute it to the correct call (last content block / highest tool‑call index).
  - Emit a Terminal error with a 200‑char raw JSON snippet; also when the cut happens before any argument fragment; aborts the turn (mirrors `openai.rs`’s `response.incomplete`).
  - Keep the `Value::Null` repair sentinel for malformed‑but‑complete JSON so the repair loop still works. Shared error builder added in `http.rs`. Tests cover truncation and SSE reassembly.

- **Migration**
  - If you hit this error, increase `max_output_tokens` or have the model emit smaller tool‑call payloads before retrying.

<sup>Written for commit a22f11504462a0bf1fb22d7057a0d2db7cae20b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
