### PR TITLE
feat(context): route retrieval through the ProviderRegistry

### DIFF
--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -7,7 +7,7 @@
 //! Data flow per turn:
 //!
 //! ```text
-//! prompt ──> recall_block(): store.recall_scoped(domains) + select_skills()
+//! prompt ──> recall_block(): registry-routed recall (crate::ocp) + select_skills()
 //!            └─ volatile message AFTER the byte-stable system prefix (L-E8)
 //! turn runs …
 //! outcome ─> reflect_and_record(): one cheap model call -> 0-3 lessons

--- a/stella-cli/src/ocp.rs
+++ b/stella-cli/src/ocp.rs
@@ -11,9 +11,11 @@
 //! gets. "Code is a graph, not text" is now the runtime path, not just a
 //! wire spec.
 //!
-//! - **`workspace-memory`** — the bi-temporal store (`stella-context`):
-//!   reflections, episodes, facts, fused by its own recall pipeline and
-//!   scoped to the workspace's domain taxonomy.
+//! - **`workspace-memory`** — the context plane: a
+//!   [`stella_context::ProviderRegistry`] fan-out with the bi-temporal store
+//!   registered domain-scoped (issue #103's wire decision — the store is
+//!   queried through the plane's own provider seam, never directly).
+//!   Reflections, episodes, facts, fused by the store's recall pipeline.
 //! - **`code-graph`** — the tree-sitter index (`stella-graph`), opened
 //!   read-only per query (the schema-gate discipline) on the blocking pool.
 //!
@@ -28,7 +30,9 @@ use ocp_host::{ContextProvider, Host, HostError, ProviderResult};
 use ocp_types::{
     Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo,
 };
-use stella_context::ContextStore;
+use stella_context::{
+    ContextError, ContextProvider as PlaneProvider, ContextStore, ProviderRegistry,
+};
 
 /// Per-provider recall timeout. Recall runs before every turn, so a wedged
 /// source must cost bounded latency — the host isolates it and the other
@@ -47,13 +51,46 @@ fn local_info(name: &str) -> ProviderInfo {
     }
 }
 
