### PR TITLE
fix(core): turn-driver correctness audit — 9 findings in one pass

### DIFF
--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -42,11 +42,13 @@ pub async fn run_accounted_call(
         &call.retry_policy,
         sleeper,
         || call.provider.complete(call.request.clone()),
-        |attempt, _error| {
+        // Per-attempt duration (retry.rs times each dispatch individually):
+        // the failed call's own latency, never cumulative across attempts.
+        |attempt, _error, attempt_duration| {
             emit_incomplete(
                 &call,
                 events,
-                started.elapsed(),
+                attempt_duration,
                 Some(attempt.saturating_sub(1)),
             );
         },

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -17,17 +17,24 @@
 //! history while synchronously exposing each failed provider attempt to the
 //! accounting path. Ordinary retry narration stays deferred until success;
 //! content-free `UsageIncomplete` envelopes are durable immediately because
-//! a later successful attempt cannot recover the failed call's usage.
+//! a later successful attempt cannot recover the failed call's usage. A
+//! caller-side hard cancel that drops the turn while an attempt is still in
+//! flight emits one `Cancelled` envelope from a drop guard
+//! ([`CancelUsageGuard`]) armed for exactly that window.
 //!
-//! # Retry never re-executes a tool call
+//! # Retry never re-executes a mutating tool call
 //!
-//! [`crate::retry::retry_with_backoff_observed`] wraps *only* the model call
-//! (`Provider::complete`). Tool execution happens exactly once, after a
-//! model call has already succeeded and returned tool calls to run — it is
-//! never inside the retried closure. A retried step therefore structurally
-//! cannot re-execute a non-idempotent tool call; see the property test
-//! `retry_never_re_executes_a_tool_call` below, which proves it by
-//! counting real executions against a flaky scripted provider.
+//! [`crate::retry::retry_with_backoff_observed`] wraps the model call
+//! (`Provider::complete_observed`) together with that attempt's speculation
+//! pump (`crate::speculation`): read-only calls announced by the stream may
+//! execute inside a failed attempt and execute again when the retry
+//! re-announces them — discarded work, safe precisely because they are
+//! read-only. MUTATING tool execution happens exactly once, after a model
+//! call has already succeeded and returned tool calls to run — it is never
+//! inside the retried closure. A retried step therefore structurally
+//! cannot re-execute a non-idempotent (mutating) tool call; see the
+//! property test `retry_never_re_executes_a_tool_call` below, which proves
+//! it by counting real executions against a flaky scripted provider.
 //!
 //! # Budget is checked between steps, never mid-tool
 //!
@@ -213,9 +220,11 @@ const MAX_CONCURRENT_TOOL_CALLS: usize = 8;
 
 /// One committed model call plus the step-scoped context the phases after
 /// it consume: the pre-call raw token estimate (drift feedback + telemetry
-/// — raw, never calibrated, see [`Engine::run_model_call`]), the read-only
-/// tool set for dispatch scheduling, and the retry/duration figures for
-/// the `StepUsage` metering record.
+/// — raw, never calibrated, see [`Engine::run_model_call`]) and the
+/// read-only tool set for dispatch scheduling. The step's `StepUsage`
+/// metering record (retry and duration figures included) was already
+/// emitted by [`Engine::run_model_call`] at the no-await settlement
+/// boundary — it is deliberately NOT carried here.
 struct CommittedStep {
     result: CompletionResultAlias,
     budget_outcome: BudgetOutcome,
@@ -530,7 +539,9 @@ impl<'a> Engine<'a> {
         let mut end = messages
             .len()
             .saturating_sub(self.config.summarize_keep_recent);
-        while end > start && messages[end].role == MessageRole::Tool {
+        // `end == messages.len()` (keep_recent 0) has no kept tail to walk
+        // off — indexing it would be out of bounds, not a Tool message.
+        while end > start && end < messages.len() && messages[end].role == MessageRole::Tool {
             end -= 1;
         }
         // A tiny span isn't worth a model call — and this guard is also the
@@ -580,7 +591,7 @@ impl<'a> Engine<'a> {
         }
         let replaced = end - start;
         let summary = CompletionMessage::user(format!(
-            "[earlier history summarized to fit context — full detail was compacted away; \
+            "{SUMMARY_MARKER_PREFIX} to fit context — full detail was compacted away; \
              re-read files or re-run tools for specifics]\n\n{}",
             result.text.trim()
         ));
@@ -696,6 +707,19 @@ impl<'a> Engine<'a> {
         });
 
         let call_started = std::time::Instant::now();
+        // Armed for exactly the interval where a paid attempt may be in
+        // flight: a caller-side hard cancel that drops this future mid-await
+        // still leaves one content-free `Cancelled` envelope behind.
+        // Disarmed on BOTH normal exits — a success reports through its
+        // `StepUsage`, and a terminal failure's attempts already reported
+        // through the per-attempt observer below.
+        let mut cancel_guard = CancelUsageGuard {
+            events: events.clone(),
+            role: self.call_role,
+            provider: self.provider.id().to_string(),
+            started: call_started,
+            armed: true,
+        };
         let incomplete_events = events.clone();
         let RetryOutcome {
             value: (result, speculation_future),
@@ -705,21 +729,28 @@ impl<'a> Engine<'a> {
             &self.config.retry_policy,
             self.sleeper,
             attempt,
-            |attempt, _error| {
+            // Per-attempt duration (retry.rs times each dispatch
+            // individually): the failed call's own latency, never
+            // cumulative across earlier attempts or backoff sleeps.
+            |attempt, _error, attempt_duration| {
                 let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
                     role: self.call_role,
                     provider: self.provider.id().to_string(),
                     model: "unknown".into(),
                     reason: stella_protocol::UsageIncompleteReason::ProviderError,
-                    duration_ms: call_started.elapsed().as_millis() as u64,
+                    duration_ms: attempt_duration.as_millis() as u64,
                     retries: Some(attempt.saturating_sub(1)),
                 });
             },
         )
         .await
         {
-            Ok(outcome) => outcome,
+            Ok(outcome) => {
+                cancel_guard.disarm();
+                outcome
+            }
             Err(error) => {
+                cancel_guard.disarm();
                 let message = error.to_string();
                 let _ = events.send(AgentEvent::Error {
                     message: message.clone(),
@@ -808,12 +839,12 @@ impl<'a> Engine<'a> {
     }
 
     /// Bookkeeping for the call that just committed: drift feedback into
-    /// the attached calibration and exactly one `StepUsage` metering record
-    /// per landed step. Its cost was already settled synchronously at the
-    /// provider-success boundary, before this method can be reached; the
-    /// carried outcome decides whether `Some` is the turn's clean abort.
-    /// That abort is issued only after delivering what was already paid for
-    /// (see body), never as a mid-tool kill.
+    /// the attached calibration. Its cost was settled — and its single
+    /// `StepUsage` metering record emitted — synchronously at the
+    /// provider-success boundary in [`Engine::run_model_call`], before this
+    /// method can be reached; the carried outcome decides whether `Some` is
+    /// the turn's clean abort. That abort is issued only after delivering
+    /// what was already paid for (see body), never as a mid-tool kill.
     fn handle_committed_result(
         &self,
         _step: usize,
@@ -852,8 +883,9 @@ impl<'a> Engine<'a> {
         // and append it to history, THEN abort before dispatching
         // anything further (its tool calls, if any, never run — recorded
         // so the transcript shows what was cut). Still not a mid-tool
-        // kill.
-        if !result.text.is_empty() {
+        // kill. Trimmed guard: whitespace-only text is not a deliverable
+        // answer and must not stream a blank `Text` event.
+        if !result.text.trim().is_empty() {
             let _ = events.send(AgentEvent::Text {
                 delta: result.text.clone(),
             });
@@ -873,7 +905,7 @@ impl<'a> Engine<'a> {
         // tool_result"). Close the pairing with a synthetic error
         // result per un-run call so resumption stays valid.
         if !result.tool_calls.is_empty() {
-            let tool_results = result
+            let tool_results: Vec<ToolResult> = result
                 .tool_calls
                 .iter()
                 .map(|call| ToolResult {
@@ -883,6 +915,19 @@ impl<'a> Engine<'a> {
                     },
                 })
                 .collect();
+            // Mirror the synthetic results onto the event stream: this
+            // step's `StepUsage` already reported `tool_calls: N`, and a
+            // transcript reconstructed from events must resolve every
+            // announced call the same way `messages` does. No `ToolStart`
+            // — these calls never ran.
+            for tool_result in &tool_results {
+                let _ = events.send(AgentEvent::ToolResult {
+                    call_id: tool_result.call_id.clone(),
+                    output: tool_result.output.clone(),
+                    duration_ms: 0,
+                    speculated: false,
+                });
+            }
             messages.push(CompletionMessage {
                 role: MessageRole::Tool,
                 content: String::new(),
@@ -923,7 +968,10 @@ impl<'a> Engine<'a> {
             ..
         } = committed;
 
-        if !result.text.is_empty() {
+        // Trimmed guard, matching the empty-turn check below: a
+        // whitespace-only response must not stream a blank `Text` event and
+        // then abort as "no text" — events and history stay consistent.
+        if !result.text.trim().is_empty() {
             let _ = events.send(AgentEvent::Text {
                 delta: result.text.clone(),
             });
@@ -1213,17 +1261,64 @@ type RetryAttemptFn<'a> = Box<
 type CompletionResultAlias = stella_protocol::CompletionResult;
 type SpeculationFuture<'a> = Pin<Box<dyn Future<Output = SpeculationPool> + 'a>>;
 
+/// Drop guard for the paid-call window ([`Engine::run_model_call`]): armed
+/// before the retried provider dispatch, disarmed on both normal exits. It
+/// fires only when the turn future is dropped mid-await — the caller-side
+/// hard cancel — leaving one content-free `Cancelled` usage envelope so a
+/// possibly-billed in-flight call never vanishes from the accounting
+/// stream. Content-free by construction, same privacy rule as every other
+/// `UsageIncomplete` envelope: no request or response body is representable.
+struct CancelUsageGuard {
+    events: EventSender,
+    role: stella_protocol::ModelCallRole,
+    provider: String,
+    started: std::time::Instant,
+    armed: bool,
+}
+
+impl CancelUsageGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelUsageGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let _ = self.events.send(AgentEvent::UsageIncomplete {
+            role: self.role,
+            provider: self.provider.clone(),
+            model: "unknown".into(),
+            reason: stella_protocol::UsageIncompleteReason::Cancelled,
+            duration_ms: self.started.elapsed().as_millis() as u64,
+            retries: None,
+        });
+    }
+}
+
+/// Prefix of the overflow summarizer's marker message
+/// ([`Engine::summarize_overflow_span`]). Shared with [`recent_tool_calls`]:
+/// the marker is User-role on the wire, but it is NOT a real user turn and
+/// must not act as a loop-detection window boundary.
+const SUMMARY_MARKER_PREFIX: &str = "[earlier history summarized";
+
 /// Flatten the tool calls of the CURRENT turn — assistant messages after
 /// the last user message — in chronological order, for
 /// `crate::loop_detect::detect_loop`. Windowing at the user boundary
 /// matters: identical calls across turns are the user re-asking a
 /// question, not a stuck loop (a REPL session asking the same thing three
 /// times would otherwise trip the exact-repeat detector), and it keeps
-/// this per-step scan O(turn) instead of O(entire history).
+/// this per-step scan O(turn) instead of O(entire history). The overflow
+/// summary is also User-role but is not a real user turn — treating it as
+/// a boundary would truncate the loop window on every summarization pass
+/// and let a stuck loop outrun detection, so it is skipped when locating
+/// the boundary.
 fn recent_tool_calls(messages: &[CompletionMessage]) -> Vec<ToolCall> {
     let turn_start = messages
         .iter()
-        .rposition(|m| m.role == MessageRole::User)
+        .rposition(|m| m.role == MessageRole::User && !m.content.starts_with(SUMMARY_MARKER_PREFIX))
         .map(|i| i + 1)
         .unwrap_or(0);
     messages[turn_start..]

--- a/stella-core/src/driver/settlement.rs
+++ b/stella-core/src/driver/settlement.rs
@@ -1,7 +1,7 @@
 use stella_protocol::AgentEvent;
 
 use super::TurnOutcome;
-use crate::budget::{BudgetGuard, BudgetOutcome};
+use crate::budget::{BudgetAxis, BudgetGuard, BudgetOutcome};
 use crate::event_sender::EventSender;
 
 pub(super) fn record_settled_cost(
@@ -15,6 +15,30 @@ pub(super) fn record_settled_cost(
         limit_usd: budget.turn_limit_usd(),
         mode: budget.mode(),
     });
+    // Observed-mode breaches surface here, once per settled call — NOT in
+    // `check_budget`, which runs twice per step and would spam the same
+    // warning at every boundary. `BudgetTick` alone cannot carry this: it
+    // reports only turn-scoped numbers, so a session-axis breach would
+    // otherwise be invisible to every event-stream consumer
+    // (`BudgetOutcome::Warn`'s contract is that the driver surfaces it).
+    if let BudgetOutcome::Warn {
+        axis,
+        spent_usd,
+        limit_usd,
+    } = outcome
+    {
+        let axis = match axis {
+            BudgetAxis::Turn => "turn",
+            BudgetAxis::Session => "session",
+        };
+        let _ = events.send(AgentEvent::Error {
+            message: format!(
+                "budget warning: spent ${spent_usd:.4} against a ${limit_usd:.2} observed {axis} \
+                 limit; continuing"
+            ),
+            retryable: true,
+        });
+    }
     outcome
 }
 

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -1965,5 +1965,6 @@ async fn session_start_hooks_run_via_the_helper_not_per_turn() {
     assert!(payloads[0].contains("\"event\":\"SessionStart\""));
 }
 
+mod audit_fixes;
 mod task4;
 mod usage_completeness;

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -1,0 +1,324 @@
+//! Witnesses for the 2026-07 turn-driver correctness audit (F1–F9): the
+//! keep-recent-0 panic guard, observed-budget warnings, budget-abort
+//! event/history parity, whitespace-only empty turns, the summary marker's
+//! loop-window neutrality, and the hard-cancel `Cancelled` usage envelope.
+
+use super::*;
+
+/// F1: `summarize_keep_recent: 0` is a legal config — the tail walk must
+/// not index one past the end (this test panicked with "index out of
+/// bounds" before the guard).
+#[tokio::test]
+async fn summarize_keep_recent_zero_does_not_panic() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("SUMMARY")), Ok(text_result("done"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        summarize_keep_recent: 0,
+        ..overflow_config()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    for i in 0..6 {
+        messages.push(big_assistant_text(&format!("t{i}")));
+    }
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "keep_recent 0 must summarize the whole span, not panic: {outcome:?}"
+    );
+    let markers = messages
+        .iter()
+        .filter(|m| m.content.starts_with("[earlier history summarized"))
+        .count();
+    assert_eq!(markers, 1, "exactly one summary message");
+}
+
+/// F2: `BudgetOutcome::Warn`'s contract is that the driver surfaces it —
+/// an Observed-mode breach must emit a visible warning (exactly once per
+/// settled call, so the twice-per-step gate checks cannot spam it).
+#[tokio::test]
+async fn observed_budget_breach_emits_a_warning_event() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("done"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    // The single $0.0001 call crosses the $0.00005 observed turn limit.
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, Some(0.00005), None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "observed mode never gates: {outcome:?}"
+    );
+    let events = drain_events(&mut rx);
+    let warnings: Vec<&AgentEvent> = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AgentEvent::Error {
+                    retryable: true,
+                    message,
+                } if message.contains("budget warning")
+            )
+        })
+        .collect();
+    assert_eq!(warnings.len(), 1, "exactly one warning: {events:?}");
+    match warnings[0] {
+        AgentEvent::Error { message, .. } => {
+            assert!(
+                message.contains("turn limit"),
+                "axis must be named: {message}"
+            );
+        }
+        other => unreachable!("{other:?}"),
+    }
+}
+
+/// F5: the budget-abort path's synthetic tool results must reach the event
+/// stream, not just `messages` — StepUsage already announced the calls, so
+/// a transcript reconstructed from events must resolve them too.
+#[tokio::test]
+async fn budget_abort_synthetic_results_are_visible_in_the_event_stream() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(tool_call_result("call_1", "bash"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tool_calls = Arc::new(AtomicU32::new(0));
+    let tools = CountingTools {
+        calls: tool_calls.clone(),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(0.00005), None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Aborted { .. }));
+    assert_eq!(
+        tool_calls.load(Ordering::SeqCst),
+        0,
+        "the aborted step's calls must never execute"
+    );
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolResult {
+                call_id,
+                speculated: false,
+                output: ToolOutput::Error { message },
+                ..
+            } if call_id == "call_1" && message.contains("not executed")
+        )),
+        "the synthetic result must be on the wire: {events:?}"
+    );
+}
+
+/// F6: a whitespace-only response is the empty-turn defect, not an answer —
+/// it must abort without first streaming a blank `Text` event.
+#[tokio::test]
+async fn whitespace_only_completion_aborts_without_a_text_event() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("\n\n"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { .. }),
+        "whitespace-only is an empty turn: {outcome:?}"
+    );
+    let events = drain_events(&mut rx);
+    assert!(events.iter().any(|e| matches!(e, AgentEvent::Error { .. })));
+    assert!(
+        !events.iter().any(|e| matches!(e, AgentEvent::Text { .. })),
+        "no blank Text event may precede the empty-turn abort: {events:?}"
+    );
+}
+
+/// F7: the overflow summary rides a User-role message, but it is not a real
+/// user turn — the loop-detection window must see straight through it.
+#[test]
+fn summary_marker_is_not_a_loop_window_boundary() {
+    let assistant_with_call = |call_id: &str| CompletionMessage {
+        role: MessageRole::Assistant,
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.into(),
+            name: "bash".into(),
+            input: serde_json::json!({"cmd": "ls"}),
+        }],
+        tool_results: vec![],
+        attachments: Vec::new(),
+    };
+    let tool_result_msg = |call_id: &str| CompletionMessage {
+        role: MessageRole::Tool,
+        content: String::new(),
+        tool_calls: vec![],
+        tool_results: vec![ToolResult {
+            call_id: call_id.into(),
+            output: ToolOutput::Ok {
+                content: "ok".into(),
+            },
+        }],
+        attachments: Vec::new(),
+    };
+    let summary = CompletionMessage::user(format!(
+        "{SUMMARY_MARKER_PREFIX} to fit context — full detail was compacted away; \
+         re-read files or re-run tools for specifics]\n\nSUMMARY"
+    ));
+
+    let with_summary = vec![
+        CompletionMessage::user("task"),
+        assistant_with_call("c1"),
+        tool_result_msg("c1"),
+        summary,
+        assistant_with_call("c2"),
+        tool_result_msg("c2"),
+    ];
+    let calls = recent_tool_calls(&with_summary);
+    assert_eq!(
+        calls.iter().map(|c| c.call_id.as_str()).collect::<Vec<_>>(),
+        vec!["c1", "c2"],
+        "a summarization pass must not truncate the loop window"
+    );
+
+    // A REAL user message (a steer, a REPL turn) still resets the window.
+    let mut with_real_user = with_summary;
+    with_real_user[3] = CompletionMessage::user("also check the tests");
+    let calls = recent_tool_calls(&with_real_user);
+    assert_eq!(
+        calls.iter().map(|c| c.call_id.as_str()).collect::<Vec<_>>(),
+        vec!["c2"],
+        "a genuine user turn is still a window boundary"
+    );
+}
+
+/// F9's provider: announces it started streaming, then never resolves —
+/// the only way out is the caller dropping the turn (hard cancel).
+struct HangingProvider {
+    started: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl Provider for HangingProvider {
+    fn id(&self) -> &str {
+        "hanging"
+    }
+
+    async fn complete(
+        &self,
+        _req: CompletionRequest,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        unreachable!("the engine must drive complete_observed, never bare complete")
+    }
+
+    async fn complete_observed(
+        &self,
+        _req: CompletionRequest,
+        _observer: &dyn stella_protocol::ToolCallObserver,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        self.started.notify_one();
+        std::future::pending().await
+    }
+}
+
+/// F9: a hard cancel that drops the turn while a paid attempt is mid-stream
+/// must leave exactly one content-free `Cancelled` usage envelope — the
+/// call may have real server-side cost and must not vanish from accounting.
+#[tokio::test]
+async fn hard_cancel_mid_stream_emits_a_cancelled_usage_envelope() {
+    let started = Arc::new(tokio::sync::Notify::new());
+    let provider = HangingProvider {
+        started: started.clone(),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![CompletionMessage::user("secret prompt text")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    {
+        let turn = engine.run_turn(&mut messages, &mut budget, &tx);
+        tokio::pin!(turn);
+        tokio::select! {
+            outcome = &mut turn => panic!("a hanging provider must keep the turn pending: {outcome:?}"),
+            _ = started.notified() => {}
+            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                panic!("provider never started streaming")
+            }
+        }
+        // Scope end drops the pinned turn future — the hard cancel.
+    }
+
+    let events = drain_events(&mut rx);
+    let incomplete: Vec<&AgentEvent> = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::UsageIncomplete { .. }))
+        .collect();
+    assert_eq!(
+        incomplete.len(),
+        1,
+        "exactly one cancelled-usage envelope: {events:?}"
+    );
+    assert!(matches!(
+        incomplete[0],
+        AgentEvent::UsageIncomplete {
+            reason: stella_protocol::UsageIncompleteReason::Cancelled,
+            model,
+            retries: None,
+            provider,
+            ..
+        } if model == "unknown" && provider == "hanging"
+    ));
+    let wire = serde_json::to_string(incomplete[0]).expect("wire");
+    assert!(
+        !wire.contains("secret prompt text"),
+        "the envelope must stay content-free: {wire}"
+    );
+}

--- a/stella-core/src/retry.rs
+++ b/stella-core/src/retry.rs
@@ -184,7 +184,7 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, ProviderError>>,
 {
-    retry_with_backoff_observed(policy, sleeper, attempt_fn, |_, _| {}).await
+    retry_with_backoff_observed(policy, sleeper, attempt_fn, |_, _, _| {}).await
 }
 
 /// Retry while synchronously observing every failed dispatched attempt.
@@ -193,6 +193,11 @@ where
 /// incompleteness envelope before any later attempt can succeed. A successful
 /// retry can report its own usage, but can never make an earlier provider
 /// attempt's unknown usage knowable after the fact.
+///
+/// The observer receives the 1-indexed attempt number, the error, and THAT
+/// attempt's own elapsed duration — never a cumulative figure across earlier
+/// attempts or the backoff sleeps between them, so a consumer characterizing
+/// provider failure latency from the durable envelopes sees per-call truth.
 pub(crate) async fn retry_with_backoff_observed<F, Fut, T, O>(
     policy: &RetryPolicy,
     sleeper: &dyn Sleeper,
@@ -202,11 +207,12 @@ pub(crate) async fn retry_with_backoff_observed<F, Fut, T, O>(
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, ProviderError>>,
-    O: FnMut(u32, &ProviderError),
+    O: FnMut(u32, &ProviderError, std::time::Duration),
 {
     let mut retries = Vec::new();
     let mut attempt: u32 = 0;
     loop {
+        let attempt_started = std::time::Instant::now();
         match attempt_fn().await {
             Ok(value) => {
                 return Ok(RetryOutcome {
@@ -216,7 +222,7 @@ where
                 });
             }
             Err(error) => {
-                observe_failure(attempt + 1, &error);
+                observe_failure(attempt + 1, &error, attempt_started.elapsed());
                 if !error.is_retryable() || attempt >= policy.max_retries {
                     return Err(error);
                 }

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -86,6 +86,12 @@ pub enum ModelCallRole {
 pub enum UsageIncompleteReason {
     ProviderError,
     Timeout,
+    /// The caller dropped the turn (hard cancel) while a paid provider
+    /// attempt was still in flight — the call may have real server-side
+    /// cost whose usage is unknowable. Emitted by the engine's drop guard,
+    /// which is armed only for exactly that window (a call that settles
+    /// normally reports through its ordinary `StepUsage` envelope instead).
+    Cancelled,
 }
 
 /// One event in the turn's stream. Every stage boundary emits an event;


### PR DESCRIPTION
Nine findings from a correctness audit of the turn-loop driver (`stella-core/src/driver.rs`), fixed in one pass. Each behavioral fix is pinned by a new witness test; the P2 was verified to panic before the fix and pass after.

## Findings

| ID | Severity | Category | Fix |
|----|----------|----------|-----|
| F1 | **P2** | correctness | `summarize_overflow_span` panicked (index out of bounds) when `summarize_keep_recent == 0` — the tail walk now stops at `messages.len` |
| F2 | P3 | traceability | Observed-mode `BudgetOutcome::Warn` was silently dropped on the engine path; `record_settled_cost` now emits one axis-named warning `Error` per settled call (session-axis breaches were previously invisible — `BudgetTick` carries only turn-scoped numbers) |
| F3 | P3 | stale doc | Module doc claimed tool execution is "never inside the retried closure" — re-scoped to *mutating* tools; speculation legitimately executes read-only calls inside attempts and re-executes them on retry |
| F4 | P3 | stale doc | `CommittedStep` / `handle_committed_result` docs still described the pre-settlement-refactor `StepUsage` emission site |
| F5 | P3 | traceability | Budget-abort synthetic tool results entered history but never the event stream — now mirrored as `ToolResult` events so transcripts reconstructed from events resolve every announced call |
| F6 | P3 | correctness | Whitespace-only responses streamed a blank `Text` event and then aborted as "no text" — both `Text` guards now trim |
| F7 | P3 | resilience | The overflow summary is User-role, so every summarization pass reset the loop-detection window; the marker prefix is now shared and skipped as a boundary |
| F8 | P3 | traceability | `UsageIncomplete.duration_ms` was cumulative across attempts + backoff sleeps; the retry observer now receives each attempt's own duration (driver + accounted-call paths) |
| F9 | P3 | resilience | Hard cancel mid-stream left a possibly-billed in-flight call with no accounting envelope — new `UsageIncompleteReason::Cancelled` + `CancelUsageGuard` drop guard armed for exactly the paid-call window |

## Tests

New witnesses in `stella-core/src/driver/tests/audit_fixes.rs`:

- `summarize_keep_recent_zero_does_not_panic` (F1 — fails with the pre-fix index-out-of-bounds)
- `observed_budget_breach_emits_a_warning_event` (F2 — exactly one, axis named)
- `budget_abort_synthetic_results_are_visible_in_the_event_stream` (F5)
- `whitespace_only_completion_aborts_without_a_text_event` (F6)
- `summary_marker_is_not_a_loop_window_boundary` (F7 — and a real user turn still resets the window)
- `hard_cancel_mid_stream_emits_a_cancelled_usage_envelope` (F9 — exactly one, content-free on the wire)

## Gate

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p stella-protocol -p stella-core --all-targets -- -D warnings` ✓
- `cargo test`: stella-core 333 ✓, stella-protocol 49 ✓, stella-cli 481 ✓, stella-pipeline 160 ✓
- `cargo check --workspace --all-targets` ✓ (retry-observer signature is `pub(crate)`; no dependent-crate fallout)

Existing pins kept as-written: `usage_completeness`'s exact `UsageIncomplete` counts, task4's exactly-one-`StepUsage` cancellation boundary, and the summary marker stays byte-identical on the wire.
