### PR TITLE
ci(main): key push concurrency group on sha so main pushes can't self-cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # PR pushes share a group keyed on the PR ref and cancel-in-progress, so a
+  # rapid string of pushes to the same PR only pays for the latest one. Pushes
+  # to main must NOT share a group across commits: GitHub only keeps one
+  # "in progress" and one "queued" run per concurrency group — a third push
+  # arriving while a prior main run is still queued silently cancels that
+  # queued run rather than running it. That's how #258/#259/#261 landing in
+  # quick succession broke main's file-size ratchet (command_deck.rs,
+  # config.rs) on 2026-07-21 without a single red run to point at: several of
+  # the intermediate push-triggered checks were superseded before they ever
+  # started. Keying the group on github.sha for non-PR events gives every
+  # commit to main its own group, so its full-repo check (fmt + ratchet +
+  # clippy + test, over ALL tracked files — see check-file-sizes.sh) always
+  # runs to completion and a ratchet-breaking union goes red within one run.
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary
- Root cause of the 2026-07-21 incident (#258/#259/#261 landing together broke main's ratchet, needing a manual repair commit d9cd8be): the push-triggered `ci` workflow already runs the FULL file-size ratchet on every tracked `.rs` file (`check-file-sizes.sh` doesn't scope to the diff — confirmed by reading it), and the push trigger on `main` already existed. The actual gap is GitHub Actions concurrency semantics: the group was keyed on `github.ref` for both PR and push events, and GitHub keeps at most one "in progress" + one "queued" run per group — a third push arriving on main while a prior run is still queued **cancels the queued run** rather than deferring it. That's exactly what the run history shows: two `cancelled` push runs sandwiched between the merge commits around the incident, instead of a red run pinned to the offending push.
- Fix: key the concurrency group on `github.sha` for non-PR (i.e. push-to-main) events, so every commit gets its own group and can never be superseded. PR pushes keep the ref-based group + `cancel-in-progress` so repeated pushes to the same PR still only pay for the latest run.
- No new workflow, no duplicated ratchet check — the existing `check` job already does fmt + ratchet (full repo) + clippy + test + release smoke build on every push to main; this just guarantees that run actually executes to completion for every commit.

## Out of scope (flagging, not fixing here)
`docs.yml` has the identical `group: docs-${{ github.ref }}` pattern and is susceptible to the same class of skip on docs-only main pushes. Lower stakes (doesn't gate the Rust ratchet), and unrelated to this issue, so left alone — worth a follow-up issue if the docs pipeline needs the same guarantee.

## Verification
- `actionlint .github/workflows/ci.yml` — clean
- YAML parses correctly
- No workflow steps changed, so no new command to test; correctness rests on GitHub's documented concurrency-group behavior (one queued run per group, newest wins) rather than something exercisable in a local Rust test.

CI-only change — no witness test (see CONTRIBUTING.md's witness-test carve-out for pure CI/config changes).

Fixes #270
