### PR TITLE
feat(pipeline): best-of-N candidates get the session's custom tools, …

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -1056,6 +1056,10 @@ pub(crate) struct WorkspacePorts {
 /// Build the [`WorkspacePorts`] bundle rooted at `root` (the session
 /// workspace, or a fleet worker's own worktree).
 pub(crate) fn workspace_ports(root: std::path::PathBuf, cfg: &Config) -> WorkspacePorts {
+    // The candidate registry mirrors the session's custom tool surface —
+    // discovered from the same root, so a candidate sees exactly the custom
+    // tools the session does (re-rooted at its snapshot at create time).
+    let custom_tools = stella_tools::custom::discover(&root).tools;
     WorkspacePorts {
         repo_structure: GitRepoStructure { root: root.clone() },
         repo_status: GitRepoStatus { root: root.clone() },
@@ -1063,6 +1067,7 @@ pub(crate) fn workspace_ports(root: std::path::PathBuf, cfg: &Config) -> Workspa
         candidate_workspaces: crate::candidate_ws::GitCandidateWorkspaces::new(
             root,
             registry_options(cfg),
+            custom_tools,
         ),
     }
 }

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -26,28 +26,37 @@
 //!
 //! # What a candidate's engine can reach
 //!
-//! Candidates drive a fresh built-in [`ToolRegistry`] rooted at the
-//! snapshot (with the session's workspace rules and schema gate applied).
-//! MCP servers, custom script tools, and the interactive/discovery layers
-//! are deliberately NOT re-wired into candidates: they were spawned against
-//! the real workspace, so routing them into a candidate would leak its edits
-//! straight into the tree isolation exists to protect.
-//! TODO(best-of-n-tool-surface): grow the candidate tool surface — custom
-//! script tools re-rooted at the snapshot are straightforward; MCP needs
-//! per-candidate server sessions (or a cwd-forwarding protocol extension)
-//! before it can be offered safely.
+//! Candidates drive the built-in [`ToolRegistry`] PLUS the session's custom
+//! script tools, both rooted at the snapshot (with the session's workspace
+//! rules and schema gate applied) — a [`CustomToolSet`] owning the registry
+//! by `Arc`. Custom tools spawn subprocesses with the snapshot as cwd
+//! ([`CustomToolSet::new_owned`]), so their writes land in the isolated
+//! shadow, never the real tree.
+//!
+//! MCP servers and the interactive/discovery layers are still NOT re-wired
+//! into candidates, and this is a CORRECTNESS boundary, not just a leak one:
+//! an MCP server was spawned against the REAL workspace, so even a read-only
+//! MCP tool would return the real tree's content — a candidate that edited a
+//! file then read it back via MCP would see the UNEDITED bytes, mixing a
+//! stale view into its snapshot-rooted work. Offering MCP to candidates
+//! needs per-candidate server sessions (cwd = snapshot); until then it is
+//! correctly withheld. The interactive layer (`ask_user`) is withheld
+//! because a fan-out of N candidates has no single owner for a prompt.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
+use std::sync::Arc;
 use stella_fleet::git::{GitCli, SystemGitCli};
 use stella_pipeline::ports::{
     AdoptedChange, CandidateWorkspace, CandidateWorkspacePort, CommandRunner, RepoStatusPort,
     WorkspaceError,
 };
 use stella_protocol::FileChangeKind;
+
+use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::{RegistryOptions, ToolRegistry};
 
 use crate::agent::{GitRepoStatus, ShellCommandRunner, fs_fingerprint};
@@ -195,11 +204,24 @@ pub(crate) struct GitCandidateWorkspaces {
     /// Registry switches for the per-candidate tool registry (same secure
     /// posture as the session's: `bash` only when settings opt in).
     options: RegistryOptions,
+    /// The session's custom script tools, re-rooted at each candidate's
+    /// snapshot (their subprocesses spawn with the snapshot as cwd, so they
+    /// stay isolated). Cloned per candidate; the manifests are identical to
+    /// the session's because the snapshot is a copy of the real tree.
+    custom_tools: Vec<CustomTool>,
 }
 
 impl GitCandidateWorkspaces {
-    pub(crate) fn new(root: PathBuf, options: RegistryOptions) -> Self {
-        Self { root, options }
+    pub(crate) fn new(
+        root: PathBuf,
+        options: RegistryOptions,
+        custom_tools: Vec<CustomTool>,
+    ) -> Self {
+        Self {
+            root,
+            options,
+            custom_tools,
+        }
     }
 
     /// The concrete create (the trait impl boxes its result): snapshot the
@@ -242,12 +264,20 @@ impl GitCandidateWorkspaces {
         match populate_snapshot(&toplevel, &dir, &root_rel).await {
             Ok(overlay_untracked) => {
                 let ws_root = dir.join(&root_rel);
-                let tools = ToolRegistry::new_detected(ws_root.clone(), self.options).await;
+                let registry = ToolRegistry::new_detected(ws_root.clone(), self.options).await;
                 // Same governance as the session registry: workspace rules
                 // and the schema gate travel with the tree — best-of-N must
-                // not be a way around them.
-                crate::agent::populate_schema_index(&tools, &ws_root);
-                crate::rules::enforce_workspace_rules(&tools, &ws_root);
+                // not be a way around them. Applied while `registry` is still
+                // a plain `ToolRegistry`, before it moves into the `Arc`.
+                crate::agent::populate_schema_index(&registry, &ws_root);
+                crate::rules::enforce_workspace_rules(&registry, &ws_root);
+                // The candidate's tool surface: the snapshot-rooted registry
+                // plus the session's custom script tools, owned as one value
+                // (the workspace outlives every borrow). Custom tools re-root
+                // to `ws_root`, so their subprocesses run in the shadow.
+                let registry: Arc<dyn stella_core::ToolExecutor> = Arc::new(registry);
+                let tools =
+                    CustomToolSet::new_owned(registry, self.custom_tools.clone(), ws_root.clone());
                 Ok(GitCandidateWorkspace {
                     toplevel,
                     dir: dir.clone(),
@@ -405,7 +435,9 @@ pub(crate) struct GitCandidateWorkspace {
     toplevel: PathBuf,
     /// The shadow worktree directory.
     dir: PathBuf,
-    tools: ToolRegistry,
+    /// The candidate's tool surface: snapshot-rooted registry + custom tools,
+    /// owned so the boxed workspace can hand out `&dyn ToolExecutor`.
+    tools: CustomToolSet<'static>,
     commands: ShellCommandRunner,
     repo_status: SnapshotRepoStatus,
 }
@@ -665,7 +697,8 @@ mod tests {
     async fn snapshot_mirrors_dirty_staged_and_untracked_state_without_touching_the_real_tree() {
         let root = scaffold("snap");
         let before = tree_state(&root);
-        let port = GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default());
+        let port =
+            GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default(), Vec::new());
 
         let ws = port.create_workspace().await.unwrap();
         // Uncommitted tracked edit, staged-but-uncommitted new file, and the
@@ -705,10 +738,66 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// A candidate's tool surface includes the session's custom script tools,
+    /// and running one executes in the SNAPSHOT (cwd = shadow), never the real
+    /// tree — the isolation guarantee for the grown tool surface.
+    #[tokio::test]
+    async fn custom_tools_reach_the_candidate_and_run_in_the_snapshot() {
+        let root = scaffold("customtools");
+        // A custom tool that writes a file into its cwd. Discovered from the
+        // real root exactly as the session discovers it.
+        std::fs::create_dir_all(root.join(".stella/tools")).unwrap();
+        std::fs::write(
+            root.join(".stella/tools/writer.toml"),
+            "name = \"writer\"\n\
+             description = \"write a marker file into the cwd\"\n\
+             command = [\"sh\", \"-c\", \"printf candidate > candidate_wrote.txt\"]\n\
+             [input_schema]\n\
+             type = \"object\"\n",
+        )
+        .unwrap();
+        let custom_tools = stella_tools::custom::discover(&root).tools;
+        assert_eq!(custom_tools.len(), 1, "the writer tool must be discovered");
+
+        let port =
+            GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default(), custom_tools);
+        let ws = port.create_workspace().await.unwrap();
+
+        // The candidate model sees the custom tool in its schema…
+        let names: Vec<String> = ws.tools().schemas().into_iter().map(|s| s.name).collect();
+        assert!(
+            names.iter().any(|n| n == "writer"),
+            "candidate schemas must include the custom tool: {names:?}"
+        );
+        // …and it also still sees a built-in (the registry is the inner set).
+        assert!(
+            names.iter().any(|n| n == "read_file"),
+            "candidate must still have the built-in registry"
+        );
+
+        // Executing it writes into the SNAPSHOT, not the real tree.
+        let out = ws.tools().execute("writer", &serde_json::json!({})).await;
+        assert!(!out.is_error(), "custom tool run failed: {out:?}");
+        assert_eq!(
+            read(&ws.dir().join("candidate_wrote.txt")),
+            "candidate",
+            "the custom tool must write inside the snapshot"
+        );
+        assert!(
+            !root.join("candidate_wrote.txt").exists(),
+            "the custom tool must NOT touch the real tree"
+        );
+
+        ws.remove().await;
+        assert_no_candidate_worktrees(&root);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     #[tokio::test]
     async fn winner_adoption_lands_only_the_winners_changes() {
         let root = scaffold("adopt");
-        let port = GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default());
+        let port =
+            GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default(), Vec::new());
         let loser = port.create_workspace().await.unwrap();
         let winner = port.create_workspace().await.unwrap();
 
@@ -758,7 +847,8 @@ mod tests {
     #[tokio::test]
     async fn a_mid_run_user_edit_fails_adoption_atomically_naming_the_path() {
         let root = scaffold("conflict");
-        let port = GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default());
+        let port =
+            GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default(), Vec::new());
         let ws = port.create_workspace().await.unwrap();
 
         std::fs::write(ws.dir().join("tracked.txt"), "base\ndirty\ncandidate\n").unwrap();
@@ -804,7 +894,8 @@ mod tests {
         ));
         std::fs::create_dir_all(&root).unwrap();
         scratch_git(&root, &["init", "-q"]);
-        let port = GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default());
+        let port =
+            GitCandidateWorkspaces::new(root.clone(), RegistryOptions::default(), Vec::new());
         match port.create_workspace().await {
             Err(WorkspaceError::Snapshot { reason }) => {
                 assert!(reason.contains("at least one commit"), "{reason}")

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -570,9 +570,27 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
 /// `schemas()` is the inner's plus the customs', and `execute()` routes an
 /// exact custom-name match, otherwise falls through to the inner executor.
 pub struct CustomToolSet<'a> {
-    inner: &'a dyn ToolExecutor,
+    inner: Inner<'a>,
     tools: Vec<CustomTool>,
     workspace_root: PathBuf,
+}
+
+/// The wrapped executor, held either by borrow (the session's per-turn tool
+/// chain, a stack local) or owned via `Arc` (a best-of-N candidate, whose
+/// chain is built dynamically and outlives every borrow — the workspace owns
+/// `Arc<ToolRegistry>` + this set together with no self-reference).
+enum Inner<'a> {
+    Borrowed(&'a dyn ToolExecutor),
+    Owned(std::sync::Arc<dyn ToolExecutor>),
+}
+
+impl Inner<'_> {
+    fn get(&self) -> &dyn ToolExecutor {
+        match self {
+            Inner::Borrowed(inner) => *inner,
+            Inner::Owned(inner) => inner.as_ref(),
+        }
+    }
 }
 
 impl<'a> CustomToolSet<'a> {
@@ -582,7 +600,25 @@ impl<'a> CustomToolSet<'a> {
         workspace_root: PathBuf,
     ) -> Self {
         Self {
-            inner,
+            inner: Inner::Borrowed(inner),
+            tools,
+            workspace_root,
+        }
+    }
+}
+
+impl CustomToolSet<'static> {
+    /// Own the inner executor by `Arc` — for callers that must hold the whole
+    /// chain (registry + customs) as one value, e.g. a boxed best-of-N
+    /// candidate workspace. `workspace_root` re-roots custom-tool subprocesses
+    /// (they spawn with it as cwd), so a snapshot root isolates them there.
+    pub fn new_owned(
+        inner: std::sync::Arc<dyn ToolExecutor>,
+        tools: Vec<CustomTool>,
+        workspace_root: PathBuf,
+    ) -> Self {
+        Self {
+            inner: Inner::Owned(inner),
             tools,
             workspace_root,
         }
@@ -592,7 +628,7 @@ impl<'a> CustomToolSet<'a> {
 #[async_trait]
 impl ToolExecutor for CustomToolSet<'_> {
     fn schemas(&self) -> Vec<ToolSchema> {
-        let mut schemas = self.inner.schemas();
+        let mut schemas = self.inner.get().schemas();
         schemas.extend(self.tools.iter().map(CustomTool::schema));
         schemas
     }
@@ -601,7 +637,7 @@ impl ToolExecutor for CustomToolSet<'_> {
         if let Some(tool) = self.tools.iter().find(|t| t.name == name) {
             return run_custom(tool, input, &self.workspace_root).await;
         }
-        self.inner.execute(name, input).await
+        self.inner.get().execute(name, input).await
     }
 }
 
@@ -1127,6 +1163,28 @@ command = []"#;
         match fell {
             ToolOutput::Ok { content } => assert_eq!(content, "inner ran bash"),
             ToolOutput::Error { message } => panic!("expected fallthrough: {message}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn owned_inner_delegates_schemas_and_fallthrough() {
+        // The Arc-owned variant (best-of-N candidates) must behave exactly
+        // like the borrowed one: inner schemas + customs, and unknown names
+        // fall through to the owned inner.
+        let dir = tempfile::tempdir().unwrap();
+        let mut tool = script_tool(dir.path(), "s.sh", "#!/bin/sh\necho from_custom\n", 5000);
+        tool.name = "my_tool".into();
+        tool.command = vec!["./s.sh".into()];
+        let inner: std::sync::Arc<dyn ToolExecutor> = std::sync::Arc::new(FakeInner);
+        let set = CustomToolSet::new_owned(inner, vec![tool], dir.path().to_path_buf());
+
+        let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
+        assert!(names.contains(&"bash".to_string()), "owned inner's schema");
+        assert!(names.contains(&"my_tool".to_string()), "custom schema");
+
+        match set.execute("bash", &serde_json::json!({})).await {
+            ToolOutput::Ok { content } => assert_eq!(content, "inner ran bash"),
+            ToolOutput::Error { message } => panic!("expected owned-inner fallthrough: {message}"),
         }
     }
 


### PR DESCRIPTION
…snapshot-rooted

#231 gave best-of-N candidates a built-in ToolRegistry only, with a TODO(best-of-n-tool-surface). This grows the candidate surface to match the session for the part that is safe AND correct: the session's custom script tools, re-rooted at each candidate's snapshot.

- `CustomToolSet` gains an owned-inner variant (`new_owned`, `Arc<dyn ToolExecutor>`) so a boxed candidate workspace can hold registry + custom set as one value with no self-referential borrow. The borrowed path (the session's per-turn chain) is unchanged.
- `GitCandidateWorkspaces` takes the session's `Vec<CustomTool>` (discovered from the same root, so a candidate sees exactly what the session does) and builds each candidate's `tools` as `CustomToolSet::new_owned(Arc<registry rooted at snapshot>, custom_tools, snapshot_root)`. Custom tools spawn with the snapshot as cwd, so their writes land in the shadow, never the real tree. The schema gate + workspace rules are applied to the registry before it moves into the Arc.

MCP and the interactive layer stay withheld — and the module doc now records WHY it's a correctness boundary, not just a leak one: an MCP server spawned against the real workspace returns the real tree's bytes even for read-only tools, so a candidate that edited a file then read it via MCP would see the UNEDITED content. Per-candidate MCP sessions (cwd = snapshot) are the prerequisite; `ask_user` has no single owner across N candidates.

Tests: `custom_tools_reach_the_candidate_and_run_in_the_snapshot` (candidate schemas include the custom tool + built-ins; execution writes into the snapshot, never the real tree) and `owned_inner_delegates_schemas_and_fallthrough`.

Note: this branch is off main and inherits main's pre-existing red gate (the `split_largest_files` forcing-test + ratchet drift from #234/#236). Its own footprint is fmt/clippy/ratchet-clean and its tests pass; it goes fully green once the monolith-split PR lands and this rebases onto it.

<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? Link the issue if one exists. -->

Closes #

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

-  This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

-  `cargo fmt --check`
-  `cargo clippy --workspace --all-targets -- -D warnings`
-  `cargo test --workspace`
-  Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  Commits signed off for DCO (`git commit -s`)

## Ground-rule check

<!-- Delete lines that don't apply. -->

-  No I/O added to `stella-core`; no new deps without justification below
-  No new outbound network calls (Stella never phones home)
-  New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->
