### PR TITLE
docs(agent-tools): one page per extension concept — split Custom Agents from Custom Commands

### DIFF
--- a/stella-docs/content/docs/agent-tools/commands.mdx
+++ b/stella-docs/content/docs/agent-tools/commands.mdx
@@ -1,17 +1,18 @@
 ---
-title: Commands & custom agents
-description: Extend the slash menu with your own COMMAND.md templates and AGENT.md personas — adopted automatically from .claude/ and .agents/ directories you already have.
+title: Custom Commands
+description: Extend the slash menu with your own COMMAND.md prompt templates — $ARGUMENTS expansion, project and user scopes, and automatic adoption from .claude/ and .agents/ directories.
 ---
 
 The Command Deck's slash menu is extensible: alongside the built-ins
-(`/help`, `/models`, `/export`, …) and your ⚡
-[skills](/docs/agent-tools/skills), you can define **commands** (prompt
-templates) and **agents** (personas with an optional restricted toolbelt).
+(`/help`, `/models`, `/export`, …), your ⚡
+[skills](/docs/agent-tools/skills), and your
+[custom agents](/docs/agent-tools/custom-agents), you can define
+**commands** — reusable prompt templates invoked as `/name`.
 
-## Custom commands
+## The format
 
-A `COMMAND.md` (nested `<slug>/COMMAND.md` or flat `<slug>.md`) under
-`.stella/commands/` (project) or `~/.config/stella/commands/` (user):
+A `COMMAND.md` (nested `<slug>/COMMAND.md` or flat `<slug>.md`) with
+optional frontmatter and a Markdown body:
 
 ```md title=".stella/commands/review.md"
 ---
@@ -26,52 +27,53 @@ Focus areas: $ARGUMENTS
 - Check error paths before happy paths.
 ```
 
-Typing `/review auth module` expands the template — `$ARGUMENTS` is replaced
-with whatever follows the command — and runs it as the prompt.
+Both frontmatter fields are optional: `name:` falls back to the filename
+stem (or the directory name in the nested layout), and `description:` falls
+back to the body's first non-empty line. Only the body is required — a
+command with an empty body is skipped with a diagnostic, never a fatal
+error.
 
-## Custom agents
+## Argument expansion
 
-An `AGENT.md` defines a persona the session can adopt with
-`/agent-name <task>`:
+Typing `/review auth module` expands the template and runs the result as
+the prompt:
 
-```md title=".stella/agents/docs-writer.md"
----
-name: docs-writer
-description: Writes end-user documentation in our house style.
-tools: [read_file, grep, glob, write_file, edit_file]
----
+- Every `$ARGUMENTS` occurrence in the body is replaced with whatever
+  follows the command name (`auth module` above).
+- A body **without** the placeholder still takes arguments — non-empty
+  arguments are appended as a trailing paragraph, so plain prompt files
+  written for other tools work unchanged.
 
-You are a technical writer. Prefer working examples over abstractions.
-Never document a flag you haven't verified against --help output.
-```
+## Where commands live
 
-The optional `tools:` frontmatter restricts the agent's toolbelt. `/agents`
-opens the Agents tab, which lists installed agents with versioned editing
-and pinning — like skills, every save is a new version you can roll back.
+| Scope | Path | Travels with |
+| --- | --- | --- |
+| Project | `<workspace>/.stella/commands/` | The repo — commit it, the team shares it |
+| User | `~/.config/stella/commands/` | You, across every workspace |
+
+Definitions load user-global first, then workspace — **workspace wins** on
+a name collision. In the slash menu, built-ins can never be shadowed, and
+when a custom name collides across kinds, commands shadow skills shadow
+agents.
 
 ## Adopted from tools you already use
 
