### PR TITLE
feat(fleet): wire the PR/CI monitor into the fleet CLI

### DIFF
--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -15,16 +15,23 @@
 //! Worktrees are deliberately left in place after the run — the branches
 //! (`fleet/<task>`) carry the work product for the user to review and merge.
 //! `git worktree list` shows them; the report names each one.
+//!
+//! With `--watch`, the run ends in the fleet PR/CI monitor
+//! (`stella_fleet::Monitor` over the real `gh`): every branch that carries
+//! successful work is watched to CI completion as a capped deferred wait,
+//! its PR status is reconciled live, and a red branch fails the command.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use colored::Colorize;
 use stella_core::{Engine, TurnOutcome};
 use stella_fleet::{
-    CommitRecord, Fleet, FleetConfig, FleetRunReport, FleetWorker, Ledger, Plan, SystemGitCli,
-    Task, WorkerOutcome, WorktreeManager,
+    CiWatchOutcome, CommitRecord, Fleet, FleetConfig, FleetRunReport, FleetWorker, GhCli, Ledger,
+    Monitor, MonitorError, Plan, SystemGhCli, SystemGitCli, Task, TaskId, TimeoutReason,
+    WatchConfig, WorkerOutcome, WorktreeManager,
 };
-use stella_protocol::{AgentEvent, CompletionMessage};
+use stella_protocol::{AgentEvent, CompletionMessage, PrStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::ShellHookRunner;
 use tokio::sync::mpsc;
@@ -37,7 +44,8 @@ use crate::tui;
 /// Cap on the per-task summary line so the report table stays a table.
 const SUMMARY_CHARS: usize = 96;
 
-/// Run a fleet: build/load the plan, dispatch it wave by wave, report.
+/// Run a fleet: build/load the plan, dispatch it wave by wave, report —
+/// then, with `watch`, hold the fleet PR/CI monitor on the branches.
 pub async fn run_fleet(
     cfg: &Config,
     prompts: &[String],
@@ -45,6 +53,7 @@ pub async fn run_fleet(
     base_ref: Option<&str>,
     max_concurrency: usize,
     budget_limit: Option<f64>,
+    watch: bool,
 ) -> Result<(), String> {
     let root = cfg.workspace_root.clone();
     let plan = load_plan(prompts, plan_file)?;
@@ -124,8 +133,47 @@ pub async fn run_fleet(
             report.total_cost_usd()
         ));
     }
+
+    // Post-fanout PR/CI watch (`--watch`): the fleet monitor over the real
+    // `gh`. Only branches carrying successful work are watched — failed
+    // tasks already fail the run below.
+    let mut red_branches: Vec<String> = Vec::new();
+    if watch {
+        let targets = watch_targets(&report);
+        if targets.is_empty() {
+            println!(
+                "  {}\n",
+                "nothing to watch — no successful task landed commits".dimmed()
+            );
+        } else {
+            let config = WatchConfig::default();
+            let monitor =
+                Monitor::new(SystemGhCli, Box::new(SystemClock::new())).with_config(config);
+            println!(
+                "  watching CI for {} fleet branch(es) — polling every {}s, wall cap {}m\n",
+                targets.len(),
+                config.poll_interval_ms / 1_000,
+                config.max_total_ms / 60_000,
+            );
+            for (task_id, branch) in &targets {
+                let watched = watch_branch(&monitor, task_id, branch).await;
+                render_watch_line(&watched);
+                if !watched.is_green() {
+                    red_branches.push(watched.branch);
+                }
+            }
+            println!();
+        }
+    }
+
     if !report.all_succeeded() {
         return Err("one or more fleet tasks failed — see the report above".to_string());
+    }
+    if !red_branches.is_empty() {
+        return Err(format!(
+            "CI is not green for: {} — see the watch report above",
+            red_branches.join(", ")
+        ));
     }
     Ok(())
 }
@@ -161,6 +209,110 @@ fn load_plan(prompts: &[String], plan_file: Option<&Path>) -> Result<Plan, Strin
             })
             .collect(),
     ))
