### PR TITLE
feat(tui): cache-hit + pipeline stat boxes

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -282,6 +282,9 @@ pub async fn run_deck_session(
         slash_commands: deck_slash_commands(&custom),
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         no_anim,
+        // The deck drives turns through the raw `Engine::run_turn` path (see
+        // `run_lead_turn`), not the staged pipeline, so PIPELINE reads OFF here.
+        pipeline: false,
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -93,6 +93,11 @@ pub struct AgentEntry {
     pub status: AgentStatus,
     pub tokens_in: u64,
     pub tokens_out: u64,
+    /// Cumulative prompt-cache *read* (hit) tokens — the `cached_input_tokens`
+    /// sum from `StepUsage`. A subset of `tokens_in` by the `CompletionUsage`
+    /// contract (`cached_input_tokens ⊆ input_tokens`), so the session
+    /// cache-hit rate `cache_read_tokens / tokens_in` is always in `[0, 1]`.
+    pub cache_read_tokens: u64,
     /// Live spend. Authoritative once a `BudgetTick` has been seen (its
     /// `spent_usd` already covers step costs — mirrors the HUD accounting in
     /// `SessionModel`); until then, `StepUsage.cost_usd` accumulates here as
@@ -118,6 +123,7 @@ impl AgentEntry {
             status: AgentStatus::Queued,
             tokens_in: 0,
             tokens_out: 0,
+            cache_read_tokens: 0,
             cost_usd: 0.0,
             budget_ticked: false,
             last_activity_ms: started,
@@ -158,6 +164,12 @@ pub struct WorkspaceModel {
     /// field (sampled by [`crate::resource::ResourceMonitor`], not folded from
     /// events). Drives the status-bar gauge and dispatch backpressure.
     pub global_cpu_pct: f32,
+    /// Whether the session drives turns through the staged pipeline (triage →
+    /// plan → execute → verify → judge) rather than the raw engine loop.
+    /// Surfaced as the `PIPELINE` stat box. The deck runs the raw
+    /// `Engine::run_turn` path today, so this reads `false` there; it is the
+    /// seam to flip if the deck ever runs the staged pipeline.
+    pub pipeline: bool,
 }
 
 impl WorkspaceModel {
@@ -183,6 +195,19 @@ impl WorkspaceModel {
     /// The most-recently-routed model, if any route has been observed.
     pub fn latest_model(&self) -> Option<&str> {
         self.routes.entries.back().map(|e| e.model.as_str())
+    }
+
+    /// Cumulative prompt-cache hit tokens across all agents — the numerator of
+    /// the session cache-hit rate (a subset of [`Self::total_input_tokens`]).
+    pub fn cache_hit_tokens(&self) -> u64 {
+        self.agents.iter().map(|a| a.cache_read_tokens).sum()
+    }
+
+    /// Cumulative input tokens across all agents — the denominator of the
+    /// session cache-hit rate. `cache_hit_tokens ⊆ total_input_tokens` by the
+    /// `CompletionUsage` contract, so the ratio never exceeds 1.
+    pub fn total_input_tokens(&self) -> u64 {
+        self.agents.iter().map(|a| a.tokens_in).sum()
     }
 
     /// The **sole** mutator: fold one inbound envelope into the deck.
@@ -302,12 +327,14 @@ impl WorkspaceModel {
                 AgentEvent::StepUsage {
                     input_tokens,
                     output_tokens,
+                    cached_input_tokens,
                     model,
                     cost_usd,
                     ..
                 } => {
                     entry.tokens_in += input_tokens;
                     entry.tokens_out += output_tokens;
+                    entry.cache_read_tokens += cached_input_tokens;
                     entry.meta.model = Some(model.clone());
                     // Fallback accounting: a stream that never emits
                     // `BudgetTick` (scenario feeds, minimal drivers) still

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -412,6 +412,40 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
         theme::EMBER_FLAME
     };
 
+    // CACHE: the session prompt-cache hit rate — cumulative cache-read (hit)
+    // tokens over cumulative input tokens (a subset of it by the
+    // `CompletionUsage` contract, so the ratio is always in `[0, 1]`; clamped
+    // regardless), with the raw counts in parens. `—` before any usage has
+    // been metered.
+    let cache_hit = model.cache_hit_tokens();
+    let cache_total = model.total_input_tokens();
+    let cache_spans: Vec<Span<'static>> = if cache_total == 0 {
+        vec![Span::styled("—", val)]
+    } else {
+        let pct = ((cache_hit as f64 / cache_total as f64) * 100.0)
+            .round()
+            .clamp(0.0, 100.0);
+        vec![
+            Span::styled(format!("{pct:.0}%"), val),
+            Span::styled(
+                format!(
+                    " ({}/{} tokens)",
+                    fmt_tokens(cache_hit),
+                    fmt_tokens(cache_total)
+                ),
+                dim,
+            ),
+        ]
+    };
+
+    // PIPELINE: ON when the session drives the staged pipeline, OFF for the
+    // raw engine loop (`model.pipeline`).
+    let (pipeline_txt, pipeline_style) = if model.pipeline {
+        ("ON", Style::default().fg(theme::SUCCESS_BRIGHT))
+    } else {
+        ("OFF", dim)
+    };
+
     // (label, value, priority) in SVG order. Higher priority survives a narrow
     // row longer; STAGE and CONTEXT are must-keep (`MUST_KEEP`) because the
     // stage and the token meter are the load-bearing cells (§5).
@@ -465,10 +499,16 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
             )],
             6,
         ),
+        ("CACHE", cache_spans, 4),
         (
             "AGENTS",
             vec![Span::styled(format!("{} active", model.active_count()), val)],
             4,
+        ),
+        (
+            "PIPELINE",
+            vec![Span::styled(pipeline_txt, pipeline_style)],
+            3,
         ),
     ];
 
@@ -585,6 +625,20 @@ fn fmt_k(n: u64) -> String {
         format!("{}k", n / 1000)
     } else if n >= 1_000 {
         format!("{:.1}k", n as f64 / 1000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Format a token count with uppercase scale suffixes and one decimal:
+/// `105.3M`, `211.4K`, `950` — the CACHE-cell convention. `fmt_k` (the context
+/// meter) caps at `k`; cumulative cache counts reach the millions, so this
+/// carries an `M` tier, matching the requested `67% (105.3M/211.4M tokens)`.
+fn fmt_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
     } else {
         n.to_string()
     }
@@ -720,7 +774,9 @@ mod tests {
             ui.composer.insert_char(c);
         }
 
-        for (w, h) in [(80u16, 24u16), (120, 40)] {
+        // 160 (was 120) so the now-wider statline (with the CACHE + PIPELINE
+        // cells) still has room for the ethos chip, which is dropped first.
+        for (w, h) in [(80u16, 24u16), (160, 40)] {
             let mut term = Terminal::new(TestBackend::new(w, h)).unwrap();
             term.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
             let text = buffer_text(term.backend().buffer());
@@ -862,10 +918,11 @@ mod tests {
 
     #[test]
     fn statline_shows_labeled_cells_and_the_ethos_chip() {
-        // A wide terminal fits every cell plus the (chrome) ethos chip.
+        // A wide terminal fits every cell plus the (chrome) ethos chip. 160
+        // (was 120) leaves room for the CACHE + PIPELINE cells added to the row.
         let model = running_model_with_queue();
         let ui = DeckUi::default();
-        let area = Rect::new(0, 0, 120, 2);
+        let area = Rect::new(0, 0, 160, 2);
         let mut buf = Buffer::empty(area);
         render_status_bar(&model, &ui, area, &mut buf);
         let text = buffer_text(&buf);
@@ -879,7 +936,9 @@ mod tests {
             "CPU",
             "CONTEXT",
             "SPEND",
+            "CACHE",
             "AGENTS",
+            "PIPELINE",
             "deterministic-first",
         ] {
             assert!(text.contains(needle), "statline missing {needle:?}:\n{text}");
@@ -900,6 +959,147 @@ mod tests {
         assert!(text.contains("stella"), "brand kept:\n{text}");
         assert!(text.contains("STAGE"), "stage kept:\n{text}");
         assert!(text.contains("CONTEXT"), "context meter kept:\n{text}");
+    }
+
+    /// One committed model call, carrying `input`/`cached` usage — the fold
+    /// that feeds the CACHE cell.
+    fn step_usage(input: u64, cached: u64) -> AgentEvent {
+        AgentEvent::StepUsage {
+            step: 1,
+            model: "glm".into(),
+            input_tokens: input,
+            output_tokens: 0,
+            cached_input_tokens: cached,
+            cache_write_tokens: 0,
+            estimated_input_tokens: 0,
+            cost_usd: 0.0,
+            duration_ms: 1,
+            retries: 0,
+            tool_calls: 0,
+        }
+    }
+
+    /// The running model plus one metered step with the given cache usage.
+    fn model_with_cache(input: u64, cached: u64) -> WorkspaceModel {
+        let mut m = running_model_with_queue();
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: step_usage(input, cached),
+        });
+        m
+    }
+
+    #[test]
+    fn statline_cache_box_shows_hit_rate_and_compact_token_counts() {
+        // 105.3M cache-read over 211.4M input → 50% (rounded), compact `M`s.
+        let model = model_with_cache(211_400_000, 105_300_000);
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 2);
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&model, &ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("CACHE"), "cache label present:\n{text}");
+        assert!(
+            text.contains("50% (105.3M/211.4M tokens)"),
+            "cache hit rate + compact counts:\n{text}"
+        );
+    }
+
+    #[test]
+    fn statline_cache_box_sits_after_spend_and_before_agents() {
+        let model = model_with_cache(1_000, 500);
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 2);
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&model, &ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        let pos = |needle: &str| {
+            text.find(needle)
+                .unwrap_or_else(|| panic!("missing {needle:?}:\n{text}"))
+        };
+        assert!(pos("SPEND") < pos("CACHE"), "CACHE after SPEND:\n{text}");
+        assert!(pos("CACHE") < pos("AGENTS"), "CACHE before AGENTS:\n{text}");
+        assert!(
+            pos("AGENTS") < pos("PIPELINE"),
+            "PIPELINE after AGENTS:\n{text}"
+        );
+    }
+
+    #[test]
+    fn statline_cache_box_renders_zero_and_full_hit_rates() {
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 2);
+
+        // 0%: input metered, nothing served from cache.
+        let cold = model_with_cache(1_000, 0);
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&cold, &ui, area, &mut buf);
+        assert!(
+            buffer_text(&buf).contains("0% (0/1.0K tokens)"),
+            "cold cache reads 0%:\n{}",
+            buffer_text(&buf)
+        );
+
+        // 100%: every input token was a cache hit.
+        let warm = model_with_cache(1_000, 1_000);
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&warm, &ui, area, &mut buf);
+        assert!(
+            buffer_text(&buf).contains("100% (1.0K/1.0K tokens)"),
+            "fully warm cache reads 100%:\n{}",
+            buffer_text(&buf)
+        );
+    }
+
+    #[test]
+    fn statline_cache_box_is_a_dash_before_any_usage() {
+        // No StepUsage metered yet → the CACHE cell shows the no-data dash and
+        // never divides by zero (the render below must not panic).
+        let model = running_model_with_queue();
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 2);
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&model, &ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("CACHE"), "cache label still present:\n{text}");
+        assert!(
+            !text.contains("tokens"),
+            "no token counts before any usage:\n{text}"
+        );
+    }
+
+    #[test]
+    fn statline_pipeline_box_reads_on_or_off_with_the_mode() {
+        let ui = DeckUi::default();
+        let area = Rect::new(0, 0, 200, 2);
+
+        let mut off = running_model_with_queue();
+        off.pipeline = false;
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&off, &ui, area, &mut buf);
+        let off_text = buffer_text(&buf);
+        assert!(off_text.contains("PIPELINE"), "pipeline label:\n{off_text}");
+        assert!(
+            off_text.contains("OFF"),
+            "raw engine loop reads OFF:\n{off_text}"
+        );
+
+        let mut on = running_model_with_queue();
+        on.pipeline = true;
+        let mut buf = Buffer::empty(area);
+        render_status_bar(&on, &ui, area, &mut buf);
+        let on_text = buffer_text(&buf);
+        assert!(
+            !on_text.contains("OFF"),
+            "staged pipeline is not OFF:\n{on_text}"
+        );
+        // The CONTEXT *label* also contains "ON", so scope the positive check
+        // to the value row (the second rendered line).
+        let values = on_text.lines().nth(1).expect("value row");
+        assert!(
+            values.contains("ON"),
+            "staged pipeline reads ON:\n{on_text}"
+        );
     }
 
     #[test]

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -67,6 +67,10 @@ pub struct DeckOptions {
     /// `--no-anim` flag, for CI and asciinema-style recordings that want a
     /// static frame. Also forced on by `STELLA_NO_ANIM` or `NO_COLOR`.
     pub no_anim: bool,
+    /// Whether this session runs turns through the staged pipeline (triage →
+    /// plan → execute → verify → judge). Seeded into
+    /// [`WorkspaceModel::pipeline`] and surfaced as the `PIPELINE` stat box.
+    pub pipeline: bool,
 }
 
 fn now_ms() -> u64 {
@@ -284,6 +288,7 @@ pub async fn run_deck(
 
     let mut model = WorkspaceModel::new();
     model.now_ms = now_ms();
+    model.pipeline = opts.pipeline;
     let mut ui = DeckUi::new(Composer::with_paste_threshold(
         crate::composer::DECK_PASTE_LINE_THRESHOLD,
     ));


### PR DESCRIPTION
## What

Adds two cells to the deck's stat-box row (AGENT / STAGE / MODEL / CPU / CONTEXT / SPEND / …):

- **CACHE** — the session prompt-cache hit rate: cumulative cache-read (hit) tokens over cumulative input tokens, with the raw counts in compact M/K form, e.g. `67% (105.3M/211.4M tokens)`. **Positioned immediately after SPEND and before AGENTS**, per spec. Reads `—` before any usage is metered (no divide-by-zero).
- **PIPELINE** — `ON`/`OFF` for whether the session drives turns through the staged pipeline.

## Where the cache numbers come from

Extends the existing usage plumbing rather than a parallel channel:

- `AgentEvent::StepUsage.cached_input_tokens` (cache reads) is a documented **subset of `input_tokens`** (`CompletionUsage` contract), so `reads / input ∈ [0, 1]` (also `clamp`ed for safety).
- `AgentEntry` gains `cache_read_tokens`, folded from `StepUsage` right next to the existing `tokens_in`/`tokens_out` accumulation.
- `WorkspaceModel::cache_hit_tokens` / `total_input_tokens` sum those workspace-wide, mirroring `total_cost`. Denominator is `input_tokens` (not `+ cache_write_tokens`) — plain "hit tokens over total tokens".

## Rendered format / labels

- `CACHE` label; value = bright `{pct}%` + dim ` ({hit}/{total} tokens)` using a local uppercase-`M/K` formatter (`fmt_tokens`) matching the requested example.
- `PIPELINE` label; value `ON` (green) / `OFF` (dim).

## Judgment call: PIPELINE reads OFF in the deck

The staged `stella_pipeline::Pipeline` is used by the one-shot `Run` path (default on, `--no-pipeline` off). The **deck** (`run_lead_turn`) drives turns through the raw `Engine::run_turn` path — which *is* the `--no-pipeline` path per `main.rs`'s own comment — so PIPELINE honestly reads **OFF** in the deck today. The flag is wired end-to-end (`DeckOptions.pipeline` → `WorkspaceModel.pipeline`, set explicitly at the `run_deck_session` call site) as the seam to flip if the deck ever runs the staged pipeline. No pipeline execution was added to the deck (out of scope).

## Tests

New `deck_render` tests: hit-rate + compact M formatting (`50% (105.3M/211.4M tokens)`), 0%/100% edges, empty-session `—`, box ordering (`SPEND < CACHE < AGENTS < PIPELINE`), and PIPELINE ON/OFF. The two ethos-chip tests widen 120→160 columns to fit the now-wider row (ethos is dropped first on a narrow statline).

## Verification (local; org Actions are billing-locked)

- `cargo build -p stella-tui -p stella-cli` — ok
- `cargo test -p stella-tui` (309 passed) · `cargo test -p stella-cli` (99 passed)
- `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` — clean (exit 0)
- rustfmt: only my added lines were formatted; the known pre-existing dirt in `deck_render.rs` was left untouched (verified the file's rustfmt hunk set is unchanged from `origin/main`).
