### PR TITLE
feat: agent_engine_config — per-agent models, prompts, effort & params + /engine TUI editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,76 @@ Prefer `api_key_env` over a literal `api_key` — settings files get committed.
 > scopes are always trusted. Project hooks are gated the same way, via
 > `STELLA_PROJECT_HOOKS`.
 
+### Agent engine config (`agent_engine_config`)
+
+The engine runs four configurable agents — **default** (the interactive /
+step-loop agent) and the pipeline's **worker**, **judge**, and **triage**.
+The `agent_engine_config` object in the same `settings.json` scope chain
+configures each one's model, gateway, system prompt, reasoning, and sampling
+parameters — and in the Command Deck, `/engine` opens an editor popup for
+all of it (`s` saves to user scope, `S` to project scope; `/model-worker`,
+`/model-judge`, `/model-triage`, `/model-default` jump straight to a model
+picker driven by `allowed_models`).
+
+```jsonc
+{
+  "agent_engine_config": {
+    // Flat per-role models ("provider/slug", or a bare catalog slug).
+    "default_model": "anthropic/claude-fable-5",
+    "pipeline_worker_model": "zai/glm-5.2",
+    "pipeline_judge_model": "openrouter/openai/gpt-5.5",
+    "pipeline_triage_model": "deepseek/deepseek-chat",
+
+    // The model vocabulary the TUI pickers offer and auto_mode selects from.
+    "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2",
+                        "openrouter/openai/gpt-5.5"],
+
+    // "on" = pick the judge automatically from allowed_models: prefer a
+    // different model family than the worker's, then the highest catalog
+    // price tier. You never worry about it.
+    "auto_mode": "off",
+    // "on" = per-agent effort is chosen for you (judge high, worker
+    // medium, triage low), overriding any per-agent "effort".
+    "effort_auto": "off",
+    // "on" = thinking mode chosen for you (on everywhere except triage).
+    "reasoning_auto": "off",
+
+    // Per-agent deep config. Every field is optional — set it and it goes
+    // on the wire; leave it out and the provider default applies.
+    "agents": {
+      "judge": {
+        "provider": "openrouter",         // gateway: the slug goes to THIS
+        "model": "openai/gpt-5.5",        // provider verbatim (BYOK per agent)
+        "prompt": "You are a strict, evidence-first code judge.",
+        "effort": "high",                  // low | medium | high | xhigh | max
+        "reasoning": "on",                 // thinking mode on/off
+        "params": {
+          "temperature": 0.2, "top_p": 0.9, "top_k": 40,
+          "frequency_penalty": 0.0, "presence_penalty": 0.0,
+          "repetition_penalty": 1.0, "max_tokens": 4096, "seed": 7,
+          "verbosity": "low",              // OpenAI/Anthropic-family models
+          "service_tier": "priority"       // providers with tiered service
+        }
+      }
+    }
+  }
+}
+```
+
+Precedence per agent: `--model` flag > `agents.<agent>.model` >
+`pipeline_<agent>_model` > `default_model` > auto-detect. An agent's
+`provider` field routes its slug through that gateway verbatim, so the
+worker can run on your Anthropic key while the judge routes
+`openai/gpt-5.5` through your OpenRouter key and triage hits Z.ai. Each
+adapter forwards only the parameters its wire supports (`verbosity` and
+`service_tier` are dropped where meaningless); reasoning maps to GLM's
+`thinking`, OpenRouter's `reasoning`, Anthropic extended thinking (with an
+effort-tiered budget), OpenAI `reasoning.effort`, and Gemini
+`thinkingLevel`. Custom prompts replace the built-in base instructions;
+workspace memories and rules still append. A judge/triage model whose
+provider has no resolvable key degrades softly — the role rides the worker
+and a notice says so.
+
 ## Usage
 
 ### Interactive chat (default)

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -212,13 +212,46 @@ Workspace memories (lessons from previous sessions — apply them):
     }
 }
 
-/// EngineConfig for a session: defaults, with the workspace root as the
-/// `cwd` every lifecycle-hook payload reports (`stella_core::hooks`).
-pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
-    EngineConfig {
+/// EngineConfig for `kind`: defaults + the workspace root as hook `cwd`,
+/// with the agent's `agent_engine_config` tuning applied — temperature and
+/// max_tokens override the engine defaults only when set (the "Include"
+/// contract), effort/reasoning/params land verbatim (they default to
+/// `None` anyway).
+fn tuned_engine_config(cfg: &Config, kind: crate::settings::EngineAgentKind) -> EngineConfig {
+    let mut engine = EngineConfig {
         cwd: cfg.workspace_root.display().to_string(),
         ..EngineConfig::default()
+    };
+    if let Some(settings) = &cfg.engine_settings {
+        let tuning = crate::engine_config::tuning_for(settings, kind);
+        if tuning.temperature.is_some() {
+            engine.temperature = tuning.temperature;
+        }
+        if tuning.max_output_tokens.is_some() {
+            engine.max_output_tokens = tuning.max_output_tokens;
+        }
+        engine.effort = tuning.effort;
+        engine.reasoning = tuning.reasoning;
+        engine.params = tuning.params;
     }
+    engine
+}
+
+/// EngineConfig for a session's default (interactive/step-loop) agent.
+pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
+    tuned_engine_config(cfg, crate::settings::EngineAgentKind::Default)
+}
+
+/// EngineConfig for a pipeline's execute turns — the WORKER agent's tuning
+/// (plan and witness ride it too, matching the router's tiering).
+pub(crate) fn pipeline_engine_config_for(cfg: &Config) -> EngineConfig {
+    tuned_engine_config(cfg, crate::settings::EngineAgentKind::Worker)
+}
+
+/// EngineConfig for the goal loop's standalone judge engine — the JUDGE
+/// agent's tuning.
+pub(crate) fn judge_engine_config_for(cfg: &Config) -> EngineConfig {
+    tuned_engine_config(cfg, crate::settings::EngineAgentKind::Judge)
 }
 
 /// Fire `SessionStart` hooks once and return their stdout — the additional
@@ -247,15 +280,35 @@ pub(crate) async fn with_session_hook_context(mut system_prompt: String, cfg: &C
     system_prompt
 }
 
