### PR TITLE
feat(stella-cli): add stella auth command to manage credentials.toml

### DIFF
--- a/stella-cli/src/auth_cmd.rs
+++ b/stella-cli/src/auth_cmd.rs
@@ -1,0 +1,371 @@
+//! `stella auth` — manage BYOK provider keys stored in
+//! `~/.config/stella/credentials.toml`. A small, flat store for a handful of
+//! keys, not a config language (`CredentialsFile`'s own doc intent) —
+//! `set`/`remove`/`list` is the whole surface. Every command here masks the
+//! secret value in its own output; the only place a plaintext key is ever
+//! written is the 0600 credentials file itself.
+//!
+//! Every subcommand splits into a pure core (operates on an already-loaded
+//! `&mut CredentialsFile`, returns the lines to print — never touches the
+//! real filesystem) and a thin `run_*` wrapper that loads/saves the real
+//! `~/.config/stella/credentials.toml`. This is what lets the core be unit
+//! tested against a temp-path `CredentialsFile` instead of ever touching a
+//! developer's actual credentials file.
+
+use colored::Colorize as _;
+use stella_model::credential::{ApiKey, CredentialsFile};
+
+use crate::credential_status;
+use crate::settings::Settings;
+
+/// Entry point for `stella auth <cmd>`.
+pub fn run(cmd: &crate::AuthCmd) -> Result<(), String> {
+    match cmd {
+        crate::AuthCmd::Set {
+            provider,
+            key,
+            stdin,
+        } => run_set(provider, key.as_deref(), *stdin),
+        crate::AuthCmd::Remove { provider } => run_remove(provider),
+        crate::AuthCmd::List => run_list(),
+    }
+}
+
+fn credentials_path_display() -> String {
+    CredentialsFile::default_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "~/.config/stella/credentials.toml".to_string())
+}
+
+fn load_file() -> Result<CredentialsFile, String> {
+    CredentialsFile::load_default()
+        .map_err(|e| format!("could not read {}: {e}", credentials_path_display()))
+}
+
+/// Reject ids that would corrupt lookups elsewhere — `config::custom_provider`
+/// enforces the same rule for settings.json-defined providers. Otherwise
+/// permissive about WHICH id: a key can legitimately be stored ahead of the
+/// provider being declared in settings.json, or under one of the built-ins.
+fn validate_provider_id(id: &str) -> Result<(), String> {
+    if id.is_empty() || id.contains('/') || id.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "`{id}` is not a valid provider id (no slashes or whitespace)"
+        ));
+    }
+    Ok(())
+}
+
+/// The key value for `set`, in priority order: `--key` (warned), `--stdin`
+/// (one line, trimmed), or an interactive masked prompt (rpassword) —
+/// mirroring `stella_model::credential`'s own interactive-prompt idiom and
+/// `connect_cmd`'s `prompt_secret`.
+fn read_key_value(provider: &str, key: Option<&str>, use_stdin: bool) -> Result<String, String> {
+    if let Some(k) = key {
+        eprintln!(
+            "  {} --key exposes the credential in shell history and `ps` output — prefer \
+             `stella auth set {provider} --stdin` or the interactive masked prompt (omit \
+             both --key and --stdin)",
+            "⚠".yellow()
+        );
+        if k.is_empty() {
+            return Err("--key value is empty".to_string());
+        }
+        return Ok(k.to_string());
+    }
+    if use_stdin {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_line(&mut buf)
+            .map_err(|e| format!("could not read key from stdin: {e}"))?;
+        let trimmed = buf.trim().to_string();
+        if trimmed.is_empty() {
+            return Err("empty key read from stdin".to_string());
+        }
+        return Ok(trimmed);
+    }
+    let value = rpassword::prompt_password(format!("  API key for `{provider}`: "))
+        .map_err(|e| format!("cannot read secret from terminal: {e}"))?;
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("empty input — no credential entered".to_string());
+    }
+    Ok(trimmed)
+}
+
+/// Pure core of `stella auth set`: validates the id, resolves the key value,
+/// and stores it into `file` (caller saves). Returns the masked confirmation
+/// line — never the raw value.
+fn set_in(
+    file: &mut CredentialsFile,
+    path_display: &str,
+    provider: &str,
+    key: Option<&str>,
+    use_stdin: bool,
+) -> Result<String, String> {
+    validate_provider_id(provider)?;
+    let value = read_key_value(provider, key, use_stdin)?;
+    let api_key = ApiKey::new(value);
+    file.set(provider, api_key.reveal());
+    Ok(format!(
+        "stored key for `{provider}` in {path_display} ({})",
+        api_key.redacted_preview()
+    ))
+}
+
+fn run_set(provider: &str, key: Option<&str>, use_stdin: bool) -> Result<(), String> {
+    let mut file = load_file()?;
+    let path_display = credentials_path_display();
+    let message = set_in(&mut file, &path_display, provider, key, use_stdin)?;
+    file.save()
+        .map_err(|e| format!("failed to save {path_display}: {e}"))?;
+    println!("  {} {}", "◆".yellow(), message);
+    Ok(())
+}
+
+/// Pure core of `stella auth remove`: removes `provider` from `file` if
+/// present. Returns `(message, removed)` — the caller only re-saves the
+/// file when `removed` is true.
+fn remove_from(file: &mut CredentialsFile, path_display: &str, provider: &str) -> (String, bool) {
+    if file.remove(provider) {
+        (
+            format!("removed key for `{provider}` from {path_display}"),
+            true,
+        )
+    } else {
+        (
+            format!("no stored key for `{provider}` in {path_display} — nothing to remove"),
+            false,
+        )
+    }
+}
+
+fn run_remove(provider: &str) -> Result<(), String> {
+    let mut file = load_file()?;
+    let path_display = credentials_path_display();
+    let (message, removed) = remove_from(&mut file, &path_display, provider);
+    if removed {
+        file.save()
+            .map_err(|e| format!("failed to save {path_display}: {e}"))?;
+        println!("  {} {}", "◆".yellow(), message);
+    } else {
+        println!("  {} {}", "·".green(), message);
+    }
+    Ok(())
+}
+
+/// Pure core of `stella auth list`: one display line per stored provider —
+/// redacted preview, the `credentials.toml` label, and (when something else
+/// currently outranks the stored key in the real resolution chain — an env
+/// var, a settings.json literal) a "shadowed by …" note, so this list stays
+/// consistent with `stella models`/`stella config` rather than a static
+/// echo of the file's own contents. Never includes a raw secret value.
+fn list_lines(file: &CredentialsFile, settings: &Settings) -> Vec<String> {
+    file.provider_ids()
+        .filter_map(|id| {
+            let value = file.get(id)?;
+            let preview = ApiKey::new(value).redacted_preview();
+            let provider = credential_status::provider_config_for(id, settings);
+            let settings_key = credential_status::settings_literal_key(&provider, settings);
+            let status =
+                credential_status::status_for(&provider, settings_key.as_deref(), file, None);
+            let note = match status.source_label {
+                Some(label) if label != "credentials.toml" => {
+                    format!("  (shadowed by {label})")
+                }
+                _ => String::new(),
+            };
+            Some(format!("{id}  {preview}  credentials.toml{note}"))
+        })
+        .collect()
+}
+
+fn run_list() -> Result<(), String> {
+    let file = load_file()?;
+    crate::tui::section_header("Stored credentials");
+    let lines = {
+        // Best-effort: a malformed settings.json costs the provider-config
+        // lookup its overrides, never the listing itself.
+        let settings = std::env::current_dir()
+            .ok()
+            .and_then(|ws| Settings::load(&ws).ok())
+            .unwrap_or_default();
+        list_lines(&file, &settings)
+    };
+    if lines.is_empty() {
+        println!(
+            "  {}",
+            "none — run `stella auth set <provider>` to store one.".dimmed()
+        );
+        return Ok(());
+    }
+    for line in lines {
+        println!("  {} {line}", "◆".yellow());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_credentials_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "stella-test-auth-cmd-{name}-{}.toml",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_empty_slash_and_whitespace() {
+        assert!(validate_provider_id("zai").is_ok());
+        assert!(validate_provider_id("my-gateway").is_ok());
+        assert!(validate_provider_id("").is_err());
+        assert!(validate_provider_id("zai/glm").is_err());
+        assert!(validate_provider_id("has space").is_err());
+    }
+
+    // ---- set: witness for masked stdout + 0600 perms on disk ------------
+
+    #[test]
+    fn set_in_stores_the_key_but_never_echoes_it_in_the_confirmation_message() {
+        let path = temp_credentials_path("set-masked");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+
+        let message = set_in(
+            &mut file,
+            "credentials.toml",
+            "zai",
+            Some("sk-super-secret-value-1234"),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !message.contains("sk-super-secret-value-1234"),
+            "confirmation message must never contain the raw secret: {message}"
+        );
+        assert!(message.contains("zai"));
+        assert_eq!(file.get("zai"), Some("sk-super-secret-value-1234"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_then_save_writes_the_real_file_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_credentials_path("set-perms");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+
+        set_in(
+            &mut file,
+            "credentials.toml",
+            "zai",
+            Some("sk-value"),
+            false,
+        )
+        .unwrap();
+        file.save().unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "stella auth set must leave a 0600 file"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn set_in_rejects_an_invalid_provider_id_before_touching_the_file() {
+        let mut file = CredentialsFile::load(temp_credentials_path("set-invalid")).unwrap();
+        let err = set_in(
+            &mut file,
+            "credentials.toml",
+            "zai/glm",
+            Some("sk-value"),
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("not a valid provider id"));
+        assert_eq!(file.get("zai/glm"), None);
+    }
+
+    // ---- remove -----------------------------------------------------------
+
+    #[test]
+    fn remove_from_reports_success_and_actually_drops_the_entry() {
+        let mut file = CredentialsFile::load(temp_credentials_path("remove-hit")).unwrap();
+        file.set("zai", "sk-value");
+
+        let (message, removed) = remove_from(&mut file, "credentials.toml", "zai");
+        assert!(removed);
+        assert!(message.contains("removed"));
+        assert_eq!(file.get("zai"), None);
+    }
+
+    #[test]
+    fn remove_from_reports_absence_without_erroring() {
+        let mut file = CredentialsFile::load(temp_credentials_path("remove-miss")).unwrap();
+        let (message, removed) = remove_from(&mut file, "credentials.toml", "nonexistent");
+        assert!(!removed, "removing an absent entry must not claim success");
+        assert!(message.contains("nothing to remove"));
+    }
+
+    // ---- list: masked, and consistent with the #249 source labels -------
+
+    #[test]
+    fn list_lines_shows_a_redacted_preview_never_the_raw_value() {
+        let mut file = CredentialsFile::load(temp_credentials_path("list-masked")).unwrap();
+        file.set("zai", "sk-super-secret-value-1234");
+        let settings = Settings::default();
+
+        let lines = list_lines(&file, &settings);
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].contains("sk-super-secret-value-1234"));
+        assert!(lines[0].contains("zai"));
+        assert!(lines[0].contains("credentials.toml"));
+    }
+
+    #[test]
+    fn list_lines_notes_when_an_env_var_shadows_the_stored_key() {
+        let _env = crate::test_env::lock();
+        // `provider_config_for` derives `<ID>_API_KEY` (uppercased,
+        // punctuation folded to `_`) for an id that matches no built-in or
+        // settings.json entry — this id's derived var is
+        // `STELLA_TEST_AUTH_LIST_SHADOW_API_KEY` (see
+        // `config::derived_env_var`'s own test for the exact rule).
+        let provider_id = "stella-test-auth-list-shadow";
+        let env_var = "STELLA_TEST_AUTH_LIST_SHADOW_API_KEY";
+        // SAFETY: guarded by test_env's lock; a unique var name unused
+        // elsewhere.
+        unsafe {
+            std::env::set_var(env_var, "sk-from-env");
+        }
+        let mut file = CredentialsFile::load(temp_credentials_path("list-shadow")).unwrap();
+        file.set(provider_id, "sk-from-credentials-file");
+        let settings = Settings::default();
+
+        let lines = list_lines(&file, &settings);
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains(&format!("shadowed by env:{env_var}")),
+            "expected a shadow note naming the winning env var, got: {}",
+            lines[0]
+        );
+
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    #[test]
+    fn list_lines_is_empty_when_nothing_stored() {
+        let file = CredentialsFile::load(temp_credentials_path("list-empty")).unwrap();
+        assert!(list_lines(&file, &Settings::default()).is_empty());
+    }
+}

--- a/stella-cli/src/credential_status.rs
+++ b/stella-cli/src/credential_status.rs
@@ -62,6 +62,33 @@ pub fn status_for(
     }
 }
 
+/// The [`ProviderConfig`] to resolve `id` against for display purposes: a
+/// built-in (with any settings.json override applied), a settings-defined
+/// custom provider, or — for an id that matches neither (e.g. a key stored
+/// via `stella auth set` ahead of the provider being declared in
+/// settings.json) — a minimal synthesized one using the same
+/// `<ID>_API_KEY` convention `config::custom_provider` falls back to.
+pub fn provider_config_for(id: &str, settings: &Settings) -> ProviderConfig {
+    if let Some(p) = config::PROVIDERS.iter().find(|p| p.id == id) {
+        return config::effective_builtin(p, settings);
+    }
+    if let Some(entry) = settings.providers.get(id)
+        && let Ok(p) = config::custom_provider(id, entry)
+    {
+        return p;
+    }
+    ProviderConfig {
+        id: Box::leak(id.to_string().into_boxed_str()),
+        env_var: Box::leak(config::derived_env_var(id).into_boxed_str()),
+        env_var_aliases: &[],
+        display_name: Box::leak(id.to_string().into_boxed_str()),
+        default_model: "",
+        base_url: "",
+        dialect: config::Dialect::OpenaiCompatible,
+        seeded: false,
+    }
+}
+
 /// A one-line summary of which project `.env*` files contributed which
 /// variable NAMES (never values) — the same information `STELLA_ENV_DEBUG`
 /// prints to stderr, but surfaced unconditionally in `stella config` rather
@@ -266,5 +293,22 @@ mod tests {
     #[test]
     fn env_files_summary_is_none_when_nothing_loaded() {
         assert!(env_files_summary(&Loaded::default()).is_none());
+    }
+
+    // ---- provider_config_for: unknown-id fallback for `stella auth list` ---
+
+    #[test]
+    fn provider_config_for_unknown_id_derives_the_conventional_env_var() {
+        let settings = Settings::default();
+        let p = provider_config_for("my-custom-gateway", &settings);
+        assert_eq!(p.id, "my-custom-gateway");
+        assert_eq!(p.env_var, "MY_CUSTOM_GATEWAY_API_KEY");
+    }
+
+    #[test]
+    fn provider_config_for_known_builtin_uses_its_real_env_var() {
+        let settings = Settings::default();
+        let p = provider_config_for("anthropic", &settings);
+        assert_eq!(p.env_var, "ANTHROPIC_API_KEY");
     }
 }

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -20,6 +20,7 @@
 mod agent;
 mod agents_installed;
 mod attachments;
+mod auth_cmd;
 mod candidate_ws;
 mod claims;
 mod command_deck;
@@ -383,8 +384,53 @@ enum Command {
     /// Show current configuration
     Config,
 
+    /// Manage BYOK provider keys stored in
+    /// ~/.config/stella/credentials.toml (set/remove/list) — keys resolved
+    /// via an env var or settings.json still take precedence per the normal
+    /// chain; `stella models`/`stella config` show which source actually
+    /// wins. Never prints a secret value; needs no model API key itself.
+    Auth {
+        #[command(subcommand)]
+        cmd: AuthCmd,
+    },
+
     /// Print the version and exit
     Version,
+}
+
+/// `stella auth` subcommands — the whole `~/.config/stella/credentials.toml`
+/// management surface. Deliberately small: a handful of BYOK keys, not a
+/// config language (mirrors `CredentialsFile`'s own doc intent).
+#[derive(Subcommand)]
+pub enum AuthCmd {
+    /// Store (or replace) a provider's API key in credentials.toml.
+    Set {
+        /// Provider id (a built-in like `zai`/`anthropic`/`openai`, or a
+        /// settings.json-defined custom provider id)
+        provider: String,
+
+        /// Pass the key directly on the command line. WARNING: this value
+        /// becomes visible in shell history and `ps` output — prefer
+        /// --stdin, or omit both flags for an interactive masked prompt.
+        #[arg(long, conflicts_with = "stdin")]
+        key: Option<String>,
+
+        /// Read the key from stdin (one line, trimmed) instead of a flag or
+        /// an interactive prompt — for scripts, e.g. `printf '%s' "$KEY" | \
+        /// stella auth set zai --stdin`.
+        #[arg(long)]
+        stdin: bool,
+    },
+
+    /// Remove a provider's stored key from credentials.toml.
+    Remove {
+        /// Provider id
+        provider: String,
+    },
+
+    /// List providers with a key stored in credentials.toml (redacted
+    /// preview + resolution source).
+    List,
 }
 
 /// `stella models` subcommands — the model-catalog surface. A bare
@@ -1072,6 +1118,13 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             }
             return connect_cmd::run(cmd);
         }
