### PR TITLE
feat(tui): Agents tab secondary nav — installed agents, versioned edit, create-from-prompt

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -2029,11 +2029,13 @@ fn spawn_renderer(
 /// Best-effort end-of-execution records: the session's file-touch telemetry
 /// (read straight off the registry's ledger), the memory citations the
 /// `cite_memory` tool collected this turn (drained, so each lands under
-/// exactly one execution — the promotion gate counts them), and how the run
-/// ended. A failure must not abort the turn, but it must not vanish either —
-/// the store is the durable audit record of what the agent did. Returns
-/// `false` when any write failed so the caller can surface a warning on its
-/// own channel (stderr for the CLI surfaces, a deck event for the TUI, where
+/// exactly one execution — the promotion gate counts them), the
+/// agent-invocation log (also drained — each invocation is attributed to
+/// exactly the execution it happened under), and how the run ended. A
+/// failure must not abort the turn, but it must not vanish either — the
+/// store is the durable audit record of what the agent did. Returns `false`
+/// when any write failed so the caller can surface a warning on its own
+/// channel (stderr for the CLI surfaces, a deck event for the TUI, where
 /// stderr belongs to the alternate screen).
 pub(crate) fn record_execution_end(
     store: &Store,
@@ -2048,10 +2050,20 @@ pub(crate) fn record_execution_end(
     let citations_ok = store
         .record_memory_citations(execution_id, &citations)
         .is_ok();
+    let uses: Vec<stella_store::AgentUseRow> = registry
+        .drain_agent_uses()
+        .into_iter()
+        .map(|u| stella_store::AgentUseRow {
+            agent: u.agent,
+            version: u.version,
+            reason: u.reason,
+        })
+        .collect();
+    let uses_ok = uses.is_empty() || store.record_agent_uses(execution_id, &uses).is_ok();
     let finish_ok = store
         .finish_execution(execution_id, outcome_label, cost_usd)
         .is_ok();
-    files_ok && citations_ok && finish_ok
+    files_ok && citations_ok && uses_ok && finish_ok
 }
 
 /// The registry's session file-touch telemetry as store rows: one per

--- a/stella-cli/src/agents_installed.rs
+++ b/stella-cli/src/agents_installed.rs
@@ -1,0 +1,795 @@
+//! Installed-agent management for the deck's INSTALLED AGENTS pane:
+//! discovery across both config scopes, filesystem-first **versioning with
+//! an explicit pin**, and the LLM-assisted create-from-prompt helpers.
+//!
+//! ## Where agents live
+//!
+//! Same directories the loaders (`crate::extensions`) read:
+//!
+//! - **project**: `<workspace>/.stella/agents/`
+//! - **user**: `~/.config/stella/agents/`
+//!
+//! A definition is either a flat `<slug>.md` or a nested `<slug>/AGENT.md`
+//! (markdown with `name:`/`description:`/`tools:` frontmatter, parsed by
+//! `stella_core::extensions::agent_from_file`).
+//!
+//! ## The versioning + pin scheme (filesystem-first, inspectable)
+//!
+//! ```text
+//! <agents-dir>/<slug>.md                  ← the LOADED definition: a
+//!                                            materialized copy of the
+//!                                            PINNED version (what every
+//!                                            loader — and every other
+//!                                            tool — reads, no code needed)
+//! <agents-dir>/.versions/<slug>/v0001.md  ← immutable version files,
+//!                                 v0002.md   oldest first
+//!                                 …
+//! <agents-dir>/.versions/<slug>/PINNED    ← one line: the pinned version
+//!                                            number (e.g. `2`)
+//! ```
+//!
+//! - An agent with **no** `.versions/<slug>/` directory is *implicitly
+//!   version 1* — the canonical file is its only version. Nothing is
+//!   created until the first edit, so hand-authored agents stay exactly as
+//!   their authors wrote them.
+//! - **Edit-save** ([`save_new_version`]): the current canonical content is
+//!   archived first (as `v0001` if the agent was never versioned), the new
+//!   content is written as `v<max+1>`, `PINNED` is set to it, and the
+//!   canonical file is rewritten. Saving **always creates a new version and
+//!   pins it**; no prior version file is ever modified or deleted.
+//! - **Pin-set** ([`pin_version`]): `PINNED` is set to an *existing*
+//!   version and the canonical file is rewritten from that version's file.
+//!   **No new version is created** — pin changes never increment anything.
+//! - The `.versions` directory is dot-prefixed, so every definition loader
+//!   (which skips hidden entries) ignores it by construction.
+//!
+//! Symlinked definitions (adopted from `.claude/`/`.agents/` by the init
+//! sync) are handled conservatively on the first save/pin: the link is
+//! replaced by a real flat `<slug>.md` in the agents dir — editing through
+//! the link would silently rewrite another tool's source file.
+
+use std::path::{Path, PathBuf};
+
+use stella_core::extensions::agent_from_file;
+use stella_protocol::CompletionMessage;
+use stella_tui::{AgentScope, AgentVersionInfo, InstalledAgentEntry};
+
+/// The project-scope agents directory.
+pub fn project_agents_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".stella").join("agents")
+}
+
+/// The user-scope agents directory (`~/.config/stella/agents`), or `None`
+/// without a home directory.
+pub fn user_agents_dir() -> Option<PathBuf> {
+    crate::extensions::user_config_root().map(|root| root.join("agents"))
+}
+
+/// The agents directory for one scope.
+pub fn agents_dir_for(scope: AgentScope, workspace_root: &Path) -> Result<PathBuf, String> {
+    match scope {
+        AgentScope::Project => Ok(project_agents_dir(workspace_root)),
+        AgentScope::User => {
+            user_agents_dir().ok_or_else(|| "no home directory for the user scope".to_string())
+        }
+    }
+}
+
+// ============================================================================
+// Discovery
+// ============================================================================
+
+/// One definition entry found in an agents dir: its slug (the versioning
+/// key) and the canonical file the loader reads.
+struct FoundDef {
+    slug: String,
+    canonical: PathBuf,
+}
+
+/// Enumerate the definition entries in `dir`: flat `<slug>.md` plus nested
+/// `<slug>/AGENT.md`, hidden entries skipped (which is exactly what keeps
+/// `.versions/` invisible to discovery). Sorted by slug for determinism.
+fn find_defs(dir: &Path) -> Vec<FoundDef> {
+    let mut defs = Vec::new();
+    for entry in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "md") {
+            let slug = name.strip_suffix(".md").unwrap_or(&name).to_string();
+            defs.push(FoundDef {
+                slug,
+                canonical: path,
+            });
+        } else if path.is_dir() && path.join("AGENT.md").symlink_metadata().is_ok() {
+            defs.push(FoundDef {
+                slug: name,
+                canonical: path.join("AGENT.md"),
+            });
+        }
+    }
+    defs.sort_by(|a, b| a.slug.cmp(&b.slug));
+    defs
+}
+
+/// Discover the installed agents in the two scope directories, project
+/// first then user, each row tagged with its scope. Both scopes are listed
+/// even on a name collision (they are separate installs; the load-time
+/// merge is the loaders' concern, not the manager's).
+pub fn discover(user_dir: Option<&Path>, project_dir: &Path) -> Vec<InstalledAgentEntry> {
+    let mut entries = Vec::new();
+    let mut scan = |dir: &Path, scope: AgentScope| {
+        for def in find_defs(dir) {
+            let Ok(raw) = std::fs::read_to_string(&def.canonical) else {
+                continue; // dangling symlink etc. — the loaders diagnose it
+            };
+            let Ok(parsed) = agent_from_file(&def.canonical.display().to_string(), &raw) else {
+                continue; // malformed — the loaders diagnose it
+            };
+            let versions = list_versions(dir, &def.slug, &def.canonical);
+            let version = active_version(dir, &def.slug);
+            entries.push(InstalledAgentEntry {
+                name: parsed.name,
+                description: parsed.description,
+                tools: parsed.tools,
+                scope,
+                source_path: def.canonical.display().to_string(),
+                version,
+                versions,
+                content: raw,
+            });
+        }
+    };
+    scan(project_dir, AgentScope::Project);
+    if let Some(user_dir) = user_dir {
+        scan(user_dir, AgentScope::User);
+    }
+    entries
+}
+
+/// The slug (versioning key) of the installed agent named `name` in `dir`,
+/// resolved through the same discovery the list pane shows.
+pub fn find_slug(dir: &Path, name: &str) -> Option<String> {
+    find_defs(dir).into_iter().find_map(|def| {
+        let raw = std::fs::read_to_string(&def.canonical).ok()?;
+        let parsed = agent_from_file(&def.canonical.display().to_string(), &raw).ok()?;
+        (parsed.name == name).then_some(def.slug)
+    })
+}
+
+// ============================================================================
+// Versions + pin
+// ============================================================================
+
+/// The `.versions/<slug>` directory for one agent.
+fn versions_dir(agents_dir: &Path, slug: &str) -> PathBuf {
+    agents_dir.join(".versions").join(slug)
+}
+
+/// The version numbers archived for `slug`, sorted ascending. Empty when
+/// the agent was never versioned.
+fn archived_versions(agents_dir: &Path, slug: &str) -> Vec<u32> {
+    let mut versions: Vec<u32> = std::fs::read_dir(versions_dir(agents_dir, slug))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            name.strip_prefix('v')?
+                .strip_suffix(".md")?
+                .parse::<u32>()
+                .ok()
+        })
+        .collect();
+    versions.sort_unstable();
+    versions
+}
+
+/// The version file path for `version` of `slug`.
+fn version_file(agents_dir: &Path, slug: &str, version: u32) -> PathBuf {
+    versions_dir(agents_dir, slug).join(format!("v{version:04}.md"))
+}
+
+/// The pinned (active) version of `slug`: the `PINNED` manifest when it
+/// names an archived version, the newest archive as a fallback, and the
+/// implicit `1` for a never-versioned agent.
+pub fn active_version(agents_dir: &Path, slug: &str) -> u32 {
+    let archived = archived_versions(agents_dir, slug);
+    if archived.is_empty() {
+        return 1;
+    }
+    let pinned = std::fs::read_to_string(versions_dir(agents_dir, slug).join("PINNED"))
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u32>().ok());
+    match pinned {
+        Some(v) if archived.contains(&v) => v,
+        // No / stale manifest: the newest archive is what the last save
+        // materialized.
+        _ => *archived.last().expect("non-empty"),
+    }
+}
+
+/// The pinned version of the definition at `source_path` (the invocation
+/// telemetry's version stamp). Resolves the agents dir + slug from the
+/// canonical path shape (`<dir>/<slug>.md` or `<dir>/<slug>/AGENT.md`).
+pub fn active_version_for_source(source_path: &str) -> u32 {
+    let path = Path::new(source_path);
+    let (dir, slug) = match (path.file_name().and_then(|n| n.to_str()), path.parent()) {
+        (Some("AGENT.md"), Some(agent_dir)) => match (
+            agent_dir.parent(),
+            agent_dir.file_name().and_then(|n| n.to_str()),
+        ) {
+            (Some(dir), Some(slug)) => (dir, slug.to_string()),
+            _ => return 1,
+        },
+        (Some(file), Some(dir)) => (dir, file.strip_suffix(".md").unwrap_or(file).to_string()),
+        _ => return 1,
+    };
+    active_version(dir, &slug)
+}
+
+/// Every version of `slug` as picker rows, oldest first — the archived
+/// files, or the implicit single version for a never-versioned agent
+/// (labeled from the canonical file's mtime).
+fn list_versions(agents_dir: &Path, slug: &str, canonical: &Path) -> Vec<AgentVersionInfo> {
+    let archived = archived_versions(agents_dir, slug);
+    if archived.is_empty() {
+        return vec![AgentVersionInfo {
+            version: 1,
+            label: mtime_label(canonical),
+        }];
+    }
+    archived
+        .into_iter()
+        .map(|version| AgentVersionInfo {
+            version,
+            label: mtime_label(&version_file(agents_dir, slug, version)),
+        })
+        .collect()
+}
+
+/// A short `YYYY-MM-DD HH:MM` label from a file's mtime, or empty when the
+/// filesystem has nothing to say.
+fn mtime_label(path: &Path) -> String {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return String::new();
+    };
+    let Ok(mtime) = meta.modified() else {
+        return String::new();
+    };
+    let Ok(unix) = mtime.duration_since(std::time::UNIX_EPOCH) else {
+        return String::new();
+    };
+    let rfc = stella_context::format_rfc3339(unix.as_secs() as i64);
+    // `2026-07-16T10:12:00Z` → `2026-07-16 10:12`
+    rfc.get(..16).unwrap_or(&rfc).replace('T', " ")
+}
+
+/// Where `slug`'s canonical definition currently lives, if anywhere:
+/// `(path, entry)` where `entry` is the directory entry to inspect for a
+/// symlink (the flat file itself, or the nested layout's directory).
+fn canonical_of(agents_dir: &Path, slug: &str) -> Option<(PathBuf, PathBuf)> {
+    let flat = agents_dir.join(format!("{slug}.md"));
+    if flat.symlink_metadata().is_ok() {
+        return Some((flat.clone(), flat));
+    }
+    let nested_dir = agents_dir.join(slug);
+    let nested = nested_dir.join("AGENT.md");
+    if nested.symlink_metadata().is_ok() {
+        return Some((nested, nested_dir));
+    }
+    None
+}
+
+/// Rewrite `slug`'s canonical definition to `content`. A symlinked entry
+/// (flat file or nested directory) is replaced by a real flat `<slug>.md` —
+/// never written through, so an adopted `.claude/` source is never silently
+/// rewritten. A real nested layout is written in place.
+fn materialize(agents_dir: &Path, slug: &str, content: &str) -> Result<(), String> {
+    let write =
+        |path: &Path| std::fs::write(path, content).map_err(|e| format!("{}: {e}", path.display()));
+    match canonical_of(agents_dir, slug) {
+        Some((path, entry)) => {
+            let is_symlink = entry
+                .symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false);
+            if is_symlink {
+                std::fs::remove_file(&entry).map_err(|e| format!("{}: {e}", entry.display()))?;
+                write(&agents_dir.join(format!("{slug}.md")))
+            } else {
+                write(&path)
+            }
+        }
+        None => {
+            std::fs::create_dir_all(agents_dir).map_err(|e| e.to_string())?;
+            write(&agents_dir.join(format!("{slug}.md")))
+        }
+    }
+}
+
+/// Save `content` as a NEW version of `slug` and pin it (the edit-save
+/// path). The prior canonical content is preserved: archived as `v0001` if
+/// the agent was never versioned. Returns the new version number.
+pub fn save_new_version(agents_dir: &Path, slug: &str, content: &str) -> Result<u32, String> {
+    let vdir = versions_dir(agents_dir, slug);
+    std::fs::create_dir_all(&vdir).map_err(|e| format!("{}: {e}", vdir.display()))?;
+
+    let mut archived = archived_versions(agents_dir, slug);
+    if archived.is_empty() {
+        // First edit of a hand-authored (never-versioned) agent: its current
+        // content becomes v1 so the edit destroys nothing.
+        if let Some((canonical, _)) = canonical_of(agents_dir, slug)
+            && let Ok(current) = std::fs::read_to_string(&canonical)
+        {
+            let v1 = version_file(agents_dir, slug, 1);
+            std::fs::write(&v1, current).map_err(|e| format!("{}: {e}", v1.display()))?;
+            archived.push(1);
+        }
+    }
+    let next = archived.last().copied().unwrap_or(0) + 1;
+    let vfile = version_file(agents_dir, slug, next);
+    std::fs::write(&vfile, content).map_err(|e| format!("{}: {e}", vfile.display()))?;
+    write_pin(agents_dir, slug, next)?;
+    materialize(agents_dir, slug, content)?;
+    Ok(next)
+}
+
+/// Re-pin `slug` to an EXISTING `version` (the pin-set path): the canonical
+/// file is rewritten from that version's archive and `PINNED` updated.
+/// Never creates a version — pinning is not an edit.
+pub fn pin_version(agents_dir: &Path, slug: &str, version: u32) -> Result<(), String> {
+    let archived = archived_versions(agents_dir, slug);
+    if archived.is_empty() {
+        // A never-versioned agent is implicitly v1 — re-pinning it to 1 is
+        // a no-op; anything else names a version that does not exist.
+        return if version == 1 {
+            Ok(())
+        } else {
+            Err(format!("{slug} has no version v{version}"))
+        };
+    }
+    if !archived.contains(&version) {
+        return Err(format!(
+            "{slug} has no version v{version} (available: {})",
+            archived
+                .iter()
+                .map(|v| format!("v{v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    let vfile = version_file(agents_dir, slug, version);
+    let content =
+        std::fs::read_to_string(&vfile).map_err(|e| format!("{}: {e}", vfile.display()))?;
+    write_pin(agents_dir, slug, version)?;
+    materialize(agents_dir, slug, &content)?;
+    Ok(())
+}
+
+fn write_pin(agents_dir: &Path, slug: &str, version: u32) -> Result<(), String> {
+    let pin = versions_dir(agents_dir, slug).join("PINNED");
+    std::fs::write(&pin, format!("{version}\n")).map_err(|e| format!("{}: {e}", pin.display()))
+}
+
+// ============================================================================
+// Create from prompt (LLM-assisted)
+// ============================================================================
+
+/// A parsed LLM-drafted agent definition, ready to install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedAgent {
+    /// The kebab-case slug the file is installed under.
+    pub slug: String,
+    /// The loaded definition name (frontmatter `name:`).
+    pub name: String,
+    /// The full file content (frontmatter + body).
+    pub content: String,
+}
+
+/// The one-shot completion messages that draft an agent definition from the
+/// user's short description — pure prompt assembly, unit-testable without a
+/// provider (the driver hands the result to `Provider::complete`, the same
+/// invocation path the reflection module uses).
+pub fn creation_messages(description: &str) -> Vec<CompletionMessage> {
+    let system = "You write agent definition files for the stella CLI. An agent definition \
+                  is a markdown file with YAML frontmatter and a body, in exactly this shape:\n\
+                  ---\n\
+                  name: kebab-case-name\n\
+                  description: one line, under 80 characters, saying what the agent does\n\
+                  tools: Comma, Separated, Tool, Names\n\
+                  ---\n\
+                  The agent's system prompt: persona, instructions, constraints.\n\n\
+                  Rules:\n\
+                  - `name` must be short, kebab-case, and specific.\n\
+                  - Include the `tools:` line ONLY when the agent should be restricted to a \
+                  subset of tools; omit it entirely to grant all tools.\n\
+                  - The body must be a complete, self-contained system prompt.\n\
+                  - Respond with ONLY the complete markdown file — no code fences, no \
+                  commentary before or after.";
+    vec![
+        CompletionMessage::system(system),
+        CompletionMessage::user(format!("Write an agent definition for: {description}")),
+    ]
+}
+
+/// Parse a model's drafted definition: code fences stripped if present, the
+/// result validated through the real loader parser (`agent_from_file`) so
+/// anything installed is guaranteed loadable.
+pub fn parse_generated_agent(text: &str) -> Result<GeneratedAgent, String> {
+    let content = strip_fences(text).trim().to_string();
+    if content.is_empty() {
+        return Err("the model returned an empty definition".to_string());
+    }
+    let parsed = agent_from_file("generated.md", &content).map_err(|diag| {
+        format!(
+            "the drafted definition is not loadable ({})",
+            match diag.problem {
+                stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
+                stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
+            }
+        )
+    })?;
+    let slug = slugify(&parsed.name);
+    if slug.is_empty() {
+        return Err(format!("`{}` yields no usable slug", parsed.name));
+    }
+    Ok(GeneratedAgent {
+        slug,
+        name: parsed.name,
+        content: format!("{content}\n"),
+    })
+}
+
+/// Install a freshly created agent as `<slug>.md` in `agents_dir`. Refuses
+/// to clobber an existing definition — creation never overwrites. No
+/// `.versions` bookkeeping yet: a new agent is implicitly v1 until its
+/// first edit (see the module docs).
+pub fn install_new_agent(agents_dir: &Path, agent: &GeneratedAgent) -> Result<PathBuf, String> {
+    if canonical_of(agents_dir, &agent.slug).is_some() {
+        return Err(format!(
+            "an agent named `{}` already exists — edit it instead",
+            agent.slug
+        ));
+    }
+    std::fs::create_dir_all(agents_dir).map_err(|e| e.to_string())?;
+    let path = agents_dir.join(format!("{}.md", agent.slug));
+    std::fs::write(&path, &agent.content).map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// `"Code Reviewer!"` → `"code-reviewer"`: lowercase, non-alphanumeric runs
+/// collapsed to single dashes, trimmed.
+pub fn slugify(name: &str) -> String {
+    let mut out = String::new();
+    let mut dash_pending = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            if dash_pending && !out.is_empty() {
+                out.push('-');
+            }
+            dash_pending = false;
+            out.push(c.to_ascii_lowercase());
+        } else {
+            dash_pending = true;
+        }
+    }
+    out
+}
+
+/// The fence-stripping half of [`parse_generated_agent`]: a response whose
+/// first non-empty line opens a code fence has the fence lines removed
+/// (info string tolerated); anything else passes through untouched.
+fn strip_fences(text: &str) -> String {
+    let trimmed = text.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed.to_string();
+    }
+    let mut lines: Vec<&str> = trimmed.lines().collect();
+    lines.remove(0); // the opening fence (``` or ```markdown)
+    if lines.last().is_some_and(|l| l.trim().starts_with("```")) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent_md(name: &str, tools: Option<&str>, body: &str) -> String {
+        let tools_line = tools.map(|t| format!("tools: {t}\n")).unwrap_or_default();
+        format!("---\nname: {name}\ndescription: about {name}\n{tools_line}---\n{body}\n")
+    }
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    // ---- discovery ----
+
+    #[test]
+    fn discover_lists_both_scopes_with_toolbelt_and_scope_tags() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("ws/.stella/agents");
+        let user = tmp.path().join("home/.config/stella/agents");
+        write(
+            &project.join("reviewer.md"),
+            &agent_md("reviewer", Some("Read, Grep"), "Review diffs."),
+        );
+        // Nested layout at the user scope, no tools restriction.
+        write(
+            &user.join("planner/AGENT.md"),
+            &agent_md("planner", None, "Plan the work."),
+        );
+
+        let entries = discover(Some(&user), &project);
+        assert_eq!(entries.len(), 2);
+        let reviewer = entries.iter().find(|e| e.name == "reviewer").unwrap();
+        assert_eq!(reviewer.scope, AgentScope::Project);
+        assert_eq!(
+            reviewer.tools,
+            Some(vec!["Read".to_string(), "Grep".to_string()])
+        );
+        assert_eq!(reviewer.version, 1, "never versioned = implicit v1");
+        assert_eq!(reviewer.versions.len(), 1);
+        assert!(reviewer.content.contains("Review diffs."));
+
+        let planner = entries.iter().find(|e| e.name == "planner").unwrap();
+        assert_eq!(planner.scope, AgentScope::User);
+        assert_eq!(planner.tools, None, "no tools key = all tools");
+        assert!(planner.source_path.ends_with("planner/AGENT.md"));
+    }
+
+    #[test]
+    fn discover_skips_hidden_entries_and_missing_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join(".stella/agents");
+        write(&project.join("real.md"), &agent_md("real", None, "Body."));
+        // The version store must never be listed as an agent.
+        write(
+            &project.join(".versions/real/v0001.md"),
+            &agent_md("real", None, "Old body."),
+        );
+        let entries = discover(None, &project);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "real");
+        // A nonexistent dir yields nothing rather than erroring.
+        assert!(discover(None, &tmp.path().join("nope")).is_empty());
+    }
+
+    // ---- versioning + pin ----
+
+    #[test]
+    fn save_creates_a_new_version_pins_it_and_preserves_the_old_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        let original = agent_md("reviewer", Some("Read"), "Old body.");
+        write(&dir.join("reviewer.md"), &original);
+
+        let edited = agent_md("reviewer", Some("Read, Grep"), "New body.");
+        let version = save_new_version(&dir, "reviewer", &edited).unwrap();
+        assert_eq!(version, 2, "the original was archived as v1");
+
+        // The new version is pinned/used: the canonical file carries it.
+        assert_eq!(active_version(&dir, "reviewer"), 2);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("reviewer.md")).unwrap(),
+            edited
+        );
+        // The prior version is preserved, byte for byte.
+        assert_eq!(
+            std::fs::read_to_string(dir.join(".versions/reviewer/v0001.md")).unwrap(),
+            original
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join(".versions/reviewer/v0002.md")).unwrap(),
+            edited
+        );
+        assert_eq!(archived_versions(&dir, "reviewer"), vec![1, 2]);
+    }
+
+    #[test]
+    fn pin_set_changes_the_active_version_without_creating_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        let v1 = agent_md("reviewer", None, "Version one.");
+        write(&dir.join("reviewer.md"), &v1);
+        let v2 = agent_md("reviewer", None, "Version two.");
+        save_new_version(&dir, "reviewer", &v2).unwrap();
+        assert_eq!(active_version(&dir, "reviewer"), 2);
+
+        // Pin back to v1 WITHOUT editing.
+        pin_version(&dir, "reviewer", 1).unwrap();
+        assert_eq!(active_version(&dir, "reviewer"), 1, "the pin moved");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("reviewer.md")).unwrap(),
+            v1,
+            "the canonical file is materialized from the pinned version"
+        );
+        assert_eq!(
+            archived_versions(&dir, "reviewer"),
+            vec![1, 2],
+            "a pin change never increments the version count"
+        );
+
+        // …and a later edit continues the sequence from the max, not the pin.
+        let v3 = agent_md("reviewer", None, "Version three.");
+        assert_eq!(save_new_version(&dir, "reviewer", &v3).unwrap(), 3);
+        assert_eq!(active_version(&dir, "reviewer"), 3);
+    }
+
+    #[test]
+    fn pinning_a_nonexistent_version_is_a_typed_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        write(&dir.join("a.md"), &agent_md("a", None, "Body."));
+        assert!(pin_version(&dir, "a", 1).is_ok(), "implicit v1 re-pin = ok");
+        assert!(pin_version(&dir, "a", 2).is_err());
+        save_new_version(&dir, "a", &agent_md("a", None, "B2.")).unwrap();
+        let err = pin_version(&dir, "a", 9).unwrap_err();
+        assert!(err.contains("no version v9"), "{err}");
+    }
+
+    #[test]
+    fn version_listing_reports_every_version_oldest_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        write(&dir.join("a.md"), &agent_md("a", None, "One."));
+        save_new_version(&dir, "a", &agent_md("a", None, "Two.")).unwrap();
+        save_new_version(&dir, "a", &agent_md("a", None, "Three.")).unwrap();
+
+        let entries = discover(None, &dir);
+        let versions: Vec<u32> = entries[0].versions.iter().map(|v| v.version).collect();
+        assert_eq!(versions, vec![1, 2, 3]);
+        assert_eq!(entries[0].version, 3, "newest save is pinned");
+    }
+
+    #[test]
+    fn saving_over_a_symlinked_definition_never_writes_through_the_link() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        let foreign = tmp.path().join(".claude/agents/adopted.md");
+        let original = agent_md("adopted", None, "Foreign body.");
+        write(&foreign, &original);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::os::unix::fs::symlink(&foreign, dir.join("adopted.md")).unwrap();
+
+        let edited = agent_md("adopted", None, "Edited in stella.");
+        save_new_version(&dir, "adopted", &edited).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&foreign).unwrap(),
+            original,
+            "the .claude source is untouched"
+        );
+        let canonical = dir.join("adopted.md");
+        assert!(
+            !canonical
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link was replaced by a real file"
+        );
+        assert_eq!(std::fs::read_to_string(&canonical).unwrap(), edited);
+        // The foreign content was still archived as v1 before the edit.
+        assert_eq!(
+            std::fs::read_to_string(dir.join(".versions/adopted/v0001.md")).unwrap(),
+            original
+        );
+    }
+
+    #[test]
+    fn nested_layout_is_versioned_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        let original = agent_md("nested", None, "One.");
+        write(&dir.join("nested/AGENT.md"), &original);
+        let edited = agent_md("nested", None, "Two.");
+        save_new_version(&dir, "nested", &edited).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("nested/AGENT.md")).unwrap(),
+            edited,
+            "a real nested layout keeps its shape"
+        );
+        assert_eq!(active_version(&dir, "nested"), 2);
+    }
+
+    #[test]
+    fn active_version_for_source_resolves_both_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        write(&dir.join("flat.md"), &agent_md("flat", None, "One."));
+        save_new_version(&dir, "flat", &agent_md("flat", None, "Two.")).unwrap();
+        assert_eq!(
+            active_version_for_source(&dir.join("flat.md").display().to_string()),
+            2
+        );
+        write(
+            &dir.join("nested/AGENT.md"),
+            &agent_md("nested", None, "B."),
+        );
+        assert_eq!(
+            active_version_for_source(&dir.join("nested/AGENT.md").display().to_string()),
+            1
+        );
+    }
+
+    #[test]
+    fn find_slug_resolves_a_frontmatter_name_to_its_file_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        // The file slug and the loaded name differ.
+        write(
+            &dir.join("cr.md"),
+            &agent_md("code-reviewer", None, "Body."),
+        );
+        assert_eq!(find_slug(&dir, "code-reviewer").as_deref(), Some("cr"));
+        assert_eq!(find_slug(&dir, "nope"), None);
+    }
+
+    // ---- creation ----
+
+    #[test]
+    fn creation_messages_carry_the_format_contract_and_the_description() {
+        let messages = creation_messages("reviews rust diffs for unsafe code");
+        assert_eq!(messages.len(), 2);
+        let system = &messages[0].content;
+        assert!(system.contains("name: kebab-case-name"), "{system}");
+        assert!(system.contains("omit it entirely to grant all tools"));
+        assert!(system.contains("no code fences"));
+        assert!(
+            messages[1]
+                .content
+                .contains("reviews rust diffs for unsafe code")
+        );
+    }
+
+    #[test]
+    fn parse_generated_agent_strips_fences_and_validates_via_the_loader() {
+        let drafted = "```markdown\n---\nname: Unsafe Auditor\ndescription: Audits unsafe \
+                       blocks\ntools: Read, Grep\n---\nYou audit unsafe Rust.\n```";
+        let agent = parse_generated_agent(drafted).unwrap();
+        assert_eq!(agent.slug, "unsafe-auditor");
+        assert_eq!(agent.name, "Unsafe Auditor");
+        assert!(!agent.content.contains("```"), "fences stripped");
+        assert!(agent.content.ends_with("You audit unsafe Rust.\n"));
+    }
+
+    #[test]
+    fn parse_generated_agent_rejects_unloadable_drafts() {
+        let err = parse_generated_agent("---\nname: x\n---\n").unwrap_err();
+        assert!(err.contains("empty body"), "{err}");
+        assert!(parse_generated_agent("   ").is_err());
+    }
+
+    #[test]
+    fn install_new_agent_writes_the_file_and_never_clobbers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents");
+        let agent = GeneratedAgent {
+            slug: "fresh".into(),
+            name: "fresh".into(),
+            content: agent_md("fresh", None, "Body."),
+        };
+        let path = install_new_agent(&dir, &agent).unwrap();
+        assert!(path.ends_with("fresh.md"));
+        let err = install_new_agent(&dir, &agent).unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn slugify_collapses_and_lowercases() {
+        assert_eq!(slugify("Code Reviewer!"), "code-reviewer");
+        assert_eq!(slugify("  A -- B  "), "a-b");
+        assert_eq!(slugify("---"), "");
+    }
+}

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -57,20 +57,22 @@ use serde_json::Value;
 use stella_core::ports::ToolExecutor;
 use stella_core::router::{CircuitBreaker, ProviderProfile};
 use stella_core::{BudgetGuard, CalibrationMap, Engine, RoleTable, Router, TurnOutcome};
