### PR TITLE
fix(tui): slash popup scrolls to keep selection visible

### DIFF
--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -545,11 +545,18 @@ pub(crate) fn render_ask_user(
         .render(area, buf);
 }
 
+/// Most command rows the slash popup shows at once before it scrolls. The
+/// list grows to this, then windows around the selection (see
+/// [`scroll_window_start`]) so ↑/↓ can walk a long menu without the highlight
+/// ever leaving the frame.
+pub(crate) const SLASH_POPUP_MAX_ROWS: usize = 8;
+
 /// Where the slash popup floats: anchored to the composer's left edge,
-/// opening upward, tall enough for the matches (capped) and clamped to the
-/// frame on small terminals.
+/// opening upward, tall enough for the matches (capped at
+/// [`SLASH_POPUP_MAX_ROWS`]) and clamped to the frame on small terminals. The
+/// `+3` reserves the two borders and the one-line key legend.
 pub(crate) fn slash_popup_area(root: Rect, composer: Rect, matches: usize) -> Rect {
-    let h = ((matches.min(8) as u16) + 3).min(root.height);
+    let h = ((matches.min(SLASH_POPUP_MAX_ROWS) as u16) + 3).min(root.height);
     let w = root.width.min(56);
     Rect {
         x: composer.x,
@@ -559,17 +566,41 @@ pub(crate) fn slash_popup_area(root: Rect, composer: Rect, matches: usize) -> Re
     }
 }
 
+/// The first visible row of a scrolling list of `len` rows that shows
+/// `visible` at a time, chosen so `selected` stays on screen — the window
+/// only moves once the selection would fall off an edge. Mirrors the
+/// composer's cursor-row windowing ([`render_composer`]) so the slash popup
+/// and the textarea scroll with identical feel.
+pub(crate) fn scroll_window_start(len: usize, selected: usize, visible: usize) -> usize {
+    if visible == 0 || len <= visible {
+        return 0;
+    }
+    let selected = selected.min(len - 1);
+    // Keep `selected` inside [first, first + visible); clamp so the last
+    // window never shows blank rows past the end.
+    (selected + 1).saturating_sub(visible).min(len - visible)
+}
+
 /// The floating slash-command menu: an accent-bordered popup with the
 /// selected row highlighted and a one-line key legend. Shared by the
 /// single-session REPL and the deck (both anchor it above their composer).
+///
+/// When more commands match than fit, the rows window around `selected` so
+/// arrow-key navigation always keeps the highlight visible, and the legend
+/// shows how many rows are hidden above (`▲`) / below (`▼`).
 pub(crate) fn render_slash_popup(menu: &SlashMenu, selected: usize, area: Rect, buf: &mut Buffer) {
     ratatui::widgets::Clear.render(area, buf);
-    let mut lines: Vec<Line<'static>> = menu
-        .matches
+    let total = menu.matches.len();
+    let selected = selected.min(total.saturating_sub(1));
+    // The interior minus the legend line is what the command rows scroll in.
+    let visible = inner_height(area).saturating_sub(1).max(1);
+    let first = scroll_window_start(total, selected, visible);
+    let last = (first + visible).min(total);
+    let mut lines: Vec<Line<'static>> = menu.matches[first..last]
         .iter()
         .enumerate()
-        .map(|(i, c)| {
-            let is_sel = i == selected;
+        .map(|(offset, c)| {
+            let is_sel = first + offset == selected;
             let marker = if is_sel { "▸ " } else { "  " };
             let mut name_style = theme::accent();
             let mut desc_style = theme::muted();
@@ -586,14 +617,19 @@ pub(crate) fn render_slash_popup(menu: &SlashMenu, selected: usize, area: Rect, 
             ])
         })
         .collect();
-    lines.push(Line::from(Span::styled(
-        " ↑/↓ choose · tab complete · enter run · esc dismiss",
-        theme::muted(),
-    )));
+    let hidden_above = first;
+    let hidden_below = total.saturating_sub(last);
+    let legend = if hidden_above > 0 || hidden_below > 0 {
+        // Compact when scrolling so the ▲/▼ affordance still fits the width.
+        format!(" ↑↓ choose · tab fill · ⏎ run · esc · ▲{hidden_above} ▼{hidden_below}")
+    } else {
+        " ↑/↓ choose · tab complete · enter run · esc dismiss".to_string()
+    };
+    lines.push(Line::from(Span::styled(legend, theme::muted())));
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(theme::accent())
-        .title(format!(" / commands · {} ", menu.matches.len()));
+        .title(format!(" / commands · {total} "));
     Paragraph::new(Text::from(lines))
         .block(block)
         .render(area, buf);
@@ -1693,6 +1729,93 @@ mod tests {
         assert!(
             text.contains("⚡  /fix-bug"),
             "custom commands carry the lightning glyph:\n{text}"
+        );
+    }
+
+    // ---- Slash-popup windowing ---------------------------------------------
+
+    #[test]
+    fn scroll_window_start_holds_still_until_the_selection_leaves_the_edge() {
+        // Fits entirely: never scrolls.
+        assert_eq!(scroll_window_start(5, 4, 8), 0);
+        // Selection inside the first window: no movement.
+        assert_eq!(scroll_window_start(20, 0, 8), 0);
+        assert_eq!(scroll_window_start(20, 7, 8), 0);
+        // One past the window's last row: scroll down by one.
+        assert_eq!(scroll_window_start(20, 8, 8), 1);
+        // The tail clamps so the final window is full, never blank-padded.
+        assert_eq!(scroll_window_start(20, 19, 8), 12);
+        // Selecting back at the top pulls the window all the way up.
+        assert_eq!(scroll_window_start(20, 0, 8), 0);
+        // A stale selection past the end (e.g. the filter just shrank the
+        // match list) clamps to the last full window instead of panicking.
+        assert_eq!(scroll_window_start(20, 999, 8), 12);
+        // Degenerate inputs don't panic.
+        assert_eq!(scroll_window_start(0, 0, 8), 0);
+        assert_eq!(scroll_window_start(5, 0, 0), 0);
+    }
+
+    /// Rendering a slash popup taller than its window keeps the *selected*
+    /// row on screen and pushes the ones scrolled past off it — the concrete
+    /// symptom of the un-windowed version (selection navigable but invisible).
+    #[test]
+    fn slash_popup_windows_the_selection_into_view() {
+        let cmds: Vec<SlashCommand> = (0..15)
+            .map(|i| SlashCommand::new(format!("/cmd{i:02}"), "desc"))
+            .collect();
+        let menu = SlashMenu::filter(&cmds, "/");
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 56,
+            height: (SLASH_POPUP_MAX_ROWS as u16) + 3,
+        };
+        // Select the very last command: without windowing it renders off the
+        // bottom of the popup box and never appears in the buffer.
+        let mut buf = Buffer::empty(area);
+        render_slash_popup(&menu, 14, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("/cmd14"), "selected row is visible:\n{text}");
+        assert!(
+            !text.contains("/cmd00"),
+            "the top rows scrolled out of view:\n{text}"
+        );
+        // The legend advertises the hidden rows above.
+        assert!(text.contains('▲'), "scroll affordance shown:\n{text}");
+
+        // Selecting the top shows the head and hides the tail instead.
+        let mut buf = Buffer::empty(area);
+        render_slash_popup(&menu, 0, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("/cmd00"), "top row visible:\n{text}");
+        assert!(!text.contains("/cmd14"), "tail hidden:\n{text}");
+        assert!(text.contains('▼'), "hidden-below affordance shown:\n{text}");
+    }
+
+    /// A stale-high selection (the match list shrank under the cursor before
+    /// the upstream clamp caught up) must still render a sane, in-bounds
+    /// window rather than panic on the slice.
+    #[test]
+    fn slash_popup_survives_a_selection_past_the_filtered_end() {
+        let cmds: Vec<SlashCommand> = (0..3)
+            .map(|i| SlashCommand::new(format!("/cmd{i:02}"), "desc"))
+            .collect();
+        let menu = SlashMenu::filter(&cmds, "/");
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 56,
+            height: (SLASH_POPUP_MAX_ROWS as u16) + 3,
+        };
+        let mut buf = Buffer::empty(area);
+        // selected far past the 3 matches — the render-side clamp keeps it in
+        // view; all three rows fit so nothing scrolls.
+        render_slash_popup(&menu, 99, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("/cmd02"), "last row still shown:\n{text}");
+        assert!(
+            !text.contains('▲') && !text.contains('▼'),
+            "short list shows no scroll affordance:\n{text}"
         );
     }
 