-/// Shortcut: the raw step-loop system prompt plus workspace memories
-/// (`pub(crate)`: the Command Deck session assembles the same prompt).
-pub(crate) fn build_system_prompt(workspace_root: &std::path::Path) -> String {
-    assemble_system_prompt(SYSTEM_PROMPT, workspace_root)
+/// The `agent_engine_config` custom prompt for `kind`, when one is set —
+/// it replaces the built-in BASE instruction set only; workspace memories
+/// and rules still append (they are workspace context, not part of the
+/// base persona, and a custom prompt should not silently disable them).
+fn custom_prompt_base(cfg: &Config, kind: crate::settings::EngineAgentKind) -> Option<String> {
+    cfg.engine_settings
+        .as_ref()
+        .and_then(|e| e.agent(kind))
+        .and_then(|a| a.prompt.clone())
+        .filter(|p| !p.trim().is_empty())
 }
 
-/// Shortcut: the pipeline-mode system prompt plus workspace memories.
-fn build_pipeline_system_prompt(workspace_root: &std::path::Path) -> String {
-    assemble_system_prompt(PIPELINE_SYSTEM_PROMPT, workspace_root)
+/// The raw step-loop system prompt plus workspace memories (`pub(crate)`:
+/// the Command Deck session assembles the same prompt). `workspace_root`
+/// is a parameter (not read off `cfg`) because fleet workers assemble the
+/// prompt for their own worktree root.
+pub(crate) fn build_system_prompt(cfg: &Config, workspace_root: &std::path::Path) -> String {
+    let base = custom_prompt_base(cfg, crate::settings::EngineAgentKind::Default);
+    assemble_system_prompt(base.as_deref().unwrap_or(SYSTEM_PROMPT), workspace_root)
+}
+
+/// The pipeline-mode system prompt plus workspace memories — the WORKER
+/// agent's custom prompt applies here.
+fn build_pipeline_system_prompt(cfg: &Config, workspace_root: &std::path::Path) -> String {
+    let base = custom_prompt_base(cfg, crate::settings::EngineAgentKind::Worker);
+    assemble_system_prompt(
+        base.as_deref().unwrap_or(PIPELINE_SYSTEM_PROMPT),
+        workspace_root,
+    )
 }
 
 /// Run a one-shot prompt. `use_pipeline` selects the staged pipeline (the
@@ -334,13 +387,19 @@ async fn run_pipeline_one_shot(
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let renderer = spawn_renderer(rx, format, execution.clone(), cfg.provider.id.to_string());
 
-    let resolver = SingleProviderResolver {
-        provider,
-        model_ref: model_ref.clone(),
-    };
+    // Role wiring from `agent_engine_config`: per-role model pins (triage/
+    // judge), their adapters, and per-role request overrides. Notices are
+    // stderr diagnostics — stdout may be machine-readable JSON.
+    let wiring = resolve_engine_wiring(cfg, &model_ref);
+    for notice in &wiring.notices {
+        eprintln!("  ! {notice}");
+    }
+    let resolver =
+        RoleProviderResolver::new(&*provider, model_ref.clone(), &wiring.extra_providers);
 
     let mut messages = vec![CompletionMessage::system(
-        with_session_hook_context(build_pipeline_system_prompt(&cfg.workspace_root), cfg).await,
+        with_session_hook_context(build_pipeline_system_prompt(cfg, &cfg.workspace_root), cfg)
+            .await,
     )];
     let mut memory = SessionMemory::open(&cfg.workspace_root, format == OutputFormat::Text);
     if let Some(m) = &memory {
@@ -368,18 +427,13 @@ async fn run_pipeline_one_shot(
             root: cfg.workspace_root.clone(),
         };
 
-        let profile = ProviderProfile::new(
-            cfg.provider.id,
-            model_ref.clone(),
-            model_ref.clone(),
-            model_ref,
-        );
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));
-        let router = Router::new(RoleTable::new(), vec![profile], breaker);
+        let router = Router::new(wiring.pins.clone(), wiring.profiles.clone(), breaker);
 
         let is_text = format == OutputFormat::Text;
         let pipeline_config = PipelineConfig {
-            engine: engine_config_for(cfg),
+            engine: pipeline_engine_config_for(cfg),
+            role_overrides: wiring.role_overrides.clone(),
             headless: !is_text,
             headless_bypass_scope_review: !is_text,
             // `--test-command` arms the deterministic verify ladder: the
@@ -496,7 +550,7 @@ async fn run_pipeline_one_shot(
         }
         let report = m
             .reflect_and_record(
-                resolver.provider(),
+                &*provider,
                 &reflect_transcript,
                 format != OutputFormat::Text,
                 result.is_ok(),
@@ -567,45 +621,201 @@ async fn run_pipeline_one_shot(
 // Pipeline port adapters
 // -----------------------------------------------------------------------
 
-/// Owns the boxed provider so the reference returned to the pipeline is
-/// valid for the pipeline's entire lifetime.
-pub(crate) struct SingleProviderResolver {
-    provider: Box<dyn Provider>,
-    model_ref: ModelRef,
+/// Everything `agent_engine_config` resolves for one pipeline run: the
+/// role router inputs (profiles + pins), owned adapters for roles routed
+/// to a model other than the worker's, the per-role request overrides,
+/// and human-readable notices about wiring decisions (a provider without
+/// a credential, an adapter that failed to build). Every failure is soft:
+/// the affected role rides the worker, exactly as before this config
+/// existed — configuration must never turn a runnable pipeline into an
+/// error.
+pub(crate) struct EngineWiring {
+    pub(crate) profiles: Vec<ProviderProfile>,
+    pub(crate) pins: RoleTable,
+    /// Adapters for pinned off-worker models, keyed by the exact
+    /// [`ModelRef`] the pins route to (adapters bind their model id at
+    /// construction, so each distinct ref needs its own instance).
+    pub(crate) extra_providers: Vec<(ModelRef, Box<dyn Provider>)>,
+    pub(crate) role_overrides: stella_pipeline::PipelineRoleOverrides,
+    pub(crate) notices: Vec<String>,
 }
 
-impl SingleProviderResolver {
-    fn provider(&self) -> &dyn Provider {
-        &*self.provider
-    }
-}
+/// Resolve the engine wiring for a pipeline run whose worker is
+/// `worker_ref` (already resolved by `Config` — an explicit `--model`
+/// flag beats the settings, see `Config::load_with_settings`).
+///
+/// Routing rules, in order:
+/// - TRIAGE and JUDGE pins come from their configured model specs
+///   ([`crate::engine_config::model_spec_for`]).
+/// - `auto_mode: on` replaces the judge spec with
+///   [`crate::engine_config::auto_judge_spec`]'s pick from
+///   `allowed_models` (cross-family from the worker, then price tier);
+///   when the allowed list yields nothing usable it falls back to the
+///   explicit judge spec, then to normal router degradation.
+/// - A pin equal to the worker's own model needs no extra adapter — the
+///   primary resolver entry already serves it.
+///
+/// Pins deliberately bypass the circuit breaker (`RoleTable` semantics —
+/// an explicit pin wins unconditionally). If a pinned judge's provider
+/// fails, the pipeline's judge call degrades to its heuristic verdict,
+/// the same soft path an unreachable judge always took.
+pub(crate) fn resolve_engine_wiring(cfg: &Config, worker_ref: &ModelRef) -> EngineWiring {
+    use crate::engine_config::{
+        ModelSpec, auto_judge_spec, model_spec_for, spec_family, tuning_for,
+    };
+    use crate::settings::EngineAgentKind;
 
-impl ProviderResolver for SingleProviderResolver {
-    fn provider_for(&self, model: &ModelRef) -> Option<&dyn Provider> {
-        if model == &self.model_ref {
-            Some(&*self.provider)
+    let worker_profile = ProviderProfile::new(
+        worker_ref.provider.clone(),
+        worker_ref.clone(),
+        worker_ref.clone(),
+        worker_ref.clone(),
+    )
+    .with_family(provider_family(&worker_ref.provider));
+
+    let mut wiring = EngineWiring {
+        profiles: vec![worker_profile],
+        pins: RoleTable::new(),
+        extra_providers: Vec::new(),
+        role_overrides: stella_pipeline::PipelineRoleOverrides::default(),
+        notices: Vec::new(),
+    };
+    let Some(engine) = cfg.engine_settings.clone() else {
+        return wiring;
+    };
+
+    let triage_tuning = tuning_for(&engine, EngineAgentKind::Triage);
+    let judge_tuning = tuning_for(&engine, EngineAgentKind::Judge);
+    wiring.role_overrides.triage = stella_pipeline::RoleCallOverrides {
+        prompt: triage_tuning.prompt,
+        effort: triage_tuning.effort,
+        reasoning: triage_tuning.reasoning,
+        temperature: triage_tuning.temperature,
+        max_output_tokens: triage_tuning.max_output_tokens,
+        params: triage_tuning.params,
+    };
+    wiring.role_overrides.judge = stella_pipeline::RoleCallOverrides {
+        prompt: judge_tuning.prompt,
+        effort: judge_tuning.effort,
+        reasoning: judge_tuning.reasoning,
+        temperature: judge_tuning.temperature,
+        max_output_tokens: judge_tuning.max_output_tokens,
+        params: judge_tuning.params,
+    };
+
+    // Credentialed providers only — a model spec naming a provider without
+    // a resolvable key is reported and skipped, never a hard error.
+    let configured = crate::config::discover_configured_providers();
+    let is_provider = |id: &str| configured.iter().any(|c| c.config.id == id);
+
+    let worker_family = spec_family(&ModelSpec {
+        provider: worker_ref.provider.clone(),
+        model: worker_ref.model_id.clone(),
+    });
+    let judge_spec = if engine.auto_mode_on() {
+        auto_judge_spec(&engine, &worker_family, &is_provider)
+            .or_else(|| model_spec_for(&engine, EngineAgentKind::Judge, &is_provider))
+    } else {
+        model_spec_for(&engine, EngineAgentKind::Judge, &is_provider)
+    };
+    let role_specs = [
+        (
+            Role::Triage,
+            "triage",
+            model_spec_for(&engine, EngineAgentKind::Triage, &is_provider),
+        ),
+        (Role::Judge, "judge", judge_spec),
+    ];
+
+    for (role, label, spec) in role_specs {
+        let Some(spec) = spec else { continue };
+        let Some(entry) = configured.iter().find(|c| c.config.id == spec.provider) else {
+            wiring.notices.push(format!(
+                "engine config: {label} model `{}/{}` skipped — no resolvable credential for \
+                 provider `{}`; {label} rides the worker",
+                spec.provider, spec.model, spec.provider
+            ));
+            continue;
+        };
+        // An empty slug is the "provider pin without a model" form — the
+        // provider's own default model.
+        let slug = if spec.model.is_empty() {
+            entry.config.default_model.to_string()
         } else {
-            None
+            spec.model.clone()
+        };
+        let pinned = ModelRef::new(entry.config.id, slug.clone());
+        if pinned == *worker_ref {
+            // Same instance as the worker: the primary resolver entry
+            // serves it; the pin still records the explicit choice.
+            wiring.pins.pin(role, pinned);
+            continue;
+        }
+        match build_provider_parts(
+            &entry.config,
+            &slug,
+            entry.api_key.clone(),
+            entry.config.base_url.to_string(),
+            None,
+        ) {
+            Ok(provider) => {
+                wiring.pins.pin(role, pinned.clone());
+                // A profile for the routed provider keeps the router's
+                // provider list honest (breaker bookkeeping, `providers()`
+                // introspection) even though the pin short-circuits it.
+                wiring.profiles.push(
+                    ProviderProfile::new(
+                        entry.config.id,
+                        pinned.clone(),
+                        pinned.clone(),
+                        pinned.clone(),
+                    )
+                    .with_family(provider_family(entry.config.id)),
+                );
+                wiring.extra_providers.push((pinned, provider));
+            }
+            Err(e) => wiring.notices.push(format!(
+                "engine config: {label} model `{}/{slug}` skipped — {e}; {label} rides the worker",
+                entry.config.id
+            )),
+        }
+    }
+    wiring
+}
+
+/// Maps each pinned [`ModelRef`] to its adapter: the primary (worker)
+/// provider plus the wiring's extra per-role adapters. The worker entry is
+/// borrowed (the caller owns it — boxed in one-shot, `&dyn` in the deck
+/// and goal paths); the extras are borrowed from the [`EngineWiring`].
+pub(crate) struct RoleProviderResolver<'p> {
+    primary: &'p dyn Provider,
+    primary_ref: ModelRef,
+    extra: &'p [(ModelRef, Box<dyn Provider>)],
+}
+
+impl<'p> RoleProviderResolver<'p> {
+    pub(crate) fn new(
+        primary: &'p dyn Provider,
+        primary_ref: ModelRef,
+        extra: &'p [(ModelRef, Box<dyn Provider>)],
+    ) -> Self {
+        Self {
+            primary,
+            primary_ref,
+            extra,
         }
     }
 }
 
-/// A [`ProviderResolver`] that borrows a single `&dyn Provider` — for
-/// pipeline paths that receive a borrowed provider (the goal loop, fleet
-/// workers) rather than owning one. Answers every model with that provider.
-pub(crate) struct BorrowedProviderResolver<'p> {
-    provider: &'p dyn Provider,
-}
-
-impl BorrowedProviderResolver<'_> {
-    pub(crate) fn new(provider: &dyn Provider) -> BorrowedProviderResolver<'_> {
-        BorrowedProviderResolver { provider }
-    }
-}
-
-impl ProviderResolver for BorrowedProviderResolver<'_> {
-    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
-        Some(self.provider)
+impl ProviderResolver for RoleProviderResolver<'_> {
+    fn provider_for(&self, model: &ModelRef) -> Option<&dyn Provider> {
+        if *model == self.primary_ref {
+            return Some(self.primary);
+        }
+        self.extra
+            .iter()
+            .find(|(model_ref, _)| model_ref == model)
+            .map(|(_, provider)| &**provider)
     }
 }
 
@@ -850,7 +1060,7 @@ async fn run_raw_one_shot(
 
     let mut messages = vec![
         CompletionMessage::system(
-            with_session_hook_context(build_system_prompt(&cfg.workspace_root), cfg).await,
+            with_session_hook_context(build_system_prompt(cfg, &cfg.workspace_root), cfg).await,
         ),
         crate::attachments::user_message(prompt),
     ];
@@ -971,7 +1181,7 @@ pub async fn run_goal_cmd(
     println!("  {}\n", goal.dimmed());
 
     let mut messages = vec![CompletionMessage::system(
-        with_session_hook_context(build_system_prompt(&cfg.workspace_root), cfg).await,
+        with_session_hook_context(build_system_prompt(cfg, &cfg.workspace_root), cfg).await,
     )];
     let mut memory = SessionMemory::open(&cfg.workspace_root, true);
     if let Some(m) = &memory {
@@ -1091,7 +1301,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     // prefix (instructions + baked memories + SessionStart hook context) is
     // the prompt-cache contract (see build_system_prompt).
     let system_prompt =
-        with_session_hook_context(build_system_prompt(&cfg.workspace_root), cfg).await;
+        with_session_hook_context(build_system_prompt(cfg, &cfg.workspace_root), cfg).await;
     let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
     let mut memory = SessionMemory::open(&cfg.workspace_root, true);
     // Custom extensions: ⚡ commands/skills invocable as `/name args`, custom
@@ -2733,11 +2943,39 @@ async fn run_goal_pipeline_turn(
     let execution = begin_execution(store, "goal", goal, cfg);
     let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
 
+    // Role wiring from `agent_engine_config` — the pinned/auto judge (when
+    // configured) also serves as the goal loop's round judge below.
+    let wiring = resolve_engine_wiring(cfg, &model_ref);
+    for notice in &wiring.notices {
+        eprintln!("  ! {notice}");
+    }
+
     // Route the goal-loop judge. The pipeline's verify judge is the same role;
-    // both want independence from the worker.
+    // both want independence from the worker. An engine-config judge pin
+    // (explicit or auto_mode) wins; otherwise the discovery-based
+    // cross-family routing applies exactly as before.
     let configured = crate::config::discover_configured_providers();
-    let routed_judge = resolve_cross_family_judge(cfg.provider.id, &cfg.model_id, &configured);
-    if let Some((_, judge_id)) = &routed_judge {
+    let engine_judge: Option<(&dyn Provider, String)> = wiring
+        .pins
+        .get(Role::Judge)
+        .and_then(|pinned| {
+            wiring
+                .extra_providers
+                .iter()
+                .find(|(model_ref, _)| model_ref == pinned)
+        })
+        .map(|(model_ref, provider)| (&**provider, model_ref.provider.clone()));
+    let routed_judge = if engine_judge.is_none() {
+        resolve_cross_family_judge(cfg.provider.id, &cfg.model_id, &configured)
+    } else {
+        None
+    };
+    let (judge, judge_id): (&dyn Provider, Option<String>) = match (&engine_judge, &routed_judge) {
+        (Some((provider, id)), _) => (*provider, Some(id.clone())),
+        (None, Some((boxed, id))) => (&**boxed, Some(id.clone())),
+        (None, None) => (provider, None),
+    };
+    if let Some(judge_id) = &judge_id {
         println!(
             "  {} cross-family judge: {} worker · {} judge — independent, bias-resistant \
              assessment\n",
@@ -2746,13 +2984,9 @@ async fn run_goal_pipeline_turn(
             judge_id.bright_green(),
         );
     }
-    let judge: &dyn Provider = match &routed_judge {
-        Some((boxed, _)) => &**boxed,
-        None => provider,
-    };
 
     let goal_config = GoalConfig::default();
-    let resolver = BorrowedProviderResolver::new(provider);
+    let resolver = RoleProviderResolver::new(provider, model_ref.clone(), &wiring.extra_providers);
 
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let renderer = spawn_renderer(
@@ -2773,14 +3007,8 @@ async fn run_goal_pipeline_turn(
         let tools = InteractiveToolSet::new(&customs, tx.clone(), default_ask_io(true))
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
 
-        let profile = ProviderProfile::new(
-            cfg.provider.id,
-            model_ref.clone(),
-            model_ref.clone(),
-            model_ref.clone(),
-        );
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));
-        let router = Router::new(RoleTable::new(), vec![profile], breaker);
+        let router = Router::new(wiring.pins.clone(), wiring.profiles.clone(), breaker);
 
         let repo_structure = GitRepoStructure {
             root: cfg.workspace_root.clone(),
@@ -2799,9 +3027,13 @@ async fn run_goal_pipeline_turn(
         // the session calibration (keyed per model, so a cross-family judge
         // learns its own drift) and a read-only view of the same tools.
         let read_only = stella_core::ports::ReadOnlyTools::new(&tools);
-        let judge_engine =
-            Engine::with_sleeper(judge, &read_only, engine_config_for(cfg), &TokioSleeper)
-                .with_calibration(calibration);
+        let judge_engine = Engine::with_sleeper(
+            judge,
+            &read_only,
+            judge_engine_config_for(cfg),
+            &TokioSleeper,
+        )
+        .with_calibration(calibration);
 
         let mut total_cost_usd = 0.0f64;
         let mut result: Option<Result<(), String>> = None;
@@ -2810,7 +3042,8 @@ async fn run_goal_pipeline_turn(
         for round in 1..=goal_config.max_rounds {
             budget.begin_turn();
             let pipeline_config = PipelineConfig {
-                engine: engine_config_for(cfg),
+                engine: pipeline_engine_config_for(cfg),
+                role_overrides: wiring.role_overrides.clone(),
                 headless: true,
                 headless_bypass_scope_review: true,
                 ..PipelineConfig::default()
@@ -3452,7 +3685,7 @@ mod tests {
         )
         .unwrap();
 
-        let prompt = build_system_prompt(root.path());
+        let prompt = build_system_prompt(&cfg_for("zai"), root.path());
         assert!(
             prompt.starts_with(SYSTEM_PROMPT),
             "rules append to the prompt; the base prefix must stay intact"
@@ -3481,6 +3714,7 @@ mod tests {
             workspace_root: std::path::PathBuf::from("/tmp"),
             base_url_override: None,
             hooks: None,
+            engine_settings: None,
         }
     }
 

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -55,12 +55,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_core::ports::ToolExecutor;
-use stella_core::router::{CircuitBreaker, ProviderProfile};
-use stella_core::{BudgetGuard, CalibrationMap, Engine, RoleTable, Router, TurnOutcome};
+use stella_core::router::CircuitBreaker;
+use stella_core::{BudgetGuard, CalibrationMap, Engine, Router, TurnOutcome};
 use stella_model::provider::Provider;
 use stella_pipeline::{
     AutoApproveGate, ContextRecallPort, NoContextRecall, Pipeline, PipelineConfig, PipelinePorts,
-    PipelineStatus, ProviderResolver,
+    PipelineStatus,
 };
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionRequest, FileChangeKind, ModelRef, ToolOutput,
@@ -239,7 +239,7 @@ pub async fn run_deck_session(
     let calibration = agent::seed_calibration(&store, cfg);
 
     let system_prompt =
-        agent::with_session_hook_context(agent::build_system_prompt(&cfg.workspace_root), cfg)
+        agent::with_session_hook_context(agent::build_system_prompt(cfg, &cfg.workspace_root), cfg)
             .await;
     let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
     // `warn: false`: past this point diagnostics would land on the alternate
@@ -286,6 +286,10 @@ pub async fn run_deck_session(
     // Seed the SKILLS tab so it has data the instant it is opened (both scopes),
     // without waiting on a `/skills` round-trip.
     let _ = in_tx.send(skills_snapshot(&cfg.workspace_root, None));
+    // Seed the ENGINE overlay (`/engine`) the same way: the merged
+    // agent_engine_config plus the picker vocabularies, ready before the
+    // user first opens it.
+    let _ = in_tx.send(engine_config_inbound(cfg, None));
 
     let ask_io = DeckAskUserIo {
         agent: LEAD.to_string(),
@@ -562,8 +566,9 @@ pub async fn run_deck_session(
                             &session_record.id,
                             &in_tx,
                         )
+                        && !handle_agents_input(&other, cfg, &in_tx)
                     {
-                        handle_agents_input(&other, cfg, &in_tx);
+                        handle_engine_config_input(&other, cfg, &in_tx);
                     }
                     continue 'session;
                 }
@@ -868,6 +873,17 @@ pub async fn run_deck_session(
                                 &session_record.id,
                                 &in_tx,
                             );
+                        }
+                        // The ENGINE overlay stays live while a turn runs —
+                        // settings reads/writes are cheap local filesystem
+                        // ops, exactly like the INSTALLED AGENTS pane. A
+                        // mid-turn save applies to runs started afterwards;
+                        // the in-flight turn keeps its resolved models.
+                        Some(
+                            input @ (WorkspaceInput::EngineConfigSave { .. }
+                            | WorkspaceInput::EngineConfigRefresh),
+                        ) => {
+                            handle_engine_config_input(&input, cfg, &in_tx);
                         }
                         // Scope review is not engine-driven yet, and deep
                         // pause/resume/restart need the fleet supervisor —
@@ -1483,12 +1499,91 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ),
     ("/inbox", "notifications — messages persist until read"),
     ("/mcp-search", "search the MCP registry & install servers"),
+    (
+        "/engine",
+        "configure the agent engine: models, prompts, effort & params per agent",
+    ),
+    ("/model-default", "pick the default agent's model"),
+    ("/model-worker", "pick the pipeline worker model"),
+    ("/model-judge", "pick the pipeline judge model"),
+    ("/model-triage", "pick the pipeline triage model"),
     ("/donate", "support stella — become a GitHub Sponsor"),
 ];
 
 /// The deck's reserved command names — see [`DECK_BUILTINS`].
 fn deck_reserved() -> Vec<&'static str> {
     DECK_BUILTINS.iter().map(|(name, _)| *name).collect()
+}
+
+// ── Agent-engine config (the `/engine` overlay) ─────────────────────────────
+
+/// Build an [`Inbound::EngineConfig`] snapshot: the freshly merged
+/// `agent_engine_config` from the settings scope chain, plus the picker
+/// vocabularies — every provider whose credential currently resolves, and
+/// the seed catalog's `provider/slug` list as the model-picker fallback
+/// when `allowed_models` is empty. Re-reading the chain (rather than
+/// caching) keeps the overlay honest about hand edits and about what a
+/// save at one scope means under the others.
+fn engine_config_inbound(cfg: &Config, status: Option<String>) -> Inbound {
+    let engine = crate::settings::Settings::load(&cfg.workspace_root)
+        .ok()
+        .and_then(|s| s.agent_engine_config)
+        .unwrap_or_default();
+    let providers: Vec<String> = crate::config::discover_configured_providers()
+        .into_iter()
+        .map(|p| p.config.id.to_string())
+        .collect();
+    let catalog_models: Vec<String> = stella_model::catalog::Catalog::seed()
+        .entries()
+        .iter()
+        .map(|entry| format!("{}/{}", entry.provider, entry.id))
+        .collect();
+    Inbound::EngineConfig {
+        state: crate::engine_config::state_from_settings(&engine, providers, catalog_models),
+        status,
+    }
+}
+
+/// Handle one ENGINE-overlay op (refresh / save) — cheap local settings
+/// I/O, answered with a fresh [`Inbound::EngineConfig`]. Called from BOTH
+/// recv sites so the overlay works mid-turn too. Returns `true` when the
+/// input was one of the overlay's.
+fn handle_engine_config_input(
+    input: &WorkspaceInput,
+    cfg: &Config,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    match input {
+        WorkspaceInput::EngineConfigRefresh => {
+            let _ = in_tx.send(engine_config_inbound(cfg, None));
+            true
+        }
+        WorkspaceInput::EngineConfigSave { state, scope } => {
+            let engine = crate::engine_config::settings_from_state(state);
+            let path = match scope {
+                AgentScope::User => crate::settings::user_settings_path(),
+                AgentScope::Project => {
+                    Some(crate::settings::project_settings_path(&cfg.workspace_root))
+                }
+            };
+            let status = match path {
+                None => "save failed: cannot determine $HOME for user settings".to_string(),
+                Some(path) => match engine.save_to(&path) {
+                    Ok(()) => format!(
+                        "saved to {} — applies to runs started from now on",
+                        path.display()
+                    ),
+                    Err(e) => format!("save failed: {e}"),
+                },
+            };
+            // The snapshot sent back is the MERGED view — if a project
+            // scope overrides what was just saved at the user scope, the
+            // overlay shows the effective value, not the wish.
+            let _ = in_tx.send(engine_config_inbound(cfg, Some(status)));
+            true
+        }
+        _ => false,
+    }
 }
 
 // ── Installed-agents manager (the AGENTS tab's INSTALLED AGENTS pane) ───────
@@ -1609,6 +1704,8 @@ async fn create_agent(
         temperature: Some(0.2),
         effort: None,
         tools: vec![],
+        reasoning: None,
+        params: None,
     };
     let result = provider
         .complete(req)
@@ -1971,6 +2068,8 @@ async fn create_skill_llm(
         temperature: Some(0.2),
         effort: None,
         tools: vec![],
+        reasoning: None,
+        params: None,
     };
     let content = match provider.complete(req).await {
         Ok(r) => extract_skill_md(&r.text),
@@ -2340,21 +2439,6 @@ async fn run_lead_turn(
     }
 }
 
-/// Maps every role's resolved model to the deck's one borrowed provider. The
-/// deck session is single-provider by construction (one `build_provider`
-/// call), and its `Router` is built from one profile whose worker/triage/
-/// judge refs all name that provider's model — so answering every query with
-/// the one adapter is exact, not a fallback.
-struct DeckProviderResolver<'p> {
-    provider: &'p dyn Provider,
-}
-
-impl ProviderResolver for DeckProviderResolver<'_> {
-    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
-        Some(self.provider)
-    }
-}
-
 /// One staged-pipeline turn for the lead agent (`/pipeline` ON): the deck
 /// analogue of the `stella run` pipeline path — same tool stack, persistence,
 /// and event forwarding as [`run_lead_turn`], with `Pipeline::run` (triage →
@@ -2414,15 +2498,19 @@ async fn run_lead_pipeline_turn(
         };
 
         let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
-        let resolver = DeckProviderResolver { provider };
-        let profile = ProviderProfile::new(
-            cfg.provider.id,
-            model_ref.clone(),
-            model_ref.clone(),
-            model_ref,
-        );
+        // Role wiring from `agent_engine_config`: triage/judge pins + their
+        // adapters + per-role request overrides. Notices land in the
+        // transcript — stderr is invisible under the alternate screen.
+        let wiring = agent::resolve_engine_wiring(cfg, &model_ref);
+        for notice in &wiring.notices {
+            let _ = tx.send(AgentEvent::Text {
+                delta: format!("! {notice}\n"),
+            });
+        }
+        let resolver =
+            agent::RoleProviderResolver::new(provider, model_ref.clone(), &wiring.extra_providers);
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));
-        let router = Router::new(RoleTable::new(), vec![profile], breaker);
+        let router = Router::new(wiring.pins.clone(), wiring.profiles.clone(), breaker);
 
         let repo_structure = agent::GitRepoStructure {
             root: cfg.workspace_root.clone(),
@@ -2455,7 +2543,8 @@ async fn run_lead_pipeline_turn(
                 .map(|h| (h, &hook_runner as &dyn stella_core::hooks::HookRunner)),
         };
         let config = PipelineConfig {
-            engine: agent::engine_config_for(cfg),
+            engine: agent::pipeline_engine_config_for(cfg),
+            role_overrides: wiring.role_overrides.clone(),
             headless: true,
             headless_bypass_scope_review: true,
             ..PipelineConfig::default()

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -370,6 +370,11 @@ pub struct Config {
     /// `Settings::load` for the project-scope trust boundary). `None` means
     /// no hooks configured anywhere — the engine runs the pre-hooks path.
     pub hooks: Option<stella_core::hooks::Hooks>,
+    /// The merged `agent_engine_config` from the settings scope chain —
+    /// per-agent models/prompts/effort/params and the auto modes. `None`
+    /// means the section is absent everywhere; consumers treat that as
+    /// all-defaults (`crate::engine_config` resolves it per run).
+    pub engine_settings: Option<crate::settings::AgentEngineConfig>,
 }
 
 impl Config {
@@ -425,6 +430,28 @@ impl Config {
         settings: &crate::settings::Settings,
         workspace_root: std::path::PathBuf,
     ) -> Result<Self, String> {
+        // The default agent's configured model sits BETWEEN the --model
+        // flag and auto-detect: an explicit flag always wins, but a
+        // settings-configured default beats "first provider with a key".
+        // The spec string is synthesized in --model's own grammar
+        // (`provider/slug`, or the agent's pinned provider prefixed onto a
+        // bare slug) so the whole existing resolution path applies
+        // unchanged. A provider pin without a model is left to the normal
+        // chain — the provider's own default_model already answers there.
+        let engine_default: Option<String> = settings.agent_engine_config.as_ref().and_then(|e| {
+            use crate::settings::EngineAgentKind;
+            let model = e.model_for(EngineAgentKind::Default)?;
+            let pinned = e
+                .agent(EngineAgentKind::Default)
+                .and_then(|a| a.provider.as_deref())
+                .filter(|p| !p.trim().is_empty());
+            Some(match pinned {
+                Some(provider) => format!("{provider}/{model}"),
+                None => model.to_string(),
+            })
+        });
+        let model_override = model_override.or(engine_default.as_deref());
+
         let mut cfg = Self::resolve_provider_config(
             model_override,
             api_key_override,
@@ -433,6 +460,7 @@ impl Config {
             workspace_root,
         )?;
         cfg.hooks = settings.hooks.clone();
+        cfg.engine_settings = settings.agent_engine_config.clone();
         Ok(cfg)
     }
 
@@ -526,6 +554,7 @@ impl Config {
                     workspace_root,
                     base_url_override: Some(base_url),
                     hooks: None,
+                    engine_settings: None,
                 });
             }
 
@@ -710,9 +739,11 @@ impl Config {
             api_key: key,
             workspace_root: workspace_root.to_path_buf(),
             base_url_override: base_url_override.map(str::to_string),
-            // Hooks ride the settings chain, not credential resolution —
-            // `load_with_settings` stamps them after the provider resolves.
+            // Hooks (and the agent-engine settings) ride the settings
+            // chain, not credential resolution — `load_with_settings`
+            // stamps both after the provider resolves.
             hooks: None,
+            engine_settings: None,
         })
     }
 
@@ -1166,6 +1197,7 @@ mod tests {
             workspace_root: std::path::PathBuf::from("/tmp/ws"),
             base_url_override: None,
             hooks: None,
+            engine_settings: None,
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains(secret), "Config Debug leaked the key: {dbg}");

--- a/stella-cli/src/domains.rs
+++ b/stella-cli/src/domains.rs
@@ -189,6 +189,8 @@ pub async fn infer_domains(provider: &dyn Provider, root: &Path) -> Domains {
             temperature: Some(0.0),
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
         match provider.complete(req).await {
             Ok(result) => match parse_domains_json(&result.text) {

--- a/stella-cli/src/engine_config.rs
+++ b/stella-cli/src/engine_config.rs
@@ -1,0 +1,653 @@
+//! `agent_engine_config` resolution — turns the declarative settings
+//! object ([`crate::settings::AgentEngineConfig`]) into concrete per-agent
+//! tuning: which provider/model each engine agent runs on, its effective
+//! prompt/effort/reasoning, and the request parameter overrides.
+//!
+//! Three consumers:
+//! - `agent.rs` builds role routers and engine configs from
+//!   [`AgentTuning`] / [`ModelSpec`] when a run starts;
+//! - `config.rs` consults [`AgentEngineConfig::model_for`] (via a combined
+//!   spec string) for the default agent's model precedence;
+//! - `command_deck.rs` maps settings ↔ the TUI's `EngineConfigState`
+//!   snapshot for the `/engine` overlay.
+//!
+//! Everything here is pure functions over owned data (no I/O), so the
+//! precedence and auto-mode rules are unit-testable without a workspace.
+
+use stella_protocol::{GenerationParams, ReasoningEffort, ServiceTier, Verbosity};
+use stella_tui::{EngineAgentState, EngineConfigState, EngineRole};
+
+use crate::settings::{
+    AgentEngineAgent, AgentEngineAgents, AgentEngineConfig, AgentEngineParams, EngineAgentKind,
+    Toggle,
+};
+
+// ---------------------------------------------------------------------
+// Model specs
+// ---------------------------------------------------------------------
+
+/// A parsed model setting: which provider serves it (when known) and the
+/// provider-native slug sent verbatim on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelSpec {
+    /// Provider id (`"anthropic"`, `"openrouter"`, a settings-defined id).
+    pub provider: String,
+    /// Provider-native model slug (`"claude-fable-5"`, `"openai/gpt-5.5"`).
+    pub model: String,
+}
+
+/// Parse one model string into a [`ModelSpec`], `--model` semantics:
+/// `provider/slug` splits on the FIRST `/` when the prefix names a known
+/// provider (so `openrouter/openai/gpt-5.5` routes `openai/gpt-5.5`
+/// through OpenRouter); a bare slug resolves through the seed catalog
+/// (`glm-5.2` → `zai`). `None` when neither matches — the caller decides
+/// whether that's a loud error (an explicit setting) or a skip (an
+/// `allowed_models` candidate).
+pub fn parse_model_spec(raw: &str, is_provider: &dyn Fn(&str) -> bool) -> Option<ModelSpec> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some((prefix, rest)) = raw.split_once('/')
+        && !rest.is_empty()
+        && is_provider(prefix)
+    {
+        return Some(ModelSpec {
+            provider: prefix.to_string(),
+            model: rest.to_string(),
+        });
+    }
+    stella_model::catalog::Catalog::seed()
+        .resolve(raw)
+        .ok()
+        .map(|entry| ModelSpec {
+            provider: entry.provider.to_string(),
+            model: raw.to_string(),
+        })
+}
+
+/// The effective [`ModelSpec`] for `kind`, honoring the agent's explicit
+/// `provider` field: when set, the model string (from the same precedence
+/// chain as [`AgentEngineConfig::model_for`]) is the verbatim slug for
+/// THAT provider — no prefix splitting, which is what lets an OpenRouter
+/// entry carry a slug that itself contains `/`.
+pub fn model_spec_for(
+    engine: &AgentEngineConfig,
+    kind: EngineAgentKind,
+    is_provider: &dyn Fn(&str) -> bool,
+) -> Option<ModelSpec> {
+    let pinned_provider = engine
+        .agent(kind)
+        .and_then(|a| a.provider.as_deref())
+        .filter(|p| !p.trim().is_empty());
+    let model = engine.model_for(kind);
+    match (pinned_provider, model) {
+        (Some(provider), Some(model)) => Some(ModelSpec {
+            provider: provider.to_string(),
+            model: model.to_string(),
+        }),
+        // A provider pin with no model: the provider's own default model
+        // applies — signalled with an empty slug the wiring layer fills
+        // from `ProviderConfig::default_model`.
+        (Some(provider), None) => Some(ModelSpec {
+            provider: provider.to_string(),
+            model: String::new(),
+        }),
+        (None, Some(model)) => parse_model_spec(model, is_provider),
+        (None, None) => None,
+    }
+}
+
+/// Cross-family grouping key for judge diversity. Same-vendor providers
+/// count as ONE family (a Gemini judge over Vertex-served Gemini work
+/// carries the same bias), and an OpenRouter spec's family is the routed
+/// slug's vendor prefix — `openrouter/openai/gpt-5.5` IS an OpenAI model,
+/// and treating it as family "openrouter" would defeat the judge's
+/// cross-family preference.
+pub fn spec_family(spec: &ModelSpec) -> String {
+    match spec.provider.as_str() {
+        "gemini" | "vertex" => "google".to_string(),
+        "anthropic" | "bedrock" => "anthropic".to_string(),
+        "openrouter" => spec
+            .model
+            .split_once('/')
+            .map(|(vendor, _)| vendor.to_string())
+            .unwrap_or_else(|| "openrouter".to_string()),
+        other => other.to_string(),
+    }
+}
+
+/// `auto_mode: on` — pick the judge from `allowed_models`, preferring a
+/// family different from the worker's, then ranking by the seed catalog's
+/// output list price (the closest objective capability proxy the catalog
+/// carries; gateway-priced entries rank last at 0), then list order.
+/// Candidates whose provider has no resolvable credential are skipped —
+/// `configured` is the filter. `None` when nothing in the list is usable
+/// (the caller falls back to the normal judge routing).
+pub fn auto_judge_spec(
+    engine: &AgentEngineConfig,
+    worker_family: &str,
+    configured: &dyn Fn(&str) -> bool,
+) -> Option<ModelSpec> {
+    let catalog = stella_model::catalog::Catalog::seed();
+    let mut best: Option<(bool, f64, usize, ModelSpec)> = None;
+    for (index, raw) in engine.allowed_models().iter().enumerate() {
+        let Some(spec) = parse_model_spec(raw, &|id| configured(id)) else {
+            continue;
+        };
+        if !configured(&spec.provider) {
+            continue;
+        }
+        let cross_family = spec_family(&spec) != worker_family;
+        let price = catalog
+            .resolve_for(&spec.provider, &spec.model)
+            .map(|entry| entry.pricing.output_usd_per_mtok)
+            .unwrap_or(0.0);
+        // Lexicographic max over (cross_family, price, earliest-in-list).
+        let better = match &best {
+            None => true,
+            Some((bf, bp, bi, _)) => {
+                (cross_family, price, std::cmp::Reverse(index)) > (*bf, *bp, std::cmp::Reverse(*bi))
+            }
+        };
+        if better {
+            best = Some((cross_family, price, index, spec));
+        }
+    }
+    best.map(|(_, _, _, spec)| spec)
+}
+
+// ---------------------------------------------------------------------
+// Per-agent tuning
+// ---------------------------------------------------------------------
+
+/// The resolved request-shaping settings for one agent: what lands on the
+/// engine config / completion requests once the auto modes are applied.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentTuning {
+    /// Custom system prompt (replaces the built-in base; memories/rules
+    /// still append).
+    pub prompt: Option<String>,
+    pub effort: Option<ReasoningEffort>,
+    pub reasoning: Option<bool>,
+    pub temperature: Option<f32>,
+    pub max_output_tokens: Option<u32>,
+    pub params: Option<GenerationParams>,
+}
+
+/// `effort_auto: on` — the per-agent effort nobody has to think about:
+/// the judge deliberates hard, the worker balances cost and quality, and
+/// triage (a one-token classification under a latency ceiling) stays low.
+fn auto_effort(kind: EngineAgentKind) -> ReasoningEffort {
+    match kind {
+        EngineAgentKind::Judge => ReasoningEffort::High,
+        EngineAgentKind::Triage => ReasoningEffort::Low,
+        EngineAgentKind::Default | EngineAgentKind::Worker => ReasoningEffort::Medium,
+    }
+}
+
+/// `reasoning_auto: on` — thinking on wherever deliberation pays (judge,
+/// worker, default), off for triage (latency-bound, one bare token out).
+fn auto_reasoning(kind: EngineAgentKind) -> bool {
+    !matches!(kind, EngineAgentKind::Triage)
+}
+
+/// Resolve `kind`'s tuning from the merged config, applying the auto
+/// modes (`effort_auto`/`reasoning_auto` override the per-agent settings
+/// when on — that is their contract: "you never worry about it").
+pub fn tuning_for(engine: &AgentEngineConfig, kind: EngineAgentKind) -> AgentTuning {
+    let agent = engine.agent(kind);
+    let effort = if engine.effort_auto_on() {
+        Some(auto_effort(kind))
+    } else {
+        agent.and_then(|a| a.effort)
+    };
+    let reasoning = if engine.reasoning_auto_on() {
+        Some(auto_reasoning(kind))
+    } else {
+        agent.and_then(|a| a.reasoning).map(Toggle::is_on)
+    };
+    let (temperature, max_output_tokens, params) = agent
+        .and_then(|a| a.params.as_ref())
+        .map(split_params)
+        .unwrap_or((None, None, None));
+    AgentTuning {
+        prompt: agent.and_then(|a| a.prompt.clone()),
+        effort,
+        reasoning,
+        temperature,
+        max_output_tokens,
+        params,
+    }
+}
+
+/// Split the settings-level params into the request's direct fields
+/// (`temperature`, `max_output_tokens`) and the [`GenerationParams`]
+/// rider (`Some` only when at least one field is set, so an all-default
+/// params object keeps the wire body byte-identical to no params at all).
+fn split_params(
+    params: &AgentEngineParams,
+) -> (Option<f32>, Option<u32>, Option<GenerationParams>) {
+    let rider = GenerationParams {
+        top_p: params.top_p,
+        top_k: params.top_k,
+        frequency_penalty: params.frequency_penalty,
+        presence_penalty: params.presence_penalty,
+        repetition_penalty: params.repetition_penalty,
+        seed: params.seed,
+        verbosity: params.verbosity,
+        service_tier: params.service_tier,
+    };
+    let rider = (rider != GenerationParams::default()).then_some(rider);
+    (params.temperature, params.max_tokens, rider)
+}
+
+// ---------------------------------------------------------------------
+// Enum ↔ string (the TUI edits strings; settings/serde hold enums)
+// ---------------------------------------------------------------------
+
+pub fn effort_to_str(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+        ReasoningEffort::Xhigh => "xhigh",
+        ReasoningEffort::Max => "max",
+    }
+}
+
+pub fn effort_from_str(raw: &str) -> Option<ReasoningEffort> {
+    match raw {
+        "low" => Some(ReasoningEffort::Low),
+        "medium" => Some(ReasoningEffort::Medium),
+        "high" => Some(ReasoningEffort::High),
+        "xhigh" => Some(ReasoningEffort::Xhigh),
+        "max" => Some(ReasoningEffort::Max),
+        _ => None,
+    }
+}
+
+pub fn verbosity_to_str(verbosity: Verbosity) -> &'static str {
+    match verbosity {
+        Verbosity::Low => "low",
+        Verbosity::Medium => "medium",
+        Verbosity::High => "high",
+    }
+}
+
+pub fn verbosity_from_str(raw: &str) -> Option<Verbosity> {
+    match raw {
+        "low" => Some(Verbosity::Low),
+        "medium" => Some(Verbosity::Medium),
+        "high" => Some(Verbosity::High),
+        _ => None,
+    }
+}
+
+pub fn service_tier_to_str(tier: ServiceTier) -> &'static str {
+    match tier {
+        ServiceTier::Auto => "auto",
+        ServiceTier::Default => "default",
+        ServiceTier::Flex => "flex",
+        ServiceTier::Priority => "priority",
+    }
+}
+
+pub fn service_tier_from_str(raw: &str) -> Option<ServiceTier> {
+    match raw {
+        "auto" => Some(ServiceTier::Auto),
+        "default" => Some(ServiceTier::Default),
+        "flex" => Some(ServiceTier::Flex),
+        "priority" => Some(ServiceTier::Priority),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Settings ↔ TUI snapshot
+// ---------------------------------------------------------------------
+
+/// The TUI's role vocabulary mapped onto the settings' — same order, so
+/// `EngineConfigState::agents[i]` is `EngineAgentKind::ALL[i]`.
+fn kind_for(role: EngineRole) -> EngineAgentKind {
+    match role {
+        EngineRole::Default => EngineAgentKind::Default,
+        EngineRole::Worker => EngineAgentKind::Worker,
+        EngineRole::Judge => EngineAgentKind::Judge,
+        EngineRole::Triage => EngineAgentKind::Triage,
+    }
+}
+
+/// The flat per-role model field (no fallback to `default_model` — the
+/// snapshot shows what THIS row sets, not what it inherits).
+fn flat_model(engine: &AgentEngineConfig, kind: EngineAgentKind) -> Option<&str> {
+    match kind {
+        EngineAgentKind::Default => engine.default_model.as_deref(),
+        EngineAgentKind::Worker => engine.pipeline_worker_model.as_deref(),
+        EngineAgentKind::Judge => engine.pipeline_judge_model.as_deref(),
+        EngineAgentKind::Triage => engine.pipeline_triage_model.as_deref(),
+    }
+}
+
+/// Build the `/engine` overlay's snapshot from the merged settings plus
+/// the picker vocabularies the driver knows (provider ids, catalog slugs).
+pub fn state_from_settings(
+    engine: &AgentEngineConfig,
+    providers: Vec<String>,
+    catalog_models: Vec<String>,
+) -> EngineConfigState {
+    let agents = EngineRole::ALL
+        .iter()
+        .map(|role| {
+            let kind = kind_for(*role);
+            let agent = engine.agent(kind);
+            let params = agent.and_then(|a| a.params.as_ref());
+            EngineAgentState {
+                model: agent
+                    .and_then(|a| a.model.clone())
+                    .or_else(|| flat_model(engine, kind).map(str::to_string)),
+                provider: agent.and_then(|a| a.provider.clone()),
+                prompt: agent.and_then(|a| a.prompt.clone()),
+                effort: agent
+                    .and_then(|a| a.effort)
+                    .map(|e| effort_to_str(e).to_string()),
+                reasoning: agent.and_then(|a| a.reasoning).map(Toggle::is_on),
+                temperature: params.and_then(|p| p.temperature),
+                top_p: params.and_then(|p| p.top_p),
+                top_k: params.and_then(|p| p.top_k),
+                frequency_penalty: params.and_then(|p| p.frequency_penalty),
+                presence_penalty: params.and_then(|p| p.presence_penalty),
+                repetition_penalty: params.and_then(|p| p.repetition_penalty),
+                max_tokens: params.and_then(|p| p.max_tokens),
+                seed: params.and_then(|p| p.seed),
+                verbosity: params
+                    .and_then(|p| p.verbosity)
+                    .map(|v| verbosity_to_str(v).to_string()),
+                service_tier: params
+                    .and_then(|p| p.service_tier)
+                    .map(|t| service_tier_to_str(t).to_string()),
+            }
+        })
+        .collect();
+    EngineConfigState {
+        auto_mode: engine.auto_mode_on(),
+        effort_auto: engine.effort_auto_on(),
+        reasoning_auto: engine.reasoning_auto_on(),
+        allowed_models: engine.allowed_models().to_vec(),
+        providers,
+        catalog_models,
+        agents,
+    }
+}
+
+/// Rebuild the settings object from an edited snapshot. Models land on
+/// the FLAT per-role keys (`default_model`, `pipeline_*_model`) — the
+/// canonical simple form — with `agents.<k>.model` cleared, so a TUI save
+/// never leaves the two sources disagreeing. Empty agent objects and an
+/// empty allowed list are omitted entirely (the file stays minimal).
+pub fn settings_from_state(state: &EngineConfigState) -> AgentEngineConfig {
+    let mut engine = AgentEngineConfig {
+        auto_mode: Some(if state.auto_mode {
+            Toggle::On
+        } else {
+            Toggle::Off
+        }),
+        effort_auto: Some(if state.effort_auto {
+            Toggle::On
+        } else {
+            Toggle::Off
+        }),
+        reasoning_auto: Some(if state.reasoning_auto {
+            Toggle::On
+        } else {
+            Toggle::Off
+        }),
+        allowed_models: (!state.allowed_models.is_empty()).then(|| state.allowed_models.clone()),
+        ..AgentEngineConfig::default()
+    };
+    let mut agents = AgentEngineAgents::default();
+    let mut any_agent = false;
+    for (index, role) in EngineRole::ALL.iter().enumerate() {
+        let kind = kind_for(*role);
+        let Some(edited) = state.agents.get(index) else {
+            continue;
+        };
+        let model = edited
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+            .map(str::to_string);
+        match kind {
+            EngineAgentKind::Default => engine.default_model = model,
+            EngineAgentKind::Worker => engine.pipeline_worker_model = model,
+            EngineAgentKind::Judge => engine.pipeline_judge_model = model,
+            EngineAgentKind::Triage => engine.pipeline_triage_model = model,
+        }
+        let params = AgentEngineParams {
+            temperature: edited.temperature,
+            top_p: edited.top_p,
+            top_k: edited.top_k,
+            frequency_penalty: edited.frequency_penalty,
+            presence_penalty: edited.presence_penalty,
+            repetition_penalty: edited.repetition_penalty,
+            max_tokens: edited.max_tokens,
+            seed: edited.seed,
+            verbosity: edited.verbosity.as_deref().and_then(verbosity_from_str),
+            service_tier: edited
+                .service_tier
+                .as_deref()
+                .and_then(service_tier_from_str),
+        };
+        let agent = AgentEngineAgent {
+            model: None,
+            provider: edited
+                .provider
+                .as_deref()
+                .map(str::trim)
+                .filter(|p| !p.is_empty())
+                .map(str::to_string),
+            prompt: edited.prompt.clone().filter(|p| !p.trim().is_empty()),
+            effort: edited.effort.as_deref().and_then(effort_from_str),
+            reasoning: edited
+                .reasoning
+                .map(|on| if on { Toggle::On } else { Toggle::Off }),
+            params: (params != AgentEngineParams::default()).then_some(params),
+        };
+        if agent != AgentEngineAgent::default() {
+            *agents.get_mut(kind) = Some(agent);
+            any_agent = true;
+        }
+    }
+    engine.agents = any_agent.then_some(agents);
+    engine
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_builtin(id: &str) -> bool {
+        crate::config::PROVIDERS.iter().any(|p| p.id == id)
+    }
+
+    fn engine_from_json(json: &str) -> AgentEngineConfig {
+        serde_json::from_str(json).expect("valid engine config json")
+    }
+
+    #[test]
+    fn parse_model_spec_splits_provider_prefixes_and_resolves_bare_slugs() {
+        // provider/slug — including a routed slug that itself contains `/`.
+        let spec = parse_model_spec("openrouter/openai/gpt-5.5", &is_builtin).unwrap();
+        assert_eq!(spec.provider, "openrouter");
+        assert_eq!(spec.model, "openai/gpt-5.5");
+        // A bare seeded slug resolves through the catalog.
+        let spec = parse_model_spec("glm-5.2", &is_builtin).unwrap();
+        assert_eq!(spec.provider, "zai");
+        // Unknown either way → None.
+        assert!(parse_model_spec("no-such-model", &is_builtin).is_none());
+        assert!(parse_model_spec("", &is_builtin).is_none());
+    }
+
+    #[test]
+    fn model_spec_honors_the_explicit_provider_pin_verbatim() {
+        let engine = engine_from_json(
+            r#"{"agents": {"judge": {"provider": "openrouter", "model": "openai/gpt-5.5"}}}"#,
+        );
+        let spec = model_spec_for(&engine, EngineAgentKind::Judge, &is_builtin).unwrap();
+        // No prefix splitting: the slug goes to the pinned provider whole.
+        assert_eq!(spec.provider, "openrouter");
+        assert_eq!(spec.model, "openai/gpt-5.5");
+
+        // A provider pin with no model → empty slug (provider default).
+        let engine = engine_from_json(r#"{"agents": {"triage": {"provider": "zai"}}}"#);
+        let spec = model_spec_for(&engine, EngineAgentKind::Triage, &is_builtin).unwrap();
+        assert_eq!(spec.provider, "zai");
+        assert!(spec.model.is_empty());
+    }
+
+    #[test]
+    fn spec_family_groups_vendors_and_unwraps_openrouter_slugs() {
+        let family = |provider: &str, model: &str| {
+            spec_family(&ModelSpec {
+                provider: provider.into(),
+                model: model.into(),
+            })
+        };
+        assert_eq!(family("vertex", "gemini-3-pro"), "google");
+        assert_eq!(family("bedrock", "anything"), "anthropic");
+        assert_eq!(family("openrouter", "openai/gpt-5.5"), "openai");
+        assert_eq!(family("zai", "glm-5.2"), "zai");
+    }
+
+    #[test]
+    fn auto_judge_prefers_cross_family_then_price_then_list_order() {
+        let engine = engine_from_json(
+            r#"{"allowed_models": [
+                "zai/glm-5.2",
+                "deepseek/deepseek-chat",
+                "anthropic/claude-fable-5"
+            ], "auto_mode": "on"}"#,
+        );
+        // Worker family zai → cross-family candidates are deepseek (1.10
+        // output) and anthropic (15.00 output): price ranks Anthropic first.
+        let spec = auto_judge_spec(&engine, "zai", &|_| true).unwrap();
+        assert_eq!(spec.provider, "anthropic");
+        // Worker family anthropic → zai (2.20) beats deepseek (1.10).
+        let spec = auto_judge_spec(&engine, "anthropic", &|_| true).unwrap();
+        assert_eq!(spec.provider, "zai");
+        // Credentials filter: with anthropic unavailable, deepseek wins for
+        // a zai worker.
+        let spec = auto_judge_spec(&engine, "zai", &|id| id != "anthropic").unwrap();
+        assert_eq!(spec.provider, "deepseek");
+        // Nothing configured → None (caller falls back to normal routing).
+        assert!(auto_judge_spec(&engine, "zai", &|_| false).is_none());
+    }
+
+    #[test]
+    fn tuning_applies_auto_modes_over_per_agent_settings() {
+        let engine = engine_from_json(
+            r#"{"effort_auto": "on", "reasoning_auto": "on",
+                "agents": {"triage": {"effort": "max", "reasoning": "on"},
+                            "judge": {"prompt": "Judge hard."}}}"#,
+        );
+        // Auto overrides the explicit triage settings (that's its contract).
+        let triage = tuning_for(&engine, EngineAgentKind::Triage);
+        assert_eq!(triage.effort, Some(ReasoningEffort::Low));
+        assert_eq!(triage.reasoning, Some(false));
+        let judge = tuning_for(&engine, EngineAgentKind::Judge);
+        assert_eq!(judge.effort, Some(ReasoningEffort::High));
+        assert_eq!(judge.reasoning, Some(true));
+        // Prompts are never auto-managed.
+        assert_eq!(judge.prompt.as_deref(), Some("Judge hard."));
+
+        // Autos off → the per-agent settings answer.
+        let engine =
+            engine_from_json(r#"{"agents": {"triage": {"effort": "max", "reasoning": "off"}}}"#);
+        let triage = tuning_for(&engine, EngineAgentKind::Triage);
+        assert_eq!(triage.effort, Some(ReasoningEffort::Max));
+        assert_eq!(triage.reasoning, Some(false));
+        // And an untouched agent has no opinions at all.
+        assert_eq!(
+            tuning_for(&engine, EngineAgentKind::Worker),
+            AgentTuning::default()
+        );
+    }
+
+    #[test]
+    fn tuning_splits_params_between_direct_fields_and_the_rider() {
+        let engine = engine_from_json(
+            r#"{"agents": {"worker": {"params": {
+                "temperature": 0.3, "max_tokens": 9000, "top_p": 0.9, "seed": 42
+            }}}}"#,
+        );
+        let worker = tuning_for(&engine, EngineAgentKind::Worker);
+        assert_eq!(worker.temperature, Some(0.3));
+        assert_eq!(worker.max_output_tokens, Some(9000));
+        let rider = worker.params.expect("rider");
+        assert_eq!(rider.top_p, Some(0.9));
+        assert_eq!(rider.seed, Some(42));
+        // temperature/max_tokens alone → no rider at all (byte-stable wire).
+        let engine =
+            engine_from_json(r#"{"agents": {"worker": {"params": {"temperature": 0.3}}}}"#);
+        assert!(
+            tuning_for(&engine, EngineAgentKind::Worker)
+                .params
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn snapshot_roundtrips_through_the_tui_state() {
+        let engine = engine_from_json(
+            r#"{"default_model": "anthropic/claude-fable-5",
+                "pipeline_judge_model": "openrouter/openai/gpt-5.5",
+                "allowed_models": ["anthropic/claude-fable-5"],
+                "auto_mode": "off", "effort_auto": "on", "reasoning_auto": "off",
+                "agents": {"judge": {"provider": "openrouter", "effort": "high",
+                                      "reasoning": "on",
+                                      "params": {"temperature": 0.2, "top_k": 40,
+                                                  "verbosity": "low",
+                                                  "service_tier": "flex"}}}}"#,
+        );
+        let state = state_from_settings(&engine, vec!["zai".into()], vec!["zai/glm-5.2".into()]);
+        assert!(!state.auto_mode);
+        assert!(state.effort_auto);
+        let judge = state.agent(EngineRole::Judge).expect("judge state");
+        assert_eq!(judge.model.as_deref(), Some("openrouter/openai/gpt-5.5"));
+        assert_eq!(judge.provider.as_deref(), Some("openrouter"));
+        assert_eq!(judge.effort.as_deref(), Some("high"));
+        assert_eq!(judge.reasoning, Some(true));
+        assert_eq!(judge.top_k, Some(40));
+        assert_eq!(judge.verbosity.as_deref(), Some("low"));
+        assert_eq!(judge.service_tier.as_deref(), Some("flex"));
+
+        let back = settings_from_state(&state);
+        // Models land on the flat keys, agents.model stays clear.
+        assert_eq!(
+            back.pipeline_judge_model.as_deref(),
+            Some("openrouter/openai/gpt-5.5")
+        );
+        assert_eq!(
+            back.default_model.as_deref(),
+            Some("anthropic/claude-fable-5")
+        );
+        let judge = back.agent(EngineAgentKind::Judge).expect("judge");
+        assert!(judge.model.is_none());
+        assert_eq!(judge.provider.as_deref(), Some("openrouter"));
+        assert_eq!(judge.effort, Some(ReasoningEffort::High));
+        assert_eq!(judge.reasoning, Some(Toggle::On));
+        let params = judge.params.expect("params");
+        assert_eq!(params.temperature, Some(0.2));
+        assert_eq!(params.service_tier, Some(ServiceTier::Flex));
+        // The toggles are written explicitly (an "off" the user chose is
+        // preserved, not dropped).
+        assert_eq!(back.auto_mode, Some(Toggle::Off));
+        assert_eq!(back.effort_auto, Some(Toggle::On));
+        // The round trip is stable: state → settings → state is identity
+        // for the fields the snapshot carries.
+        let state2 = state_from_settings(&back, vec!["zai".into()], vec!["zai/glm-5.2".into()]);
+        assert_eq!(state2.agents, state.agents);
+        assert_eq!(state2.allowed_models, state.allowed_models);
+    }
+}

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -415,7 +415,7 @@ async fn run_task(
     let mut messages = vec![CompletionMessage::system(
         // Each worker is its own session in its own workspace, so its
         // SessionStart hooks fire here, in the worktree.
-        agent::with_session_hook_context(agent::build_system_prompt(root), &cfg).await,
+        agent::with_session_hook_context(agent::build_system_prompt(&cfg, root), &cfg).await,
     )];
     // The raw step-loop path needs the task prompt as a user message in the
     // history; the pipeline path takes the goal separately and appends its own
@@ -434,21 +434,25 @@ async fn run_task(
     // `success`/`summary` are set by whichever path runs, then folded into
     // the WorkerOutcome after the channel drains.
     let (summary, success): (String, bool) = if use_pipeline {
-        use stella_core::router::{CircuitBreaker, ProviderProfile, RoleTable, Router};
+        use stella_core::router::{CircuitBreaker, Router};
         use stella_pipeline::{
             AutoApproveGate, NoContextRecall, Pipeline, PipelineConfig, PipelinePorts,
             PipelineStatus,
         };
         let model_ref = stella_protocol::ModelRef::new(cfg.provider.id, cfg.model_id.clone());
-        let resolver = agent::BorrowedProviderResolver::new(&*provider);
-        let profile = ProviderProfile::new(
-            cfg.provider.id,
+        // Role wiring from `agent_engine_config` — fleet workers honor the
+        // same triage/judge pins and per-role overrides as `stella run`.
+        let wiring = agent::resolve_engine_wiring(&cfg, &model_ref);
+        for notice in &wiring.notices {
+            eprintln!("  ! {notice}");
+        }
+        let resolver = agent::RoleProviderResolver::new(
+            &*provider,
             model_ref.clone(),
-            model_ref.clone(),
-            model_ref,
+            &wiring.extra_providers,
         );
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));
-        let router = Router::new(RoleTable::new(), vec![profile], breaker);
+        let router = Router::new(wiring.pins.clone(), wiring.profiles.clone(), breaker);
         let repo_structure = agent::GitRepoStructure {
             root: root.to_path_buf(),
         };
@@ -476,7 +480,8 @@ async fn run_task(
                 .map(|h| (h, &hook_runner as &dyn stella_core::hooks::HookRunner)),
         };
         let config = PipelineConfig {
-            engine: agent::engine_config_for(&cfg),
+            engine: agent::pipeline_engine_config_for(&cfg),
+            role_overrides: wiring.role_overrides.clone(),
             headless: true,
             headless_bypass_scope_review: true,
             ..PipelineConfig::default()

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -23,6 +23,7 @@ mod attachments;
 mod command_deck;
 mod config;
 mod domains;
+mod engine_config;
 mod export;
 mod extensions;
 mod fleet_cmd;

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -871,6 +871,8 @@ pub async fn reflect_on_turn(
         temperature: Some(0.0),
         effort: None,
         tools: vec![],
+        reasoning: None,
+        params: None,
     };
 
     let result = provider.complete(req).await.map_err(|e| e.to_string())?;

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -19,8 +19,9 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use stella_core::hooks::Hooks;
+use stella_protocol::{ReasoningEffort, ServiceTier, Verbosity};
 
 use crate::config::Dialect;
 
@@ -89,6 +90,386 @@ pub struct Settings {
     /// ([`Settings::mcp_registry_url`]).
     #[serde(default)]
     pub mcp: Option<McpSettings>,
+    /// Agent-engine configuration: per-role models, prompts, effort, and
+    /// sampling parameters for the four engine agents (default / worker /
+    /// judge / triage), plus the allowed-model vocabulary and the auto
+    /// modes. Scopes overlay per field like `providers`. Deliberately NOT
+    /// behind the project trust boundary: it carries no credential routing
+    /// (an agent's `provider` names an id whose `base_url`/`api_key_env`
+    /// are themselves gated above), and repo-supplied prompt text is
+    /// already the status quo via `.stella/memories` and workspace rules.
+    #[serde(default)]
+    pub agent_engine_config: Option<AgentEngineConfig>,
+}
+
+/// An `on`/`off` switch. A dedicated enum rather than `bool` because the
+/// JSON reads as configuration prose (`"auto_mode": "on"`) and because a
+/// typo'd value must be a loud parse error, not a silently-false bool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Toggle {
+    On,
+    Off,
+}
+
+impl Toggle {
+    pub fn is_on(self) -> bool {
+        matches!(self, Toggle::On)
+    }
+}
+
+/// The four configurable engine agents. `Default` is the interactive /
+/// step-loop agent; the other three are the staged pipeline's roles
+/// (`stella_protocol::Role::{Worker, Judge, Triage}` — `Plan` rides the
+/// worker's settings, matching the router's tiering).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineAgentKind {
+    Default,
+    Worker,
+    Judge,
+    Triage,
+}
+
+impl EngineAgentKind {
+    pub const ALL: [EngineAgentKind; 4] = [
+        EngineAgentKind::Default,
+        EngineAgentKind::Worker,
+        EngineAgentKind::Judge,
+        EngineAgentKind::Triage,
+    ];
+}
+
+/// The `agent_engine_config` root object — issue-style schema:
+///
+/// ```jsonc
+/// {
+///   "agent_engine_config": {
+///     "default_model": "anthropic/claude-fable-5",
+///     "pipeline_worker_model": "zai/glm-5.2",
+///     "pipeline_judge_model": "openrouter/openai/gpt-5.5",
+///     "pipeline_triage_model": "deepseek/deepseek-chat",
+///     "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2"],
+///     "auto_mode": "off",
+///     "effort_auto": "on",
+///     "reasoning_auto": "on",
+///     "agents": {
+///       "judge": {
+///         "provider": "openrouter",
+///         "model": "openai/gpt-5.5",
+///         "prompt": "You are a strict code-review judge…",
+///         "effort": "high",
+///         "reasoning": "on",
+///         "params": {"temperature": 0.2, "top_p": 0.9}
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// Model precedence per agent: `agents.<agent>.model` >
+/// `pipeline_<agent>_model` (or `default_model` for the default agent) >
+/// `default_model` > the provider's own default. A model string is either
+/// `provider/slug` (`--model` semantics) or, when the agent's `provider`
+/// field is set, a bare slug sent verbatim to THAT provider — which is how
+/// an OpenRouter key routes `openai/gpt-5.5` while an Anthropic key serves
+/// the worker.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentEngineConfig {
+    /// Model for the default (interactive/step-loop) agent, and the base
+    /// for every pipeline role that has no more specific setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_judge_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_worker_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_triage_model: Option<String>,
+    /// The model vocabulary the TUI pickers offer and `auto_mode` selects
+    /// from. Entries are `provider/slug` strings. Empty/absent = no
+    /// restriction (pickers fall back to the seed catalog).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_models: Option<Vec<String>>,
+    /// `on` = pick the judge model automatically from `allowed_models`,
+    /// preferring a different model family than the worker's and ranking
+    /// by catalog list price (the closest objective proxy for capability
+    /// tier the seed catalog carries). You never worry about it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_mode: Option<Toggle>,
+    /// `on` = per-agent reasoning effort is chosen automatically (judge
+    /// high, worker medium, triage low, default medium), overriding any
+    /// per-agent `effort`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort_auto: Option<Toggle>,
+    /// `on` = thinking mode is chosen automatically (on for judge/worker/
+    /// default, off for triage), overriding any per-agent `reasoning`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_auto: Option<Toggle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agents: Option<AgentEngineAgents>,
+}
+
+/// The `agents` map — fixed keys rather than a `BTreeMap` so per-role
+/// access is exhaustive and typed instead of stringly (a misspelled agent
+/// key in JSON is simply ignored, the same tolerance every other settings
+/// object has for unknown fields).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentEngineAgents {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<AgentEngineAgent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker: Option<AgentEngineAgent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge: Option<AgentEngineAgent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triage: Option<AgentEngineAgent>,
+}
+
+impl AgentEngineAgents {
+    pub fn get(&self, kind: EngineAgentKind) -> Option<&AgentEngineAgent> {
+        match kind {
+            EngineAgentKind::Default => self.default.as_ref(),
+            EngineAgentKind::Worker => self.worker.as_ref(),
+            EngineAgentKind::Judge => self.judge.as_ref(),
+            EngineAgentKind::Triage => self.triage.as_ref(),
+        }
+    }
+
+    pub fn get_mut(&mut self, kind: EngineAgentKind) -> &mut Option<AgentEngineAgent> {
+        match kind {
+            EngineAgentKind::Default => &mut self.default,
+            EngineAgentKind::Worker => &mut self.worker,
+            EngineAgentKind::Judge => &mut self.judge,
+            EngineAgentKind::Triage => &mut self.triage,
+        }
+    }
+}
+
+/// One agent's engine overrides. Every field optional — an absent field
+/// means "no opinion", falling through to the flat model fields / engine
+/// defaults / the provider's own defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentEngineAgent {
+    /// Model slug — `provider/slug`, or a bare slug when `provider` is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Gateway/provider id this agent's requests go through (a built-in id
+    /// or a settings-defined provider). When set, `model` is sent verbatim
+    /// as the slug to this provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Custom system prompt replacing the built-in one for this agent.
+    /// Workspace memories/rules still append to it (they are additive
+    /// context, not part of the base instruction set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// Reasoning effort (`low`/`medium`/`high`/`xhigh`/`max`), forwarded
+    /// as `CompletionRequest::effort`. Overridden by `effort_auto: on`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
+    /// Thinking mode on/off, forwarded as `CompletionRequest::reasoning`.
+    /// Absent = the provider's default. Overridden by `reasoning_auto: on`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Toggle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<AgentEngineParams>,
+}
+
+/// Per-agent generation parameters — the "Include" checkbox model: a
+/// `Some` value goes on the wire (where the provider's dialect supports
+/// it), `None` leaves the provider default untouched. `temperature` and
+/// `max_tokens` land on `CompletionRequest` directly; the rest ride
+/// `CompletionRequest::params`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentEngineParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repetition_penalty: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<Verbosity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+}
+
+impl AgentEngineParams {
+    /// Overlay `other` (higher precedence) onto `self`, per field.
+    fn overlay(&mut self, other: &AgentEngineParams) {
+        macro_rules! take {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field;
+                }
+            };
+        }
+        take!(temperature);
+        take!(top_p);
+        take!(top_k);
+        take!(frequency_penalty);
+        take!(presence_penalty);
+        take!(repetition_penalty);
+        take!(max_tokens);
+        take!(seed);
+        take!(verbosity);
+        take!(service_tier);
+    }
+}
+
+impl AgentEngineAgent {
+    /// Overlay `other` (higher precedence) onto `self`, per field —
+    /// `params` composes recursively so a project scope can set one knob
+    /// without clobbering the user scope's others.
+    fn overlay(&mut self, other: &AgentEngineAgent) {
+        macro_rules! take {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field.clone();
+                }
+            };
+        }
+        take!(model);
+        take!(provider);
+        take!(prompt);
+        take!(effort);
+        take!(reasoning);
+        if let Some(params) = &other.params {
+            self.params
+                .get_or_insert_with(AgentEngineParams::default)
+                .overlay(params);
+        }
+    }
+}
+
+impl AgentEngineConfig {
+    /// Overlay `other` (higher precedence) onto `self`, per field, per
+    /// agent — the same composition rule as `ProviderSettings::overlay`.
+    /// `allowed_models` REPLACES wholesale (it is one vocabulary, not a
+    /// set of independent knobs — concatenating scopes would make it
+    /// impossible for a project to narrow the user's list).
+    fn overlay(&mut self, other: &AgentEngineConfig) {
+        macro_rules! take {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field.clone();
+                }
+            };
+        }
+        take!(default_model);
+        take!(pipeline_judge_model);
+        take!(pipeline_worker_model);
+        take!(pipeline_triage_model);
+        take!(allowed_models);
+        take!(auto_mode);
+        take!(effort_auto);
+        take!(reasoning_auto);
+        if let Some(agents) = &other.agents {
+            let target = self.agents.get_or_insert_with(AgentEngineAgents::default);
+            for kind in EngineAgentKind::ALL {
+                if let Some(agent) = agents.get(kind) {
+                    target
+                        .get_mut(kind)
+                        .get_or_insert_with(AgentEngineAgent::default)
+                        .overlay(agent);
+                }
+            }
+        }
+    }
+
+    /// The per-agent overrides for `kind`, if any.
+    pub fn agent(&self, kind: EngineAgentKind) -> Option<&AgentEngineAgent> {
+        self.agents.as_ref().and_then(|a| a.get(kind))
+    }
+
+    /// The effective model STRING for `kind` (not yet resolved to a
+    /// provider): `agents.<kind>.model` > the flat per-role field >
+    /// `default_model`. `None` = no opinion (auto-detect / `--model` /
+    /// provider default decide, exactly as before this config existed).
+    pub fn model_for(&self, kind: EngineAgentKind) -> Option<&str> {
+        if let Some(model) = self.agent(kind).and_then(|a| a.model.as_deref()) {
+            return Some(model);
+        }
+        let flat = match kind {
+            EngineAgentKind::Default => None,
+            EngineAgentKind::Worker => self.pipeline_worker_model.as_deref(),
+            EngineAgentKind::Judge => self.pipeline_judge_model.as_deref(),
+            EngineAgentKind::Triage => self.pipeline_triage_model.as_deref(),
+        };
+        flat.or(self.default_model.as_deref())
+    }
+
+    /// The allowed-model vocabulary, empty when unrestricted.
+    pub fn allowed_models(&self) -> &[String] {
+        self.allowed_models.as_deref().unwrap_or(&[])
+    }
+
+    pub fn auto_mode_on(&self) -> bool {
+        self.auto_mode.is_some_and(Toggle::is_on)
+    }
+
+    pub fn effort_auto_on(&self) -> bool {
+        self.effort_auto.is_some_and(Toggle::is_on)
+    }
+
+    pub fn reasoning_auto_on(&self) -> bool {
+        self.reasoning_auto.is_some_and(Toggle::is_on)
+    }
+
+    /// Persist THIS config as the `agent_engine_config` key of the
+    /// settings file at `path`, preserving every other key in the file
+    /// byte-for-byte at the value level (providers, hooks, mcp, and any
+    /// forward-compat keys survive a TUI save untouched). Creates the file
+    /// (and parent directories) when absent.
+    pub fn save_to(&self, path: &Path) -> Result<(), String> {
+        let mut root: serde_json::Value = match std::fs::read_to_string(path) {
+            Ok(contents) => serde_json::from_str(&contents)
+                .map_err(|e| format!("invalid settings file {}: {e}", path.display()))?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+            Err(e) => return Err(format!("cannot read {}: {e}", path.display())),
+        };
+        let object = root
+            .as_object_mut()
+            .ok_or_else(|| format!("settings file {} is not a JSON object", path.display()))?;
+        let value = serde_json::to_value(self)
+            .map_err(|e| format!("cannot serialize agent_engine_config: {e}"))?;
+        object.insert("agent_engine_config".to_string(), value);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+        }
+        let mut rendered = serde_json::to_string_pretty(&root)
+            .map_err(|e| format!("cannot render settings: {e}"))?;
+        rendered.push('\n');
+        std::fs::write(path, rendered).map_err(|e| format!("cannot write {}: {e}", path.display()))
+    }
+}
+
+/// The user-scope settings path (`~/.config/stella/settings.json`), when
+/// `HOME` is known — the TUI save target for user-scope edits and the
+/// first file of [`Settings::load`]'s chain.
+pub fn user_settings_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".config")
+            .join("stella")
+            .join("settings.json")
+    })
+}
+
+/// The project-scope settings path (`<workspace>/.stella/settings.json`).
+pub fn project_settings_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".stella").join("settings.json")
 }
 
 /// The `mcp` section of settings.json. All fields optional so an absent
