### PR TITLE
fix(deck): progress bar resets on command submit; /clear blanks the session

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -1633,9 +1633,16 @@ async fn run_deck_command(
             say(help);
         }
         "/clear" => {
+            // Reset the driver's own LLM history…
             messages.clear();
             messages.push(CompletionMessage::system(system_prompt.to_string()));
-            say("conversation cleared".to_string());
+            // …and the deck's session view: blank the transcript (including the
+            // `/clear` echo the paired PromptStarted just pushed), zero the cost
+            // stat, and return the progress bar to idle. No `say()` — that would
+            // re-populate the transcript we are clearing.
+            let _ = in_tx.send(Inbound::SessionReset {
+                agent: LEAD.to_string(),
+            });
         }
         "/models" => {
             say(Config::available_models_plain());

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -317,6 +317,12 @@ impl WorkspaceModel {
                     // to the live count.
                     self.agents[idx].turn_started_ms = Some(ts);
                     self.agents[idx].last_turn_ms = None;
+                    // Flip to Running now so the progress bar reads in-progress
+                    // from the instant of submission — a driver command (e.g.
+                    // `/init`) emits no stage events, and the prior turn may have
+                    // left the status at `Done`, which would otherwise keep the
+                    // bar frozen at full-green until the engine spoke.
+                    self.agents[idx].status = AgentStatus::Running;
                 }
             }
             Inbound::PromptRequeued { agent, text } => {
@@ -332,6 +338,24 @@ impl WorkspaceModel {
                     kind: TraceKind::Stage,
                     summary: format!("↩ {}", snip(text)),
                 });
+            }
+            // `/clear`: reset the agent's session to seq-0 — blank the
+            // transcript, zero the cost/token counters and the header clock, and
+            // return the HUD (progress bar) to idle. The prompt echo the paired
+            // `PromptStarted` pushed is wiped along with the rest.
+            Inbound::SessionReset { agent } => {
+                if let Some(idx) = self.index_of(agent) {
+                    let entry = &mut self.agents[idx];
+                    entry.model = SessionModel::new();
+                    entry.status = AgentStatus::WaitingInput;
+                    entry.tokens_in = 0;
+                    entry.tokens_out = 0;
+                    entry.cache_read_tokens = 0;
+                    entry.cost_usd = 0.0;
+                    entry.budget_ticked = false;
+                    entry.turn_started_ms = None;
+                    entry.last_turn_ms = None;
+                }
             }
             // The driver flipped staged-pipeline routing (`/pipeline`) — the
             // PIPELINE stat box tracks it live.
@@ -845,6 +869,67 @@ mod tests {
             agent: agent.into(),
             text: text.into(),
         }
