### PR TITLE
fix(tui): graph explorer file picker — browse all indexed files

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -1319,8 +1319,26 @@ pub(crate) async fn init_workspace(
 /// best-connected file's neighborhood, converted to the deck's Graph-tab
 /// snapshot. `None` when there is no index, it is empty, or any read fails —
 /// the tab then shows its "run stella init" hint instead of an empty graph.
+///
+/// This is [`graph_snapshot_focus`] with no explicit focus, so the neighborhood
+/// centers on [`busiest_file`](stella_graph::CodeGraph::busiest_file) — the
+/// sensible default the deck opens on and can re-root away from via the picker.
 pub(crate) fn graph_snapshot(
     workspace_root: &std::path::Path,
+) -> Option<stella_tui::GraphSnapshot> {
+    graph_snapshot_focus(workspace_root, None)
+}
+
+/// Build the Graph-tab snapshot centered on `focus` (a root-relative file
+/// path), or on the busiest file when `focus` is `None`. The snapshot always
+/// carries the full [`files`](stella_tui::GraphSnapshot::files) list so the
+/// deck's picker can re-root onto any of them — the deck answers a
+/// `FocusGraphFile` request by calling this with `Some(file)` and shipping the
+/// result back as a fresh `Inbound::GraphSnapshot`. `None` when there is no
+/// index, it is empty, or any read fails.
+pub(crate) fn graph_snapshot_focus(
+    workspace_root: &std::path::Path,
+    focus: Option<&str>,
 ) -> Option<stella_tui::GraphSnapshot> {
     use stella_tui::{GraphEdge, GraphNode, GraphSnapshot};
 
@@ -1329,8 +1347,14 @@ pub(crate) fn graph_snapshot(
         return None;
     }
     let graph = stella_graph::CodeGraph::open(workspace_root, &db_path).ok()?;
-    let focus = graph.busiest_file().ok()??;
+    // An explicit pick roots there; otherwise fall back to the busiest file.
+    let focus = match focus {
+        Some(f) => f.to_string(),
+        None => graph.busiest_file().ok()??,
+    };
     let hood = graph.file_neighborhood(std::path::Path::new(&focus)).ok()?;
+    // The full file list backs the picker (a superset of this neighborhood).
+    let files = graph.all_files().unwrap_or_default();
     graph.shutdown();
 
     let mut nodes = vec![GraphNode {
@@ -1379,6 +1403,7 @@ pub(crate) fn graph_snapshot(
         focus: hood.file,
         nodes,
         edges,
+        files,
     })
 }
 
@@ -2626,6 +2651,61 @@ mod tests {
             row.cache_write_tokens, 640,
             "the event's cache-write count must reach the store, never a hard-coded 0"
         );
+    }
+
+    /// Build a real code-graph index in a tempdir: `hub.rs` (three symbols) is
+    /// busiest, `leaf.rs` (one) is not. Returns the workspace root tempdir.
+    fn graph_fixture() -> tempfile::TempDir {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            root.path().join("hub.rs"),
+            "pub fn a() {}\npub fn b() {}\npub struct C;\n",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("leaf.rs"), "pub fn d() {}\n").unwrap();
+        std::fs::create_dir_all(root.path().join(".stella")).unwrap();
+        let db = root.path().join(".stella").join("codegraph.db");
+        let graph = stella_graph::CodeGraph::open(root.path(), &db).expect("open graph");
+        graph.index_all().expect("index");
+        graph.shutdown();
+        root
+    }
+
+    /// The default snapshot roots on the busiest file and carries the full,
+    /// sorted file list the deck's picker browses — sourced straight from the
+    /// graph store, a superset of the rooted neighborhood.
+    #[test]
+    fn graph_snapshot_defaults_to_the_busiest_file_and_lists_all_files() {
+        let root = graph_fixture();
+        let snap = graph_snapshot(root.path()).expect("snapshot");
+        assert_eq!(snap.focus, "hub.rs", "default focus is the busiest file");
+        assert_eq!(
+            snap.files,
+            vec!["hub.rs".to_string(), "leaf.rs".to_string()],
+            "the picker's file list is every indexed file, sorted"
+        );
+    }
+
+    /// An explicit focus re-roots the neighborhood on that file — the picker's
+    /// selection path — while still shipping the same browsable file list.
+    #[test]
+    fn graph_snapshot_focus_re_roots_on_the_requested_file() {
+        let root = graph_fixture();
+        let snap = graph_snapshot_focus(root.path(), Some("leaf.rs")).expect("snapshot");
+        assert_eq!(snap.focus, "leaf.rs", "re-rooted on the requested file");
+        assert!(
+            snap.nodes.iter().any(|n| n.label == "leaf.rs"),
+            "the neighborhood is centered on leaf.rs, not the busiest file"
+        );
+        assert!(snap.files.contains(&"hub.rs".to_string()));
+    }
+
+    /// No index → no snapshot (the tab shows its "run stella init" hint).
+    #[test]
+    fn graph_snapshot_is_none_without_an_index() {
+        let root = tempfile::tempdir().expect("tempdir");
+        assert!(graph_snapshot(root.path()).is_none());
+        assert!(graph_snapshot_focus(root.path(), Some("x.rs")).is_none());
     }
 
     /// Tier-1 rule wiring (issue #103): a workspace rule renders into the

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -413,6 +413,18 @@ pub async fn run_deck_session(
                     requeue_front(&mut queue, &in_tx, dispatch.stop_and_hold(None));
                     continue 'session;
                 }
