### PR TITLE
fix(stella-model): fail-fast + diagnostic 4xx classification for provider errors

### DIFF
--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -732,6 +732,7 @@ impl AnthropicProvider {
                 status,
                 retry_after_ms,
                 &body,
+                &self.model,
             ));
         }
 

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -670,6 +670,7 @@ impl Provider for BedrockProvider {
                 status,
                 retry_after_ms,
                 &body,
+                &self.model,
             ));
         }
 

--- a/stella-model/src/gemini.rs
+++ b/stella-model/src/gemini.rs
@@ -549,6 +549,7 @@ pub(crate) fn build_generation_config(req: &CompletionRequest) -> Option<GeminiG
 pub(crate) async fn classify_google_error(
     label: &str,
     response: reqwest::Response,
+    model: &str,
 ) -> ProviderError {
     let status = response.status();
     let retry_after_ms = crate::http::parse_retry_after_ms(response.headers());
@@ -562,7 +563,7 @@ pub(crate) async fn classify_google_error(
     if status == reqwest::StatusCode::BAD_REQUEST && body.contains("API_KEY_INVALID") {
         return ProviderError::Auth(format!("{label} rejected the API key: {body}"));
     }
-    crate::http::classify_http_status(label, status, retry_after_ms, &body)
+    crate::http::classify_http_status(label, status, retry_after_ms, &body, model)
 }
 
 #[async_trait]
@@ -593,7 +594,7 @@ impl Provider for GeminiProvider {
             .map_err(|e| ProviderError::Transport(e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(classify_google_error("Gemini", response).await);
+            return Err(classify_google_error("Gemini", response, &self.model).await);
         }
 
         let (text, tool_calls, usage, finish_reason) =

--- a/stella-model/src/http.rs
+++ b/stella-model/src/http.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use futures_util::{Stream, StreamExt};
+use serde::Deserialize;
 use stella_protocol::ProviderError;
 
 /// How long to wait for the initial TCP/TLS connection before giving up. A
@@ -50,30 +51,145 @@ pub(crate) fn parse_retry_after_ms(headers: &reqwest::header::HeaderMap) -> Opti
     Some(seconds.saturating_mul(1000))
 }
 
+/// Best-effort extraction of the human `message` from a provider's
+/// structured error body (issue #250: 401/403 used to discard the body
+/// entirely). OpenAI, Anthropic, and every OpenAI-compatible gateway
+/// (OpenRouter, xAI, DeepSeek, Z.ai, Gemini direct) nest it under an `error`
+/// object — `{"error": {"message": "...", ...}}`; Bedrock/AWS report the
+/// same field flat at the top level — `{"message": "...", "__type": ...}`.
+/// Tried in that order; `None` when the body is not JSON or carries no
+/// non-empty `message`, in which case callers fall back to the raw body.
+fn parse_error_reason(body: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct Wrapped {
+        error: Inner,
+    }
+    #[derive(Deserialize, Default)]
+    struct Inner {
+        #[serde(default)]
+        message: Option<String>,
+    }
+    #[derive(Deserialize, Default)]
+    struct Flat {
+        #[serde(default)]
+        message: Option<String>,
+    }
+
+    let reason = serde_json::from_str::<Wrapped>(body)
+        .ok()
+        .and_then(|w| w.error.message)
+        .or_else(|| {
+            serde_json::from_str::<Flat>(body)
+                .ok()
+                .and_then(|f| f.message)
+        });
+
+    reason
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty())
+}
+
+/// Bucket an HTTP 403's reason text into the right remediation hint. A 403
+/// means the key itself is valid — the account/key/model combination is
+/// refused for one of three provider-observed reasons, and each has a
+/// different fix: billing/credits exhausted, this specific model not
+/// enabled for the key/org, or a bare permission/scope refusal with neither
+/// signal present. Matched on lowercase text since providers share no
+/// stable machine code for this (the same body-sniffing tradeoff
+/// `zai.rs`'s 429 billing classifier makes) — a false negative that falls
+/// through to the generic hint beats a wrong diagnosis.
+fn forbidden_hint(haystack: &str) -> &'static str {
+    if haystack.contains("credit")
+        || haystack.contains("balance")
+        || haystack.contains("insufficient")
+        || haystack.contains("quota")
+        || haystack.contains("spend")
+        || haystack.contains("billing")
+    {
+        "the key is valid but the account is out of credits or over its spend cap — add \
+         credit or raise the cap, then retry"
+    } else if haystack.contains("model")
+        || haystack.contains("enable")
+        || haystack.contains("access")
+    {
+        "the key is valid but isn't enabled for this model — enable it for this key/org, or \
+         switch models on the SETTINGS tab / with `--model provider/slug`"
+    } else {
+        "the key is valid but lacks permission for this request — check the key's scopes \
+         and organization on the provider's dashboard"
+    }
+}
+
+/// Whether a non-success body appears to be about the model the caller
+/// configured — either literally (the gateway echoes back the rejected
+/// slug, e.g. OpenRouter's `"{slug} is not a valid model ID"`) or generically
+/// (any mention of "model" in a 4xx we already know isn't an auth/rate-limit
+/// failure). Used to gate the invalid-model recovery hint (issue #271) so it
+/// fires on "unknown model" without also firing on an unrelated malformed
+/// request that happens to 400 for some other reason.
+fn mentions_configured_model(body: &str, model: &str) -> bool {
+    (!model.trim().is_empty() && body.contains(model)) || body.to_lowercase().contains("model")
+}
+
 /// The mechanical non-success ladder shared by every adapter, applied AFTER
 /// any vendor-specific pre-check (Z.ai's billing-encoded 429s, Google's
