### PR TITLE
feat: custom commands, skills, and agents — adopted from .claude/.agents on init

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -903,6 +903,10 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         with_session_hook_context(build_system_prompt(&cfg.workspace_root), cfg).await;
     let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
     let mut memory = SessionMemory::open(&cfg.workspace_root, true);
+    // Custom extensions: ⚡ commands/skills invocable as `/name args`, custom
+    // agents behind `/agents`. Reloaded after `/init`, which may adopt new
+    // ones from `.claude/`/`.agents/`.
+    let mut custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
 
     loop {
         // The rocket-vs-UFO duel animates one line above the prompt while
@@ -955,6 +959,10 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             println!();
             continue;
         }
+        if input == "/agents" {
+            println!("  {}\n", custom.render_agent_list().replace('\n', "\n  "));
+            continue;
+        }
         if input == "/init" {
             println!();
             let mut emit = |line: String| println!("  {line}");
@@ -972,6 +980,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                     // `/init` just wrote — otherwise the cached domains stay
                     // stale until the next launch.
                     memory = SessionMemory::open(&cfg.workspace_root, true);
+                    // `/init` may also have adopted new custom
+                    // commands/skills/agents — make them invocable now.
+                    custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
                 }
                 Err(e) => println!("  {} init failed: {e}", "✗".red()),
             }
@@ -1058,6 +1069,15 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             }
             continue;
         }
+
+        // A custom command/skill (⚡): expand the template — arguments and
+        // all — into the prompt the model turn runs.
+        let expanded = if input.starts_with('/') {
+            custom.expand(input)
+        } else {
+            None
+        };
+        let input = expanded.as_deref().unwrap_or(input);
 
         messages.push(CompletionMessage::user(input));
         println!();
@@ -1231,6 +1251,11 @@ pub(crate) async fn init_workspace(
     // The code graph needs no provider — build it regardless of how the
     // domains were inferred, so the index exists even fully offline.
     build_code_graph(workspace_root, emit).await;
+
+    // Adopt commands/skills/agents other code agents keep in `.claude/` and
+    // `.agents/` (workspace + user scope) as symlinks into stella's own
+    // directories — idempotent, never clobbers, never fatal.
+    crate::extensions::sync_extensions(workspace_root, emit);
 
     let path = domains.save(workspace_root)?;
 
@@ -2391,6 +2416,10 @@ fn print_help() {
     println!(
         "  {}       Show files touched this session",
         "/files".bright_blue()
+    );
+    println!(
+        "  {}      List custom agents (⚡ definitions in .stella/agents)",
+        "/agents".bright_blue()
     );
     println!(
         "  {} Rename this terminal tab",

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -869,6 +869,15 @@ pub async fn run_goal_cmd(
     outcome
 }
 
+/// The REPL's productized command names — reserved: a custom definition can
+/// never run under one of these, argument-carrying forms included (the
+/// exact-match handlers in the loop only claim the bare forms). Must cover
+/// every `/`-command the loop below handles.
+const REPL_RESERVED: &[&str] = &[
+    "/exit", "/quit", "/models", "/config", "/help", "/clear", "/files", "/agents", "/init",
+    "/rename", "/color", "/goal",
+];
+
 /// Run an interactive REPL session. `budget_limit` is per-session: the
 /// `BudgetGuard`'s session-scoped total accumulates across every turn in
 /// the conversation, while `BudgetGuard::begin_turn` resets only the
@@ -905,8 +914,15 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     let mut memory = SessionMemory::open(&cfg.workspace_root, true);
     // Custom extensions: ⚡ commands/skills invocable as `/name args`, custom
     // agents behind `/agents`. Reloaded after `/init`, which may adopt new
-    // ones from `.claude/`/`.agents/`.
+    // ones from `.claude/`/`.agents/`. Load problems print up front so a
+    // definition that failed to parse is visible, not silently absent.
     let mut custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
+    if let Some(report) = custom.problems_report() {
+        for line in report.lines() {
+            println!("  {line}");
+        }
+        println!();
+    }
 
     loop {
         // The rocket-vs-UFO duel animates one line above the prompt while
@@ -981,8 +997,14 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                     // stale until the next launch.
                     memory = SessionMemory::open(&cfg.workspace_root, true);
                     // `/init` may also have adopted new custom
-                    // commands/skills/agents — make them invocable now.
+                    // commands/skills/agents — make them invocable now, and
+                    // report anything that failed to load.
                     custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
+                    if let Some(report) = custom.problems_report() {
+                        for line in report.lines() {
+                            println!("  {line}");
+                        }
+                    }
                 }
                 Err(e) => println!("  {} init failed: {e}", "✗".red()),
             }
@@ -1071,9 +1093,12 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         }
 
         // A custom command/skill (⚡): expand the template — arguments and
-        // all — into the prompt the model turn runs.
+        // all — into the prompt the model turn runs. Reserved names never
+        // reach a custom definition, so the REPL vocabulary above cannot be
+        // shadowed even in argument-carrying forms the exact-match handlers
+        // let through (e.g. `/help topic`).
         let expanded = if input.starts_with('/') {
-            custom.expand(input)
+            custom.expand(input, REPL_RESERVED)
         } else {
             None
         };
@@ -2418,7 +2443,7 @@ fn print_help() {
         "/files".bright_blue()
     );
     println!(
-        "  {}      List custom agents (⚡ definitions in .stella/agents)",
+        "  {}      List custom agents (⚡ from .stella/agents or ~/.config/stella/agents)",
         "/agents".bright_blue()
     );
     println!(

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -134,6 +134,9 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
     // `warn: false`: past this point diagnostics would land on the alternate
     // screen; a memory-less session degrades silently here.
     let mut memory = SessionMemory::open(&cfg.workspace_root, false);
+    // Custom extensions: ⚡ commands/skills in the slash menu, custom agents
+    // behind `/agents`. Reloaded after `/init`, which may adopt new ones.
+    let mut custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
 
     // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
     let (in_tx, in_rx) = mpsc::unbounded_channel::<Inbound>();
@@ -165,15 +168,7 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
 
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
-        slash_commands: vec![
-            SlashCommand::new("/help", "show commands"),
-            SlashCommand::new("/clear", "reset the conversation"),
-            SlashCommand::new("/models", "list providers & models"),
-            SlashCommand::new("/init", "index the workspace: domains + code graph"),
-            SlashCommand::new("/files", "open the Files tab"),
-            SlashCommand::new("/diff", "open the diff viewer"),
-            SlashCommand::new("/graph", "open the code-graph tab"),
-        ],
+        slash_commands: deck_slash_commands(&custom),
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         ..Default::default()
     };
@@ -217,9 +212,10 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
             &*provider,
             &registry,
             cfg,
+            &custom,
         )
         .await;
-        if !matches!(command, DeckCommand::Prompt) {
+        if matches!(command, DeckCommand::Handled | DeckCommand::InitCompleted) {
             // A handled command emits its answer as `Text`, which flips the
             // lead to `Running` in the deck's fold — but no turn is in flight.
             // Return it to `WaitingInput` so the dashboard reflects reality.
@@ -228,8 +224,12 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
                 status: AgentStatus::WaitingInput,
             });
         }
-        match command {
-            DeckCommand::Prompt => {}
+        let prompt = match command {
+            DeckCommand::Prompt => prompt,
+            // A custom command/skill invocation: the transcript already shows
+            // what was typed (`PromptStarted` above); the model runs the
+            // expanded template.
+            DeckCommand::Expanded(text) => text,
             DeckCommand::Handled => continue 'session,
             DeckCommand::InitCompleted => {
                 // `/init` changed the taxonomy and rebuilt the index. Re-open
@@ -239,9 +239,13 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
                 if let Some(snapshot) = agent::graph_snapshot(&cfg.workspace_root) {
                     let _ = in_tx.send(Inbound::GraphSnapshot(snapshot));
                 }
+                // `/init` may also have adopted new custom commands/skills —
+                // reload them and refresh the deck's slash menu in place.
+                custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
+                let _ = in_tx.send(Inbound::SlashCommands(deck_slash_commands(&custom)));
                 continue 'session;
             }
-        }
+        };
 
         // Per-turn conversation bookkeeping, mirroring `run_interactive`:
         // refresh the volatile recall block, then append the user prompt.
@@ -398,23 +402,48 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
 enum DeckCommand {
     /// Not a command — run the model turn as usual.
     Prompt,
+    /// A custom command/skill invocation — run the model turn with this
+    /// expanded prompt instead of the raw `/name args` input.
+    Expanded(String),
     /// Handled as a command; skip the model turn.
     Handled,
     /// `/init` finished successfully; skip the turn AND refresh the session's
-    /// derived state (memory domains, Graph tab) which the new taxonomy/index
-    /// changed.
+    /// derived state (memory domains, Graph tab, custom extensions) which the
+    /// new taxonomy/index changed.
     InitCompleted,
+}
+
+/// The deck's slash vocabulary: the productized commands (🔒) followed by
+/// every custom command/skill (⚡) currently on disk. Rebuilt after `/init`
+/// so just-adopted definitions appear without a restart.
+fn deck_slash_commands(custom: &crate::extensions::CustomExtensions) -> Vec<SlashCommand> {
+    let mut commands = vec![
+        SlashCommand::new("/help", "show commands"),
+        SlashCommand::new("/clear", "reset the conversation"),
+        SlashCommand::new("/models", "list providers & models"),
+        SlashCommand::new("/init", "index the workspace: domains + code graph"),
+        SlashCommand::new("/agents", "list custom agents"),
+        SlashCommand::new("/files", "open the Files tab"),
+        SlashCommand::new("/diff", "open the diff viewer"),
+        SlashCommand::new("/graph", "open the code-graph tab"),
+    ];
+    let customs = custom.slash_entries(&commands);
+    commands.extend(customs);
+    commands
 }
 
 /// Handle a session-level slash command. Output goes into the lead agent's
 /// transcript as `Text` events — the deck renders exclusively from events, so
 /// printing to stdout (which the alternate screen owns) is never an option.
 ///