+        Some(Command::Auth { cmd }) => {
+            // Reads/writes ~/.config/stella/credentials.toml directly — no
+            // provider needs to already resolve (this is often how the
+            // FIRST key gets configured), so this short-circuits before
+            // `Config::load` like `Connect`/`Mcp` do.
+            return auth_cmd::run(cmd);
+        }
         Some(Command::Observe { port, open }) => {
             // Loopback-only dashboard over local telemetry — no provider or
             // API key required; the stores are opened strictly read-only.
@@ -1234,6 +1287,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Memory { .. }
         | Command::Mcp { .. }
         | Command::Connect { .. }
+        | Command::Auth { .. }
         | Command::Observe { .. }
         | Command::Models { .. }
         | Command::Version => {

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -7,7 +7,7 @@
 
 use clap::{CommandFactory, Parser};
 
-use super::{Cli, Command, ConnectCmd, OutputFormat};
+use super::{AuthCmd, Cli, Command, ConnectCmd, OutputFormat};
 
 /// clap's own consistency audit (conflicting ids, broken defaults,
 /// mis-typed value parsers) — panics on the first violation. Runs the same
@@ -167,4 +167,69 @@ fn connect_linear_paste_key_parses() {
         }) => assert!(!paste_key),
         _ => panic!("expected `connect linear`"),
     }
