### PR TITLE
feat(tui): /skills command + SKILLS deck tab (manage, search, LLM-assisted create)

### DIFF
--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -43,7 +43,7 @@ clap.workspace = true
 colored.workspace = true
 toml.workspace = true
 libc.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-tempfile.workspace = true

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -71,8 +71,8 @@ use stella_tools::ToolRegistry;
 use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentScope, AgentStatus, DeckOptions, Inbound, SlashCommand, UserInput,
-    WorkspaceInput, run_deck,
+    AgentMeta, AgentScope, AgentStatus, DeckOptions, Inbound, SkillOp, SkillScope, SkillSearchHit,
+    SkillsView, SlashCommand, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -248,6 +248,9 @@ pub async fn run_deck_session(
     // Custom extensions: ⚡ commands/skills in the slash menu, custom agents
     // behind `/agents`. Reloaded after `/init`, which may adopt new ones.
     let mut custom = crate::extensions::CustomExtensions::load(&cfg.workspace_root);
+    // The npx skills registry (search/install), constructed once for the whole
+    // session — the SKILLS tab's ops route through it (see `handle_skills_input`).
+    let skill_registry = SkillRegistry::from_env(cfg.workspace_root.clone());
 
     // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
     let (in_tx, in_rx) = mpsc::unbounded_channel::<Inbound>();
@@ -280,6 +283,9 @@ pub async fn run_deck_session(
         agent: LEAD.to_string(),
         status: AgentStatus::WaitingInput,
     });
+    // Seed the SKILLS tab so it has data the instant it is opened (both scopes),
+    // without waiting on a `/skills` round-trip.
+    let _ = in_tx.send(skills_snapshot(&cfg.workspace_root, None));
 
     let ask_io = DeckAskUserIo {
         agent: LEAD.to_string(),
@@ -431,9 +437,12 @@ pub async fn run_deck_session(
                     }
                     continue 'session;
                 }
-                // A stray answer/decision/control with no turn in flight has
-                // nothing to act on.
-                Some(_) => continue 'session,
+                // SKILLS-tab ops work whether or not a turn is running — handled
+                // at both recv sites so the manager is live mid-turn too.
+                Some(WorkspaceInput::Skill(op)) => {
+                    handle_skills_input(&op, cfg, &in_tx, &skill_registry);
+                    continue 'session;
+                }
                 // LLM-assisted agent creation needs the provider, which is
                 // free here (no turn in flight) — draft, install, refresh.
                 Some(WorkspaceInput::AgentCreate { description, scope }) => {
@@ -547,6 +556,27 @@ pub async fn run_deck_session(
         );
         let files_before = registry.files_touched().len();
         let started_unix = crate::memory::unix_now_secs();
+
+        // Skill-version usage telemetry: record which skills recall selected for
+        // this turn, at their pinned version, keyed to this execution. Recorded
+        // at turn start (the skills are injected regardless of how the turn
+        // ends); best-effort, and only for the deck path for now — the other
+        // `record_execution_end` sites can adopt it later.
+        if let (Some((store, id)), Some(m)) = (&execution, &memory) {
+            let selected = m.selected_skills(&prompt);
+            if !selected.is_empty() {
+                let versions = crate::skill_manager::pinned_versions(&cfg.workspace_root);
+                let rows: Vec<stella_store::SkillUsageRow> = selected
+                    .into_iter()
+                    .map(|(skill, reason)| stella_store::SkillUsageRow {
+                        version: versions.get(&skill).copied().unwrap_or(1),
+                        skill,
+                        reason,
+                    })
+                    .collect();
+                let _ = store.record_skill_usage(*id, &rows);
+            }
+        }
 
         let end = {
             // Both arms return `Result<(), String>`, so one pinned future
@@ -662,6 +692,13 @@ pub async fn run_deck_session(
                                         .to_string(),
                                 ),
                             ));
+                        }
+                        // SKILLS-tab ops run alongside the in-flight turn (disk
+                        // ops inline, npx/model ops spawned) — the manager stays
+                        // usable while an agent is working. Create spawns its own
+                        // provider, so unlike AgentCreate it needs no parking.
+                        Some(WorkspaceInput::Skill(op)) => {
+                            handle_skills_input(&op, cfg, &in_tx, &skill_registry);
                         }
                         // Scope review is not engine-driven yet, and deep
                         // pause/resume/restart need the fleet supervisor —
@@ -819,7 +856,6 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ("/clear", "reset the conversation"),
     ("/models", "list providers & models"),
     ("/init", "index the workspace: domains + code graph"),
-
     (
         "/agents",
         "open the Agents tab: executions & installed agents",
@@ -831,6 +867,7 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ("/files", "open the Files tab"),
     ("/diff", "open the diff viewer"),
     ("/graph", "open the code-graph tab"),
+    ("/skills", "open the SKILLS tab: manage · search · create"),
 ];
 
 /// The deck's reserved command names — see [`DECK_BUILTINS`].
@@ -1012,6 +1049,289 @@ fn deck_slash_commands(custom: &crate::extensions::CustomExtensions) -> Vec<Slas
     commands
 }
 
