### PR TITLE
test(cgp): gate shipped providers on the CGP conformance suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -392,7 +392,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -414,6 +414,21 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "contextgraph-conformance"
+version = "0.1.0"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=58a933a2e1f894ae98adc9994bd9d0062a610ae8#58a933a2e1f894ae98adc9994bd9d0062a610ae8"
+dependencies = [
+ "async-trait",
+ "clap",
+ "colored",
+ "contextgraph-host",
+ "contextgraph-types",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "contextgraph-host"
@@ -836,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2350,7 +2365,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2737,7 +2752,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3018,7 +3033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3052,6 +3067,7 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
+ "contextgraph-conformance",
  "contextgraph-host",
  "contextgraph-types",
  "dotenvy",
@@ -3488,10 +3504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3515,7 +3531,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4319,7 +4335,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -58,3 +58,7 @@ rpassword.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 rusqlite.workspace = true
+# The protocol's own conformance suite (§3.6), pinned to the same rev as the
+# types/host we consume. Wired into `contextgraph.rs` tests so "CGP-conformant"
+# is a checked claim about the providers this CLI ships, not a documented one.
+contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "58a933a2e1f894ae98adc9994bd9d0062a610ae8" }

--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -535,4 +535,115 @@ mod tests {
         let ids: Vec<&str> = result.frames.iter().map(|f| f.id.as_str()).collect();
         assert_eq!(ids, vec!["plane-graph"]);
     }
+
+    // ---- CGP conformance -------------------------------------------------
+    //
+    // The providers this host registers are green on the protocol's own
+    // conformance suite (§3.6), verified in-tree — not merely asserted to be
+    // by documentation. Both are exercised through `run_conformance` exactly
+    // as `session_host` constructs them, so a regression that made a shipped
+    // provider lie about cost, drop a citation label, or fail to shut down
+    // cleanly turns this suite red.
+
+    use contextgraph_conformance::{
+        CHECK_FRAME_VALIDITY, CheckStatus, ConformanceReport, ProviderTarget, run_conformance,
+    };
+
+    /// Render a report's failures for a panic message, so a red run names the
+    /// exact contract that broke rather than just "not conformant".
+    fn conformance_failures(report: &ConformanceReport) -> String {
+        report
+            .failures()
+            .map(|check| format!("{}: {}", check.name, check.evidence))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    #[tokio::test]
+    async fn workspace_memory_provider_is_cgp_conformant() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = seeded_store(&dir).await;
+        // Constructed exactly as `session_host` builds the shipped
+        // `workspace-memory` provider: the store behind the plane registry,
+        // advertising the kinds it serves.
+        let provider = MemoryProvider {
+            plane: memory_plane(store, vec![]),
+            info: local_info("workspace-memory"),
+            caps: Capabilities {
+                query: contextgraph_types::capability::QueryCapability {
+                    kinds: ["memory", "episode", "fact", "snippet", "symbol", "doc"]
+                        .map(String::from)
+                        .to_vec(),
+                    filters: Vec::new(),
+                },
+                ..Capabilities::default()
+            },
+        };
+        let report = run_conformance(ProviderTarget::InProcess(Box::new(provider))).await;
+        assert!(
+            report.passed(),
+            "workspace-memory is not CGP-conformant: {}",
+            conformance_failures(&report)
+        );
+    }
+
+    #[tokio::test]
+    async fn code_graph_provider_is_cgp_conformant() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // The `code-graph` provider as `session_host` registers it. With no
+        // index on disk it returns zero frames — permitted by §3.4 — so this
+        // pins handshake, budget honesty, and clean shutdown for the graph leg.
+        let provider = GraphProvider {
+            workspace_root: dir.path().to_path_buf(),
+            info: local_info("code-graph"),
+            caps: Capabilities {
+                graph: true,
+                query: contextgraph_types::capability::QueryCapability {
+                    kinds: ["symbol", "snippet", "graph"].map(String::from).to_vec(),
+                    filters: Vec::new(),
+                },
+                ..Capabilities::default()
+            },
+        };
+        let report = run_conformance(ProviderTarget::InProcess(Box::new(provider))).await;
+        assert!(
+            report.passed(),
+            "code-graph is not CGP-conformant: {}",
+            conformance_failures(&report)
+        );
+    }
+
+    #[tokio::test]
+    async fn conformance_gate_catches_a_frame_without_a_citation_label() {
+        // Teeth: a provider that returns a bare-id frame (§3.4 — "NEVER a
+        // bare uuid") must FAIL frame-validity. This proves the two passing
+        // tests above are a real gate that would catch a regression, not a
+        // suite that waves everything through.
+        let mut bare_id = frame("bare-id", 0.9, 8);
+        bare_id.citation_label = None;
+        let report =
+            run_conformance(ProviderTarget::InProcess(scripted("bad", vec![bare_id]))).await;
+        assert!(
+            !report.passed(),
+            "a frame with no citation label must not be judged conformant"
+        );
+        assert!(
+            report.checks.iter().any(
+                |check| check.name == CHECK_FRAME_VALIDITY && check.status == CheckStatus::Fail
+            ),
+            "the missing citation label must surface as a frame-validity failure"
+        );
+    }
+
+    #[test]
+    fn pinned_protocol_version_is_the_expected_draft() {
+        // Tripwire: our conformance is verified against this exact wire
+        // version. If a pin bump moves the protocol version, this fails loudly
+        // so conformance is re-audited rather than silently assumed to hold.
+        assert_eq!(
+            contextgraph_types::PROTOCOL_VERSION,
+            "contextgraph/1.0-draft",
+            "CGP protocol version changed — re-verify the conformance suite before bumping the pin"
+        );
+    }
 }


