### PR TITLE
feat(cli): optional end-of-run recap (settings enable_recap)

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -484,6 +484,9 @@ async fn run_pipeline_one_shot(
                     &format!("{}/{}", cfg.provider.id, cfg.model_id),
                     turn_start.elapsed(),
                 );
+                if cfg.enable_recap {
+                    tui::recap_panel(&outcome.status, outcome.verdict.as_ref(), &files);
+                }
                 println!();
             }
 

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -599,6 +599,7 @@ fn cfg_for(provider_id: &str) -> Config {
         hooks: None,
         engine_settings: None,
         tools_bash: false,
+        enable_recap: false,
         tools_web: false,
         authority: crate::settings::AuthorityPolicy::default(),
     }

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -487,6 +487,8 @@ pub struct Config {
     /// construction via `agent::registry_options` — the default tool
     /// surface has no shell.
     pub tools_bash: bool,
+    /// End-of-run recap in text mode (settings `enable_recap`).
+    pub enable_recap: bool,
     /// Whether the web tool family is enabled (`tools.web`; absent = OFF).
     /// Same threading as `tools_bash` — the default tool surface has no
     /// network egress.
@@ -630,6 +632,7 @@ impl Config {
         cfg.engine_settings = settings.agent_engine_config.clone();
         cfg.authority = settings.authority_policy;
         cfg.tools_bash = settings.bash_tool_enabled() && cfg.authority.bash_allowed;
+        cfg.enable_recap = settings.recap_enabled();
         cfg.tools_web = settings.web_tools_enabled() && cfg.authority.web_allowed;
         Ok(cfg)
     }
@@ -749,6 +752,7 @@ impl Config {
                     hooks: None,
                     engine_settings: None,
                     tools_bash: false,
+                    enable_recap: false,
                     tools_web: false,
                     authority: crate::settings::AuthorityPolicy::default(),
                     credential_source,
@@ -943,6 +947,7 @@ impl Config {
             hooks: None,
             engine_settings: None,
             tools_bash: false,
+            enable_recap: false,
             tools_web: false,
             authority: crate::settings::AuthorityPolicy::default(),
             credential_source: Some(source),

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -124,6 +124,7 @@ fn config_debug_never_leaks_the_api_key() {
         hooks: None,
         engine_settings: None,
         tools_bash: false,
+        enable_recap: false,
         tools_web: false,
         authority: crate::settings::AuthorityPolicy::default(),
         credential_source: Some(stella_model::credential::CredentialSource::EnvVar),

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -124,6 +124,11 @@ pub struct Settings {
     /// subject to repository trust and the non-overridable managed ceiling.
     #[serde(default)]
     pub tools: Option<ToolsSettings>,
+    /// `on` = print an end-of-run recap in text mode: a deterministic
+    /// synthesis of the outcome (completed/verified/failed/aborted) and what
+    /// changed, beside the file and cost panels. No model call. Default off.
+    #[serde(default)]
+    pub enable_recap: Option<Toggle>,
     /// Authority ceilings are honored only from the org-managed settings
     /// file. The serde name is intentionally short because the containing
     /// file is already the policy source.
@@ -564,6 +569,13 @@ impl Settings {
             .is_some_and(Toggle::is_on)
     }
 
+    /// Whether the end-of-run recap is enabled for this workspace. Default
+    /// off; only an explicit `"enable_recap": "on"` in the scope chain turns
+    /// it on (a later `"off"` turns it back off — project wins per field).
+    pub fn recap_enabled(&self) -> bool {
+        self.enable_recap.is_some_and(Toggle::is_on)
+    }
+
     /// Whether the web tool family is enabled for this workspace. Same
     /// posture as [`Settings::bash_tool_enabled`]: default OFF everywhere,
     /// only an explicit `"tools": {"web": "on"}` in the chain turns it on.
@@ -973,6 +985,22 @@ mod tests {
     fn bash_tool_defaults_off_and_the_project_scope_wins_per_field() {
         // Absent everywhere → off.
         assert!(!Settings::default().bash_tool_enabled());
+        // Recap mirrors the same on/off-string switch discipline.
+        assert!(!Settings::default().recap_enabled(), "recap defaults off");
+        assert!(
+            serde_json::from_str::<Settings>(r#"{"enable_recap":"on"}"#)
+                .unwrap()
+                .recap_enabled(),
+            "\"on\" enables the recap"
+        );
+        assert!(
+            !serde_json::from_str::<Settings>(r#"{"enable_recap":"off"}"#)
+                .unwrap()
+                .recap_enabled()
+        );
+        // A typo'd value is a loud parse error, not a silent false (the whole
+        // point of the Toggle enum over a bool).
+        assert!(serde_json::from_str::<Settings>(r#"{"enable_recap":true}"#).is_err());
         let dir = tempfile::tempdir().unwrap();
         let silent = write(dir.path(), "silent.json", r#"{"providers": {}}"#);
         let merged = Settings::load_from(std::slice::from_ref(&silent)).unwrap();

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -271,6 +271,62 @@ pub fn cost_summary(cost_usd: f64, model: &str, elapsed: Duration) {
     );
 }
 
+/// The end-of-run recap (settings `enable_recap`): a deterministic synthesis
+/// of the outcome and what changed, printed after the file and cost panels in
+/// text mode. No model call — it reads the run's own facts. Complements the
+/// file-list panel with the "so what": did it complete, was it verified, and
+/// a created/modified/deleted tally.
+pub fn recap_panel(
+    status: &stella_pipeline::PipelineStatus,
+    verdict: Option<&stella_pipeline::Verdict>,
+    files: &[(String, String)],
+) {
+    use stella_pipeline::PipelineStatus;
+    let headline = match status {
+        PipelineStatus::Completed => match verdict {
+            Some(v) if v.passed && v.deterministic => {
+                "✓ completed — verified (deterministic)".to_string()
+            }
+            Some(v) if v.passed => "✓ completed — verified".to_string(),
+            _ => "✓ completed".to_string(),
+        },
+        PipelineStatus::VerificationFailed { verdict } => {
+            format!("✗ verification failed — {}", verdict.summary)
+        }
+        PipelineStatus::Aborted { reason } => format!("⚠ aborted — {reason}"),
+    };
+
+    let mut created = 0usize;
+    let mut modified = 0usize;
+    let mut deleted = 0usize;
+    for (_, op) in files {
+        match op.to_ascii_lowercase().as_str() {
+            o if o.contains("creat") || o.contains("add") => created += 1,
+            o if o.contains("delet") || o.contains("remov") => deleted += 1,
+            _ => modified += 1,
+        }
+    }
+    let changes = if files.is_empty() {
+        "no files changed".to_string()
+    } else {
+        let mut parts = Vec::new();
+        if created > 0 {
+            parts.push(format!("{created} created"));
+        }
+        if modified > 0 {
+            parts.push(format!("{modified} modified"));
+        }
+        if deleted > 0 {
+            parts.push(format!("{deleted} deleted"));
+        }
+        parts.join(" · ")
+    };
+
+    println!("\n  {} Recap", "◆".dimmed());
+    println!("    {headline}");
+    println!("    {changes}");
+}
+
 /// Print the welcome banner: the STELLA block-letter logomark swept with the
 /// stellar gradient, then the session info line. (The previous banner was a
 /// hand-pasted figlet that had drifted into garbage — it did not actually


### PR DESCRIPTION
## What

An opt-in end-of-run recap in text mode — a deterministic synthesis of what happened, printed after the file and cost panels:

```
  ◆ Recap
    ✓ completed — verified (deterministic)
    2 created · 1 modified
```

Outcome headline covers all terminal states: `✓ completed` (+ verified / deterministic when a verdict says so), `✗ verification failed — <summary>`, `⚠ aborted — <reason>`. The change tally complements the existing file-list panel with the "so what".

**No model call** — it reads the run's own facts (`PipelineOutcome.status` / `verdict` and the registry's touched-files list), so it's free and can't be wrong.

## Config

Off by default. Enabled with:

```json
{ "enable_recap": "on" }
```

I used the `Toggle` (`"on"`/`"off"`) convention every other switch uses (`bash`, `web`, `auto_mode`, `headless_scope_bypass`) rather than a bare `true`, so a typo is a **loud parse error** instead of a silently-false bool — the reason the `Toggle` enum exists. (Happy to accept a bare bool instead if you'd prefer `"enable_recap": true`; it's a one-line change.)

Threads `Settings::recap_enabled` → `Config.enable_recap` → the one-shot text-mode completion, mirroring the `tools_bash` plumbing exactly.

## Tests
- Setting parse: default-off, `"on"` enables, `"off"` disables, and `true` (bool) is a parse error.
- `cargo test -p stella-cli` + `clippy -D warnings` green.

## Note
Deterministic recap is the cheapest, always-correct version. If you want a *prose* recap (a model-written narrative of the session), that's a natural follow-up — it'd cost one summarization call, so it should be its own opt-in tier.