+use stella_model::provider::Provider;
 use stella_pipeline::{
     AutoApproveGate, ContextRecallPort, NoContextRecall, Pipeline, PipelineConfig, PipelinePorts,
     PipelineStatus, ProviderResolver,
 };
-use stella_model::provider::Provider;
 use stella_protocol::{
-    AgentEvent, CompletionMessage, FileChangeKind, ModelRef, ToolOutput, ToolSchema,
+    AgentEvent, CompletionMessage, CompletionRequest, FileChangeKind, ModelRef, ToolOutput,
+    ToolSchema,
 };
 use stella_store::Store;
 use stella_tools::ToolRegistry;
 use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentStatus, DeckOptions, Inbound, SlashCommand, UserInput, WorkspaceInput, run_deck,
+    AgentMeta, AgentScope, AgentStatus, DeckOptions, Inbound, SlashCommand, UserInput,
+    WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -360,6 +362,10 @@ pub async fn run_deck_session(
     // Session-local, OFF at start — mirrored to the PIPELINE stat box via
     // `Inbound::Pipeline`.
     let mut pipeline_on = false;
+    // An agent-creation request that arrived mid-turn: drafting needs the
+    // provider (borrowed by the running turn), so it parks here and runs
+    // right after the turn settles.
+    let mut pending_create: Option<(String, AgentScope)> = None;
     'session: loop {
         // Take the next prompt: backlog first (unless held), else wait for
         // deck input.
@@ -413,9 +419,21 @@ pub async fn run_deck_session(
                     requeue_front(&mut queue, &in_tx, dispatch.stop_and_hold(None));
                     continue 'session;
                 }
-                // A stray answer/decision/control with no turn in flight has
-                // nothing to act on.
-                Some(_) => continue 'session,
+                // LLM-assisted agent creation needs the provider, which is
+                // free here (no turn in flight) — draft, install, refresh.
+                Some(WorkspaceInput::AgentCreate { description, scope }) => {
+                    handle_agent_create(&description, scope, cfg, &*provider, &in_tx).await;
+                    continue 'session;
+                }
+                // The INSTALLED AGENTS pane's synchronous ops (refresh /
+                // save / pin) are pure filesystem work — the shared helper
+                // serves this idle site and the in-turn site alike. A stray
+                // answer/decision/control with no turn in flight falls
+                // through it with nothing to act on.
+                Some(other) => {
+                    handle_agents_input(&other, cfg, &in_tx);
+                    continue 'session;
+                }
             },
         };
 
