### PR TITLE
feat(deck): migrate engine config to a new SETTINGS tab; rename AGENT ENGINE → AGENTS

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -3106,7 +3106,7 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ("/init", "index the workspace: domains + code graph"),
     (
         "/agents",
-        "open the AGENT ENGINE tab: executions, installed agents & engine config",
+        "open the AGENTS tab: executions & installed agents",
     ),
     (
         "/pipeline",
@@ -3131,9 +3131,13 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
     ),
     ("/inbox", "notifications — messages persist until read"),
     ("/mcp-search", "search the MCP registry & install servers"),
-    // The engine-config editor lives permanently in the AGENT ENGINE tab's
-    // right column (no `/engine` popup anymore); the /model-* commands jump
-    // straight to it with that agent's model picker open.
+    (
+        "/settings",
+        "open the SETTINGS tab — the home of all config",
+    ),
+    // The engine-config editor lives on the SETTINGS tab, full-width (no
+    // `/engine` popup anymore); the /model-* commands jump straight to it
+    // with that agent's model picker open.
     ("/model-default", "pick the default agent's model"),
     ("/model-worker", "pick the pipeline worker model"),
     ("/model-judge", "pick the pipeline judge model"),
@@ -3146,7 +3150,7 @@ fn deck_reserved() -> Vec<&'static str> {
     DECK_BUILTINS.iter().map(|(name, _)| *name).collect()
 }
 
-// ── Agent-engine config (the AGENT ENGINE panel) ──────────────────────────────
+// ── Agent-engine config (the SETTINGS tab's config panel) ─────────────────────
 
 /// Build an [`Inbound::EngineConfig`] snapshot: the freshly merged
 /// `agent_engine_config` from the settings scope chain, plus the picker

--- a/stella-docs/content/docs/agent-engine-paths.mdx
+++ b/stella-docs/content/docs/agent-engine-paths.mdx
@@ -41,7 +41,7 @@ came through:
 - **Everything is recorded.** Each turn opens an execution record (files
   touched, tool use, memory citations, cost, outcome) in the workspace
   store, feeding [telemetry](/docs/telemetry), `stella stats`, and the
-  deck's AGENT ENGINE tab. Sessions are durable and resumable
+  deck's AGENTS tab. Sessions are durable and resumable
   (`stella resume`).
 - **Per-role model routing applies.** The
   [agent engine config](/docs/configuration/agent-engine-config) pins models
@@ -92,9 +92,10 @@ TUI over the engine. Each prompt becomes a lead-agent turn; `/pipeline`
 toggles between staged turns (the default) and the raw step loop. The deck
 is more than a chat surface: prompts queue while a turn runs, `!` lines run
 shell commands in their own lane, Esc cancels, and tabs expose the session's
-files, diff, code graph, skills, MCP servers, and the
-[AGENT ENGINE panel](/docs/configuration/agent-engine-config) with live
-executions and per-role model pickers.
+files, diff, code graph, skills, MCP servers, the AGENTS tab with live
+executions, and the SETTINGS tab's
+[config panel](/docs/configuration/agent-engine-config) with per-role model
+pickers.
 
 Two things are unique to deck turns:
 
@@ -121,7 +122,7 @@ keeps working, its spend metered into the session's **shared** budget guard
 (child spend always reaches the parent's ledger; fleet children, by
 contrast, each run under their own slice of the cap). Results return to the
 lead for review; every sub-agent turn is recorded (`deck-sub`) and visible in the
-AGENT ENGINE tab. You don't invoke this path directly — you ask for work
+AGENTS tab. You don't invoke this path directly — you ask for work
 that warrants it, and the lead fans out.
 
 **Use it when** (implicitly) a deck task decomposes into independent chunks —
