### PR TITLE
feat(engine): three-tier token efficiency — supersession, aging, overflow summarization

### DIFF
--- a/stella-core/src/compaction.rs
+++ b/stella-core/src/compaction.rs
@@ -1,13 +1,22 @@
 //! Context compaction — pure synchronous logic over owned data
-//! Two mechanisms, applied in order:
+//! Four mechanisms, applied least-lossy first:
 //!
-//! 1. **Tool-output eviction**: oldest large tool outputs are replaced with
-//!    a stub once the conversation exceeds the budget. A tool result whose
-//!    call is still the most recent one is never evicted (the property test
-//!    below: compaction never drops a still-referenced tool result).
-//! 2. **Dedup of repeated identical tool outputs** (L-E3): a byte-identical
+//! 1. **Dedup of repeated identical tool outputs** (L-E3): a byte-identical
 //!    tool output appearing more than once keeps only its latest copy; the
 //!    older ones are stubbed with a pointer.
+//! 2. **Supersession**: when the SAME call (same tool name, byte-identical
+//!    input) ran more than once, only the latest result reflects current
+//!    state — the older ones are stale by construction (a re-read after an
+//!    edit, a re-listed directory) and are stubbed even though their
+//!    content differs.
+//! 3. **Aging**: still over budget, old large outputs are middle-out
+//!    truncated to head+tail before anything is dropped whole — error
+//!    lines and file headers survive where full eviction would lose them.
+//! 4. **Tool-output eviction**: oldest large tool outputs are replaced with
+//!    a stub once the conversation still exceeds the budget. A tool result
+//!    whose call is still the most recent one is never evicted (the
+//!    property test below: compaction never drops a still-referenced tool
+//!    result).
 //!
 //! The system message and the latest user message are never touched.
 
@@ -16,22 +25,59 @@ use stella_protocol::{CompletionMessage, MessageRole, ToolOutput};
 use crate::estimator::{estimate_conversation_tokens, estimate_message_tokens};
 
 /// What a compaction pass did, for the `Compaction` event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CompactionReport {
     pub before_tokens: u64,
     pub after_tokens: u64,
     pub evicted: usize,
     pub deduped: usize,
+    /// Older results of a repeated identical call, stubbed as stale.
+    pub superseded: usize,
+    /// Large old outputs middle-out truncated instead of dropped whole.
+    pub aged: usize,
 }
 
 const EVICTION_STUB: &str =
     "[tool output evicted to fit context — re-run the tool if you need it again]";
+
+/// Aging only touches outputs big enough that head+tail plus the marker is
+/// a real saving; below this it would churn bytes for nothing.
+const AGE_THRESHOLD_CHARS: usize = 2_000;
+/// What aging keeps from each end. Head carries the tool's framing (the
+/// PASSED/FAILED line, file headers); tail carries the errors.
+const AGE_KEEP_CHARS: usize = 800;
 
 fn dedup_stub() -> String {
     // Models can't see message indices — point at the surviving copy in
     // terms they can act on.
     "[identical output repeated — the full content appears again in a more recent tool result]"
         .to_string()
+}
+
+fn supersession_stub() -> String {
+    "[stale result of a repeated call — the same tool ran again with identical input; the \
+     current output appears in a more recent tool result]"
+        .to_string()
+}
+
+/// Middle-out truncate `content` on char boundaries, keeping
+/// [`AGE_KEEP_CHARS`] from each end. Caller guarantees
+/// `content.len() > AGE_THRESHOLD_CHARS`, which the keep windows never
+/// overlap.
+fn age_content(content: &str) -> String {
+    let mut head_end = AGE_KEEP_CHARS.min(content.len());
+    while !content.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = content.len() - AGE_KEEP_CHARS.min(content.len());
+    while !content.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    format!(
+        "{}\n[… middle elided during compaction — re-run the tool for the full output …]\n{}",
+        &content[..head_end],
+        &content[tail_start..]
+    )
 }
 
 /// Evict + dedup until the conversation fits `budget_tokens`, or until
@@ -46,6 +92,8 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
     }
 
     let mut deduped = 0usize;
