### PR TITLE
fix: cap transcript retention with chunked front-eviction (fixes #95)

### DIFF
--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -92,6 +92,10 @@ pub struct DeckUi {
     pub expanded: std::collections::HashMap<String, std::collections::HashSet<usize>>,
     /// Bumped on every expansion toggle so the fold cache invalidates.
     pub expanded_rev: u64,
+    /// Per-agent eviction count last reconciled by [`ingest_inbound`] —
+    /// front-eviction shifts every retained index, so when it advances that
+    /// agent's `expanded` set is stale and must drop.
+    pub evicted_seen: std::collections::HashMap<String, usize>,
     /// Armed by a `ctrl+o` pressed from the prompt (no selection); a second
     /// consecutive `ctrl+o` escalates to the all-thinking toggle. Any other
     /// key disarms.
@@ -128,6 +132,7 @@ impl Default for DeckUi {
             session_pending_scroll: None,
             expanded: std::collections::HashMap::new(),
             expanded_rev: 0,
+            evicted_seen: std::collections::HashMap::new(),
             ctrl_o_primed: false,
             session_fold: crate::views::session::SessionFold::default(),
         }
@@ -218,6 +223,29 @@ fn clamp(model: &WorkspaceModel, ui: &mut DeckUi) {
     } else {
         ui.queue_sel.min(queued - 1)
     };
+    // Front-eviction shifts every retained index: a ctrl+o flag would
+    // silently re-attach to whichever entry slid into its slot, so when an
+    // agent's cumulative eviction count advances its expansion set drops
+    // (bumping the rev invalidates the fold cache).
+    for agent in &model.agents {
+        let evicted = agent.model.evicted_entries();
+        if evicted > ui.evicted_seen.get(&agent.meta.id).copied().unwrap_or(0) {
+            ui.evicted_seen.insert(agent.meta.id.clone(), evicted);
+            if ui.expanded.remove(&agent.meta.id).is_some() {
+                ui.expanded_rev += 1;
+            }
+        }
+    }
+    // The ↑/↓ highlight must stay inside the retained window — eviction can
+    // shrink the transcript below a selection taken before the pass.
+    let entries = model
+        .agents
+        .get(ui.focused)
+        .map(|a| a.model.transcript.len())
+        .unwrap_or(0);
+    ui.session_selected = ui
+        .session_selected
+        .and_then(|sel| (entries > 0).then(|| sel.min(entries - 1)));
 }
 
 /// Map one key to a [`DeckAction`]. Pure over `(key, model)`, mutating `ui`.
@@ -968,6 +996,41 @@ mod tests {
         let mut ui = DeckUi::default();
         ui.splash.skip(); // past the splash for interaction tests
         ui
+    }
+
+    #[test]
+    fn eviction_clamps_the_selection_and_drops_stale_expansions() {
+        use crate::model::MAX_TRANSCRIPT_ENTRIES;
+        let mut model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        let retry = |i: usize| Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Retry {
+                attempt: i as u32,
+                reason: "r".into(),
+            },
+        };
+        // Grow to just under the cap, then highlight + expand near the tail.
+        for i in 0..(MAX_TRANSCRIPT_ENTRIES - 1) {
+            ingest_inbound(&retry(i), &mut model, &mut ui);
+        }
+        ui.session_selected = Some(MAX_TRANSCRIPT_ENTRIES - 2);
+        toggle_expanded(&mut ui, "lead", MAX_TRANSCRIPT_ENTRIES - 2);
+        let rev = ui.expanded_rev;
+
+        // One more event crosses the cap: a chunk of the front evicts.
+        ingest_inbound(&retry(MAX_TRANSCRIPT_ENTRIES), &mut model, &mut ui);
+        let len = model.agents[0].model.transcript.len();
+        assert!(len < MAX_TRANSCRIPT_ENTRIES, "a chunk was evicted");
+        assert!(
+            ui.session_selected.is_some_and(|sel| sel < len),
+            "selection clamped into the retained window"
+        );
+        assert!(
+            !ui.expanded.contains_key("lead"),
+            "index-keyed expansions are stale once the front moved"
+        );
+        assert!(ui.expanded_rev > rev, "fold cache invalidated");
     }
 
     #[test]

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -27,6 +27,24 @@ use stella_protocol::{
 /// one-line card (the diff panel and detail views carry the rest).
 const SUMMARY_BUDGET: usize = 200;
 
+/// Retention cap on transcript entries. The per-entry char budgets
+/// ([`INPUT_BUDGET`], [`OUTPUT_BUDGET`]) bound one entry to ~20 KiB, but
+/// without an entry-count cap a long-running session grows without bound;
+/// 4 000 entries bounds the worst case to low tens of MiB while staying far
+/// deeper than any scrollback a user actually walks. Below the cap the fold
+/// is unchanged.
+pub(crate) const MAX_TRANSCRIPT_ENTRIES: usize = 4_000;
+
+/// Entries dropped per eviction pass — 10% of the cap, so the O(chunk) drain
+/// and the deck fold-cache rebuild amortize over hundreds of events instead
+/// of firing on every push once the cap is reached.
+pub(crate) const TRANSCRIPT_EVICTION_CHUNK: usize = MAX_TRANSCRIPT_ENTRIES / 10;
+
+// A pass must drop more than the one marker it inserts (or the transcript
+// never shrinks) and must never drain the live tail.
+const _: () =
+    assert!(TRANSCRIPT_EVICTION_CHUNK >= 2 && TRANSCRIPT_EVICTION_CHUNK < MAX_TRANSCRIPT_ENTRIES);
+
 /// The whole derived state of a session, folded from its `AgentEvent` log.
 ///
 /// Every field is a pure function of the sequence of events applied so far;
@@ -74,6 +92,14 @@ pub struct AskUserPrompt {
 /// is applied by [`crate::render`]; this type carries only content.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TranscriptEntry {
+    /// Stands in for entries dropped by the retention cap
+    /// ([`MAX_TRANSCRIPT_ENTRIES`]) — always the first entry when present.
+    /// `count` is cumulative across eviction passes (a pass that drains an
+    /// earlier marker absorbs its count), so the retained window stays a pure
+    /// function of the event sequence and the monotonically growing count
+    /// doubles as a cache-invalidation generation for consumers indexing the
+    /// transcript (front-eviction shifts every retained index).
+    Evicted { count: usize },
     /// A user-submitted prompt. Not an `AgentEvent` — the deck driver pushes
     /// this when `PromptStarted` arrives so the user's message is visible
     /// inline in the transcript, matching the Crush-style conversational layout.
@@ -487,6 +513,7 @@ impl SessionModel {
                 });
             }
         }