+// ── SKILLS tab: driver-side ops (the deck routes `WorkspaceInput::Skill`) ────
+
+/// Snapshot the installed skills across BOTH scopes into an [`Inbound::Skills`].
+fn skills_snapshot(workspace_root: &std::path::Path, status: Option<String>) -> Inbound {
+    Inbound::Skills(SkillsView {
+        rows: crate::skill_manager::enumerate(workspace_root),
+        status,
+        busy: false,
+    })
+}
+
+/// Parse `npx skills find` stdout into hit rows: one per non-empty line (cap
+/// 50); `id` = the leading token (skipping a list marker), `label` = the whole
+/// line kept verbatim for display.
+fn parse_skill_hits(out: &str) -> Vec<SkillSearchHit> {
+    out.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .take(50)
+        .map(|line| {
+            let mut toks = line.split_whitespace();
+            let first = toks.next().unwrap_or("");
+            let id = if matches!(first, "-" | "*" | "•" | "▸") {
+                toks.next().unwrap_or(first)
+            } else {
+                first
+            };
+            SkillSearchHit {
+                id: id.to_string(),
+                label: line.to_string(),
+            }
+        })
+        .collect()
+}
+
+/// Run `npx skills add <id>` in an isolated temp dir, then adopt the produced
+/// skill into `scope`. Running in a temp cwd (not the workspace) makes the
+/// destination ours to control — that is how "install for me →
+/// ~/.config/stella/skills" lands there despite the registry CLI's fixed cwd.
+async fn install_skill(
+    registry: &SkillRegistry,
+    scope: SkillScope,
+    id: &str,
+    workspace_root: &std::path::Path,
+) -> String {
+    let tmp = match tempfile::Builder::new().prefix("stella-skill-").tempdir() {
+        Ok(t) => t,
+        Err(e) => return format!("install failed: {e}"),
+    };
+    let mut reg = registry.clone();
+    reg.workspace_root = tmp.path().to_path_buf();
+    let argv = SkillRegistry::render(&reg.install_cmd, "{id}", id);
+    if let Err(e) = reg.run(argv, 300).await {
+        return format!("install failed: {e}");
+    }
+    match crate::skill_manager::adopt_tree(scope, workspace_root, tmp.path(), id) {
+        Ok(name) => format!("installed {name} ({})", scope.label()),
+        Err(e) => format!("install produced nothing usable: {e}"),
+    }
+}
+
+/// A crude popularity signal: the largest integer on a registry result line
+/// (stars/downloads if the CLI prints them), else 0.
+fn hit_popularity(label: &str) -> u64 {
+    label
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|t| t.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Rank registry hits for LLM-assisted creation by (a) relevance — how many of
+/// the request's words appear in the hit's line — then (b) popularity as a
+/// usefulness signal. Returns the top few labels, most useful first.
+fn rank_hits(hits: &[SkillSearchHit], request: &str) -> Vec<String> {
+    let want: Vec<String> = request
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.len() > 2)
+        .map(|w| w.to_ascii_lowercase())
+        .collect();
+    let mut scored: Vec<(usize, u64, &SkillSearchHit)> = hits
+        .iter()
+        .map(|h| {
+            let lower = h.label.to_ascii_lowercase();
+            let relevance = want.iter().filter(|w| lower.contains(w.as_str())).count();
+            (relevance, hit_popularity(&h.label), h)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
+    scored
+        .into_iter()
+        .take(6)
+        .map(|(_, _, h)| h.label.clone())
+        .collect()
+}
+
+/// The system prompt for one-shot skill authoring.
+const SKILL_AUTHOR_SYSTEM: &str = "You author `SKILL.md` files for a coding agent. A skill is reusable \
+know-how (a convention, procedure, or preference) the agent applies when relevant. Output ONLY the \
+file content: YAML frontmatter delimited by `---` with `name:` (a short kebab-case slug), \
+`description:` (one line — the primary selection signal), and optional `domains:` (comma-separated \
+tags), followed by a concise markdown body. No commentary before or after.";
+
+/// Assemble the user prompt for LLM-assisted creation: the request plus the
+/// ranked registry candidates the model may borrow from (whole or in part,
+/// across several) to deliver ONE coherent skill. Pure — unit-tested.
+fn build_skill_creation_prompt(request: &str, ranked_candidates: &[String]) -> String {
+    let mut p = String::new();
+    p.push_str("Create ONE new skill for this request:\n\n");
+    p.push_str(request.trim());
+    p.push_str("\n\n");
+    if ranked_candidates.is_empty() {
+        p.push_str(
+            "No existing skills were found in the registry. Author the skill from scratch.\n",
+        );
+    } else {
+        p.push_str(
+            "Existing registry skills, ranked by usefulness (relevance, then popularity). You may \
+             borrow whole or in part from any of them, and assemble bits from several into one \
+             coherent skill — but deliver a SINGLE skill:\n",
+        );
+        for (i, c) in ranked_candidates.iter().enumerate() {
+            p.push_str(&format!("{}. {}\n", i + 1, c));
+        }
+    }
+    p.push_str(
+        "\nWrite the SKILL.md now. Keep the body focused and actionable; the description must make \
+         it easy to select for the right task.",
+    );
+    p
+}
+
+/// Extract the `SKILL.md` content from a model reply: prefer the first fenced
+/// code block; otherwise, from the first `---` (frontmatter) onward; otherwise
+/// the trimmed whole reply.
+fn extract_skill_md(text: &str) -> String {
+    if let Some(start) = text.find("```") {
+        let after = &text[start + 3..];
+        let after = after
+            .split_once('\n')
+            .map(|(_, rest)| rest)
+            .unwrap_or(after);
+        if let Some(end) = after.find("```") {
+            return after[..end].trim().to_string();
+        }
+    }
+    if let Some(fm) = text.find("---") {
+        return text[fm..].trim().to_string();
+    }
+    text.trim().to_string()
+}
+
+/// LLM-assisted creation: search the registry for the request, rank the hits,
+/// have the model assemble ONE `SKILL.md` (reusing the existing provider path),
+/// and write it into `scope` as version 1. Returns a status string.
+async fn create_skill_llm(
+    cfg: &Config,
+    registry: &SkillRegistry,
+    scope: SkillScope,
+    description: &str,
+    workspace_root: &std::path::Path,
+) -> String {
+    // 1. Search existing skills for inspiration (best-effort — a registry
+    //    failure just means authoring from scratch).
+    let argv = SkillRegistry::render(&registry.search_cmd, "{query}", description);
+    let search_out = registry.run(argv, 90).await.unwrap_or_default();
+    let ranked = rank_hits(&parse_skill_hits(&search_out), description);
+    // 2. Assemble the prompt and run a one-shot model call (the same provider
+    //    path the rest of the session uses — never hand-rolled HTTP).
+    let provider = match agent::build_provider(cfg) {
+        Ok(p) => p,
+        Err(e) => return format!("create failed: {e}"),
+    };
+    let req = CompletionRequest {
+        messages: vec![
+            CompletionMessage::system(SKILL_AUTHOR_SYSTEM),
+            CompletionMessage::user(build_skill_creation_prompt(description, &ranked)),
+        ],
+        max_output_tokens: Some(1200),
+        temperature: Some(0.2),
+        effort: None,
+        tools: vec![],
+    };
+    let content = match provider.complete(req).await {
+        Ok(r) => extract_skill_md(&r.text),
+        Err(e) => return format!("model call failed: {e}"),
+    };
+    // 3. Validate it parses as a real skill, then write it as v1.
+    let name = match stella_core::skills::skill_from_file("SKILL.md", &content) {
+        Ok(s) => s.name,
+        Err(_) => return "the model did not return a valid SKILL.md — try again".to_string(),
+    };
+    match crate::skill_manager::create(scope, &name, &content, workspace_root) {
+        Ok(n) => format!("created {n} ({}) — v1", scope.label()),
+        Err(e) => format!("create failed: {e}"),
+    }
+}
+
+/// Route one SKILLS-tab op. Disk ops run inline and answer immediately with a
+/// refreshed [`Inbound::Skills`]; npx/model ops spawn a task (like `!` shell
+/// commands) so a slow child never stalls the driver, then answer on
+/// completion. Called at both driver recv sites so the tab works mid-turn.
+fn handle_skills_input(
+    op: &SkillOp,
+    cfg: &Config,
+    in_tx: &UnboundedSender<Inbound>,
+    registry: &SkillRegistry,
+) {
+    let root = cfg.workspace_root.clone();
+    match op {
+        SkillOp::List => {
+            let _ = in_tx.send(skills_snapshot(&root, None));
+        }
+        SkillOp::SetEnabled {
+            scope,
+            name,
+            enabled,
+        } => {
+            let status = crate::skill_manager::set_enabled(*scope, name, *enabled, &root)
+                .unwrap_or_else(|e| e);
+            let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+        }
+        SkillOp::Uninstall { scope, name } => {
+            let status = crate::skill_manager::uninstall(*scope, name, &root).unwrap_or_else(|e| e);
+            let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+        }
+        SkillOp::Edit { scope, name, body } => {
+            let status =
+                crate::skill_manager::save_edit(*scope, name, body, &root).unwrap_or_else(|e| e);
+            let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+        }
+        SkillOp::Pin {
+            scope,
+            name,
+            version,
+        } => {
+            let status =
+                crate::skill_manager::set_pin(*scope, name, *version, &root).unwrap_or_else(|e| e);
+            let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+        }
+        SkillOp::Search { query } => {
+            let registry = registry.clone();
+            let in_tx = in_tx.clone();
+            let query = query.clone();
+            tokio::spawn(async move {
+                let argv = SkillRegistry::render(&registry.search_cmd, "{query}", &query);
+                let (hits, status) = match registry.run(argv, 90).await {
+                    Ok(out) => (parse_skill_hits(&out), None),
+                    Err(e) => (Vec::new(), Some(format!("search failed: {e}"))),
+                };
+                let _ = in_tx.send(Inbound::SkillSearch {
+                    query,
+                    hits,
+                    status,
+                });
+            });
+        }
+        SkillOp::Install { scope, id } => {
+            let registry = registry.clone();
+            let in_tx = in_tx.clone();
+            let id = id.clone();
+            let scope = *scope;
+            let root = root.clone();
+            tokio::spawn(async move {
+                let status = install_skill(&registry, scope, &id, &root).await;
+                let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+            });
+        }
+        SkillOp::Create { scope, description } => {
+            let registry = registry.clone();
+            let in_tx = in_tx.clone();
+            let cfg = cfg.clone();
+            let scope = *scope;
+            let description = description.clone();
+            let root = root.clone();
+            tokio::spawn(async move {
+                let status = create_skill_llm(&cfg, &registry, scope, &description, &root).await;
+                let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+            });
+        }
+    }
+}
+
 /// Handle a session-level slash command. Output goes into the lead agent's
 /// transcript as `Text` events — the deck renders exclusively from events, so
 /// printing to stdout (which the alternate screen owns) is never an option.
@@ -1105,7 +1425,7 @@ async fn run_deck_command(
         // tab) are normally consumed TUI-side, but a queued one reaches
         // here — accept it as handled (a no-op) rather than calling it
         // "unknown".
-        "/files" | "/diff" | "/graph" | "/agents" => {}
+        "/files" | "/diff" | "/graph" | "/agents" | "/skills" => {}
         _ => {
             // A custom command/skill/agent (⚡): expand its template —
             // arguments and all — into the prompt the model turn runs.
@@ -1625,6 +1945,74 @@ fn pseudo_diff(old: &str, new: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_skill_hits_takes_id_first_and_keeps_the_label() {
+        let out = "acme/auth  OAuth helper\n- foo/bar  another one\n\n";
+        let hits = parse_skill_hits(out);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].id, "acme/auth");
+        assert_eq!(hits[0].label, "acme/auth  OAuth helper");
+        assert_eq!(hits[1].id, "foo/bar", "leading list marker skipped");
+    }
+
+    #[test]
+    fn parse_skill_hits_caps_at_fifty() {
+        let out = (0..100)
+            .map(|i| format!("pkg/skill-{i}  desc"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(parse_skill_hits(&out).len(), 50);
+    }
+
+    #[test]
+    fn rank_hits_orders_by_relevance_then_popularity() {
+        let hits = vec![
+            SkillSearchHit {
+                id: "a/pdf".into(),
+                label: "a/pdf extract pdf tables  120".into(),
+            },
+            SkillSearchHit {
+                id: "b/img".into(),
+                label: "b/img resize images  9000".into(),
+            },
+            SkillSearchHit {
+                id: "c/pdf".into(),
+                label: "c/pdf pdf reader  5".into(),
+            },
+        ];
+        let ranked = rank_hits(&hits, "extract tables from pdf");
+        assert!(ranked[0].contains("a/pdf"), "{ranked:?}");
+        assert!(
+            ranked.iter().position(|l| l.contains("a/pdf"))
+                < ranked.iter().position(|l| l.contains("b/img")),
+            "relevance beats popularity: {ranked:?}"
+        );
+    }
+
+    #[test]
+    fn build_skill_creation_prompt_includes_request_and_ranked_candidates() {
+        let p = build_skill_creation_prompt(
+            "format sql nicely",
+            &["a/sql-fmt  sql formatter".to_string()],
+        );
+        assert!(p.contains("format sql nicely"));
+        assert!(p.contains("a/sql-fmt"));
+        assert!(p.contains("SINGLE skill"));
+        let empty = build_skill_creation_prompt("do a thing", &[]);
+        assert!(empty.contains("from scratch"));
+    }
+
+    #[test]
+    fn extract_skill_md_unwraps_a_fenced_block_or_frontmatter() {
+        let fenced =
+            "Here you go:\n```markdown\n---\nname: x\ndescription: d\n---\nbody\n```\ndone";
+        let got = extract_skill_md(fenced);
+        assert!(got.starts_with("---"), "{got}");
+        assert!(got.ends_with("body"), "{got}");
+        let bare = "prose\n---\nname: y\ndescription: d\n---\nbody";
+        assert!(extract_skill_md(bare).starts_with("---\nname: y"));
+    }
 
     /// A minimal inner executor that always succeeds (or always errors).
     struct FakeInner {

--- a/stella-cli/src/interactive.rs
+++ b/stella-cli/src/interactive.rs
@@ -144,7 +144,7 @@ impl SkillRegistry {
             .collect()
     }
 
-    async fn run(&self, argv: Vec<String>, timeout_secs: u64) -> Result<String, String> {
+    pub(crate) async fn run(&self, argv: Vec<String>, timeout_secs: u64) -> Result<String, String> {
         let Some((program, args)) = argv.split_first() else {
             return Err("empty registry command".into());
         };

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -31,6 +31,7 @@ mod ocp;
 mod rules;
 mod runtime;
 mod settings;
+mod skill_manager;
 mod stats;
 mod tui;
 

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -142,13 +142,17 @@ pub(crate) fn load_workspace_skills(workspace_root: &Path) -> Vec<Skill> {
 pub(crate) fn load_workspace_skills_with_diagnostics(
     workspace_root: &Path,
 ) -> skills::LoadedSkills {
-    skills::load_skills_with_diagnostics(
+    let mut loaded = skills::load_skills_with_diagnostics(
         &FsSkillSource,
         &LoadSkillsOptions {
             workspace_skills_dir: workspace_skills_dir(workspace_root),
             user_skills_dir: user_skills_dir(),
         },
-    )
+    );
+    // A skill disabled from the SKILLS tab is excluded from recall/selection
+    // and the ⚡ slash menu — its file stays on disk (see `crate::skill_manager`).
+    crate::skill_manager::retain_enabled(&mut loaded.skills, workspace_root);
+    loaded
 }
 
 impl SessionMemory {
@@ -243,6 +247,31 @@ impl SessionMemory {
         } else {
             Some(format!("{RECALL_MARKER}\n\n{}", sections.join("\n\n")))
         }
+    }
+
+    /// The skills recall would inject for `prompt`, as `(name, reason)` pairs
+    /// for skill-version usage telemetry — `reason` is the matched
+    /// domains/terms that selected it. Same enabled-filtered load + selection
+    /// as [`Self::recall_block`], so this reports exactly what was applied.
+    pub fn selected_skills(&self, prompt: &str) -> Vec<(String, String)> {
+        skills::select_skills(
+            &self.load_skills(),
+            prompt,
+            &self.domains.names(),
+            &SelectionConfig::default(),
+        )
+        .into_iter()
+        .map(|s| {
+            let mut why: Vec<String> = Vec::new();
+            if !s.matched_domains.is_empty() {
+                why.push(format!("domains: {}", s.matched_domains.join(", ")));
+            }
+            if !s.matched_terms.is_empty() {
+                why.push(format!("terms: {}", s.matched_terms.join(", ")));
+            }
+            (s.skill.name, why.join("; "))
+        })
+        .collect()
     }
 
     /// Record the turn that just finished as an episodic memory: a summary,

--- a/stella-cli/src/skill_manager.rs
+++ b/stella-cli/src/skill_manager.rs
@@ -1,0 +1,850 @@
+//! The SKILLS-tab disk half — the I/O the deck driver owns on behalf of the
+//! `stella-tui` SKILLS tab (`command_deck.rs` routes the ops, this module does
+//! the filesystem work). Pure `std::fs` over a workspace root + `$HOME`, so it
+//! is unit-tested against tempdirs with no live npx / model.
+//!
+//! ## Two scopes
+//!
+//! Skills live in two directories the loader already reads
+//! ([`crate::memory`]): the **project** scope `<workspace>/.stella/skills` and
+//! the **user** scope `~/.config/stella/skills`. The tab shows both (a
+//! same-named skill in each is listed twice, each independently manageable —
+//! unlike the recall loader, which merges by name with the project winning).
+//!
+//! ## State that isn't in the `SKILL.md`
+//!
+//! `stella_core::skills::Skill` carries no enabled/version/pin state, so this
+//! module keeps it in a per-scope sidecar `<skills_dir>/.stella-skills.json`
+//! (invisible to the shallow recall walk, which only reads `*.md` and
+//! `<slug>/SKILL.md`). Enabled/disabled and the pinned version live there;
+//! version *history* lives under `<slug>/versions/vN/SKILL.md` (the versioning
+//! layer). A disabled skill is excluded from recall/selection — the file stays
+//! on disk (see [`retain_enabled`]).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use stella_core::skills::{Skill, SkillOrigin, skill_from_file_with_origin};
+use stella_tui::{SkillRow, SkillScope};
+
+/// The per-scope sidecar that records state the `SKILL.md` files don't: which
+/// skills are disabled and (versioning layer) which version each is pinned to.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScopeState {
+    /// Skill names disabled in this scope (excluded from recall; file kept).
+    #[serde(default)]
+    pub disabled: Vec<String>,
+    /// Skill name → pinned version (versioning layer). Absent ⇒ latest.
+    #[serde(default)]
+    pub pins: std::collections::BTreeMap<String, u32>,
+}
+
+const STATE_FILE: &str = ".stella-skills.json";
+
+/// `<workspace>/.stella/skills` (project) or `~/.config/stella/skills` (user).
+/// `None` for the user scope when `$HOME` is unset.
+pub fn scope_root(scope: SkillScope, workspace_root: &Path) -> Option<PathBuf> {
+    match scope {
+        SkillScope::Project => Some(workspace_root.join(".stella").join("skills")),
+        SkillScope::User => std::env::var_os("HOME").map(|home| {
+            PathBuf::from(home)
+                .join(".config")
+                .join("stella")
+                .join("skills")
+        }),
+    }
+}
+
+/// The default [`SkillOrigin`] for a skill physically under `scope`.
+fn origin_for(scope: SkillScope) -> SkillOrigin {
+    match scope {
+        SkillScope::Project => SkillOrigin::Workspace,
+        SkillScope::User => SkillOrigin::User,
+    }
+}
+
+/// A short provenance label for the tab row.
+fn origin_label(origin: SkillOrigin) -> &'static str {
+    match origin {
+        SkillOrigin::Workspace => "workspace",
+        SkillOrigin::User => "user",
+        SkillOrigin::Installed => "installed",
+        SkillOrigin::AutoCreated => "auto",
+    }
+}
+
+// ── State file I/O ──────────────────────────────────────────────────────────
+
+fn state_path(scope_root: &Path) -> PathBuf {
+    scope_root.join(STATE_FILE)
+}
+
+/// Read a scope's sidecar state (a missing/corrupt file reads as default —
+/// state is a convenience layer, never load-bearing enough to fail an op).
+pub fn read_state(scope_root: &Path) -> ScopeState {
+    std::fs::read_to_string(state_path(scope_root))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_state(scope_root: &Path, state: &ScopeState) -> Result<(), String> {
+    std::fs::create_dir_all(scope_root)
+        .map_err(|e| format!("cannot create {}: {e}", scope_root.display()))?;
+    let json = serde_json::to_string_pretty(state).map_err(|e| e.to_string())?;
+    std::fs::write(state_path(scope_root), json)
+        .map_err(|e| format!("cannot write skills state: {e}"))
+}
+
+// ── Discovery (shallow, both layouts, per scope) ────────────────────────────
+
+/// One on-disk skill entry: the direct child of the skills dir (a `<slug>.md`
+/// file or a `<slug>/` directory) plus the parsed skill.
+struct Entry {
+    /// The direct child of the scope dir — the thing uninstall deletes.
+    entry_path: PathBuf,
+    skill: Skill,
+}
+
+/// List every skill directly under `scope_root`, honoring both the flat
+/// `<slug>.md` and nested `<slug>/SKILL.md` layouts (shallow — never descends
+/// into `<slug>/versions/`, matching the recall loader).
+fn list_scope(scope: SkillScope, scope_root: &Path) -> Vec<Entry> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(scope_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let (skill_file, content) = if path.extension().is_some_and(|e| e == "md") {
+            match std::fs::read_to_string(&path) {
+                Ok(c) => (path.clone(), c),
+                Err(_) => continue,
+            }
+        } else if path.is_dir() {
+            let nested = path.join("SKILL.md");
+            match std::fs::read_to_string(&nested) {
+                Ok(c) => (nested, c),
+                Err(_) => continue,
+            }
+        } else {
+            continue;
+        };
+        if let Ok(skill) = skill_from_file_with_origin(
+            &skill_file.display().to_string(),
+            &content,
+            origin_for(scope),
+        ) {
+            out.push(Entry {
+                entry_path: path,
+                skill,
+            });
+        }
+    }
+    // Deterministic order for a stable tab + stable tests.
+    out.sort_by(|a, b| a.skill.name.cmp(&b.skill.name));
+    out
+}
+
+/// The highest version present under `<slug>/versions/vN/` (0 if none). The
+/// versioning layer writes those; commit-1 skills report 1/1.
+fn latest_version(entry_path: &Path) -> u32 {
+    let versions = entry_path.join("versions");
+    let Ok(entries) = std::fs::read_dir(&versions) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter_map(|e| {
+            e.file_name()
+                .to_str()
+                .and_then(|n| n.strip_prefix('v'))
+                .and_then(|n| n.parse::<u32>().ok())
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// Enumerate every installed skill across BOTH scopes, with its enabled /
+/// version / pin state, as the wire rows the SKILLS tab renders.
+pub fn enumerate(workspace_root: &Path) -> Vec<SkillRow> {
+    let mut rows = Vec::new();
+    for scope in [SkillScope::Project, SkillScope::User] {
+        let Some(root) = scope_root(scope, workspace_root) else {
+            continue;
+        };
+        let state = read_state(&root);
+        let disabled: HashSet<&String> = state.disabled.iter().collect();
+        for entry in list_scope(scope, &root) {
+            let name = entry.skill.name.clone();
+            let latest = latest_version(&entry.entry_path).max(1);
+            let version = state.pins.get(&name).copied().unwrap_or(latest).min(latest);
+            rows.push(SkillRow {
+                scope,
+                enabled: !disabled.contains(&name),
+                name,
+                description: entry.skill.description,
+                body: entry.skill.body,
+                origin: origin_label(entry.skill.origin).to_string(),
+                version,
+                latest,
+                // Everything under a managed scope dir is deletable — uninstall
+                // is symlink-safe (it unlinks the entry, never the source).
+                removable: true,
+            });
+        }
+    }
+    rows
+}
+
+// ── Enable / disable (persistent) ───────────────────────────────────────────
+
+/// Persistently enable or disable `name` in `scope`. Returns a status string.
+pub fn set_enabled(
+    scope: SkillScope,
+    name: &str,
+    enabled: bool,
+    workspace_root: &Path,
+) -> Result<String, String> {
+    let root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let mut state = read_state(&root);
+    state.disabled.retain(|n| n != name);
+    if !enabled {
+        state.disabled.push(name.to_string());
+    }
+    write_state(&root, &state)?;
+    Ok(format!(
+        "{name} {} ({})",
+        if enabled { "enabled" } else { "disabled" },
+        scope.label()
+    ))
+}
+
+/// The set of skill names disabled in `scope_root` (for the recall filter).
+pub fn disabled_names(scope_root: &Path) -> HashSet<String> {
+    read_state(scope_root).disabled.into_iter().collect()
+}
+
+/// Drop disabled skills from a merged skill list (used by the recall/selection
+/// path so a disabled skill is never injected — its file stays on disk). A
+/// skill is matched to its scope by `source_path` containment.
+pub fn retain_enabled(skills: &mut Vec<Skill>, workspace_root: &Path) {
+    let project = scope_root(SkillScope::Project, workspace_root);
+    let user = scope_root(SkillScope::User, workspace_root);
+    let project_disabled = project.as_deref().map(disabled_names).unwrap_or_default();
+    let user_disabled = user.as_deref().map(disabled_names).unwrap_or_default();
+    skills.retain(|s| {
+        let under = |root: &Option<PathBuf>| {
+            root.as_ref()
+                .is_some_and(|r| Path::new(&s.source_path).starts_with(r))
+        };
+        if under(&project) {
+            !project_disabled.contains(&s.name)
+        } else if under(&user) {
+            !user_disabled.contains(&s.name)
+        } else {
+            true
+        }
+    });
+}
+
+// ── Uninstall (symlink-safe delete, both scopes) ────────────────────────────
+
+/// Delete `name` from `scope` entirely. Symlink-safe: it removes the entry
+/// directly under the scope dir — unlinking a symlinked entry rather than
+/// following it into a shared source — and refuses anything resolving outside
+/// the scope dir.
+pub fn uninstall(scope: SkillScope, name: &str, workspace_root: &Path) -> Result<String, String> {
+    let root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let entry = list_scope(scope, &root)
+        .into_iter()
+        .find(|e| e.skill.name == name)
+        .ok_or_else(|| format!("no skill named {name} in the {} scope", scope.label()))?;
+    // Containment guard: the entry must be a direct child of the scope dir.
+    let parent = entry.entry_path.parent();
+    if parent != Some(root.as_path()) {
+        return Err(format!(
+            "{name} is not directly under {} — refusing to delete it",
+            root.display()
+        ));
+    }
+    let meta = std::fs::symlink_metadata(&entry.entry_path)
+        .map_err(|e| format!("cannot read {}: {e}", entry.entry_path.display()))?;
+    let outcome = if meta.file_type().is_symlink() || meta.is_file() {
+        // Unlink a symlinked/flat entry — never follow into a shared source.
+        std::fs::remove_file(&entry.entry_path)
+    } else {
+        std::fs::remove_dir_all(&entry.entry_path)
+    };
+    outcome.map_err(|e| format!("delete failed: {e}"))?;
+    // Forget any lingering state for the deleted name.
+    let mut state = read_state(&root);
+    state.disabled.retain(|n| n != name);
+    state.pins.remove(name);
+    let _ = write_state(&root, &state);
+    Ok(format!("deleted {name} ({})", scope.label()))
+}
+
+// ── Install adoption (from an external installer's output tree) ─────────────
+
+/// Recursively find the first `SKILL.md` under `dir` (breadth-ish, shallow
+/// dirs first via sort), so we adopt whatever `npx skills add` produced no
+/// matter which subdirectory layout it used.
+fn find_skill_md(dir: &Path) -> Option<PathBuf> {
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let direct = d.join("SKILL.md");
+        if direct.is_file() {
+            return Some(direct);
+        }
+        if let Ok(entries) = std::fs::read_dir(&d) {
+            let mut subs: Vec<PathBuf> = entries
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.is_dir())
+                .collect();
+            subs.sort();
+            stack.extend(subs);
+        }
+    }
+    None
+}
+
+/// Adopt a skill produced by an external installer under `produced_dir` into
+/// `scope`'s skills dir. Derives the slug from the produced `SKILL.md`'s parent
+/// directory (falling back to `id`'s last path segment), copies it to
+/// `<scope>/<slug>/SKILL.md`, and returns the adopted skill's name. Copying
+/// (not moving) into our own dir means a user-scope install lands in
+/// `~/.config/stella/skills` regardless of where the installer wrote — the
+/// scope-destination problem the registry CLI's fixed cwd can't solve.
+pub fn adopt_tree(
+    scope: SkillScope,
+    workspace_root: &Path,
+    produced_dir: &Path,
+    id: &str,
+) -> Result<String, String> {
+    let skill_md = find_skill_md(produced_dir)
+        .ok_or_else(|| "the installer produced no SKILL.md".to_string())?;
+    let content = std::fs::read_to_string(&skill_md).map_err(|e| e.to_string())?;
+    let slug = skill_md
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .filter(|s| !s.eq_ignore_ascii_case("skills") && !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| id.rsplit(['/', '@']).next().unwrap_or(id).to_string());
+    let dest_root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let dest = dest_root.join(&slug);
+    std::fs::create_dir_all(&dest).map_err(|e| format!("cannot create {}: {e}", dest.display()))?;
+    std::fs::write(dest.join("SKILL.md"), &content)
+        .map_err(|e| format!("cannot write skill: {e}"))?;
+    let name = skill_from_file_with_origin(
+        &dest.join("SKILL.md").display().to_string(),
+        &content,
+        SkillOrigin::Installed,
+    )
+    .map(|s| s.name)
+    .unwrap_or(slug);
+    Ok(name)
+}
+
+// ── Versioning: edit (new version), pin (no bump), create ───────────────────
+
+/// The raw `---\n…\n---\n` frontmatter prefix of a `SKILL.md` (empty when there
+/// is none / it is unterminated), so an edit can preserve the authored
+/// name/description/domains verbatim and swap only the body.
+fn frontmatter_prefix(content: &str) -> String {
+    let s = content.strip_prefix('\u{feff}').unwrap_or(content);
+    if !s.starts_with("---") {
+        return String::new();
+    }
+    let mut prefix = String::new();
+    let mut fences = 0;
+    for line in s.split_inclusive('\n') {
+        prefix.push_str(line);
+        if line.trim_end() == "---" {
+            fences += 1;
+            if fences == 2 {
+                return prefix;
+            }
+        }
+    }
+    String::new()
+}
+
+/// The managed directory for a skill, and the current `SKILL.md` content —
+/// promoting a flat `<slug>.md` or an adopted **symlink** into a real managed
+/// `<slug>/` directory with a `versions/v1/SKILL.md` snapshot first. Copy-on-
+/// write: an adopted skill's symlink is broken and replaced by our own copy, so
+/// editing never writes back through the link into a shared source.
+fn promote_to_managed(scope: SkillScope, scope_root: &Path, name: &str) -> Result<PathBuf, String> {
+    let entry = list_scope(scope, scope_root)
+        .into_iter()
+        .find(|e| e.skill.name == name)
+        .ok_or_else(|| format!("no skill named {name} in the {} scope", scope.label()))?;
+    let entry_path = entry.entry_path;
+    let content = std::fs::read_to_string(&entry.skill.source_path)
+        .map_err(|e| format!("cannot read {}: {e}", entry.skill.source_path))?;
+
+    let sym = std::fs::symlink_metadata(&entry_path)
+        .map_err(|e| format!("cannot read {}: {e}", entry_path.display()))?;
+    let is_symlink = sym.file_type().is_symlink();
+    let is_real_dir = !is_symlink && entry_path.is_dir();
+
+    let slug = entry_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.strip_suffix(".md").unwrap_or(n).to_string())
+        .ok_or_else(|| "unusable skill path".to_string())?;
+    let managed = scope_root.join(&slug);
+
+    // Already a managed real dir with history — nothing to do.
+    if is_real_dir && managed.join("versions").is_dir() {
+        return Ok(managed);
+    }
+    // Break a symlink or delete a flat file so we own a fresh copy (CoW).
+    if is_symlink || sym.is_file() {
+        std::fs::remove_file(&entry_path)
+            .map_err(|e| format!("cannot replace {}: {e}", entry_path.display()))?;
+    }
+    let v1 = managed.join("versions").join("v1");
+    std::fs::create_dir_all(&v1).map_err(|e| format!("cannot create {}: {e}", v1.display()))?;
+    std::fs::write(v1.join("SKILL.md"), &content).map_err(|e| e.to_string())?;
+    std::fs::write(managed.join("SKILL.md"), &content).map_err(|e| e.to_string())?;
+    Ok(managed)
+}
+
+/// Save an edited body as a NEW version: writes `versions/v{N+1}/SKILL.md`
+/// (authored frontmatter preserved, body swapped), mirrors it to the pinned
+/// `SKILL.md`, and records the new pin. Increments the version.
+pub fn save_edit(
+    scope: SkillScope,
+    name: &str,
+    new_body: &str,
+    workspace_root: &Path,
+) -> Result<String, String> {
+    let root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let managed = promote_to_managed(scope, &root, name)?;
+    let current = std::fs::read_to_string(managed.join("SKILL.md")).map_err(|e| e.to_string())?;
+    let fm = frontmatter_prefix(&current);
+    let content = if fm.is_empty() {
+        format!(
+            "---\nname: {name}\ndescription: {name}\n---\n{}\n",
+            new_body.trim()
+        )
+    } else {
+        format!("{fm}{}\n", new_body.trim())
+    };
+    let next = latest_version(&managed).max(1) + 1;
+    let vdir = managed.join("versions").join(format!("v{next}"));
+    std::fs::create_dir_all(&vdir).map_err(|e| e.to_string())?;
+    std::fs::write(vdir.join("SKILL.md"), &content).map_err(|e| e.to_string())?;
+    // The pinned SKILL.md the recall loader reads is the just-saved version.
+    std::fs::write(managed.join("SKILL.md"), &content).map_err(|e| e.to_string())?;
+    let mut state = read_state(&root);
+    state.pins.insert(name.to_string(), next);
+    write_state(&root, &state)?;
+    Ok(format!("saved {name} v{next} ({})", scope.label()))
+}
+
+/// Pin `version` as the active one WITHOUT editing — mirrors that version's
+/// content to `SKILL.md` and records the pin. No version bump.
+pub fn set_pin(
+    scope: SkillScope,
+    name: &str,
+    version: u32,
+    workspace_root: &Path,
+) -> Result<String, String> {
+    let root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let entry = list_scope(scope, &root)
+        .into_iter()
+        .find(|e| e.skill.name == name)
+        .ok_or_else(|| format!("no skill named {name} in the {} scope", scope.label()))?;
+    let latest = latest_version(&entry.entry_path).max(1);
+    if version == 0 || version > latest {
+        return Err(format!("{name} has no v{version} (latest is v{latest})"));
+    }
+    // Mirror the chosen version's content to the pinned SKILL.md (managed skills
+    // only; a single-version skill is already its own pin).
+    let vfile = entry
+        .entry_path
+        .join("versions")
+        .join(format!("v{version}"))
+        .join("SKILL.md");
+    if vfile.is_file() {
+        let content = std::fs::read_to_string(&vfile).map_err(|e| e.to_string())?;
+        std::fs::write(entry.entry_path.join("SKILL.md"), content).map_err(|e| e.to_string())?;
+    }
+    let mut state = read_state(&root);
+    state.pins.insert(name.to_string(), version);
+    write_state(&root, &state)?;
+    Ok(format!("pinned {name} to v{version} ({})", scope.label()))
+}
+
+/// A filesystem-safe slug from a skill name (lowercase alnum, dashes elsewhere).
+fn slugify(name: &str) -> String {
+    let mut out = String::new();
+    let mut dash = false;
+    for c in name.trim().chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            dash = false;
+        } else if !dash && !out.is_empty() {
+            out.push('-');
+            dash = true;
+        }
+    }
+    let s = out.trim_matches('-').to_string();
+    if s.is_empty() { "skill".to_string() } else { s }
+}
+
+/// Create a new skill at version 1 in `scope` with the given `SKILL.md`
+/// content. Errors if a skill directory of that slug already exists.
+pub fn create(
+    scope: SkillScope,
+    name: &str,
+    content: &str,
+    workspace_root: &Path,
+) -> Result<String, String> {
+    let root = scope_root(scope, workspace_root)
+        .ok_or_else(|| "no $HOME for the user scope".to_string())?;
+    let slug = slugify(name);
+    let managed = root.join(&slug);
+    if managed.exists() {
+        return Err(format!(
+            "a skill dir named {slug} already exists in the {} scope",
+            scope.label()
+        ));
+    }
+    let v1 = managed.join("versions").join("v1");
+    std::fs::create_dir_all(&v1).map_err(|e| format!("cannot create {}: {e}", v1.display()))?;
+    std::fs::write(v1.join("SKILL.md"), content).map_err(|e| e.to_string())?;
+    std::fs::write(managed.join("SKILL.md"), content).map_err(|e| e.to_string())?;
+    // The parsed name (frontmatter) is what the tab/recall key on.
+    let parsed = skill_from_file_with_origin(
+        &managed.join("SKILL.md").display().to_string(),
+        content,
+        SkillOrigin::Installed,
+    )
+    .map(|s| s.name)
+    .unwrap_or_else(|_| slug.clone());
+    Ok(parsed)
+}
+
+/// A `skill name → pinned version` map across both scopes (project wins on a
+/// name collision, matching the recall loader's merge) — for usage telemetry.
+pub fn pinned_versions(workspace_root: &Path) -> std::collections::HashMap<String, u32> {
+    let mut map = std::collections::HashMap::new();
+    // User first, then project, so project overwrites on a collision.
+    for scope in [SkillScope::User, SkillScope::Project] {
+        if let Some(row_scope) = scope_root(scope, workspace_root) {
+            let state = read_state(&row_scope);
+            for entry in list_scope(scope, &row_scope) {
+                let latest = latest_version(&entry.entry_path).max(1);
+                let v = state
+                    .pins
+                    .get(&entry.skill.name)
+                    .copied()
+                    .unwrap_or(latest)
+                    .min(latest);
+                map.insert(entry.skill.name, v);
+            }
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill(dir: &Path, slug: &str, desc: &str) {
+        let sub = dir.join(slug);
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(
+            sub.join("SKILL.md"),
+            format!("---\nname: {slug}\ndescription: {desc}\n---\nbody of {slug}"),
+        )
+        .unwrap();
+    }
+
+    /// A tempdir workspace with `HOME` pointed inside it so the user scope is
+    /// isolated. Holds the process-wide env lock for the whole test (returned
+    /// as the third element) — `setenv`/`getenv` races are UB and the harness
+    /// runs these on parallel threads. Returns (workspace_root, home, lock).
+    fn scratch() -> (
+        tempfile::TempDir,
+        PathBuf,
+        std::sync::MutexGuard<'static, ()>,
+    ) {
+        let lock = crate::test_env::lock();
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path().join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        // SAFETY: the env lock above serializes every HOME-mutating test in
+        // this binary; the guard is held for the caller's whole test.
+        unsafe {
+            std::env::set_var("HOME", &home);
+        }
+        (td, home, lock)
+    }
+
+    #[test]
+    fn enumerate_reads_both_scopes() {
+        let (td, home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        write_skill(&ws.join(".stella/skills"), "proj-skill", "a project skill");
+        write_skill(
+            &home.join(".config/stella/skills"),
+            "user-skill",
+            "a user skill",
+        );
+        let rows = enumerate(&ws);
+        assert!(rows.iter().any(|r| r.name == "proj-skill"
+            && r.scope == SkillScope::Project
+            && r.origin == "workspace"));
+        assert!(
+            rows.iter().any(|r| r.name == "user-skill"
+                && r.scope == SkillScope::User
+                && r.origin == "user")
+        );
+        assert!(rows.iter().all(|r| r.enabled), "all enabled by default");
+    }
+
+    #[test]
+    fn disable_persists_and_recall_filter_drops_it() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        write_skill(&ws.join(".stella/skills"), "sql-style", "format sql");
+        write_skill(&ws.join(".stella/skills"), "keep-me", "keep");
+
+        set_enabled(SkillScope::Project, "sql-style", false, &ws).unwrap();
+        // Persisted across a fresh read: the tab still lists it, marked off.
+        let rows = enumerate(&ws);
+        let sql = rows.iter().find(|r| r.name == "sql-style").unwrap();
+        assert!(!sql.enabled, "disable persisted");
+        assert!(rows.iter().find(|r| r.name == "keep-me").unwrap().enabled);
+
+        // The recall/selection loader now filters disabled skills (the file
+        // stays on disk — the tab still shows it above), keeping the enabled one.
+        let recalled = crate::memory::load_workspace_skills(&ws);
+        assert!(
+            !recalled.iter().any(|s| s.name == "sql-style"),
+            "disabled excluded from recall"
+        );
+        assert!(
+            recalled.iter().any(|s| s.name == "keep-me"),
+            "enabled kept in recall"
+        );
+
+        // Re-enable brings it back everywhere.
+        set_enabled(SkillScope::Project, "sql-style", true, &ws).unwrap();
+        assert!(
+            enumerate(&ws)
+                .iter()
+                .find(|r| r.name == "sql-style")
+                .unwrap()
+                .enabled
+        );
+        assert!(
+            crate::memory::load_workspace_skills(&ws)
+                .iter()
+                .any(|s| s.name == "sql-style")
+        );
+    }
+
+    #[test]
+    fn uninstall_deletes_the_directory() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        let dir = ws.join(".stella/skills");
+        write_skill(&dir, "doomed", "delete me");
+        assert!(dir.join("doomed/SKILL.md").exists());
+
+        let msg = uninstall(SkillScope::Project, "doomed", &ws).unwrap();
+        assert!(msg.contains("deleted doomed"));
+        assert!(!dir.join("doomed").exists(), "directory removed");
+        assert!(enumerate(&ws).iter().all(|r| r.name != "doomed"));
+    }
+
+    #[test]
+    fn uninstall_a_symlinked_entry_unlinks_without_touching_the_source() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        let dir = ws.join(".stella/skills");
+        std::fs::create_dir_all(&dir).unwrap();
+        // A shared source outside the scope dir, adopted as a symlink.
+        let source = ws.join("shared/adopted");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(
+            source.join("SKILL.md"),
+            "---\nname: adopted\ndescription: shared\n---\nbody",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&source, dir.join("adopted")).unwrap();
+
+        #[cfg(unix)]
+        {
+            uninstall(SkillScope::Project, "adopted", &ws).unwrap();
+            assert!(!dir.join("adopted").exists(), "symlink unlinked");
+            assert!(
+                source.join("SKILL.md").exists(),
+                "shared source untouched — never followed"
+            );
+        }
+    }
+
+    #[test]
+    fn uninstall_unknown_skill_is_an_error() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        write_skill(&ws.join(".stella/skills"), "present", "here");
+        assert!(uninstall(SkillScope::Project, "absent", &ws).is_err());
+    }
+
+    #[test]
+    fn edit_creates_a_new_version_pins_it_and_preserves_frontmatter() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        write_skill(&ws.join(".stella/skills"), "sql-style", "format sql");
+
+        let msg = save_edit(SkillScope::Project, "sql-style", "New body v2", &ws).unwrap();
+        assert!(msg.contains("v2"), "{msg}");
+
+        let dir = ws.join(".stella/skills/sql-style");
+        assert!(dir.join("versions/v1/SKILL.md").exists(), "v1 snapshotted");
+        assert!(dir.join("versions/v2/SKILL.md").exists(), "v2 written");
+        let pinned = std::fs::read_to_string(dir.join("SKILL.md")).unwrap();
+        assert!(pinned.contains("New body v2"), "pinned is the new version");
+        assert!(
+            pinned.contains("description: format sql"),
+            "frontmatter preserved"
+        );
+
+        let row = enumerate(&ws)
+            .into_iter()
+            .find(|r| r.name == "sql-style")
+            .unwrap();
+        assert_eq!(row.version, 2);
+        assert_eq!(row.latest, 2);
+
+        // A second edit bumps to v3.
+        save_edit(SkillScope::Project, "sql-style", "body v3", &ws).unwrap();
+        let row = enumerate(&ws)
+            .into_iter()
+            .find(|r| r.name == "sql-style")
+            .unwrap();
+        assert_eq!(row.version, 3);
+        assert_eq!(row.latest, 3);
+    }
+
+    #[test]
+    fn pin_switches_the_active_version_without_bumping() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        write_skill(&ws.join(".stella/skills"), "s", "d");
+        save_edit(SkillScope::Project, "s", "second", &ws).unwrap(); // now v2, pinned v2
+
+        // Pin back to v1 — no new version is created.
+        let msg = set_pin(SkillScope::Project, "s", 1, &ws).unwrap();
+        assert!(msg.contains("v1"), "{msg}");
+        let row = enumerate(&ws).into_iter().find(|r| r.name == "s").unwrap();
+        assert_eq!(row.version, 1, "pinned back to v1");
+        assert_eq!(row.latest, 2, "history unchanged — no bump");
+        let pinned = std::fs::read_to_string(ws.join(".stella/skills/s/SKILL.md")).unwrap();
+        assert!(pinned.contains("body of s"), "SKILL.md mirrors v1");
+
+        // Pinning a nonexistent version errors.
+        assert!(set_pin(SkillScope::Project, "s", 9, &ws).is_err());
+    }
+
+    #[test]
+    fn create_writes_a_v1_managed_skill() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        let content = "---\nname: my-skill\ndescription: does things\n---\nthe body";
+        let name = create(SkillScope::Project, "my-skill", content, &ws).unwrap();
+        assert_eq!(name, "my-skill");
+        assert!(
+            ws.join(".stella/skills/my-skill/versions/v1/SKILL.md")
+                .exists()
+        );
+        let row = enumerate(&ws)
+            .into_iter()
+            .find(|r| r.name == "my-skill")
+            .unwrap();
+        assert_eq!(row.version, 1);
+        // Recreating the same slug is refused.
+        assert!(create(SkillScope::Project, "my-skill", content, &ws).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn editing_an_adopted_symlink_is_copy_on_write() {
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        let dir = ws.join(".stella/skills");
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = ws.join("shared/adopted");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(
+            source.join("SKILL.md"),
+            "---\nname: adopted\ndescription: shared\n---\noriginal body",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&source, dir.join("adopted")).unwrap();
+
+        save_edit(SkillScope::Project, "adopted", "edited body", &ws).unwrap();
+
+        // The shared source is untouched (never written through the link).
+        let src = std::fs::read_to_string(source.join("SKILL.md")).unwrap();
+        assert!(
+            src.contains("original body"),
+            "shared source preserved: {src}"
+        );
+        // Our copy owns the edit, and the symlink was replaced by a real dir.
+        assert!(
+            !dir.join("adopted")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        let ours = std::fs::read_to_string(dir.join("adopted/SKILL.md")).unwrap();
+        assert!(ours.contains("edited body"));
+    }
+
+    #[test]
+    fn adopt_tree_pulls_a_produced_skill_into_the_user_scope() {
+        let (td, home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        // Simulate what `npx skills add acme/auth` leaves behind in its cwd.
+        let produced = td.path().join("produced");
+        write_skill(
+            &produced.join(".claude/skills"),
+            "auth-helper",
+            "oauth helper",
+        );
+
+        let name = adopt_tree(SkillScope::User, &ws, &produced, "acme/auth").unwrap();
+        assert_eq!(name, "auth-helper");
+        // It landed in ~/.config/stella/skills, NOT the project — proving the
+        // scope is honored regardless of the installer's cwd.
+        assert!(
+            home.join(".config/stella/skills/auth-helper/SKILL.md")
+                .exists()
+        );
+        assert!(
+            enumerate(&ws)
+                .iter()
+                .any(|r| r.name == "auth-helper" && r.scope == SkillScope::User)
+        );
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -340,6 +340,10 @@ const MIGRATIONS: [Migration; 4] = [
     // NOTE: several in-flight branches each add a store.db migration — the
     // slot number is taken naively here and reconciled at merge time.
     migrate_v3_to_v4,
+    // v4 → v5: the skill_usage invocation log (purely additive — SKILLS tab).
+    // NOTE: same naive-slot caveat — may need a one-line renumber at
+    // cascade-merge since sibling branches also append migrations.
+    migrate_v4_to_v5,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -350,7 +354,7 @@ const SCHEMA_VERSION: i64 = MIGRATIONS.len() as i64;
 
 /// Every table the store owns — the allowlist for [`Store::count`] and the
 /// fresh-file probe in [`Store::migrate`].
-const TABLES: [&str; 10] = [
+const TABLES: [&str; 11] = [
     "executions",
     "events",
     "telemetry",
@@ -361,6 +365,7 @@ const TABLES: [&str; 10] = [
     "graph_nodes",
     "graph_edges",
     "agent_uses",
+    "skill_usage",
 ];
 
 /// Tables whose shape has not changed since v0. `IF NOT EXISTS` keeps one
@@ -532,6 +537,20 @@ const AGENT_USES_DDL: &str = "CREATE TABLE IF NOT EXISTS agent_uses (
      CREATE INDEX IF NOT EXISTS agent_uses_by_agent
        ON agent_uses(agent, version, execution_id);";
 
+/// `skill_usage` DDL at [`SCHEMA_VERSION`] — per-execution skill-version
+/// invocation telemetry (SKILLS tab), the exact analogue of [`AGENT_USES_DDL`].
+/// Append-only: one row per skill applied in a turn, no UNIQUE key. The
+/// by-skill index serves per-skill/version aggregate queries.
+const SKILL_USAGE_DDL: &str = "CREATE TABLE IF NOT EXISTS skill_usage (
+       execution_id INTEGER NOT NULL,
+       skill TEXT NOT NULL,
+       version INTEGER NOT NULL,
+       reason TEXT NOT NULL DEFAULT '',
+       ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+     );
+     CREATE INDEX IF NOT EXISTS skill_usage_by_skill
+       ON skill_usage(skill, version, execution_id);";
+
 /// The full latest schema, applied in one shot to fresh databases only.
 /// Existing files never see this — [`MIGRATIONS`] upgrades them shape by
 /// shape, so this can always describe the CURRENT shape.
@@ -544,6 +563,7 @@ fn create_latest_schema(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(TELEMETRY_INDEX)?;
     tx.execute_batch(MEMORY_CITATIONS_DDL)?;
     tx.execute_batch(AGENT_USES_DDL)?;
+    tx.execute_batch(SKILL_USAGE_DDL)?;
     Ok(())
 }
 
@@ -744,6 +764,13 @@ fn migrate_v2_to_v3(tx: &rusqlite::Transaction<'_>) -> Result<()> {
 /// EXISTS` also covers a partial file that somehow already grew the table.
 fn migrate_v3_to_v4(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(AGENT_USES_DDL)?;
+    Ok(())
+}
+
+/// v4 → v5: the additive `skill_usage` table (skill-version usage telemetry,
+/// SKILLS tab). Purely additive, mirroring [`migrate_v3_to_v4`].
+fn migrate_v4_to_v5(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    tx.execute_batch(SKILL_USAGE_DDL)?;
     Ok(())
 }
 
@@ -1036,6 +1063,21 @@ impl Store {
                 "INSERT INTO agent_uses (execution_id, agent, version, reason) \
                  VALUES (?, ?, ?, ?)",
                 params![execution_id, row.agent, row.version as i64, row.reason],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Record the skills applied in one execution — one row per skill at its
+    /// pinned version, never aggregated (see [`SkillUsageRow`]). The analogue
+    /// of [`Self::record_agent_uses`] for the SKILLS tab.
+    pub fn record_skill_usage(&self, execution_id: i64, skills: &[SkillUsageRow]) -> Result<()> {
+        let conn = self.lock();
+        for row in skills {
+            conn.execute(
+                "INSERT INTO skill_usage (execution_id, skill, version, reason) \
+                 VALUES (?, ?, ?, ?)",
+                params![execution_id, row.skill, row.version as i64, row.reason],
             )?;
         }
         Ok(())

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -221,6 +221,16 @@ pub struct AgentUseRow {
     pub reason: String,
 }
 
+/// One skill-invocation row for the `skill_usage` log — the analogue of
+/// [`AgentUseRow`] for the SKILLS tab: which skill (by name) at which pinned
+/// version was applied under an execution, with a short reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillUsageRow {
+    pub skill: String,
+    pub version: u32,
+    pub reason: String,
+}
+
 /// One aggregated analytics row per (provider, model): the numbers behind
 /// "$-per-resolved-task" receipts, straight from local telemetry.
 ///
@@ -324,7 +334,7 @@ type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-const MIGRATIONS: [Migration; 4] = [
+const MIGRATIONS: [Migration; 5] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -1771,6 +1781,45 @@ mod tests {
         assert_eq!((agent.as_str(), version), ("reviewer", 2));
         assert_eq!(reason, "review the diff");
         assert!(!ts.is_empty(), "the insert stamps a timestamp");
+    }
+
+    #[test]
+    fn skill_usage_records_per_execution_version_rows() {
+        let store = Store::in_memory().unwrap();
+        assert_eq!(user_version(&store), SCHEMA_VERSION);
+        assert_eq!(SCHEMA_VERSION, 5, "skill_usage lands at v5 on this branch");
+
+        let id = store
+            .begin_execution("deck", "format the sql", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_skill_usage(
+                id,
+                &[
+                    SkillUsageRow {
+                        skill: "sql-style".into(),
+                        version: 3,
+                        reason: "matched: sql, format".into(),
+                    },
+                    SkillUsageRow {
+                        skill: "prefer-tables".into(),
+                        version: 1,
+                        reason: "matched: tables".into(),
+                    },
+                ],
+            )
+            .unwrap();
+        assert_eq!(store.count("skill_usage").unwrap(), 2);
+        let conn = store.lock();
+        let (skill, version): (String, i64) = conn
+            .query_row(
+                "SELECT skill, version FROM skill_usage WHERE execution_id = ? \
+                 ORDER BY rowid LIMIT 1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((skill.as_str(), version), ("sql-style", 3));
     }
 
     #[test]

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -23,7 +23,7 @@ use tokio::sync::mpsc;
 use stella_tui::scenario::{demo_graph, demo_inbound};
 use stella_tui::{
     AgentControl, AgentMeta, AgentStatus, DeckOptions, GraphNode, GraphSnapshot, Inbound,
-    ScopeDecision, SlashCommand, UserInput, WorkspaceInput, run_deck,
+    ScopeDecision, SkillsView, SlashCommand, UserInput, WorkspaceInput, run_deck,
 };
 
 fn now_ms() -> u64 {
@@ -158,6 +158,15 @@ async fn main() -> std::io::Result<()> {
                         entries: vec![],
                         status: Some("the demo has no agents on disk".to_string()),
                     });
+                }
+                // The demo has no skills engine — answer with an empty list so
+                // the SKILLS tab renders its empty state instead of hanging.
+                WorkspaceInput::Skill(_) => {
+                    let _ = react_tx.send(Inbound::Skills(SkillsView {
+                        rows: vec![],
+                        status: Some("the demo has no skills on disk".to_string()),
+                        busy: false,
+                    }));
                 }
                 WorkspaceInput::Quit => break,
             }

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -34,15 +34,17 @@ pub enum DeckTab {
     Traces,
     Graph,
     Files,
+    Skills,
 }
 
 impl DeckTab {
-    pub const ALL: [DeckTab; 5] = [
+    pub const ALL: [DeckTab; 6] = [
         DeckTab::Session,
         DeckTab::Agents,
         DeckTab::Traces,
         DeckTab::Graph,
         DeckTab::Files,
+        DeckTab::Skills,
     ];
 
     /// The tab-bar label. Deck tab labels are UPPERCASE by convention —
@@ -54,6 +56,7 @@ impl DeckTab {
             DeckTab::Traces => "TRACES",
             DeckTab::Graph => "GRAPH",
             DeckTab::Files => "FILES",
+            DeckTab::Skills => "SKILLS",
         }
     }
 
@@ -334,7 +337,11 @@ impl WorkspaceModel {
             // agents list are out-of-band read-models, not part of the
             // event-log fold — the view state owns them, applied in
             // `ingest_inbound`, so the model deliberately ignores them here.
-            Inbound::GraphSnapshot(_) | Inbound::SlashCommands(_) | Inbound::AgentsList { .. } => {}
+            Inbound::GraphSnapshot(_)
+            | Inbound::SlashCommands(_)
+            | Inbound::AgentsList { .. }
+            | Inbound::Skills(_)
+            | Inbound::SkillSearch { .. } => {}
         }
     }
 
@@ -1301,8 +1308,9 @@ mod tests {
     #[test]
     fn deck_tab_cycles_both_ways() {
         assert_eq!(DeckTab::Session.next(), DeckTab::Agents);
-        assert_eq!(DeckTab::Session.prev(), DeckTab::Files);
-        assert_eq!(DeckTab::Files.next(), DeckTab::Session);
+        assert_eq!(DeckTab::Session.prev(), DeckTab::Skills);
+        assert_eq!(DeckTab::Files.next(), DeckTab::Skills);
+        assert_eq!(DeckTab::Skills.next(), DeckTab::Session);
     }
 
     #[test]

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -74,6 +74,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         DeckTab::Traces => views::traces::render(model, ui, content, buf),
         DeckTab::Graph => views::graph::render(model, ui, content, buf),
         DeckTab::Files => views::files::render(model, ui, content, buf),
+        DeckTab::Skills => views::skills::render(model, ui, content, buf),
     }
 
     crate::progress::render(model, ui, bands[2], buf);
@@ -746,7 +747,7 @@ fn fmt_tokens(n: u64) -> String {
 /// A centered help overlay listing the deck's keys.
 fn render_help(area: Rect, buf: &mut Buffer) {
     let w = area.width.min(62);
-    let h = area.height.min(23);
+    let h = area.height.min(27);
     let popup = Rect {
         x: area.x + (area.width.saturating_sub(w)) / 2,
         y: area.y + (area.height.saturating_sub(h)) / 2,
@@ -816,6 +817,14 @@ fn render_help(area: Rect, buf: &mut Buffer) {
         )),
         Line::from(Span::styled(
             "  Graph:  / or Enter  browse & filter indexed files",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
+            "  SKILLS: space on/off · ctrl+x×2 delete · ←/→ pane",
+            theme::body(),
+        )),
+        Line::from(Span::styled(
+            "          e edit · p pin · n new (LLM) · /skills opens",
             theme::body(),
         )),
         Line::from(Span::styled(

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -29,7 +29,8 @@ use crate::composer::{
 };
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::envelope::{
-    AgentControl, AgentId, AgentScope, AgentStatus, Inbound, InstalledAgentEntry, WorkspaceInput,
+    AgentControl, AgentId, AgentScope, AgentStatus, Inbound, InstalledAgentEntry, SkillOp,
+    SkillScope, SkillSearchHit, SkillsView, WorkspaceInput,
 };
 use crate::graph::GraphSnapshot;
 use crate::input::{ScopeDecision, UserInput};
@@ -156,6 +157,79 @@ impl InstalledPanel {
     }
 }
 
+/// Which pane of the SKILLS tab has the keyboard: the installed list or the
+/// registry search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillsFocus {
+    #[default]
+    Installed,
+    Search,
+}
+
+/// An active SKILLS-tab overlay that captures keys ahead of the list/search
+/// panes — the scope picker, the create-description input, the edit buffer, or
+/// the version pin picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillPrompt {
+    /// Choose install/create scope (project or user) before dispatching.
+    Scope {
+        action: ScopeAction,
+        /// Highlighted choice: `false` = project, `true` = user.
+        user: bool,
+    },
+    /// Type a short description for LLM-assisted creation (then the scope
+    /// picker follows).
+    CreateDescription { buffer: String },
+    /// Edit a skill's body; saving increments its version and pins the new one.
+    Edit {
+        scope: SkillScope,
+        name: String,
+        buffer: String,
+    },
+    /// Pick a version to pin (no edit, no version bump).
+    Pin {
+        scope: SkillScope,
+        name: String,
+        latest: u32,
+        sel: u32,
+    },
+}
+
+/// The deferred action a [`SkillPrompt::Scope`] picker resolves into once the
+/// user chooses a scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopeAction {
+    Install { id: String },
+    Create { description: String },
+}
+
+/// All SKILLS-tab view state. The installed list + `busy`/`status` come from
+/// [`Inbound::Skills`] snapshots the driver owns; the rest (selection, the
+/// live search query, transient arming, the active overlay) is local.
+#[derive(Debug, Clone, Default)]
+pub struct SkillsPanel {
+    /// The installed-skills read-model, from [`Inbound::Skills`].
+    pub view: SkillsView,
+    pub focus: SkillsFocus,
+    /// Selected row in the installed list.
+    pub sel: usize,
+    /// The live search-query buffer.
+    pub query: String,
+    /// Last search results, from [`Inbound::SkillSearch`].
+    pub hits: Vec<SkillSearchHit>,
+    pub search_sel: usize,
+    /// Query changed since the last search → Enter re-searches, not installs.
+    pub query_dirty: bool,
+    /// An npx search/install is in flight (client-side optimism).
+    pub searching: bool,
+    /// One-line hint (last op outcome / affordance).
+    pub status: Option<String>,
+    /// First `ctrl+x` arms; the second uninstalls.
+    pub uninstall_armed: bool,
+    /// An active overlay capturing keys ahead of the panes.
+    pub prompt: Option<SkillPrompt>,
+}
+
 /// All ephemeral view state for the deck.
 #[derive(Debug, Clone)]
 pub struct DeckUi {
@@ -164,6 +238,8 @@ pub struct DeckUi {
     pub agents_pane: AgentsPane,
     /// The INSTALLED AGENTS pane's state.
     pub installed: InstalledPanel,
+    /// The SKILLS tab's view state (installed list, search, overlays).
+    pub skills: SkillsPanel,
     /// The one global composer — typing works from any tab.
     pub composer: Composer,
     pub splash: SplashState,
@@ -265,6 +341,7 @@ impl Default for DeckUi {
             tab: DeckTab::Session,
             agents_pane: AgentsPane::default(),
             installed: InstalledPanel::default(),
+            skills: SkillsPanel::default(),
             composer: Composer::with_paste_threshold(crate::composer::DECK_PASTE_LINE_THRESHOLD),
             splash: SplashState::new(),
             help_open: false,
@@ -396,6 +473,42 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         if let Some(status) = status {
             ui.installed.status = Some(status.clone());
         }
+        return;
+    }
+    // Skills snapshots are out-of-band view state (like the graph, the slash
+    // vocabulary, and the agents list): applied straight to `DeckUi::skills`.
+    if let Inbound::Skills(view) = inbound {
+        ui.skills.view = view.clone();
+        // A fresh list is the completion signal for a disk/npx op: stop the
+        // spinner and disarm any half-armed uninstall.
+        ui.skills.searching = false;
+        ui.skills.uninstall_armed = false;
+        if view.status.is_some() {
+            ui.skills.status = view.status.clone();
+        }
+        let n = ui.skills.view.rows.len();
+        ui.skills.sel = if n == 0 { 0 } else { ui.skills.sel.min(n - 1) };
+        return;
+    }
+    if let Inbound::SkillSearch {
+        query,
+        hits,
+        status,
+    } = inbound
+    {
+        if ui.skills.query.trim() == query.trim() {
+            ui.skills.query_dirty = false;
+        }
+        ui.skills.hits = hits.clone();
+        ui.skills.search_sel = 0;
+        ui.skills.searching = false;
+        ui.skills.status = status.clone().or_else(|| {
+            Some(if hits.is_empty() {
+                format!("no skills found for “{query}”")
+            } else {
+                format!("{} result(s) — ⏎ installs the selected one", hits.len())
+            })
+        });
         return;
     }
     model.apply_inbound(inbound);
@@ -577,6 +690,17 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
 
     let composer_empty = ui.composer.buffer().is_empty();
 
+    // The SKILLS tab is a keyboard-owning manager: it claims the keys for its
+    // list, search query, and overlays *ahead* of tab-nav and the global
+    // composer, so a search term (or a manage hotkey like space) is never
+    // swallowed as prompt text. Keys it declines (`None`) fall through — Tab
+    // still leaves the tab, `?` still opens help from the installed pane.
+    if ui.tab == DeckTab::Skills
+        && let Some(action) = handle_skills_key(key, ui)
+    {
+        return action;
+    }
+
     // Deck-global tab navigation (Tab / Shift-Tab only — digits never switch
     // tabs: they quick-pick ask-user answers and must be typeable as the
     // first character of a prompt). The slash popup claims Tab first —
@@ -653,6 +777,10 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         DeckTab::Graph => handle_graph_key(key, ui, composer_empty),
         DeckTab::Files => handle_files_key(key, model, ui, composer_empty),
         DeckTab::Session => handle_session_key(key, model, ui),
+        // The SKILLS tab claims its keys earlier (before the composer), so a
+        // key that reaches here fell through on purpose — leave it to the
+        // deck-global handlers below.
+        DeckTab::Skills => None,
     } {
         return action;
     }
@@ -747,6 +875,13 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
                 ui.agents_pane = AgentsPane::Installed;
                 ui.installed.busy = true;
                 DeckAction::Send(WorkspaceInput::AgentsRefresh)
+            }
+            // `/skills` opens the SKILLS tab directly and asks the driver —
+            // which owns the skills on disk — for a fresh installed list.
+            "/skills" => {
+                ui.set_tab(DeckTab::Skills);
+                ui.skills.status = Some("loading skills…".to_string());
+                DeckAction::Send(WorkspaceInput::Skill(SkillOp::List))
             }
             // Everything else — including `/help` — is enqueued for the
             // driver, which owns the session vocabulary and answers into the
@@ -992,6 +1127,385 @@ fn handle_pick_version_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             })
         }
         _ => DeckAction::Handled,
+    }
+}
+
+/// SKILLS-tab keys. Returns `Some` for keys the tab claims ahead of the
+/// composer (nav, manage hotkeys, the search query, overlays), `None` for keys
+/// that should fall through to the deck-global handlers — Tab still leaves the
+/// tab and `?` still opens help from the installed pane.
+fn handle_skills_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
+    // An overlay (scope picker / create / edit / pin) is fully modal.
+    if ui.skills.prompt.is_some() {
+        return Some(handle_skills_prompt_key(key, ui));
+    }
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match ui.skills.focus {
+        SkillsFocus::Installed => handle_skills_installed_key(key, ui, ctrl),
+        SkillsFocus::Search => handle_skills_search_key(key, ui),
+    }
+}
+
+/// The installed-skills (manage) pane: navigate, toggle enabled (space),
+/// uninstall (ctrl+x twice), edit (e), pin (p), create (n), cross to search (→).
+fn handle_skills_installed_key(key: KeyEvent, ui: &mut DeckUi, ctrl: bool) -> Option<DeckAction> {
+    let count = ui.skills.view.rows.len();
+    // Any key other than a fresh ctrl+x disarms the two-press uninstall.
+    let was_armed = ui.skills.uninstall_armed;
+    let is_ctrl_x = ctrl && matches!(key.code, KeyCode::Char('x'));
+    if !is_ctrl_x {
+        ui.skills.uninstall_armed = false;
+    }
+    match key.code {
+        KeyCode::Right => {
+            ui.skills.focus = SkillsFocus::Search;
+            ui.skills.status = None;
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Up => {
+            ui.skills.sel = ui.skills.sel.saturating_sub(1);
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Down => {
+            if count > 0 {
+                ui.skills.sel = (ui.skills.sel + 1).min(count - 1);
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char(' ') => {
+            let Some(row) = ui.skills.view.rows.get(ui.skills.sel) else {
+                return Some(DeckAction::Handled);
+            };
+            let enabled = !row.enabled;
+            let name = row.name.clone();
+            let scope = row.scope;
+            ui.skills.status = Some(format!(
+                "{name} {}",
+                if enabled { "enabled" } else { "disabled" }
+            ));
+            // Optimistic flip; the driver's refreshed snapshot is authoritative.
+            if let Some(r) = ui.skills.view.rows.get_mut(ui.skills.sel) {
+                r.enabled = enabled;
+            }
+            Some(DeckAction::Send(WorkspaceInput::Skill(SkillOp::SetEnabled {
+                scope,
+                name,
+                enabled,
+            })))
+        }
+        KeyCode::Char('x') if ctrl => {
+            let Some(row) = ui.skills.view.rows.get(ui.skills.sel) else {
+                return Some(DeckAction::Handled);
+            };
+            if !row.removable {
+                ui.skills.status = Some(format!(
+                    "{} can't be deleted here — press space to disable it",
+                    row.name
+                ));
+                return Some(DeckAction::Handled);
+            }
+            if was_armed {
+                let name = row.name.clone();
+                let scope = row.scope;
+                ui.skills.searching = true;
+                ui.skills.status = Some(format!("deleting {name}…"));
+                Some(DeckAction::Send(WorkspaceInput::Skill(SkillOp::Uninstall {
+                    scope,
+                    name,
+                })))
+            } else {
+                ui.skills.uninstall_armed = true;
+                ui.skills.status = Some(format!(
+                    "press ctrl+x again to DELETE {} ({}) from disk",
+                    row.name,
+                    row.scope.label()
+                ));
+                Some(DeckAction::Handled)
+            }
+        }
+        // Edit the selected skill's body (saving makes a new pinned version).
+        KeyCode::Char('e') if !ctrl => {
+            if let Some(row) = ui.skills.view.rows.get(ui.skills.sel) {
+                ui.skills.prompt = Some(SkillPrompt::Edit {
+                    scope: row.scope,
+                    name: row.name.clone(),
+                    buffer: row.body.clone(),
+                });
+            }
+            Some(DeckAction::Handled)
+        }
+        // Pin a specific version (no edit, no version bump).
+        KeyCode::Char('p') if !ctrl => {
+            if let Some(row) = ui.skills.view.rows.get(ui.skills.sel) {
+                if row.latest <= 1 {
+                    ui.skills.status = Some(format!("{} has only one version", row.name));
+                } else {
+                    ui.skills.prompt = Some(SkillPrompt::Pin {
+                        scope: row.scope,
+                        name: row.name.clone(),
+                        latest: row.latest,
+                        sel: row.version,
+                    });
+                }
+            }
+            Some(DeckAction::Handled)
+        }
+        // Create a new skill with LLM assistance from a short description.
+        KeyCode::Char('n') if !ctrl => {
+            ui.skills.prompt = Some(SkillPrompt::CreateDescription {
+                buffer: String::new(),
+            });
+            Some(DeckAction::Handled)
+        }
+        _ => None,
+    }
+}
+
+/// The registry-search pane: type a query, run it (⏎), pick a hit, and install
+/// the highlighted one (⏎ again → scope picker). ← returns to the manage pane.
+fn handle_skills_search_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    match key.code {
+        KeyCode::Left => {
+            ui.skills.focus = SkillsFocus::Installed;
+            ui.skills.status = None;
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Up => {
+            ui.skills.search_sel = ui.skills.search_sel.saturating_sub(1);
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Down => {
+            let n = ui.skills.hits.len();
+            if n > 0 {
+                ui.skills.search_sel = (ui.skills.search_sel + 1).min(n - 1);
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Backspace => {
+            ui.skills.query.pop();
+            ui.skills.query_dirty = true;
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Enter => {
+            if !ui.skills.query_dirty && !ui.skills.hits.is_empty() {
+                // Install the highlighted hit — ask the scope first.
+                let idx = ui.skills.search_sel.min(ui.skills.hits.len() - 1);
+                let id = ui.skills.hits[idx].id.clone();
+                ui.skills.prompt = Some(SkillPrompt::Scope {
+                    action: ScopeAction::Install { id },
+                    user: false,
+                });
+                Some(DeckAction::Handled)
+            } else {
+                let query = ui.skills.query.trim().to_string();
+                if query.is_empty() {
+                    ui.skills.status = Some("type a search term first".into());
+                    return Some(DeckAction::Handled);
+                }
+                ui.skills.searching = true;
+                ui.skills.query_dirty = false;
+                ui.skills.status = Some(format!("searching “{query}”…"));
+                Some(DeckAction::Send(WorkspaceInput::Skill(SkillOp::Search {
+                    query,
+                })))
+            }
+        }
+        // Printable chars (space included — queries have spaces) type into the
+        // query; modified chords are left for the global handlers.
+        KeyCode::Char(c) if !ctrl && !alt => {
+            ui.skills.query.push(c);
+            ui.skills.query_dirty = true;
+            Some(DeckAction::Handled)
+        }
+        _ => None,
+    }
+}
+
+/// The active SKILLS overlay's keys (fully modal): the scope picker (resolves
+/// an install/create into a scoped op), the create-description input, the edit
+/// buffer (ctrl+s saves a new version), and the version pin picker.
+fn handle_skills_prompt_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match ui.skills.prompt.clone() {
+        Some(SkillPrompt::Scope { action, user }) => {
+            match key.code {
+                KeyCode::Esc => {
+                    ui.skills.prompt = None;
+                    ui.skills.status = Some("cancelled".into());
+                    DeckAction::Handled
+                }
+                KeyCode::Left | KeyCode::Up | KeyCode::Char('p') | KeyCode::Char('P') => {
+                    ui.skills.prompt = Some(SkillPrompt::Scope {
+                        action,
+                        user: false,
+                    });
+                    DeckAction::Handled
+                }
+                KeyCode::Right | KeyCode::Down | KeyCode::Char('u') | KeyCode::Char('U') => {
+                    ui.skills.prompt = Some(SkillPrompt::Scope { action, user: true });
+                    DeckAction::Handled
+                }
+                KeyCode::Enter => {
+                    let scope = if user {
+                        SkillScope::User
+                    } else {
+                        SkillScope::Project
+                    };
+                    ui.skills.prompt = None;
+                    ui.skills.searching = true;
+                    match action {
+                        ScopeAction::Install { id } => {
+                            ui.skills.status =
+                                Some(format!("installing {id} for {}…", scope.label()));
+                            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Install { scope, id }))
+                        }
+                        ScopeAction::Create { description } => {
+                            ui.skills.status =
+                                Some(format!("assembling a skill for {}…", scope.label()));
+                            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Create {
+                                scope,
+                                description,
+                            }))
+                        }
+                    }
+                }
+                // Modal: swallow everything else.
+                _ => DeckAction::Handled,
+            }
+        }
+        // The create-description input: type a short description, ⏎ moves on to
+        // the scope picker (which dispatches the LLM-assisted create).
+        Some(SkillPrompt::CreateDescription { mut buffer }) => match key.code {
+            KeyCode::Esc => {
+                ui.skills.prompt = None;
+                DeckAction::Handled
+            }
+            KeyCode::Enter => {
+                let description = buffer.trim().to_string();
+                if description.is_empty() {
+                    ui.skills.status = Some("describe the skill first".into());
+                    DeckAction::Handled
+                } else {
+                    ui.skills.prompt = Some(SkillPrompt::Scope {
+                        action: ScopeAction::Create { description },
+                        user: false,
+                    });
+                    DeckAction::Handled
+                }
+            }
+            KeyCode::Backspace => {
+                buffer.pop();
+                ui.skills.prompt = Some(SkillPrompt::CreateDescription { buffer });
+                DeckAction::Handled
+            }
+            KeyCode::Char(c)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                buffer.push(c);
+                ui.skills.prompt = Some(SkillPrompt::CreateDescription { buffer });
+                DeckAction::Handled
+            }
+            _ => DeckAction::Handled,
+        },
+        // The edit buffer: a minimal textarea. ⏎ inserts a newline; ctrl+s saves
+        // (a new pinned version); esc cancels.
+        Some(SkillPrompt::Edit {
+            scope,
+            name,
+            mut buffer,
+        }) => {
+            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+            let alt = key.modifiers.contains(KeyModifiers::ALT);
+            match key.code {
+                KeyCode::Esc => {
+                    ui.skills.prompt = None;
+                    ui.skills.status = Some("edit cancelled".into());
+                    DeckAction::Handled
+                }
+                KeyCode::Char('s') if ctrl => {
+                    ui.skills.prompt = None;
+                    ui.skills.searching = true;
+                    ui.skills.status = Some(format!("saving {name}…"));
+                    DeckAction::Send(WorkspaceInput::Skill(SkillOp::Edit {
+                        scope,
+                        name,
+                        body: buffer,
+                    }))
+                }
+                KeyCode::Enter => {
+                    buffer.push('\n');
+                    ui.skills.prompt = Some(SkillPrompt::Edit {
+                        scope,
+                        name,
+                        buffer,
+                    });
+                    DeckAction::Handled
+                }
+                KeyCode::Backspace => {
+                    buffer.pop();
+                    ui.skills.prompt = Some(SkillPrompt::Edit {
+                        scope,
+                        name,
+                        buffer,
+                    });
+                    DeckAction::Handled
+                }
+                KeyCode::Char(c) if !ctrl && !alt => {
+                    buffer.push(c);
+                    ui.skills.prompt = Some(SkillPrompt::Edit {
+                        scope,
+                        name,
+                        buffer,
+                    });
+                    DeckAction::Handled
+                }
+                _ => DeckAction::Handled,
+            }
+        }
+        // The pin picker: ↑/↓ choose a version, ⏎ pins it (no version bump).
+        Some(SkillPrompt::Pin {
+            scope,
+            name,
+            latest,
+            sel,
+        }) => match key.code {
+            KeyCode::Esc => {
+                ui.skills.prompt = None;
+                DeckAction::Handled
+            }
+            KeyCode::Up => {
+                ui.skills.prompt = Some(SkillPrompt::Pin {
+                    scope,
+                    name,
+                    latest,
+                    sel: sel.saturating_sub(1).max(1),
+                });
+                DeckAction::Handled
+            }
+            KeyCode::Down => {
+                ui.skills.prompt = Some(SkillPrompt::Pin {
+                    scope,
+                    name,
+                    latest,
+                    sel: (sel + 1).min(latest),
+                });
+                DeckAction::Handled
+            }
+            KeyCode::Enter => {
+                ui.skills.prompt = None;
+                ui.skills.searching = true;
+                ui.skills.status = Some(format!("pinning {name} to v{sel}…"));
+                DeckAction::Send(WorkspaceInput::Skill(SkillOp::Pin {
+                    scope,
+                    name,
+                    version: sel,
+                }))
+            }
+            _ => DeckAction::Handled,
+        },
+        None => DeckAction::Ignored,
     }
 }
 

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -1187,11 +1187,13 @@ fn handle_skills_installed_key(key: KeyEvent, ui: &mut DeckUi, ctrl: bool) -> Op
             if let Some(r) = ui.skills.view.rows.get_mut(ui.skills.sel) {
                 r.enabled = enabled;
             }
-            Some(DeckAction::Send(WorkspaceInput::Skill(SkillOp::SetEnabled {
-                scope,
-                name,
-                enabled,
-            })))
+            Some(DeckAction::Send(WorkspaceInput::Skill(
+                SkillOp::SetEnabled {
+                    scope,
+                    name,
+                    enabled,
+                },
+            )))
         }
         KeyCode::Char('x') if ctrl => {
             let Some(row) = ui.skills.view.rows.get(ui.skills.sel) else {
@@ -1209,10 +1211,9 @@ fn handle_skills_installed_key(key: KeyEvent, ui: &mut DeckUi, ctrl: bool) -> Op
                 let scope = row.scope;
                 ui.skills.searching = true;
                 ui.skills.status = Some(format!("deleting {name}…"));
-                Some(DeckAction::Send(WorkspaceInput::Skill(SkillOp::Uninstall {
-                    scope,
-                    name,
-                })))
+                Some(DeckAction::Send(WorkspaceInput::Skill(
+                    SkillOp::Uninstall { scope, name },
+                )))
             } else {
                 ui.skills.uninstall_armed = true;
                 ui.skills.status = Some(format!(
@@ -3471,5 +3472,242 @@ mod tests {
             "a typed `n` is prompt text, not the create verb"
         );
         assert_eq!(ui.composer.buffer(), "hn");
+    }
+
+    // ── SKILLS tab ──────────────────────────────────────────────────────────
+
+    // `SkillOp`, `SkillScope`, `SkillSearchHit`, `SkillsView` arrive via
+    // `use super::*`; only `SkillRow` is not imported at module scope.
+    use crate::envelope::SkillRow;
+
+    fn skills_ui() -> DeckUi {
+        let mut ui = ready_ui();
+        ui.tab = DeckTab::Skills;
+        ui
+    }
+
+    fn a_row(name: &str, scope: SkillScope, enabled: bool) -> SkillRow {
+        SkillRow {
+            scope,
+            name: name.to_string(),
+            description: "d".to_string(),
+            body: "b".to_string(),
+            origin: "workspace".to_string(),
+            enabled,
+            version: 1,
+            latest: 1,
+            removable: true,
+        }
+    }
+
+    #[test]
+    fn skills_search_pane_types_a_query_and_dispatches_a_search() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        ui.skills.focus = SkillsFocus::Search;
+        for c in "pdf tools".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        assert_eq!(ui.skills.query, "pdf tools", "typed into the query");
+        assert!(
+            ui.composer.is_empty(),
+            "the global composer never saw the keys"
+        );
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Search {
+                query: "pdf tools".into()
+            }))
+        );
+    }
+
+    #[test]
+    fn skills_enter_on_a_hit_opens_the_scope_prompt_then_installs_scoped() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        ui.skills.focus = SkillsFocus::Search;
+        ui.skills.hits = vec![SkillSearchHit {
+            id: "acme/auth".into(),
+            label: "acme/auth  oauth".into(),
+        }];
+        ui.skills.query = "auth".into();
+        ui.skills.query_dirty = false;
+
+        let a = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(a, DeckAction::Handled);
+        assert!(matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::Scope {
+                action: ScopeAction::Install { .. },
+                ..
+            })
+        ));
+        handle_deck_key(ch('u'), &model, &mut ui);
+        let a = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            a,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Install {
+                scope: SkillScope::User,
+                id: "acme/auth".into()
+            }))
+        );
+        assert!(ui.skills.prompt.is_none());
+    }
+
+    #[test]
+    fn skills_space_toggles_and_two_ctrl_x_uninstalls() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        ui.skills.view = SkillsView {
+            rows: vec![a_row("sql-style", SkillScope::Project, true)],
+            status: None,
+            busy: false,
+        };
+        let a = handle_deck_key(ch(' '), &model, &mut ui);
+        assert_eq!(
+            a,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::SetEnabled {
+                scope: SkillScope::Project,
+                name: "sql-style".into(),
+                enabled: false
+            }))
+        );
+        assert!(!ui.skills.view.rows[0].enabled, "optimistic flip");
+
+        let a1 = handle_deck_key(ctrl('x'), &model, &mut ui);
+        assert_eq!(a1, DeckAction::Handled);
+        assert!(ui.skills.uninstall_armed);
+        let a2 = handle_deck_key(ctrl('x'), &model, &mut ui);
+        assert_eq!(
+            a2,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Uninstall {
+                scope: SkillScope::Project,
+                name: "sql-style".into()
+            }))
+        );
+    }
+
+    #[test]
+    fn skills_e_opens_edit_overlay_and_ctrl_s_saves() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        let mut r = a_row("sql-style", SkillScope::Project, true);
+        r.body = "old body".into();
+        ui.skills.view = SkillsView {
+            rows: vec![r],
+            status: None,
+            busy: false,
+        };
+        handle_deck_key(ch('e'), &model, &mut ui);
+        assert!(matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::Edit { ref buffer, .. }) if buffer == "old body"
+        ));
+        for c in " +more".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let a = handle_deck_key(ctrl('s'), &model, &mut ui);
+        assert_eq!(
+            a,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Edit {
+                scope: SkillScope::Project,
+                name: "sql-style".into(),
+                body: "old body +more".into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn skills_p_opens_pin_picker_and_enter_pins() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        let mut r = a_row("s", SkillScope::Project, true);
+        r.version = 3;
+        r.latest = 3;
+        ui.skills.view = SkillsView {
+            rows: vec![r],
+            status: None,
+            busy: false,
+        };
+        handle_deck_key(ch('p'), &model, &mut ui);
+        assert!(matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::Pin {
+                sel: 3,
+                latest: 3,
+                ..
+            })
+        ));
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        let a = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            a,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Pin {
+                scope: SkillScope::Project,
+                name: "s".into(),
+                version: 1,
+            }))
+        );
+    }
+
+    #[test]
+    fn skills_n_creates_via_description_then_scope() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        handle_deck_key(ch('n'), &model, &mut ui);
+        assert!(matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::CreateDescription { .. })
+        ));
+        for c in "extract tables from pdfs".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let a = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(a, DeckAction::Handled);
+        assert!(matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::Scope {
+                action: ScopeAction::Create { .. },
+                ..
+            })
+        ));
+        let a = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            a,
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Create {
+                scope: SkillScope::Project,
+                description: "extract tables from pdfs".into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn skills_snapshot_ingest_updates_view_and_clears_searching() {
+        let mut model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        ui.skills.searching = true;
+        let view = SkillsView {
+            rows: vec![a_row("a", SkillScope::Project, true)],
+            status: Some("done".into()),
+            busy: false,
+        };
+        ingest_inbound(&Inbound::Skills(view), &mut model, &mut ui);
+        assert_eq!(ui.skills.view.rows.len(), 1);
+        assert!(!ui.skills.searching, "a fresh list clears the spinner");
+        assert_eq!(ui.skills.status.as_deref(), Some("done"));
+        assert!(
+            model.agents.is_empty(),
+            "model fold ignores skills snapshots"
+        );
+    }
+
+    #[test]
+    fn skills_tab_still_leaves_via_tab_key() {
+        let model = WorkspaceModel::new();
+        let mut ui = skills_ui();
+        handle_deck_key(key(KeyCode::Tab), &model, &mut ui);
+        assert_eq!(ui.tab, DeckTab::Session, "Tab cycles Skills → Session");
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -160,6 +160,20 @@ pub enum Inbound {
         entries: Vec<InstalledAgentEntry>,
         status: Option<String>,
     },
+    /// A refreshed snapshot of the installed skills for the SKILLS tab. The
+    /// driver owns the skills on disk (both scopes), their enabled/version/pin
+    /// state, and the npx registry; the deck renders this read-model. Applied
+    /// straight to `DeckUi::skills` by [`crate::deck_ui::ingest_inbound`],
+    /// ignored by the model fold — same out-of-band contract as
+    /// [`Inbound::GraphSnapshot`].
+    Skills(SkillsView),
+    /// The result of a registry search (`npx skills find <query>`). Folded
+    /// into the SKILLS tab's search pane; out-of-band like [`Inbound::Skills`].
+    SkillSearch {
+        query: String,
+        hits: Vec<SkillSearchHit>,
+        status: Option<String>,
+    },
 }
 
 /// Which config level an installed agent definition lives at.
@@ -286,8 +300,113 @@ pub enum WorkspaceInput {
         description: String,
         scope: AgentScope,
     },
+    /// A SKILLS-tab operation (list / enable / uninstall / search / install /
+    /// create / edit / pin). The driver owns the skills on disk + npx + model
+    /// and answers with a refreshed [`Inbound::Skills`] / [`Inbound::SkillSearch`].
+    Skill(SkillOp),
     /// Tear down the deck.
     Quit,
+}
+
+/// Which scope a skill lives in / is installed to. The loader reads both
+/// (`<workspace>/.stella/skills` and `~/.config/stella/skills`); the SKILLS
+/// tab asks this on install/create.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkillScope {
+    /// `<workspace>/.stella/skills` — travels with the repo.
+    Project,
+    /// `~/.config/stella/skills` — the user-global directory.
+    User,
+}
+
+impl SkillScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            SkillScope::Project => "project",
+            SkillScope::User => "user",
+        }
+    }
+}
+
+/// One installed-skill row in the SKILLS tab — a driver snapshot, deliberately
+/// decoupled from `stella_core::skills::Skill` so the TUI crate stays
+/// independent of the skills engine (the driver maps one to the other).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillRow {
+    pub scope: SkillScope,
+    pub name: String,
+    pub description: String,
+    /// The pinned version's markdown body — carried so the tab can open the
+    /// edit overlay with no extra round-trip.
+    pub body: String,
+    /// Provenance label — `"workspace"`, `"user"`, `"installed"`, `"auto"`.
+    pub origin: String,
+    /// Session/persistent enabled state (a disabled skill is excluded from
+    /// recall injection; the file stays on disk).
+    pub enabled: bool,
+    /// The pinned/current version the recall path uses.
+    pub version: u32,
+    /// The highest version on disk (`version < latest` ⇒ pinned to an older one).
+    pub latest: u32,
+    /// Whether the deck may uninstall (delete) it.
+    pub removable: bool,
+}
+
+/// One registry search hit. Minimal by design: `id` (the leading token,
+/// passed verbatim to `npx skills add`) + the full `label` line as printed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillSearchHit {
+    pub id: String,
+    pub label: String,
+}
+
+/// The full installed-skills read-model rendered by the SKILLS tab.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SkillsView {
+    pub rows: Vec<SkillRow>,
+    /// A one-line status/outcome hint (last op result), or `None`.
+    pub status: Option<String>,
+    /// True while a driver op (npx search/install, LLM create) is in flight,
+    /// so the tab can show a working state.
+    pub busy: bool,
+}
+
+/// A SKILLS-tab operation routed to the driver, which owns the disk + npx +
+/// model. The deck emits one and folds back the refreshed [`Inbound::Skills`]
+/// / [`Inbound::SkillSearch`] snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SkillOp {
+    /// Re-enumerate installed skills → [`Inbound::Skills`].
+    List,
+    /// Persistently enable/disable a skill → re-send the list.
+    SetEnabled {
+        scope: SkillScope,
+        name: String,
+        enabled: bool,
+    },
+    /// Delete a skill entirely from disk (deck double-confirms first).
+    Uninstall { scope: SkillScope, name: String },
+    /// `npx skills find <query>` → [`Inbound::SkillSearch`].
+    Search { query: String },
+    /// Install a registry skill into `scope` → refresh the list.
+    Install { scope: SkillScope, id: String },
+    /// LLM-assisted creation from a short description → refresh the list.
+    Create {
+        scope: SkillScope,
+        description: String,
+    },
+    /// Save an edited body as a NEW version (increments + pins it).
+    Edit {
+        scope: SkillScope,
+        name: String,
+        body: String,
+    },
+    /// Pin `version` as the active one WITHOUT editing (no version bump).
+    Pin {
+        scope: SkillScope,
+        name: String,
+        version: u32,
+    },
 }
 
 /// The agent-control verbs surfaced by the dashboard. `Stop` maps to a clean

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -75,10 +75,13 @@ pub use deck::{
 };
 pub use deck_render::render_deck;
 pub use deck_shell::{DeckOptions, run_deck};
