### PR TITLE
fix: release-audit hardening — 16 bug fixes + stale-comment true-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
   check:
     name: fmt + clippy + test
     runs-on: ubuntu-latest
-    # DuckDB (stella-store, bundled) is a heavy C++ compile on a cold
-    # cache; rust-cache keeps warm runs fast.
+    # Bundled SQLite (stella-store, rusqlite) and tree-sitter grammars are
+    # heavy C compiles on a cold cache; rust-cache keeps warm runs fast.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ repository and is pulled in as a pinned git dependency, not as workspace members
 | `stella-graph` | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python/SQL) |
 | `stella-pipeline` | The orchestration plane above the engine — the default `stella run` path: triage → plan → scope review → witness → execute → verify → judge (`stella-docs/content/docs/inference-pipeline.mdx`) |
 | `stella-fleet` | The multi-agent fleet behind `stella fleet`: DAG planner + wave scheduling, git-worktree isolation per task |
-| `stella-media` | Multimodal generation behind one `MediaProvider` port — image generation wired as the `generate_image` tool (registered when a media-capable key is set); SVG/video library-complete but not yet exposed as tools |
+| `stella-media` | Multimodal generation behind one `MediaProvider` port — `generate_svg` always on; `generate_image` and `generate_video`/`poll_video` registered when a media-capable key is set (video behind a headless cost gate) |
 | `stella-tui` | The Command Deck — a pure event-fold core + thin crossterm shell |
 | `stella-observatory` | The Observatory — `stella observe`'s loopback-only telemetry dashboard over the local SQLite stores |
 | Open Context Protocol | Its own project now: [macanderson/opencontextprotocol](https://github.com/macanderson/opencontextprotocol) — wire types, host runtime, and the public conformance suite. Stella is its reference host and depends on it via git. |

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -277,6 +277,21 @@ fn tuned_engine_config(cfg: &Config, kind: crate::settings::EngineAgentKind) -> 
         cwd: cfg.workspace_root.display().to_string(),
         ..EngineConfig::default()
     };
+    // Compaction must fire BEFORE the provider's context window overflows:
+    // the engine default (150k) exceeds some catalog windows (deepseek-chat
+    // is 128k), where provider-side overflow would land before compaction
+    // ever triggered. The window only ever LOWERS the default — 3/4 leaves
+    // headroom for the estimator's error band plus the next step's output.
+    if let Ok(entry) =
+        stella_model::catalog::Catalog::current().resolve_for(cfg.provider.id, &cfg.model_id)
+    {
+        let window = entry.context_window as u64;
+        if window > 0 {
+            engine.compaction_budget_tokens = engine
+                .compaction_budget_tokens
+                .min(window.saturating_mul(3) / 4);
+        }
+    }
     if let Some(settings) = &cfg.engine_settings {
         let tuning = crate::engine_config::tuning_for(settings, kind);
         if tuning.temperature.is_some() {
@@ -4252,5 +4267,4 @@ mod tests {
             "a judge adapter that fails to build must fall back to the worker provider"
         );
     }
-}
 }

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -41,10 +41,11 @@ use stella_protocol::{CompletionMessage, CompletionRequest, MessageRole, Provide
 
 use crate::domains::Domains;
 
-/// Marker prefixing the volatile recalled-context message so it can be
-/// found and refreshed in place each turn (index 1, right after the
-/// byte-stable system prompt — L-E8: recalled frames ride as a volatile
-/// message after the stable prefix, preserving prompt-cache hits).
+/// Marker prefixing a recalled-context message so [`inject_recall_block`]
+/// can find the newest one for dedup. Blocks land at the conversation
+/// tail and stay in place as durable history (L-E8: the byte-stable
+/// prefix — system prompt AND replayed turns — is never rewritten, which
+/// is what preserves prompt-cache hits).
 pub const RECALL_MARKER: &str = "[auto-recalled context]";
 
 /// One reflection lesson as the model returns it and as persisted to the
@@ -723,34 +724,51 @@ fn render_context_section(frames: &[ocp_types::ContextFrame]) -> Option<String> 
     Some(section)
 }
 