@@ -222,7 +223,7 @@ If you're changing engine behavior, these are the seams:
 The execution-kind strings in [the map](#the-map) are what these paths stamp
 on their execution records — the same strings you'll see in
 `stella stats`, the exported [dashboard](/docs/telemetry/dashboard), and the
-deck's AGENT ENGINE tab, so a telemetry row always traces back to the door
+deck's AGENTS tab, so a telemetry row always traces back to the door
 the work came through.
 
 ## Where to go next

--- a/stella-docs/content/docs/agent-modes.mdx
+++ b/stella-docs/content/docs/agent-modes.mdx
@@ -29,8 +29,9 @@ tabs and overlays:
 | `/models` | List providers and models |
 | `/files` · `/diff` | What this session changed, and the working diff |
 | `/graph` | The code-graph tab |
-| `/agents` · `/skills` · `/mcp` | The AGENT ENGINE tab (executions, installed agents & the [engine-config panel](/docs/configuration/agent-engine-config)), skills, MCP servers |
-| `/model-worker` (& `-default`, `-judge`, `-triage`) | Jump to that agent's model picker in the engine panel |
+| `/agents` · `/skills` · `/mcp` | The AGENTS tab (executions & installed agents), skills, MCP servers |
+| `/settings` | The SETTINGS tab — home of all config, incl. the [engine-config panel](/docs/configuration/agent-engine-config) |
+| `/model-worker` (& `-default`, `-judge`, `-triage`) | Jump to that agent's model picker in the config panel |
 | `/pipeline` | Toggle staged-pipeline turns (ON by default) |
 | `/sessions` · `/inbox` | Every session on this machine; notifications |
 | `/export` | Export session telemetry to a ZIP + [HTML dashboard](/docs/telemetry/dashboard) |

--- a/stella-docs/content/docs/commands/chat.mdx
+++ b/stella-docs/content/docs/commands/chat.mdx
@@ -23,7 +23,7 @@ stella chat --plain
 
 `stella chat` opens a conversational session. You type a message, the agent runs its step loop — proposing tool calls, executing them, and feeding results back until the turn is done — and then hands the prompt back to you. Conversation history is retained across turns within the session.
 
-The default **Command Deck** presents the session as a set of tabs — **SESSION** (the transcript), **AGENT ENGINE** (executions, installed agents, and the embedded engine-config panel), **TRACES**, **GRAPH**, **FILES**, **SKILLS**, **MCP**, and **ISSUES** (your connected GitHub/Linear tracker, with instant type-ahead). Slash commands jump between tabs and run actions, and `?` opens a tab-aware key list. The **plain REPL** (`--plain`) is a single scrolling line-based loop with a smaller command set — handy for narrow terminals, screen readers, and recordings.
+The default **Command Deck** presents the session as a set of tabs — **SESSION** (the transcript), **AGENTS** (executions & installed agents), **TRACES**, **GRAPH**, **FILES**, **SKILLS**, **MCP**, **ISSUES** (your connected GitHub/Linear tracker, with instant type-ahead), and **SETTINGS** (the home of all config, incl. the engine-config panel). Slash commands jump between tabs and run actions, and `?` opens a tab-aware key list. The **plain REPL** (`--plain`) is a single scrolling line-based loop with a smaller command set — handy for narrow terminals, screen readers, and recordings.
 
 ### Multimodal input
 
@@ -60,7 +60,8 @@ Open a tab or run an action:
 | `/models` | List providers and models (same output as `stella models`). |
 | `/init` | Run workspace initialization. |
 | `/pipeline` | Toggle the staged pipeline on or off for subsequent turns. |
-| `/agents` | Open the AGENT ENGINE tab — executions, installed agents, and the engine-config panel. |
+| `/agents` | Open the AGENTS tab — executions & installed agents. |
+| `/settings` | Open the SETTINGS tab — the home of all config, incl. the engine-config panel. |
 | `/files` | Open the FILES (files-touched) tab. |
 | `/diff` | Show the working diff. |
 | `/graph` | Open the GRAPH (code-graph) tab. |

--- a/stella-docs/content/docs/configuration/agent-engine-config.mdx
+++ b/stella-docs/content/docs/configuration/agent-engine-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent engine config
-description: Configure each engine agent — default, worker, judge, triage — with its own model, gateway, prompt, reasoning effort, and sampling parameters via agent_engine_config in settings.json, or interactively in the AGENT ENGINE tab's engine panel.
+description: Configure each engine agent — default, worker, judge, triage — with its own model, gateway, prompt, reasoning effort, and sampling parameters via agent_engine_config in settings.json, or interactively in the SETTINGS tab's config panel.
 ---
 
 The `agent_engine_config` object in [`settings.json`](/docs/configuration/settings)
@@ -169,17 +169,18 @@ their built-in output contracts (the classification token, the `PASS`/`FAIL`
 verdict line); a custom prompt for those agents is prepended as an extra
 system message rather than replacing the task prompt.
 
-## The engine panel in the Command Deck
+## The config panel in the Command Deck
 
-Everything above is editable interactively. The editor lives permanently in
-the **AGENT ENGINE** tab's right column (a 60/40 split beside the
-executions dashboard — the former `/engine` popup, now always in view):
+Everything above is editable interactively. The editor is the full-width body
+of the **SETTINGS** tab — the home of all config (the former `/engine` popup,
+then the AGENT ENGINE tab's right column, now a tab of its own; open it with
+`/settings` or by tabbing to it):
 
-- **`e`** on the AGENT ENGINE tab focuses the panel — a tab per agent plus
+- **`e`** on the SETTINGS tab focuses the panel — a tab per agent plus
   a GLOBAL tab (auto modes, `allowed_models`). Navigate with ↑/↓, press ⏎
   to edit a row (enum rows cycle; numeric and text rows take inline input),
