### PR TITLE
feat(tui): Space Invaders launch cinematic for the deck splash

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -72,7 +72,7 @@ use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
     AgentMeta, AgentScope, AgentStatus, DeckOptions, Inbound, SkillOp, SkillScope, SkillSearchHit,
-    SkillsView, SlashCommand, UserInput, WorkspaceInput, run_deck,
+    SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -309,6 +309,24 @@ pub async fn run_deck_session(
     // never waits on the driver (and vice versa).
     let deck = tokio::spawn(run_deck(opts, in_rx, sub_tx));
 
+    // The launch cinematic: hold the splash's battle loop open over session
+    // init and release it once BOTH async legs — the background code-graph
+    // build below and the MCP connect after it — have finished, so the movie
+    // covers however long a first launch's indexing takes instead of handing
+    // off to a deck that is still visibly assembling itself. Any key still
+    // skips; `--no-anim` sessions ignore the cue entirely.
+    let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
+    let init_pending = Arc::new(std::sync::atomic::AtomicUsize::new(2));
+    let release_splash = {
+        let tx = in_tx.clone();
+        move || {
+            if init_pending.fetch_sub(1, Ordering::SeqCst) == 1 {
+                let _ = tx.send(Inbound::Splash(SplashCue::Release));
+            }
+        }
+    };
+    let release_on_graph_ready = release_splash.clone();
+
     // Auto-build the code-graph index in the background (a cheap incremental
     // refresh if it already exists) and keep it fresh via the live watcher, so
     // `graph_query` is available this session — and the Graph tab populates —
@@ -339,6 +357,8 @@ pub async fn run_deck_session(
                 agent: LEAD.to_string(),
                 status: AgentStatus::WaitingInput,
             });
+            // One of the two init legs the launch splash waits on.
+            release_on_graph_ready();
         }),
     );
 
@@ -408,6 +428,9 @@ pub async fn run_deck_session(
     };
     // Seed the MCP tab with the configured servers and their live state.
     send_mcp_snapshot(cfg, &mcp, &mcp_disabled, &in_tx).await;
+    // MCP connect settled (or there was nothing to connect) — the other init
+    // leg the launch splash waits on.
+    release_splash();
 
     // ── The driver loop ─────────────────────────────────────────────────────
     let mut queue: VecDeque<String> = VecDeque::new();
