### PR TITLE
fix(stella-store): schema-too-new error names the stale binary + upgrade path

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,18 +42,26 @@ This has to exist and be writable before the first release:
    (Homebrew maps the tap `macanderson/tap` → repo `homebrew-tap`). It can
    start empty; the release job commits `Formula/stella.rb` into it.
 
-2. **Create a push token.** A GitHub token with **contents: write** on the tap
-   repo — a fine-grained PAT scoped to `macanderson/homebrew-tap`, or a classic
-   PAT with `repo`. The default `GITHUB_TOKEN` can't push to another repo, so a
-   dedicated one is required.
+2. **Create write access, either way** (the release job tries the deploy key
+   first, falling back to the token — see `.github/workflows/release.yml`'s
+   `homebrew` job):
+   - **SSH deploy key (what's actually configured today)** — generate a
+     dedicated keypair, add the public half as a **write-enabled deploy key**
+     on `macanderson/homebrew-tap` (repo Settings → Deploy keys), and the
+     private half as the `HOMEBREW_TAP_DEPLOY_KEY` secret below. Scoped to
+     exactly that one repo, unlike a PAT.
+   - **PAT (fallback)** — a GitHub token with **contents: write** on the tap
+     repo — a fine-grained PAT scoped to `macanderson/homebrew-tap`, or a
+     classic PAT with `repo`. The default `GITHUB_TOKEN` can't push to
+     another repo, so a dedicated one is required either way.
 
 3. **Add it as a secret** on **this** repo (`macanderson/stella`):
    Settings → Secrets and variables → Actions → New repository secret →
-   name `HOMEBREW_TAP_TOKEN`, value the token from step 2.
+   name `HOMEBREW_TAP_DEPLOY_KEY` (deploy key) or `HOMEBREW_TAP_TOKEN` (PAT).
 
 The prebuilt tarballs, checksums, and the `curl | sh` installer are published
 to this repo's GitHub Releases and need no extra secrets — only the Homebrew
-tap push does. If `HOMEBREW_TAP_TOKEN` is absent, the release still succeeds and
+tap push does. If neither secret is set, the release still succeeds and
 the `homebrew` job skips with a warning.
 
 ## Cut a release

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -609,7 +609,11 @@ impl Store {
             // newer schema added.
             return Err(StoreError(format!(
                 "store.db is at schema version {version}, but this build only \
-                 knows {SCHEMA_VERSION} — refusing to open it with older code"
+                 knows {SCHEMA_VERSION} — your stella binary is out of date, not \
+                 the workspace. Upgrade with `brew upgrade stella`, re-run \
+                 install.sh, or grab a newer build from \
+                 https://github.com/macanderson/stella/releases, then reopen \
+                 this workspace."
             )));
         }
         if version == 0 && !any_store_table_exists(&conn)? {
@@ -3491,9 +3495,23 @@ mod tests {
             Ok(_) => panic!("a newer-versioned file must refuse to open"),
             Err(e) => e,
         };
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("schema version"),
+            msg.contains("schema version"),
             "downgrade must refuse, not silently write into a newer shape: {err}"
+        );
+        // The real cause is a stale binary, not a corrupt workspace — the
+        // message must name that and point at an upgrade path, not just
+        // refuse (#252).
+        assert!(
+            msg.contains("out of date"),
+            "message must name the stale binary as the cause, not just refuse: {err}"
+        );
+        assert!(
+            msg.contains("brew upgrade stella")
+                && msg.contains("install.sh")
+                && msg.contains("github.com/macanderson/stella/releases"),
+            "message must name every supported upgrade path: {err}"
         );
         std::fs::remove_dir_all(&root).ok();
     }


### PR DESCRIPTION
## Summary — issue #252, part (b)
The "store.db is at schema version N, but this build only knows M — refusing to open it" message is accurate but not actionable — it reads like a corrupt/foreign workspace when the real cause is almost always a stale `stella` binary (e.g. a `brew`-installed build that's lagged behind main) opening a workspace some newer build already touched. The message now names the real cause and every supported upgrade path: `brew upgrade stella`, re-running `install.sh`, or a newer GitHub release.

## Investigation — issue #252, part (a) is already done, not missing
The issue also asks to "automate the Homebrew formula bump on release." That's already fully wired and working in current `main`, verified live:
- `auto-tag.yml`'s `bot/version-sync` PR already bumps `packaging/homebrew/stella.rb`'s `tag:`/`version:` on every version bump.
- `release.yml`'s `homebrew` job already renders `.github/homebrew/stella.rb.tmpl` and pushes `Formula/stella.rb` to `macanderson/homebrew-tap` on every tag push.
- Confirmed via the GitHub API: the tap's current `Formula/stella.rb` already matches the latest release version, and `HOMEBREW_TAP_DEPLOY_KEY` is set as a repo secret.

The only real gap I found there was documentation drift: `RELEASING.md`'s one-time-setup section only described the PAT (`HOMEBREW_TAP_TOKEN`) path, but the repo actually has the SSH-deploy-key path configured (`HOMEBREW_TAP_DEPLOY_KEY`, which `release.yml` already prefers). Updated the doc to describe both so it matches reality. No code change was needed for part (a) — the original issue's "0.4.25 vs 0.4.42" evidence predates this automation (it landed 2026-07-13, the issue was filed 2026-07-20 against stale evidence).

## Witness test
Strengthened the existing `refuses_a_database_stamped_by_a_newer_build` test in `stella-store/src/lib.rs` to assert the message contains `"out of date"` and all three upgrade paths. Verified by hand: temporarily reverting only the message string (keeping the new assertions) makes the test fail with `message must name the stale binary as the cause, not just refuse`; restoring the new message makes it pass again.

## Verification
- `cargo test -p stella-store` — 74 passed
- `cargo clippy -p stella-store --all-targets -- -D warnings` — clean
- `scripts/check-file-sizes.sh` — 277 tracked files within limits (`stella-store/src/lib.rs` grew 3904 → 3922, well inside its +50 slack)
- `cargo fmt --all` — clean, no diff

Fixes #252
