### PR TITLE
fix: skip namespaced command/agent directories the loader can never load (#104)

### DIFF
--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -75,6 +75,22 @@ fn definition_name_for(path: &Path, kind: ExtensionKind) -> String {
         .unwrap_or(fallback)
 }
 
+/// Whether the loader can read a definition out of this entry: a flat file
+/// always can (`read_definition_files` matches any `.md` extension); a
+/// directory only can when it holds the kind's nested definition file. This
+/// mirrors, exactly, the condition under which `read_definition_files`
+/// silently skips a directory — no nested file present at all, so nothing
+/// loads and nothing is diagnosed. A namespace directory such as
+/// `.claude/commands/vercel/` holding only `deploy.md` (no `COMMAND.md`) is
+/// not loadable by this measure.
+fn is_loadable_entry(path: &Path, kind: ExtensionKind) -> bool {
+    if path.is_dir() {
+        path.join(nested_file(kind)).symlink_metadata().is_ok()
+    } else {
+        true
+    }
+}
+
 /// Scan one source directory for one kind (`<source_root>/<kind>`), with
 /// per-entry symlink detection and best-effort frontmatter-name resolution.
 /// Hidden entries (`.DS_Store`, `.skill-lock.json`, …) are ignored. Sorted by
@@ -97,6 +113,7 @@ fn scan_source(source_root: &Path, kind: ExtensionKind) -> SyncSource {
                 .unwrap_or(false);
             Some(SyncEntry {
                 definition_name: definition_name_for(&entry.path(), kind),
+                is_loadable: is_loadable_entry(&entry.path(), kind),
                 name,
                 path: entry.path().display().to_string(),
                 is_symlink,
@@ -122,6 +139,21 @@ fn existing_targets(dir: &Path, kind: ExtensionKind) -> stella_core::extensions:
         targets.file_names.push(name);
     }
     targets
+}
+
+/// One human-readable line for a `NotLoadable` skip — named individually
+/// (unlike the benign skip reasons, which are just a count) because the bug
+/// this reason exists to fix (#104) is exactly a silently-adopted entry;
+/// folding it into "N already present" would also misdescribe it, since
+/// nothing with this name was actually present anywhere.
+fn describe_unloadable_skip(skip: &stella_core::extensions::SyncSkip) -> String {
+    format!(
+        "{} ({}): namespaced directory — no {}.md or {} found, not loadable",
+        skip.name,
+        skip.kind.dir_name(),
+        skip.name,
+        nested_file(skip.kind)
+    )
 }
 
 /// The relative path from inside `from_dir` to `target` — symlinks are
@@ -155,11 +187,20 @@ fn relative_symlink_target(from_dir: &Path, target: &Path) -> PathBuf {
 pub struct SyncOutcome {
     /// Created links as `(kind, name)`.
     pub linked: Vec<(ExtensionKind, String)>,
-    /// Entries skipped by the plan (symlink sources, existing names). Not
-    /// yet surfaced in the progress line, so only tests read it — the bin
-    /// target's dead-code analysis needs the explicit allow.
+    /// Entries skipped for the benign, expected reasons (symlink sources,
+    /// already-present names, duplicate loaded names) — folded into the
+    /// summary's "N already present" rather than named individually.
+    /// Deliberately excludes `NotLoadable` skips, which are named
+    /// individually in `unloadable` instead (see its doc).
     #[allow(dead_code)]
     pub skipped: usize,
+    /// One human-readable line per entry skipped as `NotLoadable` (a
+    /// namespace directory with no nested definition file — see issue
+    /// #104). Unlike `skipped`, these are always surfaced by
+    /// `sync_extensions`, even when nothing else in this scope was linked
+    /// or already present: the bug this reason exists to fix is exactly a
+    /// silently-adopted entry, so going quiet here would reintroduce it.
+    pub unloadable: Vec<String>,
     pub errors: Vec<String>,
 }
 
@@ -180,8 +221,10 @@ impl SyncOutcome {
 
 /// Adopt every command/skill/agent found under `source_roots` (in precedence
 /// order) into `dest_root` (`.stella` or `~/.config/stella`) as symlinks.
-/// Idempotent: symlink sources, already-present names, and duplicate names
-/// are skipped by the plan (`stella_core::extensions::plan_extension_sync`).
+/// Idempotent: symlink sources, already-present names, duplicate names, and
+/// unloadable entries (namespace directories with no nested definition
+/// file) are skipped by the plan
+/// (`stella_core::extensions::plan_extension_sync`).
 fn sync_into(dest_root: &Path, source_roots: &[PathBuf]) -> SyncOutcome {
     let sources: Vec<SyncSource> = ExtensionKind::ALL
         .iter()
@@ -192,7 +235,17 @@ fn sync_into(dest_root: &Path, source_roots: &[PathBuf]) -> SyncOutcome {
     let plan = plan_extension_sync(&sources, &existing);
 
     let mut outcome = SyncOutcome {
-        skipped: plan.skips.len(),
+        skipped: plan
+            .skips
+            .iter()
+            .filter(|s| s.reason != stella_core::extensions::SyncSkipReason::NotLoadable)
+            .count(),
+        unloadable: plan
+            .skips
+            .iter()
+            .filter(|s| s.reason == stella_core::extensions::SyncSkipReason::NotLoadable)
+            .map(describe_unloadable_skip)
+            .collect(),
         ..SyncOutcome::default()
     };
     for link in &plan.links {
@@ -231,7 +284,11 @@ fn user_config_root() -> Option<PathBuf> {
 
 /// Run the sync at both scopes and report through `emit` — the shared init
 /// hook (`agent::init_workspace`) calls this so `stella init` and `/init`
-/// behave identically. Quiet when there is nothing to do.
+/// behave identically. Quiet when there is nothing to do — except a
+/// `NotLoadable` skip (a namespace directory adopted from another agent's
+/// dirs that stella's loader could never read), which always gets a line,
+/// even in a scope where nothing else linked (issue #104: the entire point
+/// is that this shape must never go unmentioned).
 pub fn sync_extensions(workspace_root: &Path, emit: &mut dyn FnMut(String)) {
     let mut scopes: Vec<(&str, PathBuf, Vec<PathBuf>)> = vec![(
         "workspace",
@@ -250,18 +307,30 @@ pub fn sync_extensions(workspace_root: &Path, emit: &mut dyn FnMut(String)) {
 
     for (scope, dest, sources) in scopes {
         let outcome = sync_into(&dest, &sources);
-        if let Some(summary) = outcome.summary() {
-            let skipped = match outcome.skipped {
-                0 => String::new(),
-                n => format!(", {n} already present"),
-            };
-            emit(format!(
-                "✓ adopted {summary} from .claude/.agents ({scope} scope{skipped})"
-            ));
-        }
-        for error in &outcome.errors {
-            emit(format!("! extension link failed: {error}"));
-        }
+        emit_sync_outcome(scope, &outcome, emit);
+    }
+}
+
+/// Emit one scope's progress lines: the `✓ adopted …` summary (only when
+/// something linked), then a line for every `NotLoadable` skip — always,
+/// even when nothing linked, so a scope holding only an unloadable
+/// namespace directory is never silent (issue #104) — then any
+/// link-creation errors.
+fn emit_sync_outcome(scope: &str, outcome: &SyncOutcome, emit: &mut dyn FnMut(String)) {
+    if let Some(summary) = outcome.summary() {
+        let skipped = match outcome.skipped {
+            0 => String::new(),
+            n => format!(", {n} already present"),
+        };
+        emit(format!(
+            "✓ adopted {summary} from .claude/.agents ({scope} scope{skipped})"
+        ));
+    }
+    for note in &outcome.unloadable {
+        emit(format!("! skipped {note} ({scope} scope)"));
+    }
+    for error in &outcome.errors {
+        emit(format!("! extension link failed: {error}"));
     }
 }
 
@@ -597,6 +666,64 @@ mod tests {
                 .unwrap()
                 .contains("body of shared")
         );
+    }
+
+    #[test]
+    fn sync_skips_a_namespace_directory_with_no_nested_definition_file() {
+        // The exact shape from issue #104: another agent's namespaced
+        // command directory `.claude/commands/vercel/deploy.md`
+        // (`/vercel:deploy` in that agent) has neither a flat `vercel.md`
+        // nor a `vercel/COMMAND.md` — nothing stella's loader can read.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join(".claude/commands/vercel/deploy.md"),
+            "---\nname: deploy\n---\nDeploy $ARGUMENTS.",
+        );
+        write(&root.join(".claude/commands/build.md"), "Build it.");
+
+        let outcome = sync_into(
+            &root.join(".stella"),
+            &[root.join(".claude"), root.join(".agents")],
+        );
+        assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+        assert_eq!(
+            outcome.linked,
+            vec![(ExtensionKind::Commands, "build.md".to_string())],
+            "the namespace directory is never linked"
+        );
+        // `NotLoadable` is reported through `unloadable`, not folded into
+        // the benign `skipped` count (nothing here was "already present").
+        assert_eq!(outcome.skipped, 0);
+        assert_eq!(outcome.unloadable.len(), 1, "{:?}", outcome.unloadable);
+        assert!(outcome.unloadable[0].contains("vercel"));
+        assert!(outcome.unloadable[0].contains("not loadable"));
+        assert!(!root.join(".stella/commands/vercel").exists());
+    }
+
+    #[test]
+    fn sync_reports_an_unloadable_namespace_directory_even_when_nothing_else_is_found() {
+        // A workspace whose ONLY entry under `.claude/commands/` is a
+        // namespace directory: `outcome.summary()` is `None` since nothing
+        // linked, so this must not go silent (issue #104's actual bug).
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(&root.join(".claude/commands/vercel/deploy.md"), "Deploy.");
+
+        let outcome = sync_into(
+            &root.join(".stella"),
+            &[root.join(".claude"), root.join(".agents")],
+        );
+        assert!(outcome.linked.is_empty());
+        assert!(outcome.summary().is_none());
+        assert_eq!(outcome.unloadable.len(), 1, "{:?}", outcome.unloadable);
+
+        let mut lines = Vec::new();
+        emit_sync_outcome("workspace", &outcome, &mut |line| lines.push(line));
+        assert_eq!(lines.len(), 1, "{lines:?}");
+        assert!(lines[0].contains("vercel"));
+        assert!(lines[0].contains("not loadable"));
+        assert!(lines[0].contains("workspace scope"));
     }
 
     #[test]

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -23,8 +23,8 @@
 //! Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
 //! `.agents/{commands,skills,agents}`. On `stella init`, entries found there
 //! are **symlinked** into the matching `.stella/`-side directory so stella
-//! sees them without copying (edits stay in one place). Two rules keep the
-//! adoption sane, both encoded in [`plan_extension_sync`]:
+//! sees them without copying (edits stay in one place). Three rules keep the
+//! adoption sane, all encoded in [`plan_extension_sync`]:
 //!
 //!   1. **Never link a symlink.** Other agents symlink between these
 //!      directories too (e.g. `.claude/skills/x -> ../../.agents/skills/x`);
@@ -33,6 +33,16 @@
 //!   2. **Never clobber.** A name already present in the destination —
 //!      user-authored or linked by a previous init — is skipped, so the sync
 //!      is idempotent and hand-written definitions always win.
+//!   3. **Never link something the loader can't read.** A directory entry
+//!      without the kind's nested definition file (`<slug>/COMMAND.md`,
+//!      `<slug>/SKILL.md`, `<slug>/AGENT.md`) — e.g. a *namespace* directory
+//!      like `.claude/commands/vercel/` holding `deploy.md` (the
+//!      `/vercel:deploy` convention some agents use) — has nothing the
+//!      loader reads: the CLI's `read_definition_files` deliberately, and
+//!      silently, skips a directory with no nested file. Linking it would
+//!      create a symlink that does nothing, with no diagnostic anywhere.
+//!      Loading namespaced commands as `/ns:name` is a separate feature
+//!      decision, not this rule's concern.
 //!
 //! # No I/O in this module (`02-architecture.md` §1.3)
 //!
@@ -292,6 +302,16 @@ pub struct SyncEntry {
     /// definition, and linking both would leave the loader's merge order
     /// (destination-lexicographic) to pick a winner instead of source order.
     pub definition_name: String,
+    /// `true` when the loader can actually read a definition out of this
+    /// entry. A flat `<slug>.md` file always is. A directory is loadable
+    /// only when it contains the kind's nested definition file
+    /// (`COMMAND.md`/`SKILL.md`/`AGENT.md`) — mirrors, exactly, the shape
+    /// the loader's `read_definition_files` silently skips (no file, no
+    /// diagnostic, nothing loaded). A *namespace* directory such as
+    /// `.claude/commands/vercel/` holding only `deploy.md` (no
+    /// `vercel.md`/`vercel/COMMAND.md`) is not loadable: linking it would
+    /// adopt a symlink the loader can never resolve into anything.
+    pub is_loadable: bool,
 }
 
 /// The scanned contents of one source directory for one kind, in the
@@ -316,6 +336,12 @@ pub enum SyncSkipReason {
     /// earlier source directory this run, or by something already in the
     /// destination under a different file name.
     DuplicateName,
+    /// The entry is a directory without the kind's nested definition file —
+    /// a namespace directory (no `<slug>.md` or `COMMAND.md`/`SKILL.md`/
+    /// `AGENT.md` found), not loadable. Linking it would produce a symlink
+    /// the loader silently ignores; skipping it here instead keeps the sync
+    /// and the loader in agreement about what "adopted" means.
+    NotLoadable,
 }
 
 /// One symlink the CLI should create: `<dest>/<kind>/<name>` → `source_path`.
@@ -364,8 +390,9 @@ pub struct ExistingTargets {
 /// `sources` are in precedence order (e.g. `.claude/<kind>` before
 /// `.agents/<kind>`); `existing` describes each kind's destination directory.
 /// Deterministic: actions come out in scan order. See the module doc for the
-/// two rules (never link a symlink, never clobber); collision precedence
-/// between sources is decided on [`SyncEntry::definition_name`].
+/// three rules (never link a symlink, never clobber, never link something
+/// unloadable); collision precedence between sources is decided on
+/// [`SyncEntry::definition_name`].
 pub fn plan_extension_sync(
     sources: &[SyncSource],
     existing: &dyn Fn(ExtensionKind) -> ExistingTargets,
@@ -398,6 +425,8 @@ pub fn plan_extension_sync(
             };
             if entry.is_symlink {
                 plan.skips.push(skip(SyncSkipReason::SourceIsSymlink));
+            } else if !entry.is_loadable {
+                plan.skips.push(skip(SyncSkipReason::NotLoadable));
             } else if present.contains(&entry.name) {
                 plan.skips.push(skip(SyncSkipReason::DestinationExists));
             } else if !claimed.insert((source.kind, entry.definition_name.clone())) {
@@ -528,6 +557,24 @@ mod tests {
             // own entries; everywhere else the definition name is the file
             // name minus a `.md` suffix, like the scanner's fallback.
             definition_name: name.strip_suffix(".md").unwrap_or(name).to_string(),
+            // Every test entry built through this helper represents a
+            // normal, loadable file/directory; the unloadable shape is
+            // exercised explicitly (see `plan_skips_a_namespace_directory...`).
+            is_loadable: true,
+        }
+    }
+
+    /// A directory entry shaped like a namespace directory: real (not a
+    /// symlink), but with neither a `<slug>.md` file nor the kind's nested
+    /// definition file inside — the shape `.claude/commands/vercel/` has
+    /// when it holds only `deploy.md`.
+    fn unloadable_dir_entry(name: &str, path: &str) -> SyncEntry {
+        SyncEntry {
+            name: name.to_string(),
+            path: path.to_string(),
+            is_symlink: false,
+            definition_name: name.to_string(),
+            is_loadable: false,
         }
     }
 
@@ -571,6 +618,28 @@ mod tests {
     }
 
     #[test]
+    fn plan_skips_a_namespace_directory_with_no_nested_definition_file() {
+        // The exact shape from issue #104: `.claude/commands/vercel/` holds
+        // `deploy.md` (another agent's `/vercel:deploy` namespaced command)
+        // but no `vercel.md` or `vercel/COMMAND.md` — the scanner marks it
+        // unloadable rather than letting it through as a dangling adoption.
+        // A normal, loadable command in the same source is still linked.
+        let sources = vec![SyncSource {
+            kind: ExtensionKind::Commands,
+            entries: vec![
+                entry("deploy", "/h/.claude/commands/deploy.md", false),
+                unloadable_dir_entry("vercel", "/h/.claude/commands/vercel"),
+            ],
+        }];
+        let plan = plan_extension_sync(&sources, &no_existing);
+        assert_eq!(plan.links.len(), 1);
+        assert_eq!(plan.links[0].name, "deploy");
+        assert_eq!(plan.skips.len(), 1);
+        assert_eq!(plan.skips[0].name, "vercel");
+        assert_eq!(plan.skips[0].reason, SyncSkipReason::NotLoadable);
+    }
+
+    #[test]
     fn plan_never_clobbers_an_existing_destination_name() {
         let sources = vec![SyncSource {
             kind: ExtensionKind::Commands,
@@ -602,6 +671,7 @@ mod tests {
             path: path.to_string(),
             is_symlink: false,
             definition_name: "deploy".to_string(),
+            is_loadable: true,
         };
         let sources = vec![
             SyncSource {


### PR DESCRIPTION
## What & why

Extension sync (from PR #94) linked any non-hidden directory entry found under `.claude/`/`.agents/` into `.stella/`, even a **namespace directory** like `.claude/commands/vercel/` that holds only `deploy.md` (the `/vercel:deploy` convention some agents use). That directory has neither a flat `vercel.md` nor a `vercel/COMMAND.md` — the only two shapes stella's loader (`read_definition_files` in `stella-cli/src/extensions.rs`) actually reads. The result: a symlink adopted into `.stella/commands/`, then silently ignored forever, with no diagnostic anywhere.

This PR makes the sync and the loader agree on what's loadable, instead of teaching the loader to read namespaces (explicitly out of scope per the issue — no new features, no `/ns:name` loading).

**Where the "loadable" detection lives:**
- `stella-core/src/extensions.rs`: `SyncEntry` gains an `is_loadable: bool` field, and `plan_extension_sync` now skips an entry with `is_loadable: false` under a new `SyncSkipReason::NotLoadable` variant — checked alongside the existing `SourceIsSymlink`/`DestinationExists`/`DuplicateName` reasons. No I/O added to this module (it stays pure, per `02-architecture.md` §1.3).
- `stella-cli/src/extensions.rs`: `scan_source` (the actual filesystem scanner) now populates `is_loadable` via a new `is_loadable_entry` helper, which mirrors the loader's own silent-skip condition exactly: a flat file is always loadable; a directory is loadable only when it contains the kind's nested definition file (`COMMAND.md`/`SKILL.md`/`AGENT.md`).

**Reporting:** unlike the other three skip reasons (folded into the init progress line's generic "N already present" count), `NotLoadable` skips are named individually — `SyncOutcome.unloadable: Vec<String>`, one human-readable line each (e.g. `vercel (commands): namespaced directory — no vercel.md or COMMAND.md found, not loadable`) — and always emitted by `sync_extensions`/`emit_sync_outcome`, even in a scope where nothing else linked. Folding it into "already present" would misdescribe it (nothing was actually present), and staying quiet when a scope holds *only* an unloadable entry would just reintroduce the original silent-adoption bug.

Closes #104

**Based on #115** (repairs main's currently-broken build) — this PR should merge after #115, or be rebased onto `main` once #115 lands. This branch is based on `origin/fix/repair-main-batch-merge-breaks` to avoid the pre-existing unrelated "unclosed delimiter" syntax error in `extensions.rs` on current `main`.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here):
  - `stella-core/src/extensions.rs`: `plan_skips_a_namespace_directory_with_no_nested_definition_file` — a namespace directory entry is skipped with `SyncSkipReason::NotLoadable`; a normal loadable entry in the same source is still linked.
  - `stella-cli/src/extensions.rs`: `sync_skips_a_namespace_directory_with_no_nested_definition_file` — end-to-end filesystem test: a real `.claude/commands/vercel/deploy.md` namespace dir is never linked, alongside a normal command that is.
  - `stella-cli/src/extensions.rs`: `sync_reports_an_unloadable_namespace_directory_even_when_nothing_else_is_found` — a scope holding *only* a namespace directory still produces a diagnostic line naming it (the actual "silent" bug from the issue title).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (clean; repo doesn't currently pass `-D warnings` explicitly but no clippy warnings were produced)
- [x] `cargo test --workspace` (0 failures, 1 expected ignored TTY test, workspace-wide)
- [x] Docs updated where behavior changed (module doc in `stella-core/src/extensions.rs` now documents three sync rules instead of two; doc comments on the new field/variant/functions)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- (N/A) No new cross-boundary types needing serde round-trip — `SyncEntry`/`SyncSkipReason` are internal, not serialized

## Anything reviewers should know?

- The new `SyncSkipReason` variant is named `NotLoadable`.
- The human-readable message format: `"{name} ({kind_dir}): namespaced directory — no {name}.md or {NESTED}.md found, not loadable"`.
- Scope: only directory entries are classified as loadable/unloadable (matching the issue's precise wording, "classify a directory entry..."). Flat non-`.md` files are left as-is — untouched, pre-existing edge case, not part of this issue.
- Namespaced command loading (`/ns:name`) is intentionally **not** implemented here — that's a separate feature decision per the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip namespaced command/agent directories the loader can’t read during extension sync, and report them explicitly to avoid dead symlinks and silent adoption. Fixes #104.

- **Bug Fixes**
  - `stella-cli`: scanner adds `is_loadable`; flat files always load; dirs must contain the nested file; `stella-core` skips them as `NotLoadable`.
  - Reporting: emits one `! skipped … not loadable` line per unloadable entry, even when nothing else links; benign skips remain in the “already present” count.
  - Loader scope unchanged: only `<name>.md` or nested `COMMAND.md`/`SKILL.md`/`AGENT.md` are read.

<sup>Written for commit 005abb04135ce3ddf2ff16ec60ff7369959f7092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

