### PR TITLE
Harden for launch: build break, RCE-on-clone, day-one crashes, install safety

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -16,10 +16,18 @@ name: auto-tag
 # No commit is pushed back to main — the tag is the source of truth, so this
 # never fights branch protection. release.yml injects the tag's version into
 # the build so `stella --version` is correct.
+#
+# GATED ON GREEN CI. This runs via `workflow_run` after the `ci` workflow
+# finishes on main, and only tags when that run *succeeded* — a commit that
+# fails to compile or fails tests can never become a tagged release (which is
+# exactly how a non-compiling commit shipped as a tag before this gate).
+# Because `ci` is path-ignored for docs-only changes, those merges never run
+# `ci` and so never trigger a release either — previously they tagged blindly.
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
 
 concurrency:
   # Serialize so rapid merges compute their version off the previous tag.
@@ -33,9 +41,18 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    # Only cut a release for a *successful* CI run triggered by a push to main.
+    # Guarding on the job (not just inside the step) keeps a red build from ever
+    # reaching the tag push.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
     steps:
       - uses: actions/checkout@v7
         with:
+          # Tag the exact commit CI validated, not whatever main is now.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 <p align="center">
   <a href="https://github.com/macanderson/stella/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/macanderson/stella/ci.yml?branch=main&style=flat-square&logo=github&label=ci" alt="CI status"></a>
   <a href="https://github.com/macanderson/stella/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/macanderson/stella/release.yml?style=flat-square&logo=github&label=release" alt="Release status"></a>
-  <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-FFAC26?style=flat-square" alt="License"></a>
-  <img src="https://img.shields.io/badge/rust-1.90%2B-FFAC26?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.90+">
-  <img src="https://img.shields.io/badge/providers-9%20%2B%20local-FFAC26?style=flat-square" alt="9 providers + local">
+  <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-3FE0FF?style=flat-square" alt="License"></a>
+  <img src="https://img.shields.io/badge/rust-1.90%2B-3FE0FF?style=flat-square&logo=rust&logoColor=white" alt="Rust 1.90+">
+  <img src="https://img.shields.io/badge/providers-9%20%2B%20local-3FE0FF?style=flat-square" alt="9 providers + local">
 </p>
 
 <p align="center">
@@ -465,9 +465,9 @@ flowchart TD
 
 ## Workspace layout
 
-Sixteen crates total: thirteen `stella-*` crates plus the three `ocp-*` crates
-that implement the Open Context Protocol (the retrieval abstraction Stella's
-recall routes through).
+Fourteen `stella-*` crates make up the workspace. The Open Context Protocol —
+the retrieval abstraction Stella's recall routes through — now lives in its own
+repository and is pulled in as a pinned git dependency, not as workspace members.
 
 | Crate | Role |
 |---|---|

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -299,11 +299,15 @@ model. This makes the trust perimeter **structurally defensible**: no
 commercial competitor can match it without ceasing to be commercial.
 
 The enforcement is architectural, not policy-based. The `stella-core` engine
-has no network code. The only crate that makes outbound HTTP calls is
-`stella-model` (to the user's chosen provider) and `stella-mcp` (to
-user-configured MCP servers, which are explicitly opt-in). There is no
-telemetry SDK, no analytics endpoint, no update checker. A code audit can
-verify this in minutes.
+has no network code. Outbound HTTP is confined to a small, enumerable set of
+crates, and every call targets an endpoint the user chose or configured:
+`stella-model` (your model provider), `stella-mcp` (MCP servers you configure,
+plus the MCP registry when you run `stella mcp search`), `stella-tools` (your
+issue tracker — GitHub or Linear — only when you invoke the issue tools), and
+`stella-media` (your image/video provider, only when you invoke the media
+tools). There is no telemetry SDK, no analytics endpoint, and no update checker.
+A code audit can verify this in minutes — `grep -rl reqwest` names every crate
+above and no others.
 
 ### The specific advantage
 

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,6 @@ set -eu
 REPO="macanderson/stella"
 BIN="stella"
 INSTALL_DIR="${STELLA_INSTALL_DIR:-$HOME/.local/bin}"
-API="https://api.github.com/repos/${REPO}"
 DOWNLOAD_BASE="https://github.com/${REPO}/releases/download"
 
 # ---- logging -------------------------------------------------------------
@@ -80,6 +79,18 @@ is_supported_target() {
   esac
 }
 