@@ -157,11 +538,11 @@ impl Settings {
     pub fn load(workspace_root: &Path) -> Result<Self, String> {
         let mut trusted: Vec<PathBuf> = Vec::new();
         // Ascending precedence: user, org-managed, project.
-        if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
-            trusted.push(home.join(".config").join("stella").join("settings.json"));
+        if let Some(user) = user_settings_path() {
+            trusted.push(user);
         }
         trusted.push(managed_settings_path());
-        let project = workspace_root.join(".stella").join("settings.json");
+        let project = project_settings_path(workspace_root);
 
         let mut all = trusted.clone();
         all.push(project.clone());
@@ -273,6 +654,15 @@ impl Settings {
                 if let Some(url) = &mcp.registry_url {
                     target.registry_url = Some(url.clone());
                 }
+            }
+            // Agent-engine config overlays per field / per agent, like
+            // `providers` — a project can pin the judge model while the
+            // user scope's worker settings survive.
+            if let Some(engine) = &scope.agent_engine_config {
+                merged
+                    .agent_engine_config
+                    .get_or_insert_with(AgentEngineConfig::default)
+                    .overlay(engine);
             }
         }
         Ok(merged)
@@ -424,6 +814,173 @@ mod tests {
         let user = write(dir.path(), "user.json", r#"{"providers": {}}"#);
         let merged = Settings::load_from(&[user]).unwrap();
         assert!(merged.hooks.is_none(), "no hooks handle at all");
+    }
+
+    #[test]
+    fn agent_engine_config_parses_the_full_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write(
+            dir.path(),
+            "engine.json",
+            r#"{"agent_engine_config": {
+                "default_model": "anthropic/claude-fable-5",
+                "pipeline_worker_model": "zai/glm-5.2",
+                "pipeline_judge_model": "openrouter/openai/gpt-5.5",
+                "pipeline_triage_model": "deepseek/deepseek-chat",
+                "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2"],
+                "auto_mode": "on",
+                "effort_auto": "off",
+                "reasoning_auto": "on",
+                "agents": {
+                    "judge": {
+                        "provider": "openrouter",
+                        "model": "openai/gpt-5.5",
+                        "prompt": "You are a strict judge.",
+                        "effort": "high",
+                        "reasoning": "on",
+                        "params": {
+                            "temperature": 0.2,
+                            "top_p": 0.9,
+                            "top_k": 40,
+                            "frequency_penalty": 0.1,
+                            "presence_penalty": 0.0,
+                            "repetition_penalty": 1.05,
+                            "max_tokens": 2048,
+                            "seed": 7,
+                            "verbosity": "low",
+                            "service_tier": "priority"
+                        }
+                    }
+                }
+            }}"#,
+        );
+        let merged = Settings::load_from(&[file]).unwrap();
+        let engine = merged.agent_engine_config.expect("engine config");
+        assert_eq!(
+            engine.model_for(EngineAgentKind::Worker),
+            Some("zai/glm-5.2")
+        );
+        // The judge's per-agent model beats the flat pipeline_judge_model.
+        assert_eq!(
+            engine.model_for(EngineAgentKind::Judge),
+            Some("openai/gpt-5.5")
+        );
+        // No triage agent entry → the flat field answers.
+        assert_eq!(
+            engine.model_for(EngineAgentKind::Triage),
+            Some("deepseek/deepseek-chat")
+        );
+        // Default falls to default_model.
+        assert_eq!(
+            engine.model_for(EngineAgentKind::Default),
+            Some("anthropic/claude-fable-5")
+        );
+        assert!(engine.auto_mode_on());
+        assert!(!engine.effort_auto_on());
+        assert!(engine.reasoning_auto_on());
+        let judge = engine.agent(EngineAgentKind::Judge).expect("judge");
+        assert_eq!(judge.provider.as_deref(), Some("openrouter"));
+        assert_eq!(judge.effort, Some(ReasoningEffort::High));
+        assert_eq!(judge.reasoning, Some(Toggle::On));
+        let params = judge.params.expect("params");
+        assert_eq!(params.top_k, Some(40));
+        assert_eq!(params.verbosity, Some(Verbosity::Low));
+        assert_eq!(params.service_tier, Some(ServiceTier::Priority));
+    }
+
+    #[test]
+    fn agent_engine_config_overlays_per_field_and_per_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = write(
+            dir.path(),
+            "user.json",
+            r#"{"agent_engine_config": {
+                "default_model": "zai/glm-5.2",
+                "allowed_models": ["zai/glm-5.2"],
+                "agents": {"worker": {"effort": "medium", "params": {"temperature": 0.0}}}
+            }}"#,
+        );
+        let project = write(
+            dir.path(),
+            "project.json",
+            r#"{"agent_engine_config": {
+                "pipeline_judge_model": "anthropic/claude-fable-5",
+                "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2"],
+                "agents": {"worker": {"params": {"top_p": 0.95}}}
+            }}"#,
+        );
+        let merged = Settings::load_from(&[user, project]).unwrap();
+        let engine = merged.agent_engine_config.expect("engine config");
+        // Project wins where it speaks; user fields it left unset survive.
+        assert_eq!(engine.default_model.as_deref(), Some("zai/glm-5.2"));
+        assert_eq!(
+            engine.pipeline_judge_model.as_deref(),
+            Some("anthropic/claude-fable-5")
+        );
+        // allowed_models replaces wholesale (one vocabulary, not knobs).
+        assert_eq!(engine.allowed_models().len(), 2);
+        // Worker params compose per field across scopes.
+        let worker = engine.agent(EngineAgentKind::Worker).expect("worker");
+        assert_eq!(worker.effort, Some(ReasoningEffort::Medium));
+        let params = worker.params.expect("params");
+        assert_eq!(params.temperature, Some(0.0));
+        assert_eq!(params.top_p, Some(0.95));
+    }
+
+    #[test]
+    fn agent_engine_config_save_preserves_other_keys_and_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "settings.json",
+            r#"{"providers": {"zai": {"default_model": "glm-5.2"}},
+                "mcp": {"registry_url": "https://my.registry/"},
+                "future_key": {"anything": true}}"#,
+        );
+        let engine = AgentEngineConfig {
+            pipeline_judge_model: Some("anthropic/claude-fable-5".to_string()),
+            auto_mode: Some(Toggle::Off),
+            ..AgentEngineConfig::default()
+        };
+        engine.save_to(&path).unwrap();
+
+        // Other keys survive byte-for-byte at the value level…
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
+        assert_eq!(raw["mcp"]["registry_url"], "https://my.registry/");
+        assert_eq!(raw["future_key"]["anything"], true);
+        // …absent options are omitted from the rendered JSON…
+        assert!(
+            raw["agent_engine_config"]
+                .as_object()
+                .unwrap()
+                .get("default_model")
+                .is_none(),
+            "None fields must not be rendered"
+        );
+        // …and the object round-trips through the normal load path.
+        let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+        let loaded = merged.agent_engine_config.expect("engine config");
+        assert_eq!(loaded, engine);
+
+        // Saving into a missing file creates it (and parents).
+        let fresh = dir.path().join("nested").join("settings.json");
+        engine.save_to(&fresh).unwrap();
+        let merged = Settings::load_from(&[fresh]).unwrap();
+        assert_eq!(merged.agent_engine_config, Some(engine));
+    }
+
+    #[test]
+    fn a_typoed_toggle_is_a_loud_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad = write(
+            dir.path(),
+            "toggle.json",
+            r#"{"agent_engine_config": {"auto_mode": "enabled"}}"#,
+        );
+        let err = Settings::load_from(&[bad]).unwrap_err();
+        assert!(err.contains("invalid settings file"), "{err}");
     }
 
     #[test]

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -80,6 +80,13 @@ pub struct EngineConfig {
     pub max_output_tokens: Option<u32>,
     pub temperature: Option<f32>,
     pub effort: Option<ReasoningEffort>,
+    /// Thinking-mode enable/disable forwarded to every completion —
+    /// `CompletionRequest::reasoning` semantics (`None` = provider default).
+    pub reasoning: Option<bool>,
+    /// Sampling/routing overrides forwarded to every completion —
+    /// `CompletionRequest::params` semantics (each adapter forwards the
+    /// subset its dialect supports).
+    pub params: Option<stella_protocol::GenerationParams>,
     pub retry_policy: RetryPolicy,
     pub loop_detection: LoopDetectionConfig,
     /// Compaction fires once the estimated conversation size exceeds this
@@ -113,6 +120,8 @@ impl Default for EngineConfig {
             max_output_tokens: Some(16384),
             temperature: Some(0.0),
             effort: None,
+            reasoning: None,
+            params: None,
             retry_policy: RetryPolicy::standard(),
             loop_detection: LoopDetectionConfig::default(),
             compaction_budget_tokens: 150_000,
@@ -439,6 +448,8 @@ impl<'a> Engine<'a> {
                 max_output_tokens: req_config.max_output_tokens,
                 temperature: req_config.temperature,
                 effort: req_config.effort,
+                reasoning: req_config.reasoning,
+                params: req_config.params,
                 tools: tools_schema.clone(),
             };
             let read_only = speculation_read_only.clone();

--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -74,11 +74,56 @@ struct AnthropicRequest<'a> {
     /// Sampling temperature, forwarded from `CompletionRequest.temperature`.
     /// Omitted when `None` so Anthropic applies its own default — dropping it
     /// unconditionally (the prior bug) meant a caller-set temperature was
-    /// silently ignored.
+    /// silently ignored. Also omitted whenever `thinking` is set: the
+    /// Messages API rejects any temperature != 1 alongside extended thinking,
+    /// and the engine's default (0.0) would fail every thinking turn.
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    /// Sampling overrides from `CompletionRequest.params`, skipped when
+    /// `None` so a request without overrides serializes byte-identical to
+    /// before (the prompt-cache contract). Only the subset the Messages API
+    /// speaks — the rest of `GenerationParams` has no slot here and is
+    /// silently dropped per the never-fail contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u32>,
+    /// Extended thinking (`{"type":"enabled","budget_tokens":N}`), set only
+    /// for `CompletionRequest.reasoning == Some(true)`. `Some(false)` and
+    /// `None` both omit the block — thinking is opt-in per request on this
+    /// API, so "off" and "provider default" are the same wire shape (which
+    /// keeps the pre-field bytes stable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<AnthropicThinking>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<AnthropicToolSchema>,
+}
+
+/// The Messages API's extended-thinking switch. `budget_tokens` is a hard
+/// cap on thinking output and must satisfy `1024 <= budget < max_tokens` —
+/// [`thinking_budget_tokens`] maps the engine's effort tiers and the caller
+/// in `complete_inner` clamps against the request's actual `max_tokens`.
+#[derive(Serialize)]
+struct AnthropicThinking {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    budget_tokens: u32,
+}
+
+/// Map the engine's effort tiers onto thinking budgets. Anthropic has no
+/// named levels — the budget IS the level — so the tiers are spaced roughly
+/// geometrically from the API's 1024-token floor up to a Max that still
+/// leaves headroom under typical output caps. `None` defaults to Medium, the
+/// same middle-tier default posture as `openai.rs` ("effort":"medium").
+fn thinking_budget_tokens(effort: Option<stella_protocol::ReasoningEffort>) -> u32 {
+    use stella_protocol::ReasoningEffort::*;
+    match effort {
+        Some(Low) => 2_048,
+        None | Some(Medium) => 8_192,
+        Some(High) => 16_384,
+        Some(Xhigh) => 32_768,
+        Some(Max) => 49_152,
+    }
 }
 
 /// The opt-in prompt-cache marker (`{"type": "ephemeral"}`, default 5-minute
@@ -458,9 +503,30 @@ impl AnthropicProvider {
         observer: Option<&dyn ToolCallObserver>,
     ) -> Result<CompletionResult, ProviderError> {
         let (system, messages) = to_anthropic_messages(&req.messages);
+        // Thinking budget, resolved before max_tokens because the two are
+        // coupled: the API requires budget < max_tokens, and this adapter's
+        // 4096-token max_tokens default would leave no room for any budget
+        // above Low. So when thinking is on and the CALLER didn't set an
+        // output cap, the default floor rises to budget + 8192 (thinking
+        // spends from the same output allowance as the answer — a budget
+        // that consumes the whole cap yields a truncated or empty turn).
+        // A caller-set cap is honored as-is and the budget clamps to it:
+        // at most max_tokens - 1024, never below the API's 1024 floor.
+        let thinking_budget =
+            (req.reasoning == Some(true)).then(|| thinking_budget_tokens(req.effort));
+        let max_tokens = match (req.max_output_tokens, thinking_budget) {
+            (Some(cap), _) => cap,
+            (None, Some(budget)) => budget + 8_192,
+            (None, None) => 4096,
+        };
+        let thinking = thinking_budget.map(|budget| AnthropicThinking {
+            kind: "enabled",
+            budget_tokens: budget.min(max_tokens.saturating_sub(1024)).max(1024),
+        });
+        let params = req.params.unwrap_or_default();
         let body = AnthropicRequest {
             model: &self.model,
-            max_tokens: req.max_output_tokens.unwrap_or(4096),
+            max_tokens,
             system: system.as_deref().map(|text| {
                 vec![AnthropicSystemBlock {
                     kind: "text",
@@ -471,7 +537,17 @@ impl AnthropicProvider {
             messages,
             stream: true,
             cache_control: EPHEMERAL_CACHE,
-            temperature: req.temperature,
+            // The API rejects temperature != 1 with thinking enabled; rather
+            // than special-casing 1.0, omit the field entirely and let the
+            // API apply its own thinking-compatible default.
+            temperature: if thinking.is_some() {
+                None
+            } else {
+                req.temperature
+            },
+            top_p: params.top_p,
+            top_k: params.top_k,
+            thinking,
             tools: req
                 .tools
                 .iter()
@@ -860,6 +936,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -908,6 +986,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -955,6 +1035,8 @@ mod tests {
                 temperature: None,
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .expect("a repairable malformed call must not abort the turn");
@@ -990,6 +1072,8 @@ mod tests {
                 temperature: None,
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .unwrap_err();
@@ -1036,6 +1120,8 @@ mod tests {
                 temperature: None,
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .unwrap_err();
@@ -1160,12 +1246,21 @@ mod tests {
             stream: true,
             cache_control: EPHEMERAL_CACHE,
             temperature: None,
+            top_p: None,
+            top_k: None,
+            thinking: None,
             tools: vec![],
         };
         let v = serde_json::to_value(&body).expect("request serializes");
         assert_eq!(v["system"][0]["type"], "text");
         assert_eq!(v["system"][0]["cache_control"]["type"], "ephemeral");
         assert_eq!(v["cache_control"]["type"], "ephemeral");
+        // The optional params/thinking fields must vanish when unset — the
+        // byte-stability contract for requests without overrides.
+        let body_json = serde_json::to_string(&v).unwrap();
+        for key in ["top_p", "top_k", "thinking"] {
+            assert!(!body_json.contains(key), "unexpected `{key}`: {body_json}");
+        }
     }
 
     #[tokio::test]
@@ -1199,6 +1294,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -1242,6 +1339,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1291,6 +1390,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1345,6 +1446,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let observer = RecordingObserver(std::sync::Mutex::new(Vec::new()));
@@ -1394,6 +1497,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let observer = RecordingObserver(std::sync::Mutex::new(Vec::new()));
@@ -1480,6 +1585,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1516,6 +1623,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1551,6 +1660,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1587,6 +1698,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1628,6 +1741,8 @@ mod tests {
             temperature: Some(0.3),
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1652,6 +1767,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1684,11 +1801,183 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
         // overloaded_error ⇒ retryable Transport.
         assert!(matches!(err, ProviderError::Transport(_)));
         assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn thinking_budgets_map_effort_tiers_and_default_to_medium() {
+        use stella_protocol::ReasoningEffort::*;
+        assert_eq!(thinking_budget_tokens(Some(Low)), 2_048);
+        assert_eq!(thinking_budget_tokens(Some(Medium)), 8_192);
+        assert_eq!(thinking_budget_tokens(None), 8_192, "None defaults Medium");
+        assert_eq!(thinking_budget_tokens(Some(High)), 16_384);
+        assert_eq!(thinking_budget_tokens(Some(Xhigh)), 32_768);
+        assert_eq!(thinking_budget_tokens(Some(Max)), 49_152);
+    }
+
+    /// Minimal happy-path SSE body for tests that only inspect the request.
+    const OK_SSE: &str = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+    );
+
+    async fn mock_ok(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(OK_SSE, "text/event-stream"))
+            .mount(server)
+            .await;
+    }
+
+    async fn first_request_body(server: &MockServer) -> String {
+        let requests = server.received_requests().await.expect("recorded requests");
+        String::from_utf8_lossy(&requests[0].body).into_owned()
+    }
+
+    #[tokio::test]
+    async fn generation_params_forward_top_p_and_top_k_and_drop_the_rest() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    top_k: Some(40),
+                    // No Messages API slot — silently dropped, never a 400.
+                    frequency_penalty: Some(0.5),
+                    presence_penalty: Some(0.25),
+                    repetition_penalty: Some(1.1),
+                    seed: Some(7),
+                    verbosity: None,
+                    service_tier: None,
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(body.contains("\"top_p\":0.9"), "{body}");
+        assert!(body.contains("\"top_k\":40"), "{body}");
+        for dropped in [
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+        ] {
+            assert!(!body.contains(dropped), "`{dropped}` leaked into: {body}");
+        }
+    }
+
+    /// `reasoning: Some(true)` with no caller output cap: the budget maps
+    /// from effort, the defaulted max_tokens rises to budget + 8192 so
+    /// thinking can't consume the whole output allowance, and temperature is
+    /// omitted entirely (the API rejects temperature != 1 with thinking).
+    #[tokio::test]
+    async fn reasoning_true_enables_thinking_raises_max_tokens_and_omits_temperature() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("think hard")],
+                max_output_tokens: None,
+                temperature: Some(0.0), // the engine default that would 400
+                effort: Some(stella_protocol::ReasoningEffort::Max),
+                tools: vec![],
+                reasoning: Some(true),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(
+            body.contains("\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":49152}"),
+            "{body}"
+        );
+        assert!(
+            body.contains("\"max_tokens\":57344"),
+            "49152 + 8192: {body}"
+        );
+        assert!(!body.contains("temperature"), "{body}");
+    }
+
+    /// A caller-set max_tokens is honored, and the budget clamps under it:
+    /// at most max_tokens - 1024 (the API requires budget < max_tokens).
+    #[tokio::test]
+    async fn thinking_budget_clamps_under_a_caller_set_max_tokens() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("think")],
+                max_output_tokens: Some(4096),
+                temperature: None,
+                effort: None, // Medium default: 8192, which exceeds the cap
+                tools: vec![],
+                reasoning: Some(true),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(body.contains("\"max_tokens\":4096"), "{body}");
+        assert!(
+            body.contains("\"budget_tokens\":3072"),
+            "4096 - 1024: {body}"
+        );
+    }
+
+    /// `Some(false)` and `None` are the same wire shape: no thinking block
+    /// (thinking is opt-in on this API), temperature forwarded as always —
+    /// i.e. exactly today's request bytes.
+    #[tokio::test]
+    async fn reasoning_false_sends_no_thinking_block_and_keeps_temperature() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+            .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: Some(0.3),
+                effort: Some(stella_protocol::ReasoningEffort::High),
+                tools: vec![],
+                reasoning: Some(false),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(!body.contains("thinking"), "{body}");
+        assert!(!body.contains("budget_tokens"), "{body}");
+        assert!(body.contains("\"temperature\":0.3"), "{body}");
+        assert!(body.contains("\"max_tokens\":4096"), "default cap: {body}");
     }
 }

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -337,6 +337,14 @@ struct BedrockInferenceConfig {
     max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    /// Nucleus sampling from `CompletionRequest.params` — `topP` is the only
+    /// sampling override Converse's model-agnostic `inferenceConfig` speaks.
+    /// The rest of `GenerationParams` (top_k, penalties, seed, …) would need
+    /// `additionalModelRequestFields`, a model-specific passthrough this
+    /// adapter doesn't have yet; per the never-fail contract those are
+    /// silently dropped rather than guessed at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
 }
 
 #[derive(Serialize)]
@@ -565,14 +573,21 @@ impl Provider for BedrockProvider {
                 });
             }
         }