+}
+
+/// `stella auth set <provider> --key <k>` parses, and the global `--api-key`
+/// (a different secret — the model-provider credential) still parses
+/// independently on the same command line, same shape as `connect linear`.
+#[test]
+fn auth_set_key_parses_and_stays_independent_of_the_global_api_key() {
+    let cli = Cli::try_parse_from([
+        "stella",
+        "auth",
+        "set",
+        "zai",
+        "--key",
+        "sk-stored",
+        "--api-key",
+        "sk-model",
+    ])
+    .expect("`auth set <provider> --key <k>` must parse alongside the global --api-key");
+    assert_eq!(cli.globals.api_key.as_deref(), Some("sk-model"));
+    match cli.command {
+        Some(Command::Auth {
+            cmd:
+                AuthCmd::Set {
+                    provider,
+                    key,
+                    stdin,
+                },
+        }) => {
+            assert_eq!(provider, "zai");
+            assert_eq!(key.as_deref(), Some("sk-stored"));
+            assert!(!stdin);
+        }
+        _ => panic!("expected `auth set`"),
+    }
+}
+
+/// `--key` and `--stdin` are mutually exclusive — a user meaning to pipe a
+/// secret in via `--stdin` must not silently also accept a (likely absent)
+/// `--key` value.
+#[test]
+fn auth_set_rejects_key_and_stdin_together() {
+    // `Cli` derives no `Debug` (it carries the model API key), so match
+    // rather than `expect_err`/`unwrap_err` (both require `T: Debug`).
+    match Cli::try_parse_from(["stella", "auth", "set", "zai", "--key", "sk-x", "--stdin"]) {
+        Err(e) => assert_eq!(e.kind(), clap::error::ErrorKind::ArgumentConflict),
+        Ok(_) => panic!("--key and --stdin must conflict"),
+    }
+}
+
+#[test]
+fn auth_remove_and_list_parse() {
+    let cli = Cli::try_parse_from(["stella", "auth", "remove", "zai"])
+        .expect("`auth remove <provider>` must parse");
+    match cli.command {
+        Some(Command::Auth {
+            cmd: AuthCmd::Remove { provider },
+        }) => assert_eq!(provider, "zai"),
+        _ => panic!("expected `auth remove`"),
+    }
+
+    let cli = Cli::try_parse_from(["stella", "auth", "list"]).expect("`auth list` must parse");
+    assert!(matches!(
+        cli.command,
+        Some(Command::Auth { cmd: AuthCmd::List })
+    ));
 }

