### PR TITLE
style(tools): apply cargo fmt to code_map.rs and grep.rs

### DIFF
--- a/stella-tools/src/code_map.rs
+++ b/stella-tools/src/code_map.rs
@@ -104,11 +104,8 @@ where
 fn render_file(hood: &stella_graph::FileNeighborhood) -> Option<String> {
     // Columns are per-table detail (SQL files index one symbol per column);
     // at file granularity they drown the tables they belong to.
-    let symbols: Vec<&stella_graph::NeighborhoodSymbol> = hood
-        .symbols
-        .iter()
-        .filter(|s| s.kind != "column")
-        .collect();
+    let symbols: Vec<&stella_graph::NeighborhoodSymbol> =
+        hood.symbols.iter().filter(|s| s.kind != "column").collect();
     if symbols.is_empty() && hood.imports.is_empty() && hood.importers.is_empty() {
         return None;
     }

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -169,7 +169,8 @@ impl Tool for Grep {
                     if lines.len() == MAX_RESULTS {
                         result.push_str(&format!("\n... (showing first {MAX_RESULTS} matches)"));
                     }
-                    if let Some(map) = code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
+                    if let Some(map) =
+                        code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
                     {
                         result.push_str(&map);
                     }


### PR DESCRIPTION
Fixes the `Run cargo fmt --check` CI failure on main (introduced in #203).

Formatting-only: `cargo fmt --all` reformatted the two hunks flagged by CI in `stella-tools/src/code_map.rs` and `stella-tools/src/grep.rs`. Verified `cargo fmt --all -- --check` now passes.
