### PR TITLE
feat(tui): per-turn wall clock in the header

### DIFF
--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -107,6 +107,15 @@ pub struct AgentEntry {
     pub res: ResourceSample,
     /// Recent activity intensity, one sample per event, for the sparkline.
     pub activity: ActivitySpark,
+    /// Wall-clock ms at which the in-flight chat turn started — set the instant
+    /// the prompt is dispatched (`Inbound::PromptStarted`) and cleared when the
+    /// turn ends. `Some` means a turn is live and the header clock counts up
+    /// from here; `None` means it holds `last_turn_ms` (see [`Self::turn_clock_ms`]).
+    pub turn_started_ms: Option<u64>,
+    /// Duration in ms of the most recently completed turn, held until the next
+    /// turn begins. `None` before any turn has finished, so the header clock
+    /// reads zero at rest.
+    pub last_turn_ms: Option<u64>,
 }
 
 impl AgentEntry {
@@ -123,12 +132,35 @@ impl AgentEntry {
             last_activity_ms: started,
             res: ResourceSample::default(),
             activity: ActivitySpark::new(ACTIVITY_WINDOW),
+            turn_started_ms: None,
+            last_turn_ms: None,
         }
     }
 
     /// Elapsed wall-clock ms given the deck's current clock.
     pub fn elapsed_ms(&self, now_ms: u64) -> u64 {
         now_ms.saturating_sub(self.meta.started_ms)
+    }
+
+    /// The value the header turn-clock displays, in ms: the live elapsed time
+    /// while a turn is in flight, otherwise the last completed turn's duration
+    /// (zero before any turn has run). Always defined — the clock is visible at
+    /// all times, even at rest.
+    pub fn turn_clock_ms(&self, now_ms: u64) -> u64 {
+        match self.turn_started_ms {
+            Some(start) => now_ms.saturating_sub(start),
+            None => self.last_turn_ms.unwrap_or(0),
+        }
+    }
+
+    /// Freeze the turn clock at `now_ms` if a turn is in flight — the turn's
+    /// elapsed becomes the held `last_turn_ms` and the live clock stops. A
+    /// no-op when no turn is running, so double-fires (e.g. a cancel that emits
+    /// its own terminal event after the engine already completed) are harmless.
+    fn end_turn(&mut self, now_ms: u64) {
+        if let Some(start) = self.turn_started_ms.take() {
+            self.last_turn_ms = Some(now_ms.saturating_sub(start));
+        }
     }
 
     /// Spend per hour, or `0.0` before any wall-clock has elapsed.
@@ -237,6 +269,12 @@ impl WorkspaceModel {
                 // the Crush-style layout where user messages are visible.
                 if let Some(idx) = self.index_of(agent) {
                     self.agents[idx].model.push_user_prompt(text);
+                    // A new chat turn begins the instant the prompt is
+                    // dispatched: start the header clock here and drop the
+                    // prior turn's held time so the readout switches straight
+                    // to the live count.
+                    self.agents[idx].turn_started_ms = Some(ts);
+                    self.agents[idx].last_turn_ms = None;
                 }
             }
             Inbound::PromptRequeued { agent, text } => {
@@ -325,7 +363,18 @@ impl WorkspaceModel {
                 AgentEvent::Complete { model, cost_usd } => {
                     entry.meta.model = Some(model.clone());
                     entry.cost_usd = entry.cost_usd.max(*cost_usd);
+                    // The turn-completion event: freeze the header clock at its
+                    // final elapsed so it holds the last turn's duration.
+                    entry.end_turn(now);
                 }
+                // A non-retryable error also ends the turn — an aborted turn,
+                // a user Stop, or a double-Esc hold all fold to one of these
+                // (see `command_deck`). Retryable errors mean the turn
+                // continues (they fold to `Running`), so the clock keeps
+                // ticking; only the terminal kind stops it.
+                AgentEvent::Error {
+                    retryable: false, ..
+                } => entry.end_turn(now),
                 _ => {}
             }
         }
@@ -737,6 +786,98 @@ mod tests {
             agent: agent.into(),
             event,
         }