+# The prebuilt Linux tarballs are glibc (`-gnu`). On musl (Alpine) a glibc
+# binary passes the checksum and "installs", then dies at exec with the loader's
+# cryptic "no such file or directory". Detect musl and build from source instead.
+is_musl() {
+  [ "$(uname -s)" = "Linux" ] || return 1
+  if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
+    return 0
+  fi
+  # ldd is often absent on musl systems; fall back to probing for its loader.
+  [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]
+}
+
 # ---- version resolution --------------------------------------------------
 
 # Resolve the release tag (e.g. "v0.1.0"). Honors STELLA_VERSION, otherwise
@@ -93,15 +104,18 @@ resolve_tag() {
     return 0
   fi
 
-  body="$(curl -fsSL "${API}/releases/latest")" ||
-    die "could not query latest release from GitHub API"
-
-  # Extract the first "tag_name": "..." value without requiring jq.
-  TAG="$(printf '%s\n' "$body" |
-    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
-    head -n1)"
-
-  [ -n "$TAG" ] || die "could not determine latest release tag"
+  # Resolve "latest" via the release redirect rather than the JSON API: the
+  # unauthenticated API is rate-limited to 60 req/hr/IP (CI farms and office
+  # NATs hit it and the install dies), and this avoids scraping JSON.
+  # /releases/latest 302-redirects to /releases/tag/<TAG>.
+  effective="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest")" ||
+    die "could not resolve the latest release"
+  TAG="${effective##*/tag/}"
+  case "$TAG" in
+    v*) : ;;
+    *) die "could not determine latest release tag (resolved to '${effective}')" ;;
+  esac
 }
 
 # ---- checksum ------------------------------------------------------------
@@ -123,9 +137,36 @@ cargo_fallback() {
   if ! command -v cargo >/dev/null 2>&1; then
     die "cargo not found; install Rust from https://rustup.rs then re-run"
   fi
-  info "installing from source with cargo (this may take a while)..."
-  cargo install --locked --git "https://github.com/${REPO}" stella-cli
-  info "done. Ensure Cargo's bin dir (usually \$HOME/.cargo/bin) is on your PATH."
+
+  # Pin the source build to STELLA_VERSION when set, so the fallback path honors
+  # the requested version instead of silently building whatever `main` happens
+  # to be (which may not even match the version the user asked for).
+  ref_args=""
+  if [ -n "${STELLA_VERSION:-}" ]; then
+    case "$STELLA_VERSION" in
+      v*) tag="$STELLA_VERSION" ;;
+      *) tag="v${STELLA_VERSION}" ;;
+    esac
+    ref_args="--tag ${tag}"
+    info "building stella ${tag} from source with cargo (this may take a while)..."
+  else
+    info "building stella from source with cargo (latest main; this may take a while)..."
+  fi
+
+  # Honor STELLA_INSTALL_DIR when it looks like a .../bin directory (the default
+  # is ~/.local/bin): cargo installs the binary into <root>/bin.
+  root_args=""
+  case "$INSTALL_DIR" in
+    */bin) root_args="--root ${INSTALL_DIR%/bin}" ;;
+  esac
+
+  # shellcheck disable=SC2086 # word-splitting of the optional arg groups is intended
+  cargo install --locked ${ref_args} ${root_args} --git "https://github.com/${REPO}" stella-cli
+  if [ -n "$root_args" ]; then
+    info "installed stella to ${INSTALL_DIR}."
+  else
+    info "done. Ensure Cargo's bin dir (usually \$HOME/.cargo/bin) is on your PATH."
+  fi
   exit 0
 }
 