-        let inference_config = if req.max_output_tokens.is_none() && req.temperature.is_none() {
-            None
-        } else {
-            Some(BedrockInferenceConfig {
-                max_tokens: req.max_output_tokens,
-                temperature: req.temperature,
-            })
-        };
+        // Only `top_p` has a Converse `inferenceConfig` slot — see the field
+        // doc on [`BedrockInferenceConfig`] for why the rest of the params
+        // (and the `reasoning` switch, which would ride the same missing
+        // `additionalModelRequestFields` passthrough) are dropped here.
+        let top_p = req.params.and_then(|p| p.top_p);
+        let inference_config =
+            if req.max_output_tokens.is_none() && req.temperature.is_none() && top_p.is_none() {
+                None
+            } else {
+                Some(BedrockInferenceConfig {
+                    max_tokens: req.max_output_tokens,
+                    temperature: req.temperature,
+                    top_p,
+                })
+            };
         let body = ConverseRequest {
             system,
             messages,
@@ -1166,6 +1181,8 @@ mod tests {
             temperature: Some(0.0),
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -1211,6 +1228,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
         let result = provider
             .complete(req)
@@ -1246,6 +1265,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1276,6 +1297,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1300,6 +1323,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1341,9 +1366,89 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
         assert_eq!(result.text, "ok");
+    }
+
+    /// Of the `GenerationParams`, only `top_p` has a Converse
+    /// `inferenceConfig` slot; the rest must be dropped silently (the
+    /// never-fail contract), not guessed into `additionalModelRequestFields`
+    /// this adapter doesn't have.
+    #[tokio::test]
+    async fn generation_params_forward_only_top_p_into_inference_config() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+                "usage": {"inputTokens": 1, "outputTokens": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    top_k: Some(40),
+                    seed: Some(7),
+                    ..Default::default()
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let body = String::from_utf8_lossy(&requests[0].body);
+        assert!(
+            body.contains("\"inferenceConfig\":{\"topP\":0.9}"),
+            "{body}"
+        );
+        assert!(!body.contains("topK"), "{body}");
+        assert!(!body.contains("seed"), "{body}");
+    }
+
+    /// The byte-stability contract: with no overrides at all, no
+    /// `inferenceConfig` key rides — exactly the pre-params request body.
+    #[tokio::test]
+    async fn absent_params_omit_inference_config_entirely() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+                "usage": {"inputTokens": 1, "outputTokens": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let body = String::from_utf8_lossy(&requests[0].body);
+        assert!(!body.contains("inferenceConfig"), "{body}");
+        assert!(!body.contains("topP"), "{body}");
     }
 }

--- a/stella-model/src/gemini.rs
+++ b/stella-model/src/gemini.rs
@@ -221,6 +221,22 @@ pub(crate) struct GeminiGenerationConfig {
     pub(crate) max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) temperature: Option<f32>,
+    /// Sampling overrides from `CompletionRequest.params` — the struct-level
+    /// `rename_all` gives them the REST API's camelCase names (`topP`,
+    /// `topK`, `frequencyPenalty`, `presencePenalty`), matching
+    /// `max_output_tokens`/`maxOutputTokens` above. Each is skipped when
+    /// `None` so a request without overrides serializes byte-identical to
+    /// before (the prompt-cache contract).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) top_k: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) seed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presence_penalty: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) thinking_config: Option<GeminiThinkingConfig>,
 }
@@ -475,15 +491,50 @@ pub(crate) fn to_gemini_tools(tools: &[stella_protocol::tool::ToolSchema]) -> Ve
 }
 
 pub(crate) fn build_generation_config(req: &CompletionRequest) -> Option<GeminiGenerationConfig> {
-    if req.max_output_tokens.is_none() && req.temperature.is_none() && req.effort.is_none() {
+    let params = req.params.unwrap_or_default();
+    // The early-out considers EVERY field that could set a key below: a
+    // request with no overrides at all must omit `generationConfig` entirely
+    // (byte-stable with the pre-params wire), but any single override —
+    // including the new params and the reasoning switch — must produce it.
+    // Only the params this dialect actually forwards count; a request
+    // carrying nothing but verbosity/service_tier (which Gemini can't
+    // express) must not degrade to an empty `"generationConfig": {}`.
+    if req.max_output_tokens.is_none()
+        && req.temperature.is_none()
+        && req.effort.is_none()
+        && req.reasoning.is_none()
+        && params.top_p.is_none()
+        && params.top_k.is_none()
+        && params.seed.is_none()
+        && params.frequency_penalty.is_none()
+        && params.presence_penalty.is_none()
+    {
         return None;
     }
+    // Thinking level: an explicit `reasoning: Some(false)` maps to "low" —
+    // Gemini 3 cannot fully disable thinking (there is no "off"), so the
+    // lowest level is the closest honest expression of "suppress thinking".
+    // It wins over a pinned effort for the same reason an explicit off wins
+    // in the other adapters. A bare `Some(true)` with no effort picks
+    // "high" (Gemini 3 has no medium tier — see [`map_thinking_level`]);
+    // otherwise a pinned effort maps as it always has, and (None, None)
+    // sends no thinkingConfig (provider default).
+    let thinking_level = match (req.reasoning, req.effort) {
+        (Some(false), _) => Some("low"),
+        (_, Some(effort)) => Some(map_thinking_level(effort)),
+        (Some(true), None) => Some("high"),
+        (None, None) => None,
+    };
     Some(GeminiGenerationConfig {
         max_output_tokens: req.max_output_tokens,
         temperature: req.temperature,
-        thinking_config: req.effort.map(|effort| GeminiThinkingConfig {
-            thinking_level: map_thinking_level(effort),
-        }),
+        top_p: params.top_p,
+        top_k: params.top_k,
+        seed: params.seed,
+        frequency_penalty: params.frequency_penalty,
+        presence_penalty: params.presence_penalty,
+        thinking_config: thinking_level
+            .map(|thinking_level| GeminiThinkingConfig { thinking_level }),
     })
 }
 
@@ -821,6 +872,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -867,6 +920,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -914,6 +969,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -940,6 +997,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -966,6 +1025,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -993,6 +1054,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1003,5 +1066,143 @@ mod tests {
             }
             other => panic!("expected RateLimited, got {other:?}"),
         }
