### PR TITLE
feat: syntax-highlighted diffs, inlined in the session transcript

### DIFF
--- a/stella-tui/src/diff.rs
+++ b/stella-tui/src/diff.rs
@@ -7,7 +7,7 @@
 //! only — the add/remove/hunk semantics stay consistent with the rest of the
 //! deck (and with any future light variant of the theme) by construction.
 
-use ratatui::style::Style;
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::theme;
@@ -94,19 +94,53 @@ pub fn footer_line(added: u32, removed: u32, width: usize) -> Line<'static> {
 /// PR view. Lines outside any hunk (`diff --git`, `index`, `+++`/`---`
 /// headers, or a diff with no hunk header at all) simply get no number —
 /// malformed input degrades to unnumbered styled text, never a panic.
-pub fn body_lines(diff: &str) -> Vec<Line<'static>> {
+///
+/// `path` is the file the diff belongs to (the diffs on stella's event path
+/// are bare hunks with no `diff --git` header, so the caller supplies it);
+/// when it names a language we recognize, the code tokens inside each body
+/// line get syntax colors *layered under* the add/remove semantics (the
+/// `+`/`-` background is preserved). A supplied path *alone* decides the
+/// language — an unknown extension disables highlighting rather than falling
+/// back to header sniffing, because on the event path the "diff" is a
+/// headerless pseudo-diff whose own content (`--- an SQL comment`) can spoof
+/// a header. Only with no path at all is the diff's real `diff --git` /
+/// `+++` header consulted. An unknown language renders plain, byte-for-byte.
+pub fn body_lines(diff: &str, path: Option<&str>) -> Vec<Line<'static>> {
+    body_lines_capped(diff, path, usize::MAX).0
+}
+
+/// Like [`body_lines`], but styles at most `cap` lines, returning the styled
+/// prefix plus the total line count the full render would produce — so a
+/// caller that collapses long diffs (the inline transcript view) never pays
+/// tokenizing cost for lines it drops.
+pub fn body_lines_capped(
+    diff: &str,
+    path: Option<&str>,
+    cap: usize,
+) -> (Vec<Line<'static>>, usize) {
+    let lang = match path {
+        Some(p) => lang_from_path(p),
+        None => lang_from_diff_header(diff),
+    };
     let mut old_no: Option<u32> = None;
     let mut new_no: Option<u32> = None;
     let mut in_hunk = false;
+    let mut lines = Vec::new();
+    let mut total = 0usize;
     // `.lines()`, not `.split('\n')`: a diff ending in a trailing newline
     // must not render (and count against hunk state) a spurious empty row.
-    diff.lines()
-        .map(|raw| body_line(raw, &mut old_no, &mut new_no, &mut in_hunk))
-        .collect()
+    for raw in diff.lines() {
+        total += 1;
+        if lines.len() < cap {
+            lines.push(body_line(raw, lang, &mut old_no, &mut new_no, &mut in_hunk));
+        }
+    }
+    (lines, total)
 }
 
 fn body_line(
     raw: &str,
+    lang: Option<Lang>,
     old_no: &mut Option<u32>,
     new_no: &mut Option<u32>,
     in_hunk: &mut bool,
@@ -156,37 +190,104 @@ fn body_line(
         ]);
     }
     match raw.as_bytes().first() {
+        // `+`/`-`/` ` are ASCII (one byte), so `raw[1..]` splits the diff
+        // marker off the code safely for tokenizing.
         Some(b'+') => {
             let n = *new_no;
             *new_no = new_no.map(|n| n + 1);
-            Line::from(vec![
-                gutter(n),
-                Span::styled(
-                    raw.to_string(),
-                    Style::default().fg(theme::OK).bg(theme::DIFF_ADD_BG),
-                ),
-            ])
+            let mut spans = vec![gutter(n)];
+            spans.extend(code_spans(
+                "+",
+                &raw[1..],
+                theme::OK,
+                Some(theme::DIFF_ADD_BG),
+                lang,
+            ));
+            Line::from(spans)
         }
         Some(b'-') => {
             let n = *old_no;
             *old_no = old_no.map(|n| n + 1);
-            Line::from(vec![
-                gutter(n),
-                Span::styled(
-                    raw.to_string(),
-                    Style::default().fg(theme::BAD).bg(theme::DIFF_DEL_BG),
-                ),
-            ])
+            let mut spans = vec![gutter(n)];
+            spans.extend(code_spans(
+                "-",
+                &raw[1..],
+                theme::BAD,
+                Some(theme::DIFF_DEL_BG),
+                lang,
+            ));
+            Line::from(spans)
         }
         _ => {
             let n = *new_no;
             *old_no = old_no.map(|n| n + 1);
             *new_no = new_no.map(|n| n + 1);
-            Line::from(vec![
-                gutter(n),
-                Span::styled(raw.to_string(), theme::muted()),
-            ])
+            // Real unified-diff context lines carry a leading-space marker;
+            // headerless pseudo-diffs may not — keep whatever prefix exists in
+            // the (uncolored) marker span so the code column stays aligned.
+            let (marker, code) = match raw.strip_prefix(' ') {
+                Some(rest) => (" ", rest),
+                None => ("", raw),
+            };
+            let mut spans = vec![gutter(n)];
+            // Context lines stay fully muted (no syntax colors — `lang` is
+            // deliberately not passed): de-emphasis is what separates the
+            // unchanged surroundings from the change itself, and a keyword
+            // glowing brand-amber on both would erase that distinction.
+            spans.extend(code_spans(marker, code, theme::MUTED, None, None));
+            Line::from(spans)
         }
+    }
+}
+
+/// Build the styled spans for one diff body line's content: the uncolored
+/// `marker` (`+`/`-`/` `) followed by the `code`. With no known language the
+/// code is one span in `base`/`bg` — byte-identical to the plain rendering.
+/// With a language, the code is tokenized and each recognized token overrides
+/// the foreground with its syntax color while keeping the same `bg`, so the
+/// add/remove tint is never lost.
+fn code_spans(
+    marker: &str,
+    code: &str,
+    base: Color,
+    bg: Option<Color>,
+    lang: Option<Lang>,
+) -> Vec<Span<'static>> {
+    let base_style = with_bg(Style::default().fg(base), bg);
+    let Some(lang) = lang else {
+        return vec![Span::styled(format!("{marker}{code}"), base_style)];
+    };
+    let mut spans = Vec::new();
+    if !marker.is_empty() {
+        spans.push(Span::styled(marker.to_string(), base_style));
+    }
+    for (text, tok) in tokenize(code, lang) {
+        let style = match tok {
+            Some(t) => with_bg(tok_style(t), bg),
+            None => base_style,
+        };
+        spans.push(Span::styled(text, style));
+    }
+    spans
+}
+
+/// Apply an optional background to a style (identity when `bg` is `None`).
+fn with_bg(style: Style, bg: Option<Color>) -> Style {
+    match bg {
+        Some(c) => style.bg(c),
+        None => style,
+    }
+}
+
+/// The foreground style for a token class (comments also italicize).
+fn tok_style(t: Tok) -> Style {
+    match t {
+        Tok::Keyword => Style::default().fg(theme::SYNTAX_KEYWORD),
+        Tok::Str => Style::default().fg(theme::SYNTAX_STRING),
+        Tok::Number => Style::default().fg(theme::SYNTAX_NUMBER),
+        Tok::Comment => Style::default()
+            .fg(theme::SYNTAX_COMMENT)
+            .add_modifier(Modifier::ITALIC),
     }
 }
 