-pub use deck_ui::{DeckAction, DeckUi, handle_deck_key, ingest_inbound};
+pub use deck_ui::{
+    DeckAction, DeckUi, ScopeAction, SkillPrompt, SkillsFocus, SkillsPanel, handle_deck_key,
+    ingest_inbound,
+};
 pub use envelope::{
-    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
-    InstalledAgentEntry, WorkspaceInput,
+    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound, SkillOp,
+    SkillRow, SkillScope, SkillSearchHit, SkillsView, InstalledAgentEntry, WorkspaceInput,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -80,8 +80,8 @@ pub use deck_ui::{
     ingest_inbound,
 };
 pub use envelope::{
-    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound, SkillOp,
-    SkillRow, SkillScope, SkillSearchHit, SkillsView, InstalledAgentEntry, WorkspaceInput,
+    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
+    InstalledAgentEntry, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView, WorkspaceInput,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;

--- a/stella-tui/src/views/mod.rs
+++ b/stella-tui/src/views/mod.rs
@@ -8,4 +8,5 @@ pub mod files;
 pub mod graph;
 pub mod installed;
 pub mod session;
+pub mod skills;
 pub mod traces;

--- a/stella-tui/src/views/skills.rs
+++ b/stella-tui/src/views/skills.rs
@@ -1,0 +1,464 @@
+//! SKILLS tab — the filesystem-first skills manager.
+//!
+//! Two panes, switched with ←/→: **Installed** (the manage list — activate,
+//! disable, uninstall, edit, pin) and **Registry search** (`npx skills find` →
+//! install). The driver owns the skills on disk (both scopes), their
+//! enabled/version/pin state, and the npx registry; this view renders the
+//! [`crate::envelope::SkillsView`] read-model it pushes and draws the scope /
+//! create / edit / pin overlays. Every color comes from [`crate::theme`]; the
+//! content is a deterministic function of `(ui.skills)` so buffer tests stay
+//! byte-stable.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+
+use crate::deck::WorkspaceModel;
+use crate::deck_ui::{DeckUi, SkillPrompt, SkillsFocus};
+use crate::theme;
+
+pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    // Two panes over a status line.
+    let bands = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
+    let panes = Layout::horizontal([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(bands[0]);
+
+    render_installed(ui, panes[0], buf);
+    render_search(ui, panes[1], buf);
+    render_status(ui, bands[1], buf);
+
+    // Overlays (scope picker / create / edit / pin) float above the panes.
+    if ui.skills.prompt.is_some() {
+        render_overlay(ui, area, buf);
+    }
+}
+
+/// The manage pane: one row per installed skill with its enabled box, pinned
+/// version, scope + origin, and description.
+fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let focused = ui.skills.focus == SkillsFocus::Installed;
+    let rows = &ui.skills.view.rows;
+    let title = format!(" Installed — {} (user + project) ", rows.len());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            theme::accent()
+        } else {
+            theme::rule()
+        })
+        .title(title);
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    if rows.is_empty() {
+        let hint = if ui.skills.view.busy {
+            "loading…"
+        } else {
+            "no skills installed — press → to search the registry and add one"
+        };
+        Paragraph::new(hint)
+            .style(theme::muted())
+            .alignment(Alignment::Center)
+            .render(centered_row(inner), buf);
+        return;
+    }
+
+    let visible = inner.height as usize;
+    let sel = ui.skills.sel.min(rows.len() - 1);
+    let start = window_start(rows.len(), sel, visible);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (i, row) in rows.iter().enumerate().skip(start).take(visible) {
+        let is_sel = i == sel && focused;
+        let marker = if is_sel { "▸ " } else { "  " };
+        let boxed = if row.enabled { "[x] " } else { "[ ] " };
+        let box_style = if row.enabled {
+            Style::default().fg(theme::AMBER)
+        } else {
+            theme::muted()
+        };
+        let ver = if row.latest > row.version {
+            format!(" v{}/{}", row.version, row.latest)
+        } else {
+            format!(" v{}", row.version)
+        };
+        let meta = format!("  ({}·{})", row.scope.label(), row.origin);
+        // Description fills whatever width remains, truncated char-safe.
+        let used = marker.len() + boxed.len() + row.name.chars().count() + ver.len() + meta.len();
+        let desc_room = (inner.width as usize).saturating_sub(used + 3);
+        let desc = if desc_room >= 6 && !row.description.is_empty() {
+            format!("  {}", truncate(&row.description, desc_room))
+        } else {
+            String::new()
+        };
+        let mut line = Line::from(vec![
+            Span::styled(marker, Style::default().fg(theme::AMBER)),
+            Span::styled(boxed, box_style),
+            Span::styled(row.name.clone(), theme::body()),
+            Span::styled(ver, theme::muted()),
+            Span::styled(meta, theme::muted()),
+            Span::styled(desc, theme::muted()),
+        ]);
+        if is_sel {
+            line = line.style(Style::default().add_modifier(Modifier::REVERSED));
+        }
+        lines.push(line);
+    }
+    Paragraph::new(lines).render(inner, buf);
+}
+
+/// The registry-search pane: the live query line, then the last search's hits.
+fn render_search(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let focused = ui.skills.focus == SkillsFocus::Search;
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            theme::accent()
+        } else {
+            theme::rule()
+        })
+        .title(" Registry search ");
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    // Query line with a block caret when this pane is focused.
+    let caret = if focused { "▌" } else { "" };
+    lines.push(Line::from(vec![
+        Span::styled("find: ", theme::muted()),
+        Span::styled(ui.skills.query.clone(), theme::body()),
+        Span::styled(caret.to_string(), Style::default().fg(theme::AMBER)),
+    ]));
+    if ui.skills.searching {
+        lines.push(Line::from(Span::styled("working…", theme::muted())));
+    }
+    lines.push(Line::default());
+
+    if ui.skills.hits.is_empty() && !ui.skills.searching {
+        lines.push(Line::from(Span::styled(
+            "type a term and press ⏎ to search",
+            theme::muted(),
+        )));
+    } else {
+        let header_rows = lines.len();
+        let visible = (inner.height as usize).saturating_sub(header_rows).max(1);
+        let sel = ui
+            .skills
+            .search_sel
+            .min(ui.skills.hits.len().saturating_sub(1));
+        let start = window_start(ui.skills.hits.len(), sel, visible);
+        for (i, hit) in ui.skills.hits.iter().enumerate().skip(start).take(visible) {
+            let is_sel = i == sel && focused;
+            let marker = if is_sel { "▸ " } else { "  " };
+            let text = truncate(&hit.label, (inner.width as usize).saturating_sub(3));
+            let mut line = Line::from(vec![
+                Span::styled(marker, Style::default().fg(theme::AMBER)),
+                Span::styled(text, theme::body()),
+            ]);
+            if is_sel {
+                line = line.style(Style::default().add_modifier(Modifier::REVERSED));
+            }
+            lines.push(line);
+        }
+    }
+    Paragraph::new(lines).render(inner, buf);
+}
+
+/// The bottom status / legend line.
+fn render_status(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let legend = match ui.skills.focus {
+        SkillsFocus::Installed => {
+            "space on/off · ctrl+x×2 delete · e edit · p pin · n new · → search · Tab leaves"
+        }
+        SkillsFocus::Search => "⏎ search / install · ↑/↓ pick · ← installed · Tab leaves",
+    };
+    let line = match &ui.skills.status {
+        Some(status) => Line::from(Span::styled(
+            format!(" {status}"),
+            theme::body().fg(theme::AMBER),
+        )),
+        None => Line::from(Span::styled(format!(" {legend}"), theme::muted())),
+    };
+    Paragraph::new(line).render(area, buf);
+}
+
+/// Draw the active overlay centered over the panes.
+fn render_overlay(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    match &ui.skills.prompt {
+        Some(SkillPrompt::Scope { action, user }) => {
+            let verb = match action {
+                crate::deck_ui::ScopeAction::Install { id } => format!("Install {id}"),
+                crate::deck_ui::ScopeAction::Create { .. } => "Create the new skill".to_string(),
+            };
+            let choose = |label: &str, hint: &str, selected: bool| {
+                let marker = if selected { "▸ " } else { "  " };
+                let style = if selected {
+                    theme::body().fg(theme::AMBER).add_modifier(Modifier::BOLD)
+                } else {
+                    theme::body()
+                };
+                Line::from(vec![
+                    Span::styled(marker, Style::default().fg(theme::AMBER)),
+                    Span::styled(label.to_string(), style),
+                    Span::styled(format!("  {hint}"), theme::muted()),
+                ])
+            };
+            let lines = vec![
+                Line::from(Span::styled(verb, theme::body())),
+                Line::from(Span::styled("Where should it live?", theme::muted())),
+                Line::default(),
+                choose(
+                    "[p] Project",
+                    ".stella/skills — travels with the repo",
+                    !*user,
+                ),
+                choose("[u] User", "~/.config/stella/skills — global to you", *user),
+                Line::default(),
+                Line::from(Span::styled(
+                    "←/→ or p/u choose · ⏎ confirm · esc cancel",
+                    theme::muted(),
+                )),
+            ];
+            popup(" install scope ", lines, area, buf);
+        }
+        Some(SkillPrompt::CreateDescription { buffer }) => {
+            let lines = vec![
+                Line::from(Span::styled(
+                    "Describe the skill you want (the agent will search the",
+                    theme::muted(),
+                )),
+                Line::from(Span::styled(
+                    "registry, rank matches, and assemble one skill):",
+                    theme::muted(),
+                )),
+                Line::default(),
+                Line::from(vec![
+                    Span::styled("> ", Style::default().fg(theme::AMBER)),
+                    Span::styled(buffer.clone(), theme::body()),
+                    Span::styled("▌", Style::default().fg(theme::AMBER)),
+                ]),
+                Line::default(),
+                Line::from(Span::styled("⏎ continue · esc cancel", theme::muted())),
+            ];
+            popup(" new skill (LLM-assisted) ", lines, area, buf);
+        }
+        Some(SkillPrompt::Pin {
+            name, latest, sel, ..
+        }) => {
+            let mut lines = vec![
+                Line::from(Span::styled(
+                    format!("Pin a version of {name}:"),
+                    theme::body(),
+                )),
+                Line::default(),
+            ];
+            for v in 1..=*latest {
+                let selected = v == *sel;
+                let marker = if selected { "▸ " } else { "  " };
+                let tag = if v == *latest { "  (latest)" } else { "" };
+                let style = if selected {
+                    theme::body().fg(theme::AMBER).add_modifier(Modifier::BOLD)
+                } else {
+                    theme::body()
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(marker, Style::default().fg(theme::AMBER)),
+                    Span::styled(format!("v{v}{tag}"), style),
+                ]));
+            }
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled(
+                "↑/↓ choose · ⏎ pin · esc cancel",
+                theme::muted(),
+            )));
+            popup(" pin version ", lines, area, buf);
+        }
+        Some(SkillPrompt::Edit { name, buffer, .. }) => {
+            render_edit_overlay(name, buffer, area, buf)
+        }
+        None => {}
+    }
+}
+
+/// A taller popup for the edit buffer: the (multi-line) body with a caret and a
+/// save/cancel legend. The buffer scrolls to keep the last line visible.
+fn render_edit_overlay(name: &str, buffer: &str, area: Rect, buf: &mut Buffer) {
+    let w = area.width.saturating_sub(6).min(88).max(20);
+    let h = area.height.saturating_sub(2).min(20).max(6);
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(rect, buf);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(format!(
+            " edit {name} — ctrl+s save (new version) · esc cancel "
+        ));
+    let inner = block.inner(rect);
+    block.render(rect, buf);
+    if inner.height == 0 {
+        return;
+    }
+    // Body lines with a block caret appended, tail-scrolled to the last rows.
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let text_lines: Vec<&str> = buffer.split('\n').collect();
+    let visible = inner.height as usize;
+    let start = text_lines.len().saturating_sub(visible);
+    for (i, l) in text_lines.iter().enumerate().skip(start) {
+        let is_last = i == text_lines.len() - 1;
+        if is_last {
+            lines.push(Line::from(vec![
+                Span::styled((*l).to_string(), theme::body()),
+                Span::styled("▌", Style::default().fg(theme::AMBER)),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled((*l).to_string(), theme::body())));
+        }
+    }
+    Paragraph::new(lines).render(inner, buf);
+}
+
+/// A centered bordered popup with `title` and `lines`.
+fn popup(title: &str, lines: Vec<Line<'static>>, area: Rect, buf: &mut Buffer) {
+    let w = area.width.min(60);
+    let h = ((lines.len() + 2) as u16).min(area.height);
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(rect, buf);
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: true })
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::accent())
+                .title(title.to_string()),
+        )
+        .render(rect, buf);
+}
+
+/// Keep `sel` visible in a window of `visible` rows over `len` items.
+fn window_start(len: usize, sel: usize, visible: usize) -> usize {
+    if len <= visible {
+        return 0;
+    }
+    sel.saturating_sub(visible.saturating_sub(1) / 2)
+        .min(len - visible)
+}
+
+/// The single centered row of an inner area, for a one-line hint.
+fn centered_row(inner: Rect) -> Rect {
+    let y = inner.y + inner.height.saturating_sub(1) / 2;
+    Rect::new(inner.x, y, inner.width, 1)
+}
+
+/// Truncate to `max` chars with a trailing ellipsis, char-safe.
+fn truncate(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{head}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{SkillRow, SkillScope, SkillsView};
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let area = *buf.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn row(name: &str, scope: SkillScope, enabled: bool, version: u32, latest: u32) -> SkillRow {
+        SkillRow {
+            scope,
+            name: name.to_string(),
+            description: format!("{name} does a thing"),
+            body: format!("body of {name}"),
+            origin: "workspace".to_string(),
+            enabled,
+            version,
+            latest,
+            removable: true,
+        }
+    }
+
+    #[test]
+    fn installed_pane_shows_rows_with_enabled_box_and_version() {
+        let mut ui = DeckUi::default();
+        ui.tab = crate::deck::DeckTab::Skills;
+        ui.skills.view = SkillsView {
+            rows: vec![
+                row("sql-style", SkillScope::Project, true, 2, 3),
+                row("pdf-extract", SkillScope::User, false, 1, 1),
+            ],
+            status: None,
+            busy: false,
+        };
+        let area = Rect::new(0, 0, 120, 12);
+        let mut buf = Buffer::empty(area);
+        render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("sql-style"), "{text}");
+        assert!(text.contains("[x]"), "enabled box:\n{text}");
+        assert!(text.contains("[ ]"), "disabled box:\n{text}");
+        assert!(text.contains("v2/3"), "pinned-older version shown:\n{text}");
+        assert!(text.contains("pdf-extract"), "{text}");
+    }
+
+    #[test]
+    fn empty_installed_pane_hints_at_search() {
+        let mut ui = DeckUi::default();
+        ui.tab = crate::deck::DeckTab::Skills;
+        let area = Rect::new(0, 0, 100, 10);
+        let mut buf = Buffer::empty(area);
+        render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
+        assert!(buffer_text(&buf).contains("no skills installed"));
+    }
+
+    #[test]
+    fn scope_overlay_lists_both_destinations() {
+        let mut ui = DeckUi::default();
+        ui.tab = crate::deck::DeckTab::Skills;
+        ui.skills.prompt = Some(SkillPrompt::Scope {
+            action: crate::deck_ui::ScopeAction::Install {
+                id: "acme/auth".into(),
+            },
+            user: false,
+        });
+        let area = Rect::new(0, 0, 90, 16);
+        let mut buf = Buffer::empty(area);
+        render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Project"), "{text}");
+        assert!(text.contains("User"), "{text}");
+        assert!(text.contains("acme/auth"), "{text}");
+    }
+}


