### PR TITLE
feat(prompt): deterministic project-map block in the system prompt

### DIFF
--- a/stella-cli/src/agent/prompt.rs
+++ b/stella-cli/src/agent/prompt.rs
@@ -131,10 +131,12 @@ pub(crate) fn assemble_system_prompt(
     // state that can carry preinstalled prompt steering across trials.
     if crate::settings::filesystem_settings_disabled() {
         append_project_scripts(&mut prompt, workspace_root);
+        append_project_orientation(&mut prompt, workspace_root);
         return prompt;
     }
     if authority.project_prompts_allowed {
         append_project_scripts(&mut prompt, workspace_root);
+        append_project_orientation(&mut prompt, workspace_root);
         append_workspace_memories(&mut prompt, workspace_root);
         append_exploration_index(&mut prompt, workspace_root);
     }
@@ -174,6 +176,23 @@ fn append_exploration_index(prompt: &mut String, workspace_root: &std::path::Pat
 fn append_project_scripts(prompt: &mut String, workspace_root: &std::path::Path) {
     let index = stella_tools::scripts::ScriptIndex::detect_blocking(workspace_root);
     if let Some(section) = index.render_prompt_section() {
+        prompt.push_str("\n\n");
+        prompt.push_str(&section);
+    }
+}
+
+/// The project-map section of [`assemble_system_prompt`]: the graph-derived
+/// languages, entry points, and storage — the complement of the scripts
+/// section above. Read-only (`stella_tools::overview::render_orientation_block`
+/// opens an existing index and never builds one), so it adds nothing to
+/// first-response latency; it appears once the session's background index
+/// build has completed (or immediately when the workspace was pre-indexed,
+/// as the benchmark adapter does). Byte-stable for a given index state, so it
+/// keeps the cache-stable system prefix stable. The point is fewer
+/// grep/glob/read_file discovery turns: the model starts knowing the shape of
+/// the code.
+fn append_project_orientation(prompt: &mut String, workspace_root: &std::path::Path) {
+    if let Some(section) = stella_tools::overview::render_orientation_block(workspace_root) {
         prompt.push_str("\n\n");
         prompt.push_str(&section);
     }

--- a/stella-tools/src/overview.rs
+++ b/stella-tools/src/overview.rs
@@ -113,9 +113,14 @@ pub fn render_orientation_block(root: &Path) -> Option<String> {
         ));
     }
 
-    let entry_points = entry_point_paths(&graph, &all_files);
-    if !entry_points.is_empty() {
-        lines.push(format!("Entry points: {}", entry_points.join(", ")));
+    // Same bound as `code_section`: deriving entry points costs one
+    // `importers_of` query per file, so past the scan limit we skip the line
+    // rather than pay an unbounded per-file scan on the first-response path.
+    if all_files.len() <= ENTRY_POINT_SCAN_LIMIT {
+        let entry_points = entry_point_paths(&graph, &all_files);
+        if !entry_points.is_empty() {
+            lines.push(format!("Entry points: {}", entry_points.join(", ")));
+        }
     }
 
     let storage = graph.storage_snapshot();

--- a/stella-tools/src/overview.rs
+++ b/stella-tools/src/overview.rs
@@ -70,6 +70,75 @@ impl Tool for ProjectOverview {
     }
 }
 
+/// A compact, deterministic orientation block for the system prompt, or
+/// `None` when there is no usable index.
+///
+/// Read-only on purpose: it opens an **existing** index and never builds one,
+/// so it can be called during system-prompt assembly without ever blocking
+/// the first response on an index build (which would defeat the point of a
+/// fast first turn). When the index is absent — a fresh session before the
+/// background build finishes — it returns `None` and the model can still call
+/// `project_overview` explicitly.
+///
+/// Deliberately the complement of the script index (which the prompt already
+/// injects separately): languages, entry points, and storage — the shape of
+/// the code the model would otherwise spend grep/glob/read_file turns
+/// discovering. Kept to a few lines so it stays cheap in the cache-stable
+/// system prefix.
+pub fn render_orientation_block(root: &Path) -> Option<String> {
+    let path = stella_store::existing_workspace_private_sqlite_path(root, "codegraph.db")
+        .ok()
+        .flatten()?;
+    let graph = stella_graph::CodeGraph::open(root, &path).ok()?;
+
+    let files = graph.file_count().unwrap_or(0);
+    if files == 0 {
+        return None;
+    }
+
+    let mut lines =
+        vec!["## Project map (indexed — you do not need to grep/glob to find this)".to_string()];
+
+    let all_files = graph.all_files().unwrap_or_default();
+    let mut languages: BTreeSet<&'static str> = BTreeSet::new();
+    for file in &all_files {
+        if let Some(language) = language_of(file) {
+            languages.insert(language);
+        }
+    }
+    if !languages.is_empty() {
+        lines.push(format!(
+            "Languages: {}",
+            languages.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    let entry_points = entry_point_paths(&graph, &all_files);
+    if !entry_points.is_empty() {
+        lines.push(format!("Entry points: {}", entry_points.join(", ")));
+    }
+
+    let storage = graph.storage_snapshot();
+    if !storage.is_empty() {
+        let layers: Vec<String> = storage.layers.iter().map(|l| l.key.clone()).collect();
+        let layer_note = if layers.is_empty() {
+            String::new()
+        } else {
+            format!(" across {}", layers.join(", "))
+        };
+        lines.push(format!(
+            "Storage: {} relation(s){layer_note}",
+            storage.relations.len()
+        ));
+    }
+
+    // Only the header means nothing worth injecting.
+    if lines.len() == 1 {
+        return None;
+    }
+    Some(lines.join("\n"))
+}
+
 /// Assemble the overview. Total by construction: every source degrades to
 /// its empty shape, because an orientation call that errors sends the agent
 /// straight back to the glob loop this exists to replace.
@@ -155,20 +224,7 @@ fn code_section(graph: &stella_graph::CodeGraph) -> Value {
         return section;
     }
 
-    // A file nothing imports is a root: a binary, a script, a test, or dead
-    // code — which is exactly the set worth reading first.
-    let mut roots: Vec<String> = files
-        .iter()
-        .filter(|file| {
-            graph
-                .importers_of(Path::new(file))
-                .map(|importers| importers.is_empty())
-                .unwrap_or(false)
-        })
-        .cloned()
-        .collect();
-    roots.sort_by_key(|path| (path.matches('/').count(), path.clone()));
-    roots.truncate(MAX_ENTRY_POINTS);
+    let roots = entry_point_paths(graph, &files);
     map.insert("entry_points".into(), json!(roots));
     section
 }
@@ -239,6 +295,25 @@ fn domains_section(root: &Path) -> Value {
         })
         .unwrap_or_default();
     json!(names)
+}
+
+/// Files nothing imports — a binary, a script, a test, or dead code, which is
+/// exactly the set worth reading first. Bounded and stably ordered
+/// (shallowest path first) so both the tool and the prompt block agree.
+fn entry_point_paths(graph: &stella_graph::CodeGraph, files: &[String]) -> Vec<String> {
+    let mut roots: Vec<String> = files
+        .iter()
+        .filter(|file| {
+            graph
+                .importers_of(Path::new(file))
+                .map(|importers| importers.is_empty())
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+    roots.sort_by_key(|path| (path.matches('/').count(), path.clone()));
+    roots.truncate(MAX_ENTRY_POINTS);
+    roots
 }
 
 /// Extension → language label, matching the grammars the indexer actually
@@ -332,6 +407,41 @@ mod tests {
         assert_eq!(
             out["domains"],
             serde_json::json!(["scheduling", "transport"])
+        );
+    }
+
+    #[test]
+    fn orientation_block_is_none_without_an_index_and_never_builds_one() {
+        // Read-only: it must not create an index during system-prompt
+        // assembly, or it would block the first response on a build.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").unwrap();
+        assert!(render_orientation_block(dir.path()).is_none());
+        assert!(
+            !crate::graph::graph_db_path(dir.path()).exists(),
+            "the read-only block must not build an index"
+        );
+    }
+
+    #[test]
+    fn orientation_block_reports_languages_and_entry_points_from_an_existing_index() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("main.rs"),
+            "mod helper;\npub fn main() {}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("helper.rs"), "pub fn help() {}\n").unwrap();
+        // Build the index first (what the session background build / adapter
+        // `stella init` does), THEN render read-only.
+        let _ = build_overview(dir.path());
+
+        let block = render_orientation_block(dir.path()).expect("an indexed workspace renders");
+        assert!(block.contains("Project map"), "{block}");
+        assert!(block.contains("Languages: rust"), "{block}");
+        assert!(
+            block.contains("Entry points:"),
+            "a file nothing imports is an entry point: {block}"
         );
     }
 


### PR DESCRIPTION
First of the three seams in #342 — ship graph context into the prompt so the model spends fewer grep/glob/read_file turns discovering basics.

## Why

Advertising code-intelligence tools isn't enough. Measured on Terminal-Bench 2:
- `graph_query`: **0 calls / 40 trials**
- `project_overview`: **first-call on 1 of 2 tasks** even after being named step 1 in the prompt

A tool that needs an argument can't be the first move, and in a small repo `read_file` is competitive with a query tool. So stop making orientation a *choice* — ship the context.

## What

`assemble_system_prompt` already injects the **script index** deterministically ("zero discovery turns"). This adds the **graph-derived complement** beside it — languages, entry points, storage — via a new `stella_tools::overview::render_orientation_block`:

```
## Project map (indexed — you do not need to grep/glob to find this)
Languages: python
Entry points: scripts/cost_model.py, scripts/baseline_packer.py, scripts/__init__.py
Storage: 4 relation(s) across postgres
```

## Design: read-only, never blocks the first response

`render_orientation_block` opens an **existing** index and **never builds one**. An inline build during prompt assembly would add first-turn latency — defeating a fast first turn, which Stella cares about. So:
- Index present (background build done, or adapter pre-indexed via `stella init`) → block appears
- Index absent → no block, and the model can still call `project_overview` explicitly

Byte-stable for a given index state, so the cache-stable system prefix stays stable. Shares the exact entry-point rule (`entry_point_paths`, "a file nothing imports is a root") with the `project_overview` tool so the two never disagree.

## Verified
- **Unit-tested**: read-only (asserts no index is built), and renders languages + entry points from an existing index. `clippy -D warnings` + `cargo test` green.
- **Wiring**: 2-line call mirroring the proven `append_project_scripts` seam, in both the benchmark-isolation and normal branches.

## NOT yet measured
The end-to-end effect — *does this actually reduce grep/glob/read_file in a benchmark run* — needs a rebuild + run and is the broader question tracked in #342. This PR lands the deterministic injection; the measurement is a follow-up.