### PR TITLE
feat(tools): bash off by default — manifest-verb execution, process group, vendor-neutral repo tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Sixteen crates. The one-sentence rule of thumb:
 |---|---|---|
 | Change the agent loop (plan / retry / compact / budget / loop-detect / hooks / skills / rules) | `stella-core` | **No I/O allowed.** Decision logic only. |
 | Add/fix a model provider (SSE, tool-call dialect, pricing) | `stella-model` | One file per adapter (`anthropic.rs`, `openai.rs`, `gemini.rs`, `vertex.rs`, `bedrock.rs`, `zai.rs`). Copy an existing adapter's shape. |
-| Add/fix a built-in tool (`read_file`, `bash`, `verify_done`, …) | `stella-tools` | Implement the `Tool` trait, register in `ToolRegistry`. |
+| Add/fix a built-in tool (`read_file`, `verify_done`, the opt-in `bash`, …) | `stella-tools` | Implement the `Tool` trait, register in `ToolRegistry`. |
 | Change CLI commands, flags, or agent wiring | `stella-cli` | This is the shipping binary. |
 | Change REPL rendering / panels / keybindings | `stella-tui` | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
 | Touch shared types crossing a crate boundary | `stella-protocol` | **Zero logic, zero I/O — types only.** |
@@ -194,7 +194,7 @@ editing Stella's own code should know what lives where:
 | `.stella/memories/*.md` | Durable lessons baked into the byte-stable system prompt prefix. Sorted by filename, loaded once per session. (Write side: the `save_memory` tool.) |
 | `.stella/skills/<slug>/SKILL.md` | Auto-promoted skills from recurring reflection lessons. Never enforced — selected and injected as volatile context. |
 | `.stella/tools/*.toml` | Developer-defined custom script tools. Also scanned at `~/.config/stella/tools/`. |
-| `.stella/settings.json` | Project-scope provider config (overrides built-ins or defines new providers). Merged per-field with org-managed and user scopes. |
+| `.stella/settings.json` | Project-scope provider config (overrides built-ins or defines new providers) and tool switches (`tools.bash: "on"` opts the shell tool in — it is off by default in every scope). Merged per-field with org-managed and user scopes. |
 | `.stella/mcp.toml` | MCP server config — extra tools merged into the registry at session start. |
 | `.stella/domains.toml` | Domain taxonomy for memory/reflection tagging, inferred by `stella init`. |
 | `.stella/reflections.jsonl` | Per-turn reflection mining log (one JSON object per line). |

--- a/README.md
+++ b/README.md
@@ -341,10 +341,14 @@ writes a failing test whose fail→pass flip proves the work (`docs/design/pipel
 | Tool | Description |
 |---|---|
 | `read_file` · `write_file` · `edit_file` · `delete_file` | File CRUD with surgical exact-substring edits |
-| `bash` | Run a shell command (timeout kill; `trace: true` echoes each line) |
+| `bash` | Run a shell command (timeout kill; `trace: true` echoes each line) — **off by default**, registered only with `"tools": {"bash": "on"}` in settings (any scope) |
 | `grep` · `glob` | Regex content search (ripgrep) · glob file discovery (fd) |
 | `graph_query` | Query the indexed code graph: symbol definitions/references, file imports/importers/neighborhood — auto-built at session start, refreshed live |
 | `build_project` · `run_tests` | Build/test with the workspace's toolchain (cargo/npm/go/make) |
+| `run_lint` · `format_code` | The project's own linter/formatter (cargo clippy/fmt, or package.json `lint`/`format` scripts), spawned argv-style — no shell |
+| `run_script` | Run a verb the project itself declares (Makefile target, package.json script, cargo alias); unknown names list the discovered vocabulary |
+| `start_process` · `read_output` · `send_stdin` · `stop_process` | Long-running processes (dev servers, REPLs, watchers) from an argv vector — capped output ring, SIGTERM-then-kill stop, reaped at session end |
+| `repo_status` · `repo_commit` · `repo_push` · `repo_pull` · `repo_rollback` | Vendor-neutral repository tools: structured status, pathspec-explicit commits, pushes that structurally refuse the default branch (never forced), fast-forward-only pulls, restore-named-paths rollback |
 | `verify_done` | Replay new test files against `git HEAD` to prove the change works |
 | `explorations` · `save_exploration` | Shared codebase maps — explore once, reuse everywhere |
 | `save_memory` | Persist a lesson into every future session's system prompt |
@@ -356,6 +360,12 @@ writes a failing test whose fail→pass flip proves the work (`docs/design/pipel
 All file tools are workspace-root-pinned, and every read/write/edit/delete is
 recorded in the Files-Touched ledger (shown per turn as `[C·R·U·D] path`, also
 via `/files`).
+
+**Bash is opt-in.** The default tool surface has no shell: the model works
+through enumerable-argv tools (build/test/lint/format, `run_script`'s
+project-declared verbs, the process group, the `repo_*` tools). Enable `bash`
+per user, org, or project by adding `"tools": {"bash": "on"}` to the
+corresponding `settings.json` scope (normal per-field merge — project wins).
 
 **Opt-in bash sandbox:** `STELLA_BASH_SANDBOX=workspace-write` confines `bash`
 file writes to the workspace root plus the standard tmp dirs (network still
@@ -438,7 +448,7 @@ flowchart TD
       ENG["step driver · goal loop · budget<br/>retry · compaction · loop-detection · router"]
     end
     CORE -->|Provider port| MODEL["stella-model — adapters<br/>anthropic · openai · gemini · vertex · bedrock · zai<br/>(+ any OpenAI-compatible: xai · deepseek · openrouter · local)"]
-    CORE -->|ToolExecutor port| TOOLS["stella-tools<br/>CRUD · bash · grep · glob · build · test · verify_done · issues · CI"]
+    CORE -->|ToolExecutor port| TOOLS["stella-tools<br/>CRUD · grep · glob · build · test · lint · scripts · processes · repo · verify_done · issues · CI · opt-in bash"]
     MCP["stella-mcp<br/>external MCP servers"] -.->|merges tools into registry| TOOLS
     CORE -->|emits AgentEvent stream| STORE["stella-store<br/>SQLite: executions · events · telemetry"]
     U -->|"recall · episodes · bi-temporal facts"| CTX["stella-context — context plane<br/>recall · embeddings · memory"]
@@ -473,7 +483,7 @@ repository and is pulled in as a pinned git dependency, not as workspace members
 |---|---|
 | `stella-cli` | CLI binary — clap surface + agent loop wiring |
 | `stella-core` | The step-driver engine (no I/O): parallel tools, goal loop, budget, retry, compaction, loop detection, router |
-| `stella-tools` | The built-in tools (CRUD, `bash`, `grep`/`glob`, build/test, `verify_done`, issues, CI) |
+| `stella-tools` | The built-in tools (CRUD, `grep`/`glob`, build/test/lint/format, `run_script`, the process group, the `repo_*` tools, `verify_done`, issues, CI — plus the opt-in `bash`) |
 | `stella-model` | The `Provider` port's adapters: anthropic, openai, gemini, vertex, bedrock, zai (SSE, tool-call dialects, SigV4, pricing) |
 | `stella-store` | SQLite persistence — executions, events, telemetry, files-touched |
 | `stella-mcp` | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry |

--- a/docs/why-stella.md
+++ b/docs/why-stella.md
@@ -61,7 +61,7 @@ plane.
 | **BYOK, model-agnostic** | Nine hosted providers (Anthropic, OpenAI, Gemini, xAI, DeepSeek, Z.ai, OpenRouter, Vertex, Bedrock) plus **any** OpenAI-compatible local server (Ollama, vLLM, LM Studio, llama.cpp). No account, no gateway. Pin per run with `--model provider/id`. |
 | **No phone-home** | The only network traffic Stella emits goes to the provider *you* chose. Executions, the full event stream, per-call token/cost telemetry, and a `[C·R·U·D] path` files-touched ledger land in a local `.stella/store.db` you can open with any SQLite client — and the store is never a dependency of a turn. |
 | **Budget you can trust** | `--budget <usd>` aborts cleanly **between** steps, never mid-tool, so a cap can't corrupt a half-written edit. |
-| **Bounded blast radius** | File tools are workspace-root-pinned; an opt-in `bash` sandbox (Seatbelt / bubblewrap) contains prompt-injection damage and **fails closed**; a cloned repo's own hooks never auto-execute (`STELLA_PROJECT_HOOKS=1` to opt in). |
+| **Bounded blast radius** | File tools are workspace-root-pinned; the `bash` tool is **off by default** (settings `tools.bash: "on"` to opt in — the default surface is enumerable argv, no shell); an opt-in `bash` sandbox (Seatbelt / bubblewrap) contains prompt-injection damage and **fails closed**; a cloned repo's own hooks never auto-execute (`STELLA_PROJECT_HOOKS=1` to opt in). |
 
 ## Also in the box
 

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -56,7 +56,10 @@ You have these tools available:
 - write_file: Create or overwrite a file (creates parent dirs)
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
-- bash: Run a shell command in the workspace root (with timeout)
+- run_lint / format_code: Run the project's own linter/formatter (cargo clippy/fmt, or the package.json lint/format scripts)
+- run_script: Run a verb the project itself declares — a Makefile target, package.json script, or cargo alias; args are passed argv-style and an unknown name lists the declared vocabulary
+- start_process / read_output / send_stdin / stop_process: Manage long-running processes (dev servers, REPLs, watchers) from an argv vector; one-shot commands belong in build_project/run_tests/run_script
+- repo_status / repo_commit / repo_push / repo_pull / repo_rollback: Version-control status, pathspec-explicit commits, guarded pushes (never the default branch, never forced), fast-forward-only pulls, and restoring named files to their last committed state
 - graph_query: Query the workspace's indexed code graph — where a symbol is defined or referenced, what a file imports, which files import it, or a file's neighborhood. The index is built automatically at session start and refreshes live as files change.
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
@@ -67,7 +70,7 @@ You have these tools available:
 - search_skills: Search the public skills registry for reusable skills you don't have locally
 - install_skill: Install a registry skill into the project (always requires the user's confirmation)
 
-Some tools have prerequisites: issue tracking (create_issue/update_issue/close_issue/search_issues/get_issue/list_labels/list_members/start_work_on_issue) appears only when a tracker is configured (`stella connect github|linear`, LINEAR_API_KEY, or gh auth) — search labels/members with list_labels/list_members before guessing names; ci_status requires the gh CLI. Use them when present.
+Some tools have prerequisites: issue tracking (create_issue/update_issue/close_issue/search_issues/get_issue/list_labels/list_members/start_work_on_issue) appears only when a tracker is configured (`stella connect github|linear`, LINEAR_API_KEY, or gh auth) — search labels/members with list_labels/list_members before guessing names; ci_status requires the gh CLI. Use them when present. The `bash` shell tool exists only when the workspace settings enable it ("tools": {"bash": "on"}); by default there is no shell — use the structured tools above.
 
 Rules:
 - For "where is X defined", "who calls/references X", or "what depends on this file" questions, reach for graph_query FIRST when it is available — it is precise and cheap. Fall back to grep/glob only when the graph can't answer (free-text search, a symbol the index doesn't carry, or no index yet).
@@ -88,7 +91,10 @@ You have these tools available:
 - write_file: Create or overwrite a file (creates parent dirs)
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
-- bash: Run a shell command in the workspace root (with timeout)
+- run_lint / format_code: Run the project's own linter/formatter (cargo clippy/fmt, or the package.json lint/format scripts)
+- run_script: Run a verb the project itself declares — a Makefile target, package.json script, or cargo alias; args are passed argv-style and an unknown name lists the declared vocabulary
+- start_process / read_output / send_stdin / stop_process: Manage long-running processes (dev servers, REPLs, watchers) from an argv vector; one-shot commands belong in build_project/run_tests/run_script
+- repo_status / repo_commit / repo_push / repo_pull / repo_rollback: Version-control status, pathspec-explicit commits, guarded pushes (never the default branch, never forced), fast-forward-only pulls, and restoring named files to their last committed state
 - graph_query: Query the workspace's indexed code graph — where a symbol is defined or referenced, what a file imports, which files import it, or a file's neighborhood. The index is built automatically at session start and refreshes live as files change. For symbol and dependency questions it is precise and cheaper than grep.
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
@@ -99,7 +105,7 @@ You have these tools available:
 - search_skills: Search the public skills registry for reusable skills you don't have locally
 - install_skill: Install a registry skill into the project (always requires the user's confirmation)
 
-Some tools have prerequisites: issue tracking (create_issue/update_issue/close_issue/search_issues/get_issue/list_labels/list_members/start_work_on_issue) appears only when a tracker is configured (`stella connect github|linear`, LINEAR_API_KEY, or gh auth) — search labels/members with list_labels/list_members before guessing names; ci_status requires the gh CLI. Use them when present.
+Some tools have prerequisites: issue tracking (create_issue/update_issue/close_issue/search_issues/get_issue/list_labels/list_members/start_work_on_issue) appears only when a tracker is configured (`stella connect github|linear`, LINEAR_API_KEY, or gh auth) — search labels/members with list_labels/list_members before guessing names; ci_status requires the gh CLI. Use them when present. The `bash` shell tool exists only when the workspace settings enable it ("tools": {"bash": "on"}); by default there is no shell — use the structured tools above.
 
 Methodology (always follow in order):
 1. REPRODUCE: Run the failing test or reproduce the bug before touching any file. Never edit blind, you must see the actual error first.
@@ -344,8 +350,9 @@ async fn run_pipeline_one_shot(
     let provider = build_provider(cfg)?;
     let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
 
-    let registry: Arc<ToolRegistry> =
-        Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
+    let registry: Arc<ToolRegistry> = Arc::new(
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), registry_options(cfg)).await,
+    );
     populate_schema_index(&registry, &cfg.workspace_root);
     crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root);
     // Auto-build + live-refresh the code graph in the background so the
@@ -1048,8 +1055,9 @@ async fn run_raw_one_shot(
     // Concrete `Arc<ToolRegistry>` (not `Arc<dyn ToolExecutor>`) so the
     // files-touched ledger is reachable after the turn — the trait object
     // hides it. It still coerces to `&dyn ToolExecutor` for the engine.
-    let registry: std::sync::Arc<ToolRegistry> =
-        std::sync::Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
+    let registry: std::sync::Arc<ToolRegistry> = std::sync::Arc::new(
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), registry_options(cfg)).await,
+    );
     populate_schema_index(&registry, &cfg.workspace_root);
     crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root);
     // Auto-build + live-refresh the code graph in the background so a
@@ -1193,8 +1201,9 @@ pub async fn run_goal_cmd(
     use_pipeline: bool,
 ) -> Result<(), String> {
     let provider = build_provider(cfg)?;
-    let registry: std::sync::Arc<ToolRegistry> =
-        std::sync::Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
+    let registry: std::sync::Arc<ToolRegistry> = std::sync::Arc::new(
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), registry_options(cfg)).await,
+    );
     populate_schema_index(&registry, &cfg.workspace_root);
     crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root);
     // Auto-build + live-refresh the code-graph index in the background so
