### PR TITLE
chore(tools): drop stale @todo for bash in the default tool list

### DIFF
--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -179,7 +179,6 @@ impl ToolRegistry {
             Arc::new(crate::write::WriteFile),
             Arc::new(crate::edit::EditFile),
             Arc::new(crate::delete::DeleteFile),
-            // Arc::new(crate::bash::Bash),  // @todo revisit and determine if bash should be in this list or not.
             // One shared tip latch: the session's first mapped search —
             // grep or glob, whichever comes first — carries the graph_query
             // pointer; every later footer is map-only.


### PR DESCRIPTION
## Summary
Removes the commented-out `Arc::new(crate::bash::Bash)` line and its `@todo revisit and determine if bash should be in this list or not` in `stella-tools/src/registry.rs`.

The question the @todo asked was already settled by #193: `bash` is off by default everywhere and settings opt-in via `RegistryOptions.bash`, with conditional registration just below the default entries list. Both postures are pinned by tests (`bash_is_absent_by_default_and_calling_it_is_unknown`, `bash_registers_and_dispatches_with_the_opt_in_flag`). The commented-out registration was a leftover from before that decision.

## Test plan
- `cargo test -p stella-tools registry` — 33 passed, including both bash opt-in tests