+                // The Graph tab's file picker asked to re-root on a file:
+                // requery its neighborhood and push a fresh snapshot back, the
+                // same out-of-band refresh `/init` uses. The loop is idle here,
+                // so the read runs inline.
+                Some(WorkspaceInput::FocusGraphFile { file }) => {
+                    if let Some(snapshot) =
+                        agent::graph_snapshot_focus(&cfg.workspace_root, Some(&file))
+                    {
+                        let _ = in_tx.send(Inbound::GraphSnapshot(snapshot));
+                    }
+                    continue 'session;
+                }
                 // A stray answer/decision/control with no turn in flight has
                 // nothing to act on.
                 Some(_) => continue 'session,
@@ -589,6 +601,22 @@ pub async fn run_deck_session(
                         // backlog and the user's next submission runs first.
                         Some(WorkspaceInput::StopAndHold { .. }) => {
                             break TurnEnd::Cancelled { hold: true }
+                        }
+                        // The Graph tab's file picker can re-root mid-turn (a
+                        // user browsing the graph while an agent works). The
+                        // requery opens SQLite + loads grammars, so run it on
+                        // the blocking pool rather than stalling this event
+                        // pump; it sends the fresh snapshot back when done.
+                        Some(WorkspaceInput::FocusGraphFile { file }) => {
+                            let tx = in_tx.clone();
+                            let root = cfg.workspace_root.clone();
+                            tokio::task::spawn_blocking(move || {
+                                if let Some(snapshot) =
+                                    agent::graph_snapshot_focus(&root, Some(&file))
+                                {
+                                    let _ = tx.send(Inbound::GraphSnapshot(snapshot));
+                                }
+                            });
                         }
                         // Scope review is not engine-driven yet, and deep
                         // pause/resume/restart need the fleet supervisor —

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -267,6 +267,16 @@ impl CodeGraph {
         store::busiest_file(&self.inner.read_guard())
     }
 
+    /// Every indexed file path (root-relative, forward-slash), sorted. The
+    /// deck's Graph tab lists these in its file picker so a user can re-root
+    /// the neighborhood on any file, not only the [`busiest_file`] default.
+    /// Empty on an empty index.
+    ///
+    /// [`busiest_file`]: CodeGraph::busiest_file
+    pub fn all_files(&self) -> Result<Vec<String>, GraphError> {
+        store::all_files(&self.inner.read_guard())
+    }
+
     /// The structured neighborhood of `file` — its symbols and import edges
     /// in both directions — for UI consumers (the deck's Graph tab). The
     /// frame methods above render prose for the model; this keeps the shape.
@@ -427,5 +437,29 @@ mod tests {
             !watcher_is_installed(&graph),
             "shutdown must clear an already-installed watcher"
         );
+    }
+
+    /// `all_files` surfaces every indexed file (root-relative, sorted) so the
+    /// deck's Graph tab can list them — the file picker's data source.
+    #[test]
+    fn all_files_lists_every_indexed_file_sorted() {
+        let ws = TempDir::new().unwrap();
+        let dbdir = TempDir::new().unwrap();
+        std::fs::write(ws.path().join("zeta.rs"), "pub fn z() {}\n").unwrap();
+        std::fs::write(ws.path().join("alpha.rs"), "pub fn a() {}\n").unwrap();
+        let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+        graph.index_all().unwrap();
+
+        assert_eq!(
+            graph.all_files().unwrap(),
+            vec!["alpha.rs".to_string(), "zeta.rs".to_string()],
+            "every indexed file, root-relative and sorted"
+        );
+    }
+
+    #[test]
+    fn all_files_is_empty_on_an_empty_index() {
+        let (graph, _ws, _dbdir) = open_graph();
+        assert!(graph.all_files().unwrap().is_empty());
     }
 }

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -22,8 +22,8 @@ use tokio::sync::mpsc;
 
 use stella_tui::scenario::{demo_graph, demo_inbound};
 use stella_tui::{
-    AgentControl, AgentMeta, AgentStatus, DeckOptions, Inbound, ScopeDecision, SlashCommand,
-    UserInput, WorkspaceInput, run_deck,
+    AgentControl, AgentMeta, AgentStatus, DeckOptions, GraphNode, GraphSnapshot, Inbound,
+    ScopeDecision, SlashCommand, UserInput, WorkspaceInput, run_deck,
 };
 
 fn now_ms() -> u64 {
@@ -132,6 +132,22 @@ async fn main() -> std::io::Result<()> {
                 // (the shell's out-of-band echo); a real engine would also
                 // drop the prompt from its own backlog here.
                 WorkspaceInput::QueueRemove { .. } | WorkspaceInput::QueueClear => {}
+                // The Graph tab's file picker re-roots on a file. The demo has
+                // no code-graph store, so it synthesizes a minimal neighborhood
+                // centered on the pick — enough to show the pick → re-root
+                // round-trip the real CLI does against `codegraph.db`.
+                WorkspaceInput::FocusGraphFile { file } => {
+                    let _ = react_tx.send(Inbound::GraphSnapshot(GraphSnapshot {
+                        focus: file.clone(),
+                        nodes: vec![GraphNode {
+                            label: file.clone(),
+                            kind: "file".into(),
+                            location: Some(file),
+                        }],
+                        edges: vec![],
+                        files: demo_graph().files,
+                    }));
+                }
                 WorkspaceInput::Quit => break,
             }
         }

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -16,7 +16,7 @@ use ratatui_comfy_tabs::{TabNav, TabNavState};
 use crate::composer::{ComposerLayout, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::deck_ui::DeckUi;
-use crate::render::{render_slash_popup, slash_popup_area};
+use crate::render::{render_slash_popup, scroll_window_start, slash_popup_area};
 use crate::textline::stage_label;
 use crate::{fx, splash, theme, views};
 
@@ -55,12 +55,12 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     let c_layout = composer_layout(&ui.composer, text_w.max(1));
     let composer_h = c_layout.rows.len().clamp(1, DECK_COMPOSER_MAX_ROWS) as u16;
     let bands = Layout::vertical([
-        Constraint::Length(3),        // tab bar
-        Constraint::Min(1),           // active view
-        Constraint::Length(1),        // run progress bar
+        Constraint::Length(3),          // tab bar
+        Constraint::Min(1),             // active view
+        Constraint::Length(1),          // run progress bar
         Constraint::Length(composer_h), // composer
-        Constraint::Length(1),        // composer footer (keys + line counter)
-        Constraint::Length(2),        // statline (label over value)
+        Constraint::Length(1),          // composer footer (keys + line counter)
+        Constraint::Length(2),          // statline (label over value)
     ])
     .split(area);
 
@@ -91,6 +91,9 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     }
     if ui.queue_open {
         render_queue_popup(model, ui, area, buf);
+    }
+    if ui.graph_picker_open {
+        render_graph_picker(ui, area, buf);
     }
 
     // Deck motion (crate::fx), scrubbed like the splash: each frame builds a
