### PR TITLE
ci: local pre-push gate hook (runs the gate while Actions is billing-locked)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Stella pre-push gate.
+#
+# Runs the exact fmt + clippy + test gate CI would run — locally, on every
+# push — because the org's GitHub Actions is billing-locked: every required
+# check (`fmt + clippy + test`, `cargo deny + cargo audit`) fast-fails in
+# seconds without ever executing, and `enforce_admins` is off, so gate-failing
+# code otherwise reaches `main` through admin/auto merges (exactly how the
+# clippy errors and the E0061 compile break landed and had to be hand-repaired).
+#
+# This is the enforcement point that still works while Actions is down: it
+# catches the break on the author's push, before the PR is merged. It is
+# advisory, not a server-side guarantee — it must be installed per clone and is
+# bypassable — but it makes the gate run automatically again.
+#
+#   Install once per clone:  make hooks           (sets core.hooksPath=.githooks)
+#   Bypass (emergencies):    SKIP_GATE=1 git push     or     git push --no-verify
+#
+set -uo pipefail
+
+if [ "${SKIP_GATE:-}" = "1" ]; then
+  printf '\033[33m⚠ SKIP_GATE=1 — skipping the pre-push gate\033[0m\n' >&2
+  exit 0
+fi
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+printf '\033[36m▸ pre-push gate — make gate (fmt-check · clippy -D warnings · test)\033[0m\n' >&2
+if make gate; then
+  printf '\033[32m✔ gate green — pushing\033[0m\n' >&2
+  exit 0
+fi
+
+printf '\033[31m✖ gate failed — push aborted.\033[0m\n' >&2
+printf '  Fix the errors above, or bypass in an emergency: SKIP_GATE=1 git push (or git push --no-verify).\n' >&2
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ make gate                # = fmt --check + clippy -D warnings + test --workspace
 
 For a faster pre-push sanity check (no tests): `make check`.
 
+**Run `make hooks` once per clone.** It installs a `pre-push` git hook
+(`core.hooksPath=.githooks`) that runs `make gate` automatically on every push
+and aborts the push if it fails. This is the gate's real enforcement point
+today: the org's GitHub Actions is **billing-locked**, so the required CI checks
+fast-fail in seconds without ever running, and with `enforce_admins` off,
+gate-failing code otherwise slips onto `main` through admin/auto merges. The
+hook catches it on the author's push instead. It is advisory (per-clone,
+bypassable with `SKIP_GATE=1 git push` or `git push --no-verify`) — not a
+server-side guarantee, which is impossible while the checks can't execute.
+
 Supply-chain checks run as a separate CI job: `make supply-chain` (or
 `cargo deny check advisories bans sources` + `cargo audit`). Note `deny.toml`
 intentionally does **not** gate on licenses; advisories, bans, and source

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ gate: format-check lint test ## Full CI gate: fmt-check + clippy + test
 .PHONY: check
 check: format-check lint ## Fast pre-push check (fmt + clippy, no tests)
 
+.PHONY: hooks
+hooks: ## Install the pre-push gate hook (runs `make gate` on every push)
+	git config core.hooksPath .githooks
+	@chmod +x .githooks/* 2>/dev/null || true
+	@printf '\033[32m✔ hooks installed\033[0m — pre-push now runs the fmt+clippy+test gate.\n'
+	@printf '  Needed because org Actions is billing-locked and never runs the gate itself.\n'
+	@printf '  Bypass in emergencies: \033[36mSKIP_GATE=1 git push\033[0m (or \033[36mgit push --no-verify\033[0m).\n'
+
 .PHONY: docs
 docs: ## Build rustdoc for the workspace (skip dep docs)
 	cargo doc --workspace --no-deps


### PR DESCRIPTION
## The problem, at the automation level

The org's GitHub Actions is **billing-locked**: the required checks (`fmt + clippy + test`, `cargo deny + cargo audit`) fast-fail in seconds without ever running, and `enforce_admins` is off — so gate-failing code reaches `main` through admin/auto merges. That is exactly how PR #139's clippy errors and PR #140's **E0061** compile break landed on `main` and had to be hand-repaired in #142. Nothing actually runs the gate today.

## The fix

Enforce the gate at the only point that still works with Actions down — the author's **push**:

- **`.githooks/pre-push`** runs `make gate` (fmt-check + clippy `-D warnings` + test) and aborts the push if it fails. Escape hatch: `SKIP_GATE=1 git push` or `git push --no-verify`.
- **`make hooks`** installs it via `core.hooksPath=.githooks` — run once per clone.
- **AGENTS.md** documents it in the gate section.

Honest scope: this is **advisory** (per-clone, bypassable), not a server-side guarantee — a true server gate is impossible while the required checks can't execute. But it makes the gate run automatically again.

## Proof — it catches the original problem

Staged in a scratch worktree against the broken commit `326cf49`, fixing one file at a time to reveal each break the gate must catch:

| Tree state | Gate stops at | Push |
|---|---|---|
| raw `326cf49` | `format-check` — fmt drift (`bedrock.rs`) | **ABORTED** |
| fmt fixed | `lint` — clippy `manual-clamp`/`field_reassign` (`stella-tui`) | **ABORTED** |
| tui fixed | `lint` — **E0061** `connect_mcp` arg mismatch (`stella-cli`) | **ABORTED** |
| fully fixed (== `main`) | all green | **ALLOWED** |

Each of the three breaks that silently reached `main` would have been blocked at the author's push.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local Git pre-push hook to run the CI gate (`fmt + clippy -D warnings + test`) while Actions is billing-locked. Stops pushes that fail the gate to keep broken code off `main`.

- **New Features**
  - Adds `.githooks/pre-push` that runs `make gate` and aborts on failure.
  - Adds `make hooks` to install hooks via `core.hooksPath=.githooks`.
  - Updates `AGENTS.md` with gate details. Advisory and per-clone.

- **Migration**
  - Run `make hooks` once per clone.
  - Bypass only if needed: `SKIP_GATE=1 git push` or `git push --no-verify`.

<sup>Written for commit 4a7673eb38e458b26b2b87cba9f3e2cda26edc0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/oxageninc/stella/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