@@ -154,6 +195,9 @@ main() {
   detect_target
   if [ -z "$TARGET" ] || ! is_supported_target "$TARGET"; then
     cargo_fallback "no prebuilt binary for this platform ($(uname -s) $(uname -m)); falling back to cargo."
+  fi
+  if is_musl; then
+    cargo_fallback "musl libc detected; prebuilt binaries are glibc-only — building from source."
   fi
 
   resolve_tag
@@ -194,8 +238,14 @@ main() {
 
   mkdir -p "$INSTALL_DIR"
   install_path="${INSTALL_DIR}/${BIN}"
-  cp "$src" "$install_path"
-  chmod +x "$install_path"
+  # Install atomically: copy to a temp file in the same dir, make it executable,
+  # then rename over the target. A plain `cp` over the destination truncates it
+  # in place — fatal if the old binary is running (ETXTBSY / a half-written exec
+  # left in PATH if the copy is interrupted). `mv` within a filesystem is atomic.
+  tmp_bin="${INSTALL_DIR}/.${BIN}.tmp.$$"
+  cp "$src" "$tmp_bin"
+  chmod +x "$tmp_bin"
+  mv -f "$tmp_bin" "$install_path"
 
   info "installed stella to ${install_path}"
   path_hint

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -2050,6 +2050,20 @@ pub(crate) fn load_mcp_plan(cfg: &Config) -> McpPlan {
     let Ok(text) = std::fs::read_to_string(&path) else {
         return McpPlan::None;
     };
+    // Trust gate. A cloned repo's `.stella/mcp.toml` can name an arbitrary
+    // stdio `command` (executed at session start — RCE on `git clone && stella`)
+    // or an attacker-controlled http endpoint (egress + a would-be-whitelisted
+    // phone-home). This is the same code-execution risk as project hooks, so it
+    // is gated by the same flag: untrusted, we do not connect and say why once.
+    // (Project settings.json hooks/credential-routing are already gated in
+    // settings.rs; this closes the parallel .stella/mcp.toml hole.)
+    if !crate::settings::project_code_execution_trusted() {
+        return McpPlan::Invalid(format!(
+            "{} was NOT loaded — set STELLA_TRUST_PROJECT=1 to let this repo start its \
+             MCP servers (they run commands / open connections on your machine)",
+            path.display()
+        ));
+    }
     let parsed = match McpConfig::from_toml_str(&text) {
         Ok(parsed) => parsed,
         Err(e) => {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -560,6 +560,19 @@ fn parse_budget(raw: &str) -> Result<f64, String> {
 }
 
 fn main() -> ExitCode {
+    // Restore the default SIGPIPE disposition. Rust masks SIGPIPE at startup, so
+    // writing to a closed stdout (`stella tools | head`, `… | grep -q`, a piped
+    // reader that quits) surfaces as an EPIPE that `println!` *panics* on — and
+    // with panic=abort that's a SIGABRT + a scary panic dump on a routine pipe.
+    // Resetting to SIG_DFL makes the process exit quietly on a broken pipe, the
+    // way every other Unix CLI does.
+    #[cfg(unix)]
+    // SAFETY: single-threaded process startup, before any threads/runtime exist;
+    // installing a default signal disposition here races nothing.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let cli = Cli::parse();
 
     match run(cli) {

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -691,6 +691,15 @@ fn project_trust() -> ProjectTrust {
     }
 }
 
+/// Whether this process trusts the current project to run code it configures.
+/// Governs project-scope lifecycle hooks and the MCP servers declared in
+/// `.stella/mcp.toml` — both spawn processes / open connections that a cloned
+/// repo must not be able to start silently. Same gate as project hooks:
+/// `STELLA_TRUST_PROJECT=1` (or the legacy hooks-only `STELLA_PROJECT_HOOKS=1`).
+pub(crate) fn project_code_execution_trusted() -> bool {
+    project_trust().hooks
+}
+
 /// The org-managed scope path. `STELLA_MANAGED_SETTINGS` overrides the
 /// platform default so fleets can mount it anywhere (and tests can point at
 /// a fixture instead of `/etc`).

--- a/stella-observatory/src/lib.rs
+++ b/stella-observatory/src/lib.rs
@@ -190,6 +190,32 @@ pub async fn serve(
     }
 }
 
+/// True when the request's `Host` header names a loopback address. Any other
+/// Host (e.g. an attacker domain rebound to 127.0.0.1) is refused — the standard
+/// DNS-rebinding defense for a header-less localhost server. A missing Host is
+/// allowed: a browser `fetch` always sends one, so its absence means the request
+/// did not originate from the web attack this guards against (raw curl, tests).
+fn host_is_local(head: &str) -> bool {
+    let host = head.lines().skip(1).find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.trim().eq_ignore_ascii_case("host") {
+            Some(value.trim())
+        } else {
+            None
+        }
+    });
+    let Some(h) = host else {
+        return true;
+    };
+    // Strip an optional :port, keeping bracketed IPv6 literals intact.
+    let hostname = if let Some(rest) = h.strip_prefix('[') {
+        rest.split(']').next().unwrap_or("")
+    } else {
+        h.rsplit_once(':').map(|(hn, _)| hn).unwrap_or(h)
+    };
+    hostname == "localhost" || hostname == "::1" || hostname.starts_with("127.")
+}
+
 /// Read one request head, answer it, close. GET only, 8 KiB head cap.
 async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result<()> {
     let mut buf = vec![0_u8; 8192];
@@ -212,7 +238,13 @@ async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result
         (Some(m), Some(p)) => (m, p),
         _ => return Ok(()),
     };
-    let response = if method == "GET" {
+    let response = if !host_is_local(&head) {
+        // DNS-rebinding defense: a web page that resolves an attacker domain to
+        // 127.0.0.1 can otherwise read this loopback dashboard cross-origin
+        // (prompts, touched-file paths, memory, code graph). A rebound request
+        // carries the attacker's hostname in Host; refuse anything non-loopback.
+        Response::error("403 Forbidden", "forbidden Host header")
+    } else if method == "GET" {
         respond(workspace_root, path)
     } else {
         Response::error("405 Method Not Allowed", "GET only")
@@ -234,6 +266,28 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn host_header_gates_dns_rebinding() {
+        let local = [
+            "GET /api/executions HTTP/1.1\r\nHost: 127.0.0.1:7787\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: localhost:7787\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+            "GET / HTTP/1.1\r\nhost: [::1]:7787\r\n\r\n",
+            "GET / HTTP/1.1\r\n\r\n", // no Host (raw socket) — allowed
+        ];
+        for h in local {
+            assert!(host_is_local(h), "should allow: {h:?}");
+        }
+        let remote = [
+            "GET / HTTP/1.1\r\nHost: attacker.example:7787\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: evil.com\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: 127evil.com\r\n\r\n",
+        ];
+        for h in remote {
+            assert!(!host_is_local(h), "should refuse: {h:?}");
+        }
+    }
 
     /// Build a workspace with a seeded `.stella/store.db` shaped like the
     /// real schema (the subset the observatory reads).

--- a/stella-tools/src/edit.rs
+++ b/stella-tools/src/edit.rs
@@ -47,6 +47,18 @@ impl Tool for EditFile {
                 };
             }
         };
+        // An empty `old_string` is destructive: `"".matches("")` reports
+        // char_count+1 hits, so the tool would tell the model to set
+        // replace_all=true and then `replace("", new)` interleaves `new` at
+        // every char boundary — shredding the file (and allocating O(len^2)).
+        // On an empty file it would silently overwrite. Refuse it outright.
+        if old_string.is_empty() {
+            return ToolOutput::Error {
+                message: "old_string must not be empty — use write_file to create or replace a \
+                          whole file"
+                    .into(),
+            };
+        }
         let new_string = match input.get("new_string").and_then(|v| v.as_str()) {
             Some(s) => s,
             None => {

--- a/stella-tools/src/issues.rs
+++ b/stella-tools/src/issues.rs
@@ -23,7 +23,7 @@ use crate::tracker_auth::{
 };
 
 /// Which tracker the issue tools talk to.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum IssueBackend {
     /// GitHub Issues via the authenticated `gh` CLI.
     GitHub,
@@ -34,6 +34,28 @@ pub enum IssueBackend {
     /// header value: a personal API key verbatim, or `Bearer <token>` for an
     /// OAuth connection.
     Linear { api_key: String, api_url: String },
+}
+
+// Manual Debug so a stray `{backend:?}` (or a future `tracing::debug!(?backend)`)
+// can never print the GitHub token or Linear key — the rest of the codebase
+// holds secrets in a redacted `ApiKey`; these two variants carry raw Strings and
+// must be redacted here to honor SECURITY.md's "credentials never in logs".
+impl std::fmt::Debug for IssueBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GitHub => f.write_str("GitHub"),
+            Self::GitHubApi { api_base, .. } => f
+                .debug_struct("GitHubApi")
+                .field("token", &"<redacted>")
+                .field("api_base", api_base)
+                .finish(),
+            Self::Linear { api_url, .. } => f
+                .debug_struct("Linear")
+                .field("api_key", &"<redacted>")
+                .field("api_url", api_url)
+                .finish(),
+        }
+    }
 }
 
 /// [`detect_issue_backend`] off the async executor: the `gh auth status`

--- a/stella-tui/src/views/issues.rs
+++ b/stella-tui/src/views/issues.rs
@@ -55,7 +55,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                     ui.issues.search_query.clone(),
                     Style::default().fg(theme::INK),
                 ),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -77,7 +77,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                 Span::styled(target, Style::default().fg(theme::INK)),
                 Span::styled(": ", theme::muted()),
                 Span::styled(ui.issues.input.clone(), Style::default().fg(theme::INK)),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -90,7 +90,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     if let Some(notice) = &ui.issues.notice {
         lines.push(Line::from(Span::styled(
             format!("  {}{notice}", if ui.issues.busy { "◌ " } else { "" }),
-            Style::default().fg(theme::EMBER_GOLD),
+            Style::default().fg(theme::AURORA_CYAN),
         )));
     }
     lines.push(footer(ui.issues.mode));
@@ -189,7 +189,7 @@ fn render_form(issues: &IssuesPanel, width: usize, lines: &mut Vec<Line<'static>
             ),
         ];
         if focused {
-            spans.push(Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)));
+            spans.push(Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)));
         }
         lines.push(Line::from(spans));
     };


