### PR TITLE
feat(store): wire the file-lock seam into fleet fan-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,7 @@ dependencies = [
  "serde_json",
  "stella-core",
  "stella-protocol",
+ "stella-store",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -2,7 +2,11 @@
 //! `stella-fleet`'s one dispatch seam: a DAG of tasks (from positional
 //! prompts or a `--plan` file), a git worktree per isolated task, wave
 //! scheduling with bounded concurrency, and every attempt/commit/dollar
-//! stamped into the SQLite ledger (`.stella/fleet.db`).
+//! stamped into the SQLite ledger (`.stella/fleet.db`). A task that declares
+//! `claims` (workspace-relative paths it will touch) holds them as
+//! cooperative file locks in `.stella/store.db` for the attempt's duration —
+//! a path another task (or another run) already claims fails that dispatch
+//! by name instead of letting two agents edit the same file.
 //!
 //! Each worker is a full Stella engine turn (the raw step-loop) running in
 //! its task's workspace with the standard tool registry — headless: no MCP,
@@ -111,6 +115,18 @@ pub async fn run_fleet(
         FleetConfig::new(&run_id, &base_sha).with_max_concurrency(max_concurrency.max(1)),
     )
     .map_err(|e| format!("could not start the fleet: {e}"))?;
+    // File claims live in the workspace store (`.stella/store.db`), opened
+    // only when the plan declares any: enforcing claims requires the store
+    // (a claim silently unenforced defeats its purpose), but a claim-free
+    // run must not grow a new failure mode.
+    let fleet = if plan.tasks.iter().any(|t| !t.claims.is_empty()) {
+        let store = stella_store::Store::open(&root).map_err(|e| {
+            format!("this plan declares file claims but the workspace store cannot open: {e}")
+        })?;
+        fleet.with_claim_store(store)
+    } else {
+        fleet
+    };
 
     let report = fleet
         .run_plan(&plan)
@@ -416,12 +432,15 @@ mod tests {
             prompt = "add the /users endpoint"
             depends_on = ["schema"]
             isolation = "shared_tree"
+            claims = ["src/users.rs"]
         "#;
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("plan.toml");
         std::fs::write(&path, toml_plan).expect("write");
         let plan = load_plan(&[], Some(&path)).expect("toml plan");
         assert_eq!(plan.tasks[1].depends_on, vec!["schema".to_string()]);
+        assert_eq!(plan.tasks[1].claims, vec!["src/users.rs".to_string()]);
+        assert!(plan.tasks[0].claims.is_empty(), "claims default to none");
         plan.validate().expect("valid");
 
         let json_path = dir.path().join("plan.json");

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -186,7 +186,8 @@ enum Command {
         tasks: Vec<String>,
 
         /// A plan file instead: .json or .toml with [[tasks]] entries
-        /// (id, title, prompt, optional depends_on + isolation)
+        /// (id, title, prompt, optional depends_on + isolation + claims —
+        /// paths held as cooperative file locks while the task runs)
         #[arg(long, value_name = "FILE", conflicts_with = "tasks")]
         plan: Option<std::path::PathBuf>,
 

--- a/stella-fleet/Cargo.toml
+++ b/stella-fleet/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
 stella-core = { path = "../stella-core" }
+stella-store = { path = "../stella-store" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -1,6 +1,8 @@
 //! THE dispatch seam (L-E9). Subagent fan-out goes through exactly one
-//! API — [`Fleet::dispatch`] — that allocates the task's workspace (a git
-//! worktree per [`Isolation`], isolate-by-default), records the attempt in the
+//! API — [`Fleet::dispatch`] — that claims the task's declared paths
+//! (cooperative file locks in the workspace [`Store`], held for the
+//! attempt's duration), allocates the task's workspace (a git worktree per
+//! [`Isolation`], isolate-by-default), records the attempt in the
 //! [`Ledger`], invokes the [`FleetWorker`] port, stamps the resulting commits
 //! and parent→child lineage into the ledger, and **meters the child's spend
 //! into the parent [`BudgetGuard`]**. No ad-hoc process spawning for agents:
@@ -23,6 +25,7 @@ use std::sync::{Mutex, MutexGuard};
 use async_trait::async_trait;
 use futures_util::{StreamExt, stream};
 use stella_core::{BudgetGuard, BudgetOutcome, Clock};
+use stella_store::Store;
 
 use crate::git::{GitCli, Worktree, WorktreeError, WorktreeManager};
 use crate::ledger::{
@@ -144,12 +147,32 @@ pub enum FleetError {
     Worktree(#[from] WorktreeError),
     #[error(transparent)]
     Ledger(#[from] LedgerError),
+    /// A declared path is already claimed — by a sibling in this run or by
+    /// another run in the same workspace. The holder is named so the user
+    /// can tell a live conflict from a crashed run's leftover claim (the
+    /// holder embeds its run id).
+    #[error("task `{task}` claims `{path}`, already claimed by `{holder}`")]
+    ClaimConflict {
+        task: TaskId,
+        path: String,
+        holder: String,
+    },
+    /// The plan declares claims but no claim store is wired
+    /// ([`Fleet::with_claim_store`]) — refusing to run unenforced claims
+    /// silently.
+    #[error("task `{task}` declares file claims but the fleet has no claim store")]
+    ClaimsWithoutStore { task: TaskId },
+    #[error(transparent)]
+    Claims(#[from] stella_store::StoreError),
 }
 
 /// The fleet orchestrator. Owns the worker, the worktree manager, the ledger,
 /// and the parent budget guard (the last two behind `Mutex`es so concurrent
 /// wave dispatch serializes their fast synchronous writes — a lock is never
-/// held across an `.await`).
+/// held across an `.await`). Optionally owns the workspace [`Store`] whose
+/// `file_locks` back task claims: workers are in-process, so this single
+/// orchestrator-held store is the multi-process "lock-holder" the store's
+/// concurrency contract prescribes.
 pub struct Fleet<W: FleetWorker, G: GitCli, C: Clock> {
     worker: W,
     worktrees: WorktreeManager<G>,
@@ -157,6 +180,7 @@ pub struct Fleet<W: FleetWorker, G: GitCli, C: Clock> {
     budget: Mutex<BudgetGuard>,
     clock: C,
     config: FleetConfig,
+    claims: Option<Store>,
 }
 
 impl<W, G, C> Fleet<W, G, C>
@@ -188,7 +212,17 @@ where
             budget: Mutex::new(budget),
             clock,
             config,
+            claims: None,
         })
+    }
+
+    /// Back task claims with the workspace store's `file_locks` table
+    /// (builder style). Without this, a plan that declares claims fails
+    /// dispatch with [`FleetError::ClaimsWithoutStore`] — claims are never
+    /// silently unenforced.
+    pub fn with_claim_store(mut self, store: Store) -> Self {
+        self.claims = Some(store);
+        self
     }
 
     /// Recover the mutex guard even if a prior holder panicked — the fleet
@@ -203,11 +237,26 @@ where
         self.budget.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    /// THE one dispatch entry point (L-E9). Allocates the workspace per the
-    /// task's isolation, records the attempt, runs the worker, then stamps
-    /// its commits + lineage + spend into the ledger (one transaction) and
-    /// meters its cost into the parent budget — returning a [`TaskHandle`].
+    /// THE one dispatch entry point (L-E9). Claims the task's declared
+    /// paths, allocates the workspace per the task's isolation, records the
+    /// attempt, runs the worker, then stamps its commits + lineage + spend
+    /// into the ledger (one transaction) and meters its cost into the parent
+    /// budget — returning a [`TaskHandle`].
     pub async fn dispatch(&self, task: &Task) -> Result<TaskHandle, FleetError> {
+        // 0. Claim the declared paths before anything else exists for this
+        //    attempt — a conflict is a plain dispatch failure with nothing
+        //    (worktree, ledger rows) to clean up.
+        self.acquire_claims(task)?;
+        let result = self.dispatch_claimed(task).await;
+        // Claims are per-attempt: released even when the worker failed (its
+        // work sits committed on its branch; holding on would starve
+        // dependents and retries).
+        self.release_claims(task);
+        result
+    }
+
+    /// [`dispatch`](Self::dispatch) after the task's claims are held.
+    async fn dispatch_claimed(&self, task: &Task) -> Result<TaskHandle, FleetError> {
         // 1. Allocate the workspace. Isolate by default.
         let worktree = match task.isolation {
             Isolation::Isolated => Some(
@@ -276,6 +325,65 @@ where
             worktree,
             budget,
         })
+    }
+
+    /// The lock-table identity a task claims under: run-scoped, so a crashed
+    /// run's leftover claim is distinguishable from this run's by eye (the
+    /// run id embeds its start time and pid).
+    fn claim_holder(&self, task: &Task) -> String {
+        format!("{}/{}", self.config.run_id, task.id)
+    }
+
+    /// Acquire every path in `task.claims` — all-or-nothing: on a conflict
+    /// (or a store error) the paths already acquired roll back and the error
+    /// names what blocked. Acquisition is re-entrant per holder, so a
+    /// duplicate path within one task is harmless.
+    fn acquire_claims(&self, task: &Task) -> Result<(), FleetError> {
+        if task.claims.is_empty() {
+            return Ok(());
+        }
+        let Some(store) = &self.claims else {
+            return Err(FleetError::ClaimsWithoutStore {
+                task: task.id.clone(),
+            });
+        };
+        let holder = self.claim_holder(task);
+        for (i, path) in task.claims.iter().enumerate() {
+            let failure = match store.acquire_file_lock(path, &holder) {
+                Ok(true) => continue,
+                Ok(false) => FleetError::ClaimConflict {
+                    task: task.id.clone(),
+                    path: path.clone(),
+                    holder: store
+                        .file_lock_holder(path)
+                        .ok()
+                        .flatten()
+                        // The holder released between the two reads — the
+                        // conflict was real when acquisition failed.
+                        .unwrap_or_else(|| "(already released)".to_string()),
+                },
+                Err(e) => FleetError::Claims(e),
+            };
+            for claimed in &task.claims[..i] {
+                let _ = store.release_file_lock(claimed, &holder);
+            }
+            return Err(failure);
+        }
+        Ok(())
+    }
+
+    /// Release the task's claims. Best-effort by design: release only
+    /// deletes rows owned by this holder, and a failed delete leaves a row
+    /// that NAMES this run — the next claimant's conflict error points
+    /// straight back here, never a silent corruption.
+    fn release_claims(&self, task: &Task) {
+        let Some(store) = &self.claims else {
+            return;
+        };
+        let holder = self.claim_holder(task);
+        for path in &task.claims {
+            let _ = store.release_file_lock(path, &holder);
+        }
     }
 
     /// Dispatch a wave of dependency-ready tasks concurrently, bounded by
@@ -591,6 +699,165 @@ mod tests {
                 .iter()
                 .any(|c| c.first().map(String::as_str) == Some("worktree")),
             "shared-tree dispatch must not create a worktree"
+        );
+    }
+
+    // ---- claims: cooperative file locks through the workspace store ---
+
+    fn fleet_with_claims(worker: FakeWorker) -> Fleet<FakeWorker, OkGit, SeqClock> {
+        fleet(
+            worker,
+            OkGit::new(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            FleetConfig::new("run1", "HEAD").with_max_concurrency(2),
+        )
+        .with_claim_store(Store::in_memory().unwrap())
+    }
+
+    /// A worker that parks until the test grants a permit — keeps its
+    /// task's attempt (and claims) open so a sibling's acquire genuinely
+    /// races a HELD claim instead of a released one.
+    struct GatedWorker {
+        gate: Arc<tokio::sync::Semaphore>,
+    }
+    #[async_trait]
+    impl FleetWorker for GatedWorker {
+        async fn run(&self, task: &Task, _workspace_root: &Path) -> WorkerOutcome {
+            if let Ok(permit) = self.gate.acquire().await {
+                permit.forget(); // one permit releases exactly one worker
+            }
+            WorkerOutcome {
+                cost_usd: 0.0,
+                commits: Vec::new(),
+                summary: format!("did {}", task.id),
+                success: true,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn parallel_siblings_claiming_the_same_path_conflict_once() {
+        // Two independent tasks in one concurrent wave, both claiming the
+        // same path: exactly one wins the claim and runs; the other is a
+        // recorded dispatch failure naming the conflict.
+        let plan = Plan::new(vec![
+            Task::new("t1", "t1", "p").claims(["src/shared.rs"]),
+            Task::new("t2", "t2", "p").claims(["src/shared.rs"]),
+        ]);
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
+        let f = Fleet::new(
+            GatedWorker { gate: gate.clone() },
+            WorktreeManager::new(OkGit::new(), "/repo"),
+            Ledger::open_in_memory().unwrap(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            SeqClock::new(),
+            FleetConfig::new("run1", "HEAD").with_max_concurrency(2),
+        )
+        .unwrap()
+        .with_claim_store(Store::in_memory().unwrap());
+
+        // On this current-thread test runtime both dispatches reach their
+        // claim before the permits below land: the winner parks in its
+        // gated worker still holding the claim, so the loser's acquire is a
+        // true mid-attempt conflict.
+        let (report, ()) = tokio::join!(f.run_plan(&plan), async {
+            gate.add_permits(2);
+        });
+        let report = report.unwrap();
+        assert_eq!(report.handles.len(), 1, "exactly one claimant ran");
+        assert!(report.handles[0].outcome.success);
+        assert_eq!(report.dispatch_failures.len(), 1);
+        let (loser, reason) = &report.dispatch_failures[0];
+        assert_ne!(loser, &report.handles[0].task_id);
+        assert!(
+            reason.contains("claims `src/shared.rs`") && reason.contains("run1/"),
+            "the conflict names the path and the winning holder: {reason}"
+        );
+
+        // Both the winner's claim and the loser's rollback released: a fresh
+        // task can claim the same path (one gate permit is left for it).
+        let retry = Task::new("t3", "t3", "p").claims(["src/shared.rs"]);
+        f.dispatch(&retry).await.expect("path released after wave");
+    }
+
+    #[tokio::test]
+    async fn dependent_tasks_reclaim_a_path_released_by_their_prerequisite() {
+        // Claims are per-attempt, so a dependent editing the same file
+        // acquires it in the next wave.
+        let plan = Plan::new(vec![
+            Task::new("a", "a", "p").claims(["src/shared.rs"]),
+            Task::new("b", "b", "p")
+                .depends_on(["a"])
+                .claims(["src/shared.rs"]),
+        ]);
+        let f = fleet_with_claims(FakeWorker::new(0.10));
+        let report = f.run_plan(&plan).await.unwrap();
+        assert!(report.all_succeeded(), "sequential claimants never clash");
+        assert_eq!(report.handles.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_failed_worker_still_releases_its_claims() {
+        let f = fleet_with_claims(FakeWorker::failing(0.10));
+        let task = Task::new("t1", "t1", "p").claims(["src/a.rs"]);
+        let handle = f.dispatch(&task).await.unwrap();
+        assert!(!handle.outcome.success);
+
+        // The failed attempt released its claim — a retry can acquire it.
+        let retry = Task::new("t2", "t2", "p").claims(["src/a.rs"]);
+        f.dispatch(&retry).await.expect("claim released on failure");
+    }
+
+    #[tokio::test]
+    async fn a_foreign_claim_fails_dispatch_by_name_and_rolls_back() {
+        // A claim held by another run (or a crashed one) in the same
+        // workspace: dispatch fails naming that holder, and the paths this
+        // task had already acquired roll back.
+        let store = Store::in_memory().unwrap();
+        assert!(store.acquire_file_lock("src/b.rs", "fleet-9/t9").unwrap());
+        let f = fleet(
+            FakeWorker::new(0.10),
+            OkGit::new(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            FleetConfig::new("run1", "HEAD"),
+        )
+        .with_claim_store(store);
+
+        let task = Task::new("t1", "t1", "p").claims(["src/a.rs", "src/b.rs"]);
+        match f.dispatch(&task).await {
+            Err(FleetError::ClaimConflict { task, path, holder }) => {
+                assert_eq!((task.as_str(), path.as_str()), ("t1", "src/b.rs"));
+                assert_eq!(holder, "fleet-9/t9");
+            }
+            other => panic!("expected a claim conflict, got {other:?}"),
+        }
+        // src/a.rs was acquired before the conflict and must have rolled
+        // back — a sibling can claim it.
+        let sibling = Task::new("t2", "t2", "p").claims(["src/a.rs"]);
+        f.dispatch(&sibling)
+            .await
+            .expect("partial claims roll back");
+    }
+
+    #[tokio::test]
+    async fn claims_without_a_store_are_a_named_dispatch_failure() {
+        // No claim store wired: a task that declares claims must fail loudly
+        // (through the same recorded-dispatch-failure path as any other
+        // dispatch error), never run with its claims silently unenforced.
+        let plan = Plan::new(vec![Task::new("t1", "t1", "p").claims(["src/a.rs"])]);
+        let f = fleet(
+            FakeWorker::new(0.10),
+            OkGit::new(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            FleetConfig::new("run1", "HEAD"),
+        );
+        let report = f.run_plan(&plan).await.unwrap();
+        assert!(report.handles.is_empty());
+        assert_eq!(report.dispatch_failures.len(), 1);
+        assert!(
+            report.dispatch_failures[0].1.contains("no claim store"),
+            "{}",
+            report.dispatch_failures[0].1
         );
     }
 

--- a/stella-fleet/src/lib.rs
+++ b/stella-fleet/src/lib.rs
@@ -16,8 +16,10 @@
 //!   reconciliation and a capped-deferred-wait CI watcher (L-E4).
 //!
 //! and [`fleet`] — **THE dispatch seam** ([`Fleet::dispatch`], L-E9): the one
-//! API subagent fan-out goes through, stamping lineage into the ledger and
-//! metering child spend into the parent [`stella_core::BudgetGuard`].
+//! API subagent fan-out goes through, claiming a task's declared paths as
+//! cooperative file locks (`stella-store`'s `file_locks`) for the attempt's
+//! duration, stamping lineage into the ledger, and metering child spend into
+//! the parent [`stella_core::BudgetGuard`].
 //!
 //! Design constraints (from the task and `02-architecture.md`): we shell out
 //! to the `git`/`gh` binaries via `tokio::process` behind port traits rather

--- a/stella-fleet/src/plan.rs
+++ b/stella-fleet/src/plan.rs
@@ -60,10 +60,19 @@ pub struct Task {
     /// from serialized input.
     #[serde(default)]
     pub isolation: Isolation,
+    /// Workspace-relative paths this task declares it will touch. The fleet
+    /// claims them as cooperative file locks (`stella-store`'s `file_locks`)
+    /// before the worker starts and releases them when the attempt settles;
+    /// a path already claimed — by a sibling or another run in the same
+    /// workspace — fails the dispatch by name. Matched as exact strings, so
+    /// a plan should spell each path one way. Empty (the default) means the
+    /// task claims nothing.
+    #[serde(default)]
+    pub claims: Vec<String>,
 }
 
 impl Task {
-    /// A dependency-free, isolate-by-default task.
+    /// A dependency-free, isolate-by-default task claiming no paths.
     pub fn new(id: impl Into<TaskId>, title: impl Into<String>, prompt: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -71,12 +80,20 @@ impl Task {
             prompt: prompt.into(),
             depends_on: Vec::new(),
             isolation: Isolation::Isolated,
+            claims: Vec::new(),
         }
     }
 
     /// Add dependency edges (builder style).
     pub fn depends_on(mut self, deps: impl IntoIterator<Item = impl Into<TaskId>>) -> Self {
         self.depends_on.extend(deps.into_iter().map(Into::into));
+        self
+    }
+
+    /// Declare workspace-relative paths this task will touch (builder
+    /// style) — the fleet claims them for the attempt's duration.
+    pub fn claims(mut self, paths: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.claims.extend(paths.into_iter().map(Into::into));
         self
     }
 
@@ -476,10 +493,12 @@ mod tests {
         let plan: Plan = serde_json::from_str(json).unwrap();
         assert_eq!(plan.tasks[0].isolation, Isolation::Isolated);
         assert!(plan.tasks[0].depends_on.is_empty());
+        assert!(plan.tasks[0].claims.is_empty(), "claims default to none");
 
-        let shared = Task::new("b", "t", "p").shared_tree();
+        let shared = Task::new("b", "t", "p").shared_tree().claims(["src/a.rs"]);
         let back: Task = serde_json::from_str(&serde_json::to_string(&shared).unwrap()).unwrap();
         assert_eq!(back.isolation, Isolation::SharedTree);
+        assert_eq!(back.claims, vec!["src/a.rs".to_string()]);
     }
 
     // ---- Properties ---------------------------------------------------

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -19,8 +19,10 @@
 //!   normalized workspace-relative path, carrying its deduplicated CRUD
 //!   letters, session line-delta totals, and the ordered JSON audit log of
 //!   every individual touch (event, reason, per-touch line delta).
-//! - **file_locks** — schema + API for cooperative file claims in multi-agent
-//!   work. Reserved: no shipping command acquires locks yet.
+//! - **file_locks** — cooperative file claims for multi-agent work. Wired:
+//!   `stella fleet`'s dispatch seam claims the paths a task declares before
+//!   its worker starts and releases them when the attempt settles, so two
+//!   agents never edit the same file at once (`stella-fleet`).
 //! - **graph_nodes / graph_edges** — schema reserved as a future seam for a
 //!   context plane; not written by any shipping command today (`stella-context`
 //!   and `stella-graph` currently use their own stores).
@@ -34,7 +36,9 @@
 //! still serializes writers per file; one `Store` per session process is the
 //! contract, and internally a `Mutex<Connection>` serializes writers across
 //! in-process parallel agents. Multi-PROCESS fleets need a lock-holder (or
-//! one store per worker + merge) — documented limitation, not a silent one.
+//! one store per worker + merge) — `stella fleet` follows exactly that: its
+//! workers are threads, and the single orchestrator process holds the one
+//! `Store` that acquires and releases their file claims.
 //!
 //! # Schema versioning
 //!
@@ -830,30 +834,42 @@ impl Store {
     /// Cooperative file lock: succeeds only if `path` is unclaimed or
     /// already held by `holder` (re-entrant). Returns whether the lock is
     /// now held.
+    ///
+    /// `INSERT … DO NOTHING` + read-back rather than check-then-insert: two
+    /// PROCESSES racing for the same path (two fleet runs in one workspace)
+    /// resolve to one winner — the losing INSERT is a no-op, never a
+    /// primary-key error — and the read-back reports honestly for both.
     pub fn acquire_file_lock(&self, path: &str, holder: &str) -> Result<bool> {
         let conn = self.lock();
-        // Only "no such lock row" means unclaimed. A genuine query error must
-        // propagate — `.optional()` maps just the no-rows case to `None`;
-        // every other error still propagates via `?`. Swallowing a real error
-        // as "unclaimed" would drive a spurious INSERT (then a PK conflict),
-        // corrupting lock state.
-        let existing: Option<String> = conn
+        conn.execute(
+            "INSERT INTO file_locks (path, holder) VALUES (?, ?) \
+             ON CONFLICT (path) DO NOTHING",
+            params![path, holder],
+        )?;
+        // A row that vanished between the two statements means the competing
+        // holder released cross-process in that window; "not held" is the
+        // conservative truthful answer for THIS call.
+        let current: Option<String> = conn
             .query_row(
                 "SELECT holder FROM file_locks WHERE path = ?",
                 params![path],
                 |row| row.get(0),
             )
             .optional()?;
-        match existing {
-            Some(current) => Ok(current == holder),
-            None => {
-                conn.execute(
-                    "INSERT INTO file_locks (path, holder) VALUES (?, ?)",
-                    params![path, holder],
-                )?;
-                Ok(true)
-            }
-        }
+        Ok(current.as_deref() == Some(holder))
+    }
+
+    /// Who currently holds the claim on `path`, if anyone — the read half a
+    /// consumer uses to NAME the conflicting holder in its error.
+    pub fn file_lock_holder(&self, path: &str) -> Result<Option<String>> {
+        self.lock()
+            .query_row(
+                "SELECT holder FROM file_locks WHERE path = ?",
+                params![path],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(StoreError::from)
     }
 
     /// Release a lock (only the holder's release removes it).
@@ -1661,6 +1677,20 @@ mod tests {
         assert!(!store.acquire_file_lock("src/a.rs", "agent-2").unwrap());
         store.release_file_lock("src/a.rs", "agent-1").unwrap();
         assert!(store.acquire_file_lock("src/a.rs", "agent-2").unwrap());
+    }
+
+    #[test]
+    fn file_lock_holder_names_the_current_holder() {
+        let store = Store::in_memory().unwrap();
+        assert_eq!(store.file_lock_holder("src/a.rs").unwrap(), None);
+        store.acquire_file_lock("src/a.rs", "agent-1").unwrap();
+        assert_eq!(
+            store.file_lock_holder("src/a.rs").unwrap(),
+            Some("agent-1".to_string()),
+            "a loser's conflict error must be able to name the winner"
+        );
+        store.release_file_lock("src/a.rs", "agent-1").unwrap();
+        assert_eq!(store.file_lock_holder("src/a.rs").unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Wires the `stella-store` **file_locks** reserved seam into production through the fleet's dispatch seam, per the wire-or-delete mandate of #103. The **graph seam is deliberately not wired** — assessment and recommendation below so that decision can be made explicitly.

## The file-lock seam, wired

- **Plan surface** (`stella-fleet::plan`): a `Task` can declare `claims` — workspace-relative paths it will touch (`claims = ["src/users.rs"]` in a `--plan` file; defaults to none).
- **Dispatch** (`Fleet::dispatch`, the one fan-out seam): before a worker starts, its task's claims are acquired as cooperative file locks in the workspace store (`.stella/store.db`, `file_locks`), holder-scoped as `<run_id>/<task_id>`. A path already claimed — by a wave sibling or another run in the same workspace — fails that dispatch as a recorded dispatch failure **naming the holder** (run-scoped, so a crashed run's leftover claim is tellable by eye). Acquisition is all-or-nothing (partial claims roll back); claims are per-attempt and released even when the worker fails, so dependents and retries are never starved.
- **Lock-holder discipline**: the store's concurrency doc prescribes that multi-process fleets need a lock-holder. The fleet follows it exactly — workers are threads, and the single orchestrator process owns the one `Store` that claims on their behalf (`Fleet::with_claim_store`).
- **Store hardening** (`stella-store`): `acquire_file_lock` now uses `INSERT … ON CONFLICT (path) DO NOTHING` + read-back instead of check-then-insert, so two racing *processes* (two `stella fleet` runs in one workspace) resolve to one winner instead of a primary-key error; same semantics in-process (exclusive, re-entrant, holder-only release). New `file_lock_holder` read API lets a loser's error name the winner.
- **CLI** (`stella fleet`): opens the claim store only when the plan declares claims — enforcing claims requires the store (declared claims are never silently unenforced → `ClaimsWithoutStore`), while a claim-free run grows no new failure mode.

## Graph seam: assessed, not wired (recommend delete)

`graph_nodes`/`graph_edges` were reserved as a future context-plane seam. The consumers that seam anticipated now exist and both ship their **own** stores:

- `stella-graph` (`.stella/codegraph.db`): typed relational schema (`code_graph_files/symbols/imports`) with FK `ON DELETE CASCADE`, name/file/to_path indexes, sha256 byte-compat skip, one-transaction-per-index-batch crash consistency, and a live re-index watcher.
- `stella-context` (`context.db`): its own schema, embeddings included.

Migrating `stella-graph` onto the store's generic property-graph would mean: flattening typed columns into JSON `properties` (every query becomes `json_extract` + new expression indexes), adding the read/delete/prune/transaction APIs `Store` doesn't have (it exposes only `upsert_graph_node`/`insert_graph_edge` — no reads), re-plumbing the indexer's crash-consistency batching through `Store`'s `Mutex<Connection>`, and coupling the indexer to the telemetry DB against its deliberate dependency posture (it depends only on `ocp-types` to keep the provider boundary one-directional). That is a storage-layer rewrite of most of `stella-graph/src/store.rs` (~600 lines) plus queries, with strictly worse typing — not a wiring change.

**Recommendation**: delete the graph seam from `stella-store` in a small follow-up (tables out of `TABLES`/`UNCHANGED_TABLES` + the two write methods + `validate_json_properties` + their tests; fresh files stop creating the tables, legacy files keep them inert or a v3 migration drops them). Git history preserves the code; the intended consumer materialized with a better-fitting store of its own.

## Verification (local — Actions is billing-locked, red CI is expected)

- `cargo build -p stella-store -p stella-fleet -p stella-cli` — clean
- `cargo test -p stella-store -p stella-fleet -p stella-cli` — 24 + 63 + 99 passed
- `cargo clippy -p stella-store -p stella-fleet -p stella-cli --all-targets -- -D warnings` — clean
- `cargo fmt --check` on touched files — clean (two pre-existing diffs on `origin/main` in `stella-cli/src/{main,tui}.rs` untouched-code regions left alone)

New tests: parallel siblings claiming one path conflict exactly once through `run_plan` (winner gated mid-attempt so the loser races a genuinely held claim), dependent tasks reclaim a released path, a failed worker still releases, a foreign holder's claim fails dispatch by name and rolls partial claims back, claims without a store are a named failure, plan serde roundtrip for `claims`, and store-level holder-naming.

Part of #103


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cooperative file locking to `stella-fleet` dispatch so tasks that declare path `claims` are locked in `stella-store` before a worker runs, preventing simultaneous edits across siblings or runs. Assesses the unused graph seam and recommends deleting it; part of #103.

- **New Features**
  - Plan: new `claims` field (workspace-relative paths). Default is empty.
  - Dispatch: acquires all-or-nothing locks before start, names the holder on conflict, and releases per attempt. `Fleet::with_claim_store` wires the workspace store; the orchestrator process is the lock-holder.
  - Store: locking backed by `stella-store` with `INSERT ... ON CONFLICT DO NOTHING` + read-back; adds `file_lock_holder` to name the current holder.
  - CLI: opens the store only when a plan declares claims; otherwise behavior is unchanged. A plan with claims but no store fails with a clear error.

- **Migration**
  - To use: add `claims = ["path", ...]` to plan tasks. No changes needed for claim-free runs.

<sup>Written for commit 11597fca0b8f74af9ed99bab4d19d666a863683f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