-/// API_KEY_INVALID-on-400):
+/// API_KEY_INVALID-on-400). `model` is the wire slug this call was sent
+/// with, used only to sharpen the invalid-model hint below — every adapter
+/// already holds it as `self.model`.
 ///
-/// - 401/403 → non-retryable `Auth`. A 403 (permission-denied key, model
-///   not enabled for the account) is a credential problem the user must fix
-///   — pointing them at their key beats a generic terminal error, and the
-///   step driver must not retry it.
+/// - 401 → non-retryable `Auth` ("authenticate": the key itself is rejected
+///   — revoked, mistyped, or never loaded). The provider's own reason
+///   ([`parse_error_reason`]) is folded in when present, plus a hint to
+///   check the SETTINGS tab / `api_key`/`api_key_env` / `--base-url`.
+/// - 403 → non-retryable `Auth` ("authorize": the key is valid but the
+///   request is refused). [`forbidden_hint`] distinguishes credits/billing,
+///   model-not-enabled, and bare permission refusal so the three don't read
+///   as one undifferentiated "credentials failed" message (issue #250).
+/// - 402 → non-retryable `Terminal`, called out explicitly as a billing
+///   failure (some gateways use Payment Required for out-of-credits rather
+///   than folding it into a 403).
 /// - 429 → retryable `RateLimited` carrying the Retry-After hint.
 /// - 5xx → retryable `Transport` (includes 529, which Anthropic and Z.ai
 ///   use for load shedding). Without this a momentary blip aborts the whole
 ///   turn (`Terminal.is_retryable() == false`).
