### PR TITLE
fix(cli): make session flags global so they parse after any subcommand

### DIFF
--- a/stella-cli/src/connect_cmd.rs
+++ b/stella-cli/src/connect_cmd.rs
@@ -19,7 +19,7 @@ use stella_tools::tracker_auth::{
 pub fn run(cmd: &crate::ConnectCmd) -> Result<(), String> {
     match cmd {
         crate::ConnectCmd::Github { token } => run_github(*token),
-        crate::ConnectCmd::Linear { api_key } => run_linear(*api_key),
+        crate::ConnectCmd::Linear { paste_key } => run_linear(*paste_key),
         crate::ConnectCmd::Status => run_status(),
         crate::ConnectCmd::Remove { provider } => run_remove(provider),
     }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -91,9 +91,36 @@ pub enum OutputFormat {
     about = "A fast, BYOK, model-agnostic terminal coding agent"
 )]
 struct Cli {
+    #[command(flatten)]
+    globals: GlobalArgs,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// Session-wide flags shared by every subcommand — model routing,
+/// credentials, output shape, spend limit, UI toggles.
+///
+/// Every field here MUST carry `global = true`. clap accepts a plain
+/// root-level flag only *before* the subcommand token, so a non-global
+/// field in this struct is silently unreachable in the position users
+/// naturally type it (`stella fleet … --budget 5` dies with "unexpected
+/// argument"). `global = true` registers the flag with every subcommand,
+/// making both positions valid. The invariant is machine-enforced by
+/// `every_root_flag_is_global` in main_tests.rs — a new field without the
+/// attribute fails the suite, not a user's shell.
+///
+/// The names here are reserved CLI-wide: a subcommand flag reusing one
+/// does not shadow cleanly — clap propagates the global's value slot into
+/// every subcommand, and the id collision panics at match time in debug
+/// builds and misbinds in release. `no_subcommand_flag_reuses_a_global_name`
+/// in main_tests.rs enforces uniqueness (it is why `connect linear` pastes
+/// a key via `--paste-key`, not `--api-key`).
+#[derive(clap::Args)]
+struct GlobalArgs {
     /// Override the worker model for this invocation: provider/model_id
     /// (e.g. zai/glm-5.2, anthropic/claude-fable-5, openai/gpt-5.5)
-    #[arg(long, env = "STELLA_MODEL")]
+    #[arg(long, global = true, env = "STELLA_MODEL")]
     model: Option<String>,
 
     /// API key for the selected provider, highest-precedence step of the
@@ -101,42 +128,45 @@ struct Cli {
     /// interactive prompt). Prefer an env var or
     /// ~/.config/stella/credentials.toml for anything long-lived — a flag
     /// value is visible in shell history and `ps`.
-    #[arg(long)]
+    #[arg(long, global = true)]
     api_key: Option<String>,
 
     /// Base URL override. Required with --model local/<model> to point at a
     /// local OpenAI-compatible server (Ollama, vLLM, LM Studio, llama.cpp
     /// server — e.g. http://localhost:11434/v1); optional for every other
     /// provider to route through a proxy.
-    #[arg(long, env = "STELLA_BASE_URL")]
+    #[arg(long, global = true, env = "STELLA_BASE_URL")]
     base_url: Option<String>,
 
     /// Output format: text (interactive), json (one final object), or
     /// stream-json (one line per agent event)
-    #[arg(long, env = "STELLA_OUTPUT_FORMAT", value_enum, default_value = "text")]
+    #[arg(
+        long,
+        global = true,
+        env = "STELLA_OUTPUT_FORMAT",
+        value_enum,
+        default_value = "text"
+    )]
     output_format: OutputFormat,
 
     /// Hard USD spend limit for the whole run/session — enforced mode
     /// : work aborts cleanly (never mid-tool) once
     /// total spend exceeds this. Omit to meter spend for the cost summary
     /// without ever blocking (observed mode).
-    #[arg(long, env = "STELLA_BUDGET", value_parser = parse_budget)]
+    #[arg(long, global = true, env = "STELLA_BUDGET", value_parser = parse_budget)]
     budget: Option<f64>,
 
     /// Use the plain line-based REPL for chat instead of the Command Deck
     /// (the tabbed TUI). The deck also steps aside automatically when stdin
     /// or stdout is not a terminal. Env: STELLA_PLAIN=1.
-    #[arg(long)]
+    #[arg(long, global = true)]
     plain: bool,
 
     /// Freeze all deck animation (the run progress bar's shimmer/pulse and the
     /// caret blink) to a static frame — for CI and asciinema-style recordings.
     /// Also forced on by STELLA_NO_ANIM or NO_COLOR.
-    #[arg(long)]
+    #[arg(long, global = true)]
     no_anim: bool,
-
-    #[command(subcommand)]
-    command: Option<Command>,
 }
 
 #[derive(Subcommand)]
@@ -403,9 +433,11 @@ pub enum ConnectCmd {
     /// Connect Linear via browser OAuth (needs STELLA_LINEAR_CLIENT_ID) or a
     /// personal API key
     Linear {
-        /// Paste a personal API key even when an OAuth app is configured
+        /// Paste a personal API key even when an OAuth app is configured.
+        /// (Named to stay clear of the session-wide `--api-key`, which is
+        /// the model-provider credential — a different secret entirely.)
         #[arg(long)]
-        api_key: bool,
+        paste_key: bool,
     },
     /// Show stored connections, their accounts, and credential precedence
     Status,
@@ -949,7 +981,7 @@ fn main() -> ExitCode {
 
     // Value-free confirmation (names only), gated on STELLA_ENV_DEBUG + a TTY +
     // a human output format so it never pollutes json/stream-json.
-    env_files::announce(&loaded_env, cli.output_format);
+    env_files::announce(&loaded_env, cli.globals.output_format);
 
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,
@@ -1026,7 +1058,17 @@ fn run(cli: Cli) -> Result<(), String> {
         }
         Some(Command::Connect { cmd }) => {
             // Tracker OAuth talks only to the tracker the user is connecting
-            // — no provider or API key required.
+            // — no provider or API key required. A `--api-key` here is
+            // almost always muscle memory from when `connect linear` had a
+            // flag by that name (now `--paste-key`): say so instead of
+            // silently running the OAuth path.
+            if cli.globals.api_key.is_some() {
+                eprintln!(
+                    "⚠ --api-key is the model-provider credential and is unused by \
+                     `stella connect`; to paste a Linear personal API key, use \
+                     `stella connect linear --paste-key`"
+                );
+            }
             return connect_cmd::run(cmd);
         }
         Some(Command::Observe { port, open }) => {
@@ -1064,18 +1106,18 @@ fn run(cli: Cli) -> Result<(), String> {
     // failure downgrades rather than aborting.
     if let Some(Command::Init) = cli.command {
         return rt()?.block_on(agent::run_init(
-            cli.model.as_deref(),
-            cli.api_key.as_deref(),
-            cli.base_url.as_deref(),
-            cli.no_anim,
+            cli.globals.model.as_deref(),
+            cli.globals.api_key.as_deref(),
+            cli.globals.base_url.as_deref(),
+            cli.globals.no_anim,
         ));
     }
 
     // Run/Chat/Config need a resolved config (which requires an API key).
     let cfg = config::Config::load(
-        cli.model.as_deref(),
-        cli.api_key.as_deref(),
-        cli.base_url.as_deref(),
+        cli.globals.model.as_deref(),
+        cli.globals.api_key.as_deref(),
+        cli.globals.base_url.as_deref(),
     )?;
 
     // Correctness pass over the resolved settings — model-slug problems (an
@@ -1095,14 +1137,19 @@ fn run(cli: Cli) -> Result<(), String> {
             rt()?.block_on(agent::run_one_shot(
                 &cfg,
                 &prompt,
-                cli.budget,
-                cli.output_format,
+                cli.globals.budget,
+                cli.globals.output_format,
                 !no_pipeline,
                 test_command.as_deref(),
             ))?;
         }
         Command::Goal { goal, no_pipeline } => {
-            rt()?.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget, !no_pipeline))?;
+            rt()?.block_on(agent::run_goal_cmd(
+                &cfg,
+                &goal,
+                cli.globals.budget,
+                !no_pipeline,
+            ))?;
         }
         Command::Fleet {
             tasks,
@@ -1118,7 +1165,7 @@ fn run(cli: Cli) -> Result<(), String> {
                 plan.as_deref(),
                 base_ref.as_deref(),
                 max_concurrency,
-                cli.budget,
+                cli.globals.budget,
                 watch,
                 !no_pipeline,
             ))?;
@@ -1133,21 +1180,21 @@ fn run(cli: Cli) -> Result<(), String> {
                  code, commit and push the fix, then re-check. The goal is met only when the \
                  latest CI run for `{target}` has completed with every check successful."
             );
-            rt()?.block_on(agent::run_goal_cmd(&cfg, &goal, cli.budget, true))?;
+            rt()?.block_on(agent::run_goal_cmd(&cfg, &goal, cli.globals.budget, true))?;
         }
         Command::Chat => {
             // The Command Deck (tabbed TUI) is the default chat surface on a
             // real terminal; `--plain` / STELLA_PLAIN=1 / a non-TTY stream
             // falls back to the line-based REPL.
-            if use_deck(cli.plain) {
+            if use_deck(cli.globals.plain) {
                 rt()?.block_on(command_deck::run_deck_session(
                     &cfg,
-                    cli.budget,
-                    cli.no_anim,
+                    cli.globals.budget,
+                    cli.globals.no_anim,
                     None,
                 ))?;
             } else {
-                rt()?.block_on(agent::run_interactive(&cfg, cli.budget))?;
+                rt()?.block_on(agent::run_interactive(&cfg, cli.globals.budget))?;
             }
         }
         Command::Resume { id, list } => {
@@ -1155,7 +1202,7 @@ fn run(cli: Cli) -> Result<(), String> {
             // actual reopen, which is a full deck session (durable state is
             // a deck feature — the plain REPL has no session to restore).
             debug_assert!(!list, "handled before provider resolution");
-            if !use_deck(cli.plain) {
+            if !use_deck(cli.globals.plain) {
                 return Err(
                     "`stella resume` reopens a Command Deck session and needs a real \
                      terminal (it cannot combine with --plain / STELLA_PLAIN / a piped \
@@ -1169,8 +1216,8 @@ fn run(cli: Cli) -> Result<(), String> {
             };
             rt()?.block_on(command_deck::run_deck_session(
                 &cfg,
-                cli.budget,
-                cli.no_anim,
+                cli.globals.budget,
+                cli.globals.no_anim,
                 Some(request),
             ))?;
         }
@@ -1197,3 +1244,7 @@ fn run(cli: Cli) -> Result<(), String> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "main_tests.rs"]
+mod main_tests;

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -1,0 +1,170 @@
+//! CLI argument-surface tests: the everything-global invariant on
+//! [`GlobalArgs`](super::GlobalArgs) and the parse positions it exists to
+//! guarantee. These are the regression fence for "`--budget` is an
+//! unexpected argument after `stella fleet`" — the flag was defined at the
+//! root without `global = true`, so clap only accepted it *before* the
+//! subcommand while README and muscle memory put it after.
+
+use clap::{CommandFactory, Parser};
+
+use super::{Cli, Command, ConnectCmd, OutputFormat};
+
+/// clap's own consistency audit (conflicting ids, broken defaults,
+/// mis-typed value parsers) — panics on the first violation. Runs the same
+/// checks release builds skip, so a bad arg table fails here instead of at
+/// a user's first `--help`.
+#[test]
+fn clap_command_is_internally_consistent() {
+    Cli::command().debug_assert();
+}
+
+/// The load-bearing invariant: every flag defined at the root MUST be
+/// `global = true`, or it is silently unaccepted after a subcommand token
+/// (`stella fleet … --budget 5` → "unexpected argument"). Introspects the
+/// built command rather than the source so any future root flag — added to
+/// `GlobalArgs` or straight onto `Cli` — is covered without editing this
+/// test. `help`/`version` are clap built-ins with their own propagation.
+#[test]
+fn every_root_flag_is_global() {
+    let cmd = Cli::command();
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        if id == "help" || id == "version" {
+            continue;
+        }
+        assert!(
+            arg.is_global_set(),
+            "root-level flag `--{id}` is not `global = true`: it will be rejected \
+             when typed after a subcommand (e.g. `stella fleet … --{id}`). Add \
+             `global = true` to its #[arg] in GlobalArgs (see the struct doc)."
+        );
+    }
+}
+
+/// The exact invocation shape README advertises for fleets — session flags
+/// after the subcommand — must parse, and the values must land at the root.
+#[test]
+fn session_flags_parse_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "stella",
+        "fleet",
+        "fix the flaky auth test",
+        "--max-concurrency",
+        "2",
+        "--budget",
+        "5.0",
+        "--model",
+        "zai/glm-5.2",
+    ])
+    .expect("session flags after `fleet` must parse");
+    assert_eq!(cli.globals.budget, Some(5.0));
+    assert_eq!(cli.globals.model.as_deref(), Some("zai/glm-5.2"));
+    match cli.command {
+        Some(Command::Fleet {
+            tasks,
+            max_concurrency,
+            ..
+        }) => {
+            assert_eq!(tasks, vec!["fix the flaky auth test".to_string()]);
+            assert_eq!(max_concurrency, 2);
+        }
+        _ => panic!("expected the fleet subcommand"),
+    }
+}
+
+/// The pre-subcommand position keeps working — global args are valid in
+/// both positions, not moved.
+#[test]
+fn session_flags_parse_before_subcommand() {
+    let cli = Cli::try_parse_from([
+        "stella",
+        "--budget",
+        "2.5",
+        "--output-format",
+        "json",
+        "run",
+        "hi",
+    ])
+    .expect("session flags before the subcommand must keep parsing");
+    assert_eq!(cli.globals.budget, Some(2.5));
+    assert_eq!(cli.globals.output_format, OutputFormat::Json);
+}
+
+/// `--budget`'s value parser still guards after a subcommand: a
+/// non-positive limit would silently disarm the hard spend cap, so it must
+/// be a parse error in every position.
+#[test]
+fn budget_validation_applies_after_subcommand() {
+    let err = Cli::try_parse_from(["stella", "fleet", "task", "--budget", "0"])
+        .err()
+        .expect("a zero budget must be rejected");
+    assert!(
+        err.to_string().contains("positive dollar amount"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Global names are reserved CLI-wide. A subcommand flag with the same id
+/// as a root global does NOT shadow it cleanly: clap propagates the
+/// global's value slot into every subcommand, and the collision panics at
+/// match-downcast time in debug builds and misbinds in release —
+/// `debug_assert` does not catch it (this is exactly how `connect linear`'s
+/// old `--api-key` bool blew up against the global credential string).
+/// Walk every subcommand recursively so a reintroduction anywhere fails
+/// here, not in a user's terminal.
+#[test]
+fn no_subcommand_flag_reuses_a_global_name() {
+    fn check(cmd: &clap::Command, globals: &[String], path: &str) {
+        for sub in cmd.get_subcommands() {
+            let sub_path = format!("{path} {}", sub.get_name());
+            for arg in sub.get_arguments() {
+                let id = arg.get_id().as_str();
+                // Propagated copies of the globals themselves are fine —
+                // only a *local* redefinition collides.
+                if !arg.is_global_set() && globals.iter().any(|g| g == id) {
+                    panic!(
+                        "`{sub_path}` defines its own `--{id}`, colliding with the \
+                         session-wide global of that name — pick a different flag \
+                         name (see the GlobalArgs doc)."
+                    );
+                }
+            }
+            check(sub, globals, &sub_path);
+        }
+    }
+    let mut cmd = Cli::command();
+    cmd.build();
+    let globals: Vec<String> = cmd
+        .get_arguments()
+        .filter(|a| a.is_global_set())
+        .map(|a| a.get_id().to_string())
+        .collect();
+    assert!(!globals.is_empty(), "expected at least one global flag");
+    check(&cmd, &globals, "stella");
+}
+
+/// `connect linear --paste-key` (the rename that resolved the collision
+/// above) binds to the subcommand's bool, and the session-wide `--api-key`
+/// stays independently usable on the same command line.
+#[test]
+fn connect_linear_paste_key_parses() {
+    let cli = Cli::try_parse_from(["stella", "connect", "linear", "--paste-key"])
+        .expect("`connect linear --paste-key` must parse");
+    assert_eq!(cli.globals.api_key, None);
+    match cli.command {
+        Some(Command::Connect {
+            cmd: ConnectCmd::Linear { paste_key },
+        }) => assert!(paste_key),
+        _ => panic!("expected `connect linear`"),
+    }
+
+    let cli = Cli::try_parse_from(["stella", "connect", "linear", "--api-key", "sk-model"])
+        .expect("the global --api-key must parse after `connect linear`");
+    assert_eq!(cli.globals.api_key.as_deref(), Some("sk-model"));
+    match cli.command {
+        Some(Command::Connect {
+            cmd: ConnectCmd::Linear { paste_key },
+        }) => assert!(!paste_key),
+        _ => panic!("expected `connect linear`"),
+    }
+}


### PR DESCRIPTION
## Problem

`stella fleet --plan .stella/fleet.toml --max-concurrency 2 --budget 5.0` — the exact invocation the README advertises — failed with:

```
error: unexpected argument '--budget' found
```

Every root-level flag (`--model`, `--api-key`, `--base-url`, `--output-format`, `--budget`, `--plain`, `--no-anim`) lacked clap's `global = true`, so clap accepted it only *before* the subcommand token. The fleet path fully supports budgets (`run_fleet` takes `cli.budget`); the flag just couldn't be typed where users naturally put it — and the same trap applied to every sibling flag on every subcommand.

## Fix (at the root cause, with a regression fence)

- **`GlobalArgs` group**: the session-wide flags move into a dedicated `#[command(flatten)]` struct whose documented rule is *every field carries `global = true`* — valid both before and after any subcommand.
- **Machine-enforced invariant**: `every_root_flag_is_global` introspects the built clap command, so any future root flag missing the attribute fails the test suite instead of a user's shell. `Cli::command.debug_assert` runs in CI too.
- **Latent collision found and resolved**: globalizing exposed that `connect linear --api-key` (a bool: "paste a personal API key instead of OAuth") shares an id with the global credential string. clap propagates global value slots into subcommands, and the collision **panics on the value downcast at match time** — `debug_assert` does *not* catch it (the new parse tests did). The local flag is renamed `--paste-key`, `stella connect` prints a pointer when the global `--api-key` is passed (old muscle memory), and `no_subcommand_flag_reuses_a_global_name` walks the whole command tree so a name reuse can never come back.
- **Behavior pinned by tests** (new `main_tests.rs`, 7 tests): both flag positions parse, `--budget` validation fires in trailing position, and the global `--api-key` composes with `connect linear` without rebinding.

## Verification

- `cargo test -p stella-cli`: 296 passed, 0 failed; clippy clean; rustfmt applied.
- End-to-end with the built binary:
  - `stella fleet --plan /dev/null --budget 5.0` → proceeds to plan-file validation (clap accepts the flag)
  - `stella fleet task --budget=-3` → `budget must be a positive dollar amount`
  - `stella --budget 5.0 fleet …` → unchanged
  - `stella connect linear --help` → shows `--paste-key` plus the propagated globals
  - `stella connect linear --api-key sk-test` → warns and points at `--paste-key`

## Breaking change

`stella connect linear --api-key` (bool) is now `stella connect linear --paste-key`. Nothing in README or docs referenced the old spelling; the runtime warning covers muscle memory.
