### PR TITLE
feat(tools): grep/glob results carry a code-map footer from the code graph

### DIFF
--- a/stella-tools/src/code_map.rs
+++ b/stella-tools/src/code_map.rs
@@ -6,8 +6,10 @@
 //! (Field Manual Part 4: "code is a graph, not text"), yet agents keep
 //! grepping instead of asking it. So the search tools bring the graph to the
 //! agent: every successful result carries a compact per-file map (symbols,
-//! import edges) drawn from `.stella/codegraph.db`, plus a pointer at
-//! `graph_query` for the precise follow-up.
+//! import edges) drawn from `.stella/codegraph.db`. The session's FIRST
+//! mapped search additionally carries a one-line pointer at `graph_query`
+//! (the [`TipOnce`] latch, shared by grep and glob) — taught once, then out
+//! of the way.
 //!
 //! Strictly additive and strictly best-effort: no index, an unopenable
 //! store, or files the graph doesn't know all mean "no footer", never an
@@ -16,6 +18,8 @@
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Files mapped per search result — enough to orient, small enough that the
 /// footer never rivals the matches themselves.
@@ -25,12 +29,29 @@ const MAX_SYMBOLS: usize = 6;
 /// Importer paths listed per file before collapsing to a count.
 const MAX_IMPORTERS: usize = 3;
 
+/// Once-per-session latch for the footer's `graph_query` tip line. The
+/// registry constructs one and hands clones to `grep` AND `glob`, so the
+/// tip appears on the session's first mapped search — whichever tool runs
+/// it — and never again; repeating it on every result is teaching that
+/// decays into noise. Consumed only when a footer actually renders: a
+/// search before the index exists doesn't burn the one showing.
+#[derive(Clone, Default)]
+pub struct TipOnce(Arc<AtomicBool>);
+
+impl TipOnce {
+    /// True exactly once, on the first call — atomic, so concurrent
+    /// read-only searches race to exactly one tip.
+    fn take(&self) -> bool {
+        !self.0.swap(true, Ordering::Relaxed)
+    }
+}
+
 /// Render the code-map footer for the files a search touched, or `None`
 /// when there is nothing to say (no index, store unopenable, or none of the
 /// candidates are in the graph). `candidates` may repeat and may mix
 /// absolute and root-relative paths — both resolve; order of first
 /// appearance is kept, so the map follows the result's own ranking.
-pub fn for_files<'a, I>(root: &Path, candidates: I) -> Option<String>
+pub fn for_files<'a, I>(root: &Path, candidates: I, tip: &TipOnce) -> Option<String>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -68,10 +89,12 @@ where
     }
     let mut out = String::from("\n\ncode map (from the code graph):\n");
     out.push_str(&lines.join("\n"));
-    out.push_str(
-        "\ntip: graph_query answers symbol/dependency questions directly \
-         (op=definitions|references|imports|importers|neighbors).",
-    );
+    if tip.take() {
+        out.push_str(
+            "\ntip: graph_query answers symbol/dependency questions directly \
+             (op=definitions|references|imports|importers|neighbors).",
+        );
+    }
     Some(out)
 }
 
