### PR TITLE
feat(fleet): per-task Pause/Resume/Stop control API through the FleetWorker port

### DIFF
--- a/COMMAND_DECK_DESIGN.md
+++ b/COMMAND_DECK_DESIGN.md
@@ -241,10 +241,18 @@ resuming is replaying it.
   task board (`task_*` tools) folds as `AgentEvent::TaskUpdate` snapshots
   into a session-view checklist card, and a `gh`-backed monitor feeds the
   footer's PR cell (`⇢ #183 open ✓`).
-- Still seam-fed: `AgentControl` beyond `Stop` (Pause/Resume/Restart) and
-  per-worker abort. `Stop` maps to `UserInput::Cancel` on the lead only; deep
-  per-agent pause/kill needs a new `stella-fleet` abort API (noted as the
-  follow-up integration), as does fleet-worktree isolation for workers.
+- Live now: **per-worker Pause/Resume/Stop/Restart — at both layers.** Deck
+  sub-session lanes route `AgentControl` through `service_worker_control`
+  (pause parks at the engine's `TurnGate` step boundary, stop is the clean
+  drop-at-await cancel, restart respawns from the lane's retained spec).
+  Fleet tasks carry the same verbs on the dispatch seam itself:
+  `stella_fleet::WorkerControls` ride the `FleetWorker` port, driven by
+  `Fleet::pause_task` / `resume_task` / `stop_task` (restart = re-dispatch;
+  the fleet keeps no respawn state).
+- Still seam-fed: the deck's in-UI hookup to *fleet* tasks (a `stella fleet`
+  run's workers are not deck lanes yet), lead-lane Pause/Resume
+  (boundary-gating the staged pipeline needs a `PipelinePorts` gate), and
+  fleet-worktree isolation for deck workers.
 
 ## ISSUES tab
 

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -19,9 +19,12 @@
 //! its live event lane, an inbox notification, and (for task workers) the
 //! board task auto-completing. Prompts queue only past the worker cap, on a
 //! dispatch hold, or when they are slash commands (the lead's dispatcher owns
-//! those). Deep pause/resume and fleet-worktree isolation for workers remain
-//! follow-ups on the `stella-fleet` seam (`COMMAND_DECK_DESIGN.md` →
-//! "Backend seams").
+//! those). The fleet layer now carries its own per-task control verbs
+//! (`Fleet::pause_task` / `resume_task` / `stop_task`, riding
+//! `stella_fleet::WorkerControls` through the `FleetWorker` port);
+//! surfacing `stella fleet` tasks as controllable deck lanes and
+//! fleet-worktree isolation for deck workers remain follow-ups on that seam
+//! (`COMMAND_DECK_DESIGN.md` → "Backend seams").
 //!
 //! ## The three engine seams handled here
 //!
@@ -1380,9 +1383,12 @@ pub async fn run_deck_session(
                         ) => {
                             handle_issues_input(&input, cfg, &issue_backend_cache, &in_tx);
                         }
-                        // Scope review is not engine-driven yet, and deep
-                        // pause/resume/restart need the fleet supervisor —
-                        // both named seams, both no-ops here.
+                        // Scope review is not engine-driven yet, and
+                        // lead-lane pause/resume/restart still need a
+                        // staged-pipeline boundary gate (the PipelinePorts
+                        // follow-up; the fleet layer's own per-task verbs
+                        // exist now, but fleet tasks are not deck lanes
+                        // yet) — named seams, no-ops here.
                         Some(WorkspaceInput::ToAgent {
                             input: UserInput::ScopeDecision(_), ..
                         })

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -16,6 +16,15 @@
 //! waves once the metered total crosses the cap (in-flight siblings settle
 //! first, never a mid-tool kill).
 //!
+//! Every worker also honors its `stella_fleet::WorkerControls`: the stop
+//! line races the turn (the clean drop-at-await cancel the deck's
+//! sub-sessions use) and the pause line gates the raw step-loop at the
+//! engine's step boundary via a `TurnGate`. `stella fleet` itself drives
+//! workers to completion — the control verbs (`Fleet::pause_task` /
+//! `resume_task` / `stop_task`) exist for a supervisor; surfacing fleet
+//! tasks as controllable deck lanes is the named follow-up in
+//! `COMMAND_DECK_DESIGN.md`.
+//!
 //! Worktrees are deliberately left in place after the run — the branches
 //! (`fleet/<task>`) carry the work product for the user to review and merge.
 //! `git worktree list` shows them; the report names each one.
@@ -33,12 +42,12 @@ use stella_core::{Engine, TurnOutcome};
 use stella_fleet::{
     CiWatchOutcome, CommitRecord, Fleet, FleetConfig, FleetRunReport, FleetWorker, GhCli, Ledger,
     Monitor, MonitorError, Plan, SystemGhCli, SystemGitCli, Task, TaskId, TimeoutReason,
-    WatchConfig, WorkerOutcome, WorktreeManager,
+    WatchConfig, WorkerControls, WorkerOutcome, WorktreeManager,
 };
 use stella_protocol::{AgentEvent, CompletionMessage, PrStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::ShellHookRunner;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use crate::agent;
 use crate::config::Config;
@@ -357,7 +366,12 @@ struct EngineWorker {
 
 #[async_trait::async_trait]
 impl FleetWorker for EngineWorker {
-    async fn run(&self, task: &Task, workspace_root: &Path) -> WorkerOutcome {
+    async fn run(
+        &self,
+        task: &Task,
+        workspace_root: &Path,
+        controls: WorkerControls,
+    ) -> WorkerOutcome {
         // The engine's turn future is deliberately not `Send` (it holds
         // provider futures and the retry jitter RNG across awaits), but the
         // fleet's worker port requires a `Send` future. Bridge the two by
@@ -384,6 +398,7 @@ impl FleetWorker for EngineWorker {
                         &task,
                         &root,
                         &claim_holder,
+                        controls,
                     ))
                 });
             let _ = tx.send(result);
@@ -404,6 +419,31 @@ impl FleetWorker for EngineWorker {
     }
 }
 
+/// `stella_core::ports::TurnGate` over the task's pause line: the worker's
+/// turn parks at its next step boundary while a supervisor holds the watch
+/// at `true` (`Fleet::pause_task`) and continues on `false`
+/// (`Fleet::resume_task`). A dropped sender (the fleet settled this task's
+/// controls) reads as resumed — a worker must never park forever on
+/// teardown.
+///
+/// A deliberate small twin of `subsession.rs`'s private `WatchGate` (the
+/// deck's sub-session gate): the two adapters sit on opposite sides of the
+/// deck/fleet boundary and share only this trivial shape, so a co-located
+/// duplicate reads better than a shared item would.
+struct WatchGate(watch::Receiver<bool>);
+
+#[async_trait::async_trait]
+impl stella_core::ports::TurnGate for WatchGate {
+    async fn wait_if_paused(&self) {
+        let mut rx = self.0.clone();
+        while *rx.borrow() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
 /// One worker turn in `root`, on the calling thread's runtime. When
 /// `use_pipeline` is true (the default), the turn runs through the staged
 /// pipeline (triage → recall → plan → witness → execute → verify → judge);
@@ -415,6 +455,7 @@ async fn run_task(
     task: &Task,
     root: &Path,
     claim_holder: &str,
+    controls: WorkerControls,
 ) -> Result<WorkerOutcome, String> {
     // Snapshot where this workspace starts so the commit report is
     // exactly this worker's commits — correct for isolated worktrees
@@ -455,6 +496,27 @@ async fn run_task(
 
     let (tx, mut rx) = mpsc::unbounded_channel::<AgentEvent>();
     let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    // The task's control lines (stella-fleet's `WorkerControls`). The stop
+    // wait mirrors `subsession.rs::run_worker` exactly: a dropped sender
+    // (the fleet settled this task's handle — no supervisor will ever
+    // signal) must not read as a stop, so the wait parks forever on a
+    // closed channel and the work always wins the race.
+    let WorkerControls { pause, stop } = controls;
+    let stop_wait = async move {
+        if stop.await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    };
+    /// How a raced future resolved — `subsession.rs`'s `RacedTurn` shape,
+    /// generic because the two paths race different outcome types.
+    enum Raced<T> {
+        Outcome(T),
+        Stopped,
+    }
+    /// The stopped attempt's summary. It reports with `success: false` so a
+    /// stopped prerequisite never unblocks its dependents.
+    const STOPPED: &str = "stopped by fleet control (Fleet::stop_task)";
 
     // `success`/`summary` are set by whichever path runs, then folded into
     // the WorkerOutcome after the channel drains.
@@ -516,31 +578,52 @@ async fn run_task(
         // pipeline appends its own volatile recall+goal message, so pass the
         // raw task prompt as the goal (the pipeline never re-reads `messages`
         // for its goal — it takes `task.prompt` directly).
-        let result = pipeline.run(&task.prompt, &mut messages, &mut budget).await;
-        match result {
-            Ok(outcome) => match outcome.status {
+        // The stop line races the whole staged run — the future drops at
+        // its next await point, the same clean cancel the raw path gets.
+        // Pause is NOT honored here yet: boundary-gating individual stages
+        // needs a gate port on `PipelinePorts` (the existing named
+        // follow-up) — only the raw step-loop path below holds a TurnGate.
+        let raced = tokio::select! {
+            result = pipeline.run(&task.prompt, &mut messages, &mut budget) => {
+                Raced::Outcome(result)
+            }
+            _ = stop_wait => Raced::Stopped,
+        };
+        match raced {
+            Raced::Outcome(Ok(outcome)) => match outcome.status {
                 PipelineStatus::Completed => (truncate(&outcome.final_text), true),
                 PipelineStatus::Aborted { reason } => (truncate(&reason), false),
             },
-            Err(e) => (truncate(&e.to_string()), false),
+            Raced::Outcome(Err(e)) => (truncate(&e.to_string()), false),
+            Raced::Stopped => (STOPPED.to_string(), false),
         }
     } else {
-        let outcome = {
+        // The pause line gates the raw step-loop at the engine's step
+        // boundary (never mid-tool), and the stop line races the turn.
+        let raced = {
+            let gate = WatchGate(pause);
             let hook_runner = ShellHookRunner;
             let mut engine = Engine::with_sleeper(
                 &*provider,
                 &claims,
                 agent::engine_config_for(&cfg),
                 &TokioSleeper,
-            );
+            )
+            .with_gate(&gate);
             if let Some(hooks) = &cfg.hooks {
                 engine = engine.with_hooks(hooks, &hook_runner);
             }
-            engine.run_turn(&mut messages, &mut budget, &tx).await
+            tokio::select! {
+                outcome = engine.run_turn(&mut messages, &mut budget, &tx) => {
+                    Raced::Outcome(outcome)
+                }
+                _ = stop_wait => Raced::Stopped,
+            }
         };
-        match outcome {
-            TurnOutcome::Completed { text, .. } => (truncate(&text), true),
-            TurnOutcome::Aborted { reason } => (truncate(&reason), false),
+        match raced {
+            Raced::Outcome(TurnOutcome::Completed { text, .. }) => (truncate(&text), true),
+            Raced::Outcome(TurnOutcome::Aborted { reason }) => (truncate(&reason), false),
+            Raced::Stopped => (STOPPED.to_string(), false),
         }
     };
     drop(tx);
@@ -737,6 +820,39 @@ mod tests {
         assert!(!out.contains('\n'));
         assert!(out.chars().count() <= SUMMARY_CHARS + 1);
         assert!(out.ends_with('…'));
+    }
+
+    // ---- the worker's control lines (stella-fleet WorkerControls) -------
+
+    #[tokio::test]
+    async fn watch_gate_parks_while_paused_and_releases_on_resume_or_teardown() {
+        use stella_core::ports::TurnGate;
+        let (tx, rx) = watch::channel(true);
+        let gate = WatchGate(rx);
+        let wait = gate.wait_if_paused();
+        tokio::pin!(wait);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut wait)
+                .await
+                .is_err(),
+            "a paused gate must park"
+        );
+        tx.send(false).unwrap();
+        tokio::time::timeout(std::time::Duration::from_millis(500), wait)
+            .await
+            .expect("resume releases the gate");
+
+        // A dropped sender (the fleet settled the task's controls) must
+        // release, never park forever.
+        let (tx2, rx2) = watch::channel(true);
+        let gate2 = WatchGate(rx2);
+        drop(tx2);
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            gate2.wait_if_paused(),
+        )
+        .await
+        .expect("teardown releases the gate");
     }
 
     // ---- the post-fanout PR/CI watch (--watch) --------------------------

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -16,9 +16,20 @@
 //! **remaining waves are not launched** — but in-flight siblings are never
 //! cancelled mid-run (no mid-tool kill; a running worker settles first).
 //!
+//! The seam also carries **per-task control**: every dispatched worker
+//! receives [`WorkerControls`] (a pause watch + a stop oneshot — the exact
+//! channel shapes the deck's sub-sessions use), and the fleet exposes the
+//! matching verbs, [`Fleet::pause_task`] / [`Fleet::resume_task`] /
+//! [`Fleet::stop_task`]. This closes the "fleet supervisor seam"
+//! `COMMAND_DECK_DESIGN.md` and `command_deck.rs` named as the follow-up:
+//! per-worker pause/stop now exists at the fleet layer, not just for deck
+//! sub-session lanes. Restart is deliberately not a fleet verb —
+//! [`Fleet::dispatch`] is re-runnable, so a restart is the caller
+//! re-dispatching the same [`Task`]; the fleet keeps no respawn state.
+//!
 //! [`Isolation`]: crate::plan::Isolation
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 
@@ -26,6 +37,7 @@ use async_trait::async_trait;
 use futures_util::{StreamExt, stream};
 use stella_core::{BudgetGuard, BudgetOutcome, Clock};
 use stella_store::Store;
+use tokio::sync::{oneshot, watch};
 
 use crate::git::{GitCli, Worktree, WorktreeError, WorktreeManager};
 use crate::ledger::{
@@ -35,14 +47,51 @@ use crate::plan::{Isolation, Plan, PlanError, Task, TaskId};
 
 /// The port a fleet worker implements — the CLI glue later backs this with
 /// `stella_core::Engine` / `stella_pipeline`; tests back it with fakes. It
-/// receives the task and the workspace root it must operate in (the isolated
-/// worktree, or the shared repo root for a [`Isolation::SharedTree`] task) and
-/// reports what it did.
+/// receives the task, the workspace root it must operate in (the isolated
+/// worktree, or the shared repo root for a [`Isolation::SharedTree`] task),
+/// and its [`WorkerControls`], and reports what it did.
 ///
 /// [`Isolation::SharedTree`]: crate::plan::Isolation::SharedTree
 #[async_trait]
 pub trait FleetWorker: Send + Sync {
-    async fn run(&self, task: &Task, workspace_root: &Path) -> WorkerOutcome;
+    async fn run(
+        &self,
+        task: &Task,
+        workspace_root: &Path,
+        controls: WorkerControls,
+    ) -> WorkerOutcome;
+}
+
+/// The receiver halves of one task's control lines, handed to the
+/// [`FleetWorker`] alongside its task — the fleet-side twin of the deck
+/// sub-sessions' channels (`stella-cli/src/subsession.rs`): a pause watch
+/// and a stop oneshot, driven by [`Fleet::pause_task`] /
+/// [`Fleet::resume_task`] / [`Fleet::stop_task`].
+///
+/// Because the controls ride the [`FleetWorker`] port itself, the
+/// capability is structural: workers run no nested spawns today (a
+/// worker's own `task_assign` requests are reported, not dispatched — the
+/// deck documents that v1 scope), so there is nothing recursive to wire —
+/// but any future nested spawn dispatched back through this port would
+/// receive its own control lines with no new machinery.
+pub struct WorkerControls {
+    /// `true` = park at the next safe step boundary until it flips back
+    /// (the engine's `TurnGate` boundary — never mid-tool). A closed
+    /// channel reads as resumed: a worker must never park forever after
+    /// the fleet dropped its handle.
+    pub pause: watch::Receiver<bool>,
+    /// Fires when [`Fleet::stop_task`] consumes this task's stop line. A
+    /// channel closed *without* firing means no stop will ever come —
+    /// treat it as "run to completion", never as a stop.
+    pub stop: oneshot::Receiver<()>,
+}
+
+/// The sender halves the fleet retains for one live task. `stop` is
+/// `Option` because firing a oneshot consumes it — a second stop on the
+/// same attempt is a stale no-op, exactly the deck sub-session semantics.
+struct TaskControlHandle {
+    pause: watch::Sender<bool>,
+    stop: Option<oneshot::Sender<()>>,
 }
 
 /// What a [`FleetWorker`] reports back for one task attempt.
@@ -172,9 +221,10 @@ pub enum FleetError {
 }
 
 /// The fleet orchestrator. Owns the worker, the worktree manager, the ledger,
-/// and the parent budget guard (the last two behind `Mutex`es so concurrent
-/// wave dispatch serializes their fast synchronous writes — a lock is never
-/// held across an `.await`). Optionally owns the workspace [`Store`] whose
+/// the parent budget guard, and the live tasks' control lines (the last
+/// three behind `Mutex`es so concurrent wave dispatch serializes their fast
+/// synchronous writes — a lock is never held across an `.await`).
+/// Optionally owns the workspace [`Store`] whose
 /// `file_locks` back task claims: workers are in-process, so this single
 /// orchestrator-held store is the multi-process "lock-holder" the store's
 /// concurrency contract prescribes.
@@ -186,6 +236,10 @@ pub struct Fleet<W: FleetWorker, G: GitCli, C: Clock> {
     clock: C,
     config: FleetConfig,
     claims: Option<Store>,
+    /// Live workers' control lines, keyed by task id — registered by
+    /// `dispatch_claimed` for exactly the span its worker runs, so the
+    /// control verbs address live workers only.
+    controls: Mutex<HashMap<TaskId, TaskControlHandle>>,
 }
 
 impl<W, G, C> Fleet<W, G, C>
@@ -218,6 +272,7 @@ where
             clock,
             config,
             claims: None,
+            controls: Mutex::new(HashMap::new()),
         })
     }
 
@@ -240,6 +295,10 @@ where
 
     fn lock_budget(&self) -> MutexGuard<'_, BudgetGuard> {
         self.budget.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn lock_controls(&self) -> MutexGuard<'_, HashMap<TaskId, TaskControlHandle>> {
+        self.controls.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// THE one dispatch entry point (L-E9). Claims the task's declared
@@ -311,9 +370,30 @@ where
             })?
         };
 
-        // 3. Run the worker — the slow part, concurrent across a wave. No lock
-        //    is held here.
-        let outcome = self.worker.run(task, &workspace_root).await;
+        // 3. Run the worker — the slow part, concurrent across a wave. No
+        //    lock is held across the await. Its control lines are registered
+        //    first and deregistered the moment it settles, so the control
+        //    verbs address exactly the tasks with a live worker. (Task ids
+        //    are unique within a plan; an ad-hoc re-dispatch of a still-live
+        //    id would re-key the registration to the newer attempt.)
+        let (pause_tx, pause_rx) = watch::channel(false);
+        let (stop_tx, stop_rx) = oneshot::channel();
+        self.lock_controls().insert(
+            task.id.clone(),
+            TaskControlHandle {
+                pause: pause_tx,
+                stop: Some(stop_tx),
+            },
+        );
+        let controls = WorkerControls {
+            pause: pause_rx,
+            stop: stop_rx,
+        };
+        let outcome = self.worker.run(task, &workspace_root, controls).await;
+        // The worker settled — drop its control handle so a later pause or
+        // stop for this id reports "no live worker" instead of signalling
+        // into the void.
+        self.lock_controls().remove(&task.id);
 
         // 4. Stamp the outcome (attempt close + commits + spend) atomically,
         //    then meter the child's cost into the parent budget (L-E9).
@@ -520,6 +600,43 @@ where
         Ok(report)
     }
 
