### PR TITLE
Pin rust-toolchain.toml to a concrete stable version (#100)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,16 @@ manual.
 
 ## Essential commands
 
-The repo is a Cargo workspace. Rust is **pinned to stable** via
-`rust-toolchain.toml` (rustup fetches it automatically). A **`Makefile`** wraps
-the common commands with the correct flags — run `make help` for the full list.
+The repo is a Cargo workspace. Rust is **pinned to a concrete version**
+(currently 1.97.0) via `rust-toolchain.toml` (rustup fetches it automatically).
+Floating on `channel = "stable"` was tried and reverted — each new stable
+release ships a slightly different rustfmt, which silently reformats
+previously-clean files and turns the CI fmt gate red with zero code changes.
+When bumping the pin for a new Rust release, do it as one dedicated PR that
+updates the version in `rust-toolchain.toml` and runs `cargo fmt --all` in the
+same commit (or the next one) so drift never accumulates. A **`Makefile`**
+wraps the common commands with the correct flags — run `make help` for the
+full list.
 
 ```bash
 make build               # cargo build --workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Problem

`rust-toolchain.toml` floated on `channel = "stable"`. Each new stable release ships a slightly different rustfmt, so previously-clean files develop `cargo fmt --check` drift overnight with zero code changes of our own, and the CI fmt gate goes red. `AGENTS.md` claimed the toolchain was "pinned," which the config did not actually do.

## Fix

Two commits:

1. **Pin `rust-toolchain.toml`** to `channel = "1.97.0"` — the currently-installed stable toolchain (confirmed via `rustc --version` / `rustup toolchain list`).
2. **Correct `AGENTS.md`** where it claimed "pinned to stable" (it wasn't), and document the bump cadence going forward: bump the pin + run `cargo fmt --all` together in one dedicated PR per Rust release, so drift never has a chance to accumulate.

Note on the one-time `cargo fmt --all` sweep the issue asked for: I ran it, and `cargo fmt --all -- --check` reported **zero drift both before and after** — `git status` showed no changes. This is because on this machine `channel = "stable"` already resolved to 1.97.0, so the tree was already formatted with 1.97.0's rustfmt. There is nothing to commit for that step here since there was no accumulated drift to zero out; the pin's value going forward is preventing drift the next time upstream stable moves past 1.97.0.

Fixes #100

**Based on #115** (repairs main's currently-broken build) — this PR is branched from `fix/repair-main-batch-merge-breaks` and should merge after #115, or be rebased onto `main` once #115 lands.

## Verified

- `cargo check --workspace` — clean
- `cargo test --workspace` — 0 failures across every crate; 1 expected `ignored` test requiring a TTY (`stella-tui/src/shell.rs`, documented as such)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (matching CI's actual flags)
- `cargo fmt --all -- --check` — no drift


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the Rust toolchain to 1.97.0 to stop rustfmt drift and keep CI consistent. Update `AGENTS.md` to reflect the pin and document the bump cadence. Fixes #100.

- **Migration**
  - No action needed; `rustup` installs 1.97.0 via `rust-toolchain.toml`.
  - For future Rust releases, bump the version and run `cargo fmt --all` in the same PR.

<sup>Written for commit 1e0991baa56caa54d59cb0030a471ed8af3565f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
