### PR TITLE
Degrade the truecolor theme to xterm-256 on non-truecolor terminals (#101)

### DIFF
--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -35,6 +35,7 @@ use crate::graph::GraphSnapshot;
 use crate::resource::ResourceMonitor;
 use crate::shell::DebugLog;
 use crate::term::{PanicHookGuard, TerminalGuard};
+use crate::theme;
 
 /// The repaint / sample cadence. ~30 fps keeps animations smooth and the CPU
 /// gauge / elapsed timers live without busy-spinning.
@@ -265,6 +266,10 @@ pub async fn run_deck(
     let guard = TerminalGuard::enter(opts.mouse_capture)?;
     let _hook_guard = PanicHookGuard::install(opts.debug_log_path.clone(), &guard);
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    // Detected once (see `theme::truecolor_supported`) and threaded through
+    // the draw loop below, rather than touching every `theme::TOKEN` call
+    // site in `deck_render.rs`/the view modules.
+    let truecolor = theme::detect_truecolor_support();
 
     let mut model = WorkspaceModel::new();
     model.now_ms = now_ms();
@@ -309,7 +314,10 @@ pub async fn run_deck(
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     'run: loop {
-        terminal.draw(|f| render_deck(&model, &mut ui, f))?;
+        terminal.draw(|f| {
+            render_deck(&model, &mut ui, f);
+            theme::degrade_buffer(f.buffer_mut(), truecolor);
+        })?;
 
         tokio::select! {
             maybe_inbound = inbound.recv() => {

--- a/stella-tui/src/shell.rs
+++ b/stella-tui/src/shell.rs
@@ -36,6 +36,7 @@ use crate::input::UserInput;
 use crate::model::SessionModel;
 use crate::render::render;
 use crate::term::{PanicHookGuard, TerminalGuard};
+use crate::theme;
 use crate::ui::{ShellAction, UiState, handle_key, ingest};
 
 /// Configuration for one interactive session.
@@ -152,6 +153,10 @@ pub async fn run(
     let _hook_guard = PanicHookGuard::install(opts.debug_log_path.clone(), &term_guard);
 
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    // Detected once (see `theme::truecolor_supported`) and threaded through
+    // the draw loop below, rather than touching every `theme::TOKEN` call
+    // site in `render.rs`/`textline.rs`/the view modules.
+    let truecolor = theme::detect_truecolor_support();
 
     let mut model = SessionModel::new();
     let mut ui = UiState::new(
@@ -185,7 +190,10 @@ pub async fn run(
     });
 
     loop {
-        terminal.draw(|f| render(&model, &mut ui, f))?;
+        terminal.draw(|f| {
+            render(&model, &mut ui, f);
+            theme::degrade_buffer(f.buffer_mut(), truecolor);
+        })?;
 
         tokio::select! {
             maybe_event = events.recv() => {

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -71,14 +71,169 @@ pub const SYNTAX_COMMENT: Color = Color::Rgb(118, 124, 134);
 
 // ── Activity spinner ────────────────────────────────────────────────────────
 
+/// Darkest stop of the ember ramp (see [`EMBER_RAMP`]).
+pub const EMBER_LOW: Color = Color::Rgb(178, 72, 20);
+/// Brightest stop of the ember ramp (see [`EMBER_RAMP`]).
+pub const EMBER_HIGH: Color = Color::Rgb(255, 214, 130);
+
 /// Burnt-sunset ember ramp, dark → bright, for the working-spinner gradient —
 /// the brand's amber answer to the pink/purple reference spinner.
-pub const EMBER_RAMP: [Color; 4] = [
-    Color::Rgb(178, 72, 20),
-    AMBER_DEEP,
-    AMBER,
-    Color::Rgb(255, 214, 130),
+pub const EMBER_RAMP: [Color; 4] = [EMBER_LOW, AMBER_DEEP, AMBER, EMBER_HIGH];
+
+// ── 256-color fallback (non-truecolor terminals) ────────────────────────────
+//
+// Every color above is a `Color::Rgb`, which some terminals — anything
+// without `COLORTERM=truecolor`/`24bit` and without a `-direct` terminfo
+// entry, which includes the ubiquitous plain `xterm`/`screen`/`linux` console
+// and (despite the name suggesting otherwise) `-256color` variants too, since
+// that suffix only promises the *indexed* 256-color palette, not 24-bit —
+// either render as a terminal-chosen approximation (the amber accent can come
+// out brown/grey) or not at all. [`truecolor_supported`] decides once, from
+// `COLORTERM`/`TERM`, whether the deck should stay on the truecolor tokens
+// above or degrade every one of them to a hand-picked xterm-256 index via
+// [`resolve`].
+//
+// The fallback table sits immediately below the last truecolor token above
+// it (deliberately, not scattered per-const) so a newly added `Color::Rgb`
+// token with no matching entry here is easy to spot on read; the
+// `every_named_token_has_a_256_fallback` test below also checks it
+// mechanically. Each index was chosen as the nearest xterm-256 color-cube (or
+// grayscale-ramp) entry by Euclidean RGB distance — the same reference
+// standard terminals themselves use — not guessed. Two entries
+// (`DIFF_ADD_BG`, `DIFF_DEL_BG`) land on nearly the same dark grey once
+// degraded: both source colors are deliberately near-black "subtle" tints
+// (see their doc comments), so the 256-cube's coarse dark end can't keep them
+// visually apart — the add/remove distinction still reads correctly through
+// the paired `OK`/`BAD` foreground text, which resolves to clearly different
+// indices (114 vs 204).
+//
+// | token            | xterm-256 | approx. RGB      |
+// |------------------|-----------|-------------------|
+// | `AMBER`          | 214       | `#ffaf00`         |
+// | `AMBER_DEEP`     | 172       | `#d78700`         |
+// | `INK`            | 255       | `#eeeeee`         |
+// | `MUTED`          | 246       | `#949494`         |
+// | `RULE`           | 238       | `#444444`         |
+// | `SELECT_BG`      | 235       | `#262626`         |
+// | `OK`             | 114       | `#87d787`         |
+// | `WARN`           | 215       | `#ffaf5f`         |
+// | `BAD`            | 204       | `#ff5f87`         |
+// | `RUN`            | 74        | `#5fafd7`         |
+// | `HELD`           | 140       | `#af87d7`         |
+// | `DIFF_ADD_BG`    | 234       | `#1c1c1c`         |
+// | `DIFF_DEL_BG`    | 235       | `#262626`         |
+// | `SYNTAX_STRING`  | 180       | `#d7af87`         |
+// | `SYNTAX_NUMBER`  | 116       | `#87d7d7`         |
+// | `SYNTAX_COMMENT` | 244       | `#808080`         |
+// | `EMBER_LOW`      | 130       | `#af5f00`         |
+// | `EMBER_HIGH`     | 222       | `#ffd787`         |
+
+/// Whether the terminal advertises 24-bit ("truecolor") support, decided
+/// purely from the two environment inputs that matter — no `std::env` access
+/// here, so this is unit-testable without touching the process environment.
+/// [`detect_truecolor_support`] is the real caller that reads the actual
+/// environment once at startup.
+///
+/// Detection order:
+/// 1. `COLORTERM` is `truecolor` or `24bit` (case-insensitive) — the de facto
+///    standard signal, set by iTerm2, kitty, alacritty, wezterm, VS Code's
+///    integrated terminal, gnome-terminal, konsole, and most other modern
+///    terminals that actually support 24-bit color.
+/// 2. Otherwise, a `TERM` whose name contains `direct` (e.g. `xterm-direct`,
+///    `st-direct`) — the one `TERM`-only terminfo convention for advertising
+///    direct (24-bit) color.
+/// 3. Anything else is treated as non-truecolor, deliberately conservative:
+///    this covers bare legacy entries (`xterm`, `screen`, `linux`) *and* the
+///    very common `-256color` family (`xterm-256color`, `tmux-256color`,
+///    `screen-256color`) which only promise the 256-color palette this
+///    fallback table targets, plus the no-`TERM`-at-all case (cron/CI/piped
+///    output). Erring toward "degrade" is the safe failure mode: a 256-color
+///    fallback on a truecolor terminal is a harmless slight color shift, but
+///    raw truecolor RGB sent to a non-supporting terminal is the illegible
+///    approximation this fix exists to avoid.
+pub fn truecolor_supported(colorterm: Option<&str>, term: Option<&str>) -> bool {
+    if let Some(colorterm) = colorterm {
+        let colorterm = colorterm.trim();
+        if colorterm.eq_ignore_ascii_case("truecolor") || colorterm.eq_ignore_ascii_case("24bit") {
+            return true;
+        }
+    }
+
+    match term {
+        Some(term) => term.to_ascii_lowercase().contains("direct"),
+        None => false,
+    }
+}
+
+/// Read `COLORTERM`/`TERM` from the real process environment once and decide
+/// truecolor support via [`truecolor_supported`]. Call this once at startup
+/// (see `shell::run`, `deck_shell::run_deck`) and thread the result through —
+/// don't call it per-frame or per-token.
+pub fn detect_truecolor_support() -> bool {
+    truecolor_supported(
+        std::env::var("COLORTERM").ok().as_deref(),
+        std::env::var("TERM").ok().as_deref(),
+    )
+}
+
+/// `(truecolor token, xterm-256 fallback index)` pairs for every
+/// `Color::Rgb` token defined above. See the module-level table for the
+/// approximate RGB each index renders as.
+const FALLBACKS: &[(Color, u8)] = &[
+    (AMBER, 214),
+    (AMBER_DEEP, 172),
+    (INK, 255),
+    (MUTED, 246),
+    (RULE, 238),
+    (SELECT_BG, 235),
+    (OK, 114),
+    (WARN, 215),
+    (BAD, 204),
+    (RUN, 74),
+    (HELD, 140),
+    (DIFF_ADD_BG, 234),
+    (DIFF_DEL_BG, 235),
+    (SYNTAX_STRING, 180),
+    (SYNTAX_NUMBER, 116),
+    (SYNTAX_COMMENT, 244),
+    (EMBER_LOW, 130),
+    (EMBER_HIGH, 222),
 ];
+
+/// Resolve one color for the terminal actually in use: unchanged when
+/// `truecolor` is `true`, or its [`FALLBACKS`] entry (an indexed 256-color)
+/// when `false`. A color with no matching entry (already-indexed, named,
+/// `Reset`, …) passes through unchanged either way — this only ever narrows
+/// the truecolor tokens defined above, never touches anything else.
+pub fn resolve(color: Color, truecolor: bool) -> Color {
+    if truecolor {
+        return color;
+    }
+    FALLBACKS
+        .iter()
+        .find_map(|(rgb, indexed)| (*rgb == color).then_some(Color::Indexed(*indexed)))
+        .unwrap_or(color)
+}
+
+/// Degrade every cell's colors in `buf` in place via [`resolve`]. A no-op
+/// when `truecolor` is `true`.
+///
+/// This is the *only* place a fallback is actually applied, and it runs once
+/// per frame, right after the widgets render into the buffer — which is what
+/// lets every other call site in this crate (`render.rs`, `textline.rs`, the
+/// view modules, …) keep referencing `theme::TOKEN` directly, unaware that a
+/// 256-color terminal might be watching. See `shell::run` /
+/// `deck_shell::run_deck` for the two call sites.
+pub fn degrade_buffer(buf: &mut ratatui::buffer::Buffer, truecolor: bool) {
+    if truecolor {
+        return;
+    }
+    for cell in buf.content.iter_mut() {
+        cell.fg = resolve(cell.fg, false);
+        cell.bg = resolve(cell.bg, false);
+        cell.underline_color = resolve(cell.underline_color, false);
+    }
+}
 
 // ── Styles ──────────────────────────────────────────────────────────────────
 
@@ -261,5 +416,113 @@ mod tests {
         ] {
             let _ = trace_kind_color(kind);
         }
+    }
+
+    /// All eighteen `Color::Rgb` tokens defined in this module — kept as an
+    /// explicit list (rather than derived) so this test and
+    /// [`every_named_token_has_a_256_fallback`] both fail loudly the moment a
+    /// new truecolor token is added without a matching [`FALLBACKS`] entry.
+    const ALL_RGB_TOKENS: [Color; 18] = [
+        AMBER,
+        AMBER_DEEP,
+        INK,
+        MUTED,
+        RULE,
+        SELECT_BG,
+        OK,
+        WARN,
+        BAD,
+        RUN,
+        HELD,
+        DIFF_ADD_BG,
+        DIFF_DEL_BG,
+        SYNTAX_STRING,
+        SYNTAX_NUMBER,
+        SYNTAX_COMMENT,
+        EMBER_LOW,
+        EMBER_HIGH,
+    ];
+
+    #[test]
+    fn every_named_token_has_a_256_fallback() {
+        for token in ALL_RGB_TOKENS {
+            assert!(
+                FALLBACKS.iter().any(|(rgb, _)| *rgb == token),
+                "token {token:?} has no xterm-256 fallback entry in FALLBACKS"
+            );
+        }
+        assert_eq!(
+            FALLBACKS.len(),
+            ALL_RGB_TOKENS.len(),
+            "FALLBACKS should have exactly one entry per named RGB token — \
+             update both ALL_RGB_TOKENS and FALLBACKS when adding a new token"
+        );
+    }
+
+    #[test]
+    fn truecolor_supported_reads_colorterm_first() {
+        assert!(truecolor_supported(Some("truecolor"), None));
+        assert!(truecolor_supported(Some("24bit"), Some("xterm")));
+        // Case-insensitive.
+        assert!(truecolor_supported(Some("TrueColor"), None));
+    }
+
+    #[test]
+    fn truecolor_supported_falls_back_to_term_direct_suffix() {
+        assert!(truecolor_supported(None, Some("xterm-direct")));
+        assert!(truecolor_supported(None, Some("st-direct")));
+    }
+
+    #[test]
+    fn truecolor_supported_is_false_for_known_limited_terms() {
+        // No COLORTERM, and TERM values that only promise 16/256-indexed
+        // color, not 24-bit — the exact scenario this fix targets.
+        assert!(!truecolor_supported(None, Some("xterm")));
+        assert!(!truecolor_supported(None, Some("xterm-256color")));
+        assert!(!truecolor_supported(None, Some("screen")));
+        assert!(!truecolor_supported(None, Some("screen-256color")));
+        assert!(!truecolor_supported(None, Some("linux")));
+        assert!(!truecolor_supported(None, Some("tmux-256color")));
+    }
+
+    #[test]
+    fn truecolor_supported_is_false_with_no_environment_at_all() {
+        assert!(!truecolor_supported(None, None));
+    }
+
+    #[test]
+    fn resolve_passes_through_when_truecolor() {
+        assert_eq!(resolve(AMBER, true), AMBER);
+    }
+
+    #[test]
+    fn resolve_maps_every_token_to_its_indexed_fallback_when_degraded() {
+        for (rgb, indexed) in FALLBACKS {
+            assert_eq!(resolve(*rgb, false), Color::Indexed(*indexed));
+        }
+    }
+
+    #[test]
+    fn resolve_leaves_unmapped_colors_unchanged_when_degraded() {
+        assert_eq!(resolve(Color::Indexed(9), false), Color::Indexed(9));
+        assert_eq!(resolve(Color::Reset, false), Color::Reset);
+    }
+
+    #[test]
+    fn degrade_buffer_is_noop_when_truecolor() {
+        let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+        buf.content[0].fg = AMBER;
+        degrade_buffer(&mut buf, true);
+        assert_eq!(buf.content[0].fg, AMBER);
+    }
+
+    #[test]
+    fn degrade_buffer_resolves_every_cell_when_degraded() {
+        let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+        buf.content[0].fg = AMBER;
+        buf.content[0].bg = HELD;
+        degrade_buffer(&mut buf, false);
+        assert_eq!(buf.content[0].fg, Color::Indexed(214));
+        assert_eq!(buf.content[0].bg, Color::Indexed(140));
     }
 }


### PR DESCRIPTION
## Problem

`stella-tui/src/theme.rs` defines every color token as `Color::Rgb` (18 uses — the amber `#FFAC26` accent, ember ramp, diff tints, status colors). Terminals without truecolor support (`COLORTERM` unset — common over ssh/tmux/legacy setups) render terminal-chosen approximations, which can be badly off (the amber accent turning brown/grey), and some low-contrast pairs render as effectively illegible.

## Fix

**Detection** (`theme::truecolor_supported(colorterm: Option<&str>, term: Option<&str>) -> bool`): a pure function, unit-testable without touching the environment.
1. `COLORTERM` is `truecolor` or `24bit` (case-insensitive) → truecolor.
2. Otherwise, `TERM` containing `direct` (e.g. `xterm-direct`) → truecolor (the one `TERM`-only terminfo convention for 24-bit color).
3. Everything else → **not** truecolor. This deliberately includes the `*-256color` family (`xterm-256color`, `tmux-256color`, `screen-256color`) — not just bare `xterm`/`screen`/`linux`.

**Note on the issue text's heuristic wording**: the issue's parenthetical ("terms known to lack truecolor like plain xterm, screen, linux *without* a `-256color`/`direct` suffix") could be read as implying a `-256color` suffix flips a terminal to "truecolor," i.e. a default-true blocklist. I resolved it the other way — `*-256color` still degrades — because that's exactly what ssh/tmux report (`TERM=xterm-256color`/`screen-256color`, `COLORTERM` unset), which the issue's own Problem statement names as the target scenario. Reading it as default-true would mean the fix doesn't fire for the headline case. Happy to flip this if the intent was actually the permissive reading.

`theme::detect_truecolor_support` is the real caller — reads `COLORTERM`/`TERM` from the process environment once at startup.

**Fallback table**: `FALLBACKS: &[(Color, u8)]` lives directly beneath the last truecolor const in `theme.rs` (not scattered per-token), pairing every `Color::Rgb` token with a hand-picked xterm-256 index chosen by nearest color-cube/grayscale Euclidean distance against the real xterm-256 palette (not guessed) — e.g. the amber accent → 214, matching the issue's own suggestion. A doc comment table shows every token → index → approximate RGB. The two ember-ramp endpoint colors, previously anonymous inline literals inside `EMBER_RAMP`, are now named consts (`EMBER_LOW`/`EMBER_HIGH`) so every RGB literal in the file has a name and a fallback entry.

`theme::resolve(color, truecolor)` maps one color; `theme::degrade_buffer(buf, truecolor)` walks a rendered `ratatui::buffer::Buffer` in place, resolving every cell's `fg`/`bg`/`underline_color`.

**Wiring — zero changes to existing token call sites.** `ratatui::style::Style::fg`/`bg` take a concrete `Color`, not `impl Into<Color>`, so the ~60 existing `theme::TOKEN` references across `render.rs`, `textline.rs`, the view modules, `diff.rs`, etc. can't be swapped for a runtime-conditional value without editing every call site. Instead, the fallback is applied once per frame, in `shell::run` and `deck_shell::run_deck`, immediately after `render`/`render_deck` populate the frame's buffer and before it's flushed to the real terminal:
```rust
terminal.draw(|f| {
    render(&model, &mut ui, f);
    theme::degrade_buffer(f.buffer_mut, truecolor);
})?;
```
`truecolor` is computed once via `detect_truecolor_support` before the draw loop starts. Every other consumer of `theme::AMBER` etc. is untouched.

**Known limitation** (disclosed, arguably out of scope per the issue's "map each token" framing): `resolve` is an exact-match lookup. tachyonfx-interpolated transition colors and blended spinner frames won't exactly equal a token and will pass through as raw RGB. Closing that fully would need a nearest-neighbor fallback for arbitrary `Color::Rgb` values rather than an exact table lookup — left for a follow-up if wanted.

Fixes #101.

**Based on #115** (repairs main's currently-broken build) — this PR should merge after #115, or be rebased onto main once #115 lands.

## Verified

- `cargo check --workspace` — clean.
- `cargo test --workspace` — 290 passed, 0 failed, 1 ignored (the pre-existing TTY-only smoke test); includes 13 new tests in `theme::tests` covering `truecolor_supported`, `resolve`, `degrade_buffer`, and a completeness check (`every_named_token_has_a_256_fallback`) that fails if a new `Color::Rgb` token is added to `ALL_RGB_TOKENS`/tested without a matching `FALLBACKS` entry.
- `cargo clippy --workspace --all-targets` — clean.
- `cargo fmt --all -- --check` — no drift on the touched files (`theme.rs`, `shell.rs`, `deck_shell.rs`).
- Confirmed no other production draw path bypasses the fix: `rg -n "\.draw\(" stella-tui/src` shows only the two wired call sites in production code plus test-only `TestBackend` usages in `#[cfg(test)]` modules; the splash screen renders through `deck_render::render_deck` (and so through the same `degrade_buffer` call), not a separate `Terminal::draw`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Degrades the TUI theme to xterm-256 on terminals without 24-bit color to keep colors readable (common over ssh/tmux). Detects support once at startup and applies a per-frame fallback without changing existing color token call sites. Fixes #101.

- **New Features**
  - Added `theme::truecolor_supported` and `detect_truecolor_support` to decide 24-bit support from `COLORTERM`/`TERM` (only `truecolor`/`24bit` or `*-direct` count as truecolor; `*-256color` degrades).
  - Added a 256-color fallback table plus `theme::resolve` and `degrade_buffer`; applied once per draw in `shell::run` and `deck_shell::run_deck` after `render`/`render_deck`.
  - Named `EMBER_LOW`/`EMBER_HIGH` for the spinner ramp to ensure complete fallback coverage.
  - Added focused tests for detection, mapping, buffer degradation, and a completeness check that fails if a new RGB token lacks a fallback.

<sup>Written for commit 07dc17c78bd9c5b4d682f9446d85a9a202d6727f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