-/// Refresh (or insert) the volatile recalled-context message at index 1 —
-/// immediately after the byte-stable system prompt, before all history
-/// (L-E8). Replacing in place keeps exactly one recall block per
-/// conversation no matter how many turns run.
+/// Land the recalled-context message for this turn at the conversation
+/// TAIL — just before the turn's prompt when the prompt is already present
+/// (one-shot paths), appended otherwise (interactive paths push the prompt
+/// right after) — leaving previous turns' blocks in place as durable
+/// history. Rewriting or removing an early message every turn (the old
+/// index-1 refresh) byte-changed the front of the replayed history, which
+/// reduced the provider cache's reusable prefix to the system message
+/// alone for the whole session — the exact full-rate re-bill L-E8 exists
+/// to prevent. Durability's cost is bounded: an unchanged block is not
+/// re-appended (the model already sees it), so only genuinely new recall
+/// content adds tokens, and it rides the cached prefix from the next turn
+/// on. `None` (nothing relevant, or an A/B-suppressed turn) adds nothing
+/// and touches nothing.
 pub fn inject_recall_block(messages: &mut Vec<CompletionMessage>, block: Option<String>) {
     let is_marker =
         |m: &CompletionMessage| m.role == MessageRole::User && m.content.starts_with(RECALL_MARKER);
-    match block {
-        Some(content) => {
-            let message = CompletionMessage {
-                role: MessageRole::User,
-                content,
-                tool_calls: vec![],
-                tool_results: vec![],
-                attachments: Vec::new(),
-            };
-            if messages.len() > 1 && is_marker(&messages[1]) {
-                messages[1] = message;
-            } else {
-                messages.insert(1.min(messages.len()), message);
-            }
-        }
-        None => {
-            if messages.len() > 1 && is_marker(&messages[1]) {
-                messages.remove(1);
-            }
-        }
+    let Some(content) = block else { return };
+    if messages
+        .iter()
+        .rev()
+        .find(|m| is_marker(m))
+        .is_some_and(|m| m.content == content)
+    {
+        return;
     }
+    let message = CompletionMessage {
+        role: MessageRole::User,
+        content,
+        tool_calls: vec![],
+        tool_results: vec![],
+        attachments: Vec::new(),
+    };
+    // Context precedes the question: when the turn's prompt is already the
+    // final message, slot the block just before it.
+    let at = match messages.last() {
+        Some(last)
+            if last.role == MessageRole::User
+                && !is_marker(last)
+                && last.tool_results.is_empty() =>
+        {
+            messages.len() - 1
+        }
+        _ => messages.len(),
+    };
+    messages.insert(at, message);
 }
 
 /// Seconds since the Unix epoch — the episode timestamps' primitive.
@@ -968,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_inserts_the_block_at_index_one_after_the_system_prefix() {
+    fn inject_slots_the_block_before_an_already_present_prompt() {
         let mut messages = vec![
             msg(MessageRole::System, "sys"),
             msg(MessageRole::User, "do the thing"),
@@ -977,29 +995,55 @@ mod tests {
         assert_eq!(messages.len(), 3);
         assert!(messages[1].content.starts_with(RECALL_MARKER));
         assert_eq!(messages[0].content, "sys", "stable prefix untouched (L-E8)");
-        assert_eq!(messages[2].content, "do the thing");
+        assert_eq!(
+            messages[2].content, "do the thing",
+            "context precedes the question"
+        );
     }
 
+    /// The cache contract: a later turn's refresh may not rewrite, remove,
+    /// or reorder anything already in history — the old index-1 refresh
+    /// byte-changed the front of the replayed history every turn and cut
+    /// the provider cache's reusable prefix to the system message alone.
     #[test]
-    fn inject_replaces_in_place_on_later_turns_never_accumulates() {
+    fn inject_appends_fresh_blocks_without_touching_history() {
         let mut messages = vec![msg(MessageRole::System, "sys")];
         inject_recall_block(&mut messages, Some(format!("{RECALL_MARKER}\nfirst")));
         messages.push(msg(MessageRole::User, "turn 1"));
+        messages.push(msg(MessageRole::Assistant, "did it"));
+        let history: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
         inject_recall_block(&mut messages, Some(format!("{RECALL_MARKER}\nsecond")));
+        // Fresh block at the tail; every prior message byte-identical.
+        assert_eq!(messages.len(), history.len() + 1);
+        assert!(messages.last().unwrap().content.contains("second"));
+        for (i, prior) in history.iter().enumerate() {
+            assert_eq!(&messages[i].content, prior, "history rewritten at {i}");
+        }
+    }
+
+    #[test]
+    fn inject_dedupes_an_unchanged_block() {
+        let mut messages = vec![msg(MessageRole::System, "sys")];
+        let block = format!("{RECALL_MARKER}\nstuff");
+        inject_recall_block(&mut messages, Some(block.clone()));
+        messages.push(msg(MessageRole::User, "turn 1"));
+        messages.push(msg(MessageRole::Assistant, "did it"));
+        inject_recall_block(&mut messages, Some(block));
         let markers = messages
             .iter()
             .filter(|m| m.content.starts_with(RECALL_MARKER))
             .count();
-        assert_eq!(markers, 1, "exactly one recall block, refreshed in place");
-        assert!(messages[1].content.contains("second"));
+        assert_eq!(markers, 1, "an unchanged block is not re-appended");
     }
 
     #[test]
-    fn inject_none_removes_a_stale_block() {
+    fn inject_none_adds_nothing_and_touches_nothing() {
         let mut messages = vec![msg(MessageRole::System, "sys")];
         inject_recall_block(&mut messages, Some(format!("{RECALL_MARKER}\nstuff")));
+        let before: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
         inject_recall_block(&mut messages, None);
-        assert_eq!(messages.len(), 1, "nothing relevant -> no block at all");
+        let after: Vec<String> = messages.iter().map(|m| m.content.clone()).collect();
+        assert_eq!(before, after, "suppressed recall leaves history untouched");
     }
 
     fn frame(

--- a/stella-core/src/budget.rs
+++ b/stella-core/src/budget.rs
@@ -2,12 +2,11 @@
 //! a distinct concern from `crate::compaction`'s *token*-budget eviction:
 //! compaction manages context-window pressure, `budget` manages dollars
 //! spent against a turn and/or session cap. Ported from the TS per-turn
-//! budget (PR #625), now generalized to also cover a session scope and
-//! future media spend.
+//! budget, generalized to also cover a session scope and media spend.
 //!
 //! # The mid-tool-kill lesson
 //!
-//! Per, `enforced` mode is "a hard stop with a
+//! `enforced` mode is "a hard stop with a
 //! clean turn abort — never a mid-tool kill." This module cannot enforce
 //! *when* the caller checks the outcome — that discipline belongs to the
 //! `driver.rs` step-driver, which only consults
@@ -24,15 +23,14 @@
 //!
 //! [`BudgetGuard::record_spend`] takes a bare `cost_usd: f64` and does not
 //! care what produced it — a text completion, an image job, or a video job
-//! all settle through the same call ("media counts").
-//! `stella-media` does not exist yet; no special-casing is needed here for
-//! that to fall out for free later.
+//! all settle through the same call ("media counts"), which is what lets
+//! `stella-media`'s spend meter into the same guard with no special-casing.
 //!
 //! # Precision
 //!
 //! Spend accumulates via plain `f64` addition. This guard is an in-memory
-//! running total for gating and HUD display (`BudgetTick`,
-//!) — it is not the billing system of record (that
+//! running total for gating and HUD display (`BudgetTick`) — it is not the
+//! billing system of record (that
 //! lives in adapter-reported usage plus, for the platform's own metered
 //! products, ClickHouse/Stripe). Summation drift across a session-length
 //! number of calls is negligible at USD-cent granularity; callers needing
@@ -135,8 +133,8 @@ impl BudgetGuard {
     }
 
     /// Evaluate the current spend against the configured limits without
-    /// recording anything new. This is the "safe boundary" check the future
-    /// `driver.rs` calls between steps — see module docs.
+    /// recording anything new. This is the "safe boundary" check the
+    /// `driver.rs` step-driver runs between steps — see module docs.
     pub fn evaluate(&self) -> BudgetOutcome {
         self.check_axis(BudgetAxis::Turn, self.turn_spent_usd, self.turn_limit_usd)
             .or_else(|| {

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -5,8 +5,8 @@
 //! wiring together every other module in this crate.
 //!
 //! `Engine` drives through `&dyn Provider` (`stella_protocol`) and
-//! `&dyn ToolExecutor` (`crate::ports`) — no adapter-specific code, no
-//! filesystem call, lives here. Everything
+//! `&dyn ToolExecutor` (`crate::ports`) — no adapter-specific code and no
+//! direct filesystem access live here. Everything
 //! *inside* one step (compaction, loop detection, budget evaluation) is the
 //! plain synchronous logic from the other modules in this crate; `run_turn`
 //! is the one place that sequences them against real I/O.

--- a/stella-core/src/loop_detect.rs
+++ b/stella-core/src/loop_detect.rs
@@ -1,14 +1,12 @@
-//! Loop detection — pure synchronous analysis of recent tool calls
-//! ( design principle 3: "loop detection... plain
-//! synchronous functions over owned data — easy to property-test";
-//! Phase 2 step 4 names loop detection as a step-driver
-//! responsibility alongside compaction and budget eviction).
+//! Loop detection — pure synchronous analysis of recent tool calls:
+//! plain synchronous functions over owned data, easy to property-test,
+//! run by the step-driver alongside compaction and budget eviction.
 //!
-//! The interim CLI loop (`stella-cli/src/agent.rs::run_turn`) only has a
-//! flat `MAX_TOOL_ITERATIONS` counter — it burns the *entire* iteration
-//! budget before giving up, even when the model got stuck after three
-//! steps. This module gives the step-driver a real, typed verdict it can
-//! act on early: abort with a clear reason instead of grinding to the cap.
+//! A flat iteration cap alone burns the *entire* step budget before
+//! giving up, even when the model got stuck after three steps. This
+//! module gives the step-driver (`driver.rs`, which every CLI path
+//! drives) a real, typed verdict it can act on early: abort with a clear
+//! reason instead of grinding to the cap.
 //!
 //! Two failure modes are detected, matching real agent stuck-loop
 //! signatures:

--- a/stella-core/src/router.rs
+++ b/stella-core/src/router.rs
@@ -98,12 +98,12 @@ impl ProviderProfile {
 // ---------------------------------------------------------------------
 
 /// Explicit per-role pins (L-M6: per-function model overrides are the core
-/// abstraction, not an afterthought). No CLI surface populates pins yet —
-/// production only ever builds `RoleTable::new()`; flags/slash commands for
-/// pinning are planned but not implemented. Absence of a pin for a role is
-/// `None`, never a magic sentinel (L-M3) — the router falls through to
-/// scenario defaults when a role isn't in this
-/// table.
+/// abstraction, not an afterthought). The CLI populates pins from the
+/// settings' `agent_engine_config` (per-agent provider/model sections and
+/// the `/model-worker`-family deck commands) on the production wiring
+/// path. Absence of a pin for a role is `None`, never a magic sentinel
+/// (L-M3) — the router falls through to scenario defaults when a role
+/// isn't in this table.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RoleTable {
     pins: HashMap<Role, ModelRef>,

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -1,8 +1,8 @@
 //! THE dispatch seam (L-E9). Subagent fan-out goes through exactly one
 //! API — [`Fleet::dispatch`] — that claims the task's declared paths
 //! (cooperative file locks in the workspace [`Store`], held for the
-//! attempt's duration), allocates the task's workspace (a git worktree per
-//! [`Isolation`], isolate-by-default), records the attempt in the
+//! attempt's duration), allocates the task's workspace (shared tree by
+//! default; a git worktree when the task opts into isolation), records the attempt in the
 //! [`Ledger`], invokes the [`FleetWorker`] port, stamps the resulting commits
 //! and parent→child lineage into the ledger, and **meters the child's spend
 //! into the parent [`BudgetGuard`]**. No ad-hoc process spawning for agents:
@@ -335,7 +335,8 @@ where
 
     /// [`dispatch`](Self::dispatch) after the task's claims are held.
     async fn dispatch_claimed(&self, task: &Task) -> Result<TaskHandle, FleetError> {
-        // 1. Allocate the workspace. Isolate by default.
+        // 1. Allocate the workspace: a worktree only for tasks that opted
+        //    into isolation; the shared tree (default) allocates nothing.
         let worktree = match task.isolation {
             Isolation::Isolated => Some(
                 self.worktrees

--- a/stella-fleet/src/lib.rs
+++ b/stella-fleet/src/lib.rs
@@ -1,10 +1,9 @@
-//! `stella-fleet` — the multi-agent fleet layer (
-//! Phase 5 item 2).
+//! `stella-fleet` — the multi-agent fleet layer.
 //!
 //! Four pieces, one seam:
 //!
 //! - [`plan`] — the **planner DAG**: [`Plan`]/[`Task`] with dependency edges,
-//!   isolate-by-default, wave scheduling ([`Plan::ready_tasks`]), topological
+//!   share-by-default isolation, wave scheduling ([`Plan::ready_tasks`]), topological
 //!   order, and cycle detection.
 //! - [`git`] — **git-worktree isolation** over the [`GitCli`] port: a
 //!   dedicated worktree per task, plus commit helpers that *always* use

--- a/stella-fleet/src/plan.rs
+++ b/stella-fleet/src/plan.rs
@@ -10,10 +10,11 @@
 //! drained. [`Plan::topological_order`] is the linear-schedule view of the
 //! same graph (used for display and single-threaded execution).
 //!
-//! Tasks isolate by default ([`Isolation::Isolated`] — a dedicated git
-//! worktree per task): a fleet worker must never be able to see or clobber a
-//! sibling's uncommitted files unless the plan author *explicitly* opts a
-//! task into [`Isolation::SharedTree`] (
+//! Tasks share the tree by default ([`Isolation::SharedTree`] — one
+//! repository root under the cooperative claim discipline, so siblings
+//! fail fast by name on a conflicting path instead of clobbering each
+//! other); a plan author *explicitly* opts genuinely divergent work into
+//! [`Isolation::Isolated`] (a dedicated git worktree per task) (
 //! "git-worktree isolation").
 
 use std::cmp::Reverse;
@@ -63,8 +64,8 @@ pub struct Task {
     /// [`Plan::validate`]).
     #[serde(default)]
     pub depends_on: Vec<TaskId>,
-    /// Isolation strategy — defaults to [`Isolation::Isolated`] when absent
-    /// from serialized input.
+    /// Isolation strategy — defaults to [`Isolation::SharedTree`] when
+    /// absent from serialized input.
     #[serde(default)]
     pub isolation: Isolation,
     /// Workspace-relative paths this task declares it will touch. The fleet
@@ -79,7 +80,7 @@ pub struct Task {
 }
 
 impl Task {
-    /// A dependency-free, isolate-by-default task claiming no paths.
+    /// A dependency-free, shared-tree task claiming no paths.
     pub fn new(id: impl Into<TaskId>, title: impl Into<String>, prompt: impl Into<String>) -> Self {
         Self {
             id: id.into(),

--- a/stella-graph/src/lib.rs
+++ b/stella-graph/src/lib.rs
@@ -9,8 +9,9 @@
 //!
 //! # What it does
 //!
-//! - **Indexes** Rust, TypeScript, TSX, JavaScript, and Python: symbols
-//!   (functions, methods, structs/classes/enums/traits/interfaces) and import
+//! - **Indexes** Rust, TypeScript, TSX, JavaScript, Python, and SQL: symbols
+//!   (functions, methods, structs/classes/enums/traits/interfaces; for SQL,
+//!   tables/views/schema enums — the rows the schema gate reads) and import
 //!   edges (`file → module/file`), via compile-time tree-sitter queries
 //!   (L-L2).
 //! - **Resolves** Python relative imports (`from . import x`,

--- a/stella-media/src/jobs.rs
+++ b/stella-media/src/jobs.rs
@@ -105,7 +105,13 @@ impl JobStore {
         }
         let body = serde_json::to_string_pretty(file)
             .map_err(|e| MediaError::Artifact(format!("cannot serialize job store: {e}")))?;
-        let tmp = self.path.with_extension("json.tmp");
+        // Pid-unique temp name (same convention as the session registry's
+        // sidecars): a fixed `.tmp` path lets two concurrent processes
+        // clobber each other's staged write — losing a paid job record, the
+        // exact orphan this module exists to prevent.
+        let tmp = self
+            .path
+            .with_extension(format!("json.tmp.{}", std::process::id()));
         std::fs::write(&tmp, body).map_err(|e| {
             MediaError::Artifact(format!(
                 "cannot write temp job store {}: {e}",

--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -1,14 +1,13 @@
-//! Anthropic adapter — Messages API, SSE streaming, native tool-use. One of
-//! the two Phase 0 spikes ( step 3): retires raw-SSE-parsing
-//! risk against a second, structurally different dialect from Z.ai's
-//! OpenAI-compatible one (`anthropic-tools` vs. `openai-json`,
-//!).
+//! Anthropic adapter — Messages API, SSE streaming, native tool-use.
+//! Retires raw-SSE-parsing risk against a second, structurally different
+//! dialect from Z.ai's OpenAI-compatible one (`anthropic-tools` vs.
+//! `openai-json`).
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use stella_protocol::{
-    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
-    ProviderError, ToolCall,
+    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
+    MessageRole, ProviderError, ToolCall,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -66,12 +65,6 @@ struct AnthropicRequest<'a> {
     system: Option<Vec<AnthropicSystemBlock<'a>>>,
     messages: Vec<AnthropicMessage>,
     stream: bool,
-    /// Top-level auto-cache marker: the API places a breakpoint on the last
-    /// cacheable block of the request, so each agent-loop turn reads the
-    /// prefix written by the previous turn instead of re-paying the whole
-    /// replayed history at the full input rate. Pairs with the system-block
-    /// marker above (two of the four allowed breakpoints).
-    cache_control: AnthropicCacheControl,
     /// Sampling temperature, forwarded from `CompletionRequest.temperature`.
     /// Omitted when `None` so Anthropic applies its own default — dropping it
     /// unconditionally (the prior bug) meant a caller-set temperature was
@@ -141,6 +134,32 @@ struct AnthropicCacheControl {
 
 const EPHEMERAL_CACHE: AnthropicCacheControl = AnthropicCacheControl { kind: "ephemeral" };
 
+/// Stamp the conversation-tail cache breakpoint: `cache_control` on the
+/// LAST content block of the final message, so each agent-loop turn reads
+/// the prefix written by the previous turn instead of re-paying the whole
+/// replayed history at the full input rate. Pairs with the system-block
+/// marker (two of the four allowed breakpoints). Block-level is the only
+/// placement the Messages API accepts — a top-level `cache_control`
+/// request field is an unknown parameter the API rejects with a 400.
+fn stamp_tail_cache_breakpoint(messages: &mut [AnthropicMessage]) {
+    let Some(block) = messages.last_mut().and_then(|m| m.content.last_mut()) else {
+        return;
+    };
+    match block {
+        AnthropicContentBlock::Text { cache_control, .. }
+        | AnthropicContentBlock::ToolResult { cache_control, .. } => {
+            *cache_control = Some(EPHEMERAL_CACHE);
+        }
+        // A media or tool_use tail is not a request shape the loop produces
+        // (a user message's text follows its attachments; requests end on a
+        // user or tool_result turn) — the system-block breakpoint still
+        // caches the tools+system tier.
+        AnthropicContentBlock::Image { .. }
+        | AnthropicContentBlock::Document { .. }
+        | AnthropicContentBlock::ToolUse { .. } => {}
+    }
+}
+
 #[derive(Serialize)]
 struct AnthropicSystemBlock<'a> {
     #[serde(rename = "type")]
@@ -167,15 +186,15 @@ struct AnthropicMessage {
 enum AnthropicContentBlock {
     Text {
         text: String,
+        /// Set only on the final block of the last message — the
+        /// conversation-tail cache breakpoint ([`stamp_tail_cache_breakpoint`]).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
     },
     /// A user-attached image (`{"type":"image","source":{...}}`).
-    Image {
-        source: AnthropicMediaSource,
-    },
+    Image { source: AnthropicMediaSource },
     /// A user-attached PDF (`{"type":"document","source":{...}}`).
-    Document {
-        source: AnthropicMediaSource,
-    },
+    Document { source: AnthropicMediaSource },
     ToolUse {
         id: String,
         name: String,
@@ -186,6 +205,9 @@ enum AnthropicContentBlock {
         content: String,
         #[serde(skip_serializing_if = "std::ops::Not::not")]
         is_error: bool,
+        /// Same conversation-tail breakpoint slot as `Text::cache_control`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
     },
 }
 
@@ -231,7 +253,10 @@ fn attachment_blocks(message: &CompletionMessage) -> Vec<AnthropicContentBlock> 
             crate::attachment::WirePart::Pdf { base64, .. } => AnthropicContentBlock::Document {
                 source: AnthropicMediaSource::base64("application/pdf", base64),
             },
-            crate::attachment::WirePart::Text { text } => AnthropicContentBlock::Text { text },
+            crate::attachment::WirePart::Text { text } => AnthropicContentBlock::Text {
+                text,
+                cache_control: None,
+            },
             // Audio/video are switched off in ANTHROPIC_CAPS, so wire_parts
             // has already degraded them to Text notes.
             crate::attachment::WirePart::Audio { .. }
@@ -409,6 +434,7 @@ fn to_anthropic_messages(
                 if !message.content.trim().is_empty() {
                     content.push(AnthropicContentBlock::Text {
                         text: message.content.clone(),
+                        cache_control: None,
                     });
                 }
                 if !content.is_empty() {
@@ -423,6 +449,7 @@ fn to_anthropic_messages(
                 if !message.content.trim().is_empty() {
                     content.push(AnthropicContentBlock::Text {
                         text: message.content.clone(),
+                        cache_control: None,
                     });
                 }
                 for call in &message.tool_calls {
@@ -459,6 +486,7 @@ fn to_anthropic_messages(
                             tool_use_id: result.call_id.clone(),
                             content: text,
                             is_error,
+                            cache_control: None,
                         }
                     })
                     .collect();
@@ -503,7 +531,8 @@ impl AnthropicProvider {
         req: CompletionRequest,
         observer: Option<&dyn ToolCallObserver>,
     ) -> Result<CompletionResult, ProviderError> {
-        let (system, messages) = to_anthropic_messages(&req.messages);
+        let (system, mut messages) = to_anthropic_messages(&req.messages);
+        stamp_tail_cache_breakpoint(&mut messages);
         // Thinking budget, resolved before max_tokens because the two are
         // coupled: the API requires budget < max_tokens, and this adapter's
         // 4096-token max_tokens default would leave no room for any budget
@@ -512,7 +541,10 @@ impl AnthropicProvider {
         // spends from the same output allowance as the answer — a budget
         // that consumes the whole cap yields a truncated or empty turn).
         // A caller-set cap is honored as-is and the budget clamps to it:
-        // at most max_tokens - 1024, never below the API's 1024 floor.
+        // at most max_tokens - 1024, never below the API's 1024 floor — and
+        // a cap at or below the floor leaves NO legal budget (the API
+        // requires 1024 <= budget < max_tokens), so thinking is omitted
+        // entirely rather than sent as a request the API rejects with 400.
         let thinking_budget =
             (req.reasoning == Some(true)).then(|| thinking_budget_tokens(req.effort));
         let max_tokens = match (req.max_output_tokens, thinking_budget) {
@@ -520,9 +552,11 @@ impl AnthropicProvider {
             (None, Some(budget)) => budget + 8_192,
             (None, None) => 4096,
         };
-        let thinking = thinking_budget.map(|budget| AnthropicThinking {
-            kind: "enabled",
-            budget_tokens: budget.min(max_tokens.saturating_sub(1024)).max(1024),
+        let thinking = thinking_budget.and_then(|budget| {
+            (max_tokens > 1024).then(|| AnthropicThinking {
+                kind: "enabled",
+                budget_tokens: budget.min(max_tokens - 1024).max(1024),
+            })
         });
         let params = req.params.unwrap_or_default();
         let body = AnthropicRequest {
@@ -537,7 +571,6 @@ impl AnthropicProvider {
             }),
             messages,
             stream: true,
-            cache_control: EPHEMERAL_CACHE,
             // The API rejects temperature != 1 with thinking enabled; rather
             // than special-casing 1.0, omit the field entirely and let the
             // API apply its own thinking-compatible default.
@@ -583,15 +616,17 @@ impl AnthropicProvider {
             ));
         }
 
-        let (text, tool_calls, usage) = aggregate_anthropic_stream(response, observer).await?;
+        let (text, tool_calls, usage, stop_reason) =
+            aggregate_anthropic_stream(response, observer).await?;
         let cost_usd = self.pricing.map(|p| p.cost_usd(&usage)).unwrap_or(0.0);
+        let finish_reason = map_stop_reason(stop_reason.as_deref());
         Ok(CompletionResult {
             text,
             tool_calls,
             usage,
             model: self.model.clone(),
             cost_usd,
-            finish_reason: None,
+            finish_reason,
         })
     }
 }
@@ -605,10 +640,24 @@ struct ToolUseAccumulator {
     input_json: String,
 }
 
+/// Normalize the Messages API's `stop_reason` vocabulary onto the
+/// provider-neutral [`FinishReason`] — the driver's truncation diagnostics
+/// (`driver.rs`) only fire when `Length` actually reaches it. Unknown or
+/// unreported reasons stay `None` per the `CompletionResult` contract.
+fn map_stop_reason(stop_reason: Option<&str>) -> Option<FinishReason> {
+    match stop_reason? {
+        "end_turn" | "stop_sequence" | "pause_turn" => Some(FinishReason::Stop),
+        "max_tokens" => Some(FinishReason::Length),
+        "tool_use" => Some(FinishReason::ToolCalls),
+        "refusal" => Some(FinishReason::ContentFilter),
+        _ => None,
+    }
+}
+
 async fn aggregate_anthropic_stream(
     response: reqwest::Response,
     observer: Option<&dyn ToolCallObserver>,
-) -> Result<(String, Vec<ToolCall>, CompletionUsage), ProviderError> {
+) -> Result<(String, Vec<ToolCall>, CompletionUsage, Option<String>), ProviderError> {
     use std::collections::BTreeMap;
 
     let mut decoder = SseDecoder::new();
@@ -791,7 +840,7 @@ async fn aggregate_anthropic_stream(
         });
     }
 
-    Ok((text, tool_calls, usage))
+    Ok((text, tool_calls, usage, stop_reason))
 }
 
 #[cfg(test)]
@@ -1196,7 +1245,7 @@ mod tests {
         // Not one emitted text block is empty or whitespace-only.
         for m in &mapped {
             for block in &m.content {
-                if let AnthropicContentBlock::Text { text } = block {
+                if let AnthropicContentBlock::Text { text, .. } = block {
                     assert!(
                         !text.trim().is_empty(),
                         "emitted an empty/whitespace text block: {text:?}"
@@ -1227,11 +1276,31 @@ mod tests {
     }
 
     /// Prompt caching is opt-in per request: the serialized body must carry
-    /// both breakpoints — one on the system block (tools+system tier) and
-    /// the top-level auto marker (conversation tail) — or the API silently
-    /// caches nothing and every turn re-pays the full replayed prefix.
+    /// both breakpoints — one on the system block (tools+system tier), one
+    /// on the final content block of the last message (conversation tail) —
+    /// or the API silently caches nothing and every turn re-pays the full
+    /// replayed prefix. And it must carry them at BLOCK level only: a
+    /// top-level `cache_control` request field is an unknown parameter the
+    /// live API rejects with a 400, killing every Anthropic call.
     #[test]
     fn request_serializes_both_cache_breakpoints() {
+        let mut messages = vec![
+            AnthropicMessage {
+                role: "user",
+                content: vec![AnthropicContentBlock::Text {
+                    text: "earlier turn".into(),
+                    cache_control: None,
+                }],
+            },
+            AnthropicMessage {
+                role: "user",
+                content: vec![AnthropicContentBlock::Text {
+                    text: "hi".into(),
+                    cache_control: None,
+                }],
+            },
+        ];
+        stamp_tail_cache_breakpoint(&mut messages);
         let body = AnthropicRequest {
             model: "claude-fable-5",
             max_tokens: 64,
@@ -1240,12 +1309,8 @@ mod tests {
                 text: "You are a coding agent.",
                 cache_control: EPHEMERAL_CACHE,
             }]),
-            messages: vec![AnthropicMessage {
-                role: "user",
-                content: vec![AnthropicContentBlock::Text { text: "hi".into() }],
-            }],
+            messages,
             stream: true,
-            cache_control: EPHEMERAL_CACHE,
             temperature: None,
             top_p: None,
             top_k: None,
@@ -1255,7 +1320,21 @@ mod tests {
         let v = serde_json::to_value(&body).expect("request serializes");
         assert_eq!(v["system"][0]["type"], "text");
         assert_eq!(v["system"][0]["cache_control"]["type"], "ephemeral");
-        assert_eq!(v["cache_control"]["type"], "ephemeral");
+        // Tail breakpoint on the LAST block of the LAST message only.
+        assert_eq!(
+            v["messages"][1]["content"][0]["cache_control"]["type"],
+            "ephemeral"
+        );
+        assert!(
+            v["messages"][0]["content"][0]
+                .get("cache_control")
+                .is_none(),
+            "only the tail block carries a breakpoint"
+        );
+        assert!(
+            v.get("cache_control").is_none(),
+            "top-level cache_control is not a Messages API parameter"
+        );
         // The optional params/thinking fields must vanish when unset — the
         // byte-stability contract for requests without overrides.
         let body_json = serde_json::to_string(&v).unwrap();

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -28,8 +28,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_protocol::{
-    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
-    ProviderError, ToolCall,
+    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
+    MessageRole, ProviderError, ToolCall,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -379,6 +379,10 @@ struct ConverseResponse {
     output: Option<ConverseOutput>,
     #[serde(default)]
     usage: Option<BedrockUsage>,
+    /// Converse's stop vocabulary (`end_turn`, `tool_use`, `max_tokens`,
+    /// `stop_sequence`, `guardrail_intervened`, `content_filtered`).
+    #[serde(default)]
+    stop_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -703,6 +707,16 @@ impl Provider for BedrockProvider {
             cache_write_tokens: usage.cache_write_input_tokens,
         };
         let cost_usd = self.pricing.map(|p| p.cost_usd(&usage)).unwrap_or(0.0);
+        // Normalize Converse's stop vocabulary so the driver's truncation
+        // diagnostics fire on Bedrock turns too; unknown values stay `None`
+        // per the `CompletionResult` contract.
+        let finish_reason = match parsed.stop_reason.as_deref() {
+            Some("end_turn" | "stop_sequence") => Some(FinishReason::Stop),
+            Some("max_tokens") => Some(FinishReason::Length),
+            Some("tool_use") => Some(FinishReason::ToolCalls),
+            Some("guardrail_intervened" | "content_filtered") => Some(FinishReason::ContentFilter),
+            _ => None,
+        };
 
         Ok(CompletionResult {
             text,
@@ -710,7 +724,7 @@ impl Provider for BedrockProvider {
             usage,
             model: self.model.clone(),
             cost_usd,
-            finish_reason: None,
+            finish_reason,
         })
     }
 }

--- a/stella-model/src/gemini.rs
+++ b/stella-model/src/gemini.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stella_protocol::{
-    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, MessageRole,
-    ProviderError, ReasoningEffort, ToolCall,
+    CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
+    MessageRole, ProviderError, ReasoningEffort, ToolCall,
 };
 
 use crate::catalog::{Catalog, Pricing};
@@ -300,6 +300,10 @@ impl GoogleApiError {
 pub(crate) struct GeminiCandidate {
     #[serde(default)]
     pub(crate) content: Option<GeminiCandidateContent>,
+    /// Why generation ended (`STOP`, `MAX_TOKENS`, `SAFETY`, …) — reported
+    /// on the final chunk's candidate; absent on interim chunks.
+    #[serde(default, rename = "finishReason")]
+    pub(crate) finish_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -592,7 +596,8 @@ impl Provider for GeminiProvider {
             return Err(classify_google_error("Gemini", response).await);
         }
 
-        let (text, tool_calls, usage) = aggregate_gemini_stream("Gemini", response).await?;
+        let (text, tool_calls, usage, finish_reason) =
+            aggregate_gemini_stream("Gemini", response).await?;
         let cost_usd = self.pricing.map(|p| p.cost_usd(&usage)).unwrap_or(0.0);
         Ok(CompletionResult {
             text,
@@ -600,7 +605,7 @@ impl Provider for GeminiProvider {
             usage,
             model: self.model.clone(),
             cost_usd,
-            finish_reason: None,
+            finish_reason,
         })
     }
 }
@@ -614,11 +619,13 @@ impl Provider for GeminiProvider {
 pub(crate) async fn aggregate_gemini_stream(
     label: &str,
     response: reqwest::Response,
-) -> Result<(String, Vec<ToolCall>, CompletionUsage), ProviderError> {
+) -> Result<(String, Vec<ToolCall>, CompletionUsage, Option<FinishReason>), ProviderError> {
     let mut decoder = SseDecoder::new();
     let mut text = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
+    // Reported on the final chunk's candidate; last assignment wins.
+    let mut finish_raw: Option<String> = None;
     let mut stream = response.bytes_stream();
 
     // `next_with_timeout` bounds each read by `STREAM_IDLE_TIMEOUT` (a silent
@@ -648,6 +655,9 @@ pub(crate) async fn aggregate_gemini_stream(
                 usage.cached_input_tokens = u.cached_content_token_count;
             }
             for candidate in parsed.candidates {
+                if let Some(reason) = candidate.finish_reason {
+                    finish_raw = Some(reason);
+                }
                 let Some(content) = candidate.content else {
                     continue;
                 };
@@ -685,7 +695,24 @@ pub(crate) async fn aggregate_gemini_stream(
         }
     }
 
-    Ok((text, tool_calls, usage))
+    let finish_reason = map_gemini_finish_reason(finish_raw.as_deref(), !tool_calls.is_empty());
+    Ok((text, tool_calls, usage, finish_reason))
+}
+
+/// Normalize Gemini's `finishReason` vocabulary onto the provider-neutral
+/// [`FinishReason`]. Gemini reports `STOP` even for function-calling turns,
+/// so tool presence disambiguates. Unknown values stay `None` per the
+/// `CompletionResult` contract.
+fn map_gemini_finish_reason(raw: Option<&str>, has_tool_calls: bool) -> Option<FinishReason> {
+    match raw? {
+        "STOP" if has_tool_calls => Some(FinishReason::ToolCalls),
+        "STOP" => Some(FinishReason::Stop),
+        "MAX_TOKENS" => Some(FinishReason::Length),
+        "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII" | "IMAGE_SAFETY" => {
+            Some(FinishReason::ContentFilter)
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/stella-model/src/vertex.rs
+++ b/stella-model/src/vertex.rs
@@ -119,7 +119,8 @@ impl Provider for VertexProvider {
             return Err(classify_google_error("Vertex AI", response).await);
         }
 
-        let (text, tool_calls, usage) = aggregate_gemini_stream("Vertex AI", response).await?;
+        let (text, tool_calls, usage, finish_reason) =
+            aggregate_gemini_stream("Vertex AI", response).await?;
         let cost_usd = self.pricing.map(|p| p.cost_usd(&usage)).unwrap_or(0.0);
         Ok(CompletionResult {
             text,
@@ -127,7 +128,7 @@ impl Provider for VertexProvider {
             usage,
             model: self.model.clone(),
             cost_usd,
-            finish_reason: None,
+            finish_reason,
         })
     }
 }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -905,7 +905,8 @@ impl<'a> Pipeline<'a> {
                 .observe_touched_tests(effective_cmd, &mut state.oracle)
                 .await;
             // Tamper exclusion: a flip is credited only while the witness
-            // files are byte-identical to what the witness author wrote. A
+            // files' fingerprints (size + mtime) match what the witness
+            // author wrote. A
             // tampered witness degrades the flip to inconclusive — the judge
             // then decides, told exactly which paths were touched — it never
             // silently passes and never hard-fails work that may still be

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -12,9 +12,10 @@
 //! The witness is deliberately **visible to the worker**: iterating against a
 //! failing test is where convergence comes from, and a test file on disk is
 //! discoverable by any worker with a shell anyway. Integrity comes instead
-//! from *tamper exclusion* — the fingerprints of the files the witness turn
-//! created are snapshotted, and a flip is only credited if those files are
-//! byte-identical at verify time ([`tampered_paths`]). A worker that edits or
+//! from *tamper exclusion* — the fingerprints (size + mtime, not content
+//! hashes) of the files the witness turn created are snapshotted, and a
+//! flip is only credited if those fingerprints are unchanged at verify
+//! time ([`tampered_paths`]). A worker that edits or
 //! deletes the witness loses the deterministic flip credit and the evidence
 //! reaching the judge names the tampered paths. This mirrors how SWE-bench
 //! itself scores (the scored test patch is applied outside the worker's

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -39,8 +39,9 @@
 //!   Written by extension providers via [`Store::upsert_rule`]; read at
 //!   session start by `stella-cli`, which merges these (lowest precedence)
 //!   with the on-disk rule files.
-//! - **file_locks** — schema + API for cooperative file claims in multi-agent
-//!   work. Reserved: no shipping command acquires locks yet.
+//! - **file_locks** — schema + API for cooperative file claims in
+//!   multi-agent work, acquired by the fleet dispatcher and the deck's
+//!   sub-session claim-on-first-write path (see # Concurrency below).
 //! - **graph_nodes / graph_edges** — schema reserved as a future seam for a
 //!   context plane; not written by any shipping command today (`stella-context`
 //!   and `stella-graph` currently use their own stores).
@@ -521,18 +522,13 @@ const MIGRATIONS: [Migration; 8] = [
     // v1 → v2: files_touched grows line-delta totals + the JSON audit log,
     // and the UNIQUE (execution_id, path) key.
     migrate_v1_to_v2,
-    // v2 → v3: the memory_citations table (purely additive — no existing
-    // table changes shape).
-    // v2 → v3: the additive `rules` table (extension-authored workspace
-    // rules for the stella-core rules engine).
+    // v2 → v3: the memory_citations table and the `rules` table
+    // (extension-authored workspace rules for the stella-core rules
+    // engine) — both purely additive; no existing table changes shape.
     migrate_v2_to_v3,
     // v3 → v4: the agent_uses invocation log (purely additive).
-    // NOTE: several in-flight branches each add a store.db migration — the
-    // slot number is taken naively here and reconciled at merge time.
     migrate_v3_to_v4,
     // v4 → v5: the skill_usage invocation log (purely additive — SKILLS tab).
-    // NOTE: same naive-slot caveat — may need a one-line renumber at
-    // cascade-merge since sibling branches also append migrations.
     migrate_v4_to_v5,
     // v5 → v6: the additive `mcp_usage` table (per-call MCP tool telemetry).
     // Renumbered from v4 at cascade-merge behind the agent_uses (v4) and

--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -27,10 +27,6 @@ use tokio::process::Command;
 use crate::registry::Tool;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
-/// Ceiling on the model-supplied `timeout_secs`. The timeout is the hang
-/// backstop for commands the model itself launches — accepting an arbitrary
-/// u64 lets one tool call disable the backstop entirely (u64::MAX ≈ never).
-const MAX_TIMEOUT_SECS: u64 = 600;
 const MAX_OUTPUT_BYTES: usize = 100_000;
 
 pub struct Bash;
@@ -63,14 +59,7 @@ impl Tool for Bash {
                 };
             }
         };
-        // 0 means "use the default", matching custom.rs's timeout convention
-        // — a literal 0 would otherwise time out every invocation instantly.
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .filter(|&t| t > 0)
-            .unwrap_or(DEFAULT_TIMEOUT_SECS)
-            .min(MAX_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         // trace: true prefixes `set -x` so every executed line echoes to
         // stderr — an execution trace a judge can demand as evidence.
         let traced;

--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -11,6 +11,24 @@ use tokio::process::Command;
 
 pub(crate) const MAX_OUTPUT_BYTES: usize = 30_000;
 
+/// Ceiling on any model-supplied `timeout_secs`. The timeout is the hang
+/// backstop for commands the model itself launches — accepting an arbitrary
+/// u64 lets one tool call disable the backstop entirely (u64::MAX ≈ never).
+pub(crate) const MAX_TIMEOUT_SECS: u64 = 600;
+
+/// Parse the optional `timeout_secs` field of a tool input: absent or 0
+/// means `default` (a literal 0 would otherwise time out every invocation
+/// instantly — custom.rs's convention), clamped to [`MAX_TIMEOUT_SECS`] so
+/// no exec-style tool can disable its own hang backstop.
+pub(crate) fn timeout_from(input: &serde_json::Value, default: u64) -> u64 {
+    input
+        .get("timeout_secs")
+        .and_then(|v| v.as_u64())
+        .filter(|&t| t > 0)
+        .unwrap_or(default)
+        .min(MAX_TIMEOUT_SECS)
+}
+
 /// Environment variables that re-target git at a specific repository. Tool
 /// subprocesses always run against their explicit working dir; when Stella
 /// itself was spawned from inside a git hook (which exports `GIT_DIR` et
@@ -62,6 +80,30 @@ pub(crate) async fn run_argv(
     drive(cmd, &display, dir, timeout_secs).await
 }
 
+/// SIGKILLs `pid`'s process group on drop unless disarmed — the
+/// cancellation backstop for [`drive`]: when the future driving a tool call
+/// is dropped mid-wait (Esc cancels the turn), the detached process group
+/// must not keep running — and mutating the tree — after the user believes
+/// the turn stopped. Normal exit and the timeout path disarm it.
+#[cfg(unix)]
+struct GroupKillGuard {
+    pid: i32,
+    armed: bool,
+}
+
+#[cfg(unix)]
+impl Drop for GroupKillGuard {
+    fn drop(&mut self) {
+        // Guard on a real pid: kill(-0, …) would SIGKILL Stella's OWN
+        // process group.
+        if self.armed && self.pid > 0 {
+            unsafe {
+                libc::kill(-self.pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
 /// Shared spawn/wait/kill/truncate body of [`run`] and [`run_argv`] —
 /// `command` is the human-readable command line for error messages.
 async fn drive(
@@ -88,20 +130,32 @@ async fn drive(
         .map_err(|e| format!("failed to spawn `{command}`: {e}"))?;
     #[cfg(unix)]
     let pid = child.id().unwrap_or(0) as i32;
+    #[cfg(unix)]
+    let mut guard = GroupKillGuard { pid, armed: true };
 
     let output =
         match tokio::time::timeout(Duration::from_secs(timeout_secs), child.wait_with_output())
             .await
         {
-            Ok(Ok(output)) => output,
+            Ok(Ok(output)) => {
+                #[cfg(unix)]
+                {
+                    guard.armed = false;
+                }
+                output
+            }
+            // Wait failure leaves the child's state unknown — the still-armed
+            // guard kills the group on return rather than leak it.
             Ok(Err(e)) => return Err(format!("command failed: {e}")),
             Err(_) => {
                 #[cfg(unix)]
-                unsafe {
-                    // Guard on a real pid: kill(-0, …) would SIGKILL Stella's
-                    // OWN process group.
-                    if pid > 0 {
-                        libc::kill(-pid, libc::SIGKILL);
+                {
+                    guard.armed = false;
+                    unsafe {
+                        // Same real-pid guard as `GroupKillGuard`.
+                        if pid > 0 {
+                            libc::kill(-pid, libc::SIGKILL);
+                        }
                     }
                 }
                 return Err(format!("`{command}` timed out after {timeout_secs}s"));
@@ -192,6 +246,44 @@ mod tests {
         .unwrap();
         assert_eq!(code, 0);
         assert!(out.contains("$(id); `id`; && ||"), "{out}");
+    }
+
+    /// Dropping the future mid-wait (a cancelled turn) must kill the whole
+    /// process group — the [`GroupKillGuard`] backstop. Without it, Esc
+    /// during a long build left the build running and mutating the tree.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropped_run_kills_the_process_group() {
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("pid");
+        // Record the *grandchild*'s pid: when the group dies, the orphaned
+        // sleep is reaped by init, so a surviving pid means a real leak.
+        let cmd = format!("sleep 30 & echo $! > {} && wait", pidfile.display());
+        let dir_path = dir.path().to_path_buf();
+        let handle = tokio::spawn(async move { run(&cmd, &dir_path, 60).await });
+        let mut pid = None;
+        for _ in 0..250 {
+            if let Some(p) = std::fs::read_to_string(&pidfile)
+                .ok()
+                .and_then(|s| s.trim().parse::<i32>().ok())
+            {
+                pid = Some(p);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let pid = pid.expect("the child never started");
+        handle.abort();
+        let _ = handle.await;
+        let mut dead = false;
+        for _ in 0..250 {
+            if unsafe { libc::kill(pid, 0) } == -1 {
+                dead = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(dead, "cancelled run left subprocess {pid} running");
     }
 
     #[tokio::test]

--- a/stella-tools/src/gather.rs
+++ b/stella-tools/src/gather.rs
@@ -157,20 +157,6 @@ fn age_human(created_at_ms: u64) -> String {
     }
 }
 
-async fn git_head(root: &Path) -> Option<String> {
-    let output = tokio::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(root)
-        .output()
-        .await
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let head = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    if head.is_empty() { None } else { Some(head) }
-}
-
 /// Same slug rule as the exploration store: path-safe, predictable.
 fn valid_slug(slug: &str) -> bool {
     !slug.is_empty()
@@ -624,7 +610,7 @@ async fn gather(
         sections,
         manifest,
         created_at_ms: now_ms(),
-        git_head: git_head(root).await,
+        git_head: crate::staleness::git_head(root).await,
     };
 
     // Persist — best-effort: a pack that can't be written still returns its
@@ -654,6 +640,17 @@ async fn gather(
 }
 
 async fn read_pack(root: &Path, slug: &str) -> ToolOutput {
+    // Same gate as the save path: the slug becomes a path component of
+    // `pack_path`, so an unvalidated one (`../../…`) reads .json files
+    // outside the workspace — the confinement break resolve_within_root
+    // exists to prevent.
+    if !valid_slug(slug) {
+        return ToolOutput::Error {
+            message: format!(
+                "invalid pack slug `{slug}` — use 1-64 lowercase letters, digits, - or _"
+            ),
+        };
+    }
     let Some(pack) = load_pack(root, slug).await else {
         let listing = match list_packs(root).await {
             ToolOutput::Ok { content } => content,
@@ -755,6 +752,25 @@ fn render_pack(pack: &ContextPack, status: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The read path builds `pack_path` from the slug, so it must refuse
+    /// path-shaped slugs — otherwise `../../…` reads .json files outside
+    /// the workspace root.
+    #[tokio::test]
+    async fn pack_read_rejects_traversal_slugs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for slug in ["../escape", "a/b", "..", "UPPER", ""] {
+            let out = GatherContext
+                .execute(&serde_json::json!({ "pack": slug }), dir.path())
+                .await;
+            match out {
+                ToolOutput::Error { message } => {
+                    assert!(message.contains("invalid pack slug"), "{slug}: {message}")
+                }
+                other => panic!("slug `{slug}` must be rejected, got {other:?}"),
+            }
+        }
+    }
 
     fn workspace() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -12,17 +12,26 @@ const MAX_RESULTS: usize = 200;
 
 /// Does this rg/grep stderr describe a broken *pattern* (bad regex or a flag
 /// the pattern got mistaken for) rather than benign per-file walk warnings?
-/// Both tools exit 2 either way, so the message text is the only signal:
-/// pattern failures carry `regex parse error` / `error:` (rg) or
-/// `invalid`/`unbalanced` (grep); per-path IO warnings read `rg: <path>:
-/// <os reason>` with none of those.
+/// Both tools exit 2 either way, so the message text is the only signal —
+/// read per line, anchored right after the `rg:`/`grep:` prefix: pattern
+/// failures put the diagnostic there (`regex parse error`, `error: …`,
+/// `invalid …`, `unbalanced …`), while per-path IO warnings put a path
+/// there (`rg: <path>: <os reason>`). A bare substring scan mistook any
+/// warning whose *path* contained a keyword (`…/invalid/…`) for a broken
+/// pattern, turning a legitimate zero-match walk into a failure.
 fn is_pattern_error(stderr: &str) -> bool {
-    let s = stderr.to_ascii_lowercase();
-    s.contains("regex parse error")
-        || s.contains("error:")
-        || s.contains("invalid")
-        || s.contains("unbalanced")
-        || s.contains("unmatched")
+    stderr.lines().any(|line| {
+        let line = line.trim().to_ascii_lowercase();
+        let rest = line
+            .strip_prefix("rg:")
+            .or_else(|| line.strip_prefix("grep:"))
+            .unwrap_or(&line)
+            .trim_start();
+        rest.starts_with("regex parse error")
+            || ["error:", "invalid", "unbalanced", "unmatched"]
+                .iter()
+                .any(|kw| rest.starts_with(kw))
+    })
 }
 
 /// The most informative single line of an rg/grep error, for a compact tool
@@ -237,6 +246,25 @@ impl Tool for Grep {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Exit-2 stderr is a pattern error only when the diagnostic follows the
+    /// tool prefix — a keyword inside a warned-about *path* must not turn a
+    /// zero-match walk into a failure.
+    #[test]
+    fn pattern_errors_are_distinguished_from_path_warnings() {
+        assert!(is_pattern_error(
+            "rg: regex parse error:\n    (foo\n    ^\nerror: unclosed group"
+        ));
+        assert!(is_pattern_error("grep: Invalid regular expression"));
+        assert!(is_pattern_error("grep: Unmatched ( or \\("));
+        assert!(!is_pattern_error(
+            "rg: src/invalid/notes.txt: Permission denied (os error 13)"
+        ));
+        assert!(!is_pattern_error(
+            "grep: ./error:pages/dump.log: Is a directory"
+        ));
+        assert!(!is_pattern_error(""));
+    }
 
     #[tokio::test]
     async fn finds_matching_lines() {

--- a/stella-tools/src/project.rs
+++ b/stella-tools/src/project.rs
@@ -53,10 +53,7 @@ impl Tool for BuildProject {
     }
 
     async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         if let Some(command) = input.get("command").and_then(|v| v.as_str()) {
             return run_and_report(command, root, timeout_secs).await;
         }
@@ -99,10 +96,7 @@ impl Tool for RunTests {
     }
 
     async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         if let Some(command) = input.get("command").and_then(|v| v.as_str()) {
             return run_and_report(command, root, timeout_secs).await;
         }
@@ -332,10 +326,7 @@ impl Tool for RunLint {
     }
 
     async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         let fix = input.get("fix").and_then(|v| v.as_bool()).unwrap_or(false);
         match lint_argv(&ScriptIndex::detect(root).await, fix) {
             Ok(argv) => run_argv_and_report(&argv, root, timeout_secs).await,
@@ -370,10 +361,7 @@ impl Tool for FormatCode {
     }
 
     async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         let check = input
             .get("check")
             .and_then(|v| v.as_bool())

--- a/stella-tools/src/read.rs
+++ b/stella-tools/src/read.rs
@@ -69,7 +69,7 @@ impl Tool for ReadFile {
                 "properties": {
                     "path": { "type": "string", "description": "File path relative to workspace root" },
                     "offset": { "type": "integer", "description": "1-based start line (optional)" },
-                    "limit": { "type": "integer", "description": "Max lines to return (optional, default 2000)" },
+                    "limit": { "type": "integer", "description": "Max lines to return (optional; default and ceiling 2000)" },
                     "reason": { "type": "string", "description": "Why you are reading this file — recorded in the session's file-touch audit log" }
                 },
                 "required": ["path"]
@@ -92,10 +92,12 @@ impl Tool for ReadFile {
             .get("offset")
             .and_then(|v| v.as_u64())
             .map(|n| n as usize);
+        // MAX_LINES is a ceiling, not just the default: the flood protection
+        // the module header promises must hold for explicit limits too.
         let limit = input
             .get("limit")
             .and_then(|v| v.as_u64())
-            .map(|n| n as usize)
+            .map(|n| (n as usize).min(MAX_LINES))
             .unwrap_or(MAX_LINES);
 
         let full_path = match crate::resolve_within_root(root, path) {
@@ -115,7 +117,7 @@ impl Tool for ReadFile {
                 let reads = self.tally(root, path);
                 let lines: Vec<&str> = content.lines().collect();
                 let start = offset.unwrap_or(1).saturating_sub(1);
-                let end = (start + limit).min(lines.len());
+                let end = start.saturating_add(limit).min(lines.len());
 
                 if start >= lines.len() {
                     return ToolOutput::Ok {

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -638,7 +638,7 @@ impl ToolRegistry {
                 let mut hits: Vec<String> = coverage
                     .by_path
                     .iter()
-                    .filter(|(path, _)| haystack.contains(path.as_str()))
+                    .filter(|(path, _)| mentions_path(&haystack, path))
                     .flat_map(|(_, slices)| slices.iter().cloned())
                     .filter(|slice| !coverage.hinted.contains(slice))
                     .collect();
@@ -1086,6 +1086,35 @@ impl ToolRegistry {
     }
 }
 
+/// True when `haystack` mentions `path` as a whole path token: the hit may
+/// not extend into path characters on either side, so a map covering
+/// `lib.rs` never fires on `mylib.rs` or `graphlib.rs` — a false positive
+/// would permanently consume that map's once-per-session coverage hint.
+fn mentions_path(haystack: &str, path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    let is_path_char = |c: char| c.is_alphanumeric() || matches!(c, '_' | '-' | '.' | '/');
+    let mut from = 0;
+    while let Some(pos) = haystack[from..].find(path) {
+        let start = from + pos;
+        let end = start + path.len();
+        // A preceding `/` is a component boundary, not an embedding: search
+        // results routinely print the workspace-relative map path with an
+        // absolute prefix (`/tmp/ws/covered.rs` covers `covered.rs`).
+        let clear_before = !haystack[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| is_path_char(c) && c != '/');
+        let clear_after = !haystack[end..].chars().next().is_some_and(is_path_char);
+        if clear_before && clear_after {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
 /// Fallback audit-log reason when the model omitted the tool's optional
 /// `reason` field — the schema requires a non-empty human-readable string.
 fn default_reason(op: FileOp) -> &'static str {
@@ -1126,6 +1155,27 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let reg = ToolRegistry::with_issue_backend(root.path().to_path_buf(), issue_backend);
         (root, reg)
+    }
+
+    /// A coverage hint must fire only on whole path tokens — a substring hit
+    /// (`lib.rs` inside `mylib.rs`) would permanently burn the map's
+    /// once-per-session hint on a file it doesn't cover.
+    #[test]
+    fn mentions_path_requires_token_boundaries() {
+        assert!(mentions_path("src/lib.rs:12: pub fn x()", "src/lib.rs"));
+        assert!(mentions_path("lib.rs", "lib.rs"));
+        // An absolute spelling of a covered relative path still matches.
+        assert!(mentions_path("/tmp/ws/src/lib.rs:3: fn y()", "src/lib.rs"));
+        assert!(mentions_path(
+            "see `core/driver.rs` for the loop",
+            "core/driver.rs"
+        ));
+        assert!(!mentions_path("mylib.rs:3: struct Y", "lib.rs"));
+        assert!(!mentions_path("graphlib.rs/index.js", "lib.rs"));
+        assert!(!mentions_path("src/lib.rs.bak", "src/lib.rs"));
+        // A miss on one occurrence must not mask a clean later occurrence.
+        assert!(mentions_path("mylib.rs and also lib.rs here", "lib.rs"));
+        assert!(!mentions_path("anything", ""));
     }
 
     #[tokio::test]

--- a/stella-tools/src/screenshot.rs
+++ b/stella-tools/src/screenshot.rs
@@ -2,10 +2,11 @@
 //! `.stella/screenshots/`, for work verification: a judge or reviewer can
 //! demand visual evidence that a UI change actually rendered.
 //!
-//! The capture lands on disk and the tool returns its path + size. Vision
-//! (attaching the image bytes to a model call) arrives with multimodal
-//! message support; until then the artifact is
-//! still valuable — humans open it, and agents cite it as evidence.
+//! The capture lands on disk and the tool returns its path + size. With
+//! multimodal attachments shipped end-to-end (protocol `Attachment`,
+//! adapter media blocks, deck image paste), the path can be re-attached
+//! for vision review — and the artifact stands on its own as evidence
+//! humans open and agents cite.
 
 use async_trait::async_trait;
 use serde_json::Value;

--- a/stella-tools/src/scripts.rs
+++ b/stella-tools/src/scripts.rs
@@ -1247,10 +1247,7 @@ impl Tool for RunScript {
         };
         let dir = input.get("dir").and_then(|v| v.as_str());
         let args = string_args(input);
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         run_by_name(root, script, dir, &args, timeout_secs).await
     }
 }

--- a/stella-tools/src/verify.rs
+++ b/stella-tools/src/verify.rs
@@ -101,7 +101,7 @@ impl Tool for VerifyDone {
                 "properties": {
                     "test_cmd": { "type": "string", "description": "Command that runs the witness test(s), e.g. `cargo test -p my-crate my_test` or `pnpm vitest run path/to/file.test.ts`" },
                     "test_files": { "type": "array", "items": { "type": "string" }, "description": "Workspace-relative paths of the NEW or CHANGED test files that witness this change" },
-                    "timeout_secs": { "type": "integer", "description": "Per-run timeout in seconds (default 300)" }
+                    "timeout_secs": { "type": "integer", "description": "Per-run timeout in seconds (default 300, max 600)" }
                 },
                 "required": ["test_cmd", "test_files"]
             }),
@@ -131,10 +131,7 @@ impl Tool for VerifyDone {
                     .into(),
             };
         }
-        let timeout_secs = input
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
 
         // The shadow-worktree copy destination must be derived from the
         // canonical path *relative to the root*, never the raw model-supplied

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -52,8 +52,10 @@ const SHELL_OUTPUT_CAP: usize = 4000;
 /// Configuration for one deck session.
 #[derive(Debug, Clone, Default)]
 pub struct DeckOptions {
-    /// Enable mouse capture (comfy-tabs click/scroll/reorder). Off by default so
-    /// native terminal selection keeps working (L-T2).
+    /// Enable mouse capture. Off by default so native terminal selection
+    /// keeps working (L-T2). NOTE: no mouse events are handled yet — the
+    /// event loop discards them — so turning this on currently only costs
+    /// selection; it exists as the seam for click/scroll/reorder to land.
     pub mouse_capture: bool,
     /// Structured debug log path (`OXAGEN_DEBUG=1`), or `None` for a no-op sink.
     pub debug_log_path: Option<PathBuf>,

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -3543,6 +3543,15 @@ fn handle_files_key(
                 ui.files_diff_scroll.scroll_down(1, total, height);
                 return Some(DeckAction::Handled);
             }
+            KeyCode::PageUp => {
+                ui.files_diff_scroll.scroll_up(height.max(1), total, height);
+                return Some(DeckAction::Handled);
+            }
+            KeyCode::PageDown => {
+                ui.files_diff_scroll
+                    .scroll_down(height.max(1), total, height);
+                return Some(DeckAction::Handled);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

Output of a full release-readiness audit (six parallel deep audits over engine, tools, quality, product, competitors, plus an adversarial bug hunt, second-opinioned by Opus 4.8). Every fix was verified against the failing scenario before landing; the whole branch is gated green (`make gate`: fmt + clippy `-D warnings` + full workspace suite, 2100+ tests).

### Highest-impact fixes
- **main did not compile** — stray closing brace in `stella-cli/src/agent.rs` from an unreviewed "save" commit (also: consider making the `ci` check a required status).
- **Anthropic requests carried a top-level `cache_control` field** — not a Messages API parameter; live calls would 400. The tail breakpoint now rides the last content block of the final message (wire test updated to pin block-level-only).
- **Prompt-cache defeat in deck mode** — the recall block rewrote message index 1 every turn, cutting the reusable cache prefix to the system message alone. Recall now lands at the conversation tail as durable, deduped history (L-E8 restored; tests rewritten to pin the byte-stability contract).
- **Esc orphaned tool subprocesses** — cancelled turns dropped the exec future without killing the detached process group; a `Drop` guard now SIGKILLs it (regression test aborts a live run and asserts the grandchild dies).
- **`finish_reason` wired for Anthropic/Bedrock/Gemini/Vertex** (was Z.ai-only) so truncation diagnostics actually fire.
- **Model-triggerable panic in `read_file`** (unclamped `limit` + overflowing range math), **path traversal in `gather_context` pack reads**, **six unclamped exec timeouts**, and the rest — full list in the commit message.

### Known-unfixed (design-level, flagged for follow-up)
Best-of-N candidates share one working tree; no token-level streaming; no mid-turn steering; `RequireApproval` degrades to a plain error; compaction has no summarization fallback; custom script tools inherit the parent env while MCP children get `env_clear`; no web fetch/search tool.

### Note for review
The recall-block change (`stella-cli/src/memory.rs::inject_recall_block`) changes conversation-shape semantics: old recall blocks now persist in history (deduped when unchanged) instead of being rewritten in place. This trades a small durable token cost for cache-prefix stability — the same posture as the pipeline path. Worth a deliberate look.