+    }
+
+    #[test]
+    fn session_reset_blanks_transcript_zeroes_cost_and_stops_the_clock() {
+        let mut w = WorkspaceModel::new();
+        w.now_ms = 1_000;
+        w.apply_inbound(&reg("lead"));
+        w.apply_inbound(&prompt_started("lead", "hello"));
+        w.apply_inbound(&ev(
+            "lead",
+            AgentEvent::Text {
+                delta: "hi there".into(),
+            },
+        ));
+        if let Some(a) = w.agents.first_mut() {
+            a.cost_usd = 0.42;
+        }
+        assert!(
+            !w.agents[0].model.transcript.is_empty(),
+            "precondition: content present"
+        );
+        assert!(
+            w.agents[0].turn_started_ms.is_some(),
+            "precondition: clock running"
+        );
+
+        // `/clear` sends this.
+        w.apply_inbound(&Inbound::SessionReset {
+            agent: "lead".into(),
+        });
+
+        let a = &w.agents[0];
+        assert!(a.model.transcript.is_empty(), "transcript blanked");
+        assert_eq!(a.cost_usd, 0.0, "cost stat zeroed");
+        assert_eq!(w.total_cost(), 0.0, "workspace cost total zeroed");
+        assert_eq!(a.turn_started_ms, None, "wall clock stopped");
+        assert!(
+            !a.model.hud.complete && a.model.hud.stage.is_none(),
+            "hud/progress reset to idle"
+        );
+    }
+
+    #[test]
+    fn prompt_started_flips_a_finished_agent_back_to_running() {
+        // A completed turn leaves the lead resting; the next submission must flip
+        // it to Running (and clear any stale stage) so the progress bar leaves
+        // the full-green complete state and restarts in-progress.
+        let mut w = WorkspaceModel::new();
+        w.now_ms = 1_000;
+        w.apply_inbound(&reg("lead"));
+        if let Some(a) = w.agents.first_mut() {
+            a.status = AgentStatus::Done;
+            a.model.hud.stage = Some(StageKind::Complete);
+            a.model.hud.complete = true;
+        }
+        w.apply_inbound(&prompt_started("lead", "next"));
+        let a = &w.agents[0];
+        assert_eq!(a.status, AgentStatus::Running, "new turn ⇒ running");
+        assert!(a.model.hud.stage.is_none(), "stale stage cleared on submit");
+        assert!(!a.model.hud.complete, "stale completion cleared on submit");
+        assert!(a.turn_started_ms.is_some(), "the header clock restarts");
     }
 
     #[test]

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -129,6 +129,12 @@ pub enum Inbound {
     /// [`Inbound::PromptStarted`]'s front-pop — so the queue view keeps
     /// matching what will actually run.
     PromptRequeued { agent: AgentId, text: String },
+    /// Reset one agent's session to its seq-0 state — a `/clear`. Folded like a
+    /// core event (it mutates the model, not just view state): the agent's
+    /// transcript is blanked, its cost/token counters and the header clock zero
+    /// out, and the progress-bar HUD returns to idle. The driver sends this on
+    /// `/clear` (alongside clearing its own LLM message history).
+    SessionReset { agent: AgentId },
     /// A refreshed code-graph snapshot for the Graph tab. Unlike the other
     /// variants this is **not** a folded event — the graph is an out-of-band
     /// read-model (see `COMMAND_DECK_DESIGN.md` → "The purity boundary"). It

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -565,6 +565,11 @@ impl SessionModel {
     pub fn push_user_prompt(&mut self, text: &str) {
         self.hud.complete = false;
         self.hud.final_cost_usd = None;
+        // Also drop the prior turn's stage, or the progress bar would resume
+        // frozen at that stale position (e.g. verify → 83%) instead of restarting
+        // at the new turn's beginning. A model turn's first `Stage` event resets
+        // this anyway; a driver command (which emits no stages) relies on it.
+        self.hud.stage = None;
         self.transcript
             .push(TranscriptEntry::User(text.to_string()));
         self.evict_transcript_overflow();

--- a/stella-tui/src/progress.rs
+++ b/stella-tui/src/progress.rs
@@ -143,9 +143,14 @@ impl ProgressState {
         let complete = hud.complete || agent.status == AgentStatus::Done;
         let error = matches!(agent.status, AgentStatus::Failed | AgentStatus::Killed);
 
-        // Idle: a registered agent that hasn't started a turn (no stage, not
-        // terminal) reads as a flat track, exactly like having no agent at all.
-        if !complete && !error && hud.stage.is_none() && !agent.status.is_active() {
+        // Idle: no turn in flight and nothing to show — a flat track, exactly
+        // like having no agent at all. Keyed on the header clock
+        // (`turn_started_ms`), the one honest "a turn is running" signal: it is
+        // set on `PromptStarted` and cleared by `end_turn` on completion. Status
+        // alone is unreliable here — `WaitingInput` is `is_active()` yet is also
+        // the post-command resting state, which would otherwise strand the bar
+        // mid-fill after a handled command (e.g. `/init`) finishes.
+        if !complete && !error && hud.stage.is_none() && agent.turn_started_ms.is_none() {
             return Self::idle();
         }
 
@@ -492,6 +497,89 @@ mod tests {
         let s = ProgressState::derive(focused(&verify), verify.now_ms, false);
         assert_eq!(s.segments[2], SegState::Active);
         assert!((s.fill - 5.0 / 6.0).abs() < 1e-9);
+    }
+
+    fn lead_registered(now_ms: u64) -> WorkspaceModel {
+        let mut m = WorkspaceModel::new();
+        m.now_ms = now_ms;
+        m.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        m
+    }
+
+    #[test]
+    fn command_in_flight_with_no_stage_reads_in_progress_not_idle() {
+        // A driver command (e.g. /init) emits no Stage events, but PromptStarted
+        // starts the clock — the bar must show the default in-progress state
+        // (plan), never a stale fill and never idle.
+        let mut m = lead_registered(5_000);
+        m.apply_inbound(&Inbound::PromptStarted {
+            agent: "lead".into(),
+            text: "/init".into(),
+        });
+        let s = ProgressState::derive(focused(&m), m.now_ms, false);
+        assert_eq!(s.phase, RunPhase::Running, "clock running ⇒ in-progress");
+        assert_eq!(
+            s.segments[0],
+            SegState::Active,
+            "default in-progress = plan"
+        );
+        assert!(
+            (s.fill - 1.0 / 6.0).abs() < 1e-9,
+            "restarts at the beginning"
+        );
+    }
+
+    #[test]
+    fn resting_after_a_command_reads_idle_not_stranded() {
+        // When a handled command completes, the clock stops (WaitingInput →
+        // end_turn) and, with no stage/complete, the bar returns to idle — it is
+        // never left frozen mid-fill even though WaitingInput is `is_active()`.
+        let mut m = lead_registered(5_000);
+        m.apply_inbound(&Inbound::PromptStarted {
+            agent: "lead".into(),
+            text: "/init".into(),
+        });
+        m.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::WaitingInput,
+        });
+        let s = ProgressState::derive(focused(&m), m.now_ms, false);
+        assert_eq!(s.phase, RunPhase::Idle, "clock stopped + no stage ⇒ idle");
+        assert_eq!(s.fill, 0.0);
+    }
+
+    #[test]
+    fn new_prompt_after_completion_restarts_from_the_beginning() {
+        // A completed turn leaves the bar full-green; the NEXT submission must
+        // reset it to the in-progress start, not resume frozen at verify/100%.
+        let mut m = agent_running(StageKind::Verify);
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Complete {
+                model: "glm-5.2".into(),
+                cost_usd: 0.1,
+            },
+        });
+        assert_eq!(
+            ProgressState::derive(focused(&m), m.now_ms, false).phase,
+            RunPhase::Complete,
+            "precondition: full-green"
+        );
+        m.apply_inbound(&Inbound::PromptStarted {
+            agent: "lead".into(),
+            text: "another".into(),
+        });
+        let s = ProgressState::derive(focused(&m), m.now_ms, false);
+        assert_eq!(
+            s.phase,
+            RunPhase::Running,
+            "reset to in-progress, not stale complete"
+        );
+        assert!(
+            (s.fill - 1.0 / 6.0).abs() < 1e-9,
+            "back to the plan-phase start, got {}",
+            s.fill
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two command-deck lifecycle gaps, reported from live use.

## 1. Submitting a command didn't reset the progress bar

`/init` (or any prompt) left the bar **frozen at the previous turn's stage** (e.g. verify → 83%) instead of restarting, and a finished turn's `Done` status kept it full-green.

Root cause: the bar is a *pure derivation* of the focused agent's HUD, and `push_user_prompt` cleared `hud.complete` but not `hud.stage`; the idle check also keyed on `is_active`, which treats the post-command resting `WaitingInput` as active.

- `push_user_prompt` now also clears `hud.stage` (a model turn's first `Stage` event reset it anyway; a driver command emits no stages, so it relied on this).
- `PromptStarted` flips the agent to `Running`, so the bar reads in-progress from the instant of submission (and leaves a stale `Done`).
- `ProgressState::derive` keys **idle** on `turn_started_ms` (the one honest "a turn is in flight" signal, set on `PromptStarted`, cleared by `end_turn`) instead of `is_active`. This is what lets the bar return to idle when a handled command finishes, rather than stranding mid-fill — the wall-clock stop already worked.

Net: submit → bar restarts at the plan-phase in-progress state; complete → clock stops and the bar goes idle.

## 2. `/clear` didn't reset the view

It only cleared the driver's LLM message history. It now also emits `Inbound::SessionReset` — a folded event that **blanks the transcript** (including the `/clear` echo), **zeroes the cost stat** + token counters, stops the header clock, and returns the HUD/progress bar to idle.

## Tests
`progress.rs`: command-in-flight reads in-progress not idle/stale; post-command reads idle not stranded; new prompt after completion restarts at plan. `deck.rs`: `SessionReset` blanks transcript + zeroes cost + stops clock; `PromptStarted` flips a finished agent to Running and clears stale stage/completion. Full `progress::` + `deck::tests::` modules green (39), clippy clean on both crates.

> The local pre-push gate ran the whole workspace suite from inside a nested git worktree, which trips two `stella-fleet` `real_git_*` worktree-isolation tests (unrelated to this change — it only touches `stella-tui` + `stella-cli`). CI runs on a clean checkout.


## Summary by Sourcery

Fix command deck progress bar lifecycle and session clearing behavior in the TUI and CLI.

Bug Fixes:
- Ensure the progress bar returns to idle when a command completes and restarts from the beginning on new prompts, including driver commands that emit no stage events.
- Fix the `/clear` command so it fully resets the command deck session state (transcript, costs, tokens, and clocks) instead of only clearing the driver's LLM history.
- Prevent stale stages and completion flags from keeping the progress bar stuck at a previous turn's state after submitting a new prompt.

Enhancements:
- Add new TUI tests covering progress bar behavior across command execution and prompt submissions, and session reset behavior.
- Introduce an explicit `SessionReset` inbound event to model session resets as a folded state change in the TUI.

Documentation:
- Replace the existing README contents with a placeholder stub.

Chores:
- Add a new placeholder file `f.txt` to the repository.