+    }
+
+    /// A bare request for config-shape tests; overrides are patched in.
+    fn bare_request() -> CompletionRequest {
+        CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        }
+    }
+
+    #[test]
+    fn generation_config_forwards_params_in_camel_case() {
+        use stella_protocol::GenerationParams;
+        let req = CompletionRequest {
+            params: Some(GenerationParams {
+                top_p: Some(0.9),
+                top_k: Some(40),
+                frequency_penalty: Some(0.5),
+                presence_penalty: Some(0.25),
+                seed: Some(7),
+                // No generateContent slot — silently dropped.
+                repetition_penalty: Some(1.1),
+                verbosity: Some(stella_protocol::Verbosity::High),
+                service_tier: Some(stella_protocol::ServiceTier::Priority),
+            }),
+            ..bare_request()
+        };
+        let config = build_generation_config(&req).expect("params force a config");
+        // Assert on the serialized string (the exact bytes reqwest sends),
+        // not a `to_value` round-trip — `to_value` widens f32 through f64
+        // and would perturb 0.9 into 0.90000003….
+        let body = serde_json::to_string(&config).unwrap();
+        // The REST API is camelCase — snake_case keys here would be silently
+        // ignored by the server, which is why the casing is pinned.
+        assert!(body.contains("\"topP\":0.9"), "{body}");
+        assert!(body.contains("\"topK\":40"), "{body}");
+        assert!(body.contains("\"seed\":7"), "{body}");
+        assert!(body.contains("\"frequencyPenalty\":0.5"), "{body}");
+        assert!(body.contains("\"presencePenalty\":0.25"), "{body}");
+        for dropped in ["repetition", "verbosity", "serviceTier", "top_p"] {
+            assert!(!body.contains(dropped), "`{dropped}` leaked into: {body}");
+        }
+    }
+
+    /// The byte-stability contract: no overrides at all — including a params
+    /// struct carrying only fields this dialect can't express — must omit
+    /// `generationConfig` entirely, exactly the pre-params wire shape.
+    #[test]
+    fn generation_config_is_omitted_without_any_forwardable_override() {
+        use stella_protocol::GenerationParams;
+        assert!(build_generation_config(&bare_request()).is_none());
+        let unforwardable = CompletionRequest {
+            params: Some(GenerationParams {
+                verbosity: Some(stella_protocol::Verbosity::Low),
+                service_tier: Some(stella_protocol::ServiceTier::Flex),
+                ..Default::default()
+            }),
+            ..bare_request()
+        };
+        assert!(
+            build_generation_config(&unforwardable).is_none(),
+            "verbosity/service_tier alone must not produce an empty config"
+        );
+    }
+
+    /// `reasoning: Some(false)` → thinkingLevel "low": Gemini 3 cannot fully
+    /// disable thinking, so the lowest level is the closest honest mapping —
+    /// and the explicit off wins over a pinned effort. A bare `Some(true)`
+    /// picks "high" (there is no medium tier).
+    #[test]
+    fn reasoning_switch_maps_to_thinking_levels() {
+        let off = CompletionRequest {
+            reasoning: Some(false),
+            effort: Some(ReasoningEffort::Max),
+            ..bare_request()
+        };
+        let config = build_generation_config(&off).expect("reasoning forces a config");
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["thinkingConfig"]["thinkingLevel"], "low", "{json}");
+
+        let on = CompletionRequest {
+            reasoning: Some(true),
+            ..bare_request()
+        };
+        let config = build_generation_config(&on).expect("reasoning forces a config");
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["thinkingConfig"]["thinkingLevel"], "high", "{json}");
+
+        // A pinned effort with no reasoning switch maps as it always has.
+        let effort_only = CompletionRequest {
+            effort: Some(ReasoningEffort::Low),
+            ..bare_request()
+        };
+        let config = build_generation_config(&effort_only).expect("effort forces a config");
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["thinkingConfig"]["thinkingLevel"], "low", "{json}");
+    }
+
+    /// End-to-end: the config rides the request body to the wire.
+    #[tokio::test]
+    async fn complete_sends_generation_config_params_on_the_wire() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        let sse_body = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/models/gemini-3-pro:streamGenerateContent"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = GeminiProvider::new(ApiKey::new("test-key"), "gemini-3-pro")
+            .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    top_k: Some(40),
+                    ..Default::default()
+                }),
+                reasoning: Some(false),
+                ..bare_request()
+            })
+            .await
+            .expect("should succeed");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let body = String::from_utf8_lossy(&requests[0].body);
+        assert!(body.contains("\"topP\":0.9"), "{body}");
+        assert!(body.contains("\"topK\":40"), "{body}");
+        assert!(
+            body.contains("\"thinkingConfig\":{\"thinkingLevel\":\"low\"}"),
+            "{body}"
+        );
     }
 }

--- a/stella-model/src/openai.rs
+++ b/stella-model/src/openai.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_protocol::{
     CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
-    ProviderError, ReasoningEffort, ToolCall,
+    ProviderError, ReasoningEffort, ServiceTier, ToolCall, Verbosity,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -98,6 +98,21 @@ struct OpenAiRequest<'a> {
     max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    /// Nucleus sampling from `CompletionRequest.params`, skipped when `None`
+    /// so a request without overrides serializes byte-identical to before
+    /// (the prompt-cache contract). Gated exactly like `temperature`: the
+    /// reasoning-model families reject sampling parameters with HTTP 400.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    /// Processing tier from `params.service_tier` ("auto"/"default"/"flex"/
+    /// "priority") — a routing hint, not a sampling one, so it is never
+    /// gated by model family.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<&'static str>,
+    /// Response-detail control from `params.verbosity`, wrapped in the
+    /// Responses API's `text` object (`{"verbosity": "low|medium|high"}`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<OpenAiText>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<OpenAiToolSchema>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,6 +125,33 @@ struct OpenAiRequest<'a> {
 #[derive(Serialize)]
 struct OpenAiReasoning {
     effort: &'static str,
+}
+
+/// The Responses API's `text` configuration object. Only `verbosity` is
+/// modeled — the object exists solely to carry it, and it is omitted
+/// entirely when the caller expressed no preference.
+#[derive(Serialize)]
+struct OpenAiText {
+    verbosity: &'static str,
+}
+
+/// Map the engine's `Verbosity` enum to the API's lowercase token.
+fn map_verbosity(verbosity: Verbosity) -> &'static str {
+    match verbosity {
+        Verbosity::Low => "low",
+        Verbosity::Medium => "medium",
+        Verbosity::High => "high",
+    }
+}
+
+/// Map the engine's `ServiceTier` enum to the API's lowercase token.
+fn map_service_tier(tier: ServiceTier) -> &'static str {
+    match tier {
+        ServiceTier::Auto => "auto",
+        ServiceTier::Default => "default",
+        ServiceTier::Flex => "flex",
+        ServiceTier::Priority => "priority",
+    }
 }
 
 /// The Responses API's function-tool shape: flat (`name`/`description`/
@@ -446,6 +488,7 @@ impl Provider for OpenAiProvider {
 
     async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
         let (instructions, input) = to_openai_input(&req.messages);
+        let params = req.params.unwrap_or_default();
         let body = OpenAiRequest {
             model: &self.model,
             input,
@@ -461,10 +504,33 @@ impl Provider for OpenAiProvider {
             } else {
                 req.temperature
             },
-            tools: to_openai_tools(&req.tools),
-            reasoning: req.effort.map(|effort| OpenAiReasoning {
-                effort: map_reasoning_effort(effort),
+            // Same 400-avoidance gate as temperature: the reasoning families
+            // reject `top_p` too, and an ungated caller override would fail
+            // every turn Terminal on exactly the models people set effort on.
+            top_p: if is_reasoning_model(&self.model) {
+                None
+            } else {
+                params.top_p
+            },
+            service_tier: params.service_tier.map(map_service_tier),
+            text: params.verbosity.map(|verbosity| OpenAiText {
+                verbosity: map_verbosity(verbosity),
             }),
+            tools: to_openai_tools(&req.tools),
+            // `reasoning == Some(false)` suppresses the reasoning object even
+            // when an effort is pinned — an explicit off must win. A bare
+            // `Some(true)` with no effort turns thinking on at the API's
+            // middle tier; otherwise a pinned effort maps as it always has,
+            // and (None, None) keeps the field (and the pre-field bytes) off
+            // the wire.
+            reasoning: match (req.reasoning, req.effort) {
+                (Some(false), _) => None,
+                (_, Some(effort)) => Some(OpenAiReasoning {
+                    effort: map_reasoning_effort(effort),
+                }),
+                (Some(true), None) => Some(OpenAiReasoning { effort: "medium" }),
+                (None, None) => None,
+            },
             prompt_cache_key: &self.prompt_cache_key,
         };
 
@@ -682,6 +748,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
         provider.complete(req()).await.expect("first turn");
         provider.complete(req()).await.expect("second turn");
@@ -728,6 +796,8 @@ mod tests {
                 temperature: Some(0.0), // the engine default that used to 400
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .expect("turn");
@@ -866,6 +936,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -920,6 +992,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -967,6 +1041,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -992,6 +1068,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1020,6 +1098,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1049,6 +1129,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1084,6 +1166,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1120,6 +1204,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1152,6 +1238,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1183,12 +1271,191 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
         match err {
             ProviderError::Terminal(msg) => assert!(msg.contains("max_output_tokens"), "{msg}"),
             other => panic!("expected Terminal incomplete error, got {other:?}"),
+        }
+    }
+
+    /// Minimal happy-path SSE body for tests that only inspect the request.
+    const OK_SSE: &str = concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+    );
+
+    async fn mock_ok(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(OK_SSE, "text/event-stream"))
+            .mount(server)
+            .await;
+    }
+
+    async fn first_request_body(server: &MockServer) -> String {
+        let requests = server.received_requests().await.expect("recorded requests");
+        String::from_utf8_lossy(&requests[0].body).into_owned()
+    }
+
+    #[tokio::test]
+    async fn generation_params_forward_top_p_service_tier_and_verbosity() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        // gpt-4.1 is a sampling model, so `top_p` passes the reasoning gate.
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-4.1").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    // No Responses API slot — silently dropped, never a 400.
+                    top_k: Some(40),
+                    frequency_penalty: None,
+                    presence_penalty: None,
+                    repetition_penalty: None,
+                    seed: None,
+                    verbosity: Some(stella_protocol::Verbosity::Low),
+                    service_tier: Some(stella_protocol::ServiceTier::Priority),
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(body.contains("\"top_p\":0.9"), "{body}");
+        assert!(body.contains("\"service_tier\":\"priority\""), "{body}");
+        assert!(body.contains("\"text\":{\"verbosity\":\"low\"}"), "{body}");
+        assert!(!body.contains("top_k"), "{body}");
+    }
+
+    /// `top_p` rides the same reasoning-model gate as `temperature`: the
+    /// gpt-5 family rejects sampling parameters with HTTP 400, so a caller
+    /// override must be dropped there — while the non-sampling routing hint
+    /// (`service_tier`) still goes through.
+    #[tokio::test]
+    async fn top_p_is_omitted_for_a_reasoning_model_like_temperature() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    service_tier: Some(stella_protocol::ServiceTier::Flex),
+                    ..Default::default()
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(!body.contains("top_p"), "{body}");
+        assert!(body.contains("\"service_tier\":\"flex\""), "{body}");
+    }
+
+    /// An explicit `reasoning: Some(false)` must win over a pinned effort —
+    /// the caller asked for thinking OFF, so no `reasoning` object rides.
+    #[tokio::test]
+    async fn reasoning_false_suppresses_the_reasoning_object_even_with_effort() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: Some(ReasoningEffort::High),
+                tools: vec![],
+                reasoning: Some(false),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(!body.contains("\"reasoning\""), "{body}");
+    }
+
+    /// A bare `Some(true)` with no effort turns thinking on at the API's
+    /// middle tier rather than silently doing nothing.
+    #[tokio::test]
+    async fn reasoning_true_without_effort_defaults_to_medium() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: Some(true),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(
+            body.contains("\"reasoning\":{\"effort\":\"medium\"}"),
+            "{body}"
+        );
+    }
+
+    /// The prompt-cache stability contract: a request without params or a
+    /// reasoning preference serializes with none of the new keys.
+    #[tokio::test]
+    async fn absent_params_and_reasoning_add_no_keys_to_the_body() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        for key in ["top_p", "service_tier", "verbosity", "\"reasoning\""] {
+            assert!(!body.contains(key), "unexpected `{key}` in: {body}");
         }
     }
 }

--- a/stella-model/src/vertex.rs
+++ b/stella-model/src/vertex.rs
@@ -193,6 +193,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -226,6 +228,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -236,5 +240,56 @@ mod tests {
             other => panic!("expected Auth, got {other:?}"),
         }
         assert!(!err.is_retryable());
+    }
+
+    /// Vertex shares `build_generation_config` with `gemini.rs`, so the
+    /// params/reasoning mapping (and its byte-stability early-out) is proven
+    /// there; this pins that the shared config actually rides the Vertex
+    /// request body — a regression guard against the two adapters drifting
+    /// onto separate builders.
+    #[tokio::test]
+    async fn complete_sends_shared_generation_config_params_on_the_wire() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        let sse_body = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n";
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider = VertexProvider::new(
+            ApiKey::new("ya29.test-token"),
+            "gemini-3-pro",
+            "my-project",
+            "global",
+        )
+        .with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: Some(true),
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    top_k: Some(40),
+                    seed: Some(7),
+                    ..Default::default()
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let body = String::from_utf8_lossy(&requests[0].body);
+        assert!(body.contains("\"topP\":0.9"), "{body}");
+        assert!(body.contains("\"topK\":40"), "{body}");
+        assert!(body.contains("\"seed\":7"), "{body}");
+        assert!(
+            body.contains("\"thinkingConfig\":{\"thinkingLevel\":\"high\"}"),
+            "{body}"
+        );
     }
 }

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_protocol::{
     CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
-    MessageRole, ProviderError, ToolCall,
+    MessageRole, ProviderError, ReasoningEffort, ToolCall,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -133,6 +133,38 @@ struct ZaiRequest<'a> {
     max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    /// Sampling overrides from `CompletionRequest.params`, each skipped when
+    /// `None` so a request without overrides serializes byte-identical to
+    /// what this adapter has always sent (the prompt-cache contract).
+    /// `top_p`/`frequency_penalty`/`presence_penalty`/`seed` are standard
+    /// Chat Completions parameters; `top_k` and `repetition_penalty` are
+    /// non-standard but accepted by OpenRouter and local servers — they are
+    /// forwarded whenever `Some` because the user explicitly opted in, and an
+    /// honest provider error beats silently dropping an explicit setting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    presence_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repetition_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+    /// GLM's native thinking switch (`{"type": "enabled"|"disabled"}`) —
+    /// only sent when this adapter is serving Z.ai itself AND the caller set
+    /// `CompletionRequest.reasoning`; other Chat Completions servers don't
+    /// speak this field and `None` keeps their wire untouched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ZaiThinking>,
+    /// OpenRouter's normalized reasoning control — only sent when this
+    /// adapter is re-identified as OpenRouter, which translates it to
+    /// whatever the routed upstream vendor calls it. See
+    /// [`openrouter_reasoning`] for the effort/enabled shape rules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<OpenRouterReasoning>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ZaiToolSchema>,
     /// OpenRouter usage accounting (`{"include": true}`) — omitted entirely
@@ -141,6 +173,70 @@ struct ZaiRequest<'a> {
     /// reject.
     #[serde(skip_serializing_if = "Option::is_none")]
     usage: Option<ZaiUsageInclude>,
+}
+
+/// GLM's request-level thinking object: `{"type": "enabled"}` /
+/// `{"type": "disabled"}`. Z.ai's default depends on the model, so the field
+/// is only sent when the caller expressed an explicit preference —
+/// `CompletionRequest.reasoning == None` keeps the provider default AND the
+/// pre-field wire bytes.
+#[derive(Serialize)]
+struct ZaiThinking {
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+/// OpenRouter's `reasoning` object. Exactly one field is set per request:
+/// `effort` when the caller pinned a level, `enabled` for a bare on/off —
+/// sending both would be redundant (effort implies enabled) and `enabled:
+/// false` with an effort would be contradictory.
+#[derive(Serialize)]
+struct OpenRouterReasoning {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+}
+
+/// Map the engine's one `ReasoningEffort` enum to OpenRouter's
+/// `reasoning.effort`, which only accepts `low`/`medium`/`high`. Same
+/// collapse posture as `openai.rs::map_reasoning_effort`: never drop the
+/// hint, never panic on a variant the gateway doesn't model.
+fn map_openrouter_effort(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High | ReasoningEffort::Xhigh | ReasoningEffort::Max => "high",
+    }
+}
+
+/// Build OpenRouter's `reasoning` object from the request's reasoning/effort
+/// pair. Rules: an explicit off (`reasoning == Some(false)`) always wins and
+/// sends `{"enabled": false}` — a pinned effort must not resurrect thinking
+/// the caller suppressed; otherwise a pinned effort sends
+/// `{"effort": …}` (implicitly enabling); a bare `Some(true)` with no effort
+/// sends `{"enabled": true}` and lets the gateway pick the level; and
+/// neither set keeps the field off the wire entirely (provider default,
+/// byte-stable with the pre-field body).
+fn openrouter_reasoning(
+    reasoning: Option<bool>,
+    effort: Option<ReasoningEffort>,
+) -> Option<OpenRouterReasoning> {
+    match (reasoning, effort) {
+        (Some(false), _) => Some(OpenRouterReasoning {
+            effort: None,
+            enabled: Some(false),
+        }),
+        (_, Some(effort)) => Some(OpenRouterReasoning {
+            effort: Some(map_openrouter_effort(effort)),
+            enabled: None,
+        }),
+        (Some(true), None) => Some(OpenRouterReasoning {
+            effort: None,
+            enabled: Some(true),
+        }),
+        (None, None) => None,
+    }
 }
 
 #[derive(Serialize)]
@@ -563,12 +659,39 @@ impl ZaiProvider {
         req: CompletionRequest,
         observer: Option<&dyn ToolCallObserver>,
     ) -> Result<CompletionResult, ProviderError> {
+        // "Include" semantics: every override is `None` unless the caller
+        // set it, and `None` never reaches the wire — a request without
+        // params serializes byte-identical to the pre-params body.
+        let params = req.params.unwrap_or_default();
         let body = ZaiRequest {
             model: &self.model,
             messages: to_zai_messages(&req.messages),
             stream: true,
             max_tokens: req.max_output_tokens,
             temperature: req.temperature,
+            top_p: params.top_p,
+            top_k: params.top_k,
+            frequency_penalty: params.frequency_penalty,
+            presence_penalty: params.presence_penalty,
+            repetition_penalty: params.repetition_penalty,
+            seed: params.seed,
+            // Reasoning routes by identity: only Z.ai itself speaks GLM's
+            // `thinking` object and only OpenRouter speaks the normalized
+            // `reasoning` object. Any other identity behind this shared
+            // adapter (xAI, DeepSeek, local, settings-defined) gets neither —
+            // there is no portable Chat Completions reasoning field, and an
+            // unknown key would risk a hard 400 on servers the user never
+            // opted into experimenting with.
+            thinking: (self.id == "zai")
+                .then(|| {
+                    req.reasoning.map(|enabled| ZaiThinking {
+                        kind: if enabled { "enabled" } else { "disabled" },
+                    })
+                })
+                .flatten(),
+            reasoning: (self.id == "openrouter")
+                .then(|| openrouter_reasoning(req.reasoning, req.effort))
+                .flatten(),
             tools: to_zai_tools(&req.tools),
             usage: self
                 .usage_accounting
@@ -1003,6 +1126,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -1047,6 +1172,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -1095,6 +1222,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let observer = RecordingObserver(std::sync::Mutex::new(Vec::new()));
@@ -1147,6 +1276,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         // The mock's matchers make a missing usage field / missing headers a
@@ -1186,6 +1317,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
         let result = provider.complete(req).await.expect("should succeed");
         assert_eq!(result.text, "thinking hard");
@@ -1225,6 +1358,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider
@@ -1271,6 +1406,8 @@ mod tests {
                 input_schema: serde_json::json!({"type":"object"}),
                 read_only: false,
             }],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1317,6 +1454,8 @@ mod tests {
                 temperature: None,
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .unwrap_err();
@@ -1357,6 +1496,8 @@ mod tests {
                 temperature: None,
                 effort: None,
                 tools: vec![],
+                reasoning: None,
+                params: None,
             })
             .await
             .unwrap_err();
@@ -1392,6 +1533,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1424,6 +1567,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1463,6 +1608,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1496,6 +1643,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1541,6 +1690,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let result = provider.complete(req).await.expect("should succeed");
@@ -1575,6 +1726,8 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
@@ -1605,11 +1758,225 @@ mod tests {
             temperature: None,
             effort: None,
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
 
         let err = provider.complete(req).await.unwrap_err();
         // server_error / overloaded ⇒ retryable Transport.
         assert!(matches!(err, ProviderError::Transport(_)));
         assert!(err.is_retryable());
+    }
+
+    /// Minimal happy-path SSE body for tests that only inspect the request.
+    const OK_SSE: &str =
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n";
+
+    async fn mock_ok(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(OK_SSE, "text/event-stream"))
+            .mount(server)
+            .await;
+    }
+
+    async fn first_request_body(server: &MockServer) -> String {
+        let requests = server.received_requests().await.expect("recorded requests");
+        String::from_utf8_lossy(&requests[0].body).into_owned()
+    }
+
+    #[tokio::test]
+    async fn generation_params_land_in_the_wire_body_including_nonstandard_fields() {
+        use stella_protocol::GenerationParams;
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: Some(GenerationParams {
+                    top_p: Some(0.9),
+                    top_k: Some(40),
+                    frequency_penalty: Some(0.5),
+                    presence_penalty: Some(0.25),
+                    repetition_penalty: Some(1.1),
+                    seed: Some(7),
+                    // Not part of this dialect — must never reach the wire.
+                    verbosity: Some(stella_protocol::Verbosity::High),
+                    service_tier: Some(stella_protocol::ServiceTier::Priority),
+                }),
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(body.contains("\"top_p\":0.9"), "{body}");
+        // top_k / repetition_penalty are non-standard but the user opted in.
+        assert!(body.contains("\"top_k\":40"), "{body}");
+        assert!(body.contains("\"frequency_penalty\":0.5"), "{body}");
+        assert!(body.contains("\"presence_penalty\":0.25"), "{body}");
+        assert!(body.contains("\"repetition_penalty\":1.1"), "{body}");
+        assert!(body.contains("\"seed\":7"), "{body}");
+        // verbosity/service_tier have no Chat Completions slot: dropped.
+        assert!(!body.contains("verbosity"), "{body}");
+        assert!(!body.contains("service_tier"), "{body}");
+    }
+
+    /// The prompt-cache stability contract: a request without params or a
+    /// reasoning preference must serialize with none of the new keys — the
+    /// body is byte-identical to what this adapter sent before they existed.
+    #[tokio::test]
+    async fn absent_params_and_reasoning_add_no_keys_to_the_body() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: None,
+                tools: vec![],
+                reasoning: None,
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        for key in [
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "thinking",
+            "reasoning",
+        ] {
+            assert!(!body.contains(key), "unexpected `{key}` in: {body}");
+        }
+    }
+
+    #[tokio::test]
+    async fn zai_identity_maps_reasoning_to_glm_thinking_object() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider =
+            ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+        let req = |reasoning| CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning,
+            params: None,
+        };
+        provider.complete(req(Some(true))).await.expect("on");
+        provider.complete(req(Some(false))).await.expect("off");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let on = String::from_utf8_lossy(&requests[0].body);
+        let off = String::from_utf8_lossy(&requests[1].body);
+        assert!(on.contains("\"thinking\":{\"type\":\"enabled\"}"), "{on}");
+        assert!(
+            off.contains("\"thinking\":{\"type\":\"disabled\"}"),
+            "{off}"
+        );
+    }
+
+    #[tokio::test]
+    async fn openrouter_identity_maps_reasoning_to_the_gateway_object() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "openrouter/auto")
+            .with_base_url(server.uri())
+            .with_identity("openrouter", "OpenRouter");
+        let req = |reasoning, effort| CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort,
+            tools: vec![],
+            reasoning,
+            params: None,
+        };
+        // Pinned effort (reasoning not suppressed) → {"effort": …}.
+        provider
+            .complete(req(None, Some(ReasoningEffort::Xhigh)))
+            .await
+            .expect("effort");
+        // Explicit off wins even over a pinned effort → {"enabled": false}.
+        provider
+            .complete(req(Some(false), Some(ReasoningEffort::High)))
+            .await
+            .expect("off");
+        // Bare on with no effort → {"enabled": true}.
+        provider.complete(req(Some(true), None)).await.expect("on");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        let bodies: Vec<String> = requests
+            .iter()
+            .map(|r| String::from_utf8_lossy(&r.body).into_owned())
+            .collect();
+        // Xhigh collapses to "high", the top tier OpenRouter models.
+        assert!(
+            bodies[0].contains("\"reasoning\":{\"effort\":\"high\"}"),
+            "{}",
+            bodies[0]
+        );
+        assert!(
+            bodies[1].contains("\"reasoning\":{\"enabled\":false}"),
+            "{}",
+            bodies[1]
+        );
+        assert!(
+            bodies[2].contains("\"reasoning\":{\"enabled\":true}"),
+            "{}",
+            bodies[2]
+        );
+        // GLM's thinking object is Z.ai-only; OpenRouter never sees it.
+        assert!(!bodies[0].contains("thinking"), "{}", bodies[0]);
+    }
+
+    /// Identities other than Z.ai and OpenRouter (xAI, DeepSeek, local, …)
+    /// have no known reasoning field on this dialect: the hint is ignored
+    /// rather than guessed at — an unknown key risks a hard 400.
+    #[tokio::test]
+    async fn other_identities_ignore_reasoning_entirely() {
+        let server = MockServer::start().await;
+        mock_ok(&server).await;
+
+        let provider = ZaiProvider::new(ApiKey::new("xai-test"), "grok-4")
+            .with_base_url(server.uri())
+            .with_identity("xai", "xAI");
+        provider
+            .complete(CompletionRequest {
+                messages: vec![CompletionMessage::user("hi")],
+                max_output_tokens: None,
+                temperature: None,
+                effort: Some(ReasoningEffort::High),
+                tools: vec![],
+                reasoning: Some(true),
+                params: None,
+            })
+            .await
+            .expect("should succeed");
+
+        let body = first_request_body(&server).await;
+        assert!(!body.contains("thinking"), "{body}");
+        assert!(!body.contains("reasoning"), "{body}");
     }
 }

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -65,8 +65,8 @@ pub mod verify;
 pub mod witness;
 
 pub use pipeline::{
-    Pipeline, PipelineConfig, PipelineError, PipelineOutcome, PipelinePorts, PipelineStatus,
-    Verdict,
+    Pipeline, PipelineConfig, PipelineError, PipelineOutcome, PipelinePorts, PipelineRoleOverrides,
+    PipelineStatus, RoleCallOverrides, Verdict,
 };
 pub use ports::{
     AlwaysAbortGate, ApprovalGate, AutoApproveGate, CmdOutcome, CommandRunner, ContextRecallPort,

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -115,11 +115,42 @@ pub struct PipelinePorts<'a> {
     pub hooks: Option<(&'a Hooks, &'a dyn HookRunner)>,
 }
 