@@ -199,6 +202,87 @@ fn render_queue_popup(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut
     Paragraph::new(lines).block(block).render(popup, buf);
 }
 
+/// The Graph tab's file picker: a centered overlay listing every indexed file,
+/// narrowed by a filter-as-you-type query, with the selection highlighted and
+/// windowed so it stays in view on long lists (the shared
+/// [`scroll_window_start`] the slash popup uses). Selecting a row re-roots the
+/// neighborhood on that file; the current focus opens pre-selected as the
+/// sensible default.
+fn render_graph_picker(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let Some(graph) = ui.graph.as_ref() else {
+        return;
+    };
+    let matches = graph.matching_files(&ui.graph_picker_query);
+
+    let w = area.width.min(64);
+    let h = area.height.min(18);
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(popup, buf);
+
+    // Query line (top) + legend line (bottom) + two borders bracket the rows.
+    let inner_h = (h as usize).saturating_sub(2);
+    let visible_rows = inner_h.saturating_sub(2).max(1);
+    let selected = ui.graph_picker_sel.min(matches.len().saturating_sub(1));
+    let first = scroll_window_start(matches.len(), selected, visible_rows);
+    let last = (first + visible_rows).min(matches.len());
+
+    // The filter query, with a violet caret so the keybind/edit accent reads.
+    let mut lines: Vec<Line<'static>> = vec![Line::from(vec![
+        Span::styled("filter ", theme::muted()),
+        Span::styled(ui.graph_picker_query.clone(), theme::body()),
+        Span::styled("▏", Style::new().fg(theme::VIOLET)),
+    ])];
+
+    if matches.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no files match — Backspace to widen",
+            theme::muted(),
+        )));
+    }
+    for (i, file) in matches.iter().enumerate().take(last).skip(first) {
+        let is_sel = i == selected;
+        let is_focus = *file == graph.focus;
+        let marker = if is_sel { "▸ " } else { "  " };
+        let mut style = theme::body();
+        if is_sel {
+            style = style.add_modifier(Modifier::REVERSED);
+        }
+        let name = (*file)
+            .chars()
+            .take((w as usize).saturating_sub(6))
+            .collect::<String>();
+        let mut spans = vec![
+            Span::styled(marker.to_string(), style.fg(theme::AMBER)),
+            Span::styled(name, style),
+        ];
+        // Mark the file the neighborhood is currently rooted on (the default).
+        if is_focus {
+            spans.push(Span::styled("  · current", theme::muted()));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    // Pad so the legend sits on the last interior row regardless of match count.
+    while lines.len() < inner_h.saturating_sub(1).max(1) {
+        lines.push(Line::default());
+    }
+    lines.push(Line::from(Span::styled(
+        " type to filter · ↑/↓ select · enter open · esc close",
+        theme::muted(),
+    )));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(format!(" files · {} indexed ", graph.files.len()));
+    Paragraph::new(lines).block(block).render(popup, buf);
+}
+
 /// Cap on the deck composer's visible rows — it grows with the prompt up to
 /// this, then scrolls (with a gutter indicator) to keep the cursor row in view.
 const DECK_COMPOSER_MAX_ROWS: usize = 4;
@@ -242,7 +326,11 @@ fn render_composer(
             spans.push(Span::styled(before, theme::body()));
             spans.push(Span::styled(
                 under_ch,
-                if caret_on { cursor_style } else { theme::body() },
+                if caret_on {
+                    cursor_style
+                } else {
+                    theme::body()
+                },
             ));
             spans.push(Span::styled(after, theme::body()));
         } else {
@@ -454,7 +542,9 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
         (
             "AGENT",
             vec![Span::styled(
-                focused.map(|a| a.meta.id.clone()).unwrap_or_else(|| "—".into()),
+                focused
+                    .map(|a| a.meta.id.clone())
+                    .unwrap_or_else(|| "—".into()),
                 val,
             )],
             5,
@@ -478,7 +568,10 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
         (
             "CPU",
             vec![
-                Span::styled(meter_bar(cpu / 100.0), Style::default().fg(theme::gauge_color(cpu / 100.0))),
+                Span::styled(
+                    meter_bar(cpu / 100.0),
+                    Style::default().fg(theme::gauge_color(cpu / 100.0)),
+                ),
                 Span::styled(format!(" {cpu:>3.0}%"), val),
             ],
             5,
@@ -486,7 +579,10 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
         (
             "CONTEXT",
             vec![
-                Span::styled(meter_bar(ctx_frac), Style::default().fg(theme::gauge_color(ctx_frac))),
+                Span::styled(
+                    meter_bar(ctx_frac),
+                    Style::default().fg(theme::gauge_color(ctx_frac)),
+                ),
                 Span::styled(format!(" {}/{}", fmt_k(ctx_tokens), fmt_k(CTX_WINDOW)), val),
             ],
             MUST_KEEP,
@@ -502,7 +598,10 @@ fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut 
         ("CACHE", cache_spans, 4),
         (
             "AGENTS",
-            vec![Span::styled(format!("{} active", model.active_count()), val)],
+            vec![Span::styled(
+                format!("{} active", model.active_count()),
+                val,
+            )],
             4,
         ),
         (
@@ -716,6 +815,10 @@ fn render_help(area: Rect, buf: &mut Buffer) {
             theme::body(),
         )),
         Line::from(Span::styled(
+            "  Graph:  / or Enter  browse & filter indexed files",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
             "  Esc          stop the turn (next queued runs)",
             theme::body(),
         )),
@@ -789,12 +892,13 @@ mod tests {
                 "new line", // composer footer affordance (§4)
                 "queue",    // footer / queue status
                 "plan",     // progress stage labels (§3)
-                "execute",
-                "verify",
-                "stella",   // statline brand (§5)
-                "CONTEXT",  // load-bearing token meter, kept at every width (§5)
+                "execute", "verify", "stella",  // statline brand (§5)
+                "CONTEXT", // load-bearing token meter, kept at every width (§5)
             ] {
-                assert!(text.contains(needle), "deck @{w}×{h} missing {needle:?}:\n{text}");
+                assert!(
+                    text.contains(needle),
+                    "deck @{w}×{h} missing {needle:?}:\n{text}"
+                );
             }
             // The ethos chip is chrome — it only needs to appear once the row is
             // wide enough (it is the first thing dropped on a narrow statline).
@@ -805,7 +909,10 @@ mod tests {
                 );
             }
             // The killed rocket/garble leave no trace (§2).
-            assert!(!text.contains("}=>"), "rocket sprite still rendered:\n{text}");
+            assert!(
+                !text.contains("}=>"),
+                "rocket sprite still rendered:\n{text}"
+            );
             assert!(!text.contains("<●>"), "UFO sprite still rendered:\n{text}");
         }
     }
@@ -846,7 +953,11 @@ mod tests {
         render_composer(&ui, &layout, 0, area, &mut buf);
         let text = buffer_text(&buf);
         let rows: Vec<&str> = text.lines().collect();
-        assert!(rows[0].starts_with(">>> "), "row 0 is the gold prompt: {:?}", rows[0]);
+        assert!(
+            rows[0].starts_with(">>> "),
+            "row 0 is the gold prompt: {:?}",
+            rows[0]
+        );
         // Exactly one prompt line — the rest of the box is empty.
         assert!(
             rows[1..].iter().all(|r| !r.contains(">>>")),
@@ -868,7 +979,10 @@ mod tests {
         let mut ui = DeckUi::default();
         let paste: String = (1..=8).map(|n| format!("line{n}\n")).collect();
         ui.composer.paste(&paste);
-        assert!(ui.composer.chips().is_empty(), "no chip — rendered per line");
+        assert!(
+            ui.composer.chips().is_empty(),
+            "no chip — rendered per line"
+        );
 
         let layout = crate::composer::layout(&ui.composer, 40);
         let area = Rect::new(0, 0, 40, 4); // capped at DECK_COMPOSER_MAX_ROWS
@@ -881,7 +995,9 @@ mod tests {
         }
         // Beyond 4 rows the box scrolls — the gutter shows a violet thumb.
         assert!(
-            (0..area.height).any(|yy| buf.cell((area.width - 1, yy)).is_some_and(|c| c.symbol() == "▐")),
+            (0..area.height).any(|yy| buf
+                .cell((area.width - 1, yy))
+                .is_some_and(|c| c.symbol() == "▐")),
             "scroll indicator present:\n{text}"
         );
     }
@@ -901,7 +1017,10 @@ mod tests {
             "queue affordance:\n{text}"
         );
         assert!(text.contains("1 line"), "live line counter:\n{text}");
-        assert!(text.contains("2 queued"), "queue status on the right:\n{text}");
+        assert!(
+            text.contains("2 queued"),
+            "queue status on the right:\n{text}"
+        );
     }
 
     #[test]
@@ -941,7 +1060,10 @@ mod tests {
             "PIPELINE",
             "deterministic-first",
         ] {
-            assert!(text.contains(needle), "statline missing {needle:?}:\n{text}");
+            assert!(
+                text.contains(needle),
+                "statline missing {needle:?}:\n{text}"
+            );
         }
     }
 
@@ -1124,6 +1246,81 @@ mod tests {
         assert!(
             warned.contains("press ctrl+d again"),
             "confirm warning:\n{warned}"
+        );
+    }
+
+    /// A `DeckUi` on the Graph tab with an `n`-file snapshot rooted on the
+    /// middle file, its picker open.
+    fn ui_with_graph_picker(n: usize) -> DeckUi {
+        use crate::graph::{GraphNode, GraphSnapshot};
+        let files: Vec<String> = (0..n).map(|i| format!("crate/mod_{i:02}.rs")).collect();
+        let focus = files[n / 2].clone();
+        let mut ui = DeckUi::default();
+        ui.tab = DeckTab::Graph;
+        ui.graph = Some(GraphSnapshot {
+            focus: focus.clone(),
+            nodes: vec![GraphNode {
+                label: focus,
+                kind: "file".into(),
+                location: None,
+            }],
+            edges: vec![],
+            files,
+        });
+        ui.graph_picker_open = true;
+        ui
+    }
+
+    #[test]
+    fn graph_picker_lists_files_marks_the_current_and_shows_the_legend() {
+        let mut ui = ui_with_graph_picker(4);
+        ui.graph_picker_sel = 2; // the focus file (crate/mod_02.rs)
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render_graph_picker(&ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("files · 4 indexed"), "title:\n{text}");
+        assert!(text.contains("filter"), "filter query line:\n{text}");
+        assert!(text.contains("crate/mod_00.rs"), "lists files:\n{text}");
+        assert!(text.contains("· current"), "marks the rooted file:\n{text}");
+        assert!(text.contains("type to filter"), "legend:\n{text}");
+    }
+
+    #[test]
+    fn graph_picker_windows_the_list_to_keep_the_selection_visible() {
+        // Far more files than the popup's rows, selection at the end: the
+        // window must slide (via the shared `scroll_window_start`) so the last
+        // file shows and the first scrolls out.
+        let mut ui = ui_with_graph_picker(60);
+        ui.graph_picker_sel = 59;
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render_graph_picker(&ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("crate/mod_59.rs"),
+            "selection scrolled in:\n{text}"
+        );
+        assert!(
+            !text.contains("crate/mod_00.rs"),
+            "head scrolled out:\n{text}"
+        );
+    }
+
+    #[test]
+    fn graph_picker_narrows_to_the_filter_query() {
+        let mut ui = ui_with_graph_picker(20);
+        ui.graph_picker_query = "mod_1".to_string();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render_graph_picker(&ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        // mod_10..mod_19 match; mod_00..mod_09 (except none contain "mod_1")
+        // do not.
+        assert!(text.contains("crate/mod_10.rs"), "matches shown:\n{text}");
+        assert!(
+            !text.contains("crate/mod_02.rs"),
+            "non-matches hidden:\n{text}"
         );
     }
 }

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -69,6 +69,17 @@ pub struct DeckUi {
     pub graph_cursor: usize,
     /// The out-of-band code-graph snapshot (set by the caller/scenario).
     pub graph: Option<GraphSnapshot>,
+    /// Whether the Graph tab's file picker is open. While open it is modal
+    /// (like the queue editor): printable keys type into its filter, ↑/↓ move
+    /// the selection, Enter re-roots the neighborhood on the chosen file, Esc
+    /// closes. Opened with `/` (or `Enter`) on the Graph tab.
+    pub graph_picker_open: bool,
+    /// The picker's filter-as-you-type query — kept separate from the global
+    /// composer so opening the picker never disturbs a half-typed prompt.
+    pub graph_picker_query: String,
+    /// Selected row in the picker, indexing the *filtered* match list
+    /// ([`GraphSnapshot::matching_files`]). Reset to 0 on every query edit.
+    pub graph_picker_sel: usize,
     pub files_sel: usize,
     pub files_diff_open: bool,
     pub files_diff_scroll: ScrollState,
@@ -153,6 +164,9 @@ impl Default for DeckUi {
             trace_filter: None,
             graph_cursor: 0,
             graph: None,
+            graph_picker_open: false,
+            graph_picker_query: String::new(),
+            graph_picker_sel: 0,
             files_sel: 0,
             files_diff_open: false,
             files_diff_scroll: ScrollState::default(),
@@ -234,6 +248,11 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
     // folds into the model, then selections are re-clamped.
     if let Inbound::GraphSnapshot(snapshot) = inbound {
         ui.graph = Some(snapshot.clone());
+        // A refreshed snapshot re-roots the neighborhood (a file pick, or an
+        // `/init` rebuild): the node list is now a different file's, so land
+        // the cursor on the new focus (index 0) rather than leaving it on a
+        // stale row that render would merely clamp into range.
+        ui.graph_cursor = 0;
         return;
     }
     if let Inbound::SlashCommands(commands) = inbound {
@@ -400,6 +419,14 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     // delete · ctrl+d twice clear all · Esc close).
     if ui.queue_open {
         return handle_queue_key(key, model, ui);
+    }
+
+    // The Graph tab's file picker is modal exactly like the queue editor: while
+    // it is open every key drives the picker (type to filter, ↑/↓ select, Enter
+    // re-root, Esc close) — before the composer or any tab handler sees it, so a
+    // filter keystroke can never leak into a half-typed prompt.
+    if ui.graph_picker_open {
+        return handle_graph_picker_key(key, ui);
     }
 
     let composer_empty = ui.composer.buffer().is_empty();
@@ -784,9 +811,98 @@ fn handle_graph_key(key: KeyEvent, ui: &mut DeckUi, composer_empty: bool) -> Opt
             }
             Some(DeckAction::Handled)
         }
-        // `/` search reserved (only when composer empty) — no-op stub for now.
-        KeyCode::Char('/') if composer_empty => Some(DeckAction::Handled),
+        // `/` (filter-as-you-type) or Enter opens the file picker so a user can
+        // re-root the neighborhood on any indexed file, not just the busiest
+        // one the tab seeds. Gated on an empty composer so both keys stay
+        // typeable as the first character of a prompt. Only meaningful once a
+        // graph with a file list has loaded.
+        KeyCode::Char('/') | KeyCode::Enter if composer_empty && graph_has_files(ui) => {
+            open_graph_picker(ui);
+            Some(DeckAction::Handled)
+        }
         _ => None,
+    }
+}
+
+/// Whether a graph snapshot with at least one listed file is loaded — the
+/// precondition for opening the file picker.
+fn graph_has_files(ui: &DeckUi) -> bool {
+    ui.graph.as_ref().is_some_and(|g| !g.files.is_empty())
+}
+
+/// Open the file picker, defaulting the selection to the file the neighborhood
+/// is currently rooted on (`focus`) — the busiest file on first load. That
+/// keeps the sensible default while making every other file reachable: the
+/// selection starts on "where you already are", not forced there.
+fn open_graph_picker(ui: &mut DeckUi) {
+    ui.graph_picker_query.clear();
+    ui.graph_picker_open = true;
+    ui.graph_picker_sel = ui
+        .graph
+        .as_ref()
+        .and_then(|g| g.files.iter().position(|f| *f == g.focus))
+        .unwrap_or(0);
+}
+
+/// The modal file picker's key map. Printable keys narrow the filter, ↑/↓ walk
+/// the filtered matches, Enter re-roots the neighborhood on the selected file
+/// (a [`WorkspaceInput::FocusGraphFile`] round-trip — see the envelope docs),
+/// and Esc / a cleared-then-Backspace closes it. Selection bounds and the
+/// selected path both come from [`GraphSnapshot::matching_files`] so they can
+/// never disagree with the rendered list.
+fn handle_graph_picker_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    // Snapshot the current match count/selection off the shared filter helper.
+    let match_count = ui
+        .graph
+        .as_ref()
+        .map(|g| g.matching_files(&ui.graph_picker_query).len())
+        .unwrap_or(0);
+
+    match key.code {
+        KeyCode::Esc => {
+            ui.graph_picker_open = false;
+            DeckAction::Handled
+        }
+        KeyCode::Up => {
+            ui.graph_picker_sel = ui.graph_picker_sel.saturating_sub(1);
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            if match_count > 0 {
+                ui.graph_picker_sel = (ui.graph_picker_sel + 1).min(match_count - 1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            let picked = ui.graph.as_ref().and_then(|g| {
+                g.matching_files(&ui.graph_picker_query)
+                    .get(ui.graph_picker_sel)
+                    .map(|f| f.to_string())
+            });
+            ui.graph_picker_open = false;
+            match picked {
+                Some(file) => DeckAction::Send(WorkspaceInput::FocusGraphFile { file }),
+                None => DeckAction::Handled, // filter matched nothing — just close
+            }
+        }
+        KeyCode::Backspace => {
+            ui.graph_picker_query.pop();
+            ui.graph_picker_sel = 0; // the match set changed — re-anchor
+            DeckAction::Handled
+        }
+        // Printable characters extend the filter. Modified chords (Ctrl/Cmd)
+        // are not filter input — let them fall through as Ignored so global
+        // shortcuts still resolve.
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            ui.graph_picker_query.push(c);
+            ui.graph_picker_sel = 0; // the match set changed — re-anchor
+            DeckAction::Handled
+        }
+        _ => DeckAction::Ignored,
     }
 }
 
@@ -2000,6 +2116,7 @@ mod tests {
                 location: Some("src/lib.rs".into()),
             }],
             edges: vec![],