@@ -1320,8 +1329,9 @@ const REPL_RESERVED: &[&str] = &[
 /// turn-scoped counter at the start of each one.
 pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<(), String> {
     let provider = build_provider(cfg)?;
-    let registry: std::sync::Arc<ToolRegistry> =
-        std::sync::Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
+    let registry: std::sync::Arc<ToolRegistry> = std::sync::Arc::new(
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), registry_options(cfg)).await,
+    );
     let mcp = connect_mcp(
         cfg,
         registry.clone(),
@@ -2271,7 +2281,14 @@ pub fn run_tools_listing() -> Result<(), String> {
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     tui::section_header("Stella tools");
 
-    let registry = ToolRegistry::new(workspace_root.clone());
+    // The listing mirrors a real session's surface, so the settings-driven
+    // switches (bash opt-in) apply here exactly as they do at session start.
+    let settings = crate::settings::Settings::load(&workspace_root)?;
+    let bash_enabled = settings.bash_tool_enabled();
+    let registry = ToolRegistry::new(
+        workspace_root.clone(),
+        stella_tools::RegistryOptions { bash: bash_enabled },
+    );
     println!("  {}", "built-in:".dimmed());
     let mut native: Vec<String> = stella_core::ports::ToolExecutor::schemas(&registry)
         .into_iter()
@@ -2280,6 +2297,14 @@ pub fn run_tools_listing() -> Result<(), String> {
     native.sort();
     for name in &native {
         println!("    {} {}", "·".dimmed(), name);
+    }
+    if !bash_enabled {
+        println!(
+            "    {} {}",
+            "·".dimmed(),
+            "bash — disabled (default); enable with \"tools\": {\"bash\": \"on\"} in settings"
+                .dimmed()
+        );
     }
     println!(
         "\n  {}",
@@ -3382,6 +3407,17 @@ async fn run_goal_pipeline_turn(
 /// served by the shared adapter re-identified per provider so its
 /// `Provider::id()` and error messages name the surface actually being
 /// called (an xAI 401 must never read "Z.ai rejected the API key").
+/// The registry feature switches for this session's config — the ONE
+/// translation point from settings (`tools.bash`, default off) to
+/// [`stella_tools::RegistryOptions`]. Every session driver (one-shot, goal,
+/// interactive, deck, sub-session workers, fleet workers) builds its
+/// registry through this, so no path can quietly re-enable the shell.
+pub(crate) fn registry_options(cfg: &Config) -> stella_tools::RegistryOptions {
+    stella_tools::RegistryOptions {
+        bash: cfg.tools_bash,
+    }
+}
+
 pub(crate) fn build_provider(cfg: &Config) -> Result<Box<dyn Provider>, String> {
     build_provider_parts(
         &cfg.provider,
@@ -3904,6 +3940,7 @@ mod tests {
             base_url_override: None,
             hooks: None,
             engine_settings: None,
+            tools_bash: false,
         }
     }
 

--- a/stella-cli/src/claims.rs
+++ b/stella-cli/src/claims.rs
@@ -22,20 +22,25 @@
 //!    process cannot release its own).
 //!
 //! The build lane is the one **transient** claim: `run_tests` /
-//! `build_project` serialize under the well-known pseudo-path
-//! [`BUILD_CLAIM`] for the duration of the call only (with a bounded wait,
-//! not a hard refusal — build contention is routine, edit contention is
-//! signal). This kills the phantom-failure class where one worker's test
-//! run observes a sibling's half-written edit.
+//! `build_project` — and the manifest-verb executors that can rewrite the
+//! tree (`run_lint`, `format_code`, `run_script`) — serialize under the
+//! well-known pseudo-path [`BUILD_CLAIM`] for the duration of the call
+//! only (with a bounded wait, not a hard refusal — build contention is
+//! routine, edit contention is signal). This kills the phantom-failure
+//! class where one worker's test run observes a sibling's half-written
+//! edit (or a sibling formatter's half-rewritten tree).
 //!
 //! A missing/failed store degrades to no coordination rather than no work —
 //! the same observability-loss-not-work-stoppage contract as every other
 //! store write.
 //!
 //! Coverage note: with `bash` OFF by default (settings `tools.bash`), the
-//! historically documented "bash hole" — shell writes invisible to claim
-//! tracking — is closed in the default configuration; it exists only in
-//! sessions that explicitly opted the shell back in.
+//! historically documented "bash hole" — arbitrary shell writes invisible
+//! to claim tracking — is closed in the default configuration; it exists
+//! only in sessions that explicitly opted the shell back in. (The
+//! manifest-verb executors still write outside per-path claims, but they
+//! run the project's own declared verbs, not arbitrary shell, and they
+//! serialize under the build lane below.)
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -166,8 +171,12 @@ impl ToolExecutor for ClaimTap<'_> {
         }
 
         // The build lane: transient, bounded-wait serialization so a test
-        // run never observes a sibling's half-written tree.
-        if matches!(name, "run_tests" | "build_project") {
+        // run never observes a sibling's half-written tree — and a sibling
+        // never observes a formatter/linter/script mid-rewrite.
+        if matches!(
+            name,
+            "run_tests" | "build_project" | "run_lint" | "format_code" | "run_script"
+        ) {
             let mut waited = 0u64;
             let acquired = loop {
                 match store.acquire_file_lock(BUILD_CLAIM, &self.holder) {
@@ -278,12 +287,22 @@ mod tests {
         let inner = Passthrough(std::sync::Mutex::new(Vec::new()));
         let tap = ClaimTap::new(&inner, Some(store.clone()), "ses-1/lead");
         let input = serde_json::json!({});
-        assert!(!tap.execute("run_tests", &input).await.is_error());
-        // Released immediately — a rival can take the lane without waiting.
-        assert!(
-            store.acquire_file_lock(BUILD_CLAIM, "ses-1/req:2").unwrap(),
-            "build lane must be free after the call"
-        );
+        // Every tree-rewriting executor rides the lane, not just tests.
+        for tool in [
+            "run_tests",
+            "build_project",
+            "run_lint",
+            "format_code",
+            "run_script",
+        ] {
+            assert!(!tap.execute(tool, &input).await.is_error());
+            // Released immediately — a rival takes the lane without waiting.
+            assert!(
+                store.acquire_file_lock(BUILD_CLAIM, "ses-1/req:2").unwrap(),
+                "build lane must be free after `{tool}`"
+            );
+            store.release_file_lock(BUILD_CLAIM, "ses-1/req:2").unwrap();
+        }
     }
 
     #[tokio::test]

--- a/stella-cli/src/claims.rs
+++ b/stella-cli/src/claims.rs
@@ -31,6 +31,11 @@
 //! A missing/failed store degrades to no coordination rather than no work —
 //! the same observability-loss-not-work-stoppage contract as every other
 //! store write.
+//!
+//! Coverage note: with `bash` OFF by default (settings `tools.bash`), the
+//! historically documented "bash hole" — shell writes invisible to claim
+//! tracking — is closed in the default configuration; it exists only in
+//! sessions that explicitly opted the shell back in.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -55,8 +60,12 @@ const BUILD_POLL_MS: u64 = 500;
 pub(crate) const STALE_CLAIM_MAX_AGE_SECS: u64 = 6 * 3600;
 
 /// The tools whose successful call mutates the path in their `path` input.
-/// `bash` is the documented hole — a shell can write anything; claims cover
-/// the structured file tools, and the witness/verify ladder covers the rest.
+/// In the DEFAULT configuration this coverage is complete for file writes:
+/// `bash` — historically the documented hole, since a shell can write
+/// anything unattributably — is no longer registered unless the workspace
+/// opts in via settings (`tools.bash: "on"`). Only in an opted-in session
+/// does the hole reopen; claims cover the structured file tools, and the
+/// witness/verify ladder covers the rest.
 fn mutating_path<'i>(name: &str, input: &'i Value) -> Option<&'i str> {
     if matches!(name, "write_file" | "edit_file" | "delete_file") {
         input.get("path").and_then(Value::as_str)

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -251,8 +251,9 @@ pub async fn run_deck_session(
     // MCP connect is NOT here: it can block up to 10s per server, so it runs
     // after the deck task spawns, narrated as transcript events (#98).
     let provider = agent::build_provider(cfg)?;
-    let registry: Arc<ToolRegistry> =
-        Arc::new(ToolRegistry::new_detected(cfg.workspace_root.clone()).await);
+    let registry: Arc<ToolRegistry> = Arc::new(
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), agent::registry_options(cfg)).await,
+    );
     agent::populate_schema_index(&registry, &cfg.workspace_root);
     crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root);
     let custom_tools = agent::discover_custom_tools(cfg, true).await;

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -375,6 +375,11 @@ pub struct Config {
     /// means the section is absent everywhere; consumers treat that as
     /// all-defaults (`crate::engine_config` resolves it per run).
     pub engine_settings: Option<crate::settings::AgentEngineConfig>,
+    /// Whether the `bash` tool is enabled (`tools.bash` in the settings
+    /// scope chain; absent = OFF). Threaded into every `ToolRegistry`
+    /// construction via `agent::registry_options` — the default tool
+    /// surface has no shell.
+    pub tools_bash: bool,
 }
 
 impl Config {
@@ -467,6 +472,7 @@ impl Config {
         )?;
         cfg.hooks = settings.hooks.clone();
         cfg.engine_settings = settings.agent_engine_config.clone();
+        cfg.tools_bash = settings.bash_tool_enabled();
         Ok(cfg)
     }
 
@@ -561,6 +567,7 @@ impl Config {
                     base_url_override: Some(base_url),
                     hooks: None,
                     engine_settings: None,
+                    tools_bash: false,
                 });
             }
 
@@ -745,11 +752,12 @@ impl Config {
             api_key: key,
             workspace_root: workspace_root.to_path_buf(),
             base_url_override: base_url_override.map(str::to_string),
-            // Hooks (and the agent-engine settings) ride the settings
-            // chain, not credential resolution — `load_with_settings`
-            // stamps both after the provider resolves.
+            // Hooks, the agent-engine settings, and the tool switches ride
+            // the settings chain, not credential resolution —
+            // `load_with_settings` stamps them after the provider resolves.
             hooks: None,
             engine_settings: None,
+            tools_bash: false,
         })
     }
 
@@ -1207,6 +1215,7 @@ mod tests {
             base_url_override: None,
             hooks: None,
             engine_settings: None,
+            tools_bash: false,
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains(secret), "Config Debug leaked the key: {dbg}");

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -430,7 +430,8 @@ async fn run_task(
     let mut cfg = cfg.clone();
     cfg.workspace_root = root.to_path_buf();
     let provider = agent::build_provider(&cfg)?;
-    let registry = ToolRegistry::new_detected(root.to_path_buf()).await;
+    let registry =
+        ToolRegistry::new_detected(root.to_path_buf(), agent::registry_options(&cfg)).await;
     crate::rules::enforce_workspace_rules(&registry, root);
     // Claim-on-first-write (crate::claims): tool-level write claims + the
     // transient build lane, coordinated across every writer in the

--- a/stella-cli/src/rules.rs
+++ b/stella-cli/src/rules.rs
@@ -436,7 +436,14 @@ mod tests {
             "Match the surrounding code style.",
         );
 
-        let registry = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+        // Command guards apply to `bash`, which is settings opt-in — this
+        // fixture opts it in the way an enabled session would.
+        let registry = ToolRegistry::with_backends_and_options(
+            root.path().to_path_buf(),
+            None,
+            None,
+            stella_tools::RegistryOptions { bash: true },
+        );
         enforce_workspace_rules(&registry, root.path());
 
         let denied = registry

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -100,6 +100,11 @@ pub struct Settings {
     /// already the status quo via `.stella/memories` and workspace rules.
     #[serde(default)]
     pub agent_engine_config: Option<AgentEngineConfig>,
+    /// Built-in tool switches ([`ToolsSettings`]). Scopes overlay per
+    /// field, project winning — so a repo may opt its sessions into (or
+    /// back out of) the `bash` tool.
+    #[serde(default)]
+    pub tools: Option<ToolsSettings>,
 }
 
 /// An `on`/`off` switch. A dedicated enum rather than `bool` because the
@@ -472,6 +477,19 @@ pub fn project_settings_path(workspace_root: &Path) -> PathBuf {
     workspace_root.join(".stella").join("settings.json")
 }
 
+/// The `tools` section of settings.json — switches for the built-in tool
+/// surface. Every field is optional, and every default is the SECURE
+/// posture: an absent key never enables anything.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+pub struct ToolsSettings {
+    /// The `bash` shell tool. **Absent or `"off"` = not registered** — the
+    /// model never sees a shell; enabling it requires a literal
+    /// `"tools": {"bash": "on"}` in some scope. [`Toggle`] rather than a
+    /// bool so a typo'd value is a loud parse error, not a silent state.
+    #[serde(default)]
+    pub bash: Option<Toggle>,
+}
+
 /// The `mcp` section of settings.json. All fields optional so an absent
 /// section behaves exactly as the defaults.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -484,6 +502,17 @@ pub struct McpSettings {
 }
 
 impl Settings {
+    /// Whether the `bash` tool is enabled for this workspace. Default OFF
+    /// in every scope and configuration — only an explicit
+    /// `"tools": {"bash": "on"}` somewhere in the chain turns it on (and a
+    /// later scope's `"off"` turns it back off; project wins per field).
+    pub fn bash_tool_enabled(&self) -> bool {
+        self.tools
+            .as_ref()
+            .and_then(|t| t.bash)
+            .is_some_and(Toggle::is_on)
+    }
+
     /// The configured MCP registry URL, or the official default. Applied at the
     /// read site (the house convention) rather than baked into serde.
     pub fn mcp_registry_url(&self) -> String {
@@ -653,6 +682,15 @@ impl Settings {
                 let target = merged.mcp.get_or_insert_with(McpSettings::default);
                 if let Some(url) = &mcp.registry_url {
                     target.registry_url = Some(url.clone());
+                }
+            }
+            // Tool switches are last-scope-wins per field, like `mcp` — a
+            // project can opt into bash while the user scope stays silent,
+            // or opt back out of a user-scope enable.
+            if let Some(tools) = &scope.tools {
+                let target = merged.tools.get_or_insert_with(ToolsSettings::default);
+                if let Some(bash) = tools.bash {
+                    target.bash = Some(bash);
                 }
             }
             // Agent-engine config overlays per field / per agent, like
@@ -978,6 +1016,58 @@ mod tests {
         engine.save_to(&fresh).unwrap();
         let merged = Settings::load_from(&[fresh]).unwrap();
         assert_eq!(merged.agent_engine_config, Some(engine));
+    }
+
+    /// Witness for the bash-off-by-default posture: an absent `tools` key
+    /// (or an absent `bash` field) parses to DISABLED, and the scope merge
+    /// is per-field with the later (project) scope winning in both
+    /// directions.
+    #[test]
+    fn bash_tool_defaults_off_and_the_project_scope_wins_per_field() {
+        // Absent everywhere → off.
+        assert!(!Settings::default().bash_tool_enabled());
+        let dir = tempfile::tempdir().unwrap();
+        let silent = write(dir.path(), "silent.json", r#"{"providers": {}}"#);
+        let merged = Settings::load_from(std::slice::from_ref(&silent)).unwrap();
+        assert!(!merged.bash_tool_enabled(), "absent key must mean off");
+        let empty_tools = write(dir.path(), "empty.json", r#"{"tools": {}}"#);
+        let merged = Settings::load_from(&[empty_tools]).unwrap();
+        assert!(!merged.bash_tool_enabled(), "empty tools section is off");
+
+        // user off + project on → on (the opt-in can live in any scope).
+        let user_off = write(dir.path(), "user.json", r#"{"tools": {"bash": "off"}}"#);
+        let project_on = write(dir.path(), "project.json", r#"{"tools": {"bash": "on"}}"#);
+        let merged = Settings::load_from(&[user_off.clone(), project_on.clone()]).unwrap();
+        assert!(merged.bash_tool_enabled(), "project-scope on wins");
+
+        // user on + project off → off (project wins per field both ways).
+        let user_on = write(dir.path(), "user_on.json", r#"{"tools": {"bash": "on"}}"#);
+        let project_off = write(
+            dir.path(),
+            "project_off.json",
+            r#"{"tools": {"bash": "off"}}"#,
+        );
+        let merged = Settings::load_from(&[user_on.clone(), project_off]).unwrap();
+        assert!(!merged.bash_tool_enabled(), "project-scope off wins");
+
+        // A scope that doesn't speak `tools` leaves the earlier value.
+        let merged = Settings::load_from(&[user_on, silent]).unwrap();
+        assert!(merged.bash_tool_enabled(), "silent scope must not reset");
+    }
+
+    /// `tools.bash` takes the Toggle vocabulary only — a bool (or any
+    /// typo) is a loud parse error, never a silently-guessed state.
+    #[test]
+    fn a_non_toggle_bash_value_is_a_loud_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, json) in [
+            ("bool.json", r#"{"tools": {"bash": true}}"#),
+            ("typo.json", r#"{"tools": {"bash": "enabled"}}"#),
+        ] {
+            let bad = write(dir.path(), name, json);
+            let err = Settings::load_from(std::slice::from_ref(&bad)).unwrap_err();
+            assert!(err.contains("invalid settings file"), "{err}");
+        }
     }
 
     #[test]

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -340,7 +340,8 @@ async fn run_worker(
         Ok(p) => p,
         Err(e) => return (None, 0.0, WorkerEnd::Failed(e)),
     };
-    let registry = ToolRegistry::new_detected(cfg.workspace_root.clone()).await;
+    let registry =
+        ToolRegistry::new_detected(cfg.workspace_root.clone(), agent::registry_options(cfg)).await;
     agent::populate_schema_index(&registry, &cfg.workspace_root);
     crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root);
 

--- a/stella-tools/Cargo.toml
+++ b/stella-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stella-tools"
-description = "Built-in agent tools: read_file, write_file, edit_file, bash, grep, glob. Workspace-root-pinned, timeout-backed, size-capped."
+description = "Built-in agent tools: file CRUD, grep/glob, build/test/lint/format, project-declared scripts, a long-running process group, vendor-neutral repo tools, and the opt-in bash. Workspace-root-pinned, timeout-backed, size-capped."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -1,6 +1,14 @@
 //! `bash` — run a shell command in the workspace root with a timeout.
 //! Process-group based kill so children don't outlive the timeout.
 //!
+//! **Opt-in, never ambient.** This tool is registered only when the host
+//! enabled it ([`crate::registry::RegistryOptions::bash`], set from the
+//! settings key `tools.bash: "on"`); the default tool surface has no
+//! shell at all. Prefer the structured executors — `run_tests`,
+//! `build_project`, `run_lint`, `format_code`, `run_script`, the process
+//! group, and the `repo_*` tools — which spawn enumerable argv and never
+//! interpret a shell string.
+//!
 //! Opt-in OS sandbox: `STELLA_BASH_SANDBOX=workspace-write|restricted` wraps
 //! the spawn in `sandbox-exec` (macOS, Seatbelt) or `bwrap` (Linux) — file
 //! writes confined to the workspace root + tmp dirs, `restricted` also

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -96,10 +96,24 @@ pub const RESERVED_NAMES: &[&str] = &[
     "write_file",
     "edit_file",
     "delete_file",
-    // Exec & search
-    "bash",
+    // Search
     "grep",
     "glob",
+    // Manifest-verb execution (argv, no shell)
+    "run_lint",
+    "format_code",
+    "run_script",
+    // The long-running process group
+    "start_process",
+    "read_output",
+    "send_stdin",
+    "stop_process",
+    // Vendor-neutral repository tools
+    "repo_status",
+    "repo_commit",
+    "repo_push",
+    "repo_pull",
+    "repo_rollback",
     // Codebase maps & memory
     "explorations",
     "save_exploration",
@@ -122,11 +136,13 @@ pub const RESERVED_NAMES: &[&str] = &[
     "task_complete",
     "task_cancel",
     "task_assign",
-    // Conditionally registered tools: graph_query only when a code-graph index
-    // exists, generate_image (and the video pair, when the key family has a
-    // video adapter) only when a media key is configured. The registry-driven
-    // drift test can't see these (a bare registry never advertises them), so
-    // they must be listed here by hand.
+    // Conditionally registered tools: bash only when the settings opt-in
+    // (`tools.bash: "on"`) enabled it, graph_query only when a code-graph
+    // index exists, generate_image (and the video pair, when the key family
+    // has a video adapter) only when a media key is configured. The
+    // registry-driven drift test can't see these (a bare registry never
+    // advertises them), so they must be listed here by hand.
+    "bash",
     "graph_query",
     "generate_image",
     "generate_video",

--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -1,6 +1,9 @@
-//! Shared subprocess runner for tools that shell out (`bash`, `verify_done`,
-//! `build_project`, `run_tests`): process-group spawn, hard timeout with a
-//! group kill, combined output, middle-out truncation.
+//! Shared subprocess runner for tools that spawn commands: process-group
+//! spawn, hard timeout with a group kill, combined output, middle-out
+//! truncation. Two entry points: [`run`] shells out via `bash -c`
+//! (`verify_done`, `build_project`, `run_tests`, the opt-in `bash` tool);
+//! [`run_argv`] execs an argv vector directly with NO shell anywhere
+//! (`run_script`, `run_lint`, `format_code`).
 
 use std::time::Duration;
 
@@ -36,6 +39,37 @@ pub(crate) async fn run(
 ) -> Result<(i32, String), String> {
     let mut cmd = Command::new("bash");
     cmd.arg("-c").arg(command);
+    drive(cmd, command, dir, timeout_secs).await
+}
+
+/// Run `program` with `args` DIRECTLY — argv exec, no shell anywhere — in
+/// `dir`. The runner for the manifest-verb tools (`run_script`, `run_lint`,
+/// `format_code`): arguments reach the child exactly as given, so no
+/// model-supplied string is ever shell-interpreted. Same process-group
+/// spawn, timeout kill, and truncation as [`run`].
+pub(crate) async fn run_argv(
+    program: &str,
+    args: &[String],
+    dir: &std::path::Path,
+    timeout_secs: u64,
+) -> Result<(i32, String), String> {
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+    let display = std::iter::once(program)
+        .chain(args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ");
+    drive(cmd, &display, dir, timeout_secs).await
+}
+
+/// Shared spawn/wait/kill/truncate body of [`run`] and [`run_argv`] —
+/// `command` is the human-readable command line for error messages.
+async fn drive(
+    mut cmd: Command,
+    command: &str,
+    dir: &std::path::Path,
+    timeout_secs: u64,
+) -> Result<(i32, String), String> {
     cmd.current_dir(dir);
     for var in GIT_REPO_ENV_VARS {
         cmd.env_remove(var);
@@ -122,6 +156,22 @@ mod tests {
             .unwrap();
         assert_eq!(code, 3);
         assert!(out.contains("hi"));
+    }
+
+    #[tokio::test]
+    async fn run_argv_execs_without_a_shell() {
+        // `echo` is a real binary; the argument is NOT shell-interpreted, so
+        // a metacharacter-laden string arrives verbatim.
+        let (code, out) = run_argv(
+            "echo",
+            &["$(id); `id`; && ||".to_string()],
+            std::path::Path::new("/tmp"),
+            30,
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 0);
+        assert!(out.contains("$(id); `id`; && ||"), "{out}");
     }
 
     #[tokio::test]

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -25,19 +25,22 @@ pub mod issue_ops;
 pub mod issues;
 pub mod media;
 pub mod memory;
+pub mod process;
 pub mod project;
 pub mod read;
 pub mod registry;
+pub mod repo;
 pub mod sandbox;
 pub mod schema_gate;
 pub mod screenshot;
+pub mod script;
 pub mod tasks;
 pub mod tracker_auth;
 pub mod validate;
 pub mod verify;
 pub mod write;
 
-pub use registry::ToolRegistry;
+pub use registry::{RegistryOptions, ToolRegistry};
 
 /// Resolve `path` against `root` and verify the result stays inside `root`.
 ///

--- a/stella-tools/src/process.rs
+++ b/stella-tools/src/process.rs
@@ -1,0 +1,684 @@
+//! Long-lived process group: `start_process`, `read_output`, `send_stdin`,
+//! `stop_process`.
+//!
+//! For servers, REPLs, and watchers — anything that outlives one tool call.
+//! One-shot work belongs in `run_tests` / `build_project` / `run_script`,
+//! and every tool description here says so, steering the model away from
+//! parking a build in a process slot.
+//!
+//! Contracts:
+//! - `start_process` spawns an **argv vector directly** (no shell), cwd
+//!   pinned to the workspace root, in its own process group, with
+//!   `kill_on_drop`. It returns a handle id (`proc-N`).
+//! - Output (stdout + stderr, interleaved by arrival) accumulates in a
+//!   capped ring buffer per process; when the cap overflows the oldest
+//!   bytes are dropped and the drop is FLAGGED on the next read.
+//! - `read_output` returns everything buffered since the last read and
+//!   reports `running` / `exited (code N)`; `clear: true` discards the
+//!   buffered output instead of returning it.
+//! - `stop_process` closes stdin, sends SIGTERM to the process group,
+//!   waits [`STOP_GRACE_MS`], then SIGKILLs the group — and any process
+//!   still alive when the registry (and with it this table) drops is
+//!   killed the same way, so nothing outlives the session.
+//!
+//! All errors are typed and named: unknown handle, exited process, closed
+//! stdin, empty argv.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStdin, Command};
+
+use crate::registry::Tool;
+
+/// Byte cap on each process's buffered (unread) output.
+const MAX_BUFFER_BYTES: usize = 200_000;
+/// How long `stop_process` waits after SIGTERM before SIGKILL.
+const STOP_GRACE_MS: u64 = 2_000;
+
+/// The shared process table — held by the registry's four process tool
+/// instances, so it lives exactly as long as the registry and its `Drop`
+/// reaps whatever is still running when the session ends.
+pub type ProcessTableHandle = Arc<Mutex<ProcessTable>>;
+
+/// Capped interleaved stdout+stderr buffer. Overflow drops the OLDEST
+/// bytes (a server's latest lines are the useful ones) and counts them so
+/// the next read can flag the gap.
+#[derive(Default)]
+struct OutputBuffer {
+    data: Vec<u8>,
+    dropped: u64,
+}
+
+impl OutputBuffer {
+    fn push(&mut self, chunk: &[u8]) {
+        self.data.extend_from_slice(chunk);
+        if self.data.len() > MAX_BUFFER_BYTES {
+            let excess = self.data.len() - MAX_BUFFER_BYTES;
+            self.data.drain(..excess);
+            self.dropped += excess as u64;
+        }
+    }
+
+    /// Take everything buffered since the last take, with the dropped-byte
+    /// count for the same window.
+    fn take(&mut self) -> (Vec<u8>, u64) {
+        (
+            std::mem::take(&mut self.data),
+            std::mem::take(&mut self.dropped),
+        )
+    }
+}
+
+/// One live (or recently exited) process.
+struct ProcessEntry {
+    /// Optional human label from `start_process`.
+    name: Option<String>,
+    /// The spawned argv, joined for display.
+    display: String,
+    child: Child,
+    /// Taken out of `child` at spawn so `send_stdin` can write without
+    /// holding the table lock across an await; `None` once closed.
+    stdin: Option<ChildStdin>,
+    output: Arc<Mutex<OutputBuffer>>,
+    /// Group-kill target (unix); 0 when the pid was unavailable.
+    pid: i32,
+    /// Cached exit code once observed (signal exits report -1).
+    exit_code: Option<i32>,
+}
+
+impl ProcessEntry {
+    /// Poll (and cache) the exit status without blocking.
+    fn poll_exit(&mut self) -> Option<i32> {
+        if self.exit_code.is_none()
+            && let Ok(Some(status)) = self.child.try_wait()
+        {
+            self.exit_code = Some(status.code().unwrap_or(-1));
+        }
+        self.exit_code
+    }
+}
+
+/// The session's process table. Handles are `proc-N`, N monotonic.
+#[derive(Default)]
+pub struct ProcessTable {
+    next_id: u64,
+    entries: HashMap<String, ProcessEntry>,
+}
+
+impl ProcessTable {
+    fn known_handles(&self) -> String {
+        if self.entries.is_empty() {
+            return "none".to_string();
+        }
+        let mut names: Vec<&str> = self.entries.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names.join(", ")
+    }
+}
+
+impl Drop for ProcessTable {
+    /// Reap every process still running when the table (and the registry
+    /// holding it) drops: group-SIGKILL on unix so grandchildren die too;
+    /// `kill_on_drop` on each `Child` backs this up for the direct child.
+    fn drop(&mut self) {
+        for entry in self.entries.values_mut() {
+            if entry.poll_exit().is_none() {
+                #[cfg(unix)]
+                if entry.pid > 0 {
+                    // SAFETY: plain libc::kill on a recorded child pgid;
+                    // guarded > 0 so we never signal our own group.
+                    unsafe {
+                        libc::kill(-entry.pid, libc::SIGKILL);
+                    }
+                }
+                let _ = entry.child.start_kill();
+            }
+        }
+    }
+}
+
+fn unknown_handle_error(table: &ProcessTable, handle: &str) -> ToolOutput {
+    ToolOutput::Error {
+        message: format!(
+            "unknown process handle `{handle}` — known handles: {}",
+            table.known_handles()
+        ),
+    }
+}
+
+/// Pump one child stream into the shared buffer until EOF. The lock is
+/// held only for the synchronous push, never across an await.
+fn spawn_pump<R>(mut reader: R, output: Arc<Mutex<OutputBuffer>>)
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => output
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(&buf[..n]),
+            }
+        }
+    });
+}
+
+/// `start_process` — see the module doc.
+pub struct StartProcess(pub ProcessTableHandle);
+
+#[async_trait]
+impl Tool for StartProcess {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "start_process".into(),
+            description: "Start a LONG-RUNNING process (dev server, REPL, watcher) from an \
+                          argv vector — no shell, cwd = workspace root. Returns a handle for \
+                          read_output / send_stdin / stop_process. For one-shot commands \
+                          prefer run_tests, build_project, or run_script instead."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "argv": { "type": "array", "items": { "type": "string" }, "minItems": 1, "description": "Program and arguments, spawned directly (argv[0] is the program)" },
+                    "name": { "type": "string", "description": "Optional human label for the handle" }
+                },
+                "required": ["argv"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
+        let argv: Vec<String> = input
+            .get("argv")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if argv.is_empty() {
+            return ToolOutput::Error {
+                message: "`argv` must be a non-empty array of strings (argv[0] is the program)"
+                    .into(),
+            };
+        }
+        let name = input
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let mut cmd = Command::new(&argv[0]);
+        cmd.args(&argv[1..]);
+        cmd.current_dir(root);
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.kill_on_drop(true);
+        // Own process group so stop/reap can take down grandchildren.
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ToolOutput::Error {
+                    message: format!("failed to spawn `{}`: {e}", argv.join(" ")),
+                };
+            }
+        };
+        let pid = child.id().unwrap_or(0) as i32;
+        let stdin = child.stdin.take();
+        let output: Arc<Mutex<OutputBuffer>> = Arc::default();
+        if let Some(stdout) = child.stdout.take() {
+            spawn_pump(stdout, output.clone());
+        }
+        if let Some(stderr) = child.stderr.take() {
+            spawn_pump(stderr, output.clone());
+        }
+
+        let display = argv.join(" ");
+        let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        table.next_id += 1;
+        let handle = format!("proc-{}", table.next_id);
+        table.entries.insert(
+            handle.clone(),
+            ProcessEntry {
+                name: name.clone(),
+                display: display.clone(),
+                child,
+                stdin,
+                output,
+                pid,
+                exit_code: None,
+            },
+        );
+        ToolOutput::Ok {
+            content: format!(
+                "started `{display}`{} as {handle} (pid {pid}) — poll it with read_output, \
+                 stop it with stop_process",
+                name.map(|n| format!(" ({n})")).unwrap_or_default()
+            ),
+        }
+    }
+}
+
+/// `read_output` — see the module doc.
+pub struct ReadOutput(pub ProcessTableHandle);
+
+#[async_trait]
+impl Tool for ReadOutput {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "read_output".into(),
+            description: "Read a started process's buffered stdout+stderr since the last \
+                          read, plus its running/exited state. clear: discard the buffered \
+                          output instead of returning it."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "handle": { "type": "string", "description": "Handle returned by start_process" },
+                    "clear": { "type": "boolean", "description": "Discard buffered output instead of returning it" }
+                },
+                "required": ["handle"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, _root: &std::path::Path) -> ToolOutput {
+        let Some(handle) = input.get("handle").and_then(|v| v.as_str()) else {
+            return ToolOutput::Error {
+                message: "missing required field `handle`".into(),
+            };
+        };
+        let clear = input
+            .get("clear")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(entry) = table.entries.get_mut(handle) else {
+            return unknown_handle_error(&table, handle);
+        };
+        let status = match entry.poll_exit() {
+            Some(code) => format!("exited (code {code})"),
+            None => "running".to_string(),
+        };
+        let (bytes, dropped) = entry
+            .output
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take();
+        let label = entry
+            .name
+            .as_deref()
+            .map(|n| format!(" ({n})"))
+            .unwrap_or_default();
+        let mut content = format!("{handle} `{}`{label}: {status}", entry.display);
+        if dropped > 0 {
+            content.push_str(&format!(
+                "\n[output truncated: {dropped} oldest bytes dropped before this read]"
+            ));
+        }
+        if clear {
+            content.push_str(&format!("\n[cleared {} buffered bytes]", bytes.len()));
+        } else if bytes.is_empty() {
+            content.push_str("\n[no new output]");
+        } else {
+            content.push('\n');
+            content.push_str(&crate::exec::truncate_middle(
+                String::from_utf8_lossy(&bytes).into_owned(),
+            ));
+        }
+        ToolOutput::Ok { content }
+    }
+}
+
+/// `send_stdin` — see the module doc.
+pub struct SendStdin(pub ProcessTableHandle);
+
+#[async_trait]
+impl Tool for SendStdin {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "send_stdin".into(),
+            description: "Write text to a started process's stdin (e.g. a REPL command — \
+                          include the trailing newline yourself). Errors if the process has \
+                          exited or its stdin was closed."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "handle": { "type": "string", "description": "Handle returned by start_process" },
+                    "text": { "type": "string", "description": "Bytes to write, verbatim (no newline is added)" }
+                },
+                "required": ["handle", "text"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, _root: &std::path::Path) -> ToolOutput {
+        let Some(handle) = input.get("handle").and_then(|v| v.as_str()) else {
+            return ToolOutput::Error {
+                message: "missing required field `handle`".into(),
+            };
+        };
+        let Some(text) = input.get("text").and_then(|v| v.as_str()) else {
+            return ToolOutput::Error {
+                message: "missing required field `text`".into(),
+            };
+        };
+        // Take stdin out under the lock, write outside it (a lock guard
+        // must not cross an await), then put it back.
+        let mut stdin = {
+            let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(entry) = table.entries.get_mut(handle) else {
+                return unknown_handle_error(&table, handle);
+            };
+            if let Some(code) = entry.poll_exit() {
+                return ToolOutput::Error {
+                    message: format!("{handle} has already exited (code {code})"),
+                };
+            }
+            match entry.stdin.take() {
+                Some(stdin) => stdin,
+                None => {
+                    return ToolOutput::Error {
+                        message: format!("{handle}'s stdin is closed"),
+                    };
+                }
+            }
+        };
+        let write = async {
+            stdin.write_all(text.as_bytes()).await?;
+            stdin.flush().await
+        }
+        .await;
+        let result = match write {
+            Ok(()) => ToolOutput::Ok {
+                content: format!("wrote {} bytes to {handle}", text.len()),
+            },
+            Err(e) => ToolOutput::Error {
+                message: format!("write to {handle} stdin failed: {e}"),
+            },
+        };
+        let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(entry) = table.entries.get_mut(handle) {
+            entry.stdin = Some(stdin);
+        }
+        result
+    }
+}
+
+/// `stop_process` — see the module doc.
+pub struct StopProcess(pub ProcessTableHandle);
+
+#[async_trait]
+impl Tool for StopProcess {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "stop_process".into(),
+            description: "Stop a started process: closes stdin, sends SIGTERM to its process \
+                          group, waits briefly, then SIGKILLs. Remaining output stays \
+                          readable via read_output."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "handle": { "type": "string", "description": "Handle returned by start_process" }
+                },
+                "required": ["handle"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, _root: &std::path::Path) -> ToolOutput {
+        let Some(handle) = input.get("handle").and_then(|v| v.as_str()) else {
+            return ToolOutput::Error {
+                message: "missing required field `handle`".into(),
+            };
+        };
+        // Phase 1, under the lock: close stdin (EOF lets well-behaved
+        // REPLs/servers exit on their own) and send the group SIGTERM.
+        let pid = {
+            let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(entry) = table.entries.get_mut(handle) else {
+                return unknown_handle_error(&table, handle);
+            };
+            entry.stdin = None;
+            if let Some(code) = entry.poll_exit() {
+                return ToolOutput::Ok {
+                    content: format!("{handle} had already exited (code {code})"),
+                };
+            }
+            #[cfg(unix)]
+            if entry.pid > 0 {
+                // SAFETY: signalling the child's own process group; the
+                // > 0 guard means we never signal our own group.
+                unsafe {
+                    libc::kill(-entry.pid, libc::SIGTERM);
+                }
+            }
+            entry.pid
+        };
+        // Phase 2: poll for exit without holding the lock across sleeps.
+        let mut waited = 0u64;
+        let exit_after_term = loop {
+            {
+                let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+                let Some(entry) = table.entries.get_mut(handle) else {
+                    return ToolOutput::Error {
+                        message: format!("{handle} disappeared while stopping"),
+                    };
+                };
+                if let Some(code) = entry.poll_exit() {
+                    break Some(code);
+                }
+            }
+            if waited >= STOP_GRACE_MS {
+                break None;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            waited += 100;
+        };
+        if let Some(code) = exit_after_term {
+            return ToolOutput::Ok {
+                content: format!("{handle} terminated (code {code})"),
+            };
+        }
+        // Phase 3: it ignored SIGTERM — SIGKILL the group.
+        #[cfg(unix)]
+        if pid > 0 {
+            // SAFETY: same guarded group signal as above.
+            unsafe {
+                libc::kill(-pid, libc::SIGKILL);
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = pid;
+        let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(entry) = table.entries.get_mut(handle) {
+            let _ = entry.child.start_kill();
+            let code = entry.poll_exit();
+            return ToolOutput::Ok {
+                content: match code {
+                    Some(code) => format!("{handle} killed after SIGTERM grace (code {code})"),
+                    None => format!("{handle} killed after SIGTERM grace"),
+                },
+            };
+        }
+        ToolOutput::Error {
+            message: format!("{handle} disappeared while stopping"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools() -> (ProcessTableHandle, std::path::PathBuf) {
+        (Arc::default(), std::env::temp_dir())
+    }
+
+    async fn start(table: &ProcessTableHandle, root: &std::path::Path, argv: &[&str]) -> String {
+        let out = StartProcess(table.clone())
+            .execute(&serde_json::json!({ "argv": argv }), root)
+            .await;
+        match out {
+            ToolOutput::Ok { content } => content
+                .split_whitespace()
+                .find(|w| w.starts_with("proc-"))
+                .expect("handle in start output")
+                .to_string(),
+            ToolOutput::Error { message } => panic!("start failed: {message}"),
+        }
+    }
+
+    #[test]
+    fn output_buffer_caps_and_counts_dropped_bytes() {
+        let mut buf = OutputBuffer::default();
+        buf.push(&vec![b'a'; MAX_BUFFER_BYTES]);
+        buf.push(&[b'z'; 10]);
+        let (bytes, dropped) = buf.take();
+        assert_eq!(bytes.len(), MAX_BUFFER_BYTES, "capped at the max");
+        assert_eq!(dropped, 10, "the 10 oldest bytes were dropped");
+        assert!(bytes.ends_with(b"zzzzzzzzzz"), "newest bytes survive");
+        // Take drains: a second take is empty with no drop count.
+        assert_eq!(buf.take(), (Vec::new(), 0));
+    }
+
+    #[tokio::test]
+    async fn empty_argv_is_a_named_error() {
+        let (table, root) = tools();
+        let out = StartProcess(table)
+            .execute(&serde_json::json!({"argv": []}), &root)
+            .await;
+        match out {
+            ToolOutput::Error { message } => assert!(message.contains("argv"), "{message}"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_handles_are_named_errors_on_every_tool() {
+        let (table, root) = tools();
+        for out in [
+            ReadOutput(table.clone())
+                .execute(&serde_json::json!({"handle": "proc-9"}), &root)
+                .await,
+            SendStdin(table.clone())
+                .execute(&serde_json::json!({"handle": "proc-9", "text": "x"}), &root)
+                .await,
+            StopProcess(table.clone())
+                .execute(&serde_json::json!({"handle": "proc-9"}), &root)
+                .await,
+        ] {
+            match out {
+                ToolOutput::Error { message } => {
+                    assert!(
+                        message.contains("unknown process handle `proc-9`"),
+                        "{message}"
+                    )
+                }
+                other => panic!("{other:?}"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cat_echoes_stdin_and_stop_reports_the_lifecycle() {
+        let (table, root) = tools();
+        let handle = start(&table, &root, &["cat"]).await;
+
+        let write = SendStdin(table.clone())
+            .execute(
+                &serde_json::json!({"handle": handle, "text": "hello_process\n"}),
+                &root,
+            )
+            .await;
+        assert!(!write.is_error(), "{write:?}");
+
+        // Poll until the pump has delivered the echo (bounded).
+        let mut echoed = String::new();
+        for _ in 0..50 {
+            let out = ReadOutput(table.clone())
+                .execute(&serde_json::json!({"handle": handle}), &root)
+                .await;
+            let ToolOutput::Ok { content } = out else {
+                panic!("read_output failed");
+            };
+            echoed.push_str(&content);
+            if echoed.contains("hello_process") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(echoed.contains("hello_process"), "{echoed}");
+        assert!(echoed.contains("running"), "{echoed}");
+
+        // Stop: cat exits on stdin EOF/SIGTERM; afterwards the state is
+        // exited and stdin writes are refused.
+        let stopped = StopProcess(table.clone())
+            .execute(&serde_json::json!({"handle": handle}), &root)
+            .await;
+        assert!(!stopped.is_error(), "{stopped:?}");
+        let after = SendStdin(table.clone())
+            .execute(&serde_json::json!({"handle": handle, "text": "x"}), &root)
+            .await;
+        match after {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("exited") || message.contains("stdin is closed"),
+                    "{message}"
+                )
+            }
+            other => panic!("stdin to a stopped process must fail: {other:?}"),
+        }
+        let status = ReadOutput(table)
+            .execute(&serde_json::json!({"handle": handle}), &root)
+            .await;
+        let ToolOutput::Ok { content } = status else {
+            panic!("read after stop must still work");
+        };
+        assert!(content.contains("exited"), "{content}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_naturally_exited_process_reports_its_code() {
+        let (table, root) = tools();
+        let handle = start(&table, &root, &["true"]).await;
+        // Wait for the exit to be observable.
+        for _ in 0..50 {
+            let out = ReadOutput(table.clone())
+                .execute(&serde_json::json!({"handle": handle}), &root)
+                .await;
+            let ToolOutput::Ok { content } = out else {
+                panic!("read_output failed");
+            };
+            if content.contains("exited (code 0)") {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("`true` never reported exit");
+    }
+}

--- a/stella-tools/src/project.rs
+++ b/stella-tools/src/project.rs
@@ -1,11 +1,15 @@
-//! `build_project` and `run_tests` — toolchain-aware build/test execution.
+//! `build_project`, `run_tests`, `run_lint`, `format_code` —
+//! toolchain-aware build/test/lint/format execution.
 //!
-//! Both detect the workspace's toolchain (Cargo, package.json + its
-//! package manager, Go, Make) and run its canonical command, or accept an
-//! explicit `command` override for anything exotic. `run_tests` supports
-//! `kind` (unit / e2e / all) and a `filter` mapped to the runner's native
-//! filtering flag — module, package, file, or test-name granularity is the
-//! runner's own semantics.
+//! All four detect the workspace's toolchain (Cargo, package.json + its
+//! package manager, Go, Make) and run its canonical command; build/test
+//! also accept an explicit `command` override for anything exotic.
+//! `run_tests` supports `kind` (unit / e2e / all) and a `filter` mapped to
+//! the runner's native filtering flag — module, package, file, or
+//! test-name granularity is the runner's own semantics. `run_lint` and
+//! `format_code` take no free-form command at all: they run the resolved
+//! toolchain verb via argv exec (no shell), and a workspace with no
+//! recognized linter/formatter is a named error, not a guess.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -217,6 +221,196 @@ impl Tool for RunTests {
     }
 }
 
+/// Named "nothing configured" error for `run_lint` / `format_code`: says
+/// exactly what was looked for, so the model can fix the project or pick a
+/// different tool instead of retrying blind.
+fn no_tool_error(what: &str, node_hint: &str) -> String {
+    format!(
+        "no {what} configured — looked for Cargo.toml (cargo) and {node_hint}; \
+         declare one, or run a project-declared verb via run_script"
+    )
+}
+
+/// The linter argv for the detected toolchain, or a named error. Pure —
+/// separable from process spawning so the command shape is unit-testable.
+fn lint_argv(toolchain: Option<&Toolchain>, fix: bool) -> Result<Vec<String>, String> {
+    match toolchain {
+        Some(Toolchain::Cargo) => {
+            let mut argv = vec!["cargo", "clippy", "--workspace", "--all-targets"];
+            if fix {
+                argv.push("--fix");
+                argv.push("--allow-dirty");
+            }
+            Ok(argv.into_iter().map(String::from).collect())
+        }
+        Some(Toolchain::Node { pm, scripts }) if scripts.contains_key("lint") => {
+            if fix {
+                // The `lint` script's fix flag is linter-specific; guessing
+                // (`-- --fix`) could rewrite files under a linter that
+                // treats it as a filename. Named refusal instead.
+                return Err("`fix` resolves to cargo only in this version — run the \
+                            project's own fix script (e.g. `lint:fix`) via run_script"
+                    .into());
+            }
+            Ok(vec![pm.to_string(), "run".into(), "lint".into()])
+        }
+        _ => Err(no_tool_error("linter", "a package.json `lint` script")),
+    }
+}
+
+/// The formatter argv for the detected toolchain, or a named error. Pure,
+/// like [`lint_argv`].
+fn format_argv(toolchain: Option<&Toolchain>, check: bool) -> Result<Vec<String>, String> {
+    match toolchain {
+        Some(Toolchain::Cargo) => {
+            let mut argv = vec!["cargo".to_string(), "fmt".to_string()];
+            if check {
+                argv.push("--check".into());
+            }
+            Ok(argv)
+        }
+        Some(Toolchain::Node { pm, scripts }) if scripts.contains_key("format") => {
+            if check {
+                return Err("`check` resolves to cargo only in this version — run the \
+                            project's own check script (e.g. `format:check`) via run_script"
+                    .into());
+            }
+            Ok(vec![pm.to_string(), "run".into(), "format".into()])
+        }
+        _ => Err(no_tool_error("formatter", "a package.json `format` script")),
+    }
+}
+
+/// Count rustc-style diagnostics in captured output — lines opening with
+/// `warning:`/`warning[` or `error:`/`error[`. The "counts where parseable"
+/// half of the structured report; toolchains with other formats just get
+/// the exit status and truncated output.
+fn diagnostic_counts(output: &str) -> (usize, usize) {
+    let mut warnings = 0;
+    let mut errors = 0;
+    for line in output.lines() {
+        let t = line.trim_start();
+        if t.starts_with("warning:") || t.starts_with("warning[") {
+            warnings += 1;
+        }
+        if t.starts_with("error:") || t.starts_with("error[") {
+            errors += 1;
+        }
+    }
+    (warnings, errors)
+}
+
+/// Spawn `argv` directly (no shell) and fold the result into the standard
+/// PASSED/FAILED report, appending diagnostic counts when any were parsed.
+/// Output is already middle-truncated by the runner.
+async fn run_argv_and_report(
+    argv: &[String],
+    root: &std::path::Path,
+    timeout_secs: u64,
+) -> ToolOutput {
+    let display = argv.join(" ");
+    match exec::run_argv(&argv[0], &argv[1..], root, timeout_secs).await {
+        Ok((code, output)) => {
+            let (warnings, errors) = diagnostic_counts(&output);
+            let counts = if warnings > 0 || errors > 0 {
+                format!(" [{errors} error(s), {warnings} warning(s)]")
+            } else {
+                String::new()
+            };
+            if code == 0 {
+                ToolOutput::Ok {
+                    content: format!("`{display}` PASSED (exit 0){counts}\n{output}"),
+                }
+            } else {
+                ToolOutput::Error {
+                    message: format!("`{display}` FAILED (exit {code}){counts}\n{output}"),
+                }
+            }
+        }
+        Err(e) => ToolOutput::Error { message: e },
+    }
+}
+
+/// `run_lint` — the project's own linter, resolved from the detected
+/// toolchain and spawned argv-style: `cargo clippy --workspace
+/// --all-targets` (plus `--fix --allow-dirty` when `fix`), or the
+/// package.json `lint` script. No free-form command surface.
+pub struct RunLint;
+
+#[async_trait]
+impl Tool for RunLint {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "run_lint".into(),
+            description: "Run the project's own linter (cargo clippy, or the package.json \
+                          `lint` script). fix: apply automatic fixes (cargo only). Prefer \
+                          this over invoking a linter by hand."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "fix": { "type": "boolean", "description": "Apply automatic fixes (cargo only)" },
+                    "timeout_secs": { "type": "integer" }
+                }
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
+        let timeout_secs = input
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let fix = input.get("fix").and_then(|v| v.as_bool()).unwrap_or(false);
+        match lint_argv(detect(root).await.as_ref(), fix) {
+            Ok(argv) => run_argv_and_report(&argv, root, timeout_secs).await,
+            Err(message) => ToolOutput::Error { message },
+        }
+    }
+}
+
+/// `format_code` — the project's own formatter, resolved and spawned like
+/// [`RunLint`]: `cargo fmt` (plus `--check` when `check`), or the
+/// package.json `format` script.
+pub struct FormatCode;
+
+#[async_trait]
+impl Tool for FormatCode {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "format_code".into(),
+            description: "Run the project's own formatter (cargo fmt, or the package.json \
+                          `format` script). check: verify formatting without rewriting \
+                          (cargo only)."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "check": { "type": "boolean", "description": "Verify without rewriting (cargo only)" },
+                    "timeout_secs": { "type": "integer" }
+                }
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
+        let timeout_secs = input
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let check = input
+            .get("check")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        match format_argv(detect(root).await.as_ref(), check) {
+            Ok(argv) => run_argv_and_report(&argv, root, timeout_secs).await,
+            Err(message) => ToolOutput::Error { message },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,6 +471,94 @@ mod tests {
             .execute(&serde_json::json!({"kind": "e2e"}), &root)
             .await;
         assert!(out.is_error(), "no e2e script → named error: {out:?}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn lint_and_format_argv_shapes_are_toolchain_resolved() {
+        let join = |argv: Vec<String>| argv.join(" ");
+        assert_eq!(
+            join(lint_argv(Some(&Toolchain::Cargo), false).unwrap()),
+            "cargo clippy --workspace --all-targets"
+        );
+        assert_eq!(
+            join(lint_argv(Some(&Toolchain::Cargo), true).unwrap()),
+            "cargo clippy --workspace --all-targets --fix --allow-dirty"
+        );
+        assert_eq!(
+            join(format_argv(Some(&Toolchain::Cargo), false).unwrap()),
+            "cargo fmt"
+        );
+        assert_eq!(
+            join(format_argv(Some(&Toolchain::Cargo), true).unwrap()),
+            "cargo fmt --check"
+        );
+
+        let scripts: serde_json::Map<String, Value> =
+            serde_json::from_str(r#"{"lint": "eslint .", "format": "prettier -w ."}"#).unwrap();
+        let node = Toolchain::Node {
+            pm: "pnpm",
+            scripts,
+        };
+        assert_eq!(
+            join(lint_argv(Some(&node), false).unwrap()),
+            "pnpm run lint"
+        );
+        assert_eq!(
+            join(format_argv(Some(&node), false).unwrap()),
+            "pnpm run format"
+        );
+        // fix/check don't guess a node flag — they refuse, pointing at
+        // run_script for the project's own fix/check verbs.
+        assert!(
+            lint_argv(Some(&node), true)
+                .unwrap_err()
+                .contains("run_script")
+        );
+        assert!(
+            format_argv(Some(&node), true)
+                .unwrap_err()
+                .contains("run_script")
+        );
+
+        // No toolchain, and node without the scripts: the error NAMES what
+        // was looked for.
+        let bare = Toolchain::Node {
+            pm: "npm",
+            scripts: serde_json::Map::new(),
+        };
+        for err in [
+            lint_argv(None, false).unwrap_err(),
+            lint_argv(Some(&bare), false).unwrap_err(),
+        ] {
+            assert!(err.contains("no linter configured"), "{err}");
+            assert!(err.contains("package.json `lint` script"), "{err}");
+        }
+        let err = format_argv(Some(&bare), false).unwrap_err();
+        assert!(err.contains("no formatter configured"), "{err}");
+        assert!(err.contains("package.json `format` script"), "{err}");
+    }
+
+    #[test]
+    fn diagnostic_counts_parse_rustc_style_lines() {
+        let out = "warning: unused variable `x`\n  --> src/a.rs:1:1\n\
+                   error[E0308]: mismatched types\nsome other line\n";
+        assert_eq!(diagnostic_counts(out), (1, 1));
+        assert_eq!(diagnostic_counts("all clean\n"), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn run_lint_names_the_missing_linter_in_an_empty_workspace() {
+        let root = temp_root("lint_none");
+        let out = RunLint.execute(&serde_json::json!({}), &root).await;
+        match &out {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("no linter configured"), "{message}")
+            }
+            other => panic!("{other:?}"),
+        }
+        let out = FormatCode.execute(&serde_json::json!({}), &root).await;
+        assert!(out.is_error(), "{out:?}");
         std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -95,32 +95,48 @@ pub struct SchemaIndex {
     pub views: HashSet<String>,
 }
 
+/// Host-decided feature switches for registry construction. `Default` is
+/// the SECURE posture — no `bash`: arbitrary shell execution is opt-in via
+/// settings (`tools.bash: "on"` in any scope), never ambient. Every
+/// construction path (CLI session drivers, fleet workers, tests) threads a
+/// value through explicitly; there is no global.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RegistryOptions {
+    /// Register the `bash` shell tool. Off by default everywhere: when off
+    /// the model never sees the schema, and calling `bash` anyway returns
+    /// the standard unknown-tool error.
+    pub bash: bool,
+}
+
 impl ToolRegistry {
     /// Construct with auto-detected optional backends (issue tracker, media
     /// provider). Prefer [`ToolRegistry::new_detected`] from async contexts —
     /// this synchronous form probes `gh` inline, blocking the calling thread.
-    pub fn new(root: PathBuf) -> Self {
-        Self::with_backends(
+    pub fn new(root: PathBuf, options: RegistryOptions) -> Self {
+        Self::with_backends_and_options(
             root,
             crate::issues::detect_issue_backend(),
             crate::media::detect_media_backend(),
+            options,
         )
     }
 
     /// [`ToolRegistry::new`] with the process-spawning issue-backend probe
     /// routed through the blocking pool (#64) — the constructor every async
     /// session driver uses.
-    pub async fn new_detected(root: PathBuf) -> Self {
-        Self::with_backends(
+    pub async fn new_detected(root: PathBuf, options: RegistryOptions) -> Self {
+        Self::with_backends_and_options(
             root,
             crate::issues::detect_issue_backend_async().await,
             crate::media::detect_media_backend(),
+            options,
         )
     }
 
-    /// Construct with an explicit issue backend (or none) and no media
-    /// backend — the seam unit tests use so tool counts depend on neither
-    /// the host's `gh` auth nor its provider env keys.
+    /// Construct with an explicit issue backend (or none), no media
+    /// backend, and default options — the seam unit tests use so tool
+    /// counts depend on neither the host's `gh` auth nor its provider env
+    /// keys (nor any bash opt-in).
     pub fn with_issue_backend(
         root: PathBuf,
         issue_backend: Option<crate::issues::IssueBackend>,
@@ -128,23 +144,40 @@ impl ToolRegistry {
         Self::with_backends(root, issue_backend, None)
     }
 
-    /// Construct with every optional backend explicit — the full seam.
+    /// [`ToolRegistry::with_backends_and_options`] with default options.
     pub fn with_backends(
         root: PathBuf,
         issue_backend: Option<crate::issues::IssueBackend>,
         media_backend: Option<crate::media::MediaBackend>,
     ) -> Self {
+        Self::with_backends_and_options(
+            root,
+            issue_backend,
+            media_backend,
+            RegistryOptions::default(),
+        )
+    }
+
+    /// Construct with every optional backend and feature switch explicit —
+    /// the full seam.
+    pub fn with_backends_and_options(
+        root: PathBuf,
+        issue_backend: Option<crate::issues::IssueBackend>,
+        media_backend: Option<crate::media::MediaBackend>,
+        options: RegistryOptions,
+    ) -> Self {
         let citations: crate::memory::CitationLedger = Arc::default();
         let mcp_usage: stella_core::mcp_usage::McpUsageLedger = Arc::default();
         let task_board: crate::tasks::TaskBoardHandle = Arc::default();
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
+        let processes: crate::process::ProcessTableHandle = Arc::default();
+        let repo_backend: Arc<dyn crate::repo::RepoBackend> = Arc::new(crate::repo::GitCli);
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
         let mut entries: Vec<Arc<dyn Tool>> = vec![
             Arc::new(crate::read::ReadFile::default()),
             Arc::new(crate::write::WriteFile),
             Arc::new(crate::edit::EditFile),
             Arc::new(crate::delete::DeleteFile),
-            Arc::new(crate::bash::Bash),
             Arc::new(crate::grep::Grep),
             Arc::new(crate::glob::Glob),
             Arc::new(crate::gather::GatherContext),
@@ -155,6 +188,21 @@ impl ToolRegistry {
             Arc::new(crate::verify::VerifyDone),
             Arc::new(crate::project::BuildProject),
             Arc::new(crate::project::RunTests),
+            Arc::new(crate::project::RunLint),
+            Arc::new(crate::project::FormatCode),
+            Arc::new(crate::script::RunScript),
+            // The process group shares one table; it lives exactly as long
+            // as the registry and its Drop reaps anything still running.
+            Arc::new(crate::process::StartProcess(processes.clone())),
+            Arc::new(crate::process::ReadOutput(processes.clone())),
+            Arc::new(crate::process::SendStdin(processes.clone())),
+            Arc::new(crate::process::StopProcess(processes)),
+            // Vendor-neutral repository tools over the RepoBackend port.
+            Arc::new(crate::repo::RepoStatusTool(repo_backend.clone())),
+            Arc::new(crate::repo::RepoCommit(repo_backend.clone())),
+            Arc::new(crate::repo::RepoPush(repo_backend.clone())),
+            Arc::new(crate::repo::RepoPull(repo_backend.clone())),
+            Arc::new(crate::repo::RepoRollback(repo_backend)),
             Arc::new(crate::ci::CiStatus),
             Arc::new(crate::screenshot::Screenshot),
             Arc::new(crate::tasks::TaskCreate(task_board.clone())),
@@ -171,6 +219,13 @@ impl ToolRegistry {
             // unlike image/video it is always registered.
             Arc::new(crate::media::GenerateSvg),
         ];
+        // `bash` is OPT-IN, never ambient: registered only when the host
+        // enabled it (settings `tools.bash: "on"`). Absent, the model never
+        // sees the schema and a call is the standard unknown-tool error —
+        // policy enforced at the tool boundary, not by prompt discipline.
+        if options.bash {
+            entries.push(Arc::new(crate::bash::Bash));
+        }
         // The code-graph query tool exists only when `stella init` has built
         // an index — same conditional-registration discipline as the issue
         // tools: no index, no dead schema entry.
@@ -933,6 +988,7 @@ mod tests {
         // drifting out of RESERVED_NAMES. Pin them explicitly — if you add a
         // new conditionally-registered tool, add its name to this array.
         const CONDITIONALLY_REGISTERED: &[&str] = &[
+            "bash",
             "graph_query",
             "generate_image",
             "generate_video",
@@ -956,7 +1012,6 @@ mod tests {
             "write_file",
             "edit_file",
             "delete_file",
-            "bash",
             "grep",
             "glob",
             "gather_context",
@@ -967,6 +1022,18 @@ mod tests {
             "verify_done",
             "build_project",
             "run_tests",
+            "run_lint",
+            "format_code",
+            "run_script",
+            "start_process",
+            "read_output",
+            "send_stdin",
+            "stop_process",
+            "repo_status",
+            "repo_commit",
+            "repo_push",
+            "repo_pull",
+            "repo_rollback",
             "ci_status",
             "screenshot",
             "generate_svg",
@@ -987,7 +1054,58 @@ mod tests {
         ] {
             assert!(names.contains(&expected.to_string()), "missing {expected}");
         }
-        assert_eq!(names.len(), 32, "unexpected tool count: {names:?}");
+        // `bash` is NOT in the default surface — it is the settings opt-in.
+        assert!(!names.contains(&"bash".to_string()), "{names:?}");
+        assert_eq!(names.len(), 43, "unexpected tool count: {names:?}");
+    }
+
+    // ---- bash opt-in (default OFF everywhere) -------------------------
+
+    /// Witness: the default registry has NO `bash` — not in the schemas
+    /// the model sees, and executing it anyway is the standard
+    /// unknown-tool error. Shell execution is settings opt-in.
+    #[tokio::test]
+    async fn bash_is_absent_by_default_and_calling_it_is_unknown() {
+        let (_root, reg) = bare_registry(None);
+        assert!(
+            !reg.schemas().iter().any(|s| s.name == "bash"),
+            "bash must not be advertised by default"
+        );
+        let out = reg
+            .execute("bash", &serde_json::json!({"command": "echo hi"}))
+            .await;
+        match out {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("unknown tool `bash`"), "{message}")
+            }
+            other => panic!("disabled bash must be an unknown tool: {other:?}"),
+        }
+        // And the default options value IS the off posture.
+        assert!(!RegistryOptions::default().bash);
+    }
+
+    /// Witness: the explicit opt-in registers `bash` — schema advertised
+    /// and dispatchable.
+    #[tokio::test]
+    async fn bash_registers_and_dispatches_with_the_opt_in_flag() {
+        let root = tempfile::tempdir().unwrap();
+        let reg = ToolRegistry::with_backends_and_options(
+            root.path().to_path_buf(),
+            None,
+            None,
+            RegistryOptions { bash: true },
+        );
+        assert!(reg.schemas().iter().any(|s| s.name == "bash"));
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({"command": "echo bash_enabled_ok"}),
+            )
+            .await;
+        match out {
+            ToolOutput::Ok { content } => assert!(content.contains("bash_enabled_ok")),
+            ToolOutput::Error { message } => panic!("enabled bash must run: {message}"),
+        }
     }
 
     /// The schema list is serialized verbatim into the prompt prefix; a
@@ -1006,7 +1124,7 @@ mod tests {
     fn issue_tools_absent_without_a_configured_backend() {
         let (_root, reg) = bare_registry(None);
         let names: Vec<String> = reg.schemas().iter().map(|s| s.name.clone()).collect();
-        assert_eq!(names.len(), 24, "unexpected tool count: {names:?}");
+        assert_eq!(names.len(), 35, "unexpected tool count: {names:?}");
         for absent in [
             "create_issue",
             "update_issue",
@@ -1146,6 +1264,7 @@ mod tests {
                     | "get_issue"
                     | "list_labels"
                     | "list_members"
+                    | "repo_status"
             );
             assert_eq!(
                 schema.read_only, expected,
@@ -1829,7 +1948,14 @@ mod tests {
 
     #[tokio::test]
     async fn a_denied_command_never_runs_and_a_bus_less_registry_is_unchanged() {
-        let (_dir, reg) = telemetry_fixture();
+        // Command guards apply to `bash`, so this fixture opts it in.
+        let dir = tempfile::tempdir().unwrap();
+        let reg = ToolRegistry::with_backends_and_options(
+            dir.path().to_path_buf(),
+            None,
+            None,
+            RegistryOptions { bash: true },
+        );
         let bus = HookBus::new("sess");
         bus.on_blocking(hook_names::COMMAND_STARTED, |_| HookDecision::Deny {
             reason: "no shell".into(),

--- a/stella-tools/src/repo.rs
+++ b/stella-tools/src/repo.rs
@@ -1,0 +1,857 @@
+//! Vendor-neutral repository tools: `repo_status`, `repo_commit`,
+//! `repo_push`, `repo_pull`, `repo_rollback`.
+//!
+//! Nothing here says "git" — not the tool names, not the argument names.
+//! The tools speak in repository concepts (branch, paths, message) through
+//! the [`RepoBackend`] port; today's only adapter is [`GitCli`], which
+//! shells to `git` via direct argv spawns (no shell interpretation, no new
+//! crates), and a future VCS is a new adapter, never a tool rewrite.
+//!
+//! Structural rules live in the TOOL layer, above the backend, so no
+//! adapter can forget them:
+//!
+//! - `repo_commit` and `repo_rollback` require a **non-empty, explicit
+//!   path list** — there is no `-A`, and a whole-tree operation must be
+//!   spelled out path by path, never implied by an empty-args call.
+//! - `repo_push` **refuses the repository's default branch** (resolved
+//!   from the remote HEAD). No override exists, and force-push does not
+//!   exist in this surface at all.
+//! - `repo_pull` is **fast-forward only** — divergence is a typed error,
+//!   not a merge.
+//! - History rewriting (`reset --hard`, rebase, amend) is deliberately
+//!   absent: `repo_rollback` restores named paths to the last committed
+//!   state and that is the only "undo" this surface offers.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::Value;
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+use crate::exec;
+use crate::registry::Tool;
+
+/// Timeout for backend commands (push/pull are network-bound).
+const REPO_TIMEOUT_SECS: u64 = 300;
+/// Cap on `repo_status` changed-file rows.
+const MAX_CHANGED_ROWS: usize = 200;
+
+/// Typed, named failures crossing the [`RepoBackend`] port.
+#[derive(Debug)]
+pub enum RepoError {
+    /// The VCS binary is missing or cannot start at all.
+    Unavailable(String),
+    /// A backend command ran and failed; `detail` carries its output.
+    Failed {
+        action: &'static str,
+        detail: String,
+    },
+    /// Local and remote histories diverged — `repo_pull` is fast-forward
+    /// only by contract, and history rewriting is out of scope.
+    Diverged(String),
+}
+
+impl std::fmt::Display for RepoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepoError::Unavailable(detail) => {
+                write!(f, "repository backend unavailable: {detail}")
+            }
+            RepoError::Failed { action, detail } => write!(f, "{action} failed: {detail}"),
+            RepoError::Diverged(detail) => write!(
+                f,
+                "histories diverged — repo_pull is fast-forward-only and never merges or \
+                 rewrites; reconcile manually. {detail}"
+            ),
+        }
+    }
+}
+
+/// One changed file in a [`RepoStatus`] — `state` is the backend's short
+/// two-column status code (e.g. ` M`, `??`, `A `).
+#[derive(Debug, Clone, Serialize)]
+pub struct ChangedFile {
+    pub state: String,
+    pub path: String,
+}
+
+/// The `repo_status` payload: typed rows, bounded.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoStatus {
+    /// Current branch; `None` when the checkout is detached.
+    pub branch: Option<String>,
+    /// Commits ahead of upstream; `None` when no upstream is configured.
+    pub ahead: Option<u32>,
+    /// Commits behind upstream; `None` when no upstream is configured.
+    pub behind: Option<u32>,
+    /// Changed files, capped at [`MAX_CHANGED_ROWS`].
+    pub changed: Vec<ChangedFile>,
+    /// True when the changed-file list was truncated at the cap.
+    pub truncated: bool,
+}
+
+/// Vendor-neutral repository port. Adapters translate these operations to
+/// their VCS; the structural refusals (default-branch push, empty path
+/// lists) live in the tools, not here — see the module doc.
+#[async_trait]
+pub trait RepoBackend: Send + Sync {
+    async fn status(&self, root: &Path) -> Result<RepoStatus, RepoError>;
+    /// Current branch, `None` when detached.
+    async fn current_branch(&self, root: &Path) -> Result<Option<String>, RepoError>;
+    /// The repository's default branch per the remote HEAD, `None` when it
+    /// cannot be determined.
+    async fn default_branch(&self, root: &Path) -> Result<Option<String>, RepoError>;
+    /// Stage exactly `paths` and commit them with `message`; returns a
+    /// one-line summary of the created commit.
+    async fn commit_paths(
+        &self,
+        root: &Path,
+        message: &str,
+        paths: &[String],
+    ) -> Result<String, RepoError>;
+    /// Push `branch` to the primary remote (upstream set; never forced).
+    async fn push_branch(&self, root: &Path, branch: &str) -> Result<String, RepoError>;
+    /// Fast-forward-only pull; divergence is [`RepoError::Diverged`].
+    async fn pull_ff_only(&self, root: &Path) -> Result<String, RepoError>;
+    /// Restore exactly `paths` to the last committed state.
+    async fn restore_paths(&self, root: &Path, paths: &[String]) -> Result<String, RepoError>;
+}
+
+/// The `git` CLI adapter — direct argv spawns through the shared runner
+/// (process-group kill, `GIT_*` repo-env scrubbing, output truncation).
+pub struct GitCli;
+
+impl GitCli {
+    async fn git(
+        root: &Path,
+        action: &'static str,
+        args: &[&str],
+    ) -> Result<(i32, String), RepoError> {
+        let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        exec::run_argv("git", &owned, root, REPO_TIMEOUT_SECS)
+            .await
+            .map_err(|e| {
+                if e.contains("failed to spawn") {
+                    RepoError::Unavailable(e)
+                } else {
+                    RepoError::Failed { action, detail: e }
+                }
+            })
+    }
+
+    /// Run and require exit 0; a nonzero exit is a named failure carrying
+    /// the command's output.
+    async fn git_ok(root: &Path, action: &'static str, args: &[&str]) -> Result<String, RepoError> {
+        match Self::git(root, action, args).await? {
+            (0, output) => Ok(output),
+            (code, output) => Err(RepoError::Failed {
+                action,
+                detail: format!("exit {code}: {}", output.trim()),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl RepoBackend for GitCli {
+    async fn status(&self, root: &Path) -> Result<RepoStatus, RepoError> {
+        let branch = self.current_branch(root).await?;
+        // No upstream configured is the common non-error case → None/None.
+        let (ahead, behind) = match Self::git(
+            root,
+            "status",
+            &["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+        )
+        .await?
+        {
+            (0, out) => {
+                let mut it = out.split_whitespace();
+                let ahead = it.next().and_then(|n| n.parse::<u32>().ok());
+                let behind = it.next().and_then(|n| n.parse::<u32>().ok());
+                (ahead, behind)
+            }
+            _ => (None, None),
+        };
+        let porcelain = Self::git_ok(root, "status", &["status", "--porcelain"]).await?;
+        let mut changed = Vec::new();
+        let mut truncated = false;
+        for line in porcelain.lines() {
+            if line.len() < 4 {
+                continue;
+            }
+            if changed.len() >= MAX_CHANGED_ROWS {
+                truncated = true;
+                break;
+            }
+            changed.push(ChangedFile {
+                state: line[..2].to_string(),
+                path: line[3..].to_string(),
+            });
+        }
+        Ok(RepoStatus {
+            branch,
+            ahead,
+            behind,
+            changed,
+            truncated,
+        })
+    }
+
+    async fn current_branch(&self, root: &Path) -> Result<Option<String>, RepoError> {
+        let out = Self::git_ok(root, "status", &["rev-parse", "--abbrev-ref", "HEAD"]).await?;
+        let name = out.trim();
+        Ok((name != "HEAD").then(|| name.to_string()))
+    }
+
+    async fn default_branch(&self, root: &Path) -> Result<Option<String>, RepoError> {
+        // Cheap local resolution first (set by clone), then ask the remote.
+        if let (0, out) = Self::git(
+            root,
+            "push",
+            &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        )
+        .await?
+            && let Some(name) = out.trim().strip_prefix("origin/")
+        {
+            return Ok(Some(name.to_string()));
+        }
+        if let (0, out) =
+            Self::git(root, "push", &["ls-remote", "--symref", "origin", "HEAD"]).await?
+        {
+            for line in out.lines() {
+                if let Some(rest) = line.strip_prefix("ref: refs/heads/")
+                    && let Some(name) = rest.split_whitespace().next()
+                {
+                    return Ok(Some(name.to_string()));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    async fn commit_paths(
+        &self,
+        root: &Path,
+        message: &str,
+        paths: &[String],
+    ) -> Result<String, RepoError> {
+        let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let mut add = vec!["add", "--"];
+        add.extend(&path_refs);
+        Self::git_ok(root, "repo_commit", &add).await?;
+        // Pathspec-limited commit: exactly the named paths land, whatever
+        // else may sit in the index stays uncommitted.
+        let mut commit = vec!["commit", "-m", message, "--"];
+        commit.extend(&path_refs);
+        Self::git_ok(root, "repo_commit", &commit).await?;
+        let summary = Self::git_ok(root, "repo_commit", &["log", "-1", "--oneline"]).await?;
+        Ok(format!("committed: {}", summary.trim()))
+    }
+
+    async fn push_branch(&self, root: &Path, branch: &str) -> Result<String, RepoError> {
+        // Fully-qualified refspec: what gets pushed can only ever be a
+        // branch head, and never with force.
+        let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+        let out = Self::git_ok(
+            root,
+            "repo_push",
+            &["push", "--set-upstream", "origin", &refspec],
+        )
+        .await?;
+        Ok(format!("pushed `{branch}`\n{}", out.trim()))
+    }
+
+    async fn pull_ff_only(&self, root: &Path) -> Result<String, RepoError> {
+        match Self::git(root, "repo_pull", &["pull", "--ff-only"]).await? {
+            (0, out) => Ok(out.trim().to_string()),
+            (_, out) if out.contains("fast-forward") || out.contains("divergent") => {
+                Err(RepoError::Diverged(out.trim().to_string()))
+            }
+            (code, out) => Err(RepoError::Failed {
+                action: "repo_pull",
+                detail: format!("exit {code}: {}", out.trim()),
+            }),
+        }
+    }
+
+    async fn restore_paths(&self, root: &Path, paths: &[String]) -> Result<String, RepoError> {
+        let mut args = vec!["checkout", "HEAD", "--"];
+        args.extend(paths.iter().map(String::as_str));
+        Self::git_ok(root, "repo_rollback", &args).await?;
+        Ok(format!(
+            "restored {} path(s) to the last committed state",
+            paths.len()
+        ))
+    }
+}
+
+/// Extract a non-empty `paths: string[]` or return the structural refusal
+/// shared by `repo_commit` and `repo_rollback` (see the module doc).
+fn required_paths(input: &Value, tool: &str, verb: &str) -> Result<Vec<String>, ToolOutput> {
+    let paths: Vec<String> = input
+        .get("paths")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    if paths.is_empty() {
+        return Err(ToolOutput::Error {
+            message: format!(
+                "{tool} {verb} exactly the paths you name — `paths` must be a non-empty \
+                 list; a whole-tree operation must be spelled out path by path, never \
+                 implied by an empty list"
+            ),
+        });
+    }
+    Ok(paths)
+}
+
+/// A branch name safe to hand to the backend as its own argv entry: no
+/// leading `-` (option injection), no whitespace or control characters.
+fn valid_branch_name(branch: &str) -> bool {
+    !branch.is_empty()
+        && !branch.starts_with('-')
+        && !branch.contains(|c: char| c.is_whitespace() || c.is_control())
+}
+
+/// `repo_status` — the one read-only repository tool.
+pub struct RepoStatusTool(pub Arc<dyn RepoBackend>);
+
+#[async_trait]
+impl Tool for RepoStatusTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "repo_status".into(),
+            description: "Repository status: current branch, commits ahead/behind upstream, \
+                          and the changed files as structured rows."
+                .into(),
+            input_schema: serde_json::json!({ "type": "object", "properties": {} }),
+            read_only: true,
+        }
+    }
+
+    async fn execute(&self, _input: &Value, root: &Path) -> ToolOutput {
+        match self.0.status(root).await {
+            Ok(status) => match serde_json::to_string_pretty(&status) {
+                Ok(json) => ToolOutput::Ok { content: json },
+                Err(e) => ToolOutput::Error {
+                    message: format!("cannot render repository status: {e}"),
+                },
+            },
+            Err(e) => ToolOutput::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+/// `repo_commit` — pathspec-explicit commit; see the module doc.
+pub struct RepoCommit(pub Arc<dyn RepoBackend>);
+
+#[async_trait]
+impl Tool for RepoCommit {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "repo_commit".into(),
+            description: "Commit EXACTLY the named paths: stages them, then commits only \
+                          them. paths is required and must be non-empty — there is no \
+                          stage-everything mode."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "message": { "type": "string", "description": "Commit message" },
+                    "paths": { "type": "array", "items": { "type": "string" }, "minItems": 1, "description": "The exact workspace-relative paths to commit" }
+                },
+                "required": ["message", "paths"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &Path) -> ToolOutput {
+        let Some(message) = input
+            .get("message")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+        else {
+            return ToolOutput::Error {
+                message: "missing required field `message`".into(),
+            };
+        };
+        let paths = match required_paths(input, "repo_commit", "commits") {
+            Ok(paths) => paths,
+            Err(refusal) => return refusal,
+        };
+        match self.0.commit_paths(root, message, &paths).await {
+            Ok(summary) => ToolOutput::Ok { content: summary },
+            Err(e) => ToolOutput::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+/// `repo_push` — never the default branch, never forced; see the module doc.
+pub struct RepoPush(pub Arc<dyn RepoBackend>);
+
+#[async_trait]
+impl Tool for RepoPush {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "repo_push".into(),
+            description: "Push the current (or named) branch to the primary remote. \
+                          STRUCTURALLY refuses the repository's default branch — publish \
+                          work on a feature branch. Force-push does not exist here."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "branch": { "type": "string", "description": "Branch to push (default: the current branch)" }
+                }
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &Path) -> ToolOutput {
+        let named = input.get("branch").and_then(|v| v.as_str());
+        if let Some(branch) = named
+            && !valid_branch_name(branch)
+        {
+            return ToolOutput::Error {
+                message: format!(
+                    "`{branch}` is not a valid branch name (must not start with `-` or \
+                     contain whitespace)"
+                ),
+            };
+        }
+        let branch = match named {
+            Some(b) => b.to_string(),
+            None => match self.0.current_branch(root).await {
+                Ok(Some(b)) => b,
+                Ok(None) => {
+                    return ToolOutput::Error {
+                        message: "the checkout is detached (no current branch) — pass \
+                                  `branch` explicitly"
+                            .into(),
+                    };
+                }
+                Err(e) => {
+                    return ToolOutput::Error {
+                        message: e.to_string(),
+                    };
+                }
+            },
+        };
+        // The structural rule: resolve the default branch and refuse it.
+        // An UNRESOLVABLE default fails closed — pushing blind could be
+        // pushing the default.
+        match self.0.default_branch(root).await {
+            Ok(Some(default)) if default == branch => {
+                return ToolOutput::Error {
+                    message: format!(
+                        "repo_push refuses to push `{branch}`: it is the repository's \
+                         default branch. Publish work on a feature branch instead — this \
+                         rule is structural and has no override"
+                    ),
+                };
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return ToolOutput::Error {
+                    message: "cannot determine the repository's default branch (remote \
+                              HEAD) — refusing to push rather than risk pushing it"
+                        .into(),
+                };
+            }
+            Err(e) => {
+                return ToolOutput::Error {
+                    message: e.to_string(),
+                };
+            }
+        }
+        match self.0.push_branch(root, &branch).await {
+            Ok(out) => ToolOutput::Ok { content: out },
+            Err(e) => ToolOutput::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+/// `repo_pull` — fast-forward only; see the module doc.
+pub struct RepoPull(pub Arc<dyn RepoBackend>);
+
+#[async_trait]
+impl Tool for RepoPull {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "repo_pull".into(),
+            description: "Update the current branch from its upstream, fast-forward only. \
+                          Diverged histories are a typed error — this tool never merges or \
+                          rewrites."
+                .into(),
+            input_schema: serde_json::json!({ "type": "object", "properties": {} }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, _input: &Value, root: &Path) -> ToolOutput {
+        match self.0.pull_ff_only(root).await {
+            Ok(out) => ToolOutput::Ok { content: out },
+            Err(e) => ToolOutput::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+/// `repo_rollback` — restore named paths to HEAD; see the module doc.
+pub struct RepoRollback(pub Arc<dyn RepoBackend>);
+
+#[async_trait]
+impl Tool for RepoRollback {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "repo_rollback".into(),
+            description: "Restore EXACTLY the named paths to their last committed state, \
+                          discarding local modifications to them. paths is required and \
+                          must be non-empty. History itself is never rewritten."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "paths": { "type": "array", "items": { "type": "string" }, "minItems": 1, "description": "The exact workspace-relative paths to restore" }
+                },
+                "required": ["paths"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &Path) -> ToolOutput {
+        let paths = match required_paths(input, "repo_rollback", "restores") {
+            Ok(paths) => paths,
+            Err(refusal) => return refusal,
+        };
+        match self.0.restore_paths(root, &paths).await {
+            Ok(out) => ToolOutput::Ok { content: out },
+            Err(e) => ToolOutput::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whether a real `git` is on PATH; these integration tests skip
+    /// cleanly (with a printed note) when it isn't — mirroring the
+    /// real-git tests in stella-fleet.
+    async fn git_available() -> bool {
+        tokio::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Fixture plumbing: run git expecting success (unwrap is fine in tests).
+    async fn sh_git(dir: &Path, args: &[&str]) {
+        let out = tokio::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Give a repo a deterministic identity and no signing, so commits work
+    /// in any environment.
+    async fn config_identity(dir: &Path) {
+        for (k, v) in [
+            ("user.email", "test@stella.local"),
+            ("user.name", "Stella Test"),
+            ("commit.gpgsign", "false"),
+        ] {
+            sh_git(dir, &["config", k, v]).await;
+        }
+    }
+
+    /// Build: a seed repo on `main` with one commit → a bare `origin.git`
+    /// → a working clone `ws` (whose `origin/HEAD` resolves to `main`).
+    /// Returns the working clone path.
+    async fn fixture(dir: &Path) -> std::path::PathBuf {
+        let seed = dir.join("seed");
+        std::fs::create_dir_all(&seed).unwrap();
+        sh_git(&seed, &["init", "--quiet"]).await;
+        // Version-portable "main" (predates `init -b`).
+        sh_git(&seed, &["symbolic-ref", "HEAD", "refs/heads/main"]).await;
+        config_identity(&seed).await;
+        std::fs::write(seed.join("README.md"), "seed\n").unwrap();
+        sh_git(&seed, &["add", "README.md"]).await;
+        sh_git(&seed, &["commit", "-q", "-m", "seed"]).await;
+
+        let origin = dir.join("origin.git");
+        sh_git(
+            dir,
+            &[
+                "clone",
+                "--quiet",
+                "--bare",
+                seed.to_str().unwrap(),
+                origin.to_str().unwrap(),
+            ],
+        )
+        .await;
+        let ws = dir.join("ws");
+        sh_git(
+            dir,
+            &[
+                "clone",
+                "--quiet",
+                origin.to_str().unwrap(),
+                ws.to_str().unwrap(),
+            ],
+        )
+        .await;
+        config_identity(&ws).await;
+        ws
+    }
+
+    fn backend() -> Arc<dyn RepoBackend> {
+        Arc::new(GitCli)
+    }
+
+    #[tokio::test]
+    async fn repo_status_reports_branch_upstream_and_changed_rows() {
+        if !git_available().await {
+            eprintln!("skipping repo_status test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+        std::fs::write(ws.join("README.md"), "changed\n").unwrap();
+        std::fs::write(ws.join("new.txt"), "new\n").unwrap();
+
+        let out = RepoStatusTool(backend()).execute(&Value::Null, &ws).await;
+        let ToolOutput::Ok { content } = out else {
+            panic!("repo_status must succeed: {out:?}");
+        };
+        let status: Value = serde_json::from_str(&content).expect("typed JSON payload");
+        assert_eq!(status["branch"], "main");
+        assert_eq!(status["ahead"], 0);
+        assert_eq!(status["behind"], 0);
+        let changed: Vec<String> = status["changed"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["path"].as_str().unwrap().to_string())
+            .collect();
+        assert!(changed.contains(&"README.md".to_string()), "{content}");
+        assert!(changed.contains(&"new.txt".to_string()), "{content}");
+        assert_eq!(status["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn repo_commit_stages_exactly_the_named_paths_and_refuses_empty() {
+        if !git_available().await {
+            eprintln!("skipping repo_commit test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+        std::fs::write(ws.join("a.txt"), "a\n").unwrap();
+        std::fs::write(ws.join("b.txt"), "b\n").unwrap();
+
+        // Empty list: the structural refusal, before anything runs.
+        let refused = RepoCommit(backend())
+            .execute(&serde_json::json!({"message": "nope", "paths": []}), &ws)
+            .await;
+        match refused {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("non-empty"), "{message}")
+            }
+            other => panic!("empty paths must be refused: {other:?}"),
+        }
+
+        let out = RepoCommit(backend())
+            .execute(
+                &serde_json::json!({"message": "add a only", "paths": ["a.txt"]}),
+                &ws,
+            )
+            .await;
+        let ToolOutput::Ok { content } = out else {
+            panic!("commit must succeed: {out:?}");
+        };
+        assert!(content.contains("add a only"), "{content}");
+
+        // b.txt was NOT swept into the commit.
+        let status = RepoStatusTool(backend()).execute(&Value::Null, &ws).await;
+        let ToolOutput::Ok { content } = status else {
+            panic!("status after commit");
+        };
+        assert!(content.contains("b.txt"), "b.txt must remain uncommitted");
+        assert!(
+            !content.contains("a.txt"),
+            "a.txt must be committed: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repo_push_refuses_the_default_branch_but_pushes_a_feature_branch() {
+        if !git_available().await {
+            eprintln!("skipping repo_push test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+
+        // On the default branch: the structural refusal names the rule.
+        let refused = RepoPush(backend())
+            .execute(&serde_json::json!({}), &ws)
+            .await;
+        match refused {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("default branch"), "{message}");
+                assert!(message.contains("`main`"), "{message}");
+            }
+            other => panic!("default-branch push must be refused: {other:?}"),
+        }
+
+        // An option-shaped branch name is rejected before any spawn.
+        let injected = RepoPush(backend())
+            .execute(&serde_json::json!({"branch": "--force"}), &ws)
+            .await;
+        match injected {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("not a valid branch name"), "{message}")
+            }
+            other => panic!("option-shaped branch must be refused: {other:?}"),
+        }
+
+        // A feature branch pushes fine and lands on the remote.
+        sh_git(&ws, &["checkout", "-q", "-b", "feature/x"]).await;
+        std::fs::write(ws.join("f.txt"), "f\n").unwrap();
+        RepoCommit(backend())
+            .execute(
+                &serde_json::json!({"message": "feature", "paths": ["f.txt"]}),
+                &ws,
+            )
+            .await;
+        let pushed = RepoPush(backend())
+            .execute(&serde_json::json!({}), &ws)
+            .await;
+        assert!(!pushed.is_error(), "{pushed:?}");
+        let origin = dir.path().join("origin.git");
+        let out = tokio::process::Command::new("git")
+            .args(["rev-parse", "--verify", "refs/heads/feature/x"])
+            .current_dir(&origin)
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success(), "feature/x must exist on the remote");
+    }
+
+    #[tokio::test]
+    async fn repo_pull_fast_forwards_and_types_divergence() {
+        if !git_available().await {
+            eprintln!("skipping repo_pull test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+        // A second clone advances origin/main (fixture plumbing, raw git —
+        // repo_push structurally refuses main, which is the point of it).
+        let ws2 = dir.path().join("ws2");
+        sh_git(
+            dir.path(),
+            &[
+                "clone",
+                "--quiet",
+                dir.path().join("origin.git").to_str().unwrap(),
+                ws2.to_str().unwrap(),
+            ],
+        )
+        .await;
+        config_identity(&ws2).await;
+        std::fs::write(ws2.join("upstream.txt"), "up\n").unwrap();
+        sh_git(&ws2, &["add", "upstream.txt"]).await;
+        sh_git(&ws2, &["commit", "-q", "-m", "upstream change"]).await;
+        sh_git(&ws2, &["push", "-q", "origin", "main"]).await;
+
+        // Clean fast-forward.
+        let pulled = RepoPull(backend()).execute(&Value::Null, &ws).await;
+        assert!(!pulled.is_error(), "{pulled:?}");
+        assert!(ws.join("upstream.txt").exists(), "ff must land the commit");
+
+        // Diverge: upstream advances again AND ws commits locally.
+        std::fs::write(ws2.join("upstream.txt"), "up2\n").unwrap();
+        sh_git(&ws2, &["add", "upstream.txt"]).await;
+        sh_git(&ws2, &["commit", "-q", "-m", "upstream 2"]).await;
+        sh_git(&ws2, &["push", "-q", "origin", "main"]).await;
+        std::fs::write(ws.join("local.txt"), "local\n").unwrap();
+        sh_git(&ws, &["add", "local.txt"]).await;
+        sh_git(&ws, &["commit", "-q", "-m", "local change"]).await;
+
+        let diverged = RepoPull(backend()).execute(&Value::Null, &ws).await;
+        match diverged {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("fast-forward"), "{message}")
+            }
+            other => panic!("divergence must be a typed error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn repo_rollback_restores_named_paths_and_refuses_an_empty_list() {
+        if !git_available().await {
+            eprintln!("skipping repo_rollback test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+        std::fs::write(ws.join("README.md"), "mangled\n").unwrap();
+
+        let refused = RepoRollback(backend())
+            .execute(&serde_json::json!({"paths": []}), &ws)
+            .await;
+        match refused {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("non-empty"), "{message}");
+            }
+            other => panic!("empty rollback must be refused: {other:?}"),
+        }
+        assert_eq!(
+            std::fs::read_to_string(ws.join("README.md")).unwrap(),
+            "mangled\n",
+            "a refused rollback must not touch the tree"
+        );
+
+        let rolled = RepoRollback(backend())
+            .execute(&serde_json::json!({"paths": ["README.md"]}), &ws)
+            .await;
+        assert!(!rolled.is_error(), "{rolled:?}");
+        assert_eq!(
+            std::fs::read_to_string(ws.join("README.md")).unwrap(),
+            "seed\n",
+            "the named path returns to its committed content"
+        );
+    }
+}

--- a/stella-tools/src/script.rs
+++ b/stella-tools/src/script.rs
@@ -1,0 +1,398 @@
+//! `run_script` — run a verb the project itself declares, and nothing else.
+//!
+//! The tool's vocabulary is enumerated from the workspace's own manifests:
+//! `Makefile` targets, `package.json` `"scripts"`, and cargo aliases from
+//! `.cargo/config.toml`. A name outside that vocabulary is a named error
+//! that LISTS the discovered verbs — the error itself is the discovery
+//! surface, so the model learns the project's real commands instead of
+//! guessing shell lines. Arguments are passed argv-style to the runner
+//! (`make <target> <args…>`, `<pm> run <script> -- <args…>`,
+//! `cargo <alias> <args…>`) — no `sh -c`, no shell interpretation anywhere.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+use crate::exec;
+use crate::registry::Tool;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 600;
+
+/// Where a discovered verb came from — decides the runner argv.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScriptSource {
+    Make,
+    Package,
+    CargoAlias,
+}
+
+/// The project's declared verbs, grouped by manifest. Resolution order on a
+/// name collision is Makefile → package.json → cargo alias (first match
+/// wins), matching the enumeration order below.
+#[derive(Debug, Default)]
+struct Vocabulary {
+    make_targets: Vec<String>,
+    package_scripts: Vec<String>,
+    /// The package manager for `package_scripts` (lockfile-detected, same
+    /// rule as [`crate::project`]).
+    pm: &'static str,
+    cargo_aliases: Vec<String>,
+}
+
+impl Vocabulary {
+    fn is_empty(&self) -> bool {
+        self.make_targets.is_empty()
+            && self.package_scripts.is_empty()
+            && self.cargo_aliases.is_empty()
+    }
+
+    /// First source declaring `name`, in resolution order.
+    fn resolve(&self, name: &str) -> Option<ScriptSource> {
+        if self.make_targets.iter().any(|t| t == name) {
+            return Some(ScriptSource::Make);
+        }
+        if self.package_scripts.iter().any(|s| s == name) {
+            return Some(ScriptSource::Package);
+        }
+        if self.cargo_aliases.iter().any(|a| a == name) {
+            return Some(ScriptSource::CargoAlias);
+        }
+        None
+    }
+
+    /// The unknown-name error: the full vocabulary, grouped by source —
+    /// this listing is the tool's discoverability surface.
+    fn unknown_name_error(&self, name: &str) -> String {
+        if self.is_empty() {
+            return format!(
+                "unknown script `{name}` — this project declares no runnable verbs \
+                 (no Makefile targets, package.json scripts, or cargo aliases found)"
+            );
+        }
+        let mut groups = Vec::new();
+        if !self.make_targets.is_empty() {
+            groups.push(format!(
+                "Makefile targets: {}",
+                self.make_targets.join(", ")
+            ));
+        }
+        if !self.package_scripts.is_empty() {
+            groups.push(format!(
+                "package.json scripts: {}",
+                self.package_scripts.join(", ")
+            ));
+        }
+        if !self.cargo_aliases.is_empty() {
+            groups.push(format!("cargo aliases: {}", self.cargo_aliases.join(", ")));
+        }
+        format!(
+            "unknown script `{name}` — this project declares: {}",
+            groups.join("; ")
+        )
+    }
+}
+
+/// Parse Makefile rule targets: lines opening with a plain
+/// `^[A-Za-z0-9_.-]+:` target. Skipped on purpose: special/`.PHONY`-style
+/// dot-targets, pattern rules (`%`), and variable assignments (`NAME :=`).
+fn parse_make_targets(src: &str) -> Vec<String> {
+    let mut targets = Vec::new();
+    for line in src.lines() {
+        let Some(colon) = line.find(':') else {
+            continue;
+        };
+        let name = &line[..colon];
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+            || name.starts_with('.')
+        {
+            continue;
+        }
+        // `NAME := value` / `NAME ::= value` are assignments, not rules.
+        let rest = &line[colon + 1..];
+        if rest.starts_with('=') || rest.starts_with(":=") {
+            continue;
+        }
+        if !targets.iter().any(|t| t == name) {
+            targets.push(name.to_string());
+        }
+    }
+    targets
+}
+
+/// Parse `[alias]` keys out of `.cargo/config.toml`.
+fn parse_cargo_aliases(src: &str) -> Vec<String> {
+    let Ok(value) = toml::from_str::<toml::Value>(src) else {
+        return Vec::new();
+    };
+    value
+        .get("alias")
+        .and_then(|a| a.as_table())
+        .map(|table| table.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Enumerate the workspace's declared verbs. Async file probes for the same
+/// reason as [`crate::project`]'s `detect` — this runs inside `execute()`.
+async fn discover(root: &std::path::Path) -> Vocabulary {
+    let mut vocab = Vocabulary {
+        pm: "npm",
+        ..Vocabulary::default()
+    };
+    if let Ok(src) = tokio::fs::read_to_string(root.join("Makefile")).await {
+        vocab.make_targets = parse_make_targets(&src);
+    }
+    if let Ok(raw) = tokio::fs::read_to_string(root.join("package.json")).await
+        && let Ok(pkg) = serde_json::from_str::<Value>(&raw)
+        && let Some(scripts) = pkg.get("scripts").and_then(|s| s.as_object())
+    {
+        vocab.package_scripts = scripts.keys().cloned().collect();
+        let exists = |name: &'static str| async move {
+            tokio::fs::try_exists(root.join(name))
+                .await
+                .unwrap_or(false)
+        };
+        vocab.pm = if exists("pnpm-lock.yaml").await {
+            "pnpm"
+        } else if exists("yarn.lock").await {
+            "yarn"
+        } else {
+            "npm"
+        };
+    }
+    if let Ok(src) = tokio::fs::read_to_string(root.join(".cargo").join("config.toml")).await {
+        vocab.cargo_aliases = parse_cargo_aliases(&src);
+    }
+    vocab
+}
+
+/// The runner argv for a resolved verb — pure, so the shape is testable.
+fn runner_argv(source: ScriptSource, pm: &str, name: &str, args: &[String]) -> Vec<String> {
+    let mut argv: Vec<String> = match source {
+        ScriptSource::Make => vec!["make".into(), name.into()],
+        ScriptSource::Package => {
+            let mut v = vec![pm.to_string(), "run".into(), name.into()];
+            if !args.is_empty() {
+                v.push("--".into());
+            }
+            v
+        }
+        ScriptSource::CargoAlias => vec!["cargo".into(), name.into()],
+    };
+    argv.extend(args.iter().cloned());
+    argv
+}
+
+/// `run_script` — see the module doc.
+pub struct RunScript;
+
+#[async_trait]
+impl Tool for RunScript {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "run_script".into(),
+            description: "Run a verb this project itself declares: a Makefile target, a \
+                          package.json script, or a cargo alias. args are passed argv-style \
+                          (never through a shell). An unknown name returns the full list of \
+                          declared verbs — call it with any name to discover them."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "A declared verb (Makefile target, package.json script, or cargo alias)" },
+                    "args": { "type": "array", "items": { "type": "string" }, "description": "Extra arguments, passed argv-style to the runner" },
+                    "timeout_secs": { "type": "integer" }
+                },
+                "required": ["name"]
+            }),
+            read_only: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
+        let Some(name) = input.get("name").and_then(|v| v.as_str()) else {
+            return ToolOutput::Error {
+                message: "missing required field `name`".into(),
+            };
+        };
+        let args: Vec<String> = input
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let timeout_secs = input
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+        let vocab = discover(root).await;
+        let Some(source) = vocab.resolve(name) else {
+            return ToolOutput::Error {
+                message: vocab.unknown_name_error(name),
+            };
+        };
+        let argv = runner_argv(source, vocab.pm, name, &args);
+        let display = argv.join(" ");
+        match exec::run_argv(&argv[0], &argv[1..], root, timeout_secs).await {
+            Ok((0, output)) => ToolOutput::Ok {
+                content: format!("`{display}` PASSED (exit 0)\n{output}"),
+            },
+            Ok((code, output)) => ToolOutput::Error {
+                message: format!("`{display}` FAILED (exit {code})\n{output}"),
+            },
+            Err(e) => ToolOutput::Error { message: e },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_targets_parse_rules_and_skip_specials_and_assignments() {
+        let src = "\
+.PHONY: build test\n\
+build: deps\n\
+\tcargo build\n\
+test:\n\
+\tcargo test\n\
+%.o: %.c\n\
+\tcc -c $<\n\
+VERSION := 1.2.3\n\
+NAME:=x\n\
+gate-all.v2: build\n";
+        assert_eq!(
+            parse_make_targets(src),
+            vec!["build", "test", "gate-all.v2"]
+        );
+    }
+
+    #[test]
+    fn cargo_aliases_parse_the_alias_table() {
+        let src = "[alias]\ntc = \"test -p stella-core\"\ngate = [\"fmt\", \"--check\"]\n\n[build]\njobs = 4\n";
+        let mut aliases = parse_cargo_aliases(src);
+        aliases.sort();
+        assert_eq!(aliases, vec!["gate", "tc"]);
+        assert!(parse_cargo_aliases("not toml [").is_empty());
+    }
+
+    #[test]
+    fn runner_argv_is_shell_free_and_source_shaped() {
+        let args = vec!["--flag".to_string(), "a b".to_string()];
+        assert_eq!(
+            runner_argv(ScriptSource::Make, "npm", "gate", &args).join("|"),
+            "make|gate|--flag|a b"
+        );
+        assert_eq!(
+            runner_argv(ScriptSource::Package, "pnpm", "dev", &args).join("|"),
+            "pnpm|run|dev|--|--flag|a b"
+        );
+        // No args → no dangling `--`.
+        assert_eq!(
+            runner_argv(ScriptSource::Package, "npm", "dev", &[]).join("|"),
+            "npm|run|dev"
+        );
+        assert_eq!(
+            runner_argv(ScriptSource::CargoAlias, "npm", "tc", &args).join("|"),
+            "cargo|tc|--flag|a b"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_name_lists_the_discovered_vocabulary() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Makefile"),
+            "build:\n\ttrue\ngate:\n\ttrue\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts": {"dev": "vite", "lint": "eslint ."}}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join(".cargo")).unwrap();
+        std::fs::write(
+            dir.path().join(".cargo/config.toml"),
+            "[alias]\ntc = \"test -p stella-core\"\n",
+        )
+        .unwrap();
+
+        let out = RunScript
+            .execute(&serde_json::json!({"name": "nope"}), dir.path())
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("unknown name must be an error");
+        };
+        for expected in [
+            "unknown script `nope`",
+            "Makefile targets: build, gate",
+            "dev",
+            "lint",
+            "cargo aliases: tc",
+        ] {
+            assert!(message.contains(expected), "missing {expected}: {message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_empty_project_names_every_manifest_it_looked_for() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = RunScript
+            .execute(&serde_json::json!({"name": "build"}), dir.path())
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("expected error");
+        };
+        assert!(message.contains("declares no runnable verbs"), "{message}");
+        assert!(message.contains("Makefile targets"), "{message}");
+    }
+
+    /// Whether `make` exists on PATH — the execution test skips cleanly
+    /// without it (mirrors the real-git skip in stella-fleet).
+    async fn make_available() -> bool {
+        tokio::process::Command::new("make")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn a_declared_make_target_runs_and_args_pass_argv_style() {
+        if !make_available().await {
+            eprintln!("skipping run_script make test: `make` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        // The target prints its first argument-variable-free marker; args
+        // land as extra make goals, so use a no-op goal to prove they are
+        // separate argv entries and never shell-joined.
+        std::fs::write(
+            dir.path().join("Makefile"),
+            "hello:\n\t@echo script_ran_ok\nnoop:\n\t@true\n",
+        )
+        .unwrap();
+        let out = RunScript
+            .execute(
+                &serde_json::json!({"name": "hello", "args": ["noop"]}),
+                dir.path(),
+            )
+            .await;
+        match out {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("script_ran_ok"), "{content}");
+                assert!(content.contains("`make hello noop` PASSED"), "{content}");
+            }
+            ToolOutput::Error { message } => panic!("expected ok: {message}"),
+        }
+    }
+}


### PR DESCRIPTION
## Security rationale — policy at the tool boundary

Until now, every Stella session handed the model an unrestricted shell. Prompt discipline ("prefer the structured tools") is not a security control; the only control that holds is one enforced where tools are registered. This PR flips the posture:

- **`bash` is OFF by default in every scope and configuration.** The default `ToolRegistry` never registers it: the model does not see the schema, and calling `bash` anyway returns the standard unknown-tool error.
- **Enabling is an explicit, auditable settings opt-in** — `"tools": {"bash": "on"}` in stella settings JSON at any scope (user `~/.config/stella/settings.json`, org-managed `STELLA_MANAGED_SETTINGS`, project `.stella/settings.json`), with the normal per-field merge: project wins, in both directions (a project can also switch a user-scope enable back off).
- **Everything that replaces the shell is enumerable argv.** Every new tool spawns a program + argument vector directly — `sh -c` does not appear anywhere in the new surface, so no model-supplied string is ever shell-interpreted.

The flag threads through **every** registry construction site (deck driver, sub-session workers, fleet `run_task`, one-shot / goal / interactive paths, `stella tools` listing) via a new `RegistryOptions` parameter — an options struct, not a global, so no path can quietly re-enable the shell. With bash off, the documented "bash hole" in claim-on-first-write coverage (`stella-cli/src/claims.rs`) **closes in the default configuration**; the module docs now say so.

## Settings semantics

New `tools` section in `settings.json` (`stella-cli/src/settings.rs`):

```jsonc
{ "tools": { "bash": "on" } }   // Toggle vocabulary: "on" / "off"
```

- Absent key (or absent section) → **off**. `Toggle` rather than a bool, so a typo'd value (`true`, `"enabled"`) is a loud parse error, never a silently-guessed state.
- Scopes merge last-wins per field, like `mcp`: user → org-managed → project.
- `Config.tools_bash` carries the merged value; `agent::registry_options(cfg)` is the single translation point to `stella_tools::RegistryOptions`.

## Tool groups and contracts

### 1. Execution tools (`stella-tools/src/project.rs`, `script.rs`)

- **`run_lint { fix?: bool }`** — resolves the project's linter from toolchain detection: cargo → `cargo clippy --workspace --all-targets` (+`--fix --allow-dirty` when `fix`); node → the package.json `lint` script when declared. Nothing resolvable → typed error naming exactly what was looked for.
- **`format_code { check?: bool }`** — `cargo fmt` (+`--check`), or the package.json `format` script; same typed miss.
- **`run_script { name, args?: string }`** — runs ONLY verbs the project itself declares: Makefile targets (parsed `^[A-Za-z0-9_.-]+:` rules; dot-specials, pattern rules, and assignments skipped), package.json `"scripts"`, cargo aliases from `.cargo/config.toml`. An unknown name is a typed error that **lists the discovered vocabulary** — the error is the discoverability surface. Args pass argv-style to `make <t>`, `<pm> run <s> -- args`, `cargo <alias>`.
- Bounded structured output: exit status, middle-truncated output, rustc-style warning/error counts where parseable.

### 2. Process group (`stella-tools/src/process.rs`)

- **`start_process { argv: string, name? }`** → handle id (`proc-N`); direct argv spawn (no shell), cwd = workspace root, own process group, `kill_on_drop`.
- **`read_output { handle, clear? }`** → everything buffered since the last read + running/exited(+code); the per-process ring is capped (200 KB) and drops of the oldest bytes are flagged on the next read. `clear: true` discards instead of returning.
- **`send_stdin { handle, text }`** — typed errors for unknown handle / exited process / closed stdin.
- **`stop_process { handle }`** — closes stdin, SIGTERM to the group, 2 s grace, then SIGKILL; remaining output stays readable. The registry-held table's `Drop` group-kills anything still alive, so no process outlives the session.
- Tool descriptions steer the model: one-shot commands belong in `run_tests`/`build_project`/`run_script`; processes are for servers, REPLs, watchers.

### 3. Vendor-neutral repo tools (`stella-tools/src/repo.rs`)

Behind a small **`RepoBackend`** port (future VCS adapters; today one `GitCli` adapter shelling to `git` via tokio argv — no new crates). Nothing in the tool names or argument names says "git". Structural rules live in the tool layer, above the port, so no future adapter can forget them:

- **`repo_status {}`** — branch, ahead/behind upstream, changed files as typed serialized rows, bounded (200-row cap, truncation flagged). The only read-only tool of the group.
- **`repo_commit { message, paths }`** — refuses an empty `paths` list; stages exactly the named paths and commits with a pathspec so nothing else is swept in. No `-A` exists.
- **`repo_push { branch? }`** — pushes the current or named branch; **structurally refuses the repository's default branch** (resolved from `origin/HEAD`, falling back to the remote symref; unresolvable fails **closed**). Never forced — force-push does not exist in this surface. Option-shaped branch names (`--force`) are rejected before any spawn.
- **`repo_pull {}`** — `--ff-only`; divergence is a typed `Diverged` error, never a merge.
- **`repo_rollback { paths }`** — restores exactly the named paths to HEAD; refuses an empty list (a whole-tree rollback must never be one empty-args call away). History-rewriting rollback (reset/rebase/amend) is deliberately absent and documented as such.

## Registry changes

- `RegistryOptions { bash: bool }` (default **false**) + `with_backends_and_options` full seam; `new` / `new_detected` now take options; the test seams (`with_issue_backend`, `with_backends`) default to the secure posture.
- Default tool count: 24 → **35** without an issue backend, 32 → **43** with one (12 new always-on tools, bash removed from the default set).
- Read-only partition: `repo_status` joins the read-only set; every other new tool is mutating.
- `RESERVED_NAMES` gains all 12 new names; `bash` moves to the conditionally-registered pin list (with `graph_query`, media tools).

## Test / witness coverage

- **Witnesses** (all reference symbols absent on `main`, so they fail there by construction): default registry has NO bash + unknown-tool error on call; a registry built with the opt-in flag advertises and dispatches it; settings parse — absent key → off, project-scope `"on"` overrides user-scope `"off"` (and vice versa), non-Toggle values are loud parse errors.
- Updated: full-tool-set/count tests, read-only partition, reserved-names drift pin, the bus command-guard tests and the rules.rs command-guard test (now opt bash in explicitly).
- New suites: make-target/cargo-alias parsers + vocabulary-listing errors + a real `make` run (skips cleanly when `make` is absent); process lifecycle over real `cat`/`true` (echo via stdin, capped-ring drop accounting, stop semantics, typed unknown-handle/exited errors); repo tools against a real temp git fixture — bare origin + clone — covering status rows, pathspec-exact commits, default-branch push refusal, feature-branch push, ff-only pull + divergence, rollback (skips cleanly when `git` is absent, mirroring stella-fleet's real-git tests).
- `make gate` (fmt --check + clippy -D warnings + full workspace tests) exits 0; the observatory socket test passes here (not the pre-existing-failure case).

## Documented v1 scopes

- `run_lint --fix` / `format_code --check` resolve for cargo only; for node the tools refuse with a pointer to the project's own `lint:fix` / `format:check` verbs via `run_script` (guessing linter-specific flags could mangle files).
- `run_script` resolution order on name collision: Makefile → package.json → cargo alias (first match wins).
- `repo_*` v1 ships one backend (`GitCli`); the port is the seam for future VCS adapters.
- The process group is Unix-complete (group signals); non-Unix falls back to direct child kill.
