### PR TITLE
fix(cli): stop a stale seeded provider pin from mangling a qualified engine model spec

### DIFF
--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -434,21 +434,27 @@ impl Config {
         // flag and auto-detect: an explicit flag always wins, but a
         // settings-configured default beats "first provider with a key".
         // The spec string is synthesized in --model's own grammar
-        // (`provider/slug`, or the agent's pinned provider prefixed onto a
-        // bare slug) so the whole existing resolution path applies
-        // unchanged. A provider pin without a model is left to the normal
-        // chain — the provider's own default_model already answers there.
+        // (`provider/slug`) so the whole existing resolution path applies
+        // unchanged. Pin-vs-spec precedence lives in `model_spec_for` — the
+        // one resolver every engine agent goes through — so a stale pin
+        // can't swallow a qualified flat spec into a phantom slug here
+        // while the judge/triage wiring resolves the same settings sanely.
         let engine_default: Option<String> = settings.agent_engine_config.as_ref().and_then(|e| {
             use crate::settings::EngineAgentKind;
-            let model = e.model_for(EngineAgentKind::Default)?;
-            let pinned = e
-                .agent(EngineAgentKind::Default)
-                .and_then(|a| a.provider.as_deref())
-                .filter(|p| !p.trim().is_empty());
-            Some(match pinned {
-                Some(provider) => format!("{provider}/{model}"),
-                None => model.to_string(),
-            })
+            let ids = all_provider_ids(settings);
+            let is_provider = |id: &str| ids.contains(&id);
+            match crate::engine_config::model_spec_for(e, EngineAgentKind::Default, &is_provider) {
+                Some(spec) if !spec.model.is_empty() => {
+                    Some(format!("{}/{}", spec.provider, spec.model))
+                }
+                // A pin with no model anywhere is left to the normal chain
+                // — the provider's own default_model already answers there.
+                Some(_) => None,
+                // No setting, or an unparseable string — pass the raw
+                // value through so `resolve_provider_config` keeps its
+                // named error for typos.
+                None => e.model_for(EngineAgentKind::Default).map(str::to_string),
+            }
         });
         let model_override = model_override.or(engine_default.as_deref());
 
@@ -1310,6 +1316,35 @@ mod tests {
             cfg.provider.seeded,
             "built-in overrides keep the catalog check"
         );
+    }
+
+    #[test]
+    fn a_stale_default_pin_does_not_mangle_a_qualified_engine_default_model() {
+        // Regression: `agents.default.provider: "zai"` alongside the flat
+        // `default_model: "openrouter/openrouter/auto"` (a provider-qualified
+        // spec, the shape every TUI save writes) used to stitch the phantom
+        // slug `zai/openrouter/openrouter/auto` and die on the catalog
+        // check. The qualified spec's own provider must win over the stale
+        // seeded pin.
+        let settings = settings_from(
+            r#"{
+                "providers": {"openrouter": {"api_key": "sk-or-test"}},
+                "agent_engine_config": {
+                    "default_model": "openrouter/openrouter/auto",
+                    "agents": {"default": {"provider": "zai"}}
+                }
+            }"#,
+        );
+        let cfg = Config::load_with_settings(
+            None,
+            None,
+            None,
+            &settings,
+            std::path::PathBuf::from("/tmp/ws"),
+        )
+        .expect("the qualified engine default must resolve");
+        assert_eq!(cfg.provider.id, "openrouter");
+        assert_eq!(cfg.model_id, "openrouter/auto");
     }
 
     #[test]

--- a/stella-cli/src/engine_config.rs
+++ b/stella-cli/src/engine_config.rs
@@ -71,6 +71,17 @@ pub fn parse_model_spec(raw: &str, is_provider: &dyn Fn(&str) -> bool) -> Option
 /// chain as [`AgentEngineConfig::model_for`]) is the verbatim slug for
 /// THAT provider — no prefix splitting, which is what lets an OpenRouter
 /// entry carry a slug that itself contains `/`.