@@ -243,6 +344,320 @@ fn elide_left(text: &str, max: usize) -> String {
     format!("…{tail}")
 }
 
+// ── Lightweight syntax highlighting ─────────────────────────────────────────
+//
+// A compact, dependency-free lexer (no `syntect`, no tree-sitter — stella-tui
+// stays decoupled) that colors keywords, string/char literals, line comments,
+// and numbers for the languages the deck edits most. It is intentionally *not*
+// a parser: one left-to-right scan per line, no cross-line state, so a diff
+// hunk that slices a block comment or a multi-line string in half degrades to
+// slightly-off coloring, never a wrong add/remove or a panic. Unknown
+// extensions never reach here (the caller passes `None`).
+
+/// A language we can syntax-highlight.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Lang {
+    Rust,
+    /// TypeScript / JavaScript (and their `x`/module variants).
+    TsJs,
+    Python,
+}
+
+/// A token class we give a syntax color; `None` runs stay the base color.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Tok {
+    Keyword,
+    Str,
+    Number,
+    Comment,
+}
+
+/// Map a file extension to a language, or `None` if we don't highlight it.
+fn lang_from_ext(ext: &str) -> Option<Lang> {
+    match ext {
+        "rs" => Some(Lang::Rust),
+        "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "mts" | "cts" => Some(Lang::TsJs),
+        "py" | "pyi" => Some(Lang::Python),
+        _ => None,
+    }
+}
+
+/// The language for a file path via its extension (the segment after the last
+/// `.`), guarding against a dot that lives in a parent directory rather than
+/// the filename.
+fn lang_from_path(path: &str) -> Option<Lang> {
+    let (_, ext) = path.rsplit_once('.')?;
+    if ext.contains('/') {
+        return None;
+    }
+    lang_from_ext(ext)
+}
+
+/// Infer the language from a diff's own header lines (`diff --git a/f.rs …`,
+/// `+++ b/f.rs`, `--- a/f.rs`), scanning only up to the first hunk.
+fn lang_from_diff_header(diff: &str) -> Option<Lang> {
+    for line in diff.lines() {
+        if line.starts_with("@@") {
+            break; // headers only ever precede the first hunk
+        }
+        if let Some(rest) = line.strip_prefix("diff --git ")
+            && let Some(lang) = rest.split_whitespace().find_map(header_path_lang)
+        {
+            return Some(lang);
+        } else if let Some(rest) = line
+            .strip_prefix("+++ ")
+            .or_else(|| line.strip_prefix("--- "))
+            && let Some(lang) = header_path_lang(rest)
+        {
+            return Some(lang);
+        }
+    }
+    None
+}
+
+/// Language of a single diff-header path token, stripping the `a/`/`b/` prefix
+/// and any trailing `\t`-separated metadata; `/dev/null` yields `None`.
+fn header_path_lang(token: &str) -> Option<Lang> {
+    let token = token.split('\t').next().unwrap_or(token).trim();
+    if token == "/dev/null" {
+        return None;
+    }
+    let token = token
+        .strip_prefix("a/")
+        .or_else(|| token.strip_prefix("b/"))
+        .unwrap_or(token);
+    lang_from_path(token)
+}
+
+/// Split one line of source `code` into consecutive runs, each tagged with an
+/// optional token class (`None` = punctuation/whitespace/plain identifier).
+/// Lossless — concatenating the run texts reproduces `code` exactly — and
+/// panic-free.
+fn tokenize(code: &str, lang: Lang) -> Vec<(String, Option<Tok>)> {
+    let chars: Vec<char> = code.chars().collect();
+    let n = chars.len();
+    let mut runs: Vec<(String, Option<Tok>)> = Vec::new();
+    let mut plain = String::new();
+    let mut i = 0;
+
+    while i < n {
+        let c = chars[i];
+
+        // Line comment: `//` (Rust/TS/JS) or `#` (Python) runs to end of line.
+        if is_comment_start(&chars, i, lang) {
+            flush(&mut plain, &mut runs);
+            runs.push((chars[i..].iter().collect(), Some(Tok::Comment)));
+            return runs;
+        }
+
+        // String / char literal.
+        if is_string_start(&chars, i, lang) {
+            let (end, closed) = scan_string(&chars, i);
+            // An unterminated single quote is far more often a contraction in
+            // prose ("Don't" in JSX text or a docstring) than a string the
+            // hunk cut in half — leave it plain instead of swallowing the
+            // rest of the line. Double quotes and backticks keep the
+            // string-to-end-of-line reading (a cut hunk is the likely cause).
+            if closed || c != '\'' {
+                flush(&mut plain, &mut runs);
+                runs.push((chars[i..end].iter().collect(), Some(Tok::Str)));
+                i = end;
+                continue;
+            }
+            plain.push(c);
+            i += 1;
+            continue;
+        }
+
+        // Number literal (only at a run boundary — identifiers below consume
+        // their own trailing digits, so a leading digit here starts a number).
+        if c.is_ascii_digit() {
+            flush(&mut plain, &mut runs);
+            let end = scan_number(&chars, i);
+            runs.push((chars[i..end].iter().collect(), Some(Tok::Number)));
+            i = end;
+            continue;
+        }
+
+        // Identifier / keyword.
+        if is_ident_start(c) {
+            let mut j = i + 1;
+            while j < n && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            let word: String = chars[i..j].iter().collect();
+            if is_keyword(&word, lang) {
+                flush(&mut plain, &mut runs);
+                runs.push((word, Some(Tok::Keyword)));
+            } else {
+                plain.push_str(&word);
+            }
+            i = j;
+            continue;
+        }
+
+        // Anything else accumulates into the current plain run.
+        plain.push(c);
+        i += 1;
+    }
+    flush(&mut plain, &mut runs);
+    runs
+}
+
+/// Push the accumulated plain run (if any) and clear the buffer.
+fn flush(plain: &mut String, runs: &mut Vec<(String, Option<Tok>)>) {
+    if !plain.is_empty() {
+        runs.push((std::mem::take(plain), None));
+    }
+}
+
+fn is_comment_start(chars: &[char], i: usize, lang: Lang) -> bool {
+    match lang {
+        Lang::Python => chars[i] == '#',
+        Lang::Rust | Lang::TsJs => chars[i] == '/' && chars.get(i + 1) == Some(&'/'),
+    }
+}
+
+/// Whether position `i` opens a string/char literal. Double quotes (and TS/JS
+/// template backticks) always do; the single quote is ambiguous in Rust
+/// (lifetimes like `&'a T`, `derive('...')`), so there it only counts when it
+/// matches a char-literal shape — otherwise the whole line would mis-color.
+fn is_string_start(chars: &[char], i: usize, lang: Lang) -> bool {
+    match chars[i] {
+        '"' => true,
+        '`' => lang == Lang::TsJs,
+        '\'' => lang != Lang::Rust || is_rust_char_literal(chars, i),
+        _ => false,
+    }
+}
+
+/// A Rust char literal at `i`: `'x'` or an escaped `'\n'` / `'\''` / `'\\'`.
+fn is_rust_char_literal(chars: &[char], i: usize) -> bool {
+    if chars.get(i + 1) == Some(&'\\') {
+        chars.get(i + 3) == Some(&'\'')
+    } else {
+        matches!(chars.get(i + 1), Some(c) if *c != '\'') && chars.get(i + 2) == Some(&'\'')
+    }
+}
+
+/// Scan a string opened at `i`, honoring backslash escapes. Returns the end
+/// index (just past the closing quote, or end of line when unterminated) and
+/// whether the closing quote was actually found — the caller uses that to
+/// tell a real string from a lone apostrophe in prose.
+fn scan_string(chars: &[char], i: usize) -> (usize, bool) {
+    let quote = chars[i];
+    let n = chars.len();
+    let mut j = i + 1;
+    while j < n {
+        match chars[j] {
+            '\\' => j = (j + 2).min(n),
+            c if c == quote => return (j + 1, true),
+            _ => j += 1,
+        }
+    }
+    (n, false)
+}
+
+/// Scan a number opened at `i`: a run of alphanumerics/underscores (covering
+/// hex `0xFF`, suffixes `10u64`, separators `1_000`), plus one embedded
+/// decimal point followed by more digits (`1.5`), so a `1..2` range keeps its
+/// `..` intact. Returns the end index.
+fn scan_number(chars: &[char], i: usize) -> usize {
+    let n = chars.len();
+    let mut j = i;
+    while j < n && (chars[j].is_ascii_alphanumeric() || chars[j] == '_') {
+        j += 1;
+    }
+    if j < n && chars[j] == '.' && chars.get(j + 1).is_some_and(|c| c.is_ascii_digit()) {
+        j += 1;
+        while j < n && (chars[j].is_ascii_alphanumeric() || chars[j] == '_') {
+            j += 1;
+        }
+    }
+    j
+}
+
+fn is_ident_start(c: char) -> bool {
+    c.is_alphabetic() || c == '_'
+}
+
+fn is_ident_continue(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Whether `word` is a keyword in `lang`. Linear scans over small, fixed
+/// slices — cheap enough for the handful of identifiers on a diff line.
+fn is_keyword(word: &str, lang: Lang) -> bool {
+    let table: &[&str] = match lang {
+        Lang::Rust => &RUST_KEYWORDS,
+        Lang::TsJs => &TSJS_KEYWORDS,
+        Lang::Python => &PYTHON_KEYWORDS,
+    };
+    table.contains(&word)
+}
+
+const RUST_KEYWORDS: [&str; 39] = [
+    "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
+    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub",
+    "ref", "return", "self", "Self", "static", "struct", "super", "trait", "true", "type",
+    "unsafe", "use", "where", "while", "yield",
+];
+
+const TSJS_KEYWORDS: [&str; 45] = [
+    "as",
+    "async",
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "from",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "let",
+    "new",
+    "null",
+    "of",
+    "readonly",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "undefined",
+    "var",
+    "void",
+    "while",
+];
+
+const PYTHON_KEYWORDS: [&str; 35] = [
+    "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif",
+    "else", "except", "False", "finally", "for", "from", "global", "if", "import", "in", "is",
+    "lambda", "None", "nonlocal", "not", "or", "pass", "raise", "return", "True", "try", "while",
+    "with", "yield",
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,7 +695,7 @@ mod tests {
 
     #[test]
     fn body_numbers_added_lines_on_the_new_side_and_removed_on_the_old() {
-        let lines = body_lines(SAMPLE);
+        let lines = body_lines(SAMPLE, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         // "@@ -1,3 +1,4 @@" starts old=1/new=1; context takes new 1.
         assert!(texts[3].starts_with("   1  context"), "{:?}", texts[3]);
@@ -293,7 +708,7 @@ mod tests {
 
     #[test]
     fn file_headers_and_hunks_get_no_number() {
-        let lines = body_lines(SAMPLE);
+        let lines = body_lines(SAMPLE, None);
         for (i, line) in lines.iter().take(3).enumerate() {
             assert!(
                 line_text(line).starts_with("     "),
@@ -305,14 +720,14 @@ mod tests {
 
     #[test]
     fn a_diff_without_hunk_headers_degrades_to_unnumbered_lines() {
-        let lines = body_lines("+first\n-gone");
+        let lines = body_lines("+first\n-gone", None);
         assert!(line_text(&lines[0]).starts_with("     +first"));
         assert!(line_text(&lines[1]).starts_with("     -gone"));
     }
 
     #[test]
     fn malformed_hunk_header_resets_numbering_without_panic() {
-        let lines = body_lines("@@ nonsense @@\n+x");
+        let lines = body_lines("@@ nonsense @@\n+x", None);
         assert!(line_text(&lines[1]).starts_with("     +x"));
     }
 
@@ -336,7 +751,7 @@ mod tests {
     #[test]
     fn body_lines_number_hunk_text_matching_header_syntax_instead_of_hiding_it() {
         let diff = "--- a/x.rs\n+++ b/x.rs\n@@ -1,2 +1,2 @@\n--- was a rule\n+++ is a rule\n";
-        let lines = body_lines(diff);
+        let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
             !texts[3].starts_with("     "),
@@ -356,8 +771,8 @@ mod tests {
     fn body_lines_ignores_a_trailing_newline() {
         let with_trailing_newline = format!("{SAMPLE}\n");
         assert_eq!(
-            body_lines(SAMPLE).len(),
-            body_lines(&with_trailing_newline).len(),
+            body_lines(SAMPLE, None).len(),
+            body_lines(&with_trailing_newline, None).len(),
             "a trailing newline must not render a spurious extra row"
         );
     }
@@ -366,7 +781,7 @@ mod tests {
     fn no_newline_marker_gets_no_number_and_does_not_shift_later_numbering() {
         let diff =
             "--- a/x.rs\n+++ b/x.rs\n@@ -1,1 +1,1 @@\n-old\n\\ No newline at end of file\n+new\n";
-        let lines = body_lines(diff);
+        let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
             texts[4].starts_with("     "),
@@ -411,5 +826,195 @@ mod tests {
         let path = "a".repeat(70);
         let text = line_text(&header_line(&path, 80));
         assert!(!text.contains('…'), "path elided too early: {text}");
+    }
+
+    // ── Syntax highlighting ─────────────────────────────────────────────
+
+    /// Find the span whose exact content is `text`, if any.
+    fn span_with<'a>(line: &'a Line<'a>, text: &str) -> Option<&'a Span<'a>> {
+        line.spans.iter().find(|s| s.content == text)
+    }
+
+    #[test]
+    fn highlighted_added_line_keeps_add_background_and_colors_tokens() {
+        // A Rust `+` line: the add background must survive on the code (never
+        // lost) AND `fn`/`let` get the keyword color, `42` the number color —
+        // syntax layered *under* the diff semantics.
+        let diff = "@@ -1,1 +1,1 @@\n+    fn f() { let x = 42; }";
+        let line = body_lines(diff, Some("src/x.rs")).pop().unwrap();
+
+        // The add background is present somewhere on the code spans.
+        assert!(
+            line.spans
+                .iter()
+                .any(|s| s.style.bg == Some(theme::DIFF_ADD_BG)),
+            "add background preserved: {:?}",
+            line.spans
+        );
+        let kw = span_with(&line, "fn").expect("`fn` is its own span");
+        assert_eq!(kw.style.fg, Some(theme::SYNTAX_KEYWORD), "keyword colored");
+        assert_eq!(
+            kw.style.bg,
+            Some(theme::DIFF_ADD_BG),
+            "keyword still on the add background"
+        );
+        assert!(span_with(&line, "let").is_some(), "second keyword present");
+        let num = span_with(&line, "42").expect("`42` is its own span");
+        assert_eq!(num.style.fg, Some(theme::SYNTAX_NUMBER), "number colored");
+        // Lossless: the text still reads back intact, marker included.
+        assert!(line_text(&line).contains("+    fn f() { let x = 42; }"));
+    }
+
+    #[test]
+    fn highlighted_removed_line_keeps_del_background_and_colors_keywords() {
+        let diff = "@@ -1,1 +1,1 @@\n-def go():";
+        let line = body_lines(diff, Some("app.py")).pop().unwrap();
+        let kw = span_with(&line, "def").expect("`def` is its own span");
+        assert_eq!(kw.style.fg, Some(theme::SYNTAX_KEYWORD));
+        assert_eq!(
+            kw.style.bg,
+            Some(theme::DIFF_DEL_BG),
+            "keyword on the del background, so removal is never lost"
+        );
+    }
+
+    #[test]
+    fn strings_and_comments_get_their_syntax_colors() {
+        let diff = "@@ -1,1 +1,1 @@\n+let s = \"hi\"; // note";
+        let line = body_lines(diff, Some("x.ts")).pop().unwrap();
+        let s = span_with(&line, "\"hi\"").expect("string is its own span");
+        assert_eq!(s.style.fg, Some(theme::SYNTAX_STRING));
+        let c = span_with(&line, "// note").expect("comment runs to end of line");
+        assert_eq!(c.style.fg, Some(theme::SYNTAX_COMMENT));
+        assert!(c.style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn unknown_language_falls_back_to_a_single_plain_code_span() {
+        // No path and no inferable header → one code span per line, exactly
+        // like the pre-highlighting rendering (gutter + one styled span).
+        let line = body_lines("@@ -1 +1 @@\n+fn x", None).pop().unwrap();
+        assert_eq!(
+            line.spans.len(),
+            2,
+            "gutter + one plain span: {:?}",
+            line.spans
+        );
+        assert_eq!(line.spans[1].content, "+fn x");
+        assert_eq!(line.spans[1].style.fg, Some(theme::OK));
+        assert_eq!(line.spans[1].style.bg, Some(theme::DIFF_ADD_BG));
+    }
+
+    #[test]
+    fn language_is_inferred_from_the_diff_header_when_no_path_is_given() {
+        let diff = "diff --git a/m.rs b/m.rs\n@@ -1 +1 @@\n+fn q() {}";
+        let line = body_lines(diff, None).pop().unwrap();
+        assert_eq!(
+            span_with(&line, "fn").map(|s| s.style.fg),
+            Some(Some(theme::SYNTAX_KEYWORD)),
+            "header-inferred Rust highlights `fn`: {:?}",
+            line.spans
+        );
+    }
+
+    #[test]
+    fn rust_lifetimes_do_not_swallow_the_line_as_a_string() {
+        // `'a` is a lifetime, not a char literal — it must not open a string
+        // run that eats the rest of the line.
+        let diff = "@@ -1 +1 @@\n+fn f<'a>(x: &'a str) {}";
+        let line = body_lines(diff, Some("x.rs")).pop().unwrap();
+        assert!(
+            !line
+                .spans
+                .iter()
+                .any(|s| s.style.fg == Some(theme::SYNTAX_STRING)),
+            "no string span from a lifetime: {:?}",
+            line.spans
+        );
+        assert!(line_text(&line).contains("&'a str"), "text intact");
+    }
+
+    #[test]
+    fn tokenizer_is_lossless_across_languages() {
+        for (code, lang) in [
+            ("let x = \"a\\\"b\"; // c", Lang::TsJs),
+            ("fn main() { 0xFF_u8; 'z' }", Lang::Rust),
+            ("def f(): return 1.5 # x", Lang::Python),
+            ("<p>Don't have an account?</p>", Lang::TsJs),
+            ("", Lang::Rust),
+        ] {
+            let rebuilt: String = tokenize(code, lang).into_iter().map(|(t, _)| t).collect();
+            assert_eq!(rebuilt, code, "tokenizer dropped/added chars for {code:?}");
+        }
+    }
+
+    #[test]
+    fn a_contraction_apostrophe_does_not_swallow_the_line_as_a_string() {
+        // An unpaired apostrophe in JSX prose must not open a string run —
+        // the old behavior painted everything after "Don" in string sand.
+        let runs = tokenize("<p>Don't have an account?</p>", Lang::TsJs);
+        assert!(
+            runs.iter().all(|(_, tok)| *tok != Some(Tok::Str)),
+            "no string run in prose: {runs:?}"
+        );
+        // A real single-quoted string on the same language still highlights.
+        let runs = tokenize("const x = 'ok';", Lang::TsJs);
+        assert!(
+            runs.iter()
+                .any(|(t, tok)| t == "'ok'" && *tok == Some(Tok::Str)),
+            "terminated strings keep their color: {runs:?}"
+        );
+    }
+
+    #[test]
+    fn an_explicit_path_alone_decides_the_language_never_the_diff_content() {
+        // Event-path pseudo-diffs have no headers, so their *content* must
+        // never be sniffed as one: a removed SQL comment `-- see load.py`
+        // renders as `--- see load.py`, which looks exactly like a header
+        // naming a Python file. With a path supplied (unknown extension),
+        // highlighting must simply stay off.
+        let diff = "--- see scripts/load.py\n+import x";
+        let line = body_lines(diff, Some("q.sql")).pop().unwrap();
+        assert_eq!(
+            line.spans.len(),
+            2,
+            "gutter + one plain span, no Python keywords: {:?}",
+            line.spans
+        );
+    }
+
+    #[test]
+    fn context_lines_stay_fully_muted_without_syntax_colors() {
+        // De-emphasis is the whole point of a context line: even with a
+        // recognized language its keywords keep the muted foreground.
+        let diff = "@@ -1,2 +1,2 @@\n fn unchanged() {}\n+fn added() {}";
+        let lines = body_lines(diff, Some("m.rs"));
+        let context = &lines[1];
+        assert_eq!(
+            context.spans.len(),
+            2,
+            "gutter + one muted span: {:?}",
+            context.spans
+        );
+        assert_eq!(context.spans[1].style.fg, Some(theme::MUTED));
+        let added = &lines[2];
+        assert_eq!(
+            span_with(added, "fn").map(|s| s.style.fg),
+            Some(Some(theme::SYNTAX_KEYWORD)),
+            "added lines still highlight: {:?}",
+            added.spans
+        );
+    }
+
+    #[test]
+    fn capped_rendering_styles_only_the_cap_but_counts_every_line() {
+        let diff = "+one\n+two\n+three\n+four\n+five";
+        let (lines, total) = body_lines_capped(diff, Some("x.rs"), 2);
+        assert_eq!(lines.len(), 2, "styles stop at the cap");
+        assert_eq!(total, 5, "the footer math sees the full length");
+        // An uncapped call is byte-identical to `body_lines`.
+        let (all, n) = body_lines_capped(diff, Some("x.rs"), usize::MAX);
+        assert_eq!(n, 5);
+        assert_eq!(all, body_lines(diff, Some("x.rs")));
     }
 }

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -85,6 +85,11 @@ pub enum TranscriptEntry {
         call_id: String,
         name: String,
         input: String,
+        /// The workspace-relative path the call targets, parsed from its
+        /// input's `path` field (every file tool uses that key). Retained so a
+        /// mutating tool's `ToolResult` can be correlated back to the file it
+        /// touched without re-parsing the elided input summary.
+        path: Option<String>,
     },
     /// A tool invocation finished — `ok` is `false` for a typed tool error.
     ToolResult {
@@ -92,6 +97,13 @@ pub enum TranscriptEntry {
         ok: bool,
         summary: String,
         duration_ms: u64,
+        /// For a *successful* file-mutating tool
+        /// (`write_file`/`edit_file`/`delete_file`), the reference the
+        /// renderer uses to show this call's diff inline. `None` for reads,
+        /// non-file tools, and failed calls — which gates the inline diff to
+        /// mutations that actually happened. The diff itself is never stored
+        /// here (L-T5: one event-borne diff path).
+        diff: Option<InlineDiffRef>,
     },
     /// A model call was retried (surfaced only once the step commits — the
     /// engine defers these, L-E10).
@@ -170,6 +182,21 @@ pub enum TranscriptEntry {
     Complete { model: String, cost_usd: f64 },
 }
 
+/// A mutating tool result's handle on the diff it may render inline: the
+/// path into [`SessionModel::files`] plus the value of that file's `changes`
+/// counter when the result folded. The renderer shows the inline diff only
+/// while the counter still matches — a later mutation of the same path bumps
+/// it, so a historical entry can never display a diff its call didn't
+/// produce. Only the *reference* lives here; the diff bytes stay on the
+/// single event-borne path (L-T5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineDiffRef {
+    /// The key into [`SessionModel::files`].
+    pub path: String,
+    /// [`FileState::changes`] at fold time — stale (hidden) once it differs.
+    pub seq: u32,
+}
+
 /// The state of one file in the files-touched panel. `latest_diff` is
 /// literally the diff carried by the most recent `FileChange` for this path
 /// — the single event-borne data path (L-T5).
@@ -224,6 +251,7 @@ impl SessionModel {
                     call_id: call.call_id.clone(),
                     name: call.name.clone(),
                     input: summarize(&compact_json(&call.input)),
+                    path: tool_input_path(&call.input),
                 });
             }
             AgentEvent::ToolResult {
@@ -235,11 +263,31 @@ impl SessionModel {
                     ToolOutput::Ok { content } => (true, summarize(content)),
                     ToolOutput::Error { message } => (false, summarize(message)),
                 };
+                // Only a *successful* mutation gets an inline-diff reference —
+                // a failed call produced no `FileChange`, and rendering the
+                // path's previous diff under its ✗ would attribute a change
+                // the call never made. The engine's `FileChangeTap` emits the
+                // `FileChange` during the tool's execution, so by the time
+                // this result folds, `files[path].changes` already counts this
+                // call's own change — that value is the freshness tag.
+                let diff = if ok {
+                    self.mutated_path_for(call_id).map(|path| {
+                        let seq = self
+                            .files
+                            .iter()
+                            .find(|f| f.path == path)
+                            .map_or(0, |f| f.changes);
+                        InlineDiffRef { path, seq }
+                    })
+                } else {
+                    None
+                };
                 self.transcript.push(TranscriptEntry::ToolResult {
                     call_id: call_id.clone(),
                     ok,
                     summary,
                     duration_ms: *duration_ms,
+                    diff,
                 });
                 // The answer to an `ask_user` question comes back as this very
                 // tool result (correlated by id) — there is no separate answer
@@ -436,6 +484,28 @@ impl SessionModel {
         }
     }
 
+    /// If tool call `call_id` was a file mutation, the path it touched —
+    /// recovered by correlating back to its `ToolStart` (which is already on
+    /// the transcript by the time the result folds). `None` for reads and
+    /// non-file tools, which is what gates the transcript's inline diff to
+    /// mutations. The diff itself is *not* looked up here — the renderer reads
+    /// it from [`SessionModel::files`] at draw time (L-T5).
+    fn mutated_path_for(&self, call_id: &str) -> Option<String> {
+        self.transcript
+            .iter()
+            .rev()
+            .find_map(|entry| match entry {
+                TranscriptEntry::ToolStart {
+                    call_id: cid,
+                    name,
+                    path,
+                    ..
+                } if cid == call_id => Some((name.clone(), path.clone())),
+                _ => None,
+            })
+            .and_then(|(name, path)| is_file_mutation(&name).then_some(path).flatten())
+    }
+
     /// Record a file touch, retaining the latest diff for the path (L-T5).
     fn touch_file(&mut self, path: &str, kind: FileChangeKind, diff: &Option<String>) {
         if let Some(existing) = self.files.iter_mut().find(|f| f.path == path) {
@@ -458,6 +528,25 @@ impl SessionModel {
 /// the model never panics on a tool card.
 fn compact_json(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_default()
+}
+
+/// The workspace-relative path a file tool targets. Every built-in file tool
+/// (`read_file`/`write_file`/`edit_file`/`delete_file`) takes its path under
+/// the `path` key, and the engine emits `FileChange` for that same path — so
+/// this is the join key between a tool result and its diff.
+fn tool_input_path(input: &serde_json::Value) -> Option<String> {
+    input
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// Whether a tool name is one of the file-*mutating* built-ins — the only
+/// tools whose result should carry an inline diff (reads must not). Must
+/// stay in lockstep with `file_change_of` in stella-cli's `command_deck.rs`,
+/// the `FileChange` emitter that owns this list.
+fn is_file_mutation(name: &str) -> bool {
+    matches!(name, "write_file" | "edit_file" | "delete_file")
 }
 
 /// Truncate a summary to [`SUMMARY_BUDGET`] chars with a middle-out elision —

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -101,7 +101,9 @@ pub fn render(model: &SessionModel, ui: &mut UiState, frame: &mut Frame) {
     let (diff_total, diff_inner_h) = if ui.diff_open {
         let file = model.files.get(ui.selected_file);
         let diff_text = file.and_then(|f| f.latest_diff.as_deref());
-        let d_lines = diff_text.map(diff::body_lines).unwrap_or_default();
+        let d_lines = diff_text
+            .map(|d| diff::body_lines(d, file.map(|f| f.path.as_str())))
+            .unwrap_or_default();
         let (added, removed) = diff_text.map(diff::count_diff_lines).unwrap_or((0, 0));
         let d_total = d_lines.len();
         let d_inner_h = inner_height(right_area);
@@ -552,14 +554,18 @@ fn render_composer(line: &str, focused: bool, area: Rect, buf: &mut Buffer) {
 pub(crate) fn transcript_lines(model: &SessionModel, expand_thinking: bool) -> Vec<Line<'static>> {
     let mut out = Vec::new();
     for entry in &model.transcript {
-        entry_lines(entry, expand_thinking, &mut out);
+        entry_lines(entry, expand_thinking, &model.files, &mut out);
     }
     out
 }
 
+/// Render one transcript entry into styled lines. `files` is the session's
+/// files-touched state, read only to inline a mutating tool result's diff
+/// (sourced from `files[].latest_diff`, the single event-borne path — L-T5).
 pub(crate) fn entry_lines(
     entry: &TranscriptEntry,
     expand_thinking: bool,
+    files: &[FileState],
     out: &mut Vec<Line<'static>>,
 ) {
     match entry {
@@ -596,6 +602,7 @@ pub(crate) fn entry_lines(
             ok,
             summary,
             duration_ms,
+            diff,
             ..
         } => {
             let (glyph, color) = if *ok {
@@ -608,6 +615,19 @@ pub(crate) fn entry_lines(
                 Span::raw(summary.clone()),
                 Span::styled(format!("  ({duration_ms}ms)"), Style::new().fg(Color::DarkGray)),
             ]));
+            // A file-mutating tool shows its diff inline, Crush-style, sourced
+            // from the same `files[].latest_diff` the Files tab reads (L-T5)
+            // and collapsed so a huge diff can't flood the scrollback. The
+            // `seq` check keeps history honest: once a later call mutates the
+            // same path, `changes` moves past this entry's tag and the stale
+            // entry shows nothing rather than someone else's diff.
+            if let Some(dref) = diff
+                && let Some(file) = files.iter().find(|f| f.path == dref.path)
+                && file.changes == dref.seq
+                && let Some(diff) = file.latest_diff.as_deref()
+            {
+                push_inline_diff(&dref.path, diff, out);
+            }
         }
         TranscriptEntry::Retry { attempt, reason } => out.push(Line::from(Span::styled(
             format!("↻ retry #{attempt}: {reason}"),
@@ -729,6 +749,35 @@ pub(crate) fn entry_lines(
             format!("✓ complete · {model} · ${cost_usd:.4}"),
             Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
         ))),
+    }
+}
+
+/// The most diff lines shown inline under a tool result before collapsing;
+/// the full diff always remains in the Files tab.
+const INLINE_DIFF_CAP: usize = 12;
+
+/// Append a mutating tool's diff inline under its result line: the same PR-styled,
+/// syntax-highlighted body the Files tab renders (`crate::diff`), capped to
+/// [`INLINE_DIFF_CAP`] lines with a "… (+N more lines)" footer when it runs
+/// longer. The cap is applied *before* styling (`body_lines_capped`), so a
+/// transcript full of large diffs never pays per-frame tokenizing cost for
+/// lines it drops.
+fn push_inline_diff(path: &str, diff: &str, out: &mut Vec<Line<'static>>) {
+    let (lines, total) = diff::body_lines_capped(diff, Some(path), INLINE_DIFF_CAP);
+    if total == 0 {
+        return;
+    }
+    let shown = lines.len();
+    out.extend(lines);
+    if total > shown {
+        let more = total - shown;
+        // Indent past the 5-wide gutter so the footer sits under the diff body.
+        out.push(Line::from(Span::styled(
+            format!("     … (+{more} more lines, open Files tab for full diff)"),
+            Style::new()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )));
     }
 }
 
@@ -1173,6 +1222,197 @@ mod tests {
         assert!(joined.contains("read_file"));
         assert!(joined.contains("not found"));
         assert!(joined.contains("12ms"));
+    }
+
+    #[test]
+    fn edit_tool_result_inlines_a_collapsed_diff_but_a_read_does_not() {
+        let mut model = SessionModel::new();
+        // An edit tool touches a file whose FileChange carries a long diff.
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "edit1".into(),
+                name: "edit_file".into(),
+                input: serde_json::json!({"path": "src/x.rs"}),
+            },
+        });
+        let mut big = String::from("@@ -1,20 +1,20 @@\n");
+        for i in 0..20 {
+            big.push_str(&format!("+let v{i} = {i};\n"));
+        }
+        model.apply(&AgentEvent::FileChange {
+            path: "src/x.rs".into(),
+            kind: FileChangeKind::Modified,
+            diff: Some(big),
+        });
+        model.apply(&AgentEvent::ToolResult {
+            call_id: "edit1".into(),
+            output: ToolOutput::Ok {
+                content: "ok".into(),
+            },
+            duration_ms: 3,
+        });
+        // A *read* of the very same (diff-carrying) file must inline nothing —
+        // the gate is the tool kind, not whether a diff exists.
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "read1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "src/x.rs"}),
+            },
+        });
+        model.apply(&AgentEvent::ToolResult {
+            call_id: "read1".into(),
+            output: ToolOutput::Ok {
+                content: "contents".into(),
+            },
+            duration_ms: 1,
+        });
+
+        let lines = transcript_lines(&model, false);
+        let all: String = lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // The edit's diff body is inlined...
+        assert!(
+            all.contains("let v0 = 0;"),
+            "inline diff body present:\n{all}"
+        );
+        // ...collapsed, with exactly one "more lines" footer (only the edit,
+        // never the read).
+        assert_eq!(
+            all.matches("more lines, open Files tab").count(),
+            1,
+            "exactly one collapsed inline diff — the edit, not the read:\n{all}"
+        );
+        // And the cap holds: no more than INLINE_DIFF_CAP diff-body lines.
+        let inlined = lines
+            .iter()
+            .filter(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+                    .contains("let v")
+            })
+            .count();
+        assert!(
+            (1..=INLINE_DIFF_CAP).contains(&inlined),
+            "inlined={inlined}"
+        );
+    }
+
+    /// When the same file is mutated twice, the earlier result's inline diff
+    /// must disappear (its freshness tag is stale) rather than retroactively
+    /// display the later edit's diff — scrollback never attributes a change
+    /// to a call that didn't make it.
+    #[test]
+    fn a_later_edit_hides_the_earlier_results_inline_diff() {
+        let mut model = SessionModel::new();
+        for (call, body) in [("edit1", "+let first = 1;"), ("edit2", "+let second = 2;")] {
+            model.apply(&AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: call.into(),
+                    name: "edit_file".into(),
+                    input: serde_json::json!({"path": "src/x.rs"}),
+                },
+            });
+            model.apply(&AgentEvent::FileChange {
+                path: "src/x.rs".into(),
+                kind: FileChangeKind::Modified,
+                diff: Some(format!("@@ -1,1 +1,1 @@\n{body}")),
+            });
+            model.apply(&AgentEvent::ToolResult {
+                call_id: call.into(),
+                output: ToolOutput::Ok {
+                    content: "ok".into(),
+                },
+                duration_ms: 1,
+            });
+        }
+
+        let all: String = transcript_lines(&model, false)
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            all.contains("let second = 2;"),
+            "the latest edit inlines its diff:\n{all}"
+        );
+        assert!(
+            !all.contains("let first = 1;"),
+            "the stale entry shows nothing, not the newer diff:\n{all}"
+        );
+    }
+
+    /// A FAILED mutating call made no change (no `FileChange` fired), so its
+    /// ✗ entry must not inline the path's previous successful diff.
+    #[test]
+    fn a_failed_mutation_inlines_no_diff() {
+        let mut model = SessionModel::new();
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "w1".into(),
+                name: "write_file".into(),
+                input: serde_json::json!({"path": "src/y.rs"}),
+            },
+        });
+        model.apply(&AgentEvent::FileChange {
+            path: "src/y.rs".into(),
+            kind: FileChangeKind::Created,
+            diff: Some("@@ -0,0 +1,1 @@\n+let y = 0;".into()),
+        });
+        model.apply(&AgentEvent::ToolResult {
+            call_id: "w1".into(),
+            output: ToolOutput::Ok {
+                content: "ok".into(),
+            },
+            duration_ms: 1,
+        });
+        // A second mutation of the same path fails: no FileChange.
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "e1".into(),
+                name: "edit_file".into(),
+                input: serde_json::json!({"path": "src/y.rs"}),
+            },
+        });
+        model.apply(&AgentEvent::ToolResult {
+            call_id: "e1".into(),
+            output: ToolOutput::Error {
+                message: "old_string not found".into(),
+            },
+            duration_ms: 1,
+        });
+
+        let all: String = transcript_lines(&model, false)
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            all.matches("let y = 0;").count(),
+            1,
+            "the diff appears only under the ✓ that produced it, never the ✗:\n{all}"
+        );
     }
 
     // ---- Replay determinism (L-T1) ------------------------------------

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -43,6 +43,28 @@ pub const DIFF_ADD_BG: Color = Color::Rgb(20, 44, 26);
 /// Subtle background tint behind removed diff lines (pair with [`BAD`]).
 pub const DIFF_DEL_BG: Color = Color::Rgb(52, 24, 26);
 
+// ── Syntax highlighting (diff bodies) ───────────────────────────────────────
+//
+// A four-color code palette layered *under* the add/remove diff semantics:
+// the `+`/`-` background always wins (add/remove is never lost — see
+// `crate::diff`), while a recognized token overrides only the foreground.
+// Every color is chosen to read on all three diff backdrops (add green, del
+// red, and the plain panel) and to stay inside the amber/ember brand family —
+// never pink/purple. Keyword rides the brand amber so code structure pops the
+// way the accent does everywhere else; strings take a softer warm sand so they
+// separate from keywords without a second saturated hue; numbers take a
+// lighter cousin of the cool [`RUN`] cyan used across the deck (brightened to
+// read on the diff backdrops); comments dim toward [`MUTED`].
+
+/// Language keyword (`fn`/`let`/`def`/`import`/`return`…).
+pub const SYNTAX_KEYWORD: Color = AMBER;
+/// String / char literal.
+pub const SYNTAX_STRING: Color = Color::Rgb(214, 184, 120);
+/// Numeric literal.
+pub const SYNTAX_NUMBER: Color = Color::Rgb(126, 197, 214);
+/// Line comment (rendered dimmed + italic).
+pub const SYNTAX_COMMENT: Color = Color::Rgb(118, 124, 134);
+
 // ── Activity spinner ────────────────────────────────────────────────────────
 
 /// Burnt-sunset ember ramp, dark → bright, for the working-spinner gradient —

--- a/stella-tui/src/views/files.rs
+++ b/stella-tui/src/views/files.rs
@@ -288,7 +288,7 @@ fn render_diff_pane(
         .unwrap_or((0, 0));
     match diff_text {
         Some(text) if !text.is_empty() => {
-            let lines = diff::body_lines(&text);
+            let lines = diff::body_lines(&text, record.map(|r| r.path.as_str()));
             let total = lines.len();
             ui.metrics.files_diff_total = total;
             ui.metrics.files_diff_height = inner_h;

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -61,7 +61,7 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
     // the line-exact scrolling transcript renderer.
     let mut lines: Vec<Line<'static>> = Vec::new();
     for entry in &sm.transcript {
-        entry_lines(entry, ui.thinking_expanded, &mut lines);
+        entry_lines(entry, ui.thinking_expanded, &sm.files, &mut lines);
     }
     let height = inner_height(bands[4]);
     ui.metrics.session_total = lines.len();


### PR DESCRIPTION
## What & why

Crush shows a pretty, syntax-highlighted diff inline in the conversation; stella's diffs were plain and lived only in the Files tab. This PR closes both gaps, scoped entirely to `stella-tui/`:

1. **Syntax highlighting** — a compact, dependency-free lexer (Rust, TS/JS, Python; no `syntect`, no tree-sitter) colors keywords, strings, numbers, and line comments, layered *under* the diff semantics: the `+`/`-` add/del background always wins, only token foregrounds change. Context lines stay fully muted so the changed lines keep their contrast. Colors live in `theme.rs` inside the amber/ember family. Unknown language → byte-identical plain rendering.
2. **Inline transcript diffs** — a successful `write_file`/`edit_file`/`delete_file` result inlines its diff (capped at 12 lines with a `… (+N more lines)` footer) in both the single-session transcript and the deck Session tab, PR-styled and highlighted via the same `diff::body_lines` the Files tab uses.

Correctness properties (each with a witness test):
- **History stays honest**: the entry carries only `(path, seq)` — the file's change counter at fold time. Once a later call mutates the same path, the stale entry shows nothing rather than someone else's diff. The diff bytes stay on the single event-borne path (L-T5).
- **Failed calls inline nothing**: the diff reference is gated on `ok`, so a ✗ never displays the previous success's change.
- **Bounded render cost**: `body_lines_capped` stops styling at the cap while counting the total, so long diffs cost per-frame tokenizing only for the visible lines.
- **A supplied path alone decides the language**: headerless pseudo-diff content (e.g. a removed SQL `--` comment rendering as `--- see load.py`) can never spoof a header into wrong highlighting.
- **Contractions aren't strings**: an unpaired apostrophe in TS/JS/Python prose (`Don't` in JSX) renders plain instead of swallowing the line.

## The witness

- [x] Witness tests (fail on `main`, pass here) in `diff.rs` (highlighting, losslessness, header-spoof guard, contraction, context muting, cap math) and `render.rs` (`edit_tool_result_inlines_a_collapsed_diff_but_a_read_does_not`, `a_later_edit_hides_the_earlier_results_inline_diff`, `a_failed_mutation_inlines_no_diff`). All buffer/span-based, never raw ANSI (L-T6); the L-T1 replay-determinism proptest still passes.

## The gate

- [x] `cargo fmt --check` (all files touched here; pre-existing drift in untouched files matches `main`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1219 passed, 0 failed
- [x] Behavior documented in doc comments
- [x] Commits signed off for DCO

## Ground-rule check

- [x] `stella-core` untouched; **no new deps** (the lexer is hand-rolled specifically to avoid one)
- [x] No new outbound network calls
- [x] No new cross-boundary types — `InlineDiffRef` is TUI-internal derived state; `AgentEvent` is unchanged

## Anything reviewers should know?

- The lexer is deliberately not a parser: one left-to-right scan per line, no cross-line state — a hunk slicing a block comment degrades to slightly-off coloring, never a panic or wrong add/remove.
- `is_file_mutation` in `model.rs` must stay in lockstep with `file_change_of` in `command_deck.rs` (now cross-referenced in the doc comment); a shared const was considered but the emitter needs per-name behavior anyway.
- The diff was written by a subagent, then adversarially reviewed by a 22-agent workflow review; all confirmed findings (stale-diff misattribution, failed-call diff, per-frame cost, header spoof, contractions, context contrast) are addressed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds syntax-highlighted diffs and inlines them in the session transcript for successful file mutations, improving readability without adding dependencies. A tiny, dependency-free lexer highlights Rust, TS/JS, and Python; inline diffs are capped for performance.

- **New Features**
  - Syntax highlighting layered under add/remove colors; supports Rust, TS/JS, Python. Unknown extensions render plain; context lines stay muted.
  - Language is chosen by the provided file path; when no path is given, real diff headers are used. Pseudo-diff content cannot spoof headers.
  - Inline transcript diffs for `write_file`/`edit_file`/`delete_file` when the call succeeds; shared renderer with the Files tab. Capped at 12 lines with a “(+N more)” footer; styling stops at the cap to avoid per-frame cost.

- **Bug Fixes**
  - History stays correct: each inline diff is gated by a freshness tag (the file’s change counter at fold time). Later edits hide older entries’ diffs; reads and failed calls inline nothing.
  - An unpaired apostrophe in TS/JS/Python prose no longer swallows the line as a string.

<sup>Written for commit 63573204e3540c44342e8de37f9a55216810e9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
