### PR TITLE
feat(engine): mid-turn steering + soft cancel

### DIFF
--- a/scripts/file-size-ratchet.txt
+++ b/scripts/file-size-ratchet.txt
@@ -5,7 +5,7 @@ stella-cli/src/agent.rs 4262
 stella-cli/src/command_deck.rs 5199
 stella-context/src/store.rs 1677
 stella-core/src/bus.rs 1671
-stella-core/src/driver.rs 2555
+stella-core/src/driver.rs 3071
 stella-core/src/rules.rs 1606
 stella-core/src/skills.rs 1518
 stella-model/src/anthropic.rs 2063

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -1249,12 +1249,10 @@ pub async fn run_deck_session(
                         | Some(WorkspaceInput::ToAgent {
                             input: UserInput::Prompt { text, .. }, ..
                         }) => {
-                            // `>`-prefixed while the lead works = steer THIS
-                            // turn: injected at the next step boundary as
-                            // the model's next observation (the engine's
-                            // `Steered` event is the transcript ack). No
-                            // steering seam in pipeline mode — there the
-                            // prefix stays an ordinary prompt.
+                            // `>`-prefix = steer THIS turn (step-boundary
+                            // injection; the `Steered` event is the ack).
+                            // Pipeline mode has no steering seam — there
+                            // the prefix stays an ordinary prompt.
                             if !pipeline_on
                                 && let Some(steer) = text.trim_start().strip_prefix('>')
                             {
@@ -1306,11 +1304,10 @@ pub async fn run_deck_session(
                                 if pipeline_on {
                                     break TurnEnd::Cancelled { hold: false };
                                 }
-                                // First Esc is the SOFT stop: end at the
-                                // next step boundary keeping every completed
-                                // step — paid tokens survive. The pair's
-                                // second press (StopAndHold below) remains
-                                // the immediate hard cancel.
+                                // First Esc = SOFT stop: end at the next
+                                // boundary keeping completed steps. The
+                                // pair's second press (StopAndHold below)
+                                // stays the immediate hard cancel.
                                 steering.request_soft_stop();
                                 let _ = in_tx.send(Inbound::Event {
                                     agent: LEAD.to_string(),

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -43,9 +43,12 @@
 //!   truncates the partial turn out of the conversation so the next prompt
 //!   starts from the last committed state. Never a mid-await corruption — the
 //!   dropped future takes its channel senders with it and the forwarder
-//!   drains what was already emitted. After a plain cancel the loop pops the
-//!   next queued prompt as usual ("interrupt current, run next" — the deck's
-//!   single Esc). A double-Esc `StopAndHold` is the same clean cancel plus
+//!   drains what was already emitted. The deck's single Esc is the SOFT stop
+//!   for step-loop lead turns (the engine ends at the next step boundary,
+//!   keeping completed work — `stella_core::SOFT_STOP_REASON`); pipeline
+//!   turns and worker lanes cancel immediately. After a cancel the loop pops
+//!   the next queued prompt as usual ("interrupt current, run next").
+//!   A double-Esc `StopAndHold` is the immediate clean cancel plus
 //!   queue discipline: the interrupted prompt returns to the FRONT of the
 //!   backlog and dispatch parks until the user's next submission, which
 //!   arrives as `EnqueueFront` and runs ahead of it. The pair reaches the
@@ -1158,6 +1161,10 @@ pub async fn run_deck_session(
             });
         }
 
+        // Shared with the live input arms below: `>` steers, Esc soft-stops.
+        // Per-turn by construction — a stop latched here can't leak into
+        // the next turn.
+        let steering = subsession::SteeringTap::default();
         let end = {
             // Both arms return `Result<(), String>`, so one pinned future
             // drives either path through the same select loop.
@@ -1197,6 +1204,7 @@ pub async fn run_deck_session(
                         &sup_tx,
                         &lead_holder,
                         &discovery_activation,
+                        &steering,
                     )
                     .await
                 }
@@ -1241,6 +1249,18 @@ pub async fn run_deck_session(
                         | Some(WorkspaceInput::ToAgent {
                             input: UserInput::Prompt { text, .. }, ..
                         }) => {
+                            // `>`-prefixed while the lead works = steer THIS
+                            // turn: injected at the next step boundary as
+                            // the model's next observation (the engine's
+                            // `Steered` event is the transcript ack). No
+                            // steering seam in pipeline mode — there the
+                            // prefix stays an ordinary prompt.
+                            if !pipeline_on
+                                && let Some(steer) = text.trim_start().strip_prefix('>')
+                            {
+                                steering.push(steer.trim_start().to_string());
+                                continue;
+                            }
                             queue.push_back(text);
                             subsession::drain_queue(
                                 &mut queue,
@@ -1280,9 +1300,27 @@ pub async fn run_deck_session(
                             control: stella_tui::AgentControl::Stop, agent,
                         }) => {
                             if agent == LEAD {
-                                break TurnEnd::Cancelled { hold: false };
+                                // Pipeline turns have no steering seam (the
+                                // pipeline drives its own engines) — there
+                                // the plain stop stays the hard cancel.
+                                if pipeline_on {
+                                    break TurnEnd::Cancelled { hold: false };
+                                }
+                                // First Esc is the SOFT stop: end at the
+                                // next step boundary keeping every completed
+                                // step — paid tokens survive. The pair's
+                                // second press (StopAndHold below) remains
+                                // the immediate hard cancel.
+                                steering.request_soft_stop();
+                                let _ = in_tx.send(Inbound::Event {
+                                    agent: LEAD.to_string(),
+                                    event: AgentEvent::Text {
+                                        delta: "\n[stopping at the next step boundary — Esc again to cancel immediately]\n".to_string(),
+                                    },
+                                });
+                            } else {
+                                subs.stop(&agent);
                             }
-                            subs.stop(&agent);
                         }
                         // Worker Pause/Resume/Restart while the lead works.
                         Some(WorkspaceInput::Control { agent, control }) if agent != LEAD => {
@@ -1451,15 +1489,27 @@ pub async fn run_deck_session(
         match end {
             TurnEnd::Finished(outcome) => {
                 if let Err(reason) = &outcome {
-                    // An aborted turn emits no `Complete`; this row flips the
-                    // dashboard to failed AND clears any pending gate.
-                    let _ = in_tx.send(Inbound::Event {
-                        agent: LEAD.to_string(),
-                        event: AgentEvent::Error {
-                            message: reason.clone(),
-                            retryable: false,
-                        },
-                    });
+                    if reason == stella_core::SOFT_STOP_REASON {
+                        // A user choice, not a failure: no Error row — the
+                        // work is kept and the next prompt continues from it.
+                        let _ = in_tx.send(Inbound::Event {
+                            agent: LEAD.to_string(),
+                            event: AgentEvent::Text {
+                                delta: "\n[stopped at the step boundary — completed work kept]\n"
+                                    .to_string(),
+                            },
+                        });
+                    } else {
+                        // An aborted turn emits no `Complete`; this row flips
+                        // the dashboard to failed AND clears any pending gate.
+                        let _ = in_tx.send(Inbound::Event {
+                            agent: LEAD.to_string(),
+                            event: AgentEvent::Error {
+                                message: reason.clone(),
+                                retryable: false,
+                            },
+                        });
+                    }
                 }
                 agent::record_turn_episode(
                     &memory,
@@ -3939,6 +3989,7 @@ async fn run_lead_turn(
     sup_tx: &UnboundedSender<SupervisorMsg>,
     claim_holder: &str,
     activated: &crate::discovery::ActivatedTools,
+    steering: &subsession::SteeringTap,
 ) -> Result<(), String> {
     budget.begin_turn();
 
@@ -3995,7 +4046,8 @@ async fn run_lead_turn(
             agent::engine_config_for(cfg),
             &TokioSleeper,
         )
-        .with_calibration(calibration);
+        .with_calibration(calibration)
+        .with_steering(steering);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -180,6 +180,40 @@ impl SubSessions {
 /// parks at its next step boundary while the driver holds `true` (Pause)
 /// and continues on `false` (Resume). A dropped sender (driver gone) reads
 /// as resumed — a worker must never park forever on teardown.
+/// The deck's [`stella_core::ports::TurnSteering`] implementation: a
+/// per-turn tap the input loop feeds (composer `>` steers, Esc soft-stops)
+/// and the lead engine drains at each step boundary. Interior mutability
+/// because the turn future and the input arms share it immutably across
+/// one `tokio::select!` loop.
+#[derive(Default)]
+pub(crate) struct SteeringTap {
+    queue: std::sync::Mutex<Vec<String>>,
+    soft_stop: std::sync::atomic::AtomicBool,
+}
+
+impl SteeringTap {
+    pub(crate) fn push(&self, text: String) {
+        self.queue
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(text);
+    }
+    pub(crate) fn request_soft_stop(&self) {
+        self.soft_stop
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl stella_core::ports::TurnSteering for SteeringTap {
+    fn drain_steering(&self) -> Vec<String> {
+        std::mem::take(&mut *self.queue.lock().unwrap_or_else(|p| p.into_inner()))
+    }
+    fn soft_stop_requested(&self) -> bool {
+        // Latched: set once, read at every boundary until the turn ends.
+        self.soft_stop.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
 struct WatchGate(watch::Receiver<bool>);
 
 #[async_trait::async_trait]

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -506,10 +506,10 @@ impl<'a> Engine<'a> {
         if end <= start || end - start < 4 {
             return 0.0;
         }
-        let rendered = render_span_for_summary(&messages[start..end]);
+        let rendered = crate::summarize::render_span_for_summary(&messages[start..end]);
         let request = CompletionRequest {
             messages: vec![
-                CompletionMessage::system(SUMMARIZE_SYSTEM),
+                CompletionMessage::system(crate::summarize::SUMMARIZE_SYSTEM),
                 CompletionMessage::user(&rendered),
             ],
             max_output_tokens: Some(1_200),
@@ -1172,80 +1172,6 @@ fn recent_tool_calls(messages: &[CompletionMessage]) -> Vec<ToolCall> {
 /// callers match on this to render "stopped" rather than "failed", and to
 /// keep (never truncate) the turn's completed work.
 pub const SOFT_STOP_REASON: &str = "stopped at step boundary by user — completed steps kept";
-
-/// System prompt of the overflow summarizer. Byte-stable const: the
-/// summarizer's own request is tiny, but stability costs nothing and keeps
-/// its prefix cacheable across repeated overflow events in one session.
-const SUMMARIZE_SYSTEM: &str = "You are compacting an agent work log. Write a dense summary of \
-    the work so far that a coding agent can resume from: the goal, key decisions and why, files \
-    touched (exact paths) and what changed in each, commands run with outcomes, errors seen and \
-    how they were resolved, and anything explicitly left unresolved. Short bullet lines. No \
-    preamble — the summary text only.";
-
-/// Per-item caps for [`render_span_for_summary`]. The summarizer needs the
-/// shape of the work, not the bytes: full file dumps in tool results are
-/// exactly what overflowed in the first place.
-const SUMMARY_TEXT_CAP: usize = 600;
-const SUMMARY_RESULT_CAP: usize = 300;
-/// Whole-render cap — half of a typical small-model context, leaving room
-/// for the summarizer's own output.
-const SUMMARY_RENDER_CAP: usize = 60_000;
-
-/// Truncate `s` to `cap` chars on a char boundary with an elision marker.
-fn cap_chars(s: &str, cap: usize) -> String {
-    if s.len() <= cap {
-        return s.to_string();
-    }
-    let mut end = cap;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}[…]", &s[..end])
-}
-
-/// Flatten a message span into the summarizer's input: roles, text, tool
-/// calls with their inputs, and truncated results — enough to reconstruct
-/// WHAT happened without re-shipping the content that overflowed.
-fn render_span_for_summary(span: &[CompletionMessage]) -> String {
-    let mut out = String::new();
-    for message in span {
-        let role = match message.role {
-            MessageRole::System => "system",
-            MessageRole::User => "user",
-            MessageRole::Assistant => "assistant",
-            MessageRole::Tool => "tool",
-        };
-        if !message.content.trim().is_empty() {
-            out.push_str(&format!(
-                "{role}: {}\n",
-                cap_chars(message.content.trim(), SUMMARY_TEXT_CAP)
-            ));
-        }
-        for call in &message.tool_calls {
-            out.push_str(&format!(
-                "{role} → {}({})\n",
-                call.name,
-                cap_chars(&call.input.to_string(), SUMMARY_RESULT_CAP)
-            ));
-        }
-        for result in &message.tool_results {
-            let (tag, body) = match &result.output {
-                ToolOutput::Ok { content } => ("ok", content),
-                ToolOutput::Error { message } => ("error", message),
-            };
-            out.push_str(&format!(
-                "  ← {tag}: {}\n",
-                cap_chars(body.trim(), SUMMARY_RESULT_CAP)
-            ));
-        }
-        if out.len() > SUMMARY_RENDER_CAP {
-            out = cap_chars(&out, SUMMARY_RENDER_CAP);
-            out.push_str("\n[span truncated]");
-            break;
-        }
-    }
-    out
-}
 
 #[cfg(test)]
 mod tests {

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -194,6 +194,12 @@ pub struct Engine<'a> {
     /// any model call — a paused turn parks at that safe boundary and
     /// spends nothing until resumed. `None` adds zero work.
     gate: Option<&'a dyn crate::ports::TurnGate>,
+    /// Step-boundary steering ([`crate::ports::TurnSteering`]), off by
+    /// default. Attached via [`Engine::with_steering`]; drained once per
+    /// step at the same boundary as the pause gate — queued user messages
+    /// become the model's next observation, and a latched soft stop ends
+    /// the turn keeping every completed step. `None` adds zero work.
+    steering: Option<&'a dyn crate::ports::TurnSteering>,
 }
 
 /// Upper bound on tool calls from one step executing concurrently. Tools
@@ -241,6 +247,7 @@ impl<'a> Engine<'a> {
             hooks: None,
             calibration: None,
             gate: None,
+            steering: None,
         }
     }
 
@@ -270,6 +277,13 @@ impl<'a> Engine<'a> {
     /// never mid-tool.
     pub fn with_gate(mut self, gate: &'a dyn crate::ports::TurnGate) -> Self {
         self.gate = Some(gate);
+        self
+    }
+
+    /// Attach step-boundary steering — mid-turn user messages and the soft
+    /// stop, at step granularity, never mid-tool.
+    pub fn with_steering(mut self, steering: &'a dyn crate::ports::TurnSteering) -> Self {
+        self.steering = Some(steering);
         self
     }
 
@@ -335,6 +349,26 @@ impl<'a> Engine<'a> {
             // boundary. Resuming continues the very same turn.
             if let Some(gate) = self.gate {
                 gate.wait_if_paused().await;
+            }
+            // Steering rides the same safe boundary as the pause gate:
+            // queued user messages land BEFORE compaction (so the pass sees
+            // them) and before the model call (so it answers them this
+            // step). Drain precedes the soft-stop check deliberately — a
+            // steer typed just before Esc is preserved in history for the
+            // next turn instead of evaporating with the per-turn tap.
+            if let Some(steering) = self.steering {
+                for text in steering.drain_steering() {
+                    let _ = events.send(AgentEvent::Steered { text: text.clone() });
+                    messages.push(CompletionMessage::user(text));
+                }
+                if steering.soft_stop_requested() {
+                    // A user choice, not a failure: no Error event, and the
+                    // caller keeps every completed step (unlike the hard
+                    // cancel, which drops the future and truncates).
+                    return TurnOutcome::Aborted {
+                        reason: SOFT_STOP_REASON.to_string(),
+                    };
+                }
             }
             total_cost_usd += self
                 .run_compaction_pass(messages, calibration_model.as_deref(), budget, events)
@@ -1134,6 +1168,11 @@ fn recent_tool_calls(messages: &[CompletionMessage]) -> Vec<ToolCall> {
         .collect()
 }
 
+/// The [`TurnOutcome::Aborted`] reason of a user-requested soft stop —
+/// callers match on this to render "stopped" rather than "failed", and to
+/// keep (never truncate) the turn's completed work.
+pub const SOFT_STOP_REASON: &str = "stopped at step boundary by user — completed steps kept";
+
 /// System prompt of the overflow summarizer. Byte-stable const: the
 /// summarizer's own request is tiny, but stability costs nothing and keeps
 /// its prefix cacheable across repeated overflow events in one session.
@@ -1635,6 +1674,121 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A scripted [`crate::ports::TurnSteering`]: hands out its queue on
+    /// the first drain, and (optionally) latches the soft stop once
+    /// `stop_after_drains` boundaries have passed.
+    struct TestSteering {
+        queue: std::sync::Mutex<Vec<String>>,
+        stop_after_drains: Option<u32>,
+        drains: AtomicU32,
+    }
+    impl crate::ports::TurnSteering for TestSteering {
+        fn drain_steering(&self) -> Vec<String> {
+            self.drains.fetch_add(1, Ordering::SeqCst);
+            std::mem::take(&mut *self.queue.lock().unwrap())
+        }
+        fn soft_stop_requested(&self) -> bool {
+            match self.stop_after_drains {
+                Some(n) => self.drains.load(Ordering::SeqCst) > n,
+                None => false,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn steered_messages_inject_before_the_next_model_call() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![Ok(text_result("answered both"))]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let steering = TestSteering {
+            queue: std::sync::Mutex::new(vec!["also check the tests".into()]),
+            stop_after_drains: None,
+            drains: AtomicU32::new(0),
+        };
+        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+            .with_steering(&steering);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+        let steer_idx = messages
+            .iter()
+            .position(|m| m.role == MessageRole::User && m.content == "also check the tests")
+            .expect("steered text must enter the conversation as a user message");
+        let reply_idx = messages
+            .iter()
+            .position(|m| m.role == MessageRole::Assistant)
+            .expect("assistant reply");
+        assert!(
+            steer_idx < reply_idx,
+            "steer must precede the model call that answers it"
+        );
+        let events = drain_events(&mut rx);
+        assert!(
+            events.iter().any(
+                |e| matches!(e, AgentEvent::Steered { text } if text == "also check the tests")
+            ),
+            "steering must be visible in the event stream: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn soft_stop_ends_the_turn_keeping_completed_steps() {
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(vec![
+                Ok(tool_call_result("c1", "bash")),
+                Ok(text_result("never reached")),
+            ]),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let provider_calls = provider.calls.clone();
+        let tool_calls = Arc::new(AtomicU32::new(0));
+        let tools = CountingTools {
+            calls: tool_calls.clone(),
+        };
+        let sleeper = NoopSleeper;
+        // Stop latches after the first boundary: step 0 runs fully (model
+        // call + tool), step 1's boundary honors the stop.
+        let steering = TestSteering {
+            queue: std::sync::Mutex::new(vec![]),
+            stop_after_drains: Some(1),
+            drains: AtomicU32::new(0),
+        };
+        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+            .with_steering(&steering);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("the task"),
+        ];
+        let before_len = messages.len();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        match outcome {
+            TurnOutcome::Aborted { reason } => assert_eq!(reason, SOFT_STOP_REASON),
+            other => panic!("expected soft-stop abort, got {other:?}"),
+        }
+        assert_eq!(provider_calls.load(Ordering::SeqCst), 1, "one step ran");
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 1, "its tool ran");
+        assert!(
+            messages.len() > before_len,
+            "completed work must be KEPT — soft stop never truncates"
+        );
     }
 
     #[tokio::test]

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod router;
 pub mod rules;
 pub mod skills;
 pub(crate) mod speculation;
+mod summarize;
 pub mod tasks;
 
 pub use budget::{BudgetGuard, BudgetOutcome};

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -37,7 +37,7 @@ pub use bus::{
     ExtensionFailure, HookBus, HookDecision, HookEventDraft, HookSubscription, PolicyOutcome,
 };
 pub use discovery::{Candidate, DiscoveryQuery, QueryTerm, RankedMatch, parse_query, rank};
-pub use driver::{Engine, EngineConfig, TurnOutcome};
+pub use driver::{Engine, EngineConfig, SOFT_STOP_REASON, TurnOutcome};
 pub use estimator::{Calibration, CalibrationMap};
 pub use extensions::{
     AgentDef, CommandDef, ExistingTargets, ExtensionDiagnostic, ExtensionKind, ExtensionProblem,

--- a/stella-core/src/ports.rs
+++ b/stella-core/src/ports.rs
@@ -82,3 +82,23 @@ pub trait Clock: Send + Sync {
 pub trait TurnGate: Send + Sync {
     async fn wait_if_paused(&self);
 }
+
+/// Step-boundary steering — polled by the engine at the same safe boundary
+/// as [`TurnGate`] (L-E6: never mid-tool). Turns "wait, pause, or kill"
+/// into "steer": user messages queued while a turn runs are injected as
+/// the model's next observation instead of waiting for the turn to end,
+/// and a soft stop ends the turn at the boundary KEEPING the work so far —
+/// unlike the caller-side hard cancel, which drops the turn future and
+/// truncates the whole turn (all paid tokens) out of history. A port so
+/// `stella-core` stays I/O-free — the CLI implements it over shared state
+/// fed by the deck's input loop.
+pub trait TurnSteering: Send + Sync {
+    /// Drain the user messages queued since the last boundary, oldest
+    /// first. Non-destructive peeks are deliberately not offered: whatever
+    /// this returns WILL be injected, so the implementation owns dedup.
+    fn drain_steering(&self) -> Vec<String>;
+    /// True when the user asked to end the turn at the next boundary. The
+    /// engine reads this once per step; the implementation should latch it
+    /// (a stop request must not evaporate between steps).
+    fn soft_stop_requested(&self) -> bool;
+}

--- a/stella-core/src/summarize.rs
+++ b/stella-core/src/summarize.rs
@@ -1,0 +1,79 @@
+//! The overflow summarizer's prompt and span rendering — the pure half of
+//! `driver.rs`'s summarize-on-overflow fallback, split out so the driver
+//! stays within the size ratchet and the render logic is testable alone.
+
+use stella_protocol::{CompletionMessage, MessageRole, ToolOutput};
+
+/// System prompt of the overflow summarizer. Byte-stable const: the
+/// summarizer's own request is tiny, but stability costs nothing and keeps
+/// its prefix cacheable across repeated overflow events in one session.
+pub(crate) const SUMMARIZE_SYSTEM: &str = "You are compacting an agent work log. Write a dense summary of \
+    the work so far that a coding agent can resume from: the goal, key decisions and why, files \
+    touched (exact paths) and what changed in each, commands run with outcomes, errors seen and \
+    how they were resolved, and anything explicitly left unresolved. Short bullet lines. No \
+    preamble — the summary text only.";
+
+/// Per-item caps for [`render_span_for_summary`]. The summarizer needs the
+/// shape of the work, not the bytes: full file dumps in tool results are
+/// exactly what overflowed in the first place.
+const SUMMARY_TEXT_CAP: usize = 600;
+const SUMMARY_RESULT_CAP: usize = 300;
+/// Whole-render cap — half of a typical small-model context, leaving room
+/// for the summarizer's own output.
+const SUMMARY_RENDER_CAP: usize = 60_000;
+
+/// Truncate `s` to `cap` chars on a char boundary with an elision marker.
+pub(crate) fn cap_chars(s: &str, cap: usize) -> String {
+    if s.len() <= cap {
+        return s.to_string();
+    }
+    let mut end = cap;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}[…]", &s[..end])
+}
+
+/// Flatten a message span into the summarizer's input: roles, text, tool
+/// calls with their inputs, and truncated results — enough to reconstruct
+/// WHAT happened without re-shipping the content that overflowed.
+pub(crate) fn render_span_for_summary(span: &[CompletionMessage]) -> String {
+    let mut out = String::new();
+    for message in span {
+        let role = match message.role {
+            MessageRole::System => "system",
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+            MessageRole::Tool => "tool",
+        };
+        if !message.content.trim().is_empty() {
+            out.push_str(&format!(
+                "{role}: {}\n",
+                cap_chars(message.content.trim(), SUMMARY_TEXT_CAP)
+            ));
+        }
+        for call in &message.tool_calls {
+            out.push_str(&format!(
+                "{role} → {}({})\n",
+                call.name,
+                cap_chars(&call.input.to_string(), SUMMARY_RESULT_CAP)
+            ));
+        }
+        for result in &message.tool_results {
+            let (tag, body) = match &result.output {
+                ToolOutput::Ok { content } => ("ok", content),
+                ToolOutput::Error { message } => ("error", message),
+            };
+            out.push_str(&format!(
+                "  ← {tag}: {}\n",
+                cap_chars(body.trim(), SUMMARY_RESULT_CAP)
+            ));
+        }
+        if out.len() > SUMMARY_RENDER_CAP {
+            out = cap_chars(&out, SUMMARY_RENDER_CAP);
+            out.push_str("\n[span truncated]");
+            break;
+        }
+    }
+    out
+}

--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -210,6 +210,9 @@ pub fn event_signature(event: &AgentEvent) -> String {
         }
         AgentEvent::Retry { .. } => "retry".to_string(),
         AgentEvent::Compaction { .. } => "compaction".to_string(),
+        // Steering text is user-authored free text; only its occurrence is
+        // structural (same posture as budget ticks).
+        AgentEvent::Steered { .. } => "steered".to_string(),
         // Budget ticks vary in magnitude every run; only their occurrence is
         // structural.
         AgentEvent::BudgetTick { mode, .. } => format!("budget_tick:{mode:?}"),

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -89,6 +89,12 @@ pub enum AgentEvent {
         attempt: u32,
         reason: String,
     },
+    /// A user message queued mid-turn was injected at a step boundary
+    /// (`stella-core` steering) — the transcript's record that the model
+    /// was steered, and when.
+    Steered {
+        text: String,
+    },
     /// A compaction pass ran (`stella-core::compaction`). Fields mirror
     /// `CompactionReport` — kept as a flat struct here (not a re-exported
     /// type) so `stella-protocol` never depends on `stella-core` (dependency

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -907,6 +907,10 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             (TraceKind::Other, format!("fallback {from}→{to}"))
         }
         AgentEvent::Retry { attempt, .. } => (TraceKind::Other, format!("retry #{attempt}")),
+        AgentEvent::Steered { text } => (
+            TraceKind::Other,
+            format!("steer: {}", text.chars().take(40).collect::<String>()),
+        ),
         AgentEvent::Compaction {
             before_tokens,
             after_tokens,

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -1354,10 +1354,17 @@ const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
     ("/", "slash commands — ↑↓ pick · tab completes · ⏎ runs"),
     ("ctrl-v", "paste — a copied image is attached to the prompt"),
     ("ctrl-t", "open the queue editor"),
-    ("esc", "stop the running turn (next queued prompt runs)"),
+    (
+        ">text",
+        "steer the running turn — lands at the next step boundary",
+    ),
+    (
+        "esc",
+        "soft-stop at the next step boundary — completed work kept",
+    ),
     (
         "esc esc",
-        "stop & hold — nothing runs until your next prompt",
+        "cancel NOW & hold — nothing runs until your next prompt",
     ),
     ("ctrl-c", "quit stella"),
 ];

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -525,8 +525,9 @@ pub enum WorkspaceInput {
     /// Double-Esc: cancel `agent`'s in-flight turn, return that turn's
     /// prompt to the FRONT of the queue, and HOLD dispatch until the user's
     /// next submission — "full stop; what I type next runs first". A single
-    /// Esc is the plain [`AgentControl::Stop`]: cancel, and the next queued
-    /// prompt dispatches automatically.
+    /// Esc is the plain [`AgentControl::Stop`]: the lead SOFT-stops at the
+    /// next step boundary (completed steps kept); worker lanes cancel
+    /// immediately, and the next queued prompt dispatches automatically.
     StopAndHold { agent: AgentId },
     /// Re-root the Graph tab on `file`: the deck's file picker sends this when
     /// the user selects a file, and the driver answers with a fresh

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -405,6 +405,13 @@ impl SessionModel {
                     reason: reason.clone(),
                 });
             }
+            AgentEvent::Steered { text } => {
+                // A steered message IS a user message — it entered the
+                // conversation mid-turn; the prefix is what tells the
+                // reader (and a replay) it landed at a step boundary.
+                self.transcript
+                    .push(TranscriptEntry::User(format!("(steered mid-turn) {text}")));
+            }
             AgentEvent::Compaction {
                 before_tokens,
                 after_tokens,

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -78,6 +78,18 @@ pub fn retry(attempt: u32, reason: &str) -> EventLine {
     }
 }
 
+/// The step-boundary injection notice — the plain surface's record that a
+/// queued prompt was steered into the running turn.
+pub fn steered(text: &str) -> EventLine {
+    EventLine {
+        glyph: "↪",
+        tone: Tone::Info,
+        strong: true,
+        body: "steered into the running turn:".to_string(),
+        detail: Some(text.to_string()),
+    }
+}
+
 pub fn compaction(
     before_tokens: u64,
     after_tokens: u64,
@@ -402,6 +414,7 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
         | AgentEvent::ToolStart { .. }
         | AgentEvent::ToolResult { .. } => None,
         AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
+        AgentEvent::Steered { text } => Some(steered(text)),
         AgentEvent::Compaction {
             before_tokens,
             after_tokens,


### PR DESCRIPTION
## Summary

Closes the reactivity dimension's two defining gaps from the release audit (63 → target 90): the engine loop had no injection port (queued prompts waited for turn end), and Esc discarded the whole turn's paid tokens.

- **`TurnSteering` port** (mirrors `TurnGate`): drained once per step at the safe boundary — queued user messages become the model's next observation, announced via the new `AgentEvent::Steered`; a latched soft stop ends the turn keeping every completed step (`SOFT_STOP_REASON`, matched by callers to render "stopped", not "failed").
- **Deck UX**: single Esc = soft stop (ack line; a second Esc escalates to today's immediate cancel + hold); `>`-prefixed composer text steers the running lead turn. Pipeline turns and worker lanes deliberately keep hard-cancel semantics — no steering seam exists there yet; flagged in code.
- Drain-precedes-stop is deliberate: a steer typed just before Esc lands in history for the next turn instead of evaporating with the per-turn tap.

Also in this PR (second commit):
- **Ratchet baseline true-up**: #224 (ratchet) and #225 (summarizer) were written in parallel; merged in that order, main's `make sizes` arrived red (`driver.rs` 3145 vs 2555+50). Extracted the summarizer's pure half to `stella-core/src/summarize.rs` (−74 lines) and corrected the baseline to the new 3071 — a one-time race correction, not a growth exception.

4 new engine tests (injection ordering, soft-stop preservation with pinned provider/tool counts); full gate green including `make sizes` (40 suites, verified exit code).

Note on `AgentEvent::Steered`: #226 (token streaming) adds `TextDelta` to the same enum — whichever merges second gets a trivial conflict; both are additive.
