### PR TITLE
Transcript UX: markdown transcripts, aligned tool rows, collapse/select/expand, O(tail) rendering

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -1248,9 +1248,7 @@ pub(crate) fn graph_snapshot(
     }
     let graph = stella_graph::CodeGraph::open(workspace_root, &db_path).ok()?;
     let focus = graph.busiest_file().ok()??;
-    let hood = graph
-        .file_neighborhood(std::path::Path::new(&focus))
-        .ok()?;
+    let hood = graph.file_neighborhood(std::path::Path::new(&focus)).ok()?;
     graph.shutdown();
 
     let mut nodes = vec![GraphNode {

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -422,10 +422,12 @@ async fn run_deck_command(
     };
     match trimmed {
         "/help" => {
-            say("commands: /help · /clear (reset conversation) · /models (list providers) · \
+            say(
+                "commands: /help · /clear (reset conversation) · /models (list providers) · \
                  /init (index the workspace: domains + code graph) · /files · /diff · /graph \
                  (switch tabs) — anything else is a prompt. ctrl+t queue · ? overlay help"
-                .to_string());
+                    .to_string(),
+            );
         }
         "/clear" => {
             messages.clear();

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -20,8 +20,8 @@ use ocp_types::{ContextFrame, ContextQuery, Provenance};
 
 use crate::error::ContextError;
 use crate::store::{
-    ContextStore, NodeRow, domains_for_node, live_nodes, neighbors, node_ids_for_uris,
-    node_ids_excluded_by_scope, vectors_for_fingerprint,
+    ContextStore, NodeRow, domains_for_node, live_nodes, neighbors, node_ids_excluded_by_scope,
+    node_ids_for_uris, vectors_for_fingerprint,
 };
 
 /// Provenance `kind` marking a frame's domain tag, so a citation view can show

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -699,7 +699,10 @@ mod tests {
         );
 
         let report = f.run_plan(&plan).await.unwrap();
-        assert!(!report.all_succeeded(), "a failed → the run did not succeed");
+        assert!(
+            !report.all_succeeded(),
+            "a failed → the run did not succeed"
+        );
         assert!(
             !report.completed.contains("a"),
             "a failed, so it is not in the succeeded set"

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -1836,14 +1836,20 @@ mod tests {
         let unchanged: HashMap<String, String> =
             std::iter::once(("src/huge.rs".to_string(), "v2".to_string())).collect();
         let (lines2, _) = pipeline.gather_diff(&unchanged).await;
-        assert_eq!(lines2, 0, "a pre-existing untracked file is not this turn's change");
+        assert_eq!(
+            lines2, 0,
+            "a pre-existing untracked file is not this turn's change"
+        );
 
         // Present before but at a DIFFERENT fingerprint → the turn edited an
         // already-untracked file; it must be visible (the P1 regression).
         let modified: HashMap<String, String> =
             std::iter::once(("src/huge.rs".to_string(), "v1".to_string())).collect();
         let (lines3, text3) = pipeline.gather_diff(&modified).await;
-        assert_eq!(lines3, 5000, "an edit to an already-untracked file is counted");
+        assert_eq!(
+            lines3, 5000,
+            "an edit to an already-untracked file is counted"
+        );
         assert!(text3.contains("src/huge.rs"));
     }
 

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -325,7 +325,7 @@ fn cpu_bar(pct: f64) -> String {
 /// A centered help overlay listing the deck's keys.
 fn render_help(area: Rect, buf: &mut Buffer) {
     let w = area.width.min(62);
-    let h = area.height.min(20);
+    let h = area.height.min(21);
     let popup = Rect {
         x: area.x + (area.width.saturating_sub(w)) / 2,
         y: area.y + (area.height.saturating_sub(h)) / 2,
@@ -351,7 +351,7 @@ fn render_help(area: Rect, buf: &mut Buffer) {
             theme::body(),
         )),
         Line::from(Span::styled(
-            "  Ctrl-T / ↑   queue editor · ctrl+x delete · ctrl+d ×2 clear",
+            "  Ctrl-T / ↑   queue editor (↑ when prompts are queued)",
             theme::body(),
         )),
         Line::from(Span::styled(
@@ -359,7 +359,11 @@ fn render_help(area: Rect, buf: &mut Buffer) {
             theme::body(),
         )),
         Line::from(Span::styled(
-            "  Ctrl-O       expand/collapse message · twice from the prompt = all thinking",
+            "  Ctrl-O       expand/collapse the selected message",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
+            "               (at the prompt: newest · ×2 = all thinking)",
             theme::body(),
         )),
         Line::from(Span::styled(

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -355,6 +355,14 @@ fn render_help(area: Rect, buf: &mut Buffer) {
             theme::body(),
         )),
         Line::from(Span::styled(
+            "  ↑ ↓          select a message (Session) · Esc clears",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
+            "  Ctrl-O       expand/collapse message · twice from the prompt = all thinking",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
             "  Ctrl-R       expand/collapse thinking",
             theme::body(),
         )),

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -82,6 +82,22 @@ pub struct DeckUi {
     /// Armed by the first `ctrl+d` in the queue editor; the second one clears
     /// the whole queue. Any other key disarms.
     pub queue_confirm_clear: bool,
+    /// The transcript entry highlighted with ↑/↓ on the Session tab —
+    /// `ctrl+o` toggles its expanded view. `None` = nothing selected.
+    pub session_selected: Option<usize>,
+    /// Set by a selection move; the session view consumes it (where visual
+    /// row ranges are known) to scroll the selected entry into view.
+    pub session_pending_scroll: Option<usize>,
+    /// Per-agent set of entry indices expanded with `ctrl+o`.
+    pub expanded: std::collections::HashMap<String, std::collections::HashSet<usize>>,
+    /// Bumped on every expansion toggle so the fold cache invalidates.
+    pub expanded_rev: u64,
+    /// Armed by a `ctrl+o` pressed from the prompt (no selection); a second
+    /// consecutive `ctrl+o` escalates to the all-thinking toggle. Any other
+    /// key disarms.
+    pub ctrl_o_primed: bool,
+    /// The Session tab's incremental transcript fold cache.
+    pub session_fold: crate::views::session::SessionFold,
 }
 
 impl Default for DeckUi {
@@ -108,6 +124,12 @@ impl Default for DeckUi {
             queue_open: false,
             queue_sel: 0,
             queue_confirm_clear: false,
+            session_selected: None,
+            session_pending_scroll: None,
+            expanded: std::collections::HashMap::new(),
+            expanded_rev: 0,
+            ctrl_o_primed: false,
+            session_fold: crate::views::session::SessionFold::default(),
         }
     }
 }
@@ -184,6 +206,12 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         return DeckAction::Ignored;
     }
 
+    let is_ctrl_o =
+        key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('o'));
+    if !is_ctrl_o {
+        ui.ctrl_o_primed = false;
+    }
+
     // Ctrl-C: clean cancel + quit, from anywhere.
     if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
         return DeckAction::Quit;
@@ -204,6 +232,31 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     // Ctrl-R toggles the collapsed-thinking view from anywhere.
     if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('r')) {
         ui.thinking_expanded = !ui.thinking_expanded;
+        return DeckAction::Handled;
+    }
+
+    // Ctrl-O: the expand/collapse verb. On a ↑/↓-highlighted message it
+    // toggles that message; from the prompt it toggles the most recent
+    // expandable message, and a second consecutive press escalates to the
+    // all-thinking toggle (chain-of-thought everywhere).
+    if is_ctrl_o {
+        if let Some(sel) = ui.session_selected {
+            if let Some(agent) = model.agents.get(ui.focused) {
+                let id = agent.meta.id.clone();
+                toggle_expanded(ui, &id, sel);
+            }
+        } else if ui.ctrl_o_primed {
+            ui.ctrl_o_primed = false;
+            ui.thinking_expanded = !ui.thinking_expanded;
+        } else {
+            if let Some(agent) = model.agents.get(ui.focused)
+                && let Some(idx) = last_expandable(&agent.model.transcript)
+            {
+                let id = agent.meta.id.clone();
+                toggle_expanded(ui, &id, idx);
+            }
+            ui.ctrl_o_primed = true;
+        }
         return DeckAction::Handled;
     }
 
@@ -282,7 +335,7 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         DeckTab::Traces => handle_traces_key(key, model, ui, composer_empty),
         DeckTab::Graph => handle_graph_key(key, ui, composer_empty),
         DeckTab::Files => handle_files_key(key, model, ui),
-        DeckTab::Session => handle_session_key(key, ui),
+        DeckTab::Session => handle_session_key(key, model, ui),
     }
     .unwrap_or_else(|| handle_composer_key(key, ui))
 }
@@ -581,9 +634,70 @@ fn handle_files_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> O
     }
 }
 