-/// Vocabulary: `/help`, `/clear`, `/models`, `/init`. `/files`, `/diff`,
-/// `/graph` are deck-local (tab switches) and consumed TUI-side; an unknown
-/// bare `/command` gets a hint rather than a wasted model call. Every command
-/// is no-argument, so the *whole* trimmed input is matched — `/init do the
-/// thing` is a model prompt, not a silent reindex that discards the rest.
+/// Vocabulary: `/help`, `/clear`, `/models`, `/init`, `/agents`. `/files`,
+/// `/diff`, `/graph` are deck-local (tab switches) and consumed TUI-side; an
+/// unknown bare `/command` gets a hint rather than a wasted model call. Every
+/// productized command is no-argument, so the *whole* trimmed input is
+/// matched — `/init do the thing` is a model prompt, not a silent reindex
+/// that discards the rest. Custom commands/skills (⚡) DO take arguments:
+/// `/fix-bug issue-42` expands the `fix-bug` template with `issue-42`.
+#[allow(clippy::too_many_arguments)]
 async fn run_deck_command(
     prompt: &str,
     in_tx: &UnboundedSender<Inbound>,
@@ -423,6 +452,7 @@ async fn run_deck_command(
     provider: &dyn Provider,
     registry: &ToolRegistry,
     cfg: &Config,
+    custom: &crate::extensions::CustomExtensions,
 ) -> DeckCommand {
     let trimmed = prompt.trim();
     if !trimmed.starts_with('/') {
@@ -436,12 +466,20 @@ async fn run_deck_command(
     };
     match trimmed {
         "/help" => {
-            say(
-                "commands: /help · /clear (reset conversation) · /models (list providers) · \
-                 /init (index the workspace: domains + code graph) · /files · /diff · /graph \
-                 (switch tabs) — anything else is a prompt. ctrl+t queue · ? overlay help"
-                    .to_string(),
-            );
+            let mut help = "commands: /help · /clear (reset conversation) · /models (list \
+                 providers) · /init (index the workspace: domains + code graph) · /agents \
+                 (list custom agents) · /files · /diff · /graph (switch tabs) — anything \
+                 else is a prompt. ctrl+t queue · ? overlay help"
+                .to_string();
+            let customs = custom.slash_entries(&[]);
+            if !customs.is_empty() {
+                let names: Vec<&str> = customs.iter().map(|c| c.name.as_str()).collect();
+                help.push_str(&format!("\ncustom (⚡): {}", names.join(" · ")));
+            }
+            say(help);
+        }
+        "/agents" => {
+            say(custom.render_agent_list());
         }
         "/clear" => {
             messages.clear();
@@ -471,15 +509,22 @@ async fn run_deck_command(
         // one reaches here — accept it as handled (a no-op) rather than
         // calling it "unknown".
         "/files" | "/diff" | "/graph" => {}
-        // A bare unknown /word is a typo'd command, not a prompt — say so
-        // instead of spending a model call. Anything with arguments (e.g.
-        // `/src/main.rs explain`) falls through and stays a prompt.
-        _ if !trimmed.contains(char::is_whitespace) => {
+        _ => {
+            // A custom command/skill (⚡): expand its template — arguments
+            // and all — into the prompt the model turn runs.
+            if let Some(expanded) = custom.expand(trimmed) {
+                return DeckCommand::Expanded(expanded);
+            }
+            // A bare unknown /word is a typo'd command, not a prompt — say so
+            // instead of spending a model call. Anything with arguments (e.g.
+            // `/src/main.rs explain`) falls through and stays a prompt.
+            if trimmed.contains(char::is_whitespace) {
+                return DeckCommand::Prompt;
+            }
             say(format!(
-                "unknown command `{trimmed}` — try /help, /clear, /models, /init, /files, /diff, /graph"
+                "unknown command `{trimmed}` — try /help, /clear, /models, /init, /agents, /files, /diff, /graph"
             ));
         }
-        _ => return DeckCommand::Prompt,
     }
     DeckCommand::Handled
 }

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -154,7 +154,17 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
         .with_pid(std::process::id());
     lead_meta.model = Some(format!("{}/{}", cfg.provider.id, cfg.model_id));
     let _ = in_tx.send(Inbound::Register(lead_meta));
-    // An idle lead is waiting on the human, not queued behind a supervisor.
+    // Custom definitions that failed to load are reported into the
+    // transcript up front — stdout belongs to the alternate screen, and a
+    // silently-missing /command is otherwise undiagnosable.
+    if let Some(report) = custom.problems_report() {
+        let _ = in_tx.send(Inbound::Event {
+            agent: LEAD.to_string(),
+            event: AgentEvent::Text { delta: report },
+        });
+    }
+    // An idle lead is waiting on the human, not queued behind a supervisor
+    // (sent after the problems report — a Text event folds to `Running`).
     let _ = in_tx.send(Inbound::Status {
         agent: LEAD.to_string(),
         status: AgentStatus::WaitingInput,
@@ -240,9 +250,21 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
                     let _ = in_tx.send(Inbound::GraphSnapshot(snapshot));
                 }
                 // `/init` may also have adopted new custom commands/skills —
-                // reload them and refresh the deck's slash menu in place.
+                // reload them and refresh the deck's slash menu in place,
+                // reporting anything that failed to load (then restoring the
+                // idle status the report's Text event flipped).
                 custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
                 let _ = in_tx.send(Inbound::SlashCommands(deck_slash_commands(&custom)));
+                if let Some(report) = custom.problems_report() {
+                    let _ = in_tx.send(Inbound::Event {
+                        agent: LEAD.to_string(),
+                        event: AgentEvent::Text { delta: report },
+                    });
+                    let _ = in_tx.send(Inbound::Status {
+                        agent: LEAD.to_string(),
+                        status: AgentStatus::WaitingInput,
+                    });
+                }
                 continue 'session;
             }
         };
@@ -413,20 +435,35 @@ enum DeckCommand {
     InitCompleted,
 }
 
+/// The deck's productized vocabulary, as `(name, menu description)`. One
+/// source of truth for the menu's 🔒 rows and the reserved-name guard: a
+/// custom definition can never run under one of these names — not from the
+/// menu (`slash_entries` drops it) and not typed with arguments either
+/// (`expand` refuses reserved heads).
+const DECK_BUILTINS: &[(&str, &str)] = &[
+    ("/help", "show commands"),
+    ("/clear", "reset the conversation"),
+    ("/models", "list providers & models"),
+    ("/init", "index the workspace: domains + code graph"),
+    ("/agents", "list custom agents"),
+    ("/files", "open the Files tab"),
+    ("/diff", "open the diff viewer"),
+    ("/graph", "open the code-graph tab"),
+];
+
+/// The deck's reserved command names — see [`DECK_BUILTINS`].
+fn deck_reserved() -> Vec<&'static str> {
+    DECK_BUILTINS.iter().map(|(name, _)| *name).collect()
+}
+
 /// The deck's slash vocabulary: the productized commands (🔒) followed by
 /// every custom command/skill (⚡) currently on disk. Rebuilt after `/init`
 /// so just-adopted definitions appear without a restart.
 fn deck_slash_commands(custom: &crate::extensions::CustomExtensions) -> Vec<SlashCommand> {
-    let mut commands = vec![
-        SlashCommand::new("/help", "show commands"),
-        SlashCommand::new("/clear", "reset the conversation"),
-        SlashCommand::new("/models", "list providers & models"),
-        SlashCommand::new("/init", "index the workspace: domains + code graph"),
-        SlashCommand::new("/agents", "list custom agents"),
-        SlashCommand::new("/files", "open the Files tab"),
-        SlashCommand::new("/diff", "open the diff viewer"),
-        SlashCommand::new("/graph", "open the code-graph tab"),
-    ];
+    let mut commands: Vec<SlashCommand> = DECK_BUILTINS
+        .iter()
+        .map(|(name, description)| SlashCommand::new(*name, *description))
+        .collect();
     let customs = custom.slash_entries(&commands);
     commands.extend(customs);
     commands
@@ -511,8 +548,10 @@ async fn run_deck_command(
         "/files" | "/diff" | "/graph" => {}
         _ => {
             // A custom command/skill (⚡): expand its template — arguments
-            // and all — into the prompt the model turn runs.
-            if let Some(expanded) = custom.expand(trimmed) {
+            // and all — into the prompt the model turn runs. Reserved names
+            // never reach a custom definition (`/init do the thing` stays a
+            // model prompt even if a custom `init` exists).
+            if let Some(expanded) = custom.expand(trimmed, &deck_reserved()) {
                 return DeckCommand::Expanded(expanded);
             }
             // A bare unknown /word is a typo'd command, not a prompt — say so

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -38,10 +38,47 @@ const SOURCE_DIRS: [&str; 2] = [".claude", ".agents"];
 // Scanning + symlink sync
 // ============================================================================
 
+/// The per-directory definition file each kind accepts alongside flat
+/// `<slug>.md` (the `npx skills` ecosystem layout, generalized).
+fn nested_file(kind: ExtensionKind) -> &'static str {
+    match kind {
+        ExtensionKind::Commands => "COMMAND.md",
+        ExtensionKind::Skills => "SKILL.md",
+        ExtensionKind::Agents => "AGENT.md",
+    }
+}
+
+/// The name a definition at `path` will *load* under: the frontmatter
+/// `name:` when readable (a directory entry is read through its
+/// `SKILL.md`-style nested file), else the filename-derived slug. Sync
+/// collision precedence keys on this — see `SyncEntry::definition_name`.
+fn definition_name_for(path: &Path, kind: ExtensionKind) -> String {
+    let fallback = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .map(|n| n.strip_suffix(".md").unwrap_or(&n).to_string())
+        .unwrap_or_default();
+    let file = if path.is_dir() {
+        path.join(nested_file(kind))
+    } else {
+        path.to_path_buf()
+    };
+    std::fs::read_to_string(&file)
+        .ok()
+        .and_then(|raw| {
+            stella_core::rules::parse_frontmatter(&raw)
+                .data
+                .get("name")
+                .map(|n| n.trim().to_string())
+                .filter(|n| !n.is_empty())
+        })
+        .unwrap_or(fallback)
+}
+
 /// Scan one source directory for one kind (`<source_root>/<kind>`), with
-/// per-entry symlink detection. Hidden entries (`.DS_Store`,
-/// `.skill-lock.json`, …) are ignored. Sorted by name so plans — and
-/// therefore init output — are deterministic.
+/// per-entry symlink detection and best-effort frontmatter-name resolution.
+/// Hidden entries (`.DS_Store`, `.skill-lock.json`, …) are ignored. Sorted by
+/// name so plans — and therefore init output — are deterministic.
 fn scan_source(source_root: &Path, kind: ExtensionKind) -> SyncSource {
     let dir = source_root.join(kind.dir_name());
     let mut entries: Vec<SyncEntry> = std::fs::read_dir(&dir)
@@ -59,6 +96,7 @@ fn scan_source(source_root: &Path, kind: ExtensionKind) -> SyncSource {
                 .map(|m| m.file_type().is_symlink())
                 .unwrap_or(false);
             Some(SyncEntry {
+                definition_name: definition_name_for(&entry.path(), kind),
                 name,
                 path: entry.path().display().to_string(),
                 is_symlink,
@@ -69,15 +107,21 @@ fn scan_source(source_root: &Path, kind: ExtensionKind) -> SyncSource {
     SyncSource { kind, entries }
 }
 
-/// Every name already present in `dir` — real files, dirs, and symlinks
-/// alike (a dangling symlink still occupies the name).
-fn existing_names(dir: &Path) -> Vec<String> {
-    std::fs::read_dir(dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .map(|e| e.file_name().to_string_lossy().to_string())
-        .collect()
+/// What already occupies one kind's destination directory: every entry
+/// basename — real files, dirs, and symlinks alike (a dangling symlink still
+/// occupies the name) — plus the names those definitions load under.
+fn existing_targets(dir: &Path, kind: ExtensionKind) -> stella_core::extensions::ExistingTargets {
+    let mut targets = stella_core::extensions::ExistingTargets::default();
+    for entry in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with('.') {
+            targets
+                .definition_names
+                .push(definition_name_for(&entry.path(), kind));
+        }
+        targets.file_names.push(name);
+    }
+    targets
 }
 
 /// The relative path from inside `from_dir` to `target` — symlinks are
@@ -141,7 +185,7 @@ fn sync_into(dest_root: &Path, source_roots: &[PathBuf]) -> SyncOutcome {
         .flat_map(|kind| source_roots.iter().map(|root| scan_source(root, *kind)))
         .filter(|s| !s.entries.is_empty())
         .collect();
-    let existing = |kind: ExtensionKind| existing_names(&dest_root.join(kind.dir_name()));
+    let existing = |kind: ExtensionKind| existing_targets(&dest_root.join(kind.dir_name()), kind);
     let plan = plan_extension_sync(&sources, &existing);
 
     let mut outcome = SyncOutcome {
@@ -220,8 +264,14 @@ pub fn sync_extensions(workspace_root: &Path, emit: &mut dyn FnMut(String)) {
 
 /// Read one kind's definition files from `dir`: flat `<slug>.md` plus the
 /// nested `<slug>/<nested_file>` layout, both read *through* symlinks (that
-/// is the point of the sync). Returns `(path, content)` pairs.
-fn read_definition_files(dir: &Path, nested_file: &str) -> Vec<(String, String)> {
+/// is the point of the sync). Returns `(path, content)` pairs; a file that
+/// exists but cannot be read (e.g. a dangling symlink left by a deleted
+/// source) lands in `problems` instead of vanishing.
+fn read_definition_files(
+    dir: &Path,
+    nested_file: &str,
+    problems: &mut Vec<String>,
+) -> Vec<(String, String)> {
     let mut files = Vec::new();
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -238,17 +288,34 @@ fn read_definition_files(dir: &Path, nested_file: &str) -> Vec<(String, String)>
             continue;
         }
         if path.extension().is_some_and(|e| e == "md") {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                files.push((path.display().to_string(), content));
+            match std::fs::read_to_string(&path) {
+                Ok(content) => files.push((path.display().to_string(), content)),
+                Err(e) => problems.push(format!("{}: {e}", path.display())),
             }
         } else if path.is_dir() {
             let nested = path.join(nested_file);
-            if let Ok(content) = std::fs::read_to_string(&nested) {
-                files.push((nested.display().to_string(), content));
+            match std::fs::read_to_string(&nested) {
+                Ok(content) => files.push((nested.display().to_string(), content)),
+                // A directory without its nested definition file is not an
+                // error (other agents keep auxiliary dirs here); one whose
+                // definition file exists but won't read is.
+                Err(e) if nested.symlink_metadata().is_ok() => {
+                    problems.push(format!("{}: {e}", nested.display()));
+                }
+                Err(_) => {}
             }
         }
     }
     files
+}
+
+/// One human-readable line for a parse diagnostic.
+fn describe_diagnostic(diag: &stella_core::extensions::ExtensionDiagnostic) -> String {
+    let why = match diag.problem {
+        stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
+        stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
+    };
+    format!("{}: {why}", diag.path)
 }
 
 /// The `.stella`-side directories one kind is loaded from, lowest precedence
@@ -262,21 +329,29 @@ fn load_dirs(workspace_root: &Path, kind: ExtensionKind) -> Vec<PathBuf> {
     dirs
 }
 
-fn load_commands_from(dirs: &[PathBuf]) -> Vec<CommandDef> {
-    let parsed = dirs
-        .iter()
-        .flat_map(|dir| read_definition_files(dir, "COMMAND.md"))
-        .filter_map(|(path, raw)| command_from_file(&path, &raw).ok())
-        .collect();
+fn load_commands_from(dirs: &[PathBuf], problems: &mut Vec<String>) -> Vec<CommandDef> {
+    let mut parsed = Vec::new();
+    for dir in dirs {
+        for (path, raw) in read_definition_files(dir, "COMMAND.md", problems) {
+            match command_from_file(&path, &raw) {
+                Ok(cmd) => parsed.push(cmd),
+                Err(diag) => problems.push(describe_diagnostic(&diag)),
+            }
+        }
+    }
     merge_by_name(parsed, |c: &CommandDef| c.name.as_str())
 }
 
-fn load_agents_from(dirs: &[PathBuf]) -> Vec<AgentDef> {
-    let parsed = dirs
-        .iter()
-        .flat_map(|dir| read_definition_files(dir, "AGENT.md"))
-        .filter_map(|(path, raw)| agent_from_file(&path, &raw).ok())
-        .collect();
+fn load_agents_from(dirs: &[PathBuf], problems: &mut Vec<String>) -> Vec<AgentDef> {
+    let mut parsed = Vec::new();
+    for dir in dirs {
+        for (path, raw) in read_definition_files(dir, "AGENT.md", problems) {
+            match agent_from_file(&path, &raw) {
+                Ok(agent) => parsed.push(agent),
+                Err(diag) => problems.push(describe_diagnostic(&diag)),
+            }
+        }
+    }
     merge_by_name(parsed, |a: &AgentDef| a.name.as_str())
 }
 
@@ -288,6 +363,10 @@ pub struct CustomExtensions {
     pub commands: Vec<CommandDef>,
     pub skills: Vec<Skill>,
     pub agents: Vec<AgentDef>,
+    /// Definition files that were found but skipped — unreadable, or
+    /// malformed per the core parsers. One human-readable line each, so a
+    /// missing `/name` or `/agents` row is diagnosable instead of silent.
+    pub problems: Vec<String>,
 }
 
 /// What a custom `/name` resolves to.
@@ -300,11 +379,44 @@ impl CustomExtensions {
     /// Load every custom definition visible from `workspace_root`
     /// (user-global + workspace `.stella` directories, workspace wins).
     pub fn load(workspace_root: &Path) -> Self {
-        Self {
-            commands: load_commands_from(&load_dirs(workspace_root, ExtensionKind::Commands)),
-            skills: crate::memory::load_workspace_skills(workspace_root),
-            agents: load_agents_from(&load_dirs(workspace_root, ExtensionKind::Agents)),
+        let mut problems = Vec::new();
+        let commands = load_commands_from(
+            &load_dirs(workspace_root, ExtensionKind::Commands),
+            &mut problems,
+        );
+        let agents = load_agents_from(
+            &load_dirs(workspace_root, ExtensionKind::Agents),
+            &mut problems,
+        );
+        let loaded_skills = crate::memory::load_workspace_skills_with_diagnostics(workspace_root);
+        for diag in &loaded_skills.diagnostics {
+            let why = match diag.problem {
+                stella_core::skills::SkillProblem::MissingName => "no usable name",
+                stella_core::skills::SkillProblem::MissingDescription => "no description",
+                stella_core::skills::SkillProblem::EmptyBody => "empty body",
+            };
+            problems.push(format!("{}: {why}", diag.path));
         }
+        Self {
+            commands,
+            skills: loaded_skills.skills,
+            agents,
+            problems,
+        }
+    }
+
+    /// The skipped-definition report, one line per file, or `None` when
+    /// everything on disk loaded. Both chat surfaces print this so a
+    /// definition that fails to parse is visible, not silently absent.
+    pub fn problems_report(&self) -> Option<String> {
+        if self.problems.is_empty() {
+            return None;
+        }
+        let mut out = format!("! {} custom definition(s) skipped:\n", self.problems.len());
+        for problem in &self.problems {
+            out.push_str(&format!("  ! {problem}\n"));
+        }
+        Some(out)
     }
 
     /// The ⚡ slash-menu rows: commands first, then skills, names prefixed
@@ -346,15 +458,20 @@ impl CustomExtensions {
     }
 
     /// Expand `input` (`/name args…`) into the prompt the model runs, or
-    /// `None` when the name matches no custom command/skill. A command's
-    /// body is its template ([`expand_command`]); a skill's body rides as
-    /// context above the user's task.
-    pub fn expand(&self, input: &str) -> Option<String> {
+    /// `None` when the name is `reserved` (a productized command can never
+    /// be shadowed — not in the menu, and not at invocation time either,
+    /// argument-carrying forms included) or matches no custom
+    /// command/skill. A command's body is its template ([`expand_command`]);
+    /// a skill's body rides as context above the user's task.
+    pub fn expand(&self, input: &str, reserved: &[&str]) -> Option<String> {
         let trimmed = input.trim();
         let (head, args) = match trimmed.split_once(char::is_whitespace) {
             Some((head, args)) => (head, args),
             None => (trimmed, ""),
         };
+        if reserved.contains(&head) {
+            return None;
+        }
         match self.lookup(head)? {
             Invocation::Command(cmd) => Some(expand_command(&cmd.body, args)),
             Invocation::Skill(skill) => Some(skill_invocation_prompt(skill, args)),
@@ -366,7 +483,7 @@ impl CustomExtensions {
     pub fn render_agent_list(&self) -> String {
         if self.agents.is_empty() {
             return "no custom agents found — add markdown definitions to .stella/agents/ \
-                    (or run /init to adopt .claude/.agents ones)"
+                    or ~/.config/stella/agents/ (or run /init to adopt .claude/.agents ones)"
                 .to_string();
         }
         let mut out = format!("custom agents ({}):\n", self.agents.len());
@@ -503,6 +620,32 @@ mod tests {
     }
 
     #[test]
+    fn sync_resolves_frontmatter_name_collisions_by_source_precedence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Different file names, same frontmatter `name: deploy` — only the
+        // earlier source (.claude) is adopted, so the loaded `/deploy` is
+        // decided by source precedence, not destination file-name order.
+        write(
+            &root.join(".claude/commands/ship.md"),
+            "---\nname: deploy\ndescription: from claude\n---\nShip.",
+        );
+        write(
+            &root.join(".agents/commands/release.md"),
+            "---\nname: deploy\ndescription: from agents\n---\nRelease.",
+        );
+        let outcome = sync_into(
+            &root.join(".stella"),
+            &[root.join(".claude"), root.join(".agents")],
+        );
+        assert_eq!(
+            outcome.linked,
+            vec![(ExtensionKind::Commands, "ship.md".to_string())]
+        );
+        assert_eq!(outcome.skipped, 1);
+    }
+
+    #[test]
     fn relative_target_walks_up_and_back_down() {
         assert_eq!(
             relative_symlink_target(
@@ -532,22 +675,40 @@ mod tests {
         );
         write(&ws.join("review/COMMAND.md"), "Review the diff.");
 
-        let commands = load_commands_from(&[user.clone(), ws.clone()]);
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[user.clone(), ws.clone()], &mut problems);
         let deploy = commands.iter().find(|c| c.name == "deploy").unwrap();
         assert_eq!(deploy.description, "workspace version");
         assert!(
             commands.iter().any(|c| c.name == "review"),
             "nested layout loads"
         );
+        assert!(problems.is_empty(), "{problems:?}");
 
         let agent_dir = tmp.path().join("ws-agents");
         write(
             &agent_dir.join("reviewer.md"),
             "---\nname: reviewer\ndescription: reviews\n---\nYou review.",
         );
-        let agents = load_agents_from(&[agent_dir]);
+        let agents = load_agents_from(&[agent_dir], &mut problems);
         assert_eq!(agents.len(), 1, "flat .md files parse as agents");
         assert_eq!(agents[0].name, "reviewer");
+    }
+
+    #[test]
+    fn loader_reports_malformed_and_unreadable_definitions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("empty.md"), "---\nname: empty\n---\n");
+        // A dangling symlink: the file exists as an entry but cannot be read.
+        std::os::unix::fs::symlink(tmp.path().join("gone.md"), dir.join("dangling.md")).unwrap();
+
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[dir], &mut problems);
+        assert!(commands.is_empty());
+        assert_eq!(problems.len(), 2, "{problems:?}");
+        assert!(problems.iter().any(|p| p.contains("empty body")));
+        assert!(problems.iter().any(|p| p.contains("dangling.md")));
     }
 
     fn custom_fixture() -> CustomExtensions {
@@ -572,6 +733,7 @@ mod tests {
                 body: "You review.".to_string(),
                 source_path: "x/reviewer.md".to_string(),
             }],
+            problems: Vec::new(),
         }
     }
 
@@ -595,21 +757,39 @@ mod tests {
     fn expand_substitutes_command_arguments() {
         let custom = custom_fixture();
         assert_eq!(
-            custom.expand("/fix-bug issue-42").as_deref(),
+            custom.expand("/fix-bug issue-42", &[]).as_deref(),
             Some("Fix issue-42 end to end.")
         );
-        assert!(custom.expand("/unknown thing").is_none());
+        assert!(custom.expand("/unknown thing", &[]).is_none());
+    }
+
+    #[test]
+    fn expand_never_runs_a_custom_definition_under_a_reserved_name() {
+        let mut custom = custom_fixture();
+        custom.commands.push(CommandDef {
+            name: "help".to_string(),
+            description: "shadowed".to_string(),
+            body: "hijacked".to_string(),
+            source_path: "x/help.md".to_string(),
+        });
+        // Hidden from the menu AND unreachable at invocation time — the
+        // argument-carrying form included, which bypasses whole-input
+        // builtin matching in both surfaces.
+        assert!(custom.expand("/help", &["/help"]).is_none());
+        assert!(custom.expand("/help topic", &["/help"]).is_none());
+        // Unreserved names still expand.
+        assert!(custom.expand("/fix-bug x", &["/help"]).is_some());
     }
 
     #[test]
     fn expand_wraps_a_skill_invocation_with_its_body_and_task() {
         let custom = custom_fixture();
-        let prompt = custom.expand("/sql-style tidy my query").unwrap();
+        let prompt = custom.expand("/sql-style tidy my query", &[]).unwrap();
         assert!(prompt.contains("# Skill: sql-style"));
         assert!(prompt.contains("Lowercase keywords."));
         assert!(prompt.contains("## Task\ntidy my query"));
         // Bare invocation: no task section.
-        let bare = custom.expand("/sql-style").unwrap();
+        let bare = custom.expand("/sql-style", &[]).unwrap();
         assert!(!bare.contains("## Task"));
     }
 

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -1,0 +1,624 @@
+//! Filesystem glue for custom extensions (`stella_core::extensions`): the
+//! init-time symlink sync that adopts `.claude/`- and `.agents/`-authored
+//! commands/skills/agents into stella's own directories, and the loaders the
+//! chat surfaces use to offer them (⚡ slash-menu rows, `/agents`).
+//!
+//! All planning and parsing is pure and lives in `stella-core`; this module
+//! owns exactly the I/O halves (`02-architecture.md` §1.3): directory
+//! scanning with symlink detection, symlink creation, and definition-file
+//! reads.
+//!
+//! ## Scopes
+//!
+//! The sync runs at both scopes, mirroring the settings/skills chain:
+//!
+//! - **workspace**: `<root>/{.claude,.agents}/<kind>` → `<root>/.stella/<kind>`
+//! - **user**: `~/{.claude,.agents}/<kind>` → `~/.config/stella/<kind>`
+//!
+//! so definitions installed for other agents at either level are visible to
+//! stella after `stella init` (or `/init`). The loaders then read the
+//! `.stella`-side directories only — user-global first, workspace last, so a
+//! workspace definition wins a name collision (same precedence as skills).
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use stella_core::extensions::{
+    AgentDef, CommandDef, ExtensionKind, SyncEntry, SyncSource, agent_from_file, command_from_file,
+    expand_command, merge_by_name, plan_extension_sync,
+};
+use stella_core::skills::Skill;
+use stella_tui::SlashCommand;
+
+/// The other-agent directories the sync adopts from, in precedence order
+/// (an entry in an earlier directory wins a real name collision).
+const SOURCE_DIRS: [&str; 2] = [".claude", ".agents"];
+
+// ============================================================================
+// Scanning + symlink sync
+// ============================================================================
+
+/// Scan one source directory for one kind (`<source_root>/<kind>`), with
+/// per-entry symlink detection. Hidden entries (`.DS_Store`,
+/// `.skill-lock.json`, …) are ignored. Sorted by name so plans — and
+/// therefore init output — are deterministic.
+fn scan_source(source_root: &Path, kind: ExtensionKind) -> SyncSource {
+    let dir = source_root.join(kind.dir_name());
+    let mut entries: Vec<SyncEntry> = std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with('.') {
+                return None;
+            }
+            let is_symlink = entry
+                .path()
+                .symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false);
+            Some(SyncEntry {
+                name,
+                path: entry.path().display().to_string(),
+                is_symlink,
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    SyncSource { kind, entries }
+}
+
+/// Every name already present in `dir` — real files, dirs, and symlinks
+/// alike (a dangling symlink still occupies the name).
+fn existing_names(dir: &Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect()
+}
+
+/// The relative path from inside `from_dir` to `target` — symlinks are
+/// created relative so a repo (or home) moved as a unit keeps working.
+/// Falls back to the absolute target when the two share no common root.
+fn relative_symlink_target(from_dir: &Path, target: &Path) -> PathBuf {
+    let from: Vec<Component> = from_dir.components().collect();
+    let to: Vec<Component> = target.components().collect();
+    let common = from
+        .iter()
+        .zip(to.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    if common == 0 {
+        return target.to_path_buf();
+    }
+    let mut rel = PathBuf::new();
+    for _ in common..from.len() {
+        rel.push("..");
+    }
+    for component in &to[common..] {
+        rel.push(component);
+    }
+    rel
+}
+
+/// What one sync run did, for the init progress line. `errors` carries any
+/// link that could not be created (permissions, non-unix platform) — the
+/// sync is best-effort and never fails init.
+#[derive(Debug, Default)]
+pub struct SyncOutcome {
+    /// Created links as `(kind, name)`.
+    pub linked: Vec<(ExtensionKind, String)>,
+    /// Entries skipped by the plan (symlink sources, existing names).
+    pub skipped: usize,
+    pub errors: Vec<String>,
+}
+
+impl SyncOutcome {
+    /// `"2 commands, 12 skills"`-style summary of the created links, or
+    /// `None` when nothing was linked.
+    pub fn summary(&self) -> Option<String> {
+        let parts: Vec<String> = ExtensionKind::ALL
+            .iter()
+            .filter_map(|kind| {
+                let n = self.linked.iter().filter(|(k, _)| k == kind).count();
+                (n > 0).then(|| format!("{n} {}", kind.dir_name()))
+            })
+            .collect();
+        (!parts.is_empty()).then(|| parts.join(", "))
+    }
+}
+
+/// Adopt every command/skill/agent found under `source_roots` (in precedence
+/// order) into `dest_root` (`.stella` or `~/.config/stella`) as symlinks.
+/// Idempotent: symlink sources, already-present names, and duplicate names
+/// are skipped by the plan (`stella_core::extensions::plan_extension_sync`).
+fn sync_into(dest_root: &Path, source_roots: &[PathBuf]) -> SyncOutcome {
+    let sources: Vec<SyncSource> = ExtensionKind::ALL
+        .iter()
+        .flat_map(|kind| source_roots.iter().map(|root| scan_source(root, *kind)))
+        .filter(|s| !s.entries.is_empty())
+        .collect();
+    let existing = |kind: ExtensionKind| existing_names(&dest_root.join(kind.dir_name()));
+    let plan = plan_extension_sync(&sources, &existing);
+
+    let mut outcome = SyncOutcome {
+        skipped: plan.skips.len(),
+        ..SyncOutcome::default()
+    };
+    for link in &plan.links {
+        let dir = dest_root.join(link.kind.dir_name());
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            outcome.errors.push(format!("{}: {e}", dir.display()));
+            continue;
+        }
+        let dest = dir.join(&link.name);
+        let target = relative_symlink_target(&dir, Path::new(&link.source_path));
+        match create_symlink(&target, &dest) {
+            Ok(()) => outcome.linked.push((link.kind, link.name.clone())),
+            Err(e) => outcome.errors.push(format!("{}: {e}", dest.display())),
+        }
+    }
+    outcome
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, dest)
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_target: &Path, _dest: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::other(
+        "extension symlinks are only supported on unix platforms",
+    ))
+}
+
+/// The user-global stella config root (`~/.config/stella`), or `None`
+/// without a home directory.
+fn user_config_root() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config").join("stella"))
+}
+
+/// Run the sync at both scopes and report through `emit` — the shared init
+/// hook (`agent::init_workspace`) calls this so `stella init` and `/init`
+/// behave identically. Quiet when there is nothing to do.
+pub fn sync_extensions(workspace_root: &Path, emit: &mut dyn FnMut(String)) {
+    let mut scopes: Vec<(&str, PathBuf, Vec<PathBuf>)> = vec![(
+        "workspace",
+        workspace_root.join(".stella"),
+        SOURCE_DIRS.iter().map(|d| workspace_root.join(d)).collect(),
+    )];
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from)
+        && let Some(config_root) = user_config_root()
+    {
+        scopes.push((
+            "user",
+            config_root,
+            SOURCE_DIRS.iter().map(|d| home.join(d)).collect(),
+        ));
+    }
+
+    for (scope, dest, sources) in scopes {
+        let outcome = sync_into(&dest, &sources);
+        if let Some(summary) = outcome.summary() {
+            emit(format!(
+                "✓ adopted {summary} from .claude/.agents ({scope} scope)"
+            ));
+        }
+        for error in &outcome.errors {
+            emit(format!("! extension link failed: {error}"));
+        }
+    }
+}
+
+// ============================================================================
+// Loading
+// ============================================================================
+
+/// Read one kind's definition files from `dir`: flat `<slug>.md` plus the
+/// nested `<slug>/<nested_file>` layout, both read *through* symlinks (that
+/// is the point of the sync). Returns `(path, content)` pairs.
+fn read_definition_files(dir: &Path, nested_file: &str) -> Vec<(String, String)> {
+    let mut files = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return files,
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_none_or(|n| n.starts_with('.'))
+        {
+            continue;
+        }
+        if path.extension().is_some_and(|e| e == "md") {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                files.push((path.display().to_string(), content));
+            }
+        } else if path.is_dir() {
+            let nested = path.join(nested_file);
+            if let Ok(content) = std::fs::read_to_string(&nested) {
+                files.push((nested.display().to_string(), content));
+            }
+        }
+    }
+    files
+}
+
+/// The `.stella`-side directories one kind is loaded from, lowest precedence
+/// first (user-global, then workspace — workspace wins, like skills).
+fn load_dirs(workspace_root: &Path, kind: ExtensionKind) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(config_root) = user_config_root() {
+        dirs.push(config_root.join(kind.dir_name()));
+    }
+    dirs.push(workspace_root.join(".stella").join(kind.dir_name()));
+    dirs
+}
+
+fn load_commands_from(dirs: &[PathBuf]) -> Vec<CommandDef> {
+    let parsed = dirs
+        .iter()
+        .flat_map(|dir| read_definition_files(dir, "COMMAND.md"))
+        .filter_map(|(path, raw)| command_from_file(&path, &raw).ok())
+        .collect();
+    merge_by_name(parsed, |c: &CommandDef| c.name.as_str())
+}
+
+fn load_agents_from(dirs: &[PathBuf]) -> Vec<AgentDef> {
+    let parsed = dirs
+        .iter()
+        .flat_map(|dir| read_definition_files(dir, "AGENT.md"))
+        .filter_map(|(path, raw)| agent_from_file(&path, &raw).ok())
+        .collect();
+    merge_by_name(parsed, |a: &AgentDef| a.name.as_str())
+}
+
+/// Everything custom a chat surface offers: commands (⚡ `/name`, prompt
+/// templates), skills (⚡ `/name`, injected know-how — the same files the
+/// recall engine auto-selects from), and agents (`/agents`).
+#[derive(Debug, Default)]
+pub struct CustomExtensions {
+    pub commands: Vec<CommandDef>,
+    pub skills: Vec<Skill>,
+    pub agents: Vec<AgentDef>,
+}
+
+/// What a custom `/name` resolves to.
+pub enum Invocation<'a> {
+    Command(&'a CommandDef),
+    Skill(&'a Skill),
+}
+
+impl CustomExtensions {
+    /// Load every custom definition visible from `workspace_root`
+    /// (user-global + workspace `.stella` directories, workspace wins).
+    pub fn load(workspace_root: &Path) -> Self {
+        Self {
+            commands: load_commands_from(&load_dirs(workspace_root, ExtensionKind::Commands)),
+            skills: crate::memory::load_workspace_skills(workspace_root),
+            agents: load_agents_from(&load_dirs(workspace_root, ExtensionKind::Agents)),
+        }
+    }
+
+    /// The ⚡ slash-menu rows: commands first, then skills, names prefixed
+    /// with `/`. A custom name shadowed by a productized command in
+    /// `reserved` is dropped (builtins always win), and a skill sharing a
+    /// command's name is dropped (the command wins — it was authored as an
+    /// invocation).
+    pub fn slash_entries(&self, reserved: &[SlashCommand]) -> Vec<SlashCommand> {
+        let mut taken: HashSet<String> = reserved.iter().map(|c| c.name.clone()).collect();
+        let mut rows = Vec::new();
+        let commands = self
+            .commands
+            .iter()
+            .map(|c| (format!("/{}", c.name), c.description.clone()));
+        let skills = self
+            .skills
+            .iter()
+            .map(|s| (format!("/{}", s.name), s.description.clone()));
+        for (name, description) in commands.chain(skills) {
+            if taken.insert(name.clone()) {
+                rows.push(SlashCommand::custom(name, description));
+            }
+        }
+        rows
+    }
+
+    /// Resolve a custom invocation: `head` is the leading `/word` of the
+    /// input (slash included). Commands shadow skills, matching
+    /// [`Self::slash_entries`].
+    pub fn lookup(&self, head: &str) -> Option<Invocation<'_>> {
+        let name = head.strip_prefix('/')?;
+        if let Some(cmd) = self.commands.iter().find(|c| c.name == name) {
+            return Some(Invocation::Command(cmd));
+        }
+        self.skills
+            .iter()
+            .find(|s| s.name == name)
+            .map(Invocation::Skill)
+    }
+
+    /// Expand `input` (`/name args…`) into the prompt the model runs, or
+    /// `None` when the name matches no custom command/skill. A command's
+    /// body is its template ([`expand_command`]); a skill's body rides as
+    /// context above the user's task.
+    pub fn expand(&self, input: &str) -> Option<String> {
+        let trimmed = input.trim();
+        let (head, args) = match trimmed.split_once(char::is_whitespace) {
+            Some((head, args)) => (head, args),
+            None => (trimmed, ""),
+        };
+        match self.lookup(head)? {
+            Invocation::Command(cmd) => Some(expand_command(&cmd.body, args)),
+            Invocation::Skill(skill) => Some(skill_invocation_prompt(skill, args)),
+        }
+    }
+
+    /// The `/agents` listing: every custom agent's name, description, and
+    /// source, or a hint when none are defined.
+    pub fn render_agent_list(&self) -> String {
+        if self.agents.is_empty() {
+            return "no custom agents found — add markdown definitions to .stella/agents/ \
+                    (or run /init to adopt .claude/.agents ones)"
+                .to_string();
+        }
+        let mut out = format!("custom agents ({}):\n", self.agents.len());
+        for agent in &self.agents {
+            out.push_str(&format!(
+                "  ⚡ {} — {}  ({})\n",
+                agent.name, agent.description, agent.source_path
+            ));
+        }
+        out
+    }
+}
+
+/// The prompt a `/skill-name` invocation runs: the skill body as explicit
+/// instructions, with any trailing text as the task to apply them to.
+fn skill_invocation_prompt(skill: &Skill, args: &str) -> String {
+    let mut out = format!(
+        "Apply the following skill.\n\n# Skill: {}\n{}\n\n{}",
+        skill.name, skill.description, skill.body
+    );
+    let args = args.trim();
+    if !args.is_empty() {
+        out.push_str(&format!("\n\n## Task\n{args}"));
+    }
+    out
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn skill_md(name: &str) -> String {
+        format!("---\nname: {name}\ndescription: about {name}\n---\nbody of {name}\n")
+    }
+
+    #[test]
+    fn sync_adopts_real_entries_and_skips_symlinked_ones() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // `.agents/skills/shared` is the real home; `.claude/skills/shared`
+        // is another agent's symlink to it — the exact in-the-wild shape.
+        write(
+            &root.join(".agents/skills/shared/SKILL.md"),
+            &skill_md("shared"),
+        );
+        write(
+            &root.join(".claude/skills/local/SKILL.md"),
+            &skill_md("local"),
+        );
+        std::os::unix::fs::symlink(
+            root.join(".agents/skills/shared"),
+            root.join(".claude/skills/shared"),
+        )
+        .unwrap();
+        write(
+            &root.join(".claude/commands/deploy.md"),
+            "---\ndescription: ship it\n---\nDeploy $ARGUMENTS now.",
+        );
+        write(
+            &root.join(".claude/agents/reviewer.md"),
+            "---\nname: reviewer\ndescription: reviews\n---\nYou review.",
+        );
+
+        let outcome = sync_into(
+            &root.join(".stella"),
+            &[root.join(".claude"), root.join(".agents")],
+        );
+        assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+        let mut linked = outcome.linked.clone();
+        linked.sort_by(|a, b| a.1.cmp(&b.1));
+        // Flat files keep their `.md` basename so the loaders' stem-derived
+        // slugs survive the link; skill directories link by directory name.
+        assert_eq!(
+            linked,
+            vec![
+                (ExtensionKind::Commands, "deploy.md".to_string()),
+                (ExtensionKind::Skills, "local".to_string()),
+                (ExtensionKind::Agents, "reviewer.md".to_string()),
+                (ExtensionKind::Skills, "shared".to_string()),
+            ]
+        );
+
+        // `shared` was adopted from its real `.agents` home, not through the
+        // `.claude` symlink — and as a relative link.
+        let link = root.join(".stella/skills/shared");
+        let target = std::fs::read_link(&link).unwrap();
+        assert!(target.is_relative());
+        assert_eq!(
+            std::fs::canonicalize(&link).unwrap(),
+            std::fs::canonicalize(root.join(".agents/skills/shared")).unwrap()
+        );
+        // The adopted definitions are readable through the links.
+        assert!(
+            std::fs::read_to_string(root.join(".stella/skills/shared/SKILL.md"))
+                .unwrap()
+                .contains("body of shared")
+        );
+    }
+
+    #[test]
+    fn sync_is_idempotent_and_never_clobbers_user_definitions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(&root.join(".claude/commands/deploy.md"), "Ship.");
+        // A user-authored definition already occupies the name.
+        write(&root.join(".stella/commands/deploy.md"), "MY deploy.");
+
+        let dest = root.join(".stella");
+        let sources = vec![root.join(".claude"), root.join(".agents")];
+        let first = sync_into(&dest, &sources);
+        assert!(
+            first.linked.is_empty(),
+            "existing names are never clobbered"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join(".stella/commands/deploy.md")).unwrap(),
+            "MY deploy."
+        );
+
+        write(&root.join(".claude/commands/fresh.md"), "New.");
+        let second = sync_into(&dest, &sources);
+        assert_eq!(second.linked.len(), 1);
+        let third = sync_into(&dest, &sources);
+        assert!(third.linked.is_empty(), "re-running links nothing new");
+    }
+
+    #[test]
+    fn relative_target_walks_up_and_back_down() {
+        assert_eq!(
+            relative_symlink_target(
+                Path::new("/ws/.stella/skills"),
+                Path::new("/ws/.agents/skills/x"),
+            ),
+            PathBuf::from("../../.agents/skills/x")
+        );
+        assert_eq!(
+            relative_symlink_target(Path::new("/a/b"), Path::new("/a/b/c")),
+            PathBuf::from("c")
+        );
+    }
+
+    #[test]
+    fn loads_commands_and_agents_with_workspace_precedence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let user = tmp.path().join("user-scope");
+        let ws = tmp.path().join("ws-scope");
+        write(
+            &user.join("deploy.md"),
+            "---\ndescription: user version\n---\nuser body",
+        );
+        write(
+            &ws.join("deploy.md"),
+            "---\ndescription: workspace version\n---\nworkspace body",
+        );
+        write(&ws.join("review/COMMAND.md"), "Review the diff.");
+
+        let commands = load_commands_from(&[user.clone(), ws.clone()]);
+        let deploy = commands.iter().find(|c| c.name == "deploy").unwrap();
+        assert_eq!(deploy.description, "workspace version");
+        assert!(
+            commands.iter().any(|c| c.name == "review"),
+            "nested layout loads"
+        );
+
+        let agent_dir = tmp.path().join("ws-agents");
+        write(
+            &agent_dir.join("reviewer.md"),
+            "---\nname: reviewer\ndescription: reviews\n---\nYou review.",
+        );
+        let agents = load_agents_from(&[agent_dir]);
+        assert_eq!(agents.len(), 1, "flat .md files parse as agents");
+        assert_eq!(agents[0].name, "reviewer");
+    }
+
+    fn custom_fixture() -> CustomExtensions {
+        CustomExtensions {
+            commands: vec![CommandDef {
+                name: "fix-bug".to_string(),
+                description: "fix the named bug".to_string(),
+                body: "Fix $ARGUMENTS end to end.".to_string(),
+                source_path: "x/fix-bug.md".to_string(),
+            }],
+            skills: vec![Skill {
+                name: "sql-style".to_string(),
+                description: "format sql".to_string(),
+                domains: vec![],
+                body: "Lowercase keywords.".to_string(),
+                source_path: "x/sql-style/SKILL.md".to_string(),
+                origin: stella_core::skills::SkillOrigin::Workspace,
+            }],
+            agents: vec![AgentDef {
+                name: "reviewer".to_string(),
+                description: "reviews diffs".to_string(),
+                body: "You review.".to_string(),
+                source_path: "x/reviewer.md".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn slash_entries_are_custom_rows_that_never_shadow_builtins() {
+        let mut custom = custom_fixture();
+        custom.commands.push(CommandDef {
+            name: "help".to_string(), // collides with the builtin /help
+            description: "shadowed".to_string(),
+            body: "body".to_string(),
+            source_path: "x/help.md".to_string(),
+        });
+        let reserved = vec![SlashCommand::new("/help", "show commands")];
+        let rows = custom.slash_entries(&reserved);
+        let names: Vec<&str> = rows.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["/fix-bug", "/sql-style"]);
+        assert!(rows.iter().all(|r| r.kind == stella_tui::SlashKind::Custom));
+    }
+
+    #[test]
+    fn expand_substitutes_command_arguments() {
+        let custom = custom_fixture();
+        assert_eq!(
+            custom.expand("/fix-bug issue-42").as_deref(),
+            Some("Fix issue-42 end to end.")
+        );
+        assert!(custom.expand("/unknown thing").is_none());
+    }
+
+    #[test]
+    fn expand_wraps_a_skill_invocation_with_its_body_and_task() {
+        let custom = custom_fixture();
+        let prompt = custom.expand("/sql-style tidy my query").unwrap();
+        assert!(prompt.contains("# Skill: sql-style"));
+        assert!(prompt.contains("Lowercase keywords."));
+        assert!(prompt.contains("## Task\ntidy my query"));
+        // Bare invocation: no task section.
+        let bare = custom.expand("/sql-style").unwrap();
+        assert!(!bare.contains("## Task"));
+    }
+
+    #[test]
+    fn agent_list_names_every_agent_and_hints_when_empty() {
+        let custom = custom_fixture();
+        let list = custom.render_agent_list();
+        assert!(list.contains("⚡ reviewer — reviews diffs"));
+        let empty = CustomExtensions::default();
+        assert!(empty.render_agent_list().contains("no custom agents"));
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -22,6 +22,7 @@ mod arena;
 mod command_deck;
 mod config;
 mod domains;
+mod extensions;
 mod fleet_cmd;
 mod interactive;
 mod memory;

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -69,7 +69,7 @@ pub struct SessionMemory {
 
 /// Filesystem-backed [`SkillSource`] reading the workspace + user-global
 /// skill directories.
-struct FsSkillSource;
+pub(crate) struct FsSkillSource;
 
 impl SkillSource for FsSkillSource {
     fn read_skill_files(&self, roots: &[String]) -> Vec<skills::SkillFile> {
@@ -101,6 +101,44 @@ impl SkillSource for FsSkillSource {
         }
         files
     }
+}
+
+/// `<workspace>/.stella/skills` — the workspace-scope skills directory.
+pub(crate) fn workspace_skills_dir(workspace_root: &Path) -> String {
+    workspace_root
+        .join(".stella")
+        .join("skills")
+        .display()
+        .to_string()
+}
+
+/// `~/.config/stella/skills` — the user-global skills directory (empty
+/// string without a home, which the loader skips silently).
+pub(crate) fn user_skills_dir() -> String {
+    std::env::var_os("HOME")
+        .map(|home| {
+            PathBuf::from(home)
+                .join(".config")
+                .join("stella")
+                .join("skills")
+                .display()
+                .to_string()
+        })
+        .unwrap_or_default()
+}
+
+/// Load every skill visible from `workspace_root` (user-global + workspace,
+/// workspace wins) — shared by [`SessionMemory::load_skills`] and the
+/// custom-extensions surface (`crate::extensions`), which offers the same
+/// files as ⚡ slash-menu entries.
+pub(crate) fn load_workspace_skills(workspace_root: &Path) -> Vec<Skill> {
+    skills::load_skills(
+        &FsSkillSource,
+        &LoadSkillsOptions {
+            workspace_skills_dir: workspace_skills_dir(workspace_root),
+            user_skills_dir: user_skills_dir(),
+        },
+    )
 }
 
 impl SessionMemory {
@@ -145,37 +183,14 @@ impl SessionMemory {
     }
 
     fn workspace_skills_dir(&self) -> String {
-        self.workspace_root
-            .join(".stella")
-            .join("skills")
-            .display()
-            .to_string()
-    }
-
-    fn user_skills_dir(&self) -> String {
-        std::env::var_os("HOME")
-            .map(|home| {
-                PathBuf::from(home)
-                    .join(".config")
-                    .join("stella")
-                    .join("skills")
-                    .display()
-                    .to_string()
-            })
-            .unwrap_or_default()
+        workspace_skills_dir(&self.workspace_root)
     }
 
     /// Load the workspace's skills fresh (cheap — a handful of file reads;
     /// fresh so a just-installed or just-auto-created skill is live on the
     /// very next turn).
     pub fn load_skills(&self) -> Vec<Skill> {
-        skills::load_skills(
-            &FsSkillSource,
-            &LoadSkillsOptions {
-                workspace_skills_dir: self.workspace_skills_dir(),
-                user_skills_dir: self.user_skills_dir(),
-            },
-        )
+        load_workspace_skills(&self.workspace_root)
     }
 
     /// Build the volatile recalled-context block for a prompt: relevant

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -68,8 +68,9 @@ pub struct SessionMemory {
 }
 
 /// Filesystem-backed [`SkillSource`] reading the workspace + user-global
-/// skill directories.
-pub(crate) struct FsSkillSource;
+/// skill directories. Private: outside consumers go through
+/// [`load_workspace_skills`] / [`load_workspace_skills_with_diagnostics`].
+struct FsSkillSource;
 
 impl SkillSource for FsSkillSource {
     fn read_skill_files(&self, roots: &[String]) -> Vec<skills::SkillFile> {
@@ -132,7 +133,16 @@ pub(crate) fn user_skills_dir() -> String {
 /// custom-extensions surface (`crate::extensions`), which offers the same
 /// files as ⚡ slash-menu entries.
 pub(crate) fn load_workspace_skills(workspace_root: &Path) -> Vec<Skill> {
-    skills::load_skills(
+    load_workspace_skills_with_diagnostics(workspace_root).skills
+}
+
+/// Same load, keeping the per-file skip diagnostics — the custom-extensions
+/// surface reports these so a malformed `SKILL.md` is visible instead of
+/// silently absent from the slash menu.
+pub(crate) fn load_workspace_skills_with_diagnostics(
+    workspace_root: &Path,
+) -> skills::LoadedSkills {
+    skills::load_skills_with_diagnostics(
         &FsSkillSource,
         &LoadSkillsOptions {
             workspace_skills_dir: workspace_skills_dir(workspace_root),

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -285,6 +285,13 @@ pub struct SyncEntry {
     pub path: String,
     /// `true` when the entry is itself a symlink (`fs::symlink_metadata`).
     pub is_symlink: bool,
+    /// The name the definition will *load* under — the frontmatter `name:`
+    /// when the scanner could parse one, else the filename-derived slug.
+    /// Collision precedence is decided on this, not on `name`: two files
+    /// with different basenames but the same frontmatter name are the same
+    /// definition, and linking both would leave the loader's merge order
+    /// (destination-lexicographic) to pick a winner instead of source order.
+    pub definition_name: String,
 }
 
 /// The scanned contents of one source directory for one kind, in the
@@ -301,11 +308,13 @@ pub enum SyncSkipReason {
     /// The source entry is itself a symlink — following it would duplicate
     /// the definition it points at, whose real home is also scanned.
     SourceIsSymlink,
-    /// The destination already has this name (a previous sync or a
+    /// The destination already has this file name (a previous sync or a
     /// user-authored definition) — never clobbered, which is also what makes
     /// re-running the sync idempotent.
     DestinationExists,
-    /// An earlier source directory already claimed this name this run.
+    /// A definition with this *loaded* name is already claimed — by an
+    /// earlier source directory this run, or by something already in the
+    /// destination under a different file name.
     DuplicateName,
 }
 
@@ -340,22 +349,46 @@ impl SyncPlan {
     }
 }
 
+/// What already occupies one kind's destination directory, as scanned by the
+/// CLI: the entry basenames (the never-clobber check is filesystem-level) and
+/// the names those entries' definitions load under (so a re-run — or a
+/// differently-named file carrying the same frontmatter `name:` — is not
+/// adopted a second time).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExistingTargets {
+    pub file_names: Vec<String>,
+    pub definition_names: Vec<String>,
+}
+
 /// Plan the adoption of scanned source entries into one destination root.
 /// `sources` are in precedence order (e.g. `.claude/<kind>` before
-/// `.agents/<kind>`); `existing` maps each kind to the names already present
-/// in the destination directory. Deterministic: actions come out in scan
-/// order. See the module doc for the two rules (never link a symlink, never
-/// clobber).
+/// `.agents/<kind>`); `existing` describes each kind's destination directory.
+/// Deterministic: actions come out in scan order. See the module doc for the
+/// two rules (never link a symlink, never clobber); collision precedence
+/// between sources is decided on [`SyncEntry::definition_name`].
 pub fn plan_extension_sync(
     sources: &[SyncSource],
-    existing: &dyn Fn(ExtensionKind) -> Vec<String>,
+    existing: &dyn Fn(ExtensionKind) -> ExistingTargets,
 ) -> SyncPlan {
     let mut plan = SyncPlan::default();
     let mut claimed: std::collections::HashSet<(ExtensionKind, String)> =
         std::collections::HashSet::new();
+    let mut present_files: std::collections::HashMap<
+        ExtensionKind,
+        std::collections::HashSet<String>,
+    > = std::collections::HashMap::new();
     for source in sources {
-        let present: std::collections::HashSet<String> =
-            existing(source.kind).into_iter().collect();
+        if !present_files.contains_key(&source.kind) {
+            let targets = existing(source.kind);
+            present_files.insert(source.kind, targets.file_names.into_iter().collect());
+            // Definitions already in the destination claim their names up
+            // front, so a same-named-but-differently-filed source entry is
+            // skipped instead of linked alongside.
+            for name in targets.definition_names {
+                claimed.insert((source.kind, name));
+            }
+        }
+        let present = &present_files[&source.kind];
         for entry in &source.entries {
             let skip = |reason| SyncSkip {
                 kind: source.kind,
@@ -367,7 +400,7 @@ pub fn plan_extension_sync(
                 plan.skips.push(skip(SyncSkipReason::SourceIsSymlink));
             } else if present.contains(&entry.name) {
                 plan.skips.push(skip(SyncSkipReason::DestinationExists));
-            } else if !claimed.insert((source.kind, entry.name.clone())) {
+            } else if !claimed.insert((source.kind, entry.definition_name.clone())) {
                 plan.skips.push(skip(SyncSkipReason::DuplicateName));
             } else {
                 plan.links.push(PlannedLink {
@@ -491,11 +524,15 @@ mod tests {
             name: name.to_string(),
             path: path.to_string(),
             is_symlink,
+            // Tests that exercise frontmatter-name collisions build their
+            // own entries; everywhere else the definition name is the file
+            // name minus a `.md` suffix, like the scanner's fallback.
+            definition_name: name.strip_suffix(".md").unwrap_or(name).to_string(),
         }
     }
 
-    fn no_existing(_: ExtensionKind) -> Vec<String> {
-        Vec::new()
+    fn no_existing(_: ExtensionKind) -> ExistingTargets {
+        ExistingTargets::default()
     }
 
     #[test]
@@ -544,12 +581,60 @@ mod tests {
         }];
         let existing = |kind: ExtensionKind| {
             assert_eq!(kind, ExtensionKind::Commands);
-            vec!["deploy".to_string()]
+            ExistingTargets {
+                file_names: vec!["deploy".to_string()],
+                definition_names: vec!["deploy".to_string()],
+            }
         };
         let plan = plan_extension_sync(&sources, &existing);
         assert_eq!(plan.links.len(), 1);
         assert_eq!(plan.links[0].name, "new-cmd");
         assert_eq!(plan.skips[0].reason, SyncSkipReason::DestinationExists);
+    }
+
+    #[test]
+    fn plan_resolves_collisions_on_the_frontmatter_name_not_the_file_name() {
+        // Two differently-named files whose frontmatter says `name: deploy`:
+        // linking both would leave the loader's merge order to pick a winner.
+        // Source precedence (`.claude` first) must decide instead.
+        let deploy = |name: &str, path: &str| SyncEntry {
+            name: name.to_string(),
+            path: path.to_string(),
+            is_symlink: false,
+            definition_name: "deploy".to_string(),
+        };
+        let sources = vec![
+            SyncSource {
+                kind: ExtensionKind::Commands,
+                entries: vec![deploy("ship.md", "/ws/.claude/commands/ship.md")],
+            },
+            SyncSource {
+                kind: ExtensionKind::Commands,
+                entries: vec![deploy("release.md", "/ws/.agents/commands/release.md")],
+            },
+        ];
+        let plan = plan_extension_sync(&sources, &no_existing);
+        assert_eq!(plan.links.len(), 1);
+        assert_eq!(plan.links[0].source_path, "/ws/.claude/commands/ship.md");
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::DuplicateName);
+    }
+
+    #[test]
+    fn plan_skips_a_source_whose_definition_name_is_already_in_the_destination() {
+        // The destination holds `mine.md` with frontmatter `name: deploy`;
+        // a source file `deploy.md` (same loaded name, different file name)
+        // must not be linked alongside it.
+        let sources = vec![SyncSource {
+            kind: ExtensionKind::Commands,
+            entries: vec![entry("deploy.md", "/ws/.claude/commands/deploy.md", false)],
+        }];
+        let existing = |_: ExtensionKind| ExistingTargets {
+            file_names: vec!["mine.md".to_string()],
+            definition_names: vec!["deploy".to_string()],
+        };
+        let plan = plan_extension_sync(&sources, &existing);
+        assert!(plan.links.is_empty());
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::DuplicateName);
     }
 
     #[test]
@@ -579,7 +664,10 @@ mod tests {
         let first = plan_extension_sync(&sources, &no_existing);
         assert_eq!(first.links.len(), 1);
         // Second run: the destination now contains what the first run linked.
-        let after: Vec<String> = first.links.iter().map(|l| l.name.clone()).collect();
+        let after = ExistingTargets {
+            file_names: first.links.iter().map(|l| l.name.clone()).collect(),
+            definition_names: first.links.iter().map(|l| l.name.clone()).collect(),
+        };
         let second = plan_extension_sync(&sources, &move |_| after.clone());
         assert!(second.links.is_empty());
         assert_eq!(second.skips[0].reason, SyncSkipReason::DestinationExists);

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -1,0 +1,605 @@
+//! Custom extensions — user-authored **commands** and **agents** parsed from
+//! markdown-with-frontmatter definition files, plus the init-time
+//! **symlink-sync plan** that adopts definitions authored for other code
+//! agents (`.claude/`, `.agents/`) into stella's own directories.
+//!
+//! A **command** is a reusable prompt template: invoking `/name args` in a
+//! composer substitutes `args` into the command's markdown body and runs the
+//! result as the model prompt. An **agent** is a named persona definition —
+//! a system-prompt-shaped markdown body with a `name:`/`description:`
+//! frontmatter header — listed by the `/agents` command (and the seam a
+//! future fleet spawn will consume). Both are distinct from a
+//! [`crate::skills`] *skill* (know-how selected into context automatically)
+//! and a [`crate::rules`] *rule* (an enforceable guardrail).
+//!
+//! Directory conventions mirror the skills engine:
+//! `<workspace>/.stella/commands/` and `<workspace>/.stella/agents/`
+//! (workspace scope, wins on name collisions) and the user-global
+//! `~/.config/stella/{commands,agents}/`. Files are flat `<slug>.md`; the
+//! frontmatter `name:` overrides the filename stem.
+//!
+//! # Adoption from other agents' directories (the sync plan)
+//!
+//! Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
+//! `.agents/{commands,skills,agents}`. On `stella init`, entries found there
+//! are **symlinked** into the matching `.stella/`-side directory so stella
+//! sees them without copying (edits stay in one place). Two rules keep the
+//! adoption sane, both encoded in [`plan_extension_sync`]:
+//!
+//!   1. **Never link a symlink.** Other agents symlink between these
+//!      directories too (e.g. `.claude/skills/x -> ../../.agents/skills/x`);
+//!      following one would adopt the same definition twice — once through
+//!      the symlink, once from its real home, which is also scanned.
+//!   2. **Never clobber.** A name already present in the destination —
+//!      user-authored or linked by a previous init — is skipped, so the sync
+//!      is idempotent and hand-written definitions always win.
+//!
+//! # No I/O in this module (`02-architecture.md` §1.3)
+//!
+//! Scanning directories, reading definition files, and creating symlinks are
+//! real I/O — `stella-cli` owns all of it. This module only plans and
+//! parses: [`plan_extension_sync`] maps already-scanned entries to typed
+//! actions, and the `*_from_file` parsers operate on already-read content,
+//! unit-tested below without touching a filesystem.
+
+use crate::rules::parse_frontmatter;
+
+// ============================================================================
+// Kinds
+// ============================================================================
+
+/// The three definition kinds the sync adopts and the loaders read. The
+/// directory name is identical across every convention involved
+/// (`.claude/<dir>`, `.agents/<dir>`, `.stella/<dir>`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExtensionKind {
+    Commands,
+    Skills,
+    Agents,
+}
+
+impl ExtensionKind {
+    /// Every kind, in the order sync reports use.
+    pub const ALL: [ExtensionKind; 3] = [
+        ExtensionKind::Commands,
+        ExtensionKind::Skills,
+        ExtensionKind::Agents,
+    ];
+
+    /// The directory basename this kind lives under, in every convention.
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            ExtensionKind::Commands => "commands",
+            ExtensionKind::Skills => "skills",
+            ExtensionKind::Agents => "agents",
+        }
+    }
+}
+
+// ============================================================================
+// Definitions + parsing
+// ============================================================================
+
+/// A custom slash command: a prompt template invoked as `/name`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandDef {
+    /// The bare command name, **without** the leading slash (frontmatter
+    /// `name:` or the filename stem). `/`-prefixed on display.
+    pub name: String,
+    /// Menu description — frontmatter `description:`, falling back to the
+    /// body's first line (see [`fallback_description`]).
+    pub description: String,
+    /// The markdown body: the prompt template ([`expand_command`]).
+    pub body: String,
+    /// The file this was loaded from.
+    pub source_path: String,
+}
+
+/// A custom agent definition: a persona with a system-prompt-shaped body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDef {
+    /// Agent name (frontmatter `name:` or the filename stem).
+    pub name: String,
+    /// One-line description for the `/agents` listing.
+    pub description: String,
+    /// The markdown body — the agent's instructions/system prompt.
+    pub body: String,
+    /// The file this was loaded from.
+    pub source_path: String,
+}
+
+/// Why one definition file could not be loaded. Mirrors
+/// [`crate::skills::SkillProblem`]: typed so the CLI can report it precisely
+/// instead of silently dropping the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionProblem {
+    /// No `name:` frontmatter and the path yields no usable slug.
+    MissingName,
+    /// The markdown body is empty — a template/persona with no content.
+    EmptyBody,
+}
+
+/// A malformed definition file, skipped during loading (never fatal).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionDiagnostic {
+    pub path: String,
+    pub problem: ExtensionProblem,
+}
+
+/// Cap on a description derived from the body's first line — menu rows are
+/// one line; anything longer is noise there.
+const FALLBACK_DESCRIPTION_MAX_CHARS: usize = 72;
+
+/// The filename stem (or, for a nested `<slug>/<FILE>.md` layout, the parent
+/// directory name) as the definition's slug — same derivation as
+/// [`crate::skills`], generalized over the nested filename.
+fn name_from_path(path: &str, nested_file: &str) -> String {
+    let base = path.rsplit('/').next().unwrap_or(path);
+    if base.eq_ignore_ascii_case(nested_file) {
+        return path.rsplit('/').nth(1).unwrap_or("").to_string();
+    }
+    base.strip_suffix(".md").unwrap_or(base).to_string()
+}
+
+/// A one-line description from a body when the frontmatter has none: the
+/// first non-empty line, markdown-heading markers stripped, truncated on a
+/// char boundary with an ellipsis.
+fn fallback_description(body: &str) -> String {
+    let line = body
+        .lines()
+        .map(|l| l.trim().trim_start_matches('#').trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    if line.chars().count() <= FALLBACK_DESCRIPTION_MAX_CHARS {
+        return line.to_string();
+    }
+    let truncated: String = line
+        .chars()
+        .take(FALLBACK_DESCRIPTION_MAX_CHARS - 1)
+        .collect();
+    format!("{}…", truncated.trim_end())
+}
+
+/// Parse one definition file into `(name, description, body)` — the shape
+/// both [`command_from_file`] and [`agent_from_file`] share. `nested_file`
+/// names the per-directory layout file (`COMMAND.md`/`AGENT.md`) accepted
+/// alongside flat `<slug>.md`.
+fn definition_from_file(
+    path: &str,
+    raw: &str,
+    nested_file: &str,
+) -> Result<(String, String, String), ExtensionDiagnostic> {
+    let fm = parse_frontmatter(raw);
+    let diag = |problem| ExtensionDiagnostic {
+        path: path.to_string(),
+        problem,
+    };
+
+    let name = fm
+        .data
+        .get("name")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| name_from_path(path, nested_file));
+    if name.trim().is_empty() {
+        return Err(diag(ExtensionProblem::MissingName));
+    }
+
+    let body = fm.body.trim().to_string();
+    if body.is_empty() {
+        return Err(diag(ExtensionProblem::EmptyBody));
+    }
+
+    let description = fm
+        .data
+        .get("description")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| fallback_description(&body));
+
+    Ok((name, description, body))
+}
+
+/// Parse one command file. Tolerant like the skills loader: `description:`
+/// is optional (many ecosystem command files carry only a body), falling
+/// back to the body's first line.
+pub fn command_from_file(path: &str, raw: &str) -> Result<CommandDef, ExtensionDiagnostic> {
+    let (name, description, body) = definition_from_file(path, raw, "COMMAND.md")?;
+    Ok(CommandDef {
+        name,
+        description,
+        body,
+        source_path: path.to_string(),
+    })
+}
+
+/// Parse one agent file.
+pub fn agent_from_file(path: &str, raw: &str) -> Result<AgentDef, ExtensionDiagnostic> {
+    let (name, description, body) = definition_from_file(path, raw, "AGENT.md")?;
+    Ok(AgentDef {
+        name,
+        description,
+        body,
+        source_path: path.to_string(),
+    })
+}
+
+// ============================================================================
+// Command expansion
+// ============================================================================
+
+/// The placeholder a command body may use to position its arguments.
+pub const ARGUMENTS_PLACEHOLDER: &str = "$ARGUMENTS";
+
+/// Expand a command body with the text the user typed after the command
+/// name: every `$ARGUMENTS` occurrence is substituted; a body without the
+/// placeholder gets non-empty arguments appended as a trailing paragraph
+/// (the ecosystem convention, so plain prompt files still take arguments).
+pub fn expand_command(body: &str, args: &str) -> String {
+    let args = args.trim();
+    if body.contains(ARGUMENTS_PLACEHOLDER) {
+        return body.replace(ARGUMENTS_PLACEHOLDER, args);
+    }
+    if args.is_empty() {
+        body.to_string()
+    } else {
+        format!("{body}\n\n{args}")
+    }
+}
+
+// ============================================================================
+// Name-merged loading (user-global, then workspace — workspace wins)
+// ============================================================================
+
+/// Merge definitions by `key`, later entries overriding earlier ones while
+/// keeping the first-seen ordering position — the same semantics as
+/// [`crate::skills::load_skills`], so "workspace beats user-global" works by
+/// passing user-scope definitions first.
+pub fn merge_by_name<T>(items: Vec<T>, key: impl Fn(&T) -> &str) -> Vec<T> {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_name: std::collections::HashMap<String, T> = std::collections::HashMap::new();
+    for item in items {
+        let name = key(&item).to_string();
+        if !by_name.contains_key(&name) {
+            order.push(name.clone());
+        }
+        by_name.insert(name, item);
+    }
+    order
+        .into_iter()
+        .filter_map(|name| by_name.remove(&name))
+        .collect()
+}
+
+// ============================================================================
+// Symlink-sync planning
+// ============================================================================
+
+/// One directory entry found while scanning a source directory
+/// (`.claude/<kind>` or `.agents/<kind>`), as reported by the CLI's scanner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncEntry {
+    /// The entry's basename — also the link name in the destination.
+    pub name: String,
+    /// The entry's absolute path (the symlink target when planned).
+    pub path: String,
+    /// `true` when the entry is itself a symlink (`fs::symlink_metadata`).
+    pub is_symlink: bool,
+}
+
+/// The scanned contents of one source directory for one kind, in the
+/// caller's precedence order (earlier sources win on a name collision).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncSource {
+    pub kind: ExtensionKind,
+    pub entries: Vec<SyncEntry>,
+}
+
+/// Why one scanned entry was not planned as a link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncSkipReason {
+    /// The source entry is itself a symlink — following it would duplicate
+    /// the definition it points at, whose real home is also scanned.
+    SourceIsSymlink,
+    /// The destination already has this name (a previous sync or a
+    /// user-authored definition) — never clobbered, which is also what makes
+    /// re-running the sync idempotent.
+    DestinationExists,
+    /// An earlier source directory already claimed this name this run.
+    DuplicateName,
+}
+
+/// One symlink the CLI should create: `<dest>/<kind>/<name>` → `source_path`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedLink {
+    pub kind: ExtensionKind,
+    pub name: String,
+    pub source_path: String,
+}
+
+/// One entry the plan skipped, with the typed reason (inspectable output).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncSkip {
+    pub kind: ExtensionKind,
+    pub name: String,
+    pub source_path: String,
+    pub reason: SyncSkipReason,
+}
+
+/// The full sync decision for one destination root.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyncPlan {
+    pub links: Vec<PlannedLink>,
+    pub skips: Vec<SyncSkip>,
+}
+
+impl SyncPlan {
+    /// How many links the plan creates for `kind`.
+    pub fn linked(&self, kind: ExtensionKind) -> usize {
+        self.links.iter().filter(|l| l.kind == kind).count()
+    }
+}
+
+/// Plan the adoption of scanned source entries into one destination root.
+/// `sources` are in precedence order (e.g. `.claude/<kind>` before
+/// `.agents/<kind>`); `existing` maps each kind to the names already present
+/// in the destination directory. Deterministic: actions come out in scan
+/// order. See the module doc for the two rules (never link a symlink, never
+/// clobber).
+pub fn plan_extension_sync(
+    sources: &[SyncSource],
+    existing: &dyn Fn(ExtensionKind) -> Vec<String>,
+) -> SyncPlan {
+    let mut plan = SyncPlan::default();
+    let mut claimed: std::collections::HashSet<(ExtensionKind, String)> =
+        std::collections::HashSet::new();
+    for source in sources {
+        let present: std::collections::HashSet<String> =
+            existing(source.kind).into_iter().collect();
+        for entry in &source.entries {
+            let skip = |reason| SyncSkip {
+                kind: source.kind,
+                name: entry.name.clone(),
+                source_path: entry.path.clone(),
+                reason,
+            };
+            if entry.is_symlink {
+                plan.skips.push(skip(SyncSkipReason::SourceIsSymlink));
+            } else if present.contains(&entry.name) {
+                plan.skips.push(skip(SyncSkipReason::DestinationExists));
+            } else if !claimed.insert((source.kind, entry.name.clone())) {
+                plan.skips.push(skip(SyncSkipReason::DuplicateName));
+            } else {
+                plan.links.push(PlannedLink {
+                    kind: source.kind,
+                    name: entry.name.clone(),
+                    source_path: entry.path.clone(),
+                });
+            }
+        }
+    }
+    plan
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- parsing ----
+
+    #[test]
+    fn command_parses_frontmatter_name_and_description() {
+        let raw = "---\nname: fix-bug\ndescription: Fix the named bug end to end\n---\nFind and fix the bug: $ARGUMENTS";
+        let cmd = command_from_file("/ws/.stella/commands/other.md", raw).unwrap();
+        assert_eq!(cmd.name, "fix-bug");
+        assert_eq!(cmd.description, "Fix the named bug end to end");
+        assert!(cmd.body.contains("$ARGUMENTS"));
+    }
+
+    #[test]
+    fn command_name_falls_back_to_the_filename_stem() {
+        let cmd = command_from_file("/ws/.stella/commands/review-pr.md", "Review the PR.").unwrap();
+        assert_eq!(cmd.name, "review-pr");
+    }
+
+    #[test]
+    fn command_supports_the_nested_layout() {
+        let cmd = command_from_file("/ws/.stella/commands/deploy/COMMAND.md", "Ship it.").unwrap();
+        assert_eq!(cmd.name, "deploy");
+    }
+
+    #[test]
+    fn command_description_falls_back_to_the_first_body_line() {
+        let raw = "# Review the diff carefully\n\nThen report findings.";
+        let cmd = command_from_file("/x/review.md", raw).unwrap();
+        assert_eq!(cmd.description, "Review the diff carefully");
+    }
+
+    #[test]
+    fn fallback_description_truncates_long_first_lines_on_a_char_boundary() {
+        let long = "é".repeat(200);
+        let desc = fallback_description(&long);
+        assert!(desc.chars().count() <= FALLBACK_DESCRIPTION_MAX_CHARS);
+        assert!(desc.ends_with('…'));
+    }
+
+    #[test]
+    fn empty_body_is_a_typed_diagnostic() {
+        let err = command_from_file("/x/cmd.md", "---\nname: cmd\n---\n").unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::EmptyBody);
+        let err = agent_from_file("/x/agent.md", "").unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::EmptyBody);
+    }
+
+    #[test]
+    fn missing_name_with_unusable_path_is_a_typed_diagnostic() {
+        let err = command_from_file("COMMAND.md", "body").unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::MissingName);
+    }
+
+    #[test]
+    fn agent_parses_like_claude_code_agent_files() {
+        let raw = "---\nname: code-reviewer\ndescription: Reviews diffs for correctness\ntools: Read, Grep\n---\nYou are a meticulous reviewer.";
+        let agent = agent_from_file("/ws/.stella/agents/code-reviewer.md", raw).unwrap();
+        assert_eq!(agent.name, "code-reviewer");
+        assert_eq!(agent.description, "Reviews diffs for correctness");
+        assert!(agent.body.contains("meticulous"));
+    }
+
+    // ---- expansion ----
+
+    #[test]
+    fn expand_substitutes_every_arguments_placeholder() {
+        let body = "Fix $ARGUMENTS. When done, verify $ARGUMENTS is closed.";
+        assert_eq!(
+            expand_command(body, "issue-42"),
+            "Fix issue-42. When done, verify issue-42 is closed."
+        );
+    }
+
+    #[test]
+    fn expand_appends_args_when_no_placeholder_exists() {
+        assert_eq!(
+            expand_command("Review the diff.", "focus on tests"),
+            "Review the diff.\n\nfocus on tests"
+        );
+    }
+
+    #[test]
+    fn expand_without_args_leaves_the_body_alone_and_clears_placeholders() {
+        assert_eq!(expand_command("Review the diff.", "  "), "Review the diff.");
+        assert_eq!(expand_command("Fix $ARGUMENTS now", ""), "Fix  now");
+    }
+
+    // ---- merging ----
+
+    #[test]
+    fn merge_by_name_lets_later_entries_override_earlier_ones_in_place() {
+        let items = vec![("a", 1), ("b", 2), ("a", 3)];
+        let merged = merge_by_name(items, |i| i.0);
+        assert_eq!(merged, vec![("a", 3), ("b", 2)]);
+    }
+
+    // ---- sync planning ----
+
+    fn entry(name: &str, path: &str, is_symlink: bool) -> SyncEntry {
+        SyncEntry {
+            name: name.to_string(),
+            path: path.to_string(),
+            is_symlink,
+        }
+    }
+
+    fn no_existing(_: ExtensionKind) -> Vec<String> {
+        Vec::new()
+    }
+
+    #[test]
+    fn plan_links_real_entries_and_skips_symlinked_ones() {
+        // The exact shape found in the wild: `.claude/skills` holds a mix of
+        // real directories and symlinks into `.agents/skills`.
+        let sources = vec![
+            SyncSource {
+                kind: ExtensionKind::Skills,
+                entries: vec![
+                    entry("motion", "/h/.claude/skills/motion", false),
+                    entry("ai-sdk", "/h/.claude/skills/ai-sdk", true),
+                ],
+            },
+            SyncSource {
+                kind: ExtensionKind::Skills,
+                entries: vec![entry("ai-sdk", "/h/.agents/skills/ai-sdk", false)],
+            },
+        ];
+        let plan = plan_extension_sync(&sources, &no_existing);
+        let linked: Vec<(&str, &str)> = plan
+            .links
+            .iter()
+            .map(|l| (l.name.as_str(), l.source_path.as_str()))
+            .collect();
+        // `ai-sdk` is adopted exactly once, from its REAL home in `.agents`.
+        assert_eq!(
+            linked,
+            vec![
+                ("motion", "/h/.claude/skills/motion"),
+                ("ai-sdk", "/h/.agents/skills/ai-sdk"),
+            ]
+        );
+        assert_eq!(plan.skips.len(), 1);
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::SourceIsSymlink);
+    }
+
+    #[test]
+    fn plan_never_clobbers_an_existing_destination_name() {
+        let sources = vec![SyncSource {
+            kind: ExtensionKind::Commands,
+            entries: vec![
+                entry("deploy", "/ws/.claude/commands/deploy.md", false),
+                entry("new-cmd", "/ws/.claude/commands/new-cmd.md", false),
+            ],
+        }];
+        let existing = |kind: ExtensionKind| {
+            assert_eq!(kind, ExtensionKind::Commands);
+            vec!["deploy".to_string()]
+        };
+        let plan = plan_extension_sync(&sources, &existing);
+        assert_eq!(plan.links.len(), 1);
+        assert_eq!(plan.links[0].name, "new-cmd");
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::DestinationExists);
+    }
+
+    #[test]
+    fn plan_gives_the_earlier_source_precedence_on_a_real_name_collision() {
+        let sources = vec![
+            SyncSource {
+                kind: ExtensionKind::Agents,
+                entries: vec![entry("reviewer", "/ws/.claude/agents/reviewer.md", false)],
+            },
+            SyncSource {
+                kind: ExtensionKind::Agents,
+                entries: vec![entry("reviewer", "/ws/.agents/agents/reviewer.md", false)],
+            },
+        ];
+        let plan = plan_extension_sync(&sources, &no_existing);
+        assert_eq!(plan.links.len(), 1);
+        assert_eq!(plan.links[0].source_path, "/ws/.claude/agents/reviewer.md");
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::DuplicateName);
+    }
+
+    #[test]
+    fn rerunning_the_plan_over_a_synced_destination_is_a_no_op() {
+        let sources = vec![SyncSource {
+            kind: ExtensionKind::Skills,
+            entries: vec![entry("motion", "/h/.claude/skills/motion", false)],
+        }];
+        let first = plan_extension_sync(&sources, &no_existing);
+        assert_eq!(first.links.len(), 1);
+        // Second run: the destination now contains what the first run linked.
+        let after: Vec<String> = first.links.iter().map(|l| l.name.clone()).collect();
+        let second = plan_extension_sync(&sources, &move |_| after.clone());
+        assert!(second.links.is_empty());
+        assert_eq!(second.skips[0].reason, SyncSkipReason::DestinationExists);
+    }
+
+    #[test]
+    fn plan_counts_links_per_kind() {
+        let sources = vec![
+            SyncSource {
+                kind: ExtensionKind::Skills,
+                entries: vec![entry("a", "/s/a", false), entry("b", "/s/b", false)],
+            },
+            SyncSource {
+                kind: ExtensionKind::Commands,
+                entries: vec![entry("c", "/c/c.md", false)],
+            },
+        ];
+        let plan = plan_extension_sync(&sources, &no_existing);
+        assert_eq!(plan.linked(ExtensionKind::Skills), 2);
+        assert_eq!(plan.linked(ExtensionKind::Commands), 1);
+        assert_eq!(plan.linked(ExtensionKind::Agents), 0);
+    }
+}

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -28,9 +28,9 @@ pub use budget::{BudgetGuard, BudgetOutcome};
 pub use driver::{Engine, EngineConfig, TurnOutcome};
 pub use estimator::{Calibration, CalibrationMap};
 pub use extensions::{
-    AgentDef, CommandDef, ExtensionDiagnostic, ExtensionKind, ExtensionProblem, PlannedLink,
-    SyncEntry, SyncPlan, SyncSkip, SyncSkipReason, SyncSource, agent_from_file, command_from_file,
-    expand_command, merge_by_name, plan_extension_sync,
+    AgentDef, CommandDef, ExistingTargets, ExtensionDiagnostic, ExtensionKind, ExtensionProblem,
+    PlannedLink, SyncEntry, SyncPlan, SyncSkip, SyncSkipReason, SyncSource, agent_from_file,
+    command_from_file, expand_command, merge_by_name, plan_extension_sync,
 };
 pub use goal::{GoalConfig, GoalOutcome};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod budget;
 pub mod compaction;
 pub mod driver;
 pub mod estimator;
+pub mod extensions;
 mod glob;
 pub mod goal;
 pub mod hooks;
@@ -26,6 +27,11 @@ pub mod skills;
 pub use budget::{BudgetGuard, BudgetOutcome};
 pub use driver::{Engine, EngineConfig, TurnOutcome};
 pub use estimator::{Calibration, CalibrationMap};
+pub use extensions::{
+    AgentDef, CommandDef, ExtensionDiagnostic, ExtensionKind, ExtensionProblem, PlannedLink,
+    SyncEntry, SyncPlan, SyncSkip, SyncSkipReason, SyncSource, agent_from_file, command_from_file,
+    expand_command, merge_by_name, plan_extension_sync,
+};
 pub use goal::{GoalConfig, GoalOutcome};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};
 pub use loop_detect::{LoopDetectionConfig, LoopVerdict, detect_loop};

--- a/stella-tui/src/composer.rs
+++ b/stella-tui/src/composer.rs
@@ -17,8 +17,20 @@
 //! REPL's [`crate::ui`] and the deck's [`crate::deck_ui`]) so a future fix to
 //! selection clamping, Esc semantics, or completion behavior can't land on
 //! one surface and drift from the other.
+//!
+//! ## Textarea semantics
+//!
+//! The live buffer is a real multi-line editor: `⏎` inserts a line break that
+//! survives verbatim into the submitted prompt, the cursor moves freely
+//! (arrows, Home/End, `⌥[`/`⌥]` to the very start/end), and [`layout`]
+//! soft-wraps the content to the viewport width so everything typed stays
+//! visible before submitting. Submission is a chord — `⌘⏎` (or `⌃⏎`) — on
+//! terminals that can report it (the kitty keyboard protocol); on legacy
+//! terminals, where a modified Enter is indistinguishable from a plain one,
+//! [`classify_enter`] falls back to Enter-submits with `⌥⏎` as the newline.
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use unicode_width::UnicodeWidthChar;
 
 /// Below this many lines a paste is inserted inline; at or above it, the
 /// paste collapses to a chip. Small on purpose (L-T3).
@@ -56,31 +68,67 @@ impl ComposerEntry {
     }
 }
 
+/// Where a slash command comes from — decides the glyph the menu row shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SlashKind {
+    /// Productized: shipped by stella itself (🔒).
+    #[default]
+    Builtin,
+    /// Custom: a user-authored command/skill definition loaded from the
+    /// workspace or user-global extension directories (⚡).
+    Custom,
+}
+
+impl SlashKind {
+    /// The menu-row glyph: 🔒 for productized commands, ⚡ for custom ones.
+    pub fn glyph(self) -> &'static str {
+        match self {
+            SlashKind::Builtin => "🔒",
+            SlashKind::Custom => "⚡",
+        }
+    }
+}
+
 /// A single slash command offered by the menu. The `name` includes the
 /// leading slash (e.g. `"/help"`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SlashCommand {
     pub name: String,
     pub description: String,
+    pub kind: SlashKind,
 }
 
 impl SlashCommand {
+    /// A productized (built-in) command — the 🔒 rows.
     pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
+            kind: SlashKind::Builtin,
+        }
+    }
+
+    /// A custom command/skill loaded from a definition file — the ⚡ rows.
+    pub fn custom(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            kind: SlashKind::Custom,
+            ..Self::new(name, description)
         }
     }
 }
 
