### PR TITLE
fix: main does not compile — repair the #168/#169/#170 merge cascade + deterministic pid_alive

### DIFF
--- a/stella-store/src/sessions.rs
+++ b/stella-store/src/sessions.rs
@@ -237,10 +237,17 @@ impl SessionRegistry {
 fn pid_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
+        // `pid_t` is signed: a stored pid that doesn't fit (a corrupt
+        // record, or a sentinel like `u32::MAX`) must read as dead — an
+        // `as` cast would wrap it negative, and `kill(-N, 0)` probes
+        // process GROUP N, which can spuriously report alive.
+        let Ok(pid) = libc::pid_t::try_from(pid) else {
+            return false;
+        };
         if pid == 0 {
             return false;
         }
-        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        let rc = unsafe { libc::kill(pid, 0) };
         rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
     }
     #[cfg(not(unix))]

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -188,8 +188,7 @@ async fn main() -> std::io::Result<()> {
                 | WorkspaceInput::SessionDelete { .. } => {
                     let _ = react_tx.send(Inbound::Sessions(vec![]));
                 }
-                WorkspaceInput::NotificationRead { .. }
-                | WorkspaceInput::NotificationsReadAll => {
+                WorkspaceInput::NotificationRead { .. } | WorkspaceInput::NotificationsReadAll => {
                     let _ = react_tx.send(Inbound::Notifications(vec![]));
                 }
                 WorkspaceInput::Quit => break,

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -383,7 +383,6 @@ impl WorkspaceModel {
             | Inbound::Sessions(_)
             | Inbound::Notifications(_)
             | Inbound::McpOauthStatus { .. }
-            | Inbound::ShowHelp => {}
             | Inbound::ShowHelp
             | Inbound::Splash(_) => {}
         }

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, StatefulWidget, Widget};

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -713,6 +713,9 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         });
         if *outcome == Some(true) {
             ui.pending_inputs.push(WorkspaceInput::McpRefresh);
+        }
+        return;
+    }
     // Launch-cinematic cues: the driver replays the splash held open over a
     // running init (`/init`, session startup) and releases it when init
     // finishes. Out-of-band view state like `ShowHelp`. `--no-anim`

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -205,6 +205,12 @@ pub enum Inbound {
     /// [`crate::deck_ui::ingest_inbound`]. Out-of-band view state, ignored by
     /// the model fold — like [`Inbound::GraphSnapshot`].
     ShowHelp,
+    /// A launch-cinematic cue (see [`SplashCue`]): the driver replays the
+    /// splash held open over a running init (session startup, `/init`) and
+    /// releases it when init finishes. Out-of-band view state, applied
+    /// straight to `DeckUi::splash` by [`crate::deck_ui::ingest_inbound`],
+    /// ignored by the model fold — like [`Inbound::ShowHelp`].
+    Splash(SplashCue),
     /// A refreshed snapshot of the **cross-process session registry** for the
     /// SESSIONS overlay (empty-prompt `←`). Every running stella session on
     /// this machine, grouped by [`SessionPhase`]. Out-of-band view state like
@@ -295,12 +301,6 @@ pub struct NotificationInfo {
     pub source: String,
     pub created_ms: u64,
     pub read: bool,
-    /// A launch-cinematic cue (see [`SplashCue`]): the driver replays the
-    /// splash held open over a running init (session startup, `/init`) and
-    /// releases it when init finishes. Out-of-band view state, applied
-    /// straight to `DeckUi::splash` by [`crate::deck_ui::ingest_inbound`],
-    /// ignored by the model fold — like [`Inbound::ShowHelp`].
-    Splash(SplashCue),
 }
 
 /// Driver → deck cues for the launch cinematic ([`crate::splash`]).

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -89,7 +89,7 @@ pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
     InstalledAgentEntry, McpSearchItem, McpSearchOutcome, McpServerInfo, NotificationInfo, Secret,
     SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView,
-    WorkspaceInput,
+    SplashCue, WorkspaceInput,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -2077,6 +2077,7 @@ mod tests {
                 summary: "hit".into(),
                 full: "src/a.rs:1: hit\nsrc/b.rs:2: hit".into(),
                 duration_ms: 5,
+                speculated: false,
                 diff: None,
             },
             false,


### PR DESCRIPTION
**Main is currently red** (`stella-tui` fails to compile at `fd1c3f0`) — this PR repairs the merge-cascade damage from #168 (splash cinematic) + #169 (MCP OAuth/sessions) + #170 (speculative tool execution) landing in quick succession, and it should merge ahead of other work.

## The five merge artifacts

1. **`deck_ui.rs`** — the `McpOauthStatus` arm lost its closing braces and `return;` (rustc reported an unclosed delimiter at line 5050, masking everything below).
2. **`envelope.rs`** — the `Splash(SplashCue)` enum variant was grafted into the middle of the `NotificationInfo` *struct* instead of the `Inbound` enum (syntax error + missing variant at all three use sites). Restored to #168's intended shape.
3. **`lib.rs`** — the `SplashCue` root re-export was dropped, breaking `stella-cli`.
4. **`deck_render.rs`** — the `Alignment` import was lost.
5. **`render.rs` / `deck.rs` / fmt** — a test's `TranscriptEntry::ToolResult` initializer predated #170's `speculated` field; a duplicated `ShowHelp` match arm (`-D unreachable-patterns`); fmt drift in `deck.rs` and `examples/deck_demo.rs`.

## Plus one real bug the gate then exposed

`sessions::tests::dead_pid_downgrades_live_statuses_to_error_at_read_time` was flaky: it uses `u32::MAX - 1` as a "certainly dead" pid, but `as libc::pid_t` wraps that to **-2**, and `kill(-2, 0)` probes process *group* 2 — which spuriously reports alive depending on what's running. This is a production defect too: a corrupt session record could probe a process group. `pid_alive` now treats any pid that doesn't fit `pid_t` as dead (`try_from` instead of `as`).

## Verification

- `make gate` green on this branch: fmt-check, clippy `-D warnings`, full workspace test suite.
- The previously-flaky pid test passes 5/5 consecutive runs (it deterministically exercises the new `try_from` path — it fails on main both ways: first as a compile error, and intermittently as the group-probe flake).


## Summary by Sourcery

Fix compilation errors and a PID liveness bug introduced by recent merges, restoring a clean build and deterministic session handling.

Bug Fixes:
- Restore the `Inbound::Splash(SplashCue)` variant and its usage so splash notifications and imports compile correctly.
- Fix `McpOauthStatus` handling in `deck_ui` to avoid unreachable patterns and ensure control flow returns early as intended.
- Correct `pid_alive` to treat PIDs that do not fit into `pid_t` as dead, preventing accidental process-group probing and eliminating test flakiness.
- Update test data to include the new `speculated` field on `TranscriptEntry::ToolResult` to match the current type definition.

Enhancements:
- Re-export `SplashCue` from the `stella-tui` crate root and restore necessary layout imports, keeping the public API and rendering intact.
- Tidy deck and example code paths and formatting in response to the corrected inbound variants and notification handling.