+}
+
+/// One fleet branch's post-fanout verdict: the capped CI watch outcome plus
+/// the branch's reconciled PR status. `pr` is `None` when the branch has no
+/// PR yet — branches are left for review, so that is a normal state, not an
+/// error.
+struct BranchWatch {
+    task_id: TaskId,
+    branch: String,
+    ci: Result<CiWatchOutcome, MonitorError>,
+    pr: Option<PrStatus>,
+}
+
+impl BranchWatch {
+    /// Green iff CI completed with a passing overall conclusion — a timeout,
+    /// a monitor error, and a failing conclusion are all red.
+    fn is_green(&self) -> bool {
+        matches!(
+            &self.ci,
+            Ok(CiWatchOutcome::Completed { conclusion, .. }) if !conclusion.is_failure()
+        )
+    }
+}
+
+/// The branches worth watching after the fan-out: every successful task that
+/// landed commits, keyed by the branch its commits actually record (correct
+/// for isolated worktrees and shared-tree tasks alike), deduped so a branch
+/// shared by several tasks is watched once.
+fn watch_targets(report: &FleetRunReport) -> Vec<(TaskId, String)> {
+    let mut seen = HashSet::new();
+    report
+        .handles
+        .iter()
+        .filter(|h| h.outcome.success)
+        .filter_map(|h| {
+            let branch = h.outcome.commits.last()?.branch.clone();
+            seen.insert(branch.clone())
+                .then(|| (h.task_id.clone(), branch))
+        })
+        .collect()
+}
+
+/// Watch one fleet branch: its CI to completion (the monitor's capped
+/// deferred wait, L-E4), then a live PR-status reconcile — `gh pr view`
+/// resolves a branch name to its PR.
+async fn watch_branch<H: GhCli>(monitor: &Monitor<H>, task_id: &str, branch: &str) -> BranchWatch {
+    let ci = monitor.watch_ci(branch).await;
+    let pr = monitor.pr_status(branch).await.ok();
+    BranchWatch {
+        task_id: task_id.to_string(),
+        branch: branch.to_string(),
+        ci,
+        pr,
+    }
+}
+
+/// One report line per watched branch: verdict mark, CI outcome, PR status.
+fn render_watch_line(watch: &BranchWatch) {
+    let mark = if watch.is_green() {
+        "✓".green()
+    } else {
+        "✗".red()
+    };
+    let ci = match &watch.ci {
+        Ok(CiWatchOutcome::Completed {
+            conclusion,
+            summary,
+        }) => {
+            let verdict = if conclusion.is_failure() {
+                "red"
+            } else {
+                "green"
+            };
+            format!("CI {verdict} — {summary}")
+        }
+        Ok(CiWatchOutcome::TimedOut {
+            reason,
+            last_observed,
+            waited_ms,
+        }) => {
+            let reason = match reason {
+                TimeoutReason::CumulativeCap => "cumulative cap",
+                TimeoutReason::Stalled => "stalled",
+                TimeoutReason::NoRunsStarted => "no CI runs started",
+            };
+            format!(
+                "CI watch timed out ({reason}) after {}m — last: {last_observed}",
+                waited_ms / 60_000
+            )
+        }
+        Err(e) => format!("CI watch failed: {e}"),
+    };
+    let pr = match watch.pr {
+        Some(PrStatus::Draft) => "PR draft",
+        Some(PrStatus::Open) => "PR open",
+        Some(PrStatus::Merged) => "PR merged",
+        Some(PrStatus::Closed) => "PR closed",
+        None => "no PR",
+    };
+    println!(
+        "  {mark} {} {} — {ci} · {pr}",
+        watch.task_id.bold(),
+        watch.branch.bright_blue()
+    );
 }
 
 /// The engine-backed [`FleetWorker`]: one raw step-loop turn per task, in