@@ -590,6 +608,30 @@ pub async fn run_deck_session(
                         Some(WorkspaceInput::StopAndHold { .. }) => {
                             break TurnEnd::Cancelled { hold: true }
                         }
+                        // The INSTALLED AGENTS pane stays live while a turn
+                        // runs — refresh / save / pin are pure filesystem
+                        // ops, the same shared helper as the idle recv site.
+                        Some(
+                            input @ (WorkspaceInput::AgentsRefresh
+                            | WorkspaceInput::AgentSave { .. }
+                            | WorkspaceInput::AgentPin { .. }),
+                        ) => {
+                            handle_agents_input(&input, cfg, &in_tx);
+                        }
+                        // Creation needs the provider, which the running
+                        // turn is borrowing — park it; it runs the moment
+                        // the turn settles (see `pending_create`).
+                        Some(WorkspaceInput::AgentCreate { description, scope }) => {
+                            pending_create = Some((description, scope));
+                            let _ = in_tx.send(agents_list_inbound(
+                                &cfg.workspace_root,
+                                Some(
+                                    "agent creation queued — it runs when the current turn \
+                                     finishes"
+                                        .to_string(),
+                                ),
+                            ));
+                        }
                         // Scope review is not engine-driven yet, and deep
                         // pause/resume/restart need the fleet supervisor —
                         // both named seams, both no-ops here.
@@ -679,6 +721,12 @@ pub async fn run_deck_session(
             }
             TurnEnd::Quit => break 'session,
         }
+
+        // A creation request parked during the turn: the provider is free
+        // again, so draft + install it before the next dispatch.
+        if let Some((description, scope)) = pending_create.take() {
+            handle_agent_create(&description, scope, cfg, &*provider, &in_tx).await;
+        }
     }
 
     // Closing our inbound sender ends the deck's stream if the user hasn't
@@ -740,8 +788,14 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ("/clear", "reset the conversation"),
     ("/models", "list providers & models"),
     ("/init", "index the workspace: domains + code graph"),
-    ("/agents", "list custom agents"),
-    ("/pipeline", "toggle the staged pipeline (witness-verified turns)"),
+    (
+        "/agents",
+        "open the Agents tab: executions & installed agents",
+    ),
+    (
+        "/pipeline",
+        "toggle the staged pipeline (witness-verified turns)",
+    ),
     ("/files", "open the Files tab"),
     ("/diff", "open the diff viewer"),
     ("/graph", "open the code-graph tab"),
@@ -750,6 +804,167 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
 /// The deck's reserved command names — see [`DECK_BUILTINS`].
 fn deck_reserved() -> Vec<&'static str> {
     DECK_BUILTINS.iter().map(|(name, _)| *name).collect()
+}
+
+// ── Installed-agents manager (the AGENTS tab's INSTALLED AGENTS pane) ───────
+
+/// Build an [`Inbound::AgentsList`] from the definitions on disk at both
+/// scopes. `status`, when set, replaces the pane's hint line.
+fn agents_list_inbound(workspace_root: &std::path::Path, status: Option<String>) -> Inbound {
+    let project = crate::agents_installed::project_agents_dir(workspace_root);
+    let user = crate::agents_installed::user_agents_dir();
+    Inbound::AgentsList {
+        entries: crate::agents_installed::discover(user.as_deref(), &project),
+        status,
+    }
+}
+
+/// Handle one synchronous installed-agents op (refresh / save / pin) —
+/// pure filesystem work, answered with a fresh [`Inbound::AgentsList`].
+/// Called from BOTH the idle and the in-turn recv sites, so the manager
+/// works whether or not a turn is running. Returns `true` when the input
+/// was one of the manager's; anything else is left to the caller's arms.
+fn handle_agents_input(
+    input: &WorkspaceInput,
+    cfg: &Config,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    let root = &cfg.workspace_root;
+    match input {
+        WorkspaceInput::AgentsRefresh => {
+            let _ = in_tx.send(agents_list_inbound(root, None));
+            true
+        }
+        WorkspaceInput::AgentSave {
+            name,
+            scope,
+            content,
+        } => {
+            let status = save_agent(root, name, *scope, content);
+            let _ = in_tx.send(agents_list_inbound(root, Some(status)));
+            true
+        }
+        WorkspaceInput::AgentPin {
+            name,
+            scope,
+            version,
+        } => {
+            let status = pin_agent(root, name, *scope, *version);
+            let _ = in_tx.send(agents_list_inbound(root, Some(status)));
+            true
+        }
+        _ => false,
+    }
+}
+
+/// The edit-save path: archive-then-write a NEW version and pin it (see
+/// `agents_installed::save_new_version`). Returns the pane's status line.
+fn save_agent(root: &std::path::Path, name: &str, scope: AgentScope, content: &str) -> String {
+    let dir = match crate::agents_installed::agents_dir_for(scope, root) {
+        Ok(dir) => dir,
+        Err(e) => return format!("save failed: {e}"),
+    };
+    let slug = crate::agents_installed::find_slug(&dir, name)
+        .unwrap_or_else(|| crate::agents_installed::slugify(name));
+    match crate::agents_installed::save_new_version(&dir, &slug, content) {
+        Ok(version) => format!(
+            "saved {name} — v{version} is now pinned (previous versions preserved under \
+             .versions/{slug}/)"
+        ),
+        Err(e) => format!("save failed: {e}"),
+    }
+}
+
+/// The pin-set path: re-point the pin at an existing version — never
+/// creates one. Returns the pane's status line.
+fn pin_agent(root: &std::path::Path, name: &str, scope: AgentScope, version: u32) -> String {
+    let dir = match crate::agents_installed::agents_dir_for(scope, root) {
+        Ok(dir) => dir,
+        Err(e) => return format!("pin failed: {e}"),
+    };
+    let Some(slug) = crate::agents_installed::find_slug(&dir, name) else {
+        return format!(
+            "no installed agent named {name} at the {} scope",
+            scope.label()
+        );
+    };
+    match crate::agents_installed::pin_version(&dir, &slug, version) {
+        Ok(()) => format!("{name} pinned to v{version} — no new version written"),
+        Err(e) => format!("pin failed: {e}"),
+    }
+}
+
+/// LLM-assisted create-from-prompt: draft the definition through the
+/// session's provider (the same one-shot `Provider::complete` path the
+/// reflection module uses — no hand-rolled HTTP), validate it with the real
+/// loader parser, install it at `scope`, and answer with a fresh list.
+async fn handle_agent_create(
+    description: &str,
+    scope: AgentScope,
+    cfg: &Config,
+    provider: &dyn Provider,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    let status = match create_agent(description, scope, cfg, provider).await {
+        Ok(status) => status,
+        Err(e) => format!("agent creation failed: {e}"),
+    };
+    let _ = in_tx.send(agents_list_inbound(&cfg.workspace_root, Some(status)));
+}
+
+async fn create_agent(
+    description: &str,
+    scope: AgentScope,
+    cfg: &Config,
+    provider: &dyn Provider,
+) -> Result<String, String> {
+    let req = CompletionRequest {
+        messages: crate::agents_installed::creation_messages(description),
+        max_output_tokens: Some(1200),
+        temperature: Some(0.2),
+        effort: None,
+        tools: vec![],
+    };
+    let result = provider
+        .complete(req)
+        .await
+        .map_err(|e| format!("draft call failed: {e}"))?;
+    let agent = crate::agents_installed::parse_generated_agent(&result.text)?;
+    let dir = crate::agents_installed::agents_dir_for(scope, &cfg.workspace_root)?;
+    let path = crate::agents_installed::install_new_agent(&dir, &agent)?;
+    Ok(format!(
+        "created {} ({} scope) at {} — v1 pinned",
+        agent.name,
+        scope.label(),
+        path.display()
+    ))
+}
+
+/// Cap on the free-text `reason` stamped on an agent-use telemetry row.
+const AGENT_USE_REASON_MAX: usize = 120;
+
+/// Record the agent-usage telemetry for a `/agent-name task…` invocation:
+/// resolution mirrors `CustomExtensions::expand` (commands shadow skills
+/// shadow agents — only a real agent invocation records), `version` is the
+/// definition's pinned version at this moment, `reason` is the task
+/// snippet. The row rides the registry's ledger and is drained into
+/// store.db by `agent::record_execution_end` under the execution the
+/// expanded prompt runs as.
+fn record_agent_invocation(
+    input: &str,
+    custom: &crate::extensions::CustomExtensions,
+    registry: &ToolRegistry,
+) {
+    let trimmed = input.trim();
+    let (head, args) = match trimmed.split_once(char::is_whitespace) {
+        Some((head, args)) => (head, args),
+        None => (trimmed, ""),
+    };
+    if let Some(crate::extensions::Invocation::Agent(agent)) = custom.lookup(head) {
+        let version = crate::agents_installed::active_version_for_source(&agent.source_path);
+        let reason: String = args.trim().chars().take(AGENT_USE_REASON_MAX).collect();
+        registry.record_agent_use(&agent.name, version, &reason);
+    }
 }
 
 /// The deck's slash vocabulary: the productized commands (🔒) followed by
