### PR TITLE
sandbox: reproduce provider/host-mismatch 401 (valid key, wrong host)

### DIFF
--- a/sandbox/provider-host-mismatch/README.md
+++ b/sandbox/provider-host-mismatch/README.md
@@ -1,0 +1,123 @@
+# Provider / host mismatch sandbox
+
+A pre-warmed, zero-dependency sandbox that reproduces the class of failure where
+**a perfectly valid API key gets an HTTP 401** — because Stella sent it to the
+*wrong host*. Fake keys, a local mock, no real network. Run it with:
+
+```sh
+sandbox/provider-host-mismatch/run.sh
+```
+
+You need `python3` and a `stella` binary on `PATH` (or `STELLA_BIN=/path/to/stella`).
+
+---
+
+## TL;DR — the bug this was built to explain
+
+Symptom: every prompt fails with
+`provider auth error: OpenRouter rejected the credential (HTTP 401 Unauthorized)`,
+even though the OpenRouter key is valid.
+
+Root cause: the `stella_dev` launcher is a shell alias that forces `--base-url`
+to **Z.ai**:
+
+```sh
+alias stella_dev='./target/release/stella --base-url https://api.z.ai/api/coding/paas/v4'
+```
+
+`--base-url` is a **global override applied to whichever provider resolves**. With
+no `--model`, Stella auto-detects the **OpenRouter** provider (the OpenRouter key
+is present and valid) and then sends that OpenRouter key to **Z.ai's** host. Z.ai
+returns 401. The error message says "OpenRouter" because Stella labels the error
+with the resolved *provider name*, not the host it actually dialed — which is why
+the message points at the wrong place.
+
+Proof it's not the key: a read-only probe against real OpenRouter returns **200**:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' https://openrouter.ai/api/v1/key \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY"   # -> 200, key is fine
+```
+
+### The fix
+
+Make the provider and the host agree. Since the alias points at Z.ai, pin the
+Z.ai provider (Z.ai uses your `ZAI_API_KEY`, not the OpenRouter key):
+
+```sh
+alias stella_dev='./target/release/stella \
+  --model zai/glm-4.6 \
+  --base-url https://api.z.ai/api/coding/paas/v4'
+```
+
+Confirm before launching the TUI:
+
+```sh
+stella --base-url https://api.z.ai/api/coding/paas/v4 --model zai/glm-4.6 config
+#   Provider:  Z.ai (GLM ...)      <- matches the host
+#   API Key:   e1150a…             <- your ZAI key, not sk-or-…
+#   Base URL:  https://api.z.ai/...
+```
+
+(If you actually want OpenRouter, just drop the `--base-url` override and run
+plain `stella` — provider and host then both default to OpenRouter.)
+
+---
+
+## What the sandbox demonstrates
+
+`run.sh` walks [`scenarios.tsv`](./scenarios.tsv). For each row it:
+
+1. starts [`mock_provider.py`](./mock_provider.py) as a stand-in "host" told which
+   single fake key it accepts (that's how it plays "Z.ai" — it 401s anything but
+   the Z.ai key);
+2. runs **real `stella config`** in a pristine, isolated `HOME` with fake keys in
+   the env and the mock as `--base-url`, and reads back which **provider / key /
+   base URL** Stella resolved — the deterministic, offline proof of the mismatch;
+3. replays the resolved key against the mock over HTTP to observe the host's real
+   **200 / 401**;
+4. compares to the expected result.
+
+Expected output — all `PASS`:
+
+```
+scenario                 | resolved   | host      | expect | verdict
+matched-openrouter       | OpenRouter | openrouter | 200    | PASS   <- everything agrees
+mismatch-or-to-zai       | OpenRouter | zai       | 401    | PASS   <- THE REPORTED BUG
+matched-zai-pinned       | Z.ai (GLM  | zai       | 200    | PASS   <- THE FIX
+autodetect-to-zai-host   | OpenRouter | zai       | 401    | PASS   <- no --model, wrong host
+trailing-space-key       | OpenRouter | openrouter | 401    | PASS   <- whitespace footgun
+quoted-key               | OpenRouter | openrouter | 401    | PASS   <- dotenv-quote footgun
+```
+
+The last two rows cover adjacent causes we ruled out for the reported case but
+which produce the same 401: the env-var path does **not** trim, so a trailing
+space/newline or leftover quotes in a key are sent verbatim. The mock logs the
+raw `Authorization` header with `repr()`, so an otherwise-invisible trailing byte
+is visible in `run.sh`'s per-scenario mock log.
+
+## Files
+
+| file | purpose |
+|------|---------|
+| `mock_provider.py` | zero-dep stand-in host; 200 for its one key, 401 for everything else; logs exact auth bytes |
+| `scenarios.tsv` | the dataset — one credential/host situation per row |
+| `run.sh` | drives real `stella` per scenario and prints a verdict table |
+
+## How to add a scenario
+
+Append a tab-separated row to `scenarios.tsv`:
+`name  model_arg  host_key(openrouter|zai)  mangle(none|trailing_space|quoted)  expect(200|401)  note`.
+Everything else is automatic.
+
+## Diagnostic recipe (no sandbox needed)
+
+If you hit a provider 401, bisect in ~1 minute:
+
+1. **Is the key actually bad?** `curl .../api/v1/key -H "Authorization: Bearer $KEY"`
+   against the *real* provider. 401 → rotate the key; 200 → keep going.
+2. **What is Stella resolving?** `stella … config` — check that **Provider**,
+   **API Key** head/tail, and **Base URL** all belong to the *same* provider.
+   A provider whose name doesn't match the base URL host is this bug.
+3. **Run it the way the failing process runs.** A GUI/IDE-launched TUI does not
+   source `~/.zshrc`; run `stella config` the same way to see its real env.

--- a/sandbox/provider-host-mismatch/README.md
+++ b/sandbox/provider-host-mismatch/README.md
@@ -50,6 +50,12 @@ alias stella_dev='./target/release/stella \
   --base-url https://api.z.ai/api/coding/paas/v4'
 ```
 
+`zai/glm-4.6` and `zai/glm-5.2` (the flagship) are both valid — verified by
+completing a real turn on the Z.ai coding endpoint. `stella models list
+--provider zai` prints every current slug if you want a different one; pick one
+that appears there, since the `run` path (unlike `config`) rejects any slug not
+in the catalog.
+
 Confirm before launching the TUI:
 
 ```sh

--- a/sandbox/provider-host-mismatch/mock_provider.py
+++ b/sandbox/provider-host-mismatch/mock_provider.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Mock LLM provider endpoint for the provider/host-mismatch sandbox.
+
+Zero dependencies (Python 3 stdlib only) so it is "pre-warmed" — no venv, no
+pip. It stands in for a real provider host (OpenRouter, Z.ai, …) and does the
+one thing that reproduces the bug class: it checks the *exact* bearer token it
+receives against the single key it was told to accept, and logs the raw bytes
+of the Authorization header it saw.
+
+Why this reproduces the real 401:
+  Stella resolves a *provider* (which picks the API key) independently from the
+  --base-url it dials. If you send provider A's key to provider B's host, host
+  B rejects it with 401 — even though the key is perfectly valid on host A.
+  This mock is "host B": it accepts ONLY --accept-key and 401s everything else,
+  exactly like Z.ai rejecting a valid OpenRouter key.
+
+Behaviour:
+  * Any POST (e.g. /v1/chat/completions) with `Authorization: Bearer <k>`:
+      - k == accepted key  -> 200 + a minimal OpenAI-compatible completion
+      - otherwise          -> 401 + an OpenRouter-shaped error body
+  * GET /whoami -> 200, reports which key this instance accepts (for the runner)
+  * Every request logs: method, path, and repr() of the Authorization header so
+    an INVISIBLE trailing space / newline / quote in a key is made visible.
+
+Usage:
+  python3 mock_provider.py --port 8801 --accept-key sk-or-FAKE-openrouter \
+      --provider-label openrouter-host
+"""
+import argparse
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ACCEPT_KEY = ""
+PROVIDER_LABEL = "mock"
+
+
+class Handler(BaseHTTPRequestHandler):
+    # Quiet the default noisy logging; we do our own structured line.
+    def log_message(self, *args):  # noqa: D401
+        pass
+
+    def _log(self, note):
+        auth = self.headers.get("Authorization")
+        # repr() is deliberate: it renders a trailing '\n', ' ', or '"' that
+        # would otherwise be invisible and is a classic 401 cause.
+        print(
+            f"[{PROVIDER_LABEL}] {self.command} {self.path} "
+            f"Authorization={auth!r} -> {note}",
+            flush=True,
+        )
+
+    def _send(self, code, body):
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _bearer(self):
+        raw = self.headers.get("Authorization", "")
+        prefix = "Bearer "
+        return raw[len(prefix):] if raw.startswith(prefix) else None
+
+    def do_GET(self):
+        if self.path == "/whoami":
+            self._log("whoami")
+            self._send(200, {"provider_label": PROVIDER_LABEL,
+                             "accepts_key_len": len(ACCEPT_KEY)})
+            return
+        self._log("404")
+        self._send(404, {"error": {"message": "not found", "code": 404}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)  # drain body; contents don't matter here
+        key = self._bearer()
+        if key == ACCEPT_KEY:
+            self._log("200 OK (key matches this host)")
+            self._send(200, {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "pong"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            })
+        else:
+            self._log("401 UNAUTHORIZED (key does NOT match this host)")
+            # Shape mirrors OpenRouter's 401 body so the adapter maps it the
+            # same way it maps the real thing.
+            self._send(401, {"error": {
+                "message": "No auth credentials found / invalid key",
+                "code": 401,
+            }})
+
+
+def main():
+    global ACCEPT_KEY, PROVIDER_LABEL
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--accept-key", required=True,
+                    help="the ONE bearer token this host accepts")
+    ap.add_argument("--provider-label", default="mock")
+    args = ap.parse_args()
+    ACCEPT_KEY = args.accept_key
+    PROVIDER_LABEL = args.provider_label
+    srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"[{PROVIDER_LABEL}] listening on http://127.0.0.1:{args.port} "
+          f"(accepts a {len(ACCEPT_KEY)}-char key)", flush=True)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        srv.server_close()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/provider-host-mismatch/run.sh
+++ b/sandbox/provider-host-mismatch/run.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Provider / host mismatch sandbox runner.
+#
+# For each row in scenarios.tsv this script:
+#   1. starts the zero-dep mock provider on a fresh port, told which fake key
+#      that "host" accepts;
+#   2. runs REAL `stella config` in a pristine, isolated HOME with fake keys in
+#      the env and the mock as --base-url, and reads back which PROVIDER + key
+#      + base URL stella resolved (this is the deterministic, network-free proof
+#      of the mismatch);
+#   3. replays the resolved provider's key against the mock over HTTP to observe
+#      the host's real 200/401 (the consequence);
+#   4. compares to the expected result and prints a verdict row.
+#
+# Nothing here uses a real API key or reaches a real provider. Safe to run
+# offline, repeatedly, on any machine with python3 + a `stella` binary on PATH.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# --- locate a stella binary -------------------------------------------------
+STELLA="${STELLA_BIN:-}"
+if [[ -z "$STELLA" ]]; then
+  if [[ -x "../../target/release/stella" ]]; then
+    STELLA="../../target/release/stella"
+  elif command -v stella >/dev/null 2>&1; then
+    STELLA="$(command -v stella)"
+  else
+    echo "error: no stella binary found. Build one (cargo build --release) or set STELLA_BIN." >&2
+    exit 1
+  fi
+fi
+echo "stella: $STELLA ($("$STELLA" --version 2>/dev/null | head -1))"
+
+OR_KEY="sk-or-FAKE-openrouter"
+ZAI_KEY="zai-FAKE-key"
+PORT_BASE=8830
+TMP="$(mktemp -d)"
+trap 'pkill -f "mock_provider.py" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+strip_ansi() { sed $'s/\x1b\\[[0-9;]*m//g'; }
+
+# Every provider credential stella might auto-detect. We strip ALL of them from
+# the inherited environment (the machine running the sandbox may legitimately
+# have real keys set) and add back only the scenario's fake ones, so detection
+# is decided by the scenario, not by ambient state.
+PROVIDER_VARS=(ZAI_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY XAI_API_KEY \
+  DEEPSEEK_API_KEY GEMINI_API_KEY GOOGLE_API_KEY OPENROUTER_API_KEY \
+  VERTEX_ACCESS_TOKEN AWS_ACCESS_KEY_ID LOCAL_API_KEY ZAI_GLM_CODING_PLAN)
+unset_args=(); for v in "${PROVIDER_VARS[@]}"; do unset_args+=(-u "$v"); done
+
+pass=0; fail=0; i=0
+printf '\n%-24s | %-10s | %-9s | %-6s | %s\n' "scenario" "resolved" "host" "expect" "verdict"
+printf -- '-------------------------|------------|-----------|--------|--------\n'
+
+while IFS=$'\t' read -r name model_arg host_key mangle expect note; do
+  [[ -z "${name:-}" || "$name" == \#* ]] && continue
+  i=$((i+1)); port=$((PORT_BASE + i))
+  [[ "$model_arg" == "(auto)" ]] && model_arg=""
+
+  # fake keys, with optional corruption of the OpenRouter key
+  or_val="$OR_KEY"
+  case "$mangle" in
+    trailing_space) or_val="${OR_KEY} " ;;
+    quoted)         or_val="\"${OR_KEY}\"" ;;
+  esac
+
+  # which key does this host accept?
+  host_accept="$OR_KEY"; [[ "$host_key" == "zai" ]] && host_accept="$ZAI_KEY"
+
+  # start the mock for this host
+  python3 mock_provider.py --port "$port" --accept-key "$host_accept" \
+      --provider-label "${host_key}-host" >"$TMP/mock.$i.log" 2>&1 &
+  mock_pid=$!
+  # wait for it to bind
+  for _ in $(seq 1 20); do curl -s "http://127.0.0.1:$port/whoami" >/dev/null 2>&1 && break; sleep 0.1; done
+
+  # pristine HOME so no real credentials.toml / settings.json interfere
+  fakehome="$TMP/home.$i"; mkdir -p "$fakehome"
+
+  # Auto-detect (no --model) is order-and-presence sensitive: to keep the
+  # scenario deterministic and portable we expose ONLY the OpenRouter key so
+  # detection lands on OpenRouter regardless of provider order. When a provider
+  # is pinned via --model, both keys are present (the pin decides).
+  env_args=(HOME="$fakehome" NO_COLOR=1 OPENROUTER_API_KEY="$or_val")
+  [[ -n "$model_arg" ]] && env_args+=(ZAI_API_KEY="$ZAI_KEY")
+
+  # (2) what does stella resolve?  (env -u strips ambient real keys first)
+  cfg="$(env "${unset_args[@]}" "${env_args[@]}" \
+        "$STELLA" --base-url "http://127.0.0.1:$port/v1" $model_arg config 2>&1 | strip_ansi)"
+  resolved_provider="$(printf '%s\n' "$cfg" | sed -n 's/.*Provider:[[:space:]]*//p' | head -1)"
+
+  # (3) replay the resolved provider's key against the host
+  case "$resolved_provider" in
+    *Z.ai*|*zai*) sent="$ZAI_KEY" ;;
+    *)            sent="$or_val" ;;   # OpenRouter (and default) -> the OR key (mangled if any)
+  esac
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+      "http://127.0.0.1:$port/v1/chat/completions" \
+      -H "Authorization: Bearer ${sent}" -H "Content-Type: application/json" \
+      -d '{"model":"x","messages":[]}')"
+
+  kill "$mock_pid" 2>/dev/null; wait "$mock_pid" 2>/dev/null
+
+  verdict="PASS"; [[ "$code" == "$expect" ]] || verdict="FAIL"
+  [[ "$verdict" == "PASS" ]] && pass=$((pass+1)) || fail=$((fail+1))
+  short_prov="$(printf '%s' "$resolved_provider" | cut -c1-10)"
+  printf '%-24s | %-10s | %-9s | %-6s | %s (got %s)\n' \
+      "$name" "$short_prov" "$host_key" "$expect" "$verdict" "$code"
+done < scenarios.tsv
+
+printf -- '-------------------------|------------|-----------|--------|--------\n'
+printf 'total: %d  pass: %d  fail: %d\n\n' "$i" "$pass" "$fail"
+[[ "$fail" -eq 0 ]] || exit 1

--- a/sandbox/provider-host-mismatch/scenarios.tsv
+++ b/sandbox/provider-host-mismatch/scenarios.tsv
@@ -1,0 +1,22 @@
+# Credential / host mismatch scenario dataset.
+# Tab-separated. Lines starting with '#' are comments.
+#
+# columns:
+#   name        short scenario id
+#   model_arg   the --model flag passed to stella ("" = auto-detect by key)
+#   host_key    which fake key the mock host accepts: openrouter | zai
+#   mangle      corruption applied to the OpenRouter env key: none | trailing_space | quoted
+#   expect      expected HTTP from the host: 200 | 401
+#   note        human explanation
+#
+# The two fake keys the runner exports (never real secrets):
+#   OPENROUTER_API_KEY = sk-or-FAKE-openrouter
+#   ZAI_API_KEY        = zai-FAKE-key
+#
+# name	model_arg	host_key	mangle	expect	note
+matched-openrouter	--model openrouter/auto	openrouter	none	200	control: provider, key and host all agree -> works
+mismatch-or-to-zai	--model openrouter/auto	zai	none	401	THE REPORTED BUG: valid OpenRouter key sent to a Z.ai host
+matched-zai-pinned	--model zai/glm-4.6	zai	none	200	THE FIX: pin the zai provider so key+host agree
+autodetect-to-zai-host	(auto)	zai	none	401	no --model: auto-detect picks a provider that may not match the forced host
+trailing-space-key	--model openrouter/auto	openrouter	trailing_space	401	footgun: a trailing space/newline in the key is sent verbatim (env path never trims)
+quoted-key	--model openrouter/auto	openrouter	quoted	401	footgun: a dotenv value kept its surrounding quotes


### PR DESCRIPTION
## What this is

A **diagnostic/regression artifact — not a code fix.** It reproduces the class of
failure where a *valid* API key still returns **HTTP 401**, because Stella dialed
the wrong host.

## The bug it explains

Reported symptom: every prompt fails with
`provider auth error: OpenRouter rejected the credential (HTTP 401 Unauthorized)`,
on a key that is valid.

Root cause (confirmed live): the `stella_dev` launcher is a shell alias that forces
`--base-url` to **Z.ai**:

```
alias stella_dev='./target/release/stella --base-url https://api.z.ai/api/coding/paas/v4'
```

`--base-url` is a global override applied to whichever provider *auto-resolves*.
With no `--model`, Stella auto-detects **OpenRouter** (key present + valid) and
sends that OpenRouter key to **Z.ai's** host → Z.ai 401s it. The error names the
resolved *provider* (`OpenRouter`), not the host actually dialed, which is why it
points at the wrong place.

Evidence:
- Real OpenRouter `/api/v1/key` returns **200** for the key → key is fine.
- `stella --base-url <z.ai> config` shows `Provider: OpenRouter` + `Base URL: z.ai` → the mismatch.
- Corrected `--model zai/glm-4.6 --base-url <z.ai> run` completes a real turn → the fix.

## The user-side fix (lives in the shell alias, NOT this repo)

Pin the provider so key + host agree:

```
alias stella_dev='./target/release/stella --model zai/glm-4.6 --base-url https://api.z.ai/api/coding/paas/v4'
```

## Contents

- `sandbox/provider-host-mismatch/mock_provider.py` — zero-dep stand-in host; 200 for its one key, 401 otherwise; logs exact `Authorization` bytes (invisible trailing whitespace becomes visible).
- `sandbox/provider-host-mismatch/scenarios.tsv` — dataset: bug, fix, auto-detect variant, whitespace/quote footguns.
- `sandbox/provider-host-mismatch/run.sh` — drives real `stella config` + HTTP replay per scenario, prints a verdict table. Runs offline with fake keys.
- `sandbox/provider-host-mismatch/README.md` — answer-first: the alias fix, the mechanism, a 1-minute diagnostic recipe.

`run.sh` → 6/6 PASS on stella 0.4.42.

## Follow-up proposal (not in this PR)

The auth error labels the failure with the resolved *provider name* rather than the
*host actually dialed*. When `--base-url` overrides the host, the message could name
the real endpoint (and flag a provider/host mismatch) — that alone would have made
this self-diagnosing. Happy to open a separate PR if wanted.