### PR TITLE
fix(core): parse toolbelt frontmatter written as arrays, quotes, or block sequences

### DIFF
--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -231,19 +231,34 @@ pub fn command_from_file(path: &str, raw: &str) -> Result<CommandDef, ExtensionD
 }
 
 /// Parse a frontmatter `tools:` value into the toolbelt grant. `None` means
-/// "all tools": no key, an empty value, or the explicit wildcard forms
-/// (`*` / `all`). Anything else is the comma-separated grant list.
+/// "all tools": no key, an empty value or list, or the explicit wildcard
+/// forms (`*` / `all` / `all tools`). Anything else is the grant list.
+///
+/// Authors write this field in every shape the ecosystem has taught them:
+/// a bare comma list (`Read, Grep`), a JSON/YAML flow array
+/// (`["Read", "Grep"]`, `[Read, Grep]`), per-item quotes without brackets,
+/// trailing commas, torn brackets, or a block sequence (already flattened
+/// to a comma list by [`parse_frontmatter`]). Brackets and quotes are list
+/// punctuation, never part of a tool's name — every shape normalizes to
+/// the same clean names, and duplicates collapse to the first occurrence.
 pub fn parse_toolbelt(value: Option<&str>) -> Option<Vec<String>> {
-    let value = value?.trim();
-    if value.is_empty() || value == "*" || value.eq_ignore_ascii_case("all") {
+    let value = value?;
+    let mut tools: Vec<String> = Vec::new();
+    for item in value.split(',') {
+        let item =
+            item.trim_matches(|c: char| c.is_whitespace() || matches!(c, '[' | ']' | '"' | '\''));
+        if item.is_empty() || tools.iter().any(|t| t == item) {
+            continue;
+        }
+        tools.push(item.to_string());
+    }
+    let wildcard = tools.iter().any(|t| t == "*")
+        || (tools.len() == 1
+            && (tools[0].eq_ignore_ascii_case("all")
+                || tools[0].eq_ignore_ascii_case("all tools")));
+    if wildcard {
         return None;
     }
-    let tools: Vec<String> = value
-        .split(',')
-        .map(str::trim)
-        .filter(|t| !t.is_empty())
-        .map(str::to_string)
-        .collect();
     (!tools.is_empty()).then_some(tools)
 }
 
@@ -565,6 +580,82 @@ mod tests {
         assert_eq!(
             parse_toolbelt(Some("Read,  Grep , Bash")),
             Some(vec!["Read".into(), "Grep".into(), "Bash".into()])
+        );
+    }
+
+    #[test]
+    fn toolbelt_flow_arrays_normalize_to_clean_names() {
+        // The JSON-style array an author pastes when a comma list would do.
+        assert_eq!(
+            parse_toolbelt(Some(r#"["Read", "Grep", "Glob", "Write"]"#)),
+            Some(vec![
+                "Read".into(),
+                "Grep".into(),
+                "Glob".into(),
+                "Write".into()
+            ])
+        );
+        // Single quotes, unquoted flow items, trailing comma, torn bracket.
+        assert_eq!(
+            parse_toolbelt(Some("['Read', 'Edit']")),
+            Some(vec!["Read".into(), "Edit".into()])
+        );
+        assert_eq!(
+            parse_toolbelt(Some("[Read, Grep,]")),
+            Some(vec!["Read".into(), "Grep".into()])
+        );
+        assert_eq!(
+            parse_toolbelt(Some(r#"["Read", "Grep""#)),
+            Some(vec!["Read".into(), "Grep".into()]),
+            "a torn bracket still yields the names"
+        );
+        // Quoted items without brackets, and MCP-style names untouched.
+        assert_eq!(
+            parse_toolbelt(Some(r#""Read", "mcp__github__get_me""#)),
+            Some(vec!["Read".into(), "mcp__github__get_me".into()])
+        );
+    }
+
+    #[test]
+    fn toolbelt_wildcard_lists_and_duplicates() {
+        assert_eq!(
+            parse_toolbelt(Some("[]")),
+            None,
+            "an empty array restricts nothing"
+        );
+        assert_eq!(parse_toolbelt(Some(r#"["*"]"#)), None);
+        assert_eq!(parse_toolbelt(Some("all tools")), None);
+        assert_eq!(
+            parse_toolbelt(Some("Read, Read, Grep")),
+            Some(vec!["Read".into(), "Grep".into()]),
+            "duplicates collapse to the first occurrence"
+        );
+    }
+
+    #[test]
+    fn agent_flow_array_tools_parse_as_clean_names() {
+        let raw = "---\nname: maker\ndescription: d\ntools: [\"Read\", \"Grep\", \"Glob\", \"Write\"]\n---\nBody.";
+        let agent = agent_from_file("/x/maker.md", raw).unwrap();
+        assert_eq!(
+            agent.tools,
+            Some(vec![
+                "Read".to_string(),
+                "Grep".to_string(),
+                "Glob".to_string(),
+                "Write".to_string()
+            ]),
+            "array brackets are punctuation, not tool names"
+        );
+    }
+
+    #[test]
+    fn agent_block_sequence_tools_parse_as_the_grant_list() {
+        let raw = "---\nname: reviewer\ndescription: d\ntools:\n  - Read\n  - \"Grep\"\n---\nBody.";
+        let agent = agent_from_file("/x/reviewer.md", raw).unwrap();
+        assert_eq!(
+            agent.tools,
+            Some(vec!["Read".to_string(), "Grep".to_string()]),
+            "a YAML block sequence is a restriction, never silently all tools"
         );
     }
 

--- a/stella-core/src/rules.rs
+++ b/stella-core/src/rules.rs
@@ -159,10 +159,25 @@ pub struct Frontmatter {
     pub body: String,
 }
 
+/// Strip one pair of matching surrounding quotes (`"…"` or `'…'`).
+pub(crate) fn strip_matched_quotes(value: &str) -> &str {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
 /// Split `---\n…\n---\nbody` into single-line key/value frontmatter plus
 /// body text. No frontmatter fence ⇒ the whole (trimmed) input is the body
 /// with empty data. Ports `parseFrontmatter` in `markdown-registry.ts`
-/// exactly, including the leading-BOM strip and quote-stripping on values.
+/// (leading-BOM strip, quote-stripping on values), and additionally
+/// flattens a YAML block sequence — a key with an empty scalar followed by
+/// `- item` lines — onto that key as a comma-separated value, so list-typed
+/// fields reach consumers in one shape no matter how the author wrote them.
 pub fn parse_frontmatter(raw: &str) -> Frontmatter {
     let text = raw.strip_prefix('\u{feff}').unwrap_or(raw);
     if !text.starts_with("---") {
@@ -188,24 +203,39 @@ pub fn parse_frontmatter(raw: &str) -> Frontmatter {
         .to_string();
 
     let mut data = HashMap::new();
+    // The key whose scalar value was empty on its own line — the head of a
+    // possible YAML block sequence (`tools:` followed by `- Read` lines).
+    let mut pending_list_key: Option<String> = None;
     for line in header.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // A `- item` line under an empty-valued key is a block-sequence
+        // element: flatten it onto that key. Without a pending key the
+        // line falls through to the scalar path (and is skipped when it
+        // has no colon), exactly as before.
+        if let Some(item) = trimmed.strip_prefix("- ")
+            && let Some(key) = &pending_list_key
+        {
+            let item = strip_matched_quotes(item.trim());
+            if !item.is_empty() {
+                let entry: &mut String = data.entry(key.clone()).or_default();
+                if !entry.is_empty() {
+                    entry.push_str(", ");
+                }
+                entry.push_str(item);
+            }
             continue;
         }
         let Some(colon) = trimmed.find(':') else {
             continue;
         };
         let key = trimmed[..colon].trim();
-        let mut value = trimmed[colon + 1..].trim();
-        let quoted = value.len() >= 2
-            && ((value.starts_with('"') && value.ends_with('"'))
-                || (value.starts_with('\'') && value.ends_with('\'')));
-        if quoted {
-            value = &value[1..value.len() - 1];
-        }
+        let value = strip_matched_quotes(trimmed[colon + 1..].trim());
         if !key.is_empty() {
             data.insert(key.to_string(), value.to_string());
+            pending_list_key = value.is_empty().then(|| key.to_string());
         }
     }
     Frontmatter { data, body }
@@ -817,6 +847,26 @@ mod tests {
     #[test]
     fn ignores_comment_and_blank_frontmatter_lines() {
         let fm = parse_frontmatter("---\n# a comment\n\ndescription: d\n---\nbody");
+        assert_eq!(fm.data.len(), 1);
+        assert_eq!(fm.data.get("description").unwrap(), "d");
+    }
+
+    #[test]
+    fn flattens_block_sequences_onto_their_key() {
+        let fm = parse_frontmatter(
+            "---\ntools:\n  - Read\n  - 'Grep'\n  - \"Web Search\"\ndescription: d\n---\nbody",
+        );
+        assert_eq!(fm.data.get("tools").unwrap(), "Read, Grep, Web Search");
+        assert_eq!(
+            fm.data.get("description").unwrap(),
+            "d",
+            "the key after the sequence parses normally"
+        );
+    }
+
+    #[test]
+    fn dash_lines_without_a_pending_list_key_stay_ignored() {
+        let fm = parse_frontmatter("---\ndescription: d\n- stray item\n---\nbody");
         assert_eq!(fm.data.len(), 1);
         assert_eq!(fm.data.get("description").unwrap(), "d");
     }


### PR DESCRIPTION
## What

The AGENTS tab's **Toolbelt** column rendered raw list punctuation whenever an author wrote the `tools:` frontmatter as a JSON/YAML flow array — rows showed `["Read", "Grep", "Glob", "Write"]` with brackets and quotes intact, next to clean rows from comma-string authors. The same garbage flowed into the agent invocation prompt ("This agent's toolbelt is restricted to: [\"Read\"...]"), so the model read it too.

Worse: the YAML **block-sequence** form (`tools:` followed by `- Read` lines) parsed as an empty value and **silently granted all tools** — a dropped restriction, not just a cosmetic bug.

## How

Both fixes land at the parsing layer so every consumer (TUI table, invocation prompt, future fleet-spawn enforcement) sees one clean shape:

- **`parse_toolbelt`** (stella-core/src/extensions.rs): brackets and quotes are list punctuation, never part of a tool name. Flow arrays (balanced or torn), per-item quotes without brackets, trailing commas, wildcard forms (`*`, `all`, `all tools`, `["*"]`, ``) all normalize; duplicates collapse to the first occurrence. MCP-style names (`mcp__server__tool`) pass through untouched.
- **`parse_frontmatter`** (stella-core/src/rules.rs): a key with an empty scalar followed by `- item` lines is flattened onto that key as a comma-separated value (block sequence → same shape as a comma list). Dash lines with no pending list key stay ignored, exactly as before.

## Verification

- `cargo clippy -p stella-core --lib -- -D warnings` clean
- 72 stella-core `extensions::tests` + `rules::tests` pass (new tests cover every sloppy shape: JSON arrays, single quotes, unquoted flow items, trailing commas, torn brackets, quoted-no-brackets, block sequences, wildcard arrays, duplicates, stray dash lines)
- 15 stella-cli `agents_installed` tests pass (discovery flows through the fixed parser)


## Summary by Sourcery

Normalize and harden parsing of frontmatter toolbelt definitions so all author-written list shapes yield consistent, safe tool grants.

New Features:
- Support parsing toolbelt definitions written as JSON/YAML-style flow arrays, quoted items without brackets, and YAML block sequences.

Bug Fixes:
- Ensure YAML block-sequence tool lists are treated as explicit restrictions instead of silently granting all tools.
- Treat empty or wildcard-style toolbelt lists (e.g., , ["*"], "all tools") as unrestricted tool access rather than malformed grants.
- Strip list punctuation and normalize duplicates so tool names render cleanly in UI and prompts.

Enhancements:
- Centralize quote-stripping logic for frontmatter values and reuse it across scalar and list parsing paths.
- Flatten YAML block sequences into comma-separated scalar values so downstream consumers see a single consistent shape for list-typed fields.

Tests:
- Add unit tests covering diverse toolbelt frontmatter shapes, including arrays, block sequences, wildcards, duplicates, and stray dash lines, and ensure agents parse tool restrictions correctly.
