### PR TITLE
fix: repair main — 4 independent breaks from today's #105-#114 batch merges

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -315,21 +315,17 @@ impl<'a> Engine<'a> {
             }
         }
 
-            // ---- Telemetry for the call that just committed: exactly one
-            // ---- StepUsage per landed step — the metering record.
-            let _ = events.send(AgentEvent::StepUsage {
-                step,
-                model: result.model.clone(),
-                input_tokens: result.usage.input_tokens,
-                output_tokens: result.usage.output_tokens,
-                cached_input_tokens: result.usage.cached_input_tokens,
-                cache_write_tokens: result.usage.cache_write_tokens,
-                estimated_input_tokens,
-                cost_usd: result.cost_usd,
-                duration_ms: call_duration_ms,
-                retries: retries.len() as u32,
-                tool_calls: result.tool_calls.len(),
-            });
+        let reason = format!(
+            "reached the step cap ({}) without completing — this is the belt-and-suspenders \
+             backstop; loop detection should normally catch a stuck turn first",
+            self.config.max_steps
+        );
+        let _ = events.send(AgentEvent::Error {
+            message: reason.clone(),
+            retryable: false,
+        });
+        TurnOutcome::Aborted { reason }
+    }
 
     /// Compaction, before every model call, per the running estimate
     /// (L-E3 dedup+evict, stable system prefix — the system message is
