### PR TITLE
fix(tui): keep wrapped transcript rows flush at the content column

### DIFF
--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -771,10 +771,7 @@ fn wrap_one_indent(
                 // space stacks on top of `indent` and pushes every wrapped row
                 // one column right of the clean left edge — the "extra blank
                 // space after the colon" bug.
-                let lead = remainder
-                    .iter()
-                    .take_while(|(c, _)| *c == ' ')
-                    .count();
+                let lead = remainder.iter().take_while(|(c, _)| *c == ' ').count();
                 remainder.drain(..lead);
                 flush(&mut current, is_first, out);
                 is_first = false;

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -765,7 +765,17 @@ fn wrap_one_indent(
         let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
         if current_w + cw > content_width && !current.is_empty() {
             if let Some(space_idx) = current.iter().rposition(|(c, _)| *c == ' ') {
-                let remainder: Vec<(char, Style)> = current.split_off(space_idx);
+                let mut remainder: Vec<(char, Style)> = current.split_off(space_idx);
+                // Consume the wrap-boundary whitespace so the continuation line
+                // starts flush at the indent column. Left in place, the leading
+                // space stacks on top of `indent` and pushes every wrapped row
+                // one column right of the clean left edge — the "extra blank
+                // space after the colon" bug.
+                let lead = remainder
+                    .iter()
+                    .take_while(|(c, _)| *c == ' ')
+                    .count();
+                remainder.drain(..lead);
                 flush(&mut current, is_first, out);
                 is_first = false;
                 current = remainder;
@@ -1530,6 +1540,36 @@ mod tests {
                 LABEL_COL,
                 "{entry:?} label tag must place content at LABEL_COL, got {:?}",
                 tag.content
+            );
+        }
+    }
+
+    /// A wrapped continuation line begins flush at the content column: exactly
+    /// `LABEL_COL` leading spaces, never one more. Regression for the bug where
+    /// the wrap-boundary space was carried onto the next line, stacking on top
+    /// of the indent and drifting every wrapped row one column right of the
+    /// clean left edge (the "extra blank space after the colon on wrap" report).
+    #[test]
+    fn wrapped_continuation_starts_flush_at_the_content_column() {
+        let content = "the quick brown fox jumps over the lazy dog and then keeps \
+                       on running well past the right edge to force several wraps";
+        let spans = vec![Span::raw(label_tag("agent")), Span::raw(content)];
+        let mut out = Vec::new();
+        // Narrow width so the content wraps several times.
+        wrap_one_indent(Line::from(spans), 60, LABEL_COL, &mut out);
+
+        assert!(
+            out.len() > 1,
+            "content must wrap into a continuation row, got {} row(s)",
+            out.len()
+        );
+        for (i, line) in out.iter().enumerate().skip(1) {
+            let text: String = line.spans.iter().flat_map(|s| s.content.chars()).collect();
+            let leading = text.chars().take_while(|c| *c == ' ').count();
+            assert_eq!(
+                leading, LABEL_COL,
+                "continuation row {i} must start exactly at the content column \
+                 (indent {LABEL_COL}, no carried wrap space); got {leading}: {text:?}",
             );
         }
     }


### PR DESCRIPTION
## Problem

In the session TUI transcript, every entry renders as a right-aligned `[label]: ` gutter with content starting at a fixed content column (`LABEL_COL = 22`: colon at col 20, one space at col 21, content at col 22). Wrapped continuation lines are supposed to indent to that same column so the left edge stays clean.

But when a line wrapped, continuations drifted **one column right** — content landed at column 23 instead of 22, reading as an extra blank space after the colon on every wrapped row.

## Root cause

`wrap_one_indent` splits the overflowing line at the last space with `current.split_off(space_idx)`, which **keeps that boundary space at the front of the remainder**. The remainder becomes the next line, so each continuation rendered as `LABEL_COL` spaces of indent **plus** the carried leading space = 23 columns before the first glyph. The wrap space was never consumed ("lines weren't trimmed before the wrap").

## Fix

Drain the leading wrap-boundary whitespace from the remainder before it becomes the next line, so every continuation starts flush at the content column.

## Verification

- New regression test `wrapped_continuation_starts_flush_at_the_content_column` asserts each continuation row has exactly `LABEL_COL` leading spaces.
- Proven before/after: with the fix removed the test fails with `got 23`; with the fix it reports exactly 22.
- Full render module suite: 39/39 pass.
- `cargo clippy -p stella-tui -- -D warnings`: clean (exit 0).


## Summary by Sourcery

Ensure wrapped transcript continuation lines in the TUI stay aligned with the content column instead of drifting one space to the right.

Bug Fixes:
- Fix wrapped transcript continuation lines rendering with an extra leading space, causing content to start one column past the intended indent.

Tests:
- Add regression test verifying wrapped continuation rows start exactly at the defined content column with no extra leading space.
