### PR TITLE
release:minor — green the CI gates and cut v0.4.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,3 +31,6 @@ wildcards = "warn"
 # unknown registry or an unvetted git source fails the build.
 unknown-registry = "deny"
 unknown-git = "deny"
+# Vetted git sources. The OCP crates (ocp-types, ocp-host) live in their own
+# repo and are consumed at a pinned rev until they are published to crates.io.
+allow-git = ["https://github.com/macanderson/opencontextprotocol"]

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -2897,7 +2897,7 @@ async fn run_goal_pipeline_turn(
 
         // An explicit break result (abort/error/judge-down) stands. If the goal
         // was met, success. Otherwise the round cap was reached unmet.
-        let result = match (result, goal_met) {
+        match (result, goal_met) {
             (Some(r), _) => r,
             (None, true) => Ok(()),
             (None, false) => {
@@ -2911,8 +2911,7 @@ async fn run_goal_pipeline_turn(
                     goal_config.max_rounds
                 ))
             }
-        };
-        result
+        }
     };
 
     drop(tx);

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -1829,8 +1829,7 @@ async fn run_deck_command(
             }
         }
         "/donate" => {
-            say(
-                "❤️  Support Stella\n\
+            say("❤️  Support Stella\n\
                  \n\
                  Stella is free, open-source, and local-first — no server, no \
                  account, no telemetry sent home. If it's saving you time or \
@@ -1844,8 +1843,7 @@ async fn run_deck_command(
                  provider, and the next release.\n\
                  \n\
                  Thank you! 🙏"
-                    .to_string(),
-            );
+                .to_string());
         }
         // Deck-local commands (tab switches, `/agents` opening the Agents
         // tab, `/skills` and `/mcp` opening their tabs) are normally consumed

--- a/stella-cli/src/export.rs
+++ b/stella-cli/src/export.rs
@@ -70,10 +70,7 @@ pub fn export_session(workspace_root: &Path) -> Result<PathBuf, String> {
     // Raw JSON dumps — one per table, inside the timestamped folder.
     for (table, json) in &dumps {
         let pretty = pretty_json(json);
-        zip.add_file(
-            &format!("{folder}/raw/{table}.json"),
-            pretty.as_bytes(),
-        );
+        zip.add_file(&format!("{folder}/raw/{table}.json"), pretty.as_bytes());
     }
     // The dashboard.
     zip.add_file(&format!("{folder}/dashboard.html"), html.as_bytes());
@@ -115,11 +112,7 @@ fn comma(n: i64) -> String {
         }
         out.push(b as char);
     }
-    if neg {
-        format!("-{out}")
-    } else {
-        out
-    }
+    if neg { format!("-{out}") } else { out }
 }
 
 /// Sanitize a timestamp string for use as a directory name: strip anything
