### PR TITLE
feat(stella-graph): exclude generated and minified files from the code-graph index

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -854,6 +854,7 @@ fn index_workspace_graph_blocking(
             .unwrap_or(stats.files_parsed + stats.files_skipped_unchanged),
         files_parsed: stats.files_parsed,
         files_unchanged: stats.files_skipped_unchanged,
+        files_skipped_generated: stats.files_skipped_generated,
     };
     graph.shutdown();
     Ok(summary)
@@ -866,13 +867,22 @@ struct GraphSummary {
     total_files: usize,
     files_parsed: usize,
     files_unchanged: usize,
+    /// Files this pass excluded as generated/minified (issue #272:
+    /// `.gitattributes` `linguist-generated=true`, `*.min.*`, or the
+    /// minified-content heuristic — see `stella_graph::generated`). Reported
+    /// separately from `total_files` so the exclusion is visible, not just
+    /// silently absent from the count.
+    files_skipped_generated: usize,
 }
 
 /// The `✓ code graph: N symbols, M imports…` summary line, shared by `stella
 /// init` and the session auto-builder so both surfaces read identically.
 /// Reports index totals; the parenthetical is this pass's parse/skip split.
+/// When this pass excluded any generated/minified files, an explicit
+/// "skipped N generated files" clause makes that visible rather than letting
+/// them silently vanish from the file count (issue #272).
 fn format_graph_stats(summary: &GraphSummary) -> String {
-    format!(
+    let base = format!(
         "✓ code graph: {} symbols, {} imports across {} file{} ({} re-parsed, {} unchanged this pass)",
         summary.total_symbols,
         summary.total_imports,
@@ -880,6 +890,18 @@ fn format_graph_stats(summary: &GraphSummary) -> String {
         if summary.total_files == 1 { "" } else { "s" },
         summary.files_parsed,
         summary.files_unchanged,
+    );
+    if summary.files_skipped_generated == 0 {
+        return base;
+    }
+    format!(
+        "{base} — skipped {} generated file{}",
+        summary.files_skipped_generated,
+        if summary.files_skipped_generated == 1 {
+            ""
+        } else {
+            "s"
+        }
     )
 }
 

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -467,3 +467,77 @@ fn judge_build_failure_falls_back_to_the_worker() {
         "a judge adapter that fails to build must fall back to the worker provider"
     );
 }
+
+/// Issue #272: `stella init`'s summary line must surface generated/minified
+/// exclusion count, not let excluded files silently vanish from the totals.
+/// Tested on the pure builder/output functions, never a live TTY.
+#[test]
+fn format_graph_stats_reports_generated_skip_count_when_nonzero() {
+    let summary = GraphSummary {
+        total_symbols: 12,
+        total_imports: 4,
+        total_files: 3,
+        files_parsed: 2,
+        files_unchanged: 1,
+        files_skipped_generated: 5,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(
+        line.contains("skipped 5 generated files"),
+        "line should surface the skip count: {line}"
+    );
+    assert!(line.contains("12 symbols"), "{line}");
+}
+
+#[test]
+fn format_graph_stats_omits_the_skip_clause_when_nothing_was_skipped() {
+    let summary = GraphSummary {
+        total_symbols: 1,
+        total_imports: 0,
+        total_files: 1,
+        files_parsed: 1,
+        files_unchanged: 0,
+        files_skipped_generated: 0,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(
+        !line.contains("skipped"),
+        "no skip clause when nothing was excluded: {line}"
+    );
+}
+
+#[test]
+fn format_graph_stats_uses_singular_file_for_a_count_of_one() {
+    let summary = GraphSummary {
+        total_symbols: 0,
+        total_imports: 0,
+        total_files: 0,
+        files_parsed: 0,
+        files_unchanged: 0,
+        files_skipped_generated: 1,
+    };
+    let line = format_graph_stats(&summary);
+    assert!(line.contains("skipped 1 generated file"), "{line}");
+    assert!(
+        !line.contains("generated files"),
+        "singular, not plural, for a count of one: {line}"
+    );
+}
+
+/// End-to-end through the real builder `stella init` calls
+/// ([`index_workspace_graph_blocking`]): a `*.min.*` file sitting at the
+/// workspace root (no denied directory involved) must be excluded and
+/// counted, while an ordinary file alongside it indexes normally.
+#[test]
+fn index_workspace_graph_blocking_reports_generated_skips_end_to_end() {
+    let ws = tempfile::tempdir().unwrap();
+    std::fs::write(ws.path().join("app.min.js"), "function refresh(){}\n").unwrap();
+    std::fs::write(ws.path().join("main.rs"), "pub fn run() {}\n").unwrap();
+
+    let summary = index_workspace_graph_blocking(ws.path()).expect("index build succeeds");
+    assert_eq!(summary.total_files, 1, "the minified file is never indexed");
+    assert_eq!(summary.files_skipped_generated, 1);
+
+    let line = format_graph_stats(&summary);
+    assert!(line.contains("skipped 1 generated file"), "{line}");
+}

--- a/stella-graph/src/generated.rs
+++ b/stella-graph/src/generated.rs
@@ -1,0 +1,291 @@
+//! Generated / minified file exclusion (issue #272).
+//!
+//! Evidence: recall inside a large monorepo surfaced five frames all citing
+//! `dist-standalone/oxagen.mjs`, a checked-in minified bundle — zero frames
+//! from real source. Indexing generated artifacts wastes recall budget and
+//! buries genuine hits, so this module keeps them out of the store entirely.
+//!
+//! Two independent signals feed the same exclusion, both evaluated in
+//! [`crate::store::index_one`] against a file's already-read bytes:
+//!
+//! - **Declared**: `.gitattributes` `linguist-generated=true` patterns
+//!   (root-level only — the same documented gap [`crate::walk`] already
+//!   carries for `.gitignore`: per-directory `.gitattributes` files are not
+//!   merged) and the `*.min.*` filename convention (`app.min.js`).
+//! - **Heuristic** ([`looks_minified`]): line-shape sniffing for generated
+//!   output that carries no path or attribute signal at all — a single
+//!   monster line, or a file uniformly wider than hand-written source ever
+//!   gets, is not something a human wrote.
+//!
+//! Directory-shaped generated output (`dist/`, `build/`, `out/`, `.next/`,
+//! `node_modules/`, `dist-standalone/`, `vendor/`) is excluded earlier, at
+//! the walk itself ([`crate::walk::DENY_DIRS`]) — cheaper, since the walk
+//! never even opens those files.
+//!
+//! Both checks here run **before** the byte-compat skip
+//! (`code_graph_files.content_sha256`), so a file already sitting in an
+//! index built before this module existed is retroactively dropped on the
+//! very next pass even though its bytes have not changed — the byte-compat
+//! skip alone would otherwise hide it forever.
+
+use std::path::Path;
+
+use crate::manifest::glob_match;
+
+/// A single line at or beyond this length is treated as minified — hand
+/// authored source essentially never reaches it, while bundlers/minifiers
+/// routinely emit output far past it (a whole module on one line).
+pub(crate) const MINIFIED_LINE_LEN: usize = 2_000;
+
+/// A file whose *average* line length is at or beyond this is treated as
+/// minified even with no single monster line — catches output wrapped at a
+/// fixed column instead of emitted as one giant line.
+pub(crate) const MINIFIED_AVG_LINE_LEN: usize = 500;
+
+/// Below this many bytes, line-length heuristics are unreliable (a short
+/// one-line JSON config, a single re-export) — content sniffing is skipped
+/// entirely rather than false-positive on a tiny legitimate file.
+pub(crate) const MIN_HEURISTIC_BYTES: usize = 2_048;
+
+/// Filename infix marking a minified build artifact by convention
+/// (`app.min.js`, `styles.min.css`).
+const MINIFIED_INFIX: &str = ".min.";
+
+/// One `.gitattributes` pattern with its resolved `linguist-generated` value
+/// (`true` for `linguist-generated` / `linguist-generated=true`, `false` for
+/// `-linguist-generated` / `linguist-generated=false`).
+struct AttrPattern {
+    pattern: String,
+    generated: bool,
+}
+
+/// Parsed `.gitattributes` `linguist-generated` rules for one workspace root,
+/// loaded once per index pass — mirrors
+/// [`crate::manifest::StorageManifest::load`]'s "loaded once, best-effort"
+/// shape. A missing or unreadable file yields an empty (no-op) filter rather
+/// than an error: most workspaces have no `.gitattributes` at all.
+pub(crate) struct GeneratedFilter {
+    patterns: Vec<AttrPattern>,
+}
+
+impl GeneratedFilter {
+    pub(crate) fn load(root: &Path) -> GeneratedFilter {
+        let text = std::fs::read_to_string(root.join(".gitattributes")).unwrap_or_default();
+        let patterns = text.lines().filter_map(parse_attr_line).collect();
+        GeneratedFilter { patterns }
+    }
+
+    /// Whether `.gitattributes` marks `rel_path` `linguist-generated=true`.
+    /// Real gitattributes semantics apply: later matching patterns win, so a
+    /// trailing `-linguist-generated` can un-mark an earlier blanket pattern.
+    /// A pattern with no `/` follows git's own convention of matching the
+    /// basename at any depth (`*.snap` hits `src/deep/foo.snap`); a pattern
+    /// containing `/` is anchored to the workspace root, matched against the
+    /// full relative path (`dist/**`).
+    fn attr_marks_generated(&self, rel_path: &str) -> bool {
+        let basename = Path::new(rel_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(rel_path);
+        let mut generated = false;
+        for p in &self.patterns {
+            let matched = if p.pattern.contains('/') {
+                glob_match(&p.pattern, rel_path)
+            } else {
+                glob_match(&p.pattern, basename)
+            };
+            if matched {
+                generated = p.generated;
+            }
+        }
+        generated
+    }
+}
+
+/// Parse one `.gitattributes` line into a pattern + resolved
+/// `linguist-generated` boolean, if that line mentions the attribute at all
+/// (every other attribute is irrelevant to this module and ignored).
+fn parse_attr_line(line: &str) -> Option<AttrPattern> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+    let mut fields = line.split_whitespace();
+    let pattern = fields.next()?.to_string();
+    for attr in fields {
+        let (name, generated) = match attr.strip_prefix('-') {
+            Some(name) => (name, false),
+            None => match attr.split_once('=') {
+                Some((name, value)) => (name, value.eq_ignore_ascii_case("true")),
+                None => (attr, true),
+            },
+        };
+        if name == "linguist-generated" {
+            return Some(AttrPattern { pattern, generated });
+        }
+    }
+    None
+}
+
+/// Filename-convention check: `*.min.*` (`app.min.js`, `styles.min.css`).
+fn is_minified_filename(rel_path: &str) -> bool {
+    Path::new(rel_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name.contains(MINIFIED_INFIX))
+}
+
+/// Line-shape sniff for generated/minified content with no path or attribute
+/// signal at all. Operates on raw bytes rather than `str` so it runs ahead of
+/// (and regardless of) UTF-8 validation — a minified bundle's byte-line shape
+/// reads the same either way, and a binary file just never crosses either
+/// threshold below the byte-count floor is meant to protect.
+pub(crate) fn looks_minified(content: &[u8]) -> bool {
+    if content.len() < MIN_HEURISTIC_BYTES {
+        return false;
+    }
+    let mut lines = 0usize;
+    for line in content.split(|&b| b == b'\n') {
+        lines += 1;
+        if line.len() >= MINIFIED_LINE_LEN {
+            return true;
+        }
+    }
+    content.len() / lines.max(1) >= MINIFIED_AVG_LINE_LEN
+}
+
+/// Whether `rel_path` (with `content` already read off disk) should be
+/// excluded from the index. Cheap path-pattern signals first, content shape
+/// last — `looks_minified` is the only signal that has to look at bytes.
+pub(crate) fn is_excluded(filter: &GeneratedFilter, rel_path: &str, content: &[u8]) -> bool {
+    is_minified_filename(rel_path)
+        || filter.attr_marks_generated(rel_path)
+        || looks_minified(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_infix_filenames_are_excluded() {
+        assert!(is_minified_filename("dist/app.min.js"));
+        assert!(is_minified_filename("styles.min.css"));
+        // "minimal"/"administration" contain "min" but never the ".min."
+        // infix — a substring match on "min" alone would false-positive here.
+        assert!(!is_minified_filename("minimal.js"));
+        assert!(!is_minified_filename("administration.rs"));
+    }
+
+    #[test]
+    fn gitattributes_generated_true_excludes_matching_paths() {
+        let filter = GeneratedFilter {
+            patterns: vec![AttrPattern {
+                pattern: "generated/**".into(),
+                generated: true,
+            }],
+        };
+        assert!(filter.attr_marks_generated("generated/schema.ts"));
+        assert!(!filter.attr_marks_generated("src/schema.ts"));
+    }
+
+    #[test]
+    fn a_later_pattern_can_unset_an_earlier_blanket_rule() {
+        let filter = GeneratedFilter {
+            patterns: vec![
+                AttrPattern {
+                    pattern: "vendor/**".into(),
+                    generated: true,
+                },
+                AttrPattern {
+                    pattern: "vendor/hand-edited.ts".into(),
+                    generated: false,
+                },
+            ],
+        };
+        assert!(filter.attr_marks_generated("vendor/bundle.js"));
+        assert!(!filter.attr_marks_generated("vendor/hand-edited.ts"));
+    }
+
+    #[test]
+    fn parses_bare_negated_and_valued_linguist_generated_forms() {
+        assert!(
+            parse_attr_line("*.g.cs linguist-generated")
+                .unwrap()
+                .generated
+        );
+        assert!(
+            parse_attr_line("*.g.cs linguist-generated=true")
+                .unwrap()
+                .generated
+        );
+        assert!(
+            !parse_attr_line("*.g.cs -linguist-generated")
+                .unwrap()
+                .generated
+        );
+        assert!(
+            !parse_attr_line("*.g.cs linguist-generated=false")
+                .unwrap()
+                .generated
+        );
+        assert!(parse_attr_line("*.g.cs linguist-language=C#").is_none());
+        assert!(parse_attr_line("# a comment").is_none());
+        assert!(parse_attr_line("   ").is_none());
+    }
+
+    #[test]
+    fn load_is_a_no_op_without_a_gitattributes_file() {
+        let root = tempfile::tempdir().unwrap();
+        let filter = GeneratedFilter::load(root.path());
+        assert!(!filter.attr_marks_generated("anything.ts"));
+    }
+
+    #[test]
+    fn load_parses_a_real_gitattributes_file() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join(".gitattributes"),
+            "dist/** linguist-generated=true\n*.snap linguist-generated\n",
+        )
+        .unwrap();
+        let filter = GeneratedFilter::load(root.path());
+        assert!(filter.attr_marks_generated("dist/bundle.js"));
+        assert!(filter.attr_marks_generated("src/foo.snap"));
+        assert!(!filter.attr_marks_generated("src/foo.rs"));
+    }
+
+    #[test]
+    fn a_single_huge_line_is_minified() {
+        // The huge line alone must clear both the line-length threshold AND
+        // the overall byte floor (a short preamble plus exactly
+        // `MINIFIED_LINE_LEN` would total just under `MIN_HEURISTIC_BYTES`).
+        let content = format!("const x = 1;\n{}\n", "a".repeat(MINIFIED_LINE_LEN + 200));
+        assert!(content.len() >= MIN_HEURISTIC_BYTES);
+        assert!(looks_minified(content.as_bytes()));
+    }
+
+    #[test]
+    fn a_uniformly_wide_file_is_minified_by_average() {
+        // 10 lines averaging well past MINIFIED_AVG_LINE_LEN, none alone
+        // reaching MINIFIED_LINE_LEN.
+        let line = "x".repeat(MINIFIED_AVG_LINE_LEN + 50);
+        let content = std::iter::repeat_n(line, 10).collect::<Vec<_>>().join("\n");
+        assert!(content.len() >= MIN_HEURISTIC_BYTES);
+        assert!(looks_minified(content.as_bytes()));
+    }
+
+    #[test]
+    fn ordinary_hand_written_source_is_not_minified() {
+        let content = "fn run_turn() {\n    // drive one turn\n}\npub struct Engine;\n".repeat(50);
+        assert!(content.len() >= MIN_HEURISTIC_BYTES);
+        assert!(!looks_minified(content.as_bytes()));
+    }
+
+    #[test]
+    fn tiny_files_never_trip_the_heuristic() {
+        let content = "a".repeat(MINIFIED_LINE_LEN); // long line, but under the byte floor
+        assert!(content.len() < MIN_HEURISTIC_BYTES);
+        assert!(!looks_minified(content.as_bytes()));
+    }
+}

--- a/stella-graph/src/lib.rs
+++ b/stella-graph/src/lib.rs
@@ -43,6 +43,7 @@
 
 mod error;
 mod frames;
+mod generated;
 mod graph;
 mod import;
 mod lang;

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -27,6 +27,7 @@ use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use sha2::{Digest, Sha256};
 
 use crate::error::GraphError;
+use crate::generated::{self, GeneratedFilter};
 use crate::import::{self, ImportKind};
 use crate::lang::Language;
 use crate::manifest::StorageManifest;
@@ -97,6 +98,11 @@ pub struct IndexStats {
     pub files_parsed: usize,
     pub files_skipped_unchanged: usize,
     pub files_skipped_binary: usize,
+    /// Files excluded as generated/minified (`crate::generated::is_excluded`)
+    /// — `.gitattributes` `linguist-generated=true`, the `*.min.*` filename
+    /// convention, or the minified-content heuristic. Surfaced by `stella
+    /// init` as "skipped N generated files" (issue #272).
+    pub files_skipped_generated: usize,
     pub files_unreadable: usize,
     pub parse_failures: usize,
     pub files_pruned: usize,
@@ -152,17 +158,27 @@ pub(crate) fn index_tree(
 ) -> Result<IndexStats, GraphError> {
     let files = walk_indexable(root);
     let mut stats = IndexStats::default();
-    // Manifest layer mapping is loaded once per pass; a malformed manifest
-    // degrades to the implicit layer, never aborts the batch (L-L1).
+    // Manifest layer mapping and the generated-file filter are each loaded
+    // once per pass; a malformed manifest or absent `.gitattributes` degrades
+    // to the implicit layer / no-op filter, never aborts the batch (L-L1).
     let manifest = StorageManifest::load(root).ok().flatten();
+    let generated_filter = GeneratedFilter::load(root);
     let tx = conn.transaction()?;
 
     let mut current: HashSet<String> = HashSet::with_capacity(files.len());
     for abs in &files {
         current.insert(rel_path(root, abs));
-        index_one(&tx, root, grammars, manifest.as_ref(), abs, &mut stats)?;
+        index_one(
+            &tx,
+            root,
+            grammars,
+            manifest.as_ref(),
+            &generated_filter,
+            abs,
+            &mut stats,
+        )?;
     }
-    stats.files_pruned = prune_missing(&tx, &current)?;
+    stats.files_pruned += prune_missing(&tx, &current)?;
 
     tx.commit()?;
     Ok(stats)
@@ -179,13 +195,22 @@ pub(crate) fn apply_changes(
 ) -> Result<IndexStats, GraphError> {
     let mut stats = IndexStats::default();
     let manifest = StorageManifest::load(root).ok().flatten();
+    let generated_filter = GeneratedFilter::load(root);
     let tx = conn.transaction()?;
     for abs in changed {
         if Language::from_path(abs).is_none() && !storage::indexes_without_language(abs) {
             continue;
         }
         if abs.is_file() {
-            index_one(&tx, root, grammars, manifest.as_ref(), abs, &mut stats)?;
+            index_one(
+                &tx,
+                root,
+                grammars,
+                manifest.as_ref(),
+                &generated_filter,
+                abs,
+                &mut stats,
+            )?;
         } else {
             let rel = rel_path(root, abs);
             stats.files_pruned +=
@@ -204,6 +229,7 @@ fn index_one(
     root: &Path,
     grammars: &Grammars,
     manifest: Option<&StorageManifest>,
+    generated_filter: &GeneratedFilter,
     abs: &Path,
     stats: &mut IndexStats,
 ) -> Result<(), GraphError> {
@@ -217,6 +243,21 @@ fn index_one(
             return Ok(());
         }
     };
+
+    // Generated/minified exclusion (issue #272) runs **before** the
+    // byte-compat skip below, on purpose: a file already sitting in an index
+    // built before this filter existed would otherwise never be re-evaluated
+    // (its bytes have not changed, so the skip would keep hiding it forever).
+    // Deleting any pre-existing row here retroactively cleans that case out
+    // on the very next index pass — the same row removal `prune_missing`
+    // does for a file that vanished from disk.
+    if generated::is_excluded(generated_filter, &rel, &content) {
+        stats.files_skipped_generated += 1;
+        stats.files_pruned +=
+            tx.execute("DELETE FROM code_graph_files WHERE path = ?1", params![rel])?;
+        return Ok(());
+    }
+
     let sha = sha256_hex(&content);
 
     // Byte-compat skip (L-C2): identical content is never re-parsed.
@@ -997,5 +1038,85 @@ mod tests {
         // The pruned file's symbols are gone (CASCADE).
         assert!(definitions(&conn, "gone").unwrap().is_empty());
         assert!(!definitions(&conn, "keep").unwrap().is_empty());
+    }
+
+    /// Issue #272: a minified bundle (one giant line, well past the byte
+    /// floor) never persists a row, while an ordinary file alongside it
+    /// indexes normally.
+    #[test]
+    fn minified_content_is_skipped_and_not_persisted() {
+        let ws = tempdir().unwrap();
+        let dbdir = tempdir().unwrap();
+        let root = canon(&ws);
+        let db = dbdir.path().join("context.db");
+        let long_line = "function bigOne(){return 1;}".repeat(200);
+        fs::write(root.join("bundle.js"), format!("{long_line}\n")).unwrap();
+        fs::write(root.join("real.js"), "function real() { return 2; }\n").unwrap();
+        let grammars = Grammars::load().unwrap();
+        let mut conn = open(&db).unwrap();
+
+        let stats = index_tree(&mut conn, &root, &grammars).unwrap();
+        assert_eq!(stats.files_skipped_generated, 1, "{stats:?}");
+        assert_eq!(
+            file_count(&conn).unwrap(),
+            1,
+            "only the real file is indexed"
+        );
+        assert!(definitions(&conn, "bigOne").unwrap().is_empty());
+        assert!(!definitions(&conn, "real").unwrap().is_empty());
+    }
+
+    /// The `*.min.*` filename convention is enough on its own — no minified
+    /// content shape required.
+    #[test]
+    fn min_dot_filename_convention_is_skipped_regardless_of_content_shape() {
+        let ws = tempdir().unwrap();
+        let dbdir = tempdir().unwrap();
+        let root = canon(&ws);
+        let db = dbdir.path().join("context.db");
+        fs::write(root.join("app.min.js"), "function tiny() {}\n").unwrap();
+        let grammars = Grammars::load().unwrap();
+        let mut conn = open(&db).unwrap();
+
+        let stats = index_tree(&mut conn, &root, &grammars).unwrap();
+        assert_eq!(stats.files_skipped_generated, 1);
+        assert!(definitions(&conn, "tiny").unwrap().is_empty());
+    }
+
+    /// Issue #272's retroactive-cleanup requirement: a file indexed normally
+    /// under an older version, then later declared `linguist-generated=true`
+    /// with its bytes completely unchanged, must still be pruned on the very
+    /// next pass — proving the exclusion check runs ahead of (and overrides)
+    /// the byte-compat skip rather than being hidden behind it forever.
+    #[test]
+    fn a_file_marked_generated_after_the_fact_is_pruned_even_with_unchanged_bytes() {
+        let ws = tempdir().unwrap();
+        let dbdir = tempdir().unwrap();
+        let root = canon(&ws);
+        let db = dbdir.path().join("context.db");
+        fs::write(root.join("legacy.js"), "function legacyThing() {}\n").unwrap();
+        let grammars = Grammars::load().unwrap();
+        let mut conn = open(&db).unwrap();
+
+        index_tree(&mut conn, &root, &grammars).unwrap();
+        assert!(
+            !definitions(&conn, "legacyThing").unwrap().is_empty(),
+            "indexed normally before any .gitattributes rule exists"
+        );
+
+        // Mark it generated without touching its bytes at all.
+        fs::write(
+            root.join(".gitattributes"),
+            "legacy.js linguist-generated=true\n",
+        )
+        .unwrap();
+        let stats = index_tree(&mut conn, &root, &grammars).unwrap();
+
+        assert_eq!(stats.files_skipped_generated, 1);
+        assert!(
+            definitions(&conn, "legacyThing").unwrap().is_empty(),
+            "a stale pre-fix row must be retroactively pruned, not hidden behind the byte-compat skip"
+        );
+        assert_eq!(file_count(&conn).unwrap(), 0);
     }
 }

--- a/stella-graph/src/walk.rs
+++ b/stella-graph/src/walk.rs
@@ -3,10 +3,18 @@
 //! L-S5 makes ripgrep-semantics (gitignore-aware,
 //! hidden-excluded) the contract for search tooling. This module implements a
 //! **deny-list approximation** rather than pulling ripgrep's `ignore` crate:
-//! it skips hidden directories (leading `.`), the usual build/vendor caches
-//! (`target`, `node_modules`, `dist`, `build`, `__pycache__`, `venv`, …), and
-//! never follows symlinked directories (cycle safety), then keeps only files
-//! whose extension [`Language::from_path`] recognizes.
+//! it skips hidden directories (leading `.`), the usual build/vendor/generated
+//! caches (`target`, `node_modules`, `dist`, `build`, `out`, `.next`,
+//! `dist-standalone`, `vendor`, `__pycache__`, `venv`, …), and never follows
+//! symlinked directories (cycle safety), then keeps only files whose
+//! extension [`Language::from_path`] recognizes.
+//!
+//! This is the cheap, structural half of generated/minified exclusion
+//! (issue #272) — a whole directory of build output never even gets opened.
+//! The other half — `.gitattributes` `linguist-generated=true`, the
+//! `*.min.*` filename convention, and minified-content sniffing for files
+//! that live outside any denied directory — runs per-file once content is
+//! already in hand, in [`crate::generated`] via `crate::store::index_one`.
 //!
 //! **Documented gap (task brief, ignore-discipline clause):** custom
 //! `.gitignore` patterns (per-directory ignore files, negations, glob rules)
@@ -21,12 +29,19 @@ use std::path::{Path, PathBuf};
 use crate::lang::Language;
 
 /// Directory names that never contain first-party source worth indexing.
+/// `dist`/`build`/`out`/`node_modules`/`vendor` are classic build/vendor
+/// caches; `.next` and `dist-standalone` are generated-bundle directories
+/// specifically called out by issue #272 (a checked-in minified
+/// `dist-standalone/*.mjs` bundle was polluting recall with zero-signal
+/// frames).
 const DENY_DIRS: &[&str] = &[
     "target",
     "node_modules",
     "dist",
+    "dist-standalone",
     "build",
     "out",
+    ".next",
     "__pycache__",
     "venv",
     ".venv",
@@ -94,4 +109,54 @@ pub(crate) fn walk_indexable(root: &Path) -> Vec<PathBuf> {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Issue #272: a checked-in minified bundle under `dist-standalone/`
+    /// (found nested inside a monorepo app directory, not at the workspace
+    /// root) must never reach the indexable set.
+    #[test]
+    fn dist_standalone_and_next_directories_are_never_walked() {
+        let ws = TempDir::new().unwrap();
+        let root = ws.path();
+        fs::create_dir_all(root.join("apps/cli/dist-standalone")).unwrap();
+        fs::write(
+            root.join("apps/cli/dist-standalone/oxagen.mjs"),
+            "function refresh() {}\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("apps/web/.next/static")).unwrap();
+        fs::write(
+            root.join("apps/web/.next/static/chunk.js"),
+            "function chunk() {}\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("apps/cli/src")).unwrap();
+        fs::write(root.join("apps/cli/src/main.rs"), "fn main() {}\n").unwrap();
+
+        let files = walk_indexable(root);
+        assert_eq!(files.len(), 1, "only real source is walked: {files:?}");
+        assert!(files[0].ends_with("apps/cli/src/main.rs"));
+    }
+
+    #[test]
+    fn is_denied_dir_covers_generated_bundle_directories() {
+        for name in [
+            "dist",
+            "dist-standalone",
+            "build",
+            "out",
+            "vendor",
+            "node_modules",
+        ] {
+            assert!(is_denied_dir(name), "{name} should be denied");
+        }
+        assert!(is_denied_dir(".next"), ".next is denied (hidden + listed)");
+        assert!(!is_denied_dir("src"));
+    }
 }

--- a/stella-graph/tests/generated_exclusion.rs
+++ b/stella-graph/tests/generated_exclusion.rs
@@ -1,0 +1,170 @@
+//! Issue #272 — generated/minified bundles must never enter the index, and
+//! therefore must never surface as recall candidates. These are witness
+//! tests: every one of them fails on the pre-#272 code (no
+//! `dist-standalone` deny-dir, no `.gitattributes`/`*.min.*`/content-shape
+//! filter) and passes with it.
+
+use std::fs;
+
+use stella_graph::{CodeGraph, ContextQuery};
+use tempfile::TempDir;
+
+fn query(text: &str) -> ContextQuery {
+    ContextQuery {
+        goal: text.to_string(),
+        query_text: Some(text.to_string()),
+        embedding: None,
+        kinds: Vec::new(),
+        anchors: Vec::new(),
+        max_frames: 50,
+        max_tokens: 20_000,
+        as_of: None,
+    }
+}
+
+/// The evidence tree from issue #272: a real source file sitting next to a
+/// checked-in minified bundle nested inside a monorepo app directory (not at
+/// the workspace root — `apps/cli/dist-standalone/…`).
+fn fixture_with_dist_standalone() -> (TempDir, TempDir, CodeGraph) {
+    let ws = TempDir::new().unwrap();
+    let dbdir = TempDir::new().unwrap();
+    fs::create_dir_all(ws.path().join("apps/cli/dist-standalone")).unwrap();
+    fs::write(
+        ws.path().join("apps/cli/dist-standalone/oxagen.mjs"),
+        format!("function refresh(){{{}}}\n", "console.log(1);".repeat(300)),
+    )
+    .unwrap();
+    fs::create_dir_all(ws.path().join("apps/cli/src")).unwrap();
+    fs::write(
+        ws.path().join("apps/cli/src/main.rs"),
+        "pub fn run_turn() {\n    // real, hand-written source\n}\n",
+    )
+    .unwrap();
+    let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+    graph.index_all().unwrap();
+    (ws, dbdir, graph)
+}
+
+#[test]
+fn dist_standalone_bundle_is_never_indexed() {
+    let (_ws, _db, graph) = fixture_with_dist_standalone();
+    let files = graph.all_files().unwrap();
+    assert!(
+        !files.iter().any(|f| f.contains("dist-standalone")),
+        "dist-standalone must never be walked: {files:?}"
+    );
+    assert!(files.iter().any(|f| f.ends_with("main.rs")));
+}
+
+#[test]
+fn dist_standalone_bundle_produces_no_recall_frames() {
+    let (_ws, _db, graph) = fixture_with_dist_standalone();
+
+    // Direct definition/reference lookups for the symbol the bundle defines.
+    assert!(
+        graph.definitions("refresh").unwrap().is_empty(),
+        "no definition frame should cite the minified bundle"
+    );
+    assert!(
+        graph.references("refresh").unwrap().is_empty(),
+        "no reference frame should cite the minified bundle"
+    );
+
+    // The OCP `query` entrypoint — the actual path `stella-cli`'s recall
+    // fans a turn's context request through (`stella-cli/src/ocp.rs`,
+    // `GraphProvider::query`).
+    let frames = graph.query(&query("why did refresh regress")).unwrap();
+    assert!(
+        frames.iter().all(|f| !f
+            .citation_label
+            .as_deref()
+            .unwrap_or("")
+            .contains("dist-standalone")),
+        "no frame in a fused query result may cite the bundle: {frames:#?}"
+    );
+    assert!(
+        frames
+            .iter()
+            .all(|f| !f.uri.as_deref().unwrap_or("").contains("dist-standalone")),
+        "no frame's uri may point into the bundle: {frames:#?}"
+    );
+}
+
+#[test]
+fn a_minified_bundle_outside_any_denied_directory_is_still_excluded() {
+    // Not every generated bundle lives under a conventionally-named
+    // directory — the content-shape heuristic is the backstop for those.
+    let ws = TempDir::new().unwrap();
+    let dbdir = TempDir::new().unwrap();
+    fs::write(
+        ws.path().join("bundle.js"),
+        format!("function refresh(){{{}}}\n", "x".repeat(3000)),
+    )
+    .unwrap();
+    let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+    graph.index_all().unwrap();
+
+    assert!(graph.all_files().unwrap().is_empty());
+    assert!(graph.definitions("refresh").unwrap().is_empty());
+}
+
+#[test]
+fn gitattributes_linguist_generated_files_are_excluded_from_recall() {
+    let ws = TempDir::new().unwrap();
+    let dbdir = TempDir::new().unwrap();
+    fs::write(
+        ws.path().join(".gitattributes"),
+        "codegen/*.ts linguist-generated=true\n",
+    )
+    .unwrap();
+    fs::create_dir_all(ws.path().join("codegen")).unwrap();
+    fs::write(
+        ws.path().join("codegen/client.ts"),
+        "export function generatedClient() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        ws.path().join("hand_written.ts"),
+        "export function handWritten() { return 2; }\n",
+    )
+    .unwrap();
+    let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+    graph.index_all().unwrap();
+
+    assert!(graph.definitions("generatedClient").unwrap().is_empty());
+    assert!(!graph.definitions("handWritten").unwrap().is_empty());
+}
+
+/// An index built before this exclusion existed (simulated here by indexing
+/// once, then adding the `.gitattributes` rule with the file's bytes
+/// untouched) must not keep serving frames from it forever — the very next
+/// `index_all` (what `stella init` re-run drives) has to retroactively drop
+/// the stale row, not just decline to add new ones.
+#[test]
+fn a_previously_indexed_file_stops_surfacing_once_declared_generated() {
+    let ws = TempDir::new().unwrap();
+    let dbdir = TempDir::new().unwrap();
+    fs::write(
+        ws.path().join("legacy.js"),
+        "function legacyThing() { return 1; }\n",
+    )
+    .unwrap();
+    let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+    graph.index_all().unwrap();
+    assert!(
+        !graph.definitions("legacyThing").unwrap().is_empty(),
+        "sanity: indexed normally before any exclusion rule exists"
+    );
+
+    fs::write(
+        ws.path().join(".gitattributes"),
+        "legacy.js linguist-generated=true\n",
+    )
+    .unwrap();
+    graph.index_all().unwrap();
+
+    assert!(
+        graph.definitions("legacyThing").unwrap().is_empty(),
+        "a stale pre-fix row must not survive an unchanged-bytes re-index"
+    );
+}


### PR DESCRIPTION
## What & why

Evidence from a real session (2026-07-20, Stella running inside a large monorepo): context recall injected five frames all citing `apps/cli/dist-standalone/oxagen.mjs`, a checked-in minified bundle — zero frames from real source. Indexing generated artifacts wastes recall budget and buries genuine hits.

This PR keeps generated/minified files out of the code-graph index (and therefore out of recall) at two layers:

- **Structural** (cheap, at the walk — `stella-graph/src/walk.rs`): `dist-standalone` and `.next` join the existing `dist`/`build`/`out`/`node_modules`/`vendor` deny-list, so a whole directory of build output never gets opened.
- **Per-file** (new `stella_graph::generated` module, evaluated in `store::index_one` once content is already in hand, **ahead of** the byte-compat skip):
  - `.gitattributes` `linguist-generated=true` patterns (root-level; git's no-slash-matches-any-depth convention honored via the existing `manifest::glob_match`)
  - the `*.min.*` filename convention
  - a minified-content heuristic (a single line ≥2000 bytes, or an average line length ≥500 bytes, gated behind a 2048-byte floor so tiny legitimate files never false-positive)

Running the exclusion check ahead of the byte-compat skip matters: a file already sitting in an index built **before** this filter existed is retroactively pruned on the very next `index_all` pass even though its bytes have not changed — the byte-compat skip alone would otherwise hide it forever. I picked this (delete-on-detection at the one write path) over a schema/rebuild bump because there is exactly one writer (`store::index_one`) and every reader (`frames::query`/`definitions`/`references`, the schema gate, the observatory dashboard) trusts what it wrote — filtering at the write path is sufficient without adding a second filter at every read path.

`stella init`'s summary line now surfaces the exclusion instead of letting it silently vanish from the file count: `✓ code graph: … — skipped N generated files`.

Closes #272

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-graph/tests/generated_exclusion.rs` builds a fixture tree with `apps/cli/dist-standalone/oxagen.mjs` (mirroring the reported evidence) and asserts:
- `dist_standalone_bundle_is_never_indexed` — the bundle never enters `all_files`
- `dist_standalone_bundle_produces_no_recall_frames` — `definitions`/`references`/the OCP `query` entrypoint never cite it
- `a_minified_bundle_outside_any_denied_directory_is_still_excluded` — the content-shape heuristic catches a bundle that isn't under a conventionally-named directory
- `gitattributes_linguist_generated_files_are_excluded_from_recall` — a `.gitattributes`-declared generated file is excluded, a hand-written sibling is not
- `a_previously_indexed_file_stops_surfacing_once_declared_generated` — the retroactive-cleanup case: index a file normally, add a `.gitattributes` rule with the file's **bytes untouched**, re-index, assert it's gone

All five fail on `main` (no `dist-standalone` deny-dir, no `.gitattributes`/`*.min.*`/content-shape filter existed) and pass here. Additional unit coverage in `stella-graph/src/generated.rs`, `stella-graph/src/walk.rs`, `stella-graph/src/store.rs`, and `stella-cli/src/agent_tests.rs` (the `stella init` output line, tested on the pure builder/formatter functions, never a live TTY).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (full `make gate`, run once before this push — 48/48 test-result blocks green)
- [x] Docs updated where behavior/flags changed (doc comments on the new module, `walk.rs`, `IndexStats`, `GraphSummary`)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core` (all changes are in `stella-graph` and `stella-cli`)
- [x] No new deps — reused the existing `stella-graph::manifest::glob_match` glob matcher for `.gitattributes` patterns rather than pulling in a new crate
- [x] No new outbound network calls
- [x] New cross-boundary types — n/a (no new wire types; `IndexStats`/`GraphSummary` are internal, `files_skipped_generated: usize` is an added field on existing internal structs)

## Anything reviewers should know?

- `.gitattributes` parsing is root-level only, matching the same documented gap `walk.rs` already carries for `.gitignore` (per-directory files aren't merged) — noted in the module doc.
- Live-watcher incremental updates (`apply_changes`) also load the filter and will catch newly-changed files, but only a full `index_all` (what `stella init`/re-init drives) walks + prunes the whole tree — that's the retroactive-cleanup path the witness test exercises.
