### PR TITLE
feat(stella-serve): headless engine service — the Rust core Oxagen drives under the hood

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,6 +3245,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stella-serve"
+version = "0.4.47"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "stella-core",
+ "stella-protocol",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "stella-store"
 version = "0.4.47"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "stella-media",
   "stella-fleet",
   "stella-observatory",
+  "stella-serve",
   "stella-tui",
   "stella-cli",
 ]

--- a/packaging/docker/Dockerfile.serve
+++ b/packaging/docker/Dockerfile.serve
@@ -1,0 +1,37 @@
+# stella-serve — the headless engine sidecar (ADR-033 Option B).
+#
+# Multi-stage: build the release binary against the pinned toolchain, then ship
+# a slim runtime that runs it. The host wires STELLA_SERVE_TOKEN and drives every
+# model/tool call back over the reverse-RPC protocol; this image serves no local
+# tool surface (STELLA_SERVE_TOOLS=remote).
+#
+#   docker build -f packaging/docker/Dockerfile.serve -t stella-serve .
+#   docker run -e STELLA_SERVE_TOKEN=$(openssl rand -hex 32) -p 8080:8080 stella-serve
+
+# rust-toolchain.toml pins the exact compiler; this base tag must track it.
+FROM rust:1.97-bookworm AS builder
+WORKDIR /src
+COPY . .
+# Build only the server binary and its dependency graph, in release.
+RUN cargo build --release --locked --bin stella-serve
+
+FROM debian:bookworm-slim AS runtime
+# rustls is used for TLS, so no OpenSSL runtime is needed; ca-certificates is
+# kept for outbound HTTPS should a future port need it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/target/release/stella-serve /usr/local/bin/stella-serve
+
+# Bind all interfaces inside the container; the bearer token is the auth gate and
+# the container runs inside the host's private network / tenant sandbox.
+ENV STELLA_SERVE_BIND=0.0.0.0:8080 \
+    STELLA_SERVE_TOOLS=remote
+EXPOSE 8080
+
+# The binary's own healthcheck probes /healthz — no wget/curl needed in the image.
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+    CMD ["/usr/local/bin/stella-serve", "healthcheck"]
+
+# STELLA_SERVE_TOKEN must be supplied at run time.
+ENTRYPOINT ["/usr/local/bin/stella-serve"]

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "stella-serve"
+description = "Headless engine server: drives the Stella engine over a wire protocol so a host (e.g. Oxagen) runs the Rust core under the hood. Every model and tool call is remoted back to the host — the engine holds no ambient authority."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+
+[dependencies]
+stella-protocol = { path = "../stella-protocol" }
+stella-core = { path = "../stella-core" }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "net", "io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }

--- a/stella-serve/src/error.rs
+++ b/stella-serve/src/error.rs
@@ -1,0 +1,28 @@
+//! Typed errors for the serve layer. Library code never panics on host input
+//! or wire data — a malformed or stale request is a named error, not a crash.
+
+use thiserror::Error;
+
+/// A failure at the serve boundary (session lifecycle, reverse-RPC resolution).
+#[derive(Debug, Error)]
+pub enum ServeError {
+    /// A reverse-RPC result arrived for a `request_id` with no in-flight
+    /// request — the host answered twice, answered after cancellation, or
+    /// used a stale id.
+    #[error("no in-flight request with id `{0}` (already resolved, or unknown)")]
+    UnknownRequest(String),
+
+    /// A reverse-RPC result arrived for a real in-flight request, but of the
+    /// wrong kind (e.g. a provider result posted to a tool request id).
+    #[error("request `{0}` is not a {1} request")]
+    RequestKindMismatch(String, &'static str),
+
+    /// The engine-driving thread ended before the turn produced an outcome —
+    /// it panicked, or its runtime failed to build.
+    #[error("engine session thread ended without an outcome: {0}")]
+    SessionThreadFailed(String),
+
+    /// Could not construct the per-session Tokio runtime.
+    #[error("failed to build the session runtime: {0}")]
+    RuntimeBuild(String),
+}

--- a/stella-serve/src/frame.rs
+++ b/stella-serve/src/frame.rs
@@ -1,0 +1,167 @@
+//! The wire vocabulary between the engine (running in this server) and the
+//! host that drives it (e.g. Oxagen).
+//!
+//! Two directions, deliberately asymmetric:
+//!
+//! - **Outbound** ([`ServerFrame`]) is the single engine → host stream. It
+//!   carries [`AgentEvent`]s for UI, plus the *reverse-RPC requests* the
+//!   engine raises when it needs the host to run a governed side effect (a
+//!   model completion, a tool call). Each request carries a `request_id`.
+//! - **Inbound** ([`ToolResultIn`], [`ProviderResultIn`]) is the host → engine
+//!   direction: the host POSTs the result of a reverse request back, keyed by
+//!   that `request_id`, which unblocks the engine step waiting on it.
+//!
+//! This is the "reverse tool-call protocol" of ADR-033 Option B. The engine
+//! never executes a tool or calls a model with ambient authority — every such
+//! effect re-enters the host, which runs it through `kernel.invoke()` /
+//! `@oxagen/ai` and reports back.
+
+use serde::{Deserialize, Serialize};
+use stella_core::TurnOutcome;
+use stella_protocol::{AgentEvent, CompletionRequest, CompletionResult, ProviderError, ToolOutput};
+
+/// One frame emitted by the engine toward the host over the outbound stream.
+///
+/// Not `Clone`: every frame is produced once and moved onto the channel; the
+/// reverse-request variants own borrowed-free payloads (the engine hands over
+/// the request by value), so nothing here needs to be duplicated.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerFrame {
+    /// A normal agent event — stream it to the UI. Never requires a response.
+    Event { event: AgentEvent },
+    /// The engine needs the host to run a tool call and POST the result back
+    /// ([`ToolResultIn`]) keyed by `request_id`. The engine step that raised
+    /// it is parked until then.
+    ToolRequest {
+        request_id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    /// The engine needs the host to run a model completion and POST the result
+    /// back ([`ProviderResultIn`]) keyed by `request_id`. The host owns the
+    /// model call (metering, gateway, BYOK); the engine only orchestrates.
+    ProviderRequest {
+        request_id: String,
+        request: CompletionRequest,
+    },
+    /// Terminal frame: the turn ended. No further frames follow for this turn.
+    TurnComplete { outcome: TurnOutcomeWire },
+}
+
+/// Serializable projection of [`TurnOutcome`] for the wire. `TurnOutcome` lives
+/// in `stella-core` and is not itself `Serialize`, so the boundary owns the
+/// mapping.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum TurnOutcomeWire {
+    Completed { text: String, cost_usd: f64 },
+    Aborted { reason: String },
+}
+
+impl From<TurnOutcome> for TurnOutcomeWire {
+    fn from(outcome: TurnOutcome) -> Self {
+        match outcome {
+            TurnOutcome::Completed { text, cost_usd } => {
+                TurnOutcomeWire::Completed { text, cost_usd }
+            }
+            TurnOutcome::Aborted { reason } => TurnOutcomeWire::Aborted { reason },
+        }
+    }
+}
+
+/// Host → engine: the result of a [`ServerFrame::ToolRequest`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultIn {
+    pub request_id: String,
+    pub output: ToolOutput,
+}
+
+/// Host → engine: the result of a [`ServerFrame::ProviderRequest`] — either a
+/// completed model response or a classified provider error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderResultIn {
+    pub request_id: String,
+    #[serde(flatten)]
+    pub outcome: ProviderOutcomeIn,
+}
+
+/// The success-or-error half of a [`ProviderResultIn`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ProviderOutcomeIn {
+    Ok { result: CompletionResult },
+    Error { error: ProviderErrorWire },
+}
+
+/// Serializable mirror of [`ProviderError`]'s taxonomy. The host classifies the
+/// failure at its adapter (never re-derived here) and sends the class; the
+/// engine reconstructs a real [`ProviderError`] so its retry logic behaves
+/// exactly as it would with a local provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ProviderErrorWire {
+    Transport {
+        message: String,
+    },
+    RateLimited {
+        message: String,
+        #[serde(default)]
+        retry_after_ms: Option<u64>,
+    },
+    Auth {
+        message: String,
+    },
+    UnknownModel {
+        slug: String,
+    },
+    Malformed {
+        message: String,
+    },
+    Cancelled,
+    Terminal {
+        message: String,
+    },
+}
+
+impl From<ProviderErrorWire> for ProviderError {
+    fn from(wire: ProviderErrorWire) -> Self {
+        match wire {
+            ProviderErrorWire::Transport { message } => ProviderError::Transport(message),
+            ProviderErrorWire::RateLimited {
+                message,
+                retry_after_ms,
+            } => ProviderError::RateLimited {
+                message,
+                retry_after_ms,
+            },
+            ProviderErrorWire::Auth { message } => ProviderError::Auth(message),
+            ProviderErrorWire::UnknownModel { slug } => ProviderError::UnknownModel { slug },
+            ProviderErrorWire::Malformed { message } => ProviderError::Malformed(message),
+            ProviderErrorWire::Cancelled => ProviderError::Cancelled,
+            ProviderErrorWire::Terminal { message } => ProviderError::Terminal(message),
+        }
+    }
+}
+
+impl From<&ProviderError> for ProviderErrorWire {
+    fn from(err: &ProviderError) -> Self {
+        match err {
+            ProviderError::Transport(m) => ProviderErrorWire::Transport { message: m.clone() },
+            ProviderError::RateLimited {
+                message,
+                retry_after_ms,
+            } => ProviderErrorWire::RateLimited {
+                message: message.clone(),
+                retry_after_ms: *retry_after_ms,
+            },
+            ProviderError::Auth(m) => ProviderErrorWire::Auth { message: m.clone() },
+            ProviderError::UnknownModel { slug } => {
+                ProviderErrorWire::UnknownModel { slug: slug.clone() }
+            }
+            ProviderError::Malformed(m) => ProviderErrorWire::Malformed { message: m.clone() },
+            ProviderError::Cancelled => ProviderErrorWire::Cancelled,
+            ProviderError::Terminal(m) => ProviderErrorWire::Terminal { message: m.clone() },
+        }
+    }
+}