-fn handle_session_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
+/// Flip entry `idx`'s expanded state for `agent`, invalidating the fold cache.
+fn toggle_expanded(ui: &mut DeckUi, agent: &str, idx: usize) {
+    let set = ui.expanded.entry(agent.to_string()).or_default();
+    if !set.remove(&idx) {
+        set.insert(idx);
+    }
+    ui.expanded_rev += 1;
+}
+
+/// The most recent transcript entry `ctrl+o` can meaningfully expand: a tool
+/// call (full args), a tool result (full output), or a collapsed thought.
+fn last_expandable(transcript: &[crate::model::TranscriptEntry]) -> Option<usize> {
+    use crate::model::TranscriptEntry as E;
+    transcript.iter().rposition(|e| {
+        matches!(
+            e,
+            E::ToolStart { .. } | E::ToolResult { .. } | E::Reasoning(_)
+        )
+    })
+}
+
+fn handle_session_key(
+    key: KeyEvent,
+    model: &WorkspaceModel,
+    ui: &mut DeckUi,
+) -> Option<DeckAction> {
     let (total, height) = (ui.metrics.session_total, ui.metrics.session_height);
+    let entries = model
+        .agents
+        .get(ui.focused)
+        .map(|a| a.model.transcript.len())
+        .unwrap_or(0);
     match key.code {
+        // ↑/↓ walk a message highlight through the transcript (the scroll
+        // window follows the highlight); ↓ past the last message drops the
+        // highlight and re-arms tail-follow. PgUp/PgDn stay pure scroll.
+        KeyCode::Up if entries > 0 => {
+            let sel = match ui.session_selected {
+                None => entries - 1,
+                Some(0) => 0,
+                Some(i) => i - 1,
+            };
+            ui.session_selected = Some(sel);
+            ui.session_pending_scroll = Some(sel);
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Down if entries > 0 => {
+            match ui.session_selected {
+                Some(i) if i + 1 < entries => {
+                    ui.session_selected = Some(i + 1);
+                    ui.session_pending_scroll = Some(i + 1);
+                }
+                Some(_) => {
+                    ui.session_selected = None;
+                    ui.session_scroll.follow = true;
+                }
+                None => ui.session_scroll.scroll_down(1, total, height),
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Esc if ui.session_selected.is_some() => {
+            ui.session_selected = None;
+            Some(DeckAction::Handled)
+        }
         KeyCode::Up => {
             ui.session_scroll.scroll_up(1, total, height);
             Some(DeckAction::Handled)
@@ -683,6 +797,101 @@ mod tests {
         }
         m
     }
+
+    /// Push one tool call + multi-line result onto `agent`'s transcript.
+    fn with_tool_exchange(m: &mut WorkspaceModel, agent: &str) {
+        use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+        m.apply_inbound(&Inbound::Event {
+            agent: agent.into(),
+            event: AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: "c1".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({ "path": "src/main.rs" }),
+                },
+            },
+        });
+        m.apply_inbound(&Inbound::Event {
+            agent: agent.into(),
+            event: AgentEvent::ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::Ok {
+                    content: "line one\nline two\nline three".into(),
+                },
+                duration_ms: 7,
+            },
+        });
+    }
+
+    #[test]
+    fn up_selects_the_last_message_and_ctrl_o_toggles_it() {
+        let mut model = model_with(&["lead"]);
+        with_tool_exchange(&mut model, "lead");
+        let mut ui = ready_ui();
+
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        assert_eq!(
+            ui.session_selected,
+            Some(1),
+            "up highlights the newest message"
+        );
+
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        assert!(
+            ui.expanded.get("lead").is_some_and(|set| set.contains(&1)),
+            "ctrl+o expands the highlighted message"
+        );
+        let rev = ui.expanded_rev;
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        assert!(
+            ui.expanded.get("lead").is_none_or(|set| !set.contains(&1)),
+            "a second ctrl+o collapses it again"
+        );
+        assert!(
+            ui.expanded_rev > rev,
+            "each toggle invalidates the fold cache"
+        );
+    }
+
+    #[test]
+    fn double_ctrl_o_from_the_prompt_toggles_all_thinking() {
+        let mut model = model_with(&["lead"]);
+        with_tool_exchange(&mut model, "lead");
+        let mut ui = ready_ui();
+        assert!(!ui.thinking_expanded);
+
+        // First press (no selection): toggles the most recent expandable
+        // message and arms the escalation…
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        assert!(ui.ctrl_o_primed);
+        assert!(!ui.thinking_expanded);
+        // …second consecutive press: the all-thinking toggle.
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        assert!(
+            ui.thinking_expanded,
+            "ctrl+o twice = chain-of-thought everywhere"
+        );
+
+        // Any other key disarms the escalation.
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        assert!(
+            !ui.ctrl_o_primed,
+            "a non-ctrl+o key disarms the double-press"
+        );
+    }
+
+    #[test]
+    fn down_past_the_last_message_clears_selection_and_rearms_follow() {
+        let mut model = model_with(&["lead"]);
+        with_tool_exchange(&mut model, "lead");
+        let mut ui = ready_ui();
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        assert_eq!(ui.session_selected, None, "down past the tail deselects");
+        assert!(ui.session_scroll.follow, "…and re-arms tail-follow");
+    }
+
     fn ready_ui() -> DeckUi {
         let mut ui = DeckUi::default();
         ui.splash.skip(); // past the splash for interaction tests
@@ -1065,7 +1274,11 @@ mod tests {
             }],
             edges: vec![],
         };
-        ingest_inbound(&Inbound::GraphSnapshot(snapshot.clone()), &mut model, &mut ui);
+        ingest_inbound(
+            &Inbound::GraphSnapshot(snapshot.clone()),
+            &mut model,
+            &mut ui,
+        );
         assert_eq!(ui.graph.as_ref(), Some(&snapshot));
     }
 }

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -151,6 +151,21 @@ impl DeckUi {
             self.tab_switched_at = Some(std::time::Instant::now());
         }
     }
+
+    /// Point the deck at agent `idx`. A session-message selection indexes the
+    /// *previously* focused agent's transcript, so it must not carry across;
+    /// dropping it also re-arms tail-follow (the selection is what pinned the
+    /// scroll window). Same-agent is a no-op.
+    pub fn focus_agent(&mut self, idx: usize) {
+        if idx == self.focused {
+            return;
+        }
+        self.focused = idx;
+        if self.session_selected.take().is_some() {
+            self.session_pending_scroll = None;
+            self.session_scroll.follow = true;
+        }
+    }
 }
 
 /// The outcome of handling one deck key.
