### PR TITLE
Release v0.3.0 + migrate oxageninc → macanderson

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://docs.oxagen.sh/stella
     about: Quickstart, provider setup, and the full manual — check here first.
   - name: 🔒 Report a security vulnerability
-    url: https://github.com/oxageninc/stella/security/advisories/new
+    url: https://github.com/macanderson/stella/security/advisories/new
     about: Please use private vulnerability reporting — never a public issue.
   - name: 💬 Questions & ideas
-    url: https://github.com/oxageninc/stella/discussions
+    url: https://github.com/macanderson/stella/discussions
     about: Not a bug, not yet a feature request? Start a discussion.

--- a/.github/homebrew/stella.rb.tmpl
+++ b/.github/homebrew/stella.rb.tmpl
@@ -3,14 +3,14 @@
 # This is NOT a hand-maintained formula — the `release` workflow renders it on
 # every tag push by substituting the @VERSION@ / @SHA_*@ placeholders below with
 # the real version and per-target SHA-256 sums of the prebuilt tarballs, then
-# commits the result to the tap repo (oxageninc/homebrew-stella) as
+# commits the result to the tap repo (macanderson/homebrew-stella) as
 # Formula/stella.rb. See .github/workflows/release.yml (the `homebrew` job).
 #
 # Unlike packaging/homebrew/stella.rb (which builds from source with cargo),
 # this installs the prebuilt binary directly — no Rust toolchain required.
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
-  homepage "https://github.com/oxageninc/stella"
+  homepage "https://github.com/macanderson/stella"
   # Explicit version is kept intentionally: brew's URL version-scan is fragile
   # for filenames containing arch tokens (x86_64/aarch64), so we pin it.
   version "@VERSION@"
@@ -18,22 +18,22 @@ class Stella < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/oxageninc/stella/releases/download/v@VERSION@/stella-@VERSION@-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/macanderson/stella/releases/download/v@VERSION@/stella-@VERSION@-aarch64-apple-darwin.tar.gz"
       sha256 "@SHA_AARCH64_DARWIN@"
     end
     on_intel do
-      url "https://github.com/oxageninc/stella/releases/download/v@VERSION@/stella-@VERSION@-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/macanderson/stella/releases/download/v@VERSION@/stella-@VERSION@-x86_64-apple-darwin.tar.gz"
       sha256 "@SHA_X86_64_DARWIN@"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/oxageninc/stella/releases/download/v@VERSION@/stella-@VERSION@-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/macanderson/stella/releases/download/v@VERSION@/stella-@VERSION@-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "@SHA_AARCH64_LINUX@"
     end
     on_intel do
-      url "https://github.com/oxageninc/stella/releases/download/v@VERSION@/stella-@VERSION@-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/macanderson/stella/releases/download/v@VERSION@/stella-@VERSION@-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "@SHA_X86_64_LINUX@"
     end
   end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
 
   # Renders .github/homebrew/stella.rb.tmpl with the real version + per-target
   # SHA-256 sums and commits it as Formula/stella.rb to the tap repo
-  # (oxageninc/homebrew-stella). Runs only after the GitHub Release exists, so
+  # (macanderson/homebrew-stella). Runs only after the GitHub Release exists, so
   # the formula's release-asset URLs resolve. Auth: HOMEBREW_TAP_DEPLOY_KEY
   # (an SSH deploy key with write access to the tap repo — scoped to exactly
   # that one repo, unlike a PAT), with HOMEBREW_TAP_TOKEN (https) honored as a
@@ -293,10 +293,10 @@ jobs:
             printf '%s\n' "${HOMEBREW_TAP_DEPLOY_KEY}" > "${keyfile}"
             chmod 600 "${keyfile}"
             export GIT_SSH_COMMAND="ssh -i ${keyfile} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-            git clone --depth 1 "git@github.com:oxageninc/homebrew-stella.git" tap
+            git clone --depth 1 "git@github.com:macanderson/homebrew-stella.git" tap
           else
             git clone --depth 1 \
