### PR TITLE
fix(ci): repair main after storage-map merges — undefined SchemaIndex + clippy collapsible_if

### DIFF
--- a/stella-graph/src/storage.rs
+++ b/stella-graph/src/storage.rs
@@ -540,11 +540,11 @@ fn collect_table_constraints(table: Node, src: &[u8], rel: &mut RelationDef) {
                 })
                 .filter(|t| !t.is_empty());
             for col in cols {
-                if let Some(field) = find_field_mut(rel, &col) {
-                    if let Some(target) = &target {
-                        field.references = Some(target.clone());
-                        field.constraints.push(format!("REFERENCES {target}"));
-                    }
+                if let Some(field) = find_field_mut(rel, &col)
+                    && let Some(target) = &target
+                {
+                    field.references = Some(target.clone());
+                    field.constraints.push(format!("REFERENCES {target}"));
                 }
             }
         }

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -79,7 +79,6 @@ pub struct ToolRegistry {
     /// drain discipline, so no request is dispatched twice.
     spawn_queue: crate::tasks::SpawnQueue,
     storage_index: std::sync::Mutex<StorageIndex>,
-    schema_index: std::sync::Mutex<SchemaIndex>,
     /// Which workspace paths are covered by a FRESH saved exploration map —
     /// the read-side analogue of `storage_index` (`docs/design/
     /// exploration-sharing.md` §6). Built once at construction, refreshed
@@ -92,11 +91,6 @@ pub struct ToolRegistry {
     bus: std::sync::RwLock<Option<HookBus>>,
 }
 
-/// The session's storage-map state for the pre-write gate
-/// (`docs/design/storage-map.md` §8): a host-seeded baseline snapshot plus
-/// the relations created by writes this session — which the on-disk index
-/// may not have re-indexed yet. The gate merges both over a fresh read of
-/// the persisted index on every gated write.
 /// Path-coverage of fresh exploration maps plus the hint dedup set.
 #[derive(Debug, Default)]
 struct ExplorationCoverage {
@@ -324,7 +318,6 @@ impl ToolRegistry {
             task_board,
             spawn_queue,
             storage_index: std::sync::Mutex::new(StorageIndex::default()),
-            schema_index: std::sync::Mutex::new(SchemaIndex::default()),
             exploration_coverage,
             bus: std::sync::RwLock::new(None),
         }


### PR DESCRIPTION
Main's CI is red after the #211/#216 storage-map merges, for two reasons:

1. **Compile error**: `stella-tools/src/registry.rs` still carried a `schema_index` field and initializer referencing the `SchemaIndex` type that the branch renamed into `StorageIndex` — the type no longer exists, so `stella-tools` fails to build. Also removes the stranded storage-map doc block the merge left above `ExplorationCoverage`.
2. **Clippy**: `clippy::collapsible_if` (denied via `-D warnings`) on the nested target check in `stella-graph/src/storage.rs` FOREIGN KEY parsing — collapsed into the let-chain shape already used elsewhere in the file. This is the exact error in the failing `cargo clippy --workspace --all-targets -- -D warnings` job.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test` for `stella-tools` + `stella-graph` (343 tests) all pass.