### PR DESCRIPTION
Pre-launch adversarial audit fixes. Grouped by theme; each is small and independently reviewable.

## 🚑 Release-blocking (fix before any tag)
- **Build break restored.** `stella-tui/src/views/issues.rs` referenced `theme::EMBER_GOLD`, which the aurora-on-navy restyle removed — so `main` (and the `v0.4.29` tag) **does not compile**. Switched the 4 refs to `theme::AURORA_CYAN`, matching the already-migrated sibling views. `cargo check -p stella-tui` green.
- **Auto-tag gated on green CI.** `auto-tag` now triggers via `workflow_run` on a *successful* `ci` completion for a push to main, and tags the exact validated commit. A non-compiling/failing commit can no longer become a tagged release (which is exactly what happened). Because `ci` is path-ignored for docs, docs-only merges no longer cut releases either.

## 🔒 Security
- **P0 — RCE-on-clone gate.** `.stella/mcp.toml` is now behind the same `STELLA_TRUST_PROJECT` gate as project hooks. Before this, `git clone && cd && stella` on a hostile repo spawned its `mcp.toml` stdio `command` (arbitrary code) or hit its http endpoint at session start — the only `.stella/` execution vector left outside the existing trust gate.
- **Observatory DNS-rebinding.** The loopback dashboard discarded all headers; it now 403s any non-loopback `Host`, so a web page can't read your prompts / touched-file paths cross-origin. (unit test added)
- **Credential `Debug` leak.** `IssueBackend`'s derived `Debug` printed the Linear key / GitHub token in the clear; replaced with a redacting impl.
- **Doc claim corrected.** "Only `stella-model` and `stella-mcp` make outbound HTTP" was false (`stella-tools`/Linear and `stella-media` do too); reworded so `grep reqwest` backs it.