+    }
+    fn prompt_started(agent: &str, text: &str) -> Inbound {
+        Inbound::PromptStarted {
+            agent: agent.into(),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn turn_clock_holds_zero_then_runs_freezes_and_resets() {
+        let mut w = WorkspaceModel::new();
+        w.now_ms = 1_000;
+        w.apply_inbound(&reg("lead"));
+
+        // Idle, pre-turn: the clock reads zero and is always defined.
+        assert_eq!(w.agents[0].turn_clock_ms(w.now_ms), 0);
+        assert_eq!(w.agents[0].turn_started_ms, None);
+
+        // A prompt is dispatched — the clock starts from now_ms and runs live.
+        w.now_ms = 5_000;
+        w.apply_inbound(&prompt_started("lead", "do the thing"));
+        assert_eq!(w.agents[0].turn_started_ms, Some(5_000));
+        w.now_ms = 8_000;
+        assert_eq!(
+            w.agents[0].turn_clock_ms(w.now_ms),
+            3_000,
+            "3s elapsed, live"
+        );
+
+        // The turn completes — the clock freezes at its final elapsed and holds
+        // it as later deck-clock frames advance.
+        w.now_ms = 9_500;
+        w.apply_inbound(&ev(
+            "lead",
+            AgentEvent::Complete {
+                model: "m".into(),
+                cost_usd: 0.0,
+            },
+        ));
+        assert_eq!(w.agents[0].turn_started_ms, None);
+        assert_eq!(w.agents[0].last_turn_ms, Some(4_500)); // 9.5s − 5.0s
+        w.now_ms = 60_000;
+        assert_eq!(
+            w.agents[0].turn_clock_ms(w.now_ms),
+            4_500,
+            "the completed turn's time is held, not still counting up"
+        );
+
+        // The next prompt resets: the prior turn's held time is dropped and the
+        // clock runs anew from zero.
+        w.apply_inbound(&prompt_started("lead", "again"));
+        assert_eq!(w.agents[0].turn_started_ms, Some(60_000));
+        assert_eq!(w.agents[0].last_turn_ms, None);
+        assert_eq!(w.agents[0].turn_clock_ms(w.now_ms), 0);
+    }
+
+    #[test]
+    fn a_cancelled_turn_freezes_the_clock_but_a_retryable_error_does_not() {
+        let mut w = WorkspaceModel::new();
+        w.now_ms = 0;
+        w.apply_inbound(&reg("lead"));
+        w.apply_inbound(&prompt_started("lead", "go"));
+
+        // A retryable error is mid-turn noise (it folds to `Running`) — the turn
+        // continues, so the clock keeps ticking.
+        w.now_ms = 2_000;
+        w.apply_inbound(&ev(
+            "lead",
+            AgentEvent::Error {
+                message: "transient".into(),
+                retryable: true,
+            },
+        ));
+        assert_eq!(
+            w.agents[0].turn_started_ms,
+            Some(0),
+            "a retryable error leaves the turn running"
+        );
+        assert_eq!(w.agents[0].turn_clock_ms(w.now_ms), 2_000);
+
+        // A non-retryable error (user Stop / abort / double-Esc all fold to
+        // this) ends the turn exactly like `Complete`.
+        w.now_ms = 3_000;
+        w.apply_inbound(&ev(
+            "lead",
+            AgentEvent::Error {
+                message: "turn stopped by user".into(),
+                retryable: false,
+            },
+        ));
+        assert_eq!(w.agents[0].turn_started_ms, None);
+        assert_eq!(w.agents[0].last_turn_ms, Some(3_000));
     }
 
     #[test]

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -155,7 +155,7 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
     ])
     .split(area);
 
-    render_header(agent, bands[0], buf);
+    render_header(agent, model.now_ms, bands[0], buf);
     render_hud(&sm.hud, bands[1], buf);
     if let Some(proposal) = &sm.pending_scope_review {
         render_scope_review(proposal, false, bands[2], buf);
@@ -223,8 +223,11 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
     );
 }
 
-/// The one-line identity header: `▶ lead · running   goal…`.
-fn render_header(agent: &AgentEntry, area: Rect, buf: &mut Buffer) {
+/// The one-line identity header: `▶ lead · running   0:00:00`. The trailing
+/// slot is the **per-turn wall clock** — live while a turn is in flight, else
+/// the last turn's held duration (zero before any turn), formatted `h:mm:ss`
+/// and always present.
+fn render_header(agent: &AgentEntry, now_ms: u64, area: Rect, buf: &mut Buffer) {
     let st = agent.status;
     let line = Line::from(vec![
         Span::styled(
@@ -238,9 +241,17 @@ fn render_header(agent: &AgentEntry, area: Rect, buf: &mut Buffer) {
             Style::new().fg(theme::status_color(st)),
         ),
         Span::raw("   "),
-        Span::styled(agent.meta.title.clone(), theme::muted()),
+        Span::styled(fmt_hms(agent.turn_clock_ms(now_ms)), theme::accent()),
     ]);
     Paragraph::new(line).render(area, buf);
+}
+
+/// Format a millisecond duration as `h:mm:ss` — hours un-padded, minutes and
+/// seconds zero-padded to two digits. Drives the per-turn header clock.
+fn fmt_hms(ms: u64) -> String {
+    let secs = ms / 1000;
+    let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
+    format!("{h}:{m:02}:{s:02}")
 }
 
 /// Shown when there are no agents at all.
@@ -399,5 +410,47 @@ mod tests {
             text.contains("first-message"),
             "selected entry still visible under streaming:\n{text}"
         );
+    }
+
+    #[test]
+    fn fmt_hms_formats_zero_sub_minute_and_over_an_hour() {
+        // Always h:mm:ss, hours un-padded, minutes/seconds zero-padded.
+        assert_eq!(fmt_hms(0), "0:00:00"); // the at-rest, pre-turn readout
+        assert_eq!(fmt_hms(45_000), "0:00:45"); // < 1 min
+        assert_eq!(fmt_hms(65_000), "0:01:05"); // rolls into minutes
+        assert_eq!(fmt_hms(3_600_000), "1:00:00"); // exactly one hour
+        assert_eq!(fmt_hms(3_661_000), "1:01:01"); // > 1 hr
+        assert_eq!(fmt_hms(45_296_000), "12:34:56"); // multi-hour, sub-ms floored
+    }
+
+    #[test]
+    fn header_shows_the_turn_clock_not_the_word_stella() {
+        // The workspace-name title used to sit to the right of `running`; in the
+        // stella repo that literally read "stella". It is now the turn clock —
+        // the header must show the h:mm:ss readout and no longer the word.
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "stella", 0)));
+        // A plain event flips the agent to `Running` (so the label reads
+        // "running") without starting a turn — the clock stays at zero.
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Text {
+                delta: "working".into(),
+            },
+        });
+        let area = Rect::new(0, 0, 80, 1);
+        let mut buf = Buffer::empty(area);
+        render_header(&model.agents[0], model.now_ms, area, &mut buf);
+
+        let text = buffer_text(&buf);
+        assert!(
+            !text.contains("stella"),
+            "the word `stella` is gone from the header:\n{text}"
+        );
+        assert!(
+            text.contains("0:00:00"),
+            "the turn clock reads zero before any turn:\n{text}"
+        );
+        assert!(text.contains("running"), "status label intact:\n{text}");
     }
 }


