### PR TITLE
fix: repair main gate — missed connect_mcp call site + clippy/fmt

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -297,7 +297,13 @@ async fn run_pipeline_one_shot(
         Box::new(|line| eprintln!("  {line}")),
         Box::new(|| {}),
     );
-    let mcp = connect_mcp(cfg, registry.clone(), format == OutputFormat::Text).await;
+    let mcp = connect_mcp(
+        cfg,
+        registry.clone(),
+        Some(registry.mcp_usage_ledger()),
+        format == OutputFormat::Text,
+    )
+    .await;
     let base_tools: &dyn ToolExecutor = match &mcp {
         Some(set) => set,
         None => &*registry,

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -997,7 +997,9 @@ mod tests {
     async fn complete_sends_cache_points_for_claude_models() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(body_string_contains("\"cachePoint\":{\"type\":\"default\"}"))
+            .and(body_string_contains(
+                "\"cachePoint\":{\"type\":\"default\"}",
+            ))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
                 "stopReason": "end_turn",

--- a/stella-tui/src/views/skills.rs
+++ b/stella-tui/src/views/skills.rs
@@ -290,8 +290,8 @@ fn render_overlay(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
 /// A taller popup for the edit buffer: the (multi-line) body with a caret and a
 /// save/cancel legend. The buffer scrolls to keep the last line visible.
 fn render_edit_overlay(name: &str, buffer: &str, area: Rect, buf: &mut Buffer) {
-    let w = area.width.saturating_sub(6).min(88).max(20);
-    let h = area.height.saturating_sub(2).min(20).max(6);
+    let w = area.width.saturating_sub(6).clamp(20, 88);
+    let h = area.height.saturating_sub(2).clamp(6, 20);
     let rect = Rect {
         x: area.x + (area.width.saturating_sub(w)) / 2,
         y: area.y + (area.height.saturating_sub(h)) / 2,
@@ -412,8 +412,10 @@ mod tests {
 
     #[test]
     fn installed_pane_shows_rows_with_enabled_box_and_version() {
-        let mut ui = DeckUi::default();
-        ui.tab = crate::deck::DeckTab::Skills;
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
         ui.skills.view = SkillsView {
             rows: vec![
                 row("sql-style", SkillScope::Project, true, 2, 3),
@@ -435,8 +437,10 @@ mod tests {
 
     #[test]
     fn empty_installed_pane_hints_at_search() {
-        let mut ui = DeckUi::default();
-        ui.tab = crate::deck::DeckTab::Skills;
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
         let area = Rect::new(0, 0, 100, 10);
         let mut buf = Buffer::empty(area);
         render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
@@ -445,8 +449,10 @@ mod tests {
 
     #[test]
     fn scope_overlay_lists_both_destinations() {
-        let mut ui = DeckUi::default();
-        ui.tab = crate::deck::DeckTab::Skills;
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
         ui.skills.prompt = Some(SkillPrompt::Scope {
             action: crate::deck_ui::ScopeAction::Install {
                 id: "acme/auth".into(),


### PR DESCRIPTION
Fresh `main` (`326cf49`) does not pass `make gate`. Two recently-merged PRs landed breaks (CI is billing-locked, so the gate never actually ran on them).

## Fixes
- **`stella-cli/src/agent.rs`** — `run_pipeline_one_shot`'s `connect_mcp` call site was never updated when PR #140 added the `usage: Option<McpUsageLedger>` parameter (E0061 — 4 args expected, 3 supplied). Now passes `Some(registry.mcp_usage_ledger)`, matching the three other call sites. Masked until `stella-tui` compiled.
- **`stella-tui/src/views/skills.rs`** — clears clippy `-D warnings` from PR #139: two clamp-like `.min.max` chains → `.clamp`, three `field_reassign_with_default` in tests → struct-literal init.
- **`stella-model/src/bedrock.rs`** — rustfmt drift on a test mock.

## Local verification (CI is billing-locked)
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo test --workspace` → **1642 passed, 0 failed, 3 ignored**
- `cargo build --release` → exit 0
- `./target/release/stella models` → runs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a green gate by fixing a missed `connect_mcp` argument in `stella-cli` and cleaning up clippy/rustfmt issues in `stella-tui` and `stella-model` so builds and tests pass again.

- **Bug Fixes**
  - `stella-cli/src/agent.rs`: Update `run_pipeline_one_shot` to pass `Some(registry.mcp_usage_ledger)` to `connect_mcp`, matching the updated function signature.
  - `stella-tui/src/views/skills.rs`: Replace `.min.max` chains with `.clamp`; update tests to use struct-literal init instead of `Default` then reassignment.
  - `stella-model/src/bedrock.rs`: Fix rustfmt drift in a test mock.

<sup>Written for commit 7354808636c6e9af64c6cd42a9047e13a8f8058c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