--- a/stella-model/src/credential.rs
+++ b/stella-model/src/credential.rs
@@ -272,6 +272,13 @@ impl CredentialsFile {
         self.data.credentials.get(provider_id).map(String::as_str)
     }
 
+    /// Every provider id currently stored, alphabetically (the underlying
+    /// map is a `BTreeMap`, so this is already sorted) — for `stella auth
+    /// list`, which enumerates the file rather than looking up one id.
+    pub fn provider_ids(&self) -> impl Iterator<Item = &str> {
+        self.data.credentials.keys().map(String::as_str)
+    }
+
     /// Set (or replace) `provider_id`'s key in memory. Call `save` to
     /// persist — kept separate so a caller can batch multiple sets into one
     /// write.
@@ -279,6 +286,12 @@ impl CredentialsFile {
         self.data
             .credentials
             .insert(provider_id.to_string(), value.into());
+    }
+
+    /// Remove `provider_id`'s key from memory, if present. Returns whether
+    /// an entry existed. Call `save` to persist.
+    pub fn remove(&mut self, provider_id: &str) -> bool {
+        self.data.credentials.remove(provider_id).is_some()
     }
 
     /// Write the current in-memory state to disk, creating parent
@@ -557,12 +570,45 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    // ---- empty (degrade-a-listing-command posture) -----------------------
+    // ---- remove / provider_ids / empty (stella auth set/remove/list) ----
+
+    #[test]
+    fn remove_reports_whether_an_entry_existed_and_drops_it() {
+        let path = temp_credentials_path("remove");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+        file.set("zai", "sk-zai-secret");
+
+        assert!(file.remove("zai"), "removing a present entry reports true");
+        assert_eq!(file.get("zai"), None);
+        assert!(
+            !file.remove("zai"),
+            "removing an already-absent entry reports false, not a panic"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn provider_ids_lists_every_stored_id_alphabetically() {
+        let path = temp_credentials_path("provider-ids");
+        let _ = std::fs::remove_file(&path);
+        let mut file = CredentialsFile::load(&path).unwrap();
+        file.set("zai", "sk-1");
+        file.set("anthropic", "sk-2");
+        file.set("openai", "sk-3");
+
+        let ids: Vec<&str> = file.provider_ids().collect();
+        assert_eq!(ids, vec!["anthropic", "openai", "zai"]);
+
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn empty_file_has_no_entries_and_refuses_to_save() {
         let file = CredentialsFile::empty();
         assert_eq!(file.get("zai"), None);
+        assert_eq!(file.provider_ids().count(), 0);
         assert!(matches!(
             file.save().unwrap_err(),
             CredentialError::FileWrite { .. }


### PR DESCRIPTION
Fixes #251

Stacked on #293 (feat/credential-status-source, issue #249) — reuses its `credential_status` module and the new `CredentialSource::SettingsJson` distinction. Base will need retargeting to `main` once #293 merges (or GitHub may do it automatically).

## Summary
A small `stella auth` command group over `~/.config/stella/credentials.toml`, matching the file's own doc intent — a handful of BYOK keys, not a config language:

- `stella auth set <provider> [--key <k> | --stdin]` — writes/replaces a key, creating the file 0600. `--key` warns that the value leaks into shell history/`ps`; `--stdin` (one line, trimmed) or the default interactive `rpassword`-masked prompt are the preferred paths. `--key`/`--stdin` are mutually exclusive (clap `conflicts_with`).
- `stella auth remove <provider>` — removes an entry, reporting (not erroring) when absent, per the spec.
- `stella auth list` — shows every stored provider's redacted preview, and flags when an env var or settings.json literal currently shadows the stored key (reuses `credential_status::status_for` so this can never disagree with `stella models`/`stella config`).

Every command masks the secret value in all of its own output; the only place a plaintext key is ever written is the 0600 credentials file itself. `set`/`remove`/`list` each split into a pure core (operates on an already-loaded `&mut CredentialsFile`, returns the lines to print) and a thin wrapper that touches the real `~/.config/stella/credentials.toml` — this is what lets the core be unit tested against a temp-path file instead of ever touching a developer's actual credentials file.

## Test plan
- [x] `cargo test -p stella-cli --bin stella` — 323 passed (includes 9 `auth_cmd` tests + 3 CLI-parsing tests)
- [x] `cargo test -p stella-model` — 194 (lib) + 1 (integration) passed
- [x] `cargo clippy -p stella-cli -p stella-model --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` applied
- [x] `sh scripts/check-file-sizes.sh` — OK, all files within the ratchet
- [x] Witness tests: `set_then_save_writes_the_real_file_0600` (perms), `set_in_stores_the_key_but_never_echoes_it_in_the_confirmation_message` (masked stdout), `remove_from_reports_success_and_actually_drops_the_entry` / `remove_from_reports_absence_without_erroring`, `list_lines_shows_a_redacted_preview_never_the_raw_value` / `list_lines_notes_when_an_env_var_shadows_the_stored_key`
- [x] CLI-parsing tests: `auth_set_key_parses_and_stays_independent_of_the_global_api_key`, `auth_set_rejects_key_and_stdin_together`, `auth_remove_and_list_parse`