+///
+/// One exception guards the pin: the flat model keys (`default_model`,
+/// `pipeline_*_model`) hold `provider/slug` specs — the TUI writes them
+/// that way on every save — and the same precedence chain hands them to a
+/// pinned agent. For a SEEDED pin the catalog arbitrates the two readings:
+/// when it rejects the verbatim one and the string parses as a qualified
+/// spec, the spec's own provider wins (a stale `zai` pin over
+/// `openrouter/openrouter/auto` must route to OpenRouter, not become the
+/// phantom slug `zai/openrouter/openrouter/auto`). Unseeded pins
+/// (openrouter, local, settings-defined) keep verbatim semantics — their
+/// slug space is open, so the catalog has no veto.
 pub fn model_spec_for(
     engine: &AgentEngineConfig,
     kind: EngineAgentKind,
@@ -82,10 +93,23 @@ pub fn model_spec_for(
         .filter(|p| !p.trim().is_empty());
     let model = engine.model_for(kind);
     match (pinned_provider, model) {
-        (Some(provider), Some(model)) => Some(ModelSpec {
-            provider: provider.to_string(),
-            model: model.to_string(),
-        }),
+        (Some(provider), Some(model)) => {
+            let pin_seeded = crate::config::PROVIDERS
+                .iter()
+                .any(|p| p.id == provider && p.seeded);
+            if pin_seeded
+                && stella_model::catalog::Catalog::seed()
+                    .resolve_for(provider, model)
+                    .is_err()
+                && let Some(spec) = parse_model_spec(model, is_provider)
+            {
+                return Some(spec);
+            }
+            Some(ModelSpec {
+                provider: provider.to_string(),
+                model: model.to_string(),
+            })
+        }
         // A provider pin with no model: the provider's own default model
         // applies — signalled with an empty slug the wiring layer fills
         // from `ProviderConfig::default_model`.
@@ -504,6 +528,51 @@ mod tests {
         let spec = model_spec_for(&engine, EngineAgentKind::Triage, &is_builtin).unwrap();
         assert_eq!(spec.provider, "zai");
         assert!(spec.model.is_empty());
+    }
+
+    #[test]
+    fn seeded_pin_yields_to_a_qualified_spec_the_catalog_rejects() {
+        // The flat keys hold `provider/slug` specs (the TUI writes them
+        // that way), and the precedence chain hands them to pinned agents
+        // too. A stale seeded pin must not swallow one into a phantom slug:
+        // `zai` + `openrouter/openrouter/auto` routed verbatim produced the
+        // unknown-model error `zai/openrouter/openrouter/auto`.
+        let engine = engine_from_json(
+            r#"{"default_model": "openrouter/openrouter/auto",
+                "agents": {"default": {"provider": "zai"}}}"#,
+        );
+        let spec = model_spec_for(&engine, EngineAgentKind::Default, &is_builtin).unwrap();
+        assert_eq!(spec.provider, "openrouter");
+        assert_eq!(spec.model, "openrouter/auto");
+
+        // The TUI-save shape — pin plus a flat spec naming the SAME seeded
+        // provider — resolves to the catalog slug, not `provider/provider/…`.
+        let engine = engine_from_json(
+            r#"{"pipeline_judge_model": "anthropic/claude-fable-5",
+                "agents": {"judge": {"provider": "anthropic"}}}"#,
+        );
+        let spec = model_spec_for(&engine, EngineAgentKind::Judge, &is_builtin).unwrap();
+        assert_eq!(spec.provider, "anthropic");
+        assert_eq!(spec.model, "claude-fable-5");
+
+        // A seeded pin with a catalog-valid slug is untouched.
+        let engine = engine_from_json(
+            r#"{"default_model": "glm-5.2", "agents": {"default": {"provider": "zai"}}}"#,
+        );
+        let spec = model_spec_for(&engine, EngineAgentKind::Default, &is_builtin).unwrap();
+        assert_eq!(spec.provider, "zai");
+        assert_eq!(spec.model, "glm-5.2");
+
+        // An UNSEEDED pin keeps verbatim semantics even for a flat-key
+        // model whose prefix names another provider — that slug shape is
+        // exactly how OpenRouter routes (`openai/gpt-5.5` IS its slug).
+        let engine = engine_from_json(
+            r#"{"pipeline_judge_model": "openai/gpt-5.5",
+                "agents": {"judge": {"provider": "openrouter"}}}"#,
+        );
+        let spec = model_spec_for(&engine, EngineAgentKind::Judge, &is_builtin).unwrap();
+        assert_eq!(spec.provider, "openrouter");
+        assert_eq!(spec.model, "openai/gpt-5.5");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`stella` failed at startup with:

> unknown model `zai/openrouter/openrouter/auto` — run `stella models refresh` or pick from `stella models list`

The flat engine-config model keys (`default_model`, `pipeline_*_model`) hold `provider/slug` specs — every TUI save writes them that way — and the per-agent precedence chain hands them to pinned agents too. A stale seeded pin then swallowed the whole spec as a verbatim slug: `agents.default.provider: "zai"` over `default_model: "openrouter/openrouter/auto"` stitched the phantom slug `zai/openrouter/openrouter/auto`, which died on the anti-phantom-slug catalog check (or on zai credential resolution before ever reaching it).

## Fix

- `model_spec_for` now lets the catalog arbitrate for **seeded** pins: when the catalog rejects the verbatim reading and the string parses as a qualified `provider/slug` spec, the spec's own provider wins. **Unseeded** pins (openrouter, local, settings-defined) keep verbatim semantics — their slug space is open, so the catalog has no veto, and `openai/gpt-5.5` through an OpenRouter pin still routes untouched.
- `Config::load_with_settings`' default-agent stitcher goes through `model_spec_for` instead of hand-prefixing the pin, so the default agent and the judge/triage wiring resolve the same settings the same way. Unparseable strings still pass through raw, keeping the named typo error.

## Verification

- New regression tests: `engine_config::tests::seeded_pin_yields_to_a_qualified_spec_the_catalog_rejects` (four pin/spec shapes) and `config::tests::a_stale_default_pin_does_not_mangle_a_qualified_engine_default_model` (full `load_with_settings` path).
- `cargo test -p stella-cli`: 208 passed. `cargo clippy`/`cargo fmt --check` clean; `cargo check --workspace` clean.
- End-to-end: with the exact settings.json that reproduced the error, the fixed binary's `stella config` resolves to Provider **OpenRouter**, Model `openrouter/auto`.
