### PR TITLE
fix(tools): scrub force-color env vars from tool subprocesses

### DIFF
--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -47,6 +47,15 @@ pub const GIT_REPO_ENV_VARS: [&str; 8] = [
     "GIT_PREFIX",
 ];
 
+/// Environment variables that force CLIs to colorize even when piped.
+/// Everything spawned here writes to a captured pipe that is parsed
+/// (`gh … --json` into serde) or fed to the model — never a terminal — so
+/// an inherited `CLICOLOR_FORCE=1` from the user's shell wraps `gh`'s JSON
+/// in ANSI escapes and every parse dies with "expected value at line 1
+/// column 1". Scrubbing only the *force* overrides restores standard
+/// pipe detection; tools stay colorless on pipes, as they'd be anywhere.
+pub const FORCED_COLOR_ENV_VARS: [&str; 3] = ["CLICOLOR_FORCE", "FORCE_COLOR", "GH_FORCE_TTY"];
+
 /// Run `command` via `bash -c` in `dir`. Returns `(exit_code, combined
 /// stdout+stderr)`; `Err` is spawn failure or timeout (the process group is
 /// killed on timeout so nothing lingers).
@@ -114,6 +123,9 @@ async fn drive(
 ) -> Result<(i32, String), String> {
     cmd.current_dir(dir);
     for var in GIT_REPO_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    for var in FORCED_COLOR_ENV_VARS {
         cmd.env_remove(var);
     }
     cmd.stdout(std::process::Stdio::piped());
@@ -284,6 +296,24 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         assert!(dead, "cancelled run left subprocess {pid} running");
+    }
+
+    /// An inherited force-color env must not reach subprocesses: `gh`
+    /// would wrap its `--json` output in ANSI escapes and every serde
+    /// parse of it dies at line 1 column 1.
+    #[tokio::test]
+    async fn run_scrubs_forced_color_env() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
+        let result = run(
+            "echo \"force=${CLICOLOR_FORCE-unset}\"",
+            std::path::Path::new("/tmp"),
+            30,
+        )
+        .await;
+        unsafe { std::env::remove_var("CLICOLOR_FORCE") };
+        let (code, out) = result.unwrap();
+        assert_eq!(code, 0);
+        assert!(out.contains("force=unset"), "{out}");
     }
 
     #[tokio::test]

--- a/stella-tools/src/issue_ops.rs
+++ b/stella-tools/src/issue_ops.rs
@@ -117,8 +117,48 @@ async fn gh_json(args: String, root: &std::path::Path) -> Result<Value, String> 
     if code != 0 {
         return Err(format!("gh failed (exit {code}): {output}"));
     }
-    serde_json::from_str(output.trim())
+    serde_json::from_str(&strip_ansi(output.trim()))
         .map_err(|e| format!("gh returned unparsable JSON ({e}) — output may be truncated"))
+}
+
+/// Strip ANSI escape sequences from CLI output. A raw 0x1b byte is invalid
+/// inside a JSON string, so this can never corrupt well-formed JSON — it
+/// only rescues output from a `gh` that colorized despite the pipe (a
+/// force-color override the exec env scrub didn't cover).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: `ESC [`, parameter/intermediate bytes, one final `@`–`~`.
+            Some('[') => {
+                chars.next();
+                for c in chars.by_ref() {
+                    if matches!(c, '@'..='~') {
+                        break;
+                    }
+                }
+            }
+            // OSC: `ESC ]` … terminated by BEL or `ESC \`.
+            Some(']') => {
+                chars.next();
+                while let Some(c) = chars.next() {
+                    if c == '\u{7}' || (c == '\u{1b}' && chars.next_if_eq(&'\\').is_some()) {
+                        break;
+                    }
+                }
+            }
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
 }
 
 async fn gh_run(args: String, root: &std::path::Path) -> Result<String, String> {
@@ -1305,6 +1345,20 @@ mod tests {
         assert_eq!(filter_members(members.clone(), "@octo", 10).len(), 1);
         assert_eq!(filter_members(members.clone(), "mona", 10).len(), 1);
         assert_eq!(filter_members(members, "", 1).len(), 1);
+    }
+
+    #[test]
+    fn strip_ansi_rescues_force_colored_gh_json() {
+        // The exact shape `gh issue list --json …` emits under
+        // CLICOLOR_FORCE=1: every token wrapped in SGR sequences.
+        let colored = "\u{1b}[1;37m[\u{1b}[m\u{1b}[1;37m]\u{1b}[m";
+        assert_eq!(strip_ansi(colored), "[]");
+        // OSC (BEL- and ST-terminated) and bare two-byte escapes go too;
+        // JSON-encoded `` inside strings is untouched (no raw 0x1b).
+        let mixed = "\u{1b}]0;title\u{7}{\"a\":\"\\u001b[1m\"}\u{1b}]8;;x\u{1b}\\\u{1b}M";
+        assert_eq!(strip_ansi(mixed), "{\"a\":\"\\u001b[1m\"}");
+        // Plain JSON passes through byte-identical.
+        assert_eq!(strip_ansi("[{\"n\":1}]"), "[{\"n\":1}]");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Command Deck's ISSUES tab showed **`gh returned unparsable JSON (expected value at line 1 column 1) — output may be truncated`** and listed nothing.

Root cause: the user's shell exports `CLICOLOR_FORCE=1`, which `gh` honors even when piped — every `gh issue list --json …` came back wrapped in ANSI SGR sequences (`ESC[1;37m[ESC[m…`), and `serde_json` dies on the leading `0x1b` byte. The same inherited env breaks `ci.rs`'s `$(gh run list --jq …)` command substitutions, which capture ANSI-wrapped run ids.

## Fix

Two layers:

1. **`exec::drive` scrubs `CLICOLOR_FORCE`, `FORCE_COLOR`, `GH_FORCE_TTY`** from every spawned subprocess, right next to the existing `GIT_DIR` scrub — same class of bug (inherited env poisoning captured output). Everything spawned here writes to a captured pipe that is parsed or fed to the model, never a terminal, so removing only the *force* overrides restores standard pipe detection; nothing gains or loses color it wouldn't have anywhere else.
2. **`gh_json` strips ANSI escapes** (CSI/OSC/two-byte) before parsing, as a backstop for force-color paths the env scrub doesn't know about. Raw `0x1b` is invalid inside JSON strings (JSON encodes it as `\u001b`), so stripping can never corrupt well-formed JSON.

## Tests

- `exec::tests::run_scrubs_forced_color_env` — sets `CLICOLOR_FORCE=1` in the parent, asserts the child sees it unset.
- `issue_ops::tests::strip_ansi_rescues_force_colored_gh_json` — the exact byte shape `gh` emits under `CLICOLOR_FORCE=1`, plus OSC/ST termination and a pass-through case.
- Full `stella-tools` suite + clippy clean; verified live that `env -u CLICOLOR_FORCE gh issue list --json …` parses.