### PR TITLE
style(tui): run cargo fmt — fix rustfmt drift from #177

### DIFF
--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -1186,10 +1186,7 @@ fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
             ("← → ↑ ↓", "walk the neighborhood"),
             ("/ or ⏎", "file picker — re-root on any indexed file"),
         ],
-        DeckTab::Files => &[
-            ("↑ ↓", "select a file"),
-            ("⏎", "open / close the diff"),
-        ],
+        DeckTab::Files => &[("↑ ↓", "select a file"), ("⏎", "open / close the diff")],
         DeckTab::Skills => &[
             ("← →", "switch panes"),
             ("↑ ↓", "select a skill"),
@@ -1223,7 +1220,10 @@ const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
     ("ctrl-v", "paste — a copied image is attached to the prompt"),
     ("ctrl-t", "open the queue editor"),
     ("esc", "stop the running turn (next queued prompt runs)"),
-    ("esc esc", "stop & hold — nothing runs until your next prompt"),
+    (
+        "esc esc",
+        "stop & hold — nothing runs until your next prompt",
+    ),
     ("ctrl-c", "quit stella"),
 ];
 

--- a/stella-tui/tests/deck_snapshot.rs
+++ b/stella-tui/tests/deck_snapshot.rs
@@ -119,7 +119,10 @@ fn help_overlay_shows_only_the_active_tabs_shortcuts() {
     };
 
     let traces = render_help(DeckTab::Traces);
-    assert!(traces.contains("TRACES tab"), "titled for the tab:\n{traces}");
+    assert!(
+        traces.contains("TRACES tab"),
+        "titled for the tab:\n{traces}"
+    );
     assert!(traces.contains("cycle the per-agent filter"), "{traces}");
     // Deck-wide keys are always present…
     assert!(traces.contains("switch tabs"), "{traces}");


### PR DESCRIPTION
## Summary
CI on `main` is red: the `cargo fmt --check` gate fails on three rustfmt diffs in `stella-tui` (`src/deck_render.rs`, `tests/deck_snapshot.rs`) introduced by the help-overlay rework in #177. Because fmt fails first, clippy and tests never ran on those commits.

This PR is the output of `cargo fmt --all` — formatting only, no logic changes.

## Verification (run locally on top of latest main, 6b47509)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo test --workspace` — all tests pass (exit 0, no failures)


## Summary by Sourcery

Run cargo fmt to fix rustfmt drift in stella-tui and keep CI formatting checks passing.

Enhancements:
- Normalize help overlay shortcut formatting in deck_render for consistency with rustfmt style.

Tests:
- Reformat help overlay snapshot test assertions in deck_snapshot to match rustfmt output.