@@ -803,9 +1018,9 @@ async fn run_deck_command(
         "/help" => {
             let mut help = "commands: /help · /clear (reset conversation) · /models (list \
                  providers) · /init (index the workspace: domains + code graph) · /agents \
-                 (list custom agents) · /pipeline (toggle witness-verified staged turns) · \
-                 /files · /diff · /graph (switch tabs) — anything \
-                 else is a prompt. ctrl+t queue · ? overlay help"
+                 (open the Agents tab: executions & installed agents) · /pipeline (toggle \
+                 witness-verified staged turns) · /files · /diff · /graph (switch tabs) — \
+                 anything else is a prompt. ctrl+t queue · ? overlay help"
                 .to_string();
             let customs = custom.slash_entries(&[]);
             if !customs.is_empty() {
@@ -813,9 +1028,6 @@ async fn run_deck_command(
                 help.push_str(&format!("\ncustom (⚡): {}", names.join(" · ")));
             }
             say(help);
-        }
-        "/agents" => {
-            say(custom.render_agent_list());
         }
         "/clear" => {
             messages.clear();
@@ -857,16 +1069,20 @@ async fn run_deck_command(
                 Err(e) => say(format!("init failed: {e}")),
             }
         }
-        // Deck-local tab commands are normally consumed TUI-side, but a queued
-        // one reaches here — accept it as handled (a no-op) rather than
-        // calling it "unknown".
-        "/files" | "/diff" | "/graph" => {}
+        // Deck-local commands (tab switches, `/agents` opening the Agents
+        // tab) are normally consumed TUI-side, but a queued one reaches
+        // here — accept it as handled (a no-op) rather than calling it
+        // "unknown".
+        "/files" | "/diff" | "/graph" | "/agents" => {}
         _ => {
-            // A custom command/skill (⚡): expand its template — arguments
-            // and all — into the prompt the model turn runs. Reserved names
-            // never reach a custom definition (`/init do the thing` stays a
-            // model prompt even if a custom `init` exists).
+            // A custom command/skill/agent (⚡): expand its template —
+            // arguments and all — into the prompt the model turn runs.
+            // Reserved names never reach a custom definition (`/init do the
+            // thing` stays a model prompt even if a custom `init` exists).
+            // An AGENT invocation additionally records a usage-telemetry
+            // row (agent, pinned version, task) on the registry's ledger.
             if let Some(expanded) = custom.expand(trimmed, &deck_reserved()) {
+                record_agent_invocation(trimmed, custom, registry);
                 return DeckCommand::Expanded(expanded);
             }
             // A bare unknown /word is a typo'd command, not a prompt — say so

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -278,7 +278,7 @@ fn create_symlink(_target: &Path, _dest: &Path) -> std::io::Result<()> {
 
 /// The user-global stella config root (`~/.config/stella`), or `None`
 /// without a home directory.
-fn user_config_root() -> Option<PathBuf> {
+pub(crate) fn user_config_root() -> Option<PathBuf> {
     std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config").join("stella"))
 }
 
@@ -449,6 +449,10 @@ pub struct CustomExtensions {
 pub enum Invocation<'a> {
     Command(&'a CommandDef),
     Skill(&'a Skill),
+    /// An installed agent persona: `/agent-name task…` runs the task under
+    /// the agent's system-prompt-shaped body (and its toolbelt note). This
+    /// is the invocation seam the agent-usage telemetry records.
+    Agent(&'a AgentDef),
 }
 
 impl CustomExtensions {
@@ -495,11 +499,11 @@ impl CustomExtensions {
         Some(out)
     }
 
-    /// The ⚡ slash-menu rows: commands first, then skills, names prefixed
-    /// with `/`. A custom name shadowed by a productized command in
-    /// `reserved` is dropped (builtins always win), and a skill sharing a
-    /// command's name is dropped (the command wins — it was authored as an
-    /// invocation).
+    /// The ⚡ slash-menu rows: commands first, then skills, then agents,
+    /// names prefixed with `/`. A custom name shadowed by a productized
+    /// command in `reserved` is dropped (builtins always win), and later
+    /// kinds sharing an earlier kind's name are dropped (a command was
+    /// authored as an invocation; it wins).
     pub fn slash_entries(&self, reserved: &[SlashCommand]) -> Vec<SlashCommand> {
         let mut taken: HashSet<String> = reserved.iter().map(|c| c.name.clone()).collect();
         let mut rows = Vec::new();
@@ -511,7 +515,11 @@ impl CustomExtensions {
             .skills
             .iter()
             .map(|s| (format!("/{}", s.name), s.description.clone()));
-        for (name, description) in commands.chain(skills) {
+        let agents = self
+            .agents
+            .iter()
+            .map(|a| (format!("/{}", a.name), a.description.clone()));
+        for (name, description) in commands.chain(skills).chain(agents) {
             if taken.insert(name.clone()) {
                 rows.push(SlashCommand::custom(name, description));
             }
@@ -520,17 +528,20 @@ impl CustomExtensions {
     }
 
     /// Resolve a custom invocation: `head` is the leading `/word` of the
-    /// input (slash included). Commands shadow skills, matching
-    /// [`Self::slash_entries`].
+    /// input (slash included). Commands shadow skills shadow agents,
+    /// matching [`Self::slash_entries`].
     pub fn lookup(&self, head: &str) -> Option<Invocation<'_>> {
         let name = head.strip_prefix('/')?;
         if let Some(cmd) = self.commands.iter().find(|c| c.name == name) {
             return Some(Invocation::Command(cmd));
         }
-        self.skills
+        if let Some(skill) = self.skills.iter().find(|s| s.name == name) {
+            return Some(Invocation::Skill(skill));
+        }
+        self.agents
             .iter()
-            .find(|s| s.name == name)
-            .map(Invocation::Skill)
+            .find(|a| a.name == name)
+            .map(Invocation::Agent)
     }
 
     /// Expand `input` (`/name args…`) into the prompt the model runs, or
@@ -551,6 +562,7 @@ impl CustomExtensions {
         match self.lookup(head)? {
             Invocation::Command(cmd) => Some(expand_command(&cmd.body, args)),
             Invocation::Skill(skill) => Some(skill_invocation_prompt(skill, args)),
+            Invocation::Agent(agent) => Some(agent_invocation_prompt(agent, args)),
         }
     }
 
@@ -571,6 +583,28 @@ impl CustomExtensions {
         }
         out
     }
+}
+
+/// The prompt a `/agent-name` invocation runs: the agent's persona body as
+/// explicit instructions (with its toolbelt grant stated when the
+/// definition restricts tools — prompt-level today; hard enforcement is the
+/// fleet-spawn seam's concern), and any trailing text as the task.
+fn agent_invocation_prompt(agent: &AgentDef, args: &str) -> String {
+    let mut out = format!(
+        "Adopt the following agent persona for this task.\n\n# Agent: {}\n{}\n\n{}",
+        agent.name, agent.description, agent.body
+    );
+    if let Some(tools) = &agent.tools {
+        out.push_str(&format!(
+            "\n\nThis agent's toolbelt is restricted to: {}.",
+            tools.join(", ")
+        ));
+    }
+    let args = args.trim();
+    if !args.is_empty() {
+        out.push_str(&format!("\n\n## Task\n{args}"));
+    }
+    out
 }
 
 /// The prompt a `/skill-name` invocation runs: the skill body as explicit
@@ -864,6 +898,7 @@ mod tests {
             agents: vec![AgentDef {
                 name: "reviewer".to_string(),
                 description: "reviews diffs".to_string(),
+                tools: None,
                 body: "You review.".to_string(),
                 source_path: "x/reviewer.md".to_string(),
             }],
@@ -883,8 +918,26 @@ mod tests {
         let reserved = vec![SlashCommand::new("/help", "show commands")];
         let rows = custom.slash_entries(&reserved);
         let names: Vec<&str> = rows.iter().map(|r| r.name.as_str()).collect();
-        assert_eq!(names, vec!["/fix-bug", "/sql-style"]);
+        // Commands, then skills, then agents — the fixture's `reviewer`
+        // agent is offered as an invocable ⚡ row too.
+        assert_eq!(names, vec!["/fix-bug", "/sql-style", "/reviewer"]);
         assert!(rows.iter().all(|r| r.kind == stella_tui::SlashKind::Custom));
+    }
+
+    #[test]
+    fn agent_invocations_expand_to_the_persona_prompt() {
+        let custom = custom_fixture();
+        let prompt = custom
+            .expand("/reviewer check the diff", &[])
+            .expect("the agent is invocable");
+        assert!(prompt.contains("# Agent: reviewer"), "{prompt}");
+        assert!(prompt.contains("You review."), "{prompt}");
+        assert!(prompt.contains("## Task\ncheck the diff"), "{prompt}");
+        // Commands and skills still shadow agents by name.
+        match custom.lookup("/reviewer") {
+            Some(Invocation::Agent(agent)) => assert_eq!(agent.name, "reviewer"),
+            _ => panic!("expected the agent invocation"),
+        }
     }
 
     #[test]

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -18,6 +18,7 @@
 //!   human-readable output).
 
 mod agent;
+mod agents_installed;
 mod command_deck;
 mod config;
 mod domains;

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -112,6 +112,13 @@ pub struct AgentDef {
     pub name: String,
     /// One-line description for the `/agents` listing.
     pub description: String,
+    /// The agent's toolbelt — frontmatter `tools:`, a comma-separated list
+    /// of tool names granted to the agent. `None` means the definition does
+    /// not restrict tools: the agent gets **all** tools (also the meaning of
+    /// an explicit `tools: *` / `tools: all`). `Some(vec![])` cannot occur —
+    /// an empty list parses to `None` as well, matching the ecosystem
+    /// convention where omission grants everything.
+    pub tools: Option<Vec<String>>,
     /// The markdown body — the agent's instructions/system prompt.
     pub body: String,
     /// The file this was loaded from.
@@ -223,12 +230,31 @@ pub fn command_from_file(path: &str, raw: &str) -> Result<CommandDef, ExtensionD
     })
 }
 
+/// Parse a frontmatter `tools:` value into the toolbelt grant. `None` means
+/// "all tools": no key, an empty value, or the explicit wildcard forms
+/// (`*` / `all`). Anything else is the comma-separated grant list.
+pub fn parse_toolbelt(value: Option<&str>) -> Option<Vec<String>> {
+    let value = value?.trim();
+    if value.is_empty() || value == "*" || value.eq_ignore_ascii_case("all") {
+        return None;
+    }
+    let tools: Vec<String> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .collect();
+    (!tools.is_empty()).then_some(tools)
+}
+
 /// Parse one agent file.
 pub fn agent_from_file(path: &str, raw: &str) -> Result<AgentDef, ExtensionDiagnostic> {
     let (name, description, body) = definition_from_file(path, raw, "AGENT.md")?;
+    let tools = parse_toolbelt(parse_frontmatter(raw).data.get("tools").map(String::as_str));
     Ok(AgentDef {
         name,
         description,
+        tools,
         body,
         source_path: path.to_string(),
     })
@@ -510,6 +536,36 @@ mod tests {
         assert_eq!(agent.name, "code-reviewer");
         assert_eq!(agent.description, "Reviews diffs for correctness");
         assert!(agent.body.contains("meticulous"));
+        assert_eq!(
+            agent.tools,
+            Some(vec!["Read".to_string(), "Grep".to_string()]),
+            "the frontmatter toolbelt is parsed as the grant list"
+        );
+    }
+
+    #[test]
+    fn agent_without_a_tools_key_grants_all_tools() {
+        let raw = "---\nname: helper\ndescription: d\n---\nBody.";
+        let agent = agent_from_file("/x/helper.md", raw).unwrap();
+        assert_eq!(agent.tools, None, "no `tools:` key = unrestricted");
+    }
+
+    #[test]
+    fn toolbelt_wildcards_and_empties_mean_all_tools() {
+        assert_eq!(parse_toolbelt(None), None);
+        assert_eq!(parse_toolbelt(Some("")), None);
+        assert_eq!(parse_toolbelt(Some("  ")), None);
+        assert_eq!(parse_toolbelt(Some("*")), None);
+        assert_eq!(parse_toolbelt(Some("ALL")), None);
+        assert_eq!(
+            parse_toolbelt(Some(", ,")),
+            None,
+            "only separators = none named"
+        );
+        assert_eq!(
+            parse_toolbelt(Some("Read,  Grep , Bash")),
+            Some(vec!["Read".into(), "Grep".into(), "Bash".into()])
+        );
     }
 
     // ---- expansion ----

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -209,6 +209,18 @@ pub struct RuleRow {
     pub source: String,
 }
 
+/// One agent-invocation row for the `agent_uses` log: which installed agent
+/// definition (by name), at which pinned version, was invoked under an
+/// execution — with a short free-text reason when one was available. The
+/// timestamp column defaults to the insert time; the ledger drains per
+/// execution, so insert time is invocation-accurate to within the turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentUseRow {
+    pub agent: String,
+    pub version: u32,
+    pub reason: String,
+}
+
 /// One aggregated analytics row per (provider, model): the numbers behind
 /// "$-per-resolved-task" receipts, straight from local telemetry.
 ///
@@ -312,7 +324,7 @@ type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-const MIGRATIONS: [Migration; 3] = [
+const MIGRATIONS: [Migration; 4] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -324,6 +336,10 @@ const MIGRATIONS: [Migration; 3] = [
     // v2 → v3: the additive `rules` table (extension-authored workspace
     // rules for the stella-core rules engine).
     migrate_v2_to_v3,
+    // v3 → v4: the agent_uses invocation log (purely additive).
+    // NOTE: several in-flight branches each add a store.db migration — the
+    // slot number is taken naively here and reconciled at merge time.
+    migrate_v3_to_v4,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -334,7 +350,7 @@ const SCHEMA_VERSION: i64 = MIGRATIONS.len() as i64;
 
 /// Every table the store owns — the allowlist for [`Store::count`] and the
 /// fresh-file probe in [`Store::migrate`].
-const TABLES: [&str; 9] = [
+const TABLES: [&str; 10] = [
     "executions",
     "events",
     "telemetry",
@@ -344,6 +360,7 @@ const TABLES: [&str; 9] = [
     "file_locks",
     "graph_nodes",
     "graph_edges",
+    "agent_uses",
 ];
 
 /// Tables whose shape has not changed since v0. `IF NOT EXISTS` keeps one
@@ -497,6 +514,24 @@ const MEMORY_CITATIONS_DDL: &str = "CREATE TABLE IF NOT EXISTS memory_citations 
      CREATE INDEX IF NOT EXISTS memory_citations_by_memory
        ON memory_citations(memory_id, execution_id);";
 
+/// `agent_uses` DDL at [`SCHEMA_VERSION`] — the agent-invocation log
+/// ([`AgentUseRow`]): one row per invocation of an installed agent
+/// definition, attributed to the execution it ran under and to the
+/// definition's pinned `version` at invocation time. Deliberately **not**
+/// UNIQUE on any key: invoking the same agent-version twice in one execution
+/// is two real events, and the drain-per-execution write path never
+/// double-writes a drained event. `IF NOT EXISTS` keeps the one DDL usable
+/// for both the fresh-file path and the additive v3 → v4 migration.
+const AGENT_USES_DDL: &str = "CREATE TABLE IF NOT EXISTS agent_uses (
+       execution_id INTEGER NOT NULL,
+       agent TEXT NOT NULL,
+       version INTEGER NOT NULL,
+       reason TEXT NOT NULL DEFAULT '',
+       ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+     );
+     CREATE INDEX IF NOT EXISTS agent_uses_by_agent
+       ON agent_uses(agent, version, execution_id);";
+
 /// The full latest schema, applied in one shot to fresh databases only.
 /// Existing files never see this — [`MIGRATIONS`] upgrades them shape by
 /// shape, so this can always describe the CURRENT shape.
@@ -508,6 +543,7 @@ fn create_latest_schema(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(RULES_TABLE)?;
     tx.execute_batch(TELEMETRY_INDEX)?;
     tx.execute_batch(MEMORY_CITATIONS_DDL)?;
+    tx.execute_batch(AGENT_USES_DDL)?;
     Ok(())
 }
 
@@ -699,6 +735,15 @@ fn migrate_v1_to_v2(tx: &rusqlite::Transaction<'_>) -> Result<()> {
 fn migrate_v2_to_v3(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(MEMORY_CITATIONS_DDL)?;
     tx.execute_batch(RULES_TABLE)?;
+    Ok(())
+}
+
+/// v3 → v4: the `agent_uses` invocation log (agent-version usage telemetry,
+/// drained per execution like `files_touched`). Purely additive — no
+/// existing table changes shape, so no §7 rebuild is needed; `IF NOT
+/// EXISTS` also covers a partial file that somehow already grew the table.
+fn migrate_v3_to_v4(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    tx.execute_batch(AGENT_USES_DDL)?;
     Ok(())
 }
 
@@ -977,6 +1022,20 @@ impl Store {
                     row.truthful,
                     row.remark,
                 ],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Record the agent invocations drained from one execution's ledger —
+    /// one row per invocation, never aggregated (see [`AgentUseRow`]).
+    pub fn record_agent_uses(&self, execution_id: i64, uses: &[AgentUseRow]) -> Result<()> {
+        let conn = self.lock();
+        for row in uses {
+            conn.execute(
+                "INSERT INTO agent_uses (execution_id, agent, version, reason) \
+                 VALUES (?, ?, ?, ?)",
+                params![execution_id, row.agent, row.version as i64, row.reason],
             )?;
         }
         Ok(())
@@ -1627,6 +1686,79 @@ mod tests {
         assert_eq!(user_version(&store), SCHEMA_VERSION);
         store.upsert_rule("r", "rule text", "ext").unwrap();
         assert_eq!(store.count("rules").unwrap(), 1);
+        drop(store);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn agent_uses_log_one_row_per_invocation_never_aggregated() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("deck", "p", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_agent_uses(
+                id,
+                &[
+                    AgentUseRow {
+                        agent: "reviewer".into(),
+                        version: 2,
+                        reason: "review the diff".into(),
+                    },
+                    // The SAME agent-version again in the same execution: a
+                    // second real invocation, a second row — the log carries
+                    // no UNIQUE key by design.
+                    AgentUseRow {
+                        agent: "reviewer".into(),
+                        version: 2,
+                        reason: "second pass".into(),
+                    },
+                ],
+            )
+            .unwrap();
+        assert_eq!(store.count("agent_uses").unwrap(), 2);
+        let conn = store.lock();
+        let (agent, version, reason, ts): (String, i64, String, String) = conn
+            .query_row(
+                "SELECT agent, version, reason, ts FROM agent_uses \
+                 WHERE execution_id = ? ORDER BY rowid LIMIT 1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!((agent.as_str(), version), ("reviewer", 2));
+        assert_eq!(reason, "review the diff");
+        assert!(!ts.is_empty(), "the insert stamps a timestamp");
+    }
+
+    #[test]
+    fn v4_migration_adds_agent_uses_to_a_pre_v4_file() {
+        let root = temp_root("v4_agent_uses");
+        {
+            let conn = Connection::open(root.join(".stella/store.db")).unwrap();
+            conn.execute_batch(LEGACY_V0_SCHEMA).unwrap();
+        }
+        let store = Store::open(&root).unwrap();
+        assert_eq!(user_version(&store), SCHEMA_VERSION);
+        assert_eq!(
+            store.count("agent_uses").unwrap(),
+            0,
+            "the migrated file grew an empty agent_uses log"
+        );
+        let id = store
+            .begin_execution("deck", "p", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_agent_uses(
+                id,
+                &[AgentUseRow {
+                    agent: "planner".into(),
+                    version: 1,
+                    reason: String::new(),
+                }],
+            )
+            .unwrap();
+        assert_eq!(store.count("agent_uses").unwrap(), 1);
         drop(store);
         std::fs::remove_dir_all(&root).ok();
     }

--- a/stella-tools/src/agent_use.rs
+++ b/stella-tools/src/agent_use.rs
@@ -1,0 +1,94 @@
+//! Per-session agent-usage telemetry: one [`AgentUseEvent`] per invocation
+//! of an installed agent definition, recorded at the moment the definition
+//! is applied to a turn and **drained** once per execution into the store's
+//! `agent_uses` table (see `stella-cli`'s `record_execution_end`).
+//!
+//! The shape mirrors the file-touch ledger ([`crate::file_touch`]): the
+//! registry holds one [`AgentUseLedger`] behind a mutex, invocation sites
+//! call `ToolRegistry::record_agent_use`, and the persistence layer takes
+//! everything recorded since the previous drain. Unlike file touches —
+//! which aggregate by path — agent uses are an **event log**: every
+//! invocation is its own row, because the unit of analysis is
+//! "agent-version X was invoked by execution Y at time T", not a per-file
+//! aggregate.
+//!
+//! `version` is the agent's *pinned* version at invocation time (see
+//! `stella-cli::agents_installed` for the on-disk versioning scheme), so the
+//! telemetry can attribute outcomes to the exact definition text that ran.
+
+use serde::{Deserialize, Serialize};
+
+/// One invocation of an installed agent definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentUseEvent {
+    /// The agent's name (its loaded definition name).
+    pub agent: String,
+    /// The pinned version of the definition at invocation time (1-based;
+    /// an un-versioned agent is version 1).
+    pub version: u32,
+    /// Why / how it was invoked — free text, kept short by the recorder
+    /// (e.g. a snipped task line). Empty when no reason was available.
+    pub reason: String,
+}
+
+/// The session's agent-use ledger. One instance lives behind the registry's
+/// mutex; [`AgentUseLedger::drain`] hands the accumulated events to the
+/// per-execution persistence step and resets the ledger, so each execution
+/// records exactly the invocations that happened on its watch.
+#[derive(Debug, Default)]
+pub struct AgentUseLedger {
+    events: Vec<AgentUseEvent>,
+}
+
+impl AgentUseLedger {
+    /// Append one invocation.
+    pub fn record(&mut self, event: AgentUseEvent) {
+        self.events.push(event);
+    }
+
+    /// Take every event recorded since the last drain, in record order,
+    /// leaving the ledger empty.
+    pub fn drain(&mut self) -> Vec<AgentUseEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    /// Events currently pending a drain (test/inspection accessor).
+    pub fn pending(&self) -> usize {
+        self.events.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(agent: &str, version: u32, reason: &str) -> AgentUseEvent {
+        AgentUseEvent {
+            agent: agent.to_string(),
+            version,
+            reason: reason.to_string(),
+        }
+    }
+
+    #[test]
+    fn drain_returns_events_in_record_order_and_resets() {
+        let mut ledger = AgentUseLedger::default();
+        ledger.record(ev("reviewer", 2, "review the diff"));
+        ledger.record(ev("reviewer", 2, "second pass"));
+        ledger.record(ev("planner", 1, ""));
+        assert_eq!(ledger.pending(), 3);
+
+        let drained = ledger.drain();
+        assert_eq!(
+            drained,
+            vec![
+                ev("reviewer", 2, "review the diff"),
+                ev("reviewer", 2, "second pass"),
+                ev("planner", 1, ""),
+            ],
+            "an event log, never aggregated — repeat invocations stay distinct rows"
+        );
+        assert_eq!(ledger.pending(), 0, "drain resets the ledger");
+        assert!(ledger.drain().is_empty(), "a second drain has nothing");
+    }
+}

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -6,6 +6,7 @@
 //! configured root, and `cd` inside `bash` cannot silently diverge the root
 //! for subsequent file operations (L-S2).
 
+pub mod agent_use;
 pub mod bash;
 pub mod ci;
 pub mod custom;

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -58,6 +58,10 @@ pub struct ToolRegistry {
     /// `cite_memory` tool instance and drained per execution by
     /// [`ToolRegistry::take_memory_citations`].
     citations: crate::memory::CitationLedger,
+    /// Per-session agent-invocation ledger (see [`crate::agent_use`]) —
+    /// drained once per execution by the persistence layer, exactly like
+    /// the file-touch ledger above but as an event log, never aggregated.
+    agent_uses: std::sync::Mutex<crate::agent_use::AgentUseLedger>,
     schema_index: std::sync::Mutex<SchemaIndex>,
     /// The session's extension hook bus, once a host attaches one
     /// ([`ToolRegistry::attach_bus`]). Every emission is `None`-guarded, so
@@ -174,6 +178,7 @@ impl ToolRegistry {
             root,
             touched: std::sync::Mutex::new(FileTouchLedger::default()),
             citations,
+            agent_uses: std::sync::Mutex::new(crate::agent_use::AgentUseLedger::default()),
             schema_index: std::sync::Mutex::new(SchemaIndex::default()),
             bus: std::sync::RwLock::new(None),
         }
@@ -716,6 +721,31 @@ impl ToolRegistry {
     /// eligibility count.
     pub fn take_memory_citations(&self) -> Vec<crate::memory::MemoryCitation> {
         std::mem::take(&mut *self.citations.lock().unwrap_or_else(|p| p.into_inner()))
+    }
+
+    /// Record one invocation of an installed agent definition (see
+    /// [`crate::agent_use`]). `version` is the definition's pinned version at
+    /// invocation time; `reason` is a short free-text why/how (may be empty).
+    pub fn record_agent_use(&self, agent: &str, version: u32, reason: &str) {
+        self.agent_uses
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .record(crate::agent_use::AgentUseEvent {
+                agent: agent.to_string(),
+                version,
+                reason: reason.to_string(),
+            });
+    }
+
+    /// Take every agent invocation recorded since the last drain — the
+    /// per-execution persistence step calls this exactly once per execution
+    /// so each invocation lands in the store attributed to the execution it
+    /// happened under.
+    pub fn drain_agent_uses(&self) -> Vec<crate::agent_use::AgentUseEvent> {
+        self.agent_uses
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .drain()
     }
 
     /// Comma-separated sorted list of registered tool names, for error

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -132,6 +132,18 @@ async fn main() -> std::io::Result<()> {
                 // (the shell's out-of-band echo); a real engine would also
                 // drop the prompt from its own backlog here.
                 WorkspaceInput::QueueRemove { .. } | WorkspaceInput::QueueClear => {}
+                // The installed-agents manager needs the real driver (disk +
+                // provider); the demo answers with an empty list so the pane
+                // renders its empty state instead of loading forever.
+                WorkspaceInput::AgentsRefresh
+                | WorkspaceInput::AgentSave { .. }
+                | WorkspaceInput::AgentPin { .. }
+                | WorkspaceInput::AgentCreate { .. } => {
+                    let _ = react_tx.send(Inbound::AgentsList {
+                        entries: vec![],
+                        status: Some("the demo has no agents on disk".to_string()),
+                    });
+                }
                 WorkspaceInput::Quit => break,
             }
         }

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -45,13 +45,15 @@ impl DeckTab {
         DeckTab::Files,
     ];
 
+    /// The tab-bar label. Deck tab labels are UPPERCASE by convention —
+    /// every tab added later must follow (e.g. `SKILLS`, `MCP`).
     pub fn title(self) -> &'static str {
         match self {
-            DeckTab::Session => "Session",
-            DeckTab::Agents => "Agents",
-            DeckTab::Traces => "Traces",
-            DeckTab::Graph => "Graph",
-            DeckTab::Files => "Files",
+            DeckTab::Session => "SESSION",
+            DeckTab::Agents => "AGENTS",
+            DeckTab::Traces => "TRACES",
+            DeckTab::Graph => "GRAPH",
+            DeckTab::Files => "FILES",
         }
     }
 
@@ -328,11 +330,11 @@ impl WorkspaceModel {
             // The driver flipped staged-pipeline routing (`/pipeline`) — the
             // PIPELINE stat box tracks it live.
             Inbound::Pipeline(on) => self.pipeline = *on,
-            // The graph snapshot and the slash vocabulary are out-of-band
-            // read-models, not part of the event-log fold — the view state
-            // owns them, applied in `ingest_inbound`, so the model
-            // deliberately ignores them here.
-            Inbound::GraphSnapshot(_) | Inbound::SlashCommands(_) => {}
+            // The graph snapshot, the slash vocabulary, and the installed-
+            // agents list are out-of-band read-models, not part of the
+            // event-log fold — the view state owns them, applied in
+            // `ingest_inbound`, so the model deliberately ignores them here.
+            Inbound::GraphSnapshot(_) | Inbound::SlashCommands(_) | Inbound::AgentsList { .. } => {}
         }
     }
 
@@ -939,8 +941,7 @@ mod tests {
             status: AgentStatus::WaitingInput,
         });
         assert_eq!(
-            w.agents[0].turn_started_ms,
-            None,
+            w.agents[0].turn_started_ms, None,
             "WaitingInput status must stop the turn clock"
         );
         assert_eq!(

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -400,8 +400,10 @@ pub async fn run_deck(
                     // (the guard enabled it), so the composer can fold it
                     // into a chip instead of replaying N raw Enter keys —
                     // each of which would have submitted a separate prompt.
+                    // Routed by the UI: the agent-definition editor claims
+                    // it while open (`DeckUi::paste`).
                     Some(Event::Paste(text)) => {
-                        ui.composer.paste(&text);
+                        ui.paste(&text);
                     }
                     // Resize / mouse: the next draw picks them up.
                     Some(_) => {}

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -28,7 +28,9 @@ use crate::composer::{
     handle_slash_popup_key, slash_popup_matches,
 };
 use crate::deck::{DeckTab, WorkspaceModel};
-use crate::envelope::{AgentControl, AgentId, AgentStatus, Inbound, WorkspaceInput};
+use crate::envelope::{
+    AgentControl, AgentId, AgentScope, AgentStatus, Inbound, InstalledAgentEntry, WorkspaceInput,
+};
 use crate::graph::GraphSnapshot;
 use crate::input::{ScopeDecision, UserInput};
 use crate::scroll::ScrollState;
@@ -52,10 +54,116 @@ pub struct DeckMetrics {
     pub files_diff_total: usize,
 }
 
+/// Which pane the AGENTS tab shows — its secondary nav, switched with ←/→
+/// (from a blank composer, exactly like the other blank-gated tab keys).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgentsPane {
+    /// The `htop`-style dashboard of currently ACTIVE agents (the
+    /// pre-existing Agents view).
+    #[default]
+    Executions,
+    /// The agents INSTALLED at the user / project level: inspect
+    /// name/description/toolbelt, edit (a save is a NEW pinned version),
+    /// re-pin an older version, create one from a prompt.
+    Installed,
+}
+
+/// The INSTALLED AGENTS pane's interaction mode. `Browse` is plain tab
+/// state (the composer stays live, like every other tab); every other mode
+/// is modal — it owns the keyboard while open, exactly like the queue
+/// editor, so its typing never leaks into the composer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InstalledMode {
+    #[default]
+    Browse,
+    /// The definition editor (⏎ on a row opens it): ctrl+s saves — always a
+    /// NEW version, immediately pinned; Esc discards the draft.
+    Edit,
+    /// Create-from-prompt, step 1: type the short description.
+    CreateDescribe,
+    /// Create-from-prompt, step 2: pick the install scope (project / user).
+    CreateScope,
+    /// The version picker (`v` on a row): ⏎ re-pins the highlighted version
+    /// WITHOUT creating a new one — pin changes never increment the version.
+    PickVersion,
+}
+
+/// The INSTALLED AGENTS pane's view state. The list itself is driven
+/// entirely by [`Inbound::AgentsList`] snapshots the driver sends — the
+/// panel owns only selection, the modal sub-states, and their input
+/// buffers, exactly like the queue editor owns only `queue_sel`.
+#[derive(Debug, Clone)]
+pub struct InstalledPanel {
+    /// Newest driver snapshot of the installed agents.
+    pub entries: Vec<InstalledAgentEntry>,
+    /// Selected row in the browse list.
+    pub sel: usize,
+    /// True once the first [`Inbound::AgentsList`] arrived.
+    pub loaded: bool,
+    /// An op is in flight driver-side (refresh / save / pin / create) —
+    /// cleared when the next list snapshot folds back.
+    pub busy: bool,
+    /// A transient one-line status/hint (op outcomes, errors).
+    pub status: Option<String>,
+    pub mode: InstalledMode,
+    /// The definition editor's buffer — a full [`Composer`] textarea, the
+    /// deck's one editing surface, reused rather than inventing a novel
+    /// editor. Paste inserts verbatim (`usize::MAX` chip threshold): an
+    /// agent file is exactly the kind of multi-line paste the chip folding
+    /// exists to intercept elsewhere.
+    pub editor: Composer,
+    /// Which agent the editor holds, as `(name, scope)`.
+    pub editing: Option<(String, AgentScope)>,
+    /// The create-from-prompt description buffer.
+    pub create_desc: String,
+    /// Scope choice in the create flow: 0 = project, 1 = user.
+    pub scope_sel: usize,
+    /// Selected row in the version picker.
+    pub version_sel: usize,
+}
+
+impl Default for InstalledPanel {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            sel: 0,
+            loaded: false,
+            busy: false,
+            status: None,
+            mode: InstalledMode::default(),
+            editor: Composer::with_paste_threshold(usize::MAX),
+            editing: None,
+            create_desc: String::new(),
+            scope_sel: 0,
+            version_sel: 0,
+        }
+    }
+}
+
+impl InstalledPanel {
+    /// The browse list's selected entry, if any.
+    pub fn selected(&self) -> Option<&InstalledAgentEntry> {
+        self.entries.get(self.sel)
+    }
+
+    /// The scope the create flow's picker currently points at.
+    pub fn create_scope(&self) -> AgentScope {
+        if self.scope_sel == 0 {
+            AgentScope::Project
+        } else {
+            AgentScope::User
+        }
+    }
+}
+
 /// All ephemeral view state for the deck.
 #[derive(Debug, Clone)]
 pub struct DeckUi {
     pub tab: DeckTab,
+    /// The AGENTS tab's secondary nav: EXECUTIONS | INSTALLED AGENTS.
+    pub agents_pane: AgentsPane,
+    /// The INSTALLED AGENTS pane's state.
+    pub installed: InstalledPanel,
     /// The one global composer — typing works from any tab.
     pub composer: Composer,
     pub splash: SplashState,
@@ -144,6 +252,8 @@ impl Default for DeckUi {
     fn default() -> Self {
         Self {
             tab: DeckTab::Session,
+            agents_pane: AgentsPane::default(),
+            installed: InstalledPanel::default(),
             composer: Composer::with_paste_threshold(crate::composer::DECK_PASTE_LINE_THRESHOLD),
             splash: SplashState::new(),
             help_open: false,
@@ -198,6 +308,17 @@ impl DeckUi {
         }
     }
 
+    /// Route a bracketed paste to whichever editing surface owns the
+    /// keyboard: the agent-definition editor while it is open, the global
+    /// composer otherwise. Keeps [`crate::deck_shell`] a dumb wire.
+    pub fn paste(&mut self, text: &str) {
+        if self.installed.mode == InstalledMode::Edit {
+            self.installed.editor.paste(text);
+        } else {
+            self.composer.paste(text);
+        }
+    }
+
     /// Point the deck at agent `idx`. A session-message selection indexes the
     /// *previously* focused agent's transcript, so it must not carry across;
     /// dropping it also re-arms tail-follow (the selection is what pinned the
@@ -239,6 +360,23 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
     if let Inbound::SlashCommands(commands) = inbound {
         ui.slash_commands = commands.clone();
         ui.slash_selected = 0;
+        return;
+    }
+    // The installed-agents list is out-of-band view state too — the driver
+    // owns the definitions on disk and pushes fresh snapshots here; the
+    // model fold ignores them.
+    if let Inbound::AgentsList { entries, status } = inbound {
+        ui.installed.entries = entries.clone();
+        ui.installed.loaded = true;
+        // A fresh list is the completion signal for a refresh / save / pin /
+        // create op — clear the working flag.
+        ui.installed.busy = false;
+        ui.installed.sel = ui.installed.sel.min(entries.len().saturating_sub(1));
+        // A driver-supplied status (op outcome, error) replaces the hint; a
+        // plain refresh sends none, leaving any client-side line standing.
+        if let Some(status) = status {
+            ui.installed.status = Some(status.clone());
+        }
         return;
     }
     model.apply_inbound(inbound);
@@ -351,6 +489,14 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     if ui.help_open {
         ui.help_open = false;
         return DeckAction::Handled;
+    }
+
+    // The INSTALLED AGENTS sub-modes (editor / create flow / version picker)
+    // are modal while open — they own the keyboard (only ctrl+c quit and the
+    // splash/help, handled above, precede them), so their typing and their
+    // Esc never leak to the composer, the tab views, or the turn-stop rules.
+    if ui.installed.mode != InstalledMode::Browse {
+        return handle_installed_modal_key(key, ui);
     }
 
     // Ctrl-R toggles the collapsed-thinking view from anywhere.
@@ -565,6 +711,16 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
                 ui.set_tab(DeckTab::Graph);
                 DeckAction::Handled
             }
+            // `/agents` opens the AGENTS tab directly, on the INSTALLED
+            // AGENTS pane (the configured-on-disk view the command has
+            // always been about) — and asks the driver, which owns the
+            // definitions on disk, for a fresh list.
+            "/agents" => {
+                ui.set_tab(DeckTab::Agents);
+                ui.agents_pane = AgentsPane::Installed;
+                ui.installed.busy = true;
+                DeckAction::Send(WorkspaceInput::AgentsRefresh)
+            }
             // Everything else — including `/help` — is enqueued for the
             // driver, which owns the session vocabulary and answers into the
             // transcript (a transient overlay would leave no record).
@@ -625,6 +781,190 @@ fn handle_queue_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
             DeckAction::Handled
         }
         _ => DeckAction::Ignored,
+    }
+}
+
+/// The INSTALLED AGENTS sub-modes' keys, dispatched by the modal gate in
+/// [`handle_deck_key`]. Every key is consumed — nothing leaks to the
+/// composer or the tab views while a sub-mode is open.
+fn handle_installed_modal_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match ui.installed.mode {
+        InstalledMode::Edit => handle_agent_editor_key(key, ui),
+        InstalledMode::CreateDescribe => handle_create_describe_key(key, ui),
+        InstalledMode::CreateScope => handle_create_scope_key(key, ui),
+        InstalledMode::PickVersion => handle_pick_version_key(key, ui),
+        // Unreachable — the gate only fires for non-Browse modes.
+        InstalledMode::Browse => DeckAction::Ignored,
+    }
+}
+
+/// The definition editor: a full textarea over the agent's file content.
+/// Every ⏎ is a line break (a file editor's Enter is never "submit");
+/// `ctrl+s` saves — always a NEW version, immediately pinned; Esc discards
+/// the draft without writing anything.
+fn handle_agent_editor_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.editing = None;
+            ui.installed.status = Some("edit discarded — no version written".into());
+            DeckAction::Handled
+        }
+        KeyCode::Char('s') if ctrl => {
+            let Some((name, scope)) = ui.installed.editing.take() else {
+                ui.installed.mode = InstalledMode::Browse;
+                return DeckAction::Handled;
+            };
+            let content = ui.installed.editor.buffer().to_string();
+            if content.trim().is_empty() {
+                // Refuse to save an empty definition — the loader would
+                // reject it as EmptyBody and the agent would vanish.
+                ui.installed.editing = Some((name, scope));
+                ui.installed.status =
+                    Some("the definition is empty — Esc to discard instead".into());
+                return DeckAction::Handled;
+            }
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.busy = true;
+            ui.installed.status = Some(format!("saving {name} as a new pinned version…"));
+            DeckAction::Send(WorkspaceInput::AgentSave {
+                name,
+                scope,
+                content,
+            })
+        }
+        KeyCode::Enter => {
+            ui.installed.editor.insert_newline();
+            DeckAction::Handled
+        }
+        KeyCode::Backspace => {
+            ui.installed.editor.backspace();
+            DeckAction::Handled
+        }
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            ui.installed.editor.insert_char(c);
+            DeckAction::Handled
+        }
+        _ => {
+            // Cursor motion (arrows, home/end, the ⌥[ / ⌥] jumps) — then
+            // swallow whatever remains: the editor is modal.
+            let _ = handle_edit_key(key, &mut ui.installed.editor);
+            DeckAction::Handled
+        }
+    }
+}
+
+/// Create-from-prompt, step 1: a one-line description buffer. ⏎ advances to
+/// the scope picker; Esc cancels the flow.
+fn handle_create_describe_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.status = None;
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            if ui.installed.create_desc.trim().is_empty() {
+                ui.installed.status = Some("describe the agent first".into());
+            } else {
+                ui.installed.mode = InstalledMode::CreateScope;
+                ui.installed.status = None;
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Backspace => {
+            ui.installed.create_desc.pop();
+            DeckAction::Handled
+        }
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            ui.installed.create_desc.push(c);
+            DeckAction::Handled
+        }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// Create-from-prompt, step 2: the install-scope picker (project / user,
+/// mirroring the skills install flow's scope question). ⏎ dispatches the
+/// LLM-assisted creation; Esc steps back to the description.
+fn handle_create_scope_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::CreateDescribe;
+            DeckAction::Handled
+        }
+        KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right => {
+            ui.installed.scope_sel = 1 - ui.installed.scope_sel.min(1);
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            let description = ui.installed.create_desc.trim().to_string();
+            let scope = ui.installed.create_scope();
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.busy = true;
+            ui.installed.status = Some(format!(
+                "drafting the agent with the session model ({} scope)…",
+                scope.label()
+            ));
+            DeckAction::Send(WorkspaceInput::AgentCreate { description, scope })
+        }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// The version picker: ↑/↓ choose, ⏎ re-pins the highlighted version
+/// (pin-only — no new version is ever written here), Esc closes.
+fn handle_pick_version_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    let Some(entry) = ui.installed.selected().cloned() else {
+        ui.installed.mode = InstalledMode::Browse;
+        return DeckAction::Handled;
+    };
+    let count = entry.versions.len();
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::Browse;
+            DeckAction::Handled
+        }
+        KeyCode::Up => {
+            ui.installed.version_sel = ui.installed.version_sel.saturating_sub(1);
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            if count > 0 {
+                ui.installed.version_sel = (ui.installed.version_sel + 1).min(count - 1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            let Some(picked) = entry.versions.get(ui.installed.version_sel) else {
+                return DeckAction::Handled;
+            };
+            ui.installed.mode = InstalledMode::Browse;
+            if picked.version == entry.version {
+                ui.installed.status = Some(format!(
+                    "v{} is already the pinned version of {}",
+                    picked.version, entry.name
+                ));
+                return DeckAction::Handled;
+            }
+            ui.installed.busy = true;
+            ui.installed.status = Some(format!("pinning {} to v{}…", entry.name, picked.version));
+            DeckAction::Send(WorkspaceInput::AgentPin {
+                name: entry.name,
+                scope: entry.scope,
+                version: picked.version,
+            })
+        }
+        _ => DeckAction::Handled,
     }
 }
 
@@ -707,6 +1047,30 @@ fn handle_agents_key(
     ui: &mut DeckUi,
     composer_empty: bool,
 ) -> Option<DeckAction> {
+    // The secondary nav: ←/→ switch EXECUTIONS ↔ INSTALLED AGENTS. These
+    // only arrive here with a blank composer (a composer holding text claims
+    // ←/→ for cursor motion first), same gate as every other tab key.
+    match key.code {
+        KeyCode::Left if ui.agents_pane == AgentsPane::Installed => {
+            ui.agents_pane = AgentsPane::Executions;
+            return Some(DeckAction::Handled);
+        }
+        KeyCode::Right if ui.agents_pane == AgentsPane::Executions => {
+            ui.agents_pane = AgentsPane::Installed;
+            // First visit loads the list; after that the driver keeps it
+            // fresh after every op, so no re-fetch on every switch.
+            if !ui.installed.loaded && !ui.installed.busy {
+                ui.installed.busy = true;
+                return Some(DeckAction::Send(WorkspaceInput::AgentsRefresh));
+            }
+            return Some(DeckAction::Handled);
+        }
+        _ => {}
+    }
+    if ui.agents_pane == AgentsPane::Installed {
+        return handle_installed_browse_key(key, ui, composer_empty);
+    }
+
     let count = model.agents.len();
     match key.code {
         KeyCode::Up => {
@@ -734,6 +1098,71 @@ fn handle_agents_key(
                 control: AgentControl::Stop,
             })
         }),
+        _ => None,
+    }
+}
+
+/// The INSTALLED AGENTS pane's browse keys (non-modal — the composer stays
+/// live, so every letter verb is gated on a blank composer exactly like the
+/// executions pane's `s`): ↑/↓ select · ⏎ edit · `v` versions · `n` new ·
+/// `r` reload.
+fn handle_installed_browse_key(
+    key: KeyEvent,
+    ui: &mut DeckUi,
+    composer_empty: bool,
+) -> Option<DeckAction> {
+    let count = ui.installed.entries.len();
+    match key.code {
+        KeyCode::Up => {
+            ui.installed.sel = ui.installed.sel.saturating_sub(1);
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Down => {
+            if count > 0 {
+                ui.installed.sel = (ui.installed.sel + 1).min(count - 1);
+            }
+            Some(DeckAction::Handled)
+        }
+        // ⏎ opens the editor on the selected agent — the queue editor's
+        // "pull it out to edit" idiom, over the pinned version's content.
+        KeyCode::Enter if composer_empty && key.modifiers.is_empty() => {
+            if let Some(entry) = ui.installed.selected().cloned() {
+                ui.installed.editor = Composer::with_paste_threshold(usize::MAX);
+                ui.installed.editor.load(entry.content.clone());
+                ui.installed.editing = Some((entry.name.clone(), entry.scope));
+                ui.installed.mode = InstalledMode::Edit;
+                ui.installed.status = None;
+            }
+            Some(DeckAction::Handled)
+        }
+        // `v` opens the version picker on the selected agent, preselecting
+        // the pinned version.
+        KeyCode::Char('v') if composer_empty => {
+            if let Some(entry) = ui.installed.selected() {
+                ui.installed.version_sel = entry
+                    .versions
+                    .iter()
+                    .position(|v| v.version == entry.version)
+                    .unwrap_or(0);
+                ui.installed.mode = InstalledMode::PickVersion;
+                ui.installed.status = None;
+            }
+            Some(DeckAction::Handled)
+        }
+        // `n` starts the create-from-prompt flow.
+        KeyCode::Char('n') if composer_empty => {
+            ui.installed.mode = InstalledMode::CreateDescribe;
+            ui.installed.create_desc.clear();
+            ui.installed.scope_sel = 0;
+            ui.installed.status = None;
+            Some(DeckAction::Handled)
+        }
+        // `r` reloads the list from disk.
+        KeyCode::Char('r') if composer_empty => {
+            ui.installed.busy = true;
+            ui.installed.status = Some("reloading installed agents…".into());
+            Some(DeckAction::Send(WorkspaceInput::AgentsRefresh))
+        }
         _ => None,
     }
 }
@@ -2007,5 +2436,261 @@ mod tests {
             &mut ui,
         );
         assert_eq!(ui.graph.as_ref(), Some(&snapshot));
+    }
+
+    // ---- AGENTS tab: INSTALLED AGENTS pane -------------------------------
+
+    fn installed_entry(name: &str, version: u32) -> InstalledAgentEntry {
+        InstalledAgentEntry {
+            name: name.into(),
+            description: format!("about {name}"),
+            tools: Some(vec!["Read".into()]),
+            scope: AgentScope::Project,
+            source_path: format!("/ws/.stella/agents/{name}.md"),
+            version,
+            versions: (1..=version)
+                .map(|v| crate::envelope::AgentVersionInfo {
+                    version: v,
+                    label: String::new(),
+                })
+                .collect(),
+            content: format!("---\nname: {name}\n---\nbody of {name}"),
+        }
+    }
+
+    /// A ready deck on the AGENTS tab's INSTALLED pane with `entries` loaded.
+    fn installed_ui(entries: Vec<InstalledAgentEntry>) -> DeckUi {
+        let mut ui = ready_ui();
+        ui.tab = DeckTab::Agents;
+        ui.agents_pane = AgentsPane::Installed;
+        ui.installed.entries = entries;
+        ui.installed.loaded = true;
+        ui
+    }
+
+    #[test]
+    fn agents_pane_arrows_switch_and_first_visit_asks_for_the_list() {
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.tab = DeckTab::Agents;
+        assert_eq!(ui.agents_pane, AgentsPane::Executions, "executions first");
+        // → switches to INSTALLED AGENTS; the unloaded list triggers one
+        // refresh request.
+        let action = handle_deck_key(key(KeyCode::Right), &model, &mut ui);
+        assert_eq!(ui.agents_pane, AgentsPane::Installed);
+        assert_eq!(action, DeckAction::Send(WorkspaceInput::AgentsRefresh));
+        // ← switches back; → again does NOT re-fetch (busy flag pending).
+        handle_deck_key(key(KeyCode::Left), &model, &mut ui);
+        assert_eq!(ui.agents_pane, AgentsPane::Executions);
+        assert_eq!(
+            handle_deck_key(key(KeyCode::Right), &model, &mut ui),
+            DeckAction::Handled,
+            "no duplicate refresh while one is in flight"
+        );
+    }
+
+    #[test]
+    fn slash_agents_opens_the_tab_on_the_installed_pane() {
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.slash_commands = vec![SlashCommand::new("/agents", "agents")];
+        for c in "/agents".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.tab, DeckTab::Agents, "/agents opens the Agents tab");
+        assert_eq!(ui.agents_pane, AgentsPane::Installed);
+        assert_eq!(action, DeckAction::Send(WorkspaceInput::AgentsRefresh));
+        assert!(ui.composer.buffer().is_empty(), "the composer cleared");
+    }
+
+    #[test]
+    fn agents_list_ingest_updates_the_panel_out_of_band_and_clamps() {
+        let mut model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![]);
+        ui.installed.sel = 5;
+        ui.installed.busy = true;
+        ingest_inbound(
+            &Inbound::AgentsList {
+                entries: vec![installed_entry("reviewer", 1)],
+                status: Some("saved".into()),
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert_eq!(ui.installed.entries.len(), 1);
+        assert_eq!(ui.installed.sel, 0, "selection clamped to the new list");
+        assert!(!ui.installed.busy, "a fresh list completes the op");
+        assert_eq!(ui.installed.status.as_deref(), Some("saved"));
+        assert_eq!(
+            model.agents.len(),
+            1,
+            "the model fold ignores the out-of-band list"
+        );
+    }
+
+    #[test]
+    fn installed_enter_opens_the_editor_and_ctrl_s_saves_a_new_version() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![installed_entry("reviewer", 2)]);
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::Edit);
+        assert_eq!(
+            ui.installed.editor.buffer(),
+            "---\nname: reviewer\n---\nbody of reviewer",
+            "the editor holds the pinned version's content"
+        );
+        // Type at the end (the cursor loads at the end of the buffer), with
+        // a plain Enter inserting a newline — never submitting.
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        for c in "x".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(ctrl('s'), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::AgentSave {
+                name: "reviewer".into(),
+                scope: AgentScope::Project,
+                content: "---\nname: reviewer\n---\nbody of reviewer\nx".into(),
+            }),
+            "ctrl+s sends the edited content — the driver writes a NEW pinned version"
+        );
+        assert_eq!(ui.installed.mode, InstalledMode::Browse);
+        assert!(ui.installed.busy, "save shows the working state");
+    }
+
+    #[test]
+    fn editor_esc_discards_without_sending_and_typing_never_leaks() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![installed_entry("reviewer", 1)]);
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        for c in "abc".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        assert!(
+            ui.composer.buffer().is_empty(),
+            "editor typing never reaches the global composer"
+        );
+        let action = handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled, "no save is sent");
+        assert_eq!(ui.installed.mode, InstalledMode::Browse);
+        assert!(
+            ui.installed
+                .status
+                .as_deref()
+                .is_some_and(|s| s.contains("discarded")),
+            "{:?}",
+            ui.installed.status
+        );
+    }
+
+    #[test]
+    fn create_flow_describes_picks_scope_and_dispatches_the_llm_draft() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![]);
+        handle_deck_key(ch('n'), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::CreateDescribe);
+        for c in "reviews diffs".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        assert_eq!(ui.installed.create_desc, "reviews diffs");
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            ui.installed.mode,
+            InstalledMode::CreateScope,
+            "⏎ advances to the scope picker (mirrors the skills install flow)"
+        );
+        // Default scope is project; ↓ flips to user, ↑ flips back.
+        assert_eq!(ui.installed.create_scope(), AgentScope::Project);
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        assert_eq!(ui.installed.create_scope(), AgentScope::User);
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::AgentCreate {
+                description: "reviews diffs".into(),
+                scope: AgentScope::Project,
+            })
+        );
+        assert_eq!(ui.installed.mode, InstalledMode::Browse);
+        assert!(ui.installed.busy);
+    }
+
+    #[test]
+    fn create_flow_requires_a_description_and_esc_steps_back() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![]);
+        handle_deck_key(ch('n'), &model, &mut ui);
+        // Empty description: ⏎ refuses to advance.
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::CreateDescribe);
+        for c in "x".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::CreateScope);
+        // Esc from the scope picker returns to the description, not Browse.
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::CreateDescribe);
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    }
+
+    #[test]
+    fn version_picker_pins_an_older_version_without_editing() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![installed_entry("reviewer", 3)]);
+        handle_deck_key(ch('v'), &model, &mut ui);
+        assert_eq!(ui.installed.mode, InstalledMode::PickVersion);
+        assert_eq!(
+            ui.installed.version_sel, 2,
+            "the picker opens on the pinned version"
+        );
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::AgentPin {
+                name: "reviewer".into(),
+                scope: AgentScope::Project,
+                version: 1,
+            }),
+            "⏎ re-pins — an AgentPin, never an AgentSave"
+        );
+        assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    }
+
+    #[test]
+    fn version_picker_on_the_already_pinned_version_sends_nothing() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![installed_entry("reviewer", 2)]);
+        handle_deck_key(ch('v'), &model, &mut ui);
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled, "re-pinning the pin is a no-op");
+        assert!(
+            ui.installed
+                .status
+                .as_deref()
+                .is_some_and(|s| s.contains("already")),
+            "{:?}",
+            ui.installed.status
+        );
+    }
+
+    #[test]
+    fn installed_browse_letter_verbs_type_when_the_composer_has_text() {
+        let model = model_with(&["lead"]);
+        let mut ui = installed_ui(vec![installed_entry("reviewer", 1)]);
+        handle_deck_key(ch('h'), &model, &mut ui);
+        handle_deck_key(ch('n'), &model, &mut ui);
+        assert_eq!(
+            ui.installed.mode,
+            InstalledMode::Browse,
+            "a typed `n` is prompt text, not the create verb"
+        );
+        assert_eq!(ui.composer.buffer(), "hn");
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -149,6 +149,72 @@ pub enum Inbound {
     /// raw engine loop. Folded into [`crate::deck::WorkspaceModel::pipeline`]
     /// so the `PIPELINE` stat box flips live.
     Pipeline(bool),
+    /// The installed-agents list for the Agents tab's INSTALLED AGENTS pane.
+    /// Out-of-band view state (applied straight to `DeckUi::installed` by
+    /// [`crate::deck_ui::ingest_inbound`], ignored by the model fold). The
+    /// driver — which owns the definitions on disk — sends one when the pane
+    /// asks ([`WorkspaceInput::AgentsRefresh`]) and after every save / pin /
+    /// create so the list stays live. `status`, when set, replaces the
+    /// pane's hint line (op outcomes, errors).
+    AgentsList {
+        entries: Vec<InstalledAgentEntry>,
+        status: Option<String>,
+    },
+}
+
+/// Which config level an installed agent definition lives at.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentScope {
+    /// The workspace's `.stella/agents/` directory.
+    Project,
+    /// The user's `~/.config/stella/agents/` directory.
+    User,
+}
+
+impl AgentScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            AgentScope::Project => "project",
+            AgentScope::User => "user",
+        }
+    }
+}
+
+/// One selectable version of an installed agent (the version picker's row).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentVersionInfo {
+    /// 1-based version number.
+    pub version: u32,
+    /// Short display label (e.g. the version file's modification time), or
+    /// empty when none was available.
+    pub label: String,
+}
+
+/// One installed agent as the Agents tab's INSTALLED AGENTS pane lists it
+/// (see [`Inbound::AgentsList`]). Decoupled from `stella-core`'s `AgentDef`
+/// so the TUI crate stays independent of the extensions engine — the driver
+/// maps one to the other and adds the version/scope bookkeeping.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstalledAgentEntry {
+    /// The agent's loaded definition name.
+    pub name: String,
+    /// One-line description shown beside the name.
+    pub description: String,
+    /// The toolbelt grant from the definition's `tools:` frontmatter.
+    /// `None` = the definition does not restrict tools — the agent gets
+    /// **all** tools, and the pane says so honestly.
+    pub tools: Option<Vec<String>>,
+    /// Which config level the definition lives at.
+    pub scope: AgentScope,
+    /// The definition file the loader reads (display/provenance).
+    pub source_path: String,
+    /// The pinned (active) version — 1 for a never-versioned agent.
+    pub version: u32,
+    /// Every version on disk, oldest first. Always contains `version`.
+    pub versions: Vec<AgentVersionInfo>,
+    /// The pinned version's full file content (frontmatter + body) — what
+    /// the editor loads.
+    pub content: String,
 }
 
 /// What the deck sends back to the caller / engine. The single-session