-/// - anything else → `Terminal`, with the body for diagnosis.
+/// - anything else (400/404/422/...) → non-retryable `Terminal` — this call
+///   can never succeed by retrying it verbatim (issue #271), so the
+///   step-driver's retry loop never re-derives a classification here, it
+///   only ever asks `is_retryable()` and gets `false` on the first attempt.
+///   When the body appears to name the configured model
+///   ([`mentions_configured_model`]), a one-line recovery hint is appended:
+///   change it on the SETTINGS tab, relaunch with `--model provider/slug`,
+///   or edit settings.json.
 pub(crate) fn classify_http_status(
     label: &str,
     status: reqwest::StatusCode,
     retry_after_ms: Option<u64>,
     body: &str,
+    model: &str,
 ) -> ProviderError {
     use reqwest::StatusCode;
+    let reason = parse_error_reason(body);
+    let reason_suffix = reason
+        .as_deref()
+        .map(|r| format!(": {r}"))
+        .unwrap_or_default();
     match status {
-        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-            ProviderError::Auth(format!("{label} rejected the credential (HTTP {status})"))
+        StatusCode::UNAUTHORIZED => ProviderError::Auth(format!(
+            "{label} rejected the credential (HTTP 401){reason_suffix} — the key looks \
+             revoked, mistyped, or was never loaded; re-check it on the SETTINGS tab, the \
+             `api_key`/`api_key_env` value, and that `--base-url` actually points at {label}"
+        )),
+        StatusCode::FORBIDDEN => {
+            let haystack = reason.as_deref().unwrap_or(body).to_lowercase();
+            let hint = forbidden_hint(&haystack);
+            ProviderError::Auth(format!(
+                "{label} rejected the credential (HTTP 403){reason_suffix} — {hint}"
+            ))
         }
+        StatusCode::PAYMENT_REQUIRED => ProviderError::Terminal(format!(
+            "{label} rejected the request (HTTP 402: payment required){reason_suffix} — the \
+             account is out of credits; add credit or switch to a funded provider/model"
+        )),
         StatusCode::TOO_MANY_REQUESTS => ProviderError::RateLimited {
             message: format!("{label} rate limit"),
             retry_after_ms,
@@ -81,7 +197,16 @@ pub(crate) fn classify_http_status(
         s if s.is_server_error() => {
             ProviderError::Transport(format!("{label} HTTP {status}: {body}"))
         }
-        _ => ProviderError::Terminal(format!("{label} HTTP {status}: {body}")),
+        _ => {
+            let mut message = format!("{label} HTTP {status}: {body}");
+            if mentions_configured_model(body, model) {
+                message.push_str(
+                    " — change the model on the deck's SETTINGS tab, relaunch with \
+                     `--model provider/slug`, or edit settings.json",
+                );
+            }
+            ProviderError::Terminal(message)
+        }
     }
 }
 
@@ -183,5 +308,189 @@ mod tests {
             .await
             .expect("clean end of stream is Ok(None)");
         assert_eq!(end, None);
+    }
+
+    // ---- classify_http_status (issue #271: terminal-on-first-attempt +
+    // invalid-model recovery hint; issue #250: sharper 401/403/402 auth
+    // diagnostics) --------------------------------------------------------
+
+    /// The real-world repro (issue #271): OpenRouter answers a doubled/typo'd
+    /// model slug with HTTP 400 and a body naming the exact slug it rejected.
+    /// On origin/main this classified fine as `Terminal` (so it was already
+    /// non-retryable) but the message carried no pointer to a fix — this
+    /// assertion is what's new.
+    #[test]
+    fn classify_http_status_400_invalid_model_names_a_recovery_hint() {
+        let err = classify_http_status(
+            "OpenRouter",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"error":{"message":"openrouter/openrouter/auto is not a valid model ID","code":400}}"#,
+            "openrouter/openrouter/auto",
+        );
+        assert!(!err.is_retryable(), "a 400 must never be retried: {err:?}");
+        assert!(matches!(err, ProviderError::Terminal(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("is not a valid model ID"), "{msg}");
+        assert!(msg.contains("SETTINGS tab"), "{msg}");
+        assert!(msg.contains("--model provider/slug"), "{msg}");
+        assert!(msg.contains("settings.json"), "{msg}");
+    }
+
+    /// A 404 "model not found" must get the same hint as a 400 — both are
+    /// the "this model can't be reached" family the issue calls out
+    /// together ("invalid model, invalid request shape, 404 model").
+    #[test]
+    fn classify_http_status_404_model_not_found_also_gets_the_hint() {
+        let err = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::NOT_FOUND,
+            None,
+            r#"{"error":{"message":"The model `gpt-nope` does not exist"}}"#,
+            "gpt-nope",
+        );
+        assert!(!err.is_retryable());
+        assert!(err.to_string().contains("SETTINGS tab"));
+    }
+
+    /// A 4xx that has nothing to do with the model (a malformed tool-call
+    /// schema, say) must NOT get the model-recovery hint — it would be a
+    /// non sequitur ("change your model" doesn't fix a bad JSON schema).
+    /// Guards the precision of `mentions_configured_model` against the
+    /// obvious failure mode of firing on every non-auth 4xx.
+    #[test]
+    fn classify_http_status_400_unrelated_to_the_model_has_no_recovery_hint() {
+        let err = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"error":{"message":"messages: array is too long"}}"#,
+            "gpt-5.5",
+        );
+        let msg = err.to_string();
+        assert!(!msg.contains("SETTINGS tab"), "{msg}");
+        assert!(!msg.contains("--model"), "{msg}");
+    }
+
+    /// Issue #250: on origin/main, 401/403 discarded the response body
+    /// entirely (`format!("{label} rejected the credential (HTTP {status})")`,
+    /// no `body` in scope at all) — the provider's own reason never reached
+    /// the user. This is the fold-in.
+    #[test]
+    fn classify_http_status_401_folds_in_the_provider_reason_and_a_credential_hint() {
+        let err = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::UNAUTHORIZED,
+            None,
+            r#"{"error":{"message":"Incorrect API key provided: sk-***abcd"}}"#,
+            "gpt-5.5",
+        );
+        assert!(!err.is_retryable());
+        assert!(matches!(err, ProviderError::Auth(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("Incorrect API key provided"), "{msg}");
+        assert!(msg.contains("SETTINGS tab"), "{msg}");
+        assert!(msg.contains("api_key"), "{msg}");
+    }
+
+    /// 403 with billing language ⇒ the credits/spend-cap hint, distinct from
+    /// a bad key and from "model not enabled" (issue #250 acceptance: the
+    /// three must read as different failures, not one "credentials failed").
+    #[test]
+    fn classify_http_status_403_with_billing_language_hints_at_credits() {
+        let err = classify_http_status(
+            "Anthropic",
+            reqwest::StatusCode::FORBIDDEN,
+            None,
+            r#"{"error":{"message":"Your organization has insufficient credit balance"}}"#,
+            "claude-opus",
+        );
+        assert!(!err.is_retryable());
+        let msg = err.to_string();
+        assert!(msg.contains("credits"), "{msg}");
+        assert!(!msg.contains("enable it"), "{msg}");
+    }
+
+    /// 403 with "not enabled for this key" ⇒ the model-permission hint, not
+    /// the credits hint and not the generic fallback.
+    #[test]
+    fn classify_http_status_403_model_not_enabled_hints_at_switching_models() {
+        let err = classify_http_status(
+            "OpenRouter",
+            reqwest::StatusCode::FORBIDDEN,
+            None,
+            r#"{"error":{"message":"model 'x/y' not enabled for this key"}}"#,
+            "x/y",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("isn't enabled for this model"), "{msg}");
+        assert!(msg.contains("enable it"), "{msg}");
+        assert!(msg.contains("--model provider/slug"), "{msg}");
+        assert!(!msg.contains("credits"), "{msg}");
+    }
+
+    /// A bare 403 with neither billing nor model language falls to the
+    /// generic permission hint — never silently identical to the 401 (key
+    /// revoked) message, since the key here is valid.
+    #[test]
+    fn classify_http_status_403_generic_falls_back_to_a_permission_hint() {
+        let err = classify_http_status(
+            "Anthropic",
+            reqwest::StatusCode::FORBIDDEN,
+            None,
+            r#"{"error":{"message":"request blocked by organization policy"}}"#,
+            "claude-opus",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("lacks permission"), "{msg}");
+        assert!(!msg.contains("credits"), "{msg}");
+        assert!(!msg.contains("enable it"), "{msg}");
+    }
+
+    /// 402 (some gateways use Payment Required rather than folding
+    /// out-of-credits into a 403) must read as a distinct billing failure,
+    /// not the generic `Terminal("{label} HTTP {status}: {body}")` bucket —
+    /// asserted against an EMPTY body so the message can only be coming from
+    /// the new dedicated arm, never from an echoed body.
+    #[test]
+    fn classify_http_status_402_is_terminal_with_a_billing_hint() {
+        let err = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::PAYMENT_REQUIRED,
+            None,
+            "",
+            "gpt-5.5",
+        );
+        assert!(!err.is_retryable());
+        assert!(matches!(err, ProviderError::Terminal(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("payment required"), "{msg}");
+        assert!(msg.contains("out of credits"), "{msg}");
+    }
+
+    /// The rest of the ladder (429/5xx) is untouched by this change — pinned
+    /// here so a future edit to the 401/403/402/model-hint arms can't
+    /// silently regress the retryable side.
+    #[test]
+    fn classify_http_status_429_and_5xx_stay_retryable() {
+        let rate_limited = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            Some(1_500),
+            "",
+            "gpt-5.5",
+        );
+        assert!(rate_limited.is_retryable());
+        assert!(matches!(rate_limited, ProviderError::RateLimited { .. }));
+
+        let server_error = classify_http_status(
+            "OpenAI",
+            reqwest::StatusCode::BAD_GATEWAY,
+            None,
+            "upstream down",
+            "gpt-5.5",
+        );
+        assert!(server_error.is_retryable());
+        assert!(matches!(server_error, ProviderError::Transport(_)));
     }
 }