+        self.evict_transcript_overflow();
     }
 
     /// Fold an entire log at once — the replay entry point.
@@ -525,6 +552,41 @@ impl SessionModel {
     pub fn push_user_prompt(&mut self, text: &str) {
         self.transcript
             .push(TranscriptEntry::User(text.to_string()));
+        self.evict_transcript_overflow();
+    }
+
+    /// Total transcript entries evicted by the retention cap so far.
+    /// Monotonic — a pass absorbs any prior marker and adds at least one —
+    /// so it serves as the invalidation generation for caches keyed on the
+    /// retained window's front (see the deck's `SessionFold`).
+    pub fn evicted_entries(&self) -> usize {
+        match self.transcript.first() {
+            Some(TranscriptEntry::Evicted { count }) => *count,
+            _ => 0,
+        }
+    }
+
+    /// Enforce [`MAX_TRANSCRIPT_ENTRIES`]: at the cap, drop the oldest
+    /// [`TRANSCRIPT_EVICTION_CHUNK`] entries and stand a single
+    /// [`TranscriptEntry::Evicted`] marker in their place, absorbing a prior
+    /// marker's count so the tally stays total, not per-pass. Runs inside
+    /// every transcript-growing mutator — the retained window is part of the
+    /// deterministic fold, never a render-time concern. Only the front is
+    /// drained, so streaming coalescing into the tail entry is unaffected.
+    fn evict_transcript_overflow(&mut self) {
+        if self.transcript.len() < MAX_TRANSCRIPT_ENTRIES {
+            return;
+        }
+        let evicted: usize = self
+            .transcript
+            .drain(..TRANSCRIPT_EVICTION_CHUNK)
+            .map(|entry| match entry {
+                TranscriptEntry::Evicted { count } => count,
+                _ => 1,
+            })
+            .sum();
+        self.transcript
+            .insert(0, TranscriptEntry::Evicted { count: evicted });
     }
 
     /// If tool call `call_id` was a file mutation, the path it touched —
@@ -1084,6 +1146,96 @@ mod tests {
             model.pending_ask_user.is_none(),
             "matching result clears it"
         );
+    }
+
+    /// A non-coalescing one-entry event, for growing the transcript by
+    /// exactly one entry per apply.
+    fn retry(attempt: u32) -> AgentEvent {
+        AgentEvent::Retry {
+            attempt,
+            reason: "r".into(),
+        }
+    }
+
+    #[test]
+    fn below_the_cap_nothing_evicts() {
+        let mut model = SessionModel::new();
+        for i in 0..(MAX_TRANSCRIPT_ENTRIES - 1) {
+            model.apply(&retry(i as u32));
+        }
+        assert_eq!(model.transcript.len(), MAX_TRANSCRIPT_ENTRIES - 1);
+        assert_eq!(model.evicted_entries(), 0);
+        assert!(matches!(
+            model.transcript[0],
+            TranscriptEntry::Retry { attempt: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn transcript_caps_with_a_front_eviction_marker() {
+        let mut model = SessionModel::new();
+        let total = MAX_TRANSCRIPT_ENTRIES + 250;
+        for i in 0..total {
+            model.apply(&retry(i as u32));
+        }
+        assert!(model.transcript.len() <= MAX_TRANSCRIPT_ENTRIES);
+        let count = match model.transcript[0] {
+            TranscriptEntry::Evicted { count } => count,
+            ref other => panic!("expected the eviction marker first, got {other:?}"),
+        };
+        // The marker plus the retained entries account for every entry pushed.
+        assert_eq!(count + (model.transcript.len() - 1), total);
+        // The tail is untouched: the newest event is still the last entry.
+        match model.transcript.last() {
+            Some(TranscriptEntry::Retry { attempt, .. }) => {
+                assert_eq!(*attempt, (total - 1) as u32);
+            }
+            other => panic!("expected the newest retry last, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eviction_marker_accumulates_across_passes() {
+        let mut model = SessionModel::new();
+        // Enough to trigger a second pass, which drains the first marker.
+        let total = MAX_TRANSCRIPT_ENTRIES + TRANSCRIPT_EVICTION_CHUNK + 10;
+        for i in 0..total {
+            model.apply(&retry(i as u32));
+        }
+        let count = model.evicted_entries();
+        assert!(
+            count > TRANSCRIPT_EVICTION_CHUNK,
+            "second pass absorbed the first marker's count: {count}"
+        );
+        assert_eq!(count + (model.transcript.len() - 1), total);
+        // Exactly one marker survives, at the front.
+        let markers = model
+            .transcript
+            .iter()
+            .filter(|e| matches!(e, TranscriptEntry::Evicted { .. }))
+            .count();
+        assert_eq!(markers, 1);
+    }
+
+    #[test]
+    fn user_prompts_count_against_the_cap() {
+        let mut model = SessionModel::new();
+        for i in 0..(MAX_TRANSCRIPT_ENTRIES + 5) {
+            model.push_user_prompt(&format!("prompt {i}"));
+        }
+        assert!(model.transcript.len() <= MAX_TRANSCRIPT_ENTRIES);
+        assert!(model.evicted_entries() >= TRANSCRIPT_EVICTION_CHUNK);
+    }
+
+    #[test]
+    fn replay_past_the_cap_stays_deterministic() {
+        let log: Vec<AgentEvent> = (0..(MAX_TRANSCRIPT_ENTRIES + TRANSCRIPT_EVICTION_CHUNK + 3))
+            .map(|i| retry(i as u32))
+            .collect();
+        let a = SessionModel::replay(&log);
+        let b = SessionModel::replay(&log);
+        assert_eq!(a, b);
+        assert!(a.transcript.len() <= MAX_TRANSCRIPT_ENTRIES);
     }
 
     #[test]

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -718,6 +718,12 @@ pub(crate) fn entry_lines(
     out: &mut Vec<Line<'static>>,
 ) {
     match entry {
+        TranscriptEntry::Evicted { count } => out.push(Line::from(Span::styled(
+            format!("… {count} earlier entries evicted"),
+            Style::new()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        ))),
         TranscriptEntry::User(text) => {
             let md = crate::markdown::render(text);
             let mut entry_out: Vec<Line<'static>> = Vec::new();
@@ -1472,6 +1478,21 @@ mod tests {
             joined.contains("[✗ read_file]"),
             "result labels itself with its tool: {joined}"
         );
+    }
+
+    #[test]
+    fn eviction_marker_renders_as_a_one_line_system_note() {
+        let mut out = Vec::new();
+        entry_lines(
+            &TranscriptEntry::Evicted { count: 1234 },
+            false,
+            false,
+            80,
+            &mut out,
+        );
+        assert_eq!(out.len(), 1, "the marker costs exactly one visual row");
+        let text: String = out[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "… 1234 earlier entries evicted");
     }
 
     // ---- Replay determinism (L-T1) ------------------------------------

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -30,12 +30,13 @@ use crate::theme;
 /// exactly once and are cached with their visual-row ranges; only the tail
 /// entry re-folds per frame. The cache invalidates whole when anything that
 /// changes how settled entries render changes: focused agent, the thinking
-/// toggle, a ctrl+o expansion, or the pane width. This turns the old
-/// O(whole-history) fold per frame into O(tail) — typing latency no longer
-/// grows with session length.
+/// toggle, a ctrl+o expansion, the pane width, or the retention cap evicting
+/// a chunk of the front (which shifts every retained index). This turns the
+/// old O(whole-history) fold per frame into O(tail) — typing latency no
+/// longer grows with session length.
 #[derive(Debug, Clone, Default)]
 pub struct SessionFold {
-    key: Option<(String, bool, u64, usize)>,
+    key: Option<(String, bool, u64, usize, usize)>,
     settled: usize,
     prefix: Vec<Line<'static>>,
     entry_rows: Vec<Range<usize>>,
@@ -53,7 +54,16 @@ impl SessionFold {
         expanded_rev: u64,
         width: usize,
     ) {
-        let key = (agent.to_string(), thinking, expanded_rev, width);
+        // Front-eviction shifts every retained index, so the settled prefix
+        // no longer describes the entries now occupying 0..settled. The
+        // marker's cumulative count grows on every pass, so keying on it
+        // invalidates exactly when the front moves — the shrink check alone
+        // misses an eviction whose survivors still outnumber `settled`.
+        let evicted = match transcript.first() {
+            Some(TranscriptEntry::Evicted { count }) => *count,
+            _ => 0,
+        };
+        let key = (agent.to_string(), thinking, expanded_rev, width, evicted);
         if self.key.as_ref() != Some(&key) || self.settled > transcript.len().saturating_sub(1) {
             self.key = Some(key);
             self.settled = 0;
@@ -256,6 +266,7 @@ fn empty_state(area: Rect, buf: &mut Buffer) {
 mod tests {
     use super::*;
     use crate::envelope::{AgentMeta, Inbound};
+    use crate::model::{MAX_TRANSCRIPT_ENTRIES, SessionModel};
     use stella_protocol::{AgentEvent, ScopeProposal};
 
     /// Flatten a `Buffer` to plain text (content, not ANSI — the crate-wide
@@ -312,6 +323,39 @@ mod tests {
         assert!(
             text.contains("Which database should the cache use?"),
             "ask-user card visible alongside the scope review:\n{text}"
+        );
+    }
+
+    #[test]
+    fn fold_cache_stays_line_exact_across_front_eviction() {
+        // The dangerous shape: the cache settles on a SHORT prefix, then the
+        // transcript grows past the cap so a chunk of the front evicts while
+        // the survivor count still exceeds `settled` — the shrink check alone
+        // cannot see it, only the eviction-count key can.
+        let mut model = SessionModel::new();
+        let expanded = HashSet::new();
+        let retry = |i: usize| AgentEvent::Retry {
+            attempt: i as u32,
+            reason: "r".into(),
+        };
+        for i in 0..1_000 {
+            model.apply(&retry(i));
+        }
+        let mut fold = SessionFold::default();
+        fold.refresh("lead", &model.transcript, false, &expanded, 0, 80);
+        for i in 1_000..(MAX_TRANSCRIPT_ENTRIES + 50) {
+            model.apply(&retry(i));
+        }
+        assert!(model.evicted_entries() > 0, "an eviction pass occurred");
+        fold.refresh("lead", &model.transcript, false, &expanded, 0, 80);
+
+        let mut fresh = SessionFold::default();
+        fresh.refresh("lead", &model.transcript, false, &expanded, 0, 80);
+        assert_eq!(fold.total(), fresh.total());
+        assert_eq!(
+            fold.window_lines(0..fold.total()),
+            fresh.window_lines(0..fresh.total()),
+            "the incrementally-maintained fold matches a from-scratch fold"
         );
     }
 


### PR DESCRIPTION
## Problem

The session/deck transcript fold (`stella-tui/src/model.rs`) retained every `TranscriptEntry` forever. Per-entry char budgets (`INPUT_BUDGET`/`OUTPUT_BUDGET`) bound each entry to ~20 KiB, but with no cap on entry count a long-running session's memory grew without bound.

## Design

**Cap** — `MAX_TRANSCRIPT_ENTRIES = 4_000`, with a doc comment stating the constraint: bounds the worst case to low tens of MiB while staying far deeper than any scrollback a user actually walks. Below the cap the fold is byte-for-byte unchanged.

**Chunked eviction** — `TRANSCRIPT_EVICTION_CHUNK = MAX / 10` (400). When the transcript reaches the cap, one pass drains the oldest chunk and stands a single `TranscriptEntry::Evicted { count }` marker in its place, so the O(chunk) drain and the fold-cache rebuild amortize over hundreds of events instead of firing on every push at the cap. A const assertion pins `2 <= CHUNK < MAX` (a pass must drop more than the one marker it inserts, and never touch the live tail — streaming coalescing into `last_mut` is unaffected).

**Marker semantics** — renders as a dim one-line system note (`… N earlier entries evicted`). It counts as one entry, always sits at the front, and survives subsequent evictions by absorption: a pass that drains an earlier marker adds its count into the new one, so `count` is the cumulative total and exactly one marker ever exists.

**Pure fold** — eviction runs inside `SessionModel::apply` and `push_user_prompt`, never on the render path. The retained window is therefore itself a deterministic function of the event sequence; `SessionModel::replay` of the same log past the cap yields identical models, and the render replay-determinism proptest is untouched.

## Cache correctness (the PR #93 O(tail) fold cache)

Front-eviction shifts every retained index, which invalidates the deck `SessionFold`'s settled prefix. Its existing shrink check (`settled > len - 1`) is **not** sufficient: an eviction can land between two distant refreshes and the survivors-plus-new-entries can outnumber the settled prefix again, leaving a stale prefix undetected. Since the marker's cumulative count strictly grows on every pass, the fold key now includes it — the cache invalidates exactly when the front moves, and rebuild cost is amortized by the chunking. `fold_cache_stays_line_exact_across_front_eviction` pins exactly this scenario (warm cache on a short prefix, evict, compare against a from-scratch fold line-for-line).

Ephemeral index-keyed UI state is reconciled at ingest time (`deck_ui::clamp`): the ctrl+o `expanded` set for an agent drops when its eviction count advances (bumping `expanded_rev`), and `session_selected` clamps into the retained window. Scroll math stays line-exact: `ScrollState::window` already clamps against the per-frame total, and the fold's row ranges are rebuilt from the retained window.

## Tests

- fold N > cap → `len <= cap`, marker first, marker + retained entries account for every push, tail untouched
- marker accumulates across multiple passes; exactly one marker survives
- user prompts (`push_user_prompt`) count against the cap
- replay determinism holds past the cap (mirrors the existing replay test)
- eviction clamps `session_selected` into range and drops stale expansions, bumping the fold-cache rev (mirrors existing clamp tests)
- incremental fold == from-scratch fold across an eviction the shrink check cannot see
- marker renders as exactly one visual row
- below-cap: nothing evicts, first entry unchanged

## Gate

- `cargo test --workspace` — all green (229 passed in stella-tui incl. 8 new tests; every suite 0 failed)
- `cargo clippy --workspace --all-targets` — zero warnings from this diff (the two remaining warnings, in `stella-core` and `stella-cli/src/extensions.rs`, are pre-existing on origin/main — verified by running clippy on the clean base)
- `rustfmt --edition 2024 --check` clean on all four touched files

Fixes #95


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps session transcript retention at 4,000 entries with chunked front-eviction and a single cumulative marker to bound memory without changing behavior below the cap. Updates cache-keying and UI clamping so rendering stays O(tail) and indexes remain correct when the front moves. Fixes #95.

- **Bug Fixes**
  - Add `MAX_TRANSCRIPT_ENTRIES = 4_000` with `TRANSCRIPT_EVICTION_CHUNK = 400`; eviction runs in `apply` and `push_user_prompt`.
  - Insert a single `TranscriptEntry::Evicted { count }` at the front; absorbs prior markers and counts as one entry.
  - Render marker as a dim, italic one-liner: "… N earlier entries evicted".
  - Key `SessionFold` cache on the cumulative eviction count to invalidate exactly when the front shifts; keeps O(tail) folding.
  - Clamp `session_selected` into the retained window; drop stale ctrl+o expansions using `evicted_seen`, bumping `expanded_rev`.
  - Retained window is deterministic; replay remains identical; below-cap behavior is unchanged.

<sup>Written for commit dbca4de74c5574545b050e9274a843de7fa3543a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
