### PR TITLE
refactor: extract Engine::run_turn sub-methods (fixes #62)

### DIFF
--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -155,7 +155,10 @@ fn relative_symlink_target(from_dir: &Path, target: &Path) -> PathBuf {
 pub struct SyncOutcome {
     /// Created links as `(kind, name)`.
     pub linked: Vec<(ExtensionKind, String)>,
-    /// Entries skipped by the plan (symlink sources, existing names).
+    /// Entries skipped by the plan (symlink sources, existing names). Not
+    /// yet folded into the init progress line, so only the sync tests read
+    /// it — dead in the bin target alone.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub skipped: usize,
     pub errors: Vec<String>,
 }

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -169,6 +169,21 @@ pub struct Engine<'a> {
 /// process pressure, not CPU.
 const MAX_CONCURRENT_TOOL_CALLS: usize = 8;
 
+/// One committed model call plus the step-scoped context the phases after
+/// it consume: the pre-call raw token estimate (drift feedback + telemetry
+/// — raw, never calibrated, see [`Engine::run_model_call`]), the read-only
+/// tool set for dispatch scheduling, and the retry/duration figures for
+/// the `StepUsage` metering record.
+struct CommittedStep {
+    result: CompletionResultAlias,
+    /// Names of tools whose schemas declare `read_only`, snapshotted from
+    /// the same `schemas()` call the request itself was built from.
+    read_only_tools: HashSet<String>,
+    estimated_input_tokens: u64,
+    retries: u32,
+    duration_ms: u64,
+}
+
 impl<'a> Engine<'a> {
     /// Construct an engine with the production [`TokioSleeper`]. Use
     /// [`Engine::with_sleeper`] in tests to run retries with zero real
@@ -255,6 +270,11 @@ impl<'a> Engine<'a> {
     /// accumulates across the turn (and, via `BudgetGuard::begin_turn`,
     /// across turns in the same session — the caller decides when to reset
     /// it, `run_turn` only reads and records).
+    ///
+    /// Every step is the same fixed phase sequence, one sub-method per
+    /// phase: compaction, loop detection, the between-steps budget check,
+    /// the model call (with retry+backoff), bookkeeping for the committed
+    /// call, then dispatch — complete the turn or execute its tool calls.
     pub async fn run_turn(
         &self,
         messages: &mut Vec<CompletionMessage>,
@@ -273,269 +293,34 @@ impl<'a> Engine<'a> {
         let mut calibration_model: Option<String> = None;
 
         for step in 0..self.config.max_steps {
-            // ---- Compaction (before every model call, per the running
-            // ---- estimate; L-E3 dedup+evict, stable system prefix — the
-            // ---- system message is index 0 and compact() never touches it).
-            //
-            // Drift correction enters here: `compact` compares the RAW
-            // estimate against the budget it is given, so dividing the
-            // configured budget by the correction factor is exactly
-            // comparing the CALIBRATED estimate (raw × factor) against the
-            // configured budget — including the eviction loop's stopping
-            // condition — without threading a factor through compaction's
-            // incremental bookkeeping. A factor > 1 (we under-estimate this
-            // model's tokenizer) shrinks the effective budget and compacts
-            // earlier; the factor's clamp (`crate::estimator`) bounds how
-            // far either way a noisy sample can move this.
-            let compaction_budget = match self.calibration {
-                Some(calibration) => {
-                    (self.config.compaction_budget_tokens as f64
-                        / calibration.factor(calibration_model.as_deref()))
-                        as u64
-                }
-                None => self.config.compaction_budget_tokens,
+            self.run_compaction_pass(messages, calibration_model.as_deref(), events);
+
+            if let Some(aborted) = self.check_loop_detection(messages, events) {
+                return aborted;
+            }
+            if let Some(aborted) = check_budget(budget, events) {
+                return aborted;
+            }
+
+            let committed = match self.run_model_call(messages, events).await {
+                Ok(committed) => committed,
+                Err(aborted) => return aborted,
             };
-            if let Some(report) = compact(messages, compaction_budget) {
-                let _ = events.send(AgentEvent::Compaction {
-                    before_tokens: report.before_tokens,
-                    after_tokens: report.after_tokens,
-                    evicted: report.evicted,
-                    deduped: report.deduped,
-                });
-            }
+            calibration_model = Some(committed.result.model.clone());
+            total_cost_usd += committed.result.cost_usd;
 
-            // ---- Loop detection (before spending a model call on a step
-            // ---- that's already stuck).
-            let recent_calls = recent_tool_calls(messages);
-            let verdict = detect_loop(&recent_calls, self.config.loop_detection);
-            if verdict.is_loop() {
-                let reason = verdict
-                    .evidence()
-                    .unwrap_or_else(|| "loop detected".to_string());
-                let _ = events.send(AgentEvent::Error {
-                    message: reason.clone(),
-                    retryable: false,
-                });
-                return TurnOutcome::Aborted {
-                    reason: format!("stuck-loop detected: {reason}"),
-                };
-            }
-
-            // ---- Budget (between steps, never mid-tool — see module docs).
-            if let BudgetOutcome::AbortTurn {
-                spent_usd,
-                limit_usd,
-                ..
-            } = budget.evaluate()
+            if let Some(aborted) =
+                self.handle_committed_result(step, &committed, budget, messages, events)
             {
-                let reason = format!(
-                    "budget exceeded: spent ${spent_usd:.4} against a ${limit_usd:.2} limit"
-                );
-                let _ = events.send(AgentEvent::Error {
-                    message: reason.clone(),
-                    retryable: false,
-                });
-                return TurnOutcome::Aborted { reason };
+                return aborted;
             }
 
-            // ---- The model call, with retry+backoff.
-            let tools_schema = self.tools.schemas();
-            let read_only_tools: HashSet<String> = tools_schema
-                .iter()
-                .filter(|s| s.read_only)
-                .map(|s| s.name.clone())
-                .collect();
-            // The raw (uncalibrated) estimate of exactly what this step
-            // sends — recorded against the provider's reported usage below.
-            // Raw, not calibrated: the drift ratio is actual/raw, and
-            // recording a corrected estimate would compound corrections on
-            // every feedback pass.
-            let estimated_input_tokens = estimate_conversation_tokens(messages);
-            let messages_snapshot = messages.clone();
-            let req_config = &self.config;
-            let attempt: RetryAttemptFn = Box::new(move || {
-                let req = CompletionRequest {
-                    messages: messages_snapshot.clone(),
-                    max_output_tokens: req_config.max_output_tokens,
-                    temperature: req_config.temperature,
-                    effort: req_config.effort,
-                    tools: tools_schema.clone(),
-                };
-                Box::pin(self.provider.complete(req))
-            });
-
-            let call_started = std::time::Instant::now();
-            let outcome =
-                retry_with_backoff(&self.config.retry_policy, self.sleeper, attempt).await;
-            let call_duration_ms = call_started.elapsed().as_millis() as u64;
-
-            let RetryOutcome {
-                value: result,
-                retries,
-                ..
-            } = match outcome {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    let message = error.to_string();
-                    let _ = events.send(AgentEvent::Error {
-                        message: message.clone(),
-                        retryable: error.is_retryable(),
-                    });
-                    return TurnOutcome::Aborted {
-                        reason: format!("model call failed: {message}"),
-                    };
-                }
-            };
-
-            // Deferred-flush: these `Retry` events only reach the wire now
-            // that the step has actually committed (see module docs).
-            for attempt in &retries {
-                let _ = events.send(AgentEvent::Retry {
-                    attempt: attempt.attempt,
-                    reason: attempt.reason.clone(),
-                });
-            }
-
-            // ---- Drift feedback for the call that just committed: the
-            // ---- provider's reported input tokens (total, cached included
-            // ---- — cached tokens were still real prompt tokens) against
-            // ---- the raw estimate, keyed by the model that actually
-            // ---- served the call. `record` ignores zero-sided pairs, so a
-            // ---- provider omitting usage never poisons the state.
-            if let Some(calibration) = self.calibration {
-                calibration.record(
-                    &result.model,
-                    estimated_input_tokens,
-                    result.usage.input_tokens,
-                );
-            }
-            calibration_model = Some(result.model.clone());
-
-            // ---- Telemetry for the call that just committed: exactly one
-            // ---- StepUsage per landed step — the metering record.
-            let _ = events.send(AgentEvent::StepUsage {
-                step,
-                model: result.model.clone(),
-                input_tokens: result.usage.input_tokens,
-                output_tokens: result.usage.output_tokens,
-                cached_input_tokens: result.usage.cached_input_tokens,
-                estimated_input_tokens,
-                cost_usd: result.cost_usd,
-                duration_ms: call_duration_ms,
-                retries: retries.len() as u32,
-                tool_calls: result.tool_calls.len(),
-            });
-
-            // ---- Budget accounting for the call that just committed.
-            let outcome = budget.record_spend(result.cost_usd);
-            total_cost_usd += result.cost_usd;
-            let _ = events.send(AgentEvent::BudgetTick {
-                spent_usd: budget.spent_usd(),
-                limit_usd: budget.turn_limit_usd(),
-                mode: budget.mode(),
-            });
-            if let BudgetOutcome::AbortTurn {
-                spent_usd,
-                limit_usd,
-                ..
-            } = outcome
+            if let Some(completed) = self
+                .dispatch_completion(committed, total_cost_usd, messages, events)
+                .await
             {
-                // The call that just landed is the one that pushed spend
-                // over the limit — it already committed (its result is
-                // real, its cost already happened), so deliver what was
-                // paid for: emit its text and append it to history, THEN
-                // abort before dispatching anything further (its tool
-                // calls, if any, never run — recorded so the transcript
-                // shows what was cut). Still not a mid-tool kill.
-                if !result.text.is_empty() {
-                    let _ = events.send(AgentEvent::Text {
-                        delta: result.text.clone(),
-                    });
-                }
-                messages.push(CompletionMessage {
-                    role: MessageRole::Assistant,
-                    content: result.text.clone(),
-                    tool_calls: result.tool_calls.clone(),
-                    tool_results: Vec::new(),
-                });
-                // The assistant message above may carry `tool_calls` that never
-                // ran (we abort before dispatching them). A recorded `tool_use`
-                // with no matching `tool_result` is a broken history: when a
-                // REPL caller reuses this `messages` vec, the next turn's first
-                // provider call is hard-rejected ("tool_use must be followed by
-                // tool_result"). Close the pairing with a synthetic error
-                // result per un-run call so resumption stays valid.
-                if !result.tool_calls.is_empty() {
-                    let tool_results = result
-                        .tool_calls
-                        .iter()
-                        .map(|call| ToolResult {
-                            call_id: call.call_id.clone(),
-                            output: ToolOutput::Error {
-                                message: "not executed — turn aborted on budget".to_string(),
-                            },
-                        })
-                        .collect();
-                    messages.push(CompletionMessage {
-                        role: MessageRole::Tool,
-                        content: String::new(),
-                        tool_calls: Vec::new(),
-                        tool_results,
-                    });
-                }
-                let reason = format!(
-                    "budget exceeded after this call: spent ${spent_usd:.4} against a ${limit_usd:.2} limit"
-                );
-                let _ = events.send(AgentEvent::Error {
-                    message: reason.clone(),
-                    retryable: false,
-                });
-                return TurnOutcome::Aborted { reason };
+                return completed;
             }
-
-            if !result.text.is_empty() {
-                let _ = events.send(AgentEvent::Text {
-                    delta: result.text.clone(),
-                });
-            }
-
-            if result.tool_calls.is_empty() {
-                messages.push(CompletionMessage {
-                    role: MessageRole::Assistant,
-                    content: result.text.clone(),
-                    tool_calls: Vec::new(),
-                    tool_results: Vec::new(),
-                });
-                let _ = events.send(AgentEvent::Stage {
-                    name: StageKind::Complete,
-                });
-                let _ = events.send(AgentEvent::Complete {
-                    model: result.model.clone(),
-                    cost_usd: total_cost_usd,
-                });
-                return TurnOutcome::Completed {
-                    text: result.text,
-                    cost_usd: total_cost_usd,
-                };
-            }
-
-            messages.push(CompletionMessage {
-                role: MessageRole::Assistant,
-                content: result.text.clone(),
-                tool_calls: result.tool_calls.clone(),
-                tool_results: Vec::new(),
-            });
-
-            let tool_results = self
-                .execute_tool_calls(&result.tool_calls, &read_only_tools, events)
-                .await;
-
-            messages.push(CompletionMessage {
-                role: MessageRole::Tool,
-                content: String::new(),
-                tool_calls: Vec::new(),
-                tool_results,
-            });
         }
 
         let reason = format!(
@@ -548,6 +333,318 @@ impl<'a> Engine<'a> {
             retryable: false,
         });
         TurnOutcome::Aborted { reason }
+    }
+
+    /// Compaction, before every model call, per the running estimate
+    /// (L-E3 dedup+evict, stable system prefix — the system message is
+    /// index 0 and `compact()` never touches it).
+    ///
+    /// Drift correction enters here: `compact` compares the RAW estimate
+    /// against the budget it is given, so dividing the configured budget
+    /// by the correction factor is exactly comparing the CALIBRATED
+    /// estimate (raw × factor) against the configured budget — including
+    /// the eviction loop's stopping condition — without threading a factor
+    /// through compaction's incremental bookkeeping. A factor > 1 (we
+    /// under-estimate this model's tokenizer) shrinks the effective budget
+    /// and compacts earlier; the factor's clamp (`crate::estimator`)
+    /// bounds how far either way a noisy sample can move this.
+    fn run_compaction_pass(
+        &self,
+        messages: &mut [CompletionMessage],
+        calibration_model: Option<&str>,
+        events: &UnboundedSender<AgentEvent>,
+    ) {
+        let compaction_budget = match self.calibration {
+            Some(calibration) => {
+                (self.config.compaction_budget_tokens as f64
+                    / calibration.factor(calibration_model)) as u64
+            }
+            None => self.config.compaction_budget_tokens,
+        };
+        if let Some(report) = compact(messages, compaction_budget) {
+            let _ = events.send(AgentEvent::Compaction {
+                before_tokens: report.before_tokens,
+                after_tokens: report.after_tokens,
+                evicted: report.evicted,
+                deduped: report.deduped,
+            });
+        }
+    }
+
+    /// Loop detection, before spending a model call on a step that's
+    /// already stuck. `Some` is the turn's clean abort.
+    fn check_loop_detection(
+        &self,
+        messages: &[CompletionMessage],
+        events: &UnboundedSender<AgentEvent>,
+    ) -> Option<TurnOutcome> {
+        let recent_calls = recent_tool_calls(messages);
+        let verdict = detect_loop(&recent_calls, self.config.loop_detection);
+        if !verdict.is_loop() {
+            return None;
+        }
+        let reason = verdict
+            .evidence()
+            .unwrap_or_else(|| "loop detected".to_string());
+        let _ = events.send(AgentEvent::Error {
+            message: reason.clone(),
+            retryable: false,
+        });
+        Some(TurnOutcome::Aborted {
+            reason: format!("stuck-loop detected: {reason}"),
+        })
+    }
+
+    /// One model call with retry+backoff (`crate::retry`). On commit,
+    /// flushes the step's deferred `Retry` events (module docs, L-E10) and
+    /// returns the result bundled with the request-time snapshots the
+    /// later phases consume; on exhausted retries, emits the terminal
+    /// error and returns the turn's clean abort.
+    ///
+    /// The estimate captured here is the raw (uncalibrated) estimate of
+    /// exactly what this step sends — recorded against the provider's
+    /// reported usage by [`Engine::handle_committed_result`]. Raw, not
+    /// calibrated: the drift ratio is actual/raw, and recording a
+    /// corrected estimate would compound corrections on every feedback
+    /// pass.
+    async fn run_model_call(
+        &self,
+        messages: &[CompletionMessage],
+        events: &UnboundedSender<AgentEvent>,
+    ) -> Result<CommittedStep, TurnOutcome> {
+        let tools_schema = self.tools.schemas();
+        let read_only_tools: HashSet<String> = tools_schema
+            .iter()
+            .filter(|s| s.read_only)
+            .map(|s| s.name.clone())
+            .collect();
+        let estimated_input_tokens = estimate_conversation_tokens(messages);
+        let messages_snapshot = messages.to_vec();
+        let req_config = &self.config;
+        let attempt: RetryAttemptFn = Box::new(move || {
+            let req = CompletionRequest {
+                messages: messages_snapshot.clone(),
+                max_output_tokens: req_config.max_output_tokens,
+                temperature: req_config.temperature,
+                effort: req_config.effort,
+                tools: tools_schema.clone(),
+            };
+            Box::pin(self.provider.complete(req))
+        });
+
+        let call_started = std::time::Instant::now();
+        let outcome = retry_with_backoff(&self.config.retry_policy, self.sleeper, attempt).await;
+        let call_duration_ms = call_started.elapsed().as_millis() as u64;
+
+        let RetryOutcome {
+            value: result,
+            retries,
+            ..
+        } = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let message = error.to_string();
+                let _ = events.send(AgentEvent::Error {
+                    message: message.clone(),
+                    retryable: error.is_retryable(),
+                });
+                return Err(TurnOutcome::Aborted {
+                    reason: format!("model call failed: {message}"),
+                });
+            }
+        };
+
+        // Deferred-flush: these `Retry` events only reach the wire now
+        // that the step has actually committed (see module docs).
+        for attempt in &retries {
+            let _ = events.send(AgentEvent::Retry {
+                attempt: attempt.attempt,
+                reason: attempt.reason.clone(),
+            });
+        }
+
+        Ok(CommittedStep {
+            result,
+            read_only_tools,
+            estimated_input_tokens,
+            retries: retries.len() as u32,
+            duration_ms: call_duration_ms,
+        })
+    }
+
+    /// Bookkeeping for the call that just committed: drift feedback into
+    /// the attached calibration, exactly one `StepUsage` metering record
+    /// per landed step, and budget accounting. `Some` is the turn's clean
+    /// abort — this call's spend pushed the turn over an enforced limit —
+    /// issued only after delivering what was already paid for (see body);
+    /// never a mid-tool kill.
+    fn handle_committed_result(
+        &self,
+        step: usize,
+        committed: &CommittedStep,
+        budget: &mut BudgetGuard,
+        messages: &mut Vec<CompletionMessage>,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> Option<TurnOutcome> {
+        let result = &committed.result;
+
+        // Drift feedback: the provider's reported input tokens (total,
+        // cached included — cached tokens were still real prompt tokens)
+        // against the raw estimate, keyed by the model that actually
+        // served the call. `record` ignores zero-sided pairs, so a
+        // provider omitting usage never poisons the state.
+        if let Some(calibration) = self.calibration {
+            calibration.record(
+                &result.model,
+                committed.estimated_input_tokens,
+                result.usage.input_tokens,
+            );
+        }
+
+        let _ = events.send(AgentEvent::StepUsage {
+            step,
+            model: result.model.clone(),
+            input_tokens: result.usage.input_tokens,
+            output_tokens: result.usage.output_tokens,
+            cached_input_tokens: result.usage.cached_input_tokens,
+            estimated_input_tokens: committed.estimated_input_tokens,
+            cost_usd: result.cost_usd,
+            duration_ms: committed.duration_ms,
+            retries: committed.retries,
+            tool_calls: result.tool_calls.len(),
+        });
+
+        let outcome = budget.record_spend(result.cost_usd);
+        let _ = events.send(AgentEvent::BudgetTick {
+            spent_usd: budget.spent_usd(),
+            limit_usd: budget.turn_limit_usd(),
+            mode: budget.mode(),
+        });
+        let BudgetOutcome::AbortTurn {
+            spent_usd,
+            limit_usd,
+            ..
+        } = outcome
+        else {
+            return None;
+        };
+
+        // The call that just landed is the one that pushed spend over the
+        // limit — it already committed (its result is real, its cost
+        // already happened), so deliver what was paid for: emit its text
+        // and append it to history, THEN abort before dispatching
+        // anything further (its tool calls, if any, never run — recorded
+        // so the transcript shows what was cut). Still not a mid-tool
+        // kill.
+        if !result.text.is_empty() {
+            let _ = events.send(AgentEvent::Text {
+                delta: result.text.clone(),
+            });
+        }
+        messages.push(CompletionMessage {
+            role: MessageRole::Assistant,
+            content: result.text.clone(),
+            tool_calls: result.tool_calls.clone(),
+            tool_results: Vec::new(),
+        });
+        // The assistant message above may carry `tool_calls` that never
+        // ran (we abort before dispatching them). A recorded `tool_use`
+        // with no matching `tool_result` is a broken history: when a
+        // REPL caller reuses this `messages` vec, the next turn's first
+        // provider call is hard-rejected ("tool_use must be followed by
+        // tool_result"). Close the pairing with a synthetic error
+        // result per un-run call so resumption stays valid.
+        if !result.tool_calls.is_empty() {
+            let tool_results = result
+                .tool_calls
+                .iter()
+                .map(|call| ToolResult {
+                    call_id: call.call_id.clone(),
+                    output: ToolOutput::Error {
+                        message: "not executed — turn aborted on budget".to_string(),
+                    },
+                })
+                .collect();
+            messages.push(CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: Vec::new(),
+                tool_results,
+            });
+        }
+        let reason = format!(
+            "budget exceeded after this call: spent ${spent_usd:.4} against a ${limit_usd:.2} limit"
+        );
+        let _ = events.send(AgentEvent::Error {
+            message: reason.clone(),
+            retryable: false,
+        });
+        Some(TurnOutcome::Aborted { reason })
+    }
+
+    /// Deliver a committed step's result: emit its text, then either
+    /// finish the turn (no tool calls — `Some(Completed)`) or record the
+    /// assistant message, execute its tool calls, record their results,
+    /// and return `None` so the loop takes another step. Consumes the
+    /// step: the result's text moves into the `Completed` outcome.
+    async fn dispatch_completion(
+        &self,
+        committed: CommittedStep,
+        total_cost_usd: f64,
+        messages: &mut Vec<CompletionMessage>,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> Option<TurnOutcome> {
+        let CommittedStep {
+            result,
+            read_only_tools,
+            ..
+        } = committed;
+
+        if !result.text.is_empty() {
+            let _ = events.send(AgentEvent::Text {
+                delta: result.text.clone(),
+            });
+        }
+
+        if result.tool_calls.is_empty() {
+            messages.push(CompletionMessage {
+                role: MessageRole::Assistant,
+                content: result.text.clone(),
+                tool_calls: Vec::new(),
+                tool_results: Vec::new(),
+            });
+            let _ = events.send(AgentEvent::Stage {
+                name: StageKind::Complete,
+            });
+            let _ = events.send(AgentEvent::Complete {
+                model: result.model.clone(),
+                cost_usd: total_cost_usd,
+            });
+            return Some(TurnOutcome::Completed {
+                text: result.text,
+                cost_usd: total_cost_usd,
+            });
+        }
+
+        messages.push(CompletionMessage {
+            role: MessageRole::Assistant,
+            content: result.text.clone(),
+            tool_calls: result.tool_calls.clone(),
+            tool_results: Vec::new(),
+        });
+
+        let tool_results = self
+            .execute_tool_calls(&result.tool_calls, &read_only_tools, events)
+            .await;
+
+        messages.push(CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: Vec::new(),
+            tool_results,
+        });
+
+        None
     }
 
     /// Execute one step's tool calls, preserving sequential semantics for
@@ -713,6 +810,28 @@ type RetryAttemptFn<'a> = Box<
         + 'a,
 >;
 type CompletionResultAlias = stella_protocol::CompletionResult;
+
+/// The between-steps budget check (never mid-tool — see module docs).
+/// `Some` is the turn's clean abort. A free function like
+/// [`recent_tool_calls`] because it reads no engine state; the wording
+/// differs from the post-call abort in `Engine::handle_committed_result`
+/// because here nothing new was spent.
+fn check_budget(budget: &BudgetGuard, events: &UnboundedSender<AgentEvent>) -> Option<TurnOutcome> {
+    let BudgetOutcome::AbortTurn {
+        spent_usd,
+        limit_usd,
+        ..
+    } = budget.evaluate()
+    else {
+        return None;
+    };
+    let reason = format!("budget exceeded: spent ${spent_usd:.4} against a ${limit_usd:.2} limit");
+    let _ = events.send(AgentEvent::Error {
+        message: reason.clone(),
+        retryable: false,
+    });
+    Some(TurnOutcome::Aborted { reason })
+}
 
 /// Flatten the tool calls of the CURRENT turn — assistant messages after
 /// the last user message — in chronological order, for

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -378,9 +378,9 @@ pub fn plan_extension_sync(
         std::collections::HashSet<String>,
     > = std::collections::HashMap::new();
     for source in sources {
-        if !present_files.contains_key(&source.kind) {
+        if let std::collections::hash_map::Entry::Vacant(entry) = present_files.entry(source.kind) {
             let targets = existing(source.kind);
-            present_files.insert(source.kind, targets.file_names.into_iter().collect());
+            entry.insert(targets.file_names.into_iter().collect());
             // Definitions already in the destination claim their names up
             // front, so a same-named-but-differently-filed source entry is
             // skipped instead of linked alongside.

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -283,6 +283,59 @@ impl CandidateResult {
     }
 }
 
+/// The candidate-local mutable state one execute+verify+revise pass threads
+/// through its phases — grouped so [`Pipeline::run_candidate`]'s sub-methods
+/// take one argument instead of seven. Every exit path moves it into the
+/// returned [`CandidateResult`].
+struct CandidateState {
+    messages: Vec<CompletionMessage>,
+    final_text: String,
+    /// `FileChange` events observed across this candidate's engine turns —
+    /// one half of the zero-diff guard's "touched files" signal (L-E2).
+    file_changes: u32,
+    oracle: FlipOracle,
+    /// Untracked-file fingerprints snapshotted before the first turn, so
+    /// every diff gather can exclude pre-existing dirty state.
+    untracked_before: HashMap<String, String>,
+    diff_lines: u32,
+    diff_text: String,
+    revisions: u32,
+}
+
+impl CandidateState {
+    /// Finish this candidate with a verification verdict — every verified
+    /// exit (deterministic or judged, passed or failed) funnels through here.
+    fn into_verified(
+        self,
+        passed: bool,
+        evidence: &JudgeEvidence,
+        score: CandidateScore,
+    ) -> CandidateResult {
+        CandidateResult {
+            messages: self.messages,
+            final_text: self.final_text,
+            aborted: None,
+            verdict: Some(Verdict::from_evidence(passed, evidence)),
+            score,
+            diff_lines: self.diff_lines,
+            revisions: self.revisions,
+        }
+    }
+
+    /// Finish a clean lookup: verification skipped, no verdict to report.
+    fn into_unverified(self) -> CandidateResult {
+        CandidateResult {
+            messages: self.messages,
+            final_text: self.final_text,
+            aborted: None,
+            verdict: None,
+            score: CandidateScore::Unverified,
+            diff_lines: self.diff_lines,
+            revisions: self.revisions,
+        }
+    }
+}
+
 /// The staged orchestrator. Holds only borrowed ports + an owned event sender
 /// and config; carries no per-run state (the caller owns the message history
 /// and budget, exactly as `stella-core::Engine` does).
@@ -640,10 +693,6 @@ impl<'a> Pipeline<'a> {
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> CandidateResult {
-        let mut messages = base_messages.to_vec();
-        let mut file_changes = 0u32;
-        let mut final_text = String::new();
-
         // Flip oracle: for classes we always verify, take a pre-execute
         // baseline of the test command so a later pass counts as a genuine
         // fail→pass flip (L-E11). Simple lookups skip the baseline — they are
@@ -664,112 +713,134 @@ impl<'a> Pipeline<'a> {
         // edited (fingerprint changed) is.
         let untracked_before = self.repo_status.untracked_fingerprints().await;
 
-        // Execute: one turn for simple/single-task; one turn per plan step for
-        // multi-step (each step guides a fresh engine turn).
-        self.emit(AgentEvent::Stage {
-            name: StageKind::Execute,
-        });
-        let steps: Vec<&PlanStep> = plan.map(|p| p.iter().collect()).unwrap_or_default();
-        if steps.is_empty() {
-            match self
-                .run_engine_turn(engine, &mut messages, budget, &mut file_changes)
-                .await
-            {
-                TurnOutcome::Completed { text, cost_usd } => {
-                    final_text = text;
-                    *total += cost_usd;
-                }
-                TurnOutcome::Aborted { reason } => {
-                    return CandidateResult::aborted(messages, reason);
-                }
-            }
-        } else {
-            let n = steps.len();
-            for (i, step) in steps.iter().enumerate() {
-                messages.push(CompletionMessage::user(format!(
-                    "Step {}/{}: {}",
-                    i + 1,
-                    n,
-                    step.description
-                )));
-                match self
-                    .run_engine_turn(engine, &mut messages, budget, &mut file_changes)
-                    .await
-                {
-                    TurnOutcome::Completed { text, cost_usd } => {
-                        final_text = text;
-                        *total += cost_usd;
-                    }
-                    TurnOutcome::Aborted { reason } => {
-                        return CandidateResult::aborted(messages, reason);
-                    }
-                }
-            }
+        let mut state = CandidateState {
+            messages: base_messages.to_vec(),
+            final_text: String::new(),
+            file_changes: 0,
+            oracle,
+            untracked_before,
+            diff_lines: 0,
+            diff_text: String::new(),
+            revisions: 0,
+        };
+
+        if let Err(reason) = self
+            .execute_plan(plan, engine, budget, total, &mut state)
+            .await
+        {
+            return CandidateResult::aborted(state.messages, reason);
         }
 
         // Decide whether to verify: unconditional for single/multi; for a
         // simple lookup, only if the turn unexpectedly touched files (the
         // zero-diff guard, L-E2). "Touched files" = FileChange events observed
         // OR a non-empty diff.
-        let (mut diff_lines, mut diff_text) = self.gather_diff(&untracked_before).await;
-        let files_touched = file_changes > 0 || !diff_text.trim().is_empty();
+        (state.diff_lines, state.diff_text) = self.gather_diff(&state.untracked_before).await;
+        let files_touched = state.file_changes > 0 || !state.diff_text.trim().is_empty();
         let should_verify = task_class.verifies_unconditionally()
             || (task_class == TaskClass::SimpleLookup && files_touched);
         if !should_verify {
             // A clean lookup: nothing to verify.
-            return CandidateResult {
-                messages,
-                final_text,
-                aborted: None,
-                verdict: None,
-                score: CandidateScore::Unverified,
-                diff_lines,
-                revisions: 0,
-            };
+            return state.into_unverified();
         }
 
-        // Verify + bounded revise loop.
+        self.verify_candidate(goal, engine, budget, total, state)
+            .await
+    }
+
+    /// Execute stage: one turn for simple/single-task; one turn per plan step
+    /// for multi-step (each step guides a fresh engine turn). The last turn's
+    /// text lands in `state.final_text`; `Err` is the first aborted turn's
+    /// reason.
+    async fn execute_plan(
+        &self,
+        plan: Option<&[PlanStep]>,
+        engine: &Engine<'_>,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+        state: &mut CandidateState,
+    ) -> Result<(), String> {
+        self.emit(AgentEvent::Stage {
+            name: StageKind::Execute,
+        });
+        let steps: Vec<&PlanStep> = plan.map(|p| p.iter().collect()).unwrap_or_default();
+        if steps.is_empty() {
+            match self
+                .run_engine_turn(engine, &mut state.messages, budget, &mut state.file_changes)
+                .await
+            {
+                TurnOutcome::Completed { text, cost_usd } => {
+                    state.final_text = text;
+                    *total += cost_usd;
+                }
+                TurnOutcome::Aborted { reason } => return Err(reason),
+            }
+        } else {
+            let n = steps.len();
+            for (i, step) in steps.iter().enumerate() {
+                state.messages.push(CompletionMessage::user(format!(
+                    "Step {}/{}: {}",
+                    i + 1,
+                    n,
+                    step.description
+                )));
+                match self
+                    .run_engine_turn(engine, &mut state.messages, budget, &mut state.file_changes)
+                    .await
+                {
+                    TurnOutcome::Completed { text, cost_usd } => {
+                        state.final_text = text;
+                        *total += cost_usd;
+                    }
+                    TurnOutcome::Aborted { reason } => return Err(reason),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Verify + bounded revise loop over an executed candidate: observe the
+    /// tests, take the deterministic ladder decision (L-E11), and either
+    /// finish with a verdict, escalate to the model judge, or spend one of
+    /// `max_revisions` on a revise pass and re-observe. Owns `state` because
+    /// every exit moves it into the returned [`CandidateResult`].
+    async fn verify_candidate(
+        &self,
+        goal: &str,
+        engine: &Engine<'_>,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+        mut state: CandidateState,
+    ) -> CandidateResult {
         self.emit(AgentEvent::Stage {
             name: StageKind::Verify,
         });
-        let mut revisions = 0u32;
         loop {
-            // Post-execute test observation for the flip oracle + touched-tests
-            // signal.
-            let (touched_tests_passed, test_tail) = match &self.config.test_command {
-                Some(cmd) => {
-                    let post = self.commands.run(cmd).await;
-                    let passed = post.passed();
-                    oracle.observe(cmd, passed);
-                    (Some(passed), post.stderr_tail)
-                }
-                None => (None, String::new()),
-            };
+            let (touched_tests_passed, test_tail) =
+                self.observe_touched_tests(&mut state.oracle).await;
             let inputs = LadderInputs {
-                flip_achieved: oracle.is_flipped(),
+                flip_achieved: state.oracle.is_flipped(),
                 touched_tests_passed,
-                diff_lines,
+                diff_lines: state.diff_lines,
                 diff_budget: self.config.diff_budget_lines,
             };
 
             match ladder_decision(&inputs) {
                 LadderDecision::SubmitFast => {
                     // Deterministic pass — judge SKIPPED (L-E11).
-                    let evidence =
-                        deterministic_pass_evidence(oracle.tracked_command(), diff_lines);
+                    let evidence = deterministic_pass_evidence(
+                        state.oracle.tracked_command(),
+                        state.diff_lines,
+                    );
                     self.emit(AgentEvent::JudgeVerdict {
                         passed: true,
                         evidence: evidence.clone(),
                     });
-                    return CandidateResult {
-                        messages,
-                        final_text,
-                        aborted: None,
-                        verdict: Some(Verdict::from_evidence(true, &evidence)),
-                        score: score_from_verification(true, None),
-                        diff_lines,
-                        revisions,
-                    };
+                    return state.into_verified(
+                        true,
+                        &evidence,
+                        score_from_verification(true, None),
+                    );
                 }
                 LadderDecision::Revise => {
                     // Deterministic failure (touched tests red) — no judge.
@@ -778,37 +849,18 @@ impl<'a> Pipeline<'a> {
                         passed: false,
                         evidence: evidence.clone(),
                     });
-                    if revisions >= self.config.max_revisions {
-                        return CandidateResult {
-                            messages,
-                            final_text,
-                            aborted: None,
-                            verdict: Some(Verdict::from_evidence(false, &evidence)),
-                            score: score_from_verification(false, Some(false)),
-                            diff_lines,
-                            revisions,
-                        };
+                    if state.revisions >= self.config.max_revisions {
+                        return state.into_verified(
+                            false,
+                            &evidence,
+                            score_from_verification(false, Some(false)),
+                        );
                     }
-                    match self
-                        .revise_turn(
-                            engine,
-                            &mut messages,
-                            budget,
-                            &evidence.summary,
-                            &mut file_changes,
-                            &mut final_text,
-                            total,
-                            &untracked_before,
-                        )
+                    if let Err(reason) = self
+                        .revise_candidate(engine, budget, &evidence.summary, total, &mut state)
                         .await
                     {
-                        Ok((dl, dt)) => {
-                            diff_lines = dl;
-                            diff_text = dt;
-                            revisions += 1;
-                            continue;
-                        }
-                        Err(reason) => return CandidateResult::aborted(messages, reason),
+                        return CandidateResult::aborted(state.messages, reason);
                     }
                 }
                 LadderDecision::ModelJudge => {
@@ -818,11 +870,18 @@ impl<'a> Pipeline<'a> {
                         "flip_achieved={}; touched_tests={:?}; diff_lines={} (budget {})",
                         inputs.flip_achieved,
                         inputs.touched_tests_passed,
-                        diff_lines,
+                        state.diff_lines,
                         self.config.diff_budget_lines,
                     );
                     let verdict = self
-                        .judge(goal, &diff_text, &evidence_summary, &inputs, budget, total)
+                        .judge(
+                            goal,
+                            &state.diff_text,
+                            &evidence_summary,
+                            &inputs,
+                            budget,
+                            total,
+                        )
                         .await;
                     let evidence = model_verdict_evidence(&verdict);
                     self.emit(AgentEvent::JudgeVerdict {
@@ -830,51 +889,72 @@ impl<'a> Pipeline<'a> {
                         evidence: evidence.clone(),
                     });
                     if verdict.passed {
-                        return CandidateResult {
-                            messages,
-                            final_text,
-                            aborted: None,
-                            verdict: Some(Verdict::from_evidence(true, &evidence)),
-                            score: score_from_verification(false, Some(true)),
-                            diff_lines,
-                            revisions,
-                        };
+                        return state.into_verified(
+                            true,
+                            &evidence,
+                            score_from_verification(false, Some(true)),
+                        );
                     }
-                    if revisions >= self.config.max_revisions {
-                        return CandidateResult {
-                            messages,
-                            final_text,
-                            aborted: None,
-                            verdict: Some(Verdict::from_evidence(false, &evidence)),
-                            score: score_from_verification(false, Some(false)),
-                            diff_lines,
-                            revisions,
-                        };
+                    if state.revisions >= self.config.max_revisions {
+                        return state.into_verified(
+                            false,
+                            &evidence,
+                            score_from_verification(false, Some(false)),
+                        );
                     }
-                    match self
-                        .revise_turn(
-                            engine,
-                            &mut messages,
-                            budget,
-                            &verdict.reasoning,
-                            &mut file_changes,
-                            &mut final_text,
-                            total,
-                            &untracked_before,
-                        )
+                    if let Err(reason) = self
+                        .revise_candidate(engine, budget, &verdict.reasoning, total, &mut state)
                         .await
                     {
-                        Ok((dl, dt)) => {
-                            diff_lines = dl;
-                            diff_text = dt;
-                            revisions += 1;
-                            continue;
-                        }
-                        Err(reason) => return CandidateResult::aborted(messages, reason),
+                        return CandidateResult::aborted(state.messages, reason);
                     }
                 }
             }
         }
+    }
+
+    /// Post-execute test observation for the flip oracle + the touched-tests
+    /// signal: `(Some(passed), stderr tail)` when a test command is
+    /// configured, `(None, "")` when there is nothing to run.
+    async fn observe_touched_tests(&self, oracle: &mut FlipOracle) -> (Option<bool>, String) {
+        match &self.config.test_command {
+            Some(cmd) => {
+                let post = self.commands.run(cmd).await;
+                let passed = post.passed();
+                oracle.observe(cmd, passed);
+                (Some(passed), post.stderr_tail)
+            }
+            None => (None, String::new()),
+        }
+    }
+
+    /// Spend one revision: run [`Pipeline::revise_turn`] with the failure
+    /// evidence and fold the fresh diff back into `state`. `Err` is the abort
+    /// reason of a turn that died mid-revision (budget/loop).
+    async fn revise_candidate(
+        &self,
+        engine: &Engine<'_>,
+        budget: &mut BudgetGuard,
+        reason: &str,
+        total: &mut f64,
+        state: &mut CandidateState,
+    ) -> Result<(), String> {
+        let (diff_lines, diff_text) = self
+            .revise_turn(
+                engine,
+                &mut state.messages,
+                budget,
+                reason,
+                &mut state.file_changes,
+                &mut state.final_text,
+                total,
+                &state.untracked_before,
+            )
+            .await?;
+        state.diff_lines = diff_lines;
+        state.diff_text = diff_text;
+        state.revisions += 1;
+        Ok(())
     }
 
     /// Run one revision turn: append an evidence-carrying instruction, execute,


### PR DESCRIPTION
## What & why

`Engine::run_turn` (stella-core/src/driver.rs) was a ~293-line method handling compaction, loop detection, budget checking, the retried model call, telemetry, budget accounting, result dispatch, and tool execution inline. The step loop now reads as a high-level orchestrator, one named sub-method per phase:

- `run_compaction_pass` — calibrated-budget compaction + `Compaction` event
- `check_loop_detection` — `detect_loop` over the current turn's calls
- `check_budget` — the between-steps `BudgetGuard::evaluate` gate (free fn; reads no engine state)
- `run_model_call` — retry+backoff model call with the deferred `Retry` flush, returning a new private `CommittedStep` (result + request-time snapshots: raw token estimate, read-only tool set, retry count, duration)
- `handle_committed_result` — drift feedback, `StepUsage` telemetry, budget accounting including the committed-delivery abort
- `dispatch_completion` — `Text`/`Complete` emission or tool execution + history recording

The issue's second target, `Pipeline::run_candidate` (stella-pipeline/src/pipeline.rs, ~246 lines), got the same treatment since it went cleanly: a private `CandidateState` struct threads the candidate-local mutable state through `execute_plan`, `verify_candidate`, `observe_touched_tests`, and `revise_candidate`; `CandidateState::into_verified`/`into_unverified` replace the four hand-rolled `CandidateResult` literals.

A small follow-up commit clears two clippy warnings that pre-existed on `main` (landed via bd9d02b while org CI was down) so the branch meets the zero-warning gate: the `clippy::map_entry` rewrite in `stella-core/src/extensions.rs` (behavior unchanged) and a scoped `dead_code` allow on `SyncOutcome::skipped` (read only by tests; removing it would weaken a test).

Fixes #62

## The witness

- [x] No witness needed (pure refactor) — because: zero behavior change is the contract. Event emission order, budget accounting, retry semantics, and message mutations are unchanged; the existing driver/pipeline test suites (including the 200-step synthetic survival turns, deferred-retry-flush, budget-abort delivery, and parallel-tool ordering tests) are the oracle and pass untouched.

## The gate

- [x] `rustfmt --edition 2024 --check` clean on all four touched files (repo has pre-existing drift elsewhere; untouched files left alone)
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` — 44 suites, 0 failures

Note: org-wide GitHub Actions is currently dead (jobs fail in seconds with zero steps) — the local gate above is authoritative for this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

Two intentional micro-moves inside `run_turn`, both unobservable: `total_cost_usd += cost` now happens just before (rather than inside) the budget-accounting phase, and `calibration_model` is assigned before (rather than after) `CalibrationMap::record` — both are plain local/state writes with no event or control-flow coupling, and on the abort paths their values were already discarded.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `stella-core` Engine::run_turn and `stella-pipeline` Pipeline::run_candidate into small, named phases so the loops act as clear orchestrators with no behavior changes. Fixes #62.

- **Refactors**
  - `stella-core`: extracted `run_compaction_pass`, `check_loop_detection`, `check_budget` (free fn), `run_model_call`, `handle_committed_result`, `dispatch_completion`; introduced `CommittedStep`.
  - `stella-pipeline`: added `CandidateState`; split logic into `execute_plan`, `verify_candidate`, `observe_touched_tests`, `revise_candidate`; added `into_verified`/`into_unverified`.
  - No behavior changes; event ordering, retries, budget accounting, and message mutations are unchanged.

- **Bug Fixes**
  - Cleared pre-existing `clippy` warnings:
    - Rewrote `contains_key`+`insert` to `Entry::Vacant` in `stella-core`.
    - Scoped `#[cfg_attr(not(test), allow(dead_code))]` for `SyncOutcome::skipped` in `stella-cli`.

<sup>Written for commit 06a834574fcb6f5c0110e01482bcd157985b266c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