-  `x` clears a field back to "provider default", Esc returns focus to the
-  executions list.
+  `x` clears a field back to "provider default", Esc hands the keyboard back
+  to the tab.
 - **`/model-default`**, **`/model-worker`**, **`/model-judge`**,
   **`/model-triage`** jump straight into a type-to-filter model picker for
   that agent, listing your `allowed_models` (or the full catalog when the

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -37,10 +37,11 @@ pub enum DeckTab {
     Skills,
     Mcp,
     Issues,
+    Settings,
 }
 
 impl DeckTab {
-    pub const ALL: [DeckTab; 8] = [
+    pub const ALL: [DeckTab; 9] = [
         DeckTab::Session,
         DeckTab::Agents,
         DeckTab::Traces,
@@ -49,22 +50,25 @@ impl DeckTab {
         DeckTab::Skills,
         DeckTab::Mcp,
         DeckTab::Issues,
+        DeckTab::Settings,
     ];
 
     /// The tab-bar label. Deck tab labels are UPPERCASE by convention —
     /// every tab added later must follow (e.g. `SKILLS`, `MCP`).
-    /// `Agents` renders as AGENT ENGINE: the tab pairs the executions
-    /// dashboard with the permanent engine-config panel (60/40).
+    /// `Agents` renders as AGENTS: the executions dashboard paired with the
+    /// installed-agents view. `Settings` is the home of all config — it hosts
+    /// the `agent_engine_config` editor that used to share the Agents tab.
     pub fn title(self) -> &'static str {
         match self {
             DeckTab::Session => "SESSION",
-            DeckTab::Agents => "AGENT ENGINE",
+            DeckTab::Agents => "AGENTS",
             DeckTab::Traces => "TRACES",
             DeckTab::Graph => "GRAPH",
             DeckTab::Files => "FILES",
             DeckTab::Skills => "SKILLS",
             DeckTab::Mcp => "MCP",
             DeckTab::Issues => "ISSUES",
+            DeckTab::Settings => "SETTINGS",
         }
     }
 
@@ -1687,13 +1691,14 @@ mod tests {
     #[test]
     fn deck_tab_cycles_both_ways() {
         assert_eq!(DeckTab::Session.next(), DeckTab::Agents);
-        // Tab order ends …Files → Skills → Mcp → Issues; Issues wraps to
+        // Tab order ends …Skills → Mcp → Issues → Settings; Settings wraps to
         // Session and is Session's predecessor backward.
         assert_eq!(DeckTab::Files.next(), DeckTab::Skills);
         assert_eq!(DeckTab::Skills.next(), DeckTab::Mcp);
         assert_eq!(DeckTab::Mcp.next(), DeckTab::Issues);
-        assert_eq!(DeckTab::Issues.next(), DeckTab::Session);
-        assert_eq!(DeckTab::Session.prev(), DeckTab::Issues);
+        assert_eq!(DeckTab::Issues.next(), DeckTab::Settings);
+        assert_eq!(DeckTab::Settings.next(), DeckTab::Session);
+        assert_eq!(DeckTab::Session.prev(), DeckTab::Settings);
     }
 
     #[test]

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -86,6 +86,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         DeckTab::Skills => views::skills::render(model, ui, content, buf),
         DeckTab::Mcp => views::mcp::render(model, ui, content, buf),
         DeckTab::Issues => views::issues::render(model, ui, content, buf),
+        DeckTab::Settings => views::settings::render(model, ui, content, buf),
     }
 
     render_trace_strip(model, bands[2], buf);
@@ -119,8 +120,8 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     if ui.context_open {
         render_context_overlay(ui, area, buf);
     }
-    // (The former ENGINE overlay is gone: the engine panel renders inside
-    // the AGENT ENGINE tab's right column — see `views::agents::render`.)
+    // (The former ENGINE overlay is gone: the engine panel is the full-width
+    // body of the SETTINGS tab — see `views::settings::render`.)
 
     // Deck motion (crate::fx), scrubbed like the splash: each frame builds a
     // fresh effect and processes it once at its wall-clock elapsed, so no
@@ -1296,13 +1297,11 @@ fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
         DeckTab::Agents => &[
             ("← →", "switch panes — executions / installed"),
             ("↑ ↓", "select an agent"),
-            ("e", "focus the engine panel — models, prompts & params"),
             ("s", "stop the selected running agent"),
             ("⏎", "edit the selected installed agent"),
             ("v", "show the selected agent's versions"),
             ("n", "new agent — drafted by the LLM"),
             ("r", "reload installed agents"),
-            ("esc", "in the engine panel: back to the left column"),
         ],
         DeckTab::Traces => &[
             ("↑ ↓ ⇞ ⇟", "scroll the event log"),
@@ -1341,6 +1340,19 @@ fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
             ("c", "comment on the selected issue"),
             ("s", "set the selected issue's status"),
             ("w", "start work on the selected issue"),
+        ],
+        DeckTab::Settings => &[
+            ("e", "edit the agents config — models, prompts & params"),
+            (
+                "tab",
+                "in the editor: switch agent — global / default / worker / …",
+            ),
+            ("⏎", "in the editor: edit the selected row / pick a model"),
+            ("space", "in the editor: toggle the selected row"),
+            ("x", "in the editor: clear the selected row"),
+            ("s / S", "in the editor: save to user / project settings"),
+            ("r", "in the editor: reload from disk"),
+            ("esc", "in the editor: hand the keyboard back to the tab"),
         ],
     }
 }

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -659,7 +659,7 @@ pub struct DeckUi {
     /// finished OAuth login refreshes the MCP snapshot). The shell drains
     /// this after every key/inbound and forwards each as a submission.
     pub pending_inputs: Vec<WorkspaceInput>,
-    /// The ENGINE panel (AGENT ENGINE tab, `/model-*`): the editor for
+    /// The ENGINE panel (SETTINGS tab, `/model-*`): the editor for
     /// `settings.json` → `agent_engine_config`, over a driver-owned snapshot
     /// ([`Inbound::EngineConfig`]). Modal while open.
     pub engine: crate::views::engine::EngineOverlay,
@@ -801,11 +801,11 @@ impl DeckUi {
             return;
         }
 
-        // 2b. The ENGINE panel is modal while focused (AGENT ENGINE tab): a
+        // 2b. The ENGINE panel is modal while focused (SETTINGS tab): a
         //     paste belongs to its inline edit (a prompt, a model list) or
         //     the picker filter — and with neither active it is swallowed,
         //     never the composer's.
-        if self.tab == DeckTab::Agents && self.engine.focused {
+        if self.tab == DeckTab::Settings && self.engine.focused {
             if let Some(edit) = self.engine.edit.as_mut() {
                 push_single_line(&mut edit.buffer, text);
             } else if let Some(picker) = self.engine.picker.as_mut() {
@@ -1324,12 +1324,12 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         return handle_graph_picker_key(key, ui);
     }
 
-    // The ENGINE panel (the AGENT ENGINE tab's right column) is modal
-    // exactly like the queue editor while focused: it owns the keyboard —
-    // its inline edit buffer, its model picker, and its letter verbs
-    // (`s`/`S`/`x`/`r`) must never leak into the composer. Scoped to its
-    // own tab so a stale focus flag can never trap the keyboard elsewhere.
-    if ui.tab == DeckTab::Agents && ui.engine.focused {
+    // The ENGINE panel (the SETTINGS tab's config editor) is modal exactly
+    // like the queue editor while focused: it owns the keyboard — its inline
+    // edit buffer, its model picker, and its letter verbs (`s`/`S`/`x`/`r`)
+    // must never leak into the composer. Scoped to its own tab so a stale
+    // focus flag can never trap the keyboard elsewhere.
+    if ui.tab == DeckTab::Settings && ui.engine.focused {
         return crate::views::engine::handle_engine_key(key, ui);
     }
 
@@ -1460,6 +1460,7 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         DeckTab::Mcp => handle_mcp_key(key, ui, composer_empty),
         DeckTab::Issues => handle_issues_browse_key(key, ui, composer_empty),
         DeckTab::Session => handle_session_key(key, model, ui),
+        DeckTab::Settings => handle_settings_key(key, ui, composer_empty),
         // The SKILLS tab claims its keys earlier (before the composer), so a
         // key that reaches here fell through on purpose — leave it to the
         // deck-global handlers below.
@@ -1615,6 +1616,12 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
                 ui.set_tab(DeckTab::Mcp);
                 DeckAction::Handled
             }
+            // `/settings` opens the SETTINGS tab — the home of all config
+            // (deck-local view state, like the tab switches above).
+            "/settings" => {
+                ui.set_tab(DeckTab::Settings);
+                DeckAction::Handled
+            }
             // The three transcript-page overlays are deck-local view state,
             // exactly like the tab switches above (their keyboard shortcuts:
             // empty-prompt `←` / `→`, and the footer's ✉ badge for the inbox).
@@ -1623,10 +1630,10 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
             "/inbox" => open_inbox_overlay(ui),
             // The ENGINE panel: deck-local view state over a driver-owned
             // settings snapshot. The old `/engine` popup is gone — the panel
-            // lives permanently in the AGENT ENGINE tab's right column, and
-            // the four `/model-<agent>` commands jump straight there with
-            // that agent's model picker already open. Intercepted here so
-            // these never get submitted as prompts.
+            // is the full-width body of the SETTINGS tab, and the four
+            // `/model-<agent>` commands jump straight there with that agent's
+            // model picker already open. Intercepted here so these never get
+            // submitted as prompts.
             "/model-default" => crate::views::engine::open_with_picker(ui, EngineRole::Default),
             "/model-worker" => crate::views::engine::open_with_picker(ui, EngineRole::Worker),
             "/model-judge" => crate::views::engine::open_with_picker(ui, EngineRole::Judge),
@@ -3231,18 +3238,24 @@ fn handle_mcp_auth_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
+/// The SETTINGS tab's browse keys (non-modal — the composer stays live). The
+/// tab hosts the `agent_engine_config` editor; `e` hands it the keyboard (its
+/// own Esc hands it back), gated on a blank composer like every other tab's
+/// letter verb so typing a prompt still works from here. Once focused, the
+/// editor claims every key ahead of this handler (see `handle_deck_key`).
+fn handle_settings_key(key: KeyEvent, ui: &mut DeckUi, composer_empty: bool) -> Option<DeckAction> {
+    if composer_empty && key.modifiers.is_empty() && matches!(key.code, KeyCode::Char('e')) {
+        return Some(crate::views::engine::focus_panel(ui));
+    }
+    None
+}
+
 fn handle_agents_key(
     key: KeyEvent,
     model: &WorkspaceModel,
     ui: &mut DeckUi,
     composer_empty: bool,
 ) -> Option<DeckAction> {
-    // `e` hands the keyboard to the engine panel (the right column) from
-    // either pane — the panel's own Esc hands it back.
-    if composer_empty && key.modifiers.is_empty() && matches!(key.code, KeyCode::Char('e')) {
-        return Some(crate::views::engine::focus_panel(ui));
-    }
-
     // The secondary nav: ←/→ switch EXECUTIONS ↔ INSTALLED AGENTS. These
     // only arrive here with a blank composer (a composer holding text claims
     // ←/→ for cursor motion first), same gate as every other tab key.

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -242,7 +242,7 @@ pub enum Inbound {
     },
     /// A refreshed snapshot of the agent-engine configuration
     /// (`settings.json` → `agent_engine_config`) for the ENGINE overlay
-    /// (the AGENT ENGINE panel). Out-of-band view state exactly like
+    /// (the SETTINGS tab's config panel). Out-of-band view state exactly like
     /// [`Inbound::GraphSnapshot`]: applied straight to `DeckUi` by
     /// [`crate::deck_ui::ingest_inbound`], ignored by the model fold. The
     /// driver sends one at startup, after every

--- a/stella-tui/src/views/agents.rs
+++ b/stella-tui/src/views/agents.rs
@@ -1,16 +1,14 @@
-//! AGENT ENGINE tab — a 60/40 two-column grid. The left 60% is the two-pane
-//! view behind a one-line secondary nav (EXECUTIONS | INSTALLED AGENTS,
-//! switched with ←/→); the right 40% is the permanent engine-config panel
-//! ([`crate::views::engine`]) that used to live behind the `/engine` popup:
+//! AGENTS tab — the two-pane agents view behind a one-line secondary nav
+//! (EXECUTIONS | INSTALLED AGENTS, switched with ←/→):
 //!
 //! - **EXECUTIONS** (this module): the flagship `htop`/`claudectl`-style
 //!   dashboard — one dense row per ACTIVE agent with live status, spend,
 //!   resource usage, and activity.
 //! - **INSTALLED AGENTS** ([`crate::views::installed`]): the agents
 //!   configured on disk at the user/project level.
-//! - **ENGINE** (right column): the `agent_engine_config` editor — global
-//!   routing toggles plus per-agent model / prompt / sampling overrides.
-//!   `e` focuses it; its Esc hands the keyboard back.
+//!
+//! The `agent_engine_config` editor that used to occupy this tab's right
+//! column now lives full-width on the SETTINGS tab ([`crate::views::settings`]).
 //!
 //! Every color comes from [`crate::theme`]; every number is read straight off
 //! [`crate::deck::AgentEntry`] (no shadow state, no re-derivation of what the
@@ -38,35 +36,20 @@ const HEADERS: [&str; 11] = [
 /// cut wherever the terminal happens to clip the column.
 const GOAL_MAX_CHARS: usize = 56;
 
-/// Below this width a 40% engine column is too narrow to read — the left
-/// view takes the whole tab and the engine panel steps aside (still one
-/// `e` press away: focusing re-renders, and wider terminals show it live).
-const ENGINE_COLUMN_MIN_WIDTH: u16 = 90;
-
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     if area.height == 0 || area.width == 0 {
         return;
     }
-    // The one-line secondary nav, then the active pane below it.
+    // The one-line secondary nav, then the active pane below it — the pane
+    // fills the whole tab now that the engine-config panel has moved to
+    // SETTINGS.
     let bands = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
     render_pane_nav(ui.agents_pane, bands[0], buf);
 
-    // The 60/40 grid: left — executions / installed; right — the permanent
-    // engine-config panel (the old `/engine` popup's content, always on).
     let body = bands[1];
-    let (left, engine_col) = if body.width >= ENGINE_COLUMN_MIN_WIDTH {
-        let cols = Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)])
-            .split(body);
-        (cols[0], Some(cols[1]))
-    } else {
-        (body, None)
-    };
     match ui.agents_pane {
-        AgentsPane::Executions => render_executions(model, ui, left, buf),
-        AgentsPane::Installed => crate::views::installed::render(ui, left, buf),
-    }
-    if let Some(engine_col) = engine_col {
-        crate::views::engine::render_panel(ui, engine_col, buf);
+        AgentsPane::Executions => render_executions(model, ui, body, buf),
+        AgentsPane::Installed => crate::views::installed::render(ui, body, buf),
     }
 }
 
@@ -90,7 +73,7 @@ fn render_pane_nav(pane: AgentsPane, area: Rect, buf: &mut Buffer) {
         Span::styled("EXECUTIONS", style_for(pane == AgentsPane::Executions)),
         Span::styled("  │  ", theme::muted()),
         Span::styled("INSTALLED AGENTS", style_for(pane == AgentsPane::Installed)),
-        Span::styled("   ←/→ · e engine", theme::muted()),
+        Span::styled("   ←/→", theme::muted()),
     ]);
     Paragraph::new(line).render(area, buf);
 }

