### PR TITLE
fix(engine): two agent-loop defects found running Terminal-Bench 2

### DIFF
--- a/scripts/file-size-ratchet.txt
+++ b/scripts/file-size-ratchet.txt
@@ -9,8 +9,9 @@ stella-core/src/driver/tests.rs 1970
 stella-core/src/rules.rs 1606
 stella-core/src/skills.rs 1518
 stella-model/src/zai.rs 2063
+stella-model/src/zai/tests.rs 1518
 stella-pipeline/src/pipeline.rs 1945
-stella-pipeline/src/pipeline/tests.rs 1299
+stella-pipeline/src/pipeline/tests.rs 1430
 stella-store/src/lib.rs 2035
 stella-store/src/tests.rs 1927
 stella-tools/src/registry.rs 2606

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -303,6 +303,19 @@ fn map_openrouter_effort(effort: ReasoningEffort) -> &'static str {
 /// sends `{"enabled": true}` and lets the gateway pick the level; and
 /// neither set keeps the field off the wire entirely (provider default,
 /// byte-stable with the pre-field body).
+/// Whether a terminal provider error says reasoning cannot be turned off.
+/// Matched on the upstream's own wording rather than a status code: the same
+/// 400 covers every other malformed-request cause, and only this one is
+/// recoverable by resending without the field.
+fn rejects_disabled_reasoning(detail: &str) -> bool {
+    let detail = detail.to_lowercase();
+    detail.contains("reasoning")
+        && (detail.contains("cannot be disabled")
+            || detail.contains("can not be disabled")
+            || detail.contains("is mandatory")
+            || detail.contains("mandatory for this endpoint"))
+}
+
 fn openrouter_reasoning(
     reasoning: Option<bool>,
     effort: Option<ReasoningEffort>,
@@ -827,6 +840,32 @@ impl ZaiProvider {
         req: CompletionRequest,
         observer: Option<&dyn ToolCallObserver>,
     ) -> Result<CompletionResult, ProviderError> {
+        // Some upstreams OpenRouter fronts make reasoning mandatory and answer
+        // `reasoning:{enabled:false}` with a hard 400. The caller's "off" is an
+        // economy preference, never a correctness requirement — losing it must
+        // not lose the call. Resend once, letting the endpoint apply its own
+        // default. Same family of provider-quirk gate as the sampling-param and
+        // thinking-shape omissions in the sibling adapters.
+        let disables_reasoning = self.id == "openrouter" && req.reasoning == Some(false);
+        match self.complete_attempt(req.clone(), observer, false).await {
+            Err(ProviderError::Terminal(detail))
+                if disables_reasoning && rejects_disabled_reasoning(&detail) =>
+            {
+                self.complete_attempt(req, observer, true).await
+            }
+            other => other,
+        }
+    }
+
+    /// One request/stream/aggregate cycle. `force_default_reasoning` drops the
+    /// `reasoning` object from the body so an endpoint that mandates reasoning
+    /// applies its own default instead of rejecting the request.
+    async fn complete_attempt(
+        &self,
+        req: CompletionRequest,
+        observer: Option<&dyn ToolCallObserver>,
+        force_default_reasoning: bool,
+    ) -> Result<CompletionResult, ProviderError> {
         // "Include" semantics: every override is `None` unless the caller
         // set it, and `None` never reaches the wire — a request without
         // params serializes byte-identical to the pre-params body.
@@ -857,7 +896,7 @@ impl ZaiProvider {
                     })
                 })
                 .flatten(),
-            reasoning: (self.id == "openrouter")
+            reasoning: (self.id == "openrouter" && !force_default_reasoning)
                 .then(|| openrouter_reasoning(req.reasoning, req.effort))
                 .flatten(),
             // xAI's Grok reasoning models speak a top-level `reasoning_effort`

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -1441,3 +1441,78 @@ async fn zai_identity_never_sends_reasoning_effort_even_when_pinned() {
 }
 
 mod error_classify_tests;