### PR DESCRIPTION
## What

Makes Stella's **CGP conformance a checked fact rather than a documented claim.**

Stella pins `contextgraph-types` + `contextgraph-host` (rev `58a933a2`, `contextgraph/1.0-draft`) and routes live session recall through the real `contextgraph-host` runtime — but nothing in-tree ever ran the protocol's own `contextgraph-conformance` suite against the two providers this CLI ships (`workspace-memory`, `code-graph`). "Conformance-verified" existed only in `docs/papers/stella-defensible-position.md`. A regression that made a provider lie about `token_cost`, drop a citation label, or fail to shut down cleanly would not have been caught.

## Changes

- **`stella-cli/Cargo.toml`** — add `contextgraph-conformance` as a dev-dependency at the *same pinned rev* as the types/host already consumed.
- **`stella-cli/src/contextgraph.rs`** — four tests in the existing `mod tests`:
  - `workspace_memory_provider_is_cgp_conformant` — runs `run_conformance` against the shipped `workspace-memory` provider, built exactly as `session_host` builds it.
  - `code_graph_provider_is_cgp_conformant` — same for the `code-graph` provider (empty index → 0 frames, which §3.4 permits; pins handshake / budget-honesty / clean shutdown).
  - `conformance_gate_catches_a_frame_without_a_citation_label` — **teeth**: a bare-id frame must *fail* frame-validity, proving the gate would catch a real regression rather than wave everything through.
  - `pinned_protocol_version_is_the_expected_draft` — tripwire on `PROTOCOL_VERSION` so a future pin bump forces a conformance re-audit instead of silently assuming conformance still holds.

For in-process providers the suite runs handshake + frame-validity + budget-honesty + shutdown-clean (the wire-level malformed-input probe is `Skipped`, as designed).

## Scope

This closes the **"conformance is claimed, not gated"** gap only. Deliberately *not* in this PR (larger / upstream-dependent): building the external-provider seam in `stella-context/src/provider.rs`, rebasing the pin forward onto the content-optional / frame-representation revision, and the protocol's unbuilt lifecycle-record half.

## Verification

```
cargo test -p stella-cli --bin stella contextgraph::   # 10 passed; 0 failed
cargo fmt -p stella-cli -- --check                      # clean
cargo clippy -p stella-cli --bin stella --tests         # no warnings
```