--- a/stella-tui/src/views/engine.rs
+++ b/stella-tui/src/views/engine.rs
@@ -1,9 +1,9 @@
-//! The ENGINE panel — the AGENT ENGINE tab's permanent right column, the
-//! editor for `settings.json` → `agent_engine_config`: the global routing
-//! toggles plus the per-agent model / prompt / sampling overrides for the
-//! four pipeline agents (default · worker · judge · triage). Formerly the
-//! `/engine` popup; the command and the popup are gone — the same content
-//! now lives beside the executions dashboard in a 60/40 split.
+//! The ENGINE panel — the config editor the SETTINGS tab hosts full-width,
+//! for `settings.json` → `agent_engine_config`: the global routing toggles
+//! plus the per-agent model / prompt / sampling overrides for the four
+//! pipeline agents (default · worker · judge · triage). Formerly the
+//! `/engine` popup, then the AGENTS tab's right column; the same content now
+//! lives on SETTINGS ([`crate::views::settings`]), the home of all config.
 //!
 //! Ownership mirrors the MCP and SKILLS surfaces: the **driver** owns the
 //! settings files on disk and pushes [`crate::envelope::Inbound::EngineConfig`]
@@ -20,9 +20,9 @@
 //! path).
 //!
 //! Interaction follows the queue-editor contract: **modal while focused**
