### PR TITLE
fix(store): deflake dead-pid session registry test

### DIFF
--- a/stella-store/src/sessions.rs
+++ b/stella-store/src/sessions.rs
@@ -301,6 +301,7 @@ mod tests {
         reg.upsert(&crashed).unwrap();
 
         let mut done = SessionRecord::new("/w/b", "b");
+        done.id = format!("{}-b", done.id); // distinct id even within one ms
         done.pid = u32::MAX - 1;
         done.status = SessionStatus::Complete;
         reg.upsert(&done).unwrap();


### PR DESCRIPTION
## Summary
- `sessions::tests::dead_pid_downgrades_live_statuses_to_error_at_read_time` was flaky (~70% failure rate locally: 36/50 runs): `SessionRecord::new` mints ids as `ses-<now_ms>-<pid>`, so the test's two records collide whenever both are created in the same millisecond (same process → same pid), and the second `upsert` overwrites the first record's file. `list` then returns only the `Complete` record and the `Error` assertion fails with `left: Complete, right: Error`.
- Fix: give the second record a distinct id, the same guard `list_skips_corrupt_files_and_sorts_newest_first` and `prune_sweeps_only_old_terminal_records` already use.

## Testing
- `cargo test -p stella-store --lib` — 48/48 pass
- Re-ran the fixed test 50×: 50/50 pass (before the fix: 14/50)


## Summary by Sourcery

Bug Fixes:
- Prevent flaky failures in the dead-pid session registry test by assigning a unique ID to the second test session record created within the same millisecond.