+    let mut superseded = 0usize;
+    let mut aged = 0usize;
     let mut evicted = 0usize;
 
     // Index of the last Tool message — its results answer the most recent
@@ -88,13 +136,106 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
         }
     }
 
-    // Pass 2: evict oldest large tool outputs until under budget. The running
+    // Pass 2: supersession — when the SAME invocation (tool name +
+    // byte-identical input) produced results more than once, older results
+    // are stale by construction: the newer run reflects newer workspace
+    // state. Unlike pass 1 this fires even when the CONTENT differs (a
+    // re-read after an edit). Keyed through the assistant messages' tool
+    // calls because results themselves only carry a call_id.
+    {
+        use std::collections::HashMap;
+        // call_id -> invocation key. Input serialization is deterministic
+        // for a given call because it round-trips the same serde_json Value.
+        let mut invocation: HashMap<&str, String> = HashMap::new();
+        for message in messages.iter() {
+            for call in &message.tool_calls {
+                invocation.insert(
+                    call.call_id.as_str(),
+                    format!("{}\u{0}{}", call.name, call.input),
+                );
+            }
+        }
+        // Latest tool-message index per invocation key.
+        let mut latest: HashMap<&str, usize> = HashMap::new();
+        for (idx, message) in messages.iter().enumerate() {
+            if message.role != MessageRole::Tool {
+                continue;
+            }
+            for result in &message.tool_results {
+                if let Some(key) = invocation.get(result.call_id.as_str()) {
+                    latest.insert(key.as_str(), idx);
+                }
+            }
+        }
+        let mut stale: Vec<(usize, String)> = Vec::new();
+        for (idx, message) in messages.iter().enumerate() {
+            if Some(idx) == last_tool_idx || message.role != MessageRole::Tool {
+                continue;
+            }
+            for result in &message.tool_results {
+                let Some(key) = invocation.get(result.call_id.as_str()) else {
+                    continue;
+                };
+                // Errors stay: a superseding success makes the old error
+                // history, but errors are small + diagnostic (same posture
+                // as eviction below).
+                let ToolOutput::Ok { content } = &result.output else {
+                    continue;
+                };
+                if content.len() > 200 && latest.get(key.as_str()).copied() > Some(idx) {
+                    stale.push((idx, result.call_id.clone()));
+                }
+            }
+        }
+        for (idx, call_id) in stale {
+            for result in &mut messages[idx].tool_results {
+                if result.call_id == call_id {
+                    result.output = ToolOutput::Ok {
+                        content: supersession_stub(),
+                    };
+                    superseded += 1;
+                }
+            }
+        }
+    }
+
+    // Pass 3: aging — before dropping anything whole, shrink old large
+    // outputs to head+tail. Oldest first, incremental accounting, stop as
+    // soon as the budget fits; what aging saves, eviction never has to
+    // destroy.
+    let mut current_tokens = estimate_conversation_tokens(messages);
+    if current_tokens > budget_tokens {
+        for (idx, message) in messages.iter_mut().enumerate() {
+            if Some(idx) == last_tool_idx || message.role != MessageRole::Tool {
+                continue;
+            }
+            let before = estimate_message_tokens(message);
+            for result in &mut message.tool_results {
+                if let ToolOutput::Ok { content } = &result.output
+                    && content.len() > AGE_THRESHOLD_CHARS
+                {
+                    result.output = ToolOutput::Ok {
+                        content: age_content(content),
+                    };
+                    aged += 1;
+                }
+            }
+            let after = estimate_message_tokens(message);
+            current_tokens = current_tokens.saturating_sub(before.saturating_sub(after));
+            if current_tokens <= budget_tokens {
+                break;
+            }
+        }
+    }
+
+    // Pass 4: evict oldest large tool outputs until under budget. The running
     // total is tracked incrementally (diffing one message's estimate before
     // and after mutation) rather than by re-scanning the whole conversation
     // on every eviction — the borrow checker won't allow an immutable
     // whole-slice re-scan while a mutable borrow of one message is live, and
