### PR TITLE
fix(tools): gate start_process through the command.started policy chain

### DIFF
--- a/stella-tools/src/process.rs
+++ b/stella-tools/src/process.rs
@@ -9,7 +9,10 @@
 //! Contracts:
 //! - `start_process` spawns an **argv vector directly** (no shell), cwd
 //!   pinned to the workspace root, in its own process group, with
-//!   `kill_on_drop`. It returns a handle id (`proc-N`).
+//!   `kill_on_drop`. It returns a handle id (`proc-N`). "No shell" is a
+//!   quoting guarantee, not a power bound — argv[0] may itself be a shell —
+//!   so the registry gates the joined argv through the same
+//!   `command.started` policy chain as `bash` before the spawn.
 //! - Output (stdout + stderr, interleaved by arrival) accumulates in a
 //!   capped ring buffer per process; when the cap overflows the oldest
 //!   bytes are dropped and the drop is FLAGGED on the next read.

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -540,13 +540,11 @@ impl ToolRegistry {
         };
         if let Some(bus) = &bus {
             let duration_ms = started_at.elapsed().as_millis() as u64;
-            // The command line the tool actually ran: bash's own input, or
-            // run_script's index-resolved command.
-            let command_line: Option<&str> = match name {
-                "bash" => Some(input.get("command").and_then(|v| v.as_str()).unwrap_or("")),
-                "run_script" => resolved_script_command.as_deref(),
-                _ => None,
-            };
+            // The command line the tool actually ran: bash's own input,
+            // run_script's index-resolved command, or start_process's
+            // joined argv.
+            let command_line =
+                Self::command_line_for(name, input, resolved_script_command.as_deref());
             match &output {
                 ToolOutput::Error { message } => {
                     bus.emit_named(
@@ -555,7 +553,7 @@ impl ToolRegistry {
                             "tool": name, "error": message, "duration_ms": duration_ms,
                         }),
                     );
-                    if let Some(command) = command_line {
+                    if let Some(command) = command_line.as_deref() {
                         bus.emit_named(
                             hook_names::COMMAND_FAILED,
                             serde_json::json!({ "command": command, "error": message }),
@@ -567,7 +565,7 @@ impl ToolRegistry {
                         hook_names::TOOL_CALL_COMPLETED,
                         serde_json::json!({ "tool": name, "duration_ms": duration_ms }),
                     );
-                    if let Some(command) = command_line {
+                    if let Some(command) = command_line.as_deref() {
                         bus.emit_named(
                             hook_names::COMMAND_COMPLETED,
                             serde_json::json!({ "command": command }),
@@ -707,9 +705,10 @@ impl ToolRegistry {
     /// detectors for one already-final input: `sensitive_operation.detected`
     /// and `secret.detected` observers first (an auditor sees the attempt
     /// even when a policy then denies it), then the `file.*` chain for a
-    /// classified C/U/D op and the `command.started` chain for `bash` and
-    /// `run_script` (`resolved_command` is the latter's index-resolved
-    /// command line).
+    /// classified C/U/D op and the `command.started` chain for `bash`,
+    /// `run_script`, and `start_process` (`resolved_command` is
+    /// `run_script`'s index-resolved command line; see
+    /// [`Self::command_line_for`]).
     /// These chains gate — `modify` decisions are recorded but not honored
     /// here, because the input was already final after
     /// `tool.call.requested`. Reads are observable but never interceptable.
@@ -785,12 +784,8 @@ impl ToolRegistry {
                 }
             }
         }
-        let command_line: Option<&str> = match name {
-            "bash" => Some(input.get("command").and_then(|v| v.as_str()).unwrap_or("")),
-            "run_script" => resolved_command,
-            _ => None,
-        };
-        if let Some(command) = command_line {
+        let command_line = Self::command_line_for(name, input, resolved_command);
+        if let Some(command) = command_line.as_deref() {
             let outcome = bus.emit_blocking(HookEventDraft::new(
                 hook_names::COMMAND_STARTED,
                 serde_json::json!({ "command": command }),
@@ -810,6 +805,45 @@ impl ToolRegistry {
             }
         }
         Ok(())
+    }
+
+    /// The effective command line of one tool call, feeding both the
+    /// blocking `command.started` policy chain and the `command.*`
+    /// observer events: `bash`'s own input, `run_script`'s index-resolved
+    /// command (`None` when resolution failed — the tool returns the named
+    /// error itself, ungated), or `start_process`'s space-joined argv. The
+    /// argv spawn MUST ride the same fence as `bash`: it sits in the
+    /// default surface while `bash` is opt-in, and argv[0] may itself be a
+    /// shell (`["bash", "-c", …]`), so leaving it out hands ambient shell
+    /// execution to the very posture that turned `bash` off.
+    fn command_line_for(
+        name: &str,
+        input: &Value,
+        resolved_script: Option<&str>,
+    ) -> Option<String> {
+        match name {
+            "bash" => Some(
+                input
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            ),
+            "run_script" => resolved_script.map(str::to_string),
+            "start_process" => Some(
+                input
+                    .get("argv")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    })
+                    .unwrap_or_default(),
+            ),
+            _ => None,
+        }
     }
 
     /// The live storage map for the gate: the persisted index + manifest,
@@ -2448,6 +2482,50 @@ mod tests {
             *denied_command.lock().unwrap(),
             "make greet",
             "the chain must see the index-resolved command line"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_command_chain_gates_start_process_with_its_joined_argv() {
+        // `start_process` sits in the DEFAULT surface while `bash` is
+        // opt-in, and argv[0] may itself be a shell — so the same
+        // `command.started` policy that fences `bash` must fence the argv
+        // spawn, seeing the joined argv, before anything runs.
+        let (_dir, reg) = telemetry_fixture();
+        let bus = HookBus::new("sess");
+        let denied_command = StdArc::new(StdMutex::new(String::new()));
+        let sink = denied_command.clone();
+        bus.on_blocking(hook_names::COMMAND_STARTED, move |event| {
+            *sink.lock().unwrap() = event.payload["command"].as_str().unwrap_or("").to_string();
+            HookDecision::Deny {
+                reason: "no shell".into(),
+            }
+        })
+        .detach();
+        reg.attach_bus(bus);
+
+        let out = reg
+            .execute(
+                "start_process",
+                &serde_json::json!({"argv": ["bash", "-c", "echo hi"]}),
+            )
+            .await;
+        assert!(
+            out.is_error(),
+            "denied start_process must not spawn: {out:?}"
+        );
+        assert_eq!(
+            *denied_command.lock().unwrap(),
+            "bash -c echo hi",
+            "the chain must see the joined argv as the command line"
+        );
+        // The denial fired before the spawn: no handle may exist.
+        let read = reg
+            .execute("read_output", &serde_json::json!({"handle": "proc-1"}))
+            .await;
+        assert!(
+            read.is_error(),
+            "no process may exist after a denied spawn: {read:?}"
         );
     }
 }


### PR DESCRIPTION
## What

`start_process` now routes its space-joined argv through the same blocking `command.started` policy chain as `bash` and `run_script`, and emits the same `command.completed` / `command.failed` audit events. The per-tool command-line derivation, previously duplicated inline at the gate and the post-execution event site, is factored into one helper (`ToolRegistry::command_line_for`).

## Why

`start_process` sits in the **default** tool surface while `bash` is deliberately opt-in ("the SECURE posture — no bash"). But its "no shell" contract is a quoting guarantee, not a power bound: argv[0] may itself be a shell. A live worker trace demonstrated the bypass — denied `bash`, the model called `start_process {argv: ["bash", "-c", "find ..."]}` and got a full shell with **zero** policy gating and no `command.*` audit trail. That's the exact combination the bash opt-in claims to prevent.

## Behavior change

- A `command.started` policy that denies (or requires approval for) a command now fences `start_process` too, **before** the spawn — a denied call launches nothing and leaves no process handle.
- Auditors observing `command.started` / `command.completed` / `command.failed` now see `start_process` invocations with the joined argv as the command line.
- Hosts with no policy attached see no change: the bus-less path is untouched.

## Witness

`the_command_chain_gates_start_process_with_its_joined_argv` — deny-all policy sees `bash -c echo hi` as the command, the tool errors, and `read_output` on the would-be handle proves nothing spawned. Full suite: 288 passed / 0 failed; clippy + rustfmt clean; workspace `cargo check` green.

## Non-goals / follow-up

This is the minimum fix (gate + audit parity). Deliberately out of scope, worth a separate look:
- `send_stdin` can feed code to an already-running REPL ungated.
- Whether `start_process` should also require the `tools.bash` opt-in outright — any argv spawn is arbitrary execution even without a shell in argv[0]; a denylist would be theater, so if the posture is meant to bound *power* rather than just *quoting*, registration-level gating is the honest lever.