+
+#[test]
+fn rejects_disabled_reasoning_matches_the_upstream_wording_only() {
+    assert!(rejects_disabled_reasoning(
+        "OpenRouter rejected the request (HTTP 400): Reasoning is mandatory for this \
+         endpoint and cannot be disabled."
+    ));
+    // Any other 400 is a genuine malformed request — resending without the
+    // reasoning field would just burn a second paid call.
+    assert!(!rejects_disabled_reasoning(
+        "OpenRouter rejected the request (HTTP 400): not a valid model id"
+    ));
+    assert!(!rejects_disabled_reasoning(
+        "OpenRouter rejected the request (HTTP 400): temperature must be <= 2"
+    ));
+}
+
+/// An upstream that mandates reasoning answers `reasoning:{enabled:false}`
+/// with a hard 400. The caller's "off" is an economy preference, not a
+/// correctness requirement, so the adapter resends once without the field
+/// rather than failing the call. This is exactly what the pipeline's triage
+/// role hit on every single turn: `reasoning: off` → 400 → dead stage.
+#[tokio::test]
+async fn openrouter_resends_without_reasoning_when_the_endpoint_mandates_it() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    // First attempt carries `enabled:false` and is rejected — once.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains("\"enabled\":false"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            "{\"error\":{\"message\":\"Reasoning is mandatory for this endpoint and \
+             cannot be disabled.\",\"code\":400}}",
+        ))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("classify this")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: Some(stella_protocol::ReasoningEffort::Low),
+        tools: vec![],
+        reasoning: Some(false),
+        params: None,
+    };
+
+    let result = provider.complete(req).await.expect("the resend succeeds");
+    assert_eq!(result.text, "ok");
+
+    let sent = server.received_requests().await.expect("recorded requests");
+    assert_eq!(sent.len(), 2, "exactly one resend, never a retry storm");
+    let first = String::from_utf8_lossy(&sent[0].body);
+    let second = String::from_utf8_lossy(&sent[1].body);
+    assert!(
+        first.contains("\"enabled\":false"),
+        "the caller's explicit off is attempted first: {first}"
+    );
+    assert!(
+        !second.contains("\"reasoning\""),
+        "the resend drops the field so the endpoint applies its own default: {second}"
+    );
+}

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -515,9 +515,16 @@ impl<'a> Pipeline<'a> {
         // --- 5. Witness + execute + verify (single-shot or best-of-N). ------
         let n = self.config.candidate_count();
         let base_messages = messages.clone();
+        // Decided here, before the single-shot/best-of-N split, because an
+        // authored witness is the *only* reason a single candidate needs
+        // disposable isolation. Resolving independence later would commit the
+        // run to snapshot machinery it then discovers it cannot use — and
+        // candidate isolation requires a git working tree, so on a plain
+        // directory that is a hard failure rather than an unused cost.
         let authored_witness = self.config.test_command.is_none()
             && self.config.witness_writer
-            && task_class.verifies_unconditionally();
+            && task_class.verifies_unconditionally()
+            && self.can_author_independent_witness();
         // Single-shot (the default) runs directly over the session ports —
         // zero snapshot/adoption machinery only when the user supplied the
         // test invocation (or witness authoring is otherwise disabled).
@@ -956,40 +963,25 @@ impl<'a> Pipeline<'a> {
         // solo-provider setups do) previously aborted here after one model
         // call, having done no work at all. Degrade to the unauthored verify
         // ladder instead, and say so once.
+        // `can_author_independent_witness` already gated `author_witness` and
+        // announced any degradation, so this is the invariant guard for that
+        // decision — silent on purpose, never a second warning.
         let mut author_witness = author_witness;
-        let witness_author = if author_witness {
-            let independent = match self.resolve_provider(Role::Judge) {
-                Ok(author) if author.model_ref != worker.model_ref => Some(author),
-                Ok(_) => {
-                    self.warn(format!(
-                        "no witness author independent of the worker (judge and worker both \
-                         resolved to `{worker_label}`); continuing without an authored witness"
-                    ));
-                    None
+        let witness_author = match author_witness
+            .then(|| self.resolve_provider(Role::Judge))
+            .and_then(Result::ok)
+            .filter(|author| author.model_ref != worker.model_ref)
+        {
+            Some(author) => {
+                if let Some(fallback) = &author.fallback {
+                    self.emit_fallback(fallback);
                 }
-                Err(_) => {
-                    self.warn(
-                        "no witness author independent of the worker (the judge role is \
-                         unresolvable); continuing without an authored witness"
-                            .to_string(),
-                    );
-                    None
-                }
-            };
-            match independent {
-                Some(author) => {
-                    if let Some(fallback) = &author.fallback {
-                        self.emit_fallback(fallback);
-                    }
-                    Some(author)
-                }
-                None => {
-                    author_witness = false;
-                    None
-                }
+                Some(author)
             }
-        } else {
-            None
+            None => {
+                author_witness = false;
+                None
+            }
         };
 
         let mut candidates: Vec<CandidateResult> = Vec::with_capacity(n as usize);
@@ -1842,6 +1834,39 @@ impl<'a> Pipeline<'a> {
             provider_mix: mix,
             tokens,
         });
+    }
+
+    /// Whether a witness author independent of the worker can be resolved.
+    ///
+    /// Losing the author costs the run its authored witness, never the task:
+    /// a `false` here routes to the ordinary single-shot path and the
+    /// deterministic/judge verify ladder. Announced once, at the one point
+    /// that decides it, so the run never pays for isolation it cannot use.
+    fn can_author_independent_witness(&self) -> bool {
+        let Ok(worker) = self.resolve_provider(Role::Worker) else {
+            // A worker that won't resolve fails later, on its own terms —
+            // not here, disguised as a witness-independence verdict.
+            return false;
+        };
+        match self.resolve_provider(Role::Judge) {
+            Ok(judge) if judge.model_ref != worker.model_ref => true,
+            Ok(_) => {
+                self.warn(format!(
+                    "no witness author independent of the worker (judge and worker both \
+                     resolved to `{}`); continuing without an authored witness",
+                    worker.model_ref
+                ));
+                false
+            }
+            Err(_) => {
+                self.warn(
+                    "no witness author independent of the worker (the judge role is \
+                     unresolvable); continuing without an authored witness"
+                        .to_string(),
+                );
+                false
+            }
+        }
     }
 
     fn emit_fallback(&self, fb: &FallbackInfo) {

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -950,32 +950,44 @@ impl<'a> Pipeline<'a> {
             self.emit_fallback(fallback);
         }
         let worker_label = worker.model_ref.to_string();
+        // Losing the independent author costs the run its authored witness —
+        // it must never cost the run the whole task. A single-model
+        // configuration (every role pinned to one model, as benchmark and
+        // solo-provider setups do) previously aborted here after one model
+        // call, having done no work at all. Degrade to the unauthored verify
+        // ladder instead, and say so once.
+        let mut author_witness = author_witness;
         let witness_author = if author_witness {
-            let Ok(author) = self.resolve_provider(Role::Judge) else {
-                return Ok((
-                    CandidateResult::aborted(
-                        base_messages.to_vec(),
-                        "could not resolve an independent witness author".to_string(),
-                    ),
-                    Some(worker_label),
-                ));
+            let independent = match self.resolve_provider(Role::Judge) {
+                Ok(author) if author.model_ref != worker.model_ref => Some(author),
+                Ok(_) => {
+                    self.warn(format!(
+                        "no witness author independent of the worker (judge and worker both \
+                         resolved to `{worker_label}`); continuing without an authored witness"
+                    ));
+                    None
+                }
+                Err(_) => {
+                    self.warn(
+                        "no witness author independent of the worker (the judge role is \
+                         unresolvable); continuing without an authored witness"
+                            .to_string(),
+                    );
+                    None
+                }
             };
-            if author.model_ref == worker.model_ref {
-                return Ok((
-                    CandidateResult::aborted(
-                        base_messages.to_vec(),
-                        format!(
-                            "could not resolve an independent witness author: judge and worker both resolved to `{}`",
-                            worker.model_ref
-                        ),
-                    ),
-                    Some(worker_label),
-                ));
+            match independent {
+                Some(author) => {
+                    if let Some(fallback) = &author.fallback {
+                        self.emit_fallback(fallback);
+                    }
+                    Some(author)
+                }
+                None => {
+                    author_witness = false;
+                    None
+                }
             }
-            if let Some(fallback) = &author.fallback {
-                self.emit_fallback(fallback);
-            }
-            Some(author)
         } else {
             None
         };

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1099,13 +1099,8 @@ async fn single_model_config_degrades_to_unauthored_witness_instead_of_aborting(
         text_result("done"),
         text_result("PASS looks right"),
     ]);
-    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
-        .with_repo_status(SeqRepoStatus::new(vec![vec![("src/lib.rs", "m")]]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
-    let (outcome, events, _) = run_isolated_with_router(
+    let (outcome, events, _) = run_unisolated_with_router(
         &provider,
-        &port,
         PipelineConfig::default(),
         "Fix the retry bug",
         single_model_router(),
@@ -1310,6 +1305,56 @@ async fn run_isolated(
     Vec<CompletionMessage>,
 ) {
     run_isolated_with_router(provider, port, config, goal, router()).await
+}
+
+/// Run over ordinary *session* ports with no candidate-workspace port, the
+/// path an unauthored run takes. Isolation exists to protect the session tree
+/// from a witness author; with no author there is nothing to protect it from,
+/// so no snapshot machinery is engaged — which is what lets Stella work in a
+/// plain directory that is not a git repository.
+async fn run_unisolated_with_router(
+    provider: &ScriptedProvider,
+    config: PipelineConfig,
+    goal: &str,
+    router: Router,
+) -> (
+    Result<PipelineOutcome, PipelineRunError>,
+    Vec<AgentEvent>,
+    Vec<CompletionMessage>,
+) {
+    let resolver = OneProvider(provider);
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline.run(goal, &mut messages, &mut budget).await;
+    (outcome, drain(&mut rx), messages)
 }
 
 /// [`run_isolated`] over a caller-supplied router, so a test can pin the

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -503,6 +503,22 @@ fn router() -> Router {
     )
 }
 
+/// Every role pinned to one model — what `--model` alone, a single-provider
+/// account, and the benchmark engine posture all produce.
+fn single_model_router() -> Router {
+    let only = ModelRef::new("scripted", "only");
+    Router::new(
+        RoleTable::new(),
+        vec![ProviderProfile::new(
+            "scripted",
+            only.clone(),
+            only.clone(),
+            only,
+        )],
+        CircuitBreaker::new(Box::new(ZeroClock)),
+    )
+}
+
 fn drain(rx: &mut mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
     let mut out = Vec::new();
     while let Ok(e) = rx.try_recv() {
@@ -1069,6 +1085,53 @@ async fn witness_authored_command_arms_the_flip_oracle_and_submits_fast() {
     assert!(!s.contains(&StageKind::Judge), "judge skipped on the flip");
 }
 
+/// Losing the independent witness author must cost the run its authored
+/// witness, never the whole task. With every role pinned to one model the
+/// pipeline used to abort here after a single model call, having executed
+/// nothing — which is what a benchmark or solo-provider account always hits.
+/// It must instead warn once and fall through to the unauthored verify ladder.
+#[tokio::test]
+async fn single_model_config_degrades_to_unauthored_witness_instead_of_aborting() {
+    // triage → "single"; worker → done; judge → verdict. No witness-author
+    // turn is scripted because no independent author can be resolved.
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("PASS looks right"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let workspace = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
+        .with_repo_status(SeqRepoStatus::new(vec![vec![("src/lib.rs", "m")]]));
+    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
+    let (outcome, events, _) = run_isolated_with_router(
+        &provider,
+        &port,
+        PipelineConfig::default(),
+        "Fix the retry bug",
+        single_model_router(),
+    )
+    .await;
+    let outcome = outcome.expect("run succeeds");
+
+    assert_eq!(
+        outcome.status,
+        PipelineStatus::Completed,
+        "a single-model config must still complete the task"
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Witness),
+        "witness authoring is skipped, not attempted without an author"
+    );
+    let warned = events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("no witness author independent of the worker")
+        )
+    });
+    assert!(warned, "the degradation is announced once: {events:?}");
+}
+
 /// A witness whose test passes on the unmodified code proves nothing: one
 /// bounded repair retry, and if it still passes the contaminated candidate is
 /// discarded rather than letting author-written files reach adoption.
@@ -1246,6 +1309,23 @@ async fn run_isolated(
     Vec<AgentEvent>,
     Vec<CompletionMessage>,
 ) {
+    run_isolated_with_router(provider, port, config, goal, router()).await
+}
+
+/// [`run_isolated`] over a caller-supplied router, so a test can pin the
+/// roles to one model (the single-model configuration every benchmark and
+/// solo-provider setup uses).
+async fn run_isolated_with_router(
+    provider: &ScriptedProvider,
+    port: &FakeWorkspacePort,
+    config: PipelineConfig,
+    goal: &str,
+    router: Router,
+) -> (
+    Result<PipelineOutcome, PipelineRunError>,
+    Vec<AgentEvent>,
+    Vec<CompletionMessage>,
+) {
     let resolver = OneProvider(provider);
     let diagnostics = NeverRunner;
     let repo_status = NeverRepoStatus;
@@ -1254,7 +1334,6 @@ async fn run_isolated(
     let repo = NoRepoStructure;
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
-    let router = router();
     let (tx, mut rx) = mpsc::unbounded_channel();
     let pipeline = Pipeline::new(
         PipelinePorts {

--- a/stella-pipeline/src/pipeline/tests/task4.rs
+++ b/stella-pipeline/src/pipeline/tests/task4.rs
@@ -155,8 +155,11 @@ async fn enforced_budget_breach_in_triage_stops_before_the_next_paid_stage() {
     );
 }
 
+/// An unresolvable judge costs the run its authored witness, not the task.
+/// The pipeline warns once and falls through to the unauthored verify ladder
+/// rather than aborting with no work done.
 #[tokio::test]
-async fn unavailable_independent_witness_fails_closed_before_authoring() {
+async fn unavailable_independent_witness_degrades_instead_of_aborting() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
@@ -178,7 +181,7 @@ async fn unavailable_independent_witness_fails_closed_before_authoring() {
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
     let router = router();
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (tx, mut rx) = mpsc::unbounded_channel();
     let pipeline = Pipeline::new(
         PipelinePorts {
             router: &router,
@@ -205,15 +208,27 @@ async fn unavailable_independent_witness_fails_closed_before_authoring() {
     let outcome = pipeline
         .run("Fix the parser", &mut messages, &mut budget)
         .await
-        .expect("unavailable independent witness is a truthful abort");
+        .expect("an unresolvable witness author is a degradation, not a failure");
 
-    assert!(matches!(
-        outcome.status,
-        PipelineStatus::Aborted { ref reason }
-            if reason.contains("independent witness author")
-    ));
     assert!(
-        (outcome.total_cost_usd - 0.0001).abs() < 1e-9,
-        "only triage spend settles before role independence is checked: {outcome:?}"
+        !matches!(
+            outcome.status,
+            PipelineStatus::Aborted { ref reason }
+                if reason.contains("independent witness author")
+        ),
+        "losing the author must not abort the task: {outcome:?}"
+    );
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("no witness author independent of the worker")
+        )),
+        "the degradation is announced once: {events:?}"
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Witness),
+        "witness authoring is skipped, never attempted without an author"
     );
 }

--- a/stella-pipeline/src/pipeline/tests/task4.rs
+++ b/stella-pipeline/src/pipeline/tests/task4.rs
@@ -1,14 +1,16 @@
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-struct FirstTwoProviderLookups<'a> {
+/// Every role resolves except the judge — "no independent witness author is
+/// available", stated by identity rather than by call count so the fixture
+/// survives a change in the order roles are resolved.
+struct NoJudgeProvider<'a> {
     provider: &'a ScriptedProvider,
-    lookups: AtomicUsize,
 }
 
-impl ProviderResolver for FirstTwoProviderLookups<'_> {
-    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
-        (self.lookups.fetch_add(1, Ordering::SeqCst) < 2).then_some(self.provider as &dyn Provider)
+impl ProviderResolver for NoJudgeProvider<'_> {
+    fn provider_for(&self, model: &ModelRef) -> Option<&dyn Provider> {
+        (model.model_id != "judge").then_some(self.provider as &dyn Provider)
     }
 }
 
@@ -164,9 +166,8 @@ async fn unavailable_independent_witness_degrades_instead_of_aborting() {
         text_result("single"),
         text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
     ]);
-    let resolver = FirstTwoProviderLookups {
+    let resolver = NoJudgeProvider {
         provider: &provider,
-        lookups: AtomicUsize::new(0),
     };
     let runner = ScriptedRunner::new(vec![false], "");
     let tools = EmptyTools;
@@ -195,7 +196,7 @@ async fn unavailable_independent_witness_degrades_instead_of_aborting() {
             approvals: &approvals,
             sleeper: &sleeper,
             hooks: None,
-            candidate_workspaces: Some(&candidate_workspaces),
+            candidate_workspaces: None,
             mcp_prefetch: None,
             steering: None,
         },

--- a/stella-pipeline/src/pipeline/tests/task4.rs
+++ b/stella-pipeline/src/pipeline/tests/task4.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Every role resolves except the judge — "no independent witness author is
 /// available", stated by identity rather than by call count so the fixture
@@ -178,7 +177,7 @@ async fn unavailable_independent_witness_degrades_instead_of_aborting() {
     let workspace = FakeWorkspace::new(0, vec![false], Ok(vec![]), log.clone()).with_repo_status(
         SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "sha256:test")]]),
     );
-    let candidate_workspaces = FakeWorkspacePort::new(vec![Ok(workspace)], log);
+    let _candidate_workspaces = FakeWorkspacePort::new(vec![Ok(workspace)], log);
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
     let router = router();

--- a/stella-pipeline/src/pipeline/tests/task5.rs
+++ b/stella-pipeline/src/pipeline/tests/task5.rs
@@ -179,17 +179,15 @@ async fn authored_witness_degrades_when_judge_is_worker() {
         text_result("PASS looks right"),
     ]);
     let resolver = OneProvider(&provider);
-    let diagnostics = NeverRunner;
-    let repo_status = NeverRepoStatus;
+    // Session ports, not candidate ones: with no author to isolate from, the
+    // run stays in the working tree and engages no snapshot machinery.
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
     let tools = EmptyTools;
     let recall = NoContextRecall;
     let repo = NoRepoStructure;
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
-    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
-        .with_repo_status(SeqRepoStatus::new(vec![vec![("src/lib.rs", "m")]]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
     let same = ModelRef::new("scripted", "same-model");
     let mut roles = RoleTable::new();
     roles.pin(Role::Worker, same.clone());
@@ -213,12 +211,12 @@ async fn authored_witness_degrades_when_judge_is_worker() {
             recall: &recall,
             repo: &repo,
             repo_status: &repo_status,
-            diagnostics: &diagnostics,
-            tests: &diagnostics,
+            diagnostics: &runner,
+            tests: &runner,
             approvals: &approvals,
             sleeper: &sleeper,
             hooks: None,
-            candidate_workspaces: Some(&port),
+            candidate_workspaces: None,
             mcp_prefetch: None,
             steering: None,
         },

--- a/stella-pipeline/src/pipeline/tests/task5.rs
+++ b/stella-pipeline/src/pipeline/tests/task5.rs
@@ -166,9 +166,18 @@ async fn witness_worker_and_revision_hooks_are_bound_to_the_candidate_root() {
     assert_eq!(std::fs::read_dir(session_root.path()).unwrap().count(), 0);
 }
 
+/// Pinning worker and judge to one model costs the run its authored witness,
+/// not the task: the pipeline warns once and proceeds down the unauthored
+/// verify ladder. (The profile-level single-model case is covered by
+/// `single_model_config_degrades_to_unauthored_witness_instead_of_aborting`;
+/// this pins the roles explicitly, which is a distinct resolution path.)
 #[tokio::test]
-async fn authored_witness_fails_closed_before_workspace_creation_when_judge_is_worker() {
-    let provider = ScriptedProvider::new(vec![text_result("single")]);
+async fn authored_witness_degrades_when_judge_is_worker() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("PASS looks right"),
+    ]);
     let resolver = OneProvider(&provider);
     let diagnostics = NeverRunner;
     let repo_status = NeverRepoStatus;
@@ -177,7 +186,10 @@ async fn authored_witness_fails_closed_before_workspace_creation_when_judge_is_w
     let repo = NoRepoStructure;
     let approvals = AutoApproveGate;
     let sleeper = NoopSleeper;
-    let port = FakeWorkspacePort::untouchable();
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let workspace = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
+        .with_repo_status(SeqRepoStatus::new(vec![vec![("src/lib.rs", "m")]]));
+    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
     let same = ModelRef::new("scripted", "same-model");
     let mut roles = RoleTable::new();
     roles.pin(Role::Worker, same.clone());
@@ -219,13 +231,22 @@ async fn authored_witness_fails_closed_before_workspace_creation_when_judge_is_w
     let outcome = pipeline
         .run("Fix the failing test", &mut messages, &mut budget)
         .await
-        .expect("independence failure is a truthful candidate abort");
-    assert!(matches!(
+        .expect("independence failure is a degradation, not a failure");
+    assert_eq!(
         outcome.status,
-        PipelineStatus::Aborted { ref reason }
-            if reason.contains("independent witness author")
-    ));
-    assert!(!stages(&drain(&mut rx)).contains(&StageKind::Witness));
+        PipelineStatus::Completed,
+        "pinning judge to the worker must not abort the task: {outcome:?}"
+    );
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("no witness author independent of the worker")
+        )),
+        "the degradation is announced once: {events:?}"
+    );
+    assert!(!stages(&events).contains(&StageKind::Witness));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Two agent-loop defects found by actually running Stella on Terminal-Bench 2, each reproduced before it was fixed.

## Measured baseline

`terminal-bench` dataset, `openrouter/anthropic/claude-fable-5`, Harbor 0.6.1, one attempt per task:

| | |
|---|---|
| `fix-git` | **1.0** — 15 model calls, 17 tool calls, $0.65, 87% cache hit |
| 7-task batch | **1/7 (0.143)**, 6 × `NonZeroAgentExitCodeError` |

Every failure was identical: **exactly 1 model call, 0 tool calls, no work attempted.**

## 1. Losing the independent witness author aborted the whole task

`authored_witness` requires the judge model to differ from the worker model. A single-model configuration — `--model X` alone, a solo-provider account, or the benchmark engine posture (`allowed_models` of one, `auto_mode: off`) — resolves both to the same model, and the pipeline aborted the entire run.

The task class is what decides whether this gate is even reached, and it lines up exactly:

| Deterministic floor | Tasks | Result |
|---|---|---|
| `SimpleLookup` → skips the verify ladder | fix-git, polyglot-c-py, overfull-hbox | all ran; 2 passed |
| `MultiStep` → verifies unconditionally → authored witness | cobol-modernization, git-multibranch, kv-store-grpc, nginx-request-logging, prove-plus-comm | **all 5 aborted** |

Independence is still required to *author* a witness — it just costs the run its authored witness now, not the task. The pipeline warns once through the existing non-fatal `warn` seam and falls through to the deterministic/judge verify ladder, which is strictly more verification than the abort it replaced.

The two tests that encoded the fail-closed contract are retargeted to the degradation contract, plus a new profile-level regression test (verified failing without the fix).

## 2. Triage failed on 100% of turns, silently

The triage role pins `reasoning: off`. OpenRouter answers `reasoning:{enabled:false}` with:

```
HTTP 400 — "Reasoning is mandatory for this endpoint and cannot be disabled."
```

Reproduced directly against `anthropic/claude-fable-5`; `{"reasoning":{"effort":"high"}}` and a bare request both succeed. Triage therefore died every turn, surfacing only a content-free `usage_incomplete`, and task classification always fell back to the deterministic floor.

Disabling reasoning is an economy preference, never a correctness requirement, so losing it must not lose the call: the adapter now resends once with the field omitted and lets the endpoint apply its own default. Matched on the upstream's own wording rather than the bare status code, so ordinary malformed-request 400s still fail fast instead of burning a second paid call.

## Not fixed here — flagged for a design call

`resolve_task_class` takes `max(model_class, deterministic_floor(goal))`, so the keyword floor can only ever *raise* ceremony. All 5 aborted tasks were pushed to `MultiStep` by keywords alone; a perfectly working triage model saying "this is simple" could not have lowered any of them. Making triage able to *reduce* pipeline ceremony (an advisory floor, or a plan carrying explicit `require_witness` / `require_judge`) is a deliberate design change, not something to slip into a bugfix PR.

Also worth noting: triage's model output is discarded — `classify_triage_response(&result.text)` reads it only to pick an enum — so there is no user-facing acknowledgment available today.

## Verification

- `cargo test --workspace` — green (54 suites, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- New regression tests confirmed to fail against unfixed code, not just pass against fixed code

