### PR TITLE
feat(sessions): durable sessions — pause, resume, and survive anything

### DIFF
--- a/COMMAND_DECK_DESIGN.md
+++ b/COMMAND_DECK_DESIGN.md
@@ -178,6 +178,42 @@ impl WorkspaceModel {
   folds or a labeled exception. (The focused-agent index is ephemeral view
   state in `DeckUi`, never in the model.)
 
+## Durable sessions (pause / resume / crash-safety)
+
+Every deck session is durable by construction, riding the same L-T1 fold the
+deck renders from: because the screen is a pure function of the inbound
+envelope stream, persisting the session is journaling that stream, and
+resuming is replaying it.
+
+- **Journal tee** (`stella-cli::session_persist`): the driver's `in_tx` reaches
+  the deck through one interception task that mirrors every fold-relevant
+  `Inbound` into `data_dir()/sessions/<id>/journal.jsonl`
+  (`stella-store::journal`, append-only JSONL, torn-tail tolerant). Adjacent
+  `Text`/`Reasoning` deltas coalesce per run; conversation transitions
+  (`PromptStarted`, `Complete`, `Error`, status, reset, pipeline) fsync.
+  Out-of-band view snapshots never journal; ephemeral chrome (boot narration,
+  hints) is sent DIRECTLY to the deck so it never replays.
+- **Sidecar snapshots**: `history.json` (the LLM `Vec<CompletionMessage>`,
+  atomic temp+fsync+rename at every turn boundary and `/clear`) and
+  `queue.json` (the prompt backlog, write-through on every mutation).
+- **Recovery rule**: a journal whose last `PromptStarted` has no settle record
+  after it (`Complete` / non-retryable `Error` / `waiting_input` status) was
+  interrupted mid-turn — resume puts that prompt back at the FRONT of the
+  queue and **parks dispatch** (the existing `HoldState`), so reopening a
+  session shows where it stood and spends nothing until the user says go.
+- **Navigation**: `stella resume [id|--list]` from the CLI;  `⏎` on a
+  resumable row in the SESSIONS overlay (`WorkspaceInput::SessionResume`,
+  serviced between turns only) switches THIS deck to that session — the
+  current one parks as `Paused` (an untouched shell is removed instead), the
+  target's journal replays behind a `SessionReset`, and its registry record
+  is re-owned (same id, new pid). Quitting with a pending backlog is a
+  `Paused` exit, not a cancellation — the work is durable.
+- **Guarantee shape**: user input (prompts, queue) and completed turns survive
+  anything up to power loss (fsynced); the worst case loses only the
+  in-flight turn's streamed tail, which re-runs from its re-queued prompt.
+  Session spend stays monotone: the budget guard reseeds from the journal's
+  last `BudgetTick`.
+
 ## Backend seams (what's live vs. seam-fed today)
 
 - Live now: per-agent event fold, file +/- from diffs, routing from

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -46,7 +46,6 @@
 //!   retains what that cancel dropped so the second press still has a
 //!   prompt to requeue and park.
 
-use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -103,6 +102,16 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// An ephemeral transcript notice for DIRECT deck sends (`deck_tx`), never
+/// the journaled `in_tx` path: boot narration, hints, and guidance that must
+/// not replay (and pile up) every time the session is resumed.
+fn chrome_note(text: String) -> Inbound {
+    Inbound::Event {
+        agent: LEAD.to_string(),
+        event: AgentEvent::Text { delta: text },
+    }
 }
 
 /// `OXAGEN_DEBUG=1` → the structured deck log path (L-T8), mirroring the
@@ -207,7 +216,7 @@ impl HoldState {
 /// (`Inbound::PromptRequeued` is the exact inverse of `PromptStarted`'s
 /// front-pop), so the two queues never drift.
 fn requeue_front(
-    queue: &mut VecDeque<String>,
+    queue: &mut crate::session_persist::DurableQueue,
     in_tx: &UnboundedSender<Inbound>,
     texts: Vec<String>,
 ) {
@@ -227,6 +236,7 @@ pub async fn run_deck_session(
     cfg: &Config,
     budget_limit: Option<f64>,
     no_anim: bool,
+    resume: Option<crate::session_persist::ResumeRequest>,
 ) -> Result<(), String> {
     // ── Session assembly (still on the normal screen — prints are fine) ────
     // MCP connect is NOT here: it can block up to 10s per server, so it runs
@@ -255,10 +265,98 @@ pub async fn run_deck_session(
     // session — the SKILLS tab's ops route through it (see `handle_skills_input`).
     let skill_registry = SkillRegistry::from_env(cfg.workspace_root.clone());
 
+    // ── Durable session identity (still on the normal screen) ──────────────
+    // This session announces itself in the machine-wide registry, and every
+    // fold-relevant envelope it produces is journaled to the record's sidecar
+    // (`session_persist`) — quit / crash / power cut, the session reopens
+    // where it stood. A resume request resolves HERE so its errors print on
+    // the normal screen instead of dying behind the alternate one.
+    let session_registry = stella_store::SessionRegistry::open_default();
+    let _ = session_registry.prune(SESSION_RECORD_MAX_AGE_MS);
+    let _ = stella_store::NotificationStore::open_default().prune(NOTIFICATION_MAX_AGE_MS);
+    let workspace_path = cfg.workspace_root.display().to_string();
+    let workspace_name = cfg
+        .workspace_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| workspace_path.clone());
+    let mut resume_state = match &resume {
+        Some(request) => {
+            let target = crate::session_persist::resolve_resume_target(
+                &session_registry,
+                &workspace_path,
+                request,
+            )?;
+            Some(crate::session_persist::load_resume(
+                &session_registry,
+                &target.id,
+                &workspace_path,
+            )?)
+        }
+        None => None,
+    };
+    let mut session_record = match &mut resume_state {
+        // Re-own the stored record: same id (the registry never forks a
+        // resumed session's identity), this process's pid, back to waiting.
+        Some(rs) => crate::session_persist::adopt_record(
+            rs.record.clone(),
+            stella_store::SessionStatus::NeedsInput,
+        ),
+        None => stella_store::SessionRecord::new(workspace_path.clone(), workspace_name.clone()),
+    };
+    let _ = session_registry.upsert(&session_record);
+    // What the record's terminal status will be at exit (last turn wins);
+    // quitting with a pending backlog overrides to Paused below — the work
+    // is durable now, so an exit with prompts waiting is a pause, not loss.
+    let mut session_exit = stella_store::SessionStatus::Complete;
+    let mut sidecar_dir = session_registry.sidecar_dir(&session_record.id);
+    if let Some(rs) = &mut resume_state {
+        messages = crate::session_persist::restore_messages(
+            std::mem::take(&mut rs.history).unwrap_or_default(),
+            &system_prompt,
+        );
+        // Session spend stays monotone across interruptions, and a
+        // `--budget` keeps meaning "this session" — the guard resumes from
+        // what the session had already spent.
+        if let Some(spent) = rs.spent_usd {
+            let _ = budget.record_spend(spent);
+        }
+    }
+
     // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
-    let (in_tx, in_rx) = mpsc::unbounded_channel::<Inbound>();
+    // The driver's send side (`in_tx`) reaches the deck through the journal
+    // tee — the single choke point that makes the session durable. Direct
+    // `deck_tx` sends bypass the journal: replay (which must never
+    // re-journal itself) and ephemeral session chrome (boot narration,
+    // hints) that would otherwise pile up in the transcript on every resume.
+    let (in_tx, raw_rx) = mpsc::unbounded_channel::<Inbound>();
+    let (deck_tx, deck_rx) = mpsc::unbounded_channel::<Inbound>();
     let (sub_tx, mut sub_rx) = mpsc::unbounded_channel::<WorkspaceInput>();
     let (ask_tx, ask_rx) = mpsc::unbounded_channel::<String>();
+    let journal_sink = crate::session_persist::SessionSink::shared(
+        match stella_store::SessionJournal::open(&sidecar_dir) {
+            Ok(j) => Some(j),
+            Err(e) => {
+                let _ = deck_tx.send(chrome_note(format!(
+                    "session journaling unavailable — this session will not be resumable ({e})"
+                )));
+                None
+            }
+        },
+    );
+    let _tee = crate::session_persist::spawn_journal_tee(
+        raw_rx,
+        deck_tx.clone(),
+        journal_sink.clone(),
+        LEAD,
+    );
+    // Replay a resumed session's journal straight onto the deck BEFORE the
+    // first live send, so the restored transcript precedes everything this
+    // run adds. (The fresh `Register` below then restamps the lead's meta —
+    // pid, model, clock — over the replayed one.)
+    if let Some(rs) = &mut resume_state {
+        crate::session_persist::replay_session(std::mem::take(&mut rs.records), now_ms(), &deck_tx);
+    }
 
     let title = cfg
         .workspace_root
@@ -273,12 +371,10 @@ pub async fn run_deck_session(
     let _ = in_tx.send(Inbound::Register(lead_meta));
     // Custom definitions that failed to load are reported into the
     // transcript up front — stdout belongs to the alternate screen, and a
-    // silently-missing /command is otherwise undiagnosable.
+    // silently-missing /command is otherwise undiagnosable. Session chrome:
+    // re-checked every boot, so it never journals.
     if let Some(report) = custom.problems_report() {
-        let _ = in_tx.send(Inbound::Event {
-            agent: LEAD.to_string(),
-            event: AgentEvent::Text { delta: report },
-        });
+        let _ = deck_tx.send(chrome_note(report));
     }
     // An idle lead is waiting on the human, not queued behind a supervisor
     // (sent after the problems report — a Text event folds to `Running`).
@@ -286,6 +382,50 @@ pub async fn run_deck_session(
         agent: LEAD.to_string(),
         status: AgentStatus::WaitingInput,
     });
+
+    // ── The durable prompt backlog ──────────────────────────────────────────
+    // Every mutation writes through to the sidecar, so a queued prompt
+    // survives any interruption from the moment it is queued. On resume the
+    // restored backlog (and the prompt an interruption cut short, back at
+    // the FRONT) is mirrored into the deck's queue view, and dispatch parks
+    // until the user's next submission — resuming shows where things stood
+    // and costs nothing until the user says go.
+    let mut queue = crate::session_persist::DurableQueue::fresh(sidecar_dir.clone());
+    let mut resume_hold = false;
+    if let Some(rs) = &mut resume_state {
+        let mut restored = std::mem::take(&mut rs.queue);
+        if let Some(interrupted) = rs.interrupted.take() {
+            restored.insert(0, interrupted);
+        }
+        if !restored.is_empty() {
+            resume_hold = true;
+            // Front-inserts mirror back-to-front so the view reads in order.
+            for text in restored.iter().rev() {
+                let _ = in_tx.send(Inbound::PromptRequeued {
+                    agent: LEAD.to_string(),
+                    text: text.clone(),
+                });
+            }
+            let _ = deck_tx.send(chrome_note(format!(
+                "session restored — {} prompt(s) waiting, dispatch held. Submit anything to \
+                 run it first (then the backlog), or ctrl+t to edit the queue.",
+                restored.len()
+            )));
+            queue.adopt(sidecar_dir.clone(), restored);
+        } else {
+            let _ = deck_tx.send(chrome_note(
+                "session restored — the conversation continues where it left off.".to_string(),
+            ));
+        }
+    } else if session_registry.latest_resumable(&workspace_path).is_some() {
+        // A fresh session in a workspace that has something to go back to:
+        // one pointer, so "navigate back in" is discoverable.
+        let _ = deck_tx.send(chrome_note(
+            "◂ a previous session is resumable — ← (on an empty prompt) opens SESSIONS, ⏎ \
+             reopens one; or run `stella resume`."
+                .to_string(),
+        ));
+    }
     // Seed the SKILLS tab so it has data the instant it is opened (both scopes),
     // without waiting on a `/skills` round-trip.
     let _ = in_tx.send(skills_snapshot(&cfg.workspace_root, None));
@@ -300,21 +440,25 @@ pub async fn run_deck_session(
         answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
     };
 
+    // The deck drives turns through the staged pipeline by default (triage →
+    // recall → plan → scope → witness → execute → verify → judge); `/pipeline`
+    // toggles back to the raw `Engine::run_turn` loop (`run_lead_turn`). A
+    // resumed session keeps whatever it last had.
+    let pipeline_init = resume_state
+        .as_ref()
+        .and_then(|rs| rs.pipeline)
+        .unwrap_or(true);
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
         slash_commands: deck_slash_commands(&custom),
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         no_anim,
-        // The deck drives turns through the staged pipeline by default (triage
-        // → recall → plan → scope → witness → execute → verify → judge), so
-        // PIPELINE reads ON here. `/pipeline` toggles back to the raw
-        // `Engine::run_turn` loop (`run_lead_turn`).
-        pipeline: true,
+        pipeline: pipeline_init,
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering
     // never waits on the driver (and vice versa).
-    let deck = tokio::spawn(run_deck(opts, in_rx, sub_tx));
+    let deck = tokio::spawn(run_deck(opts, deck_rx, sub_tx));
 
     // The launch cinematic: hold the splash's battle loop open over session
     // init and release it once BOTH async legs — the background code-graph
@@ -341,17 +485,17 @@ pub async fn run_deck_session(
     // `◈ indexing…`/`✓ …` lines render as transcript events; non-blocking, and
     // the watcher stops when `_session_graph` drops at session end. `_graph_build`
     // (the setup task's JoinHandle) is detached — freshness outlives it.
-    let status_tx = in_tx.clone();
-    let ready_tx = in_tx.clone();
+    // Indexing narration is session chrome (direct `deck_tx`): it re-runs at
+    // every boot, so journaling it would replay stale "indexing…" lines on
+    // top of every resumed transcript.
+    let status_tx = deck_tx.clone();
+    let ready_tx = deck_tx.clone();
     let ready_root = cfg.workspace_root.clone();
     let (_session_graph, _graph_build) = agent::spawn_session_graph(
         &cfg.workspace_root,
         registry.clone(),
         Box::new(move |line| {
-            let _ = status_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Text { delta: line },
-            });
+            let _ = status_tx.send(chrome_note(line));
         }),
         Box::new(move || {
             // Populate the Graph tab now the index exists (it opened on the
@@ -389,10 +533,8 @@ pub async fn run_deck_session(
     let mcp = match agent::load_mcp_plan(cfg) {
         agent::McpPlan::None => None,
         agent::McpPlan::Invalid(reason) => {
-            let _ = in_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Text { delta: reason },
-            });
+            // Boot narration — chrome, re-derived every start, never journaled.
+            let _ = deck_tx.send(chrome_note(reason));
             let _ = in_tx.send(Inbound::Status {
                 agent: LEAD.to_string(),
                 status: AgentStatus::WaitingInput,
@@ -400,12 +542,10 @@ pub async fn run_deck_session(
             None
         }
         agent::McpPlan::Servers(servers) => {
-            let _ = in_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Text {
-                    delta: format!("connecting {} MCP server(s)…", servers.len()),
-                },
-            });
+            let _ = deck_tx.send(chrome_note(format!(
+                "connecting {} MCP server(s)…",
+                servers.len()
+            )));
             let set = agent::connect_mcp_servers(
                 &servers,
                 registry.clone(),
@@ -414,12 +554,10 @@ pub async fn run_deck_session(
                 Some(crate::mcp_cmd::oauth_manager(&cfg.workspace_root)),
             )
             .await;
-            let _ = in_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Text {
-                    delta: mcp_outcome_report(&set.connected_names(), set.failed_servers()),
-                },
-            });
+            let _ = deck_tx.send(chrome_note(mcp_outcome_report(
+                &set.connected_names(),
+                set.failed_servers(),
+            )));
             // The Text events above fold the lead to `Running`, but no turn
             // is in flight — restore the idle status or the dashboard would
             // show a busy lead forever.
@@ -440,28 +578,9 @@ pub async fn run_deck_session(
     // leg the launch splash waits on.
     release_splash();
 
-    // ── Cross-process session registry + persist-until-read notifications ──
-    // This session announces itself machine-wide (every deck's SESSIONS
-    // overlay reads the same registry), and a poller keeps the inbox badge
-    // live as other sessions produce notifications. Registry hygiene runs
-    // opportunistically at startup; both stores are best-effort — a failed
-    // write never disturbs the session.
-    let session_registry = stella_store::SessionRegistry::open_default();
-    let _ = session_registry.prune(SESSION_RECORD_MAX_AGE_MS);
-    let _ = stella_store::NotificationStore::open_default().prune(NOTIFICATION_MAX_AGE_MS);
-    let workspace_name = cfg
-        .workspace_root
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| cfg.workspace_root.display().to_string());
-    let mut session_record = stella_store::SessionRecord::new(
-        cfg.workspace_root.display().to_string(),
-        workspace_name.clone(),
-    );
-    let _ = session_registry.upsert(&session_record);
-    // What the record's terminal status will be at exit (last turn wins);
-    // quitting with an abandoned backlog overrides to Cancelled below.
-    let mut session_exit = stella_store::SessionStatus::Complete;
+    // The registry record and hygiene ran during assembly (the durable
+    // session identity block); here the inbox poller starts once the deck is
+    // up, keeping the badge live as other sessions produce notifications.
     spawn_notification_poller(in_tx.clone());
 
     // The ISSUES tab's lazily-detected tracker backend (see
@@ -469,15 +588,20 @@ pub async fn run_deck_session(
     let issue_backend_cache: IssueBackendCache = Arc::new(tokio::sync::Mutex::new(None));
 
     // ── The driver loop ─────────────────────────────────────────────────────
-    let mut queue: VecDeque<String> = VecDeque::new();
+    // (`queue` — the durable backlog — was constructed with the session
+    // identity above, restored contents and all.)
     // Double-Esc bookkeeping: parks dispatch and retains what the pair's
-    // first press cancelled (see [`HoldState`]).
+    // first press cancelled (see [`HoldState`]). A resumed backlog starts
+    // parked — reopening a session shows where it stood; the user's next
+    // submission is what sets it moving (and runs first).
     let mut dispatch = HoldState::new();
+    dispatch.held = resume_hold;
     // `/pipeline`: route lead turns through the staged pipeline (triage →
     // witness → execute → verify → judge) instead of the raw engine loop.
-    // Session-local, ON at start (the deck loads with the pipeline active) —
-    // mirrored to the PIPELINE stat box via `Inbound::Pipeline`.
-    let mut pipeline_on = true;
+    // Session-local, ON at start (the deck loads with the pipeline active)
+    // unless a resumed session had toggled it — mirrored to the PIPELINE
+    // stat box via `Inbound::Pipeline`.
+    let mut pipeline_on = pipeline_init;
     // An agent-creation request that arrived mid-turn: drafting needs the
     // provider (borrowed by the running turn), so it parks here and runs
     // right after the turn settles.
@@ -559,6 +683,126 @@ pub async fn run_deck_session(
                     handle_agent_create(&description, scope, cfg, &*provider, &in_tx).await;
                     continue 'session;
                 }
+                // ⏎ on a resumable row in the SESSIONS overlay: navigate into
+                // that session. Only serviced HERE, between turns — live work
+                // is never torn down by a navigation (the mid-turn arm answers
+                // with guidance instead). The current session's durable state
+                // is already on disk, so switching away loses nothing.
+                Some(WorkspaceInput::SessionResume { id }) => {
+                    let loaded = if id == session_record.id {
+                        Err("that is this session — you are already in it".to_string())
+                    } else {
+                        crate::session_persist::load_resume(&session_registry, &id, &workspace_path)
+                    };
+                    match loaded {
+                        Err(reason) => {
+                            let _ = deck_tx
+                                .send(chrome_note(format!("cannot resume `{id}`: {reason}")));
+                        }
+                        Ok(mut rs) => {
+                            // Park the CURRENT session: sync the journal,
+                            // snapshot the conversation, and either mark it
+                            // Paused — or, if nothing ever happened in it,
+                            // remove the empty shell instead of littering
+                            // the registry with it.
+                            journal_sink
+                                .lock()
+                                .unwrap_or_else(|p| p.into_inner())
+                                .sync();
+                            let _ =
+                                crate::session_persist::snapshot_history(&sidecar_dir, &messages);
+                            if session_record.summary.is_empty() && queue.is_empty() {
+                                let _ = session_registry.remove(&session_record.id);
+                            } else {
+                                session_record.status = stella_store::SessionStatus::Paused;
+                                let _ = session_registry.upsert(&session_record);
+                            }
+
+                            // Adopt the target: same id, this pid, waiting.
+                            session_record = crate::session_persist::adopt_record(
+                                rs.record.clone(),
+                                stella_store::SessionStatus::NeedsInput,
+                            );
+                            let _ = session_registry.upsert(&session_record);
+                            sidecar_dir = session_registry.sidecar_dir(&session_record.id);
+                            {
+                                let mut sink =
+                                    journal_sink.lock().unwrap_or_else(|p| p.into_inner());
+                                match stella_store::SessionJournal::open(&sidecar_dir) {
+                                    Ok(j) => sink.swap(Some(j)),
+                                    Err(e) => {
+                                        sink.swap(None);
+                                        let _ = deck_tx.send(chrome_note(format!(
+                                            "session journaling unavailable — this session \
+                                             will no longer be resumable ({e})"
+                                        )));
+                                    }
+                                }
+                            }
+
+                            // Blank the lead pane, replay the adopted
+                            // transcript in its place (direct sends — a
+                            // replay must never re-journal itself), then
+                            // restore conversation, backlog, and pipeline.
+                            let _ = deck_tx.send(Inbound::SessionReset {
+                                agent: LEAD.to_string(),
+                            });
+                            crate::session_persist::replay_session(
+                                std::mem::take(&mut rs.records),
+                                now_ms(),
+                                &deck_tx,
+                            );
+                            messages = crate::session_persist::restore_messages(
+                                rs.history.take().unwrap_or_default(),
+                                &system_prompt,
+                            );
+                            let mut restored = std::mem::take(&mut rs.queue);
+                            if let Some(interrupted) = rs.interrupted.take() {
+                                restored.insert(0, interrupted);
+                            }
+                            dispatch = HoldState::new();
+                            dispatch.held = !restored.is_empty();
+                            for text in restored.iter().rev() {
+                                let _ = in_tx.send(Inbound::PromptRequeued {
+                                    agent: LEAD.to_string(),
+                                    text: text.clone(),
+                                });
+                            }
+                            queue.adopt(sidecar_dir.clone(), restored);
+                            pipeline_on = rs.pipeline.unwrap_or(true);
+                            let _ = in_tx.send(Inbound::Pipeline(pipeline_on));
+
+                            // Fresh meta over the replayed one (pid, model,
+                            // clock), back to waiting-on-you, and a fresh
+                            // overlay snapshot reflecting the handover.
+                            let mut meta = AgentMeta::new(LEAD, workspace_name.clone(), now_ms())
+                                .with_role("lead")
+                                .with_pid(std::process::id());
+                            meta.model = Some(format!("{}/{}", cfg.provider.id, cfg.model_id));
+                            let _ = in_tx.send(Inbound::Register(meta));
+                            let _ = in_tx.send(Inbound::Status {
+                                agent: LEAD.to_string(),
+                                status: AgentStatus::WaitingInput,
+                            });
+                            let _ = deck_tx.send(chrome_note(match queue.len() {
+                                0 => "session restored — the conversation continues where it \
+                                      left off."
+                                    .to_string(),
+                                n => format!(
+                                    "session restored — {n} prompt(s) waiting, dispatch held. \
+                                     Submit anything to run it first, or ctrl+t to edit the \
+                                     queue."
+                                ),
+                            }));
+                            let _ = in_tx.send(sessions_inbound(
+                                &session_registry,
+                                &session_record.id,
+                                &workspace_path,
+                            ));
+                        }
+                    }
+                    continue 'session;
+                }
                 // Fallthrough for everything else, serviced between turns
                 // (install/search hit the network, so they must not stall a
                 // live turn): MCP tab actions first, then the session-registry
@@ -572,6 +816,7 @@ pub async fn run_deck_session(
                             &other,
                             &session_registry,
                             &session_record.id,
+                            &workspace_path,
                             &in_tx,
                         )
                         && !handle_agents_input(&other, cfg, &in_tx)
@@ -612,10 +857,15 @@ pub async fn run_deck_session(
             // A handled command emits its answer as `Text`, which flips the
             // lead to `Running` in the deck's fold — but no turn is in flight.
             // Return it to `WaitingInput` so the dashboard reflects reality.
+            // (That status is also the journal's settle marker for this
+            // prompt — a resume must not re-run `/clear`.)
             let _ = in_tx.send(Inbound::Status {
                 agent: LEAD.to_string(),
                 status: AgentStatus::WaitingInput,
             });
+            // `/clear` (and friends) may have rewritten the conversation —
+            // keep the boundary snapshot current before the next dispatch.
+            let _ = crate::session_persist::snapshot_history(&sidecar_dir, &messages);
         }
         let prompt = match command {
             DeckCommand::Prompt => prompt,
@@ -880,8 +1130,19 @@ pub async fn run_deck_session(
                                 &input,
                                 &session_registry,
                                 &session_record.id,
+                                &workspace_path,
                                 &in_tx,
                             );
+                        }
+                        // Navigation waits for the road to clear: switching
+                        // sessions mid-turn would tear down live work, so the
+                        // deck is told how to proceed instead.
+                        Some(WorkspaceInput::SessionResume { .. }) => {
+                            let _ = deck_tx.send(chrome_note(
+                                "a turn is running — esc stops it (esc esc holds the queue \
+                                 too), then press ⏎ on the session again."
+                                    .to_string(),
+                            ));
                         }
                         // The ENGINE overlay stays live while a turn runs —
                         // settings reads/writes are cheap local filesystem
@@ -1026,7 +1287,31 @@ pub async fn run_deck_session(
                 session_record.status = stella_store::SessionStatus::NeedsInput;
                 let _ = session_registry.upsert(&session_record);
             }
-            TurnEnd::Quit => break 'session,
+            // Quit landing mid-turn: erase the partial turn from the
+            // conversation before the boundary snapshot below — a dangling
+            // assistant tool call with no result is a broken history, and
+            // the journal's unsettled `PromptStarted` puts this prompt back
+            // at the front of the queue on resume anyway.
+            TurnEnd::Quit => {
+                messages.truncate(turn_base);
+                break 'session;
+            }
+        }
+
+        // Durable turn boundary: the conversation as committed (post-turn or
+        // post-cancel-truncation) — what a resume continues from. The queue
+        // is write-through already; its one-time failure warning surfaces
+        // here, on the same cadence as every other persistence warning.
+        if let Some(warning) = crate::session_persist::snapshot_history(&sidecar_dir, &messages)
+            .or_else(|| queue.take_warning())
+        {
+            let _ = in_tx.send(Inbound::Event {
+                agent: LEAD.to_string(),
+                event: AgentEvent::Error {
+                    message: warning,
+                    retryable: true,
+                },
+            });
         }
 
         // A creation request parked during the turn: the provider is free
@@ -1036,18 +1321,29 @@ pub async fn run_deck_session(
         }
     }
 
-    // The session is over — leave the registry record in its terminal state.
-    // (A crash never reaches here; readers downgrade a dead pid to Error.)
-    // Quitting with prompts still queued means the work was abandoned.
+    // The session is over — leave the registry record in its terminal state
+    // and the durable state current. (A crash never reaches here; readers
+    // downgrade a dead pid to Error — and the journal makes even that
+    // resumable.) Quitting with prompts still queued is a PAUSE now, not an
+    // abandonment: the backlog is durable and reopens intact. The journal
+    // syncs HERE, not just in the tee's own teardown — background senders
+    // (the inbox poller) keep the tee alive past this point, and runtime
+    // teardown must never be what a buffered tail was waiting on.
+    journal_sink
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .sync();
+    let _ = crate::session_persist::snapshot_history(&sidecar_dir, &messages);
     session_record.status = if queue.is_empty() {
         session_exit
     } else {
-        stella_store::SessionStatus::Cancelled
+        stella_store::SessionStatus::Paused
     };
     let _ = session_registry.upsert(&session_record);
 
     // Closing our inbound sender ends the deck's stream if the user hasn't
-    // already quit; then wait for it to restore the terminal.
+    // already quit (the journal tee drains, fsyncs, and forwards the close);
+    // then wait for it to restore the terminal.
     drop(in_tx);
     let deck_result = deck.await;
     if let Some(set) = &mcp {
@@ -1298,15 +1594,16 @@ fn service_registry_action(
     input: &WorkspaceInput,
     registry: &stella_store::SessionRegistry,
     my_session_id: &str,
+    workspace: &str,
     in_tx: &mpsc::UnboundedSender<Inbound>,
 ) -> bool {
     match input {
         WorkspaceInput::SessionsRefresh => {
-            let _ = in_tx.send(sessions_inbound(registry, my_session_id));
+            let _ = in_tx.send(sessions_inbound(registry, my_session_id, workspace));
         }
         WorkspaceInput::SessionArchive { id } => {
             let _ = registry.set_status(id, stella_store::SessionStatus::Archived);
-            let _ = in_tx.send(sessions_inbound(registry, my_session_id));
+            let _ = in_tx.send(sessions_inbound(registry, my_session_id, workspace));
         }
         WorkspaceInput::SessionDelete { id } => {
             // The deck refuses to delete its own record UI-side too; this is
@@ -1314,7 +1611,7 @@ fn service_registry_action(
             if id != my_session_id {
                 let _ = registry.remove(id);
             }
-            let _ = in_tx.send(sessions_inbound(registry, my_session_id));
+            let _ = in_tx.send(sessions_inbound(registry, my_session_id, workspace));
         }
         WorkspaceInput::NotificationRead { id } => {
             let store = stella_store::NotificationStore::open_default();
@@ -1332,13 +1629,20 @@ fn service_registry_action(
 }
 
 /// The SESSIONS overlay snapshot: every registry record mapped to the deck's
-/// [`stella_tui::SessionInfo`], flagging this process's own record.
-fn sessions_inbound(registry: &stella_store::SessionRegistry, mine: &str) -> Inbound {
+/// [`stella_tui::SessionInfo`], flagging this process's own record and the
+/// rows that can be reopened HERE (no live owner, this workspace, durable
+/// state on disk — ⏎ navigates into those).
+fn sessions_inbound(
+    registry: &stella_store::SessionRegistry,
+    mine: &str,
+    workspace: &str,
+) -> Inbound {
     let sessions = registry
         .list()
         .into_iter()
         .map(|r| stella_tui::SessionInfo {
             mine: r.id == mine,
+            resumable: r.id != mine && r.workspace == workspace && registry.resumable(&r.id),
             phase: session_phase(r.status),
             id: r.id,
             title: r.title,
@@ -1357,6 +1661,7 @@ fn session_phase(status: stella_store::SessionStatus) -> stella_tui::SessionPhas
     match status {
         stella_store::SessionStatus::InProgress => stella_tui::SessionPhase::InProgress,
         stella_store::SessionStatus::NeedsInput => stella_tui::SessionPhase::NeedsInput,
+        stella_store::SessionStatus::Paused => stella_tui::SessionPhase::Paused,
         stella_store::SessionStatus::Cancelled => stella_tui::SessionPhase::Cancelled,
         stella_store::SessionStatus::Complete => stella_tui::SessionPhase::Complete,
         stella_store::SessionStatus::Archived => stella_tui::SessionPhase::Archived,
@@ -3954,12 +4259,19 @@ mod tests {
     #[test]
     fn requeue_front_mirrors_each_front_insert_to_the_deck() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut queue: VecDeque<String> = VecDeque::from(["c".to_string()]);
+        let dir = std::env::temp_dir().join(format!("stella-requeue-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut queue = crate::session_persist::DurableQueue::fresh(dir.clone());
+        queue.push_back("c".to_string());
         requeue_front(&mut queue, &tx, vec!["b".to_string(), "a".to_string()]);
+        // The backlog is durable + write-through: the authoritative order is
+        // ON DISK the moment the inserts return.
+        assert_eq!(queue.len(), 3);
         assert_eq!(
-            queue,
-            VecDeque::from(["a".to_string(), "b".to_string(), "c".to_string()])
+            stella_store::journal::read_queue(&dir),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
         );
+        let _ = std::fs::remove_dir_all(&dir);
         for expected in ["b", "a"] {
             match rx.try_recv() {
                 Ok(Inbound::PromptRequeued { agent, text }) => {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -37,6 +37,7 @@ mod model_catalog;
 mod ocp;
 mod rules;
 mod runtime;
+mod session_persist;
 mod settings;
 mod skill_manager;
 mod stats;
@@ -176,6 +177,20 @@ enum Command {
 
     /// Start an interactive REPL session
     Chat,
+
+    /// Reopen a previous session exactly where it stood — transcript,
+    /// conversation, pending prompts. Sessions are durable (quit, crash, and
+    /// power loss included); the deck's SESSIONS overlay (`←` on an empty
+    /// prompt, `⏎` on a row) is the same navigation from inside a session.
+    Resume {
+        /// Registry id (`ses-…`) of the session to reopen. Omitted: the most
+        /// recently active resumable session of this workspace.
+        id: Option<String>,
+
+        /// List this machine's sessions (resumable ones marked) and exit.
+        #[arg(long)]
+        list: bool,
+    },
 
     /// Analyze this workspace and infer its domain taxonomy
     /// (.stella/domains.toml) — the tagging vocabulary for memories,
@@ -468,6 +483,48 @@ fn use_deck(plain_flag: bool) -> bool {
     !plain_flag && !plain_env && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
 }
 
+/// `stella resume --list`: every session in the machine-wide registry,
+/// newest activity first, with the rows resumable from THIS directory
+/// marked `↩`. Local reads only — works with zero API keys.
+fn run_resume_list() -> Result<(), String> {
+    let registry = stella_store::SessionRegistry::open_default();
+    let mut sessions = registry.list();
+    if sessions.is_empty() {
+        println!("no stella sessions recorded on this machine yet");
+        return Ok(());
+    }
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.updated_at_ms));
+    let cwd = std::env::current_dir()
+        .map(|d| d.display().to_string())
+        .unwrap_or_default();
+    println!("{:2} {:<24} {:<12} SESSION", "", "ID", "STATUS");
+    for s in &sessions {
+        let resumable = registry.resumable(&s.id);
+        let marker = if resumable && s.workspace == cwd {
+            "↩"
+        } else if resumable {
+            "·"
+        } else {
+            " "
+        };
+        let title = if s.title.is_empty() {
+            s.workspace.clone()
+        } else {
+            s.title.clone()
+        };
+        println!(
+            "{marker:2} {:<24} {:<12} {title}",
+            s.id,
+            stella_store::SessionRegistry::presented_status(s).label(),
+        );
+    }
+    println!(
+        "\n↩ resumable here (`stella resume [ID]`) · resumable from its own workspace\n\
+         inside the deck: `←` on an empty prompt opens SESSIONS, `⏎` reopens a session"
+    );
+    Ok(())
+}
+
 /// The five code-graph queries, mirroring the `graph_query` agent tool's ops
 /// one-for-one so a human at the CLI and the model inside a turn see the
 /// same frames for the same question.
@@ -638,6 +695,10 @@ fn run(cli: Cli) -> Result<(), String> {
             println!("stella v{}", version_string());
             return Ok(());
         }
+        Some(Command::Resume { list: true, .. }) => {
+            // Listing reads the local registry only — no provider required.
+            return run_resume_list();
+        }
         _ => {}
     }
 
@@ -731,10 +792,35 @@ fn run(cli: Cli) -> Result<(), String> {
                     &cfg,
                     cli.budget,
                     cli.no_anim,
+                    None,
                 ))?;
             } else {
                 rt()?.block_on(agent::run_interactive(&cfg, cli.budget))?;
             }
+        }
+        Command::Resume { id, list } => {
+            // `--list` returned before provider resolution; this arm is the
+            // actual reopen, which is a full deck session (durable state is
+            // a deck feature — the plain REPL has no session to restore).
+            debug_assert!(!list, "handled before provider resolution");
+            if !use_deck(cli.plain) {
+                return Err(
+                    "`stella resume` reopens a Command Deck session and needs a real \
+                     terminal (it cannot combine with --plain / STELLA_PLAIN / a piped \
+                     stream). `stella resume --list` works anywhere."
+                        .to_string(),
+                );
+            }
+            let request = match id {
+                Some(id) => session_persist::ResumeRequest::Id(id),
+                None => session_persist::ResumeRequest::Latest,
+            };
+            rt()?.block_on(command_deck::run_deck_session(
+                &cfg,
+                cli.budget,
+                cli.no_anim,
+                Some(request),
+            ))?;
         }
         // Models/Version (and Tools) short-circuit in the first match at the
         // top of `run` before a provider is resolved; Init is handled by the

--- a/stella-cli/src/session_persist.rs
+++ b/stella-cli/src/session_persist.rs
@@ -1,0 +1,744 @@
+//! Deck-session durability — the driver-side half of `stella-store::journal`.
+//!
+//! The deck renders exclusively from its inbound envelope stream (L-T1), so
+//! durably persisting a session is one interception: every fold-relevant
+//! [`Inbound`] is mirrored to the session's append-only journal at the single
+//! channel choke point ([`spawn_journal_tee`]), and resuming is replaying
+//! that journal back through the same fold. The two remaining pieces of
+//! state the envelope stream cannot carry — the LLM conversation
+//! (`Vec<CompletionMessage>`, snapshotted at turn boundaries) and the pending
+//! prompt backlog ([`DurableQueue`], write-through on every mutation) — are
+//! atomic sidecar snapshots.
+//!
+//! Net effect: quit, Ctrl-C, a killed terminal, a dropped connection, or a
+//! power cut — the session reopens where it stood (`stella resume`, or ⏎ in
+//! the SESSIONS overlay), with at most the in-flight turn's streamed tail to
+//! re-run (its prompt comes back at the front of the queue).
+//!
+//! Everything here is best-effort by the store's own contract: persistence
+//! failure degrades to a one-time transcript warning, never a work stoppage.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use stella_protocol::CompletionMessage;
+use stella_store::journal::{self, JournalRecord, SessionJournal};
+use stella_store::{SessionRecord, SessionRegistry, SessionStatus};
+use stella_tui::{AgentMeta, AgentStatus, Inbound};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// What `stella resume` was asked to reopen.
+#[derive(Debug, Clone)]
+pub enum ResumeRequest {
+    /// The most recently active resumable session for this workspace.
+    Latest,
+    /// One specific registry id (`ses-…`).
+    Id(String),
+}
+
+/// The fold-relevant subset of one [`Inbound`], mapped to its journal form.
+/// `None` for everything the fold ignores — out-of-band view snapshots
+/// (graph, skills, MCP, sessions, notifications, issues…) are regenerated at
+/// startup, and `PromptRequeued` is deliberately excluded: the pending
+/// backlog is restored from `queue.json` and re-seeded, so journaling
+/// requeues would double-display those prompts after a resume.
+pub fn journal_record(inbound: &Inbound) -> Option<JournalRecord> {
+    match inbound {
+        Inbound::Register(meta) => Some(JournalRecord::Register {
+            agent: meta.id.clone(),
+            title: meta.title.clone(),
+            role: meta.role.clone(),
+            model: meta.model.clone(),
+        }),
+        Inbound::Event { agent, event } => Some(JournalRecord::Event {
+            agent: agent.clone(),
+            event: event.clone(),
+        }),
+        Inbound::Status { agent, status } => Some(JournalRecord::Status {
+            agent: agent.clone(),
+            status: status_key(*status).to_string(),
+        }),
+        Inbound::PromptStarted { agent, text } => Some(JournalRecord::PromptStarted {
+            agent: agent.clone(),
+            text: text.clone(),
+        }),
+        Inbound::SessionReset { agent } => Some(JournalRecord::SessionReset {
+            agent: agent.clone(),
+        }),
+        Inbound::Pipeline(on) => Some(JournalRecord::Pipeline { on: *on }),
+        _ => None,
+    }
+}
+
+/// A journal record mapped back to the [`Inbound`] the fold replays.
+/// `started_ms` stamps re-registered agents (elapsed clocks restart at
+/// resume time — the honest reading, since the old wall-clock gap wasn't
+/// work). `None` for a `Status` word this build doesn't know (a record from
+/// a newer version): skipped, exactly like an unparsable journal line.
+pub fn replay_inbound(record: JournalRecord, started_ms: u64) -> Option<Inbound> {
+    match record {
+        JournalRecord::Register {
+            agent,
+            title,
+            role,
+            model,
+        } => {
+            let mut meta = AgentMeta::new(agent, title, started_ms).with_role(role);
+            meta.model = model;
+            Some(Inbound::Register(meta))
+        }
+        JournalRecord::Event { agent, event } => Some(Inbound::Event { agent, event }),
+        JournalRecord::Status { agent, status } => Some(Inbound::Status {
+            agent,
+            status: status_from_key(&status)?,
+        }),
+        JournalRecord::PromptStarted { agent, text } => {
+            Some(Inbound::PromptStarted { agent, text })
+        }
+        JournalRecord::SessionReset { agent } => Some(Inbound::SessionReset { agent }),
+        JournalRecord::Pipeline { on } => Some(Inbound::Pipeline(on)),
+    }
+}
+
+/// Stable snake_case wire words for [`AgentStatus`] — the journal's status
+/// vocabulary. `waiting_input` is also the settle marker
+/// (`stella_store::journal::unsettled_prompt`) — renaming any of these is a
+/// wire break.
+fn status_key(status: AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Queued => "queued",
+        AgentStatus::Running => "running",
+        AgentStatus::Paused => "paused",
+        AgentStatus::WaitingInput => "waiting_input",
+        AgentStatus::Done => "done",
+        AgentStatus::Failed => "failed",
+        AgentStatus::Killed => "killed",
+    }
+}
+
+fn status_from_key(key: &str) -> Option<AgentStatus> {
+    Some(match key {
+        "queued" => AgentStatus::Queued,
+        "running" => AgentStatus::Running,
+        "paused" => AgentStatus::Paused,
+        "waiting_input" => AgentStatus::WaitingInput,
+        "done" => AgentStatus::Done,
+        "failed" => AgentStatus::Failed,
+        "killed" => AgentStatus::Killed,
+        _ => return None,
+    })
+}
+
+/// The shared journal handle: the tee task writes through it, and the driver
+/// swaps it when the deck navigates to another session. `None` = journaling
+/// unavailable (open failed) — the session still runs, it just isn't durable,
+/// and the tee surfaces that once.
+pub struct SessionSink {
+    journal: Option<SessionJournal>,
+}
+
+pub type SharedSink = Arc<Mutex<SessionSink>>;
+
+impl SessionSink {
+    pub fn shared(journal: Option<SessionJournal>) -> SharedSink {
+        Arc::new(Mutex::new(SessionSink { journal }))
+    }
+
+    fn write(&mut self, record: &JournalRecord) -> Result<(), String> {
+        match &mut self.journal {
+            Some(j) => j.write(record).map_err(|e| e.to_string()),
+            None => Ok(()),
+        }
+    }
+
+    /// Drain + fsync (clean-shutdown / handoff barrier).
+    pub fn sync(&mut self) {
+        if let Some(j) = &mut self.journal {
+            let _ = j.sync();
+        }
+    }
+
+    /// Swap to another session's journal; the old one drains and fsyncs on
+    /// drop. `None` turns journaling off (the replacement failed to open).
+    pub fn swap(&mut self, journal: Option<SessionJournal>) {
+        self.journal = journal;
+    }
+}
+
+/// Sit between the driver's send side and the deck's receive side: mirror
+/// every fold-relevant envelope into the session journal, then forward it
+/// untouched. One interception point — every producer (the driver loop, the
+/// turn forwarder, the ask-user io, spawned notifiers) already funnels
+/// through this channel, so nothing can bypass the journal by construction.
+///
+/// The first persistence failure lands one warning in the transcript (via
+/// the forward path, so it is visible wherever the user is looking) and
+/// journaling goes quiet — the store contract: observability loss, never a
+/// work stoppage.
+pub fn spawn_journal_tee(
+    mut raw_rx: UnboundedReceiver<Inbound>,
+    deck_tx: UnboundedSender<Inbound>,
+    sink: SharedSink,
+    lead: &'static str,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut warned = false;
+        while let Some(inbound) = raw_rx.recv().await {
+            if let Some(record) = journal_record(&inbound) {
+                let outcome = {
+                    let mut sink = sink.lock().unwrap_or_else(|p| p.into_inner());
+                    sink.write(&record)
+                };
+                if let Err(reason) = outcome
+                    && !warned
+                {
+                    warned = true;
+                    let _ = deck_tx.send(Inbound::Event {
+                        agent: lead.to_string(),
+                        event: stella_protocol::AgentEvent::Error {
+                            message: format!(
+                                "session journal write failed — this session will not be \
+                                 resumable past this point ({reason})"
+                            ),
+                            retryable: true,
+                        },
+                    });
+                }
+            }
+            let _ = deck_tx.send(inbound);
+        }
+        // The driver dropped its sender: final barrier before the deck ends.
+        sink.lock().unwrap_or_else(|p| p.into_inner()).sync();
+    })
+}
+
+/// The dispatch backlog with write-through durability: every mutation lands
+/// `queue.json` before it is observable, so a prompt the user queued
+/// survives any interruption from that instant on. Persistence failures are
+/// remembered once ([`DurableQueue::take_warning`]) and never block.
+pub struct DurableQueue {
+    items: VecDeque<String>,
+    dir: PathBuf,
+    warning: Option<String>,
+}
+
+impl DurableQueue {
+    /// A fresh, empty backlog for `dir` (no eager write — the sidecar
+    /// appears when there is something to persist).
+    pub fn fresh(dir: PathBuf) -> Self {
+        Self {
+            items: VecDeque::new(),
+            dir,
+            warning: None,
+        }
+    }
+
+    /// Adopt a restored backlog (resume / session switch): contents replace
+    /// wholesale and are persisted immediately, so the on-disk state and the
+    /// adopted state can never drift.
+    pub fn adopt(&mut self, dir: PathBuf, items: Vec<String>) {
+        self.dir = dir;
+        self.items = items.into();
+        self.persist();
+    }
+
+    fn persist(&mut self) {
+        let items: Vec<String> = self.items.iter().cloned().collect();
+        if let Err(e) = journal::write_queue(&self.dir, &items)
+            && self.warning.is_none()
+        {
+            self.warning = Some(format!(
+                "prompt-queue persistence failed — queued prompts will not survive an \
+                 interruption ({e})"
+            ));
+        }
+    }
+
+    /// One-time persistence-failure warning for the driver to surface.
+    pub fn take_warning(&mut self) -> Option<String> {
+        self.warning.take()
+    }
+
+    pub fn pop_front(&mut self) -> Option<String> {
+        let item = self.items.pop_front();
+        if item.is_some() {
+            self.persist();
+        }
+        item
+    }
+
+    pub fn push_back(&mut self, text: String) {
+        self.items.push_back(text);
+        self.persist();
+    }
+
+    pub fn push_front(&mut self, text: String) {
+        self.items.push_front(text);
+        self.persist();
+    }
+
+    pub fn remove(&mut self, index: usize) -> Option<String> {
+        let item = self.items.remove(index);
+        if item.is_some() {
+            self.persist();
+        }
+        item
+    }
+
+    pub fn clear(&mut self) {
+        if !self.items.is_empty() {
+            self.items.clear();
+            self.persist();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// Everything loaded from disk to reopen one session.
+pub struct ResumeState {
+    /// The registry record as stored (adopt it: new pid, live status).
+    pub record: SessionRecord,
+    /// The full journal, ready to replay through the fold.
+    pub records: Vec<JournalRecord>,
+    /// The LLM conversation at the last committed turn boundary.
+    pub history: Option<Vec<CompletionMessage>>,
+    /// The pending backlog exactly as the user last saw it.
+    pub queue: Vec<String>,
+    /// The prompt an interruption cut short mid-turn, if any — goes back to
+    /// the FRONT of the queue (already deduplicated against `queue`).
+    pub interrupted: Option<String>,
+    /// The staged-pipeline toggle to restore (`None` = default).
+    pub pipeline: Option<bool>,
+    /// Cumulative session spend to re-seed the budget guard (monotone spend
+    /// across interruptions; a session budget keeps meaning "this session").
+    pub spent_usd: Option<f64>,
+}
+
+/// Resolve what a `stella resume` invocation points at, without loading it.
+pub fn resolve_resume_target(
+    registry: &SessionRegistry,
+    workspace: &str,
+    request: &ResumeRequest,
+) -> Result<SessionRecord, String> {
+    match request {
+        ResumeRequest::Id(id) => registry
+            .get(id)
+            .ok_or_else(|| format!("no session `{id}` in the registry")),
+        ResumeRequest::Latest => registry.latest_resumable(workspace).ok_or_else(|| {
+            format!(
+                "no resumable session for this workspace — `stella resume --list` shows \
+                 every session ({workspace})"
+            )
+        }),
+    }
+}
+
+/// Load one session's durable state, validating that it can be reopened
+/// HERE: it must exist, must not be owned by a live process, must belong to
+/// this workspace (the deck's tools, memory, and graph are workspace-bound),
+/// and must have state on disk.
+pub fn load_resume(
+    registry: &SessionRegistry,
+    id: &str,
+    workspace: &str,
+) -> Result<ResumeState, String> {
+    let record = registry
+        .get(id)
+        .ok_or_else(|| format!("no session `{id}` in the registry"))?;
+    if SessionRegistry::presented_status(&record).is_live() {
+        return Err(format!(
+            "session `{id}` is live in another stella process (pid {}) — attach is not a \
+             thing yet; stop that session first",
+            record.pid
+        ));
+    }
+    if record.workspace != workspace {
+        return Err(format!(
+            "session `{id}` belongs to {} — resume it from that workspace",
+            record.workspace
+        ));
+    }
+    let dir = registry.sidecar_dir(id);
+    if !journal::has_state(&dir) {
+        return Err(format!(
+            "session `{id}` has no durable state to restore (it predates session journaling)"
+        ));
+    }
+    let records = journal::read_journal(&dir);
+    let history = journal::read_history(&dir);
+    let queue = journal::read_queue(&dir);
+    let interrupted = journal::unsettled_prompt(&records)
+        .map(|(_, text)| text)
+        // Already at the front of the restored backlog (a crash between the
+        // requeue and the next dispatch) → re-adding would double it.
+        .filter(|text| queue.first() != Some(text));
+    let pipeline = journal::last_pipeline(&records);
+    let spent_usd = journal::last_spent_usd(&records);
+    Ok(ResumeState {
+        record,
+        records,
+        history,
+        queue,
+        interrupted,
+        pipeline,
+        spent_usd,
+    })
+}
+
+/// Replay a loaded journal straight into the deck (bypassing the tee — a
+/// replay must never re-journal itself, or every resume would double the
+/// file). The caller replays BEFORE its first live send so ordering is the
+/// original stream's.
+pub fn replay_session(
+    records: Vec<JournalRecord>,
+    started_ms: u64,
+    deck_tx: &UnboundedSender<Inbound>,
+) {
+    for record in records {
+        if let Some(inbound) = replay_inbound(record, started_ms) {
+            let _ = deck_tx.send(inbound);
+        }
+    }
+}
+
+/// Atomically snapshot the conversation at a turn boundary. Returns the
+/// one-line warning to surface on the first failure (`None` = landed).
+pub fn snapshot_history(dir: &Path, messages: &[CompletionMessage]) -> Option<String> {
+    journal::write_history(dir, messages).err().map(|e| {
+        format!(
+            "conversation snapshot failed — resuming this session would lose the latest \
+             turn ({e})"
+        )
+    })
+}
+
+/// Rebuild `messages` for a resumed conversation: the stored history with
+/// the system prompt regenerated fresh (rules/config may have changed since
+/// the session first started; the stable prefix must reflect today's).
+pub fn restore_messages(
+    stored: Vec<CompletionMessage>,
+    system_prompt: &str,
+) -> Vec<CompletionMessage> {
+    let mut messages = stored;
+    match messages.first() {
+        Some(first) if first.role == stella_protocol::MessageRole::System => {
+            messages[0] = CompletionMessage::system(system_prompt.to_string());
+        }
+        _ => messages.insert(0, CompletionMessage::system(system_prompt.to_string())),
+    }
+    messages
+}
+
+/// A stored registry record re-owned by THIS process at resume time.
+pub fn adopt_record(mut record: SessionRecord, status: SessionStatus) -> SessionRecord {
+    record.pid = std::process::id();
+    record.status = status;
+    record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::AgentEvent;
+
+    fn wire(r: &JournalRecord) -> String {
+        serde_json::to_string(r).unwrap()
+    }
+
+    #[test]
+    fn fold_relevant_inbounds_journal_and_out_of_band_ones_do_not() {
+        let meta = AgentMeta::new("lead", "t", 7).with_role("lead");
+        assert!(journal_record(&Inbound::Register(meta)).is_some());
+        assert!(
+            journal_record(&Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Text { delta: "x".into() },
+            })
+            .is_some()
+        );
+        assert!(
+            journal_record(&Inbound::Status {
+                agent: "lead".into(),
+                status: AgentStatus::WaitingInput,
+            })
+            .is_some()
+        );
+        assert!(
+            journal_record(&Inbound::PromptStarted {
+                agent: "lead".into(),
+                text: "p".into(),
+            })
+            .is_some()
+        );
+        assert!(
+            journal_record(&Inbound::SessionReset {
+                agent: "lead".into(),
+            })
+            .is_some()
+        );
+        assert!(journal_record(&Inbound::Pipeline(true)).is_some());
+
+        // Out-of-band view state must never journal…
+        assert!(journal_record(&Inbound::Sessions(vec![])).is_none());
+        assert!(journal_record(&Inbound::Notifications(vec![])).is_none());
+        assert!(journal_record(&Inbound::ShowHelp).is_none());
+        // …and neither does PromptRequeued: the backlog restores from
+        // queue.json, so a journaled requeue would double-display it.
+        assert!(
+            journal_record(&Inbound::PromptRequeued {
+                agent: "lead".into(),
+                text: "p".into(),
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn status_words_roundtrip_and_unknown_words_skip() {
+        for status in [
+            AgentStatus::Queued,
+            AgentStatus::Running,
+            AgentStatus::Paused,
+            AgentStatus::WaitingInput,
+            AgentStatus::Done,
+            AgentStatus::Failed,
+            AgentStatus::Killed,
+        ] {
+            assert_eq!(status_from_key(status_key(status)), Some(status));
+        }
+        assert_eq!(status_from_key("hyperspace"), None);
+        assert!(
+            replay_inbound(
+                JournalRecord::Status {
+                    agent: "lead".into(),
+                    status: "hyperspace".into(),
+                },
+                0,
+            )
+            .is_none(),
+            "a status word from the future is skipped, not misread"
+        );
+    }
+
+    #[test]
+    fn journal_then_replay_is_identity_on_the_fold_relevant_stream() {
+        let mut meta = AgentMeta::new("lead", "acme", 1).with_role("lead");
+        meta.model = Some("z/glm".into());
+        let stream = vec![
+            Inbound::Register(meta),
+            Inbound::PromptStarted {
+                agent: "lead".into(),
+                text: "fix it".into(),
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Text { delta: "on".into() },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Complete {
+                    model: "z/glm".into(),
+                    cost_usd: 0.01,
+                },
+            },
+            Inbound::Status {
+                agent: "lead".into(),
+                status: AgentStatus::WaitingInput,
+            },
+            Inbound::Pipeline(false),
+        ];
+        for inbound in stream {
+            let record = journal_record(&inbound).expect("fold-relevant");
+            let replayed = replay_inbound(record.clone(), 1).expect("replayable");
+            let back = journal_record(&replayed).expect("still fold-relevant");
+            assert_eq!(wire(&record), wire(&back), "replay must not distort");
+        }
+    }
+
+    #[test]
+    fn restore_messages_regenerates_the_system_prefix() {
+        let stored = vec![
+            CompletionMessage::system("old prompt"),
+            CompletionMessage::user("hi"),
+        ];
+        let restored = restore_messages(stored, "new prompt");
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[0].content, "new prompt");
+        assert_eq!(restored[1].content, "hi");
+
+        // A history that somehow lost its system head gets one prepended.
+        let headless = vec![CompletionMessage::user("hi")];
+        let restored = restore_messages(headless, "new prompt");
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[0].role, stella_protocol::MessageRole::System);
+    }
+
+    /// THE durability witness: a live envelope stream folded directly vs.
+    /// the same stream journaled to disk (coalescing, torn-tail handling and
+    /// all), read back, and replayed through the same fold — the deck state
+    /// must be indistinguishable. This is what "nothing is ever lost" means
+    /// mechanically: the session on screen IS a pure function of what is on
+    /// disk.
+    #[test]
+    fn replaying_the_journal_reproduces_the_deck_fold_exactly() {
+        use stella_protocol::{ToolCall, ToolOutput};
+        use stella_tui::WorkspaceModel;
+
+        let mut meta = AgentMeta::new("lead", "acme", 0).with_role("lead");
+        meta.model = Some("z/glm".into());
+        let stream = vec![
+            Inbound::Register(meta),
+            Inbound::PromptStarted {
+                agent: "lead".into(),
+                text: "fix the flaky test".into(),
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Stage {
+                    name: stella_protocol::StageKind::Execute,
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Text {
+                    delta: "loo".into(),
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Text {
+                    delta: "king…".into(),
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::ToolStart {
+                    call: ToolCall {
+                        call_id: "c1".into(),
+                        name: "read_file".into(),
+                        input: serde_json::json!({ "path": "src/lib.rs" }),
+                    },
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::ToolResult {
+                    call_id: "c1".into(),
+                    output: ToolOutput::Ok {
+                        content: "fn x() {}".into(),
+                    },
+                    duration_ms: 12,
+                    speculated: false,
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::StepUsage {
+                    step: 1,
+                    model: "z/glm".into(),
+                    input_tokens: 900,
+                    output_tokens: 60,
+                    cached_input_tokens: 300,
+                    cache_write_tokens: 0,
+                    estimated_input_tokens: 880,
+                    cost_usd: 0.004,
+                    duration_ms: 900,
+                    retries: 0,
+                    tool_calls: 1,
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Text {
+                    delta: "done.".into(),
+                },
+            },
+            Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Complete {
+                    model: "z/glm".into(),
+                    cost_usd: 0.004,
+                },
+            },
+            Inbound::Status {
+                agent: "lead".into(),
+                status: AgentStatus::WaitingInput,
+            },
+            Inbound::Pipeline(false),
+        ];
+
+        // Live fold.
+        let mut live = WorkspaceModel::new();
+        for inbound in &stream {
+            live.apply_inbound(inbound);
+        }
+
+        // Journal → disk → read → replay → fold.
+        let dir = std::env::temp_dir().join(format!("stella-replay-equiv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let mut j = SessionJournal::open(&dir).unwrap();
+            for inbound in &stream {
+                if let Some(record) = journal_record(inbound) {
+                    j.write(&record).unwrap();
+                }
+            }
+        }
+        let mut replayed = WorkspaceModel::new();
+        for record in journal::read_journal(&dir) {
+            if let Some(inbound) = replay_inbound(record, 0) {
+                replayed.apply_inbound(&inbound);
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(live.agents.len(), replayed.agents.len());
+        let (a, b) = (&live.agents[0], &replayed.agents[0]);
+        // The entire per-agent transcript fold (`SessionModel` is PartialEq):
+        // prompt echo, stages, coalesced text, tool cards, HUD state.
+        assert_eq!(a.model, b.model, "transcripts must be indistinguishable");
+        assert_eq!(a.status, b.status);
+        assert_eq!(a.tokens_in, b.tokens_in);
+        assert_eq!(a.tokens_out, b.tokens_out);
+        assert_eq!(a.cost_usd, b.cost_usd);
+        assert_eq!(a.meta.model, b.meta.model);
+        assert_eq!(live.pipeline, replayed.pipeline);
+        // NOT asserted: trace-row count. The trace is a per-event activity
+        // ring, and the journal coalesces adjacent streaming deltas by
+        // design — two `Text` deltas replay as one event. Everything the
+        // user reads back (transcript, HUD, spend, status) is identical.
+    }
+
+    #[test]
+    fn durable_queue_writes_through_every_mutation() {
+        let dir = std::env::temp_dir().join(format!("stella-durable-queue-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut q = DurableQueue::fresh(dir.clone());
+        q.push_back("a".into());
+        q.push_back("b".into());
+        q.push_front("first".into());
+        assert_eq!(
+            journal::read_queue(&dir),
+            vec!["first".to_string(), "a".to_string(), "b".to_string()]
+        );
+
+        assert_eq!(q.pop_front().as_deref(), Some("first"));
+        assert_eq!(q.remove(1).as_deref(), Some("b"));
+        assert_eq!(journal::read_queue(&dir), vec!["a".to_string()]);
+
+        q.clear();
+        assert!(journal::read_queue(&dir).is_empty());
+        assert!(q.take_warning().is_none(), "healthy disk, no warning");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/stella-store/src/journal.rs
+++ b/stella-store/src/journal.rs
@@ -1,0 +1,631 @@
+//! Durable per-session state — the crash-safe sidecar that makes every deck
+//! session resumable: quit, Ctrl-C, a killed terminal, or a power cut, and
+//! `stella resume` (or ⏎ in the SESSIONS overlay) reopens the session exactly
+//! where it stood. Nothing the user typed, and nothing a finished turn
+//! produced, is ever lost to an interruption.
+//!
+//! Each session owns one sidecar directory next to its registry record
+//! (`data_dir()/sessions/<id>/`, see [`crate::sessions::SessionRegistry`]):
+//!
+//! - **`journal.jsonl`** — the append-only transcript journal: one
+//!   [`JournalRecord`] per line, written live at the deck driver's single
+//!   envelope choke point. Replaying it through the deck's pure fold rebuilds
+//!   the visible session (transcript, spend, files, traces) byte-for-byte —
+//!   the same replay-determinism the fold was designed around.
+//! - **`history.json`** — the LLM conversation (`Vec<CompletionMessage>`),
+//!   snapshotted atomically at every turn boundary. This is what makes the
+//!   conversation *continuable*: the next prompt after a resume picks up from
+//!   the last committed turn.
+//! - **`queue.json`** — the pending prompt backlog, rewritten atomically on
+//!   every queue mutation. A prompt the user queued is durable the moment it
+//!   is queued.
+//!
+//! ## Crash-safety contract
+//!
+//! The journal is append-only; a torn final line (the write a power cut
+//! interrupted) is tolerated and skipped on read. Snapshots are
+//! temp+fsync+rename, so a reader sees the old state or the new state, never
+//! a torn one. Streamed `Text`/`Reasoning` deltas are coalesced per run and
+//! written through the OS page cache; conversation *transitions* (a prompt
+//! dispatched, a turn completed or failed, a reset) are fsynced. The worst a
+//! power cut can lose is the streamed tail of the turn that was in flight —
+//! and that turn's prompt is re-queued on resume (its `PromptStarted` has no
+//! settle record after it), so the work itself is never lost.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write as _;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use stella_protocol::{AgentEvent, CompletionMessage};
+
+use crate::{Result, StoreError};
+
+/// The append-only transcript journal file inside a session's sidecar dir.
+pub const JOURNAL_FILE: &str = "journal.jsonl";
+/// The LLM conversation snapshot inside a session's sidecar dir.
+pub const HISTORY_FILE: &str = "history.json";
+/// The pending prompt backlog snapshot inside a session's sidecar dir.
+pub const QUEUE_FILE: &str = "queue.json";
+
+/// Flush the coalescing buffer once it holds this many bytes even if the
+/// delta run hasn't ended — bounds journal-write latency on very long
+/// uninterrupted streams without fsyncing per token.
+const DELTA_FLUSH_BYTES: usize = 8 * 1024;
+
+/// One journaled record — the serializable mirror of the deck's fold-relevant
+/// inbound envelope (the TUI's `Inbound`). The deck crate deliberately never
+/// links this store, so the driver maps one to the other; out-of-band view
+/// snapshots (graph, skills, MCP, sessions, notifications…) are regenerated
+/// at startup and are *not* journaled — only what the pure fold consumes.
+///
+/// The wire is additive-only, exactly like `--output-format stream-json`:
+/// variants and fields may be added, never renamed, and readers skip lines
+/// they cannot parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum JournalRecord {
+    /// An agent joined the workspace (dashboard row + display meta).
+    Register {
+        agent: String,
+        title: String,
+        role: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+    },
+    /// One `AgentEvent` belonging to one agent — the transcript stream.
+    Event { agent: String, event: AgentEvent },
+    /// A supervisor lifecycle transition (snake_case, e.g. `waiting_input`).
+    /// `waiting_input` doubles as the settle marker for prompts that were
+    /// handled without a model turn (`/help`, `/init`, …).
+    Status { agent: String, status: String },
+    /// The dispatcher handed a prompt to an agent. A `PromptStarted` with no
+    /// settle record after it (`Complete`, a non-retryable `Error`, or a
+    /// `waiting_input` status) marks the turn an interruption cut short —
+    /// resume returns its text to the front of the queue.
+    PromptStarted { agent: String, text: String },
+    /// `/clear` — the agent's transcript and counters reset to seq 0.
+    SessionReset { agent: String },
+    /// Staged-pipeline routing toggled; the last value wins on resume.
+    Pipeline { on: bool },
+}
+
+impl JournalRecord {
+    /// Whether landing this record must reach the disk platter (fsync), not
+    /// just the OS page cache: the conversation-transition records that a
+    /// power cut must never take back. The high-frequency mid-turn stream
+    /// (deltas, tool activity, usage ticks) is buffered instead — an
+    /// interrupted turn re-runs on resume, so its tail is reproducible.
+    fn is_transition(&self) -> bool {
+        match self {
+            JournalRecord::Register { .. }
+            | JournalRecord::Status { .. }
+            | JournalRecord::PromptStarted { .. }
+            | JournalRecord::SessionReset { .. }
+            | JournalRecord::Pipeline { .. } => true,
+            JournalRecord::Event { event, .. } => {
+                matches!(
+                    event,
+                    AgentEvent::Complete { .. } | AgentEvent::Error { .. }
+                )
+            }
+        }
+    }
+}
+
+/// Which streaming-delta kind a pending coalescing run holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeltaKind {
+    Text,
+    Reasoning,
+}
+
+/// An open, coalescing run of streaming deltas not yet written out.
+#[derive(Debug)]
+struct PendingDeltas {
+    agent: String,
+    kind: DeltaKind,
+    buf: String,
+}
+
+/// The append-only journal writer for one session's sidecar dir. One writer
+/// per session process (the same single-writer discipline as the registry);
+/// readers only ever open the file independently via [`read_journal`].
+///
+/// Consecutive `Text` (or `Reasoning`) deltas for the same agent are
+/// coalesced into one record before hitting the file — the fold concatenates
+/// deltas, so replaying the coalesced run is byte-identical to replaying the
+/// original stream, at a fraction of the lines and syncs.
+#[derive(Debug)]
+pub struct SessionJournal {
+    file: File,
+    pending: Option<PendingDeltas>,
+}
+
+impl SessionJournal {
+    /// Open (creating the sidecar dir and file as needed) for appending.
+    pub fn open(dir: &Path) -> Result<Self> {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| StoreError(format!("cannot create {}: {e}", dir.display())))?;
+        let path = dir.join(JOURNAL_FILE);
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| StoreError(format!("cannot open {}: {e}", path.display())))?;
+        // Heal a torn tail before appending: without the terminator, the
+        // first record written after recovery would fuse into the very line
+        // the interruption tore, corrupting BOTH.
+        if unterminated_tail(&path) {
+            file.write_all(b"\n")
+                .map_err(|e| StoreError(format!("cannot heal {}: {e}", path.display())))?;
+        }
+        Ok(Self {
+            file,
+            pending: None,
+        })
+    }
+
+    /// Append one record. Streaming deltas coalesce into a pending run;
+    /// anything else flushes that run first (order is preserved) and then
+    /// lands itself — fsynced when it is a conversation transition.
+    pub fn write(&mut self, record: &JournalRecord) -> Result<()> {
+        if let JournalRecord::Event { agent, event } = record {
+            let (kind, delta) = match event {
+                AgentEvent::Text { delta } => (DeltaKind::Text, delta),
+                AgentEvent::Reasoning { delta } => (DeltaKind::Reasoning, delta),
+                _ => {
+                    self.flush_pending()?;
+                    return self.write_line(record);
+                }
+            };
+            match &mut self.pending {
+                Some(p) if p.agent == *agent && p.kind == kind => p.buf.push_str(delta),
+                _ => {
+                    self.flush_pending()?;
+                    self.pending = Some(PendingDeltas {
+                        agent: agent.clone(),
+                        kind,
+                        buf: delta.clone(),
+                    });
+                }
+            }
+            if self
+                .pending
+                .as_ref()
+                .is_some_and(|p| p.buf.len() >= DELTA_FLUSH_BYTES)
+            {
+                self.flush_pending()?;
+            }
+            return Ok(());
+        }
+        self.flush_pending()?;
+        self.write_line(record)
+    }
+
+    /// Write any pending coalesced run out (page cache, no fsync).
+    fn flush_pending(&mut self) -> Result<()> {
+        let Some(p) = self.pending.take() else {
+            return Ok(());
+        };
+        let event = match p.kind {
+            DeltaKind::Text => AgentEvent::Text { delta: p.buf },
+            DeltaKind::Reasoning => AgentEvent::Reasoning { delta: p.buf },
+        };
+        self.write_line_unsynced(&JournalRecord::Event {
+            agent: p.agent,
+            event,
+        })
+    }
+
+    fn write_line(&mut self, record: &JournalRecord) -> Result<()> {
+        self.write_line_unsynced(record)?;
+        if record.is_transition() {
+            self.file
+                .sync_data()
+                .map_err(|e| StoreError(format!("journal fsync failed: {e}")))?;
+        }
+        Ok(())
+    }
+
+    fn write_line_unsynced(&mut self, record: &JournalRecord) -> Result<()> {
+        let mut line = serde_json::to_string(record)
+            .map_err(|e| StoreError(format!("cannot serialize journal record: {e}")))?;
+        line.push('\n');
+        self.file
+            .write_all(line.as_bytes())
+            .map_err(|e| StoreError(format!("journal write failed: {e}")))
+    }
+
+    /// Drain any pending run and fsync — the clean-shutdown / handoff barrier
+    /// (called before a session switch and at deck exit).
+    pub fn sync(&mut self) -> Result<()> {
+        self.flush_pending()?;
+        self.file
+            .sync_data()
+            .map_err(|e| StoreError(format!("journal fsync failed: {e}")))
+    }
+}
+
+impl Drop for SessionJournal {
+    fn drop(&mut self) {
+        // Best-effort: never lose a buffered tail to an orderly drop. Errors
+        // are unreportable here by construction.
+        let _ = self.sync();
+    }
+}
+
+/// Whether the journal's last byte is NOT a newline — the signature of a
+/// write an interruption tore mid-line. Missing/empty/unreadable → false.
+fn unterminated_tail(path: &Path) -> bool {
+    use std::io::{Read as _, Seek as _, SeekFrom};
+    let Ok(mut f) = File::open(path) else {
+        return false;
+    };
+    let Ok(len) = f.seek(SeekFrom::End(0)) else {
+        return false;
+    };
+    if len == 0 {
+        return false;
+    }
+    if f.seek(SeekFrom::End(-1)).is_err() {
+        return false;
+    }
+    let mut last = [0u8; 1];
+    f.read_exact(&mut last).is_ok() && last[0] != b'\n'
+}
+
+/// Read a session's journal, oldest first. Missing file → empty. A line that
+/// does not parse — the torn tail of an interrupted write, or a record from
+/// a newer version — is skipped: one bad line never hides the session.
+pub fn read_journal(dir: &Path) -> Vec<JournalRecord> {
+    let Ok(text) = std::fs::read_to_string(dir.join(JOURNAL_FILE)) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Atomically snapshot the LLM conversation (`history.json`).
+pub fn write_history(dir: &Path, messages: &[CompletionMessage]) -> Result<()> {
+    write_snapshot(dir, HISTORY_FILE, messages)
+}
+
+/// Load the LLM conversation snapshot; `None` when absent or unreadable.
+pub fn read_history(dir: &Path) -> Option<Vec<CompletionMessage>> {
+    let text = std::fs::read_to_string(dir.join(HISTORY_FILE)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Atomically snapshot the pending prompt backlog (`queue.json`).
+pub fn write_queue(dir: &Path, queue: &[String]) -> Result<()> {
+    write_snapshot(dir, QUEUE_FILE, queue)
+}
+
+/// Load the pending prompt backlog; empty when absent or unreadable.
+pub fn read_queue(dir: &Path) -> Vec<String> {
+    std::fs::read_to_string(dir.join(QUEUE_FILE))
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+/// Whether a sidecar dir holds anything to restore — the resumability test.
+pub fn has_state(dir: &Path) -> bool {
+    dir.join(HISTORY_FILE).exists() || dir.join(JOURNAL_FILE).exists()
+}
+
+/// temp + fsync + rename: a reader (or a resume after a power cut) sees the
+/// old snapshot or the new one, never a torn mix. The registry's plain
+/// temp+rename is not enough here — an unfsynced rename can surface an empty
+/// file after a crash, and these snapshots ARE the conversation.
+fn write_snapshot<T: Serialize + ?Sized>(dir: &Path, name: &str, value: &T) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| StoreError(format!("cannot create {}: {e}", dir.display())))?;
+    let json = serde_json::to_string(value)
+        .map_err(|e| StoreError(format!("cannot serialize {name}: {e}")))?;
+    let path = dir.join(name);
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    let mut file = File::create(&tmp)
+        .map_err(|e| StoreError(format!("cannot create {}: {e}", tmp.display())))?;
+    file.write_all(json.as_bytes())
+        .map_err(|e| StoreError(format!("cannot write {}: {e}", tmp.display())))?;
+    file.sync_data()
+        .map_err(|e| StoreError(format!("cannot fsync {}: {e}", tmp.display())))?;
+    drop(file);
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| StoreError(format!("cannot replace {}: {e}", path.display())))
+}
+
+/// Scan a journal for the prompt an interruption cut short: the LAST
+/// `PromptStarted` with no settle record after it. Settle records are a
+/// `Complete`, a **non-retryable** `Error` (a retryable one is a mid-turn
+/// warning, not an outcome), or a `waiting_input` status (how prompts that
+/// never ran a model turn — `/help`, `/init` — settle). Turns are serial per
+/// agent, so at most one prompt can be unsettled.
+pub fn unsettled_prompt(records: &[JournalRecord]) -> Option<(String, String)> {
+    let started = records
+        .iter()
+        .rposition(|r| matches!(r, JournalRecord::PromptStarted { .. }))?;
+    let Some(JournalRecord::PromptStarted { agent, text }) = records.get(started) else {
+        return None;
+    };
+    let settled = records[started + 1..].iter().any(|r| match r {
+        JournalRecord::Event { agent: a, event } if a == agent => matches!(
+            event,
+            AgentEvent::Complete { .. }
+                | AgentEvent::Error {
+                    retryable: false,
+                    ..
+                }
+        ),
+        JournalRecord::Status { agent: a, status } if a == agent => status == "waiting_input",
+        _ => false,
+    });
+    (!settled).then(|| (agent.clone(), text.clone()))
+}
+
+/// The last journaled staged-pipeline toggle, if any — resume restores it.
+pub fn last_pipeline(records: &[JournalRecord]) -> Option<bool> {
+    records.iter().rev().find_map(|r| match r {
+        JournalRecord::Pipeline { on } => Some(*on),
+        _ => None,
+    })
+}
+
+/// The last journaled cumulative session spend (`BudgetTick.spent_usd`), if
+/// any — resume re-seeds the budget guard so spend stays monotone across
+/// interruptions instead of silently resetting to zero.
+pub fn last_spent_usd(records: &[JournalRecord]) -> Option<f64> {
+    records.iter().rev().find_map(|r| match r {
+        JournalRecord::Event {
+            event: AgentEvent::BudgetTick { spent_usd, .. },
+            ..
+        } => Some(*spent_usd),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "stella-journal-{tag}-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("t").len()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn text(agent: &str, delta: &str) -> JournalRecord {
+        JournalRecord::Event {
+            agent: agent.into(),
+            event: AgentEvent::Text {
+                delta: delta.into(),
+            },
+        }
+    }
+
+    fn complete(agent: &str) -> JournalRecord {
+        JournalRecord::Event {
+            agent: agent.into(),
+            event: AgentEvent::Complete {
+                model: "m".into(),
+                cost_usd: 0.0,
+            },
+        }
+    }
+
+    fn started(agent: &str, t: &str) -> JournalRecord {
+        JournalRecord::PromptStarted {
+            agent: agent.into(),
+            text: t.into(),
+        }
+    }
+
+    /// Wire-form equality — the honest comparison for a wire type
+    /// (`AgentEvent` deliberately derives no `PartialEq`).
+    fn js(records: &[JournalRecord]) -> Vec<String> {
+        records
+            .iter()
+            .map(|r| serde_json::to_string(r).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn roundtrip_coalesces_delta_runs_preserving_order_and_bytes() {
+        let dir = temp_dir("roundtrip");
+        {
+            let mut j = SessionJournal::open(&dir).unwrap();
+            j.write(&JournalRecord::Register {
+                agent: "lead".into(),
+                title: "t".into(),
+                role: "lead".into(),
+                model: None,
+            })
+            .unwrap();
+            j.write(&started("lead", "do the thing")).unwrap();
+            j.write(&text("lead", "hel")).unwrap();
+            j.write(&text("lead", "lo")).unwrap();
+            j.write(&JournalRecord::Event {
+                agent: "lead".into(),
+                event: AgentEvent::Reasoning { delta: "hm".into() },
+            })
+            .unwrap();
+            j.write(&text("lead", " world")).unwrap();
+            j.write(&complete("lead")).unwrap();
+        }
+        let back = read_journal(&dir);
+        // Runs coalesce (hel+lo), kind changes split, order is preserved.
+        assert_eq!(
+            js(&back),
+            js(&[
+                JournalRecord::Register {
+                    agent: "lead".into(),
+                    title: "t".into(),
+                    role: "lead".into(),
+                    model: None,
+                },
+                started("lead", "do the thing"),
+                text("lead", "hello"),
+                JournalRecord::Event {
+                    agent: "lead".into(),
+                    event: AgentEvent::Reasoning { delta: "hm".into() },
+                },
+                text("lead", " world"),
+                complete("lead"),
+            ])
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delta_runs_do_not_merge_across_agents() {
+        let dir = temp_dir("agents");
+        {
+            let mut j = SessionJournal::open(&dir).unwrap();
+            j.write(&text("a", "1")).unwrap();
+            j.write(&text("b", "2")).unwrap();
+            j.write(&text("a", "3")).unwrap();
+        }
+        assert_eq!(
+            js(&read_journal(&dir)),
+            js(&[text("a", "1"), text("b", "2"), text("a", "3")])
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn torn_tail_is_skipped_and_the_clean_prefix_survives() {
+        let dir = temp_dir("torn");
+        {
+            let mut j = SessionJournal::open(&dir).unwrap();
+            j.write(&started("lead", "p")).unwrap();
+            j.write(&complete("lead")).unwrap();
+        }
+        // Simulate the write a power cut interrupted: a truncated line.
+        use std::io::Write as _;
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(dir.join(JOURNAL_FILE))
+            .unwrap();
+        f.write_all(b"{\"type\":\"prompt_start").unwrap();
+        drop(f);
+
+        assert_eq!(
+            js(&read_journal(&dir)),
+            js(&[started("lead", "p"), complete("lead")])
+        );
+        // And appending after recovery keeps working.
+        let mut j = SessionJournal::open(&dir).unwrap();
+        j.write(&started("lead", "again")).unwrap();
+        drop(j);
+        assert_eq!(read_journal(&dir).len(), 3);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unsettled_prompt_is_the_interrupted_one_only() {
+        let a = "lead".to_string();
+        // Settled by Complete.
+        let settled = vec![started(&a, "one"), complete(&a)];
+        assert_eq!(unsettled_prompt(&settled), None);
+        // Settled by a handled command's waiting_input status.
+        let handled = vec![
+            started(&a, "/help"),
+            JournalRecord::Status {
+                agent: a.clone(),
+                status: "waiting_input".into(),
+            },
+        ];
+        assert_eq!(unsettled_prompt(&handled), None);
+        // A retryable error is a warning, not a settle.
+        let interrupted = vec![
+            started(&a, "one"),
+            complete(&a),
+            started(&a, "two"),
+            JournalRecord::Event {
+                agent: a.clone(),
+                event: AgentEvent::Error {
+                    message: "store write failed".into(),
+                    retryable: true,
+                },
+            },
+        ];
+        assert_eq!(
+            unsettled_prompt(&interrupted),
+            Some((a.clone(), "two".into()))
+        );
+        // A non-retryable error (cancel/abort) settles.
+        let aborted = vec![
+            started(&a, "two"),
+            JournalRecord::Event {
+                agent: a.clone(),
+                event: AgentEvent::Error {
+                    message: "turn stopped by user".into(),
+                    retryable: false,
+                },
+            },
+        ];
+        assert_eq!(unsettled_prompt(&aborted), None);
+        assert_eq!(unsettled_prompt(&[]), None);
+    }
+
+    #[test]
+    fn history_and_queue_snapshots_roundtrip_and_default_empty() {
+        let dir = temp_dir("snap");
+        assert_eq!(read_history(&dir), None);
+        assert!(read_queue(&dir).is_empty());
+        assert!(!has_state(&dir));
+
+        let history = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("hi"),
+            CompletionMessage::assistant("hello"),
+        ];
+        write_history(&dir, &history).unwrap();
+        write_queue(&dir, &["a".into(), "b".into()]).unwrap();
+        assert_eq!(read_history(&dir).unwrap(), history);
+        assert_eq!(read_queue(&dir), vec!["a".to_string(), "b".to_string()]);
+        assert!(has_state(&dir));
+
+        // Overwrite is atomic-replace, not append.
+        write_queue(&dir, &[]).unwrap();
+        assert!(read_queue(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pipeline_and_spend_scans_take_the_last_value() {
+        let records = vec![
+            JournalRecord::Pipeline { on: true },
+            JournalRecord::Event {
+                agent: "lead".into(),
+                event: AgentEvent::BudgetTick {
+                    spent_usd: 0.5,
+                    limit_usd: None,
+                    mode: stella_protocol::BudgetMode::Observed,
+                },
+            },
+            JournalRecord::Pipeline { on: false },
+            JournalRecord::Event {
+                agent: "lead".into(),
+                event: AgentEvent::BudgetTick {
+                    spent_usd: 1.25,
+                    limit_usd: None,
+                    mode: stella_protocol::BudgetMode::Observed,
+                },
+            },
+        ];
+        assert_eq!(last_pipeline(&records), Some(false));
+        assert_eq!(last_spent_usd(&records), Some(1.25));
+        assert_eq!(last_pipeline(&[]), None);
+        assert_eq!(last_spent_usd(&[]), None);
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -74,11 +74,13 @@ use serde::Serialize;
 use stella_protocol::{AgentEvent, ToolOutput};
 
 pub mod catalog;
+pub mod journal;
 pub mod notify;
 pub mod sessions;
 pub mod usage;
 
 pub use catalog::CatalogStore;
+pub use journal::{JournalRecord, SessionJournal};
 pub use notify::{Notification, NotificationStore};
 pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
 

--- a/stella-store/src/sessions.rs
+++ b/stella-store/src/sessions.rs
@@ -15,6 +15,10 @@
 //! boundary (title/summary/status), and on exit. `Archived` is a user action
 //! from the SESSIONS view; archived and other terminal records stay until
 //! removed there (or swept by [`SessionRegistry::prune`]).
+//!
+//! Each record may own a **sidecar directory** (`data_dir()/sessions/<id>/`,
+//! see [`crate::journal`]) holding the durable session state that makes it
+//! resumable — deleting a record deletes its sidecar with it.
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -32,6 +36,10 @@ pub enum SessionStatus {
     InProgress,
     /// The session is blocked on a human answer (ask-user, scope review).
     NeedsInput,
+    /// Deliberately set aside with its state intact — the deck exited (or
+    /// switched away) with work still pending. Not live (no pid downgrade
+    /// applies), and the first thing `resume` looks for.
+    Paused,
     /// The user interrupted the work (Ctrl-C mid-turn, queue abandoned).
     Cancelled,
     /// The session ended after finishing its work.
@@ -45,9 +53,10 @@ pub enum SessionStatus {
 
 impl SessionStatus {
     /// Grouping/order for the SESSIONS view: active work first.
-    pub const ALL: [SessionStatus; 6] = [
+    pub const ALL: [SessionStatus; 7] = [
         SessionStatus::InProgress,
         SessionStatus::NeedsInput,
+        SessionStatus::Paused,
         SessionStatus::Cancelled,
         SessionStatus::Complete,
         SessionStatus::Archived,
@@ -59,6 +68,7 @@ impl SessionStatus {
         match self {
             SessionStatus::InProgress => "In Progress",
             SessionStatus::NeedsInput => "Needs Input",
+            SessionStatus::Paused => "Paused",
             SessionStatus::Cancelled => "Cancelled",
             SessionStatus::Complete => "Complete",
             SessionStatus::Archived => "Archived",
@@ -128,11 +138,10 @@ impl SessionRegistry {
         Self { dir: dir.into() }
     }
 
-    fn path_for(&self, id: &str) -> PathBuf {
-        // Ids are self-minted (`ses-<ms>-<pid>`), but never trust a name to
-        // stay a single path component.
-        let safe: String = id
-            .chars()
+    /// Ids are self-minted (`ses-<ms>-<pid>`), but never trust a name to
+    /// stay a single path component.
+    fn safe_id(id: &str) -> String {
+        id.chars()
             .map(|c| {
                 if c.is_alphanumeric() || c == '-' {
                     c
@@ -140,8 +149,18 @@ impl SessionRegistry {
                     '_'
                 }
             })
-            .collect();
-        self.dir.join(format!("{safe}.json"))
+            .collect()
+    }
+
+    fn path_for(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{}.json", Self::safe_id(id)))
+    }
+
+    /// The session's sidecar directory (journal + snapshots — see
+    /// [`crate::journal`]), beside its record file. `list` only reads
+    /// `.json` files, so the directory never shadows a record.
+    pub fn sidecar_dir(&self, id: &str) -> PathBuf {
+        self.dir.join(Self::safe_id(id))
     }
 
     /// Write (create or replace) `record` atomically, stamping
@@ -180,9 +199,7 @@ impl SessionRegistry {
                 }
                 let text = std::fs::read_to_string(&path).ok()?;
                 let mut record: SessionRecord = serde_json::from_str(&text).ok()?;
-                if record.status.is_live() && !pid_alive(record.pid) {
-                    record.status = SessionStatus::Error;
-                }
+                record.status = Self::presented_status(&record);
                 Some(record)
             })
             .collect();
@@ -207,13 +224,50 @@ impl SessionRegistry {
         Ok(true)
     }
 
-    /// Delete `id`'s record; returns whether it existed.
+    /// Delete `id`'s record — and its sidecar state with it (a deleted
+    /// session must not leave an orphaned journal behind); returns whether
+    /// the record existed.
     pub fn remove(&self, id: &str) -> Result<bool> {
-        match std::fs::remove_file(self.path_for(id)) {
-            Ok(()) => Ok(true),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(StoreError(format!("cannot remove session record: {e}"))),
+        let existed = match std::fs::remove_file(self.path_for(id)) {
+            Ok(()) => true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+            Err(e) => return Err(StoreError(format!("cannot remove session record: {e}"))),
+        };
+        if let Err(e) = std::fs::remove_dir_all(self.sidecar_dir(id))
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(StoreError(format!("cannot remove session state: {e}")));
         }
+        Ok(existed)
+    }
+
+    /// `record`'s status as presented to viewers: a live status whose owning
+    /// process is gone reads as `Error` ("crashed") without rewriting the
+    /// dead process's file. Every other status is returned as stored.
+    pub fn presented_status(record: &SessionRecord) -> SessionStatus {
+        if record.status.is_live() && !pid_alive(record.pid) {
+            SessionStatus::Error
+        } else {
+            record.status
+        }
+    }
+
+    /// Whether `id` can be reopened: its record exists, no live process owns
+    /// it, and there is durable state on disk to restore ([`crate::journal`]).
+    pub fn resumable(&self, id: &str) -> bool {
+        self.get(id).is_some_and(|r| {
+            !Self::presented_status(&r).is_live()
+                && crate::journal::has_state(&self.sidecar_dir(&r.id))
+        })
+    }
+
+    /// The most recently *active* resumable session for `workspace` — what a
+    /// bare `stella resume` reopens.
+    pub fn latest_resumable(&self, workspace: &str) -> Option<SessionRecord> {
+        self.list()
+            .into_iter()
+            .filter(|r| r.workspace == workspace && self.resumable(&r.id))
+            .max_by_key(|r| r.updated_at_ms)
     }
 
     /// Sweep terminal records older than `max_age_ms` (registry hygiene —
@@ -345,6 +399,93 @@ mod tests {
         assert_eq!(listed.len(), 2);
         assert_eq!(listed[0].id, new.id);
         assert_eq!(listed[1].id, old.id);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn paused_is_not_live_and_survives_the_owners_death() {
+        let (dir, reg) = temp_registry("paused");
+        let mut rec = SessionRecord::new("/w/p", "p");
+        rec.pid = u32::MAX - 1; // certainly not a live pid
+        rec.status = SessionStatus::Paused;
+        reg.upsert(&rec).unwrap();
+        // A paused session is deliberate, not crashed: no Error downgrade.
+        assert_eq!(reg.list()[0].status, SessionStatus::Paused);
+        assert!(!SessionStatus::Paused.is_live());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_deletes_the_sidecar_state_with_the_record() {
+        let (dir, reg) = temp_registry("sidecar");
+        let rec = SessionRecord::new("/w/s", "s");
+        reg.upsert(&rec).unwrap();
+        let sidecar = reg.sidecar_dir(&rec.id);
+        crate::journal::write_queue(&sidecar, &["pending".into()]).unwrap();
+        assert!(sidecar.exists());
+
+        assert!(reg.remove(&rec.id).unwrap());
+        assert!(!sidecar.exists(), "sidecar must not outlive its record");
+        // Removing a missing record (and missing sidecar) stays a clean no.
+        assert!(!reg.remove(&rec.id).unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn latest_resumable_wants_matching_workspace_state_and_no_live_owner() {
+        let (dir, reg) = temp_registry("resumable");
+
+        // Live (our own pid): never resumable, even with state on disk.
+        let mut live = SessionRecord::new("/w/a", "live");
+        reg.upsert(&live).unwrap();
+        live = reg.get(&live.id).unwrap();
+        crate::journal::write_history(&reg.sidecar_dir(&live.id), &[]).unwrap();
+
+        // Dead + state, with explicit activity stamps (bypassing upsert's
+        // restamp, as the prune test does) so the winner is deterministic
+        // even when every upsert lands in the same millisecond.
+        let pin_updated = |mut rec: SessionRecord, updated_at_ms: u64| {
+            rec.pid = u32::MAX - 1;
+            rec.status = SessionStatus::Paused;
+            reg.upsert(&rec).unwrap();
+            rec.updated_at_ms = updated_at_ms;
+            std::fs::write(
+                dir.join(format!("{}.json", rec.id)),
+                serde_json::to_string(&rec).unwrap(),
+            )
+            .unwrap();
+            crate::journal::write_history(&reg.sidecar_dir(&rec.id), &[]).unwrap();
+            rec
+        };
+        let mut old = SessionRecord::new("/w/a", "old");
+        old.id = format!("{}-old", old.id);
+        let old = pin_updated(old, 1_000);
+        let mut newest = SessionRecord::new("/w/a", "newest");
+        newest.id = format!("{}-new", newest.id);
+        let newest = pin_updated(newest, 2_000);
+
+        // Dead, right workspace, but nothing on disk to restore.
+        let mut bare = SessionRecord::new("/w/a", "bare");
+        bare.id = format!("{}-bare", bare.id);
+        bare.pid = u32::MAX - 1;
+        bare.status = SessionStatus::Complete;
+        reg.upsert(&bare).unwrap();
+
+        // Other workspace.
+        let mut other = SessionRecord::new("/w/b", "other");
+        other.id = format!("{}-other", other.id);
+        other.pid = u32::MAX - 1;
+        other.status = SessionStatus::Paused;
+        reg.upsert(&other).unwrap();
+        crate::journal::write_history(&reg.sidecar_dir(&other.id), &[]).unwrap();
+
+        assert!(!reg.resumable(&live.id));
+        assert!(!reg.resumable(&bare.id));
+        assert!(reg.resumable(&old.id));
+        let picked = reg.latest_resumable("/w/a").expect("one resumable");
+        assert_eq!(picked.id, newest.id);
+        assert_eq!(reg.latest_resumable("/w/none"), None);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -200,7 +200,8 @@ async fn main() -> std::io::Result<()> {
                 // overlays render their empty states instead of waiting.
                 WorkspaceInput::SessionsRefresh
                 | WorkspaceInput::SessionArchive { .. }
-                | WorkspaceInput::SessionDelete { .. } => {
+                | WorkspaceInput::SessionDelete { .. }
+                | WorkspaceInput::SessionResume { .. } => {
                     let _ = react_tx.send(Inbound::Sessions(vec![]));
                 }
                 WorkspaceInput::NotificationRead { .. } | WorkspaceInput::NotificationsReadAll => {

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -292,16 +292,25 @@ fn render_sessions_overlay(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf:
                         .add_modifier(Modifier::BOLD);
                 }
                 let mine = if session.mine { "  (this session)" } else { "" };
+                // The ⏎ affordance rides the selected row, right where the
+                // eye already is — every resumable row also carries a subtle
+                // ↩ so the list is scannable for "where can I go back in".
+                let tag = if session.resumable && !session.mine {
+                    if is_sel { "  ↩ ⏎ resume" } else { "  ↩" }
+                } else {
+                    ""
+                };
                 let title: String = session
                     .title
                     .chars()
-                    .take((w as usize).saturating_sub(24 + mine.len()))
+                    .take((w as usize).saturating_sub(24 + mine.len() + tag.chars().count()))
                     .collect();
                 lines.push(Line::from(vec![
                     Span::raw(marker),
                     dot,
                     Span::styled(title, title_style),
                     Span::styled(mine.to_string(), theme::muted()),
+                    Span::styled(tag.to_string(), theme::accent()),
                 ]));
                 let summary = if session.summary.is_empty() {
                     "(no work recorded yet)".to_string()
@@ -326,7 +335,7 @@ fn render_sessions_overlay(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf:
 
     lines.push(Line::default());
     lines.push(Line::from(Span::styled(
-        " ↑/↓ select · a archive · x delete · r refresh · esc/← close",
+        " ↑/↓ select · ⏎ resume · a archive · x delete · r refresh · esc/← close",
         theme::muted(),
     )));
 
@@ -343,6 +352,7 @@ fn phase_color(phase: crate::envelope::SessionPhase) -> ratatui::style::Color {
     match phase {
         SessionPhase::InProgress => theme::SUCCESS_BRIGHT,
         SessionPhase::NeedsInput => theme::WARNING_BRIGHT,
+        SessionPhase::Paused => theme::ACCENT,
         SessionPhase::Cancelled => theme::TEXT_TERTIARY,
         SessionPhase::Complete => theme::SUCCESS,
         SessionPhase::Archived => theme::TEXT_TERTIARY,

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -1723,9 +1723,11 @@ pub fn grouped_session_rows(ui: &DeckUi) -> Vec<&crate::envelope::SessionInfo> {
     rows
 }
 
-/// The SESSIONS overlay key map: ↑/↓ select, `a` archive, `x` delete
-/// (another session's record only — never this session's own), `r` refresh,
-/// Esc/`←`/`q` close. Modal: everything else is swallowed.
+/// The SESSIONS overlay key map: ↑/↓ select, `⏎` resume the selected session
+/// (resumable rows only — the durable-state sessions of THIS workspace with
+/// no live owner), `a` archive, `x` delete (another session's record only —
+/// never this session's own), `r` refresh, Esc/`←`/`q` close. Modal:
+/// everything else is swallowed.
 fn handle_sessions_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     let count = grouped_session_rows(ui).len();
     ui.sessions_sel = ui.sessions_sel.min(count.saturating_sub(1));
@@ -1733,6 +1735,22 @@ fn handle_sessions_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
         KeyCode::Esc | KeyCode::Left | KeyCode::Char('q') => {
             ui.sessions_open = false;
             DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            match grouped_session_rows(ui).get(ui.sessions_sel).copied() {
+                // Navigate INTO the chosen session: close the overlay and
+                // hand over to the driver, which replays it into this deck.
+                // The current session's own row (`mine`) and rows that
+                // cannot be reopened here swallow the key — a ⏎ that
+                // visibly does nothing is announced by the row's own
+                // dimmed state, not by a surprise action.
+                Some(row) if row.resumable && !row.mine => {
+                    let id = row.id.clone();
+                    ui.sessions_open = false;
+                    DeckAction::Send(WorkspaceInput::SessionResume { id })
+                }
+                _ => DeckAction::Handled,
+            }
         }
         KeyCode::Up => {
             ui.sessions_sel = ui.sessions_sel.saturating_sub(1);
@@ -4013,6 +4031,83 @@ mod tests {
             ui.splash.is_done(),
             "a no-anim session never replays the cinematic"
         );
+    }
+
+    fn session_row(
+        id: &str,
+        phase: crate::envelope::SessionPhase,
+        mine: bool,
+        resumable: bool,
+    ) -> crate::envelope::SessionInfo {
+        crate::envelope::SessionInfo {
+            id: id.into(),
+            title: format!("ws: {id}"),
+            summary: String::new(),
+            workspace: "/w".into(),
+            phase,
+            started_ms: 0,
+            updated_ms: 0,
+            mine,
+            resumable,
+        }
+    }
+
+    #[test]
+    fn sessions_overlay_enter_resumes_only_a_resumable_foreign_row() {
+        use crate::envelope::SessionPhase;
+        let model = model_with(&["lead"]);
+        let mut ui = ready_ui();
+        ui.sessions_open = true;
+        ui.sessions = vec![
+            session_row("ses-mine", SessionPhase::InProgress, true, false),
+            session_row("ses-paused", SessionPhase::Paused, false, true),
+            session_row("ses-foreign", SessionPhase::Complete, false, false),
+        ];
+
+        // Grouped order: InProgress (mine) · Paused (resumable) · Complete.
+        // ⏎ on this deck's own row is swallowed; the overlay stays open.
+        ui.sessions_sel = 0;
+        assert_eq!(
+            handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert!(ui.sessions_open);
+
+        // ⏎ on the resumable row navigates into it: the overlay closes and
+        // the driver is told to resume exactly that session.
+        ui.sessions_sel = 1;
+        assert_eq!(
+            handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+            DeckAction::Send(WorkspaceInput::SessionResume {
+                id: "ses-paused".into()
+            })
+        );
+        assert!(!ui.sessions_open, "the overlay closes on navigation");
+
+        // ⏎ on a foreign row with nothing to restore is swallowed too.
+        ui.sessions_open = true;
+        ui.sessions_sel = 2;
+        assert_eq!(
+            handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert!(ui.sessions_open);
+    }
+
+    #[test]
+    fn paused_sessions_group_between_needs_input_and_cancelled() {
+        use crate::envelope::SessionPhase;
+        let mut ui = DeckUi::default();
+        ui.sessions = vec![
+            session_row("c", SessionPhase::Cancelled, false, true),
+            session_row("p", SessionPhase::Paused, false, true),
+            session_row("n", SessionPhase::NeedsInput, false, false),
+        ];
+        let order: Vec<&str> = grouped_session_rows(&ui)
+            .iter()
+            .map(|s| s.id.as_str())
+            .collect();
+        assert_eq!(order, ["n", "p", "c"]);
     }
 
     #[test]

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -341,6 +341,9 @@ pub enum IssueAction {
 pub enum SessionPhase {
     InProgress,
     NeedsInput,
+    /// Set aside with its durable state intact — quit (or switched away
+    /// from) with work still pending; the first thing resume looks for.
+    Paused,
     Cancelled,
     Complete,
     Archived,
@@ -349,9 +352,10 @@ pub enum SessionPhase {
 
 impl SessionPhase {
     /// Display/grouping order: attention-worthy first.
-    pub const ALL: [SessionPhase; 6] = [
+    pub const ALL: [SessionPhase; 7] = [
         SessionPhase::InProgress,
         SessionPhase::NeedsInput,
+        SessionPhase::Paused,
         SessionPhase::Cancelled,
         SessionPhase::Complete,
         SessionPhase::Archived,
@@ -362,6 +366,7 @@ impl SessionPhase {
         match self {
             SessionPhase::InProgress => "In Progress",
             SessionPhase::NeedsInput => "Needs Input",
+            SessionPhase::Paused => "Paused",
             SessionPhase::Cancelled => "Cancelled",
             SessionPhase::Complete => "Complete",
             SessionPhase::Archived => "Archived",
@@ -389,6 +394,11 @@ pub struct SessionInfo {
     /// True for the record of THIS deck process (rendered with a marker and
     /// protected from delete).
     pub mine: bool,
+    /// True when the session can be reopened here: no live process owns it,
+    /// it belongs to this deck's workspace, and its durable state (journal /
+    /// history) is on disk. `⏎` on such a row sends
+    /// [`WorkspaceInput::SessionResume`].
+    pub resumable: bool,
 }
 
 /// One persist-until-read notification as the inbox overlay lists it. A
@@ -580,6 +590,15 @@ pub enum WorkspaceInput {
     /// SESSIONS overlay: delete a session record from the registry.
     /// Answered with a fresh [`Inbound::Sessions`].
     SessionDelete { id: String },
+    /// SESSIONS overlay: reopen a resumable session (⏎ on a
+    /// [`SessionInfo::resumable`] row) — the deck-native "navigate back
+    /// into a session". The driver parks the current session (its durable
+    /// state is already on disk; its record flips to Paused), replays the
+    /// chosen session's journal through the fold, restores its conversation
+    /// and prompt backlog, and re-owns its registry record. Only serviced
+    /// between turns — mid-turn the driver answers with a transcript notice
+    /// instead of tearing down live work.
+    SessionResume { id: String },
     /// Inbox overlay: mark one notification read (it may then be pruned —
     /// "persists until read" is the store's contract). Answered with a fresh
     /// [`Inbound::Notifications`].

--- a/stella-tui/src/views/issues.rs
+++ b/stella-tui/src/views/issues.rs
@@ -55,7 +55,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                     ui.issues.search_query.clone(),
                     Style::default().fg(theme::INK),
                 ),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::ACCENT)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -77,7 +77,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                 Span::styled(target, Style::default().fg(theme::INK)),
                 Span::styled(": ", theme::muted()),
                 Span::styled(ui.issues.input.clone(), Style::default().fg(theme::INK)),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::ACCENT)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -90,7 +90,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     if let Some(notice) = &ui.issues.notice {
         lines.push(Line::from(Span::styled(
             format!("  {}{notice}", if ui.issues.busy { "◌ " } else { "" }),
-            Style::default().fg(theme::EMBER_GOLD),
+            Style::default().fg(theme::ACCENT),
         )));
     }
     lines.push(footer(ui.issues.mode));
@@ -189,7 +189,7 @@ fn render_form(issues: &IssuesPanel, width: usize, lines: &mut Vec<Line<'static>
             ),
         ];
         if focused {
-            spans.push(Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)));
+            spans.push(Span::styled("▏", Style::default().fg(theme::ACCENT)));
         }
         lines.push(Line::from(spans));
     };


### PR DESCRIPTION
## What & why

**Nothing a session holds is ever lost or reset again, and you can navigate in and out of sessions freely.** Quit, Ctrl-C, a killed terminal, dropped internet, or a power cut — the session reopens exactly where it stood: transcript, conversation, spend, and every pending prompt. Pausing is now just leaving.

The design deliberately adds no daemon, no attach protocol, and no second data path. The deck already renders exclusively from its inbound envelope stream (the L-T1 pure fold), so durability is one interception: journal that stream at its single channel choke point, and resume by replaying it through the same fold. Less is more — the guarantee falls out of the architecture the deck already had.

**Navigate out**: quit whenever — an exit with a pending backlog parks the session as `Paused` (a new registry status), not `Cancelled`. Nothing is dropped.
**Navigate in**: `stella resume` (latest for this workspace), `stella resume <id>`, `stella resume --list` — or, inside the deck, `←` opens the SESSIONS overlay and `⏎` on a resumable row switches the live deck to that session (the current one parks as Paused; an untouched shell is cleaned up instead).
**Crash recovery**: a turn interrupted mid-flight re-queues its prompt at the FRONT with dispatch **held** — reopening shows where things stood and spends nothing until you say go. Session spend stays monotone (the budget guard reseeds from the journal), so `--budget` keeps meaning *this session*.

### How it's built

| Piece | Where | What |
|---|---|---|
| Sidecar store | `stella-store/src/journal.rs` | `data_dir/sessions/<id>/`: append-only `journal.jsonl` (torn-tail tolerant, delta-coalescing, fsync on conversation transitions), atomic `history.json` (LLM conversation at each turn boundary), write-through `queue.json` |
| Registry | `stella-store/src/sessions.rs` | `SessionStatus::Paused`, sidecar cleanup on delete/prune, `presented_status` / `resumable` / `latest_resumable` |
| Journal tee | `stella-cli/src/session_persist.rs` | one task between driver and deck mirrors every fold-relevant `Inbound` to disk; replay bypasses it (a resume never re-journals itself); `Inbound↔JournalRecord` mappers; `DurableQueue` |
| Driver | `stella-cli/src/command_deck.rs` | adopt-on-startup + in-deck switch (idle-only), unsettled-prompt recovery, Paused exits, boot narration sent direct to the deck so it never replays into resumed transcripts |
| TUI | `stella-tui` | `SessionPhase::Paused`, resumable rows (`↩` marker, `⏎ resume` on selection), `WorkspaceInput::SessionResume` |

Worst case on a power cut: the in-flight turn's streamed tail (which re-runs from its re-queued prompt). User input and completed turns are fsynced and survive.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Flagship: `replaying_the_journal_reproduces_the_deck_fold_exactly` — a live envelope stream folded directly vs. journaled to disk (coalescing and all), read back, replayed: the per-agent `SessionModel`, status, tokens, and spend must be indistinguishable. Around it: torn-tail healing (caught a real fuse-into-the-torn-line bug during development), unsettled-prompt settlement rules, write-through queue ordering on disk, `Paused` liveness semantics, sidecar cleanup on delete, and the overlay's `⏎` key contract. All of these are new surfaces absent on `main`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (`make gate` green end-to-end)
- [x] Docs updated where behavior/flags changed (`COMMAND_DECK_DESIGN.md` durability section, `stella resume --help`, module doc comments)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (zero new crates)
- [x] No new outbound network calls (everything is local files under `data_dir`)
- [x] New cross-boundary types round-trip through serde (`JournalRecord` roundtrip + mapper-identity tests)

## Anything reviewers should know?

- **First commit is a build fix**: `main` did not compile — the aurora restyle (#185) removed `theme::EMBER_GOLD` but the ISSUES tab still referenced it (billing-locked CI never caught it). Moved to `theme::ACCENT` per the restyle's own guard test.
- **Semantics choice**: resume never auto-runs anything. A restored backlog (or an interrupted turn's prompt) is parked via the existing `HoldState`; the next submission releases it. "Pause a running turn" = the existing double-Esc stop-and-hold, then quit — the prompt is at the front when you come back.
- **Deliberately out of scope** (named seams, not regressions): live *attach* to a session running in another process (needs a socket/daemon; resume of a live session is refused with a clear message), deep per-agent pause (`AgentControl::Pause` stays the fleet-supervisor seam), and journal compaction across many resumes (bounded by session length today).
- Startup chrome (MCP connect report, graph indexing lines, hints) is sent direct to the deck, bypassing the journal — otherwise every resume would replay a stack of stale boot banners.