@@ -149,13 +172,14 @@ mod tests {
     fn no_index_means_no_footer() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").expect("write");
-        assert_eq!(for_files(dir.path(), ["lib.rs"]), None);
+        assert_eq!(for_files(dir.path(), ["lib.rs"], &TipOnce::default()), None);
     }
 
     #[test]
     fn maps_an_indexed_file_with_symbols_and_a_graph_query_tip() {
         let dir = indexed_workspace();
-        let map = for_files(dir.path(), ["lib.rs"]).expect("footer for an indexed file");
+        let map = for_files(dir.path(), ["lib.rs"], &TipOnce::default())
+            .expect("footer for an indexed file");
         assert!(map.contains("code map"), "labeled: {map}");
         assert!(map.contains("lib.rs"), "names the file: {map}");
         assert!(map.contains("function greet:1"), "cites the symbol: {map}");
@@ -173,7 +197,8 @@ mod tests {
             .join("lib.rs")
             .to_string_lossy()
             .into_owned();
-        let map = for_files(dir.path(), [abs.as_str(), "lib.rs"]).expect("footer");
+        let map =
+            for_files(dir.path(), [abs.as_str(), "lib.rs"], &TipOnce::default()).expect("footer");
         assert_eq!(
             map.matches("function greet:1").count(),
             1,
@@ -185,10 +210,74 @@ mod tests {
     fn unknown_files_are_skipped_not_rendered_empty() {
         let dir = indexed_workspace();
         assert_eq!(
-            for_files(dir.path(), ["README.md", "no/such/file.rs"]),
+            for_files(
+                dir.path(),
+                ["README.md", "no/such/file.rs"],
+                &TipOnce::default()
+            ),
             None,
             "files the graph doesn't know produce no footer at all"
         );
+    }
+
+    #[test]
+    fn the_tip_renders_once_then_footers_stay_map_only() {
+        let dir = indexed_workspace();
+        let tip = TipOnce::default();
+        let first = for_files(dir.path(), ["lib.rs"], &tip).expect("first footer");
+        assert!(first.contains("tip: graph_query"), "teaches once: {first}");
+        let second = for_files(dir.path(), ["lib.rs"], &tip).expect("second footer");
+        assert!(second.contains("code map"), "the map stays: {second}");
+        assert!(
+            !second.contains("tip: graph_query"),
+            "already taught: {second}"
+        );
+    }
+
+    /// The one showing must land where it can teach: a search that renders
+    /// no footer (nothing mapped) leaves the latch unspent.
+    #[test]
+    fn a_search_without_a_footer_does_not_consume_the_tip() {
+        let dir = indexed_workspace();
+        let tip = TipOnce::default();
+        assert_eq!(for_files(dir.path(), ["README.md"], &tip), None);
+        let mapped = for_files(dir.path(), ["lib.rs"], &tip).expect("footer");
+        assert!(
+            mapped.contains("tip: graph_query"),
+            "still unspent after a footer-less search: {mapped}"
+        );
+    }
+
+    /// The session-level contract: grep and glob share one latch through the
+    /// registry, so whichever searches first carries the tip and the other
+    /// never repeats it.
+    #[tokio::test]
+    async fn the_tip_shows_once_per_session_across_grep_and_glob() {
+        let dir = indexed_workspace();
+        let reg = crate::ToolRegistry::with_issue_backend(dir.path().to_path_buf(), None);
+        let first = reg
+            .execute("grep", &serde_json::json!({"pattern": "greet"}))
+            .await;
+        let second = reg
+            .execute("glob", &serde_json::json!({"pattern": "*.rs"}))
+            .await;
+        match (first, second) {
+            (
+                stella_protocol::tool::ToolOutput::Ok { content: grep_out },
+                stella_protocol::tool::ToolOutput::Ok { content: glob_out },
+            ) => {
+                assert!(
+                    grep_out.contains("tip: graph_query"),
+                    "the session's first mapped search teaches: {grep_out}"
+                );
+                assert!(glob_out.contains("code map"), "later maps stay: {glob_out}");
+                assert!(
+                    !glob_out.contains("tip: graph_query"),
+                    "taught once per session, across tools: {glob_out}"
+                );
+            }
+            other => panic!("expected two ok results, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -208,7 +297,12 @@ mod tests {
         graph.shutdown();
 
         let names: Vec<String> = (0..(MAX_FILES + 3)).map(|i| format!("m{i}.rs")).collect();
-        let map = for_files(dir.path(), names.iter().map(String::as_str)).expect("footer");
+        let map = for_files(
+            dir.path(),
+            names.iter().map(String::as_str),
+            &TipOnce::default(),
+        )
+        .expect("footer");
         assert_eq!(
             map.matches("- m").count(),
             MAX_FILES,

--- a/stella-tools/src/code_map.rs
+++ b/stella-tools/src/code_map.rs
@@ -1,0 +1,218 @@
+//! Best-effort code-map footer for text-search results.
+//!
+//! `grep` and `glob` answer "where does this string/file live" — but the
+//! agent's next question is almost always structural: what's defined there,
+//! who imports it, where do I go next. The code graph already knows
+//! (Field Manual Part 4: "code is a graph, not text"), yet agents keep
+//! grepping instead of asking it. So the search tools bring the graph to the
+//! agent: every successful result carries a compact per-file map (symbols,
+//! import edges) drawn from `.stella/codegraph.db`, plus a pointer at
+//! `graph_query` for the precise follow-up.
+//!
+//! Strictly additive and strictly best-effort: no index, an unopenable
+//! store, or files the graph doesn't know all mean "no footer", never an
+//! error and never a changed search result. Open → query → shutdown per
+//! call, the same no-held-handles discipline as `graph_query`.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Files mapped per search result — enough to orient, small enough that the
+/// footer never rivals the matches themselves.
+const MAX_FILES: usize = 5;
+/// Symbols listed per file before eliding the tail.
+const MAX_SYMBOLS: usize = 6;
+/// Importer paths listed per file before collapsing to a count.
+const MAX_IMPORTERS: usize = 3;
+
+/// Render the code-map footer for the files a search touched, or `None`
+/// when there is nothing to say (no index, store unopenable, or none of the
+/// candidates are in the graph). `candidates` may repeat and may mix
+/// absolute and root-relative paths — both resolve; order of first
+/// appearance is kept, so the map follows the result's own ranking.
+pub fn for_files<'a, I>(root: &Path, candidates: I) -> Option<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    if !crate::graph::graph_available(root) {
+        return None;
+    }
+    let graph = stella_graph::CodeGraph::open(root, &crate::graph::graph_db_path(root)).ok()?;
+
+    // Two dedup layers: `seen` skips repeated candidate strings cheaply;
+    // `mapped` keys on the graph-resolved path, so an absolute and a
+    // relative spelling of the same file still collapse to one entry.
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut mapped: HashSet<String> = HashSet::new();
+    let mut lines: Vec<String> = Vec::new();
+    for candidate in candidates {
+        if lines.len() == MAX_FILES {
+            break;
+        }
+        if candidate.is_empty() || !seen.insert(candidate) {
+            continue;
+        }
+        let Ok(hood) = graph.file_neighborhood(Path::new(candidate)) else {
+            continue;
+        };
+        if let Some(line) = render_file(&hood)
+            && mapped.insert(hood.file)
+        {
+            lines.push(line);
+        }
+    }
+    graph.shutdown();
+
+    if lines.is_empty() {
+        return None;
+    }
+    let mut out = String::from("\n\ncode map (from the code graph):\n");
+    out.push_str(&lines.join("\n"));
+    out.push_str(
+        "\ntip: graph_query answers symbol/dependency questions directly \
+         (op=definitions|references|imports|importers|neighbors).",
+    );
+    Some(out)
+}
+
+/// One file's line, or `None` when the graph has nothing on it (unindexed
+/// language, or a path the index doesn't know) — an empty entry would be
+/// noise, not a map.
+fn render_file(hood: &stella_graph::FileNeighborhood) -> Option<String> {
+    // Columns are per-table detail (SQL files index one symbol per column);
+    // at file granularity they drown the tables they belong to.
+    let symbols: Vec<&stella_graph::NeighborhoodSymbol> = hood
+        .symbols
+        .iter()
+        .filter(|s| s.kind != "column")
+        .collect();
+    if symbols.is_empty() && hood.imports.is_empty() && hood.importers.is_empty() {
+        return None;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if !symbols.is_empty() {
+        let mut listed: Vec<String> = symbols
+            .iter()
+            .take(MAX_SYMBOLS)
+            .map(|s| format!("{} {}:{}", s.kind, s.name, s.start_line))
+            .collect();
+        if symbols.len() > MAX_SYMBOLS {
+            listed.push(format!("+{} more", symbols.len() - MAX_SYMBOLS));
+        }
+        parts.push(listed.join(", "));
+    }
+    if !hood.imports.is_empty() {
+        parts.push(format!("imports {}", hood.imports.len()));
+    }
+    if !hood.importers.is_empty() {
+        let mut listed: Vec<&str> = hood
+            .importers
+            .iter()
+            .take(MAX_IMPORTERS)
+            .map(String::as_str)
+            .collect();
+        let extra = hood.importers.len().saturating_sub(MAX_IMPORTERS);
+        let mut s = format!("imported by {}", listed.join(", "));
+        if extra > 0 {
+            listed.truncate(MAX_IMPORTERS);
+            s.push_str(&format!(" (+{extra} more)"));
+        }
+        parts.push(s);
+    }
+    Some(format!("- {} — {}", hood.file, parts.join(" · ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A workspace with a built index: `lib.rs` defines `greet`, `main.rs`
+    /// imports nothing resolvable — the same minimal fixture the graph
+    /// tool's tests use.
+    fn indexed_workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn greet() -> &'static str { \"hi\" }\npub struct Greeter;\n",
+        )
+        .expect("write source");
+        let db = crate::graph::graph_db_path(dir.path());
+        std::fs::create_dir_all(db.parent().expect("parent")).expect("mkdir");
+        let graph = stella_graph::CodeGraph::open(dir.path(), &db).expect("open graph");
+        graph.index_all().expect("index");
+        graph.shutdown();
+        dir
+    }
+
+    #[test]
+    fn no_index_means_no_footer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").expect("write");
+        assert_eq!(for_files(dir.path(), ["lib.rs"]), None);
+    }
+
+    #[test]
+    fn maps_an_indexed_file_with_symbols_and_a_graph_query_tip() {
+        let dir = indexed_workspace();
+        let map = for_files(dir.path(), ["lib.rs"]).expect("footer for an indexed file");
+        assert!(map.contains("code map"), "labeled: {map}");
+        assert!(map.contains("lib.rs"), "names the file: {map}");
+        assert!(map.contains("function greet:1"), "cites the symbol: {map}");
+        assert!(map.contains("struct Greeter:2"), "cites the struct: {map}");
+        assert!(map.contains("graph_query"), "nudges at the tool: {map}");
+    }
+
+    #[test]
+    fn absolute_and_relative_spellings_dedupe_to_one_entry() {
+        let dir = indexed_workspace();
+        let abs = dir
+            .path()
+            .canonicalize()
+            .expect("canon")
+            .join("lib.rs")
+            .to_string_lossy()
+            .into_owned();
+        let map = for_files(dir.path(), [abs.as_str(), "lib.rs"]).expect("footer");
+        assert_eq!(
+            map.matches("function greet:1").count(),
+            1,
+            "one entry, not one per spelling: {map}"
+        );
+    }
+
+    #[test]
+    fn unknown_files_are_skipped_not_rendered_empty() {
+        let dir = indexed_workspace();
+        assert_eq!(
+            for_files(dir.path(), ["README.md", "no/such/file.rs"]),
+            None,
+            "files the graph doesn't know produce no footer at all"
+        );
+    }
+
+    #[test]
+    fn the_footer_is_bounded_to_max_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for i in 0..(MAX_FILES + 3) {
+            std::fs::write(
+                dir.path().join(format!("m{i}.rs")),
+                format!("pub fn f{i}() {{}}\n"),
+            )
+            .expect("write");
+        }
+        let db = crate::graph::graph_db_path(dir.path());
+        std::fs::create_dir_all(db.parent().expect("parent")).expect("mkdir");
+        let graph = stella_graph::CodeGraph::open(dir.path(), &db).expect("open");
+        graph.index_all().expect("index");
+        graph.shutdown();
+
+        let names: Vec<String> = (0..(MAX_FILES + 3)).map(|i| format!("m{i}.rs")).collect();
+        let map = for_files(dir.path(), names.iter().map(String::as_str)).expect("footer");
+        assert_eq!(
+            map.matches("- m").count(),
+            MAX_FILES,
+            "caps at {MAX_FILES}: {map}"
+        );
+    }
+}

--- a/stella-tools/src/gather.rs
+++ b/stella-tools/src/gather.rs
@@ -462,7 +462,9 @@ async fn gather(
         async move {
             (
                 pattern.clone(),
-                crate::glob::Glob.execute(&input, root).await,
+                // `bare()`: no code-map footer inside packs — the pack runs
+                // its own graph queries; a per-section footer is duplication.
+                crate::glob::Glob::bare().execute(&input, root).await,
             )
         }
     }));
@@ -471,7 +473,7 @@ async fn gather(
         async move {
             (
                 pattern.clone(),
-                crate::grep::Grep.execute(&input, root).await,
+                crate::grep::Grep::bare().execute(&input, root).await,
             )
         }
     }));

--- a/stella-tools/src/glob.rs
+++ b/stella-tools/src/glob.rs
@@ -10,7 +10,34 @@ use crate::registry::Tool;
 
 const MAX_RESULTS: usize = 500;
 
-pub struct Glob;
+pub struct Glob {
+    /// Code-map footer state; `None` disables the footer entirely (the
+    /// embedded sweeps in `gather_context` — see [`crate::grep::Grep`]).
+    code_map: Option<crate::code_map::TipOnce>,
+}
+
+impl Glob {
+    /// The model-facing tool: footer on, `graph_query` tip latch shared
+    /// with `grep` (the registry passes both clones of one
+    /// [`crate::code_map::TipOnce`]).
+    pub fn with_code_map(tip: crate::code_map::TipOnce) -> Self {
+        Self {
+            code_map: Some(tip),
+        }
+    }
+
+    /// Footer-less instance for embedded use.
+    pub fn bare() -> Self {
+        Self { code_map: None }
+    }
+}
+
+impl Default for Glob {
+    /// Footer on with a private latch — the standalone shape tests use.
+    fn default() -> Self {
+        Self::with_code_map(crate::code_map::TipOnce::default())
+    }
+}
 
 #[async_trait]
 impl Tool for Glob {
@@ -86,7 +113,7 @@ impl Tool for Glob {
                     .collect::<Vec<_>>()
                     .join("\n");
                 ToolOutput::Ok {
-                    content: with_code_map(content, root),
+                    content: with_code_map(content, root, self.code_map.as_ref()),
                 }
             }
             Err(_) => {
@@ -113,7 +140,7 @@ impl Tool for Glob {
                                 .collect::<Vec<_>>()
                                 .join("\n");
                             ToolOutput::Ok {
-                                content: with_code_map(content, root),
+                                content: with_code_map(content, root, self.code_map.as_ref()),
                             }
                         }
                     }
@@ -126,11 +153,19 @@ impl Tool for Glob {
     }
 }
 
-/// Append the code-map footer for these matched paths, when the graph has
-/// one to give (see [`crate::code_map`]). Bound separately from the `if let`
-/// so the `content.lines()` borrow ends before `content` is mutated.
-fn with_code_map(mut content: String, root: &std::path::Path) -> String {
-    let map = crate::code_map::for_files(root, content.lines());
+/// Append the code-map footer for these matched paths, when a footer is
+/// enabled and the graph has one to give (see [`crate::code_map`]). Bound
+/// separately from the `if let` so the `content.lines()` borrow ends before
+/// `content` is mutated.
+fn with_code_map(
+    mut content: String,
+    root: &std::path::Path,
+    tip: Option<&crate::code_map::TipOnce>,
+) -> String {
+    let Some(tip) = tip else {
+        return content;
+    };
+    let map = crate::code_map::for_files(root, content.lines(), tip);
     if let Some(map) = map {
         content.push_str(&map);
     }
@@ -168,7 +203,7 @@ mod tests {
 
         // Use a glob pattern (not regex) so both `fd` and `find -name`
         // handle it identically across platforms.
-        let result = Glob
+        let result = Glob::default()
             .execute(
                 &serde_json::json!({"pattern": "*.rs", "path": &subdir}),
                 &dir,
@@ -197,7 +232,7 @@ mod tests {
         graph.index_all().expect("index");
         graph.shutdown();
 
-        let result = Glob
+        let result = Glob::default()
             .execute(&serde_json::json!({"pattern": "*.rs"}), dir.path())
             .await;
         match result {
@@ -216,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn no_files_returns_ok() {
         let dir = std::env::temp_dir();
-        let result = Glob
+        let result = Glob::default()
             .execute(&serde_json::json!({"pattern": "*.nonexistent"}), &dir)
             .await;
         match result {

--- a/stella-tools/src/glob.rs
+++ b/stella-tools/src/glob.rs
@@ -17,9 +17,10 @@ impl Tool for Glob {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "glob".into(),
-            description:
-                "Find files matching a glob pattern. Returns relative paths from workspace root."
-                    .into(),
+            description: "Find files matching a glob pattern. Returns relative paths from \
+                          workspace root. When the code-graph index exists, results carry a \
+                          code-map footer (matched files' symbols and import edges)."
+                .into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -84,7 +85,9 @@ impl Tool for Glob {
                     .map(|l| relativize(l, canon_root.as_deref()))
                     .collect::<Vec<_>>()
                     .join("\n");
-                ToolOutput::Ok { content }
+                ToolOutput::Ok {
+                    content: with_code_map(content, root),
+                }
             }
             Err(_) => {
                 // fd not installed — fall back to find (same pinned dir).
@@ -109,7 +112,9 @@ impl Tool for Glob {
                                 .map(|l| relativize(l, canon_root.as_deref()))
                                 .collect::<Vec<_>>()
                                 .join("\n");
-                            ToolOutput::Ok { content }
+                            ToolOutput::Ok {
+                                content: with_code_map(content, root),
+                            }
                         }
                     }
                     Err(e) => ToolOutput::Error {
@@ -119,6 +124,17 @@ impl Tool for Glob {
             }
         }
     }
+}
+
+/// Append the code-map footer for these matched paths, when the graph has
+/// one to give (see [`crate::code_map`]). Bound separately from the `if let`
+/// so the `content.lines()` borrow ends before `content` is mutated.
+fn with_code_map(mut content: String, root: &std::path::Path) -> String {
+    let map = crate::code_map::for_files(root, content.lines());
+    if let Some(map) = map {
+        content.push_str(&map);
+    }
+    content
 }
 
 /// Render an absolute match path relative to the workspace root, honoring the
@@ -169,6 +185,32 @@ mod tests {
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
         let _ = tokio::fs::remove_dir_all(dir.join(&subdir)).await;
+    }
+
+    #[tokio::test]
+    async fn results_carry_a_code_map_footer_when_an_index_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn greet() {}\n").expect("write");
+        let db = crate::graph::graph_db_path(dir.path());
+        std::fs::create_dir_all(db.parent().expect("parent")).expect("mkdir");
+        let graph = stella_graph::CodeGraph::open(dir.path(), &db).expect("open graph");
+        graph.index_all().expect("index");
+        graph.shutdown();
+
+        let result = Glob
+            .execute(&serde_json::json!({"pattern": "*.rs"}), dir.path())
+            .await;
+        match result {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("lib.rs"), "the file list stays: {content}");
+                assert!(content.contains("code map"), "footer attached: {content}");
+                assert!(
+                    content.contains("function greet:1"),
+                    "maps the listed file's symbols: {content}"
+                );
+            }
+            ToolOutput::Error { message } => panic!("expected files, got: {message}"),
+        }
     }
 
     #[tokio::test]

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -41,19 +41,22 @@ fn first_error_line(stderr: &str) -> String {
 }
 
 /// The code-map footer for these `path:line:text` matches (see
-/// [`crate::code_map`]). A directory search prints an absolute path before
-/// the first `:`; a single-file search omits the filename entirely (rg and
-/// grep both do), so there the search target itself is the mapped file.
-/// Non-path prefixes (a bare line number, a match containing `:`) simply
-/// miss in the graph — best-effort by construction.
+/// [`crate::code_map`]), or `None` for a footer-less instance. A directory
+/// search prints an absolute path before the first `:`; a single-file
+/// search omits the filename entirely (rg and grep both do), so there the
+/// search target itself is the mapped file. Non-path prefixes (a bare line
+/// number, a match containing `:`) simply miss in the graph — best-effort
+/// by construction.
 fn code_map_for(
+    tip: Option<&crate::code_map::TipOnce>,
     search_dir: &std::path::Path,
     root: &std::path::Path,
     lines: &[&str],
 ) -> Option<String> {
+    let tip = tip?;
     if search_dir.is_file() {
         let target = search_dir.to_string_lossy();
-        return crate::code_map::for_files(root, [target.as_ref()]);
+        return crate::code_map::for_files(root, [target.as_ref()], tip);
     }
     crate::code_map::for_files(
         root,
@@ -61,10 +64,38 @@ fn code_map_for(
             .iter()
             .filter_map(|l| l.split(':').next())
             .filter(|p| std::path::Path::new(p).is_absolute()),
+        tip,
     )
 }
 
-pub struct Grep;
+pub struct Grep {
+    /// Code-map footer state; `None` disables the footer entirely (the
+    /// embedded sweeps in `gather_context`, whose packs run their own graph
+    /// queries — a per-section footer there is duplication, not context).
+    code_map: Option<crate::code_map::TipOnce>,
+}
+
+impl Grep {
+    /// The model-facing tool: footer on, `graph_query` tip latch shared
+    /// with `glob` (the registry passes both clones of one [`TipOnce`]).
+    pub fn with_code_map(tip: crate::code_map::TipOnce) -> Self {
+        Self {
+            code_map: Some(tip),
+        }
+    }
+
+    /// Footer-less instance for embedded use.
+    pub fn bare() -> Self {
+        Self { code_map: None }
+    }
+}
+
+impl Default for Grep {
+    /// Footer on with a private latch — the standalone shape tests use.
+    fn default() -> Self {
+        Self::with_code_map(crate::code_map::TipOnce::default())
+    }
+}
 
 #[async_trait]
 impl Tool for Grep {
@@ -138,7 +169,8 @@ impl Tool for Grep {
                     if lines.len() == MAX_RESULTS {
                         result.push_str(&format!("\n... (showing first {MAX_RESULTS} matches)"));
                     }
-                    if let Some(map) = code_map_for(&search_dir, root, &lines) {
+                    if let Some(map) = code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
+                    {
                         result.push_str(&map);
                     }
                     return ToolOutput::Ok { content: result };
@@ -175,7 +207,9 @@ impl Tool for Grep {
                         if !text.is_empty() {
                             let lines: Vec<&str> = text.lines().take(MAX_RESULTS).collect();
                             let mut result = lines.join("\n");
-                            if let Some(map) = code_map_for(&search_dir, root, &lines) {
+                            if let Some(map) =
+                                code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
+                            {
                                 result.push_str(&map);
                             }
                             return ToolOutput::Ok { content: result };
@@ -211,7 +245,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "hello", "path": path}), &dir)
             .await;
         match result {
@@ -226,7 +260,7 @@ mod tests {
     #[tokio::test]
     async fn no_matches_returns_ok_empty() {
         let dir = std::env::temp_dir();
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "zzz_not_found_xyz"}), &dir)
             .await;
         match result {
@@ -246,7 +280,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "->"}), &dir)
             .await;
         match result {
@@ -273,7 +307,7 @@ mod tests {
             .unwrap();
 
         // Unclosed character class — invalid for both rg and grep.
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "[unclosed"}), &dir)
             .await;
         assert!(
@@ -303,7 +337,7 @@ mod tests {
     #[tokio::test]
     async fn matches_carry_a_code_map_footer_when_an_index_exists() {
         let dir = indexed_workspace();
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "greet"}), dir.path())
             .await;
         match result {
@@ -324,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn a_single_file_search_still_maps_the_target_file() {
         let dir = indexed_workspace();
-        let result = Grep
+        let result = Grep::default()
             .execute(
                 &serde_json::json!({"pattern": "greet", "path": "lib.rs"}),
                 dir.path(),
@@ -345,7 +379,7 @@ mod tests {
     async fn no_index_means_no_code_map_footer() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("lib.rs"), "pub fn greet() {}\n").expect("write");
-        let result = Grep
+        let result = Grep::default()
             .execute(&serde_json::json!({"pattern": "greet"}), dir.path())
             .await;
         match result {

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -40,6 +40,30 @@ fn first_error_line(stderr: &str) -> String {
         .to_string()
 }
 
+/// The code-map footer for these `path:line:text` matches (see
+/// [`crate::code_map`]). A directory search prints an absolute path before
+/// the first `:`; a single-file search omits the filename entirely (rg and
+/// grep both do), so there the search target itself is the mapped file.
+/// Non-path prefixes (a bare line number, a match containing `:`) simply
+/// miss in the graph — best-effort by construction.
+fn code_map_for(
+    search_dir: &std::path::Path,
+    root: &std::path::Path,
+    lines: &[&str],
+) -> Option<String> {
+    if search_dir.is_file() {
+        let target = search_dir.to_string_lossy();
+        return crate::code_map::for_files(root, [target.as_ref()]);
+    }
+    crate::code_map::for_files(
+        root,
+        lines
+            .iter()
+            .filter_map(|l| l.split(':').next())
+            .filter(|p| std::path::Path::new(p).is_absolute()),
+    )
+}
+
 pub struct Grep;
 
 #[async_trait]
@@ -47,7 +71,7 @@ impl Tool for Grep {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "grep".into(),
-            description: "Search file contents with a regex. Returns matching file:line:text. Shells to ripgrep when available.".into(),
+            description: "Search file contents with a regex. Returns matching file:line:text. Shells to ripgrep when available. When the code-graph index exists, matches carry a code-map footer (matched files' symbols and import edges).".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -114,6 +138,9 @@ impl Tool for Grep {
                     if lines.len() == MAX_RESULTS {
                         result.push_str(&format!("\n... (showing first {MAX_RESULTS} matches)"));
                     }
+                    if let Some(map) = code_map_for(&search_dir, root, &lines) {
+                        result.push_str(&map);
+                    }
                     return ToolOutput::Ok { content: result };
                 }
                 // No results. Exit 2 with a *pattern* error (bad regex, bad
@@ -147,9 +174,11 @@ impl Tool for Grep {
                         let text = String::from_utf8_lossy(&output.stdout);
                         if !text.is_empty() {
                             let lines: Vec<&str> = text.lines().take(MAX_RESULTS).collect();
-                            return ToolOutput::Ok {
-                                content: lines.join("\n"),
-                            };
+                            let mut result = lines.join("\n");
+                            if let Some(map) = code_map_for(&search_dir, root, &lines) {
+                                result.push_str(&map);
+                            }
+                            return ToolOutput::Ok { content: result };
                         }
                         let stderr = String::from_utf8_lossy(&output.stderr);
                         if output.status.code() == Some(2) && is_pattern_error(&stderr) {
@@ -252,5 +281,79 @@ mod tests {
             "a broken regex must report an error, got: {result:?}"
         );
         let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    /// A workspace with one indexed source file, exactly what `stella init`
+    /// leaves behind.
+    fn indexed_workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn greet() -> &'static str { \"hi\" }\n",
+        )
+        .expect("write source");
+        let db = crate::graph::graph_db_path(dir.path());
+        std::fs::create_dir_all(db.parent().expect("parent")).expect("mkdir");
+        let graph = stella_graph::CodeGraph::open(dir.path(), &db).expect("open graph");
+        graph.index_all().expect("index");
+        graph.shutdown();
+        dir
+    }
+
+    #[tokio::test]
+    async fn matches_carry_a_code_map_footer_when_an_index_exists() {
+        let dir = indexed_workspace();
+        let result = Grep
+            .execute(&serde_json::json!({"pattern": "greet"}), dir.path())
+            .await;
+        match result {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("lib.rs"), "the raw match stays: {content}");
+                assert!(content.contains("code map"), "footer attached: {content}");
+                assert!(
+                    content.contains("function greet:1"),
+                    "maps the matched file's symbols: {content}"
+                );
+            }
+            ToolOutput::Error { message } => panic!("expected matches, got: {message}"),
+        }
+    }
+
+    /// rg/grep omit the filename when handed a single file, so the footer
+    /// must come from the search target itself, not the match prefix.
+    #[tokio::test]
+    async fn a_single_file_search_still_maps_the_target_file() {
+        let dir = indexed_workspace();
+        let result = Grep
+            .execute(
+                &serde_json::json!({"pattern": "greet", "path": "lib.rs"}),
+                dir.path(),
+            )
+            .await;
+        match result {
+            ToolOutput::Ok { content } => {
+                assert!(
+                    content.contains("function greet:1"),
+                    "single-file searches map the target: {content}"
+                );
+            }
+            ToolOutput::Error { message } => panic!("expected matches, got: {message}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_index_means_no_code_map_footer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn greet() {}\n").expect("write");
+        let result = Grep
+            .execute(&serde_json::json!({"pattern": "greet"}), dir.path())
+            .await;
+        match result {
+            ToolOutput::Ok { content } => assert!(
+                !content.contains("code map"),
+                "no index → the result is exactly the matches: {content}"
+            ),
+            ToolOutput::Error { message } => panic!("expected matches, got: {message}"),
+        }
     }
 }

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod agent_use;
 pub mod bash;
 pub mod ci;
+pub mod code_map;
 pub mod custom;
 pub mod delete;
 pub mod edit;

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -138,6 +138,7 @@ impl ToolRegistry {
         let mcp_usage: stella_core::mcp_usage::McpUsageLedger = Arc::default();
         let task_board: crate::tasks::TaskBoardHandle = Arc::default();
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
+        let code_map_tip = crate::code_map::TipOnce::default();
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
         let mut entries: Vec<Arc<dyn Tool>> = vec![
             Arc::new(crate::read::ReadFile::default()),
@@ -145,8 +146,11 @@ impl ToolRegistry {
             Arc::new(crate::edit::EditFile),
             Arc::new(crate::delete::DeleteFile),
             Arc::new(crate::bash::Bash),
-            Arc::new(crate::grep::Grep),
-            Arc::new(crate::glob::Glob),
+            // One shared tip latch: the session's first mapped search —
+            // grep or glob, whichever comes first — carries the graph_query
+            // pointer; every later footer is map-only.
+            Arc::new(crate::grep::Grep::with_code_map(code_map_tip.clone())),
+            Arc::new(crate::glob::Glob::with_code_map(code_map_tip)),
             Arc::new(crate::gather::GatherContext),
             Arc::new(crate::exploration::Explorations),
             Arc::new(crate::exploration::SaveExploration),


### PR DESCRIPTION
## What

Every successful `grep`/`glob` result now ends with a compact **code map** drawn from the code graph (`.stella/codegraph.db`): for each matched file (up to 5), its symbols with kinds and line numbers, an import count, and who imports it. The session's **first** mapped search additionally carries a one-line pointer at `graph_query`; later results are map-only — taught once, then out of the way.

```
stella-tools/src/grep.rs:19:fn is_pattern_error(stderr: &str) -> bool {

code map (from the code graph):
- stella-tools/src/grep.rs — function is_pattern_error:19, function first_error_line:30, struct Grep:43 · imports 5 · imported by stella-tools/src/lib.rs
tip: graph_query answers symbol/dependency questions directly (op=definitions|references|imports|importers|neighbors).   ← first search only
```

## Why

Agents keep grepping instead of asking the graph. Rather than hoping they discover `graph_query`, the search tools bring the graph to them: every text search yields structural context for free, and the first one advertises the tool that answers the follow-up question directly.

## How

- New `stella-tools/src/code_map.rs`: open → query → shutdown per call (same no-held-handles discipline as `graph_query`), rendering `CodeGraph::file_neighborhood` per matched file.
- **Once-per-session tip**: a `TipOnce` latch (atomic, race-safe under parallel read-only tools) constructed by the registry and shared by `grep` + `glob` — whichever searches first teaches. Consumed only when a footer actually renders, so a pre-index search doesn't burn the one showing.
- **`gather_context` sweeps are footer-less** (`Grep::bare` / `Glob::bare`): packs run their own graph queries, so a per-section footer would be persisted duplication.
- **Strictly additive, strictly best-effort**: no index / unopenable store / unknown files ⇒ no footer, never an error, never a changed match list. Without an index, results are byte-identical to before.
- **Bounded**: 5 files × 6 symbols × 3 importers; SQL `column` symbols filtered (per-table noise at file granularity).
- Edge cases: single-file greps (rg/grep omit the filename) map the search target itself; absolute + relative spellings of one file dedupe on the graph-resolved path.

## Testing

`cargo test -p stella-tools`: 236 passed, including tests for the footer, tip-once semantics (per instance and end-to-end across grep→glob through the registry), tip non-consumption on footer-less searches, the single-file case, dedup across path spellings, the MAX_FILES cap, and the no-index no-footer guarantee. `cargo clippy --workspace --all-targets` clean.
