### PR TITLE
fix(stella-tui): ISSUES tab referenced removed EMBER_GOLD — main does not build

### DIFF
--- a/stella-tui/src/views/issues.rs
+++ b/stella-tui/src/views/issues.rs
@@ -55,7 +55,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                     ui.issues.search_query.clone(),
                     Style::default().fg(theme::INK),
                 ),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -77,7 +77,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
                 Span::styled(target, Style::default().fg(theme::INK)),
                 Span::styled(": ", theme::muted()),
                 Span::styled(ui.issues.input.clone(), Style::default().fg(theme::INK)),
-                Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)),
+                Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)),
             ]));
             lines.push(Line::default());
             render_list(&ui.issues, inner, &mut lines);
@@ -90,7 +90,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     if let Some(notice) = &ui.issues.notice {
         lines.push(Line::from(Span::styled(
             format!("  {}{notice}", if ui.issues.busy { "◌ " } else { "" }),
-            Style::default().fg(theme::EMBER_GOLD),
+            Style::default().fg(theme::AURORA_CYAN),
         )));
     }
     lines.push(footer(ui.issues.mode));
@@ -189,7 +189,7 @@ fn render_form(issues: &IssuesPanel, width: usize, lines: &mut Vec<Line<'static>
             ),
         ];
         if focused {
-            spans.push(Span::styled("▏", Style::default().fg(theme::EMBER_GOLD)));
+            spans.push(Span::styled("▏", Style::default().fg(theme::AURORA_CYAN)));
         }
         lines.push(Line::from(spans));
     };


### PR DESCRIPTION
## What

`cargo check -p stella-tui` fails on main: the aurora-on-navy restyle (#185) removed the ember palette, but `views/issues.rs` (#182, merged just before it) still references `theme::EMBER_GOLD` four times for its selection bars. The billing-locked CI fast-failed without ever compiling, so the break landed silently.

## Fix

Selection bars use `theme::AURORA_CYAN`, matching the MCP tab's idiom for the same `▏` glyph. One file, four lines.

## Verification

- `cargo check -p stella-tui`: builds again.
- `cargo test -p stella-tui`: 452 passed, 0 failed — including the restyle's own palette-ban test, which is the witness here (it forbids the ember colors ever reappearing; this change keeps it green while making the crate compile at all).
- `cargo clippy -p stella-tui --all-targets -- -D warnings` + `cargo fmt --check`: clean.

Note: PR #186 already carries this same fix inside its merge commit; whichever lands first, the other merges cleanly.