--- a/stella-serve/src/http.rs
+++ b/stella-serve/src/http.rs
@@ -1,0 +1,138 @@
+//! A tiny hand-rolled HTTP/1.1 layer, following `stella-observatory`'s idiom
+//! (no web-framework dependency) but extended for what an engine server needs
+//! the read-only dashboard did not: request bodies (POST), bearer auth, and
+//! long-lived Server-Sent-Events responses.
+//!
+//! Deliberately minimal: one request per connection, `Connection: close`, an
+//! SSE writer that streams frames until the turn ends and then closes. Enough
+//! for a governed sidecar behind the host, not a general-purpose server.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Cap on the request head + body we will buffer. A turn request carries an
+/// assembled conversation, so it is larger than the dashboard's 8 KiB GET cap,
+/// but still bounded — a host that needs more is misusing the endpoint.
+const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+
+/// One parsed HTTP request.
+pub(crate) struct Request {
+    pub method: String,
+    pub path: String,
+    /// Header names lowercased for case-insensitive lookup; values trimmed.
+    headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl Request {
+    /// Case-insensitive header lookup.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        let name = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| *k == name)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// The bearer token from `Authorization: Bearer <token>`, if present.
+    pub fn bearer(&self) -> Option<&str> {
+        self.header("authorization")
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(str::trim)
+    }
+}
+
+/// Read and parse one request (head + `Content-Length` body). Returns `None` on
+/// a clean early hangup or a malformed/over-cap request — the caller closes the
+/// connection without a response, exactly as the observatory does.
+pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Option<Request>> {
+    let mut buf = Vec::with_capacity(8192);
+    let mut chunk = [0_u8; 8192];
+    let head_end = loop {
+        if let Some(pos) = find_head_end(&buf) {
+            break pos;
+        }
+        if buf.len() > MAX_REQUEST_BYTES {
+            return Ok(None);
+        }
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    };
+
+    let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+    let mut lines = head.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut req_parts = request_line.split_whitespace();
+    let (Some(method), Some(path)) = (req_parts.next(), req_parts.next()) else {
+        return Ok(None);
+    };
+
+    let mut headers = Vec::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.push((name.trim().to_ascii_lowercase(), value.trim().to_string()));
+        }
+    }
+
+    let content_length = headers
+        .iter()
+        .find(|(k, _)| k == "content-length")
+        .and_then(|(_, v)| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    if content_length > MAX_REQUEST_BYTES {
+        return Ok(None);
+    }
+
+    let body_start = head_end + 4;
+    let mut body = buf[body_start..].to_vec();
+    while body.len() < content_length {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+    body.truncate(content_length);
+
+    Ok(Some(Request {
+        method: method.to_string(),
+        path: path.to_string(),
+        headers,
+        body,
+    }))
+}
+
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Write a one-shot response (status, JSON content type, body) and close.
+pub(crate) async fn write_json(
+    stream: &mut TcpStream,
+    status: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
+        body.len(),
+    );
+    stream.write_all(head.as_bytes()).await?;
+    stream.write_all(body).await?;
+    stream.shutdown().await
+}
+
+/// Write the SSE response head, leaving the connection open to stream frames.
+pub(crate) async fn write_sse_head(stream: &mut TcpStream) -> std::io::Result<()> {
+    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n";
+    stream.write_all(head.as_bytes()).await
+}
+
+/// Write one SSE `data:` frame carrying a JSON payload.
+pub(crate) async fn write_sse_frame(stream: &mut TcpStream, json: &str) -> std::io::Result<()> {
+    stream.write_all(b"data: ").await?;
+    stream.write_all(json.as_bytes()).await?;
+    stream.write_all(b"\n\n").await
+}

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -1,0 +1,40 @@
+//! `stella-serve` — the Stella engine as a headless, host-driven service.
+//!
+//! This crate lets a host (e.g. Oxagen's platform) run the Stella Rust engine
+//! "under the hood": the host assembles a turn ([`SessionSpec`]), the engine
+//! orchestrates it, and **every governed side effect — model calls and tool
+//! calls — is remoted back to the host** over a wire protocol. The engine never
+//! holds ambient authority; the host runs each effect through its own kernel and
+//! metering and reports the result back. This is ADR-033 Option B (the Rust
+//! sidecar), whose port surface is identical to the in-process embed, so the
+//! transport is swappable.
+//!
+//! # Shape
+//!
+//! - [`Session`] drives one turn on a dedicated OS thread (the engine turn
+//!   future is `!Send`), emitting a stream of [`ServerFrame`]s.
+//! - Most frames are [`ServerFrame::Event`] (agent events for the UI). The
+//!   reverse-RPC frames — [`ServerFrame::ProviderRequest`] and
+//!   [`ServerFrame::ToolRequest`] — each carry a `request_id`; the host runs the
+//!   effect and answers with [`Session::resolve_provider`] /
+//!   [`Session::resolve_tool`], unblocking the parked engine step.
+//! - The terminal frame is [`ServerFrame::TurnComplete`].
+//!
+//! The HTTP/SSE transport that exposes this over a socket is a thin layer on top
+//! of [`Session`] (SSE = the frame stream; POST endpoints = the resolve calls);
+//! it is deliberately a separate slice so the `!Send` concurrency bridge here is
+//! provable in isolation.
+
+mod error;
+mod frame;
+mod pending;
+mod remote;
+mod session;
+
+pub use error::ServeError;
+pub use frame::{
+    ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn,
+    TurnOutcomeWire,
+};
+pub use pending::Pending;
+pub use session::{Session, SessionSpec};

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -27,8 +27,10 @@
 
 mod error;
 mod frame;
