### PR TITLE
fix(docs): remove leading H1s that duplicated the frontmatter title

### DIFF
--- a/stella-docs/content/docs/agent-fleets.mdx
+++ b/stella-docs/content/docs/agent-fleets.mdx
@@ -3,8 +3,6 @@ title: Agent Fleets
 description: Fan a dependency-ordered task DAG out to parallel worker agents, each isolated in its own git worktree — with cooperative file claims, a SQLite ledger of every attempt and dollar, and an optional CI watch.
 ---
 
-# Agent Fleets
-
 `stella fleet` runs **many tasks at once** — each task handled by a full
 Stella worker in its **own git worktree**, on its own branch, isolated from
 your working copy and from every other worker.

--- a/stella-docs/content/docs/agent-modes/goal-mode.mdx
+++ b/stella-docs/content/docs/agent-modes/goal-mode.mdx
@@ -3,8 +3,6 @@ title: Goal Mode
 description: Run Stella in judged rounds until an independent judge model — routed to a different model family than the worker — confirms from evidence that your objective has been met.
 ---
 
-# Goal Mode
-
 Goal mode turns Stella loose on an objective and keeps it working until the goal
 is actually met — as judged by an independent model, not by the worker's own
 say-so.

--- a/stella-docs/content/docs/agent-modes/index.mdx
+++ b/stella-docs/content/docs/agent-modes/index.mdx
@@ -3,8 +3,6 @@ title: Agent Modes
 description: The ways to drive Stella — interactive Command Deck chat, one-shot pipeline runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
 ---
 
-# Agent Modes
-
 Stella has one engine and several ways to drive it. Pick the mode by how much
 autonomy you're delegating and how the work should be checked.
 

--- a/stella-docs/content/docs/agent-tools/commands.mdx
+++ b/stella-docs/content/docs/agent-tools/commands.mdx
@@ -3,8 +3,6 @@ title: Commands & custom agents
 description: Extend the slash menu with your own COMMAND.md templates and AGENT.md personas — adopted automatically from .claude/ and .agents/ directories you already have.
 ---
 
