### PR TITLE
fix(tools): reconcile registry tool-count pins after #127/#131 merge

### DIFF
--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -859,14 +859,14 @@ mod tests {
         ] {
             assert!(names.contains(&expected.to_string()), "missing {expected}");
         }
-        assert_eq!(names.len(), 21, "unexpected tool count: {names:?}");
+        assert_eq!(names.len(), 22, "unexpected tool count: {names:?}");
     }
 
     #[test]
     fn issue_tools_absent_without_a_configured_backend() {
         let reg = ToolRegistry::with_issue_backend(PathBuf::from("/tmp"), None);
         let names: Vec<String> = reg.schemas().iter().map(|s| s.name.clone()).collect();
-        assert_eq!(names.len(), 16, "unexpected tool count: {names:?}");
+        assert_eq!(names.len(), 17, "unexpected tool count: {names:?}");
         for absent in [
             "create_issue",
             "update_issue",


### PR DESCRIPTION
## Problem

Merging #127 and #131 broke `cargo test --workspace` on main: each PR added one always-registered tool (`generate_svg`, `cite_memory`) and each bumped the same tool-count literals in `stella-tools/src/registry.rs` from the same base, so the textual merge kept only one bump. The registry now serves 17/22 tools while the pins asserted 16/21.

## Fix

Bump the two pinned counts to match reality (both tools were already present in the expected-names list — only the literals were stale).

## Verification

Full `cargo test --workspace` on this branch: all suites green, 0 failures (stella-tools 176 passed; stella-tui 318 passed; the crates cargo never reached after main's failure all pass too). Red CI on this PR is the org Actions billing lock.