+mod http;
 mod pending;
 mod remote;
+mod server;
 mod session;
 
 pub use error::ServeError;
@@ -37,4 +39,5 @@ pub use frame::{
     TurnOutcomeWire,
 };
 pub use pending::Pending;
+pub use server::{ServeConfig, serve};
 pub use session::{Session, SessionSpec};

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -1,0 +1,103 @@
+//! The `stella-serve` binary — run the engine service from environment config.
+//!
+//! ```text
+//! STELLA_SERVE_BIND   address to bind (default 127.0.0.1:8080; container: 0.0.0.0:8080)
+//! STELLA_SERVE_TOKEN  bearer token every request must present (required)
+//! STELLA_SERVE_TOOLS  must be `remote` (the default) — all tool execution is
+//!                     remoted to the host; a local tool surface is never served
+//! ```
+//!
+//! `stella-serve healthcheck` probes `/healthz` on the bind port and exits 0/1,
+//! so a container HEALTHCHECK needs no extra tooling in the runtime image.
+
+use std::process::ExitCode;
+
+use stella_serve::{ServeConfig, serve};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const DEFAULT_BIND: &str = "127.0.0.1:8080";
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match std::env::args().nth(1).as_deref() {
+        None => run().await,
+        Some("healthcheck") => healthcheck().await,
+        Some(other) => {
+            eprintln!("stella-serve: unknown argument `{other}` (expected none, or `healthcheck`)");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> ExitCode {
+    let bind = std::env::var("STELLA_SERVE_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_string());
+    let addr = match bind.parse() {
+        Ok(addr) => addr,
+        Err(err) => {
+            eprintln!("stella-serve: invalid STELLA_SERVE_BIND `{bind}`: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let token = match std::env::var("STELLA_SERVE_TOKEN") {
+        Ok(token) if !token.is_empty() => token,
+        _ => {
+            eprintln!(
+                "stella-serve: STELLA_SERVE_TOKEN is required — the bearer token every request must present"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    // Server mode is remote-only: the engine holds no local tool surface, so any
+    // other value is a misconfiguration we refuse rather than silently ignore.
+    if let Ok(tools) = std::env::var("STELLA_SERVE_TOOLS")
+        && tools != "remote"
+    {
+        eprintln!(
+            "stella-serve: STELLA_SERVE_TOOLS=`{tools}` is unsupported; only `remote` is served — every tool and model call is remoted to the host"
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let config = ServeConfig { bind: addr, token };
+    match serve(config, |bound| {
+        println!("stella-serve listening on {bound}")
+    })
+    .await
+    {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("stella-serve: server error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn healthcheck() -> ExitCode {
+    let bind = std::env::var("STELLA_SERVE_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_string());
+    let port = bind
+        .rsplit(':')
+        .next()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(8080);
+    match probe_health(port).await {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => {
+            eprintln!("stella-serve: healthcheck: /healthz did not return 200");
+            ExitCode::FAILURE
+        }
+        Err(err) => {
+            eprintln!("stella-serve: healthcheck: could not reach the server: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn probe_health(port: u16) -> std::io::Result<bool> {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port)).await?;
+    stream
+        .write_all(b"GET /healthz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await?;
+    Ok(response.lines().next().is_some_and(|l| l.contains("200")))
+}

--- a/stella-serve/src/pending.rs
+++ b/stella-serve/src/pending.rs
@@ -1,0 +1,112 @@
+//! The in-flight reverse-request registry.
+//!
+//! When the engine raises a reverse-RPC request (a tool call or a model
+//! completion), it registers a one-shot reply channel here keyed by a fresh
+//! `request_id`, then emits the request frame and awaits the receiver. When the
+//! host POSTs the matching result, the serve layer looks the id up here and
+//! fires the sender — unblocking the parked engine step.
+//!
+//! The registry is shared (`Arc<Mutex<..>>`) between the engine-driving thread
+//! (which registers) and the inbound HTTP handlers (which resolve). The one-shot
+//! senders bridge the two Tokio runtimes: the receiver is awaited on the session
+//! thread's current-thread runtime, the sender fired from the server runtime —
+//! `tokio::sync::oneshot` is runtime-agnostic, so the wake crosses cleanly. This
+//! is the fleet's `!Send`-future bridge pattern (`stella-cli::fleet_cmd`).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use stella_protocol::{CompletionResult, ProviderError, ToolOutput};
+use tokio::sync::oneshot;
+
+use crate::error::ServeError;
+
+/// A registered reply channel, discriminated by the kind of request it answers.
+enum PendingReply {
+    Tool(oneshot::Sender<ToolOutput>),
+    Provider(oneshot::Sender<Result<CompletionResult, ProviderError>>),
+}
+
+/// A cloneable handle to the shared registry. Cloning shares the same map.
+#[derive(Clone, Default)]
+pub struct Pending {
+    inner: Arc<Mutex<HashMap<String, PendingReply>>>,
+}
+
+impl Pending {
+    /// Register a tool reply channel under `id`. Called by the engine thread
+    /// before it emits the request frame, so the entry always exists by the
+    /// time the host can answer.
+    pub(crate) fn register_tool(&self, id: String, reply: oneshot::Sender<ToolOutput>) {
+        self.lock().insert(id, PendingReply::Tool(reply));
+    }
+
+    /// Register a provider reply channel under `id`.
+    pub(crate) fn register_provider(
+        &self,
+        id: String,
+        reply: oneshot::Sender<Result<CompletionResult, ProviderError>>,
+    ) {
+        self.lock().insert(id, PendingReply::Provider(reply));
+    }
+
+    /// Resolve a tool request with the host-supplied output. Errors if `id` is
+    /// unknown or names a provider request.
+    pub fn resolve_tool(&self, id: &str, output: ToolOutput) -> Result<(), ServeError> {
+        match self.take(id)? {
+            PendingReply::Tool(tx) => {
+                // A receive-side drop (the engine step was cancelled) is not an
+                // error to the host: the request is simply gone.
+                let _ = tx.send(output);
+                Ok(())
+            }
+            other => {
+                self.reinsert(id, other);
+                Err(ServeError::RequestKindMismatch(id.to_string(), "tool"))
+            }
+        }
+    }
+
+    /// Resolve a provider request with the host-supplied result. Errors if `id`
+    /// is unknown or names a tool request.
+    pub fn resolve_provider(
+        &self,
+        id: &str,
+        result: Result<CompletionResult, ProviderError>,
+    ) -> Result<(), ServeError> {
+        match self.take(id)? {
+            PendingReply::Provider(tx) => {
+                let _ = tx.send(result);
+                Ok(())
+            }
+            other => {
+                self.reinsert(id, other);
+                Err(ServeError::RequestKindMismatch(id.to_string(), "provider"))
+            }
+        }
+    }
+
+    /// Drop every in-flight request. Their receivers observe a channel close,
+    /// which each port impl maps to a clean error for the engine — used when a
+    /// session is torn down or its host disconnects.
+    pub(crate) fn clear(&self) {
+        self.lock().clear();
+    }
+
+    fn take(&self, id: &str) -> Result<PendingReply, ServeError> {
+        self.lock()
+            .remove(id)
+            .ok_or_else(|| ServeError::UnknownRequest(id.to_string()))
+    }
+
+    fn reinsert(&self, id: &str, reply: PendingReply) {
+        self.lock().insert(id.to_string(), reply);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, PendingReply>> {
+        // The registry guards only map insert/remove — no await is held across
+        // the lock, so poisoning can only follow a panic while mutating the map
+        // itself; recover the guard rather than propagate the poison.
+        self.inner.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}

--- a/stella-serve/src/remote.rs
+++ b/stella-serve/src/remote.rs
@@ -1,0 +1,159 @@
+//! The engine's ports, remoted.
+//!
+//! Server-side the engine must never run a model call or a tool with ambient
+//! authority — the whole containment story of ADR-033 Option B rests on this.
+//! So [`RemoteProvider`] and [`RemoteToolExecutor`] implement the engine's
+//! `Provider` / `ToolExecutor` ports by emitting a reverse-RPC request frame to
+//! the host and awaiting the host's answer. The host runs the effect through
+//! its own governance (`kernel.invoke()`, `@oxagen/ai`) and posts the result
+//! back, which resolves the one-shot the port is parked on.
+//!
+//! Both ports are constructed on, and driven by, the session thread's
+//! current-thread runtime; the one-shot receivers they await are fired from the
+//! server runtime. That cross-runtime wake is the `!Send`-future bridge.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_core::ports::ToolExecutor;
+use stella_core::retry::Sleeper;
+use stella_protocol::{
+    CompletionRequest, CompletionResult, Provider, ProviderError, ToolOutput, ToolSchema,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::frame::ServerFrame;
+use crate::pending::Pending;
+
+/// A Tokio-backed [`Sleeper`] for the session runtime's retry backoff. The
+/// session runtime is built with the time driver enabled, so `sleep` resolves
+/// there.
+pub(crate) struct TokioSleeper;
+
+#[async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, duration_ms: u64) {
+        tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
+    }
+}
+
+/// The `Provider` port as a reverse-RPC to the host. `complete` emits a
+/// [`ServerFrame::ProviderRequest`] and blocks the step on the host's answer.
+pub(crate) struct RemoteProvider {
+    id: String,
+    frames: mpsc::UnboundedSender<ServerFrame>,
+    pending: Pending,
+    counter: AtomicU64,
+}
+
+impl RemoteProvider {
+    pub(crate) fn new(
+        id: String,
+        frames: mpsc::UnboundedSender<ServerFrame>,
+        pending: Pending,
+    ) -> Self {
+        Self {
+            id,
+            frames,
+            pending,
+            counter: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for RemoteProvider {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        let request_id = format!("prov-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let (tx, rx) = oneshot::channel();
+        // Register before emitting so the entry always exists by the time the
+        // host can answer (register → send ordering closes the race).
+        self.pending.register_provider(request_id.clone(), tx);
+        if self
+            .frames
+            .send(ServerFrame::ProviderRequest {
+                request_id,
+                request: req,
+            })
+            .is_err()
+        {
+            // The host stream is gone; a disconnect mid-flight is a retryable
+            // transport condition, classified here at the adapter as upstream.
+            return Err(ProviderError::Transport(
+                "serve host disconnected before the model call could be dispatched".to_string(),
+            ));
+        }
+        match rx.await {
+            Ok(result) => result,
+            Err(_) => Err(ProviderError::Transport(
+                "serve host dropped the model call without answering".to_string(),
+            )),
+        }
+    }
+}
+
+/// The `ToolExecutor` port as a reverse-RPC to the host. `schemas` returns the
+/// tool set the host advertised at session start (including `read_only` flags,
+/// so the engine's partitioned concurrency still applies); `execute` emits a
+/// [`ServerFrame::ToolRequest`] and blocks on the host's answer.
+pub(crate) struct RemoteToolExecutor {
+    schemas: Vec<ToolSchema>,
+    frames: mpsc::UnboundedSender<ServerFrame>,
+    pending: Pending,
+    counter: AtomicU64,
+}
+
+impl RemoteToolExecutor {
+    pub(crate) fn new(
+        schemas: Vec<ToolSchema>,
+        frames: mpsc::UnboundedSender<ServerFrame>,
+        pending: Pending,
+    ) -> Self {
+        Self {
+            schemas,
+            frames,
+            pending,
+            counter: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RemoteToolExecutor {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        self.schemas.clone()
+    }
+
+    async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
+        let request_id = format!("tool-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        let (tx, rx) = oneshot::channel();
+        self.pending.register_tool(request_id.clone(), tx);
+        if self
+            .frames
+            .send(ServerFrame::ToolRequest {
+                request_id,
+                name: name.to_string(),
+                input: input.clone(),
+            })
+            .is_err()
+        {
+            // A tool failure is model-visible data, never an engine error — the
+            // port contract is that `execute` never returns `Err`.
+            return ToolOutput::Error {
+                message: "serve host disconnected before the tool call could be dispatched"
+                    .to_string(),
+            };
+        }
+        match rx.await {
+            Ok(output) => output,
+            Err(_) => ToolOutput::Error {
+                message: "serve host dropped the tool call without answering".to_string(),
+            },
+        }
+    }
+}

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -1,0 +1,318 @@
+//! The HTTP/SSE transport over [`Session`].
+//!
+//! Endpoints (all under a bearer token except `/healthz`):
+//!
+//! | Method + path | Purpose |
+//! |---|---|
+//! | `GET /healthz` | liveness |
+//! | `POST /v1/turns` | start a turn ([`TurnRequest`] body) → `{ "turn_id": … }` |
+//! | `GET /v1/turns/{id}/events` | SSE stream of [`ServerFrame`]s until `turn_complete` |
+//! | `POST /v1/turns/{id}/tool-result` | answer a `tool_request` ([`ToolResultIn`]) |
+//! | `POST /v1/turns/{id}/provider-result` | answer a `provider_request` ([`ProviderResultIn`]) |
+//!
+//! The SSE stream is the engine → host direction; the two result POSTs are the
+//! host → engine direction. Together they are the reverse tool-call protocol —
+//! the engine never runs a model or tool call itself.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use stella_core::{BudgetGuard, EngineConfig};
+use stella_protocol::{BudgetMode, CompletionMessage, ToolSchema};
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::frame::{ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn};
+use crate::http::{read_request, write_json, write_sse_frame, write_sse_head};
+use crate::pending::Pending;
+use crate::session::{Session, SessionSpec};
+
+/// How to bind and authenticate the server.
+pub struct ServeConfig {
+    /// Address to bind. `127.0.0.1:0` picks a free loopback port (tests); a
+    /// containerized deployment binds `0.0.0.0:<port>`.
+    pub bind: SocketAddr,
+    /// The bearer token every request (except `/healthz`) must present. This is
+    /// the auth gate — the server may bind a non-loopback address behind the
+    /// host's private network.
+    pub token: String,
+}
+
+/// Body of `POST /v1/turns`. The host owns prompt assembly, model selection, and
+/// the tool set; engine knobs are optional overrides on top of the defaults.
+#[derive(Debug, Deserialize)]
+struct TurnRequest {
+    provider_id: String,
+    #[serde(default)]
+    tools: Vec<ToolSchema>,
+    messages: Vec<CompletionMessage>,
+    #[serde(default)]
+    budget: BudgetSpec,
+    #[serde(default)]
+    max_steps: Option<usize>,
+}
+
+/// Spend policy for a turn — the serializable projection of a [`BudgetGuard`].
+#[derive(Debug, Deserialize)]
+struct BudgetSpec {
+    #[serde(default = "budget_mode_off")]
+    mode: BudgetMode,
+    #[serde(default)]
+    turn_limit_usd: Option<f64>,
+    #[serde(default)]
+    session_limit_usd: Option<f64>,
+}
+
+impl Default for BudgetSpec {
+    fn default() -> Self {
+        Self {
+            mode: BudgetMode::Off,
+            turn_limit_usd: None,
+            session_limit_usd: None,
+        }
+    }
+}
+
+fn budget_mode_off() -> BudgetMode {
+    BudgetMode::Off
+}
+
+/// Response to `POST /v1/turns`.
+#[derive(Debug, Serialize)]
+struct TurnCreated<'a> {
+    turn_id: &'a str,
+}
+
+/// One registered turn. `pending` answers reverse requests (shared, always
+/// available); `session` is taken exactly once by the SSE stream.
+struct Entry {
+    pending: Pending,
+    session: Mutex<Option<Session>>,
+}
+
+/// Shared server state across connections.
+struct ServerState {
+    token: String,
+    turns: Mutex<HashMap<String, Arc<Entry>>>,
+    counter: AtomicU64,
+}
+
+impl ServerState {
+    fn turns(&self) -> MutexGuard<'_, HashMap<String, Arc<Entry>>> {
+        self.turns.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn lookup(&self, id: &str) -> Option<Arc<Entry>> {
+        self.turns().get(id).cloned()
+    }
+}
+
+/// Bind and serve until the accept loop errors. `on_ready` fires once with the
+/// bound address (so a `:0` bind can report its port).
+pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> std::io::Result<()> {
+    let listener = TcpListener::bind(config.bind).await?;
+    on_ready(listener.local_addr()?);
+    let state = Arc::new(ServerState {
+        token: config.token,
+        turns: Mutex::new(HashMap::new()),
+        counter: AtomicU64::new(0),
+    });
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let state = Arc::clone(&state);
+        // Per-connection errors (client hangup, bad request) stay local to the
+        // connection; the accept loop keeps serving.
+        tokio::spawn(async move {
+            let _ = handle_conn(stream, state).await;
+        });
+    }
+}
+
+async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
+    let Some(req) = read_request(&mut stream).await? else {
+        return Ok(());
+    };
+    let path = req.path.split('?').next().unwrap_or(&req.path);
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if req.method == "GET" && segs.as_slice() == ["healthz"] {
+        return write_json(&mut stream, "200 OK", br#"{"status":"ok"}"#).await;
+    }
+    if req.bearer() != Some(state.token.as_str()) {
+        return write_json(
+            &mut stream,
+            "401 Unauthorized",
+            br#"{"error":"missing or invalid bearer token"}"#,
+        )
+        .await;
+    }
+
+    match (req.method.as_str(), segs.as_slice()) {
+        ("POST", ["v1", "turns"]) => handle_create(&mut stream, &state, &req.body).await,
+        ("GET", ["v1", "turns", id, "events"]) => handle_events(&mut stream, &state, id).await,
+        ("POST", ["v1", "turns", id, "tool-result"]) => {
+            handle_tool_result(&mut stream, &state, id, &req.body).await
+        }
+        ("POST", ["v1", "turns", id, "provider-result"]) => {
+            handle_provider_result(&mut stream, &state, id, &req.body).await
+        }
+        _ => write_json(&mut stream, "404 Not Found", br#"{"error":"not found"}"#).await,
+    }
+}
+
+async fn handle_create(
+    stream: &mut TcpStream,
+    state: &ServerState,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let turn: TurnRequest = match serde_json::from_slice(body) {
+        Ok(turn) => turn,
+        Err(err) => {
+            return write_json(
+                stream,
+                "400 Bad Request",
+                &error_body(&format!("invalid turn request: {err}")),
+            )
+            .await;
+        }
+    };
+
+    let mut config = EngineConfig::default();
+    if let Some(max_steps) = turn.max_steps {
+        config.max_steps = max_steps;
+    }
+    let spec = SessionSpec {
+        provider_id: turn.provider_id,
+        tools: turn.tools,
+        messages: turn.messages,
+        config,
+        budget: BudgetGuard::new(
+            turn.budget.mode,
+            turn.budget.turn_limit_usd,
+            turn.budget.session_limit_usd,
+        ),
+    };
+
+    let session = Session::start(spec);
+    let id = format!("turn-{}", state.counter.fetch_add(1, Ordering::Relaxed));
+    let entry = Arc::new(Entry {
+        pending: session.pending(),
+        session: Mutex::new(Some(session)),
+    });
+    state.turns().insert(id.clone(), entry);
+
+    let body = serde_json::to_vec(&TurnCreated { turn_id: &id }).unwrap_or_default();
+    write_json(stream, "200 OK", &body).await
+}
+
+async fn handle_events(
+    stream: &mut TcpStream,
+    state: &ServerState,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
+    };
+    // Take the session out in its own scope so the (non-`Send`) mutex guard is
+    // dropped before any `.await` — the connection future must stay `Send`.
+    let taken = {
+        entry
+            .session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+    };
+    let mut session = match taken {
+        Some(session) => session,
+        None => {
+            return write_json(
+                stream,
+                "409 Conflict",
+                &error_body("events are already being streamed for this turn"),
+            )
+            .await;
+        }
+    };
+
+    write_sse_head(stream).await?;
+    while let Some(frame) = session.next_frame().await {
+        let done = matches!(frame, ServerFrame::TurnComplete { .. });
+        let json = serde_json::to_string(&frame).unwrap_or_else(|_| "{}".to_string());
+        if write_sse_frame(stream, &json).await.is_err() {
+            break;
+        }
+        if done {
+            break;
+        }
+    }
+    // The turn is finished streaming; drop it so its thread and registry entry
+    // are reclaimed.
+    state.turns().remove(id);
+    stream.shutdown().await
+}
+
+async fn handle_tool_result(
+    stream: &mut TcpStream,
+    state: &ServerState,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
+    };
+    let result: ToolResultIn = match serde_json::from_slice(body) {
+        Ok(result) => result,
+        Err(err) => {
+            return write_json(
+                stream,
+                "400 Bad Request",
+                &error_body(&format!("invalid tool result: {err}")),
+            )
+            .await;
+        }
+    };
+    match entry
+        .pending
+        .resolve_tool(&result.request_id, result.output)
+    {
+        Ok(()) => write_json(stream, "200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => write_json(stream, "409 Conflict", &error_body(&err.to_string())).await,
+    }
+}
+
+async fn handle_provider_result(
+    stream: &mut TcpStream,
+    state: &ServerState,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
+    };
+    let posted: ProviderResultIn = match serde_json::from_slice(body) {
+        Ok(posted) => posted,
+        Err(err) => {
+            return write_json(
+                stream,
+                "400 Bad Request",
+                &error_body(&format!("invalid provider result: {err}")),
+            )
+            .await;
+        }
+    };
+    let result = match posted.outcome {
+        ProviderOutcomeIn::Ok { result } => Ok(result),
+        ProviderOutcomeIn::Error { error } => Err(error.into()),
+    };
+    match entry.pending.resolve_provider(&posted.request_id, result) {
+        Ok(()) => write_json(stream, "200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => write_json(stream, "409 Conflict", &error_body(&err.to_string())).await,
+    }
+}
+
+fn error_body(message: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({ "error": message })).unwrap_or_default()
+}

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -1,0 +1,162 @@
+//! A single engine session: one turn driven on a dedicated OS thread.
+//!
+//! The engine's turn future is deliberately `!Send` (it holds provider futures
+//! and the retry-jitter RNG across awaits — `stella-cli::fleet_cmd`), so it
+//! cannot be `tokio::spawn`ed onto the server's multi-thread runtime. Instead
+//! each session gets its own OS thread running a **current-thread** runtime that
+//! `block_on`s `run_turn`; the server side communicates with it purely through
+//! `Send` channels — an outbound [`ServerFrame`] stream and the shared
+//! [`Pending`] one-shot registry. This is the fleet's bridge, reused for a
+//! long-lived server instead of a batch worker.
+//!
+//! Scope note: one [`Session`] drives one turn. Multi-turn sessions (retaining
+//! the message history across turns) and per-step checkpointing layer on top of
+//! this without changing the transport — they are the next slice.
+
+use std::thread::JoinHandle;
+
+use stella_core::{BudgetGuard, Engine, EngineConfig};
+use stella_protocol::{
+    AgentEvent, CompletionMessage, CompletionResult, ProviderError, ToolOutput, ToolSchema,
+};
+use tokio::runtime::Builder;
+use tokio::sync::mpsc;
+
+use crate::error::ServeError;
+use crate::frame::{ServerFrame, TurnOutcomeWire};
+use crate::pending::Pending;
+use crate::remote::{RemoteProvider, RemoteToolExecutor, TokioSleeper};
+
+/// Everything needed to run one turn. The host assembles this — it owns prompt
+/// construction, recall, model selection, and the tool set (advertised as
+/// schemas here; execution is remoted). The engine only orchestrates.
+pub struct SessionSpec {
+    /// Stable provider id echoed on `Provider::id()` (telemetry/labeling only —
+    /// the model call itself is remoted to the host).
+    pub provider_id: String,
+    /// Tool schemas the model may call, including `read_only` flags.
+    pub tools: Vec<ToolSchema>,
+    /// The already-assembled conversation to run this turn.
+    pub messages: Vec<CompletionMessage>,
+    /// Engine knobs (step cap, compaction budget, sampling). `Default` is a
+    /// sane starting point.
+    pub config: EngineConfig,
+    /// Spend guard for the turn.
+    pub budget: BudgetGuard,
+}
+
+/// A running session. The host drives it by reading [`ServerFrame`]s with
+/// [`Session::next_frame`] and answering reverse-RPC requests with
+/// [`Session::resolve_tool`] / [`Session::resolve_provider`].
+pub struct Session {
+    frames: mpsc::UnboundedReceiver<ServerFrame>,
+    pending: Pending,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Session {
+    /// Spawn the session thread and begin the turn. Frames start arriving
+    /// immediately; the terminal one is [`ServerFrame::TurnComplete`].
+    pub fn start(spec: SessionSpec) -> Session {
+        let (frame_tx, frame_rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let pending = Pending::default();
+        let thread = {
+            let pending = pending.clone();
+            std::thread::spawn(move || run_session(spec, frame_tx, pending))
+        };
+        Session {
+            frames: frame_rx,
+            pending,
+            thread: Some(thread),
+        }
+    }
+
+    /// Await the next frame from the engine. `None` once the session thread has
+    /// finished and dropped its sender (i.e. after `TurnComplete`).
+    pub async fn next_frame(&mut self) -> Option<ServerFrame> {
+        self.frames.recv().await
+    }
+
+    /// Answer a [`ServerFrame::ToolRequest`] with the host-run tool output.
+    pub fn resolve_tool(&self, request_id: &str, output: ToolOutput) -> Result<(), ServeError> {
+        self.pending.resolve_tool(request_id, output)
+    }
+
+    /// Answer a [`ServerFrame::ProviderRequest`] with a completed model result.
+    pub fn resolve_provider(
+        &self,
+        request_id: &str,
+        result: CompletionResult,
+    ) -> Result<(), ServeError> {
+        self.pending.resolve_provider(request_id, Ok(result))
+    }
+
+    /// Answer a [`ServerFrame::ProviderRequest`] with a classified failure.
+    pub fn fail_provider(&self, request_id: &str, error: ProviderError) -> Result<(), ServeError> {
+        self.pending.resolve_provider(request_id, Err(error))
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Unblock any parked reverse request so the engine turn aborts cleanly
+        // and the thread can finish, rather than leaking a thread wedged on a
+        // host that will never answer. We do not join (a still-running turn
+        // could take arbitrarily long) — the thread detaches and drains itself.
+        self.pending.clear();
+        drop(self.thread.take());
+    }
+}
+
+/// The body of the session thread: build a current-thread runtime, construct the
+/// remoted ports, and drive one turn to its outcome.
+fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, pending: Pending) {
+    let runtime = match Builder::new_current_thread().enable_time().build() {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            let _ = frame_tx.send(ServerFrame::TurnComplete {
+                outcome: TurnOutcomeWire::Aborted {
+                    reason: ServeError::RuntimeBuild(err.to_string()).to_string(),
+                },
+            });
+            return;
+        }
+    };
+
+    runtime.block_on(async move {
+        let provider = RemoteProvider::new(spec.provider_id, frame_tx.clone(), pending.clone());
+        let tools = RemoteToolExecutor::new(spec.tools, frame_tx.clone(), pending.clone());
+        let sleeper = TokioSleeper;
+        let engine = Engine::with_sleeper(&provider, &tools, spec.config, &sleeper);
+
+        // The engine emits `AgentEvent`s; wrap each as a frame for the host. The
+        // reverse-RPC request frames bypass this and go straight to `frame_tx`
+        // from the ports, so a starved forwarder never stalls the turn — it only
+        // affects UI-event latency.
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<AgentEvent>();
+        let forward_tx = frame_tx.clone();
+        let forwarder = tokio::spawn(async move {
+            while let Some(event) = event_rx.recv().await {
+                if forward_tx.send(ServerFrame::Event { event }).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut messages = spec.messages;
+        let mut budget = spec.budget;
+        let outcome = engine.run_turn(&mut messages, &mut budget, &event_tx).await;
+
+        // Close the event channel so the forwarder drains and exits before the
+        // terminal frame — a well-behaved host thus sees every event first.
+        drop(event_tx);
+        let _ = forwarder.await;
+
+        let _ = frame_tx.send(ServerFrame::TurnComplete {
+            outcome: outcome.into(),
+        });
+        // A clean turn leaves nothing parked; belt-and-suspenders for an aborted
+        // one, so no reverse-RPC one-shot outlives the session.
+        pending.clear();
+    });
+}

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -77,6 +77,14 @@ impl Session {
         self.frames.recv().await
     }
 
+    /// A handle to this session's reverse-RPC registry, cloneable and `Send`.
+    /// The HTTP layer keeps one alongside the session so a POST resolve handler
+    /// can answer a reverse request without holding the (exclusively-streamed)
+    /// session itself.
+    pub fn pending(&self) -> Pending {
+        self.pending.clone()
+    }
+
     /// Answer a [`ServerFrame::ToolRequest`] with the host-run tool output.
     pub fn resolve_tool(&self, request_id: &str, output: ToolOutput) -> Result<(), ServeError> {
         self.pending.resolve_tool(request_id, output)

--- a/stella-serve/tests/bridge.rs
+++ b/stella-serve/tests/bridge.rs
@@ -1,0 +1,178 @@
+//! Proves the `!Send` concurrency bridge in isolation, with no HTTP: a mock
+//! "host" reads [`ServerFrame`]s off a live [`Session`] and answers the
+//! reverse-RPC requests, exactly as the real host (Oxagen) will over HTTP. If
+//! this holds, wrapping a socket around it is transport plumbing.
+
+use serde_json::json;
+use stella_core::{BudgetGuard, EngineConfig};
+use stella_protocol::{
+    BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, ToolCall, ToolOutput,
+    ToolSchema,
+};
+use stella_serve::{ServerFrame, Session, SessionSpec, TurnOutcomeWire};
+
+/// Build a mock model result carrying a final text answer and no tool calls —
+/// the engine treats this as "the turn is done."
+fn final_answer(text: &str) -> CompletionResult {
+    CompletionResult {
+        text: text.to_string(),
+        tool_calls: vec![],
+        usage: CompletionUsage::default(),
+        model: "mock".to_string(),
+        cost_usd: 0.0,
+        finish_reason: None,
+    }
+}
+
+/// Build a mock model result that asks for one tool call.
+fn wants_tool(call_id: &str, name: &str, input: serde_json::Value) -> CompletionResult {
+    CompletionResult {
+        text: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.to_string(),
+            name: name.to_string(),
+            input,
+        }],
+        usage: CompletionUsage::default(),
+        model: "mock".to_string(),
+        cost_usd: 0.0,
+        finish_reason: None,
+    }
+}
+
+fn echo_tool() -> ToolSchema {
+    ToolSchema {
+        name: "echo".to_string(),
+        description: "echo its input".to_string(),
+        input_schema: json!({ "type": "object" }),
+        read_only: false,
+    }
+}
+
+fn spec_for(prompt: &str) -> SessionSpec {
+    SessionSpec {
+        provider_id: "mock".to_string(),
+        tools: vec![echo_tool()],
+        messages: vec![CompletionMessage::user(prompt)],
+        config: EngineConfig::default(),
+        budget: BudgetGuard::new(BudgetMode::Off, None, None),
+    }
+}
+
+/// The full loop: model asks for a tool, the host runs it and answers, the model
+/// then produces a final answer, and the turn completes. Proves both reverse-RPC
+/// ports (provider + tool) round-trip across the thread boundary.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tool_round_trip_completes_the_turn() {
+    let mut session = Session::start(spec_for("use the echo tool then answer"));
+
+    let mut provider_calls = 0usize;
+    let mut tool_calls = 0usize;
+    let mut events = 0usize;
+    let mut outcome = None;
+
+    while let Some(frame) = session.next_frame().await {
+        match frame {
+            ServerFrame::Event { .. } => events += 1,
+            ServerFrame::ProviderRequest { request_id, .. } => {
+                provider_calls += 1;
+                let result = if provider_calls == 1 {
+                    wants_tool("call-1", "echo", json!({ "text": "hi" }))
+                } else {
+                    final_answer("done")
+                };
+                session.resolve_provider(&request_id, result).unwrap();
+            }
+            ServerFrame::ToolRequest {
+                request_id, name, ..
+            } => {
+                tool_calls += 1;
+                assert_eq!(name, "echo");
+                session
+                    .resolve_tool(
+                        &request_id,
+                        ToolOutput::Ok {
+                            content: "echoed".to_string(),
+                        },
+                    )
+                    .unwrap();
+            }
+            ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+        }
+    }
+
+    assert_eq!(provider_calls, 2, "model called before and after the tool");
+    assert_eq!(tool_calls, 1, "the one requested tool call round-tripped");
+    assert!(events > 0, "the turn emitted agent events for the UI");
+    assert_eq!(
+        outcome,
+        Some(TurnOutcomeWire::Completed {
+            text: "done".to_string(),
+            cost_usd: 0.0,
+        }),
+    );
+}
+
+/// A turn whose model answers immediately needs no tool round-trip and still
+/// completes — the minimal path through the bridge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn immediate_completion_needs_no_tools() {
+    let mut session = Session::start(spec_for("just answer"));
+
+    let mut provider_calls = 0usize;
+    let mut tool_calls = 0usize;
+    let mut outcome = None;
+
+    while let Some(frame) = session.next_frame().await {
+        match frame {
+            ServerFrame::Event { .. } => {}
+            ServerFrame::ProviderRequest { request_id, .. } => {
+                provider_calls += 1;
+                session
+                    .resolve_provider(&request_id, final_answer("hello"))
+                    .unwrap();
+            }
+            ServerFrame::ToolRequest { .. } => tool_calls += 1,
+            ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+        }
+    }
+
+    assert_eq!(provider_calls, 1);
+    assert_eq!(tool_calls, 0);
+    assert_eq!(
+        outcome,
+        Some(TurnOutcomeWire::Completed {
+            text: "hello".to_string(),
+            cost_usd: 0.0,
+        }),
+    );
+}
+
+/// A classified provider failure aborts the turn cleanly (no panic, a terminal
+/// frame). Uses a retryable transport error the engine will retry then give up
+/// on — the point is the bridge surfaces the error path, not the retry count.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_error_aborts_cleanly() {
+    let mut session = Session::start(spec_for("this will fail"));
+
+    let mut outcome = None;
+    while let Some(frame) = session.next_frame().await {
+        match frame {
+            ServerFrame::ProviderRequest { request_id, .. } => {
+                session
+                    .fail_provider(
+                        &request_id,
+                        stella_protocol::ProviderError::Terminal("mock outage".to_string()),
+                    )
+                    .unwrap();
+            }
+            ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            _ => {}
+        }
+    }
+
+    match outcome {
+        Some(TurnOutcomeWire::Aborted { .. }) => {}
+        other => panic!("expected a clean abort, got {other:?}"),
+    }
+}

--- a/stella-serve/tests/http.rs
+++ b/stella-serve/tests/http.rs
@@ -1,0 +1,232 @@
+//! End-to-end over a real socket: a mock host binds the server, POSTs a turn,
+//! opens the SSE stream, and answers the engine's reverse-RPC requests with
+//! `provider-result` / `tool-result` POSTs — exactly the protocol Oxagen's
+//! client will speak. Proves the transport on top of the (separately proven)
+//! `!Send` bridge.
+
+use std::net::SocketAddr;
+
+use serde_json::json;
+use stella_protocol::{CompletionMessage, ToolSchema};
+use stella_serve::{ServeConfig, serve};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+
+const TOKEN: &str = "test-secret";
+
+fn echo_tool() -> serde_json::Value {
+    serde_json::to_value(ToolSchema {
+        name: "echo".to_string(),
+        description: "echo".to_string(),
+        input_schema: json!({ "type": "object" }),
+        read_only: false,
+    })
+    .unwrap()
+}
+
+/// Start the server on an ephemeral loopback port; returns its address.
+async fn start_server() -> SocketAddr {
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let config = ServeConfig {
+            bind: "127.0.0.1:0".parse().unwrap(),
+            token: TOKEN.to_string(),
+        };
+        let _ = serve(config, move |addr| {
+            let _ = tx.send(addr);
+        })
+        .await;
+    });
+    rx.await.expect("server reported its bound address")
+}
+
+/// POST a JSON body and read the whole response (server sends `Connection:
+/// close`). Returns `(status_line, body)`.
+async fn post_json(
+    addr: SocketAddr,
+    path: &str,
+    token: Option<&str>,
+    body: &str,
+) -> (String, String) {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let auth = token
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: engine\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    let (head, body) = response.split_once("\r\n\r\n").unwrap_or((&response, ""));
+    let status = head.lines().next().unwrap_or_default().to_string();
+    (status, body.to_string())
+}
+
+/// GET a plain endpoint (used for `/healthz`), returning `(status_line, body)`.
+async fn get_json(addr: SocketAddr, path: &str) -> (String, String) {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let request = format!("GET {path} HTTP/1.1\r\nHost: engine\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    let (head, body) = response.split_once("\r\n\r\n").unwrap_or((&response, ""));
+    (
+        head.lines().next().unwrap_or_default().to_string(),
+        body.to_string(),
+    )
+}
+
+/// Open the SSE stream and consume the HTTP response head, leaving the reader at
+/// the first event.
+async fn open_sse(addr: SocketAddr, path: &str, token: &str) -> BufReader<TcpStream> {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut reader = BufReader::new(stream);
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await.unwrap();
+        if n == 0 || line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+    reader
+}
+
+/// Read one SSE `data:` payload; `None` at end of stream.
+async fn next_event(reader: &mut BufReader<TcpStream>) -> Option<serde_json::Value> {
+    let mut data: Option<String> = None;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await.ok()?;
+        if n == 0 {
+            return data.map(|d| serde_json::from_str(&d).unwrap());
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            if let Some(d) = &data {
+                return Some(serde_json::from_str(d).unwrap());
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("data: ") {
+            data = Some(rest.to_string());
+        }
+    }
+}
+
+fn model_result(text: &str) -> serde_json::Value {
+    json!({
+        "text": text,
+        "usage": { "input_tokens": 0, "output_tokens": 0 },
+        "model": "mock",
+        "cost_usd": 0.0,
+    })
+}
+
+fn model_wants_echo() -> serde_json::Value {
+    json!({
+        "text": "",
+        "tool_calls": [{ "call_id": "c1", "name": "echo", "input": { "text": "hi" } }],
+        "usage": { "input_tokens": 0, "output_tokens": 0 },
+        "model": "mock",
+        "cost_usd": 0.0,
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn healthz_needs_no_auth_and_missing_token_is_rejected() {
+    let addr = start_server().await;
+
+    let (status, body) = get_json(addr, "/healthz").await;
+    assert!(status.contains("200"), "health status: {status}");
+    assert!(body.contains("\"status\":\"ok\""), "health body: {body}");
+
+    // A turn without the bearer token is refused.
+    let (status, _) = post_json(addr, "/v1/turns", None, "{}").await;
+    assert!(status.contains("401"), "unauthenticated status: {status}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn full_turn_round_trips_over_http() {
+    let addr = start_server().await;
+
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [echo_tool()],
+        "messages": [serde_json::to_value(CompletionMessage::user("use echo then answer")).unwrap()],
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(
+        status.contains("200"),
+        "create status: {status}, body: {body}"
+    );
+    let created: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let turn_id = created["turn_id"].as_str().unwrap().to_string();
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let mut provider_calls = 0;
+    let mut tool_calls = 0;
+    let mut outcome = None;
+
+    while let Some(event) = next_event(&mut sse).await {
+        match event["type"].as_str().unwrap_or_default() {
+            "provider_request" => {
+                provider_calls += 1;
+                let request_id = event["request_id"].as_str().unwrap();
+                let result = if provider_calls == 1 {
+                    model_wants_echo()
+                } else {
+                    model_result("done")
+                };
+                let body = json!({
+                    "request_id": request_id,
+                    "status": "ok",
+                    "result": result,
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &body,
+                )
+                .await;
+                assert!(status.contains("200"), "provider-result: {status} {resp}");
+            }
+            "tool_request" => {
+                tool_calls += 1;
+                assert_eq!(event["name"].as_str(), Some("echo"));
+                let request_id = event["request_id"].as_str().unwrap();
+                let body = json!({
+                    "request_id": request_id,
+                    "output": { "ok": { "content": "echoed" } },
+                })
+                .to_string();
+                let (status, resp) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/tool-result"),
+                    Some(TOKEN),
+                    &body,
+                )
+                .await;
+                assert!(status.contains("200"), "tool-result: {status} {resp}");
+            }
+            "turn_complete" => outcome = Some(event["outcome"].clone()),
+            _ => {}
+        }
+    }
+
+    assert_eq!(provider_calls, 2, "model called before and after the tool");
+    assert_eq!(tool_calls, 1, "one tool call round-tripped over HTTP");
+    let outcome = outcome.expect("turn produced a terminal outcome");
+    assert_eq!(outcome["status"].as_str(), Some("completed"));
+    assert_eq!(outcome["text"].as_str(), Some("done"));
+}


### PR DESCRIPTION
## What

Full first implementation of the Stella engine-as-a-service (ADR-033 Option B / `docs/design/serve-surface.md`): a new **`stella-serve`** crate that runs the Stella Rust engine as a **host-driven sidecar**. The host assembles a turn; the engine orchestrates it; **every governed side effect (model + tool calls) is remoted back to the host** — the engine holds no ambient authority. This is the "Oxagen drives the rust app under the hood" model.

## What's in this PR (all tested + gate-passing)

1. **Core + `!Send` bridge** — `Session` drives `run_turn` on a dedicated OS thread with a current-thread runtime (the engine turn future is deliberately `!Send`), bridged to the server by `Send` channels + a shared one-shot registry (the fleet's pattern, reused for a long-lived server).
2. **Remote ports** — `RemoteProvider` / `RemoteToolExecutor` implement the engine's `Provider` / `ToolExecutor` by emitting a reverse-RPC frame (with `request_id`) and parking on a one-shot the host resolves. `ProviderErrorWire` mirrors the error taxonomy so the engine's retry logic is unchanged.
3. **HTTP/SSE transport** — hand-rolled HTTP/1.1 (Observatory idiom, **no web-framework dep**), extended for POST bodies + bearer auth + long-lived SSE:
   - `POST /v1/turns` → `{ turn_id }`
   - `GET /v1/turns/{id}/events` → SSE of `ServerFrame`s until `turn_complete`
   - `POST /v1/turns/{id}/tool-result` · `POST /v1/turns/{id}/provider-result` → answer reverse requests
   - `GET /healthz`
4. **Runnable binary + `packaging/docker/Dockerfile.serve`** — env-configured (`STELLA_SERVE_BIND`/`_TOKEN`/`_TOOLS=remote`), with a `healthcheck` subcommand; multi-stage image the oxagen infra deploys.

## Verification

- `tests/bridge.rs` (3) — model→tool→model→complete round trip across the thread boundary; minimal no-tool path; clean provider-error abort.
- `tests/http.rs` (2) — full turn round trip over a **real ephemeral socket** (create → SSE → reverse-RPC resolves → complete); healthz-without-auth + 401-without-token.
- Gate (local): `cargo fmt --check` clean, `cargo clippy -p stella-serve --all-targets -D warnings` clean, file-size ratchet OK (largest file 318 lines), `cargo test -p stella-serve` **5 passed / 0 failed**, binary builds + `healthcheck` exits cleanly.

## Sovereignty

The engine runs no model/tool call itself — each re-enters the host over the reverse-RPC (Oxagen: `kernel.invoke` for tools, `@oxagen/ai` for models, so metering/IAM/billing stay intact). Server mode serves no local tool surface (`STELLA_SERVE_TOOLS=remote`).

## Next slices (follow-ups)
- `complete_observed` delta streaming for token-level UI.
- Multi-turn sessions + per-step checkpointing (needs the `run_step` facade; driver.rs is at its ratchet cap so that's its own split PR).
- The oxagen `@oxagen/stella-engine-client` that speaks this wire API (oxagen #1072's plan).

Additive crate; existing crates untouched. Design + fleet-plan context in stella #258 / oxagen #1072.
