### PR TITLE
feat(pipeline): verification cannot lie — a blind empty diff never reads as "no changes"

### DIFF
--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -88,6 +88,33 @@ use run_error::RoleResolveError;
 pub use run_error::{PipelineError, PipelineRunError};
 use stage_budget::{PipelineBudgetAbort, budget_abort};
 use task5::BoundHookRunner;
+/// Make a diff that verification hands downstream *incapable of lying*.
+///
+/// An empty diff is ambiguous: it can mean the agent genuinely changed
+/// nothing, OR that the diff machinery is blind to changes that DID happen
+/// (work that was committed, a baseline mismatch, an uncaptured file). Handed
+/// a bare empty string, a judge reads the second case as the first and
+/// concludes "no changes were made" — the archetypal verification lie that
+/// once drove an agent to reinitialize git to beat the check.
+///
+/// The pipeline already has the independent signal that resolves the
+/// ambiguity: `file_changes`, the count of `FileChange` events the turn
+/// emitted. When that is positive but the diff is empty, the honest report is
+/// "the tree changed but the diff could not be captured" — a *couldn't
+/// verify*, never a *verified nothing*. Every consumer (judge, guidance,
+/// evidence) then sees the truth.
+fn verification_honest_diff(diff_text: String, file_changes: u32) -> String {
+    if file_changes > 0 && diff_text.trim().is_empty() {
+        format!(
+            "[{file_changes} file-change event(s) were observed this turn, but the diff could \
+             not be captured — the change is real; the diff is blind to it. This is NOT evidence \
+             that nothing changed; verify the result on its own merits.]"
+        )
+    } else {
+        diff_text
+    }
+}
+
 /// Minimal fallback when the caller supplies no stable system prefix.
 const DEFAULT_SYSTEM_PROMPT: &str =
     "You are a precise, careful software engineering agent. Make the smallest correct change.";
