### PR TITLE
refactor: shared event-rendering primitives for plain + deck surfaces (fixes #66)

### DIFF
--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -30,8 +30,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
-use colored::{Color, Colorize};
-use stella_protocol::AgentEvent;
+use colored::{Color, ColoredString, Colorize};
+use stella_protocol::{AgentEvent, BudgetMode, StageKind};
+use stella_tui::textline::{self, EventLine, Tone, fmt_cost};
 
 /// Truncate `s` to at most `max` characters, appending `…` when it was
 /// shortened. Char-boundary-safe: operates on `char`s, never byte indices,
@@ -44,17 +45,6 @@ fn truncate_with_ellipsis(s: &str, max: usize) -> String {
         format!("{head}…")
     } else {
         s.to_string()
-    }
-}
-
-/// Render a token count compactly: `842`, `12.3k`, `1.2M`.
-fn fmt_tokens(tokens: u64) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}M", tokens as f64 / 1_000_000.0)
-    } else if tokens >= 1_000 {
-        format!("{:.1}k", tokens as f64 / 1_000.0)
-    } else {
-        tokens.to_string()
     }
 }
 
@@ -276,9 +266,10 @@ pub fn assistant_response(text: &str) {
 /// turn-end.
 pub fn cost_summary(cost_usd: f64, model: &str, elapsed: Duration) {
     println!(
-        "\n  {} {} · ${cost_usd:.4} · {:.1}s",
+        "\n  {} {} · {} · {:.1}s",
         "◆".dimmed(),
         model.bright_blue(),
+        fmt_cost(cost_usd),
         elapsed.as_secs_f64(),
     );
 }
@@ -317,10 +308,15 @@ pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
 /// `agent.rs`'s event-draining task. Every other event kind (including
 /// `Text` — the engine emits one per step, not just at turn-end, since a
 /// step with tool calls can still carry commentary text) is rendered here.
+///
+/// Wording comes from `stella_tui::textline` — the one event→text table
+/// both this surface and the deck consume (issue #66); the arms below carry
+/// only this surface's *policy* (what to suppress, what goes to stderr) and
+/// styling. A new annotation variant needs a `textline` entry, nothing here.
 pub fn render_event(event: &AgentEvent) {
     match event {
         AgentEvent::Stage {
-            name: stella_protocol::StageKind::Execute,
+            name: StageKind::Execute,
         } => {
             println!("  {}", "thinking…".dimmed());
         }
@@ -330,192 +326,16 @@ pub fn render_event(event: &AgentEvent) {
         }
         AgentEvent::Text { delta } => assistant_response(delta),
         AgentEvent::Reasoning { .. } => {}
-        AgentEvent::Retry { attempt, reason } => {
-            println!("  {} retry #{attempt}: {}", "↻".yellow(), reason.dimmed());
-        }
-        AgentEvent::Compaction {
-            before_tokens,
-            after_tokens,
-            evicted,
-            deduped,
-        } => {
-            println!(
-                "  {} compacted context: {before_tokens} → {after_tokens} tokens ({evicted} evicted, {deduped} deduped)",
-                "⤵".cyan(),
-            );
-        }
         AgentEvent::BudgetTick {
-            spent_usd,
-            limit_usd,
-            mode,
-        } => {
-            if matches!(mode, stella_protocol::BudgetMode::Off) {
-                return;
-            }
-            match limit_usd {
-                Some(limit) => println!("  {} spend: ${spent_usd:.4} / ${limit:.2}", "$".dimmed()),
-                None => println!("  {} spend: ${spent_usd:.4}", "$".dimmed()),
-            }
-        }
-        AgentEvent::ProviderFallback { from, to, reason } => {
-            println!(
-                "  {} provider fallback {} → {}: {}",
-                "⚠".yellow().bold(),
-                from.bright_yellow(),
-                to.bright_green(),
-                reason.dimmed()
-            );
-        }
-        AgentEvent::StepUsage {
-            step,
-            model,
-            input_tokens,
-            output_tokens,
-            cached_input_tokens,
-            cost_usd,
-            duration_ms,
-            retries,
-            tool_calls,
-            // `estimated_input_tokens` is calibration feedback for the
-            // estimator (stella-core), not HUD material.
+            mode: BudgetMode::Off,
             ..
         } => {
-            // One dimmed telemetry line per committed model call: the live
-            // HUD a metering consumer would reconstruct from this event.
-            let cached = if *cached_input_tokens > 0 {
-                format!(" ({} cached)", fmt_tokens(*cached_input_tokens))
-            } else {
-                String::new()
-            };
-            let retried = if *retries > 0 {
-                format!(" · {retries} retry")
-            } else {
-                String::new()
-            };
-            let tools = if *tool_calls > 0 {
-                format!(
-                    " · {tool_calls} tool call{}",
-                    if *tool_calls == 1 { "" } else { "s" }
-                )
-            } else {
-                String::new()
-            };
-            println!(
-                "  {} step {} · {} · {}{} in → {} out · ${cost_usd:.4} · {:.1}s{}{}",
-                "·".dimmed(),
-                step + 1,
-                model.dimmed(),
-                fmt_tokens(*input_tokens),
-                cached.dimmed(),
-                fmt_tokens(*output_tokens),
-                (*duration_ms as f64) / 1000.0,
-                retried.dimmed(),
-                tools.dimmed(),
-            );
+            // Unmetered sessions stay quiet about spend.
         }
-        AgentEvent::GoalVerdict {
-            round,
-            met,
-            reasoning,
-            ..
-        } => {
-            if *met {
-                println!(
-                    "  {} judge verdict (round {round}): goal met — {}",
-                    "✓".green().bold(),
-                    reasoning
-                );
-            } else {
-                println!(
-                    "  {} judge verdict (round {round}): not yet met — {}",
-                    "○".yellow(),
-                    reasoning
-                );
-            }
-        }
-        AgentEvent::FileChange { path, kind, .. } => {
-            let verb = match kind {
-                stella_protocol::FileChangeKind::Created => "created",
-                stella_protocol::FileChangeKind::Modified => "modified",
-                stella_protocol::FileChangeKind::Deleted => "deleted",
-            };
-            println!("  {} {} {}", "±".cyan(), verb.dimmed(), path);
-        }
-        AgentEvent::ContextRecall {
-            frames,
-            provider_mix,
-            tokens,
-        } => {
-            let mix = provider_mix
-                .iter()
-                .map(|share| format!("{}×{}", share.frames, share.provider))
-                .collect::<Vec<_>>()
-                .join(", ");
-            println!(
-                "  {} recalled {} frames ({tokens} tokens: {mix})",
-                "◈".cyan(),
-                frames.len()
-            );
-        }
-        AgentEvent::ContextWrite {
-            provider,
-            upserts,
-            superseded,
-        } => {
-            println!(
-                "  {} context write-back via {provider}: {upserts} upserts, {superseded} superseded",
-                "◈".dimmed()
-            );
-        }
-        AgentEvent::MediaProgress {
-            artifact_id,
-            kind,
-            state,
-        } => {
-            let state_str = match state {
-                stella_protocol::MediaJobState::Queued => "queued".dimmed(),
-                stella_protocol::MediaJobState::Running => "running".cyan(),
-                stella_protocol::MediaJobState::Succeeded => "succeeded".green(),
-                stella_protocol::MediaJobState::Failed { reason } => {
-                    println!(
-                        "  {} {kind:?} job {artifact_id} failed: {reason}",
-                        "✗".red()
-                    );
-                    return;
-                }
-            };
-            println!("  {} {kind:?} job {artifact_id}: {state_str}", "▣".cyan());
-        }
-        AgentEvent::MediaComplete { artifact } => {
-            println!(
-                "  {} {} ready: {} ({})",
-                "▣".green(),
-                artifact.label,
-                artifact.path,
-                format!("{:?}", artifact.kind).to_lowercase()
-            );
-        }
-        AgentEvent::JudgeVerdict { passed, evidence } => {
-            let icon = if *passed { "✓".green() } else { "✗".red() };
-            let source = if evidence.deterministic {
-                "deterministic"
-            } else {
-                "model judge"
-            };
-            println!("  {icon} verify ({source}): {}", evidence.summary.dimmed());
-        }
-        AgentEvent::ScopeReview { proposal } => {
-            println!(
-                "  {} scope review: {} ({} steps, ~{} files{})",
-                "⌾".yellow().bold(),
-                proposal.summary,
-                proposal.steps.len(),
-                proposal.estimated_files,
-                proposal
-                    .estimated_cost_usd
-                    .map(|c| format!(", ~${c:.2}"))
-                    .unwrap_or_default()
-            );
+        AgentEvent::Complete { .. } => {
+            // The call site prints `cost_summary` from `TurnOutcome`
+            // directly (it has the same model/cost_usd this event carries,
+            // plus wall-clock elapsed time this event doesn't).
         }
         AgentEvent::AskUser {
             question, options, ..
@@ -526,31 +346,39 @@ pub fn render_event(event: &AgentEvent) {
             // consumers of the event log. The binding free-text contract
             // (every question always offers a type-your-own option) is
             // enforced at the prompt site, not here.
-            println!("  {} {}", "?".yellow().bold(), question.bold());
+            println!("  {}", styled_event_line(&textline::ask_user(question)));
             for (i, option) in options.iter().enumerate() {
                 println!("    {} {}", format!("{})", i + 1).dimmed(), option);
             }
         }
-        AgentEvent::Commit { sha, message } => {
-            let short = sha.get(..8).unwrap_or(sha.as_str());
-            println!("  {} committed {short} {}", "●".green(), message.dimmed());
+        AgentEvent::Error { .. } => {
+            // Errors belong on stderr — routing is policy, wording is shared.
+            if let Some(line) = textline::event_line(event) {
+                eprintln!("  {}", styled_event_line(&line));
+            }
         }
-        AgentEvent::Pr { url, status } => {
-            println!(
-                "  {} PR {}: {url}",
-                "⇡".cyan(),
-                format!("{status:?}").to_lowercase()
-            );
+        other => {
+            if let Some(line) = textline::event_line(other) {
+                println!("  {}", styled_event_line(&line));
+            }
         }
-        AgentEvent::Error { message, retryable } => {
-            let label = if *retryable { "warning" } else { "error" };
-            eprintln!("  {} {}: {}", "✗".red(), label.red().bold(), message);
-        }
-        AgentEvent::Complete { .. } => {
-            // The call site prints `cost_summary` from `TurnOutcome`
-            // directly (it has the same model/cost_usd this event carries,
-            // plus wall-clock elapsed time this event doesn't).
-        }
+    }
+}
+
+/// A shared [`EventLine`] in this surface's dress: the glyph carries the
+/// tone via `colored` (bold when `strong`), the detail tail is dimmed.
+fn styled_event_line(line: &EventLine) -> String {
+    let glyph = match line.tone {
+        Tone::Info => line.glyph.cyan(),
+        Tone::Success => line.glyph.green(),
+        Tone::Warn => line.glyph.yellow(),
+        Tone::Error => line.glyph.red(),
+        Tone::Muted => line.glyph.dimmed(),
+    };
+    let glyph: ColoredString = if line.strong { glyph.bold() } else { glyph };
+    match &line.detail {
+        Some(detail) => format!("{} {} {}", glyph, line.body, detail.dimmed()),
+        None => format!("{} {}", glyph, line.body),
     }
 }
 
@@ -850,6 +678,42 @@ impl PromptDuel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── shared event lines ─────────────────────────────────────────────────
+
+    /// Drop ANSI SGR sequences so assertions pin visible text regardless of
+    /// whether `colored` detects a tty in the test harness.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for e in chars.by_ref() {
+                    if e == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn styled_event_line_composes_glyph_body_detail_with_single_spaces() {
+        // Wording is pinned byte-exactly in `stella_tui::textline`'s own
+        // fixtures; this guards the composition this surface adds around it
+        // (the old renderers wrote `"  {glyph} {body} {detail}"`).
+        assert_eq!(
+            strip_ansi(&styled_event_line(&textline::retry(2, "rate limited"))),
+            "↻ retry #2: rate limited"
+        );
+        assert_eq!(
+            strip_ansi(&styled_event_line(&textline::budget_tick(0.42, None))),
+            "$ spend: $0.4200"
+        );
+    }
 
     // ── wordmark ───────────────────────────────────────────────────────────
 

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -17,7 +17,8 @@ use crate::composer::{ComposerLayout, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::envelope::AgentStatus;
-use crate::render::{render_slash_popup, slash_popup_area, stage_label};
+use crate::render::{render_slash_popup, slash_popup_area};
+use crate::textline::stage_label;
 use crate::{fx, splash, theme, views};
 
 /// How long the deck fades in from muted after the splash hands off.

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -34,6 +34,7 @@ pub mod render;
 pub mod scroll;
 pub mod shell;
 pub(crate) mod term;
+pub mod textline;
 pub mod ui;
 
 // ── Command Deck: the multi-tab, multi-agent operations workspace ───────────
@@ -63,6 +64,7 @@ pub use model::{FileState, Hud, SessionModel, TranscriptEntry};
 pub use render::render;
 pub use scroll::ScrollState;
 pub use shell::{DebugLog, RunOptions, run};
+pub use textline::{EventLine, Tone, event_line};
 pub use ui::{PanelFocus, ShellAction, UiState, ViewportMetrics, handle_key, ingest};
 
 // Command Deck public surface.

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -18,8 +18,8 @@
 //! backing cell buffer (the replay-determinism test in [`crate::render`]).
 
 use stella_protocol::{
-    AgentEvent, BudgetMode, FileChangeKind, MediaKind, PrStatus, ScopeProposal, StageKind,
-    ToolOutput,
+    AgentEvent, BudgetMode, FileChangeKind, MediaJobState, MediaKind, PrStatus, ScopeProposal,
+    StageKind, ToolOutput,
 };
 
 /// How many characters of a tool input / output summary we retain on a
@@ -155,11 +155,13 @@ pub enum TranscriptEntry {
         upserts: u32,
         superseded: u32,
     },
-    /// A media job changed state.
+    /// A media job changed state. The wire enum is retained (not a label)
+    /// so the renderer can distinguish failure — labeling is wording, and
+    /// wording lives in [`crate::textline`].
     MediaProgress {
         artifact_id: String,
         kind: MediaKind,
-        state: String,
+        state: MediaJobState,
     },
     /// A media artifact landed on disk.
     MediaComplete {
@@ -407,7 +409,7 @@ impl SessionModel {
                 self.transcript.push(TranscriptEntry::MediaProgress {
                     artifact_id: artifact_id.clone(),
                     kind: *kind,
-                    state: media_state_label(state),
+                    state: state.clone(),
                 });
             }
             AgentEvent::MediaComplete { artifact } => {
@@ -751,18 +753,6 @@ fn summarize(text: &str) -> String {
     let head_str: String = chars[..head].iter().collect();
     let tail_str: String = chars[chars.len() - tail..].iter().collect();
     format!("{head_str}...{tail_str}")
-}
-
-/// A short display label for a media job state (the wire enum is tagged; the
-/// TUI needs a flat human string).
-fn media_state_label(state: &stella_protocol::MediaJobState) -> String {
-    use stella_protocol::MediaJobState::*;
-    match state {
-        Queued => "queued".to_string(),
-        Running => "running".to_string(),
-        Succeeded => "succeeded".to_string(),
-        Failed { reason } => format!("failed: {reason}"),
-    }
 }
 
 #[cfg(test)]

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -29,10 +29,11 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 use unicode_width::UnicodeWidthChar;
 
-use stella_protocol::{BudgetMode, FileChangeKind, MediaKind, PrStatus, StageKind};
+use stella_protocol::FileChangeKind;
 
 use crate::composer::{ComposerLayout, SlashMenu, layout as composer_layout, split_row_at};
 use crate::model::{AskUserPrompt, FileState, Hud, SessionModel, TranscriptEntry};
+use crate::textline::{self, EventLine, Tone, budget_mode_label, stage_label};
 use crate::ui::{PanelFocus, UiState, ViewportMetrics};
 use crate::{diff, theme};
 
@@ -317,7 +318,10 @@ pub(crate) fn render_hud(hud: &Hud, area: Rect, buf: &mut Buffer) {
         Span::raw(hud.model.clone().unwrap_or_else(|| "—".to_string())),
         Span::raw("   "),
         Span::styled("spend: ", Style::new().fg(Color::DarkGray)),
-        Span::styled(spend_label(hud), Style::new().fg(spend_color(hud))),
+        Span::styled(
+            textline::spend_amount(hud.spent_usd, hud.limit_usd),
+            Style::new().fg(spend_color(hud)),
+        ),
     ];
     if let Some(mode) = hud.budget_mode {
         spans.push(Span::styled(
@@ -831,10 +835,7 @@ pub(crate) fn entry_lines(
                 .add_modifier(Modifier::ITALIC);
             if show_all {
                 for l in text.split('\n') {
-                    out.push(Line::from(Span::styled(
-                        format!("  {l}"),
-                        reasoning_style,
-                    )));
+                    out.push(Line::from(Span::styled(format!("  {l}"), reasoning_style)));
                 }
             } else {
                 let preview_count = 3;
@@ -844,10 +845,7 @@ pub(crate) fn entry_lines(
                         break;
                     }
                     if !l.trim().is_empty() {
-                        out.push(Line::from(Span::styled(
-                            format!("  {l}"),
-                            reasoning_style,
-                        )));
+                        out.push(Line::from(Span::styled(format!("  {l}"), reasoning_style)));
                         shown += 1;
                     }
                 }
@@ -949,126 +947,137 @@ pub(crate) fn entry_lines(
                 wrap_one_indent(line, width, LABEL_COL, out);
             }
         }
-        TranscriptEntry::Retry { attempt, reason } => out.push(Line::from(Span::styled(
-            format!("↻ retry #{attempt}: {reason}"),
-            Style::new().fg(Color::Yellow),
-        ))),
+        // Annotation rows: wording comes from the shared `textline` table
+        // (issue #66 — one lookup per `AgentEvent` variant, styled here).
+        TranscriptEntry::Retry { attempt, reason } => {
+            out.push(note_line(textline::retry(*attempt, reason)));
+        }
         TranscriptEntry::Compaction {
             before_tokens,
             after_tokens,
             evicted,
             deduped,
-        } => out.push(Line::from(Span::styled(
-            format!(
-                "⇣ compacted {before_tokens}→{after_tokens} tok (evicted {evicted}, deduped {deduped})"
-            ),
-            Style::new().fg(Color::Blue),
+        } => out.push(note_line(textline::compaction(
+            *before_tokens,
+            *after_tokens,
+            *evicted,
+            *deduped,
         ))),
         TranscriptEntry::BudgetTick {
             spent_usd,
             limit_usd,
             mode,
         } => {
-            let limit = limit_usd
-                .map(|l| format!("/${l:.2}"))
-                .unwrap_or_default();
-            out.push(Line::from(Span::styled(
-                format!("$ spend ${spent_usd:.4}{limit} ({})", budget_mode_label(*mode)),
-                Style::new().fg(Color::DarkGray),
-            )));
+            // The deck keeps the enforcement mode on the row (the plain
+            // surface suppresses `Off` ticks instead).
+            let mut line = textline::budget_tick(*spent_usd, *limit_usd);
+            line.detail = Some(format!("({})", budget_mode_label(*mode)));
+            out.push(note_line(line));
         }
-        TranscriptEntry::ProviderFallback { from, to, reason } => out.push(Line::from(Span::styled(
-            format!("⚡ provider fallback {from} → {to}: {reason}"),
-            Style::new().fg(Color::Magenta),
-        ))),
+        TranscriptEntry::ProviderFallback { from, to, reason } => {
+            out.push(note_line(textline::provider_fallback(from, to, reason)));
+        }
         TranscriptEntry::ContextRecall {
             frames,
             tokens,
             labels,
         } => {
-            let cited = labels.join(", ");
-            out.push(Line::from(Span::styled(
-                format!("◉ recalled {frames} frames ({tokens} tok): {cited}"),
-                Style::new().fg(Color::Blue),
+            // Cited by human label, never raw id (L-C4); the plain surface
+            // cites the provider mix on the same shared line instead.
+            out.push(note_line(textline::context_recall(
+                *frames,
+                *tokens,
+                &labels.join(", "),
             )));
         }
         TranscriptEntry::ContextWrite {
             provider,
             upserts,
             superseded,
-        } => out.push(Line::from(Span::styled(
-            format!("✎ wrote {upserts} facts ({superseded} superseded) → {provider}"),
-            Style::new().fg(Color::Blue),
+        } => out.push(note_line(textline::context_write(
+            provider,
+            *upserts,
+            *superseded,
         ))),
         TranscriptEntry::MediaProgress {
             artifact_id,
             kind,
             state,
-        } => out.push(Line::from(Span::styled(
-            format!("🎞 {} {artifact_id}: {state}", media_kind_label(*kind)),
-            Style::new().fg(Color::Magenta),
+        } => out.push(note_line(textline::media_progress(
+            *kind,
+            artifact_id,
+            state,
         ))),
-        TranscriptEntry::MediaComplete { label, path, kind } => out.push(Line::from(vec![
-            Span::styled(
-                format!("🎨 {} {label} ", media_kind_label(*kind)),
-                Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(path.clone(), Style::new().fg(Color::DarkGray)),
-        ])),
+        TranscriptEntry::MediaComplete { label, path, kind } => {
+            out.push(note_line(textline::media_complete(label, path, *kind)));
+        }
         TranscriptEntry::JudgeVerdict {
             passed,
             summary,
             deterministic,
-        } => {
-            let (glyph, color) = if *passed {
-                ("✓", Color::Green)
-            } else {
-                ("✗", Color::Red)
-            };
-            let tag = if *deterministic { "deterministic" } else { "model-judge" };
-            out.push(Line::from(vec![
-                Span::styled(format!("{glyph} verdict "), Style::new().fg(color).add_modifier(Modifier::BOLD)),
-                Span::styled(format!("[{tag}] "), Style::new().fg(Color::DarkGray)),
-                Span::raw(summary.clone()),
-            ]));
-        }
+        } => out.push(note_line(textline::judge_verdict(
+            *passed,
+            *deterministic,
+            summary,
+        ))),
         TranscriptEntry::ScopeReview {
             summary,
             steps,
             estimated_files,
-        } => out.push(Line::from(Span::styled(
-            format!("⏸ scope review: {summary} ({steps} steps, ~{estimated_files} files)"),
-            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        } => out.push(note_line(textline::scope_review(
+            summary,
+            *steps,
+            *estimated_files,
+            // The entry retains no cost estimate; the pending card carries it.
+            None,
         ))),
-        TranscriptEntry::AskUser { question, options } => out.push(Line::from(Span::styled(
-            format!("? {question} ({options} options + free text)"),
-            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-        ))),
+        TranscriptEntry::AskUser { question, options } => {
+            // The shared line is the question; the option count + free-text
+            // affordance is this surface's card cue.
+            let mut line = textline::ask_user(question);
+            line.detail = Some(format!("({options} options + free text)"));
+            out.push(note_line(line));
+        }
         TranscriptEntry::Commit { sha, message } => {
-            let short = sha.chars().take(9).collect::<String>();
-            out.push(Line::from(vec![
-                Span::styled(format!("● {short} "), Style::new().fg(Color::Cyan)),
-                Span::raw(message.clone()),
-            ]));
+            out.push(note_line(textline::commit(sha, message)));
         }
-        TranscriptEntry::Pr { url, status } => out.push(Line::from(vec![
-            Span::styled(
-                format!("⇢ PR [{}] ", pr_status_label(*status)),
-                Style::new().fg(pr_status_color(*status)).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(url.clone(), Style::new().fg(Color::DarkGray)),
-        ])),
+        TranscriptEntry::Pr { url, status } => out.push(note_line(textline::pr(url, *status))),
         TranscriptEntry::Error { message, retryable } => {
-            let tag = if *retryable { " (retryable)" } else { "" };
-            out.push(Line::from(Span::styled(
-                format!("✗ error{tag}: {message}"),
-                Style::new().fg(Color::Red).add_modifier(Modifier::BOLD),
-            )));
+            out.push(note_line(textline::error(message, *retryable)));
         }
-        TranscriptEntry::Complete { model, cost_usd } => out.push(Line::from(Span::styled(
-            format!("✓ complete · {model} · ${cost_usd:.4}"),
-            Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
-        ))),
+        TranscriptEntry::Complete { model, cost_usd } => {
+            out.push(note_line(textline::complete(model, *cost_usd)));
+        }
+    }
+}
+
+/// One shared [`EventLine`] as a styled transcript row: glyph+body carry the
+/// tone's theme color (bold when `strong`), the detail tail reads muted —
+/// this fn and the palette map below are the *entire* deck-side presentation
+/// of an annotation.
+fn note_line(note: EventLine) -> Line<'static> {
+    let mut style = Style::new().fg(tone_color(note.tone));
+    if note.strong {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    let mut spans = vec![Span::styled(format!("{} {}", note.glyph, note.body), style)];
+    if let Some(detail) = note.detail {
+        spans.push(Span::styled(
+            format!(" {detail}"),
+            Style::new().fg(theme::MUTED),
+        ));
+    }
+    Line::from(spans)
+}
+
+/// Semantic tone → deck palette.
+fn tone_color(tone: Tone) -> Color {
+    match tone {
+        Tone::Info => theme::RUN,
+        Tone::Success => theme::OK,
+        Tone::Warn => theme::WARN,
+        Tone::Error => theme::BAD,
+        Tone::Muted => theme::MUTED,
     }
 }
 
@@ -1094,64 +1103,8 @@ fn file_line(file: &FileState, selected: bool) -> Line<'static> {
 }
 
 // ---------------------------------------------------------------------------
-// Labels
+// Labels — wording in `crate::textline`; only palette mapping lives here
 // ---------------------------------------------------------------------------
-
-pub(crate) fn stage_label(stage: StageKind) -> &'static str {
-    match stage {
-        StageKind::Triage => "triage",
-        StageKind::ContextRecall => "context recall",
-        StageKind::Plan => "plan",
-        StageKind::ScopeReview => "scope review",
-        StageKind::Execute => "execute",
-        StageKind::Verify => "verify",
-        StageKind::Judge => "judge",
-        StageKind::Reflect => "reflect",
-        StageKind::ContextWrite => "context write",
-        StageKind::Complete => "complete",
-    }
-}
-
-fn budget_mode_label(mode: BudgetMode) -> &'static str {
-    match mode {
-        BudgetMode::Off => "off",
-        BudgetMode::Observed => "observed",
-        BudgetMode::Enforced => "enforced",
-    }
-}
-
-fn media_kind_label(kind: MediaKind) -> &'static str {
-    match kind {
-        MediaKind::Image => "image",
-        MediaKind::Svg => "svg",
-        MediaKind::Video => "video",
-    }
-}
-
-fn pr_status_label(status: PrStatus) -> &'static str {
-    match status {
-        PrStatus::Draft => "draft",
-        PrStatus::Open => "open",
-        PrStatus::Merged => "merged",
-        PrStatus::Closed => "closed",
-    }
-}
-
-fn pr_status_color(status: PrStatus) -> Color {
-    match status {
-        PrStatus::Draft => Color::DarkGray,
-        PrStatus::Open => Color::Green,
-        PrStatus::Merged => Color::Magenta,
-        PrStatus::Closed => Color::Red,
-    }
-}
-
-fn spend_label(hud: &Hud) -> String {
-    match hud.limit_usd {
-        Some(limit) => format!("${:.4} / ${:.2}", hud.spent_usd, limit),
-        None => format!("${:.4}", hud.spent_usd),
-    }
-}
 
 fn spend_color(hud: &Hud) -> Color {
     match hud.limit_usd {
@@ -1172,7 +1125,7 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use stella_protocol::{
-        AgentEvent, FileChangeKind, ScopeProposal, StageKind, ToolCall, ToolOutput,
+        AgentEvent, BudgetMode, FileChangeKind, ScopeProposal, StageKind, ToolCall, ToolOutput,
     };
 
     /// Flatten a `TestBackend` buffer to one `String` per row (styling

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -1,0 +1,877 @@
+//! The shared event→text vocabulary — one lookup table for both rendering
+//! surfaces (issue #66).
+//!
+//! Two independent renderers consume [`stella_protocol::AgentEvent`]s: the
+//! plain `colored`+`println` surface in `stella-cli` (REPL and one-shot
+//! modes) and this crate's ratatui transcript. Before this module each kept
+//! its own event→string mapping, so every new `AgentEvent` variant had to be
+//! worded twice. The contract now: **wording lives here, styling stays with
+//! each surface.** A constructor per annotation variant yields an
+//! [`EventLine`] of semantic pieces (glyph, tone, body, detail) that each
+//! surface maps onto its own palette — `colored` codes on the plain surface,
+//! `ratatui` styles on the deck.
+//!
+//! The wording is byte-load-bearing: the plain renderer's observable output
+//! is composed as `"  {glyph} {body}"` (plus `" {detail}"` when present), and
+//! the fixture tests at the bottom pin every line to the exact strings the
+//! plain surface printed before the extraction. Change a string here and the
+//! plain CLI's output changes with it — that is the point, but it must be
+//! deliberate.
+//!
+//! Deliberately *not* here: streaming `Text`/`Reasoning` (accumulated, then
+//! markdown-rendered or printed raw per surface), `Stage` transitions (the
+//! deck draws rules, the plain surface prints only a "thinking…" cue), and
+//! the `ToolStart`/`ToolResult` cards (the two surfaces present tool traffic
+//! structurally differently — key=value cards vs an aligned label column —
+//! and unifying them is a behavior change out of scope for #66).
+
+use stella_protocol::{
+    AgentEvent, BudgetMode, FileChangeKind, MediaJobState, MediaKind, PrStatus, ProviderShare,
+    StageKind,
+};
+
+/// Semantic weight of an annotation line. Each surface owns the mapping to
+/// its palette (e.g. plain maps `Muted` to ANSI dim, the deck to
+/// `theme::MUTED`); no color name may appear in this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tone {
+    Info,
+    Success,
+    Warn,
+    Error,
+    Muted,
+}
+
+/// One transcript annotation, split where the surfaces apply different
+/// emphasis: a `glyph` carrying the line's `tone` (and `strong` for the few
+/// glyphs both surfaces embolden), the `body` text, and an optional trailing
+/// `detail` each surface de-emphasizes (dimmed / muted).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventLine {
+    pub glyph: &'static str,
+    pub tone: Tone,
+    pub strong: bool,
+    pub body: String,
+    pub detail: Option<String>,
+}
+
+impl EventLine {
+    /// The line's unstyled text, exactly as the plain surface prints it
+    /// (minus its two-space indent) — what the fixture tests pin.
+    pub fn text(&self) -> String {
+        match &self.detail {
+            Some(detail) => format!("{} {} {}", self.glyph, self.body, detail),
+            None => format!("{} {}", self.glyph, self.body),
+        }
+    }
+}
+
+// ── Per-variant constructors: the one place each line is worded ─────────────
+
+pub fn retry(attempt: u32, reason: &str) -> EventLine {
+    EventLine {
+        glyph: "↻",
+        tone: Tone::Warn,
+        strong: false,
+        body: format!("retry #{attempt}:"),
+        detail: Some(reason.to_string()),
+    }
+}
+
+pub fn compaction(
+    before_tokens: u64,
+    after_tokens: u64,
+    evicted: usize,
+    deduped: usize,
+) -> EventLine {
+    EventLine {
+        glyph: "⤵",
+        tone: Tone::Info,
+        strong: false,
+        body: format!(
+            "compacted context: {before_tokens} → {after_tokens} tokens ({evicted} evicted, {deduped} deduped)"
+        ),
+        detail: None,
+    }
+}
+
+/// The spend line. Visibility policy stays surface-side (the plain surface
+/// suppresses ticks in `BudgetMode::Off`; the deck shows every tick and may
+/// append the mode as detail).
+pub fn budget_tick(spent_usd: f64, limit_usd: Option<f64>) -> EventLine {
+    EventLine {
+        glyph: "$",
+        tone: Tone::Muted,
+        strong: false,
+        body: format!("spend: {}", spend_amount(spent_usd, limit_usd)),
+        detail: None,
+    }
+}
+
+pub fn provider_fallback(from: &str, to: &str, reason: &str) -> EventLine {
+    EventLine {
+        glyph: "⚠",
+        tone: Tone::Warn,
+        strong: true,
+        body: format!("provider fallback {from} → {to}:"),
+        detail: Some(reason.to_string()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // mirrors the event's metering fields 1:1
+pub fn step_usage(
+    step: usize,
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_input_tokens: u64,
+    cost_usd: f64,
+    duration_ms: u64,
+    retries: u32,
+    tool_calls: usize,
+) -> EventLine {
+    let cached = if cached_input_tokens > 0 {
+        format!(" ({} cached)", fmt_tokens(cached_input_tokens))
+    } else {
+        String::new()
+    };
+    let retried = if retries > 0 {
+        format!(" · {retries} retry")
+    } else {
+        String::new()
+    };
+    let tools = if tool_calls > 0 {
+        format!(
+            " · {tool_calls} tool call{}",
+            if tool_calls == 1 { "" } else { "s" }
+        )
+    } else {
+        String::new()
+    };
+    EventLine {
+        glyph: "·",
+        tone: Tone::Muted,
+        strong: false,
+        body: format!(
+            "step {} · {model} · {}{cached} in → {} out · {} · {:.1}s{retried}{tools}",
+            step + 1,
+            fmt_tokens(input_tokens),
+            fmt_tokens(output_tokens),
+            fmt_cost(cost_usd),
+            duration_ms as f64 / 1000.0,
+        ),
+        detail: None,
+    }
+}
+
+pub fn goal_verdict(round: usize, met: bool, reasoning: &str) -> EventLine {
+    if met {
+        EventLine {
+            glyph: "✓",
+            tone: Tone::Success,
+            strong: true,
+            body: format!("judge verdict (round {round}): goal met — {reasoning}"),
+            detail: None,
+        }
+    } else {
+        EventLine {
+            glyph: "○",
+            tone: Tone::Warn,
+            strong: false,
+            body: format!("judge verdict (round {round}): not yet met — {reasoning}"),
+            detail: None,
+        }
+    }
+}
+
+pub fn file_change(path: &str, kind: FileChangeKind) -> EventLine {
+    EventLine {
+        glyph: "±",
+        tone: Tone::Info,
+        strong: false,
+        body: format!("{} {path}", file_change_verb(kind)),
+        detail: None,
+    }
+}
+
+/// `cited` is the citation tail each surface owns the data for: the plain
+/// surface passes the provider mix ([`provider_mix_label`]), the deck the
+/// frames' human citation labels (L-C4).
+pub fn context_recall(frames: usize, tokens: u32, cited: &str) -> EventLine {
+    EventLine {
+        glyph: "◈",
+        tone: Tone::Info,
+        strong: false,
+        body: format!("recalled {frames} frames ({tokens} tokens: {cited})"),
+        detail: None,
+    }
+}
+
+pub fn context_write(provider: &str, upserts: u32, superseded: u32) -> EventLine {
+    EventLine {
+        glyph: "◈",
+        tone: Tone::Muted,
+        strong: false,
+        body: format!(
+            "context write-back via {provider}: {upserts} upserts, {superseded} superseded"
+        ),
+        detail: None,
+    }
+}
+
+pub fn media_progress(kind: MediaKind, artifact_id: &str, state: &MediaJobState) -> EventLine {
+    match state {
+        MediaJobState::Failed { reason } => EventLine {
+            glyph: "✗",
+            tone: Tone::Error,
+            strong: false,
+            body: format!("{kind:?} job {artifact_id} failed: {reason}"),
+            detail: None,
+        },
+        other => EventLine {
+            glyph: "▣",
+            tone: Tone::Info,
+            strong: false,
+            body: format!("{kind:?} job {artifact_id}: {}", media_state_label(other)),
+            detail: None,
+        },
+    }
+}
+
+pub fn media_complete(label: &str, path: &str, kind: MediaKind) -> EventLine {
+    EventLine {
+        glyph: "▣",
+        tone: Tone::Success,
+        strong: false,
+        body: format!("{label} ready: {path} ({})", media_kind_label(kind)),
+        detail: None,
+    }
+}
+
+pub fn judge_verdict(passed: bool, deterministic: bool, summary: &str) -> EventLine {
+    let source = if deterministic {
+        "deterministic"
+    } else {
+        "model judge"
+    };
+    EventLine {
+        glyph: if passed { "✓" } else { "✗" },
+        tone: if passed { Tone::Success } else { Tone::Error },
+        strong: false,
+        body: format!("verify ({source}):"),
+        detail: Some(summary.to_string()),
+    }
+}
+
+pub fn scope_review(
+    summary: &str,
+    steps: usize,
+    estimated_files: u32,
+    estimated_cost_usd: Option<f64>,
+) -> EventLine {
+    let cost = estimated_cost_usd
+        .map(|c| format!(", ~${c:.2}"))
+        .unwrap_or_default();
+    EventLine {
+        glyph: "⌾",
+        tone: Tone::Warn,
+        strong: true,
+        body: format!("scope review: {summary} ({steps} steps, ~{estimated_files} files{cost})"),
+        detail: None,
+    }
+}
+
+/// The question line only. The structured options — and the binding
+/// free-text affordance — are presented by each surface's own interaction
+/// machinery (numbered stdin list vs the deck's answer card).
+pub fn ask_user(question: &str) -> EventLine {
+    EventLine {
+        glyph: "?",
+        tone: Tone::Warn,
+        strong: true,
+        body: question.to_string(),
+        detail: None,
+    }
+}
+
+pub fn commit(sha: &str, message: &str) -> EventLine {
+    // `get(..8)` not a slice: a sha shorter than 8 bytes (or a non-ASCII
+    // test fixture) must fall back whole rather than panic.
+    let short = sha.get(..8).unwrap_or(sha);
+    EventLine {
+        glyph: "●",
+        tone: Tone::Success,
+        strong: false,
+        body: format!("committed {short}"),
+        detail: Some(message.to_string()),
+    }
+}
+
+pub fn pr(url: &str, status: PrStatus) -> EventLine {
+    EventLine {
+        glyph: "⇡",
+        tone: Tone::Info,
+        strong: false,
+        body: format!("PR {}: {url}", pr_status_label(status)),
+        detail: None,
+    }
+}
+
+/// Routing (stdout vs stderr, transcript row vs toast) stays surface-side.
+pub fn error(message: &str, retryable: bool) -> EventLine {
+    let label = if retryable { "warning" } else { "error" };
+    EventLine {
+        glyph: "✗",
+        tone: Tone::Error,
+        strong: false,
+        body: format!("{label}: {message}"),
+        detail: None,
+    }
+}
+
+pub fn complete(model: &str, cost_usd: f64) -> EventLine {
+    EventLine {
+        glyph: "✓",
+        tone: Tone::Success,
+        strong: true,
+        body: format!("complete · {model} · {}", fmt_cost(cost_usd)),
+        detail: None,
+    }
+}
+
+// ── Event dispatcher ─────────────────────────────────────────────────────────
+
+/// The per-variant lookup table over a raw event stream. `None` for the
+/// variants whose presentation is structural per surface (streamed
+/// `Text`/`Reasoning`, `Stage`, and the tool cards — see the module doc); a
+/// consumer must handle those (or deliberately skip them) itself, and gets
+/// every annotation variant — including future ones — from this one table.
+pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
+    match event {
+        AgentEvent::Stage { .. }
+        | AgentEvent::Text { .. }
+        | AgentEvent::Reasoning { .. }
+        | AgentEvent::ToolStart { .. }
+        | AgentEvent::ToolResult { .. } => None,
+        AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
+        AgentEvent::Compaction {
+            before_tokens,
+            after_tokens,
+            evicted,
+            deduped,
+        } => Some(compaction(
+            *before_tokens,
+            *after_tokens,
+            *evicted,
+            *deduped,
+        )),
+        AgentEvent::BudgetTick {
+            spent_usd,
+            limit_usd,
+            ..
+        } => Some(budget_tick(*spent_usd, *limit_usd)),
+        AgentEvent::ProviderFallback { from, to, reason } => {
+            Some(provider_fallback(from, to, reason))
+        }
+        AgentEvent::StepUsage {
+            step,
+            model,
+            input_tokens,
+            output_tokens,
+            cached_input_tokens,
+            cost_usd,
+            duration_ms,
+            retries,
+            tool_calls,
+            // Estimator calibration feedback, not display material.
+            ..
+        } => Some(step_usage(
+            *step,
+            model,
+            *input_tokens,
+            *output_tokens,
+            *cached_input_tokens,
+            *cost_usd,
+            *duration_ms,
+            *retries,
+            *tool_calls,
+        )),
+        AgentEvent::GoalVerdict {
+            round,
+            met,
+            reasoning,
+            ..
+        } => Some(goal_verdict(*round, *met, reasoning)),
+        AgentEvent::FileChange { path, kind, .. } => Some(file_change(path, *kind)),
+        AgentEvent::ContextRecall {
+            frames,
+            provider_mix,
+            tokens,
+        } => Some(context_recall(
+            frames.len(),
+            *tokens,
+            &provider_mix_label(provider_mix),
+        )),
+        AgentEvent::ContextWrite {
+            provider,
+            upserts,
+            superseded,
+        } => Some(context_write(provider, *upserts, *superseded)),
+        AgentEvent::MediaProgress {
+            artifact_id,
+            kind,
+            state,
+        } => Some(media_progress(*kind, artifact_id, state)),
+        AgentEvent::MediaComplete { artifact } => Some(media_complete(
+            &artifact.label,
+            &artifact.path,
+            artifact.kind,
+        )),
+        AgentEvent::JudgeVerdict { passed, evidence } => Some(judge_verdict(
+            *passed,
+            evidence.deterministic,
+            &evidence.summary,
+        )),
+        AgentEvent::ScopeReview { proposal } => Some(scope_review(
+            &proposal.summary,
+            proposal.steps.len(),
+            proposal.estimated_files,
+            proposal.estimated_cost_usd,
+        )),
+        AgentEvent::AskUser { question, .. } => Some(ask_user(question)),
+        AgentEvent::Commit { sha, message } => Some(commit(sha, message)),
+        AgentEvent::Pr { url, status } => Some(pr(url, *status)),
+        AgentEvent::Error { message, retryable } => Some(error(message, *retryable)),
+        AgentEvent::Complete { model, cost_usd } => Some(complete(model, *cost_usd)),
+    }
+}
+
+// ── Enum label tables ────────────────────────────────────────────────────────
+
+pub fn stage_label(stage: StageKind) -> &'static str {
+    match stage {
+        StageKind::Triage => "triage",
+        StageKind::ContextRecall => "context recall",
+        StageKind::Plan => "plan",
+        StageKind::ScopeReview => "scope review",
+        StageKind::Execute => "execute",
+        StageKind::Verify => "verify",
+        StageKind::Judge => "judge",
+        StageKind::Reflect => "reflect",
+        StageKind::ContextWrite => "context write",
+        StageKind::Complete => "complete",
+    }
+}
+
+pub fn budget_mode_label(mode: BudgetMode) -> &'static str {
+    match mode {
+        BudgetMode::Off => "off",
+        BudgetMode::Observed => "observed",
+        BudgetMode::Enforced => "enforced",
+    }
+}
+
+pub fn media_kind_label(kind: MediaKind) -> &'static str {
+    match kind {
+        MediaKind::Image => "image",
+        MediaKind::Svg => "svg",
+        MediaKind::Video => "video",
+    }
+}
+
+pub fn pr_status_label(status: PrStatus) -> &'static str {
+    match status {
+        PrStatus::Draft => "draft",
+        PrStatus::Open => "open",
+        PrStatus::Merged => "merged",
+        PrStatus::Closed => "closed",
+    }
+}
+
+/// A flat display label for a media job state (the wire enum is tagged).
+pub fn media_state_label(state: &MediaJobState) -> String {
+    match state {
+        MediaJobState::Queued => "queued".to_string(),
+        MediaJobState::Running => "running".to_string(),
+        MediaJobState::Succeeded => "succeeded".to_string(),
+        MediaJobState::Failed { reason } => format!("failed: {reason}"),
+    }
+}
+
+/// Past-tense verb for a `FileChange` transcript line.
+pub fn file_change_verb(kind: FileChangeKind) -> &'static str {
+    match kind {
+        FileChangeKind::Created => "created",
+        FileChangeKind::Modified => "modified",
+        FileChangeKind::Deleted => "deleted",
+    }
+}
+
+/// The CRUD badge letter for a file-change kind — the vocabulary the
+/// files-touched panels share (the plain CLI's registry ledger additionally
+/// mints `R` for reads, which never rides a `FileChange` event).
+pub fn crud_letter(kind: FileChangeKind) -> &'static str {
+    match kind {
+        FileChangeKind::Created => "C",
+        FileChangeKind::Modified => "U",
+        FileChangeKind::Deleted => "D",
+    }
+}
+
+// ── Number / amount formatting ───────────────────────────────────────────────
+
+/// Render a token count compactly: `842`, `12.3k`, `1.2M`.
+pub fn fmt_tokens(tokens: u64) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", tokens as f64 / 1_000.0)
+    } else {
+        tokens.to_string()
+    }
+}
+
+/// A USD cost at the 4-decimal precision every spend line uses.
+pub fn fmt_cost(cost_usd: f64) -> String {
+    format!("${cost_usd:.4}")
+}
+
+/// Spend against an optional limit — the HUD's spend gauge and the budget
+/// tick line share this exact form.
+pub fn spend_amount(spent_usd: f64, limit_usd: Option<f64>) -> String {
+    match limit_usd {
+        Some(limit) => format!("${spent_usd:.4} / ${limit:.2}"),
+        None => format!("${spent_usd:.4}"),
+    }
+}
+
+/// `2×code-graph, 1×memory` — a recall's provider mix as cited text.
+pub fn provider_mix_label(mix: &[ProviderShare]) -> String {
+    mix.iter()
+        .map(|share| format!("{}×{}", share.frames, share.provider))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::{ContextFrameRef, JudgeEvidence, MediaArtifactRef, ScopeProposal};
+
+    // ── Byte-exact fixtures ──────────────────────────────────────────────
+    //
+    // These strings are the plain CLI's pre-extraction output (issue #66):
+    // `stella-cli` prints `"  {}"` around `EventLine::text()`, so each
+    // fixture pins the visible line the extraction must not change.
+
+    #[test]
+    fn wording_matches_the_pre_extraction_plain_renderer_byte_for_byte() {
+        assert_eq!(retry(2, "rate limited").text(), "↻ retry #2: rate limited");
+        assert_eq!(
+            compaction(10_000, 4_000, 3, 2).text(),
+            "⤵ compacted context: 10000 → 4000 tokens (3 evicted, 2 deduped)"
+        );
+        assert_eq!(
+            budget_tick(0.42, Some(2.5)).text(),
+            "$ spend: $0.4200 / $2.50"
+        );
+        assert_eq!(budget_tick(0.42, None).text(), "$ spend: $0.4200");
+        assert_eq!(
+            provider_fallback("zai", "anthropic", "circuit open").text(),
+            "⚠ provider fallback zai → anthropic: circuit open"
+        );
+        assert_eq!(
+            step_usage(3, "glm-5.2", 12_000, 450, 9_000, 0.0042, 1_830, 1, 4).text(),
+            "· step 4 · glm-5.2 · 12.0k (9.0k cached) in → 450 out · $0.0042 · 1.8s · 1 retry · 4 tool calls"
+        );
+        assert_eq!(
+            step_usage(0, "glm-5.2", 842, 10, 0, 0.001, 500, 0, 1).text(),
+            "· step 1 · glm-5.2 · 842 in → 10 out · $0.0010 · 0.5s · 1 tool call"
+        );
+        assert_eq!(
+            goal_verdict(2, true, "tests pass").text(),
+            "✓ judge verdict (round 2): goal met — tests pass"
+        );
+        assert_eq!(
+            goal_verdict(1, false, "still failing").text(),
+            "○ judge verdict (round 1): not yet met — still failing"
+        );
+        assert_eq!(
+            file_change("src/lib.rs", FileChangeKind::Modified).text(),
+            "± modified src/lib.rs"
+        );
+        assert_eq!(
+            context_recall(2, 120, "2×code-graph").text(),
+            "◈ recalled 2 frames (120 tokens: 2×code-graph)"
+        );
+        assert_eq!(
+            context_write("mem0", 3, 1).text(),
+            "◈ context write-back via mem0: 3 upserts, 1 superseded"
+        );
+        assert_eq!(
+            media_progress(MediaKind::Image, "a1", &MediaJobState::Running).text(),
+            "▣ Image job a1: running"
+        );
+        assert_eq!(
+            media_progress(
+                MediaKind::Video,
+                "a2",
+                &MediaJobState::Failed {
+                    reason: "nsfw".into()
+                }
+            )
+            .text(),
+            "✗ Video job a2 failed: nsfw"
+        );
+        assert_eq!(
+            media_complete("diagram", ".stella/artifacts/a2.png", MediaKind::Image).text(),
+            "▣ diagram ready: .stella/artifacts/a2.png (image)"
+        );
+        assert_eq!(
+            judge_verdict(true, true, "flip oracle passed").text(),
+            "✓ verify (deterministic): flip oracle passed"
+        );
+        assert_eq!(
+            judge_verdict(false, false, "inconclusive").text(),
+            "✗ verify (model judge): inconclusive"
+        );
+        assert_eq!(
+            scope_review("refactor auth", 2, 12, Some(1.25)).text(),
+            "⌾ scope review: refactor auth (2 steps, ~12 files, ~$1.25)"
+        );
+        assert_eq!(
+            scope_review("small fix", 1, 1, None).text(),
+            "⌾ scope review: small fix (1 steps, ~1 files)"
+        );
+        assert_eq!(ask_user("which database?").text(), "? which database?");
+        assert_eq!(
+            commit("abc1234567", "feat: x").text(),
+            "● committed abc12345 feat: x"
+        );
+        assert_eq!(
+            commit("abc", "short sha").text(),
+            "● committed abc short sha"
+        );
+        assert_eq!(
+            pr("https://x/pr/1", PrStatus::Open).text(),
+            "⇡ PR open: https://x/pr/1"
+        );
+        assert_eq!(error("boom", false).text(), "✗ error: boom");
+        assert_eq!(error("blip", true).text(), "✗ warning: blip");
+        assert_eq!(
+            complete("glm-5.2", 0.0123).text(),
+            "✓ complete · glm-5.2 · $0.0123"
+        );
+    }
+
+    #[test]
+    fn fmt_helpers_keep_their_exact_forms() {
+        assert_eq!(fmt_tokens(842), "842");
+        assert_eq!(fmt_tokens(12_300), "12.3k");
+        assert_eq!(fmt_tokens(1_200_000), "1.2M");
+        assert_eq!(fmt_cost(0.0042), "$0.0042");
+        assert_eq!(spend_amount(0.42, Some(2.0)), "$0.4200 / $2.00");
+        assert_eq!(spend_amount(0.42, None), "$0.4200");
+        assert_eq!(
+            provider_mix_label(&[
+                ProviderShare {
+                    provider: "code-graph".into(),
+                    frames: 2,
+                },
+                ProviderShare {
+                    provider: "memory".into(),
+                    frames: 1,
+                },
+            ]),
+            "2×code-graph, 1×memory"
+        );
+        assert_eq!(provider_mix_label(&[]), "");
+    }
+
+    #[test]
+    fn label_tables_cover_every_variant() {
+        assert_eq!(stage_label(StageKind::ContextRecall), "context recall");
+        assert_eq!(budget_mode_label(BudgetMode::Enforced), "enforced");
+        assert_eq!(media_kind_label(MediaKind::Svg), "svg");
+        assert_eq!(pr_status_label(PrStatus::Merged), "merged");
+        assert_eq!(
+            media_state_label(&MediaJobState::Failed { reason: "x".into() }),
+            "failed: x"
+        );
+        assert_eq!(file_change_verb(FileChangeKind::Created), "created");
+        assert_eq!(crud_letter(FileChangeKind::Deleted), "D");
+    }
+
+    // ── Dispatch coverage ────────────────────────────────────────────────
+
+    #[test]
+    fn event_line_maps_every_annotation_variant_and_skips_the_structural_ones() {
+        let annotations: Vec<AgentEvent> = vec![
+            AgentEvent::Retry {
+                attempt: 1,
+                reason: "x".into(),
+            },
+            AgentEvent::Compaction {
+                before_tokens: 2,
+                after_tokens: 1,
+                evicted: 1,
+                deduped: 0,
+            },
+            AgentEvent::BudgetTick {
+                spent_usd: 0.1,
+                limit_usd: None,
+                mode: BudgetMode::Observed,
+            },
+            AgentEvent::ProviderFallback {
+                from: "a".into(),
+                to: "b".into(),
+                reason: "x".into(),
+            },
+            AgentEvent::StepUsage {
+                step: 0,
+                model: "m".into(),
+                input_tokens: 1,
+                output_tokens: 1,
+                cached_input_tokens: 0,
+                estimated_input_tokens: 0,
+                cost_usd: 0.0,
+                duration_ms: 1,
+                retries: 0,
+                tool_calls: 0,
+            },
+            AgentEvent::GoalVerdict {
+                round: 1,
+                met: true,
+                reasoning: "x".into(),
+                cost_usd: 0.0,
+            },
+            AgentEvent::FileChange {
+                path: "a.rs".into(),
+                kind: FileChangeKind::Created,
+                diff: None,
+            },
+            AgentEvent::ContextRecall {
+                frames: vec![ContextFrameRef {
+                    id: None,
+                    citation_label: "l".into(),
+                    source: "s".into(),
+                    token_cost: 1,
+                }],
+                provider_mix: vec![],
+                tokens: 1,
+            },
+            AgentEvent::ContextWrite {
+                provider: "p".into(),
+                upserts: 1,
+                superseded: 0,
+            },
+            AgentEvent::MediaProgress {
+                artifact_id: "a".into(),
+                kind: MediaKind::Image,
+                state: MediaJobState::Queued,
+            },
+            AgentEvent::MediaComplete {
+                artifact: MediaArtifactRef {
+                    id: "a".into(),
+                    kind: MediaKind::Image,
+                    path: "p".into(),
+                    label: "l".into(),
+                },
+            },
+            AgentEvent::JudgeVerdict {
+                passed: true,
+                evidence: JudgeEvidence {
+                    summary: "s".into(),
+                    deterministic: true,
+                    evidence_refs: vec![],
+                },
+            },
+            AgentEvent::ScopeReview {
+                proposal: ScopeProposal {
+                    summary: "s".into(),
+                    steps: vec![],
+                    estimated_files: 1,
+                    estimated_cost_usd: None,
+                },
+            },
+            AgentEvent::AskUser {
+                id: "q".into(),
+                question: "?".into(),
+                options: vec![],
+            },
+            AgentEvent::Commit {
+                sha: "abc".into(),
+                message: "m".into(),
+            },
+            AgentEvent::Pr {
+                url: "u".into(),
+                status: PrStatus::Open,
+            },
+            AgentEvent::Error {
+                message: "e".into(),
+                retryable: false,
+            },
+            AgentEvent::Complete {
+                model: "m".into(),
+                cost_usd: 0.0,
+            },
+        ];
+        for event in &annotations {
+            assert!(
+                event_line(event).is_some(),
+                "annotation variant unmapped: {event:?}"
+            );
+        }
+
+        use stella_protocol::{ToolCall, ToolOutput};
+        let structural: Vec<AgentEvent> = vec![
+            AgentEvent::Stage {
+                name: StageKind::Execute,
+            },
+            AgentEvent::Text { delta: "t".into() },
+            AgentEvent::Reasoning { delta: "r".into() },
+            AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: "c".into(),
+                    name: "n".into(),
+                    input: serde_json::Value::Null,
+                },
+            },
+            AgentEvent::ToolResult {
+                call_id: "c".into(),
+                output: ToolOutput::Ok {
+                    content: "o".into(),
+                },
+                duration_ms: 1,
+            },
+        ];
+        for event in &structural {
+            assert!(
+                event_line(event).is_none(),
+                "structural variant must stay surface-owned: {event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn event_line_recall_cites_the_provider_mix_on_the_event_path() {
+        let line = event_line(&AgentEvent::ContextRecall {
+            frames: vec![ContextFrameRef {
+                id: None,
+                citation_label: "driver.rs".into(),
+                source: "code-graph".into(),
+                token_cost: 120,
+            }],
+            provider_mix: vec![ProviderShare {
+                provider: "code-graph".into(),
+                frames: 1,
+            }],
+            tokens: 120,
+        })
+        .expect("recall is an annotation");
+        assert_eq!(
+            line.text(),
+            "◈ recalled 1 frames (120 tokens: 1×code-graph)"
+        );
+    }
+}

--- a/stella-tui/src/views/files.rs
+++ b/stella-tui/src/views/files.rs
@@ -223,13 +223,16 @@ fn record_line(rec: &FileRecord, width: usize, selected: bool) -> Line<'static> 
     Line::from(spans)
 }
 
-/// CRUD glyph + semantic color for one [`FileChangeKind`].
+/// CRUD badge for one [`FileChangeKind`]: the letter comes from the shared
+/// files-panel vocabulary (`textline::crud_letter`, one table for both
+/// rendering surfaces — issue #66); only the palette is this view's.
 fn op_style(kind: FileChangeKind) -> (&'static str, ratatui::style::Color) {
-    match kind {
-        FileChangeKind::Created => ("C", theme::OK),
-        FileChangeKind::Modified => ("U", theme::WARN),
-        FileChangeKind::Deleted => ("D", theme::BAD),
-    }
+    let color = match kind {
+        FileChangeKind::Created => theme::OK,
+        FileChangeKind::Modified => theme::WARN,
+        FileChangeKind::Deleted => theme::BAD,
+    };
+    (crate::textline::crud_letter(kind), color)
 }
 
 /// Left-elide `text` to at most `max` chars, keeping the tail (the


### PR DESCRIPTION
## What

Two independent renderers consumed the same `AgentEvent` stream — the plain `colored`+`println` surface (`stella-cli/src/tui.rs`, REPL + one-shot modes) and the ratatui deck (`stella-tui`) — each with its own event→string mapping, so every new variant had to be worded twice. This extracts the wording into one shared, styling-free module that both surfaces consume: **`stella-tui/src/textline.rs`** (pub API; `stella-cli` already depends on `stella-tui`).

## Extraction map

| Primitive | From | To |
|---|---|---|
| Per-variant event→text table: `event_line(&AgentEvent) -> Option<EventLine>` + one constructor per annotation variant (retry, compaction, budget tick, provider fallback, step usage, goal verdict, file change, context recall/write, media progress/complete, judge verdict, scope review, ask-user question, commit, PR, error, complete) | `stella-cli/src/tui.rs::render_event` match arms + `stella-tui/src/render.rs::entry_lines` match arms | `stella-tui/src/textline.rs` |
| `EventLine { glyph, tone, strong, body, detail }` — semantic pieces each surface styles itself (`colored` vs ratatui `theme`) | (new) | `textline` |
| Enum label tables: `stage_label`, `budget_mode_label`, `media_kind_label`, `pr_status_label`, `media_state_label`, `file_change_verb`, `crud_letter` | private copies in `render.rs` / `model.rs` / Debug-format hacks in `stella-cli/tui.rs` | `textline` |
| Cost/turn summary formatting: `fmt_cost`, `fmt_tokens`, `spend_amount` (HUD spend gauge, budget-tick line, step-usage line, complete row, plain `cost_summary` all share these) | `fmt_tokens` in `stella-cli/tui.rs`; inline `format!` in both | `textline` |
| Recall citation tail: `provider_mix_label` | inline in `stella-cli/tui.rs` | `textline` |

Consumers:
- `stella-cli/src/tui.rs::render_event` keeps only *policy* (BudgetTick suppressed when mode=off, errors to stderr, ask-user options list, "thinking…" cue) and maps `Tone`→`colored`; every annotation arm collapsed into one generic `event_line` print.
- `stella-tui/src/render.rs::entry_lines` annotation arms each collapse to `note_line(textline::…)`; `note_line` + a `Tone`→theme map are the entire deck-side presentation of an annotation. `TranscriptEntry::MediaProgress` now retains the wire `MediaJobState` instead of a pre-rendered label (wording is textline's job).
- `views/files.rs` CRUD badge letter from `crud_letter`; deck HUD spend from `spend_amount`.

A new `AgentEvent` annotation variant now needs one `textline` constructor + dispatch arm; both surfaces render it from that.

## Behavior / output stability

- **Plain surface, byte-verified:** built an identical probe (all event variants + `cost_summary` + `files_touched_panel`, forced ANSI) on this branch and on `origin/main`, and diffed the captured output. Visible text is **byte-identical everywhere** (39/39 lines, stdout and stderr). The only differences are sub-segment ANSI emphasis on 11 lines (e.g. bright-colored from/to in provider fallback, dimmed verb in file-change, bold ask-user question) — glyph colors, glyph bolds, and dimmed detail tails are all preserved via `Tone`/`strong`/`detail`; only intra-body mixed emphasis was flattened, since representing it would have meant a rich-text AST for cosmetic nuance. Wording is pinned by byte-exact fixture tests in `textline.rs`.
- **Deck transcript** adopts the shared wording (its annotation rows were slightly differently worded; nothing pinned them — all existing tests pass unmodified). Deck-specific data is composed on top: context-recall rows still cite frame labels (L-C4), budget rows keep the mode tag, ask-user rows keep the option-count cue.

## Deliberately not extracted (and why)

- **Tool cards** (`tool_call_card`/`tool_result_card` vs the deck's `format_tool_input` + aligned label column): the two surfaces present tool traffic structurally differently (key=value one-liner cards vs correlated start/result rows with expand state). Unifying is a real behavior change on both sides — out of scope for #66's "wording once" goal.
- **Files-panel rows**: the plain panel renders the CLI registry's CRUD *ledger* (`(path, "CRU")`, including `R` for reads) while the deck panels fold `FileChange` events — different data models, so only the badge vocabulary (`crud_letter`, `file_change_verb`) is shared; row layout stays per-surface.
- **`Stage` / streamed `Text` / `Reasoning`**: presentation is structural per surface (rules + markdown vs raw print + "thinking…"); the stage *labels* are shared.
- **Deck trace rows** (`deck.rs::trace_of`): a third, deliberately shorter-form summary granularity for the cross-agent timeline; left as is.

## Gate

- `cargo test --workspace`: **1315 passed, 0 failed** (includes new textline fixtures + dispatch-coverage tests)
- `cargo clippy --workspace --all-targets`: **0 warnings**
- `rustfmt --edition 2024 --check` on all touched files: clean

Rebased onto current `main` (378b3ac); the two pre-existing extensions.rs clippy warnings were fixed upstream in the meantime, so this PR no longer touches those files.

Fixes #66


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized event-to-text rendering in `stella-tui::textline` so both the CLI and deck share one vocabulary, eliminating duplicate mappings and addressing #66. Output for the plain CLI remains byte-identical; the deck now uses the same wording.

- **Refactors**
  - Added `stella-tui/src/textline.rs` with `EventLine` (`glyph`, `tone`, `strong`, `body`, `detail`), `event_line(&AgentEvent)`, label helpers (`stage_label`, `budget_mode_label`, `media_kind_label`, `pr_status_label`, `crud_letter`), and formatters (`fmt_tokens`, `fmt_cost`, `spend_amount`, `provider_mix_label`).
  - `stella-cli/src/tui.rs`: now renders via `textline::event_line` and a local tone→`colored` map; keeps only policy (suppress `BudgetTick` when mode=`Off`, route `Error` to stderr) and styling; `cost_summary` uses `fmt_cost`.
  - `stella-tui` deck: transcript rows call `note_line(textline::…)` with a tone→theme map; HUD spend uses `spend_amount`; `ContextRecall` continues to cite frame labels while the CLI cites provider mix; `MediaProgress` now stores `MediaJobState` (labeling handled in `textline`).
  - Tools and files-panel rows were left per-surface (only shared CRUD vocabulary), matching #66’s “wording once” scope.
  - Tests pin wording; plain CLI output is byte-identical; existing deck tests pass.

<sup>Written for commit 8f7fab4b9022268d4a642fb6e6be1bc81b989fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
