### PR TITLE
docs(cgp): CGP acronym convention in public docs + de-OCP research papers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Every one of these is genuinely valued — pick the one that fits your energy:
 | 🧭 **Docs & examples** — fix a lie in the README before it fools someone else | Any `*.md` file, `--help` text, doc comments | Small |
 | 🔌 **A new provider adapter** — Stella is BYOK; every model provider we speak makes it more useful | `stella-model/src/` — copy the shape of an existing adapter | Medium |
 | 🛠 **A new built-in tool** | `stella-tools/src/` — implement the tool trait, register it | Medium |
-| 🌐 **An CGP provider** — implement the Context Graph Protocol in your language and prove it green | [macanderson/context-graph-protocol](https://github.com/macanderson/context-graph-protocol) — its own repo, no Stella code required | Medium |
+| 🌐 **A Context Graph Protocol (CGP) provider** — implement it in your language and prove it green | [macanderson/context-graph-protocol](https://github.com/macanderson/context-graph-protocol) — its own repo, no Stella code required | Medium |
 | 🏗 **Core engine work** | `good first issue` / `help wanted` labels | Varies |
 
 If you're not sure where something fits, open an issue first — a ten-line

--- a/README.md
+++ b/README.md
@@ -414,7 +414,8 @@ take effect the next session — hot-injection would invalidate the cache.
 
 Every working turn is also recorded as an **episode** (summary, files touched,
 outcome, time window) in `.stella/private/context.db`, and `stella init` writes the
-domain taxonomy as bi-temporal facts. Recall fans out through the CGP host to
+domain taxonomy as bi-temporal facts. Recall fans out through the Context Graph
+Protocol host to
 the memory store and the code graph, fused by score under one budget.
 
 ## Telemetry
@@ -526,7 +527,8 @@ flowchart TD
 
 ## Workspace layout
 
-Fourteen `stella-*` crates make up the workspace. The Context Graph Protocol —
+Fourteen `stella-*` crates make up the workspace. The Context Graph Protocol
+(CGP) —
 the retrieval abstraction Stella's recall routes through — now lives in its own
 repository and is pulled in as a pinned git dependency, not as workspace members.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Especially interesting, given what Stella promises:
 - **Prompt/tool injection with impact** — untrusted content (repo files, MCP
   frames, provider responses) escalating into actions the user didn't sanction,
   beyond what the model is already trusted to do.
-- **CGP host boundary breaks** — providers escaping quarantine: inheriting
+- **Context Graph Protocol (CGP) host boundary breaks** — providers escaping quarantine: inheriting
   credentials, ambient filesystem access, or ungated egress.
 - **install.sh / release integrity** — checksum bypasses, tag/asset confusion.
 

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -1,6 +1,6 @@
 # Research papers
 
-Original analysis on Stella's architecture, the Open Context Protocol, and
+Original analysis on Stella's architecture, the Context Graph Protocol (CGP), and
 the defensible properties of deterministic coding-agent design. These are
 research-grade documents — written for engineers and architecture reviewers,
 grounded in primary research, and referencing the shipping implementation by
@@ -14,7 +14,7 @@ file and line.
   not any single property — constitutes the moat. Covers ports-not-concretions,
   no-I/O-in-the-engine, the witness-test contract, BYOK + no-phone-home,
   prompt-cache-native memory, budget enforcement at safe boundaries, and the
-  Open Context Protocol.
+  Context Graph Protocol.
 
 - [**The Deterministic Engine: Why Single-Thread Beats the Swarm**](./deterministic-engine.md)
   — a focused analysis of one defensible property: Stella's decision to build
@@ -25,8 +25,8 @@ file and line.
 
 ## Related
 
-- [**The Open Context Protocol: Advantages and Uniqueness**](https://github.com/macanderson/opencontextprotocol/blob/main/docs/protocol-advantages.md)
-  — standalone analysis of the OCP's trust architecture: the seven advantages
+- [**The Context Graph Protocol: Advantages and Uniqueness**](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md)
+  — standalone analysis of the CGP's trust architecture: the seven advantages
   (provenance, budget honesty, consent enforcement, conformance verification,
   citation guarantees, version stability, temporal validity) and why the
   combination is irreducible.

--- a/docs/papers/deterministic-engine.md
+++ b/docs/papers/deterministic-engine.md
@@ -178,7 +178,8 @@ Stella does parallelize where it is safe and beneficial:
 - **Read-only tool concurrency.** When the model requests multiple read-only
   operations (read three files, grep for two patterns), they execute
   concurrently. This is safe because read-only tools have no side effects.
-- **Context fan-out.** When the context plane queries multiple OCP providers,
+- **Context fan-out.** When the context plane queries multiple Context Graph
+  Protocol providers,
   they are fanned out concurrently (`Host::query_all`). Each provider is
   isolated; one provider's failure never affects another.
 

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -44,7 +44,7 @@ not any individual property — constitutes the moat.
 6. [Property IV: BYOK + zero telemetry egress by default — the trust perimeter](#6-property-iv-byok--zero-telemetry-egress-by-default--the-trust-perimeter)
 7. [Property V: Prompt-cache-native memory — the cost discipline](#7-property-v-prompt-cache-native-memory--the-cost-discipline)
 8. [Property VI: Budget enforcement at safe boundaries](#8-property-vi-budget-enforcement-at-safe-boundaries)
-9. [Property VII: The Context Graph Protocol — an open standard](#9-property-vii-the-open-context-protocol--an-open-standard)
+9. [Property VII: The Context Graph Protocol — an open standard](#9-property-vii-the-context-graph-protocol--an-open-standard)
 10. [Why the combination is the moat](#10-why-the-combination-is-the-moat)
 11. [Competitive analysis](#11-competitive-analysis)
 12. [Threats to defensibility](#12-threats-to-defensibility)

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -10,7 +10,7 @@
 >
 > **Reading order.** This is the capstone paper. For domain-specific depth,
 > read alongside:
-> - [The Open Context Protocol: Advantages and Uniqueness](https://github.com/macanderson/opencontextprotocol/blob/main/docs/protocol-advantages.md) — the
+> - [The Context Graph Protocol: Advantages and Uniqueness](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md) — the
 >   retrieval protocol's trust architecture.
 > - [`stella-core/src/lib.rs`](../../stella-core/src/lib.rs) and
 >   [`stella-core/src/driver.rs`](../../stella-core/src/driver.rs) — the engine.
@@ -44,7 +44,7 @@ not any individual property — constitutes the moat.
 6. [Property IV: BYOK + zero telemetry egress by default — the trust perimeter](#6-property-iv-byok--zero-telemetry-egress-by-default--the-trust-perimeter)
 7. [Property V: Prompt-cache-native memory — the cost discipline](#7-property-v-prompt-cache-native-memory--the-cost-discipline)
 8. [Property VI: Budget enforcement at safe boundaries](#8-property-vi-budget-enforcement-at-safe-boundaries)
-9. [Property VII: The Open Context Protocol — an open standard](#9-property-vii-the-open-context-protocol--an-open-standard)
+9. [Property VII: The Context Graph Protocol — an open standard](#9-property-vii-the-open-context-protocol--an-open-standard)
 10. [Why the combination is the moat](#10-why-the-combination-is-the-moat)
 11. [Competitive analysis](#11-competitive-analysis)
 12. [Threats to defensibility](#12-threats-to-defensibility)
@@ -95,7 +95,7 @@ We identify seven such properties in Stella's design.
 | IV | BYOK + zero telemetry egress by default | Community/default telemetry is local; only an explicitly enrolled Oxagen Enterprise managed deployment may send a signed-policy-authorized, content-free operational rollup | Architectural invariant; local SQLite (`stella-store`) plus the [managed enrollment boundary](../../stella-docs/content/docs/telemetry/index.mdx#oxagen-enterprise-managed-export) |
 | V | Prompt-cache-native memory | Lessons load into a byte-stable system prompt prefix at ~0.1x input price | `build_system_prompt` (`stella-cli::agent`); L-E8 cache discipline |
 | VI | Budget at safe boundaries | The budget guard consults only between model calls, never interrupts a tool | `run_turn` budget check (`stella-core::driver`); property-tested |
-| VII | Open Context Protocol | Retrieval is a typed, budgeted, provenance-carrying, consent-gated, conformance-verified protocol | `ocp-types`, `ocp-host`, `ocp-conformance` |
+| VII | Context Graph Protocol | Retrieval is a typed, budgeted, provenance-carrying, consent-gated, conformance-verified protocol | `contextgraph-types`, `contextgraph-host`, `contextgraph-conformance` |
 
 Each property is examined below.
 
@@ -446,45 +446,45 @@ reported metric, but an abort condition.
 
 ---
 
-## 9. Property VII: The Open Context Protocol — an open standard
+## 9. Property VII: The Context Graph Protocol — an open standard
 
 ### The invariant
 
-Retrieval in Stella is designed as an open, versioned wire protocol (OCP,
-`ocp/1.0-draft`): the `ocp-types` crate (zero dependencies beyond `serde`),
-the `ocp-host` host runtime, and the `ocp-conformance` conformance suite. See
-[The Open Context Protocol: Advantages and Uniqueness](https://github.com/macanderson/opencontextprotocol/blob/main/docs/protocol-advantages.md) for the
+Retrieval in Stella is designed as an open, versioned wire protocol (CGP,
+`contextgraph/1.0-draft`): the `contextgraph-types` crate (zero dependencies beyond `serde`),
+the `contextgraph-host` host runtime, and the `contextgraph-conformance` conformance suite. See
+[The Context Graph Protocol: Advantages and Uniqueness](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md) for the
 full analysis.
 
 ### Why it is hard to copy
 
 An open standard is defensible for the same reason TCP/IP is defensible: once
 ecosystem participants build against the standard, switching costs become
-prohibitive. OCP's specific defensibility comes from three properties:
+prohibitive. CGP's specific defensibility comes from three properties:
 
-1. **Zero-dependency wire types.** `ocp-types` depends only on `serde`. A
-   third party can implement an OCP provider in any language without pulling
+1. **Zero-dependency wire types.** `contextgraph-types` depends only on `serde`. A
+   third party can implement an CGP provider in any language without pulling
    in Stella code. The barrier to entry is a JSON codec and the wire table.
 
-2. **Machine-checked conformance.** "OCP conformant" is defined as green on
-   `ocp-conformance`'s suite — a checkable claim. This makes
+2. **Machine-checked conformance.** "CGP conformant" is defined as green on
+   `contextgraph-conformance`'s suite — a checkable claim. This makes
    interoperability a testable property. A provider that passes conformance
-   works with any OCP host; a provider that fails is caught at CI time, not
+   works with any CGP host; a provider that fails is caught at CI time, not
    at integration time.
 
-3. **The trust architecture.** OCP's seven durability properties (provenance,
+3. **The trust architecture.** CGP's seven durability properties (provenance,
    budget honesty, consent, conformance, citation, version stability,
    temporal validity) are irreducible. A competitor proposing an alternative
    retrieval protocol must match all seven or accept a weaker trust model. See
-   [The Open Context Protocol: Advantages and Uniqueness](https://github.com/macanderson/opencontextprotocol/blob/main/docs/protocol-advantages.md) §10 for
+   [The Context Graph Protocol: Advantages and Uniqueness](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md) §10 for
    why the combination is irreducible.
 
 ### The ecosystem play
 
-OCP positions Stella not just as a coding agent but as the **reference
-implementation of a standard.** If OCP becomes the standard for context
+CGP positions Stella not just as a coding agent but as the **reference
+implementation of a standard.** If CGP becomes the standard for context
 retrieval in AI coding tools — the way MCP is becoming the standard for tool
-invocation — then Stella is the first and most mature host. Every OCP
+invocation — then Stella is the first and most mature host. Every CGP
 provider built by the ecosystem (a Jira context provider, a Figma context
 provider, a Confluence context provider) works with Stella for free. The
 standard creates network effects that compound with each adoption.
@@ -508,10 +508,10 @@ are mutually reinforcing:
   the budget guard ensures the agent doesn't spend unboundedly trying. Together,
   they define "done" as both *verified* and *bounded*.
 
-- **BYOK + zero telemetry egress by default (IV) + OCP (VII)** define a trust
+- **BYOK + zero telemetry egress by default (IV) + CGP (VII)** define a trust
   perimeter. BYOK means the user controls the model; Community/default local
   telemetry plus the explicit signed Enterprise exception makes operational
-  egress inspectable and governed; OCP means the user controls the context
+  egress inspectable and governed; CGP means the user controls the context
   sources. The trust perimeter is not one property but three, each closing a
   gap the others don't address.
 
@@ -546,7 +546,7 @@ Stella on:
   integration. Stella's engine is SDK-free.
 - **Witness-test**: Claude Code does not have a verify_done-equivalent. It
   stops at "the suite is green."
-- **OCP**: Claude Code does not expose a context-retrieval protocol. Its
+- **CGP**: Claude Code does not expose a context-retrieval protocol. Its
   retrieval is opaque and vendor-locked.
 
 Claude Code's advantage is deep integration with Anthropic's model
@@ -569,7 +569,7 @@ feature (tree-sitter-based). It is Stella's closest open-source peer.
 
 Aider pioneered the tree-sitter repo map that Stella's `stella-graph` builds
 on. The key differentiator is that Stella treats retrieval as a *protocol*
-(OCP), not a *feature* — making it extensible by third parties and
+(CGP), not a *feature* — making it extensible by third parties and
 conformance-verified.
 
 ### vs. Cursor / Windsurf (IDE-based agents)
@@ -585,7 +585,7 @@ cannot match Stella on:
   exception documented above.
 - **Ports and I/O purity**: Both embed provider integration in the agent loop.
   Stella's engine is SDK-free and property-testable.
-- **Witness-test, budget, OCP**: Neither has these properties.
+- **Witness-test, budget, CGP**: Neither has these properties.
 
 Their advantage is IDE integration (inline diffs, multi-file editing,
 language-server awareness). Stella operates in the terminal, which is a
@@ -600,10 +600,10 @@ A rigorous analysis must consider what could erode Stella's position:
 1. **Model convergence.** If a single model becomes so dominant that
    model-agnosticism stops mattering, BYOK loses its edge. *Mitigation:*
    Stella's other properties (zero telemetry egress by default, witness-test,
-   budget, OCP) do not depend on model diversity.
+   budget, CGP) do not depend on model diversity.
 
-2. **OCP non-adoption.** If the ecosystem does not build OCP providers, the
-   protocol's network effects don't materialize, and OCP becomes an internal
+2. **CGP non-adoption.** If the ecosystem does not build CGP providers, the
+   protocol's network effects don't materialize, and CGP becomes an internal
    architecture rather than a standard. *Mitigation:* the zero-dependency wire
    types, the public conformance suite, and the MIT license lower the barrier
    to adoption. But adoption is not guaranteed.
@@ -677,6 +677,6 @@ is the running code that proves it.
 
 ---
 
-*See also: [The Open Context Protocol: Advantages and Uniqueness](https://github.com/macanderson/opencontextprotocol/blob/main/docs/protocol-advantages.md)
+*See also: [The Context Graph Protocol: Advantages and Uniqueness](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md)
 for the retrieval protocol's trust architecture, and the
-[OCP reference docs](./README.md) for implementation guides.*
+[CGP reference docs](./README.md) for implementation guides.*


### PR DESCRIPTION
## What & Why

Follow-up to **#323** (the `ocp-*` → `contextgraph-*` rename, already merged). #323 merged at the rename commit before these two doc refinements were pushed, so they never landed. This PR carries them on top of current `main`.

Per maintainer guidance:

1. **CGP acronym convention** — public docs (README, CONTRIBUTING, SECURITY) now **spell out "Context Graph Protocol (CGP)" on first use**, then use the CGP abbreviation; deeper/technical docs use CGP freely. Also fixes an "An CGP" grammar artifact left by the rename's blanket substitution.
2. **No CGP technical papers in the Stella repo** — the canonical CGP paper (`protocol-advantages.md`) already lives in the `context-graph-protocol` repo, so nothing needed to move there. Stella's `docs/papers/*` are Stella-architecture papers (deterministic-engine, defensible-position) that discuss CGP as *one Stella property* ("Property VII") and defer to the canonical paper. This de-OCPs their prose and **repoints the 5 stale `opencontextprotocol` links → `context-graph-protocol`** (including the paper title *The Context Graph Protocol: Advantages and Uniqueness*, matching the canonical heading).

## Scope

Docs only — 6 Markdown files, no code/`.rs` changes (the rename itself, including `stella-docs/context-engine.mdx`, is already on `main`).

## Verification

`rg opencontextprotocol docs/papers/` → 0 hits; README/SECURITY first-mention now spelled out with "(CGP)"; no `An CGP` artifacts remain.

## Open question

I kept the "Property VII" CGP discussion inside the Stella defensibility paper (it's a Stella property that references the canonical paper). If you'd rather extract that CGP analysis into the `context-graph-protocol` repo as well, say so and I'll do it as a cross-repo follow-up.