@@ -1315,8 +1342,10 @@ impl<'a> Pipeline<'a> {
         // simple lookup, only if the turn unexpectedly touched files (the
         // zero-diff guard, L-E2). "Touched files" = FileChange events observed
         // OR a non-empty diff.
-        (state.diff_lines, state.diff_text) =
+        let (gathered_lines, gathered_diff) =
             self.gather_diff(surface, &state.untracked_before).await;
+        state.diff_lines = gathered_lines;
+        state.diff_text = verification_honest_diff(gathered_diff, state.file_changes);
         let files_touched = state.file_changes > 0 || !state.diff_text.trim().is_empty();
         let should_verify = assessment.class.verifies_unconditionally()
             || (assessment.class == TaskClass::SimpleLookup && files_touched);
@@ -1560,11 +1589,13 @@ impl<'a> Pipeline<'a> {
                     // Inconclusive — escalate to the model judge (judge ≠
                     // worker; a judge-call failure falls back to a heuristic).
                     let evidence_summary = format!(
-                        "flip_achieved={}; touched_tests={:?}; diff_lines={} (budget {})",
+                        "flip_achieved={}; touched_tests={:?}; diff_lines={} (budget {}); \
+                         file_change_events={}",
                         inputs.flip_achieved,
                         inputs.touched_tests_passed,
                         state.diff_lines,
                         self.config.diff_budget_lines,
+                        state.file_changes,
                     );
                     let verdict = match self
                         .judge(
@@ -1686,7 +1717,7 @@ impl<'a> Pipeline<'a> {
             )
             .await?;
         state.diff_lines = diff_lines;
-        state.diff_text = diff_text;
+        state.diff_text = verification_honest_diff(diff_text, state.file_changes);
         state.revisions += 1;
         Ok(())
     }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -1159,13 +1159,18 @@ impl<'a> Pipeline<'a> {
                         .await
                     {
                         Ok(witness) => witness,
-                        Err(reason) => {
-                            // A witness-integrity rejection is fail-closed
-                            // security, not a degradable setup failure — keep
-                            // the abort so the poisoned witness cannot be
-                            // silently traded for an unverified run.
-                            candidates
-                                .push(CandidateResult::aborted(base_messages.to_vec(), reason));
+                        Err(abort) => {
+                            // A witness that couldn't be AUTHORED degrades to a
+                            // bare run (the task needs no witness). An
+                            // artifact-INTEGRITY violation stays fail-closed,
+                            // so a poisoned witness is surfaced, never silently
+                            // traded for an unverified run.
+                            let candidate = if abort.degradable {
+                                CandidateResult::setup_aborted(base_messages.to_vec(), abort.reason)
+                            } else {
+                                CandidateResult::aborted(base_messages.to_vec(), abort.reason)
+                            };
+                            candidates.push(candidate);
                             workspaces.push(Some(ws));
                             continue;
                         }

--- a/stella-pipeline/src/pipeline/task5.rs
+++ b/stella-pipeline/src/pipeline/task5.rs
@@ -21,6 +21,37 @@ impl HookRunner for BoundHookRunner<'_> {
     }
 }
 
+/// Why an authored witness could not be produced or accepted, and whether the
+/// pipeline may degrade past it.
+///
+/// `degradable` = the witness simply couldn't be AUTHORED (no test command,
+/// an unusable command, a test that proves nothing, the author engine getting
+/// stuck). The task needs no witness to proceed, so the run degrades to a
+/// bare worker turn rather than dying. NOT degradable = a resource limit
+/// (budget) or an artifact-INTEGRITY violation (the author modified tracked
+/// files, produced a non-single-file / symlink artifact, or a runner/identity
+/// mismatch) — fail-closed decisions that surface the problem rather than
+/// silently completing unverified.
+pub(super) struct WitnessAbort {
+    pub(super) reason: String,
+    pub(super) degradable: bool,
+}
+
+impl WitnessAbort {
+    pub(super) fn degradable(reason: String) -> Self {
+        Self {
+            reason,
+            degradable: true,
+        }
+    }
+    pub(super) fn rejected(reason: String) -> Self {
+        Self {
+            reason,
+            degradable: false,
+        }
+    }
+}
+
 impl<'a> Pipeline<'a> {
     pub(super) fn engine_config_for(&self, surface: CandidateSurface<'_>) -> EngineConfig {
         let mut config = self.config.engine.clone();
@@ -40,7 +71,7 @@ impl<'a> Pipeline<'a> {
         surface: CandidateSurface<'_>,
         budget: &mut BudgetGuard,
         total: &mut f64,
-    ) -> Result<Option<Witness>, String> {
+    ) -> Result<Option<Witness>, WitnessAbort> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Witness,
         });
@@ -76,19 +107,23 @@ impl<'a> Pipeline<'a> {
             TurnOutcome::Aborted { reason, cost_usd } => {
                 *total += cost_usd;
                 if let Some(abort) = budget_abort(budget.evaluate()) {
-                    return Err(abort.reason);
+                    return Err(WitnessAbort::rejected(abort.reason));
                 }
-                return Err(format!("witness author turn aborted: {reason}"));
+                return Err(WitnessAbort::degradable(format!(
+                    "witness author turn aborted: {reason}"
+                )));
             }
         };
         let Some(mut command) = parse_witness_command(&text) else {
-            return Err("witness author produced no TEST_COMMAND line".to_string());
+            return Err(WitnessAbort::degradable(
+                "witness author produced no TEST_COMMAND line".to_string(),
+            ));
         };
 
         let Ok(mut invocation) = parse_test_invocation(&command) else {
-            return Err(format!(
+            return Err(WitnessAbort::degradable(format!(
                 "witness author produced an unsafe or unsupported test command `{command}`"
-            ));
+            )));
         };
         if surface.tests.run_test(&invocation).await.passed() {
             messages.push(CompletionMessage::user(witness_repair_prompt(&command)));
@@ -110,22 +145,24 @@ impl<'a> Pipeline<'a> {
                 TurnOutcome::Aborted { reason, cost_usd } => {
                     *total += cost_usd;
                     if let Some(abort) = budget_abort(budget.evaluate()) {
-                        return Err(abort.reason);
+                        return Err(WitnessAbort::rejected(abort.reason));
                     }
-                    return Err(format!("witness repair turn aborted: {reason}"));
+                    return Err(WitnessAbort::degradable(format!(
+                        "witness repair turn aborted: {reason}"
+                    )));
                 }
             };
             command = parse_witness_command(&repaired).unwrap_or(command);
             let Ok(repaired_invocation) = parse_test_invocation(&command) else {
-                return Err(format!(
+                return Err(WitnessAbort::degradable(format!(
                     "witness repair produced an unsafe or unsupported test command `{command}`"
-                ));
+                )));
             };
             invocation = repaired_invocation;
             if surface.tests.run_test(&invocation).await.passed() {
-                return Err(
+                return Err(WitnessAbort::degradable(
                     "witness test still passes on the unmodified code after one repair".to_string(),
-                );
+                ));
             }
         }
 
@@ -137,15 +174,16 @@ impl<'a> Pipeline<'a> {
             &untracked_before,
             &untracked_after,
         )
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
         let path = fingerprints
             .keys()
             .next()
             .expect("validated witness artifact contains exactly one path");
-        validate_witness_invocation(path, &invocation).map_err(|error| error.to_string())?;
+        validate_witness_invocation(path, &invocation)
+            .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
         let identity = surface.repo_status.artifact_identity(path).await;
         validate_witness_identity(path, &fingerprints[path], identity.as_ref())
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
         let files = HashMap::from([(
             path.clone(),
             identity.expect("validated witness identity is present"),

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1622,6 +1622,47 @@ fn isolated_config(n: u32) -> PipelineConfig {
 
 /// Best-of-N candidate isolation tests — see the module doc there for why
 /// the shared infra (`run_isolated`, `isolated_config`, ...) stays here.
+#[cfg(test)]
+mod verification_honesty {
+    use super::super::verification_honest_diff;
+
+    /// The archetypal lie: the turn emitted file-change events, but the diff
+    /// came back empty (committed work, a baseline miss, an uncaptured file).
+    /// A bare empty string reads to a judge as "no changes were made" — the
+    /// signal that once drove an agent to reinitialize git. The guard must
+    /// turn it into an honest "couldn't capture", never "verified nothing".
+    #[test]
+    fn a_blind_empty_diff_with_file_changes_is_reported_as_uncaptured_not_absent() {
+        let out = verification_honest_diff(String::new(), 3);
+        assert!(
+            !out.trim().is_empty(),
+            "an empty diff with file changes must not stay empty"
+        );
+        assert!(out.contains("could not be captured"), "{out}");
+        assert!(
+            out.contains("NOT evidence that nothing changed"),
+            "the marker must foreclose the 'no changes' reading: {out}"
+        );
+        assert!(out.contains('3'), "it names the file-change count: {out}");
+    }
+
+    /// A genuinely empty diff — no file-change events — is the truth and stays
+    /// empty. The guard must not invent changes that did not happen.
+    #[test]
+    fn a_truly_empty_diff_with_no_file_changes_stays_empty() {
+        assert_eq!(verification_honest_diff(String::new(), 0), "");
+        assert_eq!(verification_honest_diff("   \n".to_string(), 0), "   \n");
+    }
+
+    /// A real diff is passed through untouched, regardless of the count.
+    #[test]
+    fn a_real_diff_passes_through_unchanged() {
+        let diff = "@@ -1 +1 @@\n-a\n+b".to_string();
+        assert_eq!(verification_honest_diff(diff.clone(), 0), diff);
+        assert_eq!(verification_honest_diff(diff.clone(), 5), diff);
+    }
+}
+
 mod best_of_n;
 mod chaos;
 /// The orchestrator MCP pre-fetch hook (issue #248 Phase 1) — split out for

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1187,27 +1187,43 @@ async fn a_witness_that_never_fails_aborts_and_removes_the_candidate() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("TEST_COMMAND: cargo test --test witness always_green -- --exact"),
-        // The repair attempt also yields a command that passes.
+        // The repair attempt also yields a command that passes -> useless.
         text_result("TEST_COMMAND: cargo test --test witness still_green -- --exact"),
+        // Then the run degrades to a bare worker turn (+ its verification),
+        // so give the fallback generous responses.
+        text_result("done"),
+        text_result("PASS looks right"),
+        text_result("done"),
+        text_result("PASS looks right"),
     ]);
-    // Pops: witness check (pass), repair check (pass) → discard. Then no
-    // test command exists for the candidate, so no further pops.
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let workspace =
         FakeWorkspace::new(0, vec![true, true], Ok(vec![]), log.clone()).with_repo_status(
             SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
         );
     let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
-    let (outcome, _, _) = run_isolated(
+    let (outcome, events) = run_degrade_over_working_session(
         &provider,
         &port,
         PipelineConfig::default(),
         "Fix the retry bug",
     )
     .await;
-    let outcome = outcome.expect("invalid witness is a truthful abort");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
-    assert_eq!(*log.lock().unwrap(), vec!["create", "remove:0"]);
+    let outcome = outcome.expect("a useless witness degrades, it does not error");
+    // A witness that proves nothing couldn't be AUTHORED — the task proceeds
+    // unwitnessed rather than dying.
+    assert!(
+        !matches!(outcome.status, PipelineStatus::Aborted { .. }),
+        "a useless witness must not end the turn: {outcome:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("running a bare worker turn")
+        )),
+        "the degradation announces itself: {events:?}"
+    );
 }
 
 /// Tamper exclusion: the worker modified the witness test file after it
@@ -1453,6 +1469,52 @@ async fn a_setup_failure_degrades_to_a_bare_execution_instead_of_aborting() {
     );
 }
 
+/// Like [`run_unisolated_with_router`] but WITH a candidate workspace port,
+/// for exercising the setup-failure -> bare-execution degrade: the candidate
+/// path fails, and the bare fallback must run over these WORKING session
+/// ports (unlike `run_isolated`, whose session ports panic on touch).
+async fn run_degrade_over_working_session(
+    provider: &ScriptedProvider,
+    port: &FakeWorkspacePort,
+    config: PipelineConfig,
+    goal: &str,
+) -> (Result<PipelineOutcome, PipelineRunError>, Vec<AgentEvent>) {
+    let resolver = OneProvider(provider);
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: Some(port),
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline.run(goal, &mut messages, &mut budget).await;
+    (outcome, drain(&mut rx))
+}
+
 async fn run_unisolated_with_router(
     provider: &ScriptedProvider,
     config: PipelineConfig,
@@ -1561,6 +1623,7 @@ fn isolated_config(n: u32) -> PipelineConfig {
 /// Best-of-N candidate isolation tests — see the module doc there for why
 /// the shared infra (`run_isolated`, `isolated_config`, ...) stays here.
 mod best_of_n;
+mod chaos;
 /// The orchestrator MCP pre-fetch hook (issue #248 Phase 1) — split out for
 /// the same file-size reason `tests.rs` itself was split from
 /// `pipeline.rs`; a child module, so it reaches the fakes above via

--- a/stella-pipeline/src/pipeline/tests/chaos.rs
+++ b/stella-pipeline/src/pipeline/tests/chaos.rs
@@ -1,0 +1,441 @@
+//! The loop-invariant / chaos harness.
+//!
+//! Most of the "the agent died having done zero work" failures this codebase
+//! has hit were not wrong *answers* — they were the orchestrator ending a
+//! turn on a setup precondition (no isolation, no independent witness author,
+//! a scope gate, a provider that 400s) instead of degrading. Volume never
+//! finds a class like that reliably; a property over the config × environment
+//! cross-product does, deterministically and in milliseconds.
+//!
+//! This harness enumerates that cross-product — provider behavior × candidate
+//! isolation × task class × single/multi-model × witness on/off × budget ×
+//! headless bypass — and asserts, for EVERY combination, the two invariants
+//! that separate a healthy loop from a dying one:
+//!
+//! 1. **Named termination.** A run ends only by returning `Ok(outcome)` or a
+//!    typed `Err(PipelineRunError)`; an `Ok(Aborted)` always carries a
+//!    non-empty reason; and a terminal event (`Complete` or `Error`) reaches
+//!    the stream on the `Ok` path. No run vanishes without an explanation.
+//! 2. **Never choose nothing.** A run that ends having executed zero worker
+//!    turns may only be a *recognized* zero-work cause — a budget/resource
+//!    limit, a user scope abort, or an unresolvable provider. A setup failure
+//!    must have degraded to a bare execution (the #345 contract), never a
+//!    silent zero-work death.
+//!
+//! When a combination violates either, the panic message names the exact
+//! scenario, so a regression points straight at the offending shape rather
+//! than "some run somewhere aborted".
+
+use super::*;
+use std::collections::VecDeque;
+
+use stella_core::router::{CircuitBreaker, ProviderProfile, RoleTable};
+use tokio::sync::Mutex as TokioMutex;
+
+/// A provider whose every call is scripted as an explicit `Result`, so a
+/// scenario can inject a terminal/transport error at any position — not just
+/// "runs out". Exhausting the script yields a terminal error, standing in for
+/// a provider that fails partway through a turn.
+struct ChaosProvider {
+    script: TokioMutex<VecDeque<Result<CompletionResult, ProviderError>>>,
+}
+
+impl ChaosProvider {
+    fn new(script: Vec<Result<CompletionResult, ProviderError>>) -> Self {
+        Self {
+            script: TokioMutex::new(script.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ChaosProvider {
+    fn id(&self) -> &str {
+        "chaos"
+    }
+    async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        self.script
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or_else(|| Err(ProviderError::Terminal("chaos provider exhausted".into())))
+    }
+}
+
+/// How a scenario's candidate-isolation port behaves.
+#[derive(Clone, Copy)]
+enum PortShape {
+    /// No candidate workspace port wired at all (a caller in a plain dir).
+    Absent,
+    /// A port that fails to snapshot every candidate (isolation unavailable).
+    Fails,
+    /// A port that snapshots successfully.
+    Works,
+}
+
+/// The provider call sequence a scenario feeds every role.
+#[derive(Clone, Copy)]
+enum ProviderShape {
+    /// Enough responses for triage + a worker turn + a judge — a clean run.
+    Healthy,
+    /// Triage answers, then the worker call errors (script exhausts).
+    WorkerErrors,
+    /// The very first call (triage) errors.
+    TriageErrors,
+}
+
+/// One point in the cross-product.
+#[derive(Clone, Copy)]
+struct Scenario {
+    provider: ProviderShape,
+    port: PortShape,
+    /// The triage class token the model returns (`lookup` / `single` / `multi`).
+    class: &'static str,
+    single_model: bool,
+    witness_writer: bool,
+    tiny_budget: bool,
+    headless_bypass: bool,
+}
+
+impl Scenario {
+    fn label(&self) -> String {
+        format!(
+            "provider={} port={} class={} single_model={} witness={} tiny_budget={} bypass={}",
+            match self.provider {
+                ProviderShape::Healthy => "healthy",
+                ProviderShape::WorkerErrors => "worker-errors",
+                ProviderShape::TriageErrors => "triage-errors",
+            },
+            match self.port {
+                PortShape::Absent => "absent",
+                PortShape::Fails => "fails",
+                PortShape::Works => "works",
+            },
+            self.class,
+            self.single_model,
+            self.witness_writer,
+            self.tiny_budget,
+            self.headless_bypass,
+        )
+    }
+
+    fn provider_script(&self) -> Vec<Result<CompletionResult, ProviderError>> {
+        // The first response is the triage classification (a bare token, so
+        // it parses whatever the assurance flags do); the rest feed the
+        // worker/judge turns. `Healthy` gives generous headroom; the error
+        // shapes cut the script short at the intended point.
+        let triage = || Ok(text_result(self.class));
+        let done = || Ok(text_result("done"));
+        let pass = || Ok(text_result("PASS looks right"));
+        match self.provider {
+            ProviderShape::TriageErrors => vec![Err(ProviderError::Terminal("triage down".into()))],
+            ProviderShape::WorkerErrors => {
+                vec![triage(), Err(ProviderError::Terminal("worker down".into()))]
+            }
+            ProviderShape::Healthy => vec![
+                triage(),
+                done(),
+                pass(),
+                // Spare responses so a revise/repair/judge never exhausts the
+                // script by accident and masks a real invariant break.
+                done(),
+                pass(),
+                done(),
+                pass(),
+            ],
+        }
+    }
+
+    fn router(&self) -> Router {
+        if self.single_model {
+            let only = ModelRef::new("chaos", "only");
+            Router::new(
+                RoleTable::new(),
+                vec![ProviderProfile::new(
+                    "chaos",
+                    only.clone(),
+                    only.clone(),
+                    only,
+                )],
+                CircuitBreaker::new(Box::new(ZeroClock)),
+            )
+        } else {
+            Router::new(
+                RoleTable::new(),
+                vec![ProviderProfile::new(
+                    "chaos",
+                    ModelRef::new("chaos", "worker"),
+                    ModelRef::new("chaos", "triage"),
+                    ModelRef::new("chaos", "judge"),
+                )],
+                CircuitBreaker::new(Box::new(ZeroClock)),
+            )
+        }
+    }
+
+    fn config(&self) -> PipelineConfig {
+        PipelineConfig {
+            witness_writer: self.witness_writer,
+            // A candidate count > 1 exercises the best-of-N isolation path.
+            candidates: Some(if matches!(self.port, PortShape::Works) {
+                2
+            } else {
+                1
+            }),
+            headless: true,
+            headless_bypass_scope_review: self.headless_bypass,
+            ..PipelineConfig::default()
+        }
+    }
+}
+
+/// A resolver that returns the one chaos provider for every model.
+struct OneChaosProvider<'p>(&'p ChaosProvider);
+impl ProviderResolver for OneChaosProvider<'_> {
+    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
+        Some(self.0)
+    }
+}
+
+/// Run one scenario over WORKING session ports (so execution can actually
+/// happen when it should) and a scenario-shaped candidate port. Returns
+/// everything the invariant checker needs.
+async fn run_scenario(
+    scenario: &Scenario,
+) -> (
+    Result<PipelineOutcome, PipelineRunError>,
+    Vec<AgentEvent>,
+    usize,
+    usize,
+) {
+    let provider = ChaosProvider::new(scenario.provider_script());
+    let resolver = OneChaosProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = scenario.router();
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    // Build the candidate port lazily so `Absent` wires none at all.
+    let fails_port;
+    let works_port;
+    let candidate_workspaces: Option<&dyn CandidateWorkspacePort> = match scenario.port {
+        PortShape::Absent => None,
+        PortShape::Fails => {
+            fails_port = FakeWorkspacePort::new(
+                vec![
+                    Err(WorkspaceError::Snapshot {
+                        reason: "chaos: not isolable".into(),
+                    }),
+                    Err(WorkspaceError::Snapshot {
+                        reason: "chaos: not isolable".into(),
+                    }),
+                ],
+                log.clone(),
+            );
+            Some(&fails_port)
+        }
+        PortShape::Works => {
+            works_port = FakeWorkspacePort::new(
+                vec![
+                    Ok(FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
+                        .with_repo_status(SeqRepoStatus::new(vec![vec![]]))),
+                    Ok(FakeWorkspace::new(1, vec![], Ok(vec![]), log.clone())
+                        .with_repo_status(SeqRepoStatus::new(vec![vec![]]))),
+                ],
+                log.clone(),
+            );
+            Some(&works_port)
+        }
+    };
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        scenario.config(),
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let base_len = messages.len();
+    let mode = if scenario.tiny_budget {
+        BudgetMode::Enforced
+    } else {
+        BudgetMode::Off
+    };
+    let limit = scenario.tiny_budget.then_some(0.0001);
+    let mut budget = BudgetGuard::new(mode, limit, limit);
+    let outcome = pipeline
+        .run("Fix the retry bug", &mut messages, &mut budget)
+        .await;
+    let events = drain(&mut rx);
+    (outcome, events, base_len, messages.len())
+}
+
+/// The heart of the harness: assert both invariants for one scenario's run.
+fn assert_loop_invariant(
+    scenario: &Scenario,
+    outcome: &Result<PipelineOutcome, PipelineRunError>,
+    events: &[AgentEvent],
+    base_len: usize,
+    final_len: usize,
+) {
+    let at = scenario.label();
+
+    // A non-empty reason on every abort.
+    if let Ok(o) = outcome
+        && let PipelineStatus::Aborted { reason } = &o.status
+    {
+        assert!(
+            !reason.trim().is_empty(),
+            "[{at}] an abort must carry a reason"
+        );
+    }
+
+    // Named termination: the Ok path must have emitted a terminal signal
+    // (Complete or a non-retryable Error). An Err return IS the signal, so it
+    // needs no event.
+    if outcome.is_ok() {
+        let terminal = events.iter().any(|e| {
+            matches!(
+                e,
+                AgentEvent::Complete { .. }
+                    | AgentEvent::Error {
+                        retryable: false,
+                        ..
+                    }
+            )
+        });
+        assert!(
+            terminal,
+            "[{at}] an Ok run must emit a terminal Complete/Error — none did: {events:?}"
+        );
+    }
+
+    // Never choose nothing: a run that executed zero worker turns and did not
+    // complete may only be a RECOGNIZED zero-work cause. The signal is the
+    // event stream, NOT the transcript length — `run` appends the user
+    // message before any execution, so message count would report "executed"
+    // even on a setup death. A worker turn is the one thing a setup abort
+    // never reaches: it emits a `StepUsage` with the `worker` purpose.
+    let _ = (base_len, final_len);
+    let worker_executed = events.iter().any(|e| {
+        matches!(
+            e,
+            AgentEvent::StepUsage {
+                role: stella_protocol::ModelCallRole::Worker,
+                ..
+            }
+        )
+    });
+    if !worker_executed {
+        match outcome {
+            // A typed hard error (e.g. no resolvable provider) is a named
+            // termination by construction.
+            Err(_) => {}
+            Ok(o) => match &o.status {
+                // Completing with no worker turn is only legitimate when the
+                // work is genuinely a no-op path; on these scenarios it would
+                // be a lookup that the class routed to zero execution, which
+                // is still a *named* completion, not a death.
+                PipelineStatus::Completed | PipelineStatus::VerificationFailed { .. } => {}
+                PipelineStatus::Aborted { reason } => {
+                    let r = reason.to_ascii_lowercase();
+                    let legitimate = r.contains("budget")
+                        || r.contains("scope review")
+                        || r.contains("provider")
+                        || r.contains("no candidate workspace port")
+                        // A witness artifact-integrity violation is a
+                        // DELIBERATE fail-closed stop (the author modified
+                        // tracked files / produced a bad artifact / a
+                        // runner-identity mismatch): a named, intended
+                        // zero-work abort, not a silent setup death. Witness
+                        // AUTHORING failures degrade instead of reaching here.
+                        || r.contains("modified tracked")
+                        || r.contains("create exactly one")
+                        || r.contains("does not match test runner")
+                        || r.contains("unsafe or unstable filesystem");
+                    assert!(
+                        legitimate,
+                        "[{at}] ZERO-WORK DEATH: the loop aborted before any worker turn for a \
+                         reason that is not a recognized resource/impossibility limit — this is \
+                         exactly the 'choose nothing' class. reason = {reason:?}"
+                    );
+                }
+            },
+        }
+    }
+}
+
+/// The cross-product. Kept as an explicit enumeration rather than a random
+/// proptest: the space is small enough to cover exhaustively, and a
+/// deterministic failure names the exact shape.
+fn matrix() -> Vec<Scenario> {
+    let mut out = Vec::new();
+    for provider in [
+        ProviderShape::Healthy,
+        ProviderShape::WorkerErrors,
+        ProviderShape::TriageErrors,
+    ] {
+        for port in [PortShape::Absent, PortShape::Fails, PortShape::Works] {
+            for class in ["lookup", "single", "multi"] {
+                for single_model in [false, true] {
+                    for witness_writer in [false, true] {
+                        for tiny_budget in [false, true] {
+                            for headless_bypass in [false, true] {
+                                out.push(Scenario {
+                                    provider,
+                                    port,
+                                    class,
+                                    single_model,
+                                    witness_writer,
+                                    tiny_budget,
+                                    headless_bypass,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Every point in the provider × isolation × class × model × witness ×
+/// budget × bypass cross-product must satisfy both loop invariants. A break
+/// names the exact scenario.
+#[tokio::test]
+async fn the_loop_never_chooses_nothing_across_the_config_environment_matrix() {
+    let scenarios = matrix();
+    assert!(
+        scenarios.len() >= 200,
+        "the matrix should be broad: {}",
+        scenarios.len()
+    );
+    for scenario in &scenarios {
+        let (outcome, events, base_len, final_len) = run_scenario(scenario).await;
+        // Reaching here at all proves the run neither panicked nor hung
+        // (NoopSleeper + the step cap make a hang impossible).
+        assert_loop_invariant(scenario, &outcome, &events, base_len, final_len);
+    }
+}

--- a/stella-pipeline/src/pipeline/tests/task5.rs
+++ b/stella-pipeline/src/pipeline/tests/task5.rs
@@ -419,7 +419,11 @@ async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
         vec![("tests/authority_witness.rs", "sha256:test")],
     ])
     .with_tracked(vec![vec![], vec![("src/lib.rs", "sha256:mutated")]]);
-    let workspace = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone()).with_repo_status(status);
+    // The witness test FAILS on unmodified code (vec![false]) so the flow
+    // reaches the tracked-file mutation check — a fail-closed SECURITY
+    // rejection — rather than the (now degradable) repair path.
+    let workspace =
+        FakeWorkspace::new(0, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
     let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
 
     let (outcome, _, _) = run_isolated(

--- a/stella-pipeline/src/pipeline/tests/usage.rs
+++ b/stella-pipeline/src/pipeline/tests/usage.rs
@@ -230,11 +230,16 @@ async fn plan_and_plan_repair_each_emit_one_paid_call_envelope() {
 }
 
 #[tokio::test]
-async fn witness_author_and_repair_are_individually_metered_on_abort() {
+async fn witness_author_and_repair_are_individually_metered_before_degrade() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("TEST_COMMAND: cargo test --test witness always_green -- --exact"),
         text_result("TEST_COMMAND: cargo test --test witness still_green -- --exact"),
+        // The useless witness degrades to a bare worker turn (+ verification).
+        text_result("done"),
+        text_result("PASS looks right"),
+        text_result("done"),
+        text_result("PASS looks right"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let workspace =
@@ -242,20 +247,24 @@ async fn witness_author_and_repair_are_individually_metered_on_abort() {
             SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
         );
     let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
-    let (outcome, events, _) = run_isolated(
+    let (outcome, events) = run_degrade_over_working_session(
         &provider,
         &port,
         PipelineConfig::default(),
         "Fix the retry bug",
     )
     .await;
-    assert!(matches!(
-        outcome.unwrap().status,
-        PipelineStatus::Aborted { .. }
-    ));
+    // The witness author and its repair are each metered individually, even
+    // though the useless witness then degrades rather than aborts.
+    let roles = usage_roles(&events);
     assert_eq!(
-        usage_roles(&events),
-        ["triage", "witness_author", "witness_repair"]
+        &roles[..3],
+        ["triage", "witness_author", "witness_repair"],
+        "author and repair are individually metered: {roles:?}"
+    );
+    assert!(
+        !matches!(outcome.unwrap().status, PipelineStatus::Aborted { .. }),
+        "a useless witness degrades rather than aborting"
     );
 }
 


### PR DESCRIPTION
Principle #4 of the loop-hardening thread — the scariest one, because a wrong verification signal doesn't just fail, it **misdirects**.

## The lie

On Terminal-Bench the judge was handed an **empty diff** and concluded *"no changes were made to the repository"* — while the agent's files sat on disk. The agent's rational response to a false signal was to **reinitialize git** to make the signal non-empty. Verification didn't just miss; it actively steered the agent wrong.

## Why an empty diff is a lie waiting to happen

Empty is ambiguous: the agent genuinely changed nothing, **or** the diff machinery is blind (work committed, a baseline miss, an uncaptured file). Handed a bare empty string, a judge reads the second case as the first.

The pipeline already carries the signal that resolves the ambiguity: **`file_changes`**, the count of `FileChange` events the turn emitted. `verification_honest_diff` uses it — when `file_changes > 0` but the gathered diff is empty, it substitutes:

```
[N file-change event(s) were observed this turn, but the diff could not be
 captured — the change is real; the diff is blind to it. This is NOT evidence
 that nothing changed; verify the result on its own merits.]
```

Applied at **both** diff-gather points (initial verify + post-revise), so every downstream consumer — the model judge, the distress-guidance call, the recorded evidence — sees a **"couldn't verify"**, never a false **"verified nothing"**. The judge's evidence summary now states the file-change count explicitly too.

That's the *confidence* notion the principle calls for: distinguish "verified false" from "couldn't verify" so a blind signal can never be read as a negative one. (The deterministic paths were already honest — the zero-diff guard keyed on `file_changes`, not the diff.)

## Tests
Pin the pure guard: a blind empty diff **with** file changes reports "uncaptured" and forecloses the "no changes" reading; a truly empty diff with **zero** file changes stays empty (no invented changes); a real diff passes through untouched. `cargo test -p stella-pipeline` (156) + `clippy -D warnings` green; the chaos harness still passes.

## Note
The root-cause diff-blindness (bare `git diff` blind to committed work) was fixed earlier by diffing against the session baseline commit. This is the *structural* guard on top: even if some future diff path goes blind again, it can no longer be read as "nothing changed".