-# Commands &amp; custom agents
-
 The Command Deck's slash menu is extensible: alongside the built-ins
 (`/help`, `/engine`, `/export`, …) and your ⚡
 [skills](/docs/agent-tools/skills), you can define **commands** (prompt

--- a/stella-docs/content/docs/agent-tools/skills.mdx
+++ b/stella-docs/content/docs/agent-tools/skills.mdx
@@ -3,8 +3,6 @@ title: Skills
 description: Reusable capabilities in SKILL.md files — project and user scopes, versioning and pinning, the public registry, and how skills reach the model through recall.
 ---
 
-# Skills
-
 A **skill** is a reusable capability described in Markdown — a checklist, a
 workflow, a house style — that Stella injects when it's relevant and that you
 can invoke explicitly as a slash command.

--- a/stella-docs/content/docs/api-providers/anthropic.mdx
+++ b/stella-docs/content/docs/api-providers/anthropic.mdx
@@ -3,8 +3,6 @@ title: Anthropic
 description: Claude over the native Anthropic Messages API — extended thinking mapped from Stella's effort tiers, first-class prompt caching, and claude-fable-5 as the default model.
 ---
 
-# Anthropic
-
 <ProviderMark id="anthropic" size={30} />
 
 Anthropic is the home of the Claude family, and `claude-fable-5` — the first of the

--- a/stella-docs/content/docs/api-providers/bedrock.mdx
+++ b/stella-docs/content/docs/api-providers/bedrock.mdx
@@ -3,8 +3,6 @@ title: Amazon Bedrock
 description: Claude under AWS governance — SigV4-signed Bedrock Converse, cross-region inference profiles, and why this provider is deliberately last in auto-detection.
 ---
 
-# Amazon Bedrock
-
 <ProviderMark id="bedrock" size={30} />
 
 Bedrock is Claude for organizations that must keep inference **inside their AWS

--- a/stella-docs/content/docs/api-providers/deepseek.mdx
+++ b/stella-docs/content/docs/api-providers/deepseek.mdx
@@ -3,8 +3,6 @@ title: DeepSeek
 description: The price/performance outlier — deepseek-chat at $0.27/$1.10 per Mtok, the natural triage model for every lineup and a very capable budget worker.
 ---
 
-# DeepSeek
-
 <ProviderMark id="deepseek" size={30} />
 
 DeepSeek is the catalog's price/performance outlier: `deepseek-chat` costs **$0.27/Mtok

--- a/stella-docs/content/docs/api-providers/gemini.mdx
+++ b/stella-docs/content/docs/api-providers/gemini.mdx
@@ -3,8 +3,6 @@ title: Google Gemini
 description: Gemini over the native generateContent API — the 1M-token context window, thinkingLevel mapped from Stella's effort setting, and gemini-3-pro as the default model.
 ---
 
-# Google Gemini
-
 <ProviderMark id="gemini" size={30} />
 
 Gemini's headline act is the context window: `gemini-3-pro` takes **one million tokens**

--- a/stella-docs/content/docs/api-providers/local.mdx
+++ b/stella-docs/content/docs/api-providers/local.mdx
@@ -3,8 +3,6 @@ title: Local
 description: Point Stella at any OpenAI-compatible server — Ollama, vLLM, LM Studio, llama.cpp — with no API key, no auto-detection, and zero token cost.
 ---
 
-# Local
-
 <ProviderMark id="local" size={30} />
 
 The `local` pseudo-provider points Stella at any **OpenAI-compatible** endpoint you run

--- a/stella-docs/content/docs/api-providers/openai.mdx
+++ b/stella-docs/content/docs/api-providers/openai.mdx
@@ -3,8 +3,6 @@ title: OpenAI
 description: GPT over the OpenAI Responses API — reasoning effort, verbosity, and service tiers mapped natively, with gpt-5.5 as the default model.
 ---
 
-# OpenAI
-
 <ProviderMark id="openai" size={30} />
 
 OpenAI's `gpt-5.5` pairs top-tier reasoning with a 400k context window at a mid-tier

--- a/stella-docs/content/docs/api-providers/openrouter.mdx
+++ b/stella-docs/content/docs/api-providers/openrouter.mdx
@@ -3,8 +3,6 @@ title: OpenRouter
 description: One key, every vendor — vendor/model slugs pass through the gateway verbatim, per-call cost comes from the gateway's own usage accounting, and any agent can route through it independently.
 ---
 
-# OpenRouter
-
 <ProviderMark id="openrouter" size={30} />
 
 OpenRouter is a gateway: one API key that fronts effectively every commercial model. If

--- a/stella-docs/content/docs/api-providers/vertex.mdx
+++ b/stella-docs/content/docs/api-providers/vertex.mdx
@@ -3,8 +3,6 @@ title: Google Vertex AI
 description: Gemini models under Google Cloud governance — project-scoped credentials via gcloud access tokens, the same generateContent wire dialect, deliberately last in auto-detection.
 ---
 
-# Google Vertex AI
-
 <ProviderMark id="vertex" size={30} />
 
 Vertex AI serves the same Gemini models over the same wire dialect as the

--- a/stella-docs/content/docs/api-providers/xai.mdx
+++ b/stella-docs/content/docs/api-providers/xai.mdx
@@ -3,8 +3,6 @@ title: xAI
 description: Grok over an OpenAI-compatible API — a distinct model family with strong reasoning, useful as an alternate judge, with grok-4 as the default model.
 ---
 
-# xAI
-
 <ProviderMark id="xai" size={30} />
 
 xAI serves the Grok family — strong reasoning models from a lineage independent of the

--- a/stella-docs/content/docs/api-providers/zai.mdx
+++ b/stella-docs/content/docs/api-providers/zai.mdx
@@ -3,8 +3,6 @@ title: Z.ai
 description: GLM models over an OpenAI-compatible API — Stella's default worker tier, first in auto-detection, with a dedicated coding-plan endpoint for subscription pricing.
 ---
 
-# Z.ai
-
 <ProviderMark id="zai" size={30} />
 
 Z.ai serves the GLM family, and `glm-5.2` is Stella's **default worker tier**: excellent

--- a/stella-docs/content/docs/context-engine.mdx
+++ b/stella-docs/content/docs/context-engine.mdx
@@ -3,8 +3,6 @@ title: Context Engine
 description: How Stella remembers — bi-temporal memory, prompt-cache-native recall, the citation loop, reflections, the tree-sitter code graph, and the domain taxonomy that ties it all together.
 ---
 
-# Context Engine
-
 Stella accumulates knowledge about your workspace so each session starts
 smarter than a blank slate — and it does so **prompt-cache-natively**: durable
 knowledge rides the provider's prompt cache instead of being re-billed at

--- a/stella-docs/content/docs/examples/balanced.mdx
+++ b/stella-docs/content/docs/examples/balanced.mdx
@@ -3,8 +3,6 @@ title: Balanced
 description: The daily-driver profile — a fast, cheap, capable worker with a flagship cross-family judge and automatic effort. Most of the quality at a fraction of the cost.
 ---
 
-# Balanced
-
 The brief: **most of the quality, a fraction of the bill**. The insight this
 profile is built on: the worker emits ~85% of your tokens, the judge emits
 almost none — so spend down on the worker and keep a flagship judge as

--- a/stella-docs/content/docs/examples/dirt-cheap.mdx
+++ b/stella-docs/content/docs/examples/dirt-cheap.mdx
@@ -3,8 +3,6 @@ title: Dirt cheap
 description: The minimum-spend profile — DeepSeek doing the work, thinking off where it doesn't pay, hard budget caps, and the free local-server escape hatch. Coding agents for pocket change.
 ---
 
-# Dirt cheap
-
 The brief: **spend as close to nothing as possible** and still get real
 work done. Point every role at the cheapest capable models, turn thinking
 off where it doesn't pay, cap output, and put a hard `--budget` under it

--- a/stella-docs/content/docs/examples/index.mdx
+++ b/stella-docs/content/docs/examples/index.mdx
@@ -3,8 +3,6 @@ title: Examples
 description: Ready-to-paste agent_engine_config profiles — maximum quality, balanced, and dirt cheap — plus an honest anatomy of what a pipeline run actually costs.
 ---
 
-# Examples
-
 The [inference pipeline](/docs/inference-pipeline) makes several model calls
 per run, and each one is [independently configurable](/docs/configuration/agent-engine-config).
 These pages give you three ready-to-paste profiles — and the cost model to

--- a/stella-docs/content/docs/examples/max-quality.mdx
+++ b/stella-docs/content/docs/examples/max-quality.mdx
@@ -3,8 +3,6 @@ title: Maximum quality
 description: Every dial to the right — the strongest worker, a flagship cross-family judge, high effort and reasoning everywhere it pays. For work where being right is worth dollars.
 ---
 
-# Maximum quality
-
 The brief: **accuracy over everything**. The strongest coding model works,
 an equally serious model from a *different family* judges, effort and
 thinking run high, and you pay list price for the privilege. Use this for

--- a/stella-docs/content/docs/inference-pipeline.mdx
+++ b/stella-docs/content/docs/inference-pipeline.mdx
@@ -3,8 +3,6 @@ title: Inference Pipeline
 description: How Stella turns a prompt into verified work — the agent step loop, the staged pipeline (triage, plan, scope, witness, execute, verify, judge), deterministic verification, and per-role model routing.
 ---
 
-# Inference Pipeline
-
 Stella's answer to "did the agent actually do the work?" is structural, not
 rhetorical. Every prompt runs through an **inference pipeline** that separates
 *doing* the work from *verifying* it — with deterministic checks preferred

--- a/stella-docs/content/docs/principles/determinism.mdx
+++ b/stella-docs/content/docs/principles/determinism.mdx
@@ -3,8 +3,6 @@ title: Determinism over intelligence
 description: Why Stella is a deterministic single-thread engine instead of a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and the case for spending intelligence only where mechanisms can't reach.
 ---
 
-# Determinism over intelligence
-
 The dominant trend in agent architecture is the swarm: a navigator agent, a
 coder agent, a reviewer agent, a tester agent, and a coordinator conducting
 them. Stella deliberately went the other way — **one deterministic,

--- a/stella-docs/content/docs/principles/index.mdx
+++ b/stella-docs/content/docs/principles/index.mdx
@@ -3,8 +3,6 @@ title: Engineering Principles
 description: The design invariants behind Stella — determinism preferred over intelligence, evidence over opinion, a zero-I/O engine, prompt-cache-native memory, and budgets enforced at safe boundaries.
 ---
 
-# Engineering Principles
-
 Stella's repository ships two research papers alongside the code — a
 [capstone analysis of seven architectural invariants](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md)
 and a focused study of

--- a/stella-docs/content/docs/telemetry/dashboard.mdx
+++ b/stella-docs/content/docs/telemetry/dashboard.mdx
@@ -3,8 +3,6 @@ title: The Observatory dashboard
 description: stella observe opens a local, loopback-only web dashboard over your workspace telemetry — runs, spend, models, tools, files, memory, MCP traffic, and the fleet ledger. Plus /export for a portable HTML report.
 ---
 
-# The Observatory dashboard
-
 `stella observe` opens the **Observatory** — a local web dashboard over the
 telemetry your own runs recorded:
 


### PR DESCRIPTION
## Summary

Every docs page rendered its title twice — once from the frontmatter `title` (via Fumadocs `DocsTitle`) and again from a `# Heading` at the top of the MDX body:

- 24 of 60 pages had the redundant H1 (Agent Fleets, Agent Modes, all API provider pages, Examples, Principles, Context Engine, Inference Pipeline, Telemetry dashboard, …)
- The other 36 pages already followed the correct convention of starting with body prose

This strips the leading H1 (and its trailing blank line) from those 24 files — content-only change, 48 deletions, nothing else touched.

## Verification

- `pnpm build` in `stella-docs` succeeds; all 69 routes prerender
- Prerendered `agent-fleets.html` now contains exactly one `<h1>Agent Fleets</h1>`
