### PR TITLE
fix(telemetry): read_file touches now reach the Files tab, with per-file read counts

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -2260,11 +2260,13 @@ impl AskUserIo for DeckAskUserIo {
 // ── FileChange synthesis ────────────────────────────────────────────────────
 
 /// A [`ToolExecutor`] wrapper that emits `AgentEvent::FileChange` when a
-/// file-mutating built-in succeeds, so the deck's Files tab / diff panel and
+/// file-touching built-in succeeds, so the deck's Files tab / diff panel and
 /// ledger are live during the turn. The diff is synthesized from the tool's
 /// own input (`edit_file` carries old/new verbatim; `write_file` the full
 /// content; `delete_file` reads the file before executing) — an honest
 /// approximation until the tool layer emits real diffs on the event path.
+/// Successful `read_file` calls emit too (kind `Read`, no diff) — the Files
+/// tab counts reads per file, matching the registry ledger's `R` events.
 struct FileChangeTap<'a> {
     inner: &'a dyn ToolExecutor,
     events: UnboundedSender<AgentEvent>,
@@ -2308,9 +2310,9 @@ impl ToolExecutor for FileChangeTap<'_> {
     }
 }
 
-/// The `(kind, pseudo-diff)` for one successful mutating tool call, or `None`
-/// for tools that don't change files. `pre` is `(existed_before, old_content)`
-/// as captured by the tap.
+/// The `(kind, pseudo-diff)` for one successful file-touching tool call, or
+/// `None` for tools that don't touch files. `pre` is
+/// `(existed_before, old_content)` as captured by the tap.
 fn file_change_of(
     name: &str,
     input: &Value,
@@ -2318,6 +2320,7 @@ fn file_change_of(
 ) -> Option<(FileChangeKind, Option<String>)> {
     let text = |key: &str| input.get(key).and_then(Value::as_str);
     match name {
+        "read_file" => Some((FileChangeKind::Read, None)),
         "write_file" => {
             let existed = pre.map(|(existed, _)| existed).unwrap_or(false);
             let kind = if existed {
@@ -2635,12 +2638,49 @@ mod tests {
             events: tx,
             root: dir.path().to_path_buf(),
         };
-        tap.execute("read_file", &serde_json::json!({ "path": "x" }))
+        tap.execute("grep", &serde_json::json!({ "pattern": "x" }))
             .await;
         assert!(
             recv_file_change(&mut rx).is_none(),
-            "read-only tools emit nothing"
+            "non-file read-only tools emit nothing"
         );
+    }
+
+    #[tokio::test]
+    async fn tap_emits_a_diffless_read_event_for_successful_reads_only() {
+        // A successful read rides the FileChange path (kind Read, no diff) so
+        // the Files tab counts reads; a failed read stays silent.
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let inner = FakeInner { error: false };
+        let tap = FileChangeTap {
+            inner: &inner,
+            events: tx,
+            root: dir.path().to_path_buf(),
+        };
+        tap.execute("read_file", &serde_json::json!({ "path": "src/lib.rs" }))
+            .await;
+        match recv_file_change(&mut rx) {
+            Some(AgentEvent::FileChange { path, kind, diff }) => {
+                assert_eq!(path, "src/lib.rs");
+                assert_eq!(kind, FileChangeKind::Read);
+                assert_eq!(diff, None, "reads never carry a diff");
+            }
+            other => panic!("expected FileChange, got {other:?}"),
+        }
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let failing = FakeInner { error: true };
+        let tap = FileChangeTap {
+            inner: &failing,
+            events: tx,
+            root: dir.path().to_path_buf(),
+        };
+        let out = tap
+            .execute("read_file", &serde_json::json!({ "path": "ghost.rs" }))
+            .await;
+        assert!(out.is_error());
+        assert!(recv_file_change(&mut rx).is_none(), "no event on error");
     }
 
     #[test]

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -1373,8 +1373,13 @@ impl<'a> Pipeline<'a> {
                     // and the terminal Complete — drop the engine's per-turn
                     // copies.
                     AgentEvent::Stage { .. } | AgentEvent::Complete { .. } => false,
-                    AgentEvent::FileChange { .. } => {
-                        seen_file_changes += 1;
+                    AgentEvent::FileChange { kind, .. } => {
+                        // Reads ride the same event for the files panel but
+                        // are not changes — counting them would defeat the
+                        // zero-diff guard on read-only turns.
+                        if kind.is_mutation() {
+                            seen_file_changes += 1;
+                        }
                         true
                     }
                     _ => true,

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -152,11 +152,13 @@ pub enum AgentEvent {
         to: String,
         reason: String,
     },
-    /// A file was created/modified/deleted by the agent, carrying the diff
-    /// so the TUI's files-touched panel renders per-edit diffs without a
+    /// A file was read/created/modified/deleted by the agent, carrying the
+    /// diff so the TUI's files-touched panel renders per-edit diffs without a
     /// second data path (L-T5: in TS, the `onFileEdit` callback had to be
     /// patched into two pipeline switches — here there is one emission
-    /// point by construction).
+    /// point by construction). Reads carry no diff; consumers that only care
+    /// about mutations (the pipeline's zero-diff guard, inline transcript
+    /// diffs) filter on the kind.
     FileChange {
         path: String,
         kind: FileChangeKind,
@@ -243,9 +245,22 @@ pub enum AgentEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FileChangeKind {
+    /// Content was successfully read — no mutation, never a diff. Rides the
+    /// same event so the files-touched panel sees reads without a second
+    /// data path.
+    Read,
     Created,
     Modified,
     Deleted,
+}
+
+impl FileChangeKind {
+    /// Whether this kind mutated the file — what the pipeline's zero-diff
+    /// guard and inline transcript diffs key on. Reads are observability,
+    /// not change.
+    pub fn is_mutation(self) -> bool {
+        !matches!(self, FileChangeKind::Read)
+    }
 }
 
 /// A context frame as cited in a `ContextRecall` event. `citation_label`
@@ -436,6 +451,24 @@ mod tests {
                 assert!(diff.is_some());
             }
             other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_kind_serializes_and_is_the_only_non_mutation() {
+        assert_eq!(
+            serde_json::to_string(&FileChangeKind::Read).unwrap(),
+            "\"read\""
+        );
+        let back: FileChangeKind = serde_json::from_str("\"read\"").unwrap();
+        assert_eq!(back, FileChangeKind::Read);
+        assert!(!FileChangeKind::Read.is_mutation());
+        for kind in [
+            FileChangeKind::Created,
+            FileChangeKind::Modified,
+            FileChangeKind::Deleted,
+        ] {
+            assert!(kind.is_mutation(), "{kind:?} is a mutation");
         }
     }
 

--- a/stella-tools/src/read.rs
+++ b/stella-tools/src/read.rs
@@ -4,6 +4,17 @@
 //! file can't flood the context. Note this bounds displayed lines, not bytes:
 //! the file is read into memory first, so a single pathologically long line is
 //! still read in full.
+//!
+//! The tool also keeps the session's per-file read tally: every successful
+//! read increments a counter keyed by the file's normalized
+//! workspace-relative path (so `src/./a.rs` and `src/a.rs` count as one
+//! file), and the running count is reported in the tool output. One
+//! [`ReadFile`] instance lives per registry, so the tally is per session by
+//! construction; the audit-grade equivalent (one `R` event per read) lands in
+//! the registry's file-touch ledger.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -13,7 +24,39 @@ use crate::registry::Tool;
 
 const MAX_LINES: usize = 2000;
 
-pub struct ReadFile;
+#[derive(Default)]
+pub struct ReadFile {
+    /// Per-session read counts by normalized workspace-relative path.
+    counts: Mutex<HashMap<String, u64>>,
+}
+
+impl ReadFile {
+    /// How many times `path` (under any workspace-relative spelling) has been
+    /// successfully read this session.
+    pub fn read_count(&self, root: &std::path::Path, path: &str) -> u64 {
+        self.counts
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(&normalized_key(root, path))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Record one successful read of `path`, returning the new total.
+    fn tally(&self, root: &std::path::Path, path: &str) -> u64 {
+        let mut counts = self.counts.lock().unwrap_or_else(|p| p.into_inner());
+        let count = counts.entry(normalized_key(root, path)).or_insert(0);
+        *count += 1;
+        *count
+    }
+}
+
+/// The aggregation key for a read: the same normalized workspace-relative
+/// path the file-touch ledger uses, falling back to the raw spelling when
+/// normalization fails (it can't for a path that resolved and read OK).
+fn normalized_key(root: &std::path::Path, path: &str) -> String {
+    crate::file_touch::normalize_workspace_path(root, path).unwrap_or_else(|| path.to_string())
+}
 
 #[async_trait]
 impl Tool for ReadFile {
@@ -66,6 +109,10 @@ impl Tool for ReadFile {
 
         match tokio::fs::read_to_string(&full_path).await {
             Ok(content) => {
+                // Count every successful read — including a past-end offset,
+                // which still read the file — so the tally matches the
+                // ledger's one-R-event-per-successful-read rule.
+                let reads = self.tally(root, path);
                 let lines: Vec<&str> = content.lines().collect();
                 let start = offset.unwrap_or(1).saturating_sub(1);
                 let end = (start + limit).min(lines.len());
@@ -86,7 +133,9 @@ impl Tool for ReadFile {
                 }
                 let total = lines.len();
                 let shown = end - start;
-                numbered.push_str(&format!("\n({shown}/{total} lines shown)"));
+                numbered.push_str(&format!(
+                    "\n({shown}/{total} lines shown · read {reads}× this session)"
+                ));
                 ToolOutput::Ok { content: numbered }
             }
             Err(e) => ToolOutput::Error {
@@ -109,7 +158,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = ReadFile
+        let result = ReadFile::default()
             .execute(&serde_json::json!({"path": path}), &dir)
             .await;
         match result {
@@ -130,7 +179,7 @@ mod tests {
         let full = dir.join(&path);
         tokio::fs::write(&full, "a\nb\nc\nd\ne\n").await.unwrap();
 
-        let result = ReadFile
+        let result = ReadFile::default()
             .execute(
                 &serde_json::json!({"path": path, "offset": 2, "limit": 2}),
                 &dir,
@@ -149,9 +198,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn counts_reads_per_file_and_reports_them() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/a.rs"), "one\ntwo\n").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "one\n").unwrap();
+        let tool = ReadFile::default();
+
+        // Two reads of the same file under different spellings aggregate.
+        for spelling in ["src/a.rs", "src/./a.rs"] {
+            let out = tool
+                .execute(&serde_json::json!({"path": spelling}), dir.path())
+                .await;
+            assert!(!out.is_error(), "{out:?}");
+        }
+        let third = tool
+            .execute(&serde_json::json!({"path": "src/a.rs"}), dir.path())
+            .await;
+        match third {
+            ToolOutput::Ok { content } => {
+                assert!(
+                    content.contains("read 3× this session"),
+                    "third read reports its count: {content}"
+                );
+            }
+            ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
+        }
+        assert_eq!(tool.read_count(dir.path(), "src/a.rs"), 3);
+        assert_eq!(tool.read_count(dir.path(), "src/./a.rs"), 3);
+
+        // Other files and failed reads don't inflate the tally.
+        let other = tool
+            .execute(&serde_json::json!({"path": "b.rs"}), dir.path())
+            .await;
+        assert!(!other.is_error());
+        assert_eq!(tool.read_count(dir.path(), "b.rs"), 1);
+        let missing = tool
+            .execute(&serde_json::json!({"path": "ghost.rs"}), dir.path())
+            .await;
+        assert!(missing.is_error());
+        assert_eq!(tool.read_count(dir.path(), "ghost.rs"), 0);
+    }
+
+    #[tokio::test]
     async fn missing_file_returns_error() {
         let dir = std::env::temp_dir();
-        let result = ReadFile
+        let result = ReadFile::default()
             .execute(
                 &serde_json::json!({"path": "nonexistent_xyz_123.txt"}),
                 &dir,
@@ -163,7 +255,7 @@ mod tests {
     #[tokio::test]
     async fn path_escape_returns_error() {
         let dir = std::env::temp_dir();
-        let result = ReadFile
+        let result = ReadFile::default()
             .execute(&serde_json::json!({"path": "../../etc/passwd"}), &dir)
             .await;
         assert!(result.is_error());
@@ -172,7 +264,9 @@ mod tests {
     #[tokio::test]
     async fn missing_path_field_returns_error() {
         let dir = std::env::temp_dir();
-        let result = ReadFile.execute(&serde_json::json!({}), &dir).await;
+        let result = ReadFile::default()
+            .execute(&serde_json::json!({}), &dir)
+            .await;
         assert!(result.is_error());
     }
 }

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -129,7 +129,7 @@ impl ToolRegistry {
         let mcp_usage: stella_core::mcp_usage::McpUsageLedger = Arc::default();
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
         let mut entries: Vec<Arc<dyn Tool>> = vec![
-            Arc::new(crate::read::ReadFile),
+            Arc::new(crate::read::ReadFile::default()),
             Arc::new(crate::write::WriteFile),
             Arc::new(crate::edit::EditFile),
             Arc::new(crate::delete::DeleteFile),

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -492,11 +492,17 @@ impl WorkspaceModel {
 pub struct FileRecord {
     pub agent: AgentId,
     pub path: String,
+    /// The latest *mutation* kind — a read only sets this on a file that has
+    /// never been mutated, so an edited file's badge never regresses to `R`
+    /// when the agent re-reads it.
     pub kind: FileChangeKind,
     pub added: u32,
     pub removed: u32,
-    /// How many `FileChange` events have touched this (agent, path).
+    /// How many *mutating* `FileChange` events have touched this
+    /// (agent, path).
     pub changes: u32,
+    /// How many times this (agent, path) has been read.
+    pub reads: u32,
 }
 
 /// Every file touched this session, with CRUD op and line +/- parsed from the
@@ -515,18 +521,24 @@ impl FileLedger {
             .iter_mut()
             .find(|r| r.agent == agent && r.path == path)
         {
-            rec.kind = kind;
-            rec.added += added;
-            rec.removed += removed;
-            rec.changes += 1;
+            if kind.is_mutation() {
+                rec.kind = kind;
+                rec.added += added;
+                rec.removed += removed;
+                rec.changes += 1;
+            } else {
+                rec.reads += 1;
+            }
         } else {
+            let mutation = kind.is_mutation();
             self.records.push(FileRecord {
                 agent: agent.to_string(),
                 path: path.to_string(),
                 kind,
                 added,
                 removed,
-                changes: 1,
+                changes: mutation as u32,
+                reads: !mutation as u32,
             });
         }
     }
@@ -539,6 +551,9 @@ impl FileLedger {
     }
     pub fn file_count(&self) -> usize {
         self.records.len()
+    }
+    pub fn total_reads(&self) -> u32 {
+        self.records.iter().map(|r| r.reads).sum()
     }
 }
 
@@ -1148,6 +1163,46 @@ mod tests {
         assert_eq!(w.ledger.total_removed(), 1);
         assert_eq!(w.ledger.file_count(), 1);
         assert_eq!(w.latest_model(), Some("glm-5.2"));
+    }
+
+    #[test]
+    fn ledger_counts_reads_without_regressing_the_mutation_badge() {
+        let mut w = WorkspaceModel::new();
+        w.apply_inbound(&reg("lead"));
+        let read = |path: &str| {
+            ev(
+                "lead",
+                AgentEvent::FileChange {
+                    path: path.into(),
+                    kind: FileChangeKind::Read,
+                    diff: None,
+                },
+            )
+        };
+        // A read-only file shows up with an R badge and a read count.
+        w.apply_inbound(&read("src/a.rs"));
+        w.apply_inbound(&read("src/a.rs"));
+        let rec = &w.ledger.records[0];
+        assert_eq!(rec.kind, FileChangeKind::Read);
+        assert_eq!((rec.changes, rec.reads), (0, 2));
+
+        // A mutation owns the badge and ± totals; a later re-read only
+        // counts.
+        w.apply_inbound(&ev(
+            "lead",
+            AgentEvent::FileChange {
+                path: "src/a.rs".into(),
+                kind: FileChangeKind::Modified,
+                diff: Some("+one\n".into()),
+            },
+        ));
+        w.apply_inbound(&read("src/a.rs"));
+        let rec = &w.ledger.records[0];
+        assert_eq!(rec.kind, FileChangeKind::Modified);
+        assert_eq!((rec.changes, rec.reads), (1, 3));
+        assert_eq!(w.ledger.total_reads(), 3);
+        assert_eq!(w.ledger.total_added(), 1);
+        assert_eq!(w.ledger.file_count(), 1);
     }
 
     #[test]

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -239,15 +239,20 @@ pub struct InlineDiffRef {
 }
 
 /// The state of one file in the files-touched panel. `latest_diff` is
-/// literally the diff carried by the most recent `FileChange` for this path
-/// — the single event-borne data path (L-T5).
+/// literally the diff carried by the most recent *mutating* `FileChange` for
+/// this path — the single event-borne data path (L-T5). Reads never touch
+/// `kind`/`latest_diff`/`changes` (the latter doubles as the inline-diff
+/// freshness tag, so a read bumping it would hide a still-current diff);
+/// they only grow `reads`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FileState {
     pub path: String,
     pub kind: FileChangeKind,
     pub latest_diff: Option<String>,
-    /// How many `FileChange` events have touched this path.
+    /// How many mutating `FileChange` events have touched this path.
     pub changes: u32,
+    /// How many times this path has been read.
+    pub reads: u32,
 }
 
 /// Live HUD numbers, all folded from the event stream.
@@ -632,17 +637,26 @@ impl SessionModel {
     }
 
     /// Record a file touch, retaining the latest diff for the path (L-T5).
+    /// A read on an already-tracked path only grows its read count — the
+    /// mutation kind, diff, and `changes` (the inline-diff freshness tag)
+    /// stay exactly as the last mutation left them.
     fn touch_file(&mut self, path: &str, kind: FileChangeKind, diff: &Option<String>) {
         if let Some(existing) = self.files.iter_mut().find(|f| f.path == path) {
-            existing.kind = kind;
-            existing.latest_diff = diff.clone();
-            existing.changes += 1;
+            if kind.is_mutation() {
+                existing.kind = kind;
+                existing.latest_diff = diff.clone();
+                existing.changes += 1;
+            } else {
+                existing.reads += 1;
+            }
         } else {
+            let mutation = kind.is_mutation();
             self.files.push(FileState {
                 path: path.to_string(),
                 kind,
                 latest_diff: diff.clone(),
-                changes: 1,
+                changes: mutation as u32,
+                reads: !mutation as u32,
             });
         }
     }
@@ -911,6 +925,43 @@ mod tests {
         assert_eq!(f.changes, 2);
         assert_eq!(f.kind, FileChangeKind::Modified);
         assert_eq!(f.latest_diff.as_deref(), Some("+second"));
+    }
+
+    #[test]
+    fn reads_count_without_clobbering_mutation_state() {
+        let mut model = SessionModel::new();
+        // First touch is a read: the file appears in the panel as read-only.
+        model.apply(&AgentEvent::FileChange {
+            path: "src/a.rs".into(),
+            kind: FileChangeKind::Read,
+            diff: None,
+        });
+        assert_eq!(model.files.len(), 1, "reads appear in the files panel");
+        let f = &model.files[0];
+        assert_eq!(f.kind, FileChangeKind::Read);
+        assert_eq!((f.changes, f.reads), (0, 1));
+
+        // A mutation takes over kind/diff; a later re-read only grows the
+        // read count — `changes` is the inline-diff freshness tag and must
+        // not move on reads.
+        model.apply(&AgentEvent::FileChange {
+            path: "src/a.rs".into(),
+            kind: FileChangeKind::Modified,
+            diff: Some("+x".into()),
+        });
+        model.apply(&AgentEvent::FileChange {
+            path: "src/a.rs".into(),
+            kind: FileChangeKind::Read,
+            diff: None,
+        });
+        let f = &model.files[0];
+        assert_eq!(
+            f.kind,
+            FileChangeKind::Modified,
+            "a re-read never regresses the badge"
+        );
+        assert_eq!(f.latest_diff.as_deref(), Some("+x"));
+        assert_eq!((f.changes, f.reads), (1, 2));
     }
 
     #[test]

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -1304,15 +1304,19 @@ fn pr_status_color(status: PrStatus) -> Color {
 
 fn file_line(file: &FileState, selected: bool) -> Line<'static> {
     let (marker, color) = match file.kind {
+        FileChangeKind::Read => ("[r]", Color::DarkGray),
         FileChangeKind::Created => ("[+]", Color::Green),
         FileChangeKind::Modified => ("[~]", Color::Yellow),
         FileChangeKind::Deleted => ("[-]", Color::Red),
     };
-    let count = if file.changes > 1 {
+    let mut count = if file.changes > 1 {
         format!(" ({})", file.changes)
     } else {
         String::new()
     };
+    if file.reads > 0 {
+        count.push_str(&format!(" ·r{}", file.reads));
+    }
     let mut style = Style::new().fg(color);
     if selected {
         style = style.add_modifier(Modifier::REVERSED);

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -502,6 +502,7 @@ pub fn media_state_label(state: &MediaJobState) -> String {
 /// Past-tense verb for a `FileChange` transcript line.
 pub fn file_change_verb(kind: FileChangeKind) -> &'static str {
     match kind {
+        FileChangeKind::Read => "read",
         FileChangeKind::Created => "created",
         FileChangeKind::Modified => "modified",
         FileChangeKind::Deleted => "deleted",
@@ -509,10 +510,10 @@ pub fn file_change_verb(kind: FileChangeKind) -> &'static str {
 }
 
 /// The CRUD badge letter for a file-change kind — the vocabulary the
-/// files-touched panels share (the plain CLI's registry ledger additionally
-/// mints `R` for reads, which never rides a `FileChange` event).
+/// files-touched panels share with the plain CLI's registry ledger.
 pub fn crud_letter(kind: FileChangeKind) -> &'static str {
     match kind {
+        FileChangeKind::Read => "R",
         FileChangeKind::Created => "C",
         FileChangeKind::Modified => "U",
         FileChangeKind::Deleted => "D",

--- a/stella-tui/src/views/files.rs
+++ b/stella-tui/src/views/files.rs
@@ -26,6 +26,7 @@ const AGENT_W: usize = 13;
 const OP_W: usize = 4;
 const ADD_W: usize = 8;
 const REM_W: usize = 8;
+const READS_W: usize = 7;
 const CHANGES_W: usize = 5;
 /// Floor on the path column so a narrow terminal still shows *something*
 /// legible rather than collapsing to zero.
@@ -150,6 +151,8 @@ fn render_footer(ledger: &FileLedger, area: Rect, buf: &mut Buffer) {
             format!("-{}", ledger.total_removed()),
             Style::default().fg(theme::BAD).add_modifier(Modifier::BOLD),
         ),
+        Span::raw("  "),
+        Span::styled(format!("{} reads", ledger.total_reads()), theme::muted()),
     ]);
     Paragraph::new(line).render(area, buf);
 }
@@ -160,7 +163,7 @@ fn render_footer(ledger: &FileLedger, area: Rect, buf: &mut Buffer) {
 /// columns the path (the row's most meaningful cell) still fits and only the
 /// tail columns clip, instead of the path column alone overflowing the pane.
 fn path_width(total_width: usize) -> usize {
-    let fixed = AGENT_W + OP_W + ADD_W + REM_W + CHANGES_W;
+    let fixed = AGENT_W + OP_W + ADD_W + REM_W + READS_W + CHANGES_W;
     total_width
         .saturating_sub(fixed)
         .max(MIN_PATH_W)
@@ -170,18 +173,20 @@ fn path_width(total_width: usize) -> usize {
 fn header_line(width: usize) -> Line<'static> {
     let pw = path_width(width);
     let text = format!(
-        "{:<pw$}{:<aw$}{:^ow$}{:>dw$}{:>rw$}{:>cw$}",
+        "{:<pw$}{:<aw$}{:^ow$}{:>dw$}{:>rw$}{:>sw$}{:>cw$}",
         "File",
         "Agent",
         "Op",
         "+",
         "-",
+        "reads",
         "×",
         pw = pw,
         aw = AGENT_W,
         ow = OP_W,
         dw = ADD_W,
         rw = REM_W,
+        sw = READS_W,
         cw = CHANGES_W,
     );
     Line::from(Span::styled(text, theme::muted()))
@@ -211,7 +216,11 @@ fn record_line(rec: &FileRecord, width: usize, selected: bool) -> Line<'static> 
             format!("-{:<w$}", rec.removed, w = REM_W.saturating_sub(1)),
             Style::default().fg(theme::BAD),
         ),
-        Span::styled(format!("×{}", rec.changes), theme::muted()),
+        Span::styled(format!("{:>w$}", rec.reads, w = READS_W), theme::muted()),
+        Span::styled(
+            format!("{:>w$}", format!("×{}", rec.changes), w = CHANGES_W),
+            theme::muted(),
+        ),
     ];
 
     if selected {
@@ -228,6 +237,7 @@ fn record_line(rec: &FileRecord, width: usize, selected: bool) -> Line<'static> 
 /// rendering surfaces — issue #66); only the palette is this view's.
 fn op_style(kind: FileChangeKind) -> (&'static str, ratatui::style::Color) {
     let color = match kind {
+        FileChangeKind::Read => theme::MUTED,
         FileChangeKind::Created => theme::OK,
         FileChangeKind::Modified => theme::WARN,
         FileChangeKind::Deleted => theme::BAD,
@@ -439,6 +449,32 @@ mod tests {
     }
 
     #[test]
+    fn read_only_files_render_with_a_read_count() {
+        let mut m = WorkspaceModel::new();
+        m.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        for _ in 0..2 {
+            m.apply_inbound(&Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::FileChange {
+                    path: "src/read_me.rs".into(),
+                    kind: FileChangeKind::Read,
+                    diff: None,
+                },
+            });
+        }
+        let mut ui = DeckUi::default();
+        let area = Rect::new(0, 0, 80, 20);
+        let mut buf = Buffer::empty(area);
+        render(&m, &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("read_me.rs"),
+            "read files appear in the tab:\n{text}"
+        );
+        assert!(text.contains("2 reads"), "footer totals the reads:\n{text}");
+    }
+
+    #[test]
     fn empty_ledger_shows_hint_without_panicking() {
         let model = WorkspaceModel::new();
         let mut ui = DeckUi::default();
@@ -451,7 +487,7 @@ mod tests {
 
     #[test]
     fn path_width_never_exceeds_the_available_row_width() {
-        let fixed = AGENT_W + OP_W + ADD_W + REM_W + CHANGES_W;
+        let fixed = AGENT_W + OP_W + ADD_W + REM_W + READS_W + CHANGES_W;
         assert_eq!(
             path_width(120),
             120 - fixed,


### PR DESCRIPTION
## Problem

Files the agent **read** never appeared in the deck's Files (files-touched) tab, even though the registry's file-touch ledger records an `R` event per successful read. The tab is fed by `AgentEvent::FileChange`, and the `FileChangeTap` only synthesized events for `write_file`/`edit_file`/`delete_file` — `FileChangeKind` had no Read variant at all (the `crud_letter` doc explicitly noted reads "never ride a `FileChange` event").

## Fix

- **stella-protocol** — `FileChangeKind::Read` + `is_mutation`; reads ride the existing single event-borne data path (L-T5), always diffless.
- **stella-cli** — `FileChangeTap` emits a `Read` `FileChange` for every *successful* `read_file` call (errors stay silent, other read-only tools unchanged).
- **stella-pipeline** — the zero-diff guard's `file_changes` tally now counts only mutating kinds, so read-only turns still register zero changes.
- **stella-tui** — deck `FileLedger`/`FileRecord` and `SessionModel`/`FileState` gain a per-file `reads` counter. Reads never clobber the mutation badge, ± totals, latest diff, or `changes` (which doubles as the inline-diff freshness tag). The Files tab gets a `reads` column, an `R` badge for read-only files, and a footer reads total.
- **stella-tools** — the read counter is baked into `read_file` itself: a per-session tally keyed by normalized workspace-relative path (so `src/./a.rs` and `src/a.rs` aggregate), reported in the tool output as `read N× this session` and exposed via `ReadFile::read_count`.

## Testing

- `cargo test --workspace` green; `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean on touched crates.
- New tests: tap emits diffless Read events for successful reads only; ledger/model reads count without regressing mutation state; Files tab renders read-only files + footer total; `read_file` per-path tally (incl. spelling aggregation and no count on failed reads); `FileChangeKind::Read` serde + mutation partition.
- Updated the test that pinned the old behavior (`tap_stays_silent_for_errors_and_non_file_tools`) to use a non-file tool.


## Summary by Sourcery

Track and surface file read operations across the stack so read_file touches appear in telemetry and the Files UI without affecting mutation-based logic.

New Features:
- Add per-session, per-file read counters to the read_file tool and expose counts in tool output and via an API.
- Include file read operations as FileChange events with a new Read kind so the Files tab and other consumers can see read-only touches.
- Display read counts, read badges, and a total reads footer in the TUI Files view and file lists.

Enhancements:
- Extend FileChangeKind with a Read variant and an is_mutation helper to distinguish reads from mutating operations.
- Ensure session models and file ledgers track read counts separately from mutation counts so badges, diffs, and zero-diff guards remain mutation-based.

Tests:
- Add tests covering read counting and reporting in read_file, including path normalization and error cases.
- Add tests verifying diffless Read events from the FileChange tap and that failed reads do not emit events.
- Add tests ensuring ledgers, session models, and TUI views correctly render and aggregate read-only file activity without regressing mutation state.