-`stella init` (and `/init`) **adopts** definitions from other agent tools'
-directories as symlinks — your existing setup carries over instead of being
-rewritten:
-
-| Source | Destination |
-| --- | --- |
-| `<workspace>/.claude/{commands,skills,agents}` · `<workspace>/.agents/…` | `<workspace>/.stella/…` |
-| `~/.claude/…` · `~/.agents/…` | `~/.config/stella/…` |
-
-`.claude` wins over `.agents` on a name collision; existing Stella-side
-definitions are never clobbered; adoption is idempotent.
-
-## Precedence
-
-Definitions load user-global first, then workspace — **workspace wins** on a
-name collision. In the slash menu, built-ins can never be shadowed, and
-commands shadow skills shadow agents when names collide.
+`stella init` (and `/init`) **adopts** command definitions from other agent
+tools' directories as symlinks — `.claude/commands/` and
+`.agents/commands/` (workspace scope), `~/.claude/commands/` and
+`~/.agents/commands/` (user scope) — so your existing setup carries over
+instead of being rewritten. `.claude` wins over `.agents` on a name
+collision, existing Stella-side definitions are never clobbered, and the
+sync is idempotent. The same adoption covers skills and agents — the full
+mechanics are documented on the
+[Custom Agents](/docs/agent-tools/custom-agents#adopted-from-claude-and-agents-on-init)
+page.
 
 <Callout type="info">
-  Commands and agents are prompt-level extensions — templates and personas.
-  To give the agent a genuinely new *action* (a deploy script, a database
-  query), define a [custom tool](/docs/agent-tools/custom-tools); to run
-  shell commands on lifecycle events, use [hooks](/docs/agent-tools/hooks).
+  Commands are prompt-level extensions — templates. For a reusable persona
+  with an optional restricted toolbelt, define a
+  [custom agent](/docs/agent-tools/custom-agents); to give the agent a
+  genuinely new *action* (a deploy script, a database query), define a
+  [custom tool](/docs/agent-tools/custom-tools); to run shell commands on
+  lifecycle events, use [hooks](/docs/agent-tools/hooks).
 </Callout>

--- a/stella-docs/content/docs/agent-tools/custom-agents.mdx
+++ b/stella-docs/content/docs/agent-tools/custom-agents.mdx
@@ -1,0 +1,116 @@
+---
+title: Custom Agents
+description: Define reusable personas in AGENT.md files — the frontmatter schema, where definitions live, versioned editing, and how stella init adopts agents from .claude/ and .agents/ directories.
+---
+
+A **custom agent** is a named persona the session can adopt: a
+system-prompt-shaped Markdown body with a frontmatter header, invoked as
+`/agent-name <task>`. Agents are distinct from
+[skills](/docs/agent-tools/skills) (know-how selected into context
+automatically) and [custom commands](/docs/agent-tools/commands) (prompt
+templates) — an agent changes *who is doing the work*, optionally with a
+restricted toolbelt.
+
+## The AGENT.md schema
+
+An agent is one Markdown file with YAML frontmatter — nested
+`<slug>/AGENT.md` or flat `<slug>.md`:
+
+```md title=".stella/agents/docs-writer.md"
+---
+name: docs-writer
+description: Writes end-user documentation in our house style.
+tools: [read_file, grep, glob, write_file, edit_file]
+---
+
+You are a technical writer. Prefer working examples over abstractions.
+Never document a flag you haven't verified against --help output.
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `name` | No | The agent's slug. Falls back to the filename stem (flat layout) or the directory name (nested layout). |
+| `description` | No | One-line summary for the `/agents` listing. Falls back to the body's first non-empty line, truncated to 72 characters. |
+| `tools` | No | The agent's toolbelt — the tool names granted to this persona. Omitted means **all** tools. |
+| *body* | **Yes** | The persona's instructions — everything after the frontmatter. A file with an empty body is skipped with a diagnostic, never a fatal error. |
+
+The `tools:` field is parsed tolerantly, accepting every shape the
+ecosystem has taught authors: a bare comma list (`Read, Grep`), a JSON/YAML
+flow array (`["Read", "Grep"]`, `[Read, Grep]`), a block sequence, per-item
+quotes, and trailing commas all normalize to the same clean list, with
+duplicates collapsed. An empty list or the explicit wildcard forms (`*`,
+`all`, `all tools`) mean the same as omitting the field: no restriction.
+
+## Where agents live
+
+| Scope | Path | Travels with |
+| --- | --- | --- |
+| Project | `<workspace>/.stella/agents/` | The repo — commit it, the team shares it |
+| User | `~/.config/stella/agents/` | You, across every workspace |
+
+Definitions load user-global first, then workspace — **workspace wins** on
+a name collision.
+
+## Invoking an agent
+
+Typing `/docs-writer polish the CLI reference` wraps the agent's body as an
+explicit persona-adoption instruction above your task and runs it as the
+prompt. In the slash menu, built-ins can never be shadowed, and when a
+custom name collides across kinds, commands shadow skills shadow agents.
+
+## Versioned editing in the Command Deck
+
+`/agents` opens the Agents tab, which lists installed agents in both scopes
+with versioned editing and pinning — like skills, every save is a new
+version you can roll back:
+
+```text
+<agents-dir>/<slug>.md                  ← the loaded definition
+<agents-dir>/.versions/<slug>/vNNNN.md  ← immutable version snapshots
+<agents-dir>/.versions/<slug>/PINNED    ← one line: the pinned version
+```
+
+No `.versions/` entry is created until the first edit, so hand-authored
+agents stay exactly as you wrote them. Editing an agent that was adopted as
+a symlink (see below) replaces the symlink with a real file in the agents
+directory — the original stays untouched, and your edit lives on the
+Stella side from then on.
+
+## Adopted from .claude/ and .agents/ on init
+
+Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
+`.agents/{commands,skills,agents}`. On `stella init` (and `/init`),
+definitions found there are **symlinked** into the matching Stella
+directory — adopted, not copied, so edits stay in one place and your
+existing setup carries over instead of being rewritten:
+
+| Source | Destination |
+| --- | --- |
+| `<workspace>/.claude/agents/` · `<workspace>/.agents/agents/` | `<workspace>/.stella/agents/` |
+| `~/.claude/agents/` · `~/.agents/agents/` | `~/.config/stella/agents/` |
+
+(The same sync adopts `commands/` and `skills/` into their matching
+directories.) Three rules keep the adoption sane:
+
+1. **`.claude` wins over `.agents`.** Sources are scanned in that
+   precedence order; the first occurrence of a name is the one adopted.
+2. **Never clobber, never re-adopt.** A name already present in the
+   destination — hand-authored or linked by a previous init — is skipped,
+   so the sync is idempotent and your own definitions always win.
+3. **Never follow a symlink.** Other tools symlink between these
+   directories too (e.g. `.claude/agents/x → ../../.agents/agents/x`);
+   Stella links each definition from its *real* home exactly once. A
+   directory entry with no `AGENT.md` inside is also skipped — and
+   reported, so nothing disappears silently.
+
+After init, the `/agents` tab lists the adopted definitions alongside your
+own, and init itself prints a per-scope `✓ adopted …` summary of what it
+linked and skipped.
+
+<Callout type="info">
+  An agent's `tools:` restriction is a prompt-level toolbelt grant. For
+  hard boundaries enforced outside the model — gated mutations, blocked
+  paths — reach for [permissions](/docs/agent-tools/permissions) and
+  [hooks](/docs/agent-tools/hooks); to add genuinely new actions, define a
+  [custom tool](/docs/agent-tools/custom-tools).
+</Callout>

--- a/stella-docs/content/docs/agent-tools/index.mdx
+++ b/stella-docs/content/docs/agent-tools/index.mdx
@@ -103,9 +103,10 @@ All told: 18 always-on tools, up to 30 native tools with the code graph, media k
 
 ## Where to go next
 
-- [Skills](/docs/agent-tools/skills) — reusable SKILL.md capabilities, versioned and registry-installable.
-- [Commands &amp; custom agents](/docs/agent-tools/commands) — extend the slash menu with templates and personas.
+- [Agent Skills](/docs/agent-tools/skills) — reusable SKILL.md capabilities, versioned and registry-installable.
+- [Custom Commands](/docs/agent-tools/commands) — extend the slash menu with your own prompt templates.
+- [Custom Agents](/docs/agent-tools/custom-agents) — reusable personas with an optional restricted toolbelt, adopted from `.claude/` and `.agents/`.
 - [Permissions](/docs/agent-tools/permissions) — how read-only and mutating tools are gated, and how hooks can block tool calls.
-- [Custom tools](/docs/agent-tools/custom-tools) — add your own script tools with a TOML manifest.
-- [MCP servers](/docs/agent-tools/mcp) — merge tools from Model Context Protocol servers.
+- [Custom Tools](/docs/agent-tools/custom-tools) — add your own script tools with a TOML manifest.
+- [MCP Servers](/docs/agent-tools/mcp) — merge tools from Model Context Protocol servers.
 - [Hooks](/docs/agent-tools/hooks) — run shell commands on agent lifecycle events.

--- a/stella-docs/content/docs/agent-tools/meta.json
+++ b/stella-docs/content/docs/agent-tools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Agent Tools",
-  "pages": ["index", "skills", "mcp", "commands", "custom-tools", "hooks", "permissions"]
+  "pages": ["index", "skills", "commands", "custom-agents", "mcp", "custom-tools", "hooks", "permissions"]
 }

--- a/stella-docs/content/docs/agent-tools/skills.mdx
+++ b/stella-docs/content/docs/agent-tools/skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Skills
+title: Agent Skills
 description: Reusable capabilities in SKILL.md files — project and user scopes, versioning and pinning, the public registry, and how skills reach the model through recall.
 ---
 

--- a/stella-docs/content/docs/getting-started/initialization.mdx
+++ b/stella-docs/content/docs/getting-started/initialization.mdx
@@ -54,7 +54,7 @@ files and SQLite databases you can inspect, version, or delete at will:
 | `.stella/settings.json` | Project-scope [settings](/docs/configuration/settings) |
 | `.stella/mcp.toml` | [MCP servers](/docs/agent-tools/mcp) to connect at session start |
 | `.stella/tools/*.toml` | [Custom script tools](/docs/agent-tools/custom-tools) |
-| `.stella/commands/` · `.stella/agents/` | Custom [slash commands](/docs/agent-tools/commands) and agent definitions |
+| `.stella/commands/` · `.stella/agents/` | [Custom commands](/docs/agent-tools/commands) and [custom agents](/docs/agent-tools/custom-agents) |
 | `.stella/fleet.db` | The [fleet](/docs/agent-fleets) ledger — runs, attempts, commits |
 | `.stella/exports/` | Session telemetry [exports](/docs/telemetry/dashboard) (ZIP + HTML) |
 


### PR DESCRIPTION
## What

Reorganizes the agent-tools docs so each extension concept has exactly one dedicated page:

| Concept | Page | Change |
| --- | --- | --- |
| Custom Commands | `agent-tools/commands.mdx` | Renamed from **Commands & custom agents**; now commands-only, adds the `$ARGUMENTS` append-when-no-placeholder behavior and frontmatter fallbacks |
| Custom Agents | `agent-tools/custom-agents.mdx` | **New page**, split off from the old combined page |
| Agent Skills | `agent-tools/skills.mdx` | Retitled from **Skills** (content unchanged) |
| MCP Servers | `agent-tools/mcp.mdx` | Already dedicated — unchanged |
| Custom Tools | `agent-tools/custom-tools.mdx` | Already dedicated — unchanged |

The Custom Agents page covers the AGENT.md schema, storage locations, versioned editing, and the init-time adoption from `.claude/` and `.agents/`, all verified against the code:

- **Schema** — `name`/`description` optional with filename-stem / first-body-line fallbacks, body required, tolerant `tools:` parsing (comma list, flow array, block sequence; `*`/`all` = unrestricted): `stella-core/src/extensions.rs` (`definition_from_file`, `parse_toolbelt`, `agent_from_file`)
- **Storage** — `.stella/agents/` (project) and `~/.config/stella/agents/` (user), flat or nested `AGENT.md`, workspace wins on collision: `stella-cli/src/agents_installed.rs`
- **Versioning** — `.versions/<slug>/vNNNN.md` + `PINNED`, nothing created until first edit, editing an adopted symlink materializes a real file: `stella-cli/src/agents_installed.rs`
- **Adoption on init** — symlink sync from `.claude/` then `.agents/` (that precedence), never clobbers, never follows symlinks, skips-and-reports namespace dirs: `stella-core/src/extensions.rs` (`plan_extension_sync`) + `stella-cli/src/extensions.rs` (`sync_extensions`, `SOURCE_DIRS`)

Page slugs are unchanged (`/docs/agent-tools/commands` keeps its URL) so no inbound links break; cross-links in the section index and `getting-started/initialization.mdx` updated, and `meta.json` orders the prompt-level extensions (skills, commands, custom-agents) together.

## Verification

`pnpm build` in `stella-docs/` passes; the generated output includes the new `/docs/agent-tools/custom-agents` route (73 static pages).
