### PR TITLE
feat(models): dynamic per-provider model discovery + capability-aware effort

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -304,6 +304,17 @@ fn tuned_engine_config(cfg: &Config, kind: crate::settings::EngineAgentKind) -> 
         engine.reasoning = tuning.reasoning;
         engine.params = tuning.params;
     }
+    // Capability clamp: a catalog-confirmed non-reasoning model must not
+    // carry effort/reasoning onto the wire — providers reject or silently
+    // ignore them, and both outcomes are worse than omitting the fields
+    // (the auto modes set effort for every role without knowing the
+    // model). Unknown capability passes through: the provider stays the
+    // authority.
+    if crate::engine_config::model_supports_reasoning(cfg.provider.id, &cfg.model_id) == Some(false)
+    {
+        engine.effort = None;
+        engine.reasoning = None;
+    }
     engine
 }
 
@@ -817,12 +828,37 @@ pub(crate) fn resolve_engine_wiring(cfg: &Config, worker_ref: &ModelRef) -> Engi
     } else {
         model_spec_for(&engine, EngineAgentKind::Judge, &is_provider)
     };
+    let triage_spec = model_spec_for(&engine, EngineAgentKind::Triage, &is_provider);
+
+    // Capability clamp, mirroring `tuned_engine_config`: a role whose
+    // model (pinned, provider-default, or riding the worker) is a
+    // catalog-confirmed non-reasoning model must not carry effort or
+    // reasoning onto the wire. Unknown capability passes through.
+    {
+        let clamp = |overrides: &mut stella_pipeline::RoleCallOverrides,
+                     spec: Option<&ModelSpec>| {
+            let resolved: Option<(String, String)> = match spec {
+                Some(s) if !s.model.is_empty() => Some((s.provider.clone(), s.model.clone())),
+                // Provider pin without a model → the provider's default.
+                Some(s) => crate::config::PROVIDERS
+                    .iter()
+                    .find(|p| p.id == s.provider && !p.default_model.is_empty())
+                    .map(|p| (s.provider.clone(), p.default_model.to_string())),
+                None => Some((worker_ref.provider.clone(), worker_ref.model_id.clone())),
+            };
+            if let Some((provider, model)) = resolved
+                && crate::engine_config::model_supports_reasoning(&provider, &model) == Some(false)
+            {
+                overrides.effort = None;
+                overrides.reasoning = None;
+            }
+        };
+        clamp(&mut wiring.role_overrides.triage, triage_spec.as_ref());
+        clamp(&mut wiring.role_overrides.judge, judge_spec.as_ref());
+    }
+
     let role_specs = [
-        (
-            Role::Triage,
-            "triage",
-            model_spec_for(&engine, EngineAgentKind::Triage, &is_provider),
-        ),
+        (Role::Triage, "triage", triage_spec),
         (Role::Judge, "judge", judge_spec),
     ];
 

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -3098,8 +3098,11 @@ fn deck_reserved() -> Vec<&'static str> {
 /// Build an [`Inbound::EngineConfig`] snapshot: the freshly merged
 /// `agent_engine_config` from the settings scope chain, plus the picker
 /// vocabularies — every provider whose credential currently resolves, and
-/// the seed catalog's `provider/slug` list as the model-picker fallback
-/// when `allowed_models` is empty. Re-reading the chain (rather than
+/// the catalog's `provider/slug` list as the model-picker fallback when
+/// `allowed_models` is empty. The model list is scoped to those same
+/// credentialed providers (plus the session's active one): a model you
+/// have no key for is not an option, and offering it anyway was exactly
+/// the "selectable but unusable" bug. Re-reading the chain (rather than
 /// caching) keeps the overlay honest about hand edits and about what a
 /// save at one scope means under the others.
 fn engine_config_inbound(cfg: &Config, status: Option<String>) -> Inbound {
@@ -3111,13 +3114,51 @@ fn engine_config_inbound(cfg: &Config, status: Option<String>) -> Inbound {
         .into_iter()
         .map(|p| p.config.id.to_string())
         .collect();
-    let catalog_models: Vec<String> = stella_model::catalog::Catalog::current()
+    // The session's provider is always usable — its credential resolved at
+    // startup (possibly interactively, which discovery never does).
+    let mut usable: std::collections::HashSet<&str> =
+        providers.iter().map(String::as_str).collect();
+    usable.insert(cfg.provider.id);
+    let catalog = stella_model::catalog::Catalog::current();
+    let mut catalog_models: Vec<String> = Vec::new();
+    let mut model_efforts: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for entry in catalog
         .entries()
         .iter()
-        .map(|entry| format!("{}/{}", entry.provider, entry.id))
-        .collect();
+        .filter(|entry| usable.contains(entry.provider.as_str()))
+    {
+        let spec = format!("{}/{}", entry.provider, entry.id);
+        let levels = crate::engine_config::effort_levels(
+            &entry.provider,
+            crate::config::PROVIDERS
+                .iter()
+                .find(|p| p.id == entry.provider)
+                .map(|p| p.dialect)
+                .unwrap_or(crate::config::Dialect::OpenaiCompatible),
+            entry.supports_reasoning,
+        );
+        model_efforts.insert(spec.clone(), levels.iter().map(|s| s.to_string()).collect());
+        catalog_models.push(spec);
+    }
+    // `allowed_models` specs are picker entries too — give each its effort
+    // vocabulary so the effort row is model-aware under a restriction.
+    for raw in engine.allowed_models() {
+        if model_efforts.contains_key(raw) {
+            continue;
+        }
+        if let Some(spec) = crate::engine_config::parse_model_spec(raw, &|id| usable.contains(id)) {
+            let levels = crate::engine_config::effort_levels_for_spec(&spec.provider, &spec.model);
+            model_efforts.insert(raw.clone(), levels.iter().map(|s| s.to_string()).collect());
+        }
+    }
     Inbound::EngineConfig {
-        state: crate::engine_config::state_from_settings(&engine, providers, catalog_models),
+        state: crate::engine_config::state_from_settings(
+            &engine,
+            providers,
+            catalog_models,
+            model_efforts,
+        ),
         status,
     }
 }

--- a/stella-cli/src/engine_config.rs
+++ b/stella-cli/src/engine_config.rs
@@ -267,6 +267,68 @@ fn split_params(
 }
 
 // ---------------------------------------------------------------------
+// Per-model effort vocabulary
+// ---------------------------------------------------------------------
+
+/// What the catalog knows about `provider/model`'s reasoning support.
+/// `None` when the model is unknown to the catalog OR known without
+/// capability data — both degrade to "the provider is the authority".
+pub fn model_supports_reasoning(provider: &str, model: &str) -> Option<bool> {
+    stella_model::catalog::Catalog::current()
+        .resolve_for(provider, model)
+        .ok()
+        .and_then(|entry| entry.supports_reasoning)
+}
+
+/// The effort levels that DO something for a model served by `provider_id`.
+/// Two constraints intersect here:
+/// - the model: a catalog-confirmed non-reasoning model has no levels at
+///   all (sending one would either error or silently no-op);
+/// - the provider's wire vocabulary: Anthropic/Bedrock budgets give all
+///   five tiers distinct meaning; Gemini's `thinkingLevel` is low/high;
+///   the OpenAI shapes document low/medium/high (higher tiers collapse to
+///   `high` on the wire — offering them would promise a distinction the
+///   request can't express); GLM's thinking switch is on/off — effort
+///   itself is not a knob there.
+///
+/// Unknown capability (`None`) keeps the provider's full vocabulary: an
+/// unknown must never *restrict*, only a confirmed "no" may.
+pub fn effort_levels(
+    provider_id: &str,
+    dialect: crate::config::Dialect,
+    supports_reasoning: Option<bool>,
+) -> &'static [&'static str] {
+    use crate::config::Dialect;
+    if supports_reasoning == Some(false) {
+        return &[];
+    }
+    if provider_id == "zai" {
+        return &[];
+    }
+    match dialect {
+        Dialect::Anthropic | Dialect::Bedrock => &["low", "medium", "high", "xhigh", "max"],
+        Dialect::Gemini | Dialect::Vertex => &["low", "high"],
+        Dialect::OpenaiResponses | Dialect::OpenaiCompatible => &["low", "medium", "high"],
+    }
+}
+
+/// [`effort_levels`] for a `provider/slug` picker spec, resolving the
+/// provider's dialect from the built-in table (settings-defined providers
+/// default to the OpenAI-compatible vocabulary, matching their adapter).
+pub fn effort_levels_for_spec(provider_id: &str, model: &str) -> &'static [&'static str] {
+    let dialect = crate::config::PROVIDERS
+        .iter()
+        .find(|p| p.id == provider_id)
+        .map(|p| p.dialect)
+        .unwrap_or(crate::config::Dialect::OpenaiCompatible);
+    effort_levels(
+        provider_id,
+        dialect,
+        model_supports_reasoning(provider_id, model),
+    )
+}
+
+// ---------------------------------------------------------------------
 // Enum ↔ string (the TUI edits strings; settings/serde hold enums)
 // ---------------------------------------------------------------------
 
@@ -353,12 +415,14 @@ fn flat_model(engine: &AgentEngineConfig, kind: EngineAgentKind) -> Option<&str>
     }
 }
 
-/// Build the engine panel's snapshot from the merged settings plus
-/// the picker vocabularies the driver knows (provider ids, catalog slugs).
+/// Build the engine panel's snapshot from the merged settings plus the
+/// picker vocabularies the driver knows (provider ids, catalog slugs, and
+/// each slug's per-model effort vocabulary).
 pub fn state_from_settings(
     engine: &AgentEngineConfig,
     providers: Vec<String>,
     catalog_models: Vec<String>,
+    model_efforts: std::collections::HashMap<String, Vec<String>>,
 ) -> EngineConfigState {
     let agents = EngineRole::ALL
         .iter()
@@ -400,6 +464,7 @@ pub fn state_from_settings(
         allowed_models: engine.allowed_models().to_vec(),
         providers,
         catalog_models,
+        model_efforts,
         agents,
     }
 }
@@ -667,6 +732,58 @@ mod tests {
     }
 
     #[test]
+    fn effort_levels_intersect_model_capability_with_the_provider_vocabulary() {
+        use crate::config::Dialect;
+        // A confirmed non-reasoning model has no levels anywhere.
+        assert!(effort_levels("anthropic", Dialect::Anthropic, Some(false)).is_empty());
+        assert!(effort_levels("openrouter", Dialect::OpenaiCompatible, Some(false)).is_empty());
+        // GLM's thinking switch is on/off — effort is not a knob even
+        // though the model reasons.
+        assert!(effort_levels("zai", Dialect::OpenaiCompatible, Some(true)).is_empty());
+        // Provider wire vocabularies.
+        assert_eq!(
+            effort_levels("anthropic", Dialect::Anthropic, Some(true)),
+            &["low", "medium", "high", "xhigh", "max"]
+        );
+        assert_eq!(
+            effort_levels("gemini", Dialect::Gemini, Some(true)),
+            &["low", "high"]
+        );
+        assert_eq!(
+            effort_levels("openai", Dialect::OpenaiResponses, Some(true)),
+            &["low", "medium", "high"]
+        );
+        // Unknown capability must not restrict — the provider's own full
+        // vocabulary stays offered.
+        assert_eq!(
+            effort_levels("openrouter", Dialect::OpenaiCompatible, None),
+            &["low", "medium", "high"]
+        );
+
+        // The spec form resolves dialect + capability from the tables: the
+        // seed marks deepseek-chat non-reasoning, claude-fable-5 reasoning.
+        assert!(effort_levels_for_spec("deepseek", "deepseek-chat").is_empty());
+        assert_eq!(
+            effort_levels_for_spec("anthropic", "claude-fable-5"),
+            &["low", "medium", "high", "xhigh", "max"]
+        );
+    }
+
+    #[test]
+    fn model_supports_reasoning_reads_the_catalog_and_defaults_to_unknown() {
+        assert_eq!(
+            model_supports_reasoning("deepseek", "deepseek-chat"),
+            Some(false)
+        );
+        assert_eq!(model_supports_reasoning("zai", "glm-5.2"), Some(true));
+        // Unknown slug or provider → unknown, never a hard no.
+        assert_eq!(
+            model_supports_reasoning("openrouter", "no-such/model"),
+            None
+        );
+    }
+
+    #[test]
     fn snapshot_roundtrips_through_the_tui_state() {
         let engine = engine_from_json(
             r#"{"default_model": "anthropic/claude-fable-5",
@@ -679,7 +796,12 @@ mod tests {
                                                   "verbosity": "low",
                                                   "service_tier": "flex"}}}}"#,
         );