@@ -185,6 +251,33 @@ pub enum WorkspaceInput {
     /// Esc is the plain [`AgentControl::Stop`]: cancel, and the next queued
     /// prompt dispatches automatically.
     StopAndHold { agent: AgentId },
+    /// The INSTALLED AGENTS pane opened (or wants a reload): enumerate the
+    /// agent definitions installed at both scopes and answer with
+    /// [`Inbound::AgentsList`].
+    AgentsRefresh,
+    /// Save an edited agent definition as a NEW version and pin it — the
+    /// prior version is preserved on disk (see `stella-cli`'s
+    /// `agents_installed` module for the on-disk scheme). The driver
+    /// answers with a fresh [`Inbound::AgentsList`].
+    AgentSave {
+        name: String,
+        scope: AgentScope,
+        content: String,
+    },
+    /// Re-pin an existing version WITHOUT editing — the version count never
+    /// changes on a pin (increments happen only on [`WorkspaceInput::AgentSave`]).
+    AgentPin {
+        name: String,
+        scope: AgentScope,
+        version: u32,
+    },
+    /// Create a new agent from a short description with LLM assistance: the
+    /// driver drafts the definition through the session's provider, installs
+    /// it at `scope`, and answers with a fresh [`Inbound::AgentsList`].
+    AgentCreate {
+        description: String,
+        scope: AgentScope,
+    },
     /// Tear down the deck.
     Quit,
 }

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -76,7 +76,10 @@ pub use deck::{
 pub use deck_render::render_deck;
 pub use deck_shell::{DeckOptions, run_deck};
 pub use deck_ui::{DeckAction, DeckUi, handle_deck_key, ingest_inbound};
-pub use envelope::{AgentControl, AgentId, AgentMeta, AgentStatus, Inbound, WorkspaceInput};
+pub use envelope::{
+    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
+    InstalledAgentEntry, WorkspaceInput,
+};
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;
 pub use splash::SplashState;

--- a/stella-tui/src/views/agents.rs
+++ b/stella-tui/src/views/agents.rs
@@ -1,18 +1,24 @@
-//! Agents tab — the flagship `htop`/`claudectl`-style dashboard: one dense
-//! row per agent with live status, spend, resource usage, and activity.
+//! AGENTS tab — a two-pane view behind a one-line secondary nav
+//! (EXECUTIONS | INSTALLED AGENTS, switched with ←/→):
+//!
+//! - **EXECUTIONS** (this module): the flagship `htop`/`claudectl`-style
+//!   dashboard — one dense row per ACTIVE agent with live status, spend,
+//!   resource usage, and activity.
+//! - **INSTALLED AGENTS** ([`crate::views::installed`]): the agents
+//!   configured on disk at the user/project level.
 //!
 //! Every color comes from [`crate::theme`]; every number is read straight off
 //! [`crate::deck::AgentEntry`] (no shadow state, no re-derivation of what the
 //! model already computed).
 
 use ratatui::buffer::Buffer;
-use ratatui::layout::{Alignment, Constraint, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Widget};
 
 use crate::deck::{ACTIVITY_WINDOW, AgentEntry, WorkspaceModel};
-use crate::deck_ui::DeckUi;
+use crate::deck_ui::{AgentsPane, DeckUi};
 use crate::theme;
 
 /// Column headers, in display order — matches the `widths` array in
@@ -28,13 +34,52 @@ const HEADERS: [&str; 11] = [
 const GOAL_MAX_CHARS: usize = 56;
 
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    // The one-line secondary nav, then the active pane below it.
+    let bands = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
+    render_pane_nav(ui.agents_pane, bands[0], buf);
+    match ui.agents_pane {
+        AgentsPane::Executions => render_executions(model, ui, bands[1], buf),
+        AgentsPane::Installed => crate::views::installed::render(ui, bands[1], buf),
+    }
+}
+
+/// The secondary nav line: the two pane labels (UPPERCASE, like the deck's
+/// tab labels), active in amber, plus the switch hint.
+fn render_pane_nav(pane: AgentsPane, area: Rect, buf: &mut Buffer) {
+    if area.height == 0 {
+        return;
+    }
+    let style_for = |active: bool| {
+        if active {
+            Style::default()
+                .fg(theme::AMBER)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme::muted()
+        }
+    };
+    let line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled("EXECUTIONS", style_for(pane == AgentsPane::Executions)),
+        Span::styled("  │  ", theme::muted()),
+        Span::styled("INSTALLED AGENTS", style_for(pane == AgentsPane::Installed)),
+        Span::styled("   ←/→", theme::muted()),
+    ]);
+    Paragraph::new(line).render(area, buf);
+}
+
+/// The EXECUTIONS pane — the pre-existing active-agents dashboard.
+fn render_executions(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     if model.agents.is_empty() {
         render_empty(area, buf);
         return;
     }
 
     let title = format!(
-        " Agents — {} active / {} total ",
+        " Executions — {} active / {} total ",
         model.active_count(),
         model.agents.len()
     );
@@ -169,7 +214,7 @@ fn agent_row(entry: &AgentEntry, now_ms: u64, is_focused: bool) -> Row<'static> 
 
 /// The centered, muted "nothing dispatched yet" state.
 fn render_empty(area: Rect, buf: &mut Buffer) {
-    let block = Block::default().borders(Borders::ALL).title(" Agents ");
+    let block = Block::default().borders(Borders::ALL).title(" Executions ");
     let inner = block.inner(area);
     block.render(area, buf);
 

--- a/stella-tui/src/views/installed.rs
+++ b/stella-tui/src/views/installed.rs
@@ -1,0 +1,426 @@
+//! The AGENTS tab's INSTALLED AGENTS pane: the agents configured on disk at
+//! the user (`~/.config/stella/agents`) and project (`.stella/agents`)
+//! levels — name, description, and toolbelt per row — plus the pane's modal
+//! sub-views (the definition editor, the create-from-prompt flow, and the
+//! version picker).
+//!
+//! Every color comes from [`crate::theme`]; the list content comes verbatim
+//! from the driver's [`crate::envelope::Inbound::AgentsList`] snapshot held
+//! on [`crate::deck_ui::InstalledPanel`] (no shadow state).
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Widget, Wrap};
+
+use crate::composer;
+use crate::deck_ui::{DeckUi, InstalledMode, InstalledPanel};
+use crate::envelope::InstalledAgentEntry;
+use crate::theme;
+
+/// Column headers for the browse list, matching `widths` in [`render_list`].
+const HEADERS: [&str; 5] = ["Agent", "Scope", "Ver", "Description", "Toolbelt"];
+
+pub fn render(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    match ui.installed.mode {
+        InstalledMode::Browse => render_list(&ui.installed, area, buf),
+        InstalledMode::Edit => render_editor(&ui.installed, area, buf),
+        InstalledMode::CreateDescribe => render_create_describe(&ui.installed, area, buf),
+        InstalledMode::CreateScope => render_create_scope(&ui.installed, area, buf),
+        InstalledMode::PickVersion => render_version_picker(&ui.installed, area, buf),
+    }
+}
+
+/// The toolbelt cell text: the granted tools, or the honest "all tools"
+/// when the definition doesn't restrict them.
+pub fn toolbelt_label(tools: &Option<Vec<String>>) -> String {
+    match tools {
+        None => "all tools".to_string(),
+        Some(list) => list.join(", "),
+    }
+}
+
+fn render_list(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    let title = format!(" Installed Agents — {} on disk ", panel.entries.len());
+    let block = Block::default().borders(Borders::ALL).title(title);
+
+    let bands = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
+    let (list_area, foot_area) = (bands[0], bands[1]);
+
+    if panel.entries.is_empty() {
+        let inner = block.inner(list_area);
+        block.render(list_area, buf);
+        let hint = if panel.busy {
+            "loading installed agents…"
+        } else if panel.loaded {
+            "no agents installed — press n to create one from a prompt"
+        } else {
+            "press r to load the installed agents"
+        };
+        if inner.height > 0 {
+            let y = inner.y + inner.height.saturating_sub(1) / 2;
+            Paragraph::new(hint)
+                .style(theme::muted())
+                .alignment(Alignment::Center)
+                .render(Rect::new(inner.x, y, inner.width, 1), buf);
+        }
+        render_footer(panel, foot_area, buf);
+        return;
+    }
+
+    let header = Row::new(HEADERS.iter().copied().map(Cell::from)).style(theme::accent());
+    let rows: Vec<Row> = panel
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| agent_row(entry, i == panel.sel))
+        .collect();
+    let widths = [
+        Constraint::Length(20), // Agent
+        Constraint::Length(8),  // Scope
+        Constraint::Length(5),  // Ver
+        Constraint::Fill(3),    // Description
+        Constraint::Fill(2),    // Toolbelt
+    ];
+    Table::new(rows, widths)
+        .header(header)
+        .block(block)
+        .column_spacing(1)
+        .render(list_area, buf);
+
+    render_footer(panel, foot_area, buf);
+}
+
+fn agent_row(entry: &InstalledAgentEntry, is_selected: bool) -> Row<'static> {
+    let caret = if is_selected {
+        Span::styled("> ", Style::default().fg(theme::AMBER))
+    } else {
+        Span::raw("  ")
+    };
+    let name_cell = Cell::from(Line::from(vec![
+        caret,
+        Span::styled(entry.name.clone(), Style::default().fg(theme::AMBER)),
+    ]));
+    let scope_cell = Cell::from(entry.scope.label()).style(theme::muted());
+    let ver_cell = Cell::from(format!("v{}", entry.version)).style(theme::body());
+    let desc_cell = Cell::from(entry.description.clone()).style(theme::body());
+    let tools_cell = Cell::from(toolbelt_label(&entry.tools)).style(theme::muted());
+    let mut row = Row::new(vec![name_cell, scope_cell, ver_cell, desc_cell, tools_cell]);
+    if is_selected {
+        row = row.style(Style::default().add_modifier(Modifier::REVERSED));
+    }
+    row
+}
+
+/// The bottom line: the transient status when set, the key legend otherwise.
+fn render_footer(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    if area.height == 0 {
+        return;
+    }
+    let text = match &panel.status {
+        Some(status) => status.clone(),
+        None => "↑/↓ select · ⏎ edit (new pinned version) · v versions · n new from prompt · \
+                 r reload · ←/→ panes"
+            .to_string(),
+    };
+    Paragraph::new(text).style(theme::muted()).render(area, buf);
+}
+
+/// The definition editor: the pinned version's full content in a textarea.
+/// A save (ctrl+s) is ALWAYS a new version; the window follows the cursor.
+fn render_editor(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    let (name, scope) = match &panel.editing {
+        Some((name, scope)) => (name.as_str(), scope.label()),
+        None => ("agent", "?"),
+    };
+    let title =
+        format!(" Edit {name} ({scope}) — ctrl+s saves a NEW pinned version · esc discards ");
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(theme::AMBER));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let layout = composer::layout(&panel.editor, inner.width as usize);
+    let height = inner.height as usize;
+    // Scroll the window so the cursor row is always visible (bottom-anchored
+    // once the content exceeds the viewport).
+    let start = (layout.cursor_row + 1).saturating_sub(height);
+    for (i, row) in layout.rows.iter().skip(start).take(height).enumerate() {
+        let y = inner.y + i as u16;
+        Paragraph::new(row.as_str())
+            .style(theme::body())
+            .render(Rect::new(inner.x, y, inner.width, 1), buf);
+    }
+    // The cursor cell, reversed — same visual as a terminal caret.
+    let cy = inner.y + (layout.cursor_row - start) as u16;
+    let cx = inner.x + (layout.cursor_col as u16).min(inner.width.saturating_sub(1));
+    if cy < inner.y + inner.height {
+        buf.set_style(
+            Rect::new(cx, cy, 1, 1),
+            Style::default().add_modifier(Modifier::REVERSED),
+        );
+    }
+}
+
+/// Create-from-prompt, step 1: the description input.
+fn render_create_describe(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" New Agent — describe what it should do · ⏎ next · esc cancel ")
+        .border_style(Style::default().fg(theme::AMBER));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 {
+        return;
+    }
+    let text = format!("> {}▏", panel.create_desc);
+    Paragraph::new(text)
+        .style(theme::body())
+        .wrap(Wrap { trim: false })
+        .render(inner, buf);
+    if inner.height > 2 {
+        let hint = "the session model drafts the definition (name, description, toolbelt, \
+                    system prompt) from this description";
+        Paragraph::new(hint).style(theme::muted()).render(
+            Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1),
+            buf,
+        );
+    }
+}
+
+/// Create-from-prompt, step 2: the install-scope picker.
+fn render_create_scope(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" New Agent — install scope · ↑/↓ choose · ⏎ create · esc back ")
+        .border_style(Style::default().fg(theme::AMBER));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 {
+        return;
+    }
+    let options = [
+        "project — .stella/agents (this workspace)",
+        "user — ~/.config/stella/agents (all projects)",
+    ];
+    for (i, option) in options.iter().enumerate() {
+        if (i as u16) >= inner.height {
+            break;
+        }
+        let selected = i == panel.scope_sel.min(1);
+        let line = format!("{} {option}", if selected { ">" } else { " " });
+        let style = if selected {
+            Style::default()
+                .fg(theme::AMBER)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme::body()
+        };
+        Paragraph::new(line)
+            .style(style)
+            .render(Rect::new(inner.x, inner.y + i as u16, inner.width, 1), buf);
+    }
+}
+
+/// The version picker: every version on disk, the pinned one marked. ⏎
+/// re-pins WITHOUT writing a new version.
+fn render_version_picker(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
+    let Some(entry) = panel.selected() else {
+        return;
+    };
+    let title = format!(
+        " Versions — {} · ⏎ pin (no new version) · esc close ",
+        entry.name
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(theme::AMBER));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    for (i, info) in entry.versions.iter().enumerate() {
+        if (i as u16) >= inner.height {
+            break;
+        }
+        let selected = i == panel.version_sel;
+        let pinned = if info.version == entry.version {
+            "  ● pinned"
+        } else {
+            ""
+        };
+        let line = format!(
+            "{} v{}  {}{pinned}",
+            if selected { ">" } else { " " },
+            info.version,
+            info.label,
+        );
+        let mut style = if selected {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            theme::body()
+        };
+        if info.version == entry.version {
+            style = style.fg(theme::AMBER);
+        }
+        Paragraph::new(line)
+            .style(style)
+            .render(Rect::new(inner.x, inner.y + i as u16, inner.width, 1), buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{AgentScope, AgentVersionInfo};
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let area = *buf.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn entry(name: &str, tools: Option<Vec<String>>) -> InstalledAgentEntry {
+        InstalledAgentEntry {
+            name: name.into(),
+            description: format!("what {name} does"),
+            tools,
+            scope: AgentScope::Project,
+            source_path: format!("/ws/.stella/agents/{name}.md"),
+            version: 2,
+            versions: vec![
+                AgentVersionInfo {
+                    version: 1,
+                    label: "2026-07-01".into(),
+                },
+                AgentVersionInfo {
+                    version: 2,
+                    label: "2026-07-16".into(),
+                },
+            ],
+            content: format!("---\nname: {name}\n---\nbody"),
+        }
+    }
+
+    fn ui_with(entries: Vec<InstalledAgentEntry>) -> DeckUi {
+        let mut ui = DeckUi::default();
+        ui.installed.entries = entries;
+        ui.installed.loaded = true;
+        ui
+    }
+
+    #[test]
+    fn toolbelt_labels_are_honest_about_unrestricted_grants() {
+        assert_eq!(toolbelt_label(&None), "all tools");
+        assert_eq!(
+            toolbelt_label(&Some(vec!["Read".into(), "Grep".into()])),
+            "Read, Grep"
+        );
+    }
+
+    #[test]
+    fn list_renders_name_description_toolbelt_and_version() {
+        let mut ui = ui_with(vec![
+            entry("reviewer", Some(vec!["Read".into(), "Grep".into()])),
+            entry("planner", None),
+        ]);
+        let area = Rect::new(0, 0, 120, 10);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("reviewer"), "name shown:\n{text}");
+        assert!(
+            text.contains("what reviewer does"),
+            "description shown:\n{text}"
+        );
+        assert!(text.contains("Read, Grep"), "toolbelt shown:\n{text}");
+        assert!(
+            text.contains("all tools"),
+            "an unrestricted grant reads as `all tools`:\n{text}"
+        );
+        assert!(text.contains("v2"), "pinned version shown:\n{text}");
+        assert!(text.contains("project"), "scope shown:\n{text}");
+    }
+
+    #[test]
+    fn empty_loaded_list_hints_at_create_from_prompt() {
+        let mut ui = ui_with(vec![]);
+        let area = Rect::new(0, 0, 80, 8);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("press n to create one from a prompt"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn editor_renders_the_loaded_content_and_the_save_contract() {
+        let mut ui = ui_with(vec![entry("reviewer", None)]);
+        ui.installed.mode = InstalledMode::Edit;
+        ui.installed.editing = Some(("reviewer".into(), AgentScope::Project));
+        ui.installed.editor.load("---\nname: reviewer\n---\nbody");
+        let area = Rect::new(0, 0, 90, 10);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Edit reviewer"), "{text}");
+        assert!(
+            text.contains("NEW pinned version"),
+            "the save-is-a-new-version contract is on screen:\n{text}"
+        );
+        assert!(text.contains("name: reviewer"), "content shown:\n{text}");
+    }
+
+    #[test]
+    fn version_picker_marks_the_pinned_version() {
+        let mut ui = ui_with(vec![entry("reviewer", None)]);
+        ui.installed.mode = InstalledMode::PickVersion;
+        ui.installed.version_sel = 0;
+        let area = Rect::new(0, 0, 80, 8);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("v1"), "{text}");
+        assert!(text.contains("v2  2026-07-16  ● pinned"), "{text}");
+        assert!(
+            text.contains("no new version"),
+            "the pin-does-not-increment contract is on screen:\n{text}"
+        );
+    }
+
+    #[test]
+    fn create_flow_renders_description_then_scope() {
+        let mut ui = ui_with(vec![]);
+        ui.installed.mode = InstalledMode::CreateDescribe;
+        ui.installed.create_desc = "reviews diffs".into();
+        let area = Rect::new(0, 0, 100, 8);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("reviews diffs"), "{text}");
+        assert!(text.contains("describe what it should do"), "{text}");
+
+        ui.installed.mode = InstalledMode::CreateScope;
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains(".stella/agents"), "{text}");
+        assert!(text.contains("~/.config/stella/agents"), "{text}");
+    }
+}

