### PR TITLE
feat(tools): persistent symbol-shaped graph_query steer + bash cwd-drift warning

### DIFF
--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -17,6 +17,7 @@
 //! silently running unsandboxed. See [`crate::sandbox`] for the full
 //! safety/capability tradeoff discussion.
 
+use std::path::Path;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -28,6 +29,137 @@ use crate::registry::Tool;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 const MAX_OUTPUT_BYTES: usize = 100_000;
+
+/// grep-family commands whose first positional arg is a search pattern.
+const GREP_CMDS: &[&str] = &["grep", "egrep", "fgrep", "rg", "ripgrep", "ag"];
+
+/// A quote-aware word split — enough to pull a `cd` target or a `grep`
+/// pattern out of the common command shapes, returning each word already
+/// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
+/// path with spaces stays one word) and preserves backslash escapes like
+/// `\|` (so an alternation survives into [`is_symbol_shaped`]); bare
+/// operators (`&&`, `|`, `;`) come back as their own words to bound a scan.
+fn shell_words(command: &str) -> Vec<String> {
+    let mut words: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut has_word = false;
+    let (mut in_single, mut in_double) = (false, false);
+    let mut chars = command.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                has_word = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                has_word = true;
+            }
+            '\\' if in_double => {
+                // Keep the escape literal (covers `\|`, `\"`, …); we don't
+                // interpret it, just preserve it for the symbol test.
+                cur.push('\\');
+                if let Some(n) = chars.next() {
+                    cur.push(n);
+                }
+                has_word = true;
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_word = true;
+            }
+        }
+    }
+    if has_word {
+        words.push(cur);
+    }
+    words
+}
+
+/// If the command `cd`s somewhere outside the workspace `root`, return that
+/// target — the graph indexes only `root`, so a search or edit under a
+/// drifted tree is silently ungraphed (the cross-tree gap the telemetry
+/// showed). Targets we can't resolve (`$VAR`, `~`, `-`, a flag) are skipped:
+/// better a missed note than a wrong one.
+fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
+    let words = shell_words(command);
+    for pair in words.windows(2) {
+        if pair[0] != "cd" {
+            continue;
+        }
+        let target = pair[1].as_str();
+        if target.is_empty()
+            || target == "-"
+            || target.starts_with('$')
+            || target.starts_with('~')
+            || target.starts_with('-')
+        {
+            continue;
+        }
+        if crate::resolve_within_root(root, target).is_none() {
+            return Some(target.to_string());
+        }
+    }
+    None
+}
+
+/// Does the command run a grep-family search whose pattern is symbol-shaped —
+/// the `grep -rn "struct X"` that graph_query answers better? The dominant
+/// path in the telemetry (symbol searches ran through bash, not the native
+/// grep tool), so the same nudge has to reach here. First positional after a
+/// grep word is the pattern; flags are skipped, a pipeline boundary ends the
+/// scan.
+fn bash_grep_is_symbol_shaped(command: &str) -> bool {
+    let words = shell_words(command);
+    for (i, w) in words.iter().enumerate() {
+        if !GREP_CMDS.contains(&w.as_str()) {
+            continue;
+        }
+        for next in &words[i + 1..] {
+            if matches!(next.as_str(), "|" | "||" | "&&" | ";") {
+                break;
+            }
+            if next.starts_with('-') {
+                continue; // a flag, not the pattern
+            }
+            if crate::code_map::is_symbol_shaped(next) {
+                return true;
+            }
+            break; // first positional was the pattern; it wasn't symbol-shaped
+        }
+    }
+    false
+}
+
+/// The advisory footer for a bash result, when the code graph exists (so its
+/// advice is actionable): a cross-root `cd` warning takes precedence — under a
+/// drifted tree graph_query can't help — otherwise a symbol-shaped grep gets
+/// the same `graph_query` pointer the native search tools carry.
+fn graph_advisory(command: &str, root: &Path) -> Option<String> {
+    if !crate::graph::graph_available(root) {
+        return None;
+    }
+    if let Some(target) = cd_escape_target(command, root) {
+        return Some(format!(
+            "\n\nnote: this cd'd to `{target}`, outside the session root `{}` — \
+             graph_query and the grep/glob code-map footers index only this root, so \
+             work under `{target}` isn't covered by the code graph. To use the \
+             structural tools there, re-root the session on that tree (run stella from \
+             it).",
+            root.display()
+        ));
+    }
+    if bash_grep_is_symbol_shaped(command) {
+        return Some(format!("\n\n{}", crate::code_map::GRAPH_QUERY_TIP));
+    }
+    None
+}
 
 pub struct Bash;
 
@@ -183,6 +315,13 @@ impl Tool for Bash {
             combined = format!("{head_str}\n... [truncated {truncated} bytes] ...\n{tail_str}");
         }
 