-              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/oxageninc/homebrew-stella.git" tap
+              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/macanderson/homebrew-stella.git" tap
           fi
 
           mkdir -p tap/Formula

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Every one of these is genuinely valued — pick the one that fits your energy:
 
 | Contribution | Where to start | Effort |
 |---|---|---|
-| 🐛 **A bug report with a repro** | [Bug report form](https://github.com/oxageninc/stella/issues/new?template=bug_report.yml) | 10 minutes |
+| 🐛 **A bug report with a repro** | [Bug report form](https://github.com/macanderson/stella/issues/new?template=bug_report.yml) | 10 minutes |
 | 🧭 **Docs & examples** — fix a lie in the README before it fools someone else | Any `*.md` file, `--help` text, doc comments | Small |
 | 🔌 **A new provider adapter** — Stella is BYOK; every model provider we speak makes it more useful | `stella-model/src/` — copy the shape of an existing adapter | Medium |
 | 🛠 **A new built-in tool** | `stella-tools/src/` — implement the tool trait, register it | Medium |
@@ -47,7 +47,7 @@ and [`fd`](https://github.com/sharkdp/fd) (the agent's `grep`/`glob` tools shell
 out to them at runtime).
 
 ```bash
-git clone https://github.com/oxageninc/stella.git
+git clone https://github.com/macanderson/stella.git
 cd stella
 
 cargo build --workspace          # first build compiles bundled SQLite — quick
@@ -191,8 +191,8 @@ normal part of the loop here, not a rejection.
 
 ## Issues and labels
 
-- **[Bug report](https://github.com/oxageninc/stella/issues/new?template=bug_report.yml)** — include `stella --version`, OS, provider/model, and a repro.
-- **[Feature request](https://github.com/oxageninc/stella/issues/new?template=feature_request.yml)** — say what you're trying to do, not just what to add.
+- **[Bug report](https://github.com/macanderson/stella/issues/new?template=bug_report.yml)** — include `stella --version`, OS, provider/model, and a repro.
+- **[Feature request](https://github.com/macanderson/stella/issues/new?template=feature_request.yml)** — say what you're trying to do, not just what to add.
 
 Labels you'll see: `area:*` routes an issue to a crate; `P0`–`P2` is priority;
 `good first issue` and `help wanted` mean what they say; `needs-witness` means

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "ocp-conformance"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "ocp-host"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "ocp-types"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2619,7 +2619,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "ocp-types",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "notify",
  "ocp-types",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "stella-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "stella-pipeline"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "libc",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crossterm",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/oxageninc/stella"
+repository = "https://github.com/macanderson/stella"
 homepage = "https://docs.oxagen.sh/stella"
 publish = false
 
@@ -71,7 +71,7 @@ wiremock = "0.6"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "oxageninc/homebrew-stella"
+tap = "macanderson/homebrew-stella"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -46,8 +46,8 @@ This is also why local pre-publish verification is asymmetric:
 ## One-time prerequisites
 
 1. A crates.io account with a verified email, linked to a GitHub account with
-   write access to `oxageninc/stella` (or another account willing to transfer
-   ownership to the `oxageninc` GitHub org's crates.io team once one exists).
+   write access to `macanderson/stella` (or another account willing to transfer
+   ownership to the `macanderson` GitHub org's crates.io team once one exists).
 2. `cargo login <token>` locally, using a crates.io API token scoped to
    `publish-new` + `publish-update` (crates.io Account Settings → API
    Tokens). Do not commit this token; it's not an env var this repo reads.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <p align="center"><strong>A fast, BYOK, model-agnostic terminal coding agent, built in Rust.</strong></p>
 <p align="center">
-  <a href="https://github.com/oxageninc/stella/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/oxageninc/stella/ci.yml?branch=main&style=flat-square&logo=github&label=ci" alt="CI status"></a>
-  <a href="https://github.com/oxageninc/stella/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/oxageninc/stella/release.yml?style=flat-square&logo=github&label=release" alt="Release status"></a>
+  <a href="https://github.com/macanderson/stella/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/macanderson/stella/ci.yml?branch=main&style=flat-square&logo=github&label=ci" alt="CI status"></a>
+  <a href="https://github.com/macanderson/stella/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/macanderson/stella/release.yml?style=flat-square&logo=github&label=release" alt="Release status"></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-FFAC26?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/rust-1.90%2B-FFAC26?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.90+">
   <img src="https://img.shields.io/badge/providers-9%20%2B%20local-FFAC26?style=flat-square" alt="9 providers + local">
@@ -67,7 +67,7 @@ workspace of focused crates.
 **Prebuilt binary:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oxageninc/stella/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
 stella --version
 ```
 
@@ -77,7 +77,7 @@ falls back to `cargo install` when no prebuilt binary matches your platform.
 **Homebrew:**
 
 ```bash
-brew install oxageninc/stella/stella
+brew install macanderson/stella/stella
 ```
 
 To build from source via Homebrew:
@@ -86,14 +86,14 @@ To build from source via Homebrew:
 **From cargo** (requires Rust 1.90+ and git):
 
 ```bash
-cargo install --locked --git https://github.com/oxageninc/stella stella-cli
+cargo install --locked --git https://github.com/macanderson/stella stella-cli
 stella --version
 ```
 
 **From source:**
 
 ```bash
-git clone https://github.com/oxageninc/stella.git
+git clone https://github.com/macanderson/stella.git
 cd stella
 cargo build --release
 ./target/release/stella --version
@@ -436,9 +436,9 @@ tests, and a release build on every PR.
 
 | You have… | Do this |
 |---|---|
-| A bug | [File it with a repro](https://github.com/oxageninc/stella/issues/new?template=bug_report.yml) |
-| An idea | [Open a feature request](https://github.com/oxageninc/stella/issues/new?template=feature_request.yml) or start a [discussion](https://github.com/oxageninc/stella/discussions) |
-| An evening | Grab a [`good first issue`](https://github.com/oxageninc/stella/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
+| A bug | [File it with a repro](https://github.com/macanderson/stella/issues/new?template=bug_report.yml) |
+| An idea | [Open a feature request](https://github.com/macanderson/stella/issues/new?template=feature_request.yml) or start a [discussion](https://github.com/macanderson/stella/discussions) |
+| An evening | Grab a [`good first issue`](https://github.com/macanderson/stella/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,16 +16,16 @@ The tag-triggered workflow publishes the Homebrew formula to a **tap repo**.
 This has to exist and be writable before the first release:
 
 1. **Create the tap repo.** A public repo named exactly
-   [`oxageninc/homebrew-stella`](https://github.com/oxageninc/homebrew-stella)
-   (Homebrew maps the tap `oxageninc/stella` → repo `homebrew-stella`). It can
+   [`macanderson/homebrew-stella`](https://github.com/macanderson/homebrew-stella)
+   (Homebrew maps the tap `macanderson/stella` → repo `homebrew-stella`). It can
    start empty; the release job commits `Formula/stella.rb` into it.
 
 2. **Create a push token.** A GitHub token with **contents: write** on the tap
-   repo — a fine-grained PAT scoped to `oxageninc/homebrew-stella`, or a classic
+   repo — a fine-grained PAT scoped to `macanderson/homebrew-stella`, or a classic
    PAT with `repo`. The default `GITHUB_TOKEN` can't push to another repo, so a
    dedicated one is required.
 
-3. **Add it as a secret** on **this** repo (`oxageninc/stella`):
+3. **Add it as a secret** on **this** repo (`macanderson/stella`):
    Settings → Secrets and variables → Actions → New repository secret →
    name `HOMEBREW_TAP_TOKEN`, value the token from step 2.
 
@@ -86,14 +86,14 @@ means cutting a new version.
 Homebrew (prebuilt binary, no Rust toolchain):
 
 ```bash
-brew install oxageninc/stella/stella
-# equivalently: brew tap oxageninc/stella && brew install stella
+brew install macanderson/stella/stella
+# equivalently: brew tap macanderson/stella && brew install stella
 ```
 
 Shell installer (macOS/Linux, no Homebrew):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oxageninc/stella/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
 ```
 
 The installer detects the platform, downloads the matching tarball from the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ researchers who help keep it tight.
 **Please do not open a public issue for security problems.**
 
 Report privately via
-[GitHub's private vulnerability reporting](https://github.com/oxageninc/stella/security/advisories/new)
+[GitHub's private vulnerability reporting](https://github.com/macanderson/stella/security/advisories/new)
 — it goes straight to the maintainers, and you get credit in the advisory when
 it's published.
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Stella CLI installer.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/oxageninc/stella/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
 #
 # Environment overrides:
 #   STELLA_VERSION      install a specific version (e.g. "0.1.0" or "v0.1.0")
@@ -18,7 +18,7 @@
 
 set -eu
 
-REPO="oxageninc/stella"
+REPO="macanderson/stella"
 BIN="stella"
 INSTALL_DIR="${STELLA_INSTALL_DIR:-$HOME/.local/bin}"
 API="https://api.github.com/repos/${REPO}"

--- a/ocp-conformance/README.md
+++ b/ocp-conformance/README.md
@@ -59,7 +59,7 @@ See [Running conformance][conformance] for the full guide.
 
 [`ocp-types`](https://crates.io/crates/ocp-types) and
 [`ocp-host`](https://crates.io/crates/ocp-host) — no dependency on
-[Stella](https://github.com/oxageninc/stella) or any of its other crates.
+[Stella](https://github.com/macanderson/stella) or any of its other crates.
 
 ## Docs
 
@@ -69,15 +69,15 @@ See [Running conformance][conformance] for the full guide.
 - [Running conformance][conformance] — this crate's full guide.
 - [Stability][stability] — the crate-semver vs. protocol-version relationship.
 
-[protocol-surface]: https://github.com/oxageninc/stella/blob/main/docs/ocp/protocol-surface.md
-[implementing]: https://github.com/oxageninc/stella/blob/main/docs/ocp/implementing-a-provider.md
-[conformance]: https://github.com/oxageninc/stella/blob/main/docs/ocp/running-conformance.md
-[stability]: https://github.com/oxageninc/stella/blob/main/docs/ocp/stability.md
+[protocol-surface]: https://github.com/macanderson/stella/blob/main/docs/ocp/protocol-surface.md
+[implementing]: https://github.com/macanderson/stella/blob/main/docs/ocp/implementing-a-provider.md
+[conformance]: https://github.com/macanderson/stella/blob/main/docs/ocp/running-conformance.md
+[stability]: https://github.com/macanderson/stella/blob/main/docs/ocp/stability.md
 [`run_conformance`]: https://docs.rs/ocp-conformance/latest/ocp_conformance/fn.run_conformance.html
 [`ConformanceReport`]: https://docs.rs/ocp-conformance/latest/ocp_conformance/struct.ConformanceReport.html
 
 ## License
 
-MIT OR Apache-2.0 — see [`LICENSE-MIT`](https://github.com/oxageninc/stella/blob/main/LICENSE-MIT)
-/ [`LICENSE-APACHE`](https://github.com/oxageninc/stella/blob/main/LICENSE-APACHE)
+MIT OR Apache-2.0 — see [`LICENSE-MIT`](https://github.com/macanderson/stella/blob/main/LICENSE-MIT)
+/ [`LICENSE-APACHE`](https://github.com/macanderson/stella/blob/main/LICENSE-APACHE)
 in the workspace root.

--- a/ocp-host/README.md
+++ b/ocp-host/README.md
@@ -13,7 +13,7 @@ its `token_cost` has its frames dropped and reported, never silently trusted.
 
 Depends only on [`ocp-types`](https://crates.io/crates/ocp-types) plus
 ordinary async/transport crates (`tokio`, `reqwest`) — no dependency on
-[Stella](https://github.com/oxageninc/stella) or any of its other crates.
+[Stella](https://github.com/macanderson/stella) or any of its other crates.
 
 ## Example: query a stdio provider
 
@@ -84,14 +84,14 @@ Rust) and the consent-gating contract for `egress` providers.
   with `ocp-conformance`.
 - [Stability][stability] — the crate-semver vs. protocol-version relationship.
 
-[protocol-surface]: https://github.com/oxageninc/stella/blob/main/docs/ocp/protocol-surface.md
-[implementing]: https://github.com/oxageninc/stella/blob/main/docs/ocp/implementing-a-provider.md
-[conformance]: https://github.com/oxageninc/stella/blob/main/docs/ocp/running-conformance.md
-[stability]: https://github.com/oxageninc/stella/blob/main/docs/ocp/stability.md
+[protocol-surface]: https://github.com/macanderson/stella/blob/main/docs/ocp/protocol-surface.md
+[implementing]: https://github.com/macanderson/stella/blob/main/docs/ocp/implementing-a-provider.md
+[conformance]: https://github.com/macanderson/stella/blob/main/docs/ocp/running-conformance.md
+[stability]: https://github.com/macanderson/stella/blob/main/docs/ocp/stability.md
 [`ContextProvider`]: https://docs.rs/ocp-host/latest/ocp_host/provider/trait.ContextProvider.html
 
 ## License
 
-MIT OR Apache-2.0 — see [`LICENSE-MIT`](https://github.com/oxageninc/stella/blob/main/LICENSE-MIT)
-/ [`LICENSE-APACHE`](https://github.com/oxageninc/stella/blob/main/LICENSE-APACHE)
+MIT OR Apache-2.0 — see [`LICENSE-MIT`](https://github.com/macanderson/stella/blob/main/LICENSE-MIT)
+/ [`LICENSE-APACHE`](https://github.com/macanderson/stella/blob/main/LICENSE-APACHE)
 in the workspace root.

--- a/ocp-types/README.md
+++ b/ocp-types/README.md
@@ -6,7 +6,7 @@ queries, capabilities, and provenance.
 `ocp-types` is the industry-facing artifact of the OCP crates: **MIT
 licensed, zero dependencies beyond `serde`.** You can implement an OCP
 provider or host in Rust against this crate alone, with no dependency on
-[Stella](https://github.com/oxageninc/stella) or any of its other crates.
+[Stella](https://github.com/macanderson/stella) or any of its other crates.
 
 Protocol version: `ocp/1.0-draft` (see [`stability.md`][stability] for what
 that means for this crate's semver).
@@ -70,10 +70,10 @@ protocol; there is no separate IDL.
 - [Running conformance][conformance] — proving your provider is conformant.
 - [Stability][stability] — the crate-semver vs. protocol-version relationship.
 
-[protocol-surface]: https://github.com/oxageninc/stella/blob/main/docs/ocp/protocol-surface.md
-[implementing]: https://github.com/oxageninc/stella/blob/main/docs/ocp/implementing-a-provider.md
-[conformance]: https://github.com/oxageninc/stella/blob/main/docs/ocp/running-conformance.md
-[stability]: https://github.com/oxageninc/stella/blob/main/docs/ocp/stability.md
+[protocol-surface]: https://github.com/macanderson/stella/blob/main/docs/ocp/protocol-surface.md
+[implementing]: https://github.com/macanderson/stella/blob/main/docs/ocp/implementing-a-provider.md
+[conformance]: https://github.com/macanderson/stella/blob/main/docs/ocp/running-conformance.md
+[stability]: https://github.com/macanderson/stella/blob/main/docs/ocp/stability.md
 [`ContextFrame`]: https://docs.rs/ocp-types/latest/ocp_types/frame/struct.ContextFrame.html
 [`FrameKind`]: https://docs.rs/ocp-types/latest/ocp_types/frame/enum.FrameKind.html
 [`Provenance`]: https://docs.rs/ocp-types/latest/ocp_types/frame/struct.Provenance.html
@@ -86,5 +86,5 @@ protocol; there is no separate IDL.
 
 ## License
 
-MIT — see [`LICENSE-MIT`](https://github.com/oxageninc/stella/blob/main/LICENSE-MIT)
+MIT — see [`LICENSE-MIT`](https://github.com/macanderson/stella/blob/main/LICENSE-MIT)
 in the workspace root.

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -15,11 +15,11 @@
 # formula into a `homebrew-tap` repo that CI updates automatically.
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
-  homepage "https://github.com/oxageninc/stella"
-  url "https://github.com/oxageninc/stella.git", tag: "v0.1.0"
+  homepage "https://github.com/macanderson/stella"
+  url "https://github.com/macanderson/stella.git", tag: "v0.1.0"
   version "0.1.0"
   license "MIT OR Apache-2.0"
-  head "https://github.com/oxageninc/stella.git", branch: "main"
+  head "https://github.com/macanderson/stella.git", branch: "main"
 
   depends_on "rust" => :build
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,8 +24,8 @@
 set -euo pipefail
 
 # ── Config ──────────────────────────────────────────────────────────────────
-REPO="oxageninc/stella"
-TAP_REPO="oxageninc/homebrew-stella"
+REPO="macanderson/stella"
+TAP_REPO="macanderson/homebrew-stella"
 BIN="stella"
 CRATE="stella-cli"
 MAC_TARGETS=(aarch64-apple-darwin x86_64-apple-darwin)

--- a/stella-tui/src/scenario.rs
+++ b/stella-tui/src/scenario.rs
@@ -164,7 +164,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(ci, AgentEvent::Stage { name: StageKind::Verify }),
         ev(ci, AgentEvent::JudgeVerdict { passed: true, evidence: JudgeEvidence { summary: "flip oracle: fail→pass on `pnpm --filter app test:unit`".into(), deterministic: true, evidence_refs: vec![] } }),
         ev(ci, AgentEvent::Commit { sha: "a1b2c3d".into(), message: "feat(automations): triggers + workflows UI".into() }),
-        ev(ci, AgentEvent::Pr { url: "https://github.com/oxageninc/stella/pull/981".into(), status: PrStatus::Open }),
+        ev(ci, AgentEvent::Pr { url: "https://github.com/macanderson/stella/pull/981".into(), status: PrStatus::Open }),
         ev(ci, AgentEvent::StepUsage { step: 1, model: "glm-5.2-air".into(), input_tokens: 3_000, output_tokens: 180, cached_input_tokens: 0, cache_write_tokens: 0, estimated_input_tokens: 2_900, cost_usd: 0.004, duration_ms: 900, retries: 0, tool_calls: 0 }),
 
         // ── lead proposes a larger scope change (gate) ──────────────────


### PR DESCRIPTION
Project transferred from the `oxageninc` org to the `macanderson` personal account.

- Rename the exact token `oxageninc` → `macanderson` across all 16 files: `scripts/release.sh` (`REPO`/`TAP_REPO`), both Homebrew formulas + `.github/homebrew/stella.rb.tmpl`, `install.sh`, `Cargo.toml` `repository`, `.github/workflows/release.yml`, issue-template links, README/RELEASING/CONTRIBUTING/SECURITY/PUBLISHING + OCP READMEs, and a demo URL in `scenario.rs`.
- `brew install` is now **`macanderson/stella/stella`**.
- Left untouched (not the GitHub org): `docs.oxagen.sh` homepage, `ops@oxagen.sh`, `oxagen-platform`.
- Bump `[workspace.package].version` 0.2.1 → **0.3.0** (Cargo.lock synced) so committed source matches the v0.3.0 release cut immediately after this merges.

Validated by the new pre-push gate hook (`make gate`: fmt + clippy `-D warnings` + test — all green).


## Summary by Sourcery

Transfer the project to the macanderson GitHub account and align release metadata with the v0.3.0 cut.

New Features:
- Update install and distribution endpoints to use the macanderson/stella repository and Homebrew tap.

Enhancements:
- Bump the workspace package version to 0.3.0 so the committed source matches the v0.3.0 release.
- Refresh documentation links and issue templates to point at the macanderson/stella repository.
- Adjust release and Homebrew packaging configuration to target the macanderson/homebrew-stella tap repository.

Build:
- Update Cargo workspace metadata and installer scripts to use the macanderson GitHub repository and tap configuration.

CI:
- Update the release workflow to clone and publish formulas to macanderson/homebrew-stella instead of oxageninc/homebrew-stella.

Documentation:
- Update README, contributing, security, publishing, and OCP crate docs to reference the new macanderson GitHub repository and Homebrew tap.