+            files: vec!["src/lib.rs".into()],
         };
         ingest_inbound(
             &Inbound::GraphSnapshot(snapshot.clone()),
@@ -2007,5 +2124,153 @@ mod tests {
             &mut ui,
         );
         assert_eq!(ui.graph.as_ref(), Some(&snapshot));
+    }
+
+    // ── Graph file picker ────────────────────────────────────────────────────
+
+    /// A three-file graph rooted on the busiest (`src/b.rs`), on the Graph tab.
+    fn ui_with_graph() -> DeckUi {
+        use crate::graph::{GraphNode, GraphSnapshot};
+        let mut ui = ready_ui();
+        ui.tab = DeckTab::Graph;
+        ui.graph = Some(GraphSnapshot {
+            focus: "src/b.rs".into(),
+            nodes: vec![GraphNode {
+                label: "src/b.rs".into(),
+                kind: "file".into(),
+                location: Some("src/b.rs".into()),
+            }],
+            edges: vec![],
+            files: vec!["src/a.rs".into(), "src/b.rs".into(), "src/c.rs".into()],
+        });
+        ui
+    }
+
+    #[test]
+    fn slash_opens_the_picker_defaulting_to_the_current_focus() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        let action = handle_deck_key(ch('/'), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert!(ui.graph_picker_open, "/ opens the picker on the Graph tab");
+        // Default selection is the busiest/focused file (index 1 = src/b.rs),
+        // the sensible default — not forced there, just pre-selected.
+        assert_eq!(ui.graph_picker_sel, 1);
+        assert!(
+            ui.composer.buffer().is_empty(),
+            "/ did not leak into the prompt"
+        );
+    }
+
+    #[test]
+    fn enter_also_opens_the_picker() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert!(ui.graph_picker_open);
+    }
+
+    #[test]
+    fn typing_filters_and_re_anchors_the_selection() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        open_graph_picker(&mut ui);
+        // Filter to just "a.rs" — one match, selection re-anchors to 0.
+        handle_deck_key(ch('a'), &model, &mut ui);
+        assert_eq!(ui.graph_picker_query, "a");
+        assert_eq!(ui.graph_picker_sel, 0);
+        let matches = ui
+            .graph
+            .as_ref()
+            .unwrap()
+            .matching_files(&ui.graph_picker_query);
+        assert_eq!(matches, vec!["src/a.rs"]);
+    }
+
+    #[test]
+    fn enter_in_the_picker_re_roots_on_the_selected_file() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        open_graph_picker(&mut ui);
+        // A multi-char needle (`c.rs`) narrows to exactly src/c.rs — a bare
+        // `c` would also match the shared `src/` prefix of every file.
+        for c in "c.rs".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::FocusGraphFile {
+                file: "src/c.rs".into()
+            }),
+            "Enter sends the re-root request for the filtered selection"
+        );
+        assert!(!ui.graph_picker_open, "the picker closes on selection");
+    }
+
+    #[test]
+    fn down_arrow_walks_the_filtered_matches_and_clamps() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        open_graph_picker(&mut ui);
+        ui.graph_picker_sel = 0;
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui); // past the end
+        assert_eq!(ui.graph_picker_sel, 2, "clamps to the last of three files");
+    }
+
+    #[test]
+    fn esc_closes_the_picker_without_re_rooting() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        open_graph_picker(&mut ui);
+        let action = handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert!(!ui.graph_picker_open);
+    }
+
+    #[test]
+    fn the_picker_is_modal_over_the_composer() {
+        // A printable key while the picker is open filters — it must NOT type
+        // into the global composer (the queue-editor modality contract).
+        let model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        open_graph_picker(&mut ui);
+        handle_deck_key(ch('b'), &model, &mut ui);
+        assert_eq!(ui.graph_picker_query, "b");
+        assert!(
+            ui.composer.buffer().is_empty(),
+            "filter keys never reach the composer"
+        );
+    }
+
+    #[test]
+    fn a_re_rooted_snapshot_resets_the_node_cursor() {
+        let mut model = model_with(&["lead"]);
+        let mut ui = ui_with_graph();
+        ui.graph_cursor = 5; // stale cursor from the previous neighborhood
+        use crate::graph::{GraphNode, GraphSnapshot};
+        let rerooted = GraphSnapshot {
+            focus: "src/a.rs".into(),
+            nodes: vec![GraphNode {
+                label: "src/a.rs".into(),
+                kind: "file".into(),
+                location: Some("src/a.rs".into()),
+            }],
+            edges: vec![],
+            files: vec!["src/a.rs".into(), "src/b.rs".into(), "src/c.rs".into()],
+        };
+        ingest_inbound(&Inbound::GraphSnapshot(rerooted), &mut model, &mut ui);
+        assert_eq!(ui.graph_cursor, 0, "the cursor lands on the new focus");
+    }
+
+    #[test]
+    fn the_picker_does_not_open_without_a_loaded_graph() {
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.tab = DeckTab::Graph; // no snapshot loaded
+        handle_deck_key(ch('/'), &model, &mut ui);
+        assert!(!ui.graph_picker_open, "nothing to pick from — stays closed");
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -185,6 +185,14 @@ pub enum WorkspaceInput {
     /// Esc is the plain [`AgentControl::Stop`]: cancel, and the next queued
     /// prompt dispatches automatically.
     StopAndHold { agent: AgentId },
+    /// Re-root the Graph tab on `file`: the deck's file picker sends this when
+    /// the user selects a file, and the driver answers with a fresh
+    /// [`Inbound::GraphSnapshot`] centered on it (the same out-of-band refresh
+    /// path `/init` uses). `stella-tui` cannot query the graph store itself, so
+    /// re-rooting is a round-trip rather than a local recompute — the picker
+    /// only knows the file *names* (shipped in [`GraphSnapshot::files`]), never
+    /// their neighborhoods. `file` is a root-relative path from that list.
+    FocusGraphFile { file: String },
     /// Tear down the deck.
     Quit,
 }

--- a/stella-tui/src/graph.rs
+++ b/stella-tui/src/graph.rs
@@ -17,6 +17,12 @@ pub struct GraphSnapshot {
     pub focus: String,
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
+    /// Every indexed code file (root-relative, sorted) — the Graph tab's file
+    /// picker lists these so any file can be re-rooted, not just the busiest
+    /// one the caller seeds `focus` with. Rides along on the snapshot because
+    /// `stella-tui` cannot reach the graph store itself (it renders data given
+    /// to it); the caller fills it from [`stella_graph::CodeGraph::all_files`].
+    pub files: Vec<String>,
 }
 
 /// One node — a symbol or file. Cited by human label, never a raw UUID (L-C4).
@@ -50,5 +56,59 @@ impl GraphSnapshot {
             .iter()
             .filter(|e| e.from == node || e.to == node)
             .count()
+    }
+
+    /// The [`files`](Self::files) that match a picker query — a case-insensitive
+    /// substring test, preserving the sorted file order. An empty (or
+    /// whitespace-only) query matches every file, so the picker opens on the
+    /// full list. Both the picker's key handler (for selection bounds) and its
+    /// renderer route through this one function so the highlighted row and the
+    /// selected path can never disagree.
+    pub fn matching_files(&self, query: &str) -> Vec<&str> {
+        let needle = query.trim().to_lowercase();
+        self.files
+            .iter()
+            .map(String::as_str)
+            .filter(|f| needle.is_empty() || f.to_lowercase().contains(&needle))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_with_files(files: &[&str]) -> GraphSnapshot {
+        GraphSnapshot {
+            focus: "root".into(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            files: files.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn an_empty_query_matches_every_file_in_order() {
+        let snap = snapshot_with_files(&["src/a.rs", "src/b.rs", "src/c.rs"]);
+        assert_eq!(
+            snap.matching_files(""),
+            vec!["src/a.rs", "src/b.rs", "src/c.rs"]
+        );
+        // Whitespace-only is treated as empty, not as a literal space search.
+        assert_eq!(
+            snap.matching_files("   "),
+            vec!["src/a.rs", "src/b.rs", "src/c.rs"]
+        );
+    }
+
+    #[test]
+    fn a_query_narrows_case_insensitively_by_substring() {
+        let snap = snapshot_with_files(&["src/Auth.rs", "src/db/pool.rs", "README.md"]);
+        // Case-insensitive.
+        assert_eq!(snap.matching_files("auth"), vec!["src/Auth.rs"]);
+        // Matches anywhere in the path, not just the basename.
+        assert_eq!(snap.matching_files("db/"), vec!["src/db/pool.rs"]);
+        // No match yields an empty list (the picker then shows its empty hint).
+        assert!(snap.matching_files("zzz").is_empty());
     }
 }

--- a/stella-tui/src/scenario.rs
+++ b/stella-tui/src/scenario.rs
@@ -80,6 +80,15 @@ pub fn demo_graph() -> GraphSnapshot {
         focus: "run_turn — engine step driver".into(),
         nodes,
         edges,
+        // The picker's file list — the demo's source files, so `/` in the
+        // Graph tab opens a browsable, filterable list during playback.
+        files: vec![
+            "stella-core/src/driver.rs".into(),
+            "stella-core/src/engine.rs".into(),
+            "stella-core/src/router.rs".into(),
+            "stella-fleet/src/ledger.rs".into(),
+            "stella-protocol/src/event.rs".into(),
+        ],
     }
 }
 

--- a/stella-tui/src/views/graph.rs
+++ b/stella-tui/src/views/graph.rs
@@ -85,7 +85,14 @@ fn render_empty(area: Rect, buf: &mut Buffer) {
 // ---------------------------------------------------------------------------
 
 fn render_node_list(snapshot: &GraphSnapshot, cursor: usize, area: Rect, buf: &mut Buffer) {
-    let title = format!(" nodes · {} ", snapshot.nodes.len());
+    // Advertise the file picker in the title (the "/ files" affordance) when a
+    // file list is available — the whole point of the tab is being able to
+    // re-root, so the way to do it must be visible, not hidden behind a key.
+    let title = if snapshot.files.is_empty() {
+        format!(" nodes · {} ", snapshot.nodes.len())
+    } else {
+        format!(" nodes · {} · / files ", snapshot.nodes.len())
+    };
     let block = Block::default().borders(Borders::ALL).title(title);
     let inner = block.inner(area);
     block.render(area, buf);
@@ -381,6 +388,7 @@ mod tests {
                     kind: "imports".into(),
                 },
             ],
+            files: vec!["driver.rs".into(), "src/lib.rs".into()],
         }
     }
 
@@ -472,6 +480,7 @@ mod tests {
                 location: None,
             }],
             edges: vec![],
+            files: vec![],
         });
         let text = draw(&mut ui, 100, 24);
         assert!(
@@ -495,6 +504,7 @@ mod tests {
                 })
                 .collect(),
             edges: vec![],