-        let state = state_from_settings(&engine, vec!["zai".into()], vec!["zai/glm-5.2".into()]);
+        let state = state_from_settings(
+            &engine,
+            vec!["zai".into()],
+            vec!["zai/glm-5.2".into()],
+            Default::default(),
+        );
         assert!(!state.auto_mode);
         assert!(state.effort_auto);
         let judge = state.agent(EngineRole::Judge).expect("judge state");
@@ -715,7 +837,12 @@ mod tests {
         assert_eq!(back.effort_auto, Some(Toggle::On));
         // The round trip is stable: state → settings → state is identity
         // for the fields the snapshot carries.
-        let state2 = state_from_settings(&back, vec!["zai".into()], vec!["zai/glm-5.2".into()]);
+        let state2 = state_from_settings(
+            &back,
+            vec!["zai".into()],
+            vec!["zai/glm-5.2".into()],
+            Default::default(),
+        );
         assert_eq!(state2.agents, state.agents);
         assert_eq!(state2.allowed_models, state.allowed_models);
     }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -358,23 +358,29 @@ enum Command {
 /// on-disk master list every slug validates against.
 #[derive(Subcommand)]
 enum ModelsCmd {
-    /// Sync the master list of valid provider/model slugs and pricing from
-    /// models.dev (public, no API key). Incremental: an unchanged list is
-    /// one conditional request (ETag) and zero writes; pricing changes
-    /// append a new model-card version (the latest version is what
-    /// displays everywhere).
+    /// Sync the model catalog: the models.dev master list (public, no API
+    /// key), then every configured provider's own live /models listing.
+    /// Incremental: an unchanged master list is one conditional request
+    /// (ETag) and zero writes; pricing changes append a new model-card
+    /// version (the latest version is what displays everywhere). Also runs
+    /// automatically once a day while a provider credential is configured.
     Refresh {
         /// Re-download even when the server says the list is unchanged
         /// (recovery hatch for a corrupted local catalog)
         #[arg(long)]
         force: bool,
     },
-    /// List the model catalog: every known provider/model slug with its
-    /// latest pricing (USD per Mtok), context window, and model maker
+    /// List the model catalog: provider/model slugs with latest pricing
+    /// (USD per Mtok), context window, capability, and model maker. Scoped
+    /// to providers whose credential resolves; --all lifts the scope.
     List {
         /// Only this provider id (e.g. anthropic, openrouter)
         #[arg(long)]
         provider: Option<String>,
+
+        /// Include providers with no configured credential
+        #[arg(long)]
+        all: bool,
     },
 }
 
@@ -957,7 +963,9 @@ fn run(cli: Cli) -> Result<(), String> {
                     .build()
                     .map_err(|e| format!("failed to start runtime: {e}"))?
                     .block_on(model_catalog::run_refresh(*force)),
-                Some(ModelsCmd::List { provider }) => model_catalog::run_list(provider.as_deref()),
+                Some(ModelsCmd::List { provider, all }) => {
+                    model_catalog::run_list(provider.as_deref(), *all)
+                }
             };
         }
         Some(Command::Tools { validate }) => {
@@ -1031,9 +1039,10 @@ fn run(cli: Cli) -> Result<(), String> {
     };
 
     // Everything past here resolves a provider (and may build one), so the
-    // model catalog must be live first: open catalog.db, refresh a stale
-    // master list (only ever after the user's first explicit
-    // `stella models refresh` — the no-phone-home rule), and install the
+    // model catalog must be live first: open catalog.db, auto-sync each
+    // configured provider's own live model listing (BYOK-clean), re-fetch a
+    // stale models.dev master list only after the user's explicit first
+    // `stella models refresh` (the no-phone-home rule), and install the
     // runtime catalog that slug validation and pricing resolve against.
     model_catalog::bootstrap();
 

--- a/stella-cli/src/model_catalog.rs
+++ b/stella-cli/src/model_catalog.rs
@@ -4,10 +4,16 @@
 //!
 //! What lives here:
 //! - **`bootstrap`** — open the user-tier `catalog.db`, lay the seed floor,
-//!   opportunistically refresh a stale master list (only after the user has
-//!   opted in by running `stella models refresh` at least once — the
-//!   no-phone-home rule), and install the merged runtime catalog every
-//!   pricing consumer resolves through `Catalog::current()`.
+//!   auto-sync each configured provider's own live `/models` listing
+//!   (BYOK-clean: traffic to the provider the user already keyed, which is
+//!   what keeps the selectable-model list complete and current as providers
+//!   ship releases — no manual refresh needed), opportunistically re-fetch
+//!   a stale models.dev master list ONLY after the user's explicit first
+//!   `stella models refresh` (models.dev is a third party — the no-phone-
+//!   home rule), and install the merged runtime catalog every pricing
+//!   consumer resolves through `Catalog::current()`.
+//!   `STELLA_CATALOG_AUTO_REFRESH=0` switches all implicit fetching off;
+//!   a zero-config install (no credentials) never fetches anything.
 //! - **`validate_model_slug`** — the anti-invalid-slug gate `build_provider`
 //!   calls for EVERY provider. Strictness is earned, never assumed: the
 //!   seed floor always passes; a provider whose master-list rows are synced
@@ -28,14 +34,26 @@ use std::sync::{Arc, Mutex, OnceLock};
 use colored::Colorize;
 use stella_model::catalog::{Catalog, CatalogEntry, Pricing, ToolDialect};
 use stella_model::modelsdev::{self, FetchOutcome, FetchedCatalog};
+use stella_model::provider_listing::{self, ProviderModel};
 use stella_store::catalog::{
     AliasForm, CatalogStore, ModelUpsert, RefreshCounts, VersionData, catalog_db_path,
 };
 
-use crate::config::{Dialect, LOCAL_PROVIDER, PROVIDERS, ProviderConfig};
+use crate::config::{ConfiguredProvider, Dialect, LOCAL_PROVIDER, PROVIDERS, ProviderConfig};
 
 /// The `catalog_sync.source` key for the models.dev master list.
 pub const SYNC_SOURCE: &str = "models.dev";
+
+/// The card `source` for rows discovered from a provider's own `/models`
+/// endpoint. A provider with rows from EITHER sync source has an
+/// authoritative slug set — `validate_model_slug` counts both.
+pub const NATIVE_SOURCE: &str = "provider";
+
+/// The per-provider `catalog_sync` bookkeeping key for native listings —
+/// each provider gets its own staleness clock.
+fn native_sync_source(provider_id: &str) -> String {
+    format!("{NATIVE_SOURCE}:{provider_id}")
+}
 
 /// How stale a previously-synced master list may get before `bootstrap`
 /// re-fetches it (conditional request — an unchanged list is one cheap 304).
@@ -326,6 +344,8 @@ pub(crate) fn build_upserts(fetched: &FetchedCatalog) -> Vec<ModelUpsert> {
                     max_output_tokens: limit.output,
                     release_date: model.release_date.clone(),
                     last_updated: model.last_updated.clone(),
+                    supports_reasoning: model.reasoning,
+                    supports_tools: model.tool_call,
                 },
                 aliases: alias_forms(api_provider, &model.id),
             });
@@ -355,6 +375,8 @@ fn seed_upserts() -> Vec<ModelUpsert> {
                 max_output_tokens: None,
                 release_date: None,
                 last_updated: None,
+                supports_reasoning: None,
+                supports_tools: None,
             },
             aliases: alias_forms(&entry.provider, &entry.id),
         })
@@ -375,6 +397,109 @@ fn ensure_seed_floor(store: &CatalogStore) {
 }
 
 // ---------------------------------------------------------------------
+// Provider-native discovery (each provider's own /models endpoint)
+// ---------------------------------------------------------------------
+
+/// Fetch `provider`'s own live model listing, dispatched on its wire
+/// dialect. Vertex and Bedrock have no key-shaped credential to list with
+/// (OAuth token / SigV4) — the master list covers them.
+async fn fetch_native_listing(
+    provider: &ProviderConfig,
+    api_key: &stella_model::credential::ApiKey,
+) -> Result<Vec<ProviderModel>, String> {
+    match provider.dialect {
+        Dialect::OpenaiCompatible if provider.id == "openrouter" => {
+            provider_listing::fetch_openrouter(provider.base_url).await
+        }
+        Dialect::OpenaiCompatible | Dialect::OpenaiResponses => {
+            provider_listing::fetch_openai_compatible(
+                provider.display_name,
+                provider.base_url,
+                api_key,
+            )
+            .await
+        }
+        Dialect::Anthropic => provider_listing::fetch_anthropic(provider.base_url, api_key).await,
+        Dialect::Gemini => provider_listing::fetch_gemini(provider.base_url, api_key).await,
+        Dialect::Vertex | Dialect::Bedrock => {
+            Err("no native listing endpoint (the master list covers this provider)".to_string())
+        }
+    }
+}
+
+/// Whether [`fetch_native_listing`] can list this provider at all.
+fn has_native_listing(provider: &ProviderConfig) -> bool {
+    !matches!(provider.dialect, Dialect::Vertex | Dialect::Bedrock)
+}
+
+/// Map one provider's native listing into store upserts. Each row is
+/// overlaid on what the catalog already knows for that (provider, slug):
+/// a native listing that carries no pricing (Anthropic, plain `/models`
+/// ids) must not blank out master-list pricing — and when it adds nothing
+/// new, the merged version hashes identically and the store appends no
+/// version at all.
+fn native_upserts(
+    provider: &ProviderConfig,
+    models: &[ProviderModel],
+    store: &CatalogStore,
+) -> Vec<ModelUpsert> {
+    models
+        .iter()
+        .filter(|m| !m.id.is_empty())
+        .map(|m| {
+            let prior = store
+                .resolve(provider.id, &m.id)
+                .ok()
+                .flatten()
+                .map(|existing| existing.pricing)
+                .unwrap_or_default();
+            ModelUpsert {
+                api_provider: provider.id.to_string(),
+                model_provider: derive_model_provider(provider.id, &m.id),
+                slug: m.id.clone(),
+                display_name: m.display_name.clone(),
+                // The card UPDATE coalesces NULL family to the existing
+                // value, so master-list families survive native re-syncs.
+                family: None,
+                source: NATIVE_SOURCE.to_string(),
+                version: VersionData {
+                    input_usd_per_mtok: m.input_usd_per_mtok.or(prior.input_usd_per_mtok),
+                    output_usd_per_mtok: m.output_usd_per_mtok.or(prior.output_usd_per_mtok),
+                    cached_input_usd_per_mtok: m
+                        .cached_input_usd_per_mtok
+                        .or(prior.cached_input_usd_per_mtok),
+                    cache_write_usd_per_mtok: m
+                        .cache_write_usd_per_mtok
+                        .or(prior.cache_write_usd_per_mtok),
+                    context_window: m.context_window.or(prior.context_window),
+                    max_output_tokens: m.max_output_tokens.or(prior.max_output_tokens),
+                    release_date: prior.release_date,
+                    last_updated: prior.last_updated,
+                    supports_reasoning: m.supports_reasoning.or(prior.supports_reasoning),
+                    supports_tools: m.supports_tools.or(prior.supports_tools),
+                },
+                aliases: alias_forms(provider.id, &m.id),
+            }
+        })
+        .collect()
+}
+
+/// One native refresh pass for one configured provider: fetch its live
+/// listing, overlay-merge, batch-apply, stamp its staleness clock.
+async fn refresh_native_provider(
+    store: &CatalogStore,
+    configured: &ConfiguredProvider,
+) -> Result<(usize, RefreshCounts), String> {
+    let models = fetch_native_listing(&configured.config, &configured.api_key).await?;
+    let upserts = native_upserts(&configured.config, &models, store);
+    let counts = store.apply_batch(&upserts).map_err(|e| e.to_string())?;
+    store
+        .record_sync(&native_sync_source(configured.config.id), None, None)
+        .map_err(|e| e.to_string())?;
+    Ok((models.len(), counts))
+}
+
+// ---------------------------------------------------------------------
 // Bootstrap & runtime catalog
 // ---------------------------------------------------------------------
 