+/// Per-role request overrides for the pipeline's raw completion calls
+/// (triage / judge / guidance), resolved by the caller from
+/// `agent_engine_config`. Every field is optional and falls through to the
+/// engine config's value — the worker's settings are the pipeline-wide
+/// base; these refine one role. `prompt`, when set, is prepended as a
+/// system message to the role's built-in task prompt (the task prompt
+/// carries the output contract — `PASS`/`FAIL`, the triage token — so it
+/// is never replaced outright).
+#[derive(Debug, Clone, Default)]
+pub struct RoleCallOverrides {
+    pub prompt: Option<String>,
+    pub effort: Option<stella_protocol::ReasoningEffort>,
+    pub reasoning: Option<bool>,
+    pub temperature: Option<f32>,
+    pub max_output_tokens: Option<u32>,
+    pub params: Option<stella_protocol::GenerationParams>,
+}
+
+/// The pipeline's per-role override set. Worker (and plan/witness, which
+/// ride the worker's tier) is configured through
+/// [`PipelineConfig::engine`] directly; only the two roles with their own
+/// models get their own request shaping.
+#[derive(Debug, Clone, Default)]
+pub struct PipelineRoleOverrides {
+    pub triage: RoleCallOverrides,
+    pub judge: RoleCallOverrides,
+}
+
 /// Tuning for the whole staged flow.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
     /// Passed to `stella-core::Engine` for every execute turn.
     pub engine: EngineConfig,
+    /// Per-role request overrides (`agent_engine_config`) for the raw
+    /// triage/judge completion calls.
+    pub role_overrides: PipelineRoleOverrides,
     /// Hard latency ceiling on the triage classification call (L-M4): if it
     /// doesn't answer within this, triage falls through to the full path.
     pub triage_latency_ceiling: Duration,
@@ -167,6 +198,7 @@ impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
             engine: EngineConfig::default(),
+            role_overrides: PipelineRoleOverrides::default(),
             triage_latency_ceiling: Duration::from_secs(10),
             scope_thresholds: crate::scope::ScopeThresholds::default(),
             headless: false,