+    // ---- Per-task control: Pause / Resume / Stop ----------------------
+
+    /// Pause a live worker at its next safe step boundary (the engine's
+    /// `TurnGate` — the same boundary budget aborts use, never mid-tool).
+    /// `false` when no live worker is registered under `id`; a stale pause
+    /// is a no-op, never an error — the deck sub-session semantics.
+    ///
+    /// Restart is deliberately NOT a fleet verb: [`dispatch`](Self::dispatch)
+    /// is already re-runnable, so a restart is the caller re-dispatching the
+    /// same [`Task`] — the fleet keeps no respawn state.
+    pub fn pause_task(&self, id: &TaskId) -> bool {
+        match self.lock_controls().get(id) {
+            Some(handle) => handle.pause.send(true).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Resume a paused worker (flip its pause watch back to `false`).
+    /// `false` when no live worker is registered under `id`.
+    pub fn resume_task(&self, id: &TaskId) -> bool {
+        match self.lock_controls().get(id) {
+            Some(handle) => handle.pause.send(false).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Fire a live worker's stop line (the CLI worker drops its turn future
+    /// at the next await point — the same clean cancel the deck uses).
+    /// Consumes the line: `false` when no live worker is registered under
+    /// `id`, or when this attempt was already stopped.
+    pub fn stop_task(&self, id: &TaskId) -> bool {
+        match self.lock_controls().get_mut(id).and_then(|h| h.stop.take()) {
+            Some(tx) => tx.send(()).is_ok(),
+            None => false,
+        }
+    }
+
     // ---- Read-through accessors (tests + real callers) ----------------
 
     /// The parent budget guard's current state (a `Copy` snapshot).
@@ -636,7 +753,12 @@ mod tests {
     }
     #[async_trait]
     impl FleetWorker for FakeWorker {
-        async fn run(&self, task: &Task, workspace_root: &Path) -> WorkerOutcome {
+        async fn run(
+            &self,
+            task: &Task,
+            workspace_root: &Path,
+            _controls: WorkerControls,
+        ) -> WorkerOutcome {
             self.seen_roots
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
@@ -753,7 +875,12 @@ mod tests {
     }
     #[async_trait]
     impl FleetWorker for GatedWorker {
-        async fn run(&self, task: &Task, _workspace_root: &Path) -> WorkerOutcome {
+        async fn run(
+            &self,
+            task: &Task,
+            _workspace_root: &Path,
+            _controls: WorkerControls,
+        ) -> WorkerOutcome {
             if let Ok(permit) = self.gate.acquire().await {
                 permit.forget(); // one permit releases exactly one worker
             }
@@ -1103,5 +1230,159 @@ mod tests {
             .map(|(id, _)| id.as_str())
             .collect();
         assert_eq!(failed, vec!["t1", "t2"], "both failures recorded, sorted");
+    }
+
+    // ---- per-task control: pause / resume / stop ----------------------
+
+    /// A worker that observes its pause line: parks until the fleet flips
+    /// it `true` (announcing the sighting on `saw_pause`), then until it
+    /// flips back `false`, recording each value it saw — proof the
+    /// pause/resume verbs reach the worker through the [`FleetWorker`]
+    /// port.
+    struct PauseProbeWorker {
+        observed: Arc<StdMutex<Vec<bool>>>,
+        /// Fired after the worker observes `true` — the test resumes only
+        /// then, so the pause edge can never be overwritten unseen (a
+        /// `join!` may poll the control arm before re-polling the worker).
+        saw_pause: Arc<tokio::sync::Notify>,
+    }
+    #[async_trait]
+    impl FleetWorker for PauseProbeWorker {
+        async fn run(
+            &self,
+            task: &Task,
+            _workspace_root: &Path,
+            mut controls: WorkerControls,
+        ) -> WorkerOutcome {
+            // `wait_for` errors only if the fleet dropped the sender — then
+            // nothing is recorded and the assertions below fail loudly.
+            if let Ok(v) = controls.pause.wait_for(|paused| *paused).await {
+                self.observed
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(*v);
+                self.saw_pause.notify_one();
+            }
+            if let Ok(v) = controls.pause.wait_for(|paused| !*paused).await {
+                self.observed
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(*v);
+            }
+            WorkerOutcome {
+                cost_usd: 0.0,
+                commits: Vec::new(),
+                summary: format!("did {}", task.id),
+                success: true,
+            }
+        }
+    }
+
+    /// A worker that runs until its stop line fires — proof `stop_task`
+    /// cancels through the port, and that the line is consumed (a second
+    /// stop on the same attempt is a stale no-op).
+    struct StopProbeWorker;
+    #[async_trait]
+    impl FleetWorker for StopProbeWorker {
+        async fn run(
+            &self,
+            _task: &Task,
+            _workspace_root: &Path,
+            controls: WorkerControls,
+        ) -> WorkerOutcome {
+            let stopped = controls.stop.await.is_ok();
+            WorkerOutcome {
+                cost_usd: 0.0,
+                commits: Vec::new(),
+                summary: if stopped { "stopped" } else { "never stopped" }.to_string(),
+                // A stopped task must not read as success — it would unblock
+                // dependents against work that never landed.
+                success: !stopped,
+            }
+        }
+    }
+
+    fn control_fleet<W: FleetWorker>(worker: W) -> Fleet<W, OkGit, SeqClock> {
+        Fleet::new(
+            worker,
+            WorktreeManager::new(OkGit::new(), "/repo"),
+            Ledger::open_in_memory().unwrap(),
+            BudgetGuard::new(BudgetMode::Observed, None, None),
+            SeqClock::new(),
+            FleetConfig::new("run1", "HEAD"),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_reach_the_worker_through_the_port() {
+        let worker = PauseProbeWorker {
+            observed: Arc::new(StdMutex::new(Vec::new())),
+            saw_pause: Arc::new(tokio::sync::Notify::new()),
+        };
+        let observed = worker.observed.clone();
+        let saw_pause = worker.saw_pause.clone();
+        let f = control_fleet(worker);
+        let task = Task::new("t1", "t1", "p").shared_tree();
+        let id = "t1".to_string();
+
+        // The first `join!` poll drives the dispatch far enough to register
+        // the task's controls and park the worker on its pause watch, so
+        // `pause_task` addresses a live worker; resuming waits for the
+        // worker's own "saw the pause" signal so the `true` edge can never
+        // be overwritten before it was observed.
+        let (handle, ()) = tokio::join!(f.dispatch(&task), async {
+            assert!(f.pause_task(&id), "a live worker accepts pause");
+            saw_pause.notified().await;
+            assert!(f.resume_task(&id), "a live worker accepts resume");
+        });
+        assert!(handle.unwrap().outcome.success);
+        assert_eq!(
+            observed.lock().unwrap().as_slice(),
+            &[true, false],
+            "the worker observed the pause, then the resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_fires_once_and_a_second_stop_is_a_stale_no_op() {
+        let f = control_fleet(StopProbeWorker);
+        let task = Task::new("t1", "t1", "p").shared_tree();
+        let id = "t1".to_string();
+
+        // The worker parks on its stop line before the verbs run (the
+        // current-thread join polls the dispatch first); both stops land
+        // while it is still parked, so the second exercises the consumed
+        // line — not a deregistered one.
+        let (handle, ()) = tokio::join!(f.dispatch(&task), async {
+            assert!(f.stop_task(&id), "a live worker accepts the stop");
+            assert!(!f.stop_task(&id), "the stop line is consumed");
+        });
+        let handle = handle.unwrap();
+        assert_eq!(handle.outcome.summary, "stopped");
+        assert!(
+            !handle.outcome.success,
+            "a stopped attempt is not a success"
+        );
+    }
+
+    #[test]
+    fn control_verbs_on_an_unknown_task_are_stale_no_ops() {
+        let f = control_fleet(FakeWorker::new(0.0));
+        let ghost = "ghost".to_string();
+        assert!(!f.pause_task(&ghost));
+        assert!(!f.resume_task(&ghost));
+        assert!(!f.stop_task(&ghost));
+    }
+
+    #[tokio::test]
+    async fn control_handles_are_removed_after_the_worker_settles() {
+        let f = control_fleet(FakeWorker::new(0.0));
+        let task = Task::new("t1", "t1", "p").shared_tree();
+        f.dispatch(&task).await.unwrap();
+        let id = "t1".to_string();
+        assert!(!f.pause_task(&id), "a settled task has no live pause line");
+        assert!(!f.resume_task(&id));
+        assert!(!f.stop_task(&id), "a settled task has no live stop line");
     }
 }

--- a/stella-fleet/src/lib.rs
+++ b/stella-fleet/src/lib.rs
@@ -18,8 +18,11 @@
 //! and [`fleet`] — **THE dispatch seam** ([`Fleet::dispatch`], L-E9): the one
 //! API subagent fan-out goes through, claiming a task's declared paths as
 //! cooperative file locks (`stella-store`'s `file_locks`) for the attempt's
-//! duration, stamping lineage into the ledger, and metering child spend into
-//! the parent [`stella_core::BudgetGuard`].
+//! duration, stamping lineage into the ledger, metering child spend into
+//! the parent [`stella_core::BudgetGuard`], and handing every worker its
+//! per-task control lines ([`WorkerControls`] through the [`FleetWorker`]
+//! port, driven by [`Fleet::pause_task`] / [`Fleet::resume_task`] /
+//! [`Fleet::stop_task`]; restart = re-dispatch).
 //!
 //! Design constraints (from the task and): we shell out
 //! to the `git`/`gh` binaries via `tokio::process` behind port traits rather
@@ -33,6 +36,11 @@
 //! [`Task`]: plan::Task
 //! [`Plan::ready_tasks`]: plan::Plan::ready_tasks
 //! [`Fleet::dispatch`]: fleet::Fleet::dispatch
+//! [`Fleet::pause_task`]: fleet::Fleet::pause_task
+//! [`Fleet::resume_task`]: fleet::Fleet::resume_task
+//! [`Fleet::stop_task`]: fleet::Fleet::stop_task
+//! [`WorkerControls`]: fleet::WorkerControls
+//! [`FleetWorker`]: fleet::FleetWorker
 
 pub mod fleet;
 pub mod git;
@@ -41,7 +49,8 @@ pub mod monitor;
 pub mod plan;
 
 pub use fleet::{
-    Fleet, FleetConfig, FleetError, FleetRunReport, FleetWorker, TaskHandle, WorkerOutcome,
+    Fleet, FleetConfig, FleetError, FleetRunReport, FleetWorker, TaskHandle, WorkerControls,
+    WorkerOutcome,
 };
 pub use git::{
     GitCli, GitError, GitOutput, RemoveOutcome, SystemGitCli, Worktree, WorktreeEntry,


### PR DESCRIPTION
## What & why

Closes the "fleet supervisor seam" named in `COMMAND_DECK_DESIGN.md` and `command_deck.rs`: PR #192 made the deck's sub-session lanes controllable, but `stella fleet` workers still ran uninterruptible — the missing per-worker abort/pause API was a documented follow-up. This PR gives every fleet task Pause/Resume/Stop, carried through the `FleetWorker` port itself.

**The control surface (`stella-fleet`):**

- `WorkerControls` — receiver halves handed to every worker alongside its task, mirroring `subsession.rs`'s channel shapes exactly:
  - `pause: watch::Receiver<bool>` — `true` parks the worker at its next safe step boundary (the engine's `TurnGate`, never mid-tool); a closed channel reads as resumed.
  - `stop: oneshot::Receiver<>` — fired = clean cancel; closed-without-firing = "no stop will ever come", never a stop.
- `FleetWorker::run(&self, task, workspace_root, controls: WorkerControls) -> WorkerOutcome` (port change; test fakes updated).
- `Fleet` keeps a control registry (`Mutex<HashMap<TaskId, TaskControlHandle>>`, the sender halves) registered by `dispatch_claimed` for exactly the span the worker runs, and exposes:
  - `pub fn pause_task(&self, id: &TaskId) -> bool`
  - `pub fn resume_task(&self, id: &TaskId) -> bool`
  - `pub fn stop_task(&self, id: &TaskId) -> bool` — consumes the oneshot; a second stop is a stale no-op
  - `false` = no live worker under that id, identical to `SubSessions` semantics.
- **Restart is deliberately not a fleet verb**: `Fleet::dispatch` is already re-runnable, so restart = the caller re-dispatching the same `Task`; the fleet keeps no respawn state (documented on the API).

**CLI wiring (`stella-cli/src/fleet_cmd.rs`):**

- `EngineWorker::run` threads `WorkerControls` into `run_task`.
- Stop races the turn on both paths — the exact `subsession.rs` `stop_wait` shape (a dropped sender parks forever on the closed channel so the work always wins the race), with the `RacedTurn`-shaped local enum. A stopped attempt reports `success: false`, so it never unblocks dependents.
- Pause becomes a `WatchGate` (a small cross-referenced twin of `subsession.rs`'s private gate) passed to `Engine::with_gate` on the raw step-loop path. The pipeline path is stop-raced but not pause-gated: boundary-gating individual stages needs a gate port on `PipelinePorts` — the existing named follow-up, now documented at the call site.

**Worker-created subagents:** delegation from workers is still v1-stranded (a worker's `task_assign` requests are reported, not spawned), so there is nothing recursive to control yet. The capability is structural instead: because controls ride the `FleetWorker` port, any future nested spawn dispatched through it receives its own control lines with no new machinery — stated in the module docs, no speculative recursion machinery built.

**Docs:** `COMMAND_DECK_DESIGN.md`'s "Backend seams" bullet updated (per-worker Pause/Resume/Stop now live at both layers; still seam-fed = the deck's in-UI hookup to *fleet* tasks, lead-lane pause via a `PipelinePorts` gate, fleet-worktree isolation for deck workers), and the stale seam comments in `command_deck.rs` chased in the same PR.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-fleet/src/fleet.rs`:
- `pause_and_resume_reach_the_worker_through_the_port` — a probe worker parks on its pause watch and observes `[true, false]`
- `stop_fires_once_and_a_second_stop_is_a_stale_no_op`
- `control_verbs_on_an_unknown_task_are_stale_no_ops`
- `control_handles_are_removed_after_the_worker_settles`

`stella-cli/src/fleet_cmd.rs`:
- `watch_gate_parks_while_paused_and_releases_on_resume_or_teardown`

None of these compile on `main` — the control API genuinely does not exist there.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (module docs, `COMMAND_DECK_DESIGN.md`)
- [x] Commits signed off for DCO (`git commit -s`)

`make gate` exit 0 locally (69 stella-fleet tests, full workspace suite green).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (tokio `sync` was already a stella-fleet dependency)
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

- The pipeline path honors stop but not pause — pause needs a gate port on `PipelinePorts` (pre-existing named follow-up; the raw step-loop path is gated).
- The deck's in-UI hookup to fleet tasks (fleet workers as deck lanes) remains future work; this PR provides the supervisor API it will call.
