### PR TITLE
chore(homebrew): tap is macanderson/tap → brew install macanderson/tap/stella

### DIFF
--- a/.github/homebrew/stella.rb.tmpl
+++ b/.github/homebrew/stella.rb.tmpl
@@ -3,7 +3,7 @@
 # This is NOT a hand-maintained formula — the `release` workflow renders it on
 # every tag push by substituting the @VERSION@ / @SHA_*@ placeholders below with
 # the real version and per-target SHA-256 sums of the prebuilt tarballs, then
-# commits the result to the tap repo (macanderson/homebrew-stella) as
+# commits the result to the tap repo (macanderson/homebrew-tap) as
 # Formula/stella.rb. See .github/workflows/release.yml (the `homebrew` job).
 #
 # Unlike packaging/homebrew/stella.rb (which builds from source with cargo),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
 
   # Renders .github/homebrew/stella.rb.tmpl with the real version + per-target
   # SHA-256 sums and commits it as Formula/stella.rb to the tap repo
-  # (macanderson/homebrew-stella). Runs only after the GitHub Release exists, so
+  # (macanderson/homebrew-tap). Runs only after the GitHub Release exists, so
   # the formula's release-asset URLs resolve. Auth: HOMEBREW_TAP_DEPLOY_KEY
   # (an SSH deploy key with write access to the tap repo — scoped to exactly
   # that one repo, unlike a PAT), with HOMEBREW_TAP_TOKEN (https) honored as a
@@ -302,10 +302,10 @@ jobs:
             printf '%s\n' "${HOMEBREW_TAP_DEPLOY_KEY}" > "${keyfile}"
             chmod 600 "${keyfile}"
             export GIT_SSH_COMMAND="ssh -i ${keyfile} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-            git clone --depth 1 "git@github.com:macanderson/homebrew-stella.git" tap
+            git clone --depth 1 "git@github.com:macanderson/homebrew-tap.git" tap
           else
             git clone --depth 1 \
-              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/macanderson/homebrew-stella.git" tap
+              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/macanderson/homebrew-tap.git" tap
           fi
 
           mkdir -p tap/Formula

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ wiremock = "0.6"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "macanderson/homebrew-stella"
+tap = "macanderson/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ falls back to `cargo install` when no prebuilt binary matches your platform.
 **Homebrew:**
 
 ```bash
-brew install macanderson/stella/stella
+brew install macanderson/tap/stella
 ```
 
 To build from source via Homebrew:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,12 +16,12 @@ The tag-triggered workflow publishes the Homebrew formula to a **tap repo**.
 This has to exist and be writable before the first release:
 
 1. **Create the tap repo.** A public repo named exactly
-   [`macanderson/homebrew-stella`](https://github.com/macanderson/homebrew-stella)
-   (Homebrew maps the tap `macanderson/stella` → repo `homebrew-stella`). It can
+   [`macanderson/homebrew-tap`](https://github.com/macanderson/homebrew-tap)
+   (Homebrew maps the tap `macanderson/tap` → repo `homebrew-tap`). It can
    start empty; the release job commits `Formula/stella.rb` into it.
 
 2. **Create a push token.** A GitHub token with **contents: write** on the tap
-   repo — a fine-grained PAT scoped to `macanderson/homebrew-stella`, or a classic
+   repo — a fine-grained PAT scoped to `macanderson/homebrew-tap`, or a classic
    PAT with `repo`. The default `GITHUB_TOKEN` can't push to another repo, so a
    dedicated one is required.
 
@@ -86,8 +86,8 @@ means cutting a new version.
 Homebrew (prebuilt binary, no Rust toolchain):
 
 ```bash
-brew install macanderson/stella/stella
-# equivalently: brew tap macanderson/stella && brew install stella
+brew install macanderson/tap/stella
+# equivalently: brew tap macanderson/tap && brew install stella
 ```
 
 Shell installer (macOS/Linux, no Homebrew):

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,7 +25,8 @@ set -euo pipefail
 
 # ── Config ──────────────────────────────────────────────────────────────────
 REPO="macanderson/stella"
-TAP_REPO="macanderson/homebrew-stella"
+TAP_REPO="macanderson/homebrew-tap"   # repo the formula is pushed to (git)
+TAP="macanderson/tap"                 # brew tap name → maps to repo homebrew-tap
 BIN="stella"
 CRATE="stella-cli"
 MAC_TARGETS=(aarch64-apple-darwin x86_64-apple-darwin)
@@ -184,15 +185,15 @@ fi
 
 # ── Verify via Homebrew (fetch = download + checksum, no install) ───────────
 info "verifying via Homebrew"
-brew tap "$REPO" >/dev/null 2>&1 || true
-brew update-reset "$(brew --repo "$REPO")" >/dev/null 2>&1 || true
-if brew fetch "${REPO}/${BIN}" >/dev/null 2>&1; then
+brew tap "$TAP" >/dev/null 2>&1 || true
+brew update-reset "$(brew --repo "$TAP")" >/dev/null 2>&1 || true
+if brew fetch "${TAP}/${BIN}" >/dev/null 2>&1; then
   ok "brew fetch + checksum verified for ${VERSION}"
 else
-  info "brew couldn't verify yet (release assets may still be propagating) — retry: brew fetch ${REPO}/${BIN}"
+  info "brew couldn't verify yet (release assets may still be propagating) — retry: brew fetch ${TAP}/${BIN}"
 fi
 
 bold ""
 ok "Released ${TAG}"
-printf '   install:  brew install %s/%s\n' "$REPO" "$BIN"
+printf '   install:  brew install %s/%s\n' "$TAP" "$BIN"
 printf '   upgrade:  brew upgrade %s\n' "$BIN"


### PR DESCRIPTION
Renames the tap repo `homebrew-stella` → `homebrew-tap` so the install command drops the `stella/stella` repetition. `brew install stella` isn't available (`stella` in homebrew-core is the Atari 2600 emulator) and Homebrew has no two-part tap-install form, so `macanderson/tap/stella` is the cleanest reachable command. Updates release.sh (TAP_REPO + new TAP var), Cargo.toml dist tap, the release workflow's tap clone, the formula template comment, and README/RELEASING install commands.


## Summary by Sourcery

Rename the Homebrew tap repository and update tooling and docs to use the new tap name and cleaner install command.

Enhancements:
- Introduce a dedicated TAP identifier in release scripts to separate the git repo name from the Homebrew tap name.
- Update release automation and Homebrew verification logic to use the new tap repo and tap name consistently.

Build:
- Update Cargo release configuration to point Homebrew formula publishing at the renamed tap repository.

CI:
- Adjust the release workflow to clone and update the renamed Homebrew tap repository.

Documentation:
- Refresh README and RELEASING instructions to reference the new Homebrew tap repo and the `brew install macanderson/tap/stella` command.