--- a/stella-model/src/openai.rs
+++ b/stella-model/src/openai.rs
@@ -553,6 +553,7 @@ impl Provider for OpenAiProvider {
                 status,
                 retry_after_ms,
                 &body,
+                &self.model,
             ));
         }
 

--- a/stella-model/src/vertex.rs
+++ b/stella-model/src/vertex.rs
@@ -116,7 +116,7 @@ impl Provider for VertexProvider {
             .map_err(|e| ProviderError::Transport(e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(classify_google_error("Vertex AI", response).await);
+            return Err(classify_google_error("Vertex AI", response, &self.model).await);
         }
 
         let (text, tool_calls, usage, finish_reason) =

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -787,6 +787,7 @@ impl ZaiProvider {
                 status,
                 retry_after_ms,
                 &body,
+                &self.model,
             ));
         }
 

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -1161,3 +1161,135 @@ async fn other_identities_ignore_reasoning_entirely() {
     // cache_control is OpenRouter-only, same 400 risk as the fields above.
     assert!(!body.contains("cache_control"), "{body}");
 }
+
+fn hi_request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The live repro behind issue #271, reproduced through the public
+/// `complete()` API exactly as it happens for real: a mistyped/decommissioned
+/// model slug gets OpenRouter's `HTTP 400 "<slug> is not a valid model ID"`.
+/// This must both stay non-retryable (already true on `origin/main` — a 400
+/// falls to `classify_http_status`'s `Terminal` arm, and `Terminal` was
+/// already excluded from `stella-core::retry::retry_with_backoff`'s retry
+/// set) AND now carry a recovery hint, which `origin/main` did not have.
+#[tokio::test]
+async fn complete_maps_openrouter_400_invalid_model_to_a_terminal_error_with_a_recovery_hint() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"error":{"message":"openrouter/auto is not a valid model ID","code":400}}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "openrouter/auto")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+
+    let err = provider.complete(hi_request()).await.unwrap_err();
+    assert!(!err.is_retryable(), "a 400 must never be retried: {err:?}");
+    assert!(matches!(err, ProviderError::Terminal(_)));
+    let msg = err.to_string();
+    assert!(msg.contains("is not a valid model ID"), "{msg}");
+    assert!(msg.contains("SETTINGS tab"), "{msg}");
+    assert!(msg.contains("--model provider/slug"), "{msg}");
+}
+
+/// Issue #250: a revoked/mistyped OpenRouter key. On `origin/main` this and
+/// the 403 test below produce the byte-identical
+/// `"OpenRouter rejected the credential (HTTP {401,403})"` — no reason, no
+/// way to tell a bad key from a valid key the account just can't use yet.
+#[tokio::test]
+async fn complete_maps_openrouter_401_to_auth_error_with_the_provider_reason() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_string(r#"{"error":{"message":"No auth credentials found"}}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-bad"), "openrouter/auto")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+
+    let err = provider.complete(hi_request()).await.unwrap_err();
+    assert!(!err.is_retryable());
+    assert!(matches!(err, ProviderError::Auth(_)));
+    let msg = err.to_string();
+    assert!(msg.contains("No auth credentials found"), "{msg}");
+    assert!(msg.contains("SETTINGS tab"), "{msg}");
+}
+
+/// Issue #250: a VALID OpenRouter key whose account hasn't enabled the
+/// requested model — a 403, not a 401, and a different fix (switch models)
+/// than a bad key (replace the key). Must read as distinct from the 401
+/// case above, not the same "credentials failed" text.
+#[tokio::test]
+async fn complete_maps_openrouter_403_model_not_enabled_to_a_distinct_hint() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(403).set_body_string(
+            r#"{"error":{"message":"openrouter/auto is not enabled for this account"}}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "openrouter/auto")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+
+    let err = provider.complete(hi_request()).await.unwrap_err();
+    assert!(!err.is_retryable());
+    assert!(matches!(err, ProviderError::Auth(_)));
+    let msg = err.to_string();
+    assert!(msg.contains("is not enabled for this account"), "{msg}");
+    assert!(msg.contains("--model provider/slug"), "{msg}");
+    assert!(
+        !msg.contains("revoked"),
+        "{msg}: must not read like a bad-key (401) message"
+    );
+}
+
+/// Issue #250: some gateways answer out-of-credits with HTTP 402 rather than
+/// folding it into a 403. On `origin/main` a 402 falls into the generic
+/// `Terminal("{label} HTTP {status}: {body}")` bucket — a message with no
+/// dedicated billing wording, just whatever text the gateway happened to
+/// send. Must stay non-retryable either way.
+#[tokio::test]
+async fn complete_maps_openrouter_402_to_a_terminal_billing_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(402)
+                .set_body_string(r#"{"error":{"message":"account balance depleted"}}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "openrouter/auto")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+
+    let err = provider.complete(hi_request()).await.unwrap_err();
+    assert!(!err.is_retryable());
+    assert!(matches!(err, ProviderError::Terminal(_)));
+    let msg = err.to_string();
+    assert!(msg.contains("payment required"), "{msg}");
+    assert!(msg.contains("out of credits"), "{msg}");
+    assert!(msg.contains("account balance depleted"), "{msg}");
+}


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`classify_http_status` (`stella-model/src/http.rs`) is the one place every provider adapter (OpenAI, Anthropic, Z.ai/OpenRouter/xAI/DeepSeek, Gemini, Vertex, Bedrock) turns a non-success HTTP response into a typed `ProviderError`. Two linked issues, both about that function:

- **#271** — a broken configured model (invalid slug, decommissioned model) surfaced as a raw `terminal provider error: OpenRouter HTTP 400 … is not a valid model ID` with no pointer to a fix, and the report described it recurring 3x per turn.
- **#250** — 401 and 403 both produced the byte-identical `"{provider} rejected the credential (HTTP {status})"`, conflating a revoked key, a valid key not permitted for the model, an out-of-credits account, and a base_url/provider mismatch into one undifferentiated message.

This PR sharpens `classify_http_status`'s messages and adds a dedicated 402 arm, without touching the retry-classification ladder itself (see "Investigation note" below — that half of #271 was already correct).

Closes #271
Closes #250

### What changed

- **401** → folds in the provider's own structured error-body reason (`{"error":{"message":...}}` / flat `{"message":...}`, tried in that order) instead of discarding the body entirely, plus a hint to check the SETTINGS tab / `api_key`/`api_key_env` / `--base-url`.
- **403** → same reason-folding, plus `forbidden_hint` buckets the failure into **credits/spend-cap**, **model not enabled for this key/org**, or a **bare permission refusal** — three different fixes, no longer one "credentials failed" message.
- **402** (new arm) → explicit billing-failure wording rather than falling into the generic terminal bucket some gateways use Payment Required for out-of-credits instead of 403.
- **400/404/anything else non-auth/non-5xx** (the bucket the invalid-model repro falls into) → appends a one-line recovery hint — *"change the model on the deck's SETTINGS tab, relaunch with `--model provider/slug`, or edit settings.json"* — when the body appears to name the configured model (`mentions_configured_model`: literal match against the wire slug the adapter sent, OR-ed with a generic "model" keyword as a fallback for providers that don't echo the slug back).
- Threaded the wire model slug into `classify_http_status` (and `classify_google_error`, its Gemini/Vertex-shared caller) — every adapter already held it as `self.model`, one extra argument at 6 call sites.

### Investigation note on #271's retry-loop claim

I traced the retry path before touching anything: `classify_http_status`'s fallthrough already mapped a 400/404/etc. to `ProviderError::Terminal`, and `stella-core::retry::retry_with_backoff` already treats `Terminal` as non-retryable (`is_retryable == false`, gated by the existing `terminal_errors_never_retry_regardless_of_policy` test in `stella-core/src/retry.rs`). So on `origin/main`, a 400 invalid-model error is *already* attempted exactly once per model call — there was no retry loop to fix here, and I did not add one. I did not find where the reported "three times" came from with certainty; my best guess from reading `stella-pipeline/src/pipeline.rs` is that it's **three separate pipeline stages** (witness author, execute, possibly plan) each independently hitting the same broken worker model and each surfacing the raw message once — a different axis than HTTP retries, and out of scope for this PR (the Task section only asked for classification + hint, not pipeline short-circuiting). Flagging this so it doesn't read as silently dropped scope.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The true witnesses are 4 new `#[tokio::test]`s in `stella-model/src/zai/tests.rs`, driven entirely through the **public** `ZaiProvider::complete` API identified as OpenRouter (the real repro's adapter — which had **zero** auth-error test coverage before this PR):