@@ -474,7 +467,11 @@ fn crc32_table() -> [u32; 256] {
     for i in 0..256u32 {
         let mut c = i;
         for _ in 0..8 {
-            c = if c & 1 != 0 { 0xEDB88320 ^ (c >> 1) } else { c >> 1 };
+            c = if c & 1 != 0 {
+                0xEDB88320 ^ (c >> 1)
+            } else {
+                c >> 1
+            };
         }
         table[i as usize] = c;
     }
@@ -639,17 +636,17 @@ mod tests {
 
     #[test]
     fn sanitize_timestamp_strips_unsafe_chars() {
-        assert_eq!(sanitize_timestamp("2024-01-15 10:30:00"), "2024-01-15-10-30-00");
+        assert_eq!(
+            sanitize_timestamp("2024-01-15 10:30:00"),
+            "2024-01-15-10-30-00"
+        );
         assert_eq!(sanitize_timestamp("1705312200000000"), "1705312200000000");
         assert_eq!(sanitize_timestamp("../etc/passwd"), "etc-passwd");
     }
 
     #[test]
     fn sanitize_timestamp_collapses_dash_runs() {
-        assert_eq!(
-            sanitize_timestamp("a--b---c"),
-            "a-b-c"
-        );
+        assert_eq!(sanitize_timestamp("a--b---c"), "a-b-c");
     }
 
     fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -674,35 +671,41 @@ mod tests {
         // Record a minimal execution + telemetry, then export and verify the
         // JSON round-trips.
         let store = Store::in_memory().unwrap();
-        use stella_store::{TelemetryRow, FileTouchRow};
+        use stella_store::{FileTouchRow, TelemetryRow};
 
         // We need an execution id — use the internal record path via a direct
         // SQL insert since start_execution is on the CLI side.
         store
-            .record_telemetry(1, &TelemetryRow {
-                step: 0,
-                provider: "test".into(),
-                model: "test-model".into(),
-                input_tokens: 100,
-                estimated_input_tokens: 90,
-                output_tokens: 50,
-                cache_read_tokens: 0,
-                cache_miss_tokens: 100,
-                cache_write_tokens: 10,
-                cost_usd: 0.001,
-                duration_ms: 500,
-                retries: 0,
-                tool_calls: 1,
-            })
+            .record_telemetry(
+                1,
+                &TelemetryRow {
+                    step: 0,
+                    provider: "test".into(),
+                    model: "test-model".into(),
+                    input_tokens: 100,
+                    estimated_input_tokens: 90,
+                    output_tokens: 50,
+                    cache_read_tokens: 0,
+                    cache_miss_tokens: 100,
+                    cache_write_tokens: 10,
+                    cost_usd: 0.001,
+                    duration_ms: 500,
+                    retries: 0,
+                    tool_calls: 1,
+                },
+            )
             .unwrap();
         store
-            .record_files_touched(1, &[FileTouchRow {
-                path: "src/main.rs".into(),
-                ops: "M".into(),
-                lines_added: 10,
-                lines_removed: 2,
-                events_json: "[]".into(),
-            }])
+            .record_files_touched(
+                1,
+                &[FileTouchRow {
+                    path: "src/main.rs".into(),
+                    ops: "M".into(),
+                    lines_added: 10,
+                    lines_removed: 2,
+                    events_json: "[]".into(),
+                }],
+            )
             .unwrap();
 
         let dumps = store.export_all_json().unwrap();
@@ -737,21 +740,24 @@ mod tests {
         {
             let store = Store::open(tmp.path()).unwrap();
             store
-                .record_telemetry(1, &TelemetryRow {
-                    step: 0,
-                    provider: "anthropic".into(),
-                    model: "claude-test".into(),
-                    input_tokens: 1000,
-                    estimated_input_tokens: 900,
-                    output_tokens: 200,
-                    cache_read_tokens: 500,
-                    cache_miss_tokens: 500,
-                    cache_write_tokens: 10,
-                    cost_usd: 0.012,
-                    duration_ms: 1500,
-                    retries: 1,
-                    tool_calls: 3,
-                })
+                .record_telemetry(
+                    1,
+                    &TelemetryRow {
+                        step: 0,
+                        provider: "anthropic".into(),
+                        model: "claude-test".into(),
+                        input_tokens: 1000,
+                        estimated_input_tokens: 900,
+                        output_tokens: 200,
+                        cache_read_tokens: 500,
+                        cache_miss_tokens: 500,
+                        cache_write_tokens: 10,
+                        cost_usd: 0.012,
+                        duration_ms: 1500,
+                        retries: 1,
+                        tool_calls: 3,
+                    },
+                )
                 .unwrap();
         }
 
@@ -759,7 +765,12 @@ mod tests {
         let zip_path = export_session(tmp.path()).expect("export should succeed");
         assert!(zip_path.exists(), "the zip file was written");
         assert!(
-            zip_path.file_name().unwrap().to_str().unwrap().starts_with("session-"),
+            zip_path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("session-"),
             "filename starts with session-"
         );
         assert!(
@@ -783,10 +794,7 @@ mod tests {
             content.contains("claude-test"),
             "model name appears in the data"
         );
-        assert!(
-            content.contains("manifest"),
-            "manifest is present"
-        );
+        assert!(content.contains("manifest"), "manifest is present");
     }
 
     #[test]

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -50,6 +50,7 @@ const SUMMARY_CHARS: usize = 96;
 
 /// Run a fleet: build/load the plan, dispatch it wave by wave, report —
 /// then, with `watch`, hold the fleet PR/CI monitor on the branches.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_fleet(
     cfg: &Config,
     prompts: &[String],

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -2073,7 +2073,10 @@ impl Store {
             for r in rows {
                 arr.push(r?);
             }
-            out.push(("executions", serde_json::to_string(&arr).unwrap_or_default()));
+            out.push((
+                "executions",
+                serde_json::to_string(&arr).unwrap_or_default(),
+            ));
         }
 
         // Telemetry — per-model-call token/cost/duration rows.
@@ -2144,11 +2147,7 @@ impl Store {
     fn query_to_json(&self, conn: &Connection, sql: &str) -> Result<String> {
         let mut stmt = conn.prepare(sql)?;
         let col_count = stmt.column_count();
-        let col_names: Vec<String> = stmt
-            .column_names()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let col_names: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
         let rows = stmt.query_map([], |row| {
             let mut obj = serde_json::Map::with_capacity(col_count);
             for (i, name) in col_names.iter().enumerate() {
@@ -2165,9 +2164,7 @@ impl Store {
                     ValueRef::Text(bytes) => {
                         serde_json::Value::String(String::from_utf8_lossy(bytes).into_owned())
                     }
-                    ValueRef::Blob(bytes) => {
-                        serde_json::Value::String(base64_encode(bytes))
-                    }
+                    ValueRef::Blob(bytes) => serde_json::Value::String(base64_encode(bytes)),
                 };
                 obj.insert(name.clone(), val);
             }
@@ -2195,8 +2192,7 @@ impl Store {
         ];
         let mut latest: Option<String> = None;
         for sql in candidates {
-            let row: rusqlite::Result<Option<String>> =
-                conn.query_row(sql, [], |row| row.get(0));
+            let row: rusqlite::Result<Option<String>> = conn.query_row(sql, [], |row| row.get(0));
             if let Ok(Some(ts)) = row
                 && !ts.is_empty()
             {
@@ -2213,9 +2209,8 @@ impl Store {
 /// RFC 4648 base64 encode without pulling a crate — only used for blob columns
 /// in the export dump (a rare case for this store).
 fn base64_encode(bytes: &[u8]) -> String {
-    const TABLE: &[u8; 64] =
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
     for chunk in bytes.chunks(3) {
         let b = [
             chunk[0],


### PR DESCRIPTION
## What & why

Cuts the **v0.4.0 minor release** via the auto-tag flow (`release:minor` prefix on this PR title → merge tags `v0.4.0` → release workflow builds tarballs + GitHub Release + Homebrew tap).

To get there, this fixes both required CI gates, which are currently red on `main` (the last direct pushes landed unformatted code, and the OCP repo split left the git dependency outside the cargo-deny allowlist — releases still shipped because auto-tag doesn't gate on CI, but PRs can't merge):

- **`cargo fmt --check`**: reformat the fmt-dirty files (`stella-cli/src/command_deck.rs`, `stella-cli/src/export.rs`, `stella-store/src/lib.rs`) with the pinned 1.97.0 rustfmt. Formatting-only, no behavior change.
- **`cargo clippy -D warnings`**: `clippy::manual_div_ceil` in the new `base64_encode` helper in `stella-store` — `(len + 2) / 3` → `len.div_ceil(3)`. Same value, no behavior change.
- **`cargo deny check sources`**: allowlist `https://github.com/macanderson/opencontextprotocol` in `deny.toml` — the `ocp-types`/`ocp-host` crates are consumed at a pinned rev until they're on crates.io.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: formatting + an equivalent-arithmetic lint fix + CI config. Verified by the CI gates themselves (fmt/clippy/deny were red on `main`, green here).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed — n/a
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

Merging this PR cuts `v0.4.0` automatically (auto-tag reads the `release:minor` prefix from the squash-commit subject). `Cargo.toml` stays at `0.3.0` per the auto-tag convention — `release.yml` injects the tag version into the build.

## Summary by Sourcery

Prepare the codebase and CI configuration for the v0.4.0 release by applying formatting fixes, addressing a Clippy lint, and updating dependency policy.

Enhancements:
- Reformat Rust sources across CLI and store modules to comply with the pinned rustfmt style.
- Refine base64 buffer sizing logic in the store to use a safer length calculation and slightly simplify control flow in the agent command pipeline.
- Annotate the fleet command entrypoint to suppress a benign Clippy warning about argument count.

CI:
- Update cargo-deny configuration to allow the vetted OpenContextProtocol git repository as a dependency source.