+        // Append after truncation so the steer is never the part that gets
+        // cut: a cross-root `cd` warning or a symbol-shaped-grep graph_query
+        // nudge, when an index exists.
+        if let Some(note) = graph_advisory(command, root) {
+            combined.push_str(&note);
+        }
+
         if output.status.success() {
             ToolOutput::Ok { content: combined }
         } else {
@@ -287,6 +426,117 @@ mod tests {
             }
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
+    }
+
+    /// An indexed workspace — a source file plus a built `.stella/codegraph.db`,
+    /// exactly what `stella init` leaves so `graph_available` is true.
+    fn indexed_tempdir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub struct Greeter;\npub fn greet() {}\n",
+        )
+        .expect("write");
+        let db = crate::graph::graph_db_path(dir.path());
+        std::fs::create_dir_all(db.parent().expect("parent")).expect("mkdir");
+        let graph = stella_graph::CodeGraph::open(dir.path(), &db).expect("open");
+        graph.index_all().expect("index");
+        graph.shutdown();
+        dir
+    }
+
+    fn text_of(out: ToolOutput) -> String {
+        match out {
+            ToolOutput::Ok { content } => content,
+            ToolOutput::Error { message } => message,
+        }
+    }
+
+    #[test]
+    fn cd_escape_target_flags_out_of_root_only() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        // In-root cd — no drift.
+        assert_eq!(cd_escape_target("cd sub && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("cd . && cargo build", dir.path()), None);
+        // Out-of-root — the target is returned.
+        assert_eq!(
+            cd_escape_target("cd / && grep -rn x .", dir.path()).as_deref(),
+            Some("/")
+        );
+        assert!(cd_escape_target("cd ../.. && ls", dir.path()).is_some());
+        // Unresolvable / no cd — skipped.
+        assert_eq!(cd_escape_target("cd $HOME && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("cd ~/foo && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("grep -rn x .", dir.path()), None);
+    }
+
+    #[test]
+    fn bash_grep_symbol_detection() {
+        assert!(bash_grep_is_symbol_shaped(
+            r#"grep -rn "struct DeckProviderResolver" stella-tools/"#
+        ));
+        assert!(bash_grep_is_symbol_shaped("grep -n ReadOnlyTools src/"));
+        assert!(bash_grep_is_symbol_shaped(r#"rg -e "pub fn resolve" ."#));
+        assert!(bash_grep_is_symbol_shaped(
+            r#"grep -rn "pub mod ports\|pub use ports" src/"#
+        ));
+        // free-text / non-symbol patterns — no nudge
+        assert!(!bash_grep_is_symbol_shaped(r#"grep -rn "unwrap()" src/"#));
+        assert!(!bash_grep_is_symbol_shaped(r#"grep -rn "TODO:" ."#));
+        assert!(!bash_grep_is_symbol_shaped("ls -la && cargo build"));
+        assert!(!bash_grep_is_symbol_shaped("cat foo.rs"));
+    }
+
+    #[tokio::test]
+    async fn a_cross_root_cd_warns_when_indexed() {
+        let dir = indexed_tempdir();
+        let out = Bash
+            .execute(&serde_json::json!({"command": "cd / && pwd"}), dir.path())
+            .await;
+        let text = text_of(out);
+        assert!(
+            text.contains("outside the session root"),
+            "drift warned: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_symbol_shaped_bash_grep_gets_the_graph_tip_when_indexed() {
+        let dir = indexed_tempdir();
+        let out = Bash
+            .execute(
+                &serde_json::json!({"command": "grep -rn \"struct Greeter\" ."}),
+                dir.path(),
+            )
+            .await;
+        let text = text_of(out);
+        assert!(text.contains("graph_query"), "grep nudged: {text}");
+    }
+
+    #[tokio::test]
+    async fn a_plain_command_gets_no_advisory() {
+        let dir = indexed_tempdir();
+        let text = text_of(
+            Bash.execute(&serde_json::json!({"command": "echo hi"}), dir.path())
+                .await,
+        );
+        assert!(!text.contains("graph_query"), "{text}");
+        assert!(!text.contains("outside the session root"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn no_index_means_no_advisory() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = text_of(
+            Bash.execute(
+                &serde_json::json!({"command": "grep -rn \"struct Foo\" . ; cd /"}),
+                dir.path(),
+            )
+            .await,
+        );
+        assert!(!text.contains("graph_query"), "{text}");
+        assert!(!text.contains("outside the session root"), "{text}");
     }
 
     /// End-to-end Seatbelt check — spawns real `sandbox-exec`. Ignored by

--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -94,8 +94,8 @@ fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
             continue;
         }
         let target = pair[1].as_str();
+        // `-` (cd to previous dir) is caught by the `-` prefix below.
         if target.is_empty()
-            || target == "-"
             || target.starts_with('$')
             || target.starts_with('~')
             || target.starts_with('-')
@@ -498,6 +498,35 @@ mod tests {
         assert!(
             text.contains("outside the session root"),
             "drift warned: {text}"
+        );
+    }
+
+    /// The motivating shape from the telemetry: `cd` to a sibling checkout AND
+    /// a symbol-shaped grep in one command. Drift takes precedence — under a
+    /// tree the graph doesn't index, the grep tip would be misleading, so only
+    /// the drift warning fires.
+    #[tokio::test]
+    async fn drift_wins_over_the_grep_tip_when_both_fire() {
+        let dir = indexed_tempdir();
+        // Grep /dev/null (instant, hermetic) — the advisory keys off the
+        // command string's `cd` + grep pattern, not what grep actually reads,
+        // so this exercises the precedence without walking `/`.
+        let out = Bash
+            .execute(
+                &serde_json::json!({"command": "cd / && grep -rn \"struct Greeter\" /dev/null"}),
+                dir.path(),
+            )
+            .await;
+        let text = text_of(out);
+        assert!(
+            text.contains("outside the session root"),
+            "drift warned: {text}"
+        );
+        // The drift note names graph_query (to explain coverage); the *tip* is
+        // the thing suppressed. Its distinctive phrase must be absent.
+        assert!(
+            !text.contains("symbol/dependency lookup"),
+            "the grep tip is suppressed under a drifted tree: {text}"
         );
     }
 

--- a/stella-tools/src/code_map.rs
+++ b/stella-tools/src/code_map.rs
@@ -6,10 +6,12 @@
 //! (Field Manual Part 4: "code is a graph, not text"), yet agents keep
 //! grepping instead of asking it. So the search tools bring the graph to the
 //! agent: every successful result carries a compact per-file map (symbols,
-//! import edges) drawn from `.stella/codegraph.db`. The session's FIRST
-//! mapped search additionally carries a one-line pointer at `graph_query`
-//! (the [`TipOnce`] latch, shared by grep and glob) — taught once, then out
-//! of the way.
+//! import edges) drawn from `.stella/codegraph.db`. A search whose *pattern is
+//! symbol-shaped* — a definition/reference hunt graph_query serves better —
+//! additionally carries a one-line pointer at the tool ([`is_symbol_shaped`]
+//! decides). Not once-per-session: the nudge fires on every symbol-shaped
+//! search, because that is exactly the moment it corrects, and stays silent on
+//! free-text scans (grep's own job) so it never decays into noise.
 //!
 //! Strictly additive and strictly best-effort: no index, an unopenable
 //! store, or files the graph doesn't know all mean "no footer", never an
@@ -18,8 +20,6 @@
 
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Files mapped per search result — enough to orient, small enough that the
 /// footer never rivals the matches themselves.
@@ -29,21 +29,107 @@ const MAX_SYMBOLS: usize = 6;
 /// Importer paths listed per file before collapsing to a count.
 const MAX_IMPORTERS: usize = 3;
 
-/// Once-per-session latch for the footer's `graph_query` tip line. The
-/// registry constructs one and hands clones to `grep` AND `glob`, so the
-/// tip appears on the session's first mapped search — whichever tool runs
-/// it — and never again; repeating it on every result is teaching that
-/// decays into noise. Consumed only when a footer actually renders: a
-/// search before the index exists doesn't burn the one showing.
-#[derive(Clone, Default)]
-pub struct TipOnce(Arc<AtomicBool>);
+/// The one-line pointer at `graph_query`, appended to a footer (and to a
+/// bash result carrying a symbol-shaped `grep`/`rg`) when the search looks
+/// like a definition/reference hunt. Shared so every surface teaches the
+/// same tool the same way.
+pub const GRAPH_QUERY_TIP: &str = "tip: this looks like a symbol/dependency lookup — graph_query answers it \
+     directly (op=definitions|references|imports|importers|neighbors), precise \
+     and cheaper than a text scan.";
 
-impl TipOnce {
-    /// True exactly once, on the first call — atomic, so concurrent
-    /// read-only searches race to exactly one tip.
-    fn take(&self) -> bool {
-        !self.0.swap(true, Ordering::Relaxed)
+/// Declaration keywords that, leading a query, mark it a definition hunt
+/// (`struct Foo`, `pub fn bar`, `class Baz`, `def qux`). Cross-language on
+/// purpose — this is a nudge heuristic, not a parser.
+const DECL_KEYWORDS: &[&str] = &[
+    "struct",
+    "enum",
+    "trait",
+    "impl",
+    "fn",
+    "func",
+    "function",
+    "class",
+    "def",
+    "interface",
+    "type",
+    "const",
+    "static",
+    "mod",
+    "module",
+    "pub",
+    "public",
+    "private",
+    "protected",
+    "use",
+    "import",
+    "let",
+    "var",
+    "val",
+    "namespace",
+];
+
+/// Does this regex look like the agent hunting for where a symbol is defined
+/// or used — the case `graph_query` serves better than a text scan? Applied
+/// to every `|`-alternation branch (so a multi-symbol `struct A|struct B`
+/// still counts), each branch must be one of two shapes:
+///   * a lone identifier or `::`/`.`-path — `ReadOnlyTools`, `stella::graph::Foo`
+///   * a declaration-keyword-led identifier — `struct Foo`, `pub fn bar`
+///
+/// A single leading `^` / trailing `$` anchor is tolerated (the everyday
+/// `^pub fn` definition search); any other regex machinery — quantifiers,
+/// char classes, wildcards, embedded metacharacters — means a genuine text
+/// pattern, grep's own job, and does NOT trip the nudge. Deliberately errs
+/// toward missing over false-firing; a stray tip line is cheap, but nudging
+/// on a real text scan is the noise the once-latch existed to avoid.
+pub fn is_symbol_shaped(pattern: &str) -> bool {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return false;
     }
+    // `\|` (escaped, from a shell-quoted rg) and `|` (raw regex) both mean
+    // alternation here; normalize, then every branch must be a symbol.
+    let normalized = pattern.replace("\\|", "|");
+    let mut branches = 0usize;
+    for branch in normalized.split('|') {
+        branches += 1;
+        if !branch_is_symbol(branch) {
+            return false;
+        }
+    }
+    branches > 0
+}
+
+/// One alternation branch: an optional run of declaration keywords followed
+/// by a single identifier/path. `^`/`$` anchors are stripped first.
+fn branch_is_symbol(branch: &str) -> bool {
+    let branch = branch
+        .trim()
+        .trim_start_matches('^')
+        .trim_end_matches('$')
+        .trim();
+    let tokens: Vec<&str> = branch.split_whitespace().collect();
+    let Some((ident, keywords)) = tokens.split_last() else {
+        return false;
+    };
+    keywords
+        .iter()
+        .all(|k| DECL_KEYWORDS.contains(&k.to_ascii_lowercase().as_str()))
+        && is_identifier_or_path(ident)
+}
+
+/// A bare identifier or a `::`/`.`-separated path of them — how a symbol name
+/// is written. Each segment starts alphabetic/underscore and is otherwise
+/// alphanumeric/underscore; the whole must contain at least one letter, so a
+/// bare number never counts as a symbol.
+fn is_identifier_or_path(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.split("::").flat_map(|p| p.split('.')).all(|seg| {
+        let mut chars = seg.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+            && seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }) && s.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 /// Render the code-map footer for the files a search touched, or `None`
@@ -51,7 +137,7 @@ impl TipOnce {
 /// candidates are in the graph). `candidates` may repeat and may mix
 /// absolute and root-relative paths — both resolve; order of first
 /// appearance is kept, so the map follows the result's own ranking.
-pub fn for_files<'a, I>(root: &Path, candidates: I, tip: &TipOnce) -> Option<String>
+pub fn for_files<'a, I>(root: &Path, candidates: I, show_tip: bool) -> Option<String>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -89,11 +175,9 @@ where
     }
     let mut out = String::from("\n\ncode map (from the code graph):\n");
     out.push_str(&lines.join("\n"));
-    if tip.take() {
-        out.push_str(
-            "\ntip: graph_query answers symbol/dependency questions directly \
-             (op=definitions|references|imports|importers|neighbors).",
-        );
+    if show_tip {
+        out.push('\n');
+        out.push_str(GRAPH_QUERY_TIP);
     }
     Some(out)
 }
@@ -169,19 +253,37 @@ mod tests {
     fn no_index_means_no_footer() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").expect("write");
-        assert_eq!(for_files(dir.path(), ["lib.rs"], &TipOnce::default()), None);
+        assert_eq!(for_files(dir.path(), ["lib.rs"], true), None);
     }
 
     #[test]
-    fn maps_an_indexed_file_with_symbols_and_a_graph_query_tip() {
+    fn maps_an_indexed_file_with_symbols() {
         let dir = indexed_workspace();
-        let map = for_files(dir.path(), ["lib.rs"], &TipOnce::default())
-            .expect("footer for an indexed file");
+        let map = for_files(dir.path(), ["lib.rs"], false).expect("footer for an indexed file");
         assert!(map.contains("code map"), "labeled: {map}");
         assert!(map.contains("lib.rs"), "names the file: {map}");
         assert!(map.contains("function greet:1"), "cites the symbol: {map}");
         assert!(map.contains("struct Greeter:2"), "cites the struct: {map}");
-        assert!(map.contains("graph_query"), "nudges at the tool: {map}");
+    }
+
+    /// `show_tip` is the only thing that gates the pointer — the map itself is
+    /// unconditional. A symbol-shaped search (tip on) teaches; a free-text one
+    /// (tip off) gets the map bare.
+    #[test]
+    fn the_tip_follows_show_tip_not_a_latch() {
+        let dir = indexed_workspace();
+        let with = for_files(dir.path(), ["lib.rs"], true).expect("footer");
+        assert!(with.contains("graph_query"), "tip on nudges: {with}");
+        // Persistent, not once-per-session: a second symbol-shaped search
+        // teaches again — no shared latch survives between calls.
+        let again = for_files(dir.path(), ["lib.rs"], true).expect("footer");
+        assert!(again.contains("graph_query"), "tip fires again: {again}");
+        let without = for_files(dir.path(), ["lib.rs"], false).expect("footer");
+        assert!(without.contains("code map"), "map stays: {without}");
+        assert!(
+            !without.contains("graph_query"),
+            "tip off stays quiet: {without}"
+        );
     }
 
     #[test]
@@ -194,8 +296,7 @@ mod tests {
             .join("lib.rs")
             .to_string_lossy()
             .into_owned();
-        let map =
-            for_files(dir.path(), [abs.as_str(), "lib.rs"], &TipOnce::default()).expect("footer");
+        let map = for_files(dir.path(), [abs.as_str(), "lib.rs"], false).expect("footer");
         assert_eq!(
             map.matches("function greet:1").count(),
             1,
@@ -207,74 +308,10 @@ mod tests {
     fn unknown_files_are_skipped_not_rendered_empty() {
         let dir = indexed_workspace();
         assert_eq!(
-            for_files(
-                dir.path(),
-                ["README.md", "no/such/file.rs"],
-                &TipOnce::default()
-            ),
+            for_files(dir.path(), ["README.md", "no/such/file.rs"], true),
             None,
             "files the graph doesn't know produce no footer at all"
         );
-    }
-
-    #[test]
-    fn the_tip_renders_once_then_footers_stay_map_only() {
-        let dir = indexed_workspace();
-        let tip = TipOnce::default();
-        let first = for_files(dir.path(), ["lib.rs"], &tip).expect("first footer");
-        assert!(first.contains("tip: graph_query"), "teaches once: {first}");
-        let second = for_files(dir.path(), ["lib.rs"], &tip).expect("second footer");
-        assert!(second.contains("code map"), "the map stays: {second}");
-        assert!(
-            !second.contains("tip: graph_query"),
-            "already taught: {second}"
-        );
-    }
-
-    /// The one showing must land where it can teach: a search that renders
-    /// no footer (nothing mapped) leaves the latch unspent.
-    #[test]
-    fn a_search_without_a_footer_does_not_consume_the_tip() {
-        let dir = indexed_workspace();
-        let tip = TipOnce::default();
-        assert_eq!(for_files(dir.path(), ["README.md"], &tip), None);
-        let mapped = for_files(dir.path(), ["lib.rs"], &tip).expect("footer");
-        assert!(
-            mapped.contains("tip: graph_query"),
-            "still unspent after a footer-less search: {mapped}"
-        );
-    }
-
-    /// The session-level contract: grep and glob share one latch through the
-    /// registry, so whichever searches first carries the tip and the other
-    /// never repeats it.
-    #[tokio::test]
-    async fn the_tip_shows_once_per_session_across_grep_and_glob() {
-        let dir = indexed_workspace();
-        let reg = crate::ToolRegistry::with_issue_backend(dir.path().to_path_buf(), None);
-        let first = reg
-            .execute("grep", &serde_json::json!({"pattern": "greet"}))
-            .await;
-        let second = reg
-            .execute("glob", &serde_json::json!({"pattern": "*.rs"}))
-            .await;
-        match (first, second) {
-            (
-                stella_protocol::tool::ToolOutput::Ok { content: grep_out },
-                stella_protocol::tool::ToolOutput::Ok { content: glob_out },
-            ) => {
-                assert!(
-                    grep_out.contains("tip: graph_query"),
-                    "the session's first mapped search teaches: {grep_out}"
-                );
-                assert!(glob_out.contains("code map"), "later maps stay: {glob_out}");
-                assert!(
-                    !glob_out.contains("tip: graph_query"),
-                    "taught once per session, across tools: {glob_out}"
-                );
-            }
-            other => panic!("expected two ok results, got: {other:?}"),
-        }
     }
 
     #[test]
@@ -294,16 +331,54 @@ mod tests {
         graph.shutdown();
 
         let names: Vec<String> = (0..(MAX_FILES + 3)).map(|i| format!("m{i}.rs")).collect();
-        let map = for_files(
-            dir.path(),
-            names.iter().map(String::as_str),
-            &TipOnce::default(),
-        )
-        .expect("footer");
+        let map = for_files(dir.path(), names.iter().map(String::as_str), false).expect("footer");
         assert_eq!(
             map.matches("- m").count(),
             MAX_FILES,
             "caps at {MAX_FILES}: {map}"
         );
+    }
+
+    #[test]
+    fn symbol_shaped_accepts_definition_hunts() {
+        // Lone identifiers and paths — the "where is X / who calls X" case.
+        for p in [
+            "ReadOnlyTools",
+            "DeckProviderResolver",
+            "stella::graph::CodeGraph",
+            "graph.file_neighborhood",
+        ] {
+            assert!(is_symbol_shaped(p), "identifier should count: {p}");
+        }
+        // Declaration-keyword-led, including anchored and multi-symbol.
+        for p in [
+            "struct DeckProviderResolver",
+            "pub fn run_goal",
+            "pub mod ports",
+            "^impl Tool",
+            "^pub fn resolve$",
+            "struct GoalConfig|fn run_goal|GoalOutcome",
+        ] {
+            assert!(is_symbol_shaped(p), "declaration hunt should count: {p}");
+        }
+    }
+
+    #[test]
+    fn symbol_shaped_rejects_text_patterns() {
+        for p in [
+            "",
+            "   ",
+            "hello world",
+            "foo.*bar",
+            "[a-z]+",
+            "TODO:",
+            "->",
+            "unwrap\\(\\)",
+            "0x1234",
+            "a|.*b",
+            "let mut x =",
+        ] {
+            assert!(!is_symbol_shaped(p), "text pattern should not count: {p:?}");
+        }
     }
 }

--- a/stella-tools/src/glob.rs
+++ b/stella-tools/src/glob.rs
@@ -11,31 +11,29 @@ use crate::registry::Tool;
 const MAX_RESULTS: usize = 500;
 
 pub struct Glob {
-    /// Code-map footer state; `None` disables the footer entirely (the
-    /// embedded sweeps in `gather_context` — see [`crate::grep::Grep`]).
-    code_map: Option<crate::code_map::TipOnce>,
+    /// Whether results carry the code-map footer. Off for the embedded sweeps
+    /// in `gather_context` — see [`crate::grep::Grep`].
+    footer: bool,
 }
 
 impl Glob {
-    /// The model-facing tool: footer on, `graph_query` tip latch shared
-    /// with `grep` (the registry passes both clones of one
-    /// [`crate::code_map::TipOnce`]).
-    pub fn with_code_map(tip: crate::code_map::TipOnce) -> Self {
-        Self {
-            code_map: Some(tip),
-        }
+    /// The model-facing tool: footer on. A glob is a file-name match, not a
+    /// symbol hunt, so it never carries the `graph_query` tip (that rides
+    /// symbol-shaped `grep` searches — see [`crate::code_map::is_symbol_shaped`]).
+    pub fn with_code_map() -> Self {
+        Self { footer: true }
     }
 
     /// Footer-less instance for embedded use.
     pub fn bare() -> Self {
-        Self { code_map: None }
+        Self { footer: false }
     }
 }
 
 impl Default for Glob {
-    /// Footer on with a private latch — the standalone shape tests use.
+    /// Footer on — the standalone shape tests use.
     fn default() -> Self {
-        Self::with_code_map(crate::code_map::TipOnce::default())
+        Self::with_code_map()
     }
 }
 
@@ -113,7 +111,7 @@ impl Tool for Glob {
                     .collect::<Vec<_>>()
                     .join("\n");
                 ToolOutput::Ok {
-                    content: with_code_map(content, root, self.code_map.as_ref()),
+                    content: with_code_map(content, root, self.footer),
                 }
             }
             Err(_) => {
@@ -140,7 +138,7 @@ impl Tool for Glob {
                                 .collect::<Vec<_>>()
                                 .join("\n");
                             ToolOutput::Ok {
-                                content: with_code_map(content, root, self.code_map.as_ref()),
+                                content: with_code_map(content, root, self.footer),
                             }
                         }
                     }
@@ -153,19 +151,16 @@ impl Tool for Glob {
     }
 }
 
-/// Append the code-map footer for these matched paths, when a footer is
-/// enabled and the graph has one to give (see [`crate::code_map`]). Bound
-/// separately from the `if let` so the `content.lines()` borrow ends before
-/// `content` is mutated.
-fn with_code_map(
-    mut content: String,
-    root: &std::path::Path,
-    tip: Option<&crate::code_map::TipOnce>,
-) -> String {
-    let Some(tip) = tip else {
+/// Append the code-map footer for these matched paths, when the footer is
+/// enabled and the graph has one to give (see [`crate::code_map`]). The
+/// `graph_query` tip never rides a glob (`show_tip = false`) — it belongs on
+/// symbol-shaped `grep` searches. Bound separately from the `if let` so the
+/// `content.lines()` borrow ends before `content` is mutated.
+fn with_code_map(mut content: String, root: &std::path::Path, footer: bool) -> String {
+    if !footer {
         return content;
-    };
-    let map = crate::code_map::for_files(root, content.lines(), tip);
+    }
+    let map = crate::code_map::for_files(root, content.lines(), false);
     if let Some(map) = map {
         content.push_str(&map);
     }

--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -50,22 +50,26 @@ fn first_error_line(stderr: &str) -> String {
 }
 
 /// The code-map footer for these `path:line:text` matches (see
-/// [`crate::code_map`]), or `None` for a footer-less instance. A directory
+/// [`crate::code_map`]), or `None` when disabled or nothing maps. A directory
 /// search prints an absolute path before the first `:`; a single-file
 /// search omits the filename entirely (rg and grep both do), so there the
 /// search target itself is the mapped file. Non-path prefixes (a bare line
 /// number, a match containing `:`) simply miss in the graph — best-effort
-/// by construction.
+/// by construction. `show_tip` appends the `graph_query` pointer, set by the
+/// caller from whether the *pattern* is symbol-shaped.
 fn code_map_for(
-    tip: Option<&crate::code_map::TipOnce>,
+    enabled: bool,
+    show_tip: bool,
     search_dir: &std::path::Path,
     root: &std::path::Path,
     lines: &[&str],
 ) -> Option<String> {
-    let tip = tip?;
+    if !enabled {
+        return None;
+    }
     if search_dir.is_file() {
         let target = search_dir.to_string_lossy();
-        return crate::code_map::for_files(root, [target.as_ref()], tip);
+        return crate::code_map::for_files(root, [target.as_ref()], show_tip);
     }
     crate::code_map::for_files(
         root,
@@ -73,36 +77,35 @@ fn code_map_for(
             .iter()
             .filter_map(|l| l.split(':').next())
             .filter(|p| std::path::Path::new(p).is_absolute()),
-        tip,
+        show_tip,
     )
 }
 
 pub struct Grep {
-    /// Code-map footer state; `None` disables the footer entirely (the
-    /// embedded sweeps in `gather_context`, whose packs run their own graph
-    /// queries — a per-section footer there is duplication, not context).
-    code_map: Option<crate::code_map::TipOnce>,
+    /// Whether results carry the code-map footer. Off for the embedded sweeps
+    /// in `gather_context`, whose packs run their own graph queries — a
+    /// per-section footer there is duplication, not context.
+    footer: bool,
 }
 
 impl Grep {
-    /// The model-facing tool: footer on, `graph_query` tip latch shared
-    /// with `glob` (the registry passes both clones of one [`TipOnce`]).
-    pub fn with_code_map(tip: crate::code_map::TipOnce) -> Self {
-        Self {
-            code_map: Some(tip),
-        }
+    /// The model-facing tool: footer on. The `graph_query` tip rides a footer
+    /// whenever the search pattern is symbol-shaped — a per-call decision, no
+    /// shared state (see [`crate::code_map::is_symbol_shaped`]).
+    pub fn with_code_map() -> Self {
+        Self { footer: true }
     }
 
     /// Footer-less instance for embedded use.
     pub fn bare() -> Self {
-        Self { code_map: None }
+        Self { footer: false }
     }
 }
 
 impl Default for Grep {
-    /// Footer on with a private latch — the standalone shape tests use.
+    /// Footer on — the standalone shape tests use.
     fn default() -> Self {
-        Self::with_code_map(crate::code_map::TipOnce::default())
+        Self::with_code_map()
     }
 }
 
@@ -136,6 +139,9 @@ impl Tool for Grep {
         };
         let search_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
         let glob_filter = input.get("glob").and_then(|v| v.as_str());
+        // The `graph_query` pointer rides a footer only when the pattern reads
+        // like a definition/reference hunt — the case the graph serves better.
+        let show_tip = self.footer && crate::code_map::is_symbol_shaped(pattern);
 
         // Confine `path` to the workspace root — `Path::join` would otherwise
         // let an absolute or `../..` path escape it. `.`/empty resolve to the
@@ -179,7 +185,7 @@ impl Tool for Grep {
                         result.push_str(&format!("\n... (showing first {MAX_RESULTS} matches)"));
                     }
                     if let Some(map) =
-                        code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
+                        code_map_for(self.footer, show_tip, &search_dir, root, &lines)
                     {
                         result.push_str(&map);
                     }
@@ -218,7 +224,7 @@ impl Tool for Grep {
                             let lines: Vec<&str> = text.lines().take(MAX_RESULTS).collect();
                             let mut result = lines.join("\n");
                             if let Some(map) =
-                                code_map_for(self.code_map.as_ref(), &search_dir, root, &lines)
+                                code_map_for(self.footer, show_tip, &search_dir, root, &lines)
                             {
                                 result.push_str(&map);
                             }
@@ -398,6 +404,42 @@ mod tests {
                 assert!(
                     content.contains("function greet:1"),
                     "single-file searches map the target: {content}"
+                );
+            }
+            ToolOutput::Error { message } => panic!("expected matches, got: {message}"),
+        }
+    }
+
+    /// A symbol-shaped pattern carries the `graph_query` pointer; a free-text
+    /// scan gets the map bare — the nudge lands only where the graph wins.
+    #[tokio::test]
+    async fn the_graph_tip_rides_symbol_shaped_searches_only() {
+        let dir = indexed_workspace();
+        let symbol = Grep::default()
+            .execute(&serde_json::json!({"pattern": "greet"}), dir.path())
+            .await;
+        match symbol {
+            ToolOutput::Ok { content } => assert!(
+                content.contains("graph_query"),
+                "a bare-identifier search nudges: {content}"
+            ),
+            ToolOutput::Error { message } => panic!("expected matches, got: {message}"),
+        }
+
+        // A regex text pattern that still matches the file but isn't a symbol
+        // hunt: map yes, tip no.
+        let text = Grep::default()
+            .execute(&serde_json::json!({"pattern": "gr.*t"}), dir.path())
+            .await;
+        match text {
+            ToolOutput::Ok { content } => {
+                assert!(
+                    content.contains("code map"),
+                    "map still attaches: {content}"
+                );
+                assert!(
+                    !content.contains("graph_query"),
+                    "no nudge on a text scan: {content}"
                 );
             }
             ToolOutput::Error { message } => panic!("expected matches, got: {message}"),

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -217,7 +217,6 @@ impl ToolRegistry {
         let mcp_usage: stella_core::mcp_usage::McpUsageLedger = Arc::default();
         let task_board: crate::tasks::TaskBoardHandle = Arc::default();
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
-        let code_map_tip = crate::code_map::TipOnce::default();
         let processes: crate::process::ProcessTableHandle = Arc::default();
         let repo_backend: Arc<dyn crate::repo::RepoBackend> = Arc::new(crate::repo::GitCli);
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
@@ -226,11 +225,11 @@ impl ToolRegistry {
             Arc::new(crate::write::WriteFile),
             Arc::new(crate::edit::EditFile),
             Arc::new(crate::delete::DeleteFile),
-            // One shared tip latch: the session's first mapped search —
-            // grep or glob, whichever comes first — carries the graph_query
-            // pointer; every later footer is map-only.
-            Arc::new(crate::grep::Grep::with_code_map(code_map_tip.clone())),
-            Arc::new(crate::glob::Glob::with_code_map(code_map_tip)),
+            // Search results carry a code-map footer; a symbol-shaped grep
+            // pattern additionally carries the graph_query pointer, decided
+            // per-call from the pattern (crate::code_map::is_symbol_shaped).
+            Arc::new(crate::grep::Grep::with_code_map()),
+            Arc::new(crate::glob::Glob::with_code_map()),
             Arc::new(crate::gather::GatherContext),
             Arc::new(crate::exploration::Explorations),
             Arc::new(crate::exploration::SaveExploration),


### PR DESCRIPTION
## Why

Investigation into "the agent never uses `graph_query` during exploration" found the index is present but the model keeps grepping. Live telemetry: **0 `graph_query` calls across 379** recorded tool calls. Two structural causes, both fixed here.

## What

**1. Persistent, symbol-shaped steer (was one-shot).** The `graph_query` pointer was a once-per-session latch (`TipOnce`) — taught on the first mapped search, then gone. Replaced with a stateless, per-call decision: the pointer rides a search result **whenever the pattern is symbol-shaped** — a lone identifier/path (`ReadOnlyTools`, `stella::graph::Foo`) or a declaration-keyword-led ident (`struct Foo`, `pub fn bar`), including all-symbol alternations (`struct A|struct B`). Free-text scans (`foo.*bar`, `[a-z]+`, `TODO:`) stay quiet — that's grep's job. New shared predicate `code_map::is_symbol_shaped`.

**2. Reach the path the model actually uses — bash.** The old nudge only instrumented the native `grep`/`glob` tools, but per telemetry the symbol searches ran as `grep -rn "struct X"` **through bash** (bash 146 calls vs native grep 21). Bash now carries the same pointer when it runs a symbol-shaped grep/rg.

**3. cwd/root-drift warning.** `graph_query` indexes only the session root. When a bash command `cd`s outside that root (the cross-tree pattern the telemetry showed — sessions rooted in one checkout, grepping a sibling), a search/edit there is silently ungraphed. Bash now warns, pointing at re-rooting.

Both bash advisories are gated on an index existing and appended **after** output truncation so the steer is never the part that gets cut. A cross-root `cd` warning takes precedence over the grep tip (under a drifted tree the graph can't help). Glob never carries the tip (a file glob isn't a symbol hunt). The shared `TipOnce` latch threaded through the registry is removed.

## Design notes / tradeoffs

- `is_symbol_shaped` deliberately errs toward **missing over false-firing**: a stray one-line tip is cheap, but nudging on a real text scan is the noise the once-latch was avoiding. It will still fire on common-word identifiers (`grep foo`) — accepted as harmless and consistent across the native and bash paths.
- Shell parsing in bash is heuristic (quote-aware word split, not a real parser): unresolvable `cd` targets (`\$VAR`, `~`) are skipped rather than guessed.

## Tests

`stella-tools` suite green (319 + integration). New coverage: `is_symbol_shaped` accept/reject tables; grep tip fires on symbol-shaped only; `cd_escape_target` flags out-of-root only; `bash_grep_is_symbol_shaped` detection; and indexed-workspace integration tests driving real `Bash::execute` for the drift warning, the grep tip, plain-command silence, and no-index silence. clippy `-D warnings` clean, rustfmt clean.
