### PR TITLE
feat(deck): Pause/Resume/Restart for worker lanes — engine boundary gate + retained-spec respawn

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -464,6 +464,9 @@ pub async fn run_deck_session(
     // waiting for one (drained oldest-first as workers end).
     let mut subs = SubSessions::new();
     let mut pending_spawns: VecDeque<stella_core::tasks::SpawnRequest> = VecDeque::new();
+    // Lanes whose Restart arrived while the worker was still live: stop
+    // first, respawn on its Ended.
+    let mut pending_restarts: std::collections::HashSet<String> = std::collections::HashSet::new();
     // Worker spend not yet metered into the session budget guard — applied
     // at the loop top, where the guard is free (budget aborts happen at
     // safe boundaries only).
@@ -518,6 +521,7 @@ pub async fn run_deck_session(
                         handle_supervisor_msg(
                             msg,
                             &mut subs,
+                            &mut pending_restarts,
                             &mut pending_spawns,
                             &mut queue,
                             dispatch.held(),
@@ -539,14 +543,21 @@ pub async fn run_deck_session(
                 match input {
                     None => break 'session,
                     Some(WorkspaceInput::Quit) => break 'session,
-                    // Stopping a worker lane works between lead turns too —
-                    // the lead being idle says nothing about a running
-                    // worker.
-                    Some(WorkspaceInput::Control {
-                        agent,
-                        control: stella_tui::AgentControl::Stop,
-                    }) if agent != LEAD => {
-                        subs.stop(&agent);
+                    // Worker controls work between lead turns too — the
+                    // lead being idle says nothing about a running worker.
+                    Some(WorkspaceInput::Control { agent, control }) if agent != LEAD => {
+                        service_worker_control(
+                            &agent,
+                            control,
+                            &mut subs,
+                            &mut pending_restarts,
+                            cfg,
+                            budget_limit,
+                            &session_record.id,
+                            &workspace_name,
+                            &in_tx,
+                            &sup_tx,
+                        );
                         continue 'session;
                     }
                     // Any submission releases a hold and runs NOW — ahead of the
@@ -848,6 +859,7 @@ pub async fn run_deck_session(
                         handle_supervisor_msg(
                             msg,
                             &mut subs,
+                            &mut pending_restarts,
                             &mut pending_spawns,
                             &mut queue,
                             dispatch.held(),
@@ -917,6 +929,21 @@ pub async fn run_deck_session(
                                 break TurnEnd::Cancelled { hold: false };
                             }
                             subs.stop(&agent);
+                        }
+                        // Worker Pause/Resume/Restart while the lead works.
+                        Some(WorkspaceInput::Control { agent, control }) if agent != LEAD => {
+                            service_worker_control(
+                                &agent,
+                                control,
+                                &mut subs,
+                                &mut pending_restarts,
+                                cfg,
+                                budget_limit,
+                                &session_record.id,
+                                &workspace_name,
+                                &in_tx,
+                                &sup_tx,
+                            );
                         }
                         // Double-Esc: cancel AND park dispatch — the
                         // interrupted prompt returns to the front of the
@@ -1635,6 +1662,7 @@ fn notifications_inbound(store: &stella_store::NotificationStore) -> Inbound {
 fn handle_supervisor_msg(
     msg: SupervisorMsg,
     subs: &mut SubSessions,
+    pending_restarts: &mut std::collections::HashSet<String>,
     pending_spawns: &mut VecDeque<stella_core::tasks::SpawnRequest>,
     queue: &mut VecDeque<String>,
     dispatch_held: bool,
@@ -1673,6 +1701,20 @@ fn handle_supervisor_msg(
             end,
         } => {
             subs.ended(&lane);
+            // A Restart that arrived while this worker was live respawns it
+            // now — restart takes the freed slot ahead of parked spawns.
+            if pending_restarts.remove(&lane) {
+                let _ = subsession::respawn(
+                    &lane,
+                    subs,
+                    cfg,
+                    budget_limit,
+                    session_id,
+                    workspace_name,
+                    in_tx,
+                    sup_tx,
+                );
+            }
             // Worker spend reaches the session's parent budget guard (the
             // L-E9 discipline). The guard is mutably borrowed by any in-
             // flight lead turn, so the driver accumulates here and meters at
@@ -1731,6 +1773,63 @@ fn handle_supervisor_msg(
                 in_tx,
                 sup_tx,
             );
+        }
+    }
+}
+
+/// Route one Pause/Resume/Stop/Restart at a worker lane. Pause parks the
+/// worker at its next step boundary (never mid-tool — the engine's
+/// `TurnGate`); Resume releases it; Restart respawns the lane from its
+/// retained spec, stopping the live worker first when necessary.
+#[allow(clippy::too_many_arguments)]
+fn service_worker_control(
+    lane: &str,
+    control: stella_tui::AgentControl,
+    subs: &mut SubSessions,
+    pending_restarts: &mut std::collections::HashSet<String>,
+    cfg: &Config,
+    budget_limit: Option<f64>,
+    session_id: &str,
+    workspace_name: &str,
+    in_tx: &UnboundedSender<Inbound>,
+    sup_tx: &UnboundedSender<SupervisorMsg>,
+) {
+    match control {
+        stella_tui::AgentControl::Stop => {
+            subs.stop(lane);
+        }
+        stella_tui::AgentControl::Pause => {
+            if subs.set_paused(lane, true) {
+                let _ = in_tx.send(Inbound::Status {
+                    agent: lane.to_string(),
+                    status: AgentStatus::Paused,
+                });
+            }
+        }
+        stella_tui::AgentControl::Resume => {
+            if subs.set_paused(lane, false) {
+                let _ = in_tx.send(Inbound::Status {
+                    agent: lane.to_string(),
+                    status: AgentStatus::Running,
+                });
+            }
+        }
+        stella_tui::AgentControl::Restart => {
+            if subs.is_live(lane) {
+                pending_restarts.insert(lane.to_string());
+                subs.stop(lane);
+            } else {
+                let _ = subsession::respawn(
+                    lane,
+                    subs,
+                    cfg,
+                    budget_limit,
+                    session_id,
+                    workspace_name,
+                    in_tx,
+                    sup_tx,
+                );
+            }
         }
     }
 }

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -30,7 +30,7 @@ use stella_protocol::{AgentEvent, CompletionMessage, TaskItem};
 use stella_tools::ToolRegistry;
 use stella_tui::{AgentMeta, AgentStatus, Inbound};
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 
 use crate::agent;
 use crate::command_deck::{now_ms, prompt_line, spawn_forwarder};
@@ -79,6 +79,11 @@ pub(crate) struct SubSessions {
     active: usize,
     next_req: u64,
     stops: HashMap<String, oneshot::Sender<()>>,
+    /// Live workers' pause switches (watch: `true` = parked at the next
+    /// step boundary).
+    pauses: HashMap<String, watch::Sender<bool>>,
+    /// Every lane's spec, retained past its end — what Restart respawns.
+    specs: HashMap<String, SubSessionSpec>,
 }
 
 impl SubSessions {
@@ -87,6 +92,8 @@ impl SubSessions {
             active: 0,
             next_req: 0,
             stops: HashMap::new(),
+            pauses: HashMap::new(),
+            specs: HashMap::new(),
         }
     }
 
@@ -94,14 +101,43 @@ impl SubSessions {
         self.active < MAX_CONCURRENT
     }
 
-    fn started(&mut self, lane: &str, stop: oneshot::Sender<()>) {
+    fn started(
+        &mut self,
+        lane: &str,
+        stop: oneshot::Sender<()>,
+        pause: watch::Sender<bool>,
+        spec: SubSessionSpec,
+    ) {
         self.active += 1;
         self.stops.insert(lane.to_string(), stop);
+        self.pauses.insert(lane.to_string(), pause);
+        self.specs.insert(lane.to_string(), spec);
     }
 
     pub(crate) fn ended(&mut self, lane: &str) {
         self.active = self.active.saturating_sub(1);
         self.stops.remove(lane);
+        self.pauses.remove(lane);
+        // `specs` is retained on purpose: Restart respawns an ended lane.
+    }
+
+    /// Pause (`true`) or resume (`false`) a live worker at its next step
+    /// boundary. `false` when no such worker is live.
+    pub(crate) fn set_paused(&mut self, lane: &str, paused: bool) -> bool {
+        match self.pauses.get(lane) {
+            Some(tx) => tx.send(paused).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Whether `lane` currently has a live worker.
+    pub(crate) fn is_live(&self, lane: &str) -> bool {
+        self.stops.contains_key(lane)
+    }
+
+    /// The retained spec for `lane`, for a Restart respawn.
+    pub(crate) fn spec(&self, lane: &str) -> Option<SubSessionSpec> {
+        self.specs.get(lane).cloned()
     }
 
     /// Signal one worker to stop (clean cancel: its turn future drops at the
@@ -121,8 +157,27 @@ impl SubSessions {
     }
 }
 
+/// `stella_core::ports::TurnGate` over a watch channel: the worker's turn
+/// parks at its next step boundary while the driver holds `true` (Pause)
+/// and continues on `false` (Resume). A dropped sender (driver gone) reads
+/// as resumed — a worker must never park forever on teardown.
+struct WatchGate(watch::Receiver<bool>);
+
+#[async_trait::async_trait]
+impl stella_core::ports::TurnGate for WatchGate {
+    async fn wait_if_paused(&self) {
+        let mut rx = self.0.clone();
+        while *rx.borrow() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
 /// Everything a worker needs to run, owned (the thread outlives the caller's
 /// borrows).
+#[derive(Clone)]
 pub(crate) struct SubSessionSpec {
     /// Deck lane id — `req:<n>` for a dispatched prompt, `sub:<task-id>` for
     /// an assigned task.
@@ -172,6 +227,7 @@ pub(crate) fn spawn(
     in_tx: UnboundedSender<Inbound>,
     sup_tx: UnboundedSender<SupervisorMsg>,
     stop_rx: oneshot::Receiver<()>,
+    pause_rx: watch::Receiver<bool>,
 ) {
     let mut meta = AgentMeta::new(spec.lane.clone(), spec.title.clone(), now_ms())
         .with_role("subagent")
@@ -197,6 +253,7 @@ pub(crate) fn spawn(
                 &session_id,
                 &in_tx,
                 stop_rx,
+                pause_rx,
             )),
             Err(e) => (
                 None,
@@ -269,6 +326,7 @@ async fn run_worker(
     session_id: &str,
     in_tx: &UnboundedSender<Inbound>,
     stop_rx: oneshot::Receiver<()>,
+    pause_rx: watch::Receiver<bool>,
 ) -> (Option<i64>, f64, WorkerEnd) {
     let provider = match agent::build_provider(cfg) {
         Ok(p) => p,
@@ -317,13 +375,15 @@ async fn run_worker(
         format!("{session_id}/{}", spec.lane),
     );
     let raced = {
+        let gate = WatchGate(pause_rx);
         let engine = Engine::with_sleeper(
             &*provider,
             &claims,
             agent::engine_config_for(cfg),
             &TokioSleeper,
         )
-        .with_calibration(&calibration);
+        .with_calibration(&calibration)
+        .with_gate(&gate);
         let turn = engine.run_turn(&mut messages, &mut budget, &tx);
         // A dropped sender (driver gone at session teardown) must not read
         // as a stop — only an actual signal cancels, so the wait parks
@@ -419,23 +479,62 @@ pub(crate) fn drain_queue(
             text: text.clone(),
         });
         let (stop_tx, stop_rx) = oneshot::channel();
-        subs.started(&lane, stop_tx);
+        let (pause_tx, pause_rx) = watch::channel(false);
+        let spec = SubSessionSpec {
+            lane: lane.clone(),
+            title: prompt_line(&text, 48),
+            notify_title: format!("reply ready — {}", prompt_line(&text, 40)),
+            prompt: text,
+        };
+        subs.started(&lane, stop_tx, pause_tx, spec.clone());
         spawn(
             cfg,
-            SubSessionSpec {
-                lane,
-                title: prompt_line(&text, 48),
-                notify_title: format!("reply ready — {}", prompt_line(&text, 40)),
-                prompt: text,
-            },
+            spec,
             budget_limit,
             session_id.to_string(),
             workspace_name.to_string(),
             in_tx.clone(),
             sup_tx.clone(),
             stop_rx,
+            pause_rx,
         );
     }
+}
+
+/// Respawn an ended lane from its retained spec — the Restart verb. `false`
+/// when the lane has no retained spec or is still live (stop it first).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn respawn(
+    lane: &str,
+    subs: &mut SubSessions,
+    cfg: &Config,
+    budget_limit: Option<f64>,
+    session_id: &str,
+    workspace_name: &str,
+    in_tx: &UnboundedSender<Inbound>,
+    sup_tx: &UnboundedSender<SupervisorMsg>,
+) -> bool {
+    if subs.is_live(lane) {
+        return false;
+    }
+    let Some(spec) = subs.spec(lane) else {
+        return false;
+    };
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let (pause_tx, pause_rx) = watch::channel(false);
+    subs.started(lane, stop_tx, pause_tx, spec.clone());
+    spawn(
+        cfg,
+        spec,
+        budget_limit,
+        session_id.to_string(),
+        workspace_name.to_string(),
+        in_tx.clone(),
+        sup_tx.clone(),
+        stop_rx,
+        pause_rx,
+    );
+    true
 }
 
 /// Dispatch one `task_assign` spawn request (or park it if no slot is free —
@@ -453,25 +552,28 @@ pub(crate) fn spawn_task_worker(
 ) {
     let lane = format!("sub:{}", req.task_id);
     let (stop_tx, stop_rx) = oneshot::channel();
-    subs.started(&lane, stop_tx);
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let spec = SubSessionSpec {
+        lane: lane.clone(),
+        title: format!("task #{}: {}", req.task_id, prompt_line(&req.subject, 40)),
+        prompt: task_prompt(req),
+        notify_title: format!(
+            "task #{} done — {}",
+            req.task_id,
+            prompt_line(&req.subject, 40)
+        ),
+    };
+    subs.started(&lane, stop_tx, pause_tx, spec.clone());
     spawn(
         cfg,
-        SubSessionSpec {
-            lane,
-            title: format!("task #{}: {}", req.task_id, prompt_line(&req.subject, 40)),
-            prompt: task_prompt(req),
-            notify_title: format!(
-                "task #{} done — {}",
-                req.task_id,
-                prompt_line(&req.subject, 40)
-            ),
-        },
+        spec,
         budget_limit,
         session_id.to_string(),
         workspace_name.to_string(),
         in_tx.clone(),
         sup_tx.clone(),
         stop_rx,
+        pause_rx,
     );
 }
 
@@ -479,13 +581,76 @@ pub(crate) fn spawn_task_worker(
 mod tests {
     use super::*;
 
+    fn dummy_spec(lane: &str) -> SubSessionSpec {
+        SubSessionSpec {
+            lane: lane.to_string(),
+            title: "t".into(),
+            prompt: "p".into(),
+            notify_title: "n".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn watch_gate_parks_while_paused_and_releases_on_resume_or_teardown() {
+        use stella_core::ports::TurnGate;
+        let (tx, rx) = watch::channel(true);
+        let gate = WatchGate(rx);
+        let wait = gate.wait_if_paused();
+        tokio::pin!(wait);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut wait)
+                .await
+                .is_err(),
+            "a paused gate must park"
+        );
+        tx.send(false).unwrap();
+        tokio::time::timeout(std::time::Duration::from_millis(500), wait)
+            .await
+            .expect("resume releases the gate");
+
+        // A dropped sender (driver teardown) must release, never park forever.
+        let (tx2, rx2) = watch::channel(true);
+        let gate2 = WatchGate(rx2);
+        drop(tx2);
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            gate2.wait_if_paused(),
+        )
+        .await
+        .expect("teardown releases the gate");
+    }
+
+    #[test]
+    fn pause_resume_flips_the_watch_and_restart_needs_a_dead_lane() {
+        let mut subs = SubSessions::new();
+        let (stop_tx, _stop_rx) = oneshot::channel();
+        let (pause_tx, pause_rx) = watch::channel(false);
+        subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+        assert!(subs.set_paused("req:1", true));
+        assert!(*pause_rx.borrow());
+        assert!(subs.set_paused("req:1", false));
+        assert!(!*pause_rx.borrow());
+        assert!(!subs.set_paused("req:404", true), "unknown lane is a no-op");
+        // A live lane refuses respawn; its spec survives its end.
+        assert!(subs.is_live("req:1"));
+        subs.ended("req:1");
+        assert!(!subs.is_live("req:1"));
+        assert!(subs.spec("req:1").is_some(), "spec retained for Restart");
+    }
+
     #[test]
     fn slot_bookkeeping_caps_and_recovers() {
         let mut subs = SubSessions::new();
         for i in 0..MAX_CONCURRENT {
             assert!(subs.has_slot());
             let (stop_tx, _stop_rx) = oneshot::channel();
-            subs.started(&format!("req:{i}"), stop_tx);
+            let (pause_tx, _pause_rx) = watch::channel(false);
+            subs.started(
+                &format!("req:{i}"),
+                stop_tx,
+                pause_tx,
+                dummy_spec(&format!("req:{i}")),
+            );
         }
         assert!(!subs.has_slot());
         subs.ended("req:0");
@@ -500,7 +665,8 @@ mod tests {
     fn stop_signals_a_live_worker_once_and_only_once() {
         let mut subs = SubSessions::new();
         let (stop_tx, mut stop_rx) = oneshot::channel();
-        subs.started("req:1", stop_tx);
+        let (pause_tx, _pause_rx) = watch::channel(false);
+        subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
         assert!(subs.stop("req:1"), "a live worker accepts the signal");
         assert_eq!(stop_rx.try_recv(), Ok(()));
         assert!(!subs.stop("req:1"), "a second stop is a stale no-op");

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -177,6 +177,11 @@ pub struct Engine<'a> {
     /// compaction decision. When `None` the turn path is exactly the
     /// uncalibrated engine.
     pub(crate) calibration: Option<&'a CalibrationMap>,
+    /// Boundary pause gate ([`crate::ports::TurnGate`]), off by default.
+    /// Attached via [`Engine::with_gate`]; consulted once per step, before
+    /// any model call — a paused turn parks at that safe boundary and
+    /// spends nothing until resumed. `None` adds zero work.
+    gate: Option<&'a dyn crate::ports::TurnGate>,
 }
 
 /// Upper bound on tool calls from one step executing concurrently. Tools
@@ -223,6 +228,7 @@ impl<'a> Engine<'a> {
             config,
             hooks: None,
             calibration: None,
+            gate: None,
         }
     }
 
@@ -245,6 +251,13 @@ impl<'a> Engine<'a> {
     /// built without this estimates exactly as before.
     pub fn with_calibration(mut self, calibration: &'a CalibrationMap) -> Self {
         self.calibration = Some(calibration);
+        self
+    }
+
+    /// Attach a boundary pause gate — Pause/Resume at step granularity,
+    /// never mid-tool.
+    pub fn with_gate(mut self, gate: &'a dyn crate::ports::TurnGate) -> Self {
+        self.gate = Some(gate);
         self
     }
 
@@ -305,6 +318,12 @@ impl<'a> Engine<'a> {
         let mut calibration_model: Option<String> = None;
 
         for step in 0..self.config.max_steps {
+            // Pause parks HERE — after the previous step fully settled and
+            // before any new model call, mirroring the budget-abort
+            // boundary. Resuming continues the very same turn.
+            if let Some(gate) = self.gate {
+                gate.wait_if_paused().await;
+            }
             self.run_compaction_pass(messages, calibration_model.as_deref(), events);
 
             if let Some(aborted) = self.check_loop_detection(messages, events) {

--- a/stella-core/src/ports.rs
+++ b/stella-core/src/ports.rs
@@ -71,3 +71,14 @@ pub trait Clock: Send + Sync {
     /// Monotonic milliseconds since an arbitrary epoch.
     fn now_ms(&self) -> u64;
 }
+
+/// Boundary pause gate — polled by the engine between model calls, the same
+/// safe boundary as budget aborts (L-E6: never mid-tool). `wait_if_paused`
+/// returns immediately when the turn may proceed and parks (await) while it
+/// is paused; the driver flips the underlying state from supervisor input.
+/// A port so `stella-core` stays I/O-free — the CLI implements it over a
+/// watch channel.
+#[async_trait::async_trait]
+pub trait TurnGate: Send + Sync {
+    async fn wait_if_paused(&self);
+}

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -3257,14 +3257,31 @@ fn handle_agents_key(
             Some(DeckAction::Handled)
         }
         // Agent controls — only when the composer is empty (else they type).
-        // Only `s` (stop) is bound: the driver drops Pause/Restart as no-ops
-        // (they need the fleet supervisor), and a key that visibly does
-        // nothing erodes trust in the ones that work. Re-add `p`/`r` here
-        // and in the help overlay when the driver honors them.
+        // `s` stop · `p` pause/resume toggle (by the row's current status) ·
+        // `r` restart. The driver honors all three on worker lanes
+        // (`req:`/`sub:`): pause parks the worker at its next step boundary
+        // (never mid-tool), restart respawns the lane from its retained
+        // spec. On the lead they are no-ops (Esc is the lead's interrupt).
         KeyCode::Char('s') if composer_empty => model.agents.get(ui.focused).map(|entry| {
             DeckAction::Send(WorkspaceInput::Control {
                 agent: entry.meta.id.clone(),
                 control: AgentControl::Stop,
+            })
+        }),
+        KeyCode::Char('p') if composer_empty => model.agents.get(ui.focused).map(|entry| {
+            DeckAction::Send(WorkspaceInput::Control {
+                agent: entry.meta.id.clone(),
+                control: if entry.status == AgentStatus::Paused {
+                    AgentControl::Resume
+                } else {
+                    AgentControl::Pause
+                },
+            })
+        }),
+        KeyCode::Char('r') if composer_empty => model.agents.get(ui.focused).map(|entry| {
+            DeckAction::Send(WorkspaceInput::Control {
+                agent: entry.meta.id.clone(),
+                control: AgentControl::Restart,
             })
         }),
         _ => None,


### PR DESCRIPTION
## What

The last named seam from the fleet-core work: worker lanes are now fully controllable from the Agents tab — `s` stop, `p` pause/resume, `r` restart.

- **TurnGate port** (stella-core/src/ports.rs): polled once per step, before any model call — the same safe-boundary discipline as budget aborts (never mid-tool). Attached via `Engine::with_gate`; absent = zero added work. No I/O enters stella-core: the CLI implements the port over a watch channel (`WatchGate`), and a dropped sender reads as *resumed* so session teardown can never park a worker forever.
- **Pause/Resume**: `p` toggles by the row's status. Pause parks the worker at its next step boundary (it spends nothing while parked) and the lane folds to *Paused*; resume releases it mid-turn, continuing the same conversation.
- **Restart**: every lane's spec is retained past its end; `r` respawns an ended lane immediately, or stop-then-respawns a live one when its Ended lands (the restart takes the freed slot ahead of parked task spawns).
- Routed from both driver arms (idle + mid-turn), so controls work regardless of what the lead is doing. Lead lanes: Esc remains the interrupt; gating the lead's staged-pipeline turn needs a `PipelinePorts` gate — noted follow-up.

## Verification

- `cargo test -p stella-core -p stella-cli -p stella-tui`: 233 + 288 + 467 passed, 0 failed. New witnesses: `watch_gate_parks_while_paused_and_releases_on_resume_or_teardown` (a paused gate parks; resume and teardown both release) and `pause_resume_flips_the_watch_and_restart_needs_a_dead_lane` — both absent on main.
- clippy `-D warnings` clean on all three crates; `cargo fmt --check` clean.
- Note: `stella-observatory::serves_over_a_real_socket` fails identically on pristine `main` on this machine (verified in a clean worktree) — pre-existing and unrelated; every other suite in `make gate` is green.
