### PR TITLE
fix(stella-cli): credential status matches the real resolver, distinct source labels

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -510,7 +510,10 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             continue;
         }
         if input == "/config" {
-            cfg.print_config();
+            // The REPL fallback has no startup dotenv-load record handy —
+            // the source label just degrades to the generic `env:VAR` form
+            // (see `Config::print_config`'s doc).
+            cfg.print_config(None);
             continue;
         }
         if input == "/help" {

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -300,6 +300,7 @@ fn cfg_for(provider_id: &str) -> Config {
         engine_settings: None,
         tools_bash: false,
         tools_web: false,
+        credential_source: None,
     }
 }
 

--- a/stella-cli/src/auth_cmd.rs
+++ b/stella-cli/src/auth_cmd.rs
@@ -1,0 +1,371 @@
+//! `stella auth` — manage BYOK provider keys stored in
+//! `~/.config/stella/credentials.toml`. A small, flat store for a handful of
+//! keys, not a config language (`CredentialsFile`'s own doc intent) —
+//! `set`/`remove`/`list` is the whole surface. Every command here masks the
+//! secret value in its own output; the only place a plaintext key is ever
+//! written is the 0600 credentials file itself.
+//!
+//! Every subcommand splits into a pure core (operates on an already-loaded
+//! `&mut CredentialsFile`, returns the lines to print — never touches the
+//! real filesystem) and a thin `run_*` wrapper that loads/saves the real
+//! `~/.config/stella/credentials.toml`. This is what lets the core be unit
+//! tested against a temp-path `CredentialsFile` instead of ever touching a
+//! developer's actual credentials file.
+
+use colored::Colorize as _;
+use stella_model::credential::{ApiKey, CredentialsFile};
+
+use crate::credential_status;
+use crate::settings::Settings;
+
+/// Entry point for `stella auth <cmd>`.
+pub fn run(cmd: &crate::AuthCmd) -> Result<(), String> {
+    match cmd {
+        crate::AuthCmd::Set {
+            provider,
+            key,
+            stdin,
+        } => run_set(provider, key.as_deref(), *stdin),
+        crate::AuthCmd::Remove { provider } => run_remove(provider),
+        crate::AuthCmd::List => run_list(),
+    }
+}
+
+fn credentials_path_display() -> String {
+    CredentialsFile::default_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "~/.config/stella/credentials.toml".to_string())
+}
+
+fn load_file() -> Result<CredentialsFile, String> {
+    CredentialsFile::load_default()
+        .map_err(|e| format!("could not read {}: {e}", credentials_path_display()))
+}
+
+/// Reject ids that would corrupt lookups elsewhere — `config::custom_provider`
+/// enforces the same rule for settings.json-defined providers. Otherwise
+/// permissive about WHICH id: a key can legitimately be stored ahead of the
+/// provider being declared in settings.json, or under one of the built-ins.
+fn validate_provider_id(id: &str) -> Result<(), String> {
+    if id.is_empty() || id.contains('/') || id.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "`{id}` is not a valid provider id (no slashes or whitespace)"
+        ));
+    }
+    Ok(())
+}
+
+/// The key value for `set`, in priority order: `--key` (warned), `--stdin`
+/// (one line, trimmed), or an interactive masked prompt (rpassword) —
+/// mirroring `stella_model::credential`'s own interactive-prompt idiom and
+/// `connect_cmd`'s `prompt_secret`.
+fn read_key_value(provider: &str, key: Option<&str>, use_stdin: bool) -> Result<String, String> {
+    if let Some(k) = key {
+        eprintln!(
+            "  {} --key exposes the credential in shell history and `ps` output — prefer \
+             `stella auth set {provider} --stdin` or the interactive masked prompt (omit \
+             both --key and --stdin)",
+            "⚠".yellow()
+        );
+        if k.is_empty() {
+            return Err("--key value is empty".to_string());
+        }
+        return Ok(k.to_string());
+    }
+    if use_stdin {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_line(&mut buf)
+            .map_err(|e| format!("could not read key from stdin: {e}"))?;
+        let trimmed = buf.trim().to_string();
+        if trimmed.is_empty() {
+            return Err("empty key read from stdin".to_string());
+        }
+        return Ok(trimmed);
+    }
+    let value = rpassword::prompt_password(format!("  API key for `{provider}`: "))
+        .map_err(|e| format!("cannot read secret from terminal: {e}"))?;
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("empty input — no credential entered".to_string());
+    }
+    Ok(trimmed)
+}
+
+/// Pure core of `stella auth set`: validates the id, resolves the key value,
+/// and stores it into `file` (caller saves). Returns the masked confirmation
+/// line — never the raw value.
+fn set_in(
+    file: &mut CredentialsFile,
+    path_display: &str,
+    provider: &str,
+    key: Option<&str>,
+    use_stdin: bool,
+) -> Result<String, String> {
+    validate_provider_id(provider)?;
+    let value = read_key_value(provider, key, use_stdin)?;
+    let api_key = ApiKey::new(value);
+    file.set(provider, api_key.reveal());
+    Ok(format!(
+        "stored key for `{provider}` in {path_display} ({})",
+        api_key.redacted_preview()
+    ))
+}
+
+fn run_set(provider: &str, key: Option<&str>, use_stdin: bool) -> Result<(), String> {
+    let mut file = load_file()?;
+    let path_display = credentials_path_display();
+    let message = set_in(&mut file, &path_display, provider, key, use_stdin)?;
+    file.save()
+        .map_err(|e| format!("failed to save {path_display}: {e}"))?;
+    println!("  {} {}", "◆".yellow(), message);
+    Ok(())
+}
+
+/// Pure core of `stella auth remove`: removes `provider` from `file` if
+/// present. Returns `(message, removed)` — the caller only re-saves the
+/// file when `removed` is true.
+fn remove_from(file: &mut CredentialsFile, path_display: &str, provider: &str) -> (String, bool) {
+    if file.remove(provider) {
+        (
+            format!("removed key for `{provider}` from {path_display}"),
+            true,
+        )
+    } else {
+        (
+            format!("no stored key for `{provider}` in {path_display} — nothing to remove"),
+            false,
+        )
+    }
+}
+
+fn run_remove(provider: &str) -> Result<(), String> {
+    let mut file = load_file()?;
+    let path_display = credentials_path_display();
+    let (message, removed) = remove_from(&mut file, &path_display, provider);
+    if removed {
+        file.save()
+            .map_err(|e| format!("failed to save {path_display}: {e}"))?;
+        println!("  {} {}", "◆".yellow(), message);
+    } else {
+        println!("  {} {}", "·".green(), message);
+    }
+    Ok(())
+}
+
+/// Pure core of `stella auth list`: one display line per stored provider —
+/// redacted preview, the `credentials.toml` label, and (when something else
+/// currently outranks the stored key in the real resolution chain — an env
+/// var, a settings.json literal) a "shadowed by …" note, so this list stays
+/// consistent with `stella models`/`stella config` rather than a static
+/// echo of the file's own contents. Never includes a raw secret value.
+fn list_lines(file: &CredentialsFile, settings: &Settings) -> Vec<String> {
+    file.provider_ids()
+        .filter_map(|id| {
+            let value = file.get(id)?;
+            let preview = ApiKey::new(value).redacted_preview();
+            let provider = credential_status::provider_config_for(id, settings);
+            let settings_key = credential_status::settings_literal_key(&provider, settings);
+            let status =
+                credential_status::status_for(&provider, settings_key.as_deref(), file, None);
+            let note = match status.source_label {
+                Some(label) if label != "credentials.toml" => {
+                    format!("  (shadowed by {label})")
+                }
+                _ => String::new(),
+            };
+            Some(format!("{id}  {preview}  credentials.toml{note}"))
+        })
+        .collect()
+}
+
+fn run_list() -> Result<(), String> {
+    let file = load_file()?;
+    crate::tui::section_header("Stored credentials");
+    let lines = {
+        // Best-effort: a malformed settings.json costs the provider-config
+        // lookup its overrides, never the listing itself.
+        let settings = std::env::current_dir()
+            .ok()
+            .and_then(|ws| Settings::load(&ws).ok())
+            .unwrap_or_default();
+        list_lines(&file, &settings)
+    };
+    if lines.is_empty() {
+        println!(
+            "  {}",
+            "none — run `stella auth set <provider>` to store one.".dimmed()
+        );
+        return Ok(());
+    }
+    for line in lines {
+        println!("  {} {line}", "◆".yellow());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_credentials_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "stella-test-auth-cmd-{name}-{}.toml",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_empty_slash_and_whitespace() {
+        assert!(validate_provider_id("zai").is_ok());
+        assert!(validate_provider_id("my-gateway").is_ok());
+        assert!(validate_provider_id("").is_err());
+        assert!(validate_provider_id("zai/glm").is_err());
+        assert!(validate_provider_id("has space").is_err());
+    }
+
+    // ---- set: witness for masked stdout + 0600 perms on disk ------------
+
+    #[test]
+    fn set_in_stores_the_key_but_never_echoes_it_in_the_confirmation_message() {
+        let path = temp_credentials_path("set-masked");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+
+        let message = set_in(
+            &mut file,
+            "credentials.toml",
+            "zai",
+            Some("sk-super-secret-value-1234"),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !message.contains("sk-super-secret-value-1234"),
+            "confirmation message must never contain the raw secret: {message}"
+        );
+        assert!(message.contains("zai"));
+        assert_eq!(file.get("zai"), Some("sk-super-secret-value-1234"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_then_save_writes_the_real_file_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_credentials_path("set-perms");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+
+        set_in(
+            &mut file,
+            "credentials.toml",
+            "zai",
+            Some("sk-value"),
+            false,
+        )
+        .unwrap();
+        file.save().unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "stella auth set must leave a 0600 file"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn set_in_rejects_an_invalid_provider_id_before_touching_the_file() {
+        let mut file = CredentialsFile::load(temp_credentials_path("set-invalid")).unwrap();
+        let err = set_in(
+            &mut file,
+            "credentials.toml",
+            "zai/glm",
+            Some("sk-value"),
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("not a valid provider id"));
+        assert_eq!(file.get("zai/glm"), None);
+    }
+
+    // ---- remove -----------------------------------------------------------
+
+    #[test]
+    fn remove_from_reports_success_and_actually_drops_the_entry() {
+        let mut file = CredentialsFile::load(temp_credentials_path("remove-hit")).unwrap();
+        file.set("zai", "sk-value");
+
+        let (message, removed) = remove_from(&mut file, "credentials.toml", "zai");
+        assert!(removed);
+        assert!(message.contains("removed"));
+        assert_eq!(file.get("zai"), None);
+    }
+
+    #[test]
+    fn remove_from_reports_absence_without_erroring() {
+        let mut file = CredentialsFile::load(temp_credentials_path("remove-miss")).unwrap();
+        let (message, removed) = remove_from(&mut file, "credentials.toml", "nonexistent");
+        assert!(!removed, "removing an absent entry must not claim success");
+        assert!(message.contains("nothing to remove"));
+    }
+
+    // ---- list: masked, and consistent with the #249 source labels -------
+
+    #[test]
+    fn list_lines_shows_a_redacted_preview_never_the_raw_value() {
+        let mut file = CredentialsFile::load(temp_credentials_path("list-masked")).unwrap();
+        file.set("zai", "sk-super-secret-value-1234");
+        let settings = Settings::default();
+
+        let lines = list_lines(&file, &settings);
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].contains("sk-super-secret-value-1234"));
+        assert!(lines[0].contains("zai"));
+        assert!(lines[0].contains("credentials.toml"));
+    }
+
+    #[test]
+    fn list_lines_notes_when_an_env_var_shadows_the_stored_key() {
+        let _env = crate::test_env::lock();
+        // `provider_config_for` derives `<ID>_API_KEY` (uppercased,
+        // punctuation folded to `_`) for an id that matches no built-in or
+        // settings.json entry — this id's derived var is
+        // `STELLA_TEST_AUTH_LIST_SHADOW_API_KEY` (see
+        // `config::derived_env_var`'s own test for the exact rule).
+        let provider_id = "stella-test-auth-list-shadow";
+        let env_var = "STELLA_TEST_AUTH_LIST_SHADOW_API_KEY";
+        // SAFETY: guarded by test_env's lock; a unique var name unused
+        // elsewhere.
+        unsafe {
+            std::env::set_var(env_var, "sk-from-env");
+        }
+        let mut file = CredentialsFile::load(temp_credentials_path("list-shadow")).unwrap();
+        file.set(provider_id, "sk-from-credentials-file");
+        let settings = Settings::default();
+
+        let lines = list_lines(&file, &settings);
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains(&format!("shadowed by env:{env_var}")),
+            "expected a shadow note naming the winning env var, got: {}",
+            lines[0]
+        );
+
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    #[test]
+    fn list_lines_is_empty_when_nothing_stored() {
+        let file = CredentialsFile::load(temp_credentials_path("list-empty")).unwrap();
+        assert!(list_lines(&file, &Settings::default()).is_empty());
+    }
+}

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -3941,7 +3941,7 @@ async fn run_deck_command(
             });
         }
         "/models" => {
-            say(Config::available_models_plain());
+            say(Config::available_models_plain(None));
         }
         "/pipeline" => {
             *pipeline_on = !*pipeline_on;
@@ -4040,7 +4040,7 @@ async fn run_deck_command(
                             say(format!("refresh failed: {e}"));
                         }
                     }