## 💥 Day-one robustness
- **SIGPIPE.** `stella tools | head` panic-aborted with a Rust panic dump; reset SIGPIPE to `SIG_DFL` so piped output exits quietly like any Unix CLI.
- **`edit_file` data loss.** An empty `old_string` shredded the target file (interleaving `new_string` at every char boundary) and could OOM; now rejected.

## 📦 Install safety (`install.sh`)
- Cargo fallback honors `STELLA_VERSION` (`--tag`) and `STELLA_INSTALL_DIR` (`--root`) instead of silently building `main`.
- musl detection → build from source (glibc tarballs "install" then fail to exec on Alpine).
- Atomic install (temp + `mv`) to avoid `ETXTBSY` / half-written binaries in `PATH`.
- Resolve "latest" via the release redirect (no 60-req/hr API limit, no JSON scraping).

## 🎨 Brand/docs
- Recolored amber (`FFAC26`) README badges to aurora cyan; fixed the workspace crate count (14 `stella-*`; OCP is a pinned git dep).

**Verification:** `cargo check`/`clippy -D warnings` green on `stella-cli`, `stella-tui`, `stella-tools`, `stella-observatory`; MCP + new observatory tests pass. Full-workspace build not run here (LTO cost) — CI covers it.

This is part of a broader two-repo launch audit (Stella + Arena); the accompanying report ranks the top 25 pitfalls and notes several higher-effort items intentionally left for follow-up (deck panel panic-boundary, fleet worktree cleanup, model-stream total deadline, negative-`user_version` startup panic, release-artifact signing/provenance).