@@ -391,12 +516,13 @@ fn tool_dialect_for(dialect: Dialect) -> ToolDialect {
     }
 }
 
-/// Open the catalog, lay the seed floor, refresh a stale master list (only
-/// ever after the explicit first `stella models refresh` — see
-/// [`maybe_auto_refresh`]), and install the merged runtime catalog. Called
-/// once at startup, before any provider is resolved; every failure
-/// degrades silently to today's seed-only behavior (the catalog is an
-/// upgrade, never a new way to break a turn).
+/// Open the catalog, lay the seed floor, auto-sync each configured
+/// provider's native listing plus (once armed) a stale models.dev master
+/// list — see [`maybe_auto_refresh`] for the two sources' distinct rules —
+/// and install the merged runtime catalog. Called once at startup, before
+/// any provider is resolved; every failure degrades silently to today's
+/// seed-only behavior (the catalog is an upgrade, never a new way to break
+/// a turn).
 pub fn bootstrap() {
     let store = match CatalogStore::open(&catalog_db_path()) {
         Ok(store) => Some(Arc::new(store)),
@@ -416,20 +542,80 @@ pub fn bootstrap() {
     let _ = STORE.set(store);
 }
 
-/// Re-fetch the master list when it is stale — but ONLY if a sync row
-/// already exists: the first fetch is always the user's explicit `stella
-/// models refresh` (the no-phone-home rule), and `STELLA_CATALOG_AUTO_REFRESH=0`
-/// switches the re-fetch off entirely. Best-effort: offline just means
-/// the catalog stays as of the last sync.
+/// Whether a NATIVE listing's staleness clock says it needs a fetch:
+/// never synced, or older than the TTL. A store error reads as "fresh" —
+/// auto-sync must never turn a flaky disk into a network storm. Native
+/// listings can fire on the never-synced case because they are traffic to
+/// the user's own chosen provider (see [`maybe_auto_refresh`]).
+fn native_sync_is_due(store: &CatalogStore, source: &str) -> bool {
+    match store.seconds_since_sync(source) {
+        Ok(Some(age)) => age >= AUTO_REFRESH_TTL_SECS,
+        Ok(None) => true,
+        Err(_) => false,
+    }
+}
+
+/// Whether the models.dev master list may auto-*re*fresh. Distinct from
+/// [`native_sync_is_due`] on the never-synced case, and deliberately so:
+/// models.dev is a THIRD PARTY, not the user's chosen provider, so the
+/// no-phone-home rule (the published "the only network traffic goes to the
+/// provider you chose" guarantee) forbids contacting it implicitly. It may
+/// only auto-refresh once a sync ROW already exists — i.e. after the user's
+/// explicit first `stella models refresh`. A fresh install never touches
+/// models.dev on its own.
+fn master_list_auto_due(store: &CatalogStore) -> bool {
+    matches!(
+        store.seconds_since_sync(SYNC_SOURCE),
+        Ok(Some(age)) if age >= AUTO_REFRESH_TTL_SECS
+    )
+}
+
+/// Keep the catalog current without anyone asking. Two sources, two rules:
+///
+/// - **Native provider listings** (each configured provider's own `/models`
+///   endpoint) auto-sync whenever stale, INCLUDING the very first time —
+///   this is what surfaces new releases as they ship. It is BYOK-clean: the
+///   request goes to the provider the user already gave stella a key for,
+///   the same host the next turn calls anyway. No credential → nothing
+///   fetched.
+/// - **The models.dev master list** is a third party, so it only auto-
+///   *re*freshes after the user's explicit first `stella models refresh`
+///   ([`master_list_auto_due`]) — the no-phone-home rule, unchanged.
+///
+/// `STELLA_CATALOG_AUTO_REFRESH=0` disables all implicit fetching. Best-
+/// effort throughout: offline just means the catalog stays as of the last
+/// sync.
 fn maybe_auto_refresh(store: &Arc<CatalogStore>) {
     if std::env::var("STELLA_CATALOG_AUTO_REFRESH").as_deref() == Ok("0") {
         return;
     }
-    let Ok(Some(age)) = store.seconds_since_sync(SYNC_SOURCE) else {
+    let configured = crate::config::discover_configured_providers();
+    if configured.is_empty() {
         return;
-    };
-    if age < AUTO_REFRESH_TTL_SECS {
+    }
+    let master_due = master_list_auto_due(store);
+    let native_due: Vec<&ConfiguredProvider> = configured
+        .iter()
+        .filter(|p| has_native_listing(&p.config))
+        .filter(|p| native_sync_is_due(store, &native_sync_source(p.config.id)))
+        .collect();
+    if !master_due && native_due.is_empty() {
         return;
+    }
+    // First-ever native sync fetches each provider's live list and takes a
+    // moment — say so once, instead of looking hung.
+    let first_native = native_due.iter().any(|p| {
+        store
+            .sync_info(&native_sync_source(p.config.id))
+            .ok()
+            .flatten()
+            .is_none()
+    });
+    if first_native {
+        eprintln!(
+            "  {} discovering models from your configured providers…",
+            "models:".dimmed()
+        );
     }
     let Ok(rt) = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -437,7 +623,14 @@ fn maybe_auto_refresh(store: &Arc<CatalogStore>) {
     else {
         return;
     };
-    let _ = rt.block_on(refresh_with_store(store, false));
+    rt.block_on(async {
+        if master_due {
+            let _ = refresh_with_store(store, false).await;
+        }
+        for provider in native_due {
+            let _ = refresh_native_provider(store, provider).await;
+        }
+    });
 }
 
 /// Assemble and install the runtime catalog: every seed row (verbatim, so
@@ -480,25 +673,28 @@ fn install_runtime_catalog(store: &CatalogStore) {
                 .family
                 .clone()
                 .unwrap_or_else(|| listing.model_provider.clone());
-            entries.push(CatalogEntry::new(
-                &listing.slug,
-                &listing.api_provider,
-                &family,
-                listing
-                    .pricing
-                    .context_window
-                    .unwrap_or(0)
-                    .min(u32::MAX as u64) as u32,
-                dialect,
-                Pricing {
-                    input_usd_per_mtok: listing.pricing.input_usd_per_mtok.unwrap_or(0.0),
-                    output_usd_per_mtok: listing.pricing.output_usd_per_mtok.unwrap_or(0.0),
-                    cached_input_usd_per_mtok: listing
+            entries.push(
+                CatalogEntry::new(
+                    &listing.slug,
+                    &listing.api_provider,
+                    &family,
+                    listing
                         .pricing
-                        .cached_input_usd_per_mtok
-                        .unwrap_or(0.0),
-                },
-            ));
+                        .context_window
+                        .unwrap_or(0)
+                        .min(u32::MAX as u64) as u32,
+                    dialect,
+                    Pricing {
+                        input_usd_per_mtok: listing.pricing.input_usd_per_mtok.unwrap_or(0.0),
+                        output_usd_per_mtok: listing.pricing.output_usd_per_mtok.unwrap_or(0.0),
+                        cached_input_usd_per_mtok: listing
+                            .pricing
+                            .cached_input_usd_per_mtok
+                            .unwrap_or(0.0),
+                    },
+                )
+                .with_reasoning(listing.pricing.supports_reasoning),
+            );
             known.insert(key);
         }
     }
@@ -539,7 +735,10 @@ pub fn validate_model_slug(provider: &ProviderConfig, model_id: &str) -> Result<
         }
         let synced = store
             .provider_model_count(provider.id, Some(SYNC_SOURCE))
-            .unwrap_or(0);
+            .unwrap_or(0)
+            + store
+                .provider_model_count(provider.id, Some(NATIVE_SOURCE))
+                .unwrap_or(0);
         if synced > 0 {
             return Err(unknown_model_message(&store, provider.id, model_id));
         }
@@ -712,25 +911,21 @@ async fn refresh_with_store(
     }
 }
 
-/// `stella models refresh [--force]`.
+/// `stella models refresh [--force]`: the master list, then every
+/// configured provider's own live `/models` listing.
 pub async fn run_refresh(force: bool) -> Result<(), String> {
     let store = store_for_command()?;
     ensure_seed_floor(&store);
-    println!(
-        "{}\n",
-        "Stella — Model Catalog Refresh (models.dev)"
-            .yellow()
-            .bold()
-    );
+    println!("{}\n", "Stella — Model Catalog Refresh".yellow().bold());
     let (not_modified, providers, counts) = refresh_with_store(&store, force).await?;
     if not_modified {
         println!(
-            "  {} master list unchanged (ETag match) — catalog already current",
+            "  {} master list (models.dev) unchanged (ETag match) — already current",
             "✓".green()
         );
     } else {
         println!(
-            "  {} synced {} models across {} providers",
+            "  {} master list (models.dev): {} models across {} providers",
             "✓".green(),
             counts.models_seen,
             providers
@@ -740,12 +935,32 @@ pub async fn run_refresh(force: bool) -> Result<(), String> {
             counts.cards_added, counts.versions_added, counts.aliases_added
         );
     }
+
+    // Live listings, straight from each configured provider's own API —
+    // the authoritative "what can this key use right now", which also
+    // catches releases the master list hasn't indexed yet.
+    for configured in crate::config::discover_configured_providers() {
+        if !has_native_listing(&configured.config) {
+            continue;
+        }
+        let id = configured.config.id;
+        match refresh_native_provider(&store, &configured).await {
+            Ok((seen, counts)) => println!(
+                "  {} {id}: {seen} models live from the provider ({} new cards)",
+                "✓".green(),
+                counts.cards_added
+            ),
+            Err(e) => println!("  {} {id}: {e}", "–".yellow()),
+        }
+    }
+
     let (cards, versions, aliases) = store.counts().map_err(|e| e.to_string())?;
     println!(
-        "  catalog now holds {cards} model cards, {versions} pricing versions, {aliases} aliases"
+        "\n  catalog now holds {cards} model cards, {versions} pricing versions, {aliases} aliases"
     );
     println!(
-        "\n  Model slugs now validate against this master list; re-run to pick up new releases."
+        "  Model slugs validate against this catalog; it re-syncs automatically once a day \
+         while a provider credential is configured."
     );
     Ok(())
 }
@@ -760,13 +975,29 @@ fn rate(value: Option<f64>) -> String {
     }
 }
 
-/// `stella models list [--provider <id>]`.
-pub fn run_list(provider: Option<&str>) -> Result<(), String> {
+/// `stella models list [--provider <id>] [--all]`. Without `--provider`,
+/// the listing is scoped to providers whose credential currently resolves —
+/// the same set the deck's model picker offers — because "what can I
+/// actually select right now" is the question this answers; `--all` lifts
+/// the scope to the whole catalog.
+pub fn run_list(provider: Option<&str>, all: bool) -> Result<(), String> {
     let store = store_for_command()?;
     ensure_seed_floor(&store);
-    let listings = store
+    let mut listings = store
         .models_for_provider(provider)
         .map_err(|e| e.to_string())?;
+    let mut hidden = 0;
+    if provider.is_none() && !all {
+        let configured: HashSet<String> = crate::config::discover_configured_providers()
+            .into_iter()
+            .map(|p| p.config.id.to_string())
+            .collect();
+        if !configured.is_empty() {
+            let before = listings.len();
+            listings.retain(|l| configured.contains(&l.api_provider));
+            hidden = before - listings.len();
+        }
+    }
     if listings.is_empty() {
         match provider {
             Some(p) => println!(
@@ -789,8 +1020,14 @@ pub fn run_list(provider: Option<&str>) -> Result<(), String> {
             .context_window
             .map(|c| format!("{}k", c / 1000))
             .unwrap_or_else(|| "-".to_string());
+        // Capability marker: `thinks` when the model supports reasoning —
+        // the flag the effort picker keys on. Unknown shows nothing.
+        let thinks = match l.pricing.supports_reasoning {
+            Some(true) => "  thinks",
+            _ => "",
+        };
         println!(
-            "  {}/{}  {} / {} / {}  ctx {}  {}  [v{}]",
+            "  {}/{}  {} / {} / {}  ctx {}  {}{}  [v{}]",
             l.api_provider.bright_magenta(),
             l.slug.bright_white(),
             rate(l.pricing.input_usd_per_mtok),
@@ -798,6 +1035,7 @@ pub fn run_list(provider: Option<&str>) -> Result<(), String> {
             rate(l.pricing.cached_input_usd_per_mtok),
             ctx,
             l.model_provider.dimmed(),
+            thinks.cyan(),
             l.version,
         );
     }
@@ -805,6 +1043,12 @@ pub fn run_list(provider: Option<&str>) -> Result<(), String> {
         "\n  {} models. Pricing shown is each card's latest version.",
         listings.len()
     );
+    if hidden > 0 {
+        println!(
+            "  {hidden} models on providers without a configured credential are hidden — \
+             `stella models list --all` shows everything."
+        );
+    }
     match store.sync_info(SYNC_SOURCE).map_err(|e| e.to_string())? {
         Some(info) => println!(
             "  master list last refreshed {} UTC — `stella models refresh` to update",
@@ -830,8 +1074,9 @@ pub fn print_catalog_status() {
             info.refreshed_at
         ),
         _ => println!(
-            "\n  Model catalog: seed only — `stella models refresh` pulls the live master list \
-             (models.dev) and turns on strict slug validation for every provider."
+            "\n  Model catalog: seed only — each configured provider's live model list syncs \
+             automatically; `stella models refresh` also pulls the models.dev master list \
+             (pricing + capabilities) and re-syncs it daily thereafter."
         ),
     }
 }
@@ -977,6 +1222,8 @@ mod tests {
                 }),
                 release_date: Some("2025-11-18".to_string()),
                 last_updated: None,
+                reasoning: Some(true),
+                tool_call: Some(true),
             },
         );
         let mut providers = BTreeMap::new();
@@ -1008,7 +1255,127 @@ mod tests {
         assert_eq!(up.version.cached_input_usd_per_mtok, Some(0.31));
         assert_eq!(up.version.context_window, Some(1_000_000));
         assert_eq!(up.version.release_date.as_deref(), Some("2025-11-18"));
+        assert_eq!(up.version.supports_reasoning, Some(true));
+        assert_eq!(up.version.supports_tools, Some(true));
         assert!(up.aliases.iter().any(|a| a.alias == "gemini/gemini-3-pro"));
+    }
+
+    #[test]
+    fn native_upserts_overlay_missing_fields_from_the_existing_card() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CatalogStore::open(&dir.path().join("catalog.db")).expect("open");
+        let anthropic = PROVIDERS
+            .iter()
+            .find(|p| p.id == "anthropic")
+            .expect("anthropic row");
+
+        // The master list already priced this model and knows it reasons.
+        store
+            .apply_batch(&[ModelUpsert {
+                api_provider: "anthropic".to_string(),
+                model_provider: "anthropic".to_string(),
+                slug: "claude-fable-5".to_string(),
+                display_name: None,
+                family: Some("claude".to_string()),
+                source: SYNC_SOURCE.to_string(),
+                version: VersionData {
+                    input_usd_per_mtok: Some(3.0),
+                    output_usd_per_mtok: Some(15.0),
+                    cached_input_usd_per_mtok: Some(0.3),
+                    cache_write_usd_per_mtok: None,
+                    context_window: Some(200_000),
+                    max_output_tokens: Some(64_000),
+                    release_date: Some("2026-01-15".to_string()),
+                    last_updated: None,
+                    supports_reasoning: Some(true),
+                    supports_tools: Some(true),
+                },
+                aliases: alias_forms("anthropic", "claude-fable-5"),
+            }])
+            .expect("master-list row");
+
+        // Anthropic's own /v1/models reports ids + display names only. The
+        // merged upsert must keep every master-list fact…
+        let native = [ProviderModel {
+            id: "claude-fable-5".to_string(),
+            display_name: Some("Claude Fable 5".to_string()),
+            ..ProviderModel::default()
+        }];
+        let ups = native_upserts(anthropic, &native, &store);
+        assert_eq!(ups.len(), 1);
+        assert_eq!(ups[0].source, NATIVE_SOURCE);
+        assert_eq!(ups[0].version.input_usd_per_mtok, Some(3.0));
+        assert_eq!(ups[0].version.supports_reasoning, Some(true));
+        assert_eq!(ups[0].version.release_date.as_deref(), Some("2026-01-15"));
+        // …which also means the merged version hashes identically and a
+        // native re-sync appends NO new pricing version.
+        let counts = store.apply_batch(&ups).expect("native apply");
+        assert_eq!(
+            counts.versions_added, 0,
+            "no-new-information sync is version-silent"
+        );
+        assert_eq!(counts.cards_added, 0);
+
+        // A model the master list has never heard of (released today) still
+        // lands as a fresh card.
+        let brand_new = [ProviderModel {
+            id: "claude-brand-new".to_string(),
+            ..ProviderModel::default()
+        }];
+        let counts = store
+            .apply_batch(&native_upserts(anthropic, &brand_new, &store))
+            .expect("new-model apply");
+        assert_eq!(counts.cards_added, 1);
+    }
+
+    #[test]
+    fn native_sync_fires_on_first_run_but_master_list_never_does() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CatalogStore::open(&dir.path().join("catalog.db")).expect("open");
+
+        // Native listings (traffic to the user's own provider) DO fire on
+        // the never-synced case — that's how new installs discover models.
+        assert!(
+            native_sync_is_due(&store, &native_sync_source("openrouter")),
+            "never synced native → due (BYOK-clean)"
+        );
+
+        // models.dev (a third party) must NOT auto-fetch until the user has
+        // explicitly refreshed at least once — the no-phone-home rule.
+        assert!(
+            !master_list_auto_due(&store),
+            "never synced master list → NOT due (no phone home on a fresh install)"
+        );
+
+        // After an explicit refresh recorded a sync row, it may auto-refresh
+        // once stale — but a just-recorded sync is still fresh.
+        store
+            .record_sync(SYNC_SOURCE, None, None)
+            .expect("record sync");
+        assert!(
+            !master_list_auto_due(&store),
+            "just refreshed → not due until the TTL passes"
+        );
+        store
+            .record_sync(&native_sync_source("openrouter"), None, None)
+            .expect("record native sync");
+        assert!(
+            !native_sync_is_due(&store, &native_sync_source("openrouter")),
+            "just synced native → not due until the TTL passes"
+        );
+    }
+
+    #[test]
+    fn every_builtin_except_vertex_and_bedrock_has_a_native_listing() {
+        for provider in PROVIDERS {
+            let expected = !matches!(provider.dialect, Dialect::Vertex | Dialect::Bedrock);
+            assert_eq!(
+                has_native_listing(provider),
+                expected,
+                "native-listing coverage drifted for `{}`",
+                provider.id
+            );
+        }
     }
 
     #[test]

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -107,12 +107,19 @@ pub struct CatalogEntry {
     /// List pricing used to compute `CompletionResult::cost_usd` on the real
     /// request path — each adapter resolves its own row in its constructor.
     pub pricing: Pricing,
+    /// Whether this model supports reasoning / extended thinking. `None` is
+    /// "unknown": effort settings pass through and the provider stays the
+    /// authority. `Some(false)` is a hard "no" from catalog data — the
+    /// effort picker hides its levels and the request path drops
+    /// effort/reasoning instead of sending a parameter the API rejects.
+    pub supports_reasoning: Option<bool>,
 }
 
 impl CatalogEntry {
     /// A catalog row without the field-by-field ceremony — the seed table
     /// below, the runtime-catalog assembly in `stella-cli`, and tests all
-    /// build entries through this.
+    /// build entries through this. Capabilities default to unknown; chain
+    /// [`CatalogEntry::with_reasoning`] where the data exists.
     pub fn new(
         id: &str,
         provider: &str,
@@ -128,7 +135,15 @@ impl CatalogEntry {
             context_window,
             tool_dialect,
             pricing,
+            supports_reasoning: None,
         }
+    }
+
+    /// Set the reasoning capability (builder-style, so the many existing
+    /// `new` call sites stay untouched).
+    pub fn with_reasoning(mut self, supports_reasoning: Option<bool>) -> Self {
+        self.supports_reasoning = supports_reasoning;
+        self
     }
 }
 
@@ -171,7 +186,8 @@ impl Catalog {
                         output_usd_per_mtok: 2.20,
                         cached_input_usd_per_mtok: 0.11,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 CatalogEntry::new(
                     "claude-fable-5",
                     "anthropic",
@@ -183,7 +199,8 @@ impl Catalog {
                         output_usd_per_mtok: 15.00,
                         cached_input_usd_per_mtok: 0.30,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 // Real adapter now exists (stella_model::openai) — this row
                 // used to be OpenaiJson, which was wrong: OpenAI was never
                 // routed through Chat Completions, only through the generic
@@ -200,7 +217,8 @@ impl Catalog {
                         output_usd_per_mtok: 10.00,
                         cached_input_usd_per_mtok: 0.125,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 CatalogEntry::new(
                     "grok-4",
                     "xai",
@@ -212,7 +230,10 @@ impl Catalog {
                         output_usd_per_mtok: 15.00,
                         cached_input_usd_per_mtok: 0.75,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
+                // The non-thinking chat model (`deepseek-reasoner` is the
+                // reasoning one) — the seed's one honest `Some(false)`.
                 CatalogEntry::new(
                     "deepseek-chat",
                     "deepseek",
@@ -224,7 +245,8 @@ impl Catalog {
                         output_usd_per_mtok: 1.10,
                         cached_input_usd_per_mtok: 0.07,
                     },
-                ),
+                )
+                .with_reasoning(Some(false)),
                 // The native Gemini-direct adapter (stella_model::gemini) —
                 // this row used to be OpenaiJson while requests routed
                 // through Google's OpenAI-compatibility shim as a stand-in.
@@ -239,7 +261,8 @@ impl Catalog {
                         output_usd_per_mtok: 10.00,
                         cached_input_usd_per_mtok: 0.31,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 // The same Google model surfaced through Vertex AI — one
                 // model genuinely existing on two providers is why
                 // uniqueness (and `resolve_for`) is keyed on
@@ -256,7 +279,8 @@ impl Catalog {
                         output_usd_per_mtok: 10.00,
                         cached_input_usd_per_mtok: 0.31,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 // A cross-region inference profile, not a bare model id —
                 // Bedrock rejects on-demand invocation of newer Anthropic
                 // models without one. Priced as Claude Sonnet 4.5 (Bedrock
@@ -272,7 +296,8 @@ impl Catalog {
                         output_usd_per_mtok: 15.00,
                         cached_input_usd_per_mtok: 0.30,
                     },
-                ),
+                )
+                .with_reasoning(Some(true)),
                 // OpenRouter's fully-qualified slug for its own meta-router.
                 // The gateway's model ids are ALL `vendor/model` — a bare
                 // `auto` is not a model there, so this row must carry the

--- a/stella-model/src/lib.rs
+++ b/stella-model/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod http;
 pub mod modelsdev;
 pub mod openai;
 pub mod provider;
+pub mod provider_listing;
 pub mod sse;
 pub mod vertex;
 pub mod zai;

--- a/stella-model/src/modelsdev.rs
+++ b/stella-model/src/modelsdev.rs
@@ -22,10 +22,14 @@ use sha2::{Digest, Sha256};
 
 use crate::http;
 
-/// The master-list endpoint. Public and unauthenticated — but never fetched
+/// The master-list endpoint. Public and unauthenticated — but a THIRD
+/// party, not the user's chosen provider, so it is never fetched
 /// implicitly: stella's no-phone-home rule means the first fetch is always
 /// an explicit `stella models refresh` (auto-refresh only re-arms after
-/// that opt-in; see `stella-cli`'s catalog bootstrap).
+/// that opt-in; see `stella-cli`'s catalog bootstrap and its
+/// `STELLA_CATALOG_AUTO_REFRESH=0` kill switch). Provider-native model
+/// discovery, which does auto-sync, talks to the user's own provider
+/// instead — see `stella_model::provider_listing`.
 pub const MODELS_DEV_URL: &str = "https://models.dev/api.json";
 
 /// One provider block: `{ id, name, models: { <model-id>: {...} } }`.
@@ -60,6 +64,13 @@ pub struct ModelEntry {
     pub release_date: Option<String>,
     #[serde(default)]
     pub last_updated: Option<String>,
+    /// Whether the model supports reasoning / extended thinking. Absent in
+    /// the document means unknown — degrade to "unknown", never assume.
+    #[serde(default)]
+    pub reasoning: Option<bool>,
+    /// Whether the model accepts tool definitions.
+    #[serde(default)]
+    pub tool_call: Option<bool>,
 }
 
 /// List pricing in USD per million tokens. All optional: free/local models
@@ -211,6 +222,8 @@ mod tests {
                     "family": "claude-sonnet",
                     "release_date": "2025-09-29",
                     "last_updated": "2025-09-29",
+                    "reasoning": true,
+                    "tool_call": true,
                     "limit": { "context": 1000000, "output": 64000 },
                     "cost": { "input": 3, "output": 15, "cache_read": 0.3, "cache_write": 3.75 }
                 },
@@ -244,6 +257,8 @@ mod tests {
         assert_eq!(cost.cache_write, Some(3.75));
         assert_eq!(sonnet.limit.unwrap().context, Some(1_000_000));
         assert_eq!(sonnet.release_date.as_deref(), Some("2025-09-29"));
+        assert_eq!(sonnet.reasoning, Some(true));
+        assert_eq!(sonnet.tool_call, Some(true));
         assert_eq!(anthropic.name.as_deref(), Some("Anthropic"));
     }
 
@@ -255,6 +270,8 @@ mod tests {
         assert_eq!(preview.id, "claude-free-preview");
         assert!(preview.cost.is_none());
         assert!(preview.limit.is_none());
+        assert_eq!(preview.reasoning, None, "absent capability stays unknown");
+        assert_eq!(preview.tool_call, None);
     }
 
     #[test]

--- a/stella-model/src/provider_listing.rs
+++ b/stella-model/src/provider_listing.rs
@@ -1,0 +1,595 @@
+//! Provider-native model discovery — "what does this provider's own API
+//! say it serves *right now*". The models.dev master list
+//! ([`crate::modelsdev`]) is broad but third-party: it can lag a release
+//! by days and its gateway coverage (OpenRouter especially) is a curated
+//! subset. Each provider's own `/models` endpoint is authoritative and
+//! instant, so `stella models refresh` (and the startup auto-sync) overlay
+//! it on top of the master list for every provider whose credential is
+//! configured.
+//!
+//! Four wire shapes cover every built-in provider:
+//! - **OpenRouter** — `GET {base}/models`, public. The richest listing:
+//!   per-token pricing strings, context/completion limits, and
+//!   `supported_parameters` (which is where per-model reasoning/tool
+//!   support comes from).
+//! - **Anthropic** — `GET {base}/v1/models`, `x-api-key` + versioned,
+//!   paginated via `after_id`/`has_more`. Ids and display names only.
+//! - **Gemini** — `GET {base}/models`, `x-goog-api-key`, paginated via
+//!   `pageToken`. Carries token limits, `thinking`, and the generation
+//!   methods used to filter out non-chat rows (embeddings, imagen, aqa).
+//! - **OpenAI-compatible** — `GET {base}/models`, bearer auth: OpenAI,
+//!   xAI, DeepSeek, Z.ai, local servers, custom gateways. Ids only.
+//!
+//! This module only fetches and parses (same division of labor as
+//! `modelsdev`); merging into the on-disk catalog belongs to `stella-cli`.
+//! Every function is best-effort by contract: a provider whose listing
+//! endpoint is down, missing (404 on a gateway that never implemented it),
+//! or shape-drifted returns an `Err(String)` the caller reports and moves
+//! past — discovery failure must never fail a refresh of OTHER providers,
+//! and never a turn.
+
+use crate::credential::ApiKey;
+use crate::http;
+
+/// One model as reported by its serving provider's own listing endpoint.
+/// Everything except the id is optional: most providers report far less
+/// than the master list knows, and a missing field must stay "unknown" so
+/// the catalog merge can keep the better value it already has.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProviderModel {
+    /// Provider-native slug, sent verbatim as a request's `model`.
+    pub id: String,
+    pub display_name: Option<String>,
+    pub context_window: Option<u64>,
+    pub max_output_tokens: Option<u64>,
+    /// USD per million tokens (the catalog's unit).
+    pub input_usd_per_mtok: Option<f64>,
+    pub output_usd_per_mtok: Option<f64>,
+    pub cached_input_usd_per_mtok: Option<f64>,
+    pub cache_write_usd_per_mtok: Option<f64>,
+    /// Whether the model supports reasoning / extended thinking — `None`
+    /// when the provider's listing doesn't say.
+    pub supports_reasoning: Option<bool>,
+    /// Whether the model accepts tool definitions.
+    pub supports_tools: Option<bool>,
+}
+
+/// GET `url` and hand back the body, with the provider's own error text on
+/// a non-success status. `headers` are (name, value) pairs — the auth
+/// vocabulary differs per provider and none of it may end up in the URL
+/// (query-string keys leak into logs and proxies).
+async fn get_json(label: &str, url: &str, headers: &[(&str, &str)]) -> Result<String, String> {
+    let client = http::client();
+    let mut request = client.get(url).header("Accept", "application/json");
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("could not reach {label}: {e}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("could not read the {label} response: {e}"))?;
+    if !status.is_success() {
+        let snippet: String = body.chars().take(200).collect();
+        return Err(format!("{label} answered HTTP {status}: {snippet}"));
+    }
+    Ok(body)
+}
+
+/// Hard cap on pagination rounds for the providers that page. Ten pages at
+/// the page sizes requested (≥100/page everywhere) is far beyond any real
+/// listing; the cap exists so a server echoing the same page token forever
+/// cannot spin the refresh.
+const MAX_PAGES: usize = 10;
+
+// ---------------------------------------------------------------------
+// OpenRouter
+// ---------------------------------------------------------------------
+
+/// A USD-per-TOKEN decimal string ("0.000003") → USD per million tokens.
+/// OpenRouter prices are strings, sometimes "-1" for dynamically-priced
+/// rows (the `openrouter/auto` meta-router) — negative means unknown.
+fn per_token_str_to_per_mtok(raw: Option<&serde_json::Value>) -> Option<f64> {
+    let value = raw?;
+    let per_token = match value {
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok()?,
+        serde_json::Value::Number(n) => n.as_f64()?,
+        _ => return None,
+    };
+    (per_token >= 0.0).then_some(per_token * 1_000_000.0)
+}
+
+/// Parse OpenRouter's `GET /models` document.
+pub fn parse_openrouter(body: &str) -> Result<Vec<ProviderModel>, String> {
+    let root: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| format!("OpenRouter model list is unparseable JSON: {e}"))?;
+    let Some(data) = root.get("data").and_then(|d| d.as_array()) else {
+        return Err("OpenRouter model list has no `data` array".to_string());
+    };
+    let mut models = Vec::new();
+    for row in data {
+        let Some(id) = row
+            .get("id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let pricing = row.get("pricing");
+        // `supported_parameters` is per-model ground truth: a model that
+        // lists `reasoning` thinks, one that lists `tools` accepts tool
+        // definitions — and one that lists neither genuinely supports
+        // neither (the field enumerates everything the model accepts).
+        let supported: Option<Vec<&str>> = row
+            .get("supported_parameters")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|p| p.as_str()).collect());
+        let (supports_reasoning, supports_tools) = match &supported {
+            Some(params) => (
+                Some(
+                    params
+                        .iter()
+                        .any(|p| *p == "reasoning" || *p == "include_reasoning"),
+                ),
+                Some(params.iter().any(|p| *p == "tools" || *p == "tool_choice")),
+            ),
+            None => (None, None),
+        };
+        models.push(ProviderModel {
+            id: id.to_string(),
+            display_name: row.get("name").and_then(|v| v.as_str()).map(str::to_string),
+            context_window: row.get("context_length").and_then(|v| v.as_u64()),
+            max_output_tokens: row
+                .get("top_provider")
+                .and_then(|t| t.get("max_completion_tokens"))
+                .and_then(|v| v.as_u64()),
+            input_usd_per_mtok: per_token_str_to_per_mtok(pricing.and_then(|p| p.get("prompt"))),
+            output_usd_per_mtok: per_token_str_to_per_mtok(
+                pricing.and_then(|p| p.get("completion")),
+            ),
+            cached_input_usd_per_mtok: per_token_str_to_per_mtok(
+                pricing.and_then(|p| p.get("input_cache_read")),
+            ),
+            cache_write_usd_per_mtok: per_token_str_to_per_mtok(
+                pricing.and_then(|p| p.get("input_cache_write")),
+            ),
+            supports_reasoning,
+            supports_tools,
+        });
+    }
+    if models.is_empty() {
+        return Err("OpenRouter model list contained no models — refusing an empty sync".into());
+    }
+    Ok(models)
+}
+
+/// Fetch OpenRouter's full live model list. The endpoint is public — no
+/// key required — but it is only ever called when the user has configured
+/// OpenRouter (key present), so discovery never phones a provider the
+/// user isn't using.
+pub async fn fetch_openrouter(base_url: &str) -> Result<Vec<ProviderModel>, String> {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let body = get_json("OpenRouter", &url, &[]).await?;
+    parse_openrouter(&body)
+}
+
+// ---------------------------------------------------------------------
+// Anthropic
+// ---------------------------------------------------------------------
+
+/// One page of Anthropic's `GET /v1/models`.
+fn parse_anthropic_page(body: &str) -> Result<(Vec<ProviderModel>, Option<String>), String> {
+    let root: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| format!("Anthropic model list is unparseable JSON: {e}"))?;
+    let Some(data) = root.get("data").and_then(|d| d.as_array()) else {
+        return Err("Anthropic model list has no `data` array".to_string());
+    };
+    let models = data
+        .iter()
+        .filter_map(|row| {
+            let id = row
+                .get("id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())?;
+            Some(ProviderModel {
+                id: id.to_string(),
+                display_name: row
+                    .get("display_name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                ..ProviderModel::default()
+            })
+        })
+        .collect();
+    let next = (root.get("has_more").and_then(|v| v.as_bool()) == Some(true))
+        .then(|| {
+            root.get("last_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .flatten();
+    Ok((models, next))
+}
+
+/// Fetch every model the Anthropic API serves this key. Ids and display
+/// names only — the API's listing carries no pricing or capability data,
+/// so the catalog merge keeps whatever the master list already knows.
+pub async fn fetch_anthropic(
+    base_url: &str,
+    api_key: &ApiKey,
+) -> Result<Vec<ProviderModel>, String> {
+    let base = base_url.trim_end_matches('/');
+    let mut models = Vec::new();
+    let mut after: Option<String> = None;
+    for _ in 0..MAX_PAGES {
+        let url = match &after {
+            Some(id) => format!("{base}/v1/models?limit=1000&after_id={id}"),
+            None => format!("{base}/v1/models?limit=1000"),
+        };
+        let body = get_json(
+            "Anthropic",
+            &url,
+            &[
+                ("x-api-key", api_key.reveal()),
+                ("anthropic-version", "2023-06-01"),
+            ],
+        )
+        .await?;
+        let (mut page, next) = parse_anthropic_page(&body)?;
+        models.append(&mut page);
+        match next {
+            Some(id) => after = Some(id),
+            None => break,
+        }
+    }
+    if models.is_empty() {
+        return Err("Anthropic model list contained no models — refusing an empty sync".into());
+    }
+    Ok(models)
+}
+
+// ---------------------------------------------------------------------
+// Gemini
+// ---------------------------------------------------------------------
+
+/// One page of Gemini's `GET /models` (the `ListModels` surface). Rows
+/// that can't serve chat (`generateContent` absent from
+/// `supportedGenerationMethods`: embeddings, imagen, aqa) are dropped —
+/// they would be unusable-but-selectable, the exact bug this module fixes.
+fn parse_gemini_page(body: &str) -> Result<(Vec<ProviderModel>, Option<String>), String> {
+    let root: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| format!("Gemini model list is unparseable JSON: {e}"))?;
+    let Some(rows) = root.get("models").and_then(|d| d.as_array()) else {
+        return Err("Gemini model list has no `models` array".to_string());
+    };
+    let models = rows
+        .iter()
+        .filter_map(|row| {
+            let name = row.get("name").and_then(|v| v.as_str())?;
+            let id = name.strip_prefix("models/").unwrap_or(name);
+            if id.is_empty() {
+                return None;
+            }
+            let methods: Vec<&str> = row
+                .get("supportedGenerationMethods")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|m| m.as_str()).collect())
+                .unwrap_or_default();
+            if !methods.contains(&"generateContent") {
+                return None;
+            }
+            Some(ProviderModel {
+                id: id.to_string(),
+                display_name: row
+                    .get("displayName")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                context_window: row.get("inputTokenLimit").and_then(|v| v.as_u64()),
+                max_output_tokens: row.get("outputTokenLimit").and_then(|v| v.as_u64()),
+                // The listing's `thinking` flag (present on 2.5+ era rows);
+                // absent means unknown, not "no".
+                supports_reasoning: row.get("thinking").and_then(|v| v.as_bool()),
+                ..ProviderModel::default()
+            })
+        })
+        .collect();
+    let next = root
+        .get("nextPageToken")
+        .and_then(|v| v.as_str())
+        .filter(|t| !t.is_empty())
+        .map(str::to_string);
+    Ok((models, next))
+}
+
+/// Fetch every chat-capable model the Gemini API serves this key.
+pub async fn fetch_gemini(base_url: &str, api_key: &ApiKey) -> Result<Vec<ProviderModel>, String> {
+    let base = base_url.trim_end_matches('/');
+    let mut models: Vec<ProviderModel> = Vec::new();
+    let mut token: Option<String> = None;
+    for _ in 0..MAX_PAGES {
+        let url = match &token {
+            Some(t) => format!("{base}/models?pageSize=1000&pageToken={t}"),
+            None => format!("{base}/models?pageSize=1000"),
+        };
+        let body = get_json("Gemini", &url, &[("x-goog-api-key", api_key.reveal())]).await?;
+        let (mut page, next) = parse_gemini_page(&body)?;
+        models.append(&mut page);
+        match next {
+            Some(t) => token = Some(t),
+            None => break,
+        }
+    }
+    if models.is_empty() {
+        return Err("Gemini model list contained no chat models — refusing an empty sync".into());
+    }
+    Ok(models)
+}
+
+// ---------------------------------------------------------------------
+// OpenAI-compatible (OpenAI, xAI, DeepSeek, Z.ai, local, custom gateways)
+// ---------------------------------------------------------------------
+
+/// Parse the OpenAI-shape `GET /models` document: `{"data": [{"id": …}]}`.
+pub fn parse_openai_compatible(label: &str, body: &str) -> Result<Vec<ProviderModel>, String> {
+    let root: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| format!("{label} model list is unparseable JSON: {e}"))?;
+    let Some(data) = root.get("data").and_then(|d| d.as_array()) else {
+        return Err(format!("{label} model list has no `data` array"));
+    };
+    let models: Vec<ProviderModel> = data
+        .iter()
+        .filter_map(|row| {
+            let id = row
+                .get("id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())?;
+            Some(ProviderModel {
+                id: id.to_string(),
+                display_name: row
+                    .get("display_name")
+                    .or_else(|| row.get("name"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                context_window: row.get("context_length").and_then(|v| v.as_u64()),
+                ..ProviderModel::default()
+            })
+        })
+        .collect();
+    if models.is_empty() {
+        return Err(format!(
+            "{label} model list contained no models — refusing an empty sync"
+        ));
+    }
+    Ok(models)
+}
+
+/// Fetch the model list from any OpenAI-compatible endpoint. `label` names
+/// the provider in error messages.
+pub async fn fetch_openai_compatible(
+    label: &str,
+    base_url: &str,
+    api_key: &ApiKey,
+) -> Result<Vec<ProviderModel>, String> {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let auth = format!("Bearer {}", api_key.reveal());
+    let body = get_json(label, &url, &[("Authorization", auth.as_str())]).await?;
+    parse_openai_compatible(label, &body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OPENROUTER_FIXTURE: &str = r#"{
+        "data": [
+            {
+                "id": "anthropic/claude-sonnet-4.5",
+                "name": "Anthropic: Claude Sonnet 4.5",
+                "context_length": 1000000,
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "input_cache_read": "0.0000003",
+                    "input_cache_write": "0.00000375"
+                },
+                "top_provider": { "max_completion_tokens": 64000 },
+                "supported_parameters": ["tools", "tool_choice", "reasoning", "max_tokens"]
+            },
+            {
+                "id": "mistralai/mistral-7b-instruct",
+                "name": "Mistral 7B Instruct",
+                "context_length": 32768,
+                "pricing": { "prompt": "0.00000006", "completion": "0.00000006" },
+                "supported_parameters": ["max_tokens", "temperature"]
+            },
+            {
+                "id": "openrouter/auto",
+                "name": "Auto Router",
+                "pricing": { "prompt": "-1", "completion": "-1" }
+            },
+            { "name": "row with no id is skipped" }
+        ]
+    }"#;
+
+    #[test]
+    fn openrouter_parses_pricing_limits_and_capability_parameters() {
+        let models = parse_openrouter(OPENROUTER_FIXTURE).expect("fixture parses");
+        assert_eq!(models.len(), 3);
+        let sonnet = &models[0];
+        assert_eq!(sonnet.id, "anthropic/claude-sonnet-4.5");
+        // Per-token strings scaled to the catalog's USD-per-Mtok unit.
+        assert_eq!(sonnet.input_usd_per_mtok, Some(3.0));
+        assert_eq!(sonnet.output_usd_per_mtok, Some(15.0));
+        assert_eq!(sonnet.cached_input_usd_per_mtok, Some(0.3));
+        assert_eq!(sonnet.cache_write_usd_per_mtok, Some(3.75));
+        assert_eq!(sonnet.context_window, Some(1_000_000));
+        assert_eq!(sonnet.max_output_tokens, Some(64_000));
+        assert_eq!(sonnet.supports_reasoning, Some(true));
+        assert_eq!(sonnet.supports_tools, Some(true));
+
+        // supported_parameters present without reasoning/tools → hard "no",
+        // which is what lets the effort picker exclude these models.
+        let mistral = &models[1];
+        assert_eq!(mistral.supports_reasoning, Some(false));
+        assert_eq!(mistral.supports_tools, Some(false));
+
+        // Dynamic pricing ("-1") and no supported_parameters → unknown.
+        let auto = &models[2];
+        assert_eq!(auto.input_usd_per_mtok, None);
+        assert_eq!(auto.supports_reasoning, None);
+    }
+
+    #[test]
+    fn openrouter_rejects_shapes_that_are_not_the_model_list() {
+        assert!(parse_openrouter("{}").is_err());
+        assert!(parse_openrouter(r#"{"data": []}"#).is_err());
+        assert!(parse_openrouter("not json").is_err());
+    }
+
+    #[test]
+    fn anthropic_page_parses_ids_and_pagination_cursor() {
+        let body = r#"{
+            "data": [
+                {"type": "model", "id": "claude-fable-5", "display_name": "Claude Fable 5"},
+                {"type": "model", "id": "claude-haiku-4-5-20251001"}
+            ],
+            "has_more": true,
+            "last_id": "claude-haiku-4-5-20251001"
+        }"#;
+        let (models, next) = parse_anthropic_page(body).expect("page parses");
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "claude-fable-5");
+        assert_eq!(models[0].display_name.as_deref(), Some("Claude Fable 5"));
+        // The listing carries no capability/pricing data — stays unknown.
+        assert_eq!(models[0].supports_reasoning, None);
+        assert_eq!(next.as_deref(), Some("claude-haiku-4-5-20251001"));
+
+        let (_, done) =
+            parse_anthropic_page(r#"{"data": [{"id": "m"}], "has_more": false}"#).expect("parses");
+        assert_eq!(done, None);
+    }
+
+    #[test]
+    fn gemini_page_keeps_chat_models_and_drops_the_rest() {
+        let body = r#"{
+            "models": [
+                {
+                    "name": "models/gemini-3-pro",
+                    "displayName": "Gemini 3 Pro",
+                    "inputTokenLimit": 1000000,
+                    "outputTokenLimit": 65536,
+                    "thinking": true,
+                    "supportedGenerationMethods": ["generateContent", "countTokens"]
+                },
+                {
+                    "name": "models/text-embedding-004",
+                    "supportedGenerationMethods": ["embedContent"]
+                },
+                {
+                    "name": "models/gemini-2.0-flash-lite",
+                    "supportedGenerationMethods": ["generateContent"]
+                }
+            ],
+            "nextPageToken": "tok-2"
+        }"#;
+        let (models, next) = parse_gemini_page(body).expect("page parses");
+        assert_eq!(models.len(), 2, "embedding row is dropped");
+        assert_eq!(models[0].id, "gemini-3-pro", "models/ prefix stripped");
+        assert_eq!(models[0].context_window, Some(1_000_000));
+        assert_eq!(models[0].max_output_tokens, Some(65_536));
+        assert_eq!(models[0].supports_reasoning, Some(true));
+        assert_eq!(
+            models[1].supports_reasoning, None,
+            "no thinking flag → unknown"
+        );
+        assert_eq!(next.as_deref(), Some("tok-2"));
+    }
+
+    #[test]
+    fn openai_compatible_parses_bare_id_lists() {
+        let body = r#"{"object": "list", "data": [
+            {"id": "gpt-5.5", "object": "model", "owned_by": "openai"},
+            {"id": "grok-4"},
+            {"id": ""}
+        ]}"#;
+        let models = parse_openai_compatible("OpenAI", body).expect("parses");
+        assert_eq!(models.len(), 2, "empty id dropped");
+        assert_eq!(models[0].id, "gpt-5.5");
+        assert_eq!(models[0].supports_reasoning, None);
+        assert!(parse_openai_compatible("OpenAI", r#"{"data": []}"#).is_err());
+        assert!(parse_openai_compatible("OpenAI", r#"{"models": []}"#).is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_openrouter_hits_the_models_route_and_parses() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(OPENROUTER_FIXTURE))
+            .mount(&server)
+            .await;
+        let models = fetch_openrouter(&format!("{}/api/v1", server.uri()))
+            .await
+            .expect("fetches");
+        assert_eq!(models.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn fetch_anthropic_paginates_with_after_id_and_sends_auth_headers() {
+        use wiremock::matchers::{header, method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("x-api-key", "sk-test"))
+            .and(header("anthropic-version", "2023-06-01"))
+            .and(query_param("after_id", "claude-a"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"data": [{"id": "claude-b"}], "has_more": false}"#),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("x-api-key", "sk-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"data": [{"id": "claude-a"}], "has_more": true, "last_id": "claude-a"}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let models = fetch_anthropic(&server.uri(), &ApiKey::new("sk-test"))
+            .await
+            .expect("fetches both pages");
+        let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["claude-a", "claude-b"]);
+    }
+
+    #[tokio::test]
+    async fn fetch_surfaces_http_errors_with_the_provider_named() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(401).set_body_string(r#"{"error": "bad key"}"#))
+            .mount(&server)
+            .await;
+        let err = fetch_openai_compatible("xAI", &server.uri(), &ApiKey::new("k"))
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("xAI") && err.contains("401"),
+            "named error: {err}"
+        );
+    }
+}

--- a/stella-store/src/catalog.rs
+++ b/stella-store/src/catalog.rs
@@ -95,6 +95,34 @@ CREATE TABLE IF NOT EXISTS catalog_sync (
 );
 ";
 
+/// Columns added after the first shipped schema. `CREATE TABLE IF NOT
+/// EXISTS` never grows an existing table, so each (table, column, type)
+/// here is applied with `ALTER TABLE … ADD COLUMN` when missing — the
+/// SQLite-idiomatic in-place migration (nullable columns only, so old rows
+/// stay valid and old binaries reading a new db just ignore the extras).
+const CATALOG_MIGRATIONS: &[(&str, &str, &str)] = &[
+    // Capability flags (0/1, NULL = unknown): whether the model can think
+    // (reasoning/extended thinking) and whether it accepts tool definitions.
+    // Synced from models.dev and from provider-native /models endpoints.
+    ("model_card_versions", "supports_reasoning", "INTEGER"),
+    ("model_card_versions", "supports_tools", "INTEGER"),
+];
+
+/// Apply [`CATALOG_MIGRATIONS`] to an open connection.
+fn migrate(conn: &Connection) -> Result<()> {
+    for (table, column, ty) in CATALOG_MIGRATIONS {
+        let present: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name = ?2",
+            params![table, column],
+            |row| row.get(0),
+        )?;
+        if present == 0 {
+            conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {ty}"))?;
+        }
+    }
+    Ok(())
+}
+
 /// One pricing configuration — the payload of a model-card version. All
 /// fields optional: the master list legitimately omits pricing for free or
 /// gateway-priced models, and an unknown price must stay unknown (a `0.0`
@@ -109,6 +137,12 @@ pub struct VersionData {
     pub max_output_tokens: Option<u64>,
     pub release_date: Option<String>,
     pub last_updated: Option<String>,
+    /// Whether the model supports reasoning / extended thinking. `None` is
+    /// "unknown" and must stay `None` — an unknown capability degrades to
+    /// today's permissive behavior, never to a hard "no".
+    pub supports_reasoning: Option<bool>,
+    /// Whether the model accepts tool definitions.
+    pub supports_tools: Option<bool>,
 }
 
 impl VersionData {
@@ -117,7 +151,7 @@ impl VersionData {
     /// pricing configuration and token limits — NOT display metadata, so a
     /// renamed model doesn't fabricate a pricing-history entry.
     pub fn content_hash(&self) -> String {
-        fnv_hex(&format!(
+        let mut key = format!(
             "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}",
             self.input_usd_per_mtok,
             self.output_usd_per_mtok,
@@ -125,7 +159,17 @@ impl VersionData {
             self.cache_write_usd_per_mtok,
             self.context_window,
             self.max_output_tokens,
-        ))
+        );
+        // Capabilities join the hash only when known, so every version
+        // stored before the columns existed keeps its historical hash and a
+        // re-sync of unchanged capability-less data appends nothing.
+        if self.supports_reasoning.is_some() || self.supports_tools.is_some() {
+            key.push_str(&format!(
+                "|{:?}|{:?}",
+                self.supports_reasoning, self.supports_tools
+            ));
+        }
+        fnv_hex(&key)
     }
 }
 
@@ -231,6 +275,7 @@ impl CatalogStore {
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.execute_batch(CATALOG_SCHEMA)?;
+        migrate(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -324,8 +369,9 @@ impl CatalogStore {
                     "INSERT INTO model_card_versions
                          (model_card_id, version, input_usd_per_mtok, output_usd_per_mtok,
                           cached_input_usd_per_mtok, cache_write_usd_per_mtok, context_window,
-                          max_output_tokens, release_date, last_updated, source, content_hash)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                          max_output_tokens, release_date, last_updated, source, content_hash,
+                          supports_reasoning, supports_tools)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                     params![
                         card_id,
                         next,
@@ -338,7 +384,9 @@ impl CatalogStore {
                         model.version.release_date,
                         model.version.last_updated,
                         model.source,
-                        new_hash
+                        new_hash,
+                        model.version.supports_reasoning,
+                        model.version.supports_tools
                     ],
                 )?;
                 counts.versions_added += 1;
@@ -450,7 +498,8 @@ impl CatalogStore {
                         COALESCE(v.version, 0),
                         v.input_usd_per_mtok, v.output_usd_per_mtok,
                         v.cached_input_usd_per_mtok, v.cache_write_usd_per_mtok,
-                        v.context_window, v.max_output_tokens, v.release_date, v.last_updated
+                        v.context_window, v.max_output_tokens, v.release_date, v.last_updated,
+                        v.supports_reasoning, v.supports_tools
                  FROM model_aliases a
                  JOIN model_cards c ON c.id = a.model_card_id
                  LEFT JOIN model_card_versions v ON v.model_card_id = c.id
@@ -478,6 +527,8 @@ impl CatalogStore {
                             max_output_tokens: row.get::<_, Option<i64>>(14)?.map(|v| v as u64),
                             release_date: row.get(15)?,
                             last_updated: row.get(16)?,
+                            supports_reasoning: row.get(17)?,
+                            supports_tools: row.get(18)?,
                         },
                     })
                 },
@@ -515,7 +566,8 @@ impl CatalogStore {
                           c.source, COALESCE(v.version, 0),
                           v.input_usd_per_mtok, v.output_usd_per_mtok,
                           v.cached_input_usd_per_mtok, v.cache_write_usd_per_mtok,
-                          v.context_window, v.max_output_tokens, v.release_date, v.last_updated
+                          v.context_window, v.max_output_tokens, v.release_date, v.last_updated,
+                          v.supports_reasoning, v.supports_tools
                    FROM model_cards c
                    LEFT JOIN model_card_versions v ON v.model_card_id = c.id
                         AND v.version = (SELECT MAX(version) FROM model_card_versions
@@ -541,6 +593,8 @@ impl CatalogStore {
                     max_output_tokens: row.get::<_, Option<i64>>(12)?.map(|v| v as u64),
                     release_date: row.get(13)?,
                     last_updated: row.get(14)?,
+                    supports_reasoning: row.get(15)?,
+                    supports_tools: row.get(16)?,
                 },
             })
         })?;
@@ -631,6 +685,8 @@ mod tests {
                 max_output_tokens: Some(64_000),
                 release_date: Some("2025-09-29".to_string()),
                 last_updated: Some("2025-09-29".to_string()),
+                supports_reasoning: Some(true),
+                supports_tools: Some(true),
             },
             aliases: vec![
                 AliasForm {
@@ -824,5 +880,79 @@ mod tests {
         assert_eq!(cards, 1);
         assert_eq!(versions, 2);
         assert_eq!(aliases, 3);
+    }
+
+    #[test]
+    fn capabilities_roundtrip_and_only_hash_when_known() {
+        let (_dir, store) = store();
+        store.apply_batch(&[sonnet_upsert()]).expect("apply");
+        let resolved = store
+            .resolve("anthropic", "claude-sonnet-4-5")
+            .unwrap()
+            .expect("hit");
+        assert_eq!(resolved.pricing.supports_reasoning, Some(true));
+        assert_eq!(resolved.pricing.supports_tools, Some(true));
+        let listing = &store.models_for_provider(Some("anthropic")).unwrap()[0];
+        assert_eq!(listing.pricing.supports_reasoning, Some(true));
+
+        // Unknown capabilities hash exactly like the pre-column format —
+        // a re-sync of capability-less data must not append a version.
+        let mut without = sonnet_upsert().version;
+        without.supports_reasoning = None;
+        without.supports_tools = None;
+        let legacy_hash = fnv_hex(&format!(
+            "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}",
+            without.input_usd_per_mtok,
+            without.output_usd_per_mtok,
+            without.cached_input_usd_per_mtok,
+            without.cache_write_usd_per_mtok,
+            without.context_window,
+            without.max_output_tokens,
+        ));
+        assert_eq!(without.content_hash(), legacy_hash);
+        assert_ne!(sonnet_upsert().version.content_hash(), legacy_hash);
+
+        // Capability data arriving for a previously capability-less card IS
+        // a real change: one new version.
+        let mut gained = sonnet_upsert();
+        gained.version.supports_reasoning = Some(false);
+        let counts = store.apply_batch(&[gained]).expect("capability change");
+        assert_eq!(counts.versions_added, 1);
+    }
+
+    #[test]
+    fn open_migrates_a_pre_capability_database_in_place() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("catalog.db");
+        {
+            // A database created by an older binary: base schema only (the
+            // CATALOG_SCHEMA string IS the original shape; columns arrive
+            // via `migrate`), with one card + version already stored.
+            let conn = Connection::open(&path).expect("raw open");
+            conn.execute_batch(CATALOG_SCHEMA).expect("old schema");
+            conn.execute_batch(
+                "INSERT INTO model_cards
+                     (api_provider, model_provider, slug, source)
+                 VALUES ('anthropic', 'anthropic', 'claude-old', 'models.dev');
+                 INSERT INTO model_card_versions
+                     (model_card_id, version, input_usd_per_mtok, source, content_hash)
+                 VALUES (1, 1, 3.0, 'models.dev', 'h');
+                 INSERT INTO model_aliases
+                     (alias, api_provider, model_provider, model_card_id, source)
+                 VALUES ('claude-old', 'anthropic', 'anthropic', 1, 'catalog');",
+            )
+            .expect("old rows");
+        }
+        let store = CatalogStore::open(&path).expect("open migrates");
+        let resolved = store
+            .resolve("anthropic", "claude-old")
+            .expect("resolve works post-migration")
+            .expect("row survived");
+        assert_eq!(resolved.pricing.input_usd_per_mtok, Some(3.0));
+        assert_eq!(resolved.pricing.supports_reasoning, None);
+        assert_eq!(resolved.pricing.supports_tools, None);
+        // Re-open: the migration is idempotent.
+        drop(store);
+        CatalogStore::open(&path).expect("second open is clean");
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -763,9 +763,17 @@ pub struct EngineConfigState {
     pub allowed_models: Vec<String>,
     /// Every configured provider id, for the provider picker.
     pub providers: Vec<String>,
-    /// `provider/slug` strings from the seed catalog — the picker's
-    /// fallback vocabulary when `allowed_models` is empty.
+    /// `provider/slug` strings from the catalog, scoped by the driver to
+    /// providers with a usable credential — the picker's fallback
+    /// vocabulary when `allowed_models` is empty.
     pub catalog_models: Vec<String>,
+    /// Per-model effort vocabularies, keyed by the same `provider/slug`
+    /// strings (plus any `allowed_models` spec): the effort levels this
+    /// model, as served by this provider, can actually act on. An empty
+    /// list means effort is not a knob for that model (no reasoning
+    /// support, or an on/off-only thinking switch); a model absent from
+    /// the map is unknown and keeps the full vocabulary.
+    pub model_efforts: std::collections::HashMap<String, Vec<String>>,
     /// Exactly one entry per [`EngineRole::ALL`] slot, in that order.
     pub agents: Vec<EngineAgentState>,
 }

--- a/stella-tui/src/views/engine.rs
+++ b/stella-tui/src/views/engine.rs
@@ -41,8 +41,53 @@ use crate::render::scroll_window_start;
 use crate::theme;
 
 /// The legal `effort` values, in cycle order (⏎ walks them, then wraps to
-/// "provider default").
+/// "provider default"). This is the FULL vocabulary — the fallback when
+/// the selected model's own levels are unknown; [`effort_values_for`]
+/// narrows it to what the model/provider pair actually supports.
 const EFFORT_VALUES: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
+
+/// The effort levels `role`'s currently-selected model can act on, from
+/// the driver-computed `model_efforts` map. Lookup tries the model string
+/// verbatim (the picker writes `provider/slug`), then provider-qualified,
+/// then any provider serving that bare slug. Unknown models keep the full
+/// vocabulary — unknown must never restrict. `Some(vec![])` means effort
+/// is genuinely not a knob for this model.
+fn effort_values_for(state: &EngineConfigState, role: EngineRole) -> Vec<String> {
+    let full = || EFFORT_VALUES.iter().map(|s| s.to_string()).collect();
+    let Some(agent) = state.agent(role) else {
+        return full();
+    };
+    let Some(model) = agent
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+    else {
+        return full();
+    };
+    let qualified = agent
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(|p| format!("{p}/{model}"));
+    let suffix = format!("/{model}");
+    let hit = state
+        .model_efforts
+        .get(model)
+        .or_else(|| qualified.as_ref().and_then(|q| state.model_efforts.get(q)))
+        .or_else(|| {
+            state
+                .model_efforts
+                .iter()
+                .find(|(spec, _)| spec.ends_with(&suffix))
+                .map(|(_, levels)| levels)
+        });
+    match hit {
+        Some(levels) => levels.clone(),
+        None => full(),
+    }
+}
 /// The legal `verbosity` values.
 const VERBOSITY_VALUES: [&str; 3] = ["low", "medium", "high"];
 /// The legal `service_tier` values.
@@ -616,11 +661,32 @@ fn activate_row(ui: &mut DeckUi, via_space: bool) -> DeckAction {
                     if via_space {
                         return DeckAction::Handled;
                     }
-                    let values: &[&str] = match field {
-                        AgentField::Effort => &EFFORT_VALUES,
-                        AgentField::Verbosity => &VERBOSITY_VALUES,
-                        _ => &SERVICE_TIER_VALUES,
+                    let owned_values: Vec<String> = match field {
+                        // Model-aware: only the levels this agent's selected
+                        // model (as served by its provider) can act on.
+                        AgentField::Effort => {
+                            let state = ui.engine.state.as_ref().expect("guarded above");
+                            effort_values_for(state, role)
+                        }
+                        AgentField::Verbosity => {
+                            VERBOSITY_VALUES.iter().map(|s| s.to_string()).collect()
+                        }
+                        _ => SERVICE_TIER_VALUES.iter().map(|s| s.to_string()).collect(),
                     };
+                    if owned_values.is_empty() {
+                        // Effort on a model with no reasoning: explain
+                        // instead of a keypress that visibly does nothing,
+                        // and drop any stale level so a save can't carry it.
+                        let state = ui.engine.state.as_mut().expect("guarded above");
+                        if let Some(agent) = agent_mut(state, role) {
+                            agent.effort = None;
+                        }
+                        ui.engine.status = Some(
+                            "this model does not support reasoning — effort does not apply".into(),
+                        );
+                        return DeckAction::Handled;
+                    }
+                    let values: Vec<&str> = owned_values.iter().map(String::as_str).collect();
                     let state = ui.engine.state.as_mut().expect("guarded above");
                     if let Some(agent) = agent_mut(state, role) {
                         let slot = match field {
@@ -628,7 +694,7 @@ fn activate_row(ui: &mut DeckUi, via_space: bool) -> DeckAction {
                             AgentField::Verbosity => &mut agent.verbosity,
                             _ => &mut agent.service_tier,
                         };
-                        cycle_enum(slot, values);
+                        cycle_enum(slot, &values);
                     }
                 }
                 AgentField::Provider => {
@@ -1197,6 +1263,7 @@ mod tests {
             allowed_models: vec!["anthropic/claude-fable-5".into(), "openai/gpt-6".into()],
             providers: vec!["anthropic".into(), "openrouter".into()],
             catalog_models: vec!["zai/glm-5".into()],
+            model_efforts: Default::default(),
             agents: vec![EngineAgentState::default(); 4],
         }
     }
@@ -1211,6 +1278,84 @@ mod tests {
         ui.engine.state = Some(sample_state());
         ui.engine.pristine = Some(sample_state());
         (model, ui)
+    }
+
+    #[test]
+    fn effort_vocabulary_follows_the_selected_model() {
+        let mut state = sample_state();
+        state.model_efforts.insert(
+            "anthropic/claude-fable-5".into(),
+            vec![
+                "low".into(),
+                "medium".into(),
+                "high".into(),
+                "xhigh".into(),
+                "max".into(),
+            ],
+        );
+        state
+            .model_efforts
+            .insert("openrouter/mistralai/mistral-7b-instruct".into(), vec![]);
+        state.model_efforts.insert(
+            "gemini/gemini-3-pro".into(),
+            vec!["low".into(), "high".into()],
+        );
+
+        // Picker-written qualified spec → exact hit.
+        state.agents[0].model = Some("anthropic/claude-fable-5".into());
+        assert_eq!(effort_values_for(&state, EngineRole::Default).len(), 5);
+
+        // A confirmed no-reasoning model → no levels at all.
+        state.agents[0].model = Some("openrouter/mistralai/mistral-7b-instruct".into());
+        assert!(effort_values_for(&state, EngineRole::Default).is_empty());
+
+        // Provider pin + bare slug → provider-qualified lookup.
+        state.agents[0].provider = Some("gemini".into());
+        state.agents[0].model = Some("gemini-3-pro".into());
+        assert_eq!(
+            effort_values_for(&state, EngineRole::Default),
+            vec!["low".to_string(), "high".to_string()]
+        );
+
+        // Unknown model (or no model at all) keeps the full vocabulary —
+        // unknown never restricts.
+        state.agents[0].provider = None;
+        state.agents[0].model = Some("something-new".into());
+        assert_eq!(effort_values_for(&state, EngineRole::Default).len(), 5);
+        state.agents[0].model = None;
+        assert_eq!(effort_values_for(&state, EngineRole::Default).len(), 5);
+    }
+
+    #[test]
+    fn cycling_effort_on_a_non_reasoning_model_clears_and_explains() {
+        let (_model, mut ui) = open_ui();
+        let mut state = sample_state();
+        state
+            .model_efforts
+            .insert("openrouter/mistralai/mistral-7b-instruct".into(), vec![]);
+        state.agents[0].model = Some("openrouter/mistralai/mistral-7b-instruct".into());
+        state.agents[0].effort = Some("xhigh".into()); // stale — model can't
+        ui.engine.state = Some(state.clone());
+        ui.engine.pristine = Some(state);
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        // Row index of the Effort field on the agent tab.
+        ui.engine.row = AgentField::ALL
+            .iter()
+            .position(|f| *f == AgentField::Effort)
+            .expect("effort row exists");
+
+        let action = handle_engine_key(key(KeyCode::Enter), &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        let agent = &ui.engine.state.as_ref().unwrap().agents[0];
+        assert_eq!(agent.effort, None, "stale effort was dropped, not cycled");
+        assert!(
+            ui.engine
+                .status
+                .as_deref()
+                .is_some_and(|s| s.contains("does not support reasoning")),
+            "status explains why nothing cycled: {:?}",
+            ui.engine.status
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Two coupled problems in model selection:

1. **The selectable-model list was a 9-row compile-time seed.** Real releases were unpickable, and models a provider doesn't serve were still selectable — you could pick a model your provider rejects.
2. **The effort picker offered all five tiers for every model,** regardless of what the provider/model actually supports (a non-reasoning model, or a provider whose thinking control is on/off, not tiered).

## What this does

**Per-provider live discovery (BYOK-clean auto-sync).** New `stella-model/src/provider_listing.rs` fetches each provider's *own* `/models` endpoint:
- **OpenRouter** — pricing + `supported_parameters` (→ per-model reasoning/tool capability)
- **Anthropic** — paginated `/v1/models`
- **Gemini** — `ListModels`, chat-capable rows only (drops embeddings/imagen)
- **OpenAI-compatible** — OpenAI, xAI, DeepSeek, Z.ai, local, custom gateways

`bootstrap` auto-syncs these on startup when stale, **including first run** — this is what surfaces new releases as they ship, with no manual step. With `OPENROUTER_API_KEY` set you now get all ~338 OpenRouter models *with pricing and capabilities* automatically.

**No-phone-home guarantee preserved.** Native listings are traffic to the provider you already keyed — BYOK-clean. The **models.dev master list is a third party**, so (unchanged) it only auto-refreshes after your explicit first `stella models refresh`; a fresh install never contacts it on its own. `stella models refresh` pulls both. `STELLA_CATALOG_AUTO_REFRESH=0` disables all implicit fetching; zero-config installs fetch nothing.

**Credential scoping.** The deck's model picker and `stella models list` are scoped to providers whose credential resolves (plus the session's active one). Unset the key → the models disappear. `stella models list --all` lifts the scope.

**Capability-aware effort.** `effort_levels` intersects the model's reasoning capability with the provider's wire vocabulary:

| provider dialect | effort levels |
|---|---|
| Anthropic / Bedrock | low, medium, high, xhigh, max |
| Gemini / Vertex | low, high |
| OpenAI (Responses/compatible) | low, medium, high |
| GLM (Z.ai) | none — on/off switch, not tiered |
| confirmed non-reasoning model | none |

The TUI effort row follows the selected model; the request path drops `effort`/`reasoning` for confirmed non-reasoning models. **Unknown capability never restricts** — the provider stays the authority.

## Schema

Capability columns (`supports_reasoning`, `supports_tools`) added to `model_card_versions` via an in-place `ALTER TABLE` migration — nullable, idempotent, and old binaries reading a new DB just ignore them. The capability hash only participates when a value is known, so re-syncing capability-less data appends no version.

## Verification

- Live **OpenRouter** refresh: 338 models synced, including one models.dev didn't yet have.
- Live **Z.ai** native fetch via the OpenAI-compatible path.
- Scope reduction confirmed end-to-end: `OPENROUTER_API_KEY` → OpenRouter models; swap to `ANTHROPIC_API_KEY` → Anthropic models only.
- Fresh-install check: `catalog_sync` holds only `provider:*` rows, zero `models.dev` — no phone-home.
- 2142 tests pass, clippy clean across the workspace.

## Reviewer notes

- **First-run / daily latency:** `bootstrap` runs the sync synchronously (`block_on`), so the first run (and once daily thereafter) does one round-trip per configured provider before the turn starts. Bounded by the 10s connect timeout; the common single-key case is one request to the same host the turn calls next. Could be made non-blocking in a follow-up if it proves annoying.
- **Honest degradation:** Anthropic's `/v1/models` carries no pricing/capability, so on a fresh install those rows show `-` pricing / unknown reasoning until an explicit `stella models refresh` overlays models.dev (the seed still fully covers `claude-fable-5`). OpenRouter's listing is rich, so it needs no refresh.