- `complete_maps_openrouter_400_invalid_model_to_a_terminal_error_with_a_recovery_hint`
- `complete_maps_openrouter_401_to_auth_error_with_the_provider_reason`
- `complete_maps_openrouter_402_to_a_terminal_billing_error`
- `complete_maps_openrouter_403_model_not_enabled_to_a_distinct_hint`

Verified the fail-half exactly as directed: stashed all 7 modified `stella-model/src` files (keeping `zai/tests.rs`), ran `cargo test -p stella-model --lib zai::` — compiled cleanly (public API unchanged) and all 4 new tests **failed** with the pre-fix messages (e.g. `provider auth error: OpenRouter rejected the credential (HTTP 401 Unauthorized)`, no reason, no hint), while the other 29 pre-existing zai tests still passed. Then `git stash pop` and reran — all 33 pass. Also added 9 lower-level unit tests directly on `classify_http_status` in `http.rs` for the full ladder (401/403×3 buckets/402/400-with-hint/400-without-hint/404/429+5xx-unchanged) — useful regression coverage, but not counted as the witness since they call the new 5-arg private function signature and wouldn't compile against `main`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (doc comments on `classify_http_status`, `parse_error_reason`, `forbidden_hint`, `mentions_configured_model` rewritten in full)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (reused `serde`/`serde_json`, already stella-model dependencies)
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types; `parse_error_reason`'s helper structs are private, non-serializing, best-effort-only (`Option`-returning, never panics on malformed/non-JSON bodies)

## Anything reviewers should know?

- `mentions_configured_model`'s generic `"model"` keyword fallback is deliberately loose (see `classify_http_status_400_unrelated_to_the_model_has_no_recovery_hint` for the guardrail it's checked against) — a false positive here is a harmless extra sentence, not a wrong classification, so I erred toward recall over precision.
- `forbidden_hint`'s bucketing is text-sniffed (no provider shares a stable machine code for "model not enabled" vs "no credits" vs "generic permission"), same tradeoff `zai.rs`'s existing 429 billing classifier (`classify_zai_429`) already makes — flagging the pattern match rather than re-justifying it.
- Bedrock/AWS error bodies (flat `{"message":...,"__type":...}`, no `error` wrapper) are covered by `parse_error_reason`'s second parse attempt, but I did not add a wiremock witness for Bedrock specifically — the acceptance criteria and the live repro are both about OpenAI-compatible/Anthropic-style gateways, and Bedrock's own existing 401/403 tests (unaffected by this change, still `matches!(_, ProviderError::Auth(_))` only) continue to pass.