@@ -1797,8 +1820,18 @@ async fn run_deck_command(
             });
         }
         "/init" => {
+            // Replay the launch cinematic over the reindex: the battle loops
+            // for as long as init runs, then the wordmark reveal hands the
+            // frame back to the deck. The progress lines still land in the
+            // transcript behind the splash (and any key skips straight to
+            // them). Released on BOTH outcomes — a failed init must never
+            // strand a held splash.
+            let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
             let mut emit = |line: String| say(line);
-            match agent::init_workspace(Some(provider), &cfg.workspace_root, &mut emit).await {
+            let outcome =
+                agent::init_workspace(Some(provider), &cfg.workspace_root, &mut emit).await;
+            let _ = in_tx.send(Inbound::Splash(SplashCue::Release));
+            match outcome {
                 Ok(_) => {
                     // A fresh index may name tables/types the schema gate
                     // should know about this session, not just the next one.

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -380,7 +380,8 @@ impl WorkspaceModel {
             | Inbound::SkillPreview { .. }
             | Inbound::McpServers(_)
             | Inbound::McpSearchResults(_)
-            | Inbound::ShowHelp => {}
+            | Inbound::ShowHelp
+            | Inbound::Splash(_) => {}
         }
     }
 

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -296,6 +296,9 @@ pub async fn run_deck(
     ui.slash_commands = opts.slash_commands.clone();
     ui.color_mode = color_mode;
     ui.no_anim = no_anim;
+    // A no-anim session collapses the launch cinematic to one brief static
+    // wordmark frame (and `ingest_inbound` drops any later replay cues).
+    ui.splash.set_reduced(no_anim);
     // Enter semantics follow the terminal's actual capability (see
     // `crate::term::TerminalGuard::kitty` and `crate::composer::classify_enter`).
     ui.enter_submits = !guard.kitty();

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -30,7 +30,7 @@ use crate::composer::{
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::envelope::{
     AgentControl, AgentId, AgentScope, AgentStatus, Inbound, InstalledAgentEntry, Secret, SkillOp,
-    SkillScope, SkillSearchHit, SkillsView, WorkspaceInput,
+    SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 use crate::graph::GraphSnapshot;
 use crate::input::{ScopeDecision, UserInput};
@@ -643,6 +643,22 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         ui.help_scroll = ScrollState::default();
         ui.help_scroll.follow = false;
         ui.help_scroll.top = 0;
+        return;
+    }
+    // Launch-cinematic cues: the driver replays the splash held open over a
+    // running init (`/init`, session startup) and releases it when init
+    // finishes. Out-of-band view state like `ShowHelp`. `--no-anim`
+    // sessions ignore the replay — their contract is a static frame — and a
+    // release on a splash that never held is a harmless no-op.
+    if let Inbound::Splash(cue) = inbound {
+        match cue {
+            SplashCue::Replay => {
+                if !ui.no_anim {
+                    ui.splash = SplashState::new_held();
+                }
+            }
+            SplashCue::Release => ui.splash.release(),
+        }
         return;
     }
     model.apply_inbound(inbound);
@@ -2798,6 +2814,36 @@ mod tests {
         );
         assert!(ui.splash.is_done(), "first key skips the splash");
         assert!(ui.composer.buffer().is_empty(), "and does not type");
+    }
+
+    #[test]
+    fn splash_cues_replay_and_release_the_cinematic() {
+        let mut model = WorkspaceModel::new();
+        let mut ui = DeckUi::default();
+        ui.splash.skip(); // the deck is up; `/init` arrives later
+        assert!(ui.splash.is_done());
+
+        // Replay: a fresh held splash owns the frame again…
+        ingest_inbound(&Inbound::Splash(SplashCue::Replay), &mut model, &mut ui);
+        assert!(!ui.splash.is_done(), "replay restarts the cinematic");
+
+        // …and Release is what lets its timeline run out (exact timing is
+        // splash::tests territory — here we only pin that the cue routes).
+        ingest_inbound(&Inbound::Splash(SplashCue::Release), &mut model, &mut ui);
+        assert!(!ui.splash.is_done(), "the battle floor still plays out");
+    }
+
+    #[test]
+    fn no_anim_sessions_ignore_splash_replays() {
+        let mut model = WorkspaceModel::new();
+        let mut ui = DeckUi::default();
+        ui.no_anim = true;
+        ui.splash.skip();
+        ingest_inbound(&Inbound::Splash(SplashCue::Replay), &mut model, &mut ui);
+        assert!(
+            ui.splash.is_done(),
+            "a no-anim session never replays the cinematic"
+        );
     }
 
     #[test]

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -205,6 +205,24 @@ pub enum Inbound {
     /// [`crate::deck_ui::ingest_inbound`]. Out-of-band view state, ignored by
     /// the model fold — like [`Inbound::GraphSnapshot`].
     ShowHelp,
+    /// A launch-cinematic cue (see [`SplashCue`]): the driver replays the
+    /// splash held open over a running init (session startup, `/init`) and
+    /// releases it when init finishes. Out-of-band view state, applied
+    /// straight to `DeckUi::splash` by [`crate::deck_ui::ingest_inbound`],
+    /// ignored by the model fold — like [`Inbound::ShowHelp`].
+    Splash(SplashCue),
+}
+
+/// Driver → deck cues for the launch cinematic ([`crate::splash`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SplashCue {
+    /// Restart the splash **held** open over a running init: the battle
+    /// scene loops until `Release`. Ignored on `--no-anim` sessions (a
+    /// static frame is their contract).
+    Replay,
+    /// Init finished — let the timeline advance to the wordmark reveal and
+    /// fade out. A no-op if no held splash is playing.
+    Release,
 }
 
 /// Which config level an installed agent definition lives at.

--- a/stella-tui/src/invaders.rs
+++ b/stella-tui/src/invaders.rs
@@ -1,0 +1,482 @@
+//! The Space Invaders battle scene the launch splash plays before the STELLA
+//! wordmark reveal (see [`crate::splash`]).
+//!
+//! Everything here is a **pure function of elapsed time**: the splash renders
+//! from `&SplashState` with no `&mut` path back into the model, so the scene
+//! cannot keep per-frame simulation state. Star positions, the fleet's march,
+//! every bolt, bomb, and explosion are computed from `t` alone — two renders
+//! at the same `t` produce byte-identical buffers, and the scene *scrubs*
+//! (a skipped frame lands exactly where continuous playback would have).
+//!
+//! The battle is a scripted loop of [`LOOP_SECS`]: the cannon slides under
+//! four invaders in turn and destroys each with a bolt (the third shot passes
+//! through the hole the first kill opened), while the fleet returns fire —
+//! one bomb bursts on the ground, one downs the escort ship. While the splash
+//! is **held** open over a still-running init, `t` wraps at the loop period
+//! and the fleet respawns for another pass, so the movie covers an
+//! arbitrarily long first-launch index without freezing.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+use crate::theme;
+
+/// One full battle loop, in seconds. The scripted choreography (shots, bombs,
+/// explosions) lives inside one period; a held splash wraps `t` here.
+pub const LOOP_SECS: f32 = 3.5;
+
+/// Below this, the sprite battle would clip into soup — only the starfield
+/// plays (the splash's wordmark phases have their own small-terminal
+/// fallback).
+const MIN_BATTLE_W: u16 = 44;
+const MIN_BATTLE_H: u16 = 14;
+
+/// Rows per second a player bolt climbs / an invader bomb falls.
+const BOLT_SPEED: f32 = 26.0;
+const BOMB_SPEED: f32 = 11.0;
+
+/// How long one explosion burst plays.
+const EXPLOSION_SECS: f32 = 0.5;
+
+/// Invader sprite geometry: 5×2 cells on a 7-column, 3-row pitch.
+const INVADER_W: i32 = 5;
+const INVADER_H: i32 = 2;
+const PITCH_X: i32 = 7;
+const PITCH_Y: i32 = 3;
+
+/// The classic two-frame march: antennae + body, legs kicking out and in.
+const INVADER_FRAMES: [[&str; 2]; 2] = [["▚▄█▄▞", "▝▘ ▝▘"], ["▚▄█▄▞", "▗▖ ▗▖"]];
+
+/// The player cannon (5×2) and the small escort ship the fleet shoots down.
+const CANNON: [&str; 2] = ["  ▲  ", " ▟█▙ "];
+const ESCORT: &str = "▙▄▟";
+
+/// The four scripted player shots: `(fire_t, column fraction, fleet row)`.
+/// Rows count from the fleet's bottom (`0` = bottom row) so the script scales
+/// to any fleet height. Shot 3 targets the row **above** shot 1's kill, in
+/// the same column — its bolt flies through the hole the first kill opened.
+const SHOTS: [(f32, f32, u32); 4] = [
+    (0.20, 0.18, 0),
+    (0.90, 0.80, 0),
+    (1.65, 0.18, 1),
+    (2.40, 0.52, 0),
+];
+
+/// The fleet's return fire: `(drop_t, kind)`. The first bomb bursts on the
+/// ground; the second leads the escort ship and downs it.
+const BOMB_GROUND_T: f32 = 0.65;
+const BOMB_ESCORT_T: f32 = 1.55;
+const BOMB_GROUND_COLF: f32 = 0.38;
+
+/// Deterministic per-index hash (seeded from [`crate::fx::FX_SEED`]) — the
+/// scene's only randomness source, so every rebuild agrees on star placement.
+fn hash(i: u32) -> u32 {
+    let mut x = i.wrapping_mul(0x9E37_79B9) ^ crate::fx::FX_SEED;
+    x ^= x >> 16;
+    x = x.wrapping_mul(0x85EB_CA6B);
+    x ^= x >> 13;
+    x
+}
+
+/// `hash` folded to `0.0..1.0`.
+fn hash_f(i: u32) -> f32 {
+    (hash(i) & 0xFFFF) as f32 / 65535.0
+}
+
+/// Paint one cell (area-relative coordinates), ignoring out-of-bounds writes
+/// so sprites can slide past the edges without clipping checks at call sites.
+fn put(buf: &mut Buffer, area: Rect, x: i32, y: i32, ch: char, color: Color) {
+    if x < 0 || y < 0 || x >= i32::from(area.width) || y >= i32::from(area.height) {
+        return;
+    }
+    if let Some(cell) = buf.cell_mut((area.x + x as u16, area.y + y as u16)) {
+        let mut utf8 = [0u8; 4];
+        cell.set_symbol(ch.encode_utf8(&mut utf8));
+        cell.set_fg(color);
+    }
+}
+
+/// Stamp a multi-row sprite; spaces are transparent (stars show through).
+fn sprite(buf: &mut Buffer, area: Rect, x: i32, y: i32, rows: &[&str], color: Color) {
+    for (dy, row) in rows.iter().enumerate() {
+        for (dx, ch) in row.chars().enumerate() {
+            if ch != ' ' {
+                put(buf, area, x + dx as i32, y + dy as i32, ch, color);
+            }
+        }
+    }
+}
+
+/// The drifting, twinkling starfield. Takes the **absolute** elapsed time
+/// (not the loop-wrapped `t`) so stars flow continuously across battle loops
+/// and on through the wordmark reveal.
+pub fn render_stars(t: f32, area: Rect, buf: &mut Buffer) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let count = (u32::from(area.width) * u32::from(area.height) / 24).clamp(12, 160);
+    for i in 0..count {
+        let x = (hash(i * 3 + 1) % u32::from(area.width)) as i32;
+        // Parallax: each star falls at its own speed, wrapping at the bottom.
+        let fall = 1.0 + hash_f(i * 3 + 2) * 2.0;
+        let y0 = hash_f(i * 3 + 3) * f32::from(area.height);
+        let y = (y0 + t * fall) % f32::from(area.height);
+        // Twinkle on a per-star phase; dim tiers dominate, with a few amber
+        // accents so the sky reads on-brand.
+        let phase = ((t * 1.6 + hash_f(i * 7 + 5) * 4.0) % 4.0) as usize;
+        let (ch, color) = match hash(i * 5 + 4) % 10 {
+            0 => (['✦', '·', '✦', '·'][phase], theme::AMBER),
+            1..=3 => (['+', '·', '˙', '·'][phase], theme::TEXT_TERTIARY),
+            _ => (['·', '·', '.', '˙'][phase], theme::TEXT_DIM),
+        };
+        put(buf, area, x, y as i32, ch, color);
+    }
+}
+
+/// Fleet shape for this terminal: `(columns, rows)`.
+fn fleet_dims(area: Rect) -> (i32, i32) {
+    let cols = ((i32::from(area.width) - 6) / PITCH_X).clamp(3, 9);
+    let rows = if area.height >= 20 { 3 } else { 2 };
+    (cols, rows)
+}
+
+/// The fleet's horizontal march: a ±3-cell triangle sweep, one full cycle
+/// per loop, with a one-row step down at the halfway point.
+fn march(t: f32) -> (i32, i32) {
+    let p = (t / LOOP_SECS).rem_euclid(1.0);
+    let tri = if p < 0.5 {
+        p * 4.0 - 1.0
+    } else {
+        3.0 - p * 4.0
+    };
+    let step_down = i32::from(t.rem_euclid(LOOP_SECS) >= LOOP_SECS * 0.5);
+    ((tri * 3.0).round() as i32, step_down)
+}
+
+/// Top-left cell of the invader at `(col, row)` — `row` counts from the TOP
+/// of the fleet here — at time `t`.
+fn invader_pos(area: Rect, col: i32, row: i32, t: f32) -> (i32, i32) {
+    let (cols, _) = fleet_dims(area);
+    let block_w = cols * PITCH_X - (PITCH_X - INVADER_W);
+    let base_x = (i32::from(area.width) - block_w) / 2;
+    let (off_x, off_y) = march(t);
+    (base_x + col * PITCH_X + off_x, 2 + row * PITCH_Y + off_y)
+}
+
+/// Resolve one scripted shot against this terminal's fleet: the target's
+/// `(col, top-row)` plus the bolt's impact moment.
+struct ResolvedShot {
+    fire: f32,
+    impact: f32,
+    col: i32,
+    row: i32,
+}
+
+fn resolve_shots(area: Rect) -> Vec<ResolvedShot> {
+    let (cols, rows) = fleet_dims(area);
+    let cannon_top = cannon_y(area);
+    SHOTS
+        .iter()
+        .map(|&(fire, colf, from_bottom)| {
+            let col = (colf * (cols - 1) as f32).round() as i32;
+            let row = (rows - 1 - from_bottom.min(rows as u32 - 1) as i32).max(0);
+            // Aim at the row's underside; travel time closes the gap.
+            let target_y = 2 + row * PITCH_Y + INVADER_H;
+            let impact = fire + (cannon_top - target_y).max(1) as f32 / BOLT_SPEED;
+            ResolvedShot {
+                fire,
+                impact,
+                col,
+                row,
+            }
+        })
+        .collect()
+}
+
+/// The cannon's top row (its ▲): two sprite rows above the ground line.
+fn cannon_y(area: Rect) -> i32 {
+    i32::from(area.height) - 3
+}
+
+/// The escort ship's patrol: a slow triangle sweep across the lower sky.
+fn escort_pos(area: Rect, t: f32) -> (i32, i32) {
+    let w = i32::from(area.width);
+    let p = (t / LOOP_SECS).rem_euclid(1.0);
+    let tri = if p < 0.5 { p * 2.0 } else { 2.0 - p * 2.0 }; // 0..1..0
+    let span = (w / 2 - 6).max(1);
+    (
+        w / 4 + (tri * span as f32) as i32,
+        i32::from(area.height) - 6,
+    )
+}
+
+/// When the escort-hunting bomb lands. The bomb "leads" the escort: its
+/// column is the escort's position at this precomputed impact moment.
+fn escort_impact(area: Rect) -> f32 {
+    let (_, rows) = fleet_dims(area);
+    let drop_y = 2 + (rows - 1) * PITCH_Y + INVADER_H;
+    let (_, escort_row) = escort_pos(area, 0.0);
+    BOMB_ESCORT_T + (escort_row - drop_y).max(1) as f32 / BOMB_SPEED
+}
+
+/// One expanding burst at `(cx, cy)`, `local` in `0.0..1.0`.
+fn explosion(buf: &mut Buffer, area: Rect, cx: i32, cy: i32, local: f32) {
+    if local < 0.2 {
+        put(buf, area, cx, cy, '✶', theme::EMBER_GOLD);
+    } else if local < 0.45 {
+        put(buf, area, cx, cy, '✹', theme::EMBER_FLAME);
+        for (dx, dy) in [(-1, 0), (1, 0), (0, -1), (0, 1)] {
+            put(buf, area, cx + dx, cy + dy, '∙', theme::WARNING_BRIGHT);
+        }
+    } else if local < 0.7 {
+        put(buf, area, cx, cy, '✺', theme::EMBER_FLAME);
+        for ((dx, dy), ch) in [
+            ((-2, 0), '·'),
+            ((2, 0), '·'),
+            ((0, -1), '·'),
+            ((0, 1), '·'),
+            ((-1, -1), '▘'),
+            ((1, -1), '▝'),
+            ((-1, 1), '▖'),
+            ((1, 1), '▗'),
+        ] {
+            put(buf, area, cx + dx, cy + dy, ch, theme::EMBER_CRIMSON);
+        }
+    } else {
+        for (dx, dy) in [(-2, -1), (2, -1), (-1, 1), (1, -2), (2, 1)] {
+            put(buf, area, cx + dx, cy + dy, '·', theme::TEXT_DIM);
+        }
+    }
+}
+
+/// Where the cannon's left edge sits at `t`: parked under the next scripted
+/// target, easing over from the previous one between shots.
+fn cannon_x(area: Rect, shots: &[ResolvedShot], t: f32) -> i32 {
+    // Muzzle-aligned park position for a shot: bolt column minus the ▲ offset.
+    let park = |s: &ResolvedShot| {
+        let (ix, _) = invader_pos(area, s.col, s.row, s.impact);
+        ix + INVADER_W / 2 - 2
+    };
+    let first = match shots.first() {
+        Some(first) => first,
+        None => return i32::from(area.width) / 2 - 2,
+    };
+    let mut from = park(first);
+    if t <= first.fire {
+        return from;
+    }
+    for pair in shots.windows(2) {
+        let (prev, next) = (&pair[0], &pair[1]);
+        if t <= next.fire {
+            // Ease across the gap, arriving shortly before the trigger pull.
+            let span = (next.fire - prev.fire - 0.15).max(0.01);
+            let p = ((t - prev.fire) / span).clamp(0.0, 1.0);
+            let eased = p * p * (3.0 - 2.0 * p); // smoothstep
+            let to = park(next);
+            return from + ((to - from) as f32 * eased).round() as i32;
+        }
+        from = park(next);
+    }
+    from
+}
+
+/// Render the battle at absolute elapsed time `t_abs` (seconds). Stars run on
+/// `t_abs`; the scripted choreography wraps at [`LOOP_SECS`].
+pub fn render(t_abs: f32, area: Rect, buf: &mut Buffer) {
+    render_stars(t_abs, area, buf);
+    if area.width < MIN_BATTLE_W || area.height < MIN_BATTLE_H {
+        return;
+    }
+    let t = t_abs.rem_euclid(LOOP_SECS);
+    let (cols, rows) = fleet_dims(area);
+    let shots = resolve_shots(area);
+
+    // Ground line under the cannon.
+    let ground_y = i32::from(area.height) - 1;
+    for x in 0..i32::from(area.width) {
+        put(buf, area, x, ground_y, '▁', theme::HAIRLINE);
+    }
+
+    // The fleet, minus anyone already shot down this loop, legs alternating
+    // every 0.4s. Rows shade bottom-to-top so depth reads at a glance.
+    let frame = &INVADER_FRAMES[((t / 0.4) as usize) % 2];
+    let row_colors = [
+        theme::WARNING_BRIGHT,
+        theme::AGENT_AMBER,
+        theme::EMBER_FLAME,
+    ];
+    for row in 0..rows {
+        for col in 0..cols {
+            let dead = shots
+                .iter()
+                .any(|s| s.col == col && s.row == row && t >= s.impact);
+            if dead {
+                continue;
+            }
+            let (x, y) = invader_pos(area, col, row, t);
+            sprite(buf, area, x, y, frame, row_colors[row as usize % 3]);
+        }
+    }
+
+    // Return fire: one bomb bursts on the ground…
+    let fleet_bottom = 2 + (rows - 1) * PITCH_Y + INVADER_H;
+    let ground_impact = BOMB_GROUND_T + (ground_y - fleet_bottom).max(1) as f32 / BOMB_SPEED;
+    let bomb_x = ((i32::from(area.width) - 6) as f32 * BOMB_GROUND_COLF) as i32 + 3;
+    if (BOMB_GROUND_T..ground_impact).contains(&t) {
+        let y = fleet_bottom as f32 + (t - BOMB_GROUND_T) * BOMB_SPEED;
+        put(buf, area, bomb_x, y as i32, '╻', theme::EMBER_FLAME);
+    } else if (ground_impact..ground_impact + 0.3).contains(&t) {
+        put(buf, area, bomb_x, ground_y - 1, '✶', theme::EMBER_CRIMSON);
+    }
+
+    // …the other leads the escort ship and downs it.
+    let hit = escort_impact(area);
+    let (ex, ey) = escort_pos(area, hit);
+    if (BOMB_ESCORT_T..hit).contains(&t) {
+        let y = fleet_bottom as f32 + (t - BOMB_ESCORT_T) * BOMB_SPEED;
+        put(buf, area, ex + 1, y as i32, '╻', theme::EMBER_FLAME);
+    }
+    if t < hit {
+        let (x, y) = escort_pos(area, t);
+        sprite(buf, area, x, y, &[ESCORT], theme::SUCCESS_BRIGHT);
+    } else if t < hit + EXPLOSION_SECS {
+        explosion(buf, area, ex + 1, ey, (t - hit) / EXPLOSION_SECS);
+    }
+
+    // The cannon, its bolts, and the kills.
+    let cy = cannon_y(area);
+    let cx = cannon_x(area, &shots, t);
+    sprite(buf, area, cx, cy, &CANNON, theme::EMBER_GOLD);
+    for shot in &shots {
+        let (ix, iy) = invader_pos(area, shot.col, shot.row, shot.impact);
+        let bolt_x = ix + INVADER_W / 2;
+        if (shot.fire..shot.impact).contains(&t) {
+            let y = cy as f32 - (t - shot.fire) * BOLT_SPEED;
+            put(buf, area, bolt_x, y as i32, '┃', theme::EMBER_GOLD);
+            // Muzzle flash right as the trigger pulls.
+            if t - shot.fire < 0.08 {
+                put(buf, area, cx + 2, cy - 1, '✶', theme::EMBER_GOLD);
+            }
+        } else if (shot.impact..shot.impact + EXPLOSION_SECS).contains(&t) {
+            explosion(
+                buf,
+                area,
+                bolt_x,
+                iy + INVADER_H / 2,
+                (t - shot.impact) / EXPLOSION_SECS,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn draw(t: f32, w: u16, h: u16) -> Buffer {
+        let area = Rect::new(0, 0, w, h);
+        let mut buf = Buffer::empty(area);
+        render(t, area, &mut buf);
+        buf
+    }
+
+    fn non_space_cells(buf: &Buffer) -> usize {
+        let area = *buf.area();
+        (0..area.height)
+            .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+            .filter(|&(x, y)| buf.cell((x, y)).is_some_and(|c| c.symbol() != " "))
+            .count()
+    }
+
+    #[test]
+    fn renders_are_deterministic_at_equal_times() {
+        let a = draw(1.234, 80, 24);
+        let b = draw(1.234, 80, 24);
+        assert_eq!(a, b, "same t must produce byte-identical frames");
+    }
+
+    #[test]
+    fn battle_draws_sprites_on_a_roomy_terminal() {
+        // Well past the stars-only floor: fleet + cannon + ground all paint.
+        let stars_only = non_space_cells(&draw(1.0, 40, 10));
+        let battle = non_space_cells(&draw(1.0, 80, 24));
+        assert!(
+            battle > stars_only + 40,
+            "the sprite battle should paint far more than a bare starfield \
+             ({battle} vs {stars_only})"
+        );
+    }
+
+    #[test]
+    fn small_terminals_get_stars_only() {
+        // No ground line on a sub-minimum area — the '▁' row is the battle's
+        // unconditional first stroke, so its absence proves the early return.
+        let buf = draw(1.0, 40, 10);
+        let bottom: String = (0..40)
+            .map(|x| buf.cell((x, 9)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            !bottom.contains('▁'),
+            "no ground line below the minimum size"
+        );
+    }
+
+    #[test]
+    fn scene_loops_at_the_loop_period() {
+        let a = draw(0.7, 80, 24);
+        let b = draw(0.7 + LOOP_SECS, 80, 24);
+        // Stars run on absolute time (they drift across loops), so compare a
+        // battle-owned cell instead: the ground line persists, and the fleet
+        // respawns — total paint should be close. Cheap invariant: both
+        // frames paint a ground line.
+        for frame in [&a, &b] {
+            let ground: String = (0..80)
+                .map(|x| frame.cell((x, 23)).map(|c| c.symbol()).unwrap_or(" "))
+                .collect::<Vec<_>>()
+                .join("");
+            assert!(ground.contains('▁'), "ground line present each loop");
+        }
+    }
+
+    #[test]
+    fn kills_remove_invaders_within_a_loop() {
+        // Just before the first impact vs. just after: the fleet loses a
+        // ship, so (stars aside) the frame should not gain paint.
+        let area = Rect::new(0, 0, 80, 24);
+        let shots = resolve_shots(area);
+        let first = &shots[0];
+        let (t_before, t_after) = (first.impact - 0.05, first.impact + EXPLOSION_SECS + 0.05);
+        let before = draw(t_before, 80, 24);
+        let after = draw(t_after, 80, 24);
+        // The fleet marches between the two frames — sample each frame at the
+        // invader's position AT THAT FRAME's time.
+        let solid_at = |frame: &Buffer, t: f32| {
+            let (x, y) = invader_pos(area, first.col, first.row, t);
+            (0..INVADER_W)
+                .filter(|dx| {
+                    frame
+                        .cell(((x + dx) as u16, y as u16))
+                        .is_some_and(|c| c.symbol() != " ")
+                })
+                .count()
+        };
+        let solid_before = solid_at(&before, t_before);
+        let solid_after = solid_at(&after, t_after);
+        assert!(solid_before >= 4, "target alive before impact");
+        assert!(
+            solid_after < solid_before,
+            "target gone after its explosion ({solid_after} vs {solid_before})"
+        );
+    }
+
+    #[test]
+    fn render_does_not_panic_across_times_and_sizes() {
+        for &(w, h) in &[(0, 0), (1, 1), (10, 4), (44, 14), (80, 24), (200, 60)] {
+            for i in 0..24 {
+                let _ = draw(i as f32 * 0.31, w, h);
+            }
+        }
+    }
+}

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -49,6 +49,7 @@ pub mod diff;
 pub mod envelope;
 pub mod fx;
 pub mod graph;
+pub mod invaders;
 pub mod markdown;
 pub mod progress;
 pub mod resource;
@@ -82,7 +83,7 @@ pub use deck_ui::{
 pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
     InstalledAgentEntry, McpSearchItem, McpSearchOutcome, McpServerInfo, Secret, SkillOp, SkillRow,
-    SkillScope, SkillSearchHit, SkillsView, WorkspaceInput,
+    SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;

--- a/stella-tui/src/splash.rs
+++ b/stella-tui/src/splash.rs
@@ -1,21 +1,28 @@
-//! The animated branded splash shown on deck launch.
+//! The animated launch cinematic shown on deck launch and replayed on `/init`.
 //!
-//! Timing/state lives here; the wordmark ([`tui_big_text`]) and the
-//! coalesce-in / dissolve-out ([`tachyonfx`]) are drawn in [`render`]. The
-//! splash is **time-boxed** and **skippable** on any key so it can never
-//! block getting to work.
+//! The timeline is a four-phase movie, never shorter than ~6 seconds:
 //!
-//! `render` takes `&SplashState` (immutable — the deck draws every frame
-//! with no `&mut` path back into the model), so the animation is *scrubbed*
-//! from [`SplashState::progress`] rather than driven by a persisted,
-//! time-advancing `tachyonfx::Effect`: each frame builds a **fresh**
-//! coalesce or dissolve effect and processes it, once, with a synthetic
-//! elapsed duration computed from `progress()` instead of a real frame
-//! delta. Since a `tachyonfx::EffectTimer` only cares about total elapsed
-//! time (not how it got there), one `process(synthetic_elapsed, ..)` call on
-//! a never-before-touched effect lands it exactly where continuous real-time
-//! playback would have — no persisted timer, no interior mutability, and
-//! `skip()` trivially scrubs to the fully-dissolved end state.
+//! 1. **Battle** ([`crate::invaders`]) — a Space Invaders skirmish over a
+//!    drifting starfield: the cannon picks off invaders, the fleet returns
+//!    fire, ships explode. Runs at least [`BATTLE_MIN`]; while the splash is
+//!    **held** open over a still-running init (session startup, `/init`) the
+//!    battle loops until [`SplashState::release`] — the movie covers the
+//!    wait, however long a first launch's indexing takes.
+//! 2. **Reveal** — the STELLA block-art wordmark ([`tui_big_text`])
+//!    materializes cell-by-cell (a seeded [`tachyonfx`] coalesce), stars
+//!    still falling behind it.
+//! 3. **Hold** — the wordmark stands fully lit.
+//! 4. **Fade** — the whole frame fades out to the deck.
+//!
+//! The splash stays **skippable** on any key so it can never block getting
+//! to work, and `--no-anim` (CI, recordings) collapses it to a brief static
+//! wordmark. `render` takes `&SplashState` (immutable — the deck draws every
+//! frame with no `&mut` path back into the model), so the animation is
+//! *scrubbed* from elapsed time rather than driven by persisted effects:
+//! each frame builds a **fresh** seeded effect and processes it once with a
+//! synthetic elapsed duration. Since a `tachyonfx::EffectTimer` only cares
+//! about total elapsed time (not how it got there), one `process` call lands
+//! exactly where continuous real-time playback would have.
 
 use std::time::{Duration, Instant};
 
@@ -23,23 +30,53 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
-use tachyonfx::{Duration as FxDuration, Effect, EffectTimer, Interpolation, SimpleRng, fx};
+use tachyonfx::{Duration as FxDuration, EffectTimer, Interpolation, SimpleRng, fx};
 use tui_big_text::{BigText, PixelSize};
 
-use crate::theme;
+use crate::{invaders, theme};
 
-/// Total on-screen time before the splash auto-dismisses.
-pub const SPLASH_DURATION: Duration = Duration::from_millis(1600);
+/// Minimum battle time before the wordmark may reveal — also the loop the
+/// battle wraps at while held. With the wordmark phases on top, the whole
+/// movie always runs ≥ ~6.3s (the product floor is 5s).
+pub const BATTLE_MIN: Duration = Duration::from_millis(3500);
 
-/// Fraction of [`SPLASH_DURATION`] spent coalescing the wordmark into view;
-/// the remainder dissolves it back out.
-const REVEAL_FRACTION: f32 = 0.6;
+/// The wordmark phases: patterned coalesce in, full-lit hold, fade out.
+const REVEAL: Duration = Duration::from_millis(1300);
+const WORDMARK_HOLD: Duration = Duration::from_millis(600);
+const FADE: Duration = Duration::from_millis(900);
 
-/// Below this width/height, `tui-big-text`'s wordmark (48 cols x 4 rows at
-/// [`PixelSize::HalfHeight`], plus subtitle and breathing room) won't fit
-/// legibly — fall back to a single styled line instead of clipping it.
+/// A held splash that never hears `release()` (a driver that died mid-init)
+/// still ends: past this cap the battle concedes and the reveal plays. Any
+/// key skips long before this matters.
+const HOLD_FAILSAFE: Duration = Duration::from_secs(120);
+
+/// `--no-anim`: the whole cinematic collapses to this brief static wordmark.
+const REDUCED_TOTAL: Duration = Duration::from_millis(1200);
+
+/// Below this width/height, `tui-big-text`'s wordmark (48 cols wide, plus
+/// subtitle and breathing room) won't fit legibly — fall back to a single
+/// styled line instead of clipping it.
 const MIN_WORDMARK_WIDTH: u16 = 50;
 const MIN_WORDMARK_HEIGHT: u16 = 8;
+
+/// Terminals at least this tall get the full 8-row block glyphs
+/// ([`PixelSize::Full`]); shorter ones get the 4-row half-height packing.
+const FULL_GLYPH_MIN_HEIGHT: u16 = 20;
+
+/// Where the timeline stands right now — the render dispatch.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Phase {
+    /// Mid-battle; carries the absolute elapsed seconds (the scene wraps it).
+    Battle(f32),
+    /// Wordmark coalescing in; carries local progress `0.0..1.0`.
+    Reveal(f32),
+    /// Wordmark fully lit.
+    Hold,
+    /// Whole frame fading out; carries local progress `0.0..1.0`.
+    Fade(f32),
+    /// Movie over — the deck owns the frame.
+    Over,
+}
 
 /// Ephemeral splash timing. Not part of the model — pure presentation.
 #[derive(Debug, Clone)]
@@ -48,6 +85,12 @@ pub struct SplashState {
     /// When `skip()` dismissed the splash early, if it did — the moment the
     /// deck took over, used by [`Self::finished_at`].
     skipped_at: Option<Instant>,
+    /// Held open over a running init: the battle loops until `release()`.
+    held: bool,
+    /// When `release()` ended the hold (init finished).
+    released_at: Option<Instant>,
+    /// `--no-anim`: collapse to a brief static wordmark, ignore hold cues.
+    reduced: bool,
 }
 
 impl Default for SplashState {
@@ -61,7 +104,36 @@ impl SplashState {
         Self {
             start: Instant::now(),
             skipped_at: None,
+            held: false,
+            released_at: None,
+            reduced: false,
         }
+    }
+
+    /// A splash held open over a running init: the battle loops until
+    /// [`Self::release`]. The driver replays the cinematic this way at
+    /// session start and on `/init`.
+    pub fn new_held() -> Self {
+        Self {
+            held: true,
+            ..Self::new()
+        }
+    }
+
+    /// Init finished — let the timeline advance to the wordmark and fade.
+    /// The battle still runs out its [`BATTLE_MIN`] floor first, so a fast
+    /// init never truncates the movie below the product minimum. Idempotent;
+    /// a no-op on an unheld splash.
+    pub fn release(&mut self) {
+        if self.held && self.released_at.is_none() {
+            self.released_at = Some(Instant::now());
+        }
+    }
+
+    /// `--no-anim` / `STELLA_NO_ANIM` / `NO_COLOR`: collapse the cinematic
+    /// to a brief static wordmark (no battle, no effects).
+    pub fn set_reduced(&mut self, reduced: bool) {
+        self.reduced = reduced;
     }
 
     /// Dismiss immediately (any key). Idempotent — the first skip wins, so
@@ -76,96 +148,161 @@ impl SplashState {
         self.start.elapsed()
     }
 
-    /// Progress `0.0..=1.0` through the splash timeline.
-    pub fn progress(&self) -> f32 {
-        if self.skipped_at.is_some() {
-            return 1.0;
+    /// When the battle phase ends, relative to `start` — or `None` while the
+    /// splash is held open and init hasn't finished (the battle loops).
+    fn battle_end(&self) -> Option<Duration> {
+        if self.reduced {
+            return Some(Duration::ZERO);
         }
-        (self.elapsed().as_secs_f32() / SPLASH_DURATION.as_secs_f32()).clamp(0.0, 1.0)
+        if !self.held {
+            return Some(BATTLE_MIN);
+        }
+        match self.released_at {
+            Some(at) => Some(BATTLE_MIN.max(at.duration_since(self.start))),
+            None if self.elapsed() >= HOLD_FAILSAFE => Some(HOLD_FAILSAFE),
+            None => None,
+        }
+    }
+
+    /// The whole movie's length, once known ([`Self::battle_end`]).
+    fn total(&self) -> Option<Duration> {
+        if self.reduced {
+            return Some(REDUCED_TOTAL);
+        }
+        self.battle_end()
+            .map(|be| be + REVEAL + WORDMARK_HOLD + FADE)
+    }
+
+    fn phase(&self) -> Phase {
+        if self.skipped_at.is_some() {
+            return Phase::Over;
+        }
+        let e = self.elapsed();
+        if self.reduced {
+            return if e < REDUCED_TOTAL {
+                Phase::Hold
+            } else {
+                Phase::Over
+            };
+        }
+        let be = match self.battle_end() {
+            None => return Phase::Battle(e.as_secs_f32()),
+            Some(be) => be,
+        };
+        if e < be {
+            Phase::Battle(e.as_secs_f32())
+        } else if e < be + REVEAL {
+            Phase::Reveal((e - be).as_secs_f32() / REVEAL.as_secs_f32())
+        } else if e < be + REVEAL + WORDMARK_HOLD {
+            Phase::Hold
+        } else if e < be + REVEAL + WORDMARK_HOLD + FADE {
+            Phase::Fade((e - be - REVEAL - WORDMARK_HOLD).as_secs_f32() / FADE.as_secs_f32())
+        } else {
+            Phase::Over
+        }
     }
 
     /// True once the splash should hand off to the deck.
     pub fn is_done(&self) -> bool {
-        self.skipped_at.is_some() || self.elapsed() >= SPLASH_DURATION
+        self.phase() == Phase::Over
     }
 
-    /// The moment the splash finished (skipped or timed out), or `None` while
-    /// it is still playing. The deck uses this to time its reveal fade
+    /// The moment the splash finished (skipped or played out), or `None`
+    /// while it is still playing. The deck uses this to time its reveal fade
     /// (`deck_render` drives [`crate::fx::fade_in`] from it).
     pub fn finished_at(&self) -> Option<Instant> {
         if let Some(at) = self.skipped_at {
             return Some(at);
         }
-        if self.elapsed() >= SPLASH_DURATION {
-            return Some(self.start + SPLASH_DURATION);
+        match self.total() {
+            Some(total) if self.elapsed() >= total => Some(self.start + total),
+            _ => None,
         }
-        None
     }
 }
 
-/// Draw the splash: a centered "STELLA" wordmark over a muted "command
-/// deck" subtitle, coalescing into view over the first ~60% of the timeline
-/// and dissolving back out as `state.progress()` approaches `1.0`. Falls
-/// back to a single compact line on terminals too small for the big-text
-/// wordmark.
+/// Draw the current frame of the cinematic. Battle → coalescing wordmark →
+/// hold → fade, all scrubbed from [`SplashState`]'s clock; reduced splashes
+/// render one static wordmark frame.
 pub fn render(state: &SplashState, area: Rect, buf: &mut Buffer) {
+    if state.reduced {
+        render_wordmark_or_fallback(area, buf);
+        return;
+    }
+    let elapsed = state.elapsed().as_secs_f32();
+    match state.phase() {
+        Phase::Over => {}
+        Phase::Battle(t) => invaders::render(t, area, buf),
+        Phase::Reveal(local) => {
+            invaders::render_stars(elapsed, area, buf);
+            let block = render_wordmark_or_fallback(area, buf);
+            // The patterned reveal: a seeded coalesce scrubbed to `local`,
+            // applied to the wordmark block only so the starfield behind it
+            // doesn't flicker in and out with the effect's cell pattern.
+            let mut effect = fx::coalesce(EffectTimer::new(
+                FxDuration::from(REVEAL),
+                Interpolation::QuadOut,
+            ))
+            .with_rng(SimpleRng::new(crate::fx::FX_SEED));
+            crate::fx::apply(
+                &mut effect,
+                REVEAL.mul_f32(local.clamp(0.0, 1.0)),
+                block,
+                buf,
+            );
+        }
+        Phase::Hold => {
+            invaders::render_stars(elapsed, area, buf);
+            render_wordmark_or_fallback(area, buf);
+        }
+        Phase::Fade(local) => {
+            invaders::render_stars(elapsed, area, buf);
+            render_wordmark_or_fallback(area, buf);
+            // Fade the whole frame — wordmark and stars — down to the ground
+            // color for the handoff.
+            let mut effect = fx::fade_to(
+                theme::GROUND,
+                theme::GROUND,
+                EffectTimer::new(FxDuration::from(FADE), Interpolation::QuadIn),
+            );
+            crate::fx::apply(&mut effect, FADE.mul_f32(local.clamp(0.0, 1.0)), area, buf);
+        }
+    }
+}
+
+/// Draw the wordmark (or the tiny-terminal fallback) and return the block it
+/// occupies, for effects that should touch only the wordmark.
+fn render_wordmark_or_fallback(area: Rect, buf: &mut Buffer) -> Rect {
     if area.width < MIN_WORDMARK_WIDTH || area.height < MIN_WORDMARK_HEIGHT {
-        render_fallback(area, buf);
+        render_fallback(area, buf)
     } else {
-        render_wordmark(area, buf);
-    }
-
-    let (mut effect, elapsed) = timeline_effect(state.progress());
-    crate::fx::apply(&mut effect, elapsed, area, buf);
-}
-
-/// Picks the coalesce-in or dissolve-out effect for the current splash
-/// `progress`, paired with the synthetic elapsed duration that, applied to a
-/// *fresh* copy of that effect, lands it exactly where continuous real-time
-/// playback would have at this point in the timeline. Both effects run on
-/// the pinned [`crate::fx::FX_SEED`] RNG so the random cell pattern is
-/// identical across per-frame rebuilds (an unseeded effect would re-roll the
-/// pattern every frame and the scrub would read as flicker).
-fn timeline_effect(progress: f32) -> (Effect, Duration) {
-    let reveal_dur = SPLASH_DURATION.mul_f32(REVEAL_FRACTION);
-    let dissolve_dur = SPLASH_DURATION.saturating_sub(reveal_dur);
-
-    if progress < REVEAL_FRACTION {
-        // Splash-specific: the coalesce-in is not part of the deck's shared
-        // motion language (crate::fx), so it is built here.
-        let local = (progress / REVEAL_FRACTION).clamp(0.0, 1.0);
-        let effect = fx::coalesce(EffectTimer::new(
-            FxDuration::from(reveal_dur),
-            Interpolation::QuadOut,
-        ))
-        .with_rng(SimpleRng::new(crate::fx::FX_SEED));
-        (effect, reveal_dur.mul_f32(local))
-    } else {
-        // The dissolve IS the deck's shared teardown motion — reuse it.
-        let local = ((progress - REVEAL_FRACTION) / (1.0 - REVEAL_FRACTION)).clamp(0.0, 1.0);
-        let effect = crate::fx::dissolve_out(dissolve_dur.as_millis() as u32);
-        (effect, dissolve_dur.mul_f32(local))
+        render_wordmark(area, buf)
     }
 }
 
-/// The full wordmark: a big "STELLA" in Stella amber over a muted "command
-/// deck" subtitle, vertically centered as one block.
-fn render_wordmark(area: Rect, buf: &mut Buffer) {
-    const TITLE_HEIGHT: u16 = 4; // PixelSize::HalfHeight packs the 8px glyph into 4 rows.
+/// The full wordmark: a big block-art "STELLA" in Stella amber over a muted
+/// "command deck" subtitle, vertically centered as one block. Tall terminals
+/// get the full 8-row glyphs; shorter ones the 4-row half-height packing.
+fn render_wordmark(area: Rect, buf: &mut Buffer) -> Rect {
+    let (pixel_size, title_height) = if area.height >= FULL_GLYPH_MIN_HEIGHT {
+        (PixelSize::Full, 8)
+    } else {
+        (PixelSize::HalfHeight, 4)
+    };
     const GAP: u16 = 1;
     const SUBTITLE_HEIGHT: u16 = 1;
-    const BLOCK_HEIGHT: u16 = TITLE_HEIGHT + GAP + SUBTITLE_HEIGHT;
+    let block_height = title_height + GAP + SUBTITLE_HEIGHT;
 
-    let top = area.y + (area.height.saturating_sub(BLOCK_HEIGHT)) / 2;
+    let top = area.y + (area.height.saturating_sub(block_height)) / 2;
 
     let title_area = Rect {
         x: area.x,
         y: top,
         width: area.width,
-        height: TITLE_HEIGHT,
+        height: title_height,
     };
     let wordmark = BigText::builder()
-        .pixel_size(PixelSize::HalfHeight)
+        .pixel_size(pixel_size)
         .style(theme::accent())
         .alignment(Alignment::Center)
         .lines(vec![Line::from("STELLA")])
@@ -174,18 +311,25 @@ fn render_wordmark(area: Rect, buf: &mut Buffer) {
 
     let subtitle_area = Rect {
         x: area.x,
-        y: top + TITLE_HEIGHT + GAP,
+        y: top + title_height + GAP,
         width: area.width,
         height: SUBTITLE_HEIGHT,
     };
     let subtitle =
         Line::from(Span::styled("command deck", theme::muted())).alignment(Alignment::Center);
     Paragraph::new(subtitle).render(subtitle_area, buf);
+
+    Rect {
+        x: area.x,
+        y: top,
+        width: area.width,
+        height: block_height.min(area.height),
+    }
 }
 
 /// Compact single-line fallback for terminals too small for the big-text
 /// wordmark — still centered, still on-brand, never clipped or garbled.
-fn render_fallback(area: Rect, buf: &mut Buffer) {
+fn render_fallback(area: Rect, buf: &mut Buffer) -> Rect {
     let line = Line::from(vec![
         Span::styled("✦ STELLA", theme::accent()),
         Span::styled(" — command deck", theme::muted()),
@@ -200,6 +344,7 @@ fn render_fallback(area: Rect, buf: &mut Buffer) {
         height: area.height.min(1),
     };
     Paragraph::new(line).render(row, buf);
+    row
 }
 
 #[cfg(test)]
@@ -243,23 +388,26 @@ mod tests {
     fn state_at(elapsed_ms: u64) -> SplashState {
         SplashState {
             start: Instant::now() - Duration::from_millis(elapsed_ms),
-            skipped_at: None,
+            ..SplashState::new()
         }
     }
 
-    /// A few milliseconds into the dissolve phase (just past the 60%
-    /// coalesce/dissolve hand-off). `EffectTimer`'s elapsed-time conversion
-    /// truncates to whole milliseconds, so this reads as the dissolve
-    /// effect's alpha `0.0` (its very start) regardless of how many
-    /// microseconds of test overhead land between construction and render —
-    /// i.e. deterministically fully visible, not a coin flip.
-    const HANDOFF_MS: u64 = 961;
+    /// Total un-held movie length, in ms — the point past which `is_done()`.
+    fn total_ms() -> u64 {
+        (BATTLE_MIN + REVEAL + WORDMARK_HOLD + FADE).as_millis() as u64
+    }
 
     #[test]
-    fn new_state_is_not_done_and_has_zero_ish_progress() {
+    fn the_movie_runs_at_least_five_seconds() {
+        // The product floor: the cinematic may never be shorter than 5s.
+        assert!(total_ms() >= 5_000, "movie is {}ms", total_ms());
+    }
+
+    #[test]
+    fn new_state_is_not_done_and_starts_in_battle() {
         let state = SplashState::new();
         assert!(!state.is_done());
-        assert!(state.progress() < 0.05);
+        assert!(matches!(state.phase(), Phase::Battle(_)));
     }
 
     #[test]
@@ -267,6 +415,7 @@ mod tests {
         let state = SplashState::default();
         assert!(!state.is_done());
         assert!(state.skipped_at.is_none());
+        assert!(!state.held);
     }
 
     #[test]
@@ -275,7 +424,67 @@ mod tests {
         assert!(!state.is_done());
         state.skip();
         assert!(state.is_done());
-        assert_eq!(state.progress(), 1.0);
+    }
+
+    #[test]
+    fn timeline_walks_battle_reveal_hold_fade_done() {
+        let battle = BATTLE_MIN.as_millis() as u64;
+        assert!(matches!(state_at(battle - 200).phase(), Phase::Battle(_)));
+        assert!(matches!(state_at(battle + 200).phase(), Phase::Reveal(_)));
+        let hold_at = battle + REVEAL.as_millis() as u64 + 100;
+        assert_eq!(state_at(hold_at).phase(), Phase::Hold);
+        let fade_at = hold_at + WORDMARK_HOLD.as_millis() as u64 + 100;
+        assert!(matches!(state_at(fade_at).phase(), Phase::Fade(_)));
+        assert_eq!(state_at(total_ms() + 100).phase(), Phase::Over);
+    }
+
+    #[test]
+    fn a_held_splash_loops_the_battle_until_released() {
+        // Held + un-released, way past BATTLE_MIN: still in battle, not done.
+        let mut state = SplashState {
+            held: true,
+            ..state_at(10_000)
+        };
+        assert!(matches!(state.phase(), Phase::Battle(_)));
+        assert!(!state.is_done());
+        assert!(state.finished_at().is_none());
+
+        // Release: battle ends at the release moment (past the floor), and
+        // the wordmark phases run from there.
+        state.release();
+        assert!(matches!(state.phase(), Phase::Reveal(_)));
+    }
+
+    #[test]
+    fn an_early_release_still_honors_the_battle_floor() {
+        // Init finished after 1s — the battle still runs out BATTLE_MIN.
+        let mut state = SplashState {
+            held: true,
+            ..state_at(1_000)
+        };
+        state.release();
+        assert!(matches!(state.phase(), Phase::Battle(_)));
+        assert_eq!(state.battle_end(), Some(BATTLE_MIN));
+    }
+
+    #[test]
+    fn release_is_a_no_op_on_an_unheld_splash() {
+        let mut state = state_at(100);
+        state.release();
+        assert!(state.released_at.is_none());
+        assert_eq!(state.battle_end(), Some(BATTLE_MIN));
+    }
+
+    #[test]
+    fn a_stuck_hold_ends_at_the_failsafe() {
+        let state = SplashState {
+            held: true,
+            ..state_at((HOLD_FAILSAFE.as_millis() as u64) + 10_000)
+        };
+        assert!(
+            state.is_done(),
+            "a held splash that never hears release() must still end"
+        );
     }
 
     #[test]
@@ -283,10 +492,13 @@ mod tests {
         // Still playing: no finish moment yet.
         assert!(state_at(100).finished_at().is_none());
 
-        // Timed out: finishes exactly at start + SPLASH_DURATION.
-        let timed_out = state_at(2_000);
+        // Played out: finishes exactly at start + the full movie.
+        let timed_out = state_at(total_ms() + 500);
         let fin = timed_out.finished_at().expect("past the timeline");
-        assert_eq!(fin, timed_out.start + SPLASH_DURATION);
+        assert_eq!(
+            fin,
+            timed_out.start + BATTLE_MIN + REVEAL + WORDMARK_HOLD + FADE
+        );
 
         // Skipped: the first skip pins the moment; a second skip won't move it.
         let mut skipped = SplashState::new();
@@ -297,24 +509,42 @@ mod tests {
     }
 
     #[test]
-    fn progress_is_clamped_to_unit_range() {
-        let state = SplashState::new();
-        let p = state.progress();
-        assert!((0.0..=1.0).contains(&p));
+    fn the_battle_paints_the_frame() {
+        let rows = draw(&state_at(1_200), 80, 24);
+        assert!(has_non_space(&rows), "mid-battle frames are never blank");
     }
 
     #[test]
-    fn renders_the_big_wordmark_on_a_roomy_terminal_at_the_handoff_point() {
-        let rows = draw(&state_at(HANDOFF_MS), 80, 24);
+    fn the_reveal_ends_with_the_wordmark_fully_visible() {
+        // Just past the coalesce: the STELLA block glyphs are materialized.
+        let at = BATTLE_MIN.as_millis() as u64 + REVEAL.as_millis() as u64 + 100;
+        let rows = draw(&state_at(at), 80, 24);
         assert!(
-            has_non_space(&rows),
-            "wordmark should be (fully) visible right past coalesce-in"
+            rows.iter().any(|r| r.contains('█')),
+            "block-art wordmark should be visible at the hold"
+        );
+        assert!(
+            rows.iter().any(|r| r.contains("command deck")),
+            "subtitle should be visible at the hold"
         );
     }
 
     #[test]
-    fn renders_the_compact_fallback_on_a_tiny_terminal_at_the_handoff_point() {
-        let rows = draw(&state_at(HANDOFF_MS), 30, 5);
+    fn tall_terminals_get_the_full_height_glyphs() {
+        let at = BATTLE_MIN.as_millis() as u64 + REVEAL.as_millis() as u64 + 100;
+        let tall = draw(&state_at(at), 80, 30);
+        let short = draw(&state_at(at), 80, 16);
+        let block_rows = |rows: &[String]| rows.iter().filter(|r| r.contains('█')).count();
+        assert!(
+            block_rows(&tall) > block_rows(&short),
+            "PixelSize::Full should paint more glyph rows than HalfHeight"
+        );
+    }
+
+    #[test]
+    fn renders_the_compact_fallback_on_a_tiny_terminal() {
+        let at = BATTLE_MIN.as_millis() as u64 + REVEAL.as_millis() as u64 + 100;
+        let rows = draw(&state_at(at), 30, 5);
         let text = rows.join("");
         assert!(
             text.contains("STELLA"),
@@ -323,49 +553,64 @@ mod tests {
     }
 
     #[test]
-    fn a_brand_new_splash_starts_hidden_and_coalesces_in() {
-        // progress() ~= 0: the coalesce effect is essentially unstarted, so
-        // almost nothing has materialized yet — the opposite end of the
-        // reveal from the handoff-point test above.
-        let rows = draw(&state_at(0), 80, 24);
-        assert!(
-            !has_non_space(&rows),
-            "a just-started splash should still read as (near-)blank"
-        );
+    fn a_reduced_splash_is_one_brief_static_wordmark() {
+        let mut state = state_at(100);
+        state.set_reduced(true);
+        assert_eq!(state.phase(), Phase::Hold);
+        let rows = draw(&state, 80, 24);
+        assert!(has_non_space(&rows), "reduced splash shows the wordmark");
+
+        let mut over = state_at(REDUCED_TOTAL.as_millis() as u64 + 100);
+        over.set_reduced(true);
+        assert!(over.is_done(), "reduced splash ends after its brief hold");
+        assert!(over.finished_at().is_some());
     }
 
     #[test]
-    fn render_does_not_panic_across_the_whole_progress_timeline() {
-        // Exercise the coalesce phase, the hand-off point, and the dissolve
-        // phase, at both the big-text and fallback sizes, plus degenerate
-        // (zero/one-cell) areas.
-        for &skip in &[true, false] {
-            for &(w, h) in &[(80_u16, 24_u16), (30, 5), (0, 0), (1, 1)] {
-                let mut state = SplashState::new();
-                if skip {
-                    state.skip();
-                }
-                let _ = draw(&state, w, h);
+    fn a_reduced_splash_ignores_hold_cues() {
+        let mut state = SplashState {
+            held: true,
+            ..state_at(REDUCED_TOTAL.as_millis() as u64 + 100)
+        };
+        state.set_reduced(true);
+        assert!(state.is_done(), "reduced splashes never loop the battle");
+    }
+
+    #[test]
+    fn render_does_not_panic_across_the_whole_timeline() {
+        // Battle, the hand-offs, reveal, hold, fade, and past the end — at
+        // full, small-battle, fallback, and degenerate sizes.
+        let battle = BATTLE_MIN.as_millis() as u64;
+        let marks = [
+            0,
+            400,
+            1_750,
+            battle - 30,
+            battle + 30,
+            battle + 700,
+            battle + REVEAL.as_millis() as u64 + 100,
+            battle + (REVEAL + WORDMARK_HOLD).as_millis() as u64 + 100,
+            total_ms() - 30,
+            total_ms() + 200,
+        ];
+        for &(w, h) in &[(80_u16, 24_u16), (44, 14), (30, 5), (0, 0), (1, 1)] {
+            for &ms in &marks {
+                let _ = draw(&state_at(ms), w, h);
             }
-        }
-        for &elapsed_ms in &[0, 100, 800, 960, HANDOFF_MS, 1200, 1600, 2000] {
-            let _ = draw(&state_at(elapsed_ms), 80, 24);
+            let mut skipped = SplashState::new();
+            skipped.skip();
+            let _ = draw(&skipped, w, h);
         }
     }
 
     #[test]
-    fn fully_dissolved_end_state_leaves_the_wordmark_area_blank() {
-        // At progress() == 1.0, the dissolve effect is processed with its
-        // own full duration, landing its alpha at exactly 1.0 — which clears
-        // every cell it touches deterministically (tachyonfx's dissolve
-        // threshold is `cell_alpha > rng()` sampled from [0.0, 1.0), so
-        // alpha == 1.0 always wins).
+    fn a_skipped_splash_renders_nothing() {
         let mut state = SplashState::new();
         state.skip();
         let rows = draw(&state, 80, 24);
         assert!(
             !has_non_space(&rows),
-            "a skipped splash should render fully dissolved"
+            "a skipped splash must leave the frame to the deck"
         );
     }
 }


### PR DESCRIPTION
## What

The deck's 1.6s branded splash becomes a **≥6-second Space Invaders launch movie**, played on every deck launch and replayed whenever `/init` runs in the deck shell.

**Timeline** (any key still skips; `--no-anim` collapses to a brief static wordmark):

1. **Battle** (≥3.5s) — drifting, twinkling starfield; a marching two-frame invader fleet in ember tiers; the player cannon slides under four targets and destroys each with a bolt (shot 3 flies through the hole shot 1 opened); the fleet returns fire — one bomb bursts on the ground, one leads and downs the escort ship; multi-frame explosion bursts throughout.
2. **Reveal** — the **STELLA** block-art wordmark (full 8-row glyphs on tall terminals) materializes cell-by-cell via a seeded coalesce — a patterned reveal — with stars still falling behind it.
3. **Hold** — wordmark fully lit over "command deck".
4. **Fade** — the whole frame fades out and the deck eases in.

**Init coverage**: the splash is *held* open while init runs — the battle loops until the driver releases it. At launch that release waits for BOTH the MCP connect and the background code-graph build, so a first launch in a fresh project keeps the movie playing for the whole index build instead of freezing. `/init` replays the cinematic and releases on success *and* failure. A 120s failsafe ends a hold whose driver died.

## How

- `stella-tui/src/invaders.rs` (new) — the battle scene as **pure functions of t** (seeded hash, no simulation state): two renders at equal t are byte-identical, so the deck's immutable scrubbed-render model holds and a held splash wraps t at the loop period seamlessly.
- `splash.rs` — rewritten four-phase timeline with `held`/`release`/`reduced` states; public API (`new`/`skip`/`is_done`/`finished_at`) unchanged.
- `envelope.rs` — `Inbound::Splash(SplashCue::{Replay,Release})`, out-of-band view-state cues ignored by the model fold.
- `command_deck.rs` — launch hold/release (atomic two-leg countdown), `/init` replay.

Scope note: the cinematic is deck-only. The `--plain`/non-TTY REPL fallback can't host a full-screen ratatui movie by design.

## Testing

- 29 new unit tests (splash timeline incl. hold/release/failsafe/reduced, battle determinism/looping/kill scripting, ingest cues incl. no-anim) — 407 pass in `stella-tui`, 190 in `stella-cli`.
- `cargo clippy --all-targets -D warnings` clean on both crates; touched files rustfmt-clean.
- Frames visually verified via a throwaway renderer (fleet march + kills + escort down + wordmark hold all render as scripted at 80×24 and 80×26).
