### PR TITLE
fix: deck starts before MCP connect; connect progress is visible (fixes #98)

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -22,7 +22,7 @@ use stella_core::{
     BudgetGuard, CalibrationMap, Engine, EngineConfig, GoalConfig, GoalOutcome, RoleTable, Router,
     TurnOutcome,
 };
-use stella_mcp::{McpConfig, McpToolSet};
+use stella_mcp::{McpConfig, McpServerConfig, McpToolSet};
 use stella_model::credential::ApiKey;
 use stella_model::provider::Provider;
 use stella_pipeline::{
@@ -1444,38 +1444,83 @@ pub async fn run_init(
     Ok(())
 }
 
+/// Cap on each MCP server's connect (and, until overridden, each later
+/// call) — the per-server bound `McpToolSet::connect` enforces.
+const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// The parse of `.stella/mcp.toml`, split from the connect so a caller that
+/// owns a UI (the deck) can announce the slow part before awaiting it (#98).
+pub(crate) enum McpPlan {
+    /// No config file, or one naming zero servers — nothing to connect.
+    None,
+    /// The config exists but is unreadable/invalid: MCP is disabled this
+    /// session, and the reason must be surfaced exactly once.
+    Invalid(String),
+    /// Servers to connect via [`connect_mcp_servers`].
+    Servers(Vec<McpServerConfig>),
+}
+
+/// Stage 1 of MCP assembly: read and parse the workspace config. Local file
+/// I/O only — never touches the network.
+pub(crate) fn load_mcp_plan(cfg: &Config) -> McpPlan {
+    let path = cfg.workspace_root.join(".stella").join("mcp.toml");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return McpPlan::None;
+    };
+    let parsed = match McpConfig::from_toml_str(&text) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            return McpPlan::Invalid(format!(
+                "{} is invalid: {e} — MCP servers disabled this session",
+                path.display()
+            ));
+        }
+    };
+    let servers = parsed.into_servers();
+    if servers.is_empty() {
+        McpPlan::None
+    } else {
+        McpPlan::Servers(servers)
+    }
+}
+
+/// Stage 2 of MCP assembly: the slow part — up to [`MCP_CONNECT_TIMEOUT`]
+/// per server. Best-effort and isolated per server (stella-mcp records
+/// failures in the set instead of propagating them); the returned set wraps
+/// `native` so non-`mcp__` tool names fall through to it.
+pub(crate) async fn connect_mcp_servers(
+    servers: &[McpServerConfig],
+    native: std::sync::Arc<dyn ToolExecutor>,
+) -> McpToolSet {
+    McpToolSet::connect(servers, MCP_CONNECT_TIMEOUT)
+        .await
+        .wrapping(native)
+}
+
 /// Connect the workspace's MCP servers (.stella/mcp.toml), wrapping the
 /// native registry so their tools merge into the agent's set under
 /// mcp__<server>__<tool> names. Absent config -> None (zero overhead).
 /// Connection is best-effort per server (stella-mcp isolates failures);
