### PR TITLE
feat(cli): load project .env / .env.local / .env.*.local at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3052,7 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
+ "dotenvy",
  "libc",
  "ocp-host",
  "ocp-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ libc = "0.2"
 rand = "0.10"
 proptest = "1"
 toml = "1.1"
+# Vetted dotenv parser (quotes, escapes, multi-line values, `export` prefixes),
+# used as a non-mutating iterator so the CLI keeps control of precedence and
+# never overrides the live shell. See stella-cli/src/env_files.rs.
+dotenvy = "0.15"
 rpassword = "7"
 base64 = "0.22"
 arboard = { version = "3", default-features = false, features = ["image-data"] }

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ route through the dedicated coding endpoint.
 **Credential chain** (first hit wins): `--api-key` flag → provider env var →
 `settings.json` `api_key` → `~/.config/stella/credentials.toml` → interactive prompt.
 
+**Project `.env` files** — so keys can follow the project you're in, Stella
+reads `.env`, `.env.local`, and `.env.<mode>.local` (e.g. `.env.production.local`)
+from the working directory (or the nearest ancestor within the same git repo)
+into the environment at startup, most-specific file first. Template files
+(`.env.example`, `.env.sample`, `.env.dist`) and non-`.local` mode files
+(`.env.production`) are never read. **Your live shell always wins** — a value
+already exported (or `OPENROUTER_API_KEY=… stella …`) is never overwritten by a
+file, so unset a stale export if you mean to switch. Disable the whole mechanism
+with `STELLA_NO_ENV_FILE=1`; see what loaded with `STELLA_ENV_DEBUG=1`.
+
 ```bash
 stella models    # list providers, models, and key status
 stella config    # show the fully resolved configuration

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -43,6 +43,7 @@ async-trait.workspace = true
 clap.workspace = true
 colored.workspace = true
 toml.workspace = true
+dotenvy.workspace = true
 libc.workspace = true
 tempfile.workspace = true
 # Masked TTY prompt for `stella connect … --token` (same crate stella-model

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -699,8 +699,9 @@ impl Config {
 
         Err(format!(
             "no API key found. Set one of: {}\n\nExample: export ZAI_API_KEY=your_key_here\n\
-             (or add it to ~/.config/stella/credentials.toml, or pass --model provider/model \
-             to be prompted interactively)",
+             (or put it in a project .env / .env.local, add it to \
+             ~/.config/stella/credentials.toml, or pass --model provider/model to be prompted \
+             interactively)",
             PROVIDERS
                 .iter()
                 .map(|p| format!("{} ({})", p.env_var, p.display_name))

--- a/stella-cli/src/env_files.rs
+++ b/stella-cli/src/env_files.rs
@@ -1,0 +1,376 @@
+//! Project-scoped `.env` loading.
+//!
+//! Stella honours the dotenv files a project keeps next to its source so
+//! credentials (and any other configuration) follow the directory you run
+//! `stella` in — no shell hook required. This is what lets a user switch
+//! keys between projects just by `cd`-ing: each project's `.env.local`
+//! carries its own provider keys, and Stella reads them itself instead of
+//! depending on the shell having exported them.
+//!
+//! The rules, in one place:
+//!
+//! - **Loaded**, most-specific first: `.env.<mode>.local` (e.g.
+//!   `.env.production.local`), then `.env.local`, then `.env`.
+//! - **Never loaded**: template files a repo commits for humans to copy —
+//!   `.env.example`, `.env.sample`, `.env.<mode>.example`, `.env.dist` — and
+//!   any `.env.<mode>` that is *not* `*.local` (committed, non-secret
+//!   defaults we deliberately stay out of). This is the `!.env.example`
+//!   guarantee.
+//! - **The live shell always wins.** A variable already present in the
+//!   process environment is never overwritten by a file, so
+//!   `OPENROUTER_API_KEY=… stella …` and an exported shell value both take
+//!   precedence over anything on disk. Between files, the more specific file
+//!   is applied first and application never overwrites, so it wins over the
+//!   less specific. (Consequence worth knowing: a value still *exported* in
+//!   your shell shadows a project file — unset it if you mean to switch.)
+//!
+//! Loading is confined to the current project: the search walks up from the
+//! working directory to the nearest ancestor that actually contains a
+//! matching file, but never crosses out of the enclosing git repository and
+//! never treats the home directory (or above) as a project scope. Only that
+//! nearest directory's files are read — this is direnv-style *nearest scope
+//! wins*, not cross-directory layering, so a monorepo's per-package
+//! `.env.local` does not also pull the repo-root `.env`.
+//!
+//! Set `STELLA_NO_ENV_FILE=1` to disable the whole mechanism.
+
+use std::collections::HashSet;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+
+use crate::OutputFormat;
+
+/// What a load pass applied, for an optional diagnostic line. `files` are the
+/// dotenv files that actually contributed at least one variable (most-specific
+/// first); `names` are the distinct variable names newly set from them — never
+/// their values.
+#[derive(Debug, Default)]
+pub struct Loaded {
+    pub files: Vec<PathBuf>,
+    pub names: Vec<String>,
+}
+
+impl Loaded {
+    fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+}
+
+/// Load project `.env*` files into the process environment, unless
+/// `STELLA_NO_ENV_FILE` is set to a truthy value. Silent; call [`announce`]
+/// afterward to surface what happened.
+///
+/// Must run during single-threaded startup (before the tokio runtime or any
+/// worker threads exist), since it mutates the process environment.
+pub fn maybe_load() -> Loaded {
+    let disabled =
+        std::env::var_os("STELLA_NO_ENV_FILE").is_some_and(|v| !v.is_empty() && v != "0");
+    if disabled {
+        return Loaded::default();
+    }
+    let Ok(cwd) = std::env::current_dir() else {
+        return Loaded::default();
+    };
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let plan = plan_from(&cwd, home.as_deref(), |k| std::env::var_os(k).is_some());
+
+    let mut names = Vec::new();
+    let mut files: Vec<PathBuf> = Vec::new();
+    for (key, value, path) in plan {
+        // SAFETY: called only from `main` during single-threaded process
+        // startup, before the tokio runtime or any worker threads exist — no
+        // concurrent `getenv`/`setenv` can race this write.
+        unsafe { std::env::set_var(&key, &value) };
+        names.push(key);
+        if !files.contains(&path) {
+            files.push(path);
+        }
+    }
+    Loaded { files, names }
+}
+
+/// The ordered list of assignments a load would apply, given a predicate for
+/// "this name is already set" (the live environment, in production). Pure over
+/// the filesystem + predicate — no process-environment mutation — so the
+/// precedence and shell-wins rules are unit-testable without env races.
+fn plan_from(
+    start: &Path,
+    home: Option<&Path>,
+    is_set: impl Fn(&str) -> bool,
+) -> Vec<(String, String, PathBuf)> {
+    let Some(base) = find_base(start, home) else {
+        return Vec::new();
+    };
+    let files = collect_files(&base);
+    plan_assignments(&files, is_set)
+}
+
+/// Walk up from `start` to the nearest ancestor that contains a loadable
+/// dotenv file. Never returns the home directory (or above), and never crosses
+/// above the enclosing git repository root — env stays scoped to one project.
+fn find_base(start: &Path, home: Option<&Path>) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        // The home directory (and anything above it) is never a project scope:
+        // we don't want a stray `~/.env` to leak into every session.
+        if Some(dir) == home {
+            return None;
+        }
+        if dir_has_env_file(dir) {
+            return Some(dir.to_path_buf());
+        }
+        // `.git` (a dir in a normal clone, a file in a worktree) marks the repo
+        // root — checked above, so stop here rather than leaking a parent
+        // project's env across the boundary.
+        if dir.join(".git").exists() {
+            return None;
+        }
+        dir = dir.parent()?;
+    }
+}
+
+fn dir_has_env_file(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if let Some(name) = entry.file_name().to_str()
+            && classify(name).is_some()
+            && entry.path().is_file()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Every loadable dotenv file in `dir`, ordered most-specific first (highest
+/// precedence rank first), with a stable alphabetical tiebreak.
+fn collect_files(dir: &Path) -> Vec<(u8, PathBuf)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files: Vec<(u8, String, PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if let Some(rank) = classify(&name) {
+            let path = entry.path();
+            if path.is_file() {
+                files.push((rank, name, path));
+            }
+        }
+    }
+    files.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    files
+        .into_iter()
+        .map(|(rank, _name, path)| (rank, path))
+        .collect()
+}
+
+/// Precedence rank for a dotenv filename, or `None` if Stella must not load it.
+/// Higher rank wins: `.env` = 0, `.env.local` = 1, `.env.<mode>.local` = 2.
+/// Every other shape — templates and non-`.local` mode files — is `None`.
+fn classify(name: &str) -> Option<u8> {
+    if name == ".env" {
+        return Some(0);
+    }
+    if name == ".env.local" {
+        return Some(1);
+    }
+    // `.env.<mode>.local`
+    let mode = name.strip_prefix(".env.")?.strip_suffix(".local")?;
+    if mode.is_empty() {
+        return None;
+    }
+    // Defensive: never treat a template as a secret, even if someone names one
+    // `.env.example.local`.
+    if matches!(
+        mode.to_ascii_lowercase().as_str(),
+        "example" | "sample" | "template" | "dist" | "defaults"
+    ) {
+        return None;
+    }
+    Some(2)
+}
+
+/// Resolve the files to the ordered assignments to apply. A name is taken from
+/// the first (most-specific) file that defines it and that neither the
+/// environment (`is_set`) nor an earlier file has already claimed — so the live
+/// shell wins over every file, and a more specific file wins over a less
+/// specific one.
+fn plan_assignments(
+    files: &[(u8, PathBuf)],
+    is_set: impl Fn(&str) -> bool,
+) -> Vec<(String, String, PathBuf)> {
+    let mut claimed: HashSet<String> = HashSet::new();
+    let mut out: Vec<(String, String, PathBuf)> = Vec::new();
+    for (_rank, path) in files {
+        // dotenvy's parser (quotes, escapes, multi-line values, `export`
+        // prefixes, `#` comments) as a non-mutating iterator — we apply our own
+        // precedence instead of letting it touch the environment.
+        let Ok(iter) = dotenvy::from_path_iter(path) else {
+            continue;
+        };
+        for item in iter {
+            let Ok((key, value)) = item else {
+                continue; // a malformed line must not abort the whole file
+            };
+            if is_set(&key) || claimed.contains(&key) {
+                continue;
+            }
+            claimed.insert(key.clone());
+            out.push((key, value, path.clone()));
+        }
+    }
+    out
+}
+
+/// Emit a concise, value-free confirmation of what [`maybe_load`] applied —
+/// only when `STELLA_ENV_DEBUG` is set, stderr is a terminal, and the output
+/// format is human (never in `json`/`stream-json`, which must stay clean).
+pub fn announce(loaded: &Loaded, format: OutputFormat) {
+    if loaded.is_empty() {
+        return;
+    }
+    let debug = std::env::var_os("STELLA_ENV_DEBUG").is_some_and(|v| !v.is_empty() && v != "0");
+    if !debug
+        || matches!(format, OutputFormat::Json | OutputFormat::StreamJson)
+        || !std::io::stderr().is_terminal()
+    {
+        return;
+    }
+    let file_list = loaded
+        .files
+        .iter()
+        .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    eprintln!(
+        "{} {}",
+        "env:".dimmed(),
+        format!("loaded {} from {file_list}", loaded.names.join(", ")).dimmed(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn classify_loads_env_local_and_mode_local_but_not_templates() {
+        assert_eq!(classify(".env"), Some(0));
+        assert_eq!(classify(".env.local"), Some(1));
+        assert_eq!(classify(".env.production.local"), Some(2));
+        assert_eq!(classify(".env.development.local"), Some(2));
+        // Templates and non-`.local` mode files are never loaded.
+        assert_eq!(classify(".env.example"), None);
+        assert_eq!(classify(".env.sample"), None);
+        assert_eq!(classify(".env.local.example"), None);
+        assert_eq!(classify(".env.example.local"), None);
+        assert_eq!(classify(".env.production"), None); // committed default, not a secret
+        assert_eq!(classify(".env.dist"), None);
+        assert_eq!(classify(".environment"), None);
+        assert_eq!(classify("env"), None);
+    }
+
+    #[test]
+    fn precedence_is_mode_local_over_local_over_env_and_shell_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path();
+        write(d, ".env", "KEY=from_env\nBASE_ONLY=base\n");
+        write(d, ".env.local", "KEY=from_local\nLOCAL_ONLY=local\n");
+        write(d, ".env.production.local", "KEY=from_mode_local\n");
+        // `.env.example` must be ignored entirely.
+        write(
+            d,
+            ".env.example",
+            "KEY=from_example\nEXAMPLE_ONLY=example\n",
+        );
+
+        let files = collect_files(d);
+        // A name already in the shell is never overwritten.
+        let shell: HashSet<String> = ["BASE_ONLY".to_string()].into_iter().collect();
+        let plan = plan_assignments(&files, |k| shell.contains(k));
+
+        let map: std::collections::HashMap<_, _> = plan
+            .iter()
+            .map(|(k, v, _)| (k.clone(), v.clone()))
+            .collect();
+
+        assert_eq!(map.get("KEY").map(String::as_str), Some("from_mode_local"));
+        assert_eq!(map.get("LOCAL_ONLY").map(String::as_str), Some("local"));
+        // Shadowed by the shell → not planned.
+        assert!(!map.contains_key("BASE_ONLY"));
+        // Template file never contributes.
+        assert!(!map.contains_key("EXAMPLE_ONLY"));
+    }
+
+    #[test]
+    fn parser_handles_quotes_export_comments_and_multiline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path();
+        write(
+            d,
+            ".env",
+            "# a comment\n\
+             export EXPORTED=yes\n\
+             QUOTED=\"has spaces\"\n\
+             SINGLE='literal $NOPE'\n\
+             INLINE=value # trailing\n\
+             MULTI=\"line1\nline2\"\n",
+        );
+        let files = collect_files(d);
+        let plan = plan_assignments(&files, |_| false);
+        let map: std::collections::HashMap<_, _> = plan
+            .iter()
+            .map(|(k, v, _)| (k.clone(), v.clone()))
+            .collect();
+
+        assert_eq!(map.get("EXPORTED").map(String::as_str), Some("yes"));
+        assert_eq!(map.get("QUOTED").map(String::as_str), Some("has spaces"));
+        assert_eq!(map.get("SINGLE").map(String::as_str), Some("literal $NOPE"));
+        assert_eq!(map.get("INLINE").map(String::as_str), Some("value"));
+        assert_eq!(map.get("MULTI").map(String::as_str), Some("line1\nline2"));
+    }
+
+    #[test]
+    fn find_base_prefers_nearest_and_stops_at_repo_and_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let home = root.join("home");
+        let repo = home.join("proj");
+        let sub = repo.join("packages").join("web");
+        fs::create_dir_all(&sub).unwrap();
+        fs::create_dir_all(repo.join(".git")).unwrap();
+
+        // No env files anywhere yet: walking up from `sub` stops at the repo
+        // root (which has `.git`) and finds nothing — never reaching `home`.
+        assert_eq!(find_base(&sub, Some(&home)), None);
+
+        // Repo-root env is found from a subdir.
+        write(&repo, ".env", "K=1\n");
+        assert_eq!(find_base(&sub, Some(&home)), Some(repo.clone()));
+
+        // A nearer scope wins over the repo root.
+        write(&sub, ".env.local", "K=2\n");
+        assert_eq!(find_base(&sub, Some(&home)), Some(sub.clone()));
+    }
+
+    #[test]
+    fn home_directory_is_never_a_project_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        write(home, ".env", "HOME_LEVEL=nope\n");
+        // Running *in* $HOME must not load `~/.env`.
+        assert_eq!(find_base(home, Some(home)), None);
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -28,6 +28,7 @@ mod connect_cmd;
 mod discovery;
 mod domains;
 mod engine_config;
