### PR TITLE
fix(deps): pin baseline-browser-mapping to 2.11.0 (unblock frozen install)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  baseline-browser-mapping: 2.11.0
+
 importers:
 
   .: {}
@@ -1029,8 +1032,8 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  baseline-browser-mapping@2.11.1:
-    resolution: {integrity: sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==}
+  baseline-browser-mapping@2.11.0:
+    resolution: {integrity: sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2735,7 +2738,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  baseline-browser-mapping@2.11.1: {}
+  baseline-browser-mapping@2.11.0: {}
 
   caniuse-lite@1.0.30001806: {}
 
@@ -3646,7 +3649,7 @@ snapshots:
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.11.1
+      baseline-browser-mapping: 2.11.0
       caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,11 @@ packages:
 allowBuilds:
   esbuild: true
   sharp: true
+
+# Pin this Next transitive dep to the previous patch: 2.11.1 (a browser-compat
+# DATA release) was published <24h before the `minimumReleaseAge` supply-chain
+# cutoff, which fails `pnpm install --frozen-lockfile`. 2.11.0 (published a day
+# earlier) is identical in kind and safely aged. Drop this override once Next
+# ships a baseline-browser-mapping that clears the release-age window.
+overrides:
+  baseline-browser-mapping: 2.11.0


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` fails the `minimumReleaseAge` supply-chain policy:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION]
  baseline-browser-mapping@2.11.1 was published at 2026-07-22T15:46:10Z,
  within the minimumReleaseAge cutoff
```

`baseline-browser-mapping@2.11.1` is a **Next 16.2.11 transitive dep** (pulled in by the Next bump in #346). It was published <24h before the release-age cutoff, so every frozen-lockfile install rejects the lockfile — the **docs CI job** (`docs.yml` runs `pnpm install --frozen-lockfile`) and any **local pre-push hook**, which blocks opening PRs.

## Fix

Pin it to **2.11.0** (published 2026-07-21T14:15Z — a day earlier, safely aged out) via a pnpm override in `pnpm-workspace.yaml`. It's browser-compat **data**, so one patch older is functionally identical.

```yaml
overrides:
  baseline-browser-mapping: 2.11.0
```

## Verified

- `pnpm install --frozen-lockfile` → **✓ Lockfile passes supply-chain policies** (359 entries), full install completes (sharp build + fumadocs postinstall).
- Lockfile diff is scoped to this one package (version refs + integrity hash) plus the `overrides` declaration — no unrelated churn.

Remove the override once Next ships a `baseline-browser-mapping` past the release-age window.