### PR TITLE
feat(pipeline): never let the loop choose nothing — degrade setup failures to a bare run

### DIFF
--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -274,6 +274,15 @@ struct CandidateResult {
     final_text: String,
     /// `Some(reason)` if a turn aborted (budget/loop/step-cap).
     aborted: Option<String>,
+    /// Whether this abort is a degradable **infrastructure** setup failure —
+    /// no isolation port, or a workspace that could not be snapshotted. `run`
+    /// degrades these to a bare worker run rather than ending the turn with
+    /// zero work (the "never choose nothing" rule). Deliberately does NOT
+    /// cover a witness-integrity rejection (symlink artifact, language
+    /// mismatch, a witness author touching production code): those are
+    /// fail-closed security decisions and keep their abort. `false` on every
+    /// executed and every verified/unverified result.
+    degradable: bool,
     /// The verification verdict, if verification ran.
     verdict: Option<Verdict>,
     /// This candidate's verification score, for best-of-N selection.
@@ -283,15 +292,31 @@ struct CandidateResult {
 }
 
 impl CandidateResult {
+    /// A candidate that aborted for a reason that is NOT a degradable
+    /// infrastructure setup failure: an execution abort (budget, loop,
+    /// step-cap — the worker ran) or a fail-closed security rejection (a
+    /// poisoned witness). These keep their stop.
     fn aborted(messages: Vec<CompletionMessage>, reason: String) -> Self {
         Self {
             messages,
             final_text: String::new(),
             aborted: Some(reason),
+            degradable: false,
             verdict: None,
             score: CandidateScore::Failed,
             diff_lines: 0,
             revisions: 0,
+        }
+    }
+
+    /// A candidate that aborted on a degradable **infrastructure** setup
+    /// failure — no isolation port, or a tree that could not be snapshotted.
+    /// Flagged so `run` degrades it to a bare worker run rather than ending
+    /// the turn having done nothing.
+    fn setup_aborted(messages: Vec<CompletionMessage>, reason: String) -> Self {
+        Self {
+            degradable: true,
+            ..Self::aborted(messages, reason)
         }
     }
 }
@@ -328,6 +353,7 @@ impl CandidateState {
             messages: self.messages,
             final_text: self.final_text,
             aborted: None,
+            degradable: false,
             verdict: Some(Verdict::from_evidence(passed, evidence)),
             score,
             diff_lines: self.diff_lines,
@@ -341,6 +367,7 @@ impl CandidateState {
             messages: self.messages,
             final_text: self.final_text,
             aborted: None,
+            degradable: false,
             verdict: None,
             score: CandidateScore::Unverified,
             diff_lines: self.diff_lines,
@@ -585,6 +612,35 @@ impl<'a> Pipeline<'a> {
                 Ok(result) => result,
                 Err(cause) => return Err(PipelineRunError::new(cause, total_cost)),
             }
+        };
+
+        // The "never choose nothing" backstop. A candidate that aborted
+        // BEFORE the worker ever ran — a setup failure (no isolation port, no
+        // independent witness author, a tree that could not be snapshotted) —
+        // must not end the turn having executed nothing. The fancy path being
+        // unavailable is a reason to do LESS, never a reason to do nothing:
+        // degrade to a bare worker run on the working tree. Execution aborts
+        // (budget, loop, step-cap) and true resource limits keep their stop —
+        // there the worker DID run, so the abort is honest.
+        let best = if best.aborted.is_some() && best.degradable {
+            match self
+                .degrade_to_bare_execution(
+                    goal,
+                    &base_messages,
+                    plan.as_deref(),
+                    assessment,
+                    budget,
+                    &mut total_cost,
+                )
+                .await
+            {
+                Some(executed) => executed,
+                // Even the bare run could not start (no resolvable worker) —
+                // that is a genuine impossibility, so keep the setup abort.
+                None => best,
+            }
+        } else {
+            best
         };
 
         // Adopt the winning candidate's trajectory.
@@ -858,6 +914,45 @@ impl<'a> Pipeline<'a> {
     /// working tree): the single-shot path, and the shared-tree degradation
     /// of best-of-N when no [`CandidateWorkspacePort`] is wired.
     #[allow(clippy::too_many_arguments)]
+    /// Last-resort execution when candidate setup failed before the worker
+    /// ever ran. Runs exactly one worker turn on the session tree — no
+    /// isolation, no authored witness, the simplest path that still does the
+    /// work. Returns `None` only when there is no resolvable worker provider
+    /// (a true impossibility, not a degradable setup failure), in which case
+    /// the caller keeps the original setup abort.
+    async fn degrade_to_bare_execution(
+        &self,
+        goal: &str,
+        base_messages: &[CompletionMessage],
+        plan: Option<&[PlanStep]>,
+        assessment: TaskAssessment,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Option<CandidateResult> {
+        let worker = self.resolve_provider(Role::Worker).ok()?;
+        if let Some(fallback) = &worker.fallback {
+            self.emit_fallback(fallback);
+        }
+        self.warn(
+            "candidate setup failed before any execution; running a bare worker turn on the \
+             working tree so the turn still does the work it was asked to"
+                .to_string(),
+        );
+        self.run_shared_candidates(
+            goal,
+            base_messages,
+            plan,
+            assessment,
+            None,
+            &worker,
+            1,
+            budget,
+            total,
+        )
+        .await
+        .pop()
+    }
+
     async fn run_shared_candidates(
         &self,
         goal: &str,
@@ -936,7 +1031,7 @@ impl<'a> Pipeline<'a> {
         let Some(port) = self.candidate_workspaces else {
             if author_witness {
                 return Ok((
-                    CandidateResult::aborted(
+                    CandidateResult::setup_aborted(
                         base_messages.to_vec(),
                         "authored witness requires candidate isolation, but no candidate \
                          workspace port is available"
@@ -1032,7 +1127,7 @@ impl<'a> Pipeline<'a> {
                     // isolated is never run in the shared tree instead: it
                     // scores as aborted and the remaining candidates go on.
                     self.warn(format!("candidate {}/{n} skipped: {e}", i + 1));
-                    candidates.push(CandidateResult::aborted(
+                    candidates.push(CandidateResult::setup_aborted(
                         base_messages.to_vec(),
                         format!("candidate isolation failed: {e}"),
                     ));
@@ -1065,6 +1160,10 @@ impl<'a> Pipeline<'a> {
                     {
                         Ok(witness) => witness,
                         Err(reason) => {
+                            // A witness-integrity rejection is fail-closed
+                            // security, not a degradable setup failure — keep
+                            // the abort so the poisoned witness cannot be
+                            // silently traded for an unverified run.
                             candidates
                                 .push(CandidateResult::aborted(base_messages.to_vec(), reason));
                             workspaces.push(Some(ws));

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1364,6 +1364,95 @@ async fn run_isolated(
 /// from a witness author; with no author there is nothing to protect it from,
 /// so no snapshot machinery is engaged — which is what lets Stella work in a
 /// plain directory that is not a git repository.
+/// The "never choose nothing" backstop: when every candidate fails ISOLATION
+/// setup before the worker runs, the pipeline must degrade to a bare
+/// execution on the working tree — not end the turn having done nothing.
+#[tokio::test]
+async fn a_setup_failure_degrades_to_a_bare_execution_instead_of_aborting() {
+    // triage → single; worker → done. No witness-author turn: the failure is
+    // pure isolation setup, and the bare fallback runs the worker once.
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
+        text_result("done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    // A candidate port that fails to isolate every candidate. Best-of-N
+    // (n=2) drives it, so both candidates are setup_aborted.
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = FakeWorkspacePort::new(
+        vec![
+            Err(WorkspaceError::Snapshot {
+                reason: "not a git repo".into(),
+            }),
+            Err(WorkspaceError::Snapshot {
+                reason: "not a git repo".into(),
+            }),
+        ],
+        log,
+    );
+    let config = PipelineConfig {
+        candidates: Some(2),
+        ..PipelineConfig::default()
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(&port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the retry bug", &mut messages, &mut budget)
+        .await
+        .expect("a setup failure is a degradation, not a run-ending error");
+
+    assert_ne!(
+        outcome.status,
+        PipelineStatus::Aborted {
+            reason: "candidate isolation failed: workspace snapshot failed: not a git repo"
+                .to_string()
+        },
+        "an isolation setup failure must not end the turn: {outcome:?}"
+    );
+    assert!(
+        !matches!(outcome.status, PipelineStatus::Aborted { .. }),
+        "the backstop must produce a real execution, not any abort: {outcome:?}"
+    );
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("running a bare worker turn")
+        )),
+        "the degradation announces itself once: {events:?}"
+    );
+}
+
 async fn run_unisolated_with_router(
     provider: &ScriptedProvider,
     config: PipelineConfig,

--- a/stella-pipeline/src/pipeline/tests/task5.rs
+++ b/stella-pipeline/src/pipeline/tests/task5.rs
@@ -333,8 +333,23 @@ async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_
 }
 
 #[tokio::test]
-async fn authored_witness_isolation_failure_aborts_before_authoring() {
-    let provider = ScriptedProvider::new(vec![text_result("single")]);
+async fn authored_witness_isolation_failure_degrades_to_a_bare_run() {
+    // Isolation is INFRASTRUCTURE, not security: if the authored-witness path
+    // can't snapshot a workspace, the run degrades to a bare worker turn on
+    // the working tree rather than ending having done nothing. (A poisoned
+    // witness is different — that keeps its fail-closed abort; see the
+    // symlink/language/production-edit tests below.)
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    // Working session ports — the bare fallback runs over these.
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let port = FakeWorkspacePort::new(
         vec![Err(WorkspaceError::Snapshot {
@@ -342,18 +357,52 @@ async fn authored_witness_isolation_failure_aborts_before_authoring() {
         })],
         log.clone(),
     );
-
-    let (outcome, events, _) = run_isolated(
-        &provider,
-        &port,
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(&port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
         PipelineConfig::default(),
-        "Fix the failing test",
-    )
-    .await;
-    let outcome = outcome.expect("isolation failure is a truthful abort");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
-    assert!(!stages(&events).contains(&StageKind::Witness));
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("isolation failure degrades, it does not error");
+
+    assert!(
+        !matches!(
+            outcome.status,
+            PipelineStatus::Aborted { ref reason } if reason.contains("isolation")
+        ),
+        "an isolation failure must not end the turn: {outcome:?}"
+    );
+    // Isolation WAS attempted (once, at n=1) before degrading.
     assert_eq!(*log.lock().unwrap(), vec!["create"]);
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("running a bare worker turn")
+        )),
+        "the degradation announces itself: {events:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Builds principle #1 from the loop-hardening discussion: **stop letting the loop choose "nothing."**

## The class of death

Most "the agent died doing zero work" failures share one shape: a guard that **fails closed into a hard abort** when a degraded-but-working path was right there. Six shipped this session — witness independence unavailable, candidate isolation on a non-git tree, a headless scope stop, judge==worker, a config-key gate, an always-abort gate. Each was "I can't do the fancy thing, so I do *nothing*" when "do the simple thing" was one branch away. Volume never fixes a philosophy; this makes it structural.

## The structural rule

A candidate now carries `degradable`, true **only for an infrastructure setup failure** (no isolation port, a tree that couldn't be snapshotted). `run` degrades those via `degrade_to_bare_execution` — one worker turn on the working tree, no isolation, no authored witness: the simplest path that still does the work. Only a genuinely unresolvable worker provider (a true impossibility) keeps the abort.

## Deliberately NOT covered

- **Execution aborts** (budget, loop, step-cap) — the worker ran; the stop is honest.
- **Witness-integrity rejections** (symlink artifact, language mismatch, a witness author touching production code) — these are **fail-closed security** decisions and keep their abort, so a poisoned witness can never be silently traded for an unverified run.

## Tests
- A setup failure over a failing isolation port (best-of-N) degrades to a bare execution and announces itself.
- The n=1 authored-witness isolation path does the same.
- The **five** witness-integrity tests still abort, unchanged.

When I first over-scoped this to *all* setup aborts, exactly those five security tests broke — direct evidence the `degradable` flag gates the behavior. `cargo test -p stella-pipeline` (152) + `clippy -D warnings` green.

## Follow-ups (the rest of principle #1 + the harness)
- The remaining pre-execute aborts in `run` (budget/no-provider/user-scope-abort) are legitimate and unchanged.
- The property/chaos harness (assert *for any provider × workspace × task class, the loop completes or aborts-with-a-reason and does N>0 work or names why zero*) is the natural next PR — it would have caught 5 of this session's 6 before a single real run.