--- a/stella-tui/src/views/mod.rs
+++ b/stella-tui/src/views/mod.rs
@@ -6,5 +6,6 @@
 pub mod agents;
 pub mod files;
 pub mod graph;
+pub mod installed;
 pub mod session;
 pub mod traces;

--- a/stella-tui/tests/deck_snapshot.rs
+++ b/stella-tui/tests/deck_snapshot.rs
@@ -59,8 +59,9 @@ fn deck_renders_every_tab_with_real_content() {
             text.contains(needle),
             "the {tab:?} tab should show {needle:?}, got:\n{text}"
         );
-        // The comfy-tabs bar labels are always present.
-        assert!(text.contains("Agents"), "tab bar should render on {tab:?}");
+        // The comfy-tabs bar labels are always present — UPPERCASE by the
+        // deck's tab-label convention.
+        assert!(text.contains("AGENTS"), "tab bar should render on {tab:?}");
     }
 
     // Write all five tabs to a human-readable artifact at the repo root.


### PR DESCRIPTION
## What

The AGENTS deck tab grows a **secondary nav** — `EXECUTIONS | INSTALLED AGENTS` (←/→) — with a full installed-agents manager behind it, plus agent-version **usage telemetry** in store.db, `/agents` now opening the tab directly, and **UPPERCASE deck tab labels** across the board.