-/// The input-line model. Committed paste chips precede the live text buffer;
-/// what the user is currently typing lives in `buffer`.
+/// The input model. Committed paste chips precede the live text buffer;
+/// what the user is currently typing lives in `buffer`, a multi-line
+/// textarea with a movable cursor.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Composer {
     /// Chips committed ahead of the live buffer, in order.
     chips: Vec<ComposerEntry>,
-    /// The text currently being typed.
+    /// The text currently being typed. May contain `\n` — line breaks are
+    /// preserved verbatim through [`Composer::take_submission`].
     buffer: String,
+    /// Byte offset of the cursor within `buffer` (always on a char boundary).
+    cursor: usize,
     /// Paste-collapse threshold in lines.
     paste_threshold: usize,
 }
@@ -117,37 +165,140 @@ impl Composer {
         self.chips.is_empty() && self.buffer.trim().is_empty()
     }
 
-    /// Type one character into the live buffer.
-    pub fn insert_char(&mut self, c: char) {
-        self.buffer.push(c);
+    /// True when there is nothing at all to edit — no chips and not even
+    /// whitespace in the buffer (stricter than [`Composer::is_empty`], which
+    /// is about submittability).
+    pub fn is_blank(&self) -> bool {
+        self.chips.is_empty() && self.buffer.is_empty()
     }
 
-    /// Delete the last character; if the buffer is empty, pop the last chip
-    /// instead (backspacing off the front of the buffer removes a paste).
+    /// Byte offset of the cursor within [`Composer::buffer`].
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Type one character at the cursor.
+    pub fn insert_char(&mut self, c: char) {
+        self.buffer.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+    }
+
+    /// Insert a line break at the cursor — the plain-`⏎` textarea action.
+    pub fn insert_newline(&mut self) {
+        self.insert_char('\n');
+    }
+
+    /// Delete the character before the cursor; at the very start of the
+    /// buffer, pop the last chip instead (backspacing off the front of the
+    /// buffer removes a paste).
     pub fn backspace(&mut self) {
-        if self.buffer.pop().is_none() {
+        if self.cursor > 0 {
+            let prev = prev_char_start(&self.buffer, self.cursor);
+            self.buffer.replace_range(prev..self.cursor, "");
+            self.cursor = prev;
+        } else {
             self.chips.pop();
         }
     }
 
-    /// Handle a paste. A paste at or above the line threshold collapses to a
-    /// chip (the full payload retained); a small paste inserts inline.
+    /// Handle a paste at the cursor. A paste at or above the line threshold
+    /// collapses to a chip (the full payload retained); a small paste inserts
+    /// inline. Terminal paste streams carry `\r`/`\r\n` line endings in raw
+    /// mode — normalized to `\n` so the buffer has one newline convention.
     pub fn paste(&mut self, pasted: &str) {
-        let line_count = line_count(pasted);
+        let pasted = pasted.replace("\r\n", "\n").replace('\r', "\n");
+        let line_count = line_count(&pasted);
         if line_count >= self.paste_threshold {
-            // Flush the in-progress buffer as its own text entry so ordering
-            // (typed text, then chip) is preserved on submit.
-            if !self.buffer.is_empty() {
-                self.chips
-                    .push(ComposerEntry::Text(std::mem::take(&mut self.buffer)));
+            // Text before the cursor is committed ahead of the chip so
+            // ordering (typed text, then chip) is preserved on submit; text
+            // after the cursor stays in the buffer, which follows the chips.
+            let before = self.buffer[..self.cursor].to_string();
+            let after = self.buffer[self.cursor..].to_string();
+            if !before.is_empty() {
+                self.chips.push(ComposerEntry::Text(before));
             }
             self.chips.push(ComposerEntry::Chip {
-                full_text: pasted.to_string(),
+                full_text: pasted,
                 line_count,
             });
+            self.buffer = after;
+            self.cursor = 0;
         } else {
-            self.buffer.push_str(pasted);
+            self.buffer.insert_str(self.cursor, &pasted);
+            self.cursor += pasted.len();
         }
+    }
+
+    // ---- Cursor motion (textarea semantics) --------------------------------
+
+    /// One character left.
+    pub fn move_left(&mut self) {
+        if self.cursor > 0 {
+            self.cursor = prev_char_start(&self.buffer, self.cursor);
+        }
+    }
+
+    /// One character right.
+    pub fn move_right(&mut self) {
+        if let Some(c) = self.buffer[self.cursor..].chars().next() {
+            self.cursor += c.len_utf8();
+        }
+    }
+
+    /// To the very start of the prompt — the `⌥[` jump (position 0, before
+    /// the first character).
+    pub fn move_to_start(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// To one past the last character — the `⌥]` jump.
+    pub fn move_to_end(&mut self) {
+        self.cursor = self.buffer.len();
+    }
+
+    /// To the start of the current logical line.
+    pub fn move_line_start(&mut self) {
+        self.cursor = line_start(&self.buffer, self.cursor);
+    }
+
+    /// To the end of the current logical line (before its `\n`).
+    pub fn move_line_end(&mut self) {
+        self.cursor = self.buffer[self.cursor..]
+            .find('\n')
+            .map(|i| self.cursor + i)
+            .unwrap_or(self.buffer.len());
+    }
+
+    /// Up one logical line, keeping the character column where possible.
+    /// On the first line, jumps to the start (matching most editors' clamp).
+    pub fn move_up(&mut self) {
+        let start = line_start(&self.buffer, self.cursor);
+        if start == 0 {
+            self.cursor = 0;
+            return;
+        }
+        let col = self.buffer[start..self.cursor].chars().count();
+        let prev_start = line_start(&self.buffer, start - 1);
+        let prev_line = &self.buffer[prev_start..start - 1];
+        self.cursor = prev_start + byte_at_char_col(prev_line, col);
+    }
+
+    /// Down one logical line, keeping the character column where possible.
+    /// On the last line, jumps to the end.
+    pub fn move_down(&mut self) {
+        let Some(newline) = self.buffer[self.cursor..].find('\n') else {
+            self.cursor = self.buffer.len();
+            return;
+        };
+        let start = line_start(&self.buffer, self.cursor);
+        let col = self.buffer[start..self.cursor].chars().count();
+        let next_start = self.cursor + newline + 1;
+        let next_end = self.buffer[next_start..]
+            .find('\n')
+            .map(|i| next_start + i)
+            .unwrap_or(self.buffer.len());
+        let next_line = &self.buffer[next_start..next_end];
+        self.cursor = next_start + byte_at_char_col(next_line, col);
     }
 
     /// The on-screen input line: chip displays joined with the live buffer.
@@ -160,7 +311,8 @@ impl Composer {
     }
 
     /// Assemble the full message the model receives — chips expanded to their
-    /// payloads — and clear the composer. Returns `None` when empty.
+    /// payloads, typed line breaks preserved verbatim — and clear the
+    /// composer. Returns `None` when empty.
     pub fn take_submission(&mut self) -> Option<String> {
         if self.is_empty() {
             return None;
@@ -174,6 +326,7 @@ impl Composer {
             parts.push(std::mem::take(&mut self.buffer));
         }
         self.chips.clear();
+        self.cursor = 0;
         Some(parts.join("\n"))
     }
 
@@ -181,14 +334,17 @@ impl Composer {
     pub fn clear(&mut self) {
         self.chips.clear();
         self.buffer.clear();
+        self.cursor = 0;
     }
 
     /// Replace the composer's content with `text` — the queue editor uses
     /// this to pull a queued prompt back in for editing. Any in-progress
     /// chips/typing are discarded (the caller decides when that is right).
+    /// The cursor lands at the end, ready to keep typing.
     pub fn load(&mut self, text: impl Into<String>) {
         self.chips.clear();
         self.buffer = text.into();
+        self.cursor = self.buffer.len();
     }
 
     /// The slash-menu view over `commands`, or `None` when the buffer is not
@@ -204,6 +360,180 @@ impl Composer {
         }
         Some(SlashMenu::filter(commands, q))
     }
+}
+
+/// Byte index of the char boundary immediately before `idx`.
+fn prev_char_start(s: &str, idx: usize) -> usize {
+    s[..idx].char_indices().last().map(|(i, _)| i).unwrap_or(0)
+}
+
+/// Byte index where the logical line containing `idx` starts.
+fn line_start(s: &str, idx: usize) -> usize {
+    s[..idx].rfind('\n').map(|i| i + 1).unwrap_or(0)
+}
+
+/// Byte offset of character column `col` within `line`, clamped to its end.
+fn byte_at_char_col(line: &str, col: usize) -> usize {
+    line.char_indices()
+        .nth(col)
+        .map(|(i, _)| i)
+        .unwrap_or(line.len())
+}
+
+// ---------------------------------------------------------------------------
+// Enter classification + shared textarea key handling
+// ---------------------------------------------------------------------------
+
+/// What an `⏎` keypress means for the composer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnterAction {
+    /// Dispatch the composer's content.
+    Submit,
+    /// Insert a line break at the cursor.
+    Newline,
+    /// The key is not Enter at all.
+    NotEnter,
+}
+
+/// Classify an Enter keypress for a textarea composer.
+///
+/// With the kitty keyboard protocol active (`enter_submits == false`) the
+/// submit action is a chord — `⌘⏎` (macOS Cmd reports as SUPER/META) or `⌃⏎`
+/// — and a plain or `⌥`-modified `⏎` is a line break. On legacy terminals
+/// (`enter_submits == true`) a modified Enter is indistinguishable from a
+/// plain one, so plain `⏎` submits and the line break moves to `⌥⏎` (its ESC
+/// prefix survives even legacy encodings).
+pub fn classify_enter(key: &KeyEvent, enter_submits: bool) -> EnterAction {
+    if !matches!(key.code, KeyCode::Enter) {
+        return EnterAction::NotEnter;
+    }
+    let chord = key
+        .modifiers
+        .intersects(KeyModifiers::SUPER | KeyModifiers::META | KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    if chord || (enter_submits && !alt) {
+        EnterAction::Submit
+    } else {
+        EnterAction::Newline
+    }
+}
+
+/// Textarea cursor-motion keys shared by every composer surface. Returns
+/// `true` when the key was consumed. Motion that would collide with a
+/// surface's own navigation (transcript scroll, tab views) is gated on the
+/// buffer actually having something to move through: ←/→ need text, ↑/↓ need
+/// a second line — so an empty composer leaves every arrow to its surface.
+pub fn handle_edit_key(key: KeyEvent, composer: &mut Composer) -> bool {
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    let cmd = key
+        .modifiers
+        .intersects(KeyModifiers::SUPER | KeyModifiers::META);
+    let has_text = !composer.buffer().is_empty();
+    let multiline = composer.buffer().contains('\n');
+    match key.code {
+        // ⌥[ / ⌥] — cursor (and the wrapped view with it) to the very start /
+        // one past the last character.
+        KeyCode::Char('[') if alt => composer.move_to_start(),
+        KeyCode::Char(']') if alt => composer.move_to_end(),
+        // ⌘↑ / ⌘↓ — the macOS-native start/end-of-document synonyms.
+        KeyCode::Up if cmd => composer.move_to_start(),
+        KeyCode::Down if cmd => composer.move_to_end(),
+        KeyCode::Left if has_text => composer.move_left(),
+        KeyCode::Right if has_text => composer.move_right(),
+        KeyCode::Up if multiline => composer.move_up(),
+        KeyCode::Down if multiline => composer.move_down(),
+        KeyCode::Home if has_text => composer.move_line_start(),
+        KeyCode::End if has_text => composer.move_line_end(),
+        _ => return false,
+    }
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Soft-wrap layout (pure, so both renderers and the tests share one truth)
+// ---------------------------------------------------------------------------
+
+/// The composer soft-wrapped to a viewport width: every visual row plus the
+/// cursor's position among them. Hard breaks (`\n`) and soft wraps both
+/// produce rows, so `rows.len()` is the height the composer wants and the
+/// caller can scroll a capped window to `cursor_row`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposerLayout {
+    /// The wrapped display rows (chips rendered as their `[pasted: …]` form).
+    pub rows: Vec<String>,
+    /// Row index the cursor sits on.
+    pub cursor_row: usize,
+    /// Display-width column of the cursor within `rows[cursor_row]`.
+    pub cursor_col: usize,
+}
+
+/// Soft-wrap the composer's display content to `width` columns
+/// (unicode-width aware; `\n` is a hard break) and locate the cursor.
+pub fn layout(composer: &Composer, width: usize) -> ComposerLayout {
+    let width = width.max(1);
+    let mut display = String::new();
+    for chip in &composer.chips {
+        display.push_str(&chip.display());
+        display.push(' ');
+    }
+    let cursor_at = display.len() + composer.cursor();
+    display.push_str(composer.buffer());
+
+    let mut rows: Vec<String> = vec![String::new()];
+    let mut col = 0usize;
+    let (mut cursor_row, mut cursor_col) = (0usize, 0usize);
+    for (idx, ch) in display.char_indices() {
+        if ch == '\n' {
+            // A cursor on the newline itself renders at this row's end.
+            if idx == cursor_at {
+                (cursor_row, cursor_col) = (rows.len() - 1, col);
+            }
+            rows.push(String::new());
+            col = 0;
+            continue;
+        }
+        let w = ch.width().unwrap_or(0);
+        if col + w > width && col > 0 {
+            rows.push(String::new());
+            col = 0;
+        }
+        if idx == cursor_at {
+            (cursor_row, cursor_col) = (rows.len() - 1, col);
+        }
+        rows.last_mut().expect("rows is never empty").push(ch);
+        col += w;
+    }
+    if cursor_at == display.len() {
+        // Cursor past the last character; if that row is exactly full the
+        // insertion point visually lives on a fresh row.
+        if col >= width {
+            rows.push(String::new());
+            col = 0;
+        }
+        (cursor_row, cursor_col) = (rows.len() - 1, col);
+    }
+    ComposerLayout {
+        rows,
+        cursor_row,
+        cursor_col,
+    }
+}
+
+/// Split one display row at `col` display columns for block-cursor drawing:
+/// `(before, under, after)`, where `under` is the character the cursor sits
+/// on (`None` at end of row — the caller draws a reversed space).
+pub fn split_row_at(row: &str, col: usize) -> (String, Option<char>, String) {
+    let mut acc = 0usize;
+    let mut chars = row.chars();
+    let mut before = String::new();
+    for ch in chars.by_ref() {
+        if acc >= col {
+            return (before, Some(ch), chars.collect());
+        }
+        acc += ch.width().unwrap_or(0);
+        before.push(ch);
+    }
+    (before, None, String::new())
 }
 
 /// The filtered slash-command list for the current query. Borrows the

--- a/stella-tui/src/composer.rs
+++ b/stella-tui/src/composer.rs
@@ -17,20 +17,8 @@
 //! REPL's [`crate::ui`] and the deck's [`crate::deck_ui`]) so a future fix to
 //! selection clamping, Esc semantics, or completion behavior can't land on
 //! one surface and drift from the other.
-//!
-//! ## Textarea semantics
-//!
-//! The live buffer is a real multi-line editor: `⏎` inserts a line break that
-//! survives verbatim into the submitted prompt, the cursor moves freely
-//! (arrows, Home/End, `⌥[`/`⌥]` to the very start/end), and [`layout`]
-//! soft-wraps the content to the viewport width so everything typed stays
-//! visible before submitting. Submission is a chord — `⌘⏎` (or `⌃⏎`) — on
-//! terminals that can report it (the kitty keyboard protocol); on legacy
-//! terminals, where a modified Enter is indistinguishable from a plain one,
-//! [`classify_enter`] falls back to Enter-submits with `⌥⏎` as the newline.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use unicode_width::UnicodeWidthChar;
+use crossterm::event::{KeyCode, KeyEvent};
 
 /// Below this many lines a paste is inserted inline; at or above it, the
 /// paste collapses to a chip. Small on purpose (L-T3).
@@ -117,18 +105,14 @@ impl SlashCommand {
     }
 }
 
-/// The input model. Committed paste chips precede the live text buffer;
-/// what the user is currently typing lives in `buffer`, a multi-line
-/// textarea with a movable cursor.
+/// The input-line model. Committed paste chips precede the live text buffer;
+/// what the user is currently typing lives in `buffer`.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Composer {
     /// Chips committed ahead of the live buffer, in order.
     chips: Vec<ComposerEntry>,
-    /// The text currently being typed. May contain `\n` — line breaks are
-    /// preserved verbatim through [`Composer::take_submission`].
+    /// The text currently being typed.
     buffer: String,
-    /// Byte offset of the cursor within `buffer` (always on a char boundary).
-    cursor: usize,
     /// Paste-collapse threshold in lines.
     paste_threshold: usize,
 }
@@ -165,140 +149,37 @@ impl Composer {
         self.chips.is_empty() && self.buffer.trim().is_empty()
     }
 
-    /// True when there is nothing at all to edit — no chips and not even
-    /// whitespace in the buffer (stricter than [`Composer::is_empty`], which
-    /// is about submittability).
-    pub fn is_blank(&self) -> bool {
-        self.chips.is_empty() && self.buffer.is_empty()
-    }
-
-    /// Byte offset of the cursor within [`Composer::buffer`].
-    pub fn cursor(&self) -> usize {
-        self.cursor
-    }
-
-    /// Type one character at the cursor.
+    /// Type one character into the live buffer.
     pub fn insert_char(&mut self, c: char) {
-        self.buffer.insert(self.cursor, c);
-        self.cursor += c.len_utf8();
+        self.buffer.push(c);
     }
 
-    /// Insert a line break at the cursor — the plain-`⏎` textarea action.
-    pub fn insert_newline(&mut self) {
-        self.insert_char('\n');
-    }
-
-    /// Delete the character before the cursor; at the very start of the
-    /// buffer, pop the last chip instead (backspacing off the front of the
-    /// buffer removes a paste).
+    /// Delete the last character; if the buffer is empty, pop the last chip
+    /// instead (backspacing off the front of the buffer removes a paste).
     pub fn backspace(&mut self) {
-        if self.cursor > 0 {
-            let prev = prev_char_start(&self.buffer, self.cursor);
-            self.buffer.replace_range(prev..self.cursor, "");
-            self.cursor = prev;
-        } else {
+        if self.buffer.pop().is_none() {
             self.chips.pop();
         }
     }
 
-    /// Handle a paste at the cursor. A paste at or above the line threshold
-    /// collapses to a chip (the full payload retained); a small paste inserts
-    /// inline. Terminal paste streams carry `\r`/`\r\n` line endings in raw
-    /// mode — normalized to `\n` so the buffer has one newline convention.
+    /// Handle a paste. A paste at or above the line threshold collapses to a
+    /// chip (the full payload retained); a small paste inserts inline.
     pub fn paste(&mut self, pasted: &str) {
-        let pasted = pasted.replace("\r\n", "\n").replace('\r', "\n");
-        let line_count = line_count(&pasted);
+        let line_count = line_count(pasted);
         if line_count >= self.paste_threshold {
-            // Text before the cursor is committed ahead of the chip so
-            // ordering (typed text, then chip) is preserved on submit; text
-            // after the cursor stays in the buffer, which follows the chips.
-            let before = self.buffer[..self.cursor].to_string();
-            let after = self.buffer[self.cursor..].to_string();
-            if !before.is_empty() {
-                self.chips.push(ComposerEntry::Text(before));
+            // Flush the in-progress buffer as its own text entry so ordering
+            // (typed text, then chip) is preserved on submit.
+            if !self.buffer.is_empty() {
+                self.chips
+                    .push(ComposerEntry::Text(std::mem::take(&mut self.buffer)));
             }
             self.chips.push(ComposerEntry::Chip {
-                full_text: pasted,
+                full_text: pasted.to_string(),
                 line_count,
             });
-            self.buffer = after;
-            self.cursor = 0;
         } else {
-            self.buffer.insert_str(self.cursor, &pasted);
-            self.cursor += pasted.len();
+            self.buffer.push_str(pasted);
         }
-    }
-
-    // ---- Cursor motion (textarea semantics) --------------------------------
-
-    /// One character left.
-    pub fn move_left(&mut self) {
-        if self.cursor > 0 {
-            self.cursor = prev_char_start(&self.buffer, self.cursor);
-        }
-    }
-
-    /// One character right.
-    pub fn move_right(&mut self) {
-        if let Some(c) = self.buffer[self.cursor..].chars().next() {
-            self.cursor += c.len_utf8();
-        }
-    }
-
-    /// To the very start of the prompt — the `⌥[` jump (position 0, before
-    /// the first character).
-    pub fn move_to_start(&mut self) {
-        self.cursor = 0;
-    }
-
-    /// To one past the last character — the `⌥]` jump.
-    pub fn move_to_end(&mut self) {
-        self.cursor = self.buffer.len();
-    }
-
-    /// To the start of the current logical line.
-    pub fn move_line_start(&mut self) {
-        self.cursor = line_start(&self.buffer, self.cursor);
-    }
-
-    /// To the end of the current logical line (before its `\n`).
-    pub fn move_line_end(&mut self) {
-        self.cursor = self.buffer[self.cursor..]
-            .find('\n')
-            .map(|i| self.cursor + i)
-            .unwrap_or(self.buffer.len());
-    }
-
-    /// Up one logical line, keeping the character column where possible.
-    /// On the first line, jumps to the start (matching most editors' clamp).
-    pub fn move_up(&mut self) {
-        let start = line_start(&self.buffer, self.cursor);
-        if start == 0 {
-            self.cursor = 0;
-            return;
-        }
-        let col = self.buffer[start..self.cursor].chars().count();
-        let prev_start = line_start(&self.buffer, start - 1);
-        let prev_line = &self.buffer[prev_start..start - 1];
-        self.cursor = prev_start + byte_at_char_col(prev_line, col);
-    }
-
-    /// Down one logical line, keeping the character column where possible.
-    /// On the last line, jumps to the end.
-    pub fn move_down(&mut self) {
-        let Some(newline) = self.buffer[self.cursor..].find('\n') else {
-            self.cursor = self.buffer.len();
-            return;
-        };
-        let start = line_start(&self.buffer, self.cursor);
-        let col = self.buffer[start..self.cursor].chars().count();
-        let next_start = self.cursor + newline + 1;
-        let next_end = self.buffer[next_start..]
-            .find('\n')
-            .map(|i| next_start + i)
-            .unwrap_or(self.buffer.len());
-        let next_line = &self.buffer[next_start..next_end];
-        self.cursor = next_start + byte_at_char_col(next_line, col);
     }
 
     /// The on-screen input line: chip displays joined with the live buffer.
@@ -311,8 +192,7 @@ impl Composer {
     }
 
     /// Assemble the full message the model receives — chips expanded to their
-    /// payloads, typed line breaks preserved verbatim — and clear the
-    /// composer. Returns `None` when empty.
+    /// payloads — and clear the composer. Returns `None` when empty.
     pub fn take_submission(&mut self) -> Option<String> {
         if self.is_empty() {
             return None;
@@ -326,7 +206,6 @@ impl Composer {
             parts.push(std::mem::take(&mut self.buffer));
         }
         self.chips.clear();
-        self.cursor = 0;
         Some(parts.join("\n"))
     }
 
@@ -334,17 +213,14 @@ impl Composer {
     pub fn clear(&mut self) {
         self.chips.clear();
         self.buffer.clear();
-        self.cursor = 0;
     }
 
     /// Replace the composer's content with `text` — the queue editor uses
     /// this to pull a queued prompt back in for editing. Any in-progress
     /// chips/typing are discarded (the caller decides when that is right).
-    /// The cursor lands at the end, ready to keep typing.
     pub fn load(&mut self, text: impl Into<String>) {
         self.chips.clear();
         self.buffer = text.into();
-        self.cursor = self.buffer.len();
     }
 
     /// The slash-menu view over `commands`, or `None` when the buffer is not
@@ -360,180 +236,6 @@ impl Composer {
         }
         Some(SlashMenu::filter(commands, q))
     }
-}
-
-/// Byte index of the char boundary immediately before `idx`.
-fn prev_char_start(s: &str, idx: usize) -> usize {
-    s[..idx].char_indices().last().map(|(i, _)| i).unwrap_or(0)
-}
-
-/// Byte index where the logical line containing `idx` starts.
-fn line_start(s: &str, idx: usize) -> usize {
-    s[..idx].rfind('\n').map(|i| i + 1).unwrap_or(0)
-}
-
-/// Byte offset of character column `col` within `line`, clamped to its end.
-fn byte_at_char_col(line: &str, col: usize) -> usize {
-    line.char_indices()
-        .nth(col)
-        .map(|(i, _)| i)
-        .unwrap_or(line.len())
-}
-
-// ---------------------------------------------------------------------------
-// Enter classification + shared textarea key handling
-// ---------------------------------------------------------------------------
-
-/// What an `⏎` keypress means for the composer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EnterAction {
-    /// Dispatch the composer's content.
-    Submit,
-    /// Insert a line break at the cursor.
-    Newline,
-    /// The key is not Enter at all.
-    NotEnter,
-}
-
-/// Classify an Enter keypress for a textarea composer.
-///
-/// With the kitty keyboard protocol active (`enter_submits == false`) the
-/// submit action is a chord — `⌘⏎` (macOS Cmd reports as SUPER/META) or `⌃⏎`
-/// — and a plain or `⌥`-modified `⏎` is a line break. On legacy terminals
-/// (`enter_submits == true`) a modified Enter is indistinguishable from a
-/// plain one, so plain `⏎` submits and the line break moves to `⌥⏎` (its ESC
-/// prefix survives even legacy encodings).
-pub fn classify_enter(key: &KeyEvent, enter_submits: bool) -> EnterAction {
-    if !matches!(key.code, KeyCode::Enter) {
-        return EnterAction::NotEnter;
-    }
-    let chord = key
-        .modifiers
-        .intersects(KeyModifiers::SUPER | KeyModifiers::META | KeyModifiers::CONTROL);
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
-    if chord || (enter_submits && !alt) {
-        EnterAction::Submit
-    } else {
-        EnterAction::Newline
-    }
-}
-
-/// Textarea cursor-motion keys shared by every composer surface. Returns
-/// `true` when the key was consumed. Motion that would collide with a
-/// surface's own navigation (transcript scroll, tab views) is gated on the
-/// buffer actually having something to move through: ←/→ need text, ↑/↓ need
-/// a second line — so an empty composer leaves every arrow to its surface.
-pub fn handle_edit_key(key: KeyEvent, composer: &mut Composer) -> bool {
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
-    let cmd = key
-        .modifiers
-        .intersects(KeyModifiers::SUPER | KeyModifiers::META);
-    let has_text = !composer.buffer().is_empty();
-    let multiline = composer.buffer().contains('\n');
-    match key.code {
-        // ⌥[ / ⌥] — cursor (and the wrapped view with it) to the very start /
-        // one past the last character.
-        KeyCode::Char('[') if alt => composer.move_to_start(),
-        KeyCode::Char(']') if alt => composer.move_to_end(),
-        // ⌘↑ / ⌘↓ — the macOS-native start/end-of-document synonyms.
-        KeyCode::Up if cmd => composer.move_to_start(),
-        KeyCode::Down if cmd => composer.move_to_end(),
-        KeyCode::Left if has_text => composer.move_left(),
-        KeyCode::Right if has_text => composer.move_right(),
-        KeyCode::Up if multiline => composer.move_up(),
-        KeyCode::Down if multiline => composer.move_down(),
-        KeyCode::Home if has_text => composer.move_line_start(),
-        KeyCode::End if has_text => composer.move_line_end(),
-        _ => return false,
-    }
-    true
-}
-
-// ---------------------------------------------------------------------------
-// Soft-wrap layout (pure, so both renderers and the tests share one truth)
-// ---------------------------------------------------------------------------
-
-/// The composer soft-wrapped to a viewport width: every visual row plus the
-/// cursor's position among them. Hard breaks (`\n`) and soft wraps both
-/// produce rows, so `rows.len()` is the height the composer wants and the
-/// caller can scroll a capped window to `cursor_row`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ComposerLayout {
-    /// The wrapped display rows (chips rendered as their `[pasted: …]` form).
-    pub rows: Vec<String>,
-    /// Row index the cursor sits on.
-    pub cursor_row: usize,
-    /// Display-width column of the cursor within `rows[cursor_row]`.
-    pub cursor_col: usize,
-}
-
-/// Soft-wrap the composer's display content to `width` columns
-/// (unicode-width aware; `\n` is a hard break) and locate the cursor.
-pub fn layout(composer: &Composer, width: usize) -> ComposerLayout {
-    let width = width.max(1);
-    let mut display = String::new();
-    for chip in &composer.chips {
-        display.push_str(&chip.display());
-        display.push(' ');
-    }
-    let cursor_at = display.len() + composer.cursor();
-    display.push_str(composer.buffer());
-
-    let mut rows: Vec<String> = vec![String::new()];
-    let mut col = 0usize;
-    let (mut cursor_row, mut cursor_col) = (0usize, 0usize);
-    for (idx, ch) in display.char_indices() {
-        if ch == '\n' {
-            // A cursor on the newline itself renders at this row's end.
-            if idx == cursor_at {
-                (cursor_row, cursor_col) = (rows.len() - 1, col);
-            }
-            rows.push(String::new());
-            col = 0;
-            continue;
-        }
-        let w = ch.width().unwrap_or(0);
-        if col + w > width && col > 0 {
-            rows.push(String::new());
-            col = 0;
-        }
-        if idx == cursor_at {
-            (cursor_row, cursor_col) = (rows.len() - 1, col);
-        }
-        rows.last_mut().expect("rows is never empty").push(ch);
-        col += w;
-    }
-    if cursor_at == display.len() {
-        // Cursor past the last character; if that row is exactly full the
-        // insertion point visually lives on a fresh row.
-        if col >= width {
-            rows.push(String::new());
-            col = 0;
-        }
-        (cursor_row, cursor_col) = (rows.len() - 1, col);
-    }
-    ComposerLayout {
-        rows,
-        cursor_row,
-        cursor_col,
-    }
-}
-
-/// Split one display row at `col` display columns for block-cursor drawing:
-/// `(before, under, after)`, where `under` is the character the cursor sits
-/// on (`None` at end of row — the caller draws a reversed space).
-pub fn split_row_at(row: &str, col: usize) -> (String, Option<char>, String) {
-    let mut acc = 0usize;
-    let mut chars = row.chars();
-    let mut before = String::new();
-    for ch in chars.by_ref() {
-        if acc >= col {
-            return (before, Some(ch), chars.collect());
-        }
-        acc += ch.width().unwrap_or(0);
-        before.push(ch);
-    }
-    (before, None, String::new())
 }
 
 /// The filtered slash-command list for the current query. Borrows the
@@ -731,6 +433,12 @@ mod tests {
             c.insert_char(ch);
         }
         assert!(c.slash_menu(&cmds).is_none());
+    }
+
+    #[test]
+    fn slash_command_constructors_set_the_kind() {
+        assert_eq!(SlashCommand::new("/help", "d").kind, SlashKind::Builtin);
+        assert_eq!(SlashCommand::custom("/x", "d").kind, SlashKind::Custom);
     }
 
     #[test]

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -239,10 +239,11 @@ impl WorkspaceModel {
                     self.agents[idx].model.push_user_prompt(text);
                 }
             }