### PR DESCRIPTION
## Problem

Typing `/` opens the slash-command popup and ↑/↓ already move the selection through the matches — but the popup rendered **every** match into a fixed-height box, so once the highlight moved past the visible window (~row 8) it was navigable but invisible. No way to tell which command was selected.

## Fix

Make the popup a proper keep-selection-in-view scrolling viewport:

- New pure `scroll_window_start(len, selected, visible)` helper computes the first visible row so the window only moves once the selection would fall off an edge, clamped at the tail so the final page is never blank-padded. It mirrors the composer's existing inlined cursor-row windowing, so the popup and the textarea scroll with identical feel.
- `render_slash_popup` now windows `matches[first..last]` around the selection and reserves one interior row for the legend.
- The key legend gains a compact `▲N ▼N` hidden-rows affordance when the list overflows. This TUI has **no** `Scrollbar` widget — sibling scrollable lists (transcript, graph node list) use pure viewport math with text/positional affordances — so a text indicator matches the established idiom rather than introducing a new widget.

Both callers benefit automatically: the single-session REPL and the deck share `render_slash_popup` / `slash_popup_area`.

This ports the windowing idea from prior-art branch `feat/skills-cmd` (commit 6623b61), reusing its `scroll_window_start` math and `▲/▼` affordance — the only adaptation was the current `SlashMenu.matches: Vec<&SlashCommand>` slice shape. The `/skills` manager half of that commit is intentionally left out.

## Tests

Added unit tests pinning the windowing math:
- `scroll_window_start_holds_still_until_the_selection_leaves_the_edge` — fits-entirely, no-move-inside-window, scroll-down-past-edge, tail clamping, scroll back to top, **stale-high selection clamps** (filter-shrink), and degenerate zero inputs.
- `slash_popup_windows_the_selection_into_view` — selecting the last of 15 commands keeps it on screen, hides the head, shows `▲`; selecting the top hides the tail, shows `▼`.
- `slash_popup_survives_a_selection_past_the_filtered_end` — render-side clamp keeps a stale-high selection in view without panicking the slice; short lists show no affordance.

## Verification (local — Actions is billing-locked)

- `cargo build -p stella-tui` — clean
- `cargo test -p stella-tui` — 307 passed (3 new), 0 failed
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean

Diff is surgical: one file (`stella-tui/src/render.rs`), windowing only, no refactors. Known pre-existing rustfmt dirt left untouched.
