### PR TITLE
docs: clarify local-first context sharing

### DIFF
--- a/stella-docs/content/docs/context-engine.mdx
+++ b/stella-docs/content/docs/context-engine.mdx
@@ -27,6 +27,30 @@ Everything is on your disk, under `.stella/`:
 when Stella believed it: re-running `stella init` **supersedes** stale facts
 rather than deleting them, so "what did we believe then?" stays answerable.
 
+## Local-first today; share rules through Git
+
+The stores above are **workspace-local**. Stella does not currently aggregate
+memories, reflection logs, or telemetry into a hosted team graph, and it does
+not silently publish a learned pattern as organization policy.
+
+The shareable boundary is `.stella/rules/*.md`: commit a reviewed rule file to
+the repository and every contributor receives the same repository steering on
+their next session. `stella memory promote <id>` creates that local rule file
+after a memory has earned promotion; it does **not** stage, commit, push, or
+open a pull request.
+
+This distinction is intentional:
+
+- **Local observations** and personal preferences remain private by default.
+- **Repository rules** are durable, human-readable instructions that can be
+  reviewed, versioned, and reverted with ordinary Git workflows.
+- **Context retrieval** remains local and bounded to the current workspace and
+  task.
+
+For the current promotion command, see [`stella memory`](/docs/commands/memory).
+Any future team-level Context PR workflow should extend this Git-governed rule
+boundary rather than make private local telemetry a shared source of truth.
+
 ## Two injection points, one cache discipline
 
 Stella feeds context to the model at exactly two places, chosen so the


### PR DESCRIPTION
Clarifies the current boundary between local workspace context and Git-shared repository rules. It makes explicit that memory promotion creates a local rule file, does not create a Git pull request, and that a future team Context PR workflow must preserve private local telemetry.\n\nVerified: 
> build
> pnpm --filter stella-cli-docs build

Scope: all 3 workspace projects
✓ Lockfile passes supply-chain policies (verified 1d ago)
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +283
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 283, reused 283, downloaded 0, added 272
Progress: resolved 283, reused 283, downloaded 0, added 282
Progress: resolved 283, reused 283, downloaded 0, added 283, done
.../sharp@0.34.5/node_modules/sharp install$ node install/check.js || npm run build
.../esbuild@0.28.1/node_modules/esbuild postinstall$ node install.js
.../esbuild@0.28.1/node_modules/esbuild postinstall: Done
.../sharp@0.34.5/node_modules/sharp install: Done

stella-docs postinstall$ fumadocs-mdx
stella-docs postinstall: [MDX] generated files in 7.309375000000017ms
stella-docs postinstall: Done
Done in 4s using pnpm v11.13.0
[MDX] generated files in 83.31166699999994ms
▲ Next.js 16.2.10 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 9.5s
  Running TypeScript ...
  Finished TypeScript in 2.1s ...
  Collecting page data using 9 workers ...
  Generating static pages using 9 workers (0/81) ...
  Generating static pages using 9 workers (20/81) 
  Generating static pages using 9 workers (40/81) 
  Generating static pages using 9 workers (60/81) 
✓ Generating static pages using 9 workers (81/81) in 812ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /api/search
├ ○ /apple-icon.png
├ ● /docs/[[...slug]]
│ ├ /docs/agent-engine-paths
│ ├ /docs/agent-fleets
│ ├ /docs/agent-modes
│ └ [+69 more paths]
├ ○ /icon.svg
├ ○ /manifest.webmanifest
├ ○ /robots.txt
└ ○ /sitemap.xml


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand, 
> typecheck
> pnpm --filter stella-cli-docs typecheck, and .