### PR TITLE
test(stella-cli): witness the run_pipeline_one_shot approval-wiring composition

### DIFF
--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -518,6 +518,49 @@ fn approval_capability_for_full_tty_text_is_stdio() {
     );
 }
 
+/// The composition gap the incident actually exploited: `approval_capability_for`
+/// and `pipeline_config_for_approval_capability` were each covered above in
+/// isolation, but nothing pinned them wired together the way
+/// `run_pipeline_one_shot` actually wires them (agent.rs, around the
+/// `pipeline_config` construction) — feeding one straight into the other. A
+/// regression that breaks *that* composition (e.g. hardcoding
+/// `PipelineApprovalCapability::Stdio` at the call site instead of using the
+/// computed value) would pass every test above while still shipping the
+/// scope-review bypass this incident (#284 x #297, fixed in #305) shipped.
+#[test]
+fn non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review() {
+    let cfg = cfg_for("zai");
+    let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
+
+    // A non-TTY text-format run (e.g. `stella run` piped in a script or CI)
+    // must not select the interactive stdio approval gate, and its wired
+    // config must stay headless.
+    let text_capability = approval_capability_for(true, false, false);
+    let text_config =
+        pipeline_config_for_approval_capability(&cfg, text_capability, None, &model_ref);
+    assert_ne!(
+        text_capability,
+        PipelineApprovalCapability::Stdio,
+        "a non-tty text run must not select the interactive stdio approval gate"
+    );
+    assert!(
+        text_config.headless,
+        "a non-tty text run's wired config must stay headless"
+    );
+
+    // A JSON-format one-shot run is headless by construction — and even with
+    // both terminal handles real, its wired config must never bypass scope
+    // review; JSON has nowhere to render a prompt regardless of TTY state.
+    let json_capability = approval_capability_for(false, true, true);
+    let json_config =
+        pipeline_config_for_approval_capability(&cfg, json_capability, None, &model_ref);
+    assert!(json_config.headless);
+    assert!(
+        !json_config.headless_bypass_scope_review,
+        "a JSON-format run's wired config must never bypass scope review"
+    );
+}
+
 #[tokio::test]
 async fn candidate_rules_reuse_the_parent_snapshot_after_source_removal() {
     let root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## What

Adds one test that composes `approval_capability_for` and
`pipeline_config_for_approval_capability` the way `run_pipeline_one_shot`
actually wires them together, instead of exercising each in isolation.

## Why

Fast-follow requested after #305 (the #284 x #297 squash-merge incident:
https://github.com/macanderson/stella/pull/305). The existing tests already
pin `approval_capability_for` against every TTY/format combination, and pin
`pipeline_config_for_approval_capability`'s output for hand-picked
`PipelineApprovalCapability` values — but nothing asserted on the two
*wired together* the way the real call site in `run_pipeline_one_shot` does.
That's precisely the shape of gap a future co-landing squash could exploit
again: a regression that breaks the composition (or reintroduces a
`headless_bypass_scope_review` bypass keyed off something other than the
`HEADLESS_SCOPE_REVIEW_BYPASS` constant) would pass every existing test.

New test: `non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review`
asserts:
- a non-TTY text-format run's wired config stays headless and never selects
  the interactive stdio approval gate
- a JSON-format run's wired config never bypasses scope review

## Witness verification

Confirmed this is a genuine witness, not a tautology: temporarily changed
`headless_bypass_scope_review` in `stella-cli/src/agent/engine.rs` to
`approval != PipelineApprovalCapability::Stdio` (the same class of bug the
original incident risked — bypass keyed off approval/TTY state instead of
the safety constant) and reran just this test:

```
test agent::tests::non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review ... FAILED
thread '...' panicked at stella-cli/src/agent_tests.rs:558:5:
a JSON-format run's wired config must never bypass scope review
```

Reverted the injected bug, reran — passes clean. `git diff --stat` against
main after reverting showed only the test file changed.

## Verification

```
cargo test -p stella-cli non_tty_text_run_wiring_stays_headless_and_json_run_wiring_never_bypasses_scope_review
# test result: ok. 1 passed; 0 failed

cargo clippy -p stella-cli --all-targets -- -D warnings
# clean, no warnings

cargo fmt --all
# no diff
```

Test-only change; no production code touched.