@@ -503,6 +499,7 @@ impl<'a> Engine<'a> {
             input_tokens: result.usage.input_tokens,
             output_tokens: result.usage.output_tokens,
             cached_input_tokens: result.usage.cached_input_tokens,
+            cache_write_tokens: result.usage.cache_write_tokens,
             estimated_input_tokens: committed.estimated_input_tokens,
             cost_usd: result.cost_usd,
             duration_ms: committed.duration_ms,

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -387,8 +387,8 @@ pub fn plan_extension_sync(
             for name in targets.definition_names {
                 claimed.insert((source.kind, name));
             }
-            targets.file_names.into_iter().collect()
-        });
+        }
+        let present = &present_files[&source.kind];
         for entry in &source.entries {
             let skip = |reason| SyncSkip {
                 kind: source.kind,

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -443,6 +443,25 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         return action;
     }
 
+    // Textarea editing beats per-tab navigation once the composer has
+    // content: Enter breaks the line / the chord submits, and cursor motion
+    // moves through the prompt instead of scrolling the active tab. A blank
+    // composer leaves all of these to the tabs (handle_edit_key gates its
+    // motion on the buffer internally).
+    if !ui.composer.is_blank() {
+        match classify_enter(&key, ui.enter_submits) {
+            EnterAction::Submit => return dispatch_submission(ui),
+            EnterAction::Newline => {
+                ui.composer.insert_newline();
+                return DeckAction::Handled;
+            }
+            EnterAction::NotEnter => {}
+        }
+    }
+    if handle_edit_key(key, &mut ui.composer) {
+        return DeckAction::Handled;
+    }
+
     // Per-tab navigation for non-typing keys…
     if let Some(action) = match ui.tab {
         DeckTab::Agents => handle_agents_key(key, model, ui, composer_empty),
@@ -897,7 +916,8 @@ fn handle_session_key(
 
 /// Dispatch the composer's content: a `!`-prefixed line is a shell command
 /// that executes IMMEDIATELY, bypassing the prompt queue and any busy agent
-/// entirely; any other prompt ALWAYS enqueues — never blocks on a busy agent.
+/// entirely; any other prompt ALWAYS enqueues — never blocks on a busy agent,
+/// though a held dispatch (see [`submit_prompt`]) jumps it to the front.
 fn dispatch_submission(ui: &mut DeckUi) -> DeckAction {
     match ui.composer.take_submission() {
         Some(text) if text.trim_start().starts_with('!') => {
@@ -917,7 +937,7 @@ fn dispatch_submission(ui: &mut DeckUi) -> DeckAction {
                 DeckAction::Shell(cmd)
             }
         }
-        Some(text) => DeckAction::Send(WorkspaceInput::Enqueue { text }),
+        Some(text) => submit_prompt(ui, text),
         None => DeckAction::Ignored,
     }
 }
@@ -1632,7 +1652,7 @@ mod tests {
             handle_deck_key(ch(c), &model, &mut ui);
         }
         assert_eq!(
-            handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+            handle_deck_key(cmd_enter(), &model, &mut ui),
             DeckAction::Send(WorkspaceInput::EnqueueFront {
                 text: "urgent fix".into()
             }),
@@ -1643,7 +1663,7 @@ mod tests {
             handle_deck_key(ch(c), &model, &mut ui);
         }
         assert_eq!(
-            handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+            handle_deck_key(cmd_enter(), &model, &mut ui),
             DeckAction::Send(WorkspaceInput::Enqueue {
                 text: "later".into()
             }),

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -29,11 +29,13 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use stella_protocol::FileChangeKind;
+use stella_protocol::{FileChangeKind, PrStatus};
 
 use crate::composer::{ComposerLayout, SlashMenu, layout as composer_layout, split_row_at};
 use crate::model::{AskUserPrompt, FileState, Hud, SessionModel, TranscriptEntry};
-use crate::textline::{self, EventLine, Tone, budget_mode_label, stage_label};
+use crate::textline::{
+    self, budget_mode_label, media_kind_label, media_state_label, pr_status_label, stage_label,
+};
 use crate::ui::{PanelFocus, UiState, ViewportMetrics};
 use crate::{diff, theme};
 
@@ -1090,7 +1092,11 @@ pub(crate) fn entry_lines(
                 "🎞 media",
                 style,
                 vec![Span::styled(
-                    format!("{} {artifact_id}: {state}", media_kind_label(*kind)),
+                    format!(
+                        "{} {artifact_id}: {}",
+                        media_kind_label(*kind),
+                        media_state_label(state)
+                    ),
                     style,
                 )],
                 width,
@@ -1220,6 +1226,15 @@ pub(crate) fn entry_lines(
     }
 }
 
+fn pr_status_color(status: PrStatus) -> Color {
+    match status {
+        PrStatus::Draft => Color::DarkGray,
+        PrStatus::Open => Color::Green,
+        PrStatus::Merged => Color::Magenta,
+        PrStatus::Closed => Color::Red,
+    }
+}
+
 fn file_line(file: &FileState, selected: bool) -> Line<'static> {
     let (marker, color) = match file.kind {
         FileChangeKind::Created => ("[+]", Color::Green),
@@ -1264,7 +1279,8 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use stella_protocol::{
-        AgentEvent, BudgetMode, FileChangeKind, ScopeProposal, StageKind, ToolCall, ToolOutput,
+        AgentEvent, BudgetMode, FileChangeKind, MediaJobState, MediaKind, ScopeProposal, StageKind,
+        ToolCall, ToolOutput,
     };
 
     /// Flatten a `TestBackend` buffer to one `String` per row (styling
@@ -1372,7 +1388,7 @@ mod tests {
             TranscriptEntry::MediaProgress {
                 artifact_id: "m1".into(),
                 kind: MediaKind::Image,
-                state: "queued".into(),
+                state: MediaJobState::Queued,
             },
             TranscriptEntry::MediaComplete {
                 label: "logo".into(),
@@ -1423,6 +1439,10 @@ mod tests {
                 | TranscriptEntry::ToolResult { .. }
                 | TranscriptEntry::Retry { .. }
                 | TranscriptEntry::Compaction { .. }
+                // Not in `samples`: it deliberately renders as an untagged
+                // system note, not a `[label]: ` line — see
+                // `eviction_marker_renders_as_a_one_line_system_note`.
+                | TranscriptEntry::Evicted { .. }
                 | TranscriptEntry::BudgetTick { .. }
                 | TranscriptEntry::ProviderFallback { .. }
                 | TranscriptEntry::ContextRecall { .. }

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -733,6 +733,7 @@ mod tests {
                 input_tokens: 1,
                 output_tokens: 1,
                 cached_input_tokens: 0,
+                cache_write_tokens: 0,
                 estimated_input_tokens: 0,
                 cost_usd: 0.0,
                 duration_ms: 1,


### PR DESCRIPTION
## Summary

`origin/main` at `58ca0b6` fails `cargo check`/`cargo test` outright. This surfaced while pulling main into a release branch — not a regression I introduced, but leftover breakage from today's rapid same-day merge sequence (#105 through #114), whose conflict resolutions and cross-PR interactions were apparently never compiled together before merging. Each of the 4 issues below is independent — a different file, a different cause.

- **`stella-tui/src/render.rs`** — #113/#114 moved `media_kind_label`, `pr_status_label`, and `media_state_label` into `textline.rs` but left 3 call sites in `render.rs` unupdated (missing imports, and one still tried to `Display`-format the `MediaJobState` enum directly instead of going through `media_state_label`). `pr_status_color` was dropped entirely during the move — restored next to the `TranscriptEntry::Pr` arm that uses it, matching its pre-refactor implementation. Also fixes the two test-only fallout errors this uncovers (a missing `MediaKind` import, and a stale `"queued".into` now that `state` is the raw enum).

- **`stella-core/src/driver.rs`** — #107's `Engine::run_turn` sub-method extraction left a dangling fragment of the pre-extraction inline loop body: dead code referencing out-of-scope locals, and **no closing brace for `run_turn` itself** — every subsequent method in the `impl` block ended up nested one level too deep as a result (a genuine "unclosed delimiter" syntax error). Replaced the dead fragment with the correct step-cap fallthrough. This also explains why #110's cache-write-token telemetry fix never actually took effect on main: it patched the `StepUsage` emission inside that same dead fragment, not the `handle_committed_result` method the extraction had actually moved it to. Ported the field there too.

- **`stella-core/src/extensions.rs`** — a botched conflict resolution in `plan_extension_sync` mixed an `.entry.or_insert_with(closure)` version with a newer `if let Entry::Vacant` version, leaving an unclosed delimiter and a dangling closure tail. Kept the newer imperative form (introduced by the most recent commit) and restored the `present` binding its lookup loop still depends on.

- **`stella-tui/src/deck_ui.rs`** — the same #112 merge dropped the composer's textarea-interception step from `handle_deck_key` entirely: cursor motion (arrows, ⌥[/⌥]) fell through to per-tab scrolling instead of editing the prompt. Restored it. Along the way, `dispatch_submission` (the one remaining caller of the pre-#112 submit path) still built a bare `Enqueue` and never checked `dispatch_held`, silently bypassing the new hold-to-front-of-queue feature whenever a submission arrived through this path — routed it through `submit_prompt` instead. Also fixed one test that pre-dates this file's `cmd_enter` chord-submit convention (a bare `Enter` doesn't submit under `enter_submits: false`).

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — clean (every crate, 0 failures)
- [x] `cargo clippy --workspace --all-targets` — clean, no warnings
- [x] Verified against actual `origin/main` in a disposable worktree (not just the release branch this fix was first found from)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four independent merge fallout issues across `stella-core` and `stella-tui` so `main` builds and tests pass again. Restores missing UI wiring and telemetry, and fixes syntax and logic errors.

- **Bug Fixes**
  - `stella-tui/src/render.rs`: Update imports to new helpers; render media state via `media_state_label`; restore `pr_status_color`; fix tests.
  - `stella-core/src/driver.rs`: Remove dead fragment and close `run_turn`; add step-cap abort path; emit `cache_write_tokens` in `handle_committed_result`.
  - `stella-core/src/extensions.rs`: Resolve conflict in `plan_extension_sync`; keep `Entry::Vacant` approach and restore `present` binding.
  - `stella-tui/src/deck_ui.rs`: Re-enable composer editing interception and Enter/newline handling; route submission through `submit_prompt` to honor hold-to-front; update tests to use `cmd_enter`.

<sup>Written for commit eade27add5ea7d148dcfcf6a18066893240131ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