-//! (`e` on the AGENT ENGINE tab focuses; Esc returns focus to the left
-//! column). Every key is claimed by [`handle_engine_key`] while focused, so
-//! the letter verbs (`s`/`S`/`x`/`r`), the inline edit buffer, and the
+//! (`e` on the SETTINGS tab focuses; Esc hands the keyboard back to the
+//! tab). Every key is claimed by [`handle_engine_key`] while focused, so the
+//! letter verbs (`s`/`S`/`x`/`r`), the inline edit buffer, and the
 //! model-picker filter can never leak a keystroke into the global composer.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -258,9 +258,9 @@ pub struct ModelPicker {
 /// All engine-panel view state (a field on [`DeckUi`]). The config itself
 /// is driver-owned — `state` is the working copy being edited and `pristine`
 /// the last snapshot adopted from the driver; everything else is ephemeral
-/// interaction state. The panel lives permanently in the AGENT ENGINE tab's
-/// right column (no popup, no `/engine` command): `focused` is what routes
-/// the keyboard to it.
+/// interaction state. The panel is the full-width body of the SETTINGS tab
+/// (no popup, no `/engine` command): `focused` is what routes the keyboard
+/// to it.
 #[derive(Debug, Clone, Default)]
 pub struct EngineOverlay {
     /// Whether the panel owns the keyboard (modal while set, on the AGENT
@@ -331,14 +331,14 @@ pub fn ingest_config(ui: &mut DeckUi, state: &EngineConfigState, status: &Option
     e.busy = false;
 }
 
-// ── focusers (`e` on the AGENT ENGINE tab, and `/model-*`) ─────────────────
+// ── focusers (`e` on the SETTINGS tab, and `/model-*`) ─────────────────────
 
-/// Focus the engine panel (switching to the AGENT ENGINE tab if needed) on
+/// Focus the engine panel (switching to the SETTINGS tab if needed) on
 /// the GLOBAL tab, and ask the driver to re-read the settings chain so the
 /// panel reflects disk truth (the reply is dirty-guarded by
 /// [`ingest_config`], so refocusing over unsaved edits is safe).
 pub fn focus_panel(ui: &mut DeckUi) -> DeckAction {
-    ui.set_tab(DeckTab::Agents);
+    ui.set_tab(DeckTab::Settings);
     let e = &mut ui.engine;
     e.focused = true;
     e.tab = EngineTab::Global;
@@ -349,11 +349,11 @@ pub fn focus_panel(ui: &mut DeckUi) -> DeckAction {
     DeckAction::Send(WorkspaceInput::EngineConfigRefresh)
 }
 
-/// `/model-<agent>`: jump to the AGENT ENGINE tab, focus the panel on that
+/// `/model-<agent>`: jump to the SETTINGS tab, focus the panel on that
 /// agent's tab with the model picker already up — the one-keystroke "change
 /// this agent's model" path.
 pub fn open_with_picker(ui: &mut DeckUi, role: EngineRole) -> DeckAction {
-    ui.set_tab(DeckTab::Agents);
+    ui.set_tab(DeckTab::Settings);
     let e = &mut ui.engine;
     e.focused = true;
     e.tab = EngineTab::Agent(role);
@@ -936,12 +936,12 @@ fn cycle_enum(current: &mut Option<String>, values: &[&str]) {
 /// Label column width — fits the longest key (`repetition_penalty`, 18).
 const LABEL_W: usize = 19;
 
-/// Render the ENGINE panel into the AGENT ENGINE tab's right column: an
-/// area-filling bordered panel (accent border while it owns the keyboard,
-/// hairline otherwise), windowed rows with the selection reversed, and the
-/// model-picker sub-overlay centered over the panel when open. This is the
-/// exact content the old `/engine` popup carried — permanent now, so the
-/// engine config is always in view beside the executions it drives.
+/// Render the ENGINE panel into the SETTINGS tab: an area-filling bordered
+/// panel (accent border while it owns the keyboard, hairline otherwise),
+/// windowed rows with the selection reversed, and the model-picker
+/// sub-overlay centered over the panel when open. This is the exact content
+/// the old `/engine` popup carried — a permanent config surface now, the
+/// full-width body of the SETTINGS tab.
 pub fn render_panel(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     let e = &ui.engine;
     let (w, h) = (area.width, area.height);
@@ -1009,15 +1009,12 @@ pub fn render_panel(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
         if e.focused {
             " tab agent · ⏎ edit · space toggle · x clear · s save user · S save project · r reload · esc done"
         } else {
-            " e edit engine config"
+            " e edit agents config"
         },
         theme::muted(),
     )));
 
-    let title = format!(
-        " agent engine{} ",
-        if e.dirty() { " · modified" } else { "" }
-    );
+    let title = format!(" agents{} ", if e.dirty() { " · modified" } else { "" });
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(if e.focused {
@@ -1268,12 +1265,12 @@ mod tests {
         }
     }
 
-    /// A deck on the AGENT ENGINE tab with the panel already focused over a
+    /// A deck on the SETTINGS tab with the panel already focused over a
     /// loaded snapshot — the state most key tests start from.
     fn open_ui() -> (WorkspaceModel, DeckUi) {
         let model = WorkspaceModel::new();
         let mut ui = ready_ui();
-        ui.set_tab(DeckTab::Agents);
+        ui.set_tab(DeckTab::Settings);
         ui.engine.focused = true;
         ui.engine.state = Some(sample_state());
         ui.engine.pristine = Some(sample_state());
@@ -1359,10 +1356,10 @@ mod tests {
     }
 
     #[test]
-    fn e_on_the_agent_engine_tab_focuses_the_panel_and_esc_unfocuses() {
+    fn e_on_the_settings_tab_focuses_the_panel_and_esc_unfocuses() {
         let model = WorkspaceModel::new();
         let mut ui = ready_ui();
-        ui.set_tab(DeckTab::Agents);
+        ui.set_tab(DeckTab::Settings);
         let action = handle_deck_key(ch('e'), &model, &mut ui);
         assert_eq!(
             action,
@@ -1373,13 +1370,13 @@ mod tests {
         assert_eq!(ui.engine.tab, EngineTab::Global);
         assert!(ui.engine.picker.is_none());
 
-        // Esc hands the keyboard back to the tab's left column.
+        // Esc hands the keyboard back to the tab.
         handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
-        assert!(!ui.engine.focused, "esc returns focus to the left column");
+        assert!(!ui.engine.focused, "esc hands the keyboard back to the tab");
     }
 
     #[test]
-    fn slash_model_worker_opens_the_agent_tab_with_the_picker() {
+    fn slash_model_worker_opens_the_settings_tab_with_the_picker() {
         let model = WorkspaceModel::new();
         let mut ui = ready_ui();
         ui.slash_commands = vec![SlashCommand::new("/model-worker", "pick the worker model")];
@@ -1391,6 +1388,7 @@ mod tests {
             action,
             DeckAction::Send(WorkspaceInput::EngineConfigRefresh)
         );
+        assert_eq!(ui.tab, DeckTab::Settings, "jumps to the SETTINGS tab");
         assert!(ui.engine.focused);
         assert_eq!(ui.engine.tab, EngineTab::Agent(EngineRole::Worker));
         assert_eq!(ui.engine.row, 0, "the model row is preselected");
@@ -1677,7 +1675,7 @@ mod tests {
         let mut buf = Buffer::empty(area);
         render_panel(&ui, area, &mut buf);
         let text = buffer_text(&buf);
-        assert!(text.contains("agent engine"), "title drawn");
+        assert!(text.contains("agents"), "title drawn");
         assert!(text.contains("temperature"), "agent rows drawn");
         assert!(text.contains("(provider default)"), "unset renders dimmed");
 

--- a/stella-tui/src/views/mod.rs
+++ b/stella-tui/src/views/mod.rs
@@ -2,9 +2,10 @@
 //! `render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer)`
 //! — a deterministic draw of the (model, ui) into a sub-area, recording any
 //! viewport metrics it needs for scroll clamping back onto `ui.metrics`.
-//! (`engine` is the exception: it is the AGENT ENGINE tab's permanent right
-//! column, not a tab of its own — it exposes `render_panel(ui, area, buf)`
-//! plus its own key handler, modal while the panel is focused.)
+//! (`engine` is the exception: it is the config editor the SETTINGS tab
+//! ([`settings`]) hosts, not a tab renderer of its own — it exposes
+//! `render_panel(ui, area, buf)` plus its own key handler, modal while the
+//! panel is focused.)
 
 pub mod agents;
 pub mod engine;
@@ -14,5 +15,6 @@ pub mod installed;
 pub mod issues;
 pub mod mcp;
 pub mod session;
+pub mod settings;
 pub mod skills;
 pub mod traces;

--- a/stella-tui/src/views/settings.rs
+++ b/stella-tui/src/views/settings.rs
@@ -1,0 +1,27 @@
+//! SETTINGS tab — the home of all config in stella. Today it hosts the
+//! `agent_engine_config` editor (the per-role model / prompt / sampling
+//! overrides plus the global routing toggles) that used to share the AGENTS
+//! tab's right column; the panel now fills the whole tab. As more config
+//! surfaces move here they become sections of this tab.
+//!
+//! The editor itself lives in [`crate::views::engine`] — this module is the
+//! thin tab shell that places [`crate::views::engine::render_panel`] into the
+//! tab's content area. The panel is **modal while focused** (`e` focuses it,
+//! Esc hands the keyboard back), exactly as it was in its former home, so the
+//! always-on composer stays live until you enter the editor.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+use crate::deck::WorkspaceModel;
+use crate::deck_ui::DeckUi;
+
+/// Draw the SETTINGS tab: the config editor, full-area. `model` is unused for
+/// now (the editor works over the driver-owned snapshot held in `ui.engine`),
+/// kept in the signature to match every other tab view.
+pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    crate::views::engine::render_panel(ui, area, buf);
+}

--- a/stella-tui/tests/deck_snapshot.rs
+++ b/stella-tui/tests/deck_snapshot.rs
@@ -60,11 +60,9 @@ fn deck_renders_every_tab_with_real_content() {
             "the {tab:?} tab should show {needle:?}, got:\n{text}"
         );
         // The comfy-tabs bar labels are always present — UPPERCASE by the
-        // deck's tab-label convention.
-        assert!(
-            text.contains("AGENT ENGINE"),
-            "tab bar should render on {tab:?}"
-        );
+        // deck's tab-label convention. (Assert on a left-anchored label: at
+        // 120 cols the 9-tab bar overflows, so the rightmost SETTINGS clips.)
+        assert!(text.contains("SESSION"), "tab bar should render on {tab:?}");
     }
 
     // Write all five tabs to a human-readable artifact at the repo root.
@@ -83,34 +81,52 @@ fn deck_renders_every_tab_with_real_content() {
 #[test]
 fn agents_dashboard_shows_status_and_spend_columns() {
     let model = folded_model();
-    // The dashboard is dense (11 columns) and shares the tab with the engine
-    // panel (60/40) — render at a roomy width so the executions table's left
-    // 60% still clears the full-column threshold; the engine panel must
-    // render beside it.
+    // The dashboard is dense (11 columns) and now fills the whole tab (the
+    // engine panel moved to SETTINGS) — render at a roomy width so every
+    // column shows.
     let text = render_tab(&model, DeckTab::Agents, 240, 20);
-    // Column headers, at least one agent's live status, and the engine
-    // panel's title all render.
-    for needle in [
-        "CPU%",
-        "MEM",
-        "In/Out",
-        "Activity",
-        "needs input",
-        "agent engine",
-    ] {
+    // Column headers and at least one agent's live status all render.
+    for needle in ["CPU%", "MEM", "In/Out", "Activity", "needs input"] {
         assert!(
             text.contains(needle),
             "dashboard missing {needle:?}:\n{text}"
         );
     }
+    // The config editor no longer shares this tab — its focus hint (unique to
+    // the engine panel) must not appear here; it lives on SETTINGS now.
+    assert!(
+        !text.contains("edit agents config"),
+        "the config panel must not render on the AGENTS tab:\n{text}"
+    );
 
-    // At a typical terminal width the table drops to its compact column set
-    // (the Goal column must survive, the density columns go).
-    let text = render_tab(&model, DeckTab::Agents, 160, 20);
+    // Below the compact threshold the table drops its density columns (the
+    // Goal column must survive, CPU%/MEM/etc. go). The dashboard now fills the
+    // whole tab, so this needs a genuinely narrow terminal to trip.
+    let text = render_tab(&model, DeckTab::Agents, 130, 20);
     assert!(!text.contains("CPU%"), "compact set drops CPU%:\n{text}");
     assert!(
         text.contains("Goal"),
         "compact set keeps the Goal column:\n{text}"
+    );
+}
+
+#[test]
+fn settings_tab_hosts_the_agents_config_editor() {
+    let model = folded_model();
+    // The config editor is the full-width body of the SETTINGS tab now.
+    let text = render_tab(&model, DeckTab::Settings, 120, 24);
+    assert!(
+        text.contains("agents"),
+        "the config panel title renders on SETTINGS:\n{text}"
+    );
+    // Its GLOBAL / per-agent sub-tabs and the focus hint render.
+    assert!(
+        text.contains("GLOBAL"),
+        "the engine panel's GLOBAL sub-tab renders:\n{text}"
+    );
+    assert!(
+        text.contains("edit agents config"),
+        "the unfocused focus hint renders:\n{text}"
     );
 }
 


### PR DESCRIPTION
## What

Migrates the `agent_engine_config` editor out of the Agents tab and into a **new SETTINGS tab** — the home of all config in stella — and renames the tab formerly known as **AGENT ENGINE** back to **AGENTS**.

Before: the Agents tab was a 60/40 split — executions dashboard on the left, the engine-config panel permanently on the right, titled "agent engine".

After:
- **AGENTS** tab — just the executions dashboard + installed-agents panes, **full-width**. Its plain name is restored.
- **SETTINGS** tab (new, rightmost) — hosts the config editor **full-width**, titled **"agents"**. This is where all config will live going forward.

## Changes

| Area | Change |
|------|--------|
| `deck.rs` | `DeckTab::Settings` variant (end of `ALL`); `Agents` title `"AGENT ENGINE"` → `"AGENTS"`, `Settings` → `"SETTINGS"` |
| `views/settings.rs` (new) | Thin tab shell — renders `views::engine::render_panel` full-area |
| `views/agents.rs` | Drops the 60/40 split + engine column; panes go full-width; nav hint loses "e engine" |
| `views/engine.rs` | Panel title `"agent engine"` → `"agents"`; unfocused hint → "e edit agents config"; `focus_panel` / `open_with_picker` retarget `DeckTab::Settings` |
| `deck_ui.rs` | Modal + paste routing scoped to `DeckTab::Settings`; new `handle_settings_key` (`e` focuses the panel); `e`-focus removed from `handle_agents_key`; `/settings` opens the tab |
| `deck_render.rs` | Settings render arm + help shortcuts (Agents drops engine keys, Settings gains editor keys) |
| `command_deck.rs` | `/agents` description reworded; new `/settings` builtin |
| `deck_snapshot.rs` | Tab-cycle + width-driven assertions updated; new `settings_tab_hosts_the_agents_config_editor` test |
| docs (4 `.mdx`) | UI-location statements updated (the `agent_engine_config` JSON key itself is unchanged) |

The `e`-to-focus / modal-while-focused contract is preserved verbatim — it just moved tabs. `/model-{default,worker,judge,triage}` now jump to SETTINGS with the picker open. The composer stays live on the SETTINGS tab until you press `e`.

## Verification

- `cargo test -p stella-tui` — **482 lib + 4 integration tests pass**; `cargo clippy -p stella-tui` clean; `cargo fmt` clean.
- Eyeballed `deck-snapshots.txt`: AGENTS renders config-free full-width; SETTINGS hosts the panel full-width titled "agents"; all 9 tabs render.
- No `DeckTab` matches exist outside `stella-tui`, so the new public enum variant breaks no other crate.
- `command_deck.rs` fmt-validated (parses standalone).

## ⚠️ Pre-existing broken main — unrelated to this PR

The base commit (`79d907e`, "Storage map impl (#245)") is **already broken** independent of this change: it committed **both** `stella-graph/src/storage.rs` and `stella-graph/src/storage/` (module ambiguity, E0761), plus duplicate `storage_snapshot` / `record_storage_objects` definitions and a missing `ToolRegistry::command_line_for` in `stella-tools`. This is the storage-map author's in-flight work and is **not touched here**.

Consequence: any CI job that builds `stella-graph` / `stella-tools` / `stella-cli` will fail on **main's** breakage, not on this diff. `stella-tui` (where ~all of this change lives) does **not** depend on `stella-graph` and builds + tests cleanly. The one-line `stella-cli` change (a slash-command string + comment) was fmt-validated but could not be compile-checked in isolation due to the upstream breakage.

## Note (not fixed)

Adding a 9th tab pushes the tab bar to ~124 cols; on an 80/120-col terminal the rightmost SETTINGS clips until selected (comfy-tabs scrolls to keep the selected tab visible). Inherent to adding the tab.