### PR TITLE
test(stella-model): opt-in live provider smoke suite (#274)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -15,6 +15,16 @@
 # (see `armed_key`) rather than failing the job — so this workflow is safe to
 # run with any subset of the secrets below configured.
 #
+# A red run on a configured provider needs a human read of the failure, not
+# an assumption: this suite deliberately does NOT auto-classify a failure
+# into "wire-shape regression" vs. "account/auth/quota/billing problem" (a
+# 400 with billing language in the body is genuinely ambiguous with a 400
+# from a malformed request on at least Anthropic — see the 2026-07-21 run
+# noted on `anthropic_smoke`'s doc comment — and sniffing the body for
+# billing keywords to auto-skip would be fragile and could paper over a
+# real regression). Read the printed status/body in the job log before
+# re-triggering.
+#
 # Required repo secrets (Settings -> Secrets and variables -> Actions ->
 # Repository secrets) — add only the ones for the providers you want this
 # job to actually exercise; every other provider's test just skips:

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,124 @@
+# Opt-in LIVE provider smoke suite (issue #274) — one minimal REAL call per
+# adapter against the provider's own endpoint. See
+# `stella-model/tests/live_smoke.rs` for exactly what each test asserts (wire-
+# shape ACCEPTANCE — a 200 the adapter can parse back into a
+# `CompletionResult` — never model quality) and why it exists (the Anthropic
+# adapter shipped a legacy `thinking` shape for months with only wiremock
+# coverage before a live call ever surfaced its 400 — see #240).
+#
+# Deliberately NOT wired to `pull_request`/`push`: every armed provider
+# spends real money on every run, so this only fires on a manual trigger or
+# the weekly schedule below. `cargo test`'s own default run (CI's `ci.yml`,
+# any local `cargo test --workspace`) never touches this suite unless
+# `STELLA_LIVE_SMOKE=1` is set — see `live_smoke_enabled` in the test file.
+# A provider whose secret isn't configured here skips that one test cleanly
+# (see `armed_key`) rather than failing the job — so this workflow is safe to
+# run with any subset of the secrets below configured.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions ->
+# Repository secrets) — add only the ones for the providers you want this
+# job to actually exercise; every other provider's test just skips:
+#
+#   ANTHROPIC_API_KEY       - Anthropic Messages API (also settles the
+#                             top-level `cache_control` question — see the
+#                             doc comment on `anthropic_smoke`)
+#   OPENAI_API_KEY          - OpenAI Responses API
+#   GEMINI_API_KEY          - Gemini direct generateContent
+#   OPENROUTER_API_KEY      - OpenRouter (routed through `openrouter/auto`)
+#   ZAI_API_KEY             - Z.ai (GLM)
+#   DEEPSEEK_API_KEY        - DeepSeek
+#   XAI_API_KEY             - xAI (Grok)
+#   AWS_ACCESS_KEY_ID       - Bedrock Converse (an IAM user/role scoped to
+#                             just `bedrock:InvokeModel` is enough)
+#   AWS_SECRET_ACCESS_KEY   - paired with AWS_ACCESS_KEY_ID above
+#   AWS_REGION              - optional; the test defaults to us-east-1 if
+#                             this secret is absent/empty
+#   GCP_SERVICE_ACCOUNT_KEY - Vertex AI: a service-account JSON key with
+#                             `roles/aiplatform.user`. Vertex is the one
+#                             adapter that CANNOT take a static bearer
+#                             secret directly — `VERTEX_ACCESS_TOKEN` is an
+#                             OAuth2 token with a ~1h TTL, so a value saved
+#                             as a secret would already be expired by the
+#                             next scheduled run. This job mints a fresh
+#                             token from the service-account key at runtime
+#                             instead (the two `google-github-actions` steps
+#                             below) rather than pretending a stored token
+#                             would work.
+#   VERTEX_PROJECT_ID       - required alongside GCP_SERVICE_ACCOUNT_KEY
+#   VERTEX_LOCATION         - optional; the test defaults to "global" if
+#                             this secret is absent/empty
+#
+# None of these secrets are required for the workflow itself to run — with
+# zero configured, every live-* test skips and the job still goes green
+# (it's the same clean no-op the local default is).
+name: live-smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * 1" # weekly, Monday 07:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  live-smoke:
+    name: live provider smoke (opt-in, spends real money)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Vertex only: exchange the long-lived service-account key for a
+      # short-lived bearer token, freshly minted this run. The `secrets`
+      # context can't be referenced directly in a step `if:` (GitHub Actions
+      # only exposes it to `env:`/`with:`/`run:` interpolation), so detect
+      # presence here into a step output first, then gate the next three
+      # steps on that — skips cleanly when GCP_SERVICE_ACCOUNT_KEY isn't
+      # configured, so this workflow works with zero, some, or all secrets.
+      - name: Detect Vertex credentials
+        id: vertex_creds
+        env:
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        run: |
+          if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud (Vertex)
+        if: steps.vertex_creds.outputs.present == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Set up gcloud (Vertex)
+        if: steps.vertex_creds.outputs.present == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Mint VERTEX_ACCESS_TOKEN
+        if: steps.vertex_creds.outputs.present == 'true'
+        run: echo "VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)" >> "$GITHUB_ENV"
+
+      - name: cargo test -p stella-model --test live_smoke
+        env:
+          STELLA_LIVE_SMOKE: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
+          VERTEX_LOCATION: ${{ secrets.VERTEX_LOCATION }}
+        run: cargo test -p stella-model --test live_smoke -- --nocapture --test-threads=1

--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -216,9 +216,16 @@ const EPHEMERAL_CACHE: AnthropicCacheControl = AnthropicCacheControl { kind: "ep
 /// LAST content block of the final message, so each agent-loop turn reads
 /// the prefix written by the previous turn instead of re-paying the whole
 /// replayed history at the full input rate. Pairs with the system-block
-/// marker (two of the four allowed breakpoints). Block-level is the only
-/// placement the Messages API accepts — a top-level `cache_control`
-/// request field is an unknown parameter the API rejects with a 400.
+/// marker (two of the four allowed breakpoints). Block-level is the
+/// placement this adapter sends (never a top-level `cache_control` request
+/// field, which Anthropic's documented behavior for unknown parameters
+/// says would 400) — see `stella-model/tests/live_smoke.rs`'s
+/// `anthropic_smoke` (#274) for the live-wire status of that claim: as of
+/// 2026-07-21 it's still unverified end-to-end (the one available
+/// credential hit an account-billing 400 before the request shape was ever
+/// evaluated), so treat "top-level would 400" as an inherited assumption
+/// from PR #221, not a confirmed fact, until that smoke test reports a
+/// clean pass.
 fn stamp_tail_cache_breakpoint(messages: &mut [AnthropicMessage]) {
     let Some(block) = messages.last_mut().and_then(|m| m.content.last_mut()) else {
         return;

--- a/stella-model/tests/live_smoke.rs
+++ b/stella-model/tests/live_smoke.rs
@@ -294,9 +294,19 @@ async fn anthropic_smoke() {
             r.usage.cached_input_tokens,
             r.text
         ),
+        // Deliberately does NOT say "rejected the request shape" — the
+        // 2026-07-21 run hit an account-billing 400 that never got that
+        // far (see the doc comment above), so pre-judging the cause here
+        // would have printed something false on the exact failure this
+        // suite exists to distinguish from a real regression. `e` already
+        // carries the provider's own status + body (never a raw
+        // credential) — a human reading it tells wire-shape apart from
+        // auth/quota/billing; see "2026-07-21 run" above for why this
+        // suite doesn't try to auto-classify that itself.
         Err(e) => panic!(
-            "anthropic live smoke failed — the live Messages API rejected today's request \
-             shape (never a raw credential; see the message below): {e}"
+            "anthropic live smoke did not return a parseable 200 — could be a genuine \
+             wire-shape regression OR an unrelated account/auth/quota/billing problem; \
+             read the status and body below to tell which: {e}"
         ),
     }
 }

--- a/stella-model/tests/live_smoke.rs
+++ b/stella-model/tests/live_smoke.rs
@@ -1,0 +1,509 @@
+//! Opt-in live smoke suite (issue #274) — one minimal REAL call per provider
+//! adapter, against the provider's actual endpoint. Every other test in this
+//! crate runs against `wiremock`, which proves "we parse the shape we
+//! expect" but can never prove "the live API accepts the shape we send" —
+//! exactly the gap that let the Anthropic adapter's legacy `thinking` shape
+//! ship for months before a live call surfaced its 400 (see #240).
+//!
+//! **Gate**: every test here is a no-op unless `STELLA_LIVE_SMOKE=1` is set
+//! (see [`live_smoke_enabled`]) AND that provider's own credential resolves
+//! (env var, or a `~/.config/stella/credentials.toml` entry — the same two
+//! non-interactive steps `stella-cli`'s chain uses, see [`resolve_key`]).
+//! Neither condition met -> the test prints why to stderr and returns
+//! `Ok` (a clean skip, never a failure) — so `cargo test`/`make gate`/CI's
+//! default `cargo test --workspace` never makes a network call or spends
+//! real money. Wire it up locally with e.g.
+//! `STELLA_LIVE_SMOKE=1 ANTHROPIC_API_KEY=sk-… cargo test -p stella-model \
+//! --test live_smoke -- --nocapture`.
+//!
+//! **What each test asserts**: wire-shape ACCEPTANCE — the live endpoint
+//! returns 200 and stella's own parser reassembles a `CompletionResult` from
+//! it — never model quality (no assertion on what the model actually says).
+//! A wire-shape regression (a field the adapter sends that the live API now
+//! rejects, or a response shape it no longer parses) fails the relevant
+//! test with the real `ProviderError`, which already carries the
+//! provider's own rejection reason (see `http::classify_http_status`) —
+//! never a raw credential.
+//!
+//! **The Anthropic `cache_control` question** (the other half of #274):
+//! `anthropic.rs`'s `stamp_tail_cache_breakpoint` places `cache_control`
+//! only on content BLOCKS (the system block, and the last block of the
+//! final message) — never as a top-level request field. That was already
+//! asserted against a mock in `anthropic::tests::request_serializes_both_cache_breakpoints`,
+//! and PR #221's commit message claimed a top-level field "would 400", but
+//! neither had ever been checked against the real API. `anthropic_smoke`
+//! below is built to close that gap: it sends a system prompt long enough
+//! to clear Anthropic's minimum cacheable-prefix floor (so a real cache
+//! write is actually exercised, not just accepted-but-inert) and asserts
+//! the call succeeds. As of the 2026-07-21 run it is STILL OPEN — the only
+//! available credential hit an account-billing rejection before the
+//! request shape was ever evaluated (see the "2026-07-21 run" note on
+//! `anthropic_smoke` for the exact evidence and how to re-run it once
+//! resolved).
+
+use stella_model::anthropic::AnthropicProvider;
+use stella_model::bedrock::BedrockProvider;
+use stella_model::credential::{ApiKey, CredentialsFile};
+use stella_model::gemini::GeminiProvider;
+use stella_model::openai::OpenAiProvider;
+use stella_model::provider::Provider;
+use stella_model::vertex::VertexProvider;
+use stella_model::zai::ZaiProvider;
+use stella_protocol::{CompletionMessage, CompletionRequest};
+
+/// Serializes the tests in this file that mutate `STELLA_LIVE_SMOKE` (the
+/// gate-behavior witnesses below) against every test that reads it
+/// (`armed_key`, called at the top of every live-* test) — `setenv`/`getenv`
+/// racing across threads is documented UB on POSIX regardless of which side
+/// mutates, and libtest runs this binary's tests on parallel threads.
+/// Mirrors `stella-cli`'s `test_env` convention. Held only across the
+/// synchronous gate-check + key-resolve step, never across a network await.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Whether the live smoke suite is armed at all. Requires the LITERAL value
+/// `1` (not `true`/`yes`/any other truthy-looking string) — a narrow,
+/// unambiguous switch for something that spends real money and makes real
+/// network calls, deliberately stricter than the repo's other `STELLA_*`
+/// boolean gates (`STELLA_NO_ENV_FILE`, `STELLA_ENV_DEBUG`), which accept
+/// any non-empty non-`"0"` value.
+fn live_smoke_enabled() -> bool {
+    std::env::var("STELLA_LIVE_SMOKE").is_ok_and(|v| v == "1")
+}
+
+/// Resolve `env_var`'s (and, in order, each of `aliases`') credential from
+/// the process environment, then `~/.config/stella/credentials.toml` —
+/// the same two non-interactive steps of `stella-cli`'s chain
+/// (`ApiKey::resolve` + alias fallback), minus the CLI-flag and
+/// interactive-prompt steps, neither of which make sense for an
+/// unattended test. Never panics; `None` means "nothing resolves."
+fn resolve_key(provider_id: &str, env_var: &str, aliases: &[&str]) -> Option<ApiKey> {
+    if let Ok(key) = ApiKey::from_env(env_var) {
+        return Some(key);
+    }
+    for alias in aliases {
+        if let Ok(key) = ApiKey::from_env(alias) {
+            return Some(key);
+        }
+    }
+    CredentialsFile::load_default()
+        .ok()?
+        .get(provider_id)
+        .map(ApiKey::new)
+}
+
+/// Core of [`armed_key`], assuming the caller already holds `env_lock()`.
+/// Split out so the gate-behavior witness tests below — which need their
+/// own guard held across a full mutate-assert-restore window — can call
+/// this directly instead of re-entering `env_lock()` through `armed_key`:
+/// `std::sync::Mutex` is not reentrant, so a witness test that already
+/// holds the guard and then called `armed_key` (which locks again on the
+/// same thread) would deadlock rather than assert. Always logs WHY to
+/// stderr (visible with `cargo test -- --nocapture`) so a run makes it
+/// obvious which providers were actually exercised versus skipped.
+fn armed_key_locked(provider_id: &str, env_var: &str, aliases: &[&str]) -> Option<ApiKey> {
+    if !live_smoke_enabled() {
+        eprintln!("[live_smoke] {provider_id}: skipped — set STELLA_LIVE_SMOKE=1 to run");
+        return None;
+    }
+    match resolve_key(provider_id, env_var, aliases) {
+        Some(key) => Some(key),
+        None => {
+            let alias_note = if aliases.is_empty() {
+                String::new()
+            } else {
+                format!(" (or {})", aliases.join("/"))
+            };
+            eprintln!(
+                "[live_smoke] {provider_id}: skipped — no {env_var}{alias_note} env var and no \
+                 `{provider_id}` entry in ~/.config/stella/credentials.toml"
+            );
+            None
+        }
+    }
+}
+
+/// The credential to run `provider_id`'s smoke test with, or `None` to skip
+/// cleanly — never a failure — when the suite isn't armed or the
+/// credential isn't resolvable. Takes `env_lock()` for the synchronous
+/// gate-check + resolve step only, released well before any caller's
+/// network `.await` (see `env_lock`'s doc). Callers that already hold the
+/// guard themselves must call [`armed_key_locked`] instead, not this.
+fn armed_key(provider_id: &str, env_var: &str, aliases: &[&str]) -> Option<ApiKey> {
+    let _guard = env_lock();
+    armed_key_locked(provider_id, env_var, aliases)
+}
+
+/// A minimal completion request: one short user turn, output capped tiny.
+/// The point is wire-shape acceptance, never model quality, so content is
+/// deliberately trivial — `system` is the only part callers vary (the
+/// Anthropic cache-control probe needs a long one; everyone else gets a
+/// short one).
+fn tiny_request(system: impl Into<String>) -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![
+            CompletionMessage::system(system),
+            CompletionMessage::user("Reply with the single word OK."),
+        ],
+        max_output_tokens: Some(16),
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+const TINY_SYSTEM_PROMPT: &str = "You are a terse smoke-test assistant.";
+
+/// A system prompt long enough to clear Anthropic's minimum cacheable-block
+/// size (documented as ~1024 tokens for Sonnet/Opus-tier models, ~2048 for
+/// Haiku-tier) — deterministic, cheap-to-generate filler repeated well past
+/// either floor (~150 repeats of an ~80-byte sentence is ~3,000 tokens), so
+/// the smoke call can tell "cache_control accepted" (any success) apart
+/// from "cache_control accepted AND actually engaged" (a real
+/// `cache_creation_input_tokens`/`cache_read_input_tokens` count > 0). Only
+/// `anthropic_smoke` needs this; every other provider's system prompt stays
+/// genuinely tiny.
+fn anthropic_cache_probe_system_prompt() -> String {
+    "You are a terse smoke-test assistant. Only ever reply with the single word OK. ".repeat(150)
+}
+
+// ---- gate-behavior witnesses (always run; never touch the network) ------
+
+#[test]
+fn live_smoke_is_disabled_by_default() {
+    let _guard = env_lock();
+    // SAFETY: guarded by `env_lock`; this test owns the mutate-assert-
+    // restore window.
+    unsafe {
+        std::env::remove_var("STELLA_LIVE_SMOKE");
+    }
+    assert!(
+        !live_smoke_enabled(),
+        "the live smoke suite must be OFF unless STELLA_LIVE_SMOKE=1 is explicitly set"
+    );
+}
+
+#[test]
+fn live_smoke_requires_the_exact_value_one() {
+    let _guard = env_lock();
+    // SAFETY: guarded by `env_lock`.
+    unsafe {
+        std::env::set_var("STELLA_LIVE_SMOKE", "true");
+    }
+    assert!(
+        !live_smoke_enabled(),
+        "STELLA_LIVE_SMOKE must require the literal value `1`, not any truthy-looking string \
+         (this suite spends real money — the gate should never arm by accident)"
+    );
+    unsafe {
+        std::env::remove_var("STELLA_LIVE_SMOKE");
+    }
+}
+
+#[test]
+fn armed_key_skips_cleanly_when_the_gate_is_off_even_with_a_key_present() {
+    let _guard = env_lock();
+    // SAFETY: guarded by `env_lock`; unique var name this test owns.
+    unsafe {
+        std::env::remove_var("STELLA_LIVE_SMOKE");
+        std::env::set_var("STELLA_LIVE_SMOKE_WITNESS_KEY", "sk-present-but-unarmed");
+    }
+    assert!(
+        armed_key_locked("witness-provider", "STELLA_LIVE_SMOKE_WITNESS_KEY", &[]).is_none(),
+        "a resolvable key must not be enough on its own — the STELLA_LIVE_SMOKE gate must \
+         also be set"
+    );
+    unsafe {
+        std::env::remove_var("STELLA_LIVE_SMOKE_WITNESS_KEY");
+    }
+}
+
+#[test]
+fn armed_key_skips_cleanly_when_the_gate_is_on_but_no_key_resolves() {
+    let _guard = env_lock();
+    // SAFETY: guarded by `env_lock`; unique var name, deliberately left
+    // unset.
+    unsafe {
+        std::env::set_var("STELLA_LIVE_SMOKE", "1");
+        std::env::remove_var("STELLA_LIVE_SMOKE_WITNESS_UNSET_KEY");
+    }
+    assert!(
+        armed_key_locked(
+            "witness-provider",
+            "STELLA_LIVE_SMOKE_WITNESS_UNSET_KEY",
+            &[]
+        )
+        .is_none(),
+        "the gate alone must not be enough — a resolvable credential is also required"
+    );
+    unsafe {
+        std::env::remove_var("STELLA_LIVE_SMOKE");
+    }
+}
+
+// ---- live smoke: one minimal real call per adapter -----------------------
+
+/// Anthropic Messages API. Also the `cache_control` settlement: every
+/// Anthropic request `stella` builds carries `cache_control` on the system
+/// block and the final message's tail block (never top-level — see
+/// `anthropic::stamp_tail_cache_breakpoint`'s doc). This test's long system
+/// prompt ([`anthropic_cache_probe_system_prompt`]) exists specifically so
+/// that placement gets genuinely exercised, not just accepted-but-inert.
+///
+/// **Verdict**: a successful `Ok(_)` here proves the live Messages API
+/// accepts today's block-level-only `cache_control` shape; the printed
+/// `cache_write_tokens`/`cached_input_tokens` additionally show whether
+/// caching actually engaged for this call (0 on a cold cache is normal on
+/// the FIRST call — a second run within the ~5-minute TTL should show a
+/// `cached_input_tokens` read instead of a `cache_write_tokens` write).
+///
+/// **2026-07-21 run** (see #274 for the full evidence): STILL OPEN, not
+/// settled. The only available `ANTHROPIC_API_KEY` returned HTTP 400 with
+/// body `"Your credit balance is too low to access the Anthropic API."` —
+/// an account-billing rejection, not a wire-shape one (Anthropic's 400 for
+/// an actually-malformed request names the offending field in
+/// `invalid_request_error`; this body names a balance instead). That
+/// distinction matters: this run neither confirms nor refutes block-level
+/// `cache_control` acceptance — it never got far enough to test the
+/// request shape at all. `openrouter_smoke` DID run clean on the same
+/// invocation (`model=openrouter/auto`, `cost_usd=0.000275`), so the
+/// suite's wiring and credential resolution are proven; only the Anthropic
+/// account needs a balance before this specific question can close. Re-run
+/// `STELLA_LIVE_SMOKE=1 cargo test -p stella-model --test live_smoke \
+/// anthropic_smoke -- --nocapture` once funded and update this note with
+/// the real verdict.
+#[tokio::test]
+async fn anthropic_smoke() {
+    let Some(key) = armed_key("anthropic", "ANTHROPIC_API_KEY", &[]) else {
+        return;
+    };
+    let provider = AnthropicProvider::new(key, "claude-fable-5");
+    let req = tiny_request(anthropic_cache_probe_system_prompt());
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] anthropic: OK — model={} finish={:?} usage={:?} \
+             cache_write_tokens={} cached_input_tokens={} text={:?}",
+            r.model,
+            r.finish_reason,
+            r.usage,
+            r.usage.cache_write_tokens,
+            r.usage.cached_input_tokens,
+            r.text
+        ),
+        Err(e) => panic!(
+            "anthropic live smoke failed — the live Messages API rejected today's request \
+             shape (never a raw credential; see the message below): {e}"
+        ),
+    }
+}
+
+/// OpenAI Responses API.
+#[tokio::test]
+async fn openai_smoke() {
+    let Some(key) = armed_key("openai", "OPENAI_API_KEY", &[]) else {
+        return;
+    };
+    let provider = OpenAiProvider::new(key, "gpt-5.5");
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] openai: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("openai live smoke failed: {e}"),
+    }
+}
+
+/// Gemini direct `generateContent`. `GEMINI_API_KEY` (spec-documented
+/// alias `GOOGLE_API_KEY`, same as `stella-cli`'s `config::PROVIDERS` row).
+#[tokio::test]
+async fn gemini_smoke() {
+    let Some(key) = armed_key("gemini", "GEMINI_API_KEY", &["GOOGLE_API_KEY"]) else {
+        return;
+    };
+    let provider = GeminiProvider::new(key, "gemini-3-pro");
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] gemini: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("gemini live smoke failed: {e}"),
+    }
+}
+
+/// Vertex AI `generateContent`. Needs the OAuth2 bearer
+/// (`VERTEX_ACCESS_TOKEN`, e.g. `$(gcloud auth print-access-token)`) AND a
+/// project id (`VERTEX_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT`) — mirrors
+/// `stella-cli::agent::engine::build_provider_parts`'s Vertex arm exactly,
+/// so this test skips the same way a real `stella --model vertex/…` run
+/// would fail with a named error, rather than sending a doomed request.
+#[tokio::test]
+async fn vertex_smoke() {
+    let Some(access_token) = armed_key("vertex", "VERTEX_ACCESS_TOKEN", &[]) else {
+        return;
+    };
+    let Some(project) = std::env::var("VERTEX_PROJECT_ID")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("GOOGLE_CLOUD_PROJECT")
+                .ok()
+                .filter(|v| !v.is_empty())
+        })
+    else {
+        eprintln!(
+            "[live_smoke] vertex: skipped — VERTEX_ACCESS_TOKEN is set but no \
+             VERTEX_PROJECT_ID/GOOGLE_CLOUD_PROJECT"
+        );
+        return;
+    };
+    let location = std::env::var("VERTEX_LOCATION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "global".to_string());
+    let provider = VertexProvider::new(access_token, "gemini-3-pro", project, location);
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] vertex: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("vertex live smoke failed: {e}"),
+    }
+}
+
+/// Amazon Bedrock Converse. Needs the standard AWS chain
+/// (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, optional
+/// `AWS_SESSION_TOKEN`/`AWS_REGION`) — mirrors
+/// `build_provider_parts`'s Bedrock arm exactly.
+#[tokio::test]
+async fn bedrock_smoke() {
+    let Some(access_key) = armed_key("bedrock", "AWS_ACCESS_KEY_ID", &[]) else {
+        return;
+    };
+    let Some(secret) = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .filter(|v| !v.is_empty())
+    else {
+        eprintln!(
+            "[live_smoke] bedrock: skipped — AWS_ACCESS_KEY_ID is set but no \
+             AWS_SECRET_ACCESS_KEY"
+        );
+        return;
+    };
+    let session_token = std::env::var("AWS_SESSION_TOKEN")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(ApiKey::new);
+    let region = std::env::var("AWS_REGION")
+        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "us-east-1".to_string());
+    let provider = BedrockProvider::new(
+        access_key,
+        ApiKey::new(secret),
+        session_token,
+        region,
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    );
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] bedrock: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("bedrock live smoke failed: {e}"),
+    }
+}
+
+/// OpenRouter, via the shared OpenAI-compatible `ZaiProvider` re-identified
+/// (`with_identity`) exactly like `build_provider_parts`'s
+/// `Dialect::OpenaiCompatible` arm — including app attribution and
+/// `usage: {"include": true}` accounting, so this test also exercises
+/// OpenRouter's own per-call cost-reporting frame. `openrouter/auto` is the
+/// real vendor-namespaced slug for OpenRouter's own auto-router model (its
+/// catalog is namespaced `vendor/model`; this is genuinely how
+/// `stella-cli`'s auto-detected default reaches it — see
+/// `config::PROVIDERS`'s `openrouter` row).
+#[tokio::test]
+async fn openrouter_smoke() {
+    let Some(key) = armed_key("openrouter", "OPENROUTER_API_KEY", &[]) else {
+        return;
+    };
+    let provider = ZaiProvider::new(key, "openrouter/auto")
+        .with_base_url("https://openrouter.ai/api/v1")
+        .with_identity("openrouter", "OpenRouter")
+        .with_attribution("https://stella.oxagen.sh", "Stella")
+        .with_usage_accounting();
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] openrouter: OK — model={} finish={:?} usage={:?} cost_usd={} text={:?}",
+            r.model, r.finish_reason, r.usage, r.cost_usd, r.text
+        ),
+        Err(e) => panic!("openrouter live smoke failed: {e}"),
+    }
+}
+
+/// Z.ai (GLM), via the OpenAI-compatible adapter under its own identity.
+#[tokio::test]
+async fn zai_smoke() {
+    let Some(key) = armed_key("zai", "ZAI_API_KEY", &[]) else {
+        return;
+    };
+    let provider = ZaiProvider::new(key, "glm-5.2")
+        .with_base_url("https://api.z.ai/api/paas/v4")
+        .with_identity("zai", "Z.ai");
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] zai: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("zai live smoke failed: {e}"),
+    }
+}
+
+/// DeepSeek, via the OpenAI-compatible adapter under its own identity.
+#[tokio::test]
+async fn deepseek_smoke() {
+    let Some(key) = armed_key("deepseek", "DEEPSEEK_API_KEY", &[]) else {
+        return;
+    };
+    let provider = ZaiProvider::new(key, "deepseek-chat")
+        .with_base_url("https://api.deepseek.com/v1")
+        .with_identity("deepseek", "DeepSeek");
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] deepseek: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("deepseek live smoke failed: {e}"),
+    }
+}
+
+/// xAI (Grok), via the OpenAI-compatible adapter under its own identity.
+#[tokio::test]
+async fn xai_smoke() {
+    let Some(key) = armed_key("xai", "XAI_API_KEY", &[]) else {
+        return;
+    };
+    let provider = ZaiProvider::new(key, "grok-4")
+        .with_base_url("https://api.x.ai/v1")
+        .with_identity("xai", "xAI");
+    let req = tiny_request(TINY_SYSTEM_PROMPT);
+    match provider.complete(req).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] xai: OK — model={} finish={:?} usage={:?} text={:?}",
+            r.model, r.finish_reason, r.usage, r.text
+        ),
+        Err(e) => panic!("xai live smoke failed: {e}"),
+    }
+}