@@ -447,5 +599,167 @@ mod tests {
         assert!(!out.contains('\n'));
         assert!(out.chars().count() <= SUMMARY_CHARS + 1);
         assert!(out.ends_with('…'));
+    }
+
+    // ---- the post-fanout PR/CI watch (--watch) --------------------------
+
+    use std::sync::{Arc, Mutex};
+
+    use stella_core::BudgetOutcome;
+    use stella_fleet::{CiConclusion, GhError, GhOutput, TaskHandle};
+
+    /// A routed fake `gh`: `run list` answers with the scripted CI snapshot,
+    /// `pr view` with the scripted PR json (or the real "no pull requests"
+    /// failure shape when the branch has no PR). Records every call.
+    struct RoutedGh {
+        runs: String,
+        pr: Option<String>,
+        calls: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl RoutedGh {
+        fn new(runs: &str, pr: Option<&str>) -> Self {
+            Self {
+                runs: runs.to_string(),
+                pr: pr.map(str::to_string),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GhCli for RoutedGh {
+        async fn run(&self, args: &[&str]) -> Result<GhOutput, GhError> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(args.iter().map(|s| s.to_string()).collect());
+            if args.first() == Some(&"run") {
+                Ok(GhOutput::ok(self.runs.clone()))
+            } else {
+                match &self.pr {
+                    Some(json) => Ok(GhOutput::ok(json.clone())),
+                    None => Ok(GhOutput::failed(1, "no pull requests found")),
+                }
+            }
+        }
+    }
+
+    fn handle(task_id: &str, success: bool, branch: Option<&str>) -> TaskHandle {
+        TaskHandle {
+            task_id: task_id.to_string(),
+            attempt_id: 1,
+            outcome: WorkerOutcome {
+                cost_usd: 0.0,
+                commits: branch
+                    .map(|b| {
+                        vec![CommitRecord {
+                            sha: format!("sha-{task_id}"),
+                            branch: b.to_string(),
+                            task_id: task_id.to_string(),
+                            message: "m".to_string(),
+                            timestamp_ms: 1,
+                        }]
+                    })
+                    .unwrap_or_default(),
+                summary: String::new(),
+                success,
+            },
+            worktree: None,
+            budget: BudgetOutcome::Continue,
+        }
+    }
+
+    #[test]
+    fn watch_targets_are_successful_committed_branches_watched_once() {
+        let report = FleetRunReport {
+            handles: vec![
+                handle("t1", true, Some("fleet/t1-a")),
+                // No commits → nothing on the branch to watch.
+                handle("t2", true, None),
+                // Failed → already fails the run; not watched.
+                handle("t3", false, Some("fleet/t3-c")),
+                // Same branch as t1 (shared-tree) → watched once.
+                handle("t4", true, Some("fleet/t1-a")),
+            ],
+            ..FleetRunReport::default()
+        };
+        assert_eq!(
+            watch_targets(&report),
+            vec![("t1".to_string(), "fleet/t1-a".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_branch_reports_green_ci_and_open_pr() {
+        let gh = RoutedGh::new(
+            r#"[{"status":"completed","conclusion":"success","name":"ci"}]"#,
+            Some(r#"{"state":"OPEN","isDraft":false}"#),
+        );
+        let calls = gh.calls.clone();
+        let monitor = Monitor::new(gh, Box::new(SystemClock::new()));
+
+        let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+        assert!(watched.is_green());
+        assert_eq!(watched.pr, Some(PrStatus::Open));
+
+        // The CI poll and the PR reconcile both targeted the fleet branch.
+        let calls = calls.lock().unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.first().map(String::as_str) == Some("run")
+                    && c.iter().any(|a| a == "fleet/t1-abc"))
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.first().map(String::as_str) == Some("pr")
+                    && c.iter().any(|a| a == "fleet/t1-abc"))
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_branch_red_ci_and_a_missing_pr_are_states_not_errors() {
+        let gh = RoutedGh::new(
+            r#"[{"status":"completed","conclusion":"failure","name":"ci"}]"#,
+            None,
+        );
+        let monitor = Monitor::new(gh, Box::new(SystemClock::new()));
+
+        let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+        assert!(!watched.is_green());
+        assert_eq!(watched.pr, None, "no PR for the branch is a normal state");
+        assert!(matches!(
+            watched.ci,
+            Ok(CiWatchOutcome::Completed {
+                conclusion: CiConclusion::Failure,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn watch_branch_treats_a_ci_timeout_as_red() {
+        // No runs ever appear and the startup grace is already spent at the
+        // first decision (elapsed >= grace with a 0ms grace) — the watch ends
+        // as NoRunsStarted without sleeping, and the branch is red.
+        let gh = RoutedGh::new("[]", None);
+        let monitor = Monitor::new(gh, Box::new(SystemClock::new())).with_config(WatchConfig {
+            poll_interval_ms: 1,
+            max_total_ms: 60_000,
+            stall_timeout_ms: 60_000,
+            startup_grace_ms: 0,
+        });
+
+        let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+        assert!(!watched.is_green());
+        assert!(matches!(
+            watched.ci,
+            Ok(CiWatchOutcome::TimedOut {
+                reason: TimeoutReason::NoRunsStarted,
+                ..
+            })
+        ));
     }
 }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -197,6 +197,13 @@ enum Command {
         /// Git ref isolated worktrees branch from (default: current HEAD)
         #[arg(long)]
         base_ref: Option<String>,
+
+        /// After the fan-out, watch each fleet branch's CI to completion and
+        /// reconcile its PR status via `gh` (the fleet PR/CI monitor). Exits
+        /// non-zero if any watched branch ends red. Meaningful once the
+        /// branches are pushed — e.g. task prompts that push and open PRs.
+        #[arg(long)]
+        watch: bool,
     },
 
     /// Query the code graph built by `stella init` — symbol definitions and
@@ -413,6 +420,7 @@ fn run(cli: Cli) -> Result<(), String> {
             plan,
             max_concurrency,
             base_ref,
+            watch,
         } => {
             rt()?.block_on(fleet_cmd::run_fleet(
                 &cfg,
@@ -421,6 +429,7 @@ fn run(cli: Cli) -> Result<(), String> {
                 base_ref.as_deref(),
                 max_concurrency,
                 cli.budget,
+                watch,
             ))?;
         }
         Command::Monitor { target } => {
@@ -440,7 +449,11 @@ fn run(cli: Cli) -> Result<(), String> {
             // real terminal; `--plain` / STELLA_PLAIN=1 / a non-TTY stream
             // falls back to the line-based REPL.
             if use_deck(cli.plain) {
-                rt()?.block_on(command_deck::run_deck_session(&cfg, cli.budget, cli.no_anim))?;
+                rt()?.block_on(command_deck::run_deck_session(
+                    &cfg,
+                    cli.budget,
+                    cli.no_anim,
+                ))?;
             } else {
                 rt()?.block_on(agent::run_interactive(&cfg, cli.budget))?;
             }

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -525,5 +525,4 @@ mod tests {
         assert_eq!(stellar_color_at(-1.0), STELLAR_STOPS[0]);
         assert_eq!(stellar_color_at(2.0), STELLAR_STOPS[3]);
     }
-
 }


### PR DESCRIPTION
## Problem

The fleet PR/CI monitor (`stella-fleet/src/monitor.rs`, ~645 lines) — live PR reconciliation (L-V3) and a capped-deferred-wait CI watcher (L-E4) behind the `GhCli` port — was fully built, tested, and re-exported, but had **zero production consumers**. Issue #103 calls for a wire-or-delete decision per staged subsystem; this is the wire half for the monitor.

## The seam

The monitor's docs name it *the fleet PR/CI monitor* (`AgentEvent::Pr`: "opened or changed status (fleet PR/CI monitor)"), and the fleet command already leaves `fleet/<task>` branches as the run's work product. The smallest wiring the docs intend is therefore the fleet command's **post-fanout flow**, where the branch names are already in hand — no new subsystems, no new ledger queries:

- `stella fleet --watch` ends the run in `stella_fleet::Monitor` over the real `gh` (`SystemGhCli` + the CLI's `SystemClock`).
- Every branch that carries **successful** work is watched to CI completion under the monitor's own caps (30s poll, 2h wall, 20m stall, 10m startup — L-E4: a deferred wait with its own cumulative cap, never a raised global timeout), then its PR status is reconciled live (`gh pr view <branch>` — L-V3).
- Branch selection keys off what the commits actually record (correct for isolated worktrees and shared-tree tasks alike) and dedupes, so a branch shared by several tasks is watched once. A branch without a PR is a normal state, not an error.
- A red branch — failing conclusion, watch timeout, or monitor error — fails the command, mirroring `gh run watch --exit-status`.

Off by default: fleet branches are local until something pushes them, so an unconditional watch would just burn the 10m startup grace per branch.

## Tests

The wired path is exercised against a routed fake `GhCli` (the port exists precisely for this — no real GitHub in tests):

- green CI + open PR (and that both `gh` calls target the fleet branch),
- red CI + missing PR reported as states, not errors,
- a CI-never-started timeout classified red,
- watch-target selection: successful+committed only, deduped by branch.

## Verification (local — Actions is billing-locked, red CI is expected)

- `cargo fmt --check -p stella-cli -p stella-fleet` ✓
- `cargo build -p stella-fleet -p stella-cli` ✓
- `cargo test -p stella-fleet -p stella-cli` — 58 + 103 passed ✓
- `cargo clippy -p stella-fleet -p stella-cli --all-targets -- -D warnings` ✓
- `stella fleet --help` smoke ✓

Also picks up a stray pre-existing rustfmt fix in `stella-cli/src/tui.rs`.

Part of #103.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--watch` to `stella fleet` to run the fleet PR/CI monitor after fan-out. It watches successful fleet branches to CI completion, reconciles PR status live, and fails the command if any branch ends red. Part of #103.

- **New Features**
  - `stella fleet --watch`: runs `stella_fleet::Monitor` over `gh` via `SystemGhCli`.
  - Watches only branches with successful commits; deduped across tasks; no-PR is a normal state.
  - Capped deferred wait: 30s poll, 2h wall, 20m stall, 10m startup; timeouts and monitor errors are red.
  - Per-branch output shows CI verdict and PR status; command exits non-zero on any red branch.

- **Migration**
  - Use when branches are pushed or tasks auto-open PRs: `stella fleet --watch`.
  - Off by default; no breaking changes.

<sup>Written for commit 3051e909e99fc36336bd3d91cb6ff592c0b46618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
