### PR TITLE
fix(tui): ember-consistent transcript prefix colors + violet user prompt

### DIFF
--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -820,16 +820,23 @@ pub(crate) fn entry_lines(
                 .add_modifier(Modifier::ITALIC),
         ))),
         TranscriptEntry::User(text) => {
-            push_labeled_block(
-                "user",
-                theme::accent(),
-                crate::markdown::render(text),
-                width,
-                out,
-            );
+            // The one transcript entry rendered in a single color end to end:
+            // the `[user]:` tag and every line of the prompt ride the same
+            // violet as the composer's keybind glyphs and the
+            // "deterministic-first" chip (`deck_render`) — the interactive-
+            // chrome accent, never the ember heat. Rendered as plain lines
+            // (not markdown) so nothing tints part of the prompt a 2nd color.
+            let violet = Style::new().fg(theme::VIOLET);
+            let lines: Vec<Line<'static>> = text
+                .split('\n')
+                .map(|l| Line::from(Span::styled(l.to_owned(), violet)))
+                .collect();
+            push_labeled_block("user", violet, lines, width, out);
         }
         TranscriptEntry::Stage(name) => {
-            let style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+            let style = Style::new()
+                .fg(theme::EMBER_FLAME)
+                .add_modifier(Modifier::BOLD);
             push_labeled(
                 "stage",
                 style,
@@ -851,7 +858,7 @@ pub(crate) fn entry_lines(
             let total_lines = text.lines().count().max(1);
             let show_all = expand_thinking || expanded;
             let chevron = if show_all { "⏶" } else { "⏵" };
-            let header_style = Style::new().fg(theme::AMBER);
+            let header_style = Style::new().fg(theme::AGENT_AMBER);
             let reasoning_style = Style::new()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::ITALIC);
@@ -895,7 +902,9 @@ pub(crate) fn entry_lines(
         } => {
             push_labeled(
                 name,
-                Style::new().fg(Color::Blue).add_modifier(Modifier::BOLD),
+                Style::new()
+                    .fg(theme::EMBER_FLAME)
+                    .add_modifier(Modifier::BOLD),
                 vec![Span::styled(
                     input.clone(),
                     Style::new().fg(Color::DarkGray),
@@ -932,9 +941,9 @@ pub(crate) fn entry_lines(
             ..
         } => {
             let (glyph, color) = if *ok {
-                ("✓", Color::Green)
+                ("✓", theme::EMBER_GOLD)
             } else {
-                ("✗", Color::Red)
+                ("✗", theme::EMBER_CRIMSON)
             };
             // The result labels itself with the tool it answers (resolved
             // from the start entry) so call/result rows read as a pair.
@@ -990,7 +999,7 @@ pub(crate) fn entry_lines(
             }
         }
         TranscriptEntry::Retry { attempt, reason } => {
-            let style = Style::new().fg(Color::Yellow);
+            let style = Style::new().fg(theme::WARNING_BRIGHT);
             push_labeled(
                 "↻ retry",
                 style,
@@ -1005,7 +1014,7 @@ pub(crate) fn entry_lines(
             evicted,
             deduped,
         } => {
-            let style = Style::new().fg(Color::Blue);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "⇣ compacted",
                 style,
@@ -1025,7 +1034,7 @@ pub(crate) fn entry_lines(
             mode,
         } => {
             let limit = limit_usd.map(|l| format!("/${l:.2}")).unwrap_or_default();
-            let style = Style::new().fg(Color::DarkGray);
+            let style = Style::new().fg(theme::WARNING);
             push_labeled(
                 "spend",
                 style,
@@ -1038,7 +1047,7 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::ProviderFallback { from, to, reason } => {
-            let style = Style::new().fg(Color::Magenta);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "⚡ fallback",
                 style,
@@ -1053,7 +1062,7 @@ pub(crate) fn entry_lines(
             labels,
         } => {
             let cited = labels.join(", ");
-            let style = Style::new().fg(Color::Blue);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "◉ recalled",
                 style,
@@ -1070,7 +1079,7 @@ pub(crate) fn entry_lines(
             upserts,
             superseded,
         } => {
-            let style = Style::new().fg(Color::Blue);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "✎ memory",
                 style,
@@ -1087,7 +1096,7 @@ pub(crate) fn entry_lines(
             kind,
             state,
         } => {
-            let style = Style::new().fg(Color::Magenta);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "🎞 media",
                 style,
@@ -1104,7 +1113,9 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::MediaComplete { label, path, kind } => {
-            let style = Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD);
+            let style = Style::new()
+                .fg(theme::EMBER_FLAME)
+                .add_modifier(Modifier::BOLD);
             push_labeled(
                 "🎨 media",
                 style,
@@ -1122,9 +1133,9 @@ pub(crate) fn entry_lines(
             deterministic,
         } => {
             let (glyph, color) = if *passed {
-                ("✓", Color::Green)
+                ("✓", theme::EMBER_GOLD)
             } else {
-                ("✗", Color::Red)
+                ("✗", theme::EMBER_CRIMSON)
             };
             let tag = if *deterministic {
                 "deterministic"
@@ -1147,7 +1158,9 @@ pub(crate) fn entry_lines(
             steps,
             estimated_files,
         } => {
-            let style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+            let style = Style::new()
+                .fg(theme::WARNING_BRIGHT)
+                .add_modifier(Modifier::BOLD);
             push_labeled(
                 "⏸ scope",
                 style,
@@ -1160,7 +1173,9 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::AskUser { question, options } => {
-            let style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+            let style = Style::new()
+                .fg(theme::WARNING_BRIGHT)
+                .add_modifier(Modifier::BOLD);
             push_labeled(
                 "? ask",
                 style,
@@ -1174,7 +1189,7 @@ pub(crate) fn entry_lines(
         }
         TranscriptEntry::Commit { sha, message } => {
             let short = sha.chars().take(9).collect::<String>();
-            let style = Style::new().fg(Color::Cyan);
+            let style = Style::new().fg(theme::EMBER_FLAME);
             push_labeled(
                 "● commit",
                 style,
@@ -1203,7 +1218,9 @@ pub(crate) fn entry_lines(
         }
         TranscriptEntry::Error { message, retryable } => {
             let tag = if *retryable { " (retryable)" } else { "" };
-            let style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
+            let style = Style::new()
+                .fg(theme::EMBER_CRIMSON)
+                .add_modifier(Modifier::BOLD);
             push_labeled(
                 "✗ error",
                 style,
@@ -1213,8 +1230,9 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::Complete { model, cost_usd } => {
-            // Fully muted on purpose: completion is a footnote, not an event.
-            let style = Style::new().fg(theme::MUTED);
+            // A quiet footnote, not an event — the dimmest ember tier keeps it
+            // inside the warm family without shouting.
+            let style = Style::new().fg(theme::WARNING);
             push_labeled(
                 "cost",
                 style,
@@ -1227,11 +1245,14 @@ pub(crate) fn entry_lines(
 }
 
 fn pr_status_color(status: PrStatus) -> Color {
+    // Kept inside the ember family so the `[⇢ pr]:` gutter reads with the rest
+    // of the transcript: quiet amber draft, flame while open, gold on merge,
+    // crimson on close.
     match status {
-        PrStatus::Draft => Color::DarkGray,
-        PrStatus::Open => Color::Green,
-        PrStatus::Merged => Color::Magenta,
-        PrStatus::Closed => Color::Red,
+        PrStatus::Draft => theme::WARNING,
+        PrStatus::Open => theme::EMBER_FLAME,
+        PrStatus::Merged => theme::EMBER_GOLD,
+        PrStatus::Closed => theme::EMBER_CRIMSON,
     }
 }
 
@@ -1804,6 +1825,107 @@ mod tests {
         assert_eq!(out.len(), 1, "the marker costs exactly one visual row");
         let text: String = out[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text, "… 1234 earlier entries evicted");
+    }
+
+    // ---- Transcript prefix colors (ember gutter + violet user prompt) ----
+
+    /// The user prompt is the single exception to the ember gutter: its
+    /// `[user]:` tag AND every line of the prompt render in exactly the violet
+    /// used for the composer's keybind glyphs and the deterministic-first
+    /// chip — as one flat color, with no markdown tinting and no ember heat.
+    #[test]
+    fn user_prompt_entry_is_one_violet_color_end_to_end() {
+        let mut out = Vec::new();
+        // Markdown that WOULD tint under `markdown::render` (a code span goes
+        // `theme::WARN`, a heading goes bold `INK`): proof none of it leaks.
+        entry_lines(
+            &TranscriptEntry::User("fix the `parser` bug\nand **ship** it".to_string()),
+            false,
+            false,
+            80,
+            &mut out,
+        );
+        let mut saw_text = false;
+        for line in &out {
+            for span in &line.spans {
+                // Skip pure-whitespace gutter/continuation indent (no fg).
+                if span.content.trim().is_empty() {
+                    continue;
+                }
+                saw_text = true;
+                assert_eq!(
+                    span.style.fg,
+                    Some(theme::VIOLET),
+                    "user entry span {:?} is not the violet accent",
+                    span.content
+                );
+                // Belt and suspenders: no ember heat anywhere on the entry.
+                for banned in [theme::EMBER_GOLD, theme::EMBER_CRIMSON, theme::WARN] {
+                    assert_ne!(
+                        span.style.fg,
+                        Some(banned),
+                        "user entry leaks an ember color: {:?}",
+                        span.content
+                    );
+                }
+            }
+        }
+        assert!(
+            saw_text,
+            "the prompt rendered at least one styled text span"
+        );
+    }
+
+    /// Every other entry's `[label]:` prefix stays inside the warm ember
+    /// family — failure crimson, success gold — so no raw ANSI cyan/blue/
+    /// magenta survives from before the ember theme landed.
+    #[test]
+    fn transcript_prefix_colors_stay_in_the_ember_family() {
+        let prefix_fg = |entry: &TranscriptEntry| -> Option<Color> {
+            let mut out = Vec::new();
+            entry_lines(entry, false, false, 80, &mut out);
+            out[0].spans[0].style.fg
+        };
+        assert_eq!(
+            prefix_fg(&TranscriptEntry::Error {
+                message: "boom".into(),
+                retryable: false,
+            }),
+            Some(theme::EMBER_CRIMSON),
+            "error prefix is crimson",
+        );
+        assert_eq!(
+            prefix_fg(&TranscriptEntry::ToolResult {
+                call_id: "c1".into(),
+                name: "read_file".into(),
+                ok: true,
+                summary: "ok".into(),
+                full: "ok".into(),
+                duration_ms: 3,
+                diff: None,
+            }),
+            Some(theme::EMBER_GOLD),
+            "successful tool-result prefix is gold",
+        );
+        assert_eq!(
+            prefix_fg(&TranscriptEntry::ToolResult {
+                call_id: "c2".into(),
+                name: "read_file".into(),
+                ok: false,
+                summary: "no".into(),
+                full: "no".into(),
+                duration_ms: 3,
+                diff: None,
+            }),
+            Some(theme::EMBER_CRIMSON),
+            "failed tool-result prefix is crimson",
+        );
+        // The stage marker moved off raw cyan onto ember flame.
+        assert_eq!(
+            prefix_fg(&TranscriptEntry::Stage(StageKind::Execute)),
+            Some(theme::EMBER_FLAME),
+            "stage prefix is ember flame",
+        );
     }
 
     // ---- Replay determinism (L-T1) ------------------------------------


### PR DESCRIPTION
## What

The transcript view gives every entry a `[label]:` prefix gutter (`render::entry_lines`, shared by the classic session view **and** the command deck). Those prefixes still used raw ANSI `Cyan`/`Blue`/`Magenta`/`Green`/`Red`/`Yellow` from before the ember theme (PR #123) landed, so they clashed with the gold/amber/crimson palette.

This recolors everything **left of the colon** onto ember-family `theme::` tokens (which degrade through the existing `FALLBACKS` table for 256/16-color terminals — no hardcoded RGB in render code), and makes the **user prompt** the single deliberate exception: entirely violet.

## Entry-kind → color

| Group | Entries | Old (raw ANSI) | New (theme token) |
|---|---|---|---|
| **User prompt (exception)** | `User` — prefix **and** whole body | gold + markdown | **`VIOLET`** (one flat color, plain text) |
| Agent voice | `Text` (agent) | `theme::accent` gold | unchanged (already ember gold) |
| Thinking | `Reasoning` | `AMBER` | `AGENT_AMBER` |
| Process / tool actions | `Stage`, `ToolStart`, `Commit`, `ContextRecall`, `ContextWrite`, `Compaction`, `ProviderFallback`, `MediaProgress`, `MediaComplete` | Cyan/Blue/Magenta | `EMBER_FLAME` |
| Positive outcomes | `ToolResult` ok, `JudgeVerdict` pass | Green | `EMBER_GOLD` |
| Needs-attention | `Retry`, `ScopeReview`, `AskUser` | Yellow/Cyan | `WARNING_BRIGHT` |
| Failure | `ToolResult` fail, `JudgeVerdict` fail, `Error`, `Pr` closed | Red | `EMBER_CRIMSON` |
| Quiet footnotes | `BudgetTick` (spend), `Complete` (cost) | DarkGray / `MUTED` | `WARNING` (dimmest ember) |
| PR status | `Pr` | Green/Magenta/Red/DarkGray | Draft `WARNING`, Open `EMBER_FLAME`, Merged `EMBER_GOLD`, Closed `EMBER_CRIMSON` |

The user-prompt violet is the **existing** `theme::VIOLET` (`Rgb A78BFA`) — the exact constant already used for the composer's keybind glyphs (`deck_render.rs:320`) and the "↝ deterministic-first" chip (`deck_render.rs:559`). No new purple invented.

## Deliberate scope boundary

Only `TranscriptEntry::User` + the `entry_lines` arms + `pr_status_color` (one call site) are touched. The standalone `render_hud` / `render_ask_user` / `render_scope_review` panels keep their cyan — they are **not** `[label]:` gutter transcript entries, so the HUD stage stays cyan while the transcript stage moves to ember flame. The live composer's gold `>>>` prompt is the input, not the `[user]:` transcript entry, and is untouched.

## Judgment calls

- **Spend/cost → `WARNING`, not `MUTED`.** `MUTED` (`TEXT_SECONDARY`) is a violet-tinted gray — out of the "yellow/gold/amber/crimson" family and adjacent to the reserved user-prompt violet. The dimmest ember (`WARNING`) preserves the "footnote" intent inside the family.
- **User prompt rendered as plain lines (markdown dropped)** so the entire entry is genuinely one color; keeping markdown structure would re-tint code spans / headings.
- **Failure uses `EMBER_CRIMSON`** (true crimson) rather than the pinker `DANGER_BRIGHT`, staying on-brand (never pink).

## Verification (local — Actions is billing-locked for this org)

- `cargo build -p stella-tui -p stella-cli` ✓
- `cargo test -p stella-tui -p stella-cli` ✓ (306 + 2 deck snapshots; incl. 2 new fg-asserting tests)
- `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` ✓
- `rustfmt --edition 2024 stella-tui/src/render.rs` (formatted only the file touched)

New tests: `user_prompt_entry_is_one_violet_color_end_to_end` (every prompt span is `VIOLET`, no ember leak even with markdown in the text) and `transcript_prefix_colors_stay_in_the_ember_family` (Error→crimson, ToolResult ok→gold / fail→crimson, Stage→flame).

Kept surgical (single file, only transcript/theme color code) to merge cleanly alongside the concurrent stat-boxes-row and header-clock branches.