@@ -182,9 +197,9 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
 /// Clamp selections to the current agent/file/queue counts.
 fn clamp(model: &WorkspaceModel, ui: &mut DeckUi) {
     if model.agents.is_empty() {
-        ui.focused = 0;
+        ui.focus_agent(0);
     } else {
-        ui.focused = ui.focused.min(model.agents.len() - 1);
+        ui.focus_agent(ui.focused.min(model.agents.len() - 1));
     }
     let files = model.ledger.records.len();
     ui.files_sel = if files == 0 {
@@ -241,7 +256,11 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     // all-thinking toggle (chain-of-thought everywhere).
     if is_ctrl_o {
         if let Some(sel) = ui.session_selected {
-            if let Some(agent) = model.agents.get(ui.focused) {
+            // Only a genuinely expandable entry toggles — a no-op press must
+            // not bump `expanded_rev` and invalidate the settled fold cache.
+            if let Some(agent) = model.agents.get(ui.focused)
+                && agent.model.transcript.get(sel).is_some_and(is_expandable)
+            {
                 let id = agent.meta.id.clone();
                 toggle_expanded(ui, &id, sel);
             }
@@ -511,12 +530,12 @@ fn handle_agents_key(
     let count = model.agents.len();
     match key.code {
         KeyCode::Up => {
-            ui.focused = ui.focused.saturating_sub(1);
+            ui.focus_agent(ui.focused.saturating_sub(1));
             Some(DeckAction::Handled)
         }
         KeyCode::Down => {
             if count > 0 {
-                ui.focused = (ui.focused + 1).min(count - 1);
+                ui.focus_agent((ui.focused + 1).min(count - 1));
             }
             Some(DeckAction::Handled)
         }
@@ -643,16 +662,20 @@ fn toggle_expanded(ui: &mut DeckUi, agent: &str, idx: usize) {
     ui.expanded_rev += 1;
 }
 
-/// The most recent transcript entry `ctrl+o` can meaningfully expand: a tool
-/// call (full args), a tool result (full output), or a collapsed thought.
-fn last_expandable(transcript: &[crate::model::TranscriptEntry]) -> Option<usize> {
+/// Whether `ctrl+o` can meaningfully expand this entry — exactly the variants
+/// whose [`crate::render::entry_lines`] rendering honors the expanded flag: a
+/// tool call (full args), a tool result (full output), or a collapsed thought.
+fn is_expandable(entry: &crate::model::TranscriptEntry) -> bool {
     use crate::model::TranscriptEntry as E;
-    transcript.iter().rposition(|e| {
-        matches!(
-            e,
-            E::ToolStart { .. } | E::ToolResult { .. } | E::Reasoning(_)
-        )
-    })
+    matches!(
+        entry,
+        E::ToolStart { .. } | E::ToolResult { .. } | E::Reasoning(_)
+    )
+}
+
+/// The most recent transcript entry `ctrl+o` can meaningfully expand.
+fn last_expandable(transcript: &[crate::model::TranscriptEntry]) -> Option<usize> {
+    transcript.iter().rposition(is_expandable)
 }
 
 fn handle_session_key(
@@ -890,6 +913,53 @@ mod tests {
         handle_deck_key(key(KeyCode::Down), &model, &mut ui);
         assert_eq!(ui.session_selected, None, "down past the tail deselects");
         assert!(ui.session_scroll.follow, "…and re-arms tail-follow");
+    }
+
+    #[test]
+    fn ctrl_o_on_a_non_expandable_selection_is_a_no_op() {
+        let mut model = model_with(&["lead"]);
+        // A plain text message — `entry_lines` ignores the expanded flag for
+        // it, so ctrl+o has nothing to toggle.
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Text {
+                delta: "hello".into(),
+            },
+        });
+        let mut ui = ready_ui();
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        assert_eq!(ui.session_selected, Some(0));
+
+        let rev = ui.expanded_rev;
+        handle_deck_key(ctrl('o'), &model, &mut ui);
+        assert!(
+            ui.expanded.get("lead").is_none_or(|set| set.is_empty()),
+            "nothing marked expanded"
+        );
+        assert_eq!(
+            ui.expanded_rev, rev,
+            "a no-op press must not invalidate the settled fold cache"
+        );
+    }
+
+    #[test]
+    fn switching_focus_drops_the_session_selection() {
+        let mut model = model_with(&["lead", "sub"]);
+        with_tool_exchange(&mut model, "lead");
+        let mut ui = ready_ui();
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        assert!(ui.session_selected.is_some());
+
+        // Focus another agent from the Agents tab: the selection indexes the
+        // *previous* agent's transcript and must not carry across.
+        ui.tab = DeckTab::Agents;
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        assert_eq!(ui.focused, 1);
+        assert_eq!(
+            ui.session_selected, None,
+            "selection cleared on focus change"
+        );
+        assert!(ui.session_scroll.follow, "…and tail-follow re-arms");
     }
 
     fn ready_ui() -> DeckUi {

--- a/stella-tui/src/markdown.rs
+++ b/stella-tui/src/markdown.rs
@@ -7,7 +7,7 @@
 //! each line. The output is a vector of styled [`Line`]s that the transcript
 //! renderer and word-wrapper consume unchanged.
 
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::theme;
@@ -29,10 +29,7 @@ pub fn render(text: &str) -> Vec<Line<'static>> {
         }
 
         if in_code_block {
-            out.push(Line::from(Span::styled(
-                format!("  {raw}"),
-                code_style(),
-            )));
+            out.push(Line::from(Span::styled(format!("  {raw}"), code_style())));
             continue;
         }
 
@@ -54,8 +51,7 @@ pub fn render(text: &str) -> Vec<Line<'static>> {
 
         // ── Blockquote (> ...) ─────────────────────────────────────────────
         if let Some(rest) = raw.strip_prefix("> ") {
-            let mut spans =
-                vec![Span::styled("▎ ", Style::new().fg(theme::MUTED))];
+            let mut spans = vec![Span::styled("▎ ", Style::new().fg(theme::MUTED))];
             spans.extend(parse_inline_spans(rest));
             out.push(Line::from(spans));
             continue;
@@ -64,7 +60,8 @@ pub fn render(text: &str) -> Vec<Line<'static>> {
         // ── Bullet list (- / * / +) ────────────────────────────────────────
         let lead = raw.trim_start();
         let indent = raw.len() - lead.len();
-        if let Some(rest) = lead.strip_prefix("- ")
+        if let Some(rest) = lead
+            .strip_prefix("- ")
             .or_else(|| lead.strip_prefix("* "))
             .or_else(|| lead.strip_prefix("+ "))
         {
@@ -118,10 +115,7 @@ fn parse_inline_spans(text: &str) -> Vec<Span<'static>> {
 
     while i < chars.len() {
         // **bold** or __bold__
-        if (chars[i] == '*' || chars[i] == '_')
-            && i + 1 < chars.len()
-            && chars[i + 1] == chars[i]
-        {
+        if (chars[i] == '*' || chars[i] == '_') && i + 1 < chars.len() && chars[i + 1] == chars[i] {
             let delim: String = std::iter::repeat_n(chars[i], 2).collect();
             let Some(end) = find_str(&chars, i + 2, &delim) else {
                 buf.push(chars[i]);
@@ -173,10 +167,7 @@ fn parse_inline_spans(text: &str) -> Vec<Span<'static>> {
         }
 
         // ~~strike~~
-        if chars[i] == '~'
-            && i + 1 < chars.len()
-            && chars[i + 1] == '~'
-        {
+        if chars[i] == '~' && i + 1 < chars.len() && chars[i + 1] == '~' {
             let Some(end) = find_str(&chars, i + 2, "~~") else {
                 buf.push(chars[i]);
                 i += 1;
@@ -209,7 +200,7 @@ fn parse_inline_spans(text: &str) -> Vec<Span<'static>> {
                     format!("{link_text} ({url})")
                 },
                 Style::new()
-                    .fg(Color::Blue)
+                    .fg(theme::RUN)
                     .add_modifier(Modifier::UNDERLINED),
             ));
             i = paren + 1;
@@ -260,15 +251,17 @@ fn strip_numbered(lead: &str) -> Option<&str> {
     if digits_end == 0 || digits_end >= lead.len() {
         return None;
     }
-    lead.get(digits_end..)?.strip_prefix(". ").or_else(|| lead.get(digits_end..)?.strip_prefix(") "))
+    lead.get(digits_end..)?
+        .strip_prefix(". ")
+        .or_else(|| lead.get(digits_end..)?.strip_prefix(") "))
 }
 
 /// Build a heading line with level-appropriate styling.
 fn heading_line(content: &str, level: usize) -> Line<'static> {
     let prefix = match level {
-        1 => "",
-        2 => "",
-        _ => "",
+        1 => "◆ ",
+        2 => "◈ ",
+        _ => "· ",
     };
     let style = match level {
         1 | 2 => theme::heading(),
@@ -282,7 +275,7 @@ fn heading_line(content: &str, level: usize) -> Line<'static> {
 
 /// Style for inline code spans and fenced code blocks.
 fn code_style() -> Style {
-    Style::new().fg(Color::Yellow)
+    Style::new().fg(theme::WARN)
 }
 
 // ── Search helpers ─────────────────────────────────────────────────────────
@@ -304,7 +297,10 @@ fn find_str(chars: &[char], start: usize, needle: &str) -> Option<usize> {
 
 /// Find the index of `target` in `chars[start..]`, or `None`.
 fn find_char(chars: &[char], start: usize, target: char) -> Option<usize> {
-    chars[start..].iter().position(|&c| c == target).map(|p| start + p)
+    chars[start..]
+        .iter()
+        .position(|&c| c == target)
+        .map(|p| start + p)
 }
 
 /// Find a single delimiter (e.g. `*`) while skipping doubled pairs (`**`).
@@ -370,7 +366,7 @@ mod tests {
         // Three spans: "inline ", code, " here"
         let code_span = &lines[0].spans[1];
         assert_eq!(code_span.content, "code");
-        assert_eq!(code_span.style.fg, Some(Color::Yellow));
+        assert_eq!(code_span.style.fg, Some(theme::WARN));
     }
 
     #[test]
@@ -384,9 +380,9 @@ mod tests {
                 "heading is bold"
             );
         }
-        assert_eq!(collect_spans_text(&lines[0]), "Title");
-        assert_eq!(collect_spans_text(&lines[1]), "Subtitle");
-        assert_eq!(collect_spans_text(&lines[2]), "Section");
+        assert_eq!(collect_spans_text(&lines[0]), "\u{25c6} Title");
+        assert_eq!(collect_spans_text(&lines[1]), "\u{25c8} Subtitle");
+        assert_eq!(collect_spans_text(&lines[2]), "\u{b7} Section");
     }
 
     #[test]
@@ -411,7 +407,10 @@ mod tests {
         let lines = render("```\nfn main() {}\n```");
         assert_eq!(lines.len(), 1);
         let text = collect_spans_text(&lines[0]);
-        assert!(text.contains("fn main"), "code block content visible: {text}");
+        assert!(
+            text.contains("fn main"),
+            "code block content visible: {text}"
+        );
     }
 
     #[test]

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -264,7 +264,7 @@ impl SessionModel {
                     call_id: call.call_id.clone(),
                     name: call.name.clone(),
                     input: format_tool_input(&call.name, &call.input),
-                    raw: cap_middle(&compact_json(&call.input), INPUT_BUDGET),
+                    raw: cap_input_json(&call.input, INPUT_BUDGET),
                     path: tool_input_path(&call.input),
                 });
             }
@@ -582,16 +582,78 @@ pub(crate) const OUTPUT_BUDGET: usize = 16_384;
 /// Middle-out char cap preserving head and tail (first error + final summary
 /// both matter), on char boundaries.
 fn cap_middle(text: &str, budget: usize) -> String {
-    let chars: Vec<char> = text.chars().collect();
-    if chars.len() <= budget {
+    cap_middle_with(text, budget, "\n[… truncated …]\n")
+}
+
+/// [`cap_middle`] with a caller-chosen elision marker. Slices at
+/// `char_indices` boundaries instead of materializing a `Vec<char>`, so a
+/// multi-megabyte payload costs no allocation beyond the capped result.
+fn cap_middle_with(text: &str, budget: usize, marker: &str) -> String {
+    // Byte length bounds char count, so an in-budget payload returns without
+    // scanning; an over-budget one probes just past the boundary instead.
+    if text.len() <= budget || text.char_indices().nth(budget).is_none() {
         return text.to_string();
     }
-    let keep = budget.saturating_sub(16);
+    let keep = budget.saturating_sub(marker.chars().count());
     let head = keep / 2;
     let tail = keep - head;
-    let head_str: String = chars[..head].iter().collect();
-    let tail_str: String = chars[chars.len() - tail..].iter().collect();
-    format!("{head_str}\n[… truncated …]\n{tail_str}")
+    let head_end = text.char_indices().nth(head).map_or(text.len(), |(i, _)| i);
+    let tail_start = if tail == 0 {
+        text.len()
+    } else {
+        text.char_indices().nth_back(tail - 1).map_or(0, |(i, _)| i)
+    };
+    format!("{}{marker}{}", &text[..head_end], &text[tail_start..])
+}
+
+/// Per-leaf caps for [`cap_input_json`]: generous enough to keep any one
+/// argument readable, small enough that leaf capping alone usually lands the
+/// whole object under [`INPUT_BUDGET`].
+const INPUT_STR_CAP: usize = 512;
+const INPUT_ARR_CAP: usize = 32;
+
+/// Cap a tool call's retained arguments **inside** the JSON: long string
+/// leaves are middle-capped and oversized arrays elided, so the compact form
+/// stays *valid* JSON and ctrl+o can still pretty-print it. Only a
+/// pathological object that remains oversized after leaf capping falls back
+/// to the raw char cap (which the renderer shows as wrapped plain text).
+fn cap_input_json(value: &serde_json::Value, budget: usize) -> String {
+    let compact = compact_json(value);
+    if compact.len() <= budget {
+        return compact;
+    }
+    let mut capped = value.clone();
+    cap_json_leaves(&mut capped);
+    cap_middle(&compact_json(&capped), budget)
+}
+
+/// Recursively shrink the leaves of `value` in place (strings middle-capped
+/// on one line, arrays truncated with a `+N more` marker) without disturbing
+/// the object structure.
+fn cap_json_leaves(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => {
+            if s.len() > INPUT_STR_CAP {
+                *s = cap_middle_with(s, INPUT_STR_CAP, " […] ");
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if items.len() > INPUT_ARR_CAP {
+                let dropped = items.len() - INPUT_ARR_CAP;
+                items.truncate(INPUT_ARR_CAP);
+                items.push(serde_json::Value::String(format!("[… +{dropped} more …]")));
+            }
+            for item in items.iter_mut() {
+                cap_json_leaves(item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values_mut() {
+                cap_json_leaves(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Format a tool-call input as a human-readable one-liner. Instead of raw
@@ -902,6 +964,48 @@ mod tests {
             }
             other => panic!("expected a tool result entry, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn oversized_tool_args_stay_valid_pretty_printable_json() {
+        let mut model = SessionModel::new();
+        let big = "x".repeat(INPUT_BUDGET * 2);
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "c1".into(),
+                name: "write_file".into(),
+                input: serde_json::json!({ "path": "a.rs", "content": big }),
+            },
+        });
+        match model.transcript.last() {
+            Some(TranscriptEntry::ToolStart { raw, .. }) => {
+                assert!(
+                    raw.chars().count() <= INPUT_BUDGET,
+                    "retained args stay within budget ({} chars)",
+                    raw.chars().count()
+                );
+                // The cap lands *inside* the JSON, so the expanded (ctrl+o)
+                // view can still pretty-print the arguments.
+                let v: serde_json::Value =
+                    serde_json::from_str(raw).expect("capped raw stays valid JSON");
+                assert_eq!(v.get("path").and_then(|p| p.as_str()), Some("a.rs"));
+                let content = v.get("content").and_then(|c| c.as_str()).unwrap();
+                assert!(content.contains("[…]"), "long leaf carries the marker");
+            }
+            other => panic!("expected a tool start entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_middle_respects_char_boundaries_on_multibyte_text() {
+        let text = "é".repeat(100);
+        let capped = cap_middle(&text, 50);
+        assert!(capped.chars().count() <= 50);
+        assert!(capped.contains("truncated"), "marker present: {capped}");
+        assert!(
+            capped.starts_with('é') && capped.ends_with('é'),
+            "head and tail preserved without splitting a char: {capped}"
+        );
     }
 
     #[test]

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -89,6 +89,9 @@ pub enum TranscriptEntry {
         call_id: String,
         name: String,
         input: String,
+        /// The call's compact-JSON arguments, capped — the expanded (ctrl+o)
+        /// view pretty-prints these; `input` stays the humanized one-liner.
+        raw: String,
         /// The workspace-relative path the call targets, parsed from its
         /// input's `path` field (every file tool uses that key). Retained so a
         /// mutating tool's `ToolResult` can be correlated back to the file it
@@ -98,8 +101,14 @@ pub enum TranscriptEntry {
     /// A tool invocation finished — `ok` is `false` for a typed tool error.
     ToolResult {
         call_id: String,
+        /// Resolved from the matching `ToolStart` at fold time so call and
+        /// result rows read as one aligned pair.
+        name: String,
         ok: bool,
         summary: String,
+        /// The output, capped at [`OUTPUT_BUDGET`] chars — the collapsed row
+        /// shows one line; ctrl+o reveals this.
+        full: String,
         duration_ms: u64,
         /// For a *successful* file-mutating tool
         /// (`write_file`/`edit_file`/`delete_file`), the reference the
@@ -255,6 +264,7 @@ impl SessionModel {
                     call_id: call.call_id.clone(),
                     name: call.name.clone(),
                     input: format_tool_input(&call.name, &call.input),
+                    raw: cap_middle(&compact_json(&call.input), INPUT_BUDGET),
                     path: tool_input_path(&call.input),
                 });
             }
@@ -263,10 +273,29 @@ impl SessionModel {
                 output,
                 duration_ms,
             } => {
-                let (ok, summary) = match output {
-                    ToolOutput::Ok { content } => (true, summarize(content)),
-                    ToolOutput::Error { message } => (false, summarize(message)),
+                let (ok, summary, full) = match output {
+                    ToolOutput::Ok { content } => {
+                        (true, summarize(content), cap_middle(content, OUTPUT_BUDGET))
+                    }
+                    ToolOutput::Error { message } => (
+                        false,
+                        summarize(message),
+                        cap_middle(message, OUTPUT_BUDGET),
+                    ),
                 };
+                // Resolve the tool's name from its start entry (results only
+                // carry the call id on the wire).
+                let name = self
+                    .transcript
+                    .iter()
+                    .rev()
+                    .find_map(|e| match e {
+                        TranscriptEntry::ToolStart {
+                            call_id: cid, name, ..
+                        } if cid == call_id => Some(name.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "tool".to_string());
                 // Only a *successful* mutation gets an inline-diff reference —
                 // a failed call produced no `FileChange`, and rendering the
                 // path's previous diff under its ✗ would attribute a change
@@ -288,8 +317,10 @@ impl SessionModel {
                 };
                 self.transcript.push(TranscriptEntry::ToolResult {
                     call_id: call_id.clone(),
+                    name,
                     ok,
                     summary,
+                    full,
                     duration_ms: *duration_ms,
                     diff,
                 });
@@ -542,13 +573,37 @@ fn compact_json(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_default()
 }
 
+/// Char budget for a tool call's retained compact-JSON arguments.
+pub(crate) const INPUT_BUDGET: usize = 4_096;
+/// Char budget for a tool result's retained output (outputs are already
+/// capped upstream by the tools; this bounds transcript memory).
+pub(crate) const OUTPUT_BUDGET: usize = 16_384;
+
+/// Middle-out char cap preserving head and tail (first error + final summary
+/// both matter), on char boundaries.
+fn cap_middle(text: &str, budget: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= budget {
+        return text.to_string();
+    }
+    let keep = budget.saturating_sub(16);
+    let head = keep / 2;
+    let tail = keep - head;
+    let head_str: String = chars[..head].iter().collect();
+    let tail_str: String = chars[chars.len() - tail..].iter().collect();
+    format!("{head_str}\n[… truncated …]\n{tail_str}")
+}
+
 /// Format a tool-call input as a human-readable one-liner. Instead of raw
 /// JSON, this extracts the most relevant field(s) per tool name so the
 /// transcript reads naturally — `path` for file tools, `cmd` for shell, the
 /// query for search tools, and so on.
 fn format_tool_input(name: &str, input: &serde_json::Value) -> String {
     let str_field = |key: &str| -> Option<String> {
-        input.get(key).and_then(|v| v.as_str()).map(|s| s.to_string())
+        input
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
     };
 
     // Primary field per tool — the one the user cares about at a glance.
@@ -574,7 +629,8 @@ fn format_tool_input(name: &str, input: &serde_json::Value) -> String {
         return truncate_field(&cmd, 120);
     }
 
-    if let Some(query) = str_field("query").or_else(|| str_field("pattern"))
+    if let Some(query) = str_field("query")
+        .or_else(|| str_field("pattern"))
         .or_else(|| str_field("symbol"))
     {
         return truncate_field(&query, 80);

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -389,11 +389,24 @@ pub(crate) fn render_transcript(
     area: Rect,
     buf: &mut Buffer,
 ) {
-    let total = lines.len();
     let visible: Vec<Line<'static>> = lines
         .get(window.clone())
         .map(<[Line]>::to_vec)
         .unwrap_or_default();
+    render_transcript_window(visible, window, lines.len(), following, area, buf);
+}
+
+/// [`render_transcript`] for a caller that already materialized just the
+/// visible window (the deck's fold cache clones ≤ one viewport of lines per
+/// frame instead of the whole history); `total` sizes the title.
+pub(crate) fn render_transcript_window(
+    visible: Vec<Line<'static>>,
+    window: Range<usize>,
+    total: usize,
+    following: bool,
+    area: Rect,
+    buf: &mut Buffer,
+) {
     let title = if following {
         format!(" transcript · {total} lines · following ")
     } else {
@@ -685,9 +698,7 @@ fn wrap_one_indent(
     let mut current: Vec<(char, Style)> = Vec::new();
     let mut current_w = 0usize;
 
-    let flush = |cur: &mut Vec<(char, Style)>,
-                 first: bool,
-                 out: &mut Vec<Line<'static>>| {
+    let flush = |cur: &mut Vec<(char, Style)>, first: bool, out: &mut Vec<Line<'static>>| {
         if !cur.is_empty() {
             let pairs = std::mem::take(cur);
             if first {
@@ -751,7 +762,7 @@ pub(crate) fn transcript_lines(
 ) -> Vec<Line<'static>> {
     let mut out = Vec::new();
     for entry in &model.transcript {
-        entry_lines(entry, expand_thinking, width, &mut out);
+        entry_lines(entry, expand_thinking, expand_thinking, width, &mut out);
     }
     out
 }
@@ -759,6 +770,7 @@ pub(crate) fn transcript_lines(
 pub(crate) fn entry_lines(
     entry: &TranscriptEntry,
     expand_thinking: bool,
+    expanded: bool,
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
@@ -801,7 +813,8 @@ pub(crate) fn entry_lines(
         }
         TranscriptEntry::Reasoning(text) => {
             let total_lines = text.lines().count().max(1);
-            let chevron = if expand_thinking { "⏶" } else { "⏵" };
+            let show_all = expand_thinking || expanded;
+            let chevron = if show_all { "⏶" } else { "⏵" };
             out.push(Line::from(vec![
                 Span::styled(format!("{chevron} "), Style::new().fg(theme::AMBER)),
                 Span::styled(
@@ -812,7 +825,7 @@ pub(crate) fn entry_lines(
             let reasoning_style = Style::new()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::ITALIC);
-            if expand_thinking {
+            if show_all {
                 for l in text.split('\n') {
                     out.push(Line::from(Span::styled(
                         format!("  {l}"),
@@ -836,13 +849,15 @@ pub(crate) fn entry_lines(
                 }
                 if total_lines > preview_count {
                     out.push(Line::from(Span::styled(
-                        "  ⋯ ctrl+r to expand",
+                        "  ⋯ ctrl+o expands this thought · ctrl+r all",
                         Style::new().fg(Color::DarkGray),
                     )));
                 }
             }
         }
-        TranscriptEntry::ToolStart { name, input, .. } => {
+        TranscriptEntry::ToolStart {
+            name, input, raw, ..
+        } => {
             let line = Line::from(vec![
                 Span::styled(
                     label_tag(name),
@@ -851,10 +866,23 @@ pub(crate) fn entry_lines(
                 Span::styled(input.clone(), Style::new().fg(Color::DarkGray)),
             ]);
             wrap_one_indent(line, width, LABEL_COL, out);
+            if expanded {
+                // ctrl+o: the full argument object, pretty-printed and dim.
+                let pretty = serde_json::from_str::<serde_json::Value>(raw)
+                    .and_then(|v| serde_json::to_string_pretty(&v))
+                    .unwrap_or_else(|_| raw.clone());
+                for l in pretty.lines() {
+                    out.push(Line::from(Span::styled(
+                        format!("    {l}"),
+                        Style::new().fg(theme::MUTED),
+                    )));
+                }
+            }
         }
         TranscriptEntry::ToolResult {
             ok,
             summary,
+            full,
             duration_ms,
             ..
         } => {
@@ -863,18 +891,49 @@ pub(crate) fn entry_lines(
             } else {
                 ("✗", Color::Red)
             };
-            let line = Line::from(vec![
-                Span::styled(
-                    label_tag(glyph),
-                    Style::new().fg(color).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(summary.clone()),
-                Span::styled(
-                    format!("  ({duration_ms}ms)"),
-                    Style::new().fg(Color::DarkGray),
-                ),
-            ]);
-            wrap_one_indent(line, width, LABEL_COL, out);
+            let extra = full.lines().count().saturating_sub(1);
+            if expanded {
+                let line = Line::from(vec![
+                    Span::styled(
+                        label_tag(glyph),
+                        Style::new().fg(color).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("({} lines · {duration_ms}ms)", extra + 1),
+                        Style::new().fg(Color::DarkGray),
+                    ),
+                ]);
+                wrap_one_indent(line, width, LABEL_COL, out);
+                for l in full.lines() {
+                    out.push(Line::from(Span::styled(
+                        format!("    {l}"),
+                        Style::new().fg(theme::MUTED),
+                    )));
+                }
+            } else {
+                // Collapsed: exactly one output line; the hint names how many
+                // more ctrl+o would reveal. Multi-line output NEVER floods the
+                // transcript uninvited.
+                let first = full
+                    .lines()
+                    .find(|l| !l.trim().is_empty())
+                    .unwrap_or(summary.as_str());
+                let shown: String = first.chars().take(160).collect();
+                let hint = if extra > 0 {
+                    format!("  (+{extra} lines · {duration_ms}ms)")
+                } else {
+                    format!("  ({duration_ms}ms)")
+                };
+                let line = Line::from(vec![
+                    Span::styled(
+                        label_tag(glyph),
+                        Style::new().fg(color).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(shown),
+                    Span::styled(hint, Style::new().fg(Color::DarkGray)),
+                ]);
+                wrap_one_indent(line, width, LABEL_COL, out);
+            }
         }
         TranscriptEntry::Retry { attempt, reason } => out.push(Line::from(Span::styled(
             format!("↻ retry #{attempt}: {reason}"),

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -189,72 +189,6 @@ pub(crate) fn inner_width(area: Rect) -> usize {
 // Word-aware line wrapping (pre-wrap so scroll math stays line-exact, L-T4)
 // ---------------------------------------------------------------------------
 
-/// Pre-wrap styled lines to fit `max_width` display columns. Lines that
-/// already fit pass through unchanged; lines that overflow are split at word
-/// boundaries (preferring spaces, hard-breaking long words) into multiple
-/// `Line`s, each preserving the original span styles.
-///
-/// This runs *before* the scroll window calculation so the line-exact scroll
-/// math operates on visual (wrapped) rows — the rendered text never overflows
-/// horizontally and the scroll offset stays accurate.
-pub(crate) fn wrap_lines(lines: Vec<Line<'static>>, max_width: usize) -> Vec<Line<'static>> {
-    if max_width == 0 {
-        return lines;
-    }
-    let mut out = Vec::with_capacity(lines.len());
-    for line in lines {
-        if line.width() <= max_width {
-            out.push(line);
-        } else {
-            wrap_one(line, max_width, &mut out);
-        }
-    }
-    out
-}
-
-/// Wrap a single overflowing line into multiple lines of at most `max_width`.
-fn wrap_one(line: Line<'static>, max_width: usize, out: &mut Vec<Line<'static>>) {
-    // Flatten the line's spans into (char, style) pairs so we can measure and
-    // split at arbitrary positions while preserving styling.
-    let styled: Vec<(char, Style)> = line
-        .spans
-        .iter()
-        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
-        .collect();
-
-    let mut current: Vec<(char, Style)> = Vec::new();
-    let mut current_w = 0usize;
-
-    let flush = |cur: &mut Vec<(char, Style)>, out: &mut Vec<Line<'static>>| {
-        if !cur.is_empty() {
-            out.push(Line::from(styled_chars_to_spans(std::mem::take(cur))));
-        }
-    };
-
-    for (ch, style) in styled {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if current_w + cw > max_width && !current.is_empty() {
-            // Prefer breaking at the last space so words stay intact.
-            if let Some(space_idx) = current.iter().rposition(|(c, _)| *c == ' ') {
-                let remainder: Vec<(char, Style)> = current.split_off(space_idx);
-                // `current` now holds everything before the space.
-                flush(&mut current, out);
-                current = remainder;
-                current_w = current
-                    .iter()
-                    .map(|(c, _)| UnicodeWidthChar::width(*c).unwrap_or(0))
-                    .sum();
-            } else {
-                flush(&mut current, out);
-                current_w = 0;
-            }
-        }
-        current.push((ch, style));
-        current_w += cw;
-    }
-    flush(&mut current, out);
-}
-
 /// Coalesce adjacent same-styled characters into spans for compact output.
 fn styled_chars_to_spans(chars: Vec<(char, Style)>) -> Vec<Span<'static>> {
     if chars.is_empty() {
@@ -868,18 +802,26 @@ pub(crate) fn entry_lines(
             wrap_one_indent(line, width, LABEL_COL, out);
             if expanded {
                 // ctrl+o: the full argument object, pretty-printed and dim.
+                // An over-budget argument may not parse (char-capped raw) —
+                // show it wrapped rather than clipped at the pane edge.
                 let pretty = serde_json::from_str::<serde_json::Value>(raw)
                     .and_then(|v| serde_json::to_string_pretty(&v))
                     .unwrap_or_else(|_| raw.clone());
                 for l in pretty.lines() {
-                    out.push(Line::from(Span::styled(
-                        format!("    {l}"),
-                        Style::new().fg(theme::MUTED),
-                    )));
+                    wrap_one_indent(
+                        Line::from(Span::styled(
+                            format!("    {l}"),
+                            Style::new().fg(theme::MUTED),
+                        )),
+                        width,
+                        4,
+                        out,
+                    );
                 }
             }
         }
         TranscriptEntry::ToolResult {
+            name,
             ok,
             summary,
             full,
@@ -891,13 +833,13 @@ pub(crate) fn entry_lines(
             } else {
                 ("✗", Color::Red)
             };
+            // The result labels itself with the tool it answers (resolved
+            // from the start entry) so call/result rows read as a pair.
+            let label = label_tag(&format!("{glyph} {name}"));
             let extra = full.lines().count().saturating_sub(1);
             if expanded {
                 let line = Line::from(vec![
-                    Span::styled(
-                        label_tag(glyph),
-                        Style::new().fg(color).add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled(label, Style::new().fg(color).add_modifier(Modifier::BOLD)),
                     Span::styled(
                         format!("({} lines · {duration_ms}ms)", extra + 1),
                         Style::new().fg(Color::DarkGray),
@@ -905,10 +847,15 @@ pub(crate) fn entry_lines(
                 ]);
                 wrap_one_indent(line, width, LABEL_COL, out);
                 for l in full.lines() {
-                    out.push(Line::from(Span::styled(
-                        format!("    {l}"),
-                        Style::new().fg(theme::MUTED),
-                    )));
+                    wrap_one_indent(
+                        Line::from(Span::styled(
+                            format!("    {l}"),
+                            Style::new().fg(theme::MUTED),
+                        )),
+                        width,
+                        4,
+                        out,
+                    );
                 }
             } else {
                 // Collapsed: exactly one output line; the hint names how many
@@ -925,10 +872,7 @@ pub(crate) fn entry_lines(
                     format!("  ({duration_ms}ms)")
                 };
                 let line = Line::from(vec![
-                    Span::styled(
-                        label_tag(glyph),
-                        Style::new().fg(color).add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled(label, Style::new().fg(color).add_modifier(Modifier::BOLD)),
                     Span::raw(shown),
                     Span::styled(hint, Style::new().fg(Color::DarkGray)),
                 ]);
@@ -1488,6 +1432,12 @@ mod tests {
         assert!(joined.contains("read_file"));
         assert!(joined.contains("not found"));
         assert!(joined.contains("12ms"));
+        // The result row resolves its tool name from the call so the two
+        // rows read as an aligned pair.
+        assert!(
+            joined.contains("[✗ read_file]"),
+            "result labels itself with its tool: {joined}"
+        );
     }
 
     // ---- Replay determinism (L-T1) ------------------------------------

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -22,6 +22,10 @@ pub const MUTED: Color = Color::Rgb(140, 146, 156);
 /// Panel border / rule.
 pub const RULE: Color = Color::Rgb(58, 62, 70);
 
+/// Background tint for the transcript entry selected with the arrow keys —
+/// a barely-there warm lift so the highlight reads without shouting.
+pub const SELECT_BG: Color = Color::Rgb(46, 42, 32);
+
 // ── Semantic ────────────────────────────────────────────────────────────────
 
 /// Success / positive / added lines.

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -172,17 +172,21 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
     let total = ui.session_fold.total();
 
     // A selection move from the key handler lands here, where visual-row
-    // ranges are known: nudge the scroll window until the entry is visible.
+    // ranges are known: nudge the scroll window until the entry is visible,
+    // then pin it. Follow drops even when no nudge was needed — a streaming
+    // tail must not slide the highlight out of view (↓ past the tail, or
+    // scrolling back to the bottom, re-arms follow).
     if let Some(sel) = ui.session_pending_scroll.take() {
         let rows = ui.session_fold.rows_of(sel);
         let current = ui.session_scroll.window(total, height);
-        if rows.start < current.start {
-            ui.session_scroll.top = rows.start;
-            ui.session_scroll.follow = false;
+        ui.session_scroll.top = if rows.start < current.start {
+            rows.start
         } else if rows.end > current.end {
-            ui.session_scroll.top = rows.end.saturating_sub(height);
-            ui.session_scroll.follow = false;
-        }
+            rows.end.saturating_sub(height)
+        } else {
+            current.start
+        };
+        ui.session_scroll.follow = false;
     }
 
     ui.metrics.session_total = total;
@@ -308,6 +312,48 @@ mod tests {
         assert!(
             text.contains("Which database should the cache use?"),
             "ask-user card visible alongside the scope review:\n{text}"
+        );
+    }
+
+    #[test]
+    fn applying_a_selection_pins_the_window_against_a_streaming_tail() {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Text {
+                delta: "first-message".into(),
+            },
+        });
+
+        // Select the (already fully visible) first entry.
+        let mut ui = DeckUi {
+            session_selected: Some(0),
+            session_pending_scroll: Some(0),
+            ..DeckUi::default()
+        };
+        let area = Rect::new(0, 0, 60, 12);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf);
+        assert!(
+            !ui.session_scroll.follow,
+            "a selection pins the window even when no scroll nudge was needed"
+        );
+
+        // A streaming tail grows past the viewport — the pinned window must
+        // keep the selected entry visible instead of following the tail.
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Text {
+                delta: "\nnoise".repeat(40),
+            },
+        });
+        let mut buf2 = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf2);
+        let text = buffer_text(&buf2);
+        assert!(
+            text.contains("first-message"),
+            "selected entry still visible under streaming:\n{text}"
         );
     }
 }

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -11,13 +11,109 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
+use std::collections::HashSet;
+use std::ops::Range;
+
 use crate::deck::{AgentEntry, WorkspaceModel};
 use crate::deck_ui::DeckUi;
+use crate::model::TranscriptEntry;
 use crate::render::{
     entry_lines, inner_height, inner_width, render_ask_user, render_hud, render_scope_review,
-    render_transcript,
+    render_transcript_window,
 };
 use crate::theme;
+
+/// Incremental transcript fold for the Session tab.
+///
+/// Everything before the last entry is *settled* — streaming deltas only ever
+/// mutate the final entry — so settled entries fold (markdown, labels, wrap)
+/// exactly once and are cached with their visual-row ranges; only the tail
+/// entry re-folds per frame. The cache invalidates whole when anything that
+/// changes how settled entries render changes: focused agent, the thinking
+/// toggle, a ctrl+o expansion, or the pane width. This turns the old
+/// O(whole-history) fold per frame into O(tail) — typing latency no longer
+/// grows with session length.
+#[derive(Debug, Clone, Default)]
+pub struct SessionFold {
+    key: Option<(String, bool, u64, usize)>,
+    settled: usize,
+    prefix: Vec<Line<'static>>,
+    entry_rows: Vec<Range<usize>>,
+    tail: Vec<Line<'static>>,
+}
+
+impl SessionFold {
+    /// Bring the cache up to date for this frame.
+    fn refresh(
+        &mut self,
+        agent: &str,
+        transcript: &[TranscriptEntry],
+        thinking: bool,
+        expanded: &HashSet<usize>,
+        expanded_rev: u64,
+        width: usize,
+    ) {
+        let key = (agent.to_string(), thinking, expanded_rev, width);
+        if self.key.as_ref() != Some(&key) || self.settled > transcript.len().saturating_sub(1) {
+            self.key = Some(key);
+            self.settled = 0;
+            self.prefix.clear();
+            self.entry_rows.clear();
+        }
+        let target = transcript.len().saturating_sub(1);
+        while self.settled < target {
+            let i = self.settled;
+            let start = self.prefix.len();
+            entry_lines(
+                &transcript[i],
+                thinking,
+                expanded.contains(&i),
+                width,
+                &mut self.prefix,
+            );
+            self.entry_rows.push(start..self.prefix.len());
+            self.settled += 1;
+        }
+        self.tail.clear();
+        if let Some(last) = transcript.last() {
+            entry_lines(
+                last,
+                thinking,
+                expanded.contains(&target),
+                width,
+                &mut self.tail,
+            );
+        }
+    }
+
+    /// Total visual rows (settled prefix + live tail).
+    pub fn total(&self) -> usize {
+        self.prefix.len() + self.tail.len()
+    }
+
+    /// The visual-row range entry `idx` occupies (the live tail entry spans
+    /// everything past the prefix).
+    pub fn rows_of(&self, idx: usize) -> Range<usize> {
+        if idx < self.entry_rows.len() {
+            self.entry_rows[idx].clone()
+        } else {
+            self.prefix.len()..self.total()
+        }
+    }
+
+    /// Materialize just the rows in `window` — ≤ one viewport of clones.
+    fn window_lines(&self, window: Range<usize>) -> Vec<Line<'static>> {
+        window
+            .filter_map(|r| {
+                if r < self.prefix.len() {
+                    self.prefix.get(r).cloned()
+                } else {
+                    self.tail.get(r - self.prefix.len()).cloned()
+                }
+            })
+            .collect()
+    }
+}
 
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     let Some(agent) = model.agents.get(ui.focused) else {
@@ -58,18 +154,59 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
         render_ask_user(prompt, false, bands[3], buf);
     }
 
-    // Transcript: fold the focused agent's entries into styled lines, then reuse
-    // the line-exact scrolling transcript renderer.
+    // Transcript: fold through the incremental cache (settled entries fold
+    // once; only the streaming tail re-folds per frame), then reuse the
+    // line-exact scroll window over the cached rows.
     let width = inner_width(bands[4]);
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    for entry in &sm.transcript {
-        entry_lines(entry, ui.thinking_expanded, width, &mut lines);
-    }
+    let empty = HashSet::new();
+    let expanded_set = ui.expanded.get(&agent.meta.id).unwrap_or(&empty);
+    ui.session_fold.refresh(
+        &agent.meta.id,
+        &sm.transcript,
+        ui.thinking_expanded,
+        expanded_set,
+        ui.expanded_rev,
+        width,
+    );
     let height = inner_height(bands[4]);
-    ui.metrics.session_total = lines.len();
+    let total = ui.session_fold.total();
+
+    // A selection move from the key handler lands here, where visual-row
+    // ranges are known: nudge the scroll window until the entry is visible.
+    if let Some(sel) = ui.session_pending_scroll.take() {
+        let rows = ui.session_fold.rows_of(sel);
+        let current = ui.session_scroll.window(total, height);
+        if rows.start < current.start {
+            ui.session_scroll.top = rows.start;
+            ui.session_scroll.follow = false;
+        } else if rows.end > current.end {
+            ui.session_scroll.top = rows.end.saturating_sub(height);
+            ui.session_scroll.follow = false;
+        }
+    }
+
+    ui.metrics.session_total = total;
     ui.metrics.session_height = height;
-    let window = ui.session_scroll.window(lines.len(), height);
-    render_transcript(&lines, window, ui.session_scroll.follow, bands[4], buf);
+    let window = ui.session_scroll.window(total, height);
+    let mut visible = ui.session_fold.window_lines(window.clone());
+    if let Some(sel) = ui.session_selected {
+        // A quiet warm background lift on the selected entry's rows.
+        for r in ui.session_fold.rows_of(sel) {
+            if window.contains(&r)
+                && let Some(line) = visible.get_mut(r - window.start)
+            {
+                line.style = line.style.bg(theme::SELECT_BG);
+            }
+        }
+    }
+    render_transcript_window(
+        visible,
+        window,
+        total,
+        ui.session_scroll.follow,
+        bands[4],
+        buf,
+    );
 }
 
 /// The one-line identity header: `▶ lead · running   goal…`.


### PR DESCRIPTION
Ships the two local "checkpoint" commits (markdown renderer, inline user prompts, humanized tool inputs, label-column layout) and finishes the work on top:

## What you get
- **Aligned tool rows**: tool name in a fixed label column, humanized args on the first line; call and result rows pair up (results resolve their tool name from the call).
- **Collapsed-by-default output**: a result longer than one row shows its first line + `(+N lines · Xms)` — the full output (retained up to 16k chars) is one Ctrl-O away. Expanded tool calls pretty-print their full JSON args.
- **Message selection**: ↑/↓ walk a highlight through the transcript (scroll follows, warm background lift on the selected message), ↓ past the tail re-arms follow, Esc clears.
- **Ctrl-O**: toggles the highlighted message; from the prompt, toggles the newest expandable message — and a second consecutive press toggles ALL chain-of-thought (Ctrl-R still works too).
- **Markdown everywhere**: agent text and user prompts render headings (◆/◈/·), bold/italic/code/links/quotes/lists/rules in the amber/ember palette.
- **O(tail) rendering** (the perf fix): settled entries fold+wrap once into a cache with visual-row ranges; only the streaming tail entry re-folds per frame and only the visible window is cloned. Scroll math stays line-exact; mouse capture stays off so native select-to-copy works.

## Notes
- Based on the local unpushed checkpoints (d0ae11e) — this PR publishes them.
- The remaining uncommitted render.rs edit in the main checkout (deleting wrap_lines) was NOT taken: wrapping is what keeps scroll line-exact, and the deletion left callers behind. Safe to discard locally.
- Stacked independently of the quality-pass PR #92 (which needs a rebase onto #91 — flagged separately).

Gate: fmt clean · clippy -D warnings clean · 212 stella-tui tests + full workspace green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the Session transcript to be readable and fast: aligned tool rows, collapsed multi‑line output with Ctrl‑O expand, markdown rendering, O(tail) rendering — plus pinned selection and JSON‑valid arg capping.

- **New Features**
  - Aligned tool call/result rows in a fixed label column; results label themselves with the tool name; humanized args on the first line.
  - Collapsed by default: first output line + "(+N lines · Xms)"; Ctrl‑O expands the selected message; from the prompt toggles the newest; double press toggles all thinking; no‑op on non‑expandable entries.
  - Expanded view shows pretty‑printed JSON args and full output; tool args are capped inside JSON (strings middle‑capped, large arrays elided) so pretty‑print stays valid; outputs kept up to 16k chars.
  - Message selection with ↑/↓ and a warm highlight; scroll pins the selection (follow drops); ↓ past the tail clears and re‑arms follow; Esc clears; switching agents drops selection.
  - Markdown everywhere: headings (◆/◈/·), themed code/links; help overlay updated and fits the popup.

- **Performance**
  - `SessionFold`: settled entries fold once and cache visual-row ranges; only the streaming tail re‑folds; only the visible window is cloned; expansion toggles bump `expanded_rev`.
  - O(tail) rendering keeps typing responsive; `cap_middle` slices on char boundaries to avoid large allocations; removed dead wrap_lines path.

<sup>Written for commit 4be862ed92c359afcf9b6ffa989b8be4d53224b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