+            files: vec![],
         };
         let mut ui = DeckUi::default();
         ui.graph = Some(snapshot);


### PR DESCRIPTION
## The bug

On the Graph tab you couldn't switch code files — the neighborhood was forced onto the single busiest file (`CodeGraph::busiest_file`), with no way to view any other file's relationships.

## The fix

A **filter-as-you-type file picker** over *all* indexed code files. Selecting a file re-roots the relationship view on it. The busiest file remains the sensible **default** (pre-selected when the picker opens), but it's no longer forced.

### UX

- On the Graph tab, press **`/`** (or **Enter**) to open the picker. It's modal, exactly like the queue editor.
- **Type** to filter (case-insensitive substring over the file paths).
- **↑/↓** move the selection (windowed via the shared `scroll_window_start` from #133, so the highlight never leaves the frame).
- **Enter** re-roots the neighborhood on the selected file; **Esc** closes.
- The picker's filter is its own buffer, so opening it never disturbs a half-typed prompt in the composer.
- Discoverability: a `/ files` affordance in the node-list title, plus a `Graph:` line in the `?` help overlay.

### Where the file list comes from

`stella-tui` can't reach the graph store (it renders data it's handed). So:

- `GraphSnapshot` gains a `files: Vec<String>` field — every indexed file, sorted.
- The CLI fills it from a new `CodeGraph::all_files` (a thin public wrapper over the existing `store::all_files`, root-relative sorted paths). It's a superset of the rooted neighborhood.

