### PR TITLE
refactor: move production Clock/Sleeper impls out of stella-core (fixes #67)

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -15,8 +15,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
-use stella_core::ports::{SystemClock, ToolExecutor};
-use stella_core::retry::TokioSleeper;
+use stella_core::ports::ToolExecutor;
 use stella_core::router::{CircuitBreaker, ProviderProfile};
 use stella_core::{
     BudgetGuard, CalibrationMap, Engine, EngineConfig, GoalConfig, GoalOutcome, RoleTable, Router,
@@ -44,6 +43,7 @@ use crate::config::Config;
 use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
 use crate::memory::{SessionMemory, inject_recall_block, turn_warrants_reflection};
+use crate::runtime::{SystemClock, TokioSleeper};
 use crate::tui;
 use stella_context::EpisodeOutcome;
 
@@ -1811,7 +1811,8 @@ async fn run_turn(
         .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
         let hook_runner = ShellHookRunner;
         let mut engine =
-            Engine::new(provider, &tools, engine_config_for(cfg)).with_calibration(calibration);
+            Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
+                .with_calibration(calibration);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }
@@ -2114,7 +2115,8 @@ async fn run_goal_turn(
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
         let hook_runner = ShellHookRunner;
         let mut engine =
-            Engine::new(provider, &tools, engine_config_for(cfg)).with_calibration(calibration);
+            Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
+                .with_calibration(calibration);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -61,6 +61,7 @@ use crate::agent;
 use crate::config::Config;
 use crate::interactive::{AskUserIo, FREE_TEXT_LABEL, InteractiveToolSet, SkillRegistry};
 use crate::memory::{SessionMemory, inject_recall_block, turn_warrants_reflection};
+use crate::runtime::TokioSleeper;
 
 /// The lead agent's id — the one conversation this driver runs.
 const LEAD: &str = "lead";
@@ -616,8 +617,13 @@ async fn run_lead_turn(
             root: cfg.workspace_root.clone(),
         };
         let hook_runner = ShellHookRunner;
-        let mut engine = Engine::new(provider, &tapped, agent::engine_config_for(cfg))
-            .with_calibration(calibration);
+        let mut engine = Engine::with_sleeper(
+            provider,
+            &tapped,
+            agent::engine_config_for(cfg),
+            &TokioSleeper,
+        )
+        .with_calibration(calibration);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -156,6 +156,9 @@ pub struct SyncOutcome {
     /// Created links as `(kind, name)`.
     pub linked: Vec<(ExtensionKind, String)>,
     /// Entries skipped by the plan (symlink sources, existing names).
+    /// Asserted by tests only — the init progress line reports links and
+    /// errors, never skips — so the bin target sees it as unread.
+    #[allow(dead_code)]
     pub skipped: usize,
     pub errors: Vec<String>,
 }

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -19,7 +19,6 @@
 use std::path::Path;
 
 use colored::Colorize;
-use stella_core::ports::SystemClock;
 use stella_core::{Engine, TurnOutcome};
 use stella_fleet::{
     CommitRecord, Fleet, FleetConfig, FleetRunReport, FleetWorker, Ledger, Plan, SystemGitCli,
@@ -32,6 +31,7 @@ use tokio::sync::mpsc;
 
 use crate::agent;
 use crate::config::Config;
+use crate::runtime::{SystemClock, TokioSleeper};
 use crate::tui;
 
 /// Cap on the per-task summary line so the report table stays a table.
@@ -242,7 +242,12 @@ async fn run_task(
     let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
     let outcome = {
         let hook_runner = ShellHookRunner;
-        let mut engine = Engine::new(&*provider, &registry, agent::engine_config_for(&cfg));
+        let mut engine = Engine::with_sleeper(
+            &*provider,
+            &registry,
+            agent::engine_config_for(&cfg),
+            &TokioSleeper,
+        );
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -27,6 +27,7 @@ mod fleet_cmd;
 mod interactive;
 mod memory;
 mod ocp;
+mod runtime;
 mod settings;
 mod stats;
 mod tui;

--- a/stella-cli/src/runtime.rs
+++ b/stella-cli/src/runtime.rs
@@ -1,0 +1,72 @@
+//! Production implementations of `stella-core`'s time ports. The engine
+//! exports only the [`Clock`] and [`Sleeper`] traits (ports, not
+//! concretions — `02-architecture.md` §3), so the binary owns the concrete
+//! wall-clock/tokio impls and wires them at construction. This is what
+//! keeps `stella-core` free of production `tokio::time` calls.
+
+use async_trait::async_trait;
+use stella_core::ports::Clock;
+use stella_core::retry::Sleeper;
+
+/// The production clock: monotonic milliseconds since construction.
+pub struct SystemClock {
+    origin: std::time::Instant,
+}
+
+impl SystemClock {
+    pub fn new() -> Self {
+        Self {
+            origin: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Default for SystemClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> u64 {
+        self.origin.elapsed().as_millis() as u64
+    }
+}
+
+/// The production [`Sleeper`]: a thin wrapper over `tokio::time::sleep`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TokioSleeper;
+
+#[async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, duration_ms: u64) {
+        tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_clock_starts_near_zero_and_advances_monotonically() {
+        let clock = SystemClock::new();
+        let first = clock.now_ms();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let second = clock.now_ms();
+        assert!(second >= first, "clock must never go backwards");
+        assert!(
+            second - first >= 4,
+            "clock must actually advance with wall time"
+        );
+    }
+
+    #[test]
+    fn default_constructs_a_fresh_clock() {
+        let clock = SystemClock::default();
+        assert!(
+            clock.now_ms() < 1000,
+            "a freshly constructed clock starts near zero"
+        );
+    }
+}

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -69,7 +69,7 @@ use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
 use crate::hooks::{HookPayload, HookRunner, Hooks, run_hooks};
 use crate::loop_detect::{LoopDetectionConfig, detect_loop};
 use crate::ports::ToolExecutor;
-use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, TokioSleeper, retry_with_backoff};
+use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, retry_with_backoff};
 
 /// Everything about a turn's execution that isn't the provider/tools
 /// themselves: prompt shape, retry/compaction/loop tuning, and hard
@@ -151,7 +151,7 @@ pub struct Engine<'a> {
     pub(crate) sleeper: &'a dyn Sleeper,
     pub(crate) config: EngineConfig,
     /// Lifecycle hooks, off by default. Attached via [`Engine::with_hooks`]
-    /// so `new`/`with_sleeper` keep their existing signatures. When `None`,
+    /// so `with_sleeper` keeps its existing signature. When `None`,
     /// no hook is ever consulted and the turn path adds zero work.
     hooks: Option<HooksHandle<'a>>,
     /// Token-drift calibration (`crate::estimator::CalibrationMap`), off by
@@ -170,19 +170,11 @@ pub struct Engine<'a> {
 const MAX_CONCURRENT_TOOL_CALLS: usize = 8;
 
 impl<'a> Engine<'a> {
-    /// Construct an engine with the production [`TokioSleeper`]. Use
-    /// [`Engine::with_sleeper`] in tests to run retries with zero real
+    /// Construct an engine with an injected [`Sleeper`]. This is the only
+    /// constructor — `stella-core` exports the port, never a production
+    /// impl, so the caller wires a real sleeper (the CLI's tokio-backed
+    /// one) and tests wire a no-op to run retries with zero real
     /// wall-clock delay.
-    pub fn new(
-        provider: &'a dyn Provider,
-        tools: &'a dyn ToolExecutor,
-        config: EngineConfig,
-    ) -> Self {
-        Self::with_sleeper(provider, tools, config, &TokioSleeper)
-    }
-
-    /// Construct an engine with an injected [`Sleeper`] — the seam that
-    /// makes `run_turn`'s retry loop testable without real sleeping.
     pub fn with_sleeper(
         provider: &'a dyn Provider,
         tools: &'a dyn ToolExecutor,
@@ -200,8 +192,8 @@ impl<'a> Engine<'a> {
     }
 
     /// Attach lifecycle hooks (`crate::hooks`) to an engine, opt-in. Kept a
-    /// builder so [`Engine::new`]/[`Engine::with_sleeper`] retain their
-    /// signatures and every existing call site is unchanged — an engine
+    /// builder so [`Engine::with_sleeper`] retains its signature and every
+    /// existing call site is unchanged — an engine
     /// built without this is exactly the pre-hooks engine. Takes both the
     /// parsed [`Hooks`] config and the [`HookRunner`] that executes the
     /// commands, because [`crate::hooks::run_hooks`] needs the port to run

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -378,9 +378,10 @@ pub fn plan_extension_sync(
         std::collections::HashSet<String>,
     > = std::collections::HashMap::new();
     for source in sources {
-        if !present_files.contains_key(&source.kind) {
+        if let std::collections::hash_map::Entry::Vacant(vacant) = present_files.entry(source.kind)
+        {
             let targets = existing(source.kind);
-            present_files.insert(source.kind, targets.file_names.into_iter().collect());
+            vacant.insert(targets.file_names.into_iter().collect());
             // Definitions already in the destination claim their names up
             // front, so a same-named-but-differently-filed source entry is
             // skipped instead of linked alongside.

--- a/stella-core/src/ports.rs
+++ b/stella-core/src/ports.rs
@@ -63,60 +63,11 @@ impl ToolExecutor for ReadOnlyTools<'_> {
     }
 }
 
-/// Time source, injectable for deterministic tests.
+/// Time source, injectable for deterministic tests. Only the trait lives
+/// here — the production implementation belongs to the binary that wires
+/// the engine (the CLI's `runtime` module), so `stella-core` never carries
+/// a concrete time source of its own.
 pub trait Clock: Send + Sync {
     /// Monotonic milliseconds since an arbitrary epoch.
     fn now_ms(&self) -> u64;
-}
-
-/// The production clock.
-pub struct SystemClock {
-    origin: std::time::Instant,
-}
-
-impl SystemClock {
-    pub fn new() -> Self {
-        Self {
-            origin: std::time::Instant::now(),
-        }
-    }
-}
-
-impl Default for SystemClock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Clock for SystemClock {
-    fn now_ms(&self) -> u64 {
-        self.origin.elapsed().as_millis() as u64
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn system_clock_starts_near_zero_and_advances_monotonically() {
-        let clock = SystemClock::new();
-        let first = clock.now_ms();
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let second = clock.now_ms();
-        assert!(second >= first, "clock must never go backwards");
-        assert!(
-            second - first >= 4,
-            "clock must actually advance with wall time"
-        );
-    }
-
-    #[test]
-    fn default_constructs_a_fresh_clock() {
-        let clock = SystemClock::default();
-        assert!(
-            clock.now_ms() < 1000,
-            "a freshly constructed clock starts near zero"
-        );
-    }
 }

--- a/stella-core/src/retry.rs
+++ b/stella-core/src/retry.rs
@@ -34,22 +34,13 @@ use stella_protocol::ProviderError;
 /// Injectable so retry-loop tests run instantly and deterministically
 /// instead of paying real wall-clock delays — the same seam
 /// [`crate::ports::Clock`] provides for reading time, but for the one place
-/// this crate needs to actually suspend a task.
+/// this crate needs to actually suspend a task. Only the trait lives here —
+/// the production tokio-backed impl belongs to the binary that constructs
+/// the engine (the CLI's `runtime` module).
 #[async_trait]
 pub trait Sleeper: Send + Sync {
     /// Suspend the current task for `duration_ms` milliseconds.
     async fn sleep(&self, duration_ms: u64);
-}
-
-/// The production [`Sleeper`]: a thin wrapper over `tokio::time::sleep`.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct TokioSleeper;
-
-#[async_trait]
-impl Sleeper for TokioSleeper {
-    async fn sleep(&self, duration_ms: u64) {
-        tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
-    }
 }
 
 /// Retry policy for one model or tool call: how many times to retry a

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -94,7 +94,8 @@ pub struct PipelinePorts<'a> {
     /// The interactive scope-review gate (L-E5).
     pub approvals: &'a dyn ApprovalGate,
     /// The delay port for retry backoff — the same testability seam
-    /// `stella-core` uses; production passes `&TokioSleeper`, tests a no-op.
+    /// `stella-core` uses; production passes the CLI's tokio-backed
+    /// sleeper, tests a no-op.
     pub sleeper: &'a dyn Sleeper,
     /// Lifecycle hooks for the execute engine — the parsed config plus the
     /// runner that spawns hook commands (`stella_core::hooks`). `None` runs


### PR DESCRIPTION
## What

`stella-core` carried the production implementations of its own time ports — `SystemClock` (`ports.rs:72-95`) and `TokioSleeper` (`retry.rs:44-53`) — and `Engine::new` wired `TokioSleeper` internally. This PR moves both concrete impls into the CLI binary (`stella-cli/src/runtime.rs`) and leaves stella-core exporting only the `Clock` and `Sleeper` traits, per the ports-not-concretions boundary the crate documents for itself.

Fixes #67

## Consumer map (who constructed the production impls)

| Site | What | Disposition |
|---|---|---|
| `stella-core/src/driver.rs` `Engine::new` | constructed `&TokioSleeper` inside the library | **removed** — `Engine::with_sleeper` is now the sole constructor; callers inject |
| `stella-cli/src/agent.rs` (pipeline + turn + goal paths) | `SystemClock` for `CircuitBreaker`, `TokioSleeper` for `PipelinePorts` and `Engine` | imports switched to `crate::runtime` |
| `stella-cli/src/fleet_cmd.rs` | `SystemClock` for `Fleet::new`, `Engine::new` | imports switched to `crate::runtime`; `with_sleeper` |
| `stella-cli/src/command_deck.rs` | `Engine::new` | `with_sleeper(&TokioSleeper)` |
| `stella-core/src/ports.rs` tests | unit tests of `SystemClock` itself | moved with the impl to `runtime.rs` |

Not consumers of stella-core's impls (unchanged, noted for completeness):
- `stella-pipeline` already takes `sleeper: &dyn Sleeper` by injection (`PipelinePorts`); only a doc comment was updated.
- `stella-fleet` defines its **own** `Sleeper` trait + `TokioSleeper` (`monitor.rs`) and takes `stella_core::Clock` purely by injection (`Fleet::new`, `Monitor::new`) — separate port, out of scope.
- `stella-context` defines its **own** `Clock` trait + wall-clock `SystemClock` (`clock.rs`); `stella-cli/src/memory.rs` uses that one, not stella-core's.
- stella-core's retry/driver/goal tests already used local no-op sleepers (`NoopSleeper`, `NoSleep`) — untouched.

## Destination choice

`stella-cli/src/runtime.rs` (new ~70-line module), not a new `stella-runtime` crate: after mapping, the CLI binary is the **only** workspace crate that constructs the production impls. Every library crate either takes the port by injection (pipeline, fleet) or owns an unrelated same-named port (context, fleet). A shared adapter crate would have exactly one consumer — the smallest change honoring the issue is the binary-local module.

## tokio-dependency findings for stella-core

- tokio **cannot be dropped**: `driver.rs` and `goal.rs` use `tokio::sync::mpsc::UnboundedSender` for the `AgentEvent` channel in production.
- The only production `tokio::time` use (`TokioSleeper`) is gone; `[dependencies] tokio = { workspace = true, features = ["sync"] }` already declares exactly what production code now needs, so no manifest change.
- Caveat: member-level `features` on a `workspace = true` dep are **additive** to the workspace spec (which enables `rt-multi-thread, macros, time, process, fs, io-util, sync`), so the `["sync"]` annotation documents intent rather than restricting the build. Real shrinkage would require opting this dep out of workspace inheritance (`default-features = false`), and workspace feature unification would neutralize it for this repo's builds anyway — left alone deliberately.

## Also in this PR (pre-existing, required by the zero-warnings gate)

Two warnings that exist on `main` (introduced by #94, unrelated to this refactor) were silenced so `cargo clippy --workspace --all-targets` is clean: a `dead_code` on `SyncOutcome::skipped` in `stella-cli/src/extensions.rs` (read by tests only; `#[allow]` + constraint comment) and a `clippy::map_entry` in `stella-core/src/extensions.rs` (mechanical `Entry::Vacant` rewrite, behavior-identical).

## Gate

- `cargo test --workspace`: all suites pass, 0 failures (unit + integration + doc-tests)
- `cargo clippy --workspace --all-targets`: 0 warnings
- `rustfmt --edition 2024 --check` on every touched file: clean

Zero behavior change: same wiring at runtime (`&TokioSleeper` is still what every production engine gets), only the crate that owns the concretion moved.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the production time ports out of `stella-core` into the CLI and made `Engine::with_sleeper` the only constructor so callers inject a sleeper. Fixes #67 with no behavior change.

- **Refactors**
  - `stella-core` now exports only the `Clock` and `Sleeper` traits; removed `SystemClock`/`TokioSleeper` and any `tokio::time` use.
  - Added `stella-cli/src/runtime.rs` with production `SystemClock` and `TokioSleeper`; moved the clock tests.
  - `Engine::new` removed; `Engine::with_sleeper` is the sole constructor.
  - Updated CLI imports to `crate::runtime::{SystemClock, TokioSleeper}`; pipeline docs note tokio-backed sleeper injection.
  - Kept `tokio` in `stella-core` for `tokio::sync::mpsc`; silenced a pre-existing `dead_code` in the CLI and rewrote a `map_entry` in core to keep clippy clean.

- **Migration**
  - Replace `Engine::new(provider, tools, config)` with `Engine::with_sleeper(provider, tools, config, &TokioSleeper)` and import `SystemClock`/`TokioSleeper` from the CLI’s `runtime` module.

<sup>Written for commit 2113cc1f47994bb4a0c6b1e8a4a68bfae9ac888c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