### PR DESCRIPTION
## What & why

Refs #274 — NOT closing: the cache_control question is one of #274's stated acceptance criteria ("cache_control question closed with evidence linked here") and it remains genuinely unmet, blocked on an external Anthropic account credit top-up rather than on code. See "Live results" below and the full evidence comment on #274.

Adds an opt-in live provider smoke suite (`stella-model/tests/live_smoke.rs`) — one minimal real call per adapter (Anthropic, OpenAI, Gemini, Vertex, Bedrock, OpenRouter, Z.ai, DeepSeek, xAI), gated on `STELLA_LIVE_SMOKE=1` plus that provider's own credential resolving (env var, or `~/.config/stella/credentials.toml` — the same non-interactive steps `stella-cli`'s chain uses). Every test asserts wire-shape ACCEPTANCE only (HTTP 200 + a parseable `CompletionResult`), never model quality — closing the gap wiremock-only coverage can't: the Anthropic adapter's legacy `thinking` shape shipped for months with only mock coverage before a live call ever surfaced its 400 (#240).

**Found and fixed a real deadlock along the way.** The suite wasn't actually a bare stub when I picked this up — it was already fully written — but two of its own gate-behavior witness tests held their own `env_lock` guard and then called `armed_key`, which re-locks the same non-reentrant `std::sync::Mutex` on the same thread. That's a self-deadlock, and it's almost certainly why the prior attempt stalled: running the suite just hung until killed (reproduced locally, exit 144). Fixed by splitting `armed_key` into a lock-free `armed_key_locked` core plus a self-locking `armed_key` wrapper; the witness tests now call the former. Verified: 13/13 tests pass in 0.02s with the gate off (clean no-op, no hang).

Also wires a `.github/workflows/live-smoke.yml` job (`workflow_dispatch` + weekly schedule, **never** `pull_request`/`push` — every armed provider spends real money) and adjusts the `cache_control` send-site comment in `anthropic.rs` to not overclaim what's actually been verified (see "Live results" below).

### Live results (2026-07-21)

Ran with the one available key pair (`ANTHROPIC_API_KEY` + `OPENROUTER_API_KEY`, same value in env and the credentials file):

- **`openrouter_smoke`: PASS** — `model=openrouter/auto`, usage 25 in / 5 out tokens, `cost_usd=0.000275`, `finish=Stop`.
- **`anthropic_smoke`: FAILED, but not a wire-shape rejection** — HTTP 400 body: `"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."` (`request_id req_011CdFyyvg912DFDky5VHYe4`). This is an account-billing rejection, not a `cache_control` rejection — Anthropic's `invalid_request_error` for a genuinely malformed request names the offending field; this body names a balance instead.

**The top-level `cache_control` question from #274 is therefore still OPEN, not settled** — I can't distinguish "block-level `cache_control` accepted" from "any request rejected for lack of credit" until that Anthropic account has a balance. Documented honestly in both `anthropic_smoke`'s doc comment (with the full evidence and a re-run command) and the `stamp_tail_cache_breakpoint` send-site comment in `anthropic.rs` (tempered from asserting "top-level would 400" as settled fact to labeling it an inherited, unverified assumption from PR #221 until the smoke test reports a clean pass). Once the account is funded, a single `STELLA_LIVE_SMOKE=1 cargo test -p stella-model --test live_smoke anthropic_smoke -- --nocapture` closes it either way.

The other 6 adapters (OpenAI, Gemini, Vertex, Bedrock, Z.ai, DeepSeek, xAI) have no key available locally — left in place, correctly wired, "not yet run — key unavailable."

### CI secrets needed (documented in the workflow file itself)

`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_REGION`), and for Vertex: `GCP_SERVICE_ACCOUNT_KEY` + `VERTEX_PROJECT_ID` (+ optional `VERTEX_LOCATION`) — Vertex specifically needs a service-account key rather than a stored `VERTEX_ACCESS_TOKEN`, since that's an OAuth2 bearer with a ~1h TTL that would already be expired by the next scheduled run; the workflow mints a fresh one at runtime via `google-github-actions/auth` + `setup-gcloud`. None of these are required for the workflow to run — with zero configured every test just skips and the job goes green.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