-/// failed servers are reported once in text mode, never fatal.
+/// failed servers are reported once in text mode, never fatal. Deck mode
+/// stages [`load_mcp_plan`] / [`connect_mcp_servers`] itself instead: the
+/// connect must run behind the live TUI, with diagnostics as transcript
+/// events rather than prints (#98).
 pub(crate) async fn connect_mcp(
     cfg: &Config,
     native: std::sync::Arc<dyn ToolExecutor>,
     print_diagnostics: bool,
 ) -> Option<McpToolSet> {
-    let path = cfg.workspace_root.join(".stella").join("mcp.toml");
-    let text = std::fs::read_to_string(&path).ok()?;
-    let parsed = match McpConfig::from_toml_str(&text) {
-        Ok(parsed) => parsed,
-        Err(e) => {
+    let servers = match load_mcp_plan(cfg) {
+        McpPlan::None => return None,
+        McpPlan::Invalid(reason) => {
             if print_diagnostics {
-                eprintln!(
-                    "  {} {} is invalid: {e} — MCP servers disabled this session",
-                    "!".yellow(),
-                    path.display()
-                );
+                eprintln!("  {} {reason}", "!".yellow());
             }
             return None;
         }
+        McpPlan::Servers(servers) => servers,
     };
-    let servers = parsed.into_servers();
-    if servers.is_empty() {
-        return None;
-    }
-    let set = McpToolSet::connect(&servers, std::time::Duration::from_secs(10))
-        .await
-        .wrapping(native);
+    let set = connect_mcp_servers(&servers, native).await;
     if print_diagnostics {
         for (name, reason) in set.failed_servers() {
             eprintln!(

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -113,15 +113,12 @@ enum TurnEnd {
 /// stream ends.
 pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result<(), String> {
     // ── Session assembly (still on the normal screen — prints are fine) ────
+    // MCP connect is NOT here: it can block up to 10s per server, so it runs
+    // after the deck task spawns, narrated as transcript events (#98).
     let provider = agent::build_provider(cfg)?;
     let registry: Arc<ToolRegistry> =
         Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
     agent::populate_schema_index(&registry, &cfg.workspace_root);
-    let mcp = agent::connect_mcp(cfg, registry.clone(), true).await;
-    let base_tools: &dyn ToolExecutor = match &mcp {
-        Some(set) => set,
-        None => &*registry,
-    };
     let custom_tools = agent::discover_custom_tools(cfg, true).await;
     let mut budget = agent::build_budget_guard(budget_limit);
     let store = agent::open_store(&cfg.workspace_root);
@@ -185,6 +182,57 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
     // The deck owns its channel ends and runs on its own task so rendering
     // never waits on the driver (and vice versa).
     let deck = tokio::spawn(run_deck(opts, in_rx, sub_tx));
+
+    // ── MCP connect, behind the live deck (#98) ─────────────────────────────
+    // This await used to run during assembly, before the deck spawned — a
+    // slow or unreachable server meant a blank terminal for up to the 10s
+    // per-server timeout. The deck is up now, so its splash absorbs the wait
+    // and the attempt is narrated in the transcript. Failure semantics are
+    // the plain REPL's: the session continues on native tools only. Prompts
+    // submitted while this await runs are never lost — the deck's input
+    // never blocks, and everything it sends buffers in `sub_rx` until the
+    // driver loop below starts reading.
+    let mcp = match agent::load_mcp_plan(cfg) {
+        agent::McpPlan::None => None,
+        agent::McpPlan::Invalid(reason) => {
+            let _ = in_tx.send(Inbound::Event {
+                agent: LEAD.to_string(),
+                event: AgentEvent::Text { delta: reason },
+            });
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::WaitingInput,
+            });
+            None
+        }
+        agent::McpPlan::Servers(servers) => {
+            let _ = in_tx.send(Inbound::Event {
+                agent: LEAD.to_string(),
+                event: AgentEvent::Text {
+                    delta: format!("connecting {} MCP server(s)…", servers.len()),
+                },
+            });
+            let set = agent::connect_mcp_servers(&servers, registry.clone()).await;
+            let _ = in_tx.send(Inbound::Event {
+                agent: LEAD.to_string(),
+                event: AgentEvent::Text {
+                    delta: mcp_outcome_report(&set.connected_names(), set.failed_servers()),
+                },
+            });
+            // The Text events above fold the lead to `Running`, but no turn
+            // is in flight — restore the idle status or the dashboard would
+            // show a busy lead forever.
+            let _ = in_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::WaitingInput,
+            });
+            Some(set)
+        }
+    };
+    let base_tools: &dyn ToolExecutor = match &mcp {
+        Some(set) => set,
+        None => &*registry,
+    };
 
     // ── The driver loop ─────────────────────────────────────────────────────
     let mut queue: VecDeque<String> = VecDeque::new();
@@ -418,6 +466,26 @@ pub async fn run_deck_session(cfg: &Config, budget_limit: Option<f64>) -> Result
         Ok(Err(e)) => Err(format!("deck terminal error: {e}")),
         Err(e) => Err(format!("deck task failed: {e}")),
     }
+}
+
+/// The transcript report for a finished MCP connect attempt: the connected
+/// servers by name, then one row per failure with its reason — the deck-mode
+/// analogue of the diagnostics [`agent::connect_mcp`] prints in the plain
+/// REPL. Zero connections is stated outright: the degraded session must be
+/// visible in the transcript, never inferred from silence.
+fn mcp_outcome_report(connected: &[&str], failed: &[(String, String)]) -> String {
+    let mut lines = Vec::new();
+    match connected.len() {
+        0 => lines.push("no MCP servers connected — continuing with native tools only".to_string()),
+        n => lines.push(format!(
+            "{n} MCP server(s) connected: {}",
+            connected.join(", ")
+        )),
+    }
+    for (name, reason) in failed {
+        lines.push(format!("MCP server `{name}` unavailable: {reason}"));
+    }
+    lines.join("\n")
 }
 
 /// The disposition of a would-be slash command.
@@ -1037,6 +1105,38 @@ mod tests {
             recv_file_change(&mut rx).is_none(),
             "read-only tools emit nothing"
         );
+    }
+
+    #[test]
+    fn mcp_outcome_report_lists_connected_servers_by_name() {
+        let report = mcp_outcome_report(&["files", "search"], &[]);
+        assert_eq!(report, "2 MCP server(s) connected: files, search");
+    }
+
+    #[test]
+    fn mcp_outcome_report_names_each_failure_with_its_reason() {
+        let failed = vec![(
+            "slow".to_string(),
+            "connect timed out after 10000ms".to_string(),
+        )];
+        let report = mcp_outcome_report(&["files"], &failed);
+        let lines: Vec<&str> = report.lines().collect();
+        assert_eq!(lines[0], "1 MCP server(s) connected: files");
+        assert_eq!(
+            lines[1],
+            "MCP server `slow` unavailable: connect timed out after 10000ms"
+        );
+    }
+
+    #[test]
+    fn mcp_outcome_report_states_total_failure_outright() {
+        let failed = vec![("a".to_string(), "spawn failed".to_string())];
+        let report = mcp_outcome_report(&[], &failed);
+        assert!(
+            report.starts_with("no MCP servers connected"),
+            "the degraded mode is stated, not implied: {report}"
+        );
+        assert!(report.contains("MCP server `a` unavailable: spawn failed"));
     }
 
     #[test]

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -155,7 +155,11 @@ fn relative_symlink_target(from_dir: &Path, target: &Path) -> PathBuf {
 pub struct SyncOutcome {
     /// Created links as `(kind, name)`.
     pub linked: Vec<(ExtensionKind, String)>,
-    /// Entries skipped by the plan (symlink sources, existing names).
+    /// Entries skipped by the plan (symlink sources, existing names). The
+    /// progress line reports only links and errors, so outside of tests this
+    /// count is currently write-only — kept because dropping it would erase
+    /// the only record of "found but not adopted" a future line can report.
+    #[allow(dead_code)]
     pub skipped: usize,
     pub errors: Vec<String>,
 }

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -378,9 +378,10 @@ pub fn plan_extension_sync(
         std::collections::HashSet<String>,
     > = std::collections::HashMap::new();
     for source in sources {
-        if !present_files.contains_key(&source.kind) {
+        if let std::collections::hash_map::Entry::Vacant(vacant) = present_files.entry(source.kind)
+        {
             let targets = existing(source.kind);
-            present_files.insert(source.kind, targets.file_names.into_iter().collect());
+            vacant.insert(targets.file_names.into_iter().collect());
             // Definitions already in the destination claim their names up
             // front, so a same-named-but-differently-filed source entry is
             // skipped instead of linked alongside.

--- a/stella-mcp/src/toolset.rs
+++ b/stella-mcp/src/toolset.rs
@@ -183,6 +183,12 @@ impl McpToolSet {
         self.clients.len()
     }
 
+    /// The live servers' names, in connect order — the counterpart of
+    /// [`McpToolSet::failed_servers`] for a caller's connect-outcome report.
+    pub fn connected_names(&self) -> Vec<&str> {
+        self.clients.iter().map(|c| c.name()).collect()
+    }
+
     /// Close every connected server's transport in order (best-effort).
     pub async fn close_all(&self) {
         for client in &self.clients {
@@ -357,6 +363,15 @@ mod tests {
         let mut client = McpClient::new(name, Box::new(transport));
         client.initialize().await.unwrap();
         client
+    }
+
+    #[tokio::test]
+    async fn connected_names_lists_live_servers_in_order() {
+        let a = connected_client("files", "read").await;
+        let b = connected_client("search", "grep").await;
+        let set = McpToolSet::from_clients(vec![a, b]);
+        assert_eq!(set.connected_names(), vec!["files", "search"]);
+        assert!(set.failed_servers().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`run_deck_session` awaited `agent::connect_mcp` (10s timeout per server) during session assembly, **before** spawning the deck task. A slow or unreachable MCP server meant a blank terminal for up to 10 seconds — it read as a hang (#98).

## The reorder

Startup order is now:

1. Assemble the session on the normal screen (provider, registry, custom tools, budget, store, memory, extensions — all fast/local; their prints still land pre-alternate-screen).
2. Register the lead, emit the custom-definitions problems report, set `WaitingInput` — unchanged.
3. **Spawn the deck task** (`tokio::spawn(run_deck(...))`) — the splash renders immediately.
4. **Then** connect MCP, narrated as transcript events:
   - `connecting N MCP server(s)…` (a `Text` event — folds the lead to `Running`, which is accurate: it is busy),
   - the await on the connect (10s cap per server, unchanged),
   - an outcome report naming **every connected server and every failure with its reason** (`mcp_outcome_report`, a pure helper),
   - `Status WaitingInput` to restore the idle lead the Text events flipped — same pattern the existing startup problems report uses, so the lead is never stranded showing `Running`.
5. Build the tool stack (`base_tools` borrows the `McpToolSet` exactly as before) and enter the driver loop.

No channel gymnastics: the tool stack is still built strictly before the first turn can dispatch, so nothing races a half-connected `McpToolSet`.

## Why prompts typed during the connect are safe

The deck's contract is "input never blocks": every submission goes down the **unbounded** `sub_tx`/`sub_rx` channel. During the connect await the driver simply isn't reading yet, so anything typed sits buffered in `sub_rx` (and shows in the deck's own queue display) until the driver loop starts and drains it in order — `PromptStarted` pops the deck's queue row per prompt exactly as it does mid-turn today. Nothing is dropped, nothing dispatches against a missing tool stack.

## Degradation semantics (unchanged, now visible)

- No `.stella/mcp.toml` / zero servers: no events at all — zero noise, same as today.
- Invalid config: the same "disabled this session" message the REPL prints, as a transcript event.
- Per-server failures: best-effort isolation as before (`stella-mcp` records them); the outcome line says which servers connected and which failed with reasons, followed by an explicit "no MCP servers connected — continuing with native tools only" when everything failed. The session always continues.

## Mechanics

- `agent::connect_mcp` is split into `load_mcp_plan` (parse, local I/O only) + `connect_mcp_servers` (the slow connect); `connect_mcp` recomposes them, so the plain REPL callers and their printed diagnostics are **byte-for-byte unchanged**.
- `McpToolSet::connected_names` added (stella-mcp) — the connected-side counterpart of `failed_servers` for the outcome line.
- Tests: `mcp_outcome_report` unit tests (all-connected / mixed / total-failure) and a `connected_names` test on the existing scripted-transport infrastructure. No fake-MCP integration test added — the reorder itself is I/O wiring.
- Drive-by: silenced the two pre-existing clippy/dead-code warnings on main (stella-core `map_entry`, stella-cli `SyncOutcome::skipped`) that broke the zero-warnings gate.

## Follow-up (not in this PR)

The plain REPL (`agent::run_interactive`) still connects MCP inline before the first prompt — but it prints `connecting`/outcome diagnostics to a normal terminal as it goes, so there is no silent blank-screen there; staging it through `load_mcp_plan`/`connect_mcp_servers` for an earlier first prompt is a possible follow-up.

## Gate

- `cargo test --workspace` — all green (44 suites, no failures)
- `cargo clippy --workspace --all-targets` — zero warnings
- `rustfmt --edition 2024 --check` on all touched files — clean

Fixes #98


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start the deck before MCP connect and narrate the connect progress/outcomes as transcript events so the UI renders immediately and no longer looks hung on slow MCP servers. Fixes #98.

- **Bug Fixes**
  - Deck spawns first; MCP connects after with “connecting N MCP server(s)…” and an outcome report, then status is reset to WaitingInput.
  - Input stays non-blocking; prompts typed during connect are queued and processed in order.
  - Failure semantics unchanged; session continues with native tools if MCP fails.

- **Refactors**
  - Split connect into `load_mcp_plan` (parse only) and `connect_mcp_servers`; `connect_mcp` recomposes them so plain REPL behavior/diagnostics are unchanged.
  - Added `McpToolSet::connected_names` in `stella-mcp` and an `mcp_outcome_report` helper with unit tests in `stella-cli`.
  - Silenced minor lints in `stella-core` and `stella-cli` to keep the zero-warnings gate.

<sup>Written for commit 6be5917fa17b2880633940d1ce107e8dc8e6f49a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