-                    ModelsCommand::List => say(Config::available_models_plain()),
+                    ModelsCommand::List => say(Config::available_models_plain(None)),
                     ModelsCommand::Usage(word) => say(format!(
                         "`/models {word}` — unknown subcommand; try `/models` or `/models list` \
                          (the listing) or `/models refresh [--force]` (re-sync the catalog)"

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -234,7 +234,7 @@ fn leak(s: &str) -> &'static str {
 /// The env var a config-defined provider reads its credential from when the
 /// entry doesn't name one: `<ID>_API_KEY`, uppercased, with anything outside
 /// `[A-Za-z0-9]` folded to `_` (`my-gateway` → `MY_GATEWAY_API_KEY`).
-fn derived_env_var(id: &str) -> String {
+pub(crate) fn derived_env_var(id: &str) -> String {
     let mut var: String = id
         .chars()
         .map(|c| {
@@ -255,7 +255,7 @@ fn derived_env_var(id: &str) -> String {
 /// `ANTHROPIC_API_KEY` keeps working). `dialect` on a built-in override is
 /// ignored — a built-in's dialect is fixed by its adapter — and the catalog
 /// check stays on (`seeded` is untouched).
-fn effective_builtin(
+pub(crate) fn effective_builtin(
     provider: &ProviderConfig,
     settings: &crate::settings::Settings,
 ) -> ProviderConfig {
@@ -287,7 +287,7 @@ fn effective_builtin(
 /// `dialect` defaults to OpenAI-compatible; the model catalog check is off
 /// (`seeded: false`) because the user's endpoint, not our seed data, is the
 /// authority on which models exist.
-fn custom_provider(
+pub(crate) fn custom_provider(
     id: &str,
     entry: &crate::settings::ProviderSettings,
 ) -> Result<ProviderConfig, String> {
@@ -384,6 +384,13 @@ pub struct Config {
     /// Same threading as `tools_bash` — the default tool surface has no
     /// network egress.
     pub tools_web: bool,
+    /// Which step in the credential chain produced `api_key` — `stella
+    /// config` displays this next to the redacted key preview so the
+    /// command can never disagree with what actually resolved it. `None`
+    /// only for the `local` provider's placeholder bearer token when no
+    /// real credential (flag/env) was involved — not a resolved secret, so
+    /// there is no source to report.
+    pub credential_source: Option<stella_model::credential::CredentialSource>,
 }
 
 impl Config {
@@ -554,16 +561,28 @@ impl Config {
                      --base-url http://localhost:11434/v1)"
                         .to_string()
                 })?;
-                let api_key = api_key_override
-                    .map(str::to_string)
-                    .or_else(|| {
-                        env::var(LOCAL_PROVIDER.env_var)
-                            .ok()
-                            .filter(|v| !v.is_empty())
-                    })
+                // Track WHERE the local key came from (if anywhere real) so
+                // `stella config` reports it accurately — the "local"
+                // fallback below is a placeholder bearer token, not a
+                // resolved credential, so it gets no source.
+                let (api_key, credential_source) = if let Some(flag) = api_key_override {
+                    (
+                        flag.to_string(),
+                        Some(stella_model::credential::CredentialSource::CliFlag),
+                    )
+                } else if let Some(env_value) = env::var(LOCAL_PROVIDER.env_var)
+                    .ok()
+                    .filter(|v| !v.is_empty())
+                {
+                    (
+                        env_value,
+                        Some(stella_model::credential::CredentialSource::EnvVar),
+                    )
+                } else {
                     // Most local servers ignore auth; OpenAI-compatible
                     // clients still send *something* as the bearer token.
-                    .unwrap_or_else(|| "local".to_string());
+                    ("local".to_string(), None)
+                };
                 return Ok(Self {
                     provider: LOCAL_PROVIDER.clone(),
                     model_id,
@@ -574,6 +593,7 @@ impl Config {
                     engine_settings: None,
                     tools_bash: false,
                     tools_web: false,
+                    credential_source,
                 });
             }
 
@@ -766,6 +786,7 @@ impl Config {
             engine_settings: None,
             tools_bash: false,
             tools_web: false,
+            credential_source: Some(source),
         })
     }
 
@@ -773,12 +794,20 @@ impl Config {
     /// depends only on `PROVIDERS` and the ambient environment, never on
     /// `self`, so it delegates to the static [`Config::print_available_models`]
     /// — one renderer backs both the `/models` REPL command and the top-level
-    /// `stella models` subcommand, and they can never drift apart.
+    /// `stella models` subcommand, and they can never drift apart. The REPL
+    /// call site has no startup `Loaded` record handy, so its source labels
+    /// degrade to the generic `env:VAR` form rather than a specific dotenv
+    /// filename — see `credential_status::label_for`.
     pub fn print_models(&self) {
-        Self::print_available_models();
+        Self::print_available_models(None);
     }
 
-    pub fn print_config(&self) {
+    /// `loaded_env` is the startup dotenv-load record (main's
+    /// `env_files::maybe_load` result) — pass `Some` so the API Key line can
+    /// name the exact `.env*` file a key came from, and so the "Env files"
+    /// line (always shown, unconditionally — unlike `STELLA_ENV_DEBUG`) can
+    /// list which files/names were loaded.
+    pub fn print_config(&self, loaded_env: Option<&crate::env_files::Loaded>) {
         println!(
             "{}\n",
             "Stella — Current Configuration".bright_cyan().bold()
@@ -792,22 +821,52 @@ impl Config {
             self.provider.id.bright_magenta(),
             self.model_id.bright_white()
         );
-        println!("  API Key:    {}", self.api_key.redacted_preview().dimmed());
+        let source = self
+            .credential_source
+            .map(|s| crate::credential_status::label_for(&self.provider, s, loaded_env))
+            .unwrap_or_else(|| "n/a (local placeholder)".to_string());
+        println!(
+            "  API Key:    {} {}",
+            self.api_key.redacted_preview().dimmed(),
+            format!("({source})").dimmed()
+        );
         println!("  Base URL:   {}", self.effective_base_url().dimmed());
         println!("  Workspace:  {}", self.workspace_root.display());
         println!("  Dialect:    {}", self.provider.dialect.label());
+        if let Some(summary) = loaded_env.and_then(crate::credential_status::env_files_summary) {
+            println!("  Env files:  {}", summary.dimmed());
+        }
     }
 }
 
 impl Config {
+    /// The credentials file to check provider status against, degrading to
+    /// an empty in-memory one (rather than aborting the whole listing) on a
+    /// read/parse failure — the listing commands must still show the
+    /// built-ins even when `~/.config/stella/credentials.toml` is malformed.
+    /// Returns the degradation warning line, if any, alongside the file.
+    fn credentials_file_for_listing() -> (CredentialsFile, Option<String>) {
+        match CredentialsFile::load_default() {
+            Ok(f) => (f, None),
+            Err(e) => (
+                CredentialsFile::empty(),
+                Some(format!(
+                    "~/.config/stella/credentials.toml could not be read: {e}"
+                )),
+            ),
+        }
+    }
+
     /// The provider/model table as plain text (no ANSI): the built-in
     /// providers with their key status, then any config-defined providers
     /// from `.stella/settings.json` — the same two sections the ANSI
     /// `print_available_models` renders, so `/models` in the deck lists
     /// exactly what `stella models` does. The Command Deck renders this into
     /// the transcript; stdout printing would corrupt the alternate screen, so
-    /// the deck needs a string, not a print.
-    pub fn available_models_plain() -> String {
+    /// the deck needs a string, not a print. `loaded_env`: see
+    /// [`Config::print_config`]'s doc — `None` at call sites that don't have
+    /// the startup dotenv record handy (the deck, the REPL fallback).
+    pub fn available_models_plain(loaded_env: Option<&crate::env_files::Loaded>) -> String {
         // Surface a settings load/parse failure rather than silently reporting
         // built-in defaults (which would hide a malformed config and wrong key
         // status), then continue with defaults so the listing still renders.
@@ -818,27 +877,33 @@ impl Config {
             Ok(s) => (s, None),
             Err(e) => (crate::settings::Settings::default(), Some(e)),
         };
+        let (credentials_file, credentials_error) = Self::credentials_file_for_listing();
         let mut lines = vec!["Available providers & models:".to_string()];
         if let Some(e) = &load_error {
             lines.push(format!("  ! settings could not be read: {e}"));
         }
+        if let Some(e) = &credentials_error {
+            lines.push(format!("  ! {e}"));
+        }
         for p in PROVIDERS {
             let p = effective_builtin(p, &settings);
-            let settings_key = settings
-                .providers
-                .get(p.id)
-                .and_then(|e| e.api_key.as_deref())
-                .is_some_and(|k| !k.is_empty());
-            let has_key = settings_key
-                || std::iter::once(&p.env_var)
-                    .chain(p.env_var_aliases)
-                    .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
+            let settings_key = crate::credential_status::settings_literal_key(&p, &settings);
+            let status = crate::credential_status::status_for(
+                &p,
+                settings_key.as_deref(),
+                &credentials_file,
+                loaded_env,
+            );
             lines.push(format!(
-                "  {} {}/{}  {}",
-                if has_key { "✓" } else { "✗" },
+                "  {} {}/{}  {}{}",
+                if status.configured { "✓" } else { "✗" },
                 p.id,
                 p.default_model,
                 p.display_name,
+                status
+                    .source_label
+                    .map(|s| format!("  [{s}]"))
+                    .unwrap_or_default(),
             ));
         }
         // Config-defined (non-built-in) providers, mirroring the ANSI table.
@@ -861,18 +926,16 @@ impl Config {
                 lines.push("Config-defined providers (settings.json):".to_string());
                 printed_header = true;
             }
-            // Key status must consider the provider's env var (settable via
-            // `api_key_env` or the derived default), not only the settings
-            // literal — otherwise a provider keyed through the environment
-            // wrongly shows ✗ (matching the built-in branch above).
-            let settings_key = entry.api_key.as_deref().is_some_and(|k| !k.is_empty());
-            let has_key = settings_key
-                || std::iter::once(&p.env_var)
-                    .chain(p.env_var_aliases)
-                    .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
+            let settings_key = entry.api_key.clone();
+            let status = crate::credential_status::status_for(
+                &p,
+                settings_key.as_deref(),
+                &credentials_file,
+                loaded_env,
+            );
             lines.push(format!(
-                "  {} {}/{}  {}",
-                if has_key { "✓" } else { "✗" },
+                "  {} {}/{}  {}{}",
+                if status.configured { "✓" } else { "✗" },
                 p.id,
                 if p.default_model.is_empty() {
                     "<model>"
@@ -880,6 +943,10 @@ impl Config {
                     p.default_model
                 },
                 p.display_name,
+                status
+                    .source_label
+                    .map(|s| format!("  [{s}]"))
+                    .unwrap_or_default(),
             ));
         }
         lines.push("Pin one with --model provider/model_id on the next launch.".to_string());
@@ -888,10 +955,11 @@ impl Config {
 
     /// Print all available providers/models without needing a resolved
     /// config: the built-in table (with any settings.json overrides
-    /// applied), then the config-defined providers. A malformed settings
-    /// file degrades to a warning here — a listing command should still
-    /// list the built-ins.
-    pub fn print_available_models() {
+    /// applied), then the config-defined providers. A malformed settings or
+    /// credentials file degrades to a warning here — a listing command
+    /// should still list the built-ins. `loaded_env`: see
+    /// [`Config::print_config`]'s doc.
+    pub fn print_available_models(loaded_env: Option<&crate::env_files::Loaded>) {
         let settings = match env::current_dir()
             .map_err(|e| e.to_string())
             .and_then(|ws| crate::settings::Settings::load(&ws))
@@ -902,35 +970,45 @@ impl Config {
                 crate::settings::Settings::default()
             }
         };
+        let (credentials_file, credentials_error) = Self::credentials_file_for_listing();
+        if let Some(e) = &credentials_error {
+            eprintln!("  {} {e}", "warning:".yellow());
+        }
         println!(
             "{}\n",
             "Stella — Available Providers & Models".bright_cyan().bold()
         );
-        let key_status = |p: &ProviderConfig, settings_key: bool| {
-            let has_key = settings_key
-                || std::iter::once(&p.env_var)
-                    .chain(p.env_var_aliases)
-                    .any(|var| env::var(var).map(|v| !v.is_empty()).unwrap_or(false));
-            if has_key {
+        let key_status = |status: &crate::credential_status::CredentialStatus| {
+            if status.configured {
                 "✓ configured".green()
             } else {
                 "✗ no key".dimmed()
             }
         };
+        let source_suffix = |status: &crate::credential_status::CredentialStatus| {
+            status
+                .source_label
+                .as_ref()
+                .map(|s| format!(" ({s})").dimmed().to_string())
+                .unwrap_or_default()
+        };
         for p in PROVIDERS {
             let p = effective_builtin(p, &settings);
-            let settings_key = settings
-                .providers
-                .get(p.id)
-                .and_then(|e| e.api_key.as_deref())
-                .is_some_and(|k| !k.is_empty());
+            let settings_key = crate::credential_status::settings_literal_key(&p, &settings);
+            let status = crate::credential_status::status_for(
+                &p,
+                settings_key.as_deref(),
+                &credentials_file,
+                loaded_env,
+            );
             println!(
-                "  {} {}/{}  {}  [{}]",
-                key_status(&p, settings_key),
+                "  {} {}/{}  {}  [{}]{}",
+                key_status(&status),
                 p.id.bright_magenta(),
                 p.default_model.bright_white(),
                 p.display_name,
                 p.base_url.dimmed(),
+                source_suffix(&status),
             );
         }
         let mut printed_header = false;
@@ -949,10 +1027,16 @@ impl Config {
                 println!("\n  {}", "Config-defined providers (settings.json):".bold());
                 printed_header = true;
             }
-            let settings_key = entry.api_key.as_deref().is_some_and(|k| !k.is_empty());
+            let settings_key = entry.api_key.clone();
+            let status = crate::credential_status::status_for(
+                &p,
+                settings_key.as_deref(),
+                &credentials_file,
+                loaded_env,
+            );
             println!(
-                "  {} {}/{}  {}  [{}] ({})",
-                key_status(&p, settings_key),
+                "  {} {}/{}  {}  [{}] ({}){}",
+                key_status(&status),
                 p.id.bright_magenta(),
                 if p.default_model.is_empty() {
                     "<model>"
@@ -963,6 +1047,7 @@ impl Config {
                 p.display_name,
                 p.base_url.dimmed(),
                 p.dialect.label().dimmed(),
+                source_suffix(&status),
             );
         }
         println!("\n  Use --model provider/model_id to pin a specific model.");
@@ -981,8 +1066,16 @@ impl Config {
 /// exactly env-var precedence — after the primary var, before the settings
 /// literal. A settings `api_key` outranks the credentials file because it
 /// is explicit, scope-merged configuration; the credentials file is the
-/// store interactive prompts write into.
-fn resolve_provider_key(
+/// store interactive prompts write into. The returned `CredentialSource`
+/// distinguishes the two file-shaped stores (`SettingsJson` for the
+/// settings.json literal, `ConfigFile` for a real credentials.toml hit) so
+/// callers displaying the source (`stella models`/`stella config`/`stella
+/// auth list`) never conflate them. This is the SAME resolution `Config`
+/// itself uses — `discover_configured_providers` and the "is this provider
+/// configured" status shown by `stella models`/`stella config` both call
+/// through here, so status can never disagree with what `stella run` would
+/// actually do.
+pub(crate) fn resolve_provider_key(
     provider: &ProviderConfig,
     api_key_override: Option<&str>,
     settings_key: Option<&str>,
@@ -1012,7 +1105,7 @@ fn resolve_provider_key(
                 }
             }
             if let Some(settings_key) = settings_key.filter(|k| !k.is_empty()) {
-                return Ok((ApiKey::new(settings_key), CredentialSource::ConfigFile));
+                return Ok((ApiKey::new(settings_key), CredentialSource::SettingsJson));
             }
             Ok((key, source))
         }
@@ -1027,7 +1120,7 @@ fn resolve_provider_key(
                 }
             }
             if let Some(settings_key) = settings_key.filter(|k| !k.is_empty()) {
-                return Ok((ApiKey::new(settings_key), CredentialSource::ConfigFile));
+                return Ok((ApiKey::new(settings_key), CredentialSource::SettingsJson));
             }
             // Nothing anywhere — rerun the full chain with the caller's
             // interactivity so the prompt step can fire when allowed.

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -104,6 +104,7 @@ fn config_debug_never_leaks_the_api_key() {
         engine_settings: None,
         tools_bash: false,
         tools_web: false,
+        credential_source: Some(stella_model::credential::CredentialSource::EnvVar),
     };
     let dbg = format!("{cfg:?}");
     assert!(!dbg.contains(secret), "Config Debug leaked the key: {dbg}");
@@ -334,7 +335,7 @@ fn a_bare_slug_matches_a_custom_providers_default_model() {
 #[test]
 fn discovery_style_resolution_accepts_the_settings_literal_key() {
     // resolve_provider_key with a settings literal and nothing else:
-    // resolves non-interactively as ConfigFile — this is what puts
+    // resolves non-interactively as SettingsJson — this is what puts
     // config-defined providers into auto-detection and judge discovery.
     let provider = ProviderConfig {
         id: "settings-key-test",
@@ -356,7 +357,45 @@ fn discovery_style_resolution_accepts_the_settings_literal_key() {
     assert_eq!(key.reveal(), "sk-settings");
     assert_eq!(
         source,
-        stella_model::credential::CredentialSource::ConfigFile
+        stella_model::credential::CredentialSource::SettingsJson
+    );
+}
+
+/// Issue #249's source-display requirement: a settings.json literal and a
+/// real credentials.toml entry are two DIFFERENT stores, and a caller
+/// showing "where did this come from" must be able to tell them apart. On
+/// origin/main both cases reported the same `CredentialSource::ConfigFile`,
+/// which is what let `stella config` conflate "declared in settings.json"
+/// with "stored in credentials.toml". This constructs a provider with BOTH
+/// present (the settings literal must win per the documented precedence)
+/// and asserts the resolved source is the settings-specific variant, not
+/// the file one — the file's differing value proves which one actually won.
+#[test]
+fn settings_json_literal_is_reported_distinctly_from_a_real_credentials_toml_entry() {
+    let provider = ProviderConfig {
+        id: "settings-vs-file-test",
+        env_var: "STELLA_TEST_SETTINGS_VS_FILE_UNSET",
+        env_var_aliases: &[],
+        display_name: "Settings vs File Test",
+        default_model: "m",
+        base_url: "https://x.example/v1",
+        dialect: Dialect::OpenaiCompatible,
+        seeded: false,
+    };
+    let mut file = CredentialsFile::load(std::env::temp_dir().join(format!(
+        "stella-test-settings-vs-file-credentials-{}.toml",
+        std::process::id()
+    )))
+    .unwrap();
+    file.set("settings-vs-file-test", "sk-from-credentials-file");
+
+    let (key, source) =
+        resolve_provider_key(&provider, None, Some("sk-from-settings-json"), &file, false).unwrap();
+    assert_eq!(key.reveal(), "sk-from-settings-json");
+    assert_eq!(
+        source,
+        stella_model::credential::CredentialSource::SettingsJson,
+        "a settings.json literal must be reported as SettingsJson, distinct from ConfigFile"
     );
 }
 

--- a/stella-cli/src/credential_status.rs
+++ b/stella-cli/src/credential_status.rs
@@ -1,0 +1,270 @@
+//! Shared "is this provider configured, and where did the key come from"
+//! logic for `stella models`, `stella config`, and `stella auth list`.
+//!
+//! All three surfaces must report the exact same verdict, because they are
+//! all describing the SAME resolution chain `stella run` actually uses
+//! (`config::resolve_provider_key`, run non-interactively so a listing
+//! command never blocks on a prompt). Before this module existed, `stella
+//! models`/`stella config` hand-rolled a narrower check that only looked at
+//! env vars and a settings.json literal — silently ignoring
+//! `~/.config/stella/credentials.toml`, so a provider keyed ONLY there
+//! showed as unconfigured even though `stella run` resolved it fine. Routing
+//! every status check through `resolve_provider_key` closes that gap for
+//! good: the display can no longer disagree with real behavior because it
+//! is asking the real resolver, not reimplementing a piece of it.
+
+use crate::config::{self, ProviderConfig};
+use crate::env_files::Loaded;
+use crate::settings::Settings;
+use stella_model::credential::{CredentialSource, CredentialsFile};
+
+/// One provider's resolved credential status for display.
+pub struct CredentialStatus {
+    pub configured: bool,
+    /// A short human label for WHERE the key came from — `env:VAR_NAME`,
+    /// a loaded dotenv filename (`.env.local`), `credentials.toml`, or
+    /// `settings.json`. `None` iff `configured` is `false`.
+    pub source_label: Option<String>,
+}
+
+/// The settings.json literal `api_key` configured for `provider.id`, if
+/// any — the lookup `config.rs` performs inline at each of its resolution
+/// call sites, centralized here so every caller of [`status_for`] shares it.
+pub fn settings_literal_key(provider: &ProviderConfig, settings: &Settings) -> Option<String> {
+    settings
+        .providers
+        .get(provider.id)
+        .and_then(|e| e.api_key.clone())
+}
+
+/// Resolve `provider`'s credential status via the exact same chain
+/// `Config::load` uses ([`config::resolve_provider_key`], non-interactively
+/// — no prompt), then attach a display label for the winning source.
+/// `loaded_env` is the startup dotenv-load record (`env_files::maybe_load`'s
+/// result); pass `None` when it isn't available in the caller's context —
+/// the label degrades to the generic `env:VAR_NAME` form instead of the
+/// specific loaded filename.
+pub fn status_for(
+    provider: &ProviderConfig,
+    settings_key: Option<&str>,
+    credentials_file: &CredentialsFile,
+    loaded_env: Option<&Loaded>,
+) -> CredentialStatus {
+    match config::resolve_provider_key(provider, None, settings_key, credentials_file, false) {
+        Ok((_, source)) => CredentialStatus {
+            configured: true,
+            source_label: Some(label_for(provider, source, loaded_env)),
+        },
+        Err(_) => CredentialStatus {
+            configured: false,
+            source_label: None,
+        },
+    }
+}
+
+/// A one-line summary of which project `.env*` files contributed which
+/// variable NAMES (never values) — the same information `STELLA_ENV_DEBUG`
+/// prints to stderr, but surfaced unconditionally in `stella config` rather
+/// than gated behind that flag. `None` when nothing was loaded.
+pub fn env_files_summary(loaded: &Loaded) -> Option<String> {
+    if loaded.names.is_empty() {
+        return None;
+    }
+    let files = loaded
+        .files
+        .iter()
+        .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("{files} ({})", loaded.names.join(", ")))
+}
+
+/// The display label for a resolved [`CredentialSource`]: which env var
+/// actually matched (and, if it was loaded from a project dotenv file, that
+/// file's name instead of the generic `env:` form), or which store.
+pub fn label_for(
+    provider: &ProviderConfig,
+    source: CredentialSource,
+    loaded_env: Option<&Loaded>,
+) -> String {
+    match source {
+        CredentialSource::CliFlag => "--api-key flag".to_string(),
+        CredentialSource::EnvVar => {
+            let var = std::iter::once(&provider.env_var)
+                .chain(provider.env_var_aliases)
+                .find(|v| std::env::var(*v).map(|s| !s.is_empty()).unwrap_or(false));
+            let Some(var) = var else {
+                // Unreachable in practice (resolve_provider_key only
+                // returns EnvVar when a var actually matched) — degrade to
+                // the primary var name rather than panic.
+                return format!("env:{}", provider.env_var);
+            };
+            match loaded_env.and_then(|l| l.file_for(var)) {
+                Some(path) => file_label(path),
+                None => format!("env:{var}"),
+            }
+        }
+        CredentialSource::ConfigFile => "credentials.toml".to_string(),
+        CredentialSource::SettingsJson => "settings.json".to_string(),
+        // Just prompted — and `Config::resolve` persists a successful
+        // interactive prompt to credentials.toml before this label is ever
+        // shown, so that's where the key now actually lives.
+        CredentialSource::Interactive => "credentials.toml (just entered)".to_string(),
+    }
+}
+
+fn file_label(path: &std::path::Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Dialect;
+    use std::path::PathBuf;
+
+    fn test_provider(id: &'static str, env_var: &'static str) -> ProviderConfig {
+        ProviderConfig {
+            id,
+            env_var,
+            env_var_aliases: &[],
+            display_name: "Test Provider",
+            default_model: "m",
+            base_url: "https://x.example/v1",
+            dialect: Dialect::OpenaiCompatible,
+            seeded: false,
+        }
+    }
+
+    fn temp_credentials_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "stella-test-credstatus-{name}-{}.toml",
+            std::process::id()
+        ))
+    }
+
+    // ---- status_for: the actual #249 root-cause witness -----------------
+    //
+    // Before this module existed, `stella models`/`stella config` never
+    // consulted the credentials file at all when deciding "configured or
+    // not" — only env vars and a settings.json literal. This is the exact
+    // scenario that silently showed `✗ no key` for a provider keyed only
+    // via credentials.toml.
+
+    #[test]
+    fn status_for_reports_configured_via_credentials_toml_alone() {
+        let _env = crate::test_env::lock();
+        // SAFETY: guarded by test_env's lock; unique var name, never used
+        // by any other test.
+        unsafe {
+            std::env::remove_var("STELLA_TEST_CREDSTATUS_TOML_ONLY_KEY");
+        }
+        let provider = test_provider(
+            "credstatus-toml-only",
+            "STELLA_TEST_CREDSTATUS_TOML_ONLY_KEY",
+        );
+        let mut file = CredentialsFile::load(temp_credentials_path("toml-only")).unwrap();
+        file.set("credstatus-toml-only", "sk-from-credentials-file");
+
+        let status = status_for(&provider, None, &file, None);
+        assert!(
+            status.configured,
+            "a provider keyed only via credentials.toml must show as configured"
+        );
+        assert_eq!(status.source_label.as_deref(), Some("credentials.toml"));
+    }
+
+    #[test]
+    fn status_for_reports_not_configured_when_nothing_resolves() {
+        let _env = crate::test_env::lock();
+        unsafe {
+            std::env::remove_var("STELLA_TEST_CREDSTATUS_UNSET_KEY");
+        }
+        let provider = test_provider("credstatus-unset", "STELLA_TEST_CREDSTATUS_UNSET_KEY");
+        let file = CredentialsFile::load(temp_credentials_path("unset")).unwrap();
+
+        let status = status_for(&provider, None, &file, None);
+        assert!(!status.configured);
+        assert_eq!(status.source_label, None);
+    }
+
+    // ---- label_for: source distinction + .env file attribution ----------
+
+    #[test]
+    fn label_for_settings_json_is_distinct_from_credentials_toml() {
+        let provider = test_provider("label-test-a", "STELLA_TEST_LABEL_A_KEY");
+        assert_eq!(
+            label_for(&provider, CredentialSource::SettingsJson, None),
+            "settings.json"
+        );
+        assert_eq!(
+            label_for(&provider, CredentialSource::ConfigFile, None),
+            "credentials.toml"
+        );
+    }
+
+    #[test]
+    fn label_for_env_var_names_the_loaded_dotenv_file_when_known() {
+        let _env = crate::test_env::lock();
+        let provider = test_provider("label-test-b", "STELLA_TEST_LABEL_B_KEY");
+        unsafe {
+            std::env::set_var("STELLA_TEST_LABEL_B_KEY", "sk-value");
+        }
+        let local_file = PathBuf::from("/proj/.env.local");
+        let loaded = Loaded {
+            files: vec![local_file.clone()],
+            names: vec!["STELLA_TEST_LABEL_B_KEY".to_string()],
+            name_files: [("STELLA_TEST_LABEL_B_KEY".to_string(), local_file)]
+                .into_iter()
+                .collect(),
+        };
+        assert_eq!(
+            label_for(&provider, CredentialSource::EnvVar, Some(&loaded)),
+            ".env.local"
+        );
+        unsafe {
+            std::env::remove_var("STELLA_TEST_LABEL_B_KEY");
+        }
+    }
+
+    #[test]
+    fn label_for_env_var_falls_back_to_generic_form_without_loaded_env() {
+        let _env = crate::test_env::lock();
+        let provider = test_provider("label-test-c", "STELLA_TEST_LABEL_C_KEY");
+        unsafe {
+            std::env::set_var("STELLA_TEST_LABEL_C_KEY", "sk-value");
+        }
+        assert_eq!(
+            label_for(&provider, CredentialSource::EnvVar, None),
+            "env:STELLA_TEST_LABEL_C_KEY"
+        );
+        unsafe {
+            std::env::remove_var("STELLA_TEST_LABEL_C_KEY");
+        }
+    }
+
+    #[test]
+    fn env_files_summary_lists_files_and_names_never_values() {
+        let loaded = Loaded {
+            files: vec![
+                PathBuf::from("/proj/.env.local"),
+                PathBuf::from("/proj/.env"),
+            ],
+            names: vec!["OPENROUTER_API_KEY".to_string(), "FOO".to_string()],
+            name_files: Default::default(),
+        };
+        let summary = env_files_summary(&loaded).unwrap();
+        assert!(summary.contains(".env.local"));
+        assert!(summary.contains(".env"));
+        assert!(summary.contains("OPENROUTER_API_KEY"));
+        assert!(summary.contains("FOO"));
+    }
+
+    #[test]
+    fn env_files_summary_is_none_when_nothing_loaded() {
+        assert!(env_files_summary(&Loaded::default()).is_none());
+    }
+}

--- a/stella-cli/src/credential_status.rs
+++ b/stella-cli/src/credential_status.rs
@@ -62,6 +62,33 @@ pub fn status_for(
     }
 }
 
+/// The [`ProviderConfig`] to resolve `id` against for display purposes: a
+/// built-in (with any settings.json override applied), a settings-defined
+/// custom provider, or — for an id that matches neither (e.g. a key stored
+/// via `stella auth set` ahead of the provider being declared in
+/// settings.json) — a minimal synthesized one using the same
+/// `<ID>_API_KEY` convention `config::custom_provider` falls back to.
+pub fn provider_config_for(id: &str, settings: &Settings) -> ProviderConfig {
+    if let Some(p) = config::PROVIDERS.iter().find(|p| p.id == id) {
+        return config::effective_builtin(p, settings);
+    }
+    if let Some(entry) = settings.providers.get(id)
+        && let Ok(p) = config::custom_provider(id, entry)
+    {
+        return p;
+    }
+    ProviderConfig {
+        id: Box::leak(id.to_string().into_boxed_str()),
+        env_var: Box::leak(config::derived_env_var(id).into_boxed_str()),
+        env_var_aliases: &[],
+        display_name: Box::leak(id.to_string().into_boxed_str()),
+        default_model: "",
+        base_url: "",
+        dialect: config::Dialect::OpenaiCompatible,
+        seeded: false,
+    }
+}
+
 /// A one-line summary of which project `.env*` files contributed which
 /// variable NAMES (never values) — the same information `STELLA_ENV_DEBUG`
 /// prints to stderr, but surfaced unconditionally in `stella config` rather
@@ -266,5 +293,22 @@ mod tests {
     #[test]
     fn env_files_summary_is_none_when_nothing_loaded() {
         assert!(env_files_summary(&Loaded::default()).is_none());
+    }
+
+    // ---- provider_config_for: unknown-id fallback for `stella auth list` ---
+
+    #[test]
+    fn provider_config_for_unknown_id_derives_the_conventional_env_var() {
+        let settings = Settings::default();
+        let p = provider_config_for("my-custom-gateway", &settings);
+        assert_eq!(p.id, "my-custom-gateway");
+        assert_eq!(p.env_var, "MY_CUSTOM_GATEWAY_API_KEY");
+    }
+
+    #[test]
+    fn provider_config_for_known_builtin_uses_its_real_env_var() {
+        let settings = Settings::default();
+        let p = provider_config_for("anthropic", &settings);
+        assert_eq!(p.env_var, "ANTHROPIC_API_KEY");
     }
 }

--- a/stella-cli/src/env_files.rs
+++ b/stella-cli/src/env_files.rs
@@ -50,11 +50,24 @@ use crate::OutputFormat;
 pub struct Loaded {
     pub files: Vec<PathBuf>,
     pub names: Vec<String>,
+    /// Which specific file each loaded variable name came from — lets a
+    /// display surface (`stella config`) attribute e.g. `OPENROUTER_API_KEY`
+    /// to `.env.local` by name, rather than only "loaded from a dotenv file"
+    /// in aggregate.
+    pub name_files: std::collections::BTreeMap<String, PathBuf>,
 }
 
 impl Loaded {
     fn is_empty(&self) -> bool {
         self.names.is_empty()
+    }
+
+    /// The dotenv file that contributed `name`, if any — `None` when `name`
+    /// resolves some other way (a real shell export, a CLI flag, a
+    /// credentials store, …) or wasn't loaded from a project `.env*` file at
+    /// all.
+    pub fn file_for(&self, name: &str) -> Option<&Path> {
+        self.name_files.get(name).map(PathBuf::as_path)
     }
 }
 
@@ -78,17 +91,23 @@ pub fn maybe_load() -> Loaded {
 
     let mut names = Vec::new();
     let mut files: Vec<PathBuf> = Vec::new();
+    let mut name_files = std::collections::BTreeMap::new();
     for (key, value, path) in plan {
         // SAFETY: called only from `main` during single-threaded process
         // startup, before the tokio runtime or any worker threads exist — no
         // concurrent `getenv`/`setenv` can race this write.
         unsafe { std::env::set_var(&key, &value) };
+        name_files.insert(key.clone(), path.clone());
         names.push(key);
         if !files.contains(&path) {
             files.push(path);
         }
     }
-    Loaded { files, names }
+    Loaded {
+        files,
+        names,
+        name_files,
+    }
 }
 
 /// The ordered list of assignments a load would apply, given a predicate for
@@ -372,5 +391,23 @@ mod tests {
         write(home, ".env", "HOME_LEVEL=nope\n");
         // Running *in* $HOME must not load `~/.env`.
         assert_eq!(find_base(home, Some(home)), None);
+    }
+
+    // ---- Loaded::file_for (stella config's "which file, which name") ----
+
+    #[test]
+    fn file_for_attributes_a_loaded_name_to_its_source_file_and_nothing_else() {
+        let local = PathBuf::from("/proj/.env.local");
+        let loaded = Loaded {
+            files: vec![local.clone()],
+            names: vec!["OPENROUTER_API_KEY".to_string()],
+            name_files: [("OPENROUTER_API_KEY".to_string(), local.clone())]
+                .into_iter()
+                .collect(),
+        };
+        assert_eq!(loaded.file_for("OPENROUTER_API_KEY"), Some(local.as_path()));
+        // A name that was never loaded from a dotenv file (a real shell
+        // export, say) must not be attributed to one.
+        assert_eq!(loaded.file_for("ANTHROPIC_API_KEY"), None);
     }
 }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -25,6 +25,7 @@ mod claims;
 mod command_deck;
 mod config;
 mod connect_cmd;
+mod credential_status;
 mod discovery;
 mod domains;
 mod engine_config;
@@ -983,7 +984,7 @@ fn main() -> ExitCode {
     // a human output format so it never pollutes json/stream-json.
     env_files::announce(&loaded_env, cli.globals.output_format);
 
-    match run(cli) {
+    match run(cli, &loaded_env) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("{} {}", "stella:".red().bold(), e);
@@ -992,13 +993,13 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> Result<(), String> {
+fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
     // Models and Version don't need a configured provider/key.
     match &cli.command {
         Some(Command::Models { cmd }) => {
             return match cmd {
                 None => {
-                    config::Config::print_available_models();
+                    config::Config::print_available_models(Some(loaded_env));
                     model_catalog::print_catalog_status();
                     Ok(())
                 }
@@ -1239,7 +1240,7 @@ fn run(cli: Cli) -> Result<(), String> {
             unreachable!("handled before provider resolution")
         }
         Command::Config => {
-            cfg.print_config();
+            cfg.print_config(Some(loaded_env));
         }
     }
     Ok(())

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -20,6 +20,7 @@
 mod agent;
 mod agents_installed;
 mod attachments;
+mod auth_cmd;
 mod candidate_ws;
 mod claims;
 mod command_deck;
@@ -383,8 +384,53 @@ enum Command {
     /// Show current configuration
     Config,
 
+    /// Manage BYOK provider keys stored in
+    /// ~/.config/stella/credentials.toml (set/remove/list) — keys resolved
+    /// via an env var or settings.json still take precedence per the normal
+    /// chain; `stella models`/`stella config` show which source actually
+    /// wins. Never prints a secret value; needs no model API key itself.
+    Auth {
+        #[command(subcommand)]
+        cmd: AuthCmd,
+    },
+
     /// Print the version and exit
     Version,
+}
+
+/// `stella auth` subcommands — the whole `~/.config/stella/credentials.toml`
+/// management surface. Deliberately small: a handful of BYOK keys, not a
+/// config language (mirrors `CredentialsFile`'s own doc intent).
+#[derive(Subcommand)]
+pub enum AuthCmd {
+    /// Store (or replace) a provider's API key in credentials.toml.
+    Set {
+        /// Provider id (a built-in like `zai`/`anthropic`/`openai`, or a
+        /// settings.json-defined custom provider id)
+        provider: String,
+
+        /// Pass the key directly on the command line. WARNING: this value
+        /// becomes visible in shell history and `ps` output — prefer
+        /// --stdin, or omit both flags for an interactive masked prompt.
+        #[arg(long, conflicts_with = "stdin")]
+        key: Option<String>,
+
+        /// Read the key from stdin (one line, trimmed) instead of a flag or
+        /// an interactive prompt — for scripts, e.g. `printf '%s' "$KEY" | \
+        /// stella auth set zai --stdin`.
+        #[arg(long)]
+        stdin: bool,
+    },
+
+    /// Remove a provider's stored key from credentials.toml.
+    Remove {
+        /// Provider id
+        provider: String,
+    },
+
+    /// List providers with a key stored in credentials.toml (redacted
+    /// preview + resolution source).
+    List,
 }
 
 /// `stella models` subcommands — the model-catalog surface. A bare
@@ -1072,6 +1118,13 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             }
             return connect_cmd::run(cmd);
         }
+        Some(Command::Auth { cmd }) => {
+            // Reads/writes ~/.config/stella/credentials.toml directly — no
+            // provider needs to already resolve (this is often how the
+            // FIRST key gets configured), so this short-circuits before
+            // `Config::load` like `Connect`/`Mcp` do.
+            return auth_cmd::run(cmd);
+        }
         Some(Command::Observe { port, open }) => {
             // Loopback-only dashboard over local telemetry — no provider or
             // API key required; the stores are opened strictly read-only.
@@ -1234,6 +1287,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Memory { .. }
         | Command::Mcp { .. }
         | Command::Connect { .. }
+        | Command::Auth { .. }
         | Command::Observe { .. }
         | Command::Models { .. }
         | Command::Version => {

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -7,7 +7,7 @@
 
 use clap::{CommandFactory, Parser};
 
-use super::{Cli, Command, ConnectCmd, OutputFormat};
+use super::{AuthCmd, Cli, Command, ConnectCmd, OutputFormat};
 
 /// clap's own consistency audit (conflicting ids, broken defaults,
 /// mis-typed value parsers) — panics on the first violation. Runs the same
@@ -167,4 +167,69 @@ fn connect_linear_paste_key_parses() {
         }) => assert!(!paste_key),
         _ => panic!("expected `connect linear`"),
     }
+}
+
+/// `stella auth set <provider> --key <k>` parses, and the global `--api-key`
+/// (a different secret — the model-provider credential) still parses
+/// independently on the same command line, same shape as `connect linear`.
+#[test]
+fn auth_set_key_parses_and_stays_independent_of_the_global_api_key() {
+    let cli = Cli::try_parse_from([
+        "stella",
+        "auth",
+        "set",
+        "zai",
+        "--key",
+        "sk-stored",
+        "--api-key",
+        "sk-model",
+    ])
+    .expect("`auth set <provider> --key <k>` must parse alongside the global --api-key");
+    assert_eq!(cli.globals.api_key.as_deref(), Some("sk-model"));
+    match cli.command {
+        Some(Command::Auth {
+            cmd:
+                AuthCmd::Set {
+                    provider,
+                    key,
+                    stdin,
+                },
+        }) => {
+            assert_eq!(provider, "zai");
+            assert_eq!(key.as_deref(), Some("sk-stored"));
+            assert!(!stdin);
+        }
+        _ => panic!("expected `auth set`"),
+    }
+}
+
+/// `--key` and `--stdin` are mutually exclusive — a user meaning to pipe a
+/// secret in via `--stdin` must not silently also accept a (likely absent)
+/// `--key` value.
+#[test]
+fn auth_set_rejects_key_and_stdin_together() {
+    // `Cli` derives no `Debug` (it carries the model API key), so match
+    // rather than `expect_err`/`unwrap_err` (both require `T: Debug`).
+    match Cli::try_parse_from(["stella", "auth", "set", "zai", "--key", "sk-x", "--stdin"]) {
+        Err(e) => assert_eq!(e.kind(), clap::error::ErrorKind::ArgumentConflict),
+        Ok(_) => panic!("--key and --stdin must conflict"),
+    }
+}
+
+#[test]
+fn auth_remove_and_list_parse() {
+    let cli = Cli::try_parse_from(["stella", "auth", "remove", "zai"])
+        .expect("`auth remove <provider>` must parse");
+    match cli.command {
+        Some(Command::Auth {
+            cmd: AuthCmd::Remove { provider },
+        }) => assert_eq!(provider, "zai"),
+        _ => panic!("expected `auth remove`"),
+    }
+
+    let cli = Cli::try_parse_from(["stella", "auth", "list"]).expect("`auth list` must parse");
+    assert!(matches!(
+        cli.command,
+        Some(Command::Auth { cmd: AuthCmd::List })
+    ));
 }

--- a/stella-model/src/credential.rs
+++ b/stella-model/src/credential.rs
@@ -44,6 +44,14 @@ pub enum CredentialSource {
     CliFlag,
     EnvVar,
     ConfigFile,
+    /// A literal `providers.<id>.api_key` in a merged settings scope
+    /// (user/org/project `settings.json`). `ApiKey::resolve` itself never
+    /// produces this — it has no notion of settings.json — a caller that
+    /// layers a settings literal on top of the base chain (`stella-cli`'s
+    /// `resolve_provider_key`) constructs it, so a display surface can tell
+    /// "this file" (`ConfigFile`) apart from "this declarative config"
+    /// (`SettingsJson`) instead of both reporting as the same source.
+    SettingsJson,
     Interactive,
 }
 
@@ -243,6 +251,19 @@ impl CredentialsFile {
                 path: PathBuf::new(),
                 data: CredentialsFileData::default(),
             }),
+        }
+    }
+
+    /// An empty, in-memory-only credentials file (no backing path — `save`
+    /// on it errors with `FileWrite`). For callers that must always have
+    /// *some* `&CredentialsFile` to pass into `ApiKey::resolve` /
+    /// `resolve_provider_key`, even when the real file failed to load (e.g.
+    /// malformed TOML) and the caller's posture is "degrade the listing,
+    /// don't crash it" rather than propagate the error.
+    pub fn empty() -> Self {
+        Self {
+            path: PathBuf::new(),
+            data: CredentialsFileData::default(),
         }
     }
 
@@ -534,6 +555,18 @@ mod tests {
         let err = CredentialsFile::load(&path).unwrap_err();
         assert!(matches!(err, CredentialError::FileParse { .. }));
         let _ = std::fs::remove_file(&path);
+    }
+
+    // ---- empty (degrade-a-listing-command posture) -----------------------
+
+    #[test]
+    fn empty_file_has_no_entries_and_refuses_to_save() {
+        let file = CredentialsFile::empty();
+        assert_eq!(file.get("zai"), None);
+        assert!(matches!(
+            file.save().unwrap_err(),
+            CredentialError::FileWrite { .. }
+        ));
     }
 
     // ---- ApiKey::resolve precedence (per-provider-per-source) --------

--- a/stella-model/src/credential.rs
+++ b/stella-model/src/credential.rs
@@ -272,6 +272,13 @@ impl CredentialsFile {
         self.data.credentials.get(provider_id).map(String::as_str)
     }
 
+    /// Every provider id currently stored, alphabetically (the underlying
+    /// map is a `BTreeMap`, so this is already sorted) — for `stella auth
+    /// list`, which enumerates the file rather than looking up one id.
+    pub fn provider_ids(&self) -> impl Iterator<Item = &str> {
+        self.data.credentials.keys().map(String::as_str)
+    }
+
     /// Set (or replace) `provider_id`'s key in memory. Call `save` to
     /// persist — kept separate so a caller can batch multiple sets into one
     /// write.
@@ -279,6 +286,12 @@ impl CredentialsFile {
         self.data
             .credentials
             .insert(provider_id.to_string(), value.into());
+    }
+
+    /// Remove `provider_id`'s key from memory, if present. Returns whether
+    /// an entry existed. Call `save` to persist.
+    pub fn remove(&mut self, provider_id: &str) -> bool {
+        self.data.credentials.remove(provider_id).is_some()
     }
 
     /// Write the current in-memory state to disk, creating parent
@@ -557,12 +570,45 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    // ---- empty (degrade-a-listing-command posture) -----------------------
+    // ---- remove / provider_ids / empty (stella auth set/remove/list) ----
+
+    #[test]
+    fn remove_reports_whether_an_entry_existed_and_drops_it() {
+        let path = temp_credentials_path("remove");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+        file.set("zai", "sk-zai-secret");
+
+        assert!(file.remove("zai"), "removing a present entry reports true");
+        assert_eq!(file.get("zai"), None);
+        assert!(
+            !file.remove("zai"),
+            "removing an already-absent entry reports false, not a panic"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn provider_ids_lists_every_stored_id_alphabetically() {
+        let path = temp_credentials_path("provider-ids");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+        file.set("zai", "sk-1");
+        file.set("anthropic", "sk-2");
+        file.set("openai", "sk-3");
+
+        let ids: Vec<&str> = file.provider_ids().collect();
+        assert_eq!(ids, vec!["anthropic", "openai", "zai"]);
+
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn empty_file_has_no_entries_and_refuses_to_save() {
         let file = CredentialsFile::empty();
         assert_eq!(file.get("zai"), None);
+        assert_eq!(file.provider_ids().count(), 0);
         assert!(matches!(
             file.save().unwrap_err(),
             CredentialError::FileWrite { .. }


### PR DESCRIPTION
Fixes #249
Fixes #251

Note: PR #294 (`stella auth` command, issue #251) auto-merged into this branch (`feat/credential-status-source`) before this PR merged to `main`, so this PR's diff now carries both fixes. Both issues are referenced here so both auto-close when this merges to `main`.

## Summary — #249 (credential status source)
- `stella models`/`stella config`'s "configured?" check previously only looked at env vars + a settings.json literal, silently ignoring `~/.config/stella/credentials.toml` — a provider keyed only there showed `✗ no key` even though `stella run` resolved it fine.
- Both surfaces now go through the exact same non-interactive `resolve_provider_key` chain `Config::load` uses (centralized in a new `credential_status` module), so status can never disagree with real behavior again.
- Both surfaces now display the winning source: `env:VAR_NAME`, the specific loaded `.env*` filename (e.g. `.env.local`) when the var came from a project dotenv file, `credentials.toml`, or `settings.json`.
- Split `CredentialSource::ConfigFile` into `ConfigFile` (real credentials.toml hit) vs a new `SettingsJson` variant (a `providers.<id>.api_key` literal) — these were previously conflated under one source, which defeats the point of a "where did this come from" feature.
- `stella config` now always shows which project `.env*` files were loaded and which variable NAMES they contributed (previously only visible via `STELLA_ENV_DEBUG`).

## Summary — #251 (stella auth command)
- `stella auth set <provider> [--key <k> | --stdin]` — writes/replaces a key in credentials.toml, creating the file 0600. `--key` warns that the value leaks into shell history/`ps`; `--stdin` (one line, trimmed) or the default interactive `rpassword`-masked prompt are preferred. `--key`/`--stdin` are mutually exclusive.
- `stella auth remove <provider>` — removes an entry, reporting (not erroring) when absent.
- `stella auth list` — shows every stored provider's redacted preview, flagging when an env var or settings.json literal currently shadows the stored key (reuses `credential_status::status_for`).
- Every command masks the secret value in its own output; the only place a plaintext key is ever written is the 0600 credentials file itself.

## Test plan
- [x] `cargo test -p stella-cli --bin stella` — 323 passed
- [x] `cargo test -p stella-model` — 194 (lib) + 1 (integration) passed
- [x] `cargo clippy -p stella-cli -p stella-model --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` applied
- [x] `sh scripts/check-file-sizes.sh` — OK, all files within the ratchet
- [x] Witness test: temporarily reverted the `SettingsJson` fix and confirmed `config::tests::settings_json_literal_is_reported_distinctly_from_a_real_credentials_toml_entry` genuinely fails (`left: ConfigFile, right: SettingsJson`), then restored and confirmed it passes.
- [x] Witness test: `credential_status::tests::status_for_reports_configured_via_credentials_toml_alone` proves the #249 root-cause scenario (a provider keyed only via credentials.toml) resolves as configured.
- [x] Witness tests for #251: `set_then_save_writes_the_real_file_0600` (perms), `set_in_stores_the_key_but_never_echoes_it_in_the_confirmation_message` (masked stdout), `remove_from_reports_success_and_actually_drops_the_entry` / `remove_from_reports_absence_without_erroring`, `list_lines_shows_a_redacted_preview_never_the_raw_value` / `list_lines_notes_when_an_env_var_shadows_the_stored_key`