@@ -590,7 +622,12 @@ impl<'a> Pipeline<'a> {
         // Deterministic policy (L-M4: max_retries = 0) under a hard latency
         // ceiling: on provider error OR timeout, fall through — never hang,
         // never retry.
-        let call = self.complete_once(resolved.provider, messages, RetryPolicy::deterministic());
+        let call = self.complete_once(
+            resolved.provider,
+            messages,
+            RetryPolicy::deterministic(),
+            &self.config.role_overrides.triage,
+        );
         let model_class = match timeout(self.config.triage_latency_ceiling, call).await {
             Ok(Ok(result)) => {
                 *total += result.cost_usd;
@@ -628,11 +665,14 @@ impl<'a> Pipeline<'a> {
         }
 
         let prompt = build_planner_prompt(goal, recall, repo_structure);
+        // Plan rides the worker's settings (same router tier, same tuning).
+        let worker_overrides = RoleCallOverrides::default();
         let result = match self
             .complete_once(
                 resolved.provider,
                 vec![CompletionMessage::user(prompt)],
                 RetryPolicy::standard(),
+                &worker_overrides,
             )
             .await
         {
@@ -652,6 +692,7 @@ impl<'a> Pipeline<'a> {
                 resolved.provider,
                 vec![CompletionMessage::user(plan_repair_prompt(&result.text))],
                 RetryPolicy::deterministic(),
+                &worker_overrides,
             )
             .await
         {
@@ -1246,6 +1287,7 @@ impl<'a> Pipeline<'a> {
                 resolved.provider,
                 vec![CompletionMessage::user(prompt)],
                 RetryPolicy::deterministic(),
+                &self.config.role_overrides.judge,
             )
             .await
         {
@@ -1288,6 +1330,7 @@ impl<'a> Pipeline<'a> {
                 resolved.provider,
                 vec![CompletionMessage::user(prompt)],
                 RetryPolicy::deterministic(),
+                &self.config.role_overrides.judge,
             )
             .await
         {
@@ -1326,17 +1369,35 @@ impl<'a> Pipeline<'a> {
 
     /// One raw provider completion (triage/plan/judge — not the execute engine)
     /// under `policy`, emitting a `Retry` event per committed retry (L-E10).
+    /// `overrides` refines the engine config per role — pass
+    /// `&RoleCallOverrides::default()` for calls that ride the worker's
+    /// settings (plan, repair). A custom role prompt is prepended as a
+    /// system message here, one place, so every call site composes it the
+    /// same way.
     async fn complete_once(
         &self,
         provider: &dyn Provider,
         messages: Vec<CompletionMessage>,
         policy: RetryPolicy,
+        overrides: &RoleCallOverrides,
     ) -> Result<CompletionResult, stella_protocol::ProviderError> {
+        let messages = match &overrides.prompt {
+            Some(prompt) => {
+                let mut with_system = Vec::with_capacity(messages.len() + 1);
+                with_system.push(CompletionMessage::system(prompt.clone()));
+                with_system.extend(messages);
+                with_system
+            }
+            None => messages,
+        };
+        let engine = &self.config.engine;
         let req = CompletionRequest {
             messages,
-            max_output_tokens: self.config.engine.max_output_tokens,
-            temperature: self.config.engine.temperature,
-            effort: self.config.engine.effort,
+            max_output_tokens: overrides.max_output_tokens.or(engine.max_output_tokens),
+            temperature: overrides.temperature.or(engine.temperature),
+            effort: overrides.effort.or(engine.effort),
+            reasoning: overrides.reasoning.or(engine.reasoning),
+            params: overrides.params.or(engine.params),
             tools: Vec::new(),
         };
         let outcome =

--- a/stella-protocol/src/completion.rs
+++ b/stella-protocol/src/completion.rs
@@ -34,6 +34,61 @@ pub enum ReasoningEffort {
     Max,
 }
 
+/// Response-detail level for providers with a verbosity parameter (OpenAI's
+/// `text.verbosity`). Adapters whose wire has no equivalent ignore it — the
+/// same never-fail contract as [`ReasoningEffort`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verbosity {
+    Low,
+    Medium,
+    High,
+}
+
+/// Provider service tier: `Priority` routes to faster paid-tier capacity,
+/// `Flex` to cheaper capacity with slower response times. Only applied by
+/// providers that support tiered service; others use their default tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    Auto,
+    Default,
+    Flex,
+    Priority,
+}
+
+/// Optional sampling/routing parameter overrides riding a
+/// [`CompletionRequest`]. Every field is independently optional —
+/// "include" semantics: `None` leaves the provider's own default in place,
+/// `Some` puts the value on the wire. Each adapter forwards the subset its
+/// dialect supports and silently drops the rest (a param the provider
+/// can't express must never fail the request).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct GenerationParams {
+    /// Nucleus sampling: cumulative-probability cutoff.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    /// Limit sampling to the k highest-probability tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Penalize tokens by their frequency in the text so far.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f32>,
+    /// Penalize tokens that have appeared at all in the text so far.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f32>,
+    /// Multiplicative repetition penalty (>1 discourages, <1 encourages).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repetition_penalty: Option<f32>,
+    /// Random seed for deterministic outputs, where supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<Verbosity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+}
+
 /// One chat message handed to a provider, including any tool calls the
 /// assistant made or tool results being reported back.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -110,6 +165,17 @@ pub struct CompletionRequest {
     /// Reasoning effort for models that support a thinking mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
+    /// Whether the model's thinking/extended-reasoning mode is enabled at
+    /// all. `Some(true)` asks the adapter to turn thinking on (at
+    /// `effort`'s level, or the adapter's default level when `effort` is
+    /// `None`); `Some(false)` asks it to suppress thinking; `None` keeps
+    /// the provider's default behavior (exactly the pre-field wire shape).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<bool>,
+    /// Optional sampling/routing overrides ([`GenerationParams`]) — each
+    /// adapter forwards the subset its dialect supports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<GenerationParams>,
     /// Tool schemas the model may call, in the engine's one internal shape
     /// (`crate::tool::ToolSchema`); each adapter translates to its own
     /// dialect.
@@ -192,6 +258,8 @@ mod tests {
             temperature: Some(0.2),
             effort: Some(ReasoningEffort::High),
             tools: vec![],
+            reasoning: None,
+            params: None,
         };
         let json = serde_json::to_string(&req).expect("serialize");
         let back: CompletionRequest = serde_json::from_str(&json).expect("deserialize");

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -21,7 +21,7 @@ pub use attachment::{
 };
 pub use completion::{
     CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
-    MessageRole, ReasoningEffort,
+    GenerationParams, MessageRole, ReasoningEffort, ServiceTier, Verbosity,
 };
 pub use error::ProviderError;
 pub use event::{

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -22,8 +22,8 @@ use tokio::sync::mpsc;
 
 use stella_tui::scenario::{demo_graph, demo_inbound};
 use stella_tui::{
-    AgentControl, AgentMeta, AgentStatus, DeckOptions, GraphNode, GraphSnapshot, Inbound,
-    ScopeDecision, SkillsView, SlashCommand, UserInput, WorkspaceInput, run_deck,
+    AgentControl, AgentMeta, AgentStatus, DeckOptions, EngineConfigState, GraphNode, GraphSnapshot,
+    Inbound, ScopeDecision, SkillsView, SlashCommand, UserInput, WorkspaceInput, run_deck,
 };
 
 fn now_ms() -> u64 {
@@ -190,6 +190,24 @@ async fn main() -> std::io::Result<()> {
                 }
                 WorkspaceInput::NotificationRead { .. } | WorkspaceInput::NotificationsReadAll => {
                     let _ = react_tx.send(Inbound::Notifications(vec![]));
+                }
+                // The ENGINE overlay edits the driver-owned settings
+                // snapshot. The demo has no settings on disk: a save echoes
+                // the submitted state back (so the round-trip and the
+                // modified-marker clearing are demoable), a refresh answers
+                // with an empty default so the overlay renders instead of
+                // waiting forever.
+                WorkspaceInput::EngineConfigSave { state, .. } => {
+                    let _ = react_tx.send(Inbound::EngineConfig {
+                        state,
+                        status: Some("demo: config accepted (not persisted)".to_string()),
+                    });
+                }
+                WorkspaceInput::EngineConfigRefresh => {
+                    let _ = react_tx.send(Inbound::EngineConfig {
+                        state: EngineConfigState::default(),
+                        status: Some("the demo has no settings on disk".to_string()),
+                    });
                 }
                 WorkspaceInput::Quit => break,
             }

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -383,6 +383,7 @@ impl WorkspaceModel {
             | Inbound::Sessions(_)
             | Inbound::Notifications(_)
             | Inbound::McpOauthStatus { .. }
+            | Inbound::EngineConfig { .. }
             | Inbound::ShowHelp
             | Inbound::Splash(_) => {}
         }

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -108,6 +108,12 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     if ui.context_open {
         render_context_overlay(ui, area, buf);
     }
+    // The ENGINE overlay draws last in the chain so it sits above the other
+    // popups (its model-picker sub-overlay draws above it in turn); the help
+    // overlay below still wins the very top.
+    if ui.engine.open {
+        views::engine::render_overlay(ui, area, buf);
+    }
 
     // Deck motion (crate::fx), scrubbed like the splash: each frame builds a
     // fresh effect and processes it once at its wall-clock elapsed, so no

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -29,8 +29,8 @@ use crate::composer::{
 };
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::envelope::{
-    AgentControl, AgentId, AgentScope, AgentStatus, Inbound, InstalledAgentEntry, Secret, SkillOp,
-    SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
+    AgentControl, AgentId, AgentScope, AgentStatus, EngineRole, Inbound, InstalledAgentEntry,
+    Secret, SkillOp, SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 use crate::graph::GraphSnapshot;
 use crate::input::{ScopeDecision, UserInput};
@@ -397,6 +397,10 @@ pub struct DeckUi {
     /// finished OAuth login refreshes the MCP snapshot). The shell drains
     /// this after every key/inbound and forwards each as a submission.
     pub pending_inputs: Vec<WorkspaceInput>,
+    /// The ENGINE overlay (`/engine`, `/model-*`): the editor for
+    /// `settings.json` → `agent_engine_config`, over a driver-owned snapshot
+    /// ([`Inbound::EngineConfig`]). Modal while open.
+    pub engine: crate::views::engine::EngineOverlay,
 }
 
 impl Default for DeckUi {
@@ -452,6 +456,7 @@ impl Default for DeckUi {
             notifications: Vec::new(),
             inbox_sel: 0,
             pending_inputs: Vec::new(),
+            engine: crate::views::engine::EngineOverlay::default(),
         }
     }
 }
@@ -500,6 +505,18 @@ impl DeckUi {
         // 2. The Graph tab's modal file-filter input.
         if self.graph_picker_open {
             push_single_line(&mut self.graph_picker_query, text);
+            return;
+        }
+
+        // 2b. The ENGINE overlay is modal while open: a paste belongs to its
+        //     inline edit (a prompt, a model list) or the picker filter —
+        //     and with neither active it is swallowed, never the composer's.
+        if self.engine.open {
+            if let Some(edit) = self.engine.edit.as_mut() {
+                push_single_line(&mut edit.buffer, text);
+            } else if let Some(picker) = self.engine.picker.as_mut() {
+                push_single_line(&mut picker.query, text);
+            }
             return;
         }
 
@@ -716,6 +733,13 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         }
         return;
     }
+    // The agent-engine configuration snapshot — out-of-band view state for
+    // the ENGINE overlay (`/engine`). Applied by the overlay's own ingest,
+    // which guards unsaved local edits; the model fold never sees it.
+    if let Inbound::EngineConfig { state, status } = inbound {
+        crate::views::engine::ingest_config(ui, state, status);
+        return;
+    }
     // Launch-cinematic cues: the driver replays the splash held open over a
     // running init (`/init`, session startup) and releases it when init
     // finishes. Out-of-band view state like `ShowHelp`. `--no-anim`
@@ -927,6 +951,14 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     // filter keystroke can never leak into a half-typed prompt.
     if ui.graph_picker_open {
         return handle_graph_picker_key(key, ui);
+    }
+
+    // The ENGINE overlay (`/engine`) is modal exactly like the queue editor
+    // while open: it owns the keyboard — its inline edit buffer, its model
+    // picker, and its letter verbs (`s`/`S`/`x`/`r`) must never leak into
+    // the composer behind the popup.
+    if ui.engine.open {
+        return crate::views::engine::handle_engine_key(key, ui);
     }
 
     // The SESSIONS / INBOX / CONTEXT overlays are modal exactly like the
@@ -1214,6 +1246,16 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
             "/sessions" => open_sessions_overlay(ui),
             "/context" => open_context_overlay(ui),
             "/inbox" => open_inbox_overlay(ui),
+            // The ENGINE overlay: deck-local view state over a driver-owned
+            // settings snapshot. `/engine` lands on the GLOBAL tab; the four
+            // `/model-<agent>` commands jump straight to that agent's tab
+            // with the model picker already open. Intercepted here so these
+            // never get submitted as prompts (registration is driver-side).
+            "/engine" => crate::views::engine::open_overlay(ui),
+            "/model-default" => crate::views::engine::open_with_picker(ui, EngineRole::Default),
+            "/model-worker" => crate::views::engine::open_with_picker(ui, EngineRole::Worker),
+            "/model-judge" => crate::views::engine::open_with_picker(ui, EngineRole::Judge),
+            "/model-triage" => crate::views::engine::open_with_picker(ui, EngineRole::Triage),
             // `/mcp-search` jumps straight into the MCP tab's registry
             // search — THE way to begin looking for a server from anywhere
             // (the old `/`-on-the-MCP-tab trigger collided with the command

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -231,6 +231,19 @@ pub enum Inbound {
         message: String,
         outcome: Option<bool>,
     },
+    /// A refreshed snapshot of the agent-engine configuration
+    /// (`settings.json` → `agent_engine_config`) for the ENGINE overlay
+    /// (`/engine`). Out-of-band view state exactly like
+    /// [`Inbound::GraphSnapshot`]: applied straight to `DeckUi` by
+    /// [`crate::deck_ui::ingest_inbound`], ignored by the model fold. The
+    /// driver sends one at startup, after every
+    /// [`WorkspaceInput::EngineConfigSave`], and on
+    /// [`WorkspaceInput::EngineConfigRefresh`]. `status`, when set,
+    /// replaces the overlay's hint line (save outcomes, errors).
+    EngineConfig {
+        state: EngineConfigState,
+        status: Option<String>,
+    },
 }
 
 /// The session-registry lifecycle phase, exactly the grouping the SESSIONS
@@ -485,8 +498,124 @@ pub enum WorkspaceInput {
     NotificationRead { id: String },
     /// Inbox overlay: mark everything read.
     NotificationsReadAll,
+    /// ENGINE overlay: persist the edited agent-engine configuration into
+    /// `settings.json` at `scope` (project `.stella/settings.json` or the
+    /// user's `~/.config/stella/settings.json`). The driver writes the
+    /// `agent_engine_config` object — preserving every other key in the
+    /// file — and answers with a fresh [`Inbound::EngineConfig`] carrying
+    /// the save outcome in `status`. Saved config applies to runs started
+    /// afterwards; in-flight turns keep their resolved models.
+    EngineConfigSave {
+        state: EngineConfigState,
+        scope: AgentScope,
+    },
+    /// ENGINE overlay opened (or wants a reload): re-read the settings
+    /// scope chain and answer with a fresh [`Inbound::EngineConfig`].
+    EngineConfigRefresh,
     /// Tear down the deck.
     Quit,
+}
+
+/// Which pipeline agent a per-agent engine override applies to — the four
+/// configurable "agents" of `agent_engine_config`. `Default` is the
+/// interactive/step-loop agent; the other three are the staged pipeline's
+/// roles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EngineRole {
+    Default,
+    Worker,
+    Judge,
+    Triage,
+}
+
+impl EngineRole {
+    /// Stable settings-key / display order.
+    pub const ALL: [EngineRole; 4] = [
+        EngineRole::Default,
+        EngineRole::Worker,
+        EngineRole::Judge,
+        EngineRole::Triage,
+    ];
+
+    /// The `agent_engine_config.agents.<key>` settings key (and display
+    /// label) for this agent.
+    pub fn key(self) -> &'static str {
+        match self {
+            EngineRole::Default => "default",
+            EngineRole::Worker => "worker",
+            EngineRole::Judge => "judge",
+            EngineRole::Triage => "triage",
+        }
+    }
+}
+
+/// One agent's engine overrides as the ENGINE overlay edits them — a
+/// TUI-local mirror of `stella-cli`'s `agent_engine_config` per-agent
+/// settings, decoupled (like [`InstalledAgentEntry`]) so the TUI crate
+/// stays independent of the settings engine; the driver maps one to the
+/// other. Every field is optional — `None` renders as "provider default"
+/// and is omitted from the saved JSON (the screenshot's unchecked
+/// "Include" box).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct EngineAgentState {
+    /// Model slug — `"provider/slug"` or a bare slug.
+    pub model: Option<String>,
+    /// Gateway/provider id override (`"anthropic"`, `"openrouter"`,
+    /// `"zai"`, or a settings-defined provider). When set, `model` is sent
+    /// verbatim as the slug to THIS provider — how an OpenRouter key routes
+    /// an `openai/...` slug.
+    pub provider: Option<String>,
+    /// Custom system prompt replacing the built-in one for this agent.
+    pub prompt: Option<String>,
+    /// Reasoning effort: `low|medium|high|xhigh|max`.
+    pub effort: Option<String>,
+    /// Thinking mode on/off (`None` = provider default).
+    pub reasoning: Option<bool>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub top_k: Option<u32>,
+    pub frequency_penalty: Option<f32>,
+    pub presence_penalty: Option<f32>,
+    pub repetition_penalty: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub seed: Option<u64>,
+    /// `low|medium|high`.
+    pub verbosity: Option<String>,
+    /// `auto|default|flex|priority`.
+    pub service_tier: Option<String>,
+}
+
+/// The full agent-engine configuration snapshot the ENGINE overlay renders
+/// and edits ([`Inbound::EngineConfig`] / [`WorkspaceInput::EngineConfigSave`]).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct EngineConfigState {
+    /// Auto judge-model selection: pick the best allowed model for the
+    /// judge (preferring a different family than the worker's).
+    pub auto_mode: bool,
+    /// Auto per-agent effort (judge high, worker medium, triage low).
+    pub effort_auto: bool,
+    /// Auto per-agent reasoning (on for judge/worker, off for triage).
+    pub reasoning_auto: bool,
+    /// The model slugs the model pickers offer (`allowed_models`). Empty
+    /// means "no restriction" — pickers fall back to `catalog_models`.
+    pub allowed_models: Vec<String>,
+    /// Every configured provider id, for the provider picker.
+    pub providers: Vec<String>,
+    /// `provider/slug` strings from the seed catalog — the picker's
+    /// fallback vocabulary when `allowed_models` is empty.
+    pub catalog_models: Vec<String>,
+    /// Exactly one entry per [`EngineRole::ALL`] slot, in that order.
+    pub agents: Vec<EngineAgentState>,
+}
+
+impl EngineConfigState {
+    /// The state for `role`, if present (the driver always sends all four).
+    pub fn agent(&self, role: EngineRole) -> Option<&EngineAgentState> {
+        EngineRole::ALL
+            .iter()
+            .position(|r| *r == role)
+            .and_then(|i| self.agents.get(i))
+    }
 }
 
 /// Which scope a skill lives in / is installed to. The loader reads both

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -86,10 +86,10 @@ pub use deck_ui::{
     ingest_inbound,
 };
 pub use envelope::{
-    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Inbound,
-    InstalledAgentEntry, McpSearchItem, McpSearchOutcome, McpServerInfo, NotificationInfo, Secret,
-    SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView,
-    SplashCue, WorkspaceInput,
+    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
+    EngineConfigState, EngineRole, Inbound, InstalledAgentEntry, McpSearchItem, McpSearchOutcome,
+    McpServerInfo, NotificationInfo, Secret, SessionInfo, SessionPhase, SkillOp, SkillRow,
+    SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -2079,7 +2079,6 @@ mod tests {
                 duration_ms: 5,
                 speculated: false,
                 diff: None,
-                speculated: false,
             },
             false,
             true,

--- a/stella-tui/src/views/engine.rs
+++ b/stella-tui/src/views/engine.rs
@@ -1,0 +1,1531 @@
+//! ENGINE overlay — the `/engine` editor for `settings.json` →
+//! `agent_engine_config`: the global routing toggles plus the per-agent
+//! model / prompt / sampling overrides for the four pipeline agents
+//! (default · worker · judge · triage).
+//!
+//! Ownership mirrors the MCP and SKILLS surfaces: the **driver** owns the
+//! settings files on disk and pushes [`crate::envelope::Inbound::EngineConfig`]
+//! snapshots (at startup, after every save, and on request); the deck edits a
+//! **working copy** in memory and sends it back whole via
+//! [`WorkspaceInput::EngineConfigSave`] — the driver merges the
+//! `agent_engine_config` object into the chosen scope's `settings.json`
+//! (preserving every other key) and answers with a fresh snapshot whose
+//! `status` carries the outcome. A `pristine` twin of the last adopted
+//! snapshot gives the overlay an honest "modified" marker and lets
+//! [`ingest_config`] tell a benign refresh (safe to adopt) from one that
+//! would clobber unsaved edits (kept until saved — or until the overlay is
+//! closed and the next snapshot arrives, which is the deliberate discard
+//! path).
+//!
+//! Interaction follows the queue-editor contract: **modal while open**.
+//! Every key is claimed by [`handle_engine_key`], so the letter verbs
+//! (`s`/`S`/`x`/`r`), the inline edit buffer, and the model-picker filter
+//! can never leak a keystroke into the global composer behind the popup.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
+
+use crate::deck_ui::{DeckAction, DeckUi};
+use crate::envelope::{
+    AgentScope, EngineAgentState, EngineConfigState, EngineRole, WorkspaceInput,
+};
+use crate::render::scroll_window_start;
+use crate::theme;
+
+/// The legal `effort` values, in cycle order (⏎ walks them, then wraps to
+/// "provider default").
+const EFFORT_VALUES: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
+/// The legal `verbosity` values.
+const VERBOSITY_VALUES: [&str; 3] = ["low", "medium", "high"];
+/// The legal `service_tier` values.
+const SERVICE_TIER_VALUES: [&str; 4] = ["auto", "default", "flex", "priority"];
+
+/// Hint shown when an action needs the config snapshot the driver has not
+/// delivered yet (a race right after startup, or a driver error).
+const NO_SNAPSHOT_HINT: &str = "waiting for the engine config snapshot — r to reload";
+
+/// Which tab of the overlay has the keyboard: the GLOBAL toggles or one of
+/// the four per-agent override pages. GLOBAL comes first — the cross-agent
+/// switches are what `/engine` is usually opened for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EngineTab {
+    #[default]
+    Global,
+    Agent(EngineRole),
+}
+
+impl EngineTab {
+    /// Display/cycle order: GLOBAL, then the agents in
+    /// [`EngineRole::ALL`] order.
+    pub const ALL: [EngineTab; 5] = [
+        EngineTab::Global,
+        EngineTab::Agent(EngineRole::Default),
+        EngineTab::Agent(EngineRole::Worker),
+        EngineTab::Agent(EngineRole::Judge),
+        EngineTab::Agent(EngineRole::Triage),
+    ];
+
+    fn index(self) -> usize {
+        EngineTab::ALL.iter().position(|t| *t == self).unwrap_or(0)
+    }
+
+    /// The next tab, wrapping past the last back to GLOBAL.
+    pub fn next(self) -> Self {
+        EngineTab::ALL[(self.index() + 1) % EngineTab::ALL.len()]
+    }
+
+    /// The previous tab, wrapping before GLOBAL to the last agent.
+    pub fn prev(self) -> Self {
+        let n = EngineTab::ALL.len();
+        EngineTab::ALL[(self.index() + n - 1) % n]
+    }
+
+    /// The header label — the settings key for agents, `GLOBAL` otherwise.
+    pub fn label(self) -> &'static str {
+        match self {
+            EngineTab::Global => "GLOBAL",
+            EngineTab::Agent(role) => role.key(),
+        }
+    }
+}
+
+/// The GLOBAL tab's rows, in display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GlobalRow {
+    AutoMode,
+    EffortAuto,
+    ReasoningAuto,
+    AllowedModels,
+}
+
+const GLOBAL_ROWS: [GlobalRow; 4] = [
+    GlobalRow::AutoMode,
+    GlobalRow::EffortAuto,
+    GlobalRow::ReasoningAuto,
+    GlobalRow::AllowedModels,
+];
+
+impl GlobalRow {
+    fn label(self) -> &'static str {
+        match self {
+            GlobalRow::AutoMode => "auto_mode",
+            GlobalRow::EffortAuto => "effort_auto",
+            GlobalRow::ReasoningAuto => "reasoning_auto",
+            GlobalRow::AllowedModels => "allowed_models",
+        }
+    }
+}
+
+/// One editable field of [`EngineAgentState`], in the struct's declaration
+/// order — the agent tabs render exactly one row per variant, so the screen
+/// order and the settings order can never drift apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentField {
+    Model,
+    Provider,
+    Prompt,
+    Effort,
+    Reasoning,
+    Temperature,
+    TopP,
+    TopK,
+    FrequencyPenalty,
+    PresencePenalty,
+    RepetitionPenalty,
+    MaxTokens,
+    Seed,
+    Verbosity,
+    ServiceTier,
+}
+
+impl AgentField {
+    pub const ALL: [AgentField; 15] = [
+        AgentField::Model,
+        AgentField::Provider,
+        AgentField::Prompt,
+        AgentField::Effort,
+        AgentField::Reasoning,
+        AgentField::Temperature,
+        AgentField::TopP,
+        AgentField::TopK,
+        AgentField::FrequencyPenalty,
+        AgentField::PresencePenalty,
+        AgentField::RepetitionPenalty,
+        AgentField::MaxTokens,
+        AgentField::Seed,
+        AgentField::Verbosity,
+        AgentField::ServiceTier,
+    ];
+
+    /// The settings key — doubles as the row label so what the user reads is
+    /// exactly what lands in `settings.json`.
+    pub fn label(self) -> &'static str {
+        match self {
+            AgentField::Model => "model",
+            AgentField::Provider => "provider",
+            AgentField::Prompt => "prompt",
+            AgentField::Effort => "effort",
+            AgentField::Reasoning => "reasoning",
+            AgentField::Temperature => "temperature",
+            AgentField::TopP => "top_p",
+            AgentField::TopK => "top_k",
+            AgentField::FrequencyPenalty => "frequency_penalty",
+            AgentField::PresencePenalty => "presence_penalty",
+            AgentField::RepetitionPenalty => "repetition_penalty",
+            AgentField::MaxTokens => "max_tokens",
+            AgentField::Seed => "seed",
+            AgentField::Verbosity => "verbosity",
+            AgentField::ServiceTier => "service_tier",
+        }
+    }
+}
+
+/// An in-progress inline edit: which row it belongs to and the live buffer.
+/// The buffer is committed on ⏎ (parsed per field type; a parse failure
+/// keeps the edit alive with a hint rather than half-applying) and dropped
+/// on Esc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineEdit {
+    /// The row index (within the current tab) the buffer edits.
+    pub row: usize,
+    pub buffer: String,
+}
+
+/// The model-picker sub-overlay's state: a filter-as-you-type query over the
+/// allowed models (falling back to the seed catalog when no restriction is
+/// configured) — the graph tab's file-picker idiom.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ModelPicker {
+    pub query: String,
+    /// Selected row, indexing the *filtered* match list. Reset to 0 on every
+    /// query edit (the match set changed under it).
+    pub sel: usize,
+}
+
+/// All ENGINE-overlay view state (a field on [`DeckUi`]). The config itself
+/// is driver-owned — `state` is the working copy being edited and `pristine`
+/// the last snapshot adopted from the driver; everything else is ephemeral
+/// interaction state.
+#[derive(Debug, Clone, Default)]
+pub struct EngineOverlay {
+    /// Whether the overlay is open (modal while set).
+    pub open: bool,
+    /// The working copy being edited. `None` until the first snapshot lands.
+    pub state: Option<EngineConfigState>,
+    /// The last driver snapshot adopted verbatim — `state != pristine` is
+    /// the "modified" marker and the unsaved-edits guard in [`ingest_config`].
+    pub pristine: Option<EngineConfigState>,
+    pub tab: EngineTab,
+    /// Selected row within the current tab, clamped on tab switches.
+    pub row: usize,
+    /// The active inline edit, if any (claims keys ahead of navigation).
+    pub edit: Option<EngineEdit>,
+    /// The model-picker sub-overlay, if open (claims keys ahead of the edit).
+    pub picker: Option<ModelPicker>,
+    /// One-line hint: driver save/refresh outcomes, local parse errors.
+    pub status: Option<String>,
+    /// A save/refresh is in flight driver-side — cleared when the next
+    /// [`crate::envelope::Inbound::EngineConfig`] folds back.
+    pub busy: bool,
+}
+
+impl EngineOverlay {
+    /// Rows on the current tab (the ↑/↓ clamp bound).
+    pub fn row_count(&self) -> usize {
+        match self.tab {
+            EngineTab::Global => GLOBAL_ROWS.len(),
+            EngineTab::Agent(_) => AgentField::ALL.len(),
+        }
+    }
+
+    /// Whether the working copy has unsaved local edits.
+    pub fn dirty(&self) -> bool {
+        self.state != self.pristine
+    }
+
+    /// The agent the current tab edits, if it is an agent tab.
+    pub fn role(&self) -> Option<EngineRole> {
+        match self.tab {
+            EngineTab::Agent(role) => Some(role),
+            EngineTab::Global => None,
+        }
+    }
+}
+
+// ── driver snapshot ingest ──────────────────────────────────────────────────
+
+/// Fold one [`crate::envelope::Inbound::EngineConfig`] snapshot. Adopted as
+/// both `pristine` + working copy unless the overlay is open with unsaved
+/// edits — a background refresh must never eat what the user typed. The one
+/// exception inside a dirty overlay is a snapshot that **equals** the working
+/// copy (the echo of our own save): adopting it re-baselines `pristine`, so
+/// the "modified" marker clears the moment the driver confirms the write.
+/// `status` (save outcomes, errors) always lands, and `busy` always clears —
+/// a snapshot is the completion signal for whatever op was in flight.
+pub fn ingest_config(ui: &mut DeckUi, state: &EngineConfigState, status: &Option<String>) {
+    let e = &mut ui.engine;
+    let echoes_working = e.state.as_ref() == Some(state);
+    if !e.open || !e.dirty() || echoes_working {
+        e.state = Some(state.clone());
+        e.pristine = Some(state.clone());
+    }
+    if let Some(status) = status {
+        e.status = Some(status.clone());
+    }
+    e.busy = false;
+}
+
+// ── openers (the deck-local slash commands land here) ───────────────────────
+
+/// `/engine`: open the overlay on the GLOBAL tab and ask the driver to
+/// re-read the settings chain so the popup reflects disk truth (the reply is
+/// dirty-guarded by [`ingest_config`], so reopening over unsaved edits is
+/// safe).
+pub fn open_overlay(ui: &mut DeckUi) -> DeckAction {
+    let e = &mut ui.engine;
+    e.open = true;
+    e.tab = EngineTab::Global;
+    e.row = 0;
+    e.edit = None;
+    e.picker = None;
+    e.busy = true;
+    DeckAction::Send(WorkspaceInput::EngineConfigRefresh)
+}
+
+/// `/model-<agent>`: open the overlay on that agent's tab with the model
+/// picker already up — the one-keystroke "change this agent's model" path.
+pub fn open_with_picker(ui: &mut DeckUi, role: EngineRole) -> DeckAction {
+    let e = &mut ui.engine;
+    e.open = true;
+    e.tab = EngineTab::Agent(role);
+    // Row 0 is the model row (AgentField::ALL[0]) — where the picker's ⏎
+    // will land its slug.
+    e.row = 0;
+    e.edit = None;
+    e.busy = true;
+    open_picker(e, role);
+    DeckAction::Send(WorkspaceInput::EngineConfigRefresh)
+}
+
+/// Open the model picker for `role`, pre-selecting the agent's current model
+/// among the candidates (the graph picker's "start where you already are").
+fn open_picker(e: &mut EngineOverlay, role: EngineRole) {
+    let sel = e
+        .state
+        .as_ref()
+        .and_then(|state| {
+            let current = state.agent(role).and_then(|a| a.model.as_deref())?;
+            picker_candidates(state)
+                .iter()
+                .position(|c| c.as_str() == current)
+        })
+        .unwrap_or(0);
+    e.picker = Some(ModelPicker {
+        query: String::new(),
+        sel,
+    });
+}
+
+/// The picker's vocabulary: `allowed_models` when a restriction is
+/// configured, otherwise the whole seed catalog.
+fn picker_candidates(state: &EngineConfigState) -> &[String] {
+    if state.allowed_models.is_empty() {
+        &state.catalog_models
+    } else {
+        &state.allowed_models
+    }
+}
+
+/// Case-insensitive substring filter over the candidates — the exact
+/// semantics of [`crate::graph::GraphSnapshot::matching_files`], so both
+/// pickers feel identical.
+fn picker_matches(state: &EngineConfigState, query: &str) -> Vec<String> {
+    let needle = query.trim().to_lowercase();
+    picker_candidates(state)
+        .iter()
+        .filter(|m| needle.is_empty() || m.to_lowercase().contains(&needle))
+        .cloned()
+        .collect()
+}
+
+// ── key handling ────────────────────────────────────────────────────────────
+
+/// The overlay's modal key map, dispatched by [`crate::deck_ui::handle_deck_key`]
+/// while `ui.engine.open`. Precedence within the overlay: the picker owns the
+/// keyboard when open, then an active inline edit, then navigation — the same
+/// innermost-context-first ladder the deck itself uses.
+pub fn handle_engine_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if ui.engine.picker.is_some() {
+        return handle_picker_key(key, ui);
+    }
+    if ui.engine.edit.is_some() {
+        return handle_inline_edit_key(key, ui);
+    }
+    handle_nav_key(key, ui)
+}
+
+/// The model picker's keys: type to filter, ↑/↓ walk the matches, ⏎ applies
+/// the picked slug to the current agent's `model`, Esc closes the picker
+/// only (the overlay stays up).
+fn handle_picker_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    // Snapshot the filtered matches up front so bounds and the picked slug
+    // can never disagree with what render showed.
+    let matches: Vec<String> = match (&ui.engine.state, &ui.engine.picker) {
+        (Some(state), Some(picker)) => picker_matches(state, &picker.query),
+        _ => Vec::new(),
+    };
+    let count = matches.len();
+    match key.code {
+        KeyCode::Esc => {
+            ui.engine.picker = None;
+            DeckAction::Handled
+        }
+        KeyCode::Up => {
+            if let Some(p) = ui.engine.picker.as_mut() {
+                p.sel = p.sel.saturating_sub(1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            if let Some(p) = ui.engine.picker.as_mut()
+                && count > 0
+            {
+                p.sel = (p.sel + 1).min(count - 1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            let sel = ui.engine.picker.as_ref().map(|p| p.sel).unwrap_or(0);
+            let picked = matches.get(sel.min(count.saturating_sub(1))).cloned();
+            ui.engine.picker = None;
+            // The filter matched nothing → just close, like the graph picker.
+            if let Some(slug) = picked
+                && let EngineTab::Agent(role) = ui.engine.tab
+                && let Some(state) = ui.engine.state.as_mut()
+                && let Some(agent) = agent_mut(state, role)
+            {
+                agent.model = Some(slug);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Backspace => {
+            if let Some(p) = ui.engine.picker.as_mut() {
+                p.query.pop();
+                p.sel = 0; // the match set changed — re-anchor
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            if let Some(p) = ui.engine.picker.as_mut() {
+                p.query.push(c);
+                p.sel = 0; // the match set changed — re-anchor
+            }
+            DeckAction::Handled
+        }
+        // Modal: swallow everything else so nothing leaks behind the popup.
+        _ => DeckAction::Handled,
+    }
+}
+
+/// The inline edit's keys: printable/backspace edit the buffer, ⏎ commits
+/// (a parse failure keeps the edit alive with a hint), Esc cancels without
+/// touching the field.
+fn handle_inline_edit_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc => {
+            ui.engine.edit = None;
+            DeckAction::Handled
+        }
+        KeyCode::Enter => commit_inline(ui),
+        KeyCode::Backspace => {
+            if let Some(e) = ui.engine.edit.as_mut() {
+                e.buffer.pop();
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            if let Some(e) = ui.engine.edit.as_mut() {
+                e.buffer.push(c);
+            }
+            DeckAction::Handled
+        }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// Commit the inline buffer into the working copy. Empty clears the field to
+/// "provider default" (`None`); numeric fields must parse or the edit stays
+/// open with a hint — a half-applied number is worse than a visible error.
+fn commit_inline(ui: &mut DeckUi) -> DeckAction {
+    let Some(edit) = ui.engine.edit.clone() else {
+        return DeckAction::Handled;
+    };
+    let tab = ui.engine.tab;
+    let Some(state) = ui.engine.state.as_mut() else {
+        ui.engine.edit = None;
+        return DeckAction::Handled;
+    };
+    let result = match tab {
+        // `allowed_models` is the only text-editable GLOBAL row: parse the
+        // comma-joined display form back into slugs (empty → no restriction,
+        // so the pickers fall back to the catalog).
+        EngineTab::Global => {
+            state.allowed_models = edit
+                .buffer
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+            Ok(())
+        }
+        EngineTab::Agent(role) => {
+            let field = AgentField::ALL[edit.row.min(AgentField::ALL.len() - 1)];
+            match agent_mut(state, role) {
+                Some(agent) => set_field_from_text(agent, field, &edit.buffer),
+                None => Ok(()),
+            }
+        }
+    };
+    match result {
+        Ok(()) => ui.engine.edit = None,
+        // Keep editing so the user can fix the buffer (or Esc out).
+        Err(hint) => ui.engine.status = Some(hint),
+    }
+    DeckAction::Handled
+}
+
+/// The overlay's navigation/verb keys (no picker, no edit active).
+fn handle_nav_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    let plain = !key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META);
+    match key.code {
+        // Close the overlay. The working copy stays in memory (reopening
+        // resumes the edits) until the next driver snapshot replaces a
+        // closed overlay's state — see `ingest_config`.
+        KeyCode::Esc => {
+            ui.engine.open = false;
+            DeckAction::Handled
+        }
+        KeyCode::Tab | KeyCode::Right => switch_tab(ui, true),
+        KeyCode::BackTab | KeyCode::Left => switch_tab(ui, false),
+        KeyCode::Up => {
+            ui.engine.row = ui.engine.row.saturating_sub(1);
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            let count = ui.engine.row_count();
+            if count > 0 {
+                ui.engine.row = (ui.engine.row + 1).min(count - 1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Enter => activate_row(ui, false),
+        // Space is the toggle chord only: it flips the on/off rows exactly
+        // like ⏎ but deliberately does NOT open pickers/edits — a stray
+        // space must not drop the user into an input they didn't ask for.
+        KeyCode::Char(' ') if plain => activate_row(ui, true),
+        KeyCode::Char('x') if plain => clear_row(ui),
+        KeyCode::Char('s') if plain => save(ui, AgentScope::User),
+        KeyCode::Char('S') if plain => save(ui, AgentScope::Project),
+        KeyCode::Char('r') if plain => refresh(ui),
+        // Modal: swallow everything else.
+        _ => DeckAction::Handled,
+    }
+}
+
+/// Cycle to the neighboring tab, keeping the row selection where possible
+/// (clamped — the GLOBAL tab is shorter than the agent tabs).
+fn switch_tab(ui: &mut DeckUi, forward: bool) -> DeckAction {
+    let e = &mut ui.engine;
+    e.tab = if forward { e.tab.next() } else { e.tab.prev() };
+    e.row = e.row.min(e.row_count().saturating_sub(1));
+    DeckAction::Handled
+}
+
+/// ⏎ (or, for toggles, space) on the selected row: flip toggles, cycle
+/// enums, open the model picker, or start an inline edit — per the row's
+/// nature.
+fn activate_row(ui: &mut DeckUi, via_space: bool) -> DeckAction {
+    if ui.engine.state.is_none() {
+        ui.engine.status = Some(NO_SNAPSHOT_HINT.into());
+        return DeckAction::Handled;
+    }
+    let row = ui.engine.row;
+    match ui.engine.tab {
+        EngineTab::Global => {
+            let state = ui.engine.state.as_mut().expect("guarded above");
+            match GLOBAL_ROWS[row.min(GLOBAL_ROWS.len() - 1)] {
+                GlobalRow::AutoMode => state.auto_mode = !state.auto_mode,
+                GlobalRow::EffortAuto => state.effort_auto = !state.effort_auto,
+                GlobalRow::ReasoningAuto => state.reasoning_auto = !state.reasoning_auto,
+                GlobalRow::AllowedModels => {
+                    if via_space {
+                        return DeckAction::Handled;
+                    }
+                    let buffer = state.allowed_models.join(", ");
+                    ui.engine.edit = Some(EngineEdit { row, buffer });
+                }
+            }
+        }
+        EngineTab::Agent(role) => {
+            let field = AgentField::ALL[row.min(AgentField::ALL.len() - 1)];
+            match field {
+                AgentField::Model => {
+                    if via_space {
+                        return DeckAction::Handled;
+                    }
+                    open_picker(&mut ui.engine, role);
+                }
+                // Reasoning is the tri-state toggle: provider default → on →
+                // off → default. Space works here too — it's a toggle.
+                AgentField::Reasoning => {
+                    let state = ui.engine.state.as_mut().expect("guarded above");
+                    if let Some(agent) = agent_mut(state, role) {
+                        agent.reasoning = match agent.reasoning {
+                            None => Some(true),
+                            Some(true) => Some(false),
+                            Some(false) => None,
+                        };
+                    }
+                }
+                AgentField::Effort | AgentField::Verbosity | AgentField::ServiceTier => {
+                    if via_space {
+                        return DeckAction::Handled;
+                    }
+                    let values: &[&str] = match field {
+                        AgentField::Effort => &EFFORT_VALUES,
+                        AgentField::Verbosity => &VERBOSITY_VALUES,
+                        _ => &SERVICE_TIER_VALUES,
+                    };
+                    let state = ui.engine.state.as_mut().expect("guarded above");
+                    if let Some(agent) = agent_mut(state, role) {
+                        let slot = match field {
+                            AgentField::Effort => &mut agent.effort,
+                            AgentField::Verbosity => &mut agent.verbosity,
+                            _ => &mut agent.service_tier,
+                        };
+                        cycle_enum(slot, values);
+                    }
+                }
+                AgentField::Provider => {
+                    if via_space {
+                        return DeckAction::Handled;
+                    }
+                    let providers = ui
+                        .engine
+                        .state
+                        .as_ref()
+                        .expect("guarded above")
+                        .providers
+                        .clone();
+                    if providers.is_empty() {
+                        // Nothing to cycle through — explain instead of a
+                        // keypress that visibly does nothing.
+                        ui.engine.status = Some(
+                            "no providers configured — the driver's settings define them".into(),
+                        );
+                        return DeckAction::Handled;
+                    }
+                    let refs: Vec<&str> = providers.iter().map(String::as_str).collect();
+                    let state = ui.engine.state.as_mut().expect("guarded above");
+                    if let Some(agent) = agent_mut(state, role) {
+                        cycle_enum(&mut agent.provider, &refs);
+                    }
+                }
+                // Free-text / numeric rows: start the inline edit seeded
+                // with the current value (None seeds empty — committing an
+                // untouched empty buffer round-trips back to None).
+                _ => {
+                    if via_space {
+                        return DeckAction::Handled;
+                    }
+                    let state = ui.engine.state.as_ref().expect("guarded above");
+                    let buffer = state
+                        .agent(role)
+                        .and_then(|a| agent_field_value(a, field))
+                        .unwrap_or_default();
+                    ui.engine.edit = Some(EngineEdit { row, buffer });
+                }
+            }
+        }
+    }
+    DeckAction::Handled
+}
+
+/// `x`: clear the selected row back to "provider default" (`None`). The
+/// GLOBAL booleans have no `None` — clearing means "off" — and clearing
+/// `allowed_models` lifts the restriction (pickers fall back to the catalog).
+fn clear_row(ui: &mut DeckUi) -> DeckAction {
+    let row = ui.engine.row;
+    let tab = ui.engine.tab;
+    let Some(state) = ui.engine.state.as_mut() else {
+        ui.engine.status = Some(NO_SNAPSHOT_HINT.into());
+        return DeckAction::Handled;
+    };
+    match tab {
+        EngineTab::Global => match GLOBAL_ROWS[row.min(GLOBAL_ROWS.len() - 1)] {
+            GlobalRow::AutoMode => state.auto_mode = false,
+            GlobalRow::EffortAuto => state.effort_auto = false,
+            GlobalRow::ReasoningAuto => state.reasoning_auto = false,
+            GlobalRow::AllowedModels => state.allowed_models.clear(),
+        },
+        EngineTab::Agent(role) => {
+            let field = AgentField::ALL[row.min(AgentField::ALL.len() - 1)];
+            if let Some(agent) = agent_mut(state, role) {
+                clear_agent_field(agent, field);
+            }
+        }
+    }
+    DeckAction::Handled
+}
+
+/// `s`/`S`: send the whole working copy to the driver for persistence at
+/// `scope`. The request rides `pending_inputs` (drained by the shell after
+/// this key) and the reply — a fresh snapshot with the outcome in `status` —
+/// clears `busy` and re-baselines the modified marker via [`ingest_config`].
+fn save(ui: &mut DeckUi, scope: AgentScope) -> DeckAction {
+    let Some(state) = ui.engine.state.clone() else {
+        ui.engine.status = Some(NO_SNAPSHOT_HINT.into());
+        return DeckAction::Handled;
+    };
+    ui.engine.busy = true;
+    ui.engine.status = Some(format!("saving to {} settings…", scope.label()));
+    ui.pending_inputs
+        .push(WorkspaceInput::EngineConfigSave { state, scope });
+    DeckAction::Handled
+}
+
+/// `r`: ask the driver to re-read the settings chain. The reply is
+/// dirty-guarded ([`ingest_config`]), so a reload can never eat unsaved
+/// edits — save or close first to adopt disk truth over them.
+fn refresh(ui: &mut DeckUi) -> DeckAction {
+    ui.engine.busy = true;
+    ui.engine.status = Some("reloading engine config…".into());
+    ui.pending_inputs.push(WorkspaceInput::EngineConfigRefresh);
+    DeckAction::Handled
+}
+
+// ── field access helpers ────────────────────────────────────────────────────
+
+/// Mutable access to `role`'s slot in `state.agents`. The driver always
+/// sends all four ([`EngineRole::ALL`] order), but a short vector (a hand-
+/// built scenario, a driver bug) must not silently drop an edit — grow it
+/// with defaults instead.
+fn agent_mut(state: &mut EngineConfigState, role: EngineRole) -> Option<&mut EngineAgentState> {
+    let idx = EngineRole::ALL.iter().position(|r| *r == role)?;
+    while state.agents.len() <= idx {
+        state.agents.push(EngineAgentState::default());
+    }
+    state.agents.get_mut(idx)
+}
+
+/// The display/edit-seed form of one agent field. `None` = unset (renders
+/// dimmed as "(provider default)"; seeds an empty edit buffer).
+fn agent_field_value(agent: &EngineAgentState, field: AgentField) -> Option<String> {
+    match field {
+        AgentField::Model => agent.model.clone(),
+        AgentField::Provider => agent.provider.clone(),
+        AgentField::Prompt => agent.prompt.clone(),
+        AgentField::Effort => agent.effort.clone(),
+        AgentField::Reasoning => agent
+            .reasoning
+            .map(|on| (if on { "on" } else { "off" }).to_string()),
+        AgentField::Temperature => agent.temperature.map(|v| v.to_string()),
+        AgentField::TopP => agent.top_p.map(|v| v.to_string()),
+        AgentField::TopK => agent.top_k.map(|v| v.to_string()),
+        AgentField::FrequencyPenalty => agent.frequency_penalty.map(|v| v.to_string()),
+        AgentField::PresencePenalty => agent.presence_penalty.map(|v| v.to_string()),
+        AgentField::RepetitionPenalty => agent.repetition_penalty.map(|v| v.to_string()),
+        AgentField::MaxTokens => agent.max_tokens.map(|v| v.to_string()),
+        AgentField::Seed => agent.seed.map(|v| v.to_string()),
+        AgentField::Verbosity => agent.verbosity.clone(),
+        AgentField::ServiceTier => agent.service_tier.clone(),
+    }
+}
+
+/// Reset one agent field to "provider default".
+fn clear_agent_field(agent: &mut EngineAgentState, field: AgentField) {
+    match field {
+        AgentField::Model => agent.model = None,
+        AgentField::Provider => agent.provider = None,
+        AgentField::Prompt => agent.prompt = None,
+        AgentField::Effort => agent.effort = None,
+        AgentField::Reasoning => agent.reasoning = None,
+        AgentField::Temperature => agent.temperature = None,
+        AgentField::TopP => agent.top_p = None,
+        AgentField::TopK => agent.top_k = None,
+        AgentField::FrequencyPenalty => agent.frequency_penalty = None,
+        AgentField::PresencePenalty => agent.presence_penalty = None,
+        AgentField::RepetitionPenalty => agent.repetition_penalty = None,
+        AgentField::MaxTokens => agent.max_tokens = None,
+        AgentField::Seed => agent.seed = None,
+        AgentField::Verbosity => agent.verbosity = None,
+        AgentField::ServiceTier => agent.service_tier = None,
+    }
+}
+
+/// Apply a committed inline buffer to one field. Empty (after trimming)
+/// clears to `None`; numeric fields must parse into their exact type.
+fn set_field_from_text(
+    agent: &mut EngineAgentState,
+    field: AgentField,
+    raw: &str,
+) -> Result<(), String> {
+    let t = raw.trim();
+    let text = || {
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    };
+    match field {
+        AgentField::Model => agent.model = text(),
+        AgentField::Provider => agent.provider = text(),
+        // The prompt keeps the buffer verbatim (minus a wholly-blank one):
+        // its inline edit is a single line, and whether whitespace matters
+        // inside a system prompt is not this layer's call.
+        AgentField::Prompt => {
+            agent.prompt = if t.is_empty() {
+                None
+            } else {
+                Some(raw.to_string())
+            }
+        }
+        AgentField::Effort => agent.effort = text(),
+        AgentField::Verbosity => agent.verbosity = text(),
+        AgentField::ServiceTier => agent.service_tier = text(),
+        // ⏎ cycles reasoning in place — it never inline-edits, so a text
+        // commit reaching here can only mean "leave it alone".
+        AgentField::Reasoning => {}
+        AgentField::Temperature => agent.temperature = parse_num::<f32>(t, "temperature")?,
+        AgentField::TopP => agent.top_p = parse_num::<f32>(t, "top_p")?,
+        AgentField::TopK => agent.top_k = parse_num::<u32>(t, "top_k")?,
+        AgentField::FrequencyPenalty => {
+            agent.frequency_penalty = parse_num::<f32>(t, "frequency_penalty")?
+        }
+        AgentField::PresencePenalty => {
+            agent.presence_penalty = parse_num::<f32>(t, "presence_penalty")?
+        }
+        AgentField::RepetitionPenalty => {
+            agent.repetition_penalty = parse_num::<f32>(t, "repetition_penalty")?
+        }
+        AgentField::MaxTokens => agent.max_tokens = parse_num::<u32>(t, "max_tokens")?,
+        AgentField::Seed => agent.seed = parse_num::<u64>(t, "seed")?,
+    }
+    Ok(())
+}
+
+/// Parse one numeric buffer: empty → `None` (provider default), otherwise
+/// the value or a keep-editing hint.
+fn parse_num<T: std::str::FromStr>(t: &str, label: &str) -> Result<Option<T>, String> {
+    if t.is_empty() {
+        return Ok(None);
+    }
+    t.parse::<T>()
+        .map(Some)
+        .map_err(|_| format!("{label}: “{t}” does not parse — fix it or Esc to cancel"))
+}
+
+/// Cycle an enum-valued field through `values` and back to `None` (provider
+/// default) past the end. An unrecognized stored value (hand-edited
+/// settings) also wraps to `None` rather than guessing a position.
+fn cycle_enum(current: &mut Option<String>, values: &[&str]) {
+    let next = match current.as_deref() {
+        None => values.first().map(|v| v.to_string()),
+        Some(cur) => match values.iter().position(|v| v.eq_ignore_ascii_case(cur)) {
+            Some(i) if i + 1 < values.len() => Some(values[i + 1].to_string()),
+            _ => None,
+        },
+    };
+    *current = next;
+}
+
+// ── render ──────────────────────────────────────────────────────────────────
+
+/// Label column width — fits the longest key (`repetition_penalty`, 18).
+const LABEL_W: usize = 19;
+
+/// Render the ENGINE overlay: a centered popup (the graph-picker pattern —
+/// `Clear`, accent border, windowed rows with the selection reversed), with
+/// the model-picker sub-overlay drawn on top when open. Called last in
+/// `render_deck`'s overlay chain so it sits above the other popups (help
+/// still wins the very top).
+pub fn render_overlay(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let e = &ui.engine;
+    let w = area.width.min(72);
+    let h = area.height.saturating_sub(2).min(26);
+    if w < 4 || h < 4 {
+        return; // no readable popup fits — draw nothing rather than garbage
+    }
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(popup, buf);
+
+    let inner_h = (h as usize).saturating_sub(2);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header: GLOBAL + the four agents as tabs, selected one highlighted.
+    let mut tabs: Vec<Span<'static>> = vec![Span::raw(" ")];
+    for tab in EngineTab::ALL {
+        let style = if tab == e.tab {
+            theme::accent().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        } else {
+            theme::muted()
+        };
+        tabs.push(Span::styled(format!(" {} ", tab.label()), style));
+        tabs.push(Span::raw(" "));
+    }
+    lines.push(Line::from(tabs));
+    lines.push(Line::default());
+
+    match &e.state {
+        None => {
+            lines.push(Line::from(Span::styled(
+                format!("  {NO_SNAPSHOT_HINT}"),
+                theme::muted(),
+            )));
+        }
+        Some(state) => {
+            let count = e.row_count();
+            let sel = e.row.min(count.saturating_sub(1));
+            // Header (1) + blank (1) + status (1) + footer (1) bracket the rows.
+            let visible = inner_h.saturating_sub(4).max(1);
+            let first = scroll_window_start(count, sel, visible);
+            let last = (first + visible).min(count);
+            for i in first..last {
+                lines.push(render_row(e, state, i, i == sel, w as usize));
+            }
+        }
+    }
+
+    // Pad so the status + footer sit on the last two interior rows.
+    while lines.len() < inner_h.saturating_sub(2) {
+        lines.push(Line::default());
+    }
+    // The driver/local status line ("saved", parse errors), or the busy hint.
+    let status = e
+        .status
+        .clone()
+        .or_else(|| e.busy.then(|| "working…".to_string()));
+    lines.push(match status {
+        Some(s) => Line::from(Span::styled(
+            format!(" {s}"),
+            Style::default().fg(theme::EMBER_GOLD),
+        )),
+        None => Line::default(),
+    });
+    lines.push(Line::from(Span::styled(
+        " tab agent · ⏎ edit · space toggle · x clear · s save user · S save project · r reload · esc close",
+        theme::muted(),
+    )));
+
+    let title = format!(
+        " agent engine{} ",
+        if e.dirty() { " · modified" } else { "" }
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(title);
+    Paragraph::new(lines).block(block).render(popup, buf);
+
+    if e.picker.is_some() {
+        render_model_picker(e, area, buf);
+    }
+}
+
+/// One config row: `▸ label  value`, the whole line reversed when selected.
+/// `None` values render dimmed as "(provider default)"; an active inline
+/// edit shows the live buffer with a caret instead of the stored value.
+fn render_row(
+    e: &EngineOverlay,
+    state: &EngineConfigState,
+    i: usize,
+    is_sel: bool,
+    popup_w: usize,
+) -> Line<'static> {
+    // Borders (2) + marker (2) + label column bound the value width.
+    let value_w = popup_w.saturating_sub(2 + 2 + LABEL_W + 1).max(8);
+    let (label, value): (&str, Option<String>) = match e.tab {
+        EngineTab::Global => {
+            let row = GLOBAL_ROWS[i.min(GLOBAL_ROWS.len() - 1)];
+            let value = match row {
+                GlobalRow::AutoMode => Some(on_off(state.auto_mode)),
+                GlobalRow::EffortAuto => Some(on_off(state.effort_auto)),
+                GlobalRow::ReasoningAuto => Some(on_off(state.reasoning_auto)),
+                GlobalRow::AllowedModels => {
+                    if state.allowed_models.is_empty() {
+                        None // dimmed placeholder below
+                    } else {
+                        Some(state.allowed_models.join(", "))
+                    }
+                }
+            };
+            (row.label(), value)
+        }
+        EngineTab::Agent(role) => {
+            let field = AgentField::ALL[i.min(AgentField::ALL.len() - 1)];
+            let value = state.agent(role).and_then(|a| agent_field_value(a, field));
+            (field.label(), value)
+        }
+    };
+
+    let sel_mod = if is_sel {
+        Modifier::REVERSED
+    } else {
+        Modifier::empty()
+    };
+    let marker = if is_sel { "▸ " } else { "  " };
+    let mut spans = vec![
+        Span::styled(
+            marker.to_string(),
+            Style::default().fg(theme::AMBER).add_modifier(sel_mod),
+        ),
+        Span::styled(
+            format!("{label:<LABEL_W$}"),
+            theme::muted().add_modifier(sel_mod),
+        ),
+    ];
+
+    if let Some(edit) = e.edit.as_ref().filter(|edit| edit.row == i) {
+        // The live buffer, tail-windowed so the caret end stays visible on
+        // long values (a prompt), with the violet edit caret.
+        let shown: String = tail_chars(&edit.buffer, value_w.saturating_sub(1));
+        spans.push(Span::styled(shown, theme::body().add_modifier(sel_mod)));
+        spans.push(Span::styled(
+            "▏",
+            Style::default().fg(theme::VIOLET).add_modifier(sel_mod),
+        ));
+    } else {
+        match value {
+            Some(v) => spans.push(Span::styled(
+                truncate_chars(&v, value_w),
+                Style::default().fg(theme::INK).add_modifier(sel_mod),
+            )),
+            None => {
+                let placeholder = match e.tab {
+                    EngineTab::Global => "(none — pickers offer the catalog)",
+                    EngineTab::Agent(_) => "(provider default)",
+                };
+                spans.push(Span::styled(
+                    placeholder.to_string(),
+                    theme::muted().add_modifier(sel_mod),
+                ));
+            }
+        }
+    }
+    Line::from(spans)
+}
+
+/// The model-picker sub-overlay, centered over the main popup: the graph
+/// file picker's exact idiom (filter line, windowed matches, legend).
+fn render_model_picker(e: &EngineOverlay, area: Rect, buf: &mut Buffer) {
+    let Some(picker) = &e.picker else { return };
+    let w = area.width.min(56);
+    let h = area.height.min(16);
+    if w < 4 || h < 4 {
+        return;
+    }
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(popup, buf);
+
+    let role_label = e.role().map(EngineRole::key).unwrap_or("agent");
+    let current = e
+        .role()
+        .and_then(|role| e.state.as_ref().and_then(|s| s.agent(role)))
+        .and_then(|a| a.model.clone());
+    let matches = e
+        .state
+        .as_ref()
+        .map(|s| picker_matches(s, &picker.query))
+        .unwrap_or_default();
+
+    let inner_h = (h as usize).saturating_sub(2);
+    let visible = inner_h.saturating_sub(2).max(1);
+    let sel = picker.sel.min(matches.len().saturating_sub(1));
+    let first = scroll_window_start(matches.len(), sel, visible);
+    let last = (first + visible).min(matches.len());
+
+    let mut lines: Vec<Line<'static>> = vec![Line::from(vec![
+        Span::styled("filter ", theme::muted()),
+        Span::styled(picker.query.clone(), theme::body()),
+        Span::styled("▏", Style::new().fg(theme::VIOLET)),
+    ])];
+
+    if e.state.is_none() {
+        lines.push(Line::from(Span::styled(
+            format!("  {NO_SNAPSHOT_HINT}"),
+            theme::muted(),
+        )));
+    } else if matches.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no models match — Backspace to widen",
+            theme::muted(),
+        )));
+    }
+    for (i, slug) in matches.iter().enumerate().take(last).skip(first) {
+        let is_sel = i == sel;
+        let marker = if is_sel { "▸ " } else { "  " };
+        let mut style = theme::body();
+        if is_sel {
+            style = style.add_modifier(Modifier::REVERSED);
+        }
+        let shown = truncate_chars(slug, (w as usize).saturating_sub(6));
+        let mut spans = vec![
+            Span::styled(marker.to_string(), style.fg(theme::AMBER)),
+            Span::styled(shown, style),
+        ];
+        if current.as_deref() == Some(slug.as_str()) {
+            spans.push(Span::styled("  · current", theme::muted()));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    // Pad so the legend sits on the last interior row regardless of matches.
+    while lines.len() < inner_h.saturating_sub(1).max(1) {
+        lines.push(Line::default());
+    }
+    lines.push(Line::from(Span::styled(
+        " type to filter · ↑/↓ select · ⏎ pick · esc back",
+        theme::muted(),
+    )));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(format!(
+            " model · {role_label} · {} available ",
+            matches.len()
+        ));
+    Paragraph::new(lines).block(block).render(popup, buf);
+}
+
+/// `on` / `off` for the GLOBAL booleans.
+fn on_off(v: bool) -> String {
+    (if v { "on" } else { "off" }).to_string()
+}
+
+/// Char-safe prefix truncation with an ellipsis (long prompts, long model
+/// lists must never wrap the row).
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+/// The last `max_chars` of a buffer (edit rendering keeps the caret end in
+/// view), with a leading ellipsis when the head is cut.
+fn tail_chars(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let tail: String = s
+        .chars()
+        .skip(count - max_chars.saturating_sub(1))
+        .collect();
+    format!("…{tail}")
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+    use crate::composer::SlashCommand;
+    use crate::deck::WorkspaceModel;
+    use crate::deck_ui::{DeckAction, DeckUi, handle_deck_key, ingest_inbound};
+    use crate::envelope::Inbound;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+    fn ch(c: char) -> KeyEvent {
+        key(KeyCode::Char(c))
+    }
+
+    fn ready_ui() -> DeckUi {
+        let mut ui = DeckUi::default();
+        ui.splash.skip(); // past the splash for interaction tests
+        ui
+    }
+
+    fn sample_state() -> EngineConfigState {
+        EngineConfigState {
+            auto_mode: false,
+            effort_auto: false,
+            reasoning_auto: false,
+            allowed_models: vec!["anthropic/claude-fable-5".into(), "openai/gpt-6".into()],
+            providers: vec!["anthropic".into(), "openrouter".into()],
+            catalog_models: vec!["zai/glm-5".into()],
+            agents: vec![EngineAgentState::default(); 4],
+        }
+    }
+
+    /// A deck with the overlay already open over a loaded snapshot — the
+    /// state most key tests start from.
+    fn open_ui() -> (WorkspaceModel, DeckUi) {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        ui.engine.open = true;
+        ui.engine.state = Some(sample_state());
+        ui.engine.pristine = Some(sample_state());
+        (model, ui)
+    }
+
+    #[test]
+    fn slash_engine_opens_the_overlay_on_the_global_tab() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        ui.slash_commands = vec![SlashCommand::new("/engine", "agent engine config")];
+        for c in "/engine".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::EngineConfigRefresh),
+            "/engine is deck-local and asks the driver for a fresh snapshot"
+        );
+        assert!(ui.engine.open);
+        assert_eq!(ui.engine.tab, EngineTab::Global);
+        assert!(ui.engine.picker.is_none());
+    }
+
+    #[test]
+    fn slash_model_worker_opens_the_agent_tab_with_the_picker() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        ui.slash_commands = vec![SlashCommand::new("/model-worker", "pick the worker model")];
+        for c in "/model-worker".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::EngineConfigRefresh)
+        );
+        assert!(ui.engine.open);
+        assert_eq!(ui.engine.tab, EngineTab::Agent(EngineRole::Worker));
+        assert_eq!(ui.engine.row, 0, "the model row is preselected");
+        assert!(ui.engine.picker.is_some(), "the picker is already open");
+    }
+
+    #[test]
+    fn tabs_cycle_and_rows_clamp() {
+        let (model, mut ui) = open_ui();
+        assert_eq!(ui.engine.tab, EngineTab::Global);
+
+        // ↓ past the last GLOBAL row clamps; ↑ past the first clamps at 0.
+        for _ in 0..10 {
+            handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        }
+        assert_eq!(ui.engine.row, GLOBAL_ROWS.len() - 1);
+        for _ in 0..10 {
+            handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+        }
+        assert_eq!(ui.engine.row, 0);
+
+        // Tab walks GLOBAL → the four agents → wraps back to GLOBAL.
+        let mut seen = vec![ui.engine.tab];
+        for _ in 0..5 {
+            handle_deck_key(key(KeyCode::Tab), &model, &mut ui);
+            seen.push(ui.engine.tab);
+        }
+        assert_eq!(seen.first(), seen.last(), "five presses wrap around");
+        assert_eq!(ui.engine.tab, EngineTab::Global);
+
+        // A deep agent-row selection clamps when returning to GLOBAL.
+        handle_deck_key(key(KeyCode::Tab), &model, &mut ui); // → default
+        for _ in 0..20 {
+            handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        }
+        assert_eq!(ui.engine.row, AgentField::ALL.len() - 1);
+        handle_deck_key(key(KeyCode::BackTab), &model, &mut ui); // → GLOBAL
+        assert_eq!(ui.engine.tab, EngineTab::Global);
+        assert_eq!(
+            ui.engine.row,
+            GLOBAL_ROWS.len() - 1,
+            "row clamped into the shorter tab"
+        );
+    }
+
+    #[test]
+    fn enter_cycles_reasoning_none_on_off() {
+        let (model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        ui.engine.row = 4; // reasoning (AgentField::ALL[4])
+
+        let reasoning = |ui: &DeckUi| ui.engine.state.as_ref().unwrap().agents[0].reasoning;
+        assert_eq!(reasoning(&ui), None);
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(reasoning(&ui), Some(true));
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(reasoning(&ui), Some(false));
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(reasoning(&ui), None, "the cycle wraps back to default");
+        // Space is the same toggle.
+        handle_deck_key(ch(' '), &model, &mut ui);
+        assert_eq!(reasoning(&ui), Some(true));
+        // `x` clears outright.
+        handle_deck_key(ch('x'), &model, &mut ui);
+        assert_eq!(reasoning(&ui), None);
+    }
+
+    #[test]
+    fn inline_temperature_edit_commits_clears_and_rejects() {
+        let (model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        ui.engine.row = 5; // temperature (AgentField::ALL[5])
+
+        let temp = |ui: &DeckUi| ui.engine.state.as_ref().unwrap().agents[0].temperature;
+
+        // ⏎ starts the edit seeded empty (the field is unset)…
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            ui.engine.edit,
+            Some(EngineEdit {
+                row: 5,
+                buffer: String::new()
+            })
+        );
+        // …"0.7" ⏎ commits Some(0.7).
+        for c in "0.7".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.engine.edit, None, "a clean parse ends the edit");
+        assert_eq!(temp(&ui), Some(0.7));
+
+        // Re-entering seeds the current value; emptying it clears to None.
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.engine.edit.as_ref().unwrap().buffer, "0.7");
+        for _ in 0..3 {
+            handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(temp(&ui), None, "an empty commit means provider default");
+
+        // Garbage sets a hint and keeps the edit alive — never half-applies.
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        for c in "abc".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert!(ui.engine.edit.is_some(), "still editing after a bad parse");
+        assert!(
+            ui.engine
+                .status
+                .as_deref()
+                .is_some_and(|s| s.contains("temperature")),
+            "the hint names the field: {:?}",
+            ui.engine.status
+        );
+        assert_eq!(temp(&ui), None, "the field is untouched");
+        // Esc abandons the bad buffer.
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert_eq!(ui.engine.edit, None);
+        assert!(ui.engine.open, "esc closed the edit, not the overlay");
+    }
+
+    #[test]
+    fn s_saves_the_working_copy_at_user_scope() {
+        let (model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        ui.engine.row = 5; // temperature
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        for c in "0.7".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+
+        let action = handle_deck_key(ch('s'), &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled, "the save rides pending_inputs");
+        let mut expected = sample_state();
+        expected.agents[0].temperature = Some(0.7);
+        assert_eq!(
+            ui.pending_inputs,
+            vec![WorkspaceInput::EngineConfigSave {
+                state: expected.clone(),
+                scope: AgentScope::User,
+            }],
+            "the edited working copy goes out whole, at user scope"
+        );
+        assert!(ui.engine.busy);
+
+        // `S` targets the project scope with the same working copy.
+        ui.pending_inputs.clear();
+        handle_deck_key(ch('S'), &model, &mut ui);
+        assert_eq!(
+            ui.pending_inputs,
+            vec![WorkspaceInput::EngineConfigSave {
+                state: expected,
+                scope: AgentScope::Project,
+            }]
+        );
+    }
+
+    #[test]
+    fn picker_filters_by_substring_and_enter_sets_the_model() {
+        let (model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        ui.engine.row = 0; // model
+
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert!(ui.engine.picker.is_some(), "⏎ on the model row opens it");
+        for c in "gpt".chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let state = ui.engine.state.as_ref().unwrap();
+        assert_eq!(
+            picker_matches(state, "gpt"),
+            vec!["openai/gpt-6".to_string()],
+            "substring filter narrows the allowed models"
+        );
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.engine.picker, None, "⏎ closes the picker");
+        assert_eq!(
+            ui.engine.state.as_ref().unwrap().agents[0].model.as_deref(),
+            Some("openai/gpt-6")
+        );
+        assert!(ui.engine.dirty(), "the pick is a local edit until saved");
+    }
+
+    #[test]
+    fn picker_falls_back_to_the_catalog_when_nothing_is_allowed() {
+        let mut state = sample_state();
+        state.allowed_models.clear();
+        assert_eq!(
+            picker_matches(&state, ""),
+            vec!["zai/glm-5".to_string()],
+            "an empty allow-list means the catalog vocabulary"
+        );
+    }
+
+    #[test]
+    fn ingest_applies_snapshot_and_status_without_clobbering_edits() {
+        let mut model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        let snap = sample_state();
+
+        // A first snapshot lands verbatim (working + pristine), with status.
+        ingest_inbound(
+            &Inbound::EngineConfig {
+                state: snap.clone(),
+                status: Some("loaded".into()),
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert_eq!(ui.engine.state.as_ref(), Some(&snap));
+        assert_eq!(ui.engine.pristine.as_ref(), Some(&snap));
+        assert_eq!(ui.engine.status.as_deref(), Some("loaded"));
+        assert!(!ui.engine.busy);
+        assert!(!ui.engine.dirty());
+
+        // A refresh over an OPEN, dirty overlay must not eat local edits…
+        ui.engine.open = true;
+        ui.engine.state.as_mut().unwrap().auto_mode = true;
+        let mut other = sample_state();
+        other.effort_auto = true;
+        ingest_inbound(
+            &Inbound::EngineConfig {
+                state: other,
+                status: None,
+            },
+            &mut model,
+            &mut ui,
+        );
+        let state = ui.engine.state.as_ref().unwrap();
+        assert!(state.auto_mode, "the local edit survives the refresh");
+        assert!(!state.effort_auto, "the conflicting snapshot was held off");
+        assert!(ui.engine.dirty());
+
+        // …but the echo of our own save re-baselines pristine: modified clears.
+        let echo = ui.engine.state.clone().unwrap();
+        ingest_inbound(
+            &Inbound::EngineConfig {
+                state: echo,
+                status: Some("saved to user settings".into()),
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert!(!ui.engine.dirty(), "the save echo clears the marker");
+        assert_eq!(ui.engine.status.as_deref(), Some("saved to user settings"));
+
+        // A CLOSED overlay always adopts the next snapshot (the deliberate
+        // discard path for edits abandoned by closing).
+        ui.engine.open = false;
+        ui.engine.state.as_mut().unwrap().auto_mode = false; // stale local edit
+        let mut newest = sample_state();
+        newest.reasoning_auto = true;
+        ingest_inbound(
+            &Inbound::EngineConfig {
+                state: newest.clone(),
+                status: None,
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert_eq!(ui.engine.state.as_ref(), Some(&newest));
+    }
+
+    #[test]
+    fn render_smoke_covers_rows_and_the_picker() {
+        fn buffer_text(buf: &Buffer) -> String {
+            let area = buf.area();
+            (0..area.height)
+                .map(|y| {
+                    (0..area.width)
+                        .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
+        let (_model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        let area = Rect::new(0, 0, 80, 30);
+        let mut buf = Buffer::empty(area);
+        render_overlay(&ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("agent engine"), "title drawn");
+        assert!(text.contains("temperature"), "agent rows drawn");
+        assert!(text.contains("(provider default)"), "unset renders dimmed");
+
+        // The picker draws over the popup.
+        ui.engine.picker = Some(ModelPicker::default());
+        let mut buf = Buffer::empty(area);
+        render_overlay(&ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("filter"), "picker filter line drawn");
+        assert!(text.contains("claude-fable-5"), "allowed models listed");
+    }
+}

--- a/stella-tui/src/views/mod.rs
+++ b/stella-tui/src/views/mod.rs
@@ -1,9 +1,12 @@
-//! The five tab views. Each exposes
+//! The deck's tab views. Each exposes
 //! `render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer)`
 //! — a deterministic draw of the (model, ui) into a sub-area, recording any
 //! viewport metrics it needs for scroll clamping back onto `ui.metrics`.
+//! (`engine` is the exception: it is a full-frame overlay, not a tab, and
+//! exposes `render_overlay(ui, area, buf)` plus its own modal key handler.)
 
 pub mod agents;
+pub mod engine;
 pub mod files;
 pub mod graph;
 pub mod installed;


### PR DESCRIPTION
## What

A new `agent_engine_config` root object in the `settings.json` scope chain (user → org-managed → project, per-field overlay like `providers`) that configures the four engine agents — **default** (interactive/step-loop), and the pipeline's **worker**, **judge**, **triage** — plus a full-featured `/engine` editor popup in the Command Deck.

### settings.json schema

```jsonc
{
  "agent_engine_config": {
    "default_model": "anthropic/claude-fable-5",
    "pipeline_worker_model": "zai/glm-5.2",
    "pipeline_judge_model": "openrouter/openai/gpt-5.5",
    "pipeline_triage_model": "deepseek/deepseek-chat",
    "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2", "openrouter/openai/gpt-5.5"],
    "auto_mode": "off",        // on = judge auto-picked from allowed_models
    "effort_auto": "off",      // on = judge high / worker medium / triage low
    "reasoning_auto": "off",   // on = thinking on everywhere except triage
    "agents": {
      "judge": {
        "provider": "openrouter",       // per-agent gateway (BYOK per agent)
        "model": "openai/gpt-5.5",      // slug sent verbatim to that gateway
        "prompt": "You are a strict, evidence-first code judge.",
        "effort": "high",               // low|medium|high|xhigh|max
        "reasoning": "on",
        "params": { "temperature": 0.2, "top_p": 0.9, "top_k": 40,
                     "frequency_penalty": 0.0, "presence_penalty": 0.0,
                     "repetition_penalty": 1.0, "max_tokens": 4096,
                     "seed": 7, "verbosity": "low", "service_tier": "priority" }
      }
    }
  }
}
```

Every param is include-when-set: absent = provider default, byte-stable wire. Precedence per agent: `--model` flag > `agents.<a>.model` > `pipeline_<a>_model` > `default_model` > auto-detect.

### How it lands, layer by layer

- **stella-protocol** — `CompletionRequest` gains `reasoning: Option<bool>` and `params: Option<GenerationParams>` (+ `Verbosity`/`ServiceTier` enums), serde-defaulted for backward compat.
- **stella-model** — every adapter forwards the subset its dialect supports: GLM `thinking`, OpenRouter `reasoning` (+ nonstandard top_k/repetition_penalty), Anthropic `top_p`/`top_k` + extended thinking with effort-tiered budgets (1024-floor/max_tokens-clamped, temperature omitted per API rules), OpenAI Responses `top_p` (reasoning-model-gated), `service_tier`, `text.verbosity`, reasoning suppression, Gemini camelCase generation config + `thinkingLevel` (Vertex shares it; Bedrock forwards `topP`). ~26 new wire-shape tests.
- **stella-core / stella-pipeline** — `EngineConfig` carries reasoning/params; `PipelineConfig.role_overrides` shapes the raw triage/judge calls (custom prompt prepends as a system message so the built-in output contracts survive); plan rides worker settings.
- **stella-cli** — settings schema + per-field/per-agent scope merge + a `save_to` writer that preserves every other key; `engine_config.rs` (pure, unit-tested) resolves specs, auto-modes, and the auto-judge ranking (cross-family from the worker, then catalog price tier, then list order); the previously-unwired `RoleTable` pins now carry triage/judge routing in **all four** pipeline paths (one-shot, Command Deck, goal loop — judge engine included — and fleet workers) with per-role adapters and soft degradation (missing credential → role rides the worker, with a notice).
- **stella-tui** — `/engine` overlay: per-agent tabs + GLOBAL tab, row navigation, inline edits, toggle/enum cycling, `x` to clear back to provider-default, type-to-filter model picker fed by `allowed_models` (catalog fallback), `s`/`S` save to user/project scope, live snapshot refresh; `/model-default|worker|judge|triage` jump straight to the picker.

### Safety

`agent_engine_config` carries no credential routing — an agent's `provider` references ids whose `base_url`/`api_key_env` remain behind the existing `STELLA_TRUST_PROJECT` gate, so the trust boundary is unchanged.

## Testing

- `make gate` (fmt-check + clippy `-D warnings` + full workspace tests) is green: 1,800+ tests, including ~60 new ones across settings merge/save round-trips, spec parsing, auto-judge ranking, tuning precedence, adapter wire shapes, and TUI overlay interaction.