+mod env_files;
 mod export;
 mod extensions;
 mod fleet_cmd;
@@ -936,7 +937,18 @@ fn main() -> ExitCode {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 
+    // Load project-scoped `.env`/`.env.local`/`.env.<mode>.local` before
+    // parsing, so both clap's `env = …` fields and downstream credential
+    // resolution see project keys. Runs here at single-threaded startup where
+    // mutating the process environment is safe. The live shell always wins;
+    // `STELLA_NO_ENV_FILE=1` opts out entirely.
+    let loaded_env = env_files::maybe_load();
+
     let cli = Cli::parse();
+
+    // Value-free confirmation (names only), gated on STELLA_ENV_DEBUG + a TTY +
+    // a human output format so it never pollutes json/stream-json.
+    env_files::announce(&loaded_env, cli.output_format);
 
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,


### PR DESCRIPTION
## What

Stella now reads a project's dotenv files itself, so provider keys **follow the directory you run it in** — no shell hook required. This directly fixes the "credentials failed for openrouter" class of problem where a key lived only in `.env.local` and was never exported into a non-interactive shell (IDE terminals, `zsh -c`, scripts, cron).

## Rules

- **Loaded, most-specific first:** `.env.<mode>.local` → `.env.local` → `.env`
- **Never loaded:** `.env.example`, `.env.sample`, `.env.dist`, `.env.<mode>.example`, and any non-`.local` `.env.<mode>` (committed defaults). This is the `!.env.example` guarantee.
- **Live shell always wins:** a name already in the environment (exported, or `OPENROUTER_API_KEY=… stella …`) is never overwritten by a file; between files the more specific one wins.
- **Scoped to the project:** nearest ancestor with a matching file, never crossing the enclosing git repo root and never treating `$HOME` (or above) as a project scope. Nearest-scope-wins (direnv-style), not cross-dir layering.
- **Opt out:** `STELLA_NO_ENV_FILE=1`. **See what loaded:** `STELLA_ENV_DEBUG=1` (names only, never values; TTY + human format).

## How

- New module `stella-cli/src/env_files.rs`. Pure core (`classify` / `find_base` / `collect_files` / `plan_assignments`) split from the thin `set_var` apply, so precedence + shell-wins are unit-testable without env races.
- Parsing via **`dotenvy` as a non-mutating iterator** (quotes, escapes, multi-line values, `export` prefixes) — the CLI keeps control of precedence and never lets it touch the environment directly.
- Loaded once at the top of `main` **before `Cli::parse`**, so both clap `env = …` fields and downstream credential resolution see project keys. Single-threaded startup → `set_var` is safe (documented).
- `dotenvy 0.15` added (crates.io, MIT, zero transitive deps → passes `cargo deny` advisories/bans/sources).

## Verification

- 5 unit tests (classify/templates, precedence + shell-wins, dotenvy parser incl. multi-line, repo/home boundaries) + full `stella-cli` suite: **279 passed**. Clippy + rustfmt clean; release builds.
- **E2E against the built binary in a clean `env -i` shell** (the exact non-interactive context that failed before), throwaway temp dir:
  | Check | Result |
  |---|---|
  | `.env` + `.env.local` load, `.env.example` ignored | zai ✓, openrouter ✓, anthropic ✗ |
  | `.env.production.local` beats `.env.local` | key `…BBBB` ✓ |
  | exported shell var shadows files | key `…ZZZZ` ✓ |
  | `STELLA_NO_ENV_FILE=1` opt-out | openrouter ✗ ✓ |

## Notes

- **Reverses a prior product stance** (Stella deliberately had no dotenv loader) — that was intentional and is exactly what this PR changes per request.
- A value still *exported* in your shell shadows a project file — documented in README + module docs so switching projects with a stale export isn't surprising.
