### PR TITLE
feat(sessions): deregister stale lanes and reseed the session budget on in-deck switch

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -324,12 +324,12 @@ pub async fn run_deck_session(
             std::mem::take(&mut rs.history).unwrap_or_default(),
             &system_prompt,
         );
-        // Session spend stays monotone across interruptions, and a
-        // `--budget` keeps meaning "this session" — the guard resumes from
-        // what the session had already spent.
-        if let Some(spent) = rs.spent_usd {
-            let _ = budget.record_spend(spent);
-        }
+        // `--budget` means THIS session on every resume path: the guard's
+        // session accumulator reseeds to exactly what the session had
+        // already spent (its journal's last `BudgetTick`), so spend stays
+        // monotone across interruptions. Same seam as the in-deck session
+        // switch (`SessionResume` in the driver loop below).
+        budget.reseed_session_spend(rs.spent_usd.unwrap_or(0.0));
     }
 
     // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
@@ -365,8 +365,13 @@ pub async fn run_deck_session(
     // Replay a resumed session's journal straight onto the deck BEFORE the
     // first live send, so the restored transcript precedes everything this
     // run adds. (The fresh `Register` below then restamps the lead's meta —
-    // pid, model, clock — over the replayed one.)
+    // pid, model, clock — over the replayed one.) The non-lead lanes the
+    // replay puts on the dashboard are remembered so an in-deck session
+    // switch can deregister them — rows of a session left behind must not
+    // linger on the next session's dashboard.
+    let mut replayed_lanes: Vec<String> = Vec::new();
     if let Some(rs) = &mut resume_state {
+        replayed_lanes = crate::session_persist::journal_lanes(&rs.records, LEAD);
         crate::session_persist::replay_session(
             std::mem::take(&mut rs.records),
             now_ms(),
@@ -820,6 +825,25 @@ pub async fn run_deck_session(
                                     let _ = session_registry.upsert(&session_record);
                                 }
 
+                                // Clear the departing session's worker rows
+                                // off the dashboard before the target's
+                                // replay claims it: every non-lead lane is
+                                // terminal here (the switch refuses while
+                                // workers are live), so each one — spawned
+                                // this tenancy or replayed at the last
+                                // adoption — gets a `Deregister`. Direct
+                                // sends (deck_tx): the removal is part of
+                                // THIS process's dashboard handover and is
+                                // never journaled, so resuming the departing
+                                // session later still shows its worker rows.
+                                let mut stale_lanes = subs.lanes();
+                                stale_lanes.append(&mut replayed_lanes);
+                                stale_lanes.sort();
+                                stale_lanes.dedup();
+                                for lane in stale_lanes {
+                                    let _ = deck_tx.send(Inbound::Deregister { agent: lane });
+                                }
+
                                 // Adopt the target: same id, this pid, waiting.
                                 // Re-key everything that names the session —
                                 // the lead's claim holder and the PR monitor's
@@ -854,13 +878,14 @@ pub async fn run_deck_session(
                                 // transcript in its place (direct sends — a
                                 // replay must never re-journal itself), then
                                 // restore conversation, backlog, and pipeline.
-                                // (Terminal worker rows from the session left
-                                // behind keep their lanes on the dashboard —
-                                // there is no unregister envelope — as visible
-                                // residue of where the process has been.)
+                                // (The departing session's worker rows were
+                                // deregistered above; the lanes THIS replay
+                                // creates are remembered for the next switch.)
                                 let _ = deck_tx.send(Inbound::SessionReset {
                                     agent: LEAD.to_string(),
                                 });
+                                replayed_lanes =
+                                    crate::session_persist::journal_lanes(&rs.records, LEAD);
                                 crate::session_persist::replay_session(
                                     std::mem::take(&mut rs.records),
                                     now_ms(),
@@ -887,6 +912,16 @@ pub async fn run_deck_session(
                                 queue.adopt(sidecar_dir.clone(), restored);
                                 pipeline_on = rs.pipeline.unwrap_or(true);
                                 let _ = in_tx.send(Inbound::Pipeline(pipeline_on));
+                                // `--budget` means THIS session, decided and
+                                // implemented on both resume paths: reseed
+                                // the guard's session accumulator to what
+                                // the adopted session had journaled
+                                // (`ResumeState::spent_usd`, its last
+                                // `BudgetTick` — the same derivation the
+                                // startup resume uses). No synthetic tick is
+                                // emitted; the next real turn's ticks
+                                // reflect the reseeded guard naturally.
+                                budget.reseed_session_spend(rs.spent_usd.unwrap_or(0.0));
 
                                 // Fresh meta over the replayed one (pid, model,
                                 // clock), back to waiting-on-you, and a fresh

--- a/stella-cli/src/session_persist.rs
+++ b/stella-cli/src/session_persist.rs
@@ -80,8 +80,37 @@ pub fn journal_record(inbound: &Inbound) -> Option<JournalRecord> {
             agent: agent.clone(),
         }),
         Inbound::Pipeline(on) => Some(JournalRecord::Pipeline { on: *on }),
+        // Deregister is visual lifecycle only — a row removal during THIS
+        // process's dashboard handover (session switch), never part of any
+        // session's history. Journaling it would erase the departing
+        // session's worker rows from its OWN future replay.
+        Inbound::Deregister { .. } => None,
         _ => None,
     }
+}
+
+/// Every non-lead lane a journal names, deduplicated in first-appearance
+/// order — the dashboard rows replaying `records` creates (the fold
+/// auto-registers a lane on any envelope naming it, not just `Register`).
+/// The driver remembers these across an adoption so that navigating to
+/// another session can [`Inbound::Deregister`] them — rows of the session
+/// left behind must not linger on the next session's dashboard.
+pub fn journal_lanes(records: &[JournalRecord], lead: &str) -> Vec<String> {
+    let mut lanes: Vec<String> = Vec::new();
+    for record in records {
+        let agent = match record {
+            JournalRecord::Register { agent, .. }
+            | JournalRecord::Event { agent, .. }
+            | JournalRecord::Status { agent, .. }
+            | JournalRecord::PromptStarted { agent, .. }
+            | JournalRecord::SessionReset { agent } => agent,
+            JournalRecord::Pipeline { .. } => continue,
+        };
+        if agent != lead && !lanes.iter().any(|l| l == agent) {
+            lanes.push(agent.clone());
+        }
+    }
+    lanes
 }
 
 /// The lane (agent id) an envelope belongs to, when it has one.
@@ -576,6 +605,54 @@ mod tests {
             })
             .is_none()
         );
+        // Deregister is visual lifecycle only (a session-switch row removal)
+        // — journaling it would erase the departing session's worker rows
+        // from its own future replay.
+        assert!(
+            journal_record(&Inbound::Deregister {
+                agent: "req:1".into(),
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn journal_lanes_names_every_non_lead_lane_once_in_order() {
+        let records = vec![
+            JournalRecord::Register {
+                agent: "lead".into(),
+                title: "t".into(),
+                role: "lead".into(),
+                model: None,
+            },
+            // A lane can first appear on ANY record kind — the fold
+            // auto-registers it either way.
+            JournalRecord::Status {
+                agent: "req:2".into(),
+                status: "running".into(),
+            },
+            JournalRecord::Register {
+                agent: "req:1".into(),
+                title: "worker".into(),
+                role: "sub".into(),
+                model: None,
+            },
+            JournalRecord::Event {
+                agent: "req:1".into(),
+                event: AgentEvent::Text { delta: "x".into() },
+            },
+            JournalRecord::Pipeline { on: true },
+            JournalRecord::PromptStarted {
+                agent: "lead".into(),
+                text: "p".into(),
+            },
+        ];
+        assert_eq!(
+            journal_lanes(&records, "lead"),
+            vec!["req:2".to_string(), "req:1".to_string()],
+            "non-lead lanes, deduplicated, first-appearance order"
+        );
+        assert!(journal_lanes(&[], "lead").is_empty());
     }
 
     #[test]

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -163,6 +163,17 @@ impl SubSessions {
         self.next_req += 1;
         format!("req:{}", self.next_req)
     }
+
+    /// Every lane a worker has ever run on this tenancy, live or ended
+    /// (specs are retained past a worker's end for Restart). Sorted for
+    /// deterministic iteration. The session-switch site deregisters these
+    /// rows when the deck navigates to another session — they are all
+    /// terminal there (the switch refuses while workers are live).
+    pub(crate) fn lanes(&self) -> Vec<String> {
+        let mut lanes: Vec<String> = self.specs.keys().cloned().collect();
+        lanes.sort();
+        lanes
+    }
 }
 
 /// `stella_core::ports::TurnGate` over a watch channel: the worker's turn
@@ -686,6 +697,29 @@ mod tests {
         let mut subs = SubSessions::new();
         assert_eq!(subs.next_req_lane(), "req:1");
         assert_eq!(subs.next_req_lane(), "req:2");
+    }
+
+    #[test]
+    fn lanes_names_every_worker_ever_started_live_or_ended() {
+        // The session-switch site deregisters exactly this set — a lane's
+        // dashboard row outlives its worker, so `lanes` must too.
+        let mut subs = SubSessions::new();
+        assert!(subs.lanes().is_empty());
+        for lane in ["req:2", "req:1", "sub:7"] {
+            let (stop_tx, _stop_rx) = oneshot::channel();
+            let (pause_tx, _pause_rx) = watch::channel(false);
+            subs.started(lane, stop_tx, pause_tx, dummy_spec(lane));
+        }
+        subs.ended("req:1");
+        assert_eq!(
+            subs.lanes(),
+            vec![
+                "req:1".to_string(),
+                "req:2".to_string(),
+                "sub:7".to_string()
+            ],
+            "ended lanes stay listed; order is deterministic (sorted)"
+        );
     }
 
     #[test]

--- a/stella-core/src/budget.rs
+++ b/stella-core/src/budget.rs
@@ -181,6 +181,21 @@ impl BudgetGuard {
         self.turn_spent_usd = 0.0;
     }
 
+    /// Set the session-scoped accumulator to exactly `spent_usd`, replacing
+    /// the running total. The turn-scoped counter is untouched.
+    ///
+    /// This is the resume/switch seam: when the driver reopens a session
+    /// (`stella resume` at startup, or an in-deck session switch), it
+    /// reseeds the guard from the target session's journaled spend so a
+    /// configured `--budget` always means "this session" — the one on
+    /// screen — never "this process". Within one session spend stays
+    /// monotone ([`record_spend`](Self::record_spend) only ever adds);
+    /// across sessions monotonicity is deliberately the caller's concern —
+    /// switching to a cheaper session legitimately lowers the accumulator.
+    pub fn reseed_session_spend(&mut self, spent_usd: f64) {
+        self.session_spent_usd = spent_usd;
+    }
+
     /// Current spend for the active turn, in USD.
     pub fn spent_usd(&self) -> f64 {
         self.turn_spent_usd
@@ -395,6 +410,65 @@ mod tests {
         let _ = guard.evaluate();
         let _ = guard.evaluate();
         assert_eq!(guard.spent_usd(), before);
+    }
+
+    #[test]
+    fn reseed_replaces_the_session_total_and_record_spend_accumulates_from_it() {
+        let mut guard = BudgetGuard::new(BudgetMode::Observed, None, None);
+        guard.record_spend(5.0);
+        assert!((guard.session_spent_usd() - 5.0).abs() < 1e-9);
+
+        // The resume/switch seam: the session accumulator becomes exactly
+        // the seed — down as well as up (switching to a cheaper session
+        // legitimately lowers it) — and the turn counter is untouched.
+        guard.reseed_session_spend(1.25);
+        assert!((guard.session_spent_usd() - 1.25).abs() < 1e-9);
+        assert!(
+            (guard.spent_usd() - 5.0).abs() < 1e-9,
+            "turn spend must survive a session reseed"
+        );
+
+        // Subsequent spend accumulates from the seed, not from zero and not
+        // from the pre-reseed total.
+        guard.record_spend(0.5);
+        assert!((guard.session_spent_usd() - 1.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn enforced_mode_gates_relative_to_the_reseeded_session_total() {
+        let mut guard = BudgetGuard::new(BudgetMode::Enforced, None, Some(2.0));
+        guard.record_spend(1.9); // near the session limit
+        assert_eq!(guard.evaluate(), BudgetOutcome::Continue);
+
+        // Reseeding DOWN (adopting a cheaper session) restores headroom…
+        guard.reseed_session_spend(0.5);
+        assert_eq!(guard.evaluate(), BudgetOutcome::Continue);
+        assert_eq!(guard.record_spend(1.0), BudgetOutcome::Continue); // 1.5
+        // …until real spend crosses the limit relative to the seed.
+        match guard.record_spend(0.6) {
+            // 2.1
+            BudgetOutcome::AbortTurn {
+                axis: BudgetAxis::Session,
+                spent_usd,
+                limit_usd,
+            } => {
+                assert!((spent_usd - 2.1).abs() < 1e-9);
+                assert_eq!(limit_usd, 2.0);
+            }
+            other => panic!("expected a session-axis AbortTurn, got {other:?}"),
+        }
+
+        // Reseeding UP (adopting a session already over budget) gates
+        // immediately at the next safe-boundary check.
+        let mut over = BudgetGuard::new(BudgetMode::Enforced, None, Some(2.0));
+        over.reseed_session_spend(3.0);
+        assert!(matches!(
+            over.evaluate(),
+            BudgetOutcome::AbortTurn {
+                axis: BudgetAxis::Session,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -285,6 +285,14 @@ impl WorkspaceModel {
     pub fn apply_inbound(&mut self, inbound: &Inbound) {
         match inbound {
             Inbound::Register(meta) => self.register(meta.clone()),
+            // The visual-lifecycle inverse of `Register`: the row disappears.
+            // An unknown id is a no-op — a stale deregister (row already
+            // gone, or never seen) must never disturb the fold.
+            Inbound::Deregister { agent } => {
+                if let Some(idx) = self.index_of(agent) {
+                    self.agents.remove(idx);
+                }
+            }
             Inbound::Event { agent, event } => self.apply_event(agent, event),
             Inbound::Status { agent, status } => {
                 // Auto-register an unknown id, exactly like `Event`:
@@ -988,6 +996,41 @@ mod tests {
             !a.model.hud.complete && a.model.hud.stage.is_none(),
             "hud/progress reset to idle"
         );
+    }
+
+    #[test]
+    fn deregister_removes_the_row_and_only_that_row() {
+        let mut w = WorkspaceModel::new();
+        w.apply_inbound(&reg("lead"));
+        w.apply_inbound(&reg("req:1"));
+        w.apply_inbound(&reg("req:2"));
+        assert_eq!(w.agents.len(), 3, "precondition: three rows");
+
+        w.apply_inbound(&Inbound::Deregister {
+            agent: "req:1".into(),
+        });
+
+        assert_eq!(w.agents.len(), 2, "the deregistered row is gone");
+        assert!(w.index_of("req:1").is_none(), "req:1 removed");
+        assert_eq!(w.index_of("lead"), Some(0), "lead untouched");
+        assert_eq!(w.index_of("req:2"), Some(1), "later rows shift down");
+    }
+
+    #[test]
+    fn deregister_of_an_unknown_id_is_a_noop() {
+        let mut w = WorkspaceModel::new();
+        w.apply_inbound(&reg("lead"));
+        w.apply_inbound(&Inbound::Deregister {
+            agent: "req:404".into(),
+        });
+        assert_eq!(w.agents.len(), 1, "unknown id disturbs nothing");
+        assert_eq!(w.index_of("lead"), Some(0));
+
+        // A stale repeat (the row already gone) is equally harmless.
+        w.apply_inbound(&Inbound::Deregister {
+            agent: "req:404".into(),
+        });
+        assert_eq!(w.agents.len(), 1);
     }
 
     #[test]

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -1099,6 +1099,25 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         }
         return;
     }
+    // A deregister removes a dashboard row, shifting every index after it:
+    // fold it, then repair the focus so the focused AGENT stays focused when
+    // an earlier row vanishes. When the focused row itself is removed, its
+    // successor inherits focus (clamped into range below) and the transcript
+    // selection drops — it indexed the removed agent's transcript.
+    if let Inbound::Deregister { agent } = inbound {
+        let removed = model.index_of(agent);
+        model.apply_inbound(inbound);
+        match removed {
+            Some(idx) if idx < ui.focused => ui.focused -= 1,
+            Some(idx) if idx == ui.focused && ui.session_selected.take().is_some() => {
+                ui.session_pending_scroll = None;
+                ui.session_scroll.follow = true;
+            }
+            _ => {}
+        }
+        clamp(model, ui);
+        return;
+    }
     model.apply_inbound(inbound);
     clamp(model, ui);
 }
@@ -4000,6 +4019,62 @@ mod tests {
             "selection cleared on focus change"
         );
         assert!(ui.session_scroll.follow, "…and tail-follow re-arms");
+    }
+
+    #[test]
+    fn deregister_keeps_focus_in_bounds_and_on_the_same_agent() {
+        let mut model = model_with(&["lead", "req:1", "req:2"]);
+        let mut ui = ready_ui();
+        ui.focused = 2; // req:2
+
+        // An EARLIER row vanishing shifts indexes down: the focused AGENT
+        // stays focused at its new index.
+        ingest_inbound(
+            &Inbound::Deregister {
+                agent: "req:1".into(),
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert_eq!(ui.focused, 1);
+        assert_eq!(model.agents[ui.focused].meta.id, "req:2");
+
+        // The focused LAST row vanishing clamps focus back into range.
+        ingest_inbound(
+            &Inbound::Deregister {
+                agent: "req:2".into(),
+            },
+            &mut model,
+            &mut ui,
+        );
+        assert_eq!(ui.focused, 0, "focus stays in bounds");
+        assert_eq!(model.agents[ui.focused].meta.id, "lead");
+    }
+
+    #[test]
+    fn deregister_of_the_focused_row_drops_the_stale_selection() {
+        let mut model = model_with(&["lead", "req:1", "req:2"]);
+        with_tool_exchange(&mut model, "req:1");
+        with_tool_exchange(&mut model, "req:2");
+        let mut ui = ready_ui();
+        ui.focused = 1; // req:1
+        ui.session_selected = Some(1); // a row of req:1's transcript
+
+        ingest_inbound(
+            &Inbound::Deregister {
+                agent: "req:1".into(),
+            },
+            &mut model,
+            &mut ui,
+        );
+        // The successor (req:2) slides into the focused index…
+        assert_eq!(ui.focused, 1);
+        assert_eq!(model.agents[1].meta.id, "req:2");
+        // …but the selection indexed the REMOVED agent's transcript, so it
+        // must not re-attach to the successor's (which is long enough that
+        // range-clamping alone would have kept it).
+        assert_eq!(ui.session_selected, None);
+        assert!(ui.session_scroll.follow, "tail-follow re-arms");
     }
 
     fn ready_ui() -> DeckUi {

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -112,6 +112,15 @@ impl AgentStatus {
 pub enum Inbound {
     /// A new agent joined the workspace — its dashboard row appears.
     Register(AgentMeta),
+    /// Remove one agent's dashboard row — the visual-lifecycle inverse of
+    /// [`Inbound::Register`]. Presentation only: journaling and model state
+    /// are unaffected (the removed lane's history stays in its own session's
+    /// journal, and the engine's conversation is untouched). The driver only
+    /// ever sends it for lanes with no live process behind them — e.g. the
+    /// terminal worker rows of a session the deck is navigating away from,
+    /// which must not linger on the next session's dashboard. Folding an
+    /// unknown id is a no-op.
+    Deregister { agent: AgentId },
     /// An `AgentEvent` belonging to one agent.
     Event { agent: AgentId, event: AgentEvent },
     /// A supervisor lifecycle transition not carried by the event stream.


### PR DESCRIPTION
## What & why

Two contained follow-ups to durable sessions (#188), both anchored at the in-deck session switch (`SessionResume` in `command_deck.rs`):

**1. `Inbound::Deregister { agent }` — no more lingering worker rows.** A new additive envelope variant that removes one agent's dashboard row. It is visual lifecycle only: journaling and model state are unaffected, and the driver only ever sends it for lanes with no live process behind them. The fold (`WorkspaceModel::apply_inbound`) removes the `AgentEntry` by id (unknown id is a no-op), and `deck_ui::ingest_inbound` repairs focus: removing an earlier row keeps the same agent focused at its shifted index; removing the focused row clamps focus into range and drops the stale transcript selection. The switch arm now deregisters every non-lead lane — worker lanes spawned this tenancy (`SubSessions::lanes`) plus lanes replayed at the last adoption (`session_persist::journal_lanes`) — before adopting the target, replacing the old "visible residue" doc comment. The deregisters are direct `deck_tx` sends and `journal_record` explicitly excludes the variant, so the departing session's own journal keeps its rows for its own future resume.

**2. Budget reseed on in-deck switch — the semantic is decided: `--budget` ALWAYS means "this session".** New pure method `BudgetGuard::reseed_session_spend(&mut self, spent_usd: f64)` in `stella-core` sets the session-scoped accumulator to exactly the given value (turn counter untouched; doc comment marks it as the resume/switch seam — within one session spend stays monotone, across sessions monotonicity is the caller's concern). Both resume paths now share one semantic and one derivation: startup resume and the in-deck switch both reseed from `ResumeState::spent_usd` (the target journal's last `BudgetTick`, via `journal::last_spent_usd`). No synthetic `BudgetTick` is emitted — the next real turn's ticks reflect the reseeded guard naturally.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Both features are new API surface (`Inbound::Deregister`, `reseed_session_spend`, `journal_lanes`, `SubSessions::lanes`), so every new test fails on `main` by construction — the code it exercises does not exist there. There is no driver-loop test harness for the switch arm itself, so the seams are covered instead:

- `stella-tui/src/deck.rs`: `deregister_removes_the_row_and_only_that_row`, `deregister_of_an_unknown_id_is_a_noop`
- `stella-tui/src/deck_ui.rs`: `deregister_keeps_focus_in_bounds_and_on_the_same_agent`, `deregister_of_the_focused_row_drops_the_stale_selection`
- `stella-cli/src/session_persist.rs`: `journal_lanes_names_every_non_lead_lane_once_in_order`, Deregister-never-journals assertion in `fold_relevant_inbounds_journal_and_out_of_band_ones_do_not`
- `stella-cli/src/subsession.rs`: `lanes_names_every_worker_ever_started_live_or_ended`
- `stella-core/src/budget.rs`: `reseed_replaces_the_session_total_and_record_spend_accumulates_from_it`, `enforced_mode_gates_relative_to_the_reseeded_session_total`

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (doc comments on the new variant, method, and both resume sites)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

- The deck-local `shell` lane and `replay:<id>` viewer lanes are deliberately NOT deregistered on switch: the shell lane is process-scoped (and can have a command in flight), and replay viewers are cross-session read-models the user opened on purpose.
- The startup-resume seed switched from `record_spend(spent)` to `reseed_session_spend(spent)`: behaviorally identical for the session axis on a fresh guard, but it no longer inflates the turn counter pre-first-turn, and both resume paths now go through the same seam.