### Nav / views

- **EXECUTIONS** — the pre-existing active-agents dashboard, unchanged (now behind the nav; block retitled `Executions`).
- **INSTALLED AGENTS** — every agent definition installed at the **project** (`.stella/agents/`) or **user** (`~/.config/stella/agents/`) level: name, scope, pinned version, description, and **toolbelt** (frontmatter `tools:`; an unrestricted definition honestly reads `all tools`).
  - `↑/↓` select · `⏎` **edit** · `v` **versions** · `n` **new from prompt** · `r` reload — letter verbs gate on a blank composer, like every deck tab.
  - `/agents` opens the tab directly on this pane (deck-local, like `/files`/`/graph`).

### Versioning + pin scheme (filesystem-first, documented in `stella-cli/src/agents_installed.rs`)

```
<agents-dir>/<slug>.md                  ← the LOADED definition: materialized copy of the PINNED version
<agents-dir>/.versions/<slug>/v0001.md  ← immutable version files, oldest first
<agents-dir>/.versions/<slug>/PINNED    ← one line: the pinned version number
```

- **Edit** (⏎ → in-TUI textarea, the deck's `Composer` reused → `ctrl+s`): archives the current content (as v1 if never versioned), writes the new content as `v<max+1>`, pins it, rewrites the canonical file. **Saving always creates a new version and pins it; nothing prior is ever destroyed.**
- **Pin-set** (`v` → picker → ⏎): re-points `PINNED` at an existing version and re-materializes the canonical file. **Never increments the version** — pin changes are not edits.
- Never-versioned agents are implicitly v1; nothing is created until the first edit. Symlinked (`.claude/`-adopted) definitions are never written through — the link is replaced by a real file, the foreign source untouched.

### Create from prompt (LLM-assisted; no npx search — that's skills-only)

`n` → type a short description → `⏎` → scope picker (**project / user**, mirroring the skills install flow) → `⏎` dispatches `AgentCreate`. The driver drafts the definition through the session provider (`Provider::complete`, the same one-shot path the reflection module uses — no hand-rolled HTTP), validates the draft with the real loader parser, and installs it (never clobbers). Mid-turn requests park and run when the turn settles (the turn borrows the provider).

### Usage telemetry (agent-version level)

- Installed agents are now **invocable** as `/agent-name task…` (persona-prompt expansion; commands ⊳ skills ⊳ agents precedence) — this is the invocation seam the telemetry records.
- Each invocation records `(agent, pinned version, reason)` on a registry ledger (`stella-tools/src/agent_use.rs`, mirroring `file_touch.rs`), **drained once per execution** in `record_execution_end` into the new **`agent_uses`** table (execution_id, agent, version, reason, ts — an event log, no UNIQUE key by design).
- ⚠️ **store.db migration**: taken naively as **v3 → v4** (v3 = memory_citations/rules on current main). Several in-flight branches each add a migration — expect a one-line renumber at cascade-merge.

### Shared-infra notes for the merge cascade

- **Registry tool-count pins (#136 trap): this branch registers NO new tools** — pins untouched. Sibling skills/mcp branches may still need the one-line reconcile.
- Deck tab labels are now UPPERCASE (`SESSION/AGENTS/TRACES/GRAPH/FILES` via `DeckTab::title`); sibling tabs should follow (`SKILLS`, `MCP`).
- New `Inbound::AgentsList` + `WorkspaceInput::{AgentsRefresh, AgentSave, AgentPin, AgentCreate}` — additive; `deck_demo` answers them with an empty list.

## Verification (local — CI is billing-locked, red is expected)

- `cargo build --workspace` ✅
- `cargo test -p stella-core -p stella-tools -p stella-store -p stella-tui -p stella-cli` ✅ (265 / 177 / 31 / 337 / 139)
- `cargo clippy --all-targets -p <the five touched crates> -- -D warnings` ✅
- New tests: two-scope discovery (tempdir), toolbelt parsing/rendering (`all tools` honesty), edit-creates-new-pinned-version (+ old preserved byte-for-byte), pin-without-increment, version listing, symlink-safety, creation prompt assembly + fence-stripping parse (no live LLM), ledger drain, v4 migration + fresh-schema, and the full key-flow suite (nav switch, editor, create, picker, modal isolation).

## Judgment calls

- Canonical-file-is-the-pinned-version keeps every other consumer (loaders, other tools, `grep`) working with zero version-awareness; `.versions/` is dot-prefixed so loaders skip it by construction.
- Editing reuses the deck's `Composer` textarea (the queue-editor "pull it out to edit" idiom) rather than shelling to `$EDITOR` — the deck owns the terminal, and no `$EDITOR` idiom exists in the codebase.
- Both scopes are listed on a name collision (they're separate installs; load-time precedence stays the loaders' concern).
- `/agent-name` invocability was added as the minimal genuine seam for the requested per-version usage telemetry (otherwise the table would be dead code); toolbelt restriction is stated in the persona prompt — hard enforcement stays the fleet-spawn seam's concern.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Installed Agents manager to the AGENTS tab behind a new EXECUTIONS | INSTALLED AGENTS secondary nav, including versioned edit/pin and create-from-prompt. Adds per-agent pinned-version usage telemetry persisted to a new agent_uses table (store.db v4), plus `/agents` shortcut and UPPERCASE tab labels.

- **New Features**
  - Agents tab nav: ←/→ toggles EXECUTIONS and INSTALLED AGENTS; `/agents` opens the tab directly.
  - Installed list shows project/user agents with name, scope, pinned version, description, and toolbelt.
  - Edit (Enter → save) always creates and pins a new version; previous versions are preserved.
  - Version picker (v) re-pins without creating a new version.
  - Create-from-prompt (n): drafts via the session provider, validates, and installs to project/user scope.
  - Invoke installed agents with `/agent-name task…`; records agent + pinned version + reason.
  - Deck tab labels are now UPPERCASE.

- **Migration**
  - store.db upgrades to v4 and adds the agent_uses event table; runs automatically on startup.

<sup>Written for commit e18e031fee73ed3eb59c63aa22e4c858368de49a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
