### PR TITLE
fix(ci): install release cross target on the pinned toolchain (fixes x86_64-apple-darwin E0463)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      # rust-toolchain.toml pins the repo to a concrete toolchain (e.g. 1.97.0),
+      # and the build runs on *that*, not `stable`. dtolnay's `targets:` above
+      # installs the target for `stable`, so a genuine cross-target (x86_64 on
+      # the arm64 macOS runner) fails with E0463 "can't find crate for `core`".
+      # Add the target to the pinned toolchain — this runs in the checkout, so
+      # rustup honors rust-toolchain.toml (auto-installing the pin on first use).
+      - name: Add the cross target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
       # Stamp the release version (from the tag) into the workspace manifest so
       # the compiled binary reports it — `stella --version` == the release tag.
       # No commit lands on main; this edit is ephemeral to the build runner.


### PR DESCRIPTION
The `x86_64-apple-darwin` release job failed with `error[E0463]: can't find crate for `core``. `rust-toolchain.toml` pins the repo to 1.97.0, but `dtolnay/rust-toolchain@stable`'s `targets:` adds the target to **stable**, not the pinned toolchain that builds — so 1.97.0 lacked the x86_64-apple-darwin std. Only the genuine cross-target (x86_64 on the arm64 runner) failed; the 3 host-native targets passed.

Fix: explicit `rustup target add ${{ matrix.target }}` in the checkout, so rustup honors `rust-toolchain.toml`. Matches what `scripts/release.sh` does locally (why the local v0.3.0 cut succeeded).


## Summary by Sourcery

CI:
- Add a rustup target installation step in the release workflow so matrix targets are installed on the repository’s pinned toolchain instead of stable.