### Re-rooting round-trip

Selecting a file can't be a local recompute — the picker only knows file *names*. So it mirrors the existing out-of-band graph refresh (`/init`):

- The deck sends `WorkspaceInput::FocusGraphFile { file }`.
- The driver answers with a fresh `Inbound::GraphSnapshot` centered on that file, via a refactored `agent::graph_snapshot_focus(root, Some(file))` (the busiest-file default is `graph_snapshot_focus(root, None)`).
- Idle loop: queried inline. Mid-turn: `spawn_blocking` so the agent's event pump never stalls on the SQLite open + grammar load.
- A re-rooted snapshot resets the node cursor to the new focus (index 0) rather than leaving a stale row.

### Styling

Ember theme tokens throughout; violet reserved for the filter caret (keybind/edit accent), per the TUI convention.

## Tests

- **stella-graph**: `all_files` lists every indexed file sorted; empty on empty index.
- **stella-cli**: `graph_snapshot` defaults to the busiest file and lists all files; `graph_snapshot_focus` re-roots on the requested file; `None` without an index. All against a real tempdir-built `codegraph.db`.
- **stella-tui**: `matching_files` narrowing; picker open/default-selection/filter/select/nav/clamp/modality/cursor-reset; render tests for the overlay (lists files, marks the current, legend, filter narrowing, windowing).

## Verification

`cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings` all pass, scoped `-p` to the three touched crates (`stella-graph`, `stella-tui`, `stella-cli`). GitHub Actions is billing-locked, so CI will fast-fail — local verification is the gate.

## Scope / notes

- Changes stay inside the graph view + its data plumbing. Shared-infra touch is minimal: one additive `WorkspaceInput` variant and two driver arms.
- Based on the latest compiling `origin/main` and rebased onto the current tip after the mid-task main updates.