### PR DESCRIPTION
## What

Deletes the workspace-name title from the Session identity header — which reads **`stella`** when running in this repo, sitting just to the right of the orange `running` label — and replaces it with a **per-turn wall clock**. The header now reads `▶ lead · running   0:00:00`.

The clock:
- shows the **live** elapsed time while a turn is in flight,
- **holds** the last completed turn's duration between turns,
- reads `0:00:00` before any turn (always visible, even at zero),
- is formatted `h:mm:ss` (hours un-padded, minutes/seconds zero-padded).

## Anchor events (turn boundaries)

Timing is anchored to the exact event-stream boundaries, not to render ticks:

- **Start** → `Inbound::PromptStarted` (the instant the dispatcher hands a prompt to the agent; `command_deck.rs:406`). Sets `turn_started_ms` and clears the held time.
- **Stop** → `AgentEvent::Complete` (emitted by `Engine::run_turn` at `stella-core/src/driver.rs:612` on the happy path) **or** a non-retryable `AgentEvent::Error`. The non-retryable-error case covers an aborted turn, a user Stop, and a double-Esc hold — all fold to `AgentEvent::Error { retryable: false }` (`command_deck.rs:623-629`). Retryable errors fold to `Running`, so they leave the clock ticking (a mid-turn retry is not a turn end).

State lives on `AgentEntry` (`turn_started_ms` / `last_turn_ms`) — deck-scoped, so the shared `SessionModel` / classic single-session path is untouched.

## Redraw tick

No new scheduling was needed. The deck's run loop (`deck_shell.rs`) already `terminal.draw`s every iteration and has a ~30fps (`33ms`) `tokio::time::interval` heartbeat that sets `model.now_ms = now_ms` on each tick. Since the clock is derived from `now_ms`, it ticks visibly (far faster than the required 1s) with zero busy-rendering added.

## Tests

- `fmt_hms` formatting: `0` → `0:00:00`, `<1min`, exactly `1:00:00`, `>1hr`, multi-hour.
- State machine (`deck.rs`): idle-zero → running (live) → completed (held, not still counting) → next prompt resets; plus a test that a **non-retryable** error freezes while a **retryable** error keeps ticking.
- Header (`views/session.rs`): `render_header` output no longer contains the word `stella`, shows `0:00:00`, and keeps the `running` label.

## Verification

Local (Actions is billing-locked for the org, so red CI is expected):
- `cargo build -p stella-tui` / `-p stella-cli` — clean
- `cargo test -p stella-tui` — 308 unit + 2 integration pass, no snapshot regressions
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean
- Formatted only the two touched files via `rustfmt --edition 2024`.

## Known limitation

A **handled slash command** (`/help`, etc.) emits `PromptStarted` but ends with `Status::WaitingInput` and no `Complete`/`Error`, so the clock keeps climbing until the next real prompt resets it. This is not cleanly fixable at the fold layer — at the moment `WaitingInput` arrives it's indistinguishable from a mid-turn ask-user pause, where the clock *should* keep running — and it self-heals on the next prompt. Called out so a climbing clock after `/help` reads as intentional.

## Scope note

The HUD box one row below still has the border title `" stella "` (`render.rs:341`). That's a separate element, not "to the right of running," and it's shared with the classic single-session path (and likely a sibling's edit target), so it's deliberately left alone.