-/// The workspace memory store behind the OCP provider trait. Domain scoping
-/// is provider-internal: OCP's `ContextQuery` is workspace-agnostic, and
-/// which taxonomy applies is exactly the kind of local knowledge a provider
-/// owns.
-struct MemoryProvider {
+/// The built-in store registered at the context-plane seam, with the
+/// session's domain scope applied. Domain scoping is provider-internal:
+/// OCP's `ContextQuery` is workspace-agnostic, and which taxonomy applies is
+/// exactly the kind of local knowledge a provider owns. Identity and
+/// capabilities are the store's own provider declarations.
+struct ScopedStore {
     store: Arc<ContextStore>,
     domains: Vec<String>,
+}
+
+#[async_trait]
+impl PlaneProvider for ScopedStore {
+    fn info(&self) -> ProviderInfo {
+        PlaneProvider::info(self.store.as_ref())
+    }
+    fn capabilities(&self) -> Capabilities {
+        PlaneProvider::capabilities(self.store.as_ref())
+    }
+    async fn query(&self, query: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
+        Ok(self.store.recall_scoped(query, &self.domains).await?.into())
+    }
+}
+
+/// The context-plane registry behind `workspace-memory`: the seam every
+/// in-plane source registers through (issue #103's wire decision). Today
+/// that is the built-in store, domain-scoped; a further plane source (a
+/// git-history provider, an adapted external OCP provider) lands by
+/// registering here, not by editing the host adapter.
+fn memory_plane(store: Arc<ContextStore>, domains: Vec<String>) -> ProviderRegistry {
+    let mut plane = ProviderRegistry::new();
+    plane.register(Arc::new(ScopedStore { store, domains }));
+    plane
+}
+
+/// The workspace context plane behind the OCP provider trait: recall fans
+/// through the plane's [`ProviderRegistry`] instead of hitting the store
+/// directly, so the registry's capability routing, id-dedup, and aggregated
+/// truncation report are the production path.
+struct MemoryProvider {
+    plane: ProviderRegistry,
     info: ProviderInfo,
     caps: Capabilities,
 }
@@ -71,28 +108,29 @@ impl ContextProvider for MemoryProvider {
     }
     async fn query(&self, query: &ContextQuery) -> Result<ContextQueryResult, HostError> {
         let result = self
-            .store
-            .recall_scoped(query, &self.domains)
+            .plane
+            .query_all(query)
             .await
             .map_err(|e| HostError::Transport {
                 id: "workspace-memory".to_string(),
                 message: e.to_string(),
             })?;
-        // The store's recall does not honor `query.kinds`, so a kind-filtered
-        // query (now routed here because we advertise those kinds) must be
+        // The registry routes `query.kinds` at provider granularity, but the
+        // store's recall does not honor it per-frame, so a kind-filtered
+        // query (routed here because we advertise those kinds) must still be
         // filtered before returning — otherwise a `kinds: [Symbol]` request
         // could surface memory/fact frames. This filtering is NOT truncation:
         // `ContextQueryResult.truncated`/`dropped_estimate` describe candidates
         // that matched the request but were cut for budget, so they reflect
-        // only the store's own drops — a non-matching kind was never a
+        // only the plane's own drops — a non-matching kind was never a
         // candidate for this query in the first place.
         let mut frames = result.frames;
         if !query.kinds.is_empty() {
             frames.retain(|f| query.kinds.contains(&f.kind));
         }
         Ok(ContextQueryResult {
-            truncated: !result.dropped.is_empty(),
-            dropped_estimate: u32::try_from(result.dropped.len()).ok(),
+            truncated: result.truncated,
+            dropped_estimate: result.dropped_estimate,
             frames,
         })
     }
@@ -169,8 +207,7 @@ pub fn session_host(
     // memory store serves every kind it mints; the graph serves symbols,
     // snippets, and graph frames).
     host.register(Box::new(MemoryProvider {
-        store,
-        domains,
+        plane: memory_plane(store, domains),
         info: local_info("workspace-memory"),
         caps: Capabilities {
             query: ocp_types::capability::QueryCapability {
@@ -356,5 +393,106 @@ mod tests {
         let mut ids = host.provider_ids();
         ids.sort();
         assert_eq!(ids, vec!["code-graph", "workspace-memory"]);
+    }
+
+    use stella_context::{ContextDelta, NodeInput, NodeKind};
+
+    /// A store with one strongly-matching node, for plane-routing tests.
+    async fn seeded_store(dir: &tempfile::TempDir) -> Arc<ContextStore> {
+        let store = Arc::new(ContextStore::open(dir.path().join("context.db")).expect("store"));
+        store
+            .upsert(
+                ContextDelta::new().with_node(
+                    NodeInput::new(NodeKind::File, "src/store.rs")
+                        .with_uri("file:///repo/src/store.rs")
+                        .with_content("open the sqlite connection in wal mode"),
+                ),
+            )
+            .await
+            .expect("seed");
+        store
+    }
+
+    #[tokio::test]
+    async fn recall_routes_through_the_plane_registry_to_the_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = seeded_store(&dir).await;
+        let host = session_host(store, vec![], dir.path().to_path_buf());
+        let mut q = query(5, 4_000);
+        q.query_text = Some("open the sqlite connection in wal mode".to_string());
+        // Host → workspace-memory → plane registry → store: the full
+        // production path, end to end.
+        let kept = recall_via_host(&host, &q).await;
+        assert!(
+            kept.iter().any(|f| f.content.contains("sqlite")),
+            "the seeded node surfaces through the registry-routed path"
+        );
+    }
+
+    /// A scripted context-plane provider (the `stella-context` seam, not the
+    /// host trait) for plane fan-out tests.
+    struct PlaneScripted {
+        kinds: Vec<String>,
+        frames: Vec<ContextFrame>,
+        truncated: bool,
+    }
+
+    #[async_trait]
+    impl PlaneProvider for PlaneScripted {
+        fn info(&self) -> ProviderInfo {
+            local_info("plane-scripted")
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                query: ocp_types::capability::QueryCapability {
+                    kinds: self.kinds.clone(),
+                    filters: Vec::new(),
+                },
+                ..Capabilities::default()
+            }
+        }
+        async fn query(&self, _q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
+            Ok(ContextQueryResult {
+                frames: self.frames.clone(),
+                truncated: self.truncated,
+                dropped_estimate: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn the_plane_fans_out_and_kind_routes_across_registered_providers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut plane = memory_plane(seeded_store(&dir).await, vec![]);
+        let mut graph_frame = frame("plane-graph", 0.9, 10);
+        graph_frame.kind = ocp_types::FrameKind::Graph;
+        plane.register(Arc::new(PlaneScripted {
+            kinds: vec!["graph".to_string()],
+            frames: vec![graph_frame],
+            truncated: true,
+        }));
+        let provider = MemoryProvider {
+            plane,
+            info: local_info("workspace-memory"),
+            caps: Capabilities::default(),
+        };
+
+        // Unfiltered: both plane providers answer — the store's frame and the
+        // second provider's graph frame merge, and the second provider's
+        // truncation survives the fan-out instead of being erased (L-C5).
+        let mut q = query(10, 4_000);
+        q.query_text = Some("open the sqlite connection in wal mode".to_string());
+        let result = provider.query(&q).await.expect("fan-out");
+        assert!(result.frames.iter().any(|f| f.id == "plane-graph"));
+        assert!(result.frames.iter().any(|f| f.content.contains("sqlite")));
+        assert!(result.truncated, "a plane provider's drop report survives");
+
+        // Kind-filtered to `graph`: the registry routes the store away (it
+        // never serves graph frames) and only the second provider answers.
+        let mut q = query(10, 4_000);
+        q.kinds = vec![ocp_types::FrameKind::Graph];
+        let result = provider.query(&q).await.expect("kind routing");
+        let ids: Vec<&str> = result.frames.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids, vec!["plane-graph"]);
     }
 }

--- a/stella-context/src/lib.rs
+++ b/stella-context/src/lib.rs
@@ -63,4 +63,6 @@ pub use writeback::{
 
 // Re-export the OCP wire types callers pass in/out, so a consumer needs only
 // this crate for the common path (they remain `ocp-types`' definitions).
-pub use ocp_types::{Capabilities, ContextFrame, ContextQuery, DataFlow, ProviderInfo};
+pub use ocp_types::{
+    Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo,
+};

--- a/stella-context/src/provider.rs
+++ b/stella-context/src/provider.rs
@@ -1,19 +1,20 @@
 //! The provider registry seam (`02-architecture.md` §7, `06-context-protocol.md`
-//! §2). One interface — [`ContextProvider`] — behind which context sources are
-//! intended to register: the built-in [`ContextStore`] implements it today (so
-//! the store is both the primary backend and a first-class provider). Wiring
-//! additional sources through this seam — a `stella-graph` code-graph provider,
-//! a git-history provider, and external OCP providers adapted from `ocp-host` —
-//! is designed here but not yet built; this crate does not depend on `ocp-host`,
-//! and the shipping CLI queries the store directly rather than via this
-//! registry.
+//! §2). One interface — [`ContextProvider`] — behind which context sources
+//! register: the built-in [`ContextStore`] implements it (so the store is both
+//! the primary backend and a first-class provider), and the shipping CLI's
+//! session recall flows through this registry (`stella-cli/src/ocp.rs` wraps
+//! it as the `workspace-memory` OCP provider, registering the store domain-
+//! scoped). Wiring further sources through this seam — a `stella-graph`
+//! code-graph provider at this layer, a git-history provider, and external OCP
+//! providers adapted from `ocp-host` — is designed here but not yet built;
+//! this crate does not depend on `ocp-host`.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ocp_types::capability::QueryCapability;
-use ocp_types::{Capabilities, ContextFrame, ContextQuery, DataFlow, ProviderInfo};
+use ocp_types::{Capabilities, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo};
 
 use crate::error::ContextError;
 use crate::store::{ContextStore, NodeKind};
@@ -30,9 +31,11 @@ pub trait ContextProvider: Send + Sync {
     /// What this provider can answer, for query routing.
     fn capabilities(&self) -> Capabilities;
 
-    /// Return frames relevant to the query. Providers return `Vec<ContextFrame>`;
-    /// budgeting/fusion across providers is the host's job.
-    async fn query(&self, q: &ContextQuery) -> Result<Vec<ContextFrame>, ContextError>;
+    /// Return frames relevant to the query, as the OCP wire result so a
+    /// provider's budget drops stay visible across the seam (`L-C5` — a bare
+    /// frame list would erase the truncation report). Budgeting/fusion across
+    /// providers is the host's job.
+    async fn query(&self, q: &ContextQuery) -> Result<ContextQueryResult, ContextError>;
 }
 
 /// Every frame kind the built-in store can serve.
@@ -93,9 +96,9 @@ impl ContextProvider for ContextStore {
         }
     }
 
-    async fn query(&self, q: &ContextQuery) -> Result<Vec<ContextFrame>, ContextError> {
+    async fn query(&self, q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
         // The OCP-shaped adapter over the rich `recall` pipeline.
-        Ok(self.recall(q).await?.frames)
+        Ok(self.recall(q).await?.into())
     }
 }
 
@@ -153,21 +156,35 @@ impl ProviderRegistry {
     }
 
     /// Fan the query to capability-matching providers and concatenate their
-    /// frames, deduping by frame id (first writer wins).
-    pub async fn query_all(&self, q: &ContextQuery) -> Result<Vec<ContextFrame>, ContextError> {
+    /// frames, deduping by frame id (first writer wins). The truncation report
+    /// aggregates across providers — `truncated` if any provider truncated,
+    /// `dropped_estimate` summed over the providers that reported one — so the
+    /// fan-out never erases a provider's honest drop report (`L-C5`).
+    pub async fn query_all(&self, q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
         let mut seen: HashSet<String> = HashSet::new();
-        let mut out = Vec::new();
+        let mut frames = Vec::new();
+        let mut truncated = false;
+        let mut dropped_estimate: Option<u32> = None;
         for provider in &self.providers {
             if !Self::matches(&provider.capabilities(), q) {
                 continue;
             }
-            for frame in provider.query(q).await? {
+            let result = provider.query(q).await?;
+            truncated |= result.truncated;
+            if let Some(d) = result.dropped_estimate {
+                dropped_estimate = Some(dropped_estimate.unwrap_or(0).saturating_add(d));
+            }
+            for frame in result.frames {
                 if seen.insert(frame.id.clone()) {
-                    out.push(frame);
+                    frames.push(frame);
                 }
             }
         }
-        Ok(out)
+        Ok(ContextQueryResult {
+            frames,
+            truncated,
+            dropped_estimate,
+        })
     }
 }
 
@@ -176,7 +193,7 @@ mod tests {
     use super::*;
     use crate::store::{ContextStore, NodeInput};
     use crate::writeback::ContextDelta;
-    use ocp_types::FrameKind;
+    use ocp_types::{ContextFrame, FrameKind};
     use tempfile::TempDir;
 
     async fn seeded_store() -> (TempDir, Arc<ContextStore>) {
@@ -240,14 +257,14 @@ mod tests {
         registry.register(store.clone());
         registry.register(store.clone());
         assert_eq!(registry.len(), 2);
-        let frames = registry
+        let result = registry
             .query_all(&query("open the sqlite connection"))
             .await
             .unwrap();
-        let ids: HashSet<_> = frames.iter().map(|f| f.id.clone()).collect();
+        let ids: HashSet<_> = result.frames.iter().map(|f| f.id.clone()).collect();
         assert_eq!(
             ids.len(),
-            frames.len(),
+            result.frames.len(),
             "no duplicate frame ids across providers"
         );
     }
@@ -261,10 +278,78 @@ mod tests {
         // (which the store's node kinds never map to) skips it.
         let mut q = query("anything");
         q.kinds = vec![FrameKind::Graph];
-        let frames = registry.query_all(&q).await.unwrap();
+        let result = registry.query_all(&q).await.unwrap();
         assert!(
-            frames.is_empty(),
+            result.frames.is_empty(),
             "provider is routed away when kinds don't intersect"
+        );
+        assert!(!result.truncated, "a routed-away provider reports no drops");
+    }
+
+    /// A scripted provider for aggregation tests.
+    struct Scripted {
+        frames: Vec<ContextFrame>,
+        truncated: bool,
+        dropped_estimate: Option<u32>,
+    }
+
+    #[async_trait]
+    impl ContextProvider for Scripted {
+        fn info(&self) -> ProviderInfo {
+            ProviderInfo {
+                name: "scripted".to_string(),
+                version: "0".to_string(),
+                data_flow: DataFlow {
+                    reads: true,
+                    writes: false,
+                    egress: false,
+                },
+            }
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                query: QueryCapability {
+                    kinds: store_kinds(),
+                    filters: vec![],
+                },
+                ..Capabilities::default()
+            }
+        }
+
+        async fn query(&self, _q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
+            Ok(ContextQueryResult {
+                frames: self.frames.clone(),
+                truncated: self.truncated,
+                dropped_estimate: self.dropped_estimate,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn fan_out_aggregates_the_truncation_report_instead_of_erasing_it() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Arc::new(Scripted {
+            frames: vec![],
+            truncated: false,
+            dropped_estimate: None,
+        }));
+        registry.register(Arc::new(Scripted {
+            frames: vec![],
+            truncated: true,
+            dropped_estimate: Some(2),
+        }));
+        registry.register(Arc::new(Scripted {
+            frames: vec![],
+            truncated: true,
+            dropped_estimate: Some(3),
+        }));
+        let result = registry.query_all(&query("anything")).await.unwrap();
+        assert!(result.truncated, "one truncating provider taints the merge");
+        assert_eq!(
+            result.dropped_estimate,
+            Some(5),
+            "estimates sum over the providers that reported one (L-C5)"
         );
     }
 }

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -16,7 +16,7 @@
 use std::collections::{HashMap, HashSet};
 
 use ocp_types::frame::FrameEmbedding;
-use ocp_types::{ContextFrame, ContextQuery, Provenance};
+use ocp_types::{ContextFrame, ContextQuery, ContextQueryResult, Provenance};
 
 use crate::error::ContextError;
 use crate::store::{
@@ -92,10 +92,23 @@ impl RecallResult {
     }
 }
 
+/// The OCP wire shape of a recall — the drop report survives as
+/// `truncated`/`dropped_estimate`, so adapting a recall to the provider seam
+/// never silently discards it (`L-C5`).
+impl From<RecallResult> for ContextQueryResult {
+    fn from(result: RecallResult) -> Self {
+        ContextQueryResult {
+            truncated: !result.dropped.is_empty(),
+            dropped_estimate: u32::try_from(result.dropped.len()).ok(),
+            frames: result.frames,
+        }
+    }
+}
+
 impl ContextStore {
     /// Hybrid retrieval with no domain scope — grounding drawn from the whole
     /// workspace. The OCP-shaped `ContextProvider::query` adapts this down to
-    /// `Vec<ContextFrame>`.
+    /// a [`ContextQueryResult`].
     pub async fn recall(&self, q: &ContextQuery) -> Result<RecallResult, ContextError> {
         self.recall_scoped(q, &[]).await
     }


### PR DESCRIPTION
## The seam

`stella_context::ProviderRegistry` — the context plane's one-interface provider seam — was fully built (trait, registry, capability routing, tests) but had **zero production consumers**: the shipping CLI's `workspace-memory` recall called `ContextStore::recall_scoped` directly (`stella-cli/src/ocp.rs`), exactly the wire-or-delete case in #103. This PR takes the **wire** decision.

## What changed

**stella-cli (`src/ocp.rs`)** — the `workspace-memory` OCP host provider now owns a `ProviderRegistry` instead of the store:

- `ScopedStore` registers the built-in `ContextStore` at the plane seam with the session's domain taxonomy applied (domain scoping stays provider-internal — OCP's `ContextQuery` is workspace-agnostic).
- `MemoryProvider::query` fans through `ProviderRegistry::query_all`, so the registry's capability routing, frame-id dedup, and aggregated truncation report are the production path. A future plane source (git-history, an adapted external OCP provider) lands by registering in `memory_plane`, not by editing the host adapter.
- The `ocp_host::Host` layer (consent, per-provider timeout, crash isolation, budget audit) is unchanged above it; the code-graph provider stays a host-level sibling.

**stella-context** — `ContextProvider::query` and `ProviderRegistry::query_all` now return the OCP wire result (`ContextQueryResult`) instead of a bare `Vec<ContextFrame>`. Routing through the seam with the old signature would have silently erased the store's budget-drop report that the CLI previously mapped by hand — banned by L-C5. The registry aggregates `truncated` (any provider) and `dropped_estimate` (summed over reporters); `From<RecallResult> for ContextQueryResult` keeps the exact mapping production used before.

No external OCP providers are registered: the CLI has no config surface that constructs stdio/HTTP providers today, so that stays the tracked follow-up the module docs name.

## Tests

- `recall_routes_through_the_plane_registry_to_the_store` — end to end: host → `workspace-memory` → registry → store, seeded frame surfaces.
- `the_plane_fans_out_and_kind_routes_across_registered_providers` — a second scripted plane provider proves fan-out (frames from both merge), capability/kind routing (a `graph`-kind query routes the store away), and that a plane provider's truncation report survives.
- `fan_out_aggregates_the_truncation_report_instead_of_erasing_it` — registry-level aggregation semantics.

## Verification (local — Actions is billing-locked, ignore red CI)

- `cargo build -p stella-context -p stella-cli` ✓
- `cargo test -p stella-context -p stella-cli` ✓ (50 + 101 passed)
- `cargo clippy -p stella-context -p stella-cli --all-targets -- -D warnings` ✓
- `cargo check --workspace --all-targets` ✓ (no other crate consumed the changed trait)
- `rustfmt --check` on touched files ✓

Part of #103


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes workspace-memory recall through `stella_context::ProviderRegistry`, making the provider seam the production path with capability routing, id dedup, and preserved truncation reports. `ContextProvider::query` and `ProviderRegistry::query_all` now return `ContextQueryResult`. Part of #103.

- **New Features**
  - `workspace-memory` builds a context plane via `ProviderRegistry`; registers a domain-scoped `ContextStore`.
  - Fan-out routes by `kinds`, dedups frame IDs, and aggregates `truncated`/`dropped_estimate`.
  - `ContextProvider::query` returns `ContextQueryResult`; `From<RecallResult>` keeps prior drop reporting.
  - Host layer in `stella-cli` stays the same; future plane sources register in one place.

- **Migration**
  - Implementations of `ContextProvider::query` must return `ContextQueryResult`.
  - Callers of `ProviderRegistry::query_all` should handle `ContextQueryResult` (use `frames`, `truncated`, `dropped_estimate`).
  - No CLI config changes.

<sup>Written for commit e45e9749c9c27d6ffb0e418933fbaf556a5e9e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