-            // The graph snapshot is an out-of-band read-model, not part of the
-            // event-log fold — the view state owns it, applied in
-            // `ingest_inbound`, so the model deliberately ignores it here.
-            Inbound::GraphSnapshot(_) => {}
+            // The graph snapshot and the slash vocabulary are out-of-band
+            // read-models, not part of the event-log fold — the view state
+            // owns them, applied in `ingest_inbound`, so the model
+            // deliberately ignores them here.
+            Inbound::GraphSnapshot(_) | Inbound::SlashCommands(_) => {}
         }
     }
 

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -183,11 +183,16 @@ pub enum DeckAction {
 
 /// Fold one inbound envelope and keep the ephemeral UI in range.
 pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) {
-    // A refreshed graph snapshot is out-of-band view state (the Graph tab),
-    // not a model fold — apply it straight to the UI. Everything else folds
-    // into the model, then selections are re-clamped.
+    // A refreshed graph snapshot or slash vocabulary is out-of-band view
+    // state, not a model fold — apply it straight to the UI. Everything else
+    // folds into the model, then selections are re-clamped.
     if let Inbound::GraphSnapshot(snapshot) = inbound {
         ui.graph = Some(snapshot.clone());
+        return;
+    }
+    if let Inbound::SlashCommands(commands) = inbound {
+        ui.slash_commands = commands.clone();
+        ui.slash_selected = 0;
         return;
     }
     model.apply_inbound(inbound);

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -131,6 +131,12 @@ pub enum Inbound {
     /// sends one after `/init` rebuilds the index so the tab reflects it
     /// without a restart.
     GraphSnapshot(GraphSnapshot),
+    /// A refreshed slash-command vocabulary for the `/` popup. Out-of-band
+    /// view state exactly like [`Inbound::GraphSnapshot`]: applied straight
+    /// to `DeckUi::slash_commands` by [`crate::deck_ui::ingest_inbound`],
+    /// ignored by the model fold. The driver sends one after `/init` adopts
+    /// custom commands/skills so the menu reflects them without a restart.
+    SlashCommands(Vec<crate::composer::SlashCommand>),
 }
 
 /// What the deck sends back to the caller / engine. The single-session

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -56,7 +56,7 @@ pub mod theme;
 pub mod views;
 
 pub use composer::{
-    Composer, ComposerEntry, DEFAULT_PASTE_LINE_THRESHOLD, SlashCommand, SlashMenu,
+    Composer, ComposerEntry, DEFAULT_PASTE_LINE_THRESHOLD, SlashCommand, SlashKind, SlashMenu,
 };
 pub use input::{ScopeDecision, UserInput};
 pub use model::{FileState, Hud, SessionModel, TranscriptEntry};

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -559,6 +559,7 @@ pub(crate) fn render_slash_popup(menu: &SlashMenu, selected: usize, area: Rect, 
             }
             Line::from(vec![
                 Span::styled(marker.to_string(), name_style),
+                Span::styled(format!("{} ", c.kind.glyph()), name_style),
                 Span::styled(c.name.clone(), name_style),
                 Span::styled("  ", desc_style),
                 Span::styled(c.description.clone(), desc_style),
@@ -1343,13 +1344,38 @@ mod tests {
         );
         ui.slash_selected = 1;
         let text = draw(&model, &mut ui, 100, 30);
+        // The glyph is double-width: its trailing filler cell dumps as an
+        // extra space before the explicit separator.
         assert!(
-            text.contains("▸ /diff"),
-            "selection marker on the second row:\n{text}"
+            text.contains("▸ 🔒  /diff"),
+            "selection marker + builtin glyph on the second row:\n{text}"
         );
         assert!(
             text.contains("/ commands · 2"),
             "popup title with the match count:\n{text}"
+        );
+    }
+
+    #[test]
+    fn slash_popup_glyphs_distinguish_builtin_from_custom_commands() {
+        let model = SessionModel::new();
+        let mut composer = Composer::new();
+        composer.insert_char('/');
+        let mut ui = UiState::new(
+            composer,
+            vec![
+                SlashCommand::new("/help", "show help"),
+                SlashCommand::custom("/fix-bug", "fix the named bug"),
+            ],
+        );
+        let text = draw(&model, &mut ui, 100, 30);
+        assert!(
+            text.contains("🔒  /help"),
+            "productized commands carry the lock glyph:\n{text}"
+        );
+        assert!(
+            text.contains("⚡  /fix-bug"),
+            "custom commands carry the lightning glyph:\n{text}"
         );
     }
 


### PR DESCRIPTION
## What

Adds first-class support for **custom commands, skills, and agents** — markdown-with-frontmatter definition files — and an init-time **symlink sync** that adopts definitions other code agents keep in `.claude/` and `.agents/`.

### Adoption on init

`stella init` (and `/init` in chat) now scans `<ws>/{.claude,.agents}/{commands,skills,agents}` and `~/{.claude,.agents}/…`, symlinking entries into `<ws>/.stella/…` and `~/.config/stella/…` respectively:

- **Never link a symlink** — ecosystem tools cross-link these directories (e.g. `.claude/skills/x -> ../../.agents/skills/x`); following one would adopt the same definition twice. Entries are adopted once, from their real home.
- **Never clobber** — names already present (hand-authored or previously linked) are skipped, so the sync is idempotent.
- Links are relative, best-effort, and never fail init. Progress lines report what was adopted per scope.

### Slash menu

- Productized commands render with 🔒, custom commands **and skills** with ⚡ — names and descriptions from frontmatter.
- `/name args` expands a custom command's body (`$ARGUMENTS` substitution, or appended) into the model prompt; `/skill-name task` injects the skill body with the task.
- Builtins can never be shadowed by custom names; commands shadow same-named skills.
- A new `Inbound::SlashCommands` envelope (same out-of-band pattern as `GraphSnapshot`) refreshes the deck's menu right after `/init`, so just-adopted definitions appear without a restart.

### /agents

Lists custom agent definitions (name — description — source path) in both the deck and the plain REPL; the persona body is parsed and retained as the seam for a future fleet spawn.

## How

House pattern throughout: pure logic in `stella-core/src/extensions.rs` (parsers, `$ARGUMENTS` expansion, name-merged precedence, typed sync **plan**), all I/O in `stella-cli/src/extensions.rs` (scanning with `symlink_metadata`, relative-link creation, loaders). Skills reuse the existing engine — `FsSkillSource` loading is extracted into a shared free function, so adopted skills are both auto-recalled and explicitly invocable.

## Testing

- 17 new unit tests in `stella-core` (parsing fallbacks/diagnostics, expansion, plan rules incl. the in-the-wild `.claude`→`.agents` symlink shape), 8 in `stella-cli` (tempdir sync end-to-end, idempotency, no-clobber, loader precedence, menu classification, expansion), 2 popup-glyph render tests in `stella-tui`.
- Full workspace suite green; clippy clean; `cargo fmt --check` clean.
- Manual smoke test: `stella init` in a scratch workspace with fixture `.claude`/`.agents` dirs (isolated `$HOME`) — verified correct relative links at both scopes, symlink-source skipping, readable definitions through links, and a no-op second run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class custom commands, skills, and agents from markdown, and safely adopts existing `.claude`/`.agents` on init via a symlink sync. Both chat surfaces support `/name args`, show ⚡ in the slash menu, list `/agents`, and surface loader errors; built-ins can’t be shadowed.

- **New Features**
  - Init adoption: scan `<ws>/{.claude,.agents}/{commands,skills,agents}` and `~/{.claude,.agents}/…`; create relative symlinks into `<ws>/.stella/…` and `~/.config/stella/…`. Never link a symlink, never clobber, never fail init.
  - Slash usage: `/name args` expands a command’s body (`$ARGUMENTS`), `/skill-name task` injects the skill body plus task. Built-ins can’t be shadowed; commands win over same-named skills.
  - Menu UX: built-ins show 🔒; custom commands/skills show ⚡. New `Inbound::SlashCommands` refreshes the menu after `/init` so adopted items appear without a restart.
  - `/agents` lists custom agents (name — description — source path) in both the deck and the REPL; hints include `~/.config/stella/agents`. Adopted skills load into recall and are invocable via slash.

- **Bug Fixes**
  - Sync collisions resolve by the parsed definition name (frontmatter `name:` or slug), not the file name; destination definitions claim their names up front.
  - Reserved-name guard: custom definitions cannot shadow productized commands at invocation time (e.g. `/help topic` stays built-in).
  - Loader diagnostics are shown at REPL start and after `/init`, and streamed into the deck transcript, so malformed or unreadable definitions (e.g. dangling symlinks) are visible.

<sup>Written for commit 7687b33200460517fe81a74c1d6ce7bd44a3ef13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