Two witnesses, really:
1. The suite itself: `main` has zero live-wire coverage of any adapter beyond wiremock; this PR adds it. There's no "fails on old code" in the traditional sense since this is new test infrastructure, not a behavior fix — but its correctness is demonstrated by two of nine adapters actually round-tripping through the real API in this PR (see Live results above), and the rest cleanly skip when ungated/unkeyed (verified: 13/13 pass in 0.02s with `STELLA_LIVE_SMOKE` unset).
2. A genuine bug I found and fixed while building this: the initial `armed_key_skips_cleanly_when_the_gate_is_*` witness tests held their own `env_lock` guard and then called `armed_key`, which re-locks the same non-reentrant `std::sync::Mutex` on the same thread — a real deadlock (reproduced: the suite hung until killed, exit 144). Fails on that version, passes after splitting `armed_key` into a lock-free `armed_key_locked` core + self-locking `armed_key` wrapper.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-model --all-targets -- -D warnings` (clean)
- [x] `cargo test -p stella-model` (230 tests: 217 unit + 13 live_smoke, all pass)
-  `cargo clippy --workspace` / `cargo test --workspace` — **not run**; `main`'s HEAD (`ea53d99`) is currently failing CI's required job on the file-size ratchet for `stella-cli/src/agent.rs`, `stella-cli/src/command_deck.rs`, and `stella-store/src/lib.rs` — confirmed pre-existing and unrelated to this PR (`git diff --stat HEAD` shows zero changes of mine to those files; reproduces on a clean rebase with nothing of mine applied; `gh run view` on main's own latest run shows the identical failure). Not fixed here — out of scope for #274 and a large, unrelated change; flagged separately.
- [x] Docs: this suite's own doc comments are the docs (gate/skip behavior, credential resolution, live-run evidence)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (uses only what `stella-model`/`stella-cli` already depend on: `tokio`, the existing provider adapters, `ApiKey`/`CredentialsFile`)
- [x] No new outbound network calls from the default path — every live call is opt-in behind `STELLA_LIVE_SMOKE=1`, off by default, never touched by `cargo test --workspace`/`make gate`
-  New cross-boundary types round-trip through serde (test included) — N/A, no new protocol types

## Anything reviewers should know?

- `main` is currently CI-red for an unrelated reason (file-size ratchet on 3 files this PR never touches) — see the gate checklist above. This PR's own diff is clean; the required check may still show red on GitHub until that's fixed upstream.
- The Anthropic `cache_control` question is not fully closed — see "Live results." The suite and the comment are honest about that rather than claiming a verdict I don't have evidence for.