### PR DESCRIPTION
## What

Adds a top-level **SKILLS** deck tab (`/skills` opens it) — a filesystem-first skills manager that mirrors the merged Agents-tab's driver-owns / deck-renders-snapshots architecture, but with **no Executions secondary nav** (skills have no runs).

### Manage (Installed pane, both scopes: project `.stella/skills` + user `~/.config/stella/skills`)
- **Activate / disable** (`space`) — persisted per scope in a `.stella-skills.json` sidecar; disabled skills are excluded from recall/selection **and** the ⚡ slash menu (file kept on disk).
- **Uninstall** (`ctrl+x` twice) — **deletes the skill entirely** from disk; symlink-safe (unlinks an adopted entry, never follows into a shared source; path-contained).
- **Edit** (`e`), **Pin** (`p`), **New** (`n`).

### Search + install (Search pane)
- `npx skills find <query>` (async, non-blocking) → install a hit, which **asks the scope** (project or user) via an overlay, runs `npx skills add` in an isolated temp dir, and **adopts** the result into the chosen scope (so "install for me" lands in `~/.config` regardless of the registry CLI's fixed cwd).

### Versioning
- Editing saves a **new pinned version** under `<slug>/versions/vN/SKILL.md` (increments); the pinned version mirrors to `<slug>/SKILL.md`, which the existing shallow recall loader reads unchanged.
- **Pin** switches the active version with **no** version bump.
- **Copy-on-write**: the first edit/pin of an adopted (symlinked) skill breaks the link and owns a private copy — a shared source is never mutated.

### LLM-assisted create
- Type a short description → the driver searches the registry, ranks candidates by **relevance then popularity**, and has the model (**one-shot, via the existing provider path** — no hand-rolled HTTP) assemble **one** coherent `SKILL.md` drawing from any/several of them, written into the chosen scope as v1.

### Telemetry
- New additive `skill_usage` store.db table (**migration v5** — next free slot; may need a one-line renumber at cascade since sibling branches also append migrations) records each recall-selected skill at its **pinned version** per deck execution, mirroring `agent_uses`.

## Architecture
Deck routes `WorkspaceInput::Skill(SkillOp)`; the driver owns the disk + npx + model and answers with out-of-band `Inbound::Skills` / `Inbound::SkillSearch` snapshots (same contract as the graph/slash-vocabulary). New `stella-cli/src/skill_manager.rs` holds the disk half.

## Salvaged vs rebuilt
Ported the npx `SkillRegistry` integration and search/install UX from the `feat/skills-cmd` prototype; **rebuilt as a tab** (prototype was a modal) on the current refactored deck, and per the spec **uninstall deletes entirely** and **install asks scope** (prototype was disable-only / workspace-only).

## Notes
- Removed a stray `Some(_)` catch-all in the driver's idle-recv match that shadowed the merged AgentCreate/agents-input arms, so the new `Skill` arm (and theirs) are reachable.
- Telemetry is wired at the deck turn site only for now; the other `record_execution_end` callers can adopt it later.

## Verification
`cargo build` (workspace), `cargo test` (stella-store/cli/tui — all green), `cargo clippy --all-targets -- -D warnings` (clean) on touched crates. Tests cover: skill discovery across both scopes, activate/disable persistence + recall filtering, uninstall (incl. symlink-safe), install adoption, versioning (edit increments, pin no-bump, CoW), scope-prompt + key plumbing, search-result parsing, creation prompt assembly (no live LLM/npx), and the v5 migration. GitHub Actions is billing-locked — local verification is the gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SKILLS deck tab (`/skills`) to manage project and user skills: activate/disable, uninstall, edit/pin/version, search/install from the registry, and LLM‑assisted create. Adds versioning with copy‑on‑write, records `skill_usage` telemetry, and hides disabled skills from recall and the slash menu.

- **New Features**
  - SKILLS tab with Installed and Search panes; actions: activate/disable (persisted), uninstall (symlink‑safe), edit, pin, create.
  - Registry integration: `npx skills find` and scoped install via `npx skills add` with adoption into project or user.
  - Versioning: edits saved under `versions/vN` and mirrored to `<slug>/SKILL.md`; pin switches without bump; breaks symlink on first change.
  - LLM‑assisted create: ranks registry hits and assembles a single `SKILL.md` via the existing provider path.
  - Driver/view pattern: `WorkspaceInput::Skill` → `Inbound::Skills` / `Inbound::SkillSearch`; new `skill_manager` owns disk/`npx` (plus routing fix so Skill/Agent inputs are handled).

- **Migration**
  - Adds schema migration v5 to create `skill_usage` (additive). No manual steps; runs on startup.

<sup>Written for commit 80048cf02e3e29c09527f70331f7d0bfb777b2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