-    // an O(n) rescan per eviction would be wasteful besides.
-    let mut current_tokens = estimate_conversation_tokens(messages);
+    // an O(n) rescan per eviction would be wasteful besides. (Re-scanned
+    // once here so aging's incremental drift can't leak into eviction.)
+    current_tokens = estimate_conversation_tokens(messages);
     if current_tokens > budget_tokens {
         for (idx, message) in messages.iter_mut().enumerate() {
             if Some(idx) == last_tool_idx || message.role != MessageRole::Tool {
@@ -121,7 +262,7 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
         }
     }
 
-    if evicted == 0 && deduped == 0 {
+    if evicted == 0 && deduped == 0 && superseded == 0 && aged == 0 {
         // Over budget but nothing compactable — don't report a no-op.
         return None;
     }
@@ -131,6 +272,8 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
         after_tokens,
         evicted,
         deduped,
+        superseded,
+        aged,
     })
 }
 
@@ -152,6 +295,23 @@ mod tests {
         }
     }
 
+    fn assistant_with_call_on(call_id: &str, path: &str) -> CompletionMessage {
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: call_id.into(),
+                name: "read_file".into(),
+                input: serde_json::json!({ "path": path }),
+            }],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        }
+    }
+
+    /// Distinct target per call id, so tests exercising dedup/eviction in
+    /// isolation don't also trip the supersession pass (which keys on
+    /// identical name+input).
     fn assistant_with_call(call_id: &str) -> CompletionMessage {
         CompletionMessage {
             role: MessageRole::Assistant,
@@ -159,7 +319,7 @@ mod tests {
             tool_calls: vec![ToolCall {
                 call_id: call_id.into(),
                 name: "read_file".into(),
-                input: serde_json::json!({"path": "x"}),
+                input: serde_json::json!({ "path": call_id }),
             }],
             tool_results: vec![],
             attachments: Vec::new(),
@@ -271,6 +431,74 @@ mod tests {
             estimate_conversation_tokens(&tight) <= estimate_conversation_tokens(&generous),
             "tighter budget must not leave more tokens"
         );
+    }
+
+    #[test]
+    fn repeated_identical_call_supersedes_older_differing_results() {
+        // Same tool, same input, run twice with DIFFERENT outputs (a
+        // re-read after an edit): the older result is stale by
+        // construction and must be stubbed even though byte-dedup can't
+        // touch it. A third call on a DIFFERENT target must be untouched.
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            assistant_with_call_on("c1", "src/lib.rs"),
+            tool_msg("c1", "pre-edit contents ".repeat(100)),
+            assistant_with_call_on("c2", "src/other.rs"),
+            tool_msg("c2", "unrelated file ".repeat(100)),
+            assistant_with_call_on("c3", "src/lib.rs"),
+            tool_msg("c3", "post-edit contents ".repeat(100)),
+        ];
+        // Below the raw total (~1300 tokens) but above what supersession
+        // alone leaves (~900), so eviction never has to fire and the
+        // untouched-neighbors assertions below stay meaningful.
+        let report = compact(&mut messages, 1_100).expect("should compact");
+        assert!(report.superseded >= 1, "{report:?}");
+        match &messages[2].tool_results[0].output {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("stale result"), "got: {content}")
+            }
+            _ => panic!("expected supersession stub"),
+        }
+        // The different-target read keeps its full content…
+        match &messages[4].tool_results[0].output {
+            ToolOutput::Ok { content } => {
+                assert!(content.starts_with("unrelated file"), "got: {content}")
+            }
+            _ => panic!("different invocation must not be superseded"),
+        }
+        // …and the superseding (latest) result is intact.
+        match &messages[6].tool_results[0].output {
+            ToolOutput::Ok { content } => {
+                assert!(content.starts_with("post-edit"), "got: {content}")
+            }
+            _ => panic!("latest result must survive"),
+        }
+    }
+
+    #[test]
+    fn aging_shrinks_old_outputs_keeping_head_and_tail_before_eviction() {
+        let body = format!("HEADLINE\n{}\nTAILLINE", "filler ".repeat(6000));
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            assistant_with_call("c1"),
+            tool_msg("c1", body),
+            assistant_with_call("c2"),
+            tool_msg("c2", "recent ".repeat(50)),
+        ];
+        // Budget below the raw size but comfortably above the aged size:
+        // aging alone must satisfy it, so nothing gets evicted whole.
+        let report = compact(&mut messages, 2_000).expect("should compact");
+        assert!(report.aged >= 1, "{report:?}");
+        assert_eq!(report.evicted, 0, "aging must run before eviction");
+        match &messages[2].tool_results[0].output {
+            ToolOutput::Ok { content } => {
+                assert!(content.starts_with("HEADLINE"), "head lost: {content:.40}");
+                assert!(content.ends_with("TAILLINE"), "tail lost");
+                assert!(content.contains("middle elided"));
+                assert!(content.len() < 2_000, "aged output still huge");
+            }
+            _ => panic!("expected aged content"),
+        }
     }
 
     #[test]

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -95,6 +95,16 @@ pub struct EngineConfig {
     /// drift-corrected estimate, so this budget is honored in the model's
     /// own observed tokens rather than raw heuristic tokens.
     pub compaction_budget_tokens: u64,
+    /// When eviction/dedup/aging alone cannot reach the compaction budget
+    /// (the oversized content is protected user/assistant text, or already
+    /// stubbed), replace the oldest span of the conversation with a
+    /// model-written summary instead of letting the next call overflow the
+    /// provider's context window. Costs one cheap completion, metered into
+    /// the same [`BudgetGuard`] as every other call.
+    pub summarize_overflow: bool,
+    /// Messages at the conversation tail the summarizer never touches —
+    /// the recent work the model is actively reasoning over.
+    pub summarize_keep_recent: usize,
     /// Hard backstop on step count, independent of loop detection — belt
     /// and suspenders, never the *primary* stuck-loop defense (that's
     /// `crate::loop_detect`).
@@ -125,6 +135,8 @@ impl Default for EngineConfig {
             retry_policy: RetryPolicy::standard(),
             loop_detection: LoopDetectionConfig::default(),
             compaction_budget_tokens: 150_000,
+            summarize_overflow: true,
+            summarize_keep_recent: 8,
             max_steps: 200,
             cwd: ".".to_string(),
         }
@@ -324,7 +336,9 @@ impl<'a> Engine<'a> {
             if let Some(gate) = self.gate {
                 gate.wait_if_paused().await;
             }
-            self.run_compaction_pass(messages, calibration_model.as_deref(), events);
+            total_cost_usd += self
+                .run_compaction_pass(messages, calibration_model.as_deref(), budget, events)
+                .await;
 
             if let Some(aborted) = self.check_loop_detection(messages, events) {
                 return aborted;
@@ -379,12 +393,16 @@ impl<'a> Engine<'a> {
     /// under-estimate this model's tokenizer) shrinks the effective budget
     /// and compacts earlier; the factor's clamp (`crate::estimator`)
     /// bounds how far either way a noisy sample can move this.
-    fn run_compaction_pass(
+    ///
+    /// Returns the summarizer's spend (0.0 on the overwhelmingly common
+    /// no-summarization path) so `run_turn` folds it into the turn total.
+    async fn run_compaction_pass(
         &self,
-        messages: &mut [CompletionMessage],
+        messages: &mut Vec<CompletionMessage>,
         calibration_model: Option<&str>,
+        budget: &mut BudgetGuard,
         events: &UnboundedSender<AgentEvent>,
-    ) {
+    ) -> f64 {
         let compaction_budget = match self.calibration {
             Some(calibration) => {
                 (self.config.compaction_budget_tokens as f64
@@ -398,8 +416,108 @@ impl<'a> Engine<'a> {
                 after_tokens: report.after_tokens,
                 evicted: report.evicted,
                 deduped: report.deduped,
+                superseded: report.superseded,
+                aged: report.aged,
+                summarized: 0,
             });
         }
+        // Overflow fallback: still over budget after every pure pass means
+        // the weight is in PROTECTED content (user/assistant text, the
+        // latest tool result) — without this, the next provider call
+        // eventually hard-fails on context overflow.
+        if self.config.summarize_overflow
+            && crate::estimator::estimate_conversation_tokens(messages) > compaction_budget
+        {
+            return self.summarize_overflow_span(messages, budget, events).await;
+        }
+        0.0
+    }
+
+    /// Replace the oldest replaceable span of the conversation with one
+    /// model-written summary message. Best-effort by contract: any failure
+    /// (no viable span, provider error, empty summary) leaves the
+    /// conversation untouched and the turn proceeds exactly as before this
+    /// mechanism existed. Returns the summarizer call's spend.
+    async fn summarize_overflow_span(
+        &self,
+        messages: &mut Vec<CompletionMessage>,
+        budget: &mut BudgetGuard,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> f64 {
+        let before_tokens = crate::estimator::estimate_conversation_tokens(messages);
+        // Span start: after the system prompt and the FIRST user message —
+        // the task statement anchors every later step and must survive
+        // verbatim. A Tool message can't open the kept tail either side of
+        // the span (its assistant partner would be summarized away and the
+        // provider rejects orphaned tool results), so both bounds walk off
+        // Tool messages.
+        let first_user = messages
+            .iter()
+            .position(|m| m.role == MessageRole::User)
+            .unwrap_or(0);
+        let mut start = first_user + 1;
+        while start < messages.len() && messages[start].role == MessageRole::Tool {
+            start += 1;
+        }
+        let mut end = messages
+            .len()
+            .saturating_sub(self.config.summarize_keep_recent);
+        while end > start && messages[end].role == MessageRole::Tool {
+            end -= 1;
+        }
+        // A tiny span isn't worth a model call — and this guard is also the
+        // convergence backstop: once a summary message occupies the span,
+        // the next over-budget step finds nothing left to replace and skips
+        // instead of summarizing its own summary every step.
+        if end <= start || end - start < 4 {
+            return 0.0;
+        }
+        let rendered = render_span_for_summary(&messages[start..end]);
+        let request = CompletionRequest {
+            messages: vec![
+                CompletionMessage::system(SUMMARIZE_SYSTEM),
+                CompletionMessage::user(&rendered),
+            ],
+            max_output_tokens: Some(1_200),
+            temperature: Some(0.0),
+            effort: Some(ReasoningEffort::Low),
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        };
+        let result = match self.provider.complete(request).await {
+            Ok(result) => result,
+            // Best-effort: a summarizer outage must never fail the turn.
+            Err(_) => return 0.0,
+        };
+        let cost_usd = result.cost_usd;
+        // The call happened — meter it honestly even if the text is unusable.
+        budget.record_spend(cost_usd);
+        let _ = events.send(AgentEvent::BudgetTick {
+            spent_usd: budget.spent_usd(),
+            limit_usd: budget.turn_limit_usd(),
+            mode: budget.mode(),
+        });
+        if result.text.trim().is_empty() {
+            return cost_usd;
+        }
+        let replaced = end - start;
+        let summary = CompletionMessage::user(format!(
+            "[earlier history summarized to fit context — full detail was compacted away; \
+             re-read files or re-run tools for specifics]\n\n{}",
+            result.text.trim()
+        ));
+        messages.splice(start..end, std::iter::once(summary));
+        let _ = events.send(AgentEvent::Compaction {
+            before_tokens,
+            after_tokens: crate::estimator::estimate_conversation_tokens(messages),
+            evicted: 0,
+            deduped: 0,
+            superseded: 0,
+            aged: 0,
+            summarized: replaced,
+        });
+        cost_usd
     }
 
     /// Loop detection, before spending a model call on a step that's
@@ -1016,6 +1134,80 @@ fn recent_tool_calls(messages: &[CompletionMessage]) -> Vec<ToolCall> {
         .collect()
 }
 
+/// System prompt of the overflow summarizer. Byte-stable const: the
+/// summarizer's own request is tiny, but stability costs nothing and keeps
+/// its prefix cacheable across repeated overflow events in one session.
+const SUMMARIZE_SYSTEM: &str = "You are compacting an agent work log. Write a dense summary of \
+    the work so far that a coding agent can resume from: the goal, key decisions and why, files \
+    touched (exact paths) and what changed in each, commands run with outcomes, errors seen and \
+    how they were resolved, and anything explicitly left unresolved. Short bullet lines. No \
+    preamble — the summary text only.";
+
+/// Per-item caps for [`render_span_for_summary`]. The summarizer needs the
+/// shape of the work, not the bytes: full file dumps in tool results are
+/// exactly what overflowed in the first place.
+const SUMMARY_TEXT_CAP: usize = 600;
+const SUMMARY_RESULT_CAP: usize = 300;
+/// Whole-render cap — half of a typical small-model context, leaving room
+/// for the summarizer's own output.
+const SUMMARY_RENDER_CAP: usize = 60_000;
+
+/// Truncate `s` to `cap` chars on a char boundary with an elision marker.
+fn cap_chars(s: &str, cap: usize) -> String {
+    if s.len() <= cap {
+        return s.to_string();
+    }
+    let mut end = cap;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}[…]", &s[..end])
+}
+
+/// Flatten a message span into the summarizer's input: roles, text, tool
+/// calls with their inputs, and truncated results — enough to reconstruct
+/// WHAT happened without re-shipping the content that overflowed.
+fn render_span_for_summary(span: &[CompletionMessage]) -> String {
+    let mut out = String::new();
+    for message in span {
+        let role = match message.role {
+            MessageRole::System => "system",
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+            MessageRole::Tool => "tool",
+        };
+        if !message.content.trim().is_empty() {
+            out.push_str(&format!(
+                "{role}: {}\n",
+                cap_chars(message.content.trim(), SUMMARY_TEXT_CAP)
+            ));
+        }
+        for call in &message.tool_calls {
+            out.push_str(&format!(
+                "{role} → {}({})\n",
+                call.name,
+                cap_chars(&call.input.to_string(), SUMMARY_RESULT_CAP)
+            ));
+        }
+        for result in &message.tool_results {
+            let (tag, body) = match &result.output {
+                ToolOutput::Ok { content } => ("ok", content),
+                ToolOutput::Error { message } => ("error", message),
+            };
+            out.push_str(&format!(
+                "  ← {tag}: {}\n",
+                cap_chars(body.trim(), SUMMARY_RESULT_CAP)
+            ));
+        }
+        if out.len() > SUMMARY_RENDER_CAP {
+            out = cap_chars(&out, SUMMARY_RENDER_CAP);
+            out.push_str("\n[span truncated]");
+            break;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1403,6 +1595,250 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, AgentEvent::Complete { .. }))
         );
+    }
+
+    /// ~900 chars of protected assistant text — compaction's pure passes
+    /// only touch tool outputs, so weight parked here can ONLY be reclaimed
+    /// by the summarization fallback.
+    fn big_assistant_text(tag: &str) -> CompletionMessage {
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: format!("{tag}: {}", "analysis ".repeat(100)),
+            tool_calls: vec![],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        }
+    }
+
+    fn overflow_config() -> EngineConfig {
+        EngineConfig {
+            compaction_budget_tokens: 500,
+            summarize_keep_recent: 2,
+            ..EngineConfig::default()
+        }
+    }
+
+    /// Every tool result's call_id must be answered by a PRECEDING
+    /// assistant tool_call — the provider-side pairing invariant that a
+    /// careless span cut would break.
+    fn assert_tool_pairing(messages: &[CompletionMessage]) {
+        let mut seen_calls: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for message in messages {
+            for call in &message.tool_calls {
+                seen_calls.insert(call.call_id.as_str());
+            }
+            for result in &message.tool_results {
+                assert!(
+                    seen_calls.contains(result.call_id.as_str()),
+                    "orphaned tool result `{}` after summarization",
+                    result.call_id
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn overflow_of_protected_content_is_summarized_and_metered() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![
+                Ok(text_result("SUMMARY: earlier steps established the plan")),
+                Ok(text_result("done!")),
+            ]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        for i in 0..6 {
+            messages.push(big_assistant_text(&format!("t{i}")));
+        }
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        match outcome {
+            TurnOutcome::Completed { text, cost_usd } => {
+                assert_eq!(text, "done!");
+                // Turn cost folds the summarizer's call in (0.0001 each).
+                assert!(
+                    (cost_usd - 0.0002).abs() < 1e-9,
+                    "summarizer spend missing from turn cost: {cost_usd}"
+                );
+            }
+            other => panic!("expected completion, got {other:?}"),
+        }
+        let markers = messages
+            .iter()
+            .filter(|m| m.content.starts_with("[earlier history summarized"))
+            .count();
+        assert_eq!(markers, 1, "exactly one summary message");
+        assert_eq!(
+            messages[1].content, "the task",
+            "the task statement must survive verbatim"
+        );
+        assert!(
+            budget.spent_usd() >= 0.0001,
+            "summarizer spend must be metered into the guard"
+        );
+        let events = drain_events(&mut rx);
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AgentEvent::Compaction { summarized, .. } if *summarized > 0
+            )),
+            "summarization must be reported: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::BudgetTick { .. })),
+            "summarizer spend must tick the budget stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn summarization_disabled_leaves_history_untouched() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![Ok(text_result("done!"))]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let calls = provider.calls.clone();
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let config = EngineConfig {
+            summarize_overflow: false,
+            ..overflow_config()
+        };
+        let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        for i in 0..6 {
+            messages.push(big_assistant_text(&format!("t{i}")));
+        }
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "no summarizer call");
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.content.starts_with("[earlier history summarized")),
+        );
+    }
+
+    #[tokio::test]
+    async fn summarizer_failure_is_non_fatal_and_leaves_history() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![
+                Err(ProviderError::Terminal("summarizer down".into())),
+                Ok(text_result("done!")),
+            ]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        for i in 0..6 {
+            messages.push(big_assistant_text(&format!("t{i}")));
+        }
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(
+            matches!(outcome, TurnOutcome::Completed { .. }),
+            "a summarizer outage must never fail the turn: {outcome:?}"
+        );
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.content.starts_with("[earlier history summarized")),
+            "failed summarization must leave the conversation untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn summarization_never_orphans_tool_results_at_the_span_edge() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![
+                Ok(text_result("SUMMARY of the early exploration")),
+                Ok(text_result("done!")),
+            ]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+        // The naive span end (len - keep_recent) lands ON the tool-result
+        // message; the summarizer must walk back so the assistant call and
+        // its result stay together in the kept tail.
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        for i in 0..4 {
+            messages.push(big_assistant_text(&format!("t{i}")));
+        }
+        messages.push(CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: "edge".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"cmd": "ls"}),
+            }],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        });
+        messages.push(CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![stella_protocol::ToolResult {
+                call_id: "edge".into(),
+                output: ToolOutput::Ok {
+                    content: "small".into(),
+                },
+            }],
+            attachments: Vec::new(),
+        });
+        messages.push(big_assistant_text("tail"));
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.content.starts_with("[earlier history summarized")),
+            "summarization should have fired"
+        );
+        assert_tool_pairing(&messages);
     }
 
     fn empty_result(finish_reason: Option<FinishReason>) -> CompletionResultAlias {

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -98,6 +98,17 @@ pub enum AgentEvent {
         after_tokens: u64,
         evicted: usize,
         deduped: usize,
+        /// Older results of a repeated identical call, stubbed as stale.
+        /// `serde(default)` so journals written before these fields parse.
+        #[serde(default)]
+        superseded: usize,
+        /// Large old outputs middle-out truncated instead of dropped whole.
+        #[serde(default)]
+        aged: usize,
+        /// Messages replaced by a model-written history summary — the
+        /// overflow fallback when eviction alone cannot reach budget.
+        #[serde(default)]
+        summarized: usize,
     },
     /// Emitted after every provider/media call that spends money
     /// The TUI HUD renders spend live from this
@@ -516,6 +527,9 @@ mod tests {
             after_tokens: 4_000,
             evicted: 3,
             deduped: 2,
+            superseded: 1,
+            aged: 1,
+            summarized: 0,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"compaction\""), "{json}");

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -410,6 +410,7 @@ impl SessionModel {
                 after_tokens,
                 evicted,
                 deduped,
+                ..
             } => {
                 self.transcript.push(TranscriptEntry::Compaction {
                     before_tokens: *before_tokens,

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -83,13 +83,31 @@ pub fn compaction(
     after_tokens: u64,
     evicted: usize,
     deduped: usize,
+    superseded: usize,
+    aged: usize,
+    summarized: usize,
 ) -> EventLine {
+    // Name only the mechanisms that actually fired — most passes use one
+    // or two, and a line of zeros reads as noise.
+    let mut parts: Vec<String> = Vec::new();
+    for (count, label) in [
+        (evicted, "evicted"),
+        (deduped, "deduped"),
+        (superseded, "superseded"),
+        (aged, "aged"),
+        (summarized, "summarized"),
+    ] {
+        if count > 0 {
+            parts.push(format!("{count} {label}"));
+        }
+    }
     EventLine {
         glyph: "⤵",
         tone: Tone::Info,
         strong: false,
         body: format!(
-            "compacted context: {before_tokens} → {after_tokens} tokens ({evicted} evicted, {deduped} deduped)"
+            "compacted context: {before_tokens} → {after_tokens} tokens ({})",
+            parts.join(", ")
         ),
         detail: None,
     }
@@ -389,11 +407,17 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
             after_tokens,
             evicted,
             deduped,
+            superseded,
+            aged,
+            summarized,
         } => Some(compaction(
             *before_tokens,
             *after_tokens,
             *evicted,
             *deduped,
+            *superseded,
+            *aged,
+            *summarized,
         )),
         AgentEvent::BudgetTick {
             spent_usd,
@@ -616,7 +640,7 @@ mod tests {
     fn wording_matches_the_pre_extraction_plain_renderer_byte_for_byte() {
         assert_eq!(retry(2, "rate limited").text(), "↻ retry #2: rate limited");
         assert_eq!(
-            compaction(10_000, 4_000, 3, 2).text(),
+            compaction(10_000, 4_000, 3, 2, 0, 0, 0).text(),
             "⤵ compacted context: 10000 → 4000 tokens (3 evicted, 2 deduped)"
         );
         assert_eq!(
@@ -774,6 +798,9 @@ mod tests {
                 after_tokens: 1,
                 evicted: 1,
                 deduped: 0,
+                superseded: 0,
+                aged: 0,
+                summarized: 0,
             },
             AgentEvent::BudgetTick {
                 spent_usd: 0.1,


### PR DESCRIPTION
## Summary

Implements the token-efficiency roadmap from the release audit (74 → target 90): compaction grows from dedup+evict into a four-tier pure pipeline plus a driver-side summarization fallback for the one case pure passes structurally cannot handle.

| Tier | Mechanism | What it saves |
|---|---|---|
| 1 | Byte-identical dedup (existing) | repeated identical outputs |
| 2 | **Supersession (new)** | older results of the *same call re-run* — stale by construction even when content differs (re-read after an edit) |
| 3 | **Aging (new)** | old large outputs shrink to head+tail (framing + error lines survive) before anything is dropped whole |
| 4 | Eviction (existing) | last resort |
| — | **Overflow summarization (new)** | weight parked in *protected* content; previously a guaranteed provider context-overflow failure |

Design notes for review:
- The summarizer is **best-effort by contract**: provider error, empty summary, or a too-small span all leave the conversation untouched — the turn proceeds exactly as before this mechanism existed. Its spend is metered into the same `BudgetGuard` (with a `BudgetTick`), and the ≥4-message span floor is the convergence backstop (a summary never summarizes itself step after step).
- Span edges walk off `Tool` messages on both sides so no `tool_result` is orphaned (provider-side pairing invariant) — pinned by a dedicated test.
- `AgentEvent::Compaction` gains `superseded`/`aged`/`summarized` counts under `#[serde(default)]` — old journals parse; pinned textline fixture wording is byte-unchanged (zero counts aren't rendered).
- `EngineConfig::summarize_overflow` (default **on** — the alternative is a hard overflow failure) and `summarize_keep_recent` (default 8).

8 new tests; full gate green (fmt + clippy `-D warnings` + 40 suites, verified exit code).

Part of the optimization series: token efficiency (this PR) · mid-turn steering + soft-cancel (stacked next) · token streaming, best-of-N isolation, size ratchet (parallel PRs).
