### PR TITLE
fix(cgp): §B3-honest frame token_cost (+ unbreak clippy CI)

### DIFF
--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use contextgraph_host::{ContextProvider, Host, HostError, ProviderResult};
-use contextgraph_types::Representation;
 use contextgraph_types::{
     Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo,
 };
@@ -305,7 +304,7 @@ mod tests {
             score,
             token_cost,
             content_digest: None,
-            representation: Representation::Full,
+            representation: contextgraph_types::Representation::Full,
             content_fidelity: None,
             canonical_content_hash: None,
             content_ref: None,

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -361,7 +361,11 @@ pub(crate) fn frame_from_node(
         content: Some(node.content.clone()),
         uri: node.uri.clone(),
         score: score.clamp(0.0, 1.0),
-        token_cost: estimate_tokens(&node.content) + estimate_tokens(&node.display_name),
+        // §B3: the declared inline cost must equal the protocol's canonical
+        // count (`budget_tokens` = ceil(bytes/4)) over the content field, with
+        // no tolerance — the title is NOT part of the inline content, so it is
+        // not counted here. `pack_to_budget` packs against this same value.
+        token_cost: contextgraph_types::budget_tokens(&node.content),
         content_digest: None,
         representation: Representation::Full,
         content_fidelity: None,
@@ -393,12 +397,6 @@ pub fn is_lexical_fallback(frame: &ContextFrame) -> bool {
         .provenance
         .iter()
         .any(|p| p.method.as_deref() == Some(LEXICAL_FALLBACK_METHOD))
-}
-
-/// A rough token estimate (~4 chars/token). Honest enough for budgeting; a
-/// real tokenizer is a follow-up but would not change the packing invariants.
-pub(crate) fn estimate_tokens(text: &str) -> u32 {
-    (text.chars().count() as u32).div_ceil(4)
 }
 
 /// Cosine similarity, guarding zero-norm vectors (defined as 0 similarity).
@@ -857,6 +855,31 @@ mod tests {
                 .map(|l| !l.is_empty())
                 .unwrap_or(false)
         }));
+    }
+
+    #[tokio::test]
+    async fn recalled_frames_declare_honest_token_cost() {
+        // §B3: a full frame's `token_cost` MUST equal `budget_tokens` over its
+        // inline content — exact, no tolerance. This drives the real `recall`
+        // builder with a query that provably surfaces a frame (same shape as
+        // `recall_returns_cited_budget_respecting_frames`), so the check has a
+        // non-empty result to bite on rather than passing vacuously.
+        let (_dir, store) = seeded().await;
+        let q = base_query(
+            "open the database",
+            "open the sqlite connection in wal mode with foreign keys on",
+        );
+        let result = store.recall(&q).await.unwrap();
+        assert!(!result.frames.is_empty(), "the query must surface a frame");
+        for frame in &result.frames {
+            assert!(
+                frame.declares_honest_token_cost(),
+                "frame {:?} declares token_cost {} but its content is worth {} budget tokens (§B3)",
+                frame.id,
+                frame.token_cost,
+                frame.expected_inline_token_cost(),
+            );
+        }
     }
 
     #[tokio::test]

--- a/stella-graph/src/frames.rs
+++ b/stella-graph/src/frames.rs
@@ -288,7 +288,10 @@ fn frame(
     provenance: Vec<Provenance>,
     relations: Vec<Relation>,
 ) -> ContextFrame {
-    let token_cost = estimate_tokens(&content);
+    // §B3: declared inline cost is the protocol's canonical count over the
+    // content, exact (`budget_tokens` = ceil(bytes/4)), so a host that meters
+    // or budgets these frames is told the truth.
+    let token_cost = contextgraph_types::budget_tokens(&content);
     ContextFrame {
         id,
         kind,
@@ -373,12 +376,6 @@ fn derivation(method: &str) -> Provenance {
 
 fn file_uri(root: &Path, rel: &str) -> String {
     format!("file://{}", root.join(rel).display())
-}
-
-fn estimate_tokens(text: &str) -> u32 {
-    // ~4 chars per token is the conventional cheap approximation; documented
-    // as an estimate so budget accounting stays honest (L-C5).
-    text.len().div_ceil(4).max(1) as u32
 }
 
 fn read_snippet(root: &Path, rel: &str, start: u32, end: u32) -> Option<String> {

--- a/stella-graph/tests/frames.rs
+++ b/stella-graph/tests/frames.rs
@@ -59,6 +59,14 @@ fn definition_frames_have_human_citation_labels_and_provenance() {
 
     assert_eq!(frame.kind, FrameKind::Symbol);
     assert!(frame.has_valid_score());
+    // §B3: the declared inline token_cost is the canonical `budget_tokens`
+    // count over the content, exact — a metering host is told the truth.
+    assert!(
+        frame.declares_honest_token_cost(),
+        "token_cost {} must equal the canonical inline count {}",
+        frame.token_cost,
+        frame.expected_inline_token_cost(),
+    );
 
     // Provenance carries the provider id `code-graph` and a file entry.
     assert!(

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -980,6 +980,7 @@ impl<'a> Pipeline<'a> {
         .pop()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_shared_candidates(
         &self,
         goal: &str,


### PR DESCRIPTION
## Context

The user asked to **rebase the CGP pin forward**. While I was doing that, **#354 landed the pin bump on `main`** (`58a933a2` → `9fb559aa`) — so the rebase itself is already done. This PR is the **residual gap #354 left**, plus the CI breakage it landed with.

## The bug: `main` claims §B3-honest, isn't

#354's description says it adopted the sweep's *"canonical token accounting."* It didn't. Both production frame builders still declare the old estimate:

- **store** (`stella-context`): `estimate_tokens(content) + estimate_tokens(title)` — adds the title's tokens (always non-zero) and counts chars, not bytes.
- **graph** (`stella-graph`): `estimate_tokens(content).max(1)` — the `.max(1)` diverges on empty content.

Under the pinned protocol, **§B3 requires `token_cost == budget_tokens(content)`** (canonical `ceil(bytes/4)`, exact, no tolerance). Neither builder is honest.

**The conformance gate (#347) didn't catch it** — its probe query returns zero frames from a mismatched seed, so §B3 never fires on a real frame (a vacuous pass).

## The fix (red → green, proven)

- Both builders now declare `contextgraph_types::budget_tokens(content)`. `pack_to_budget` already packs against each frame's own `token_cost`, so the summed-budget invariant is preserved.
- New `recalled_frames_declare_honest_token_cost` drives the **real `recall` builder** with a query that provably surfaces a frame (mirrors `recall_returns_cited_budget_respecting_frames`) and asserts `declares_honest_token_cost`. It **fails on pre-fix code** (`token_cost 18` vs canonical `15` — the 3-token gap is the title) and **passes after**. A matching assertion guards the graph builder. Dead `estimate_tokens` helpers removed.

## Second commit: unbreak CI (pre-existing, unrelated)

`main` currently **fails `cargo clippy --workspace --all-targets -- -D warnings`** — the exact CI gate — on two warnings that merged unprotected: a missing `#[allow(clippy::too_many_arguments)]` on `run_shared_candidates` (from #352, its five siblings have it) and an unused `Representation` import (from #354, used only in a test helper). Cleared so this PR's CI is green. **Heads-up: `main` is red on CI right now** — worth branch-protecting (tracked P0).

## Verification

```
cargo test --workspace                              # 2753 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings   # clean (was 2 warnings)
cargo fmt --all -- --check                          # clean
```
