### PR TITLE
fix: small-fix sweep from the agent-loop audit (issue #373)

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -40,7 +40,8 @@ use crate::config::Config;
 use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::interactive::{InteractiveToolSet, SkillRegistry, default_ask_io};
 use crate::memory::{
-    ReflectionReport, SessionMemory, inject_recall_block, turn_warrants_reflection,
+    ReflectionReport, SessionMemory, inject_recall_block, should_reflect_on,
+    turn_warrants_reflection,
 };
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::tui;
@@ -489,7 +490,32 @@ async fn run_pipeline_one_shot(
 
             pipeline_status_result(&outcome.status)
         }
-        Err(e) => Err(e.to_string()),
+        Err(e) => {
+            // A hard pipeline error must still produce the JSON summary a
+            // `--output-format json` consumer contracted for: without this,
+            // stdout is empty, the collected event log is lost, and only
+            // stderr says anything (issue #373, item 2). Same shape as the
+            // success summary, `text: null`, spend read from the guard (the
+            // pipeline metered whatever it spent before failing).
+            if format == OutputFormat::Json {
+                let summary = serde_json::json!({
+                    "status": "error",
+                    "text": null,
+                    "cost_usd": budget.session_spent_usd(),
+                    "reason": e.to_string(),
+                    "model": format!("{}/{}", cfg.provider.id, cfg.model_id),
+                    "events": collected,
+                    "reflection": reflection_json(&reflection_report),
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&summary).unwrap_or_else(|e| format!(
+                        "{{\"status\":\"error\",\"reason\":\"serialize: {e}\"}}"
+                    ))
+                );
+            }
+            Err(e.to_string())
+        }
     }
 }
 
@@ -663,9 +689,12 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 Ok((_domains, _cost_usd)) => {
                     // A fresh index may name tables/types the schema gate
                     // should know about this session, not just the next one.
+                    // Warn-and-fall-through: a schema-index failure must not
+                    // skip the graph-tool enable, the memory reopen, or the
+                    // extensions reload below — those refreshes are
+                    // independent of it (issue #373, item 3).
                     if let Err(error) = populate_schema_index(&registry, &cfg.workspace_root) {
                         println!("  {} schema governance unavailable: {error}", "!".yellow());
-                        continue;
                     }
                     // The code graph now exists — expose the `graph_query` tool
                     // to the rest of this session (it is registered only when
@@ -775,9 +804,15 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 &messages[turn_start..],
             )
             .await;
-            if let Err(e) = result {
+            if let Err(e) = &result {
                 eprintln!("  {} {}\n", "Error:".red().bold(), e);
-            } else if turn_warrants_reflection(&messages[turn_start..])
+            }
+            // Failures reflect too (minus the user's own soft stop) — the
+            // one-shot pipeline path has always treated a failed run as a
+            // high-value learning signal; interactive paths now match
+            // (issue #373, item 7).
+            if should_reflect_on(&result)
+                && turn_warrants_reflection(&messages[turn_start..])
                 && let Some(m) = &mut memory
             {
                 let mut report = m
@@ -786,7 +821,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                         &cfg.model_id,
                         &messages,
                         false,
-                        true,
+                        result.is_ok(),
                         remaining_budget(&budget),
                     )
                     .await;
@@ -854,9 +889,14 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             &messages[turn_start..],
         )
         .await;
-        if let Err(e) = result {
+        if let Err(e) = &result {
             eprintln!("  {} {}\n", "Error:".red().bold(), e);
-        } else if turn_warrants_reflection(&messages[turn_start..])
+        }
+        // Same reflect-on-failure policy as the `/goal` block above and the
+        // one-shot pipeline path (issue #373, item 7): a soft stop is a user
+        // choice and stays excluded; a real failure is a learning signal.
+        if should_reflect_on(&result)
+            && turn_warrants_reflection(&messages[turn_start..])
             && let Some(m) = &mut memory
         {
             let mut report = m
@@ -865,7 +905,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                     &cfg.model_id,
                     &messages,
                     false,
-                    true,
+                    result.is_ok(),
                     remaining_budget(&budget),
                 )
                 .await;

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -178,6 +178,12 @@ pub(crate) async fn session_start_hook_context(cfg: &Config) -> Option<String> {
         &stella_core::hooks::HookPayload::session_start(cfg.workspace_root.display().to_string()),
     )
     .await;
+    // A SessionStart hook that failed stays non-fatal, but must not vanish:
+    // without this line a typo'd hook silently contributes no context all
+    // session and nothing ever says why (issue #373, item 6).
+    for diagnostic in &outcome.diagnostics {
+        eprintln!("  ! SessionStart {diagnostic}");
+    }
     (!outcome.output.is_empty()).then_some(outcome.output)
 }
 

--- a/stella-cli/src/agent/goal.rs
+++ b/stella-cli/src/agent/goal.rs
@@ -296,7 +296,11 @@ pub async fn run_goal_cmd(
                 .await;
         }
     }
-    if outcome.is_ok()
+    // Reflect on success AND failure, matching the one-shot path above — a
+    // failed goal run is a prime learning signal (root-cause prompt via
+    // `succeeded=false`). Only a user-chosen soft stop is excluded
+    // (issue #373, item 7).
+    if crate::memory::should_reflect_on(&outcome)
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
@@ -306,7 +310,7 @@ pub async fn run_goal_cmd(
                 &cfg.model_id,
                 &messages,
                 false,
-                true,
+                outcome.is_ok(),
                 crate::agent::remaining_budget(&budget),
             )
             .await;
@@ -515,8 +519,9 @@ async fn run_goal_pipeline_turn(
     // Route the goal-loop judge. The pipeline's verify judge is the same role;
     // both want independence from the worker. An engine-config judge pin
     // (explicit or auto_mode) wins; otherwise the discovery-based
-    // cross-family routing applies exactly as before.
-    let configured = crate::config::discover_configured_providers();
+    // cross-family routing applies exactly as before. (`configured` from the
+    // wiring block above is reused — same disk state, nothing mutates it
+    // in between; issue #373, item 4.)
     let engine_judge: Option<(&dyn Provider, String)> = wiring
         .pins
         .get(Role::Judge)
@@ -587,9 +592,13 @@ async fn run_goal_pipeline_turn(
         let recall: &dyn ContextRecallPort = &no_recall;
         let hook_runner = ShellHookRunner;
 
-        // The goal judge engine, built once and reused across rounds — shares
-        // the session calibration (keyed per model, so a cross-family judge
-        // learns its own drift) and a read-only view of the same tools.
+        // The goal judge's provider/tool/config bundle. NOT reused across
+        // rounds in any load-bearing way: `Engine::assess` constructs a
+        // fresh inner engine (and re-wraps the tools in `ReadOnlyTools`) on
+        // every call — this outer engine only carries the judge provider,
+        // the read-only tool view, the judge tuning, and the session
+        // calibration (keyed per model, so a cross-family judge learns its
+        // own drift) into each assessment.
         let read_only = stella_core::ports::ReadOnlyTools::new(&tools);
         let judge_engine = Engine::with_sleeper(
             judge,

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -74,7 +74,9 @@ pub struct ReflectionLesson {
 mod reflection;
 #[cfg(test)]
 use reflection::parse_lessons;
-pub use reflection::{ReflectionReport, reflect_on_turn, turn_warrants_reflection};
+pub use reflection::{
+    ReflectionReport, reflect_on_turn, should_reflect_on, turn_warrants_reflection,
+};
 
 /// Session-scoped memory state: the context store, the CGP host that
 /// routes every recall (workspace memory + code graph as in-process CGP

--- a/stella-cli/src/memory/reflection.rs
+++ b/stella-cli/src/memory/reflection.rs
@@ -22,6 +22,22 @@ pub fn turn_warrants_reflection(turn_messages: &[CompletionMessage]) -> bool {
         .any(|message| !message.tool_calls.is_empty())
 }
 
+/// Whether a finished interactive turn should feed reflection at all.
+/// Failures ARE reflected on — a failed turn is a high-value learning
+/// signal, and the one-shot pipeline path has always treated it as one —
+/// EXCEPT a user-chosen soft stop, which is not a failure: reflecting on
+/// it would teach the memory that deliberate interruptions are errors.
+/// (`contains`, not `==`: goal paths wrap the turn's abort reason in their
+/// own prefix.) Callers still pass `result.is_ok()` as
+/// `reflect_and_record`'s `succeeded` flag so a failure is recorded AS a
+/// failure.
+pub fn should_reflect_on(result: &Result<(), String>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(reason) => !reason.contains(stella_core::SOFT_STOP_REASON),
+    }
+}
+
 pub async fn reflect_on_turn(
     provider: &dyn Provider,
     model_hint: &str,

--- a/stella-cli/src/session_persist.rs
+++ b/stella-cli/src/session_persist.rs
@@ -484,15 +484,26 @@ pub fn replay_session(
 ) {
     let mut last_status: std::collections::HashMap<String, AgentStatus> =
         std::collections::HashMap::new();
+    // First-appearance order for the downgrade pass below — same convention
+    // as [`journal_lanes`]. Iterating the map directly would replay the
+    // synthetic `Killed` statuses in a nondeterministic order run-to-run,
+    // undermining byte-for-byte replay of the deck trace surface.
+    let mut lane_order: Vec<String> = Vec::new();
     for record in records {
         if let Some(inbound) = replay_inbound(record, started_ms) {
             match &inbound {
                 Inbound::Register(meta) => {
+                    if !last_status.contains_key(&meta.id) {
+                        lane_order.push(meta.id.clone());
+                    }
                     last_status
                         .entry(meta.id.clone())
                         .or_insert(AgentStatus::Queued);
                 }
                 Inbound::Status { agent, status } => {
+                    if !last_status.contains_key(agent) {
+                        lane_order.push(agent.clone());
+                    }
                     last_status.insert(agent.clone(), *status);
                 }
                 _ => {}
@@ -500,7 +511,8 @@ pub fn replay_session(
             let _ = deck_tx.send(inbound);
         }
     }
-    for (agent, status) in last_status {
+    for agent in lane_order {
+        let status = last_status[&agent];
         if agent != lead
             && !matches!(
                 status,
@@ -653,6 +665,60 @@ mod tests {
             "non-lead lanes, deduplicated, first-appearance order"
         );
         assert!(journal_lanes(&[], "lead").is_empty());
+    }
+
+    #[test]
+    fn stale_lane_downgrades_replay_in_first_appearance_order_deterministically() {
+        // Two non-lead lanes left in live statuses, first appearing as
+        // "req:9" then "req:1" — adversarial against both alphabetical and
+        // hash order. The synthetic `Killed` downgrades must come back in
+        // first-appearance order on EVERY replay: a `HashMap` iteration
+        // here previously made the deck trace surface differ run-to-run
+        // (issue #373, item 5).
+        let records = || {
+            vec![
+                JournalRecord::Register {
+                    agent: "lead".into(),
+                    title: "t".into(),
+                    role: "lead".into(),
+                    model: None,
+                },
+                JournalRecord::Status {
+                    agent: "req:9".into(),
+                    status: "running".into(),
+                },
+                JournalRecord::Status {
+                    agent: "req:1".into(),
+                    status: "running".into(),
+                },
+            ]
+        };
+        let downgrades = |records: Vec<JournalRecord>| -> Vec<String> {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            replay_session(records, 0, "lead", &tx);
+            drop(tx);
+            // The replayed stream itself carries no `Killed` (both lanes
+            // journaled "running"), so filtering for `Killed` isolates
+            // exactly the synthetic downgrades.
+            let mut order = Vec::new();
+            while let Ok(inbound) = rx.try_recv() {
+                if let Inbound::Status {
+                    agent,
+                    status: AgentStatus::Killed,
+                } = inbound
+                {
+                    order.push(agent);
+                }
+            }
+            order
+        };
+        for _ in 0..16 {
+            assert_eq!(
+                downgrades(records()),
+                vec!["req:9".to_string(), "req:1".to_string()],
+                "downgrade order must be first-appearance, every run"
+            );
+        }
     }
 
     #[test]

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -818,7 +818,7 @@ impl<'a> Engine<'a> {
         let mut in_flight = announced
             .map(|call| async move {
                 let started = std::time::Instant::now();
-                let output = self.execute_with_repair(&call).await;
+                let output = self.execute_with_repair(&call, None).await;
                 (call, output, started.elapsed().as_millis() as u64)
             })
             .buffer_unordered(MAX_CONCURRENT_TOOL_CALLS);
@@ -1126,7 +1126,7 @@ impl<'a> Engine<'a> {
                                 Some(s) => (index, call, s.output, s.duration_ms, true),
                                 None => {
                                     let started = std::time::Instant::now();
-                                    let output = self.execute_with_repair(call).await;
+                                    let output = self.execute_with_repair(call, Some(events)).await;
                                     let duration_ms = started.elapsed().as_millis() as u64;
                                     (index, call, output, duration_ms, false)
                                 }
@@ -1170,7 +1170,17 @@ impl<'a> Engine<'a> {
     /// and no `PreToolUse`/`PostToolUse` hook is fired for it. When no hooks
     /// are attached this is exactly the previous body:
     /// `self.tools.execute(...)`.
-    async fn execute_with_repair(&self, call: &ToolCall) -> ToolOutput {
+    ///
+    /// `events` carries non-blocking hook diagnostics (a hook that failed to
+    /// spawn, or exited non-zero on an event that cannot block) to the turn
+    /// stream as one non-fatal `Error` per call. `None` on the speculative
+    /// path: speculation emits no events until harvest, and a failed
+    /// attempt's hook noise must not reach the wire with it.
+    async fn execute_with_repair(
+        &self,
+        call: &ToolCall,
+        events: Option<&EventSender>,
+    ) -> ToolOutput {
         if call.input.is_null() {
             return ToolOutput::Error {
                 message: format!(
@@ -1183,7 +1193,7 @@ impl<'a> Engine<'a> {
         }
         match self.hooks {
             None => self.tools.execute(&call.name, &call.input).await,
-            Some(handle) => self.execute_with_hooks(handle, call).await,
+            Some(handle) => self.execute_with_hooks(handle, call, events).await,
         }
     }
 
@@ -1195,10 +1205,18 @@ impl<'a> Engine<'a> {
     /// executed and the model instead sees a `ToolOutput::Error` naming the
     /// block, exactly as the engine surfaces every other tool failure as
     /// model-visible data rather than an engine error. Otherwise the tool
-    /// runs and `PostToolUse` fires as a pure observation — its outcome is
-    /// discarded (it can never block or alter the result), so a failing
-    /// post-hook cannot abort the turn.
-    async fn execute_with_hooks(&self, handle: HooksHandle<'a>, call: &ToolCall) -> ToolOutput {
+    /// runs and `PostToolUse` fires as a pure observation — its outcome can
+    /// never block or alter the result, so a failing post-hook cannot abort
+    /// the turn. Non-blocking failures from either phase (spawn failures,
+    /// non-zero exits on events that cannot block) are no longer discarded:
+    /// they surface as one non-fatal `Error { retryable: true }` on the
+    /// turn stream when an event channel is present.
+    async fn execute_with_hooks(
+        &self,
+        handle: HooksHandle<'a>,
+        call: &ToolCall,
+        events: Option<&EventSender>,
+    ) -> ToolOutput {
         let pre = run_hooks(
             handle.runner,
             Some(handle.hooks),
@@ -1215,6 +1233,7 @@ impl<'a> Engine<'a> {
             };
             return ToolOutput::Error { message };
         }
+        let mut diagnostics = pre.diagnostics;
 
         let output = self.tools.execute(&call.name, &call.input).await;
 
@@ -1222,9 +1241,9 @@ impl<'a> Engine<'a> {
             ToolOutput::Ok { content } => content.clone(),
             ToolOutput::Error { message } => message.clone(),
         };
-        // Observation only — the outcome is intentionally ignored so a
-        // non-zero PostToolUse exit never blocks or rewrites the result.
-        let _ = run_hooks(
+        // Observation only — a non-zero PostToolUse exit never blocks or
+        // rewrites the result; its failures ride `diagnostics` instead.
+        let post = run_hooks(
             handle.runner,
             Some(handle.hooks),
             &HookPayload::post_tool_use(
@@ -1235,6 +1254,20 @@ impl<'a> Engine<'a> {
             ),
         )
         .await;
+        diagnostics.extend(post.diagnostics);
+
+        if !diagnostics.is_empty()
+            && let Some(events) = events
+        {
+            let _ = events.send(AgentEvent::Error {
+                message: format!(
+                    "hook problem(s) around tool `{}` (non-blocking): {}",
+                    call.name,
+                    diagnostics.join("; ")
+                ),
+                retryable: true,
+            });
+        }
 
         output
     }

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -1862,6 +1862,77 @@ async fn post_tool_use_hook_runs_after_the_tool_and_never_blocks() {
 }
 
 #[tokio::test]
+async fn non_blocking_hook_failure_surfaces_as_one_retryable_error_event() {
+    // A PostToolUse hook exiting non-zero stays non-blocking (pinned by the
+    // test above) but must no longer vanish: the dispatch path forwards the
+    // hook diagnostics as exactly one non-fatal Error event per tool call
+    // (issue #373, item 6).
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("call_1", "bash")),
+            Ok(text_result("done")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let payloads = Arc::new(TokioMutex::new(Vec::new()));
+    let runner = RecordingHookRunner {
+        exit_code: 3,
+        stdout: String::new(),
+        stderr: "post hook broke".into(),
+        payloads: payloads.clone(),
+    };
+    let hooks = Hooks {
+        post_tool_use: Some(vec![HookMatcher {
+            matcher: Some("*".into()),
+            hooks: vec![HookAction::new("exit 3")],
+        }]),
+        ..Hooks::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+        .with_hooks(&hooks, &runner);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "a failing post-hook must never abort the turn: {outcome:?}"
+    );
+    let events = drain_events(&mut rx);
+    let hook_errors: Vec<&AgentEvent> = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AgentEvent::Error { message, retryable: true } if message.contains("hook problem")
+            )
+        })
+        .collect();
+    assert_eq!(
+        hook_errors.len(),
+        1,
+        "exactly one non-fatal diagnostic event per affected call: {events:?}"
+    );
+    assert!(
+        matches!(
+            hook_errors[0],
+            AgentEvent::Error { message, .. }
+                if message.contains("bash") && message.contains("exited 3")
+        ),
+        "the event must name the tool and the failure: {hook_errors:?}"
+    );
+}
+
+#[tokio::test]
 async fn no_hooks_configured_leaves_the_turn_path_unchanged() {
     // With no hooks attached the tool executes normally and the turn
     // completes exactly as it did before the hooks seam existed — the

--- a/stella-core/src/hooks.rs
+++ b/stella-core/src/hooks.rs
@@ -284,6 +284,13 @@ pub struct HookRunOutcome {
     /// Concatenated stdout of every hook that ran to completion (used for
     /// `SessionStart` context).
     pub output: String,
+    /// Non-blocking failures observed while running the event's hooks: a
+    /// hook that failed to spawn, or exited non-zero on an event that
+    /// cannot block (`PostToolUse`, `SessionStart`). Empty means every
+    /// hook ran clean. Callers surface these as warnings — never as
+    /// errors — so a typo'd hook is visible instead of silently
+    /// contributing nothing all session.
+    pub diagnostics: Vec<String>,
 }
 
 impl HookRunOutcome {
@@ -296,6 +303,7 @@ impl HookRunOutcome {
             blocked: true,
             reason: Some(reason),
             output,
+            diagnostics: Vec::new(),
         }
     }
 }
@@ -333,6 +341,7 @@ pub async fn run_hooks(
 
     let payload_json = serde_json::to_string(payload).unwrap_or_else(|_| "{}".to_string());
     let mut outputs: Vec<String> = Vec::new();
+    let mut diagnostics: Vec<String> = Vec::new();
 
     for matcher in selected {
         for action in &matcher.hooks {
@@ -342,16 +351,30 @@ pub async fn run_hooks(
                     if !trimmed_stdout.is_empty() {
                         outputs.push(trimmed_stdout.to_string());
                     }
-                    if payload.event == HookEvent::PreToolUse && result.exit_code != 0 {
+                    if result.exit_code != 0 {
+                        if payload.event == HookEvent::PreToolUse {
+                            let trimmed_stderr = result.stderr.trim();
+                            let reason = if !trimmed_stderr.is_empty() {
+                                trimmed_stderr.to_string()
+                            } else if !trimmed_stdout.is_empty() {
+                                trimmed_stdout.to_string()
+                            } else {
+                                format!("hook `{}` exited {}", action.command, result.exit_code)
+                            };
+                            return HookRunOutcome::blocked(reason, outputs.join("\n"));
+                        }
+                        // Non-blocking event: the failure must still leave a
+                        // trace (a broken hook silently contributing nothing
+                        // is the defect), so it lands in `diagnostics`.
                         let trimmed_stderr = result.stderr.trim();
-                        let reason = if !trimmed_stderr.is_empty() {
-                            trimmed_stderr.to_string()
-                        } else if !trimmed_stdout.is_empty() {
-                            trimmed_stdout.to_string()
-                        } else {
+                        diagnostics.push(if trimmed_stderr.is_empty() {
                             format!("hook `{}` exited {}", action.command, result.exit_code)
-                        };
-                        return HookRunOutcome::blocked(reason, outputs.join("\n"));
+                        } else {
+                            format!(
+                                "hook `{}` exited {}: {trimmed_stderr}",
+                                action.command, result.exit_code
+                            )
+                        });
                     }
                 }
                 Err(err) => {
@@ -359,7 +382,9 @@ pub async fn run_hooks(
                         return HookRunOutcome::blocked(err.to_string(), outputs.join("\n"));
                     }
                     // PostToolUse/SessionStart never block, even on a hook
-                    // that failed to run at all — keep going.
+                    // that failed to run at all — keep going, but record
+                    // the failure for the caller to surface as a warning.
+                    diagnostics.push(format!("hook `{}` failed to run: {err}", action.command));
                 }
             }
         }
@@ -369,6 +394,7 @@ pub async fn run_hooks(
         blocked: false,
         reason: None,
         output: outputs.join("\n"),
+        diagnostics,
     }
 }
 
@@ -619,6 +645,60 @@ mod tests {
         let out = run_hooks(&runner, Some(&hooks), &payload).await;
         assert!(!out.blocked);
         assert!(out.output.contains("done"));
+        // Non-blocking, but never silent: the non-zero exit must leave a
+        // diagnostic for the caller to surface (issue #373, item 6).
+        assert_eq!(out.diagnostics.len(), 1);
+        assert!(
+            out.diagnostics[0].contains("exited 3"),
+            "diagnostic must name the exit: {:?}",
+            out.diagnostics
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_hooks_produce_no_diagnostics() {
+        let mut scripted = HashMap::new();
+        scripted.insert("echo ok".to_string(), ok(0, "ok", ""));
+        let runner = FakeHookRunner::new(scripted);
+        let hooks = Hooks {
+            session_start: Some(vec![HookMatcher {
+                matcher: None,
+                hooks: vec![HookAction::new("echo ok")],
+            }]),
+            ..Hooks::default()
+        };
+        let payload = HookPayload::session_start("/proj".to_string());
+        let out = run_hooks(&runner, Some(&hooks), &payload).await;
+        assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    }
+
+    #[tokio::test]
+    async fn session_start_spawn_failure_lands_in_diagnostics_not_silence() {
+        let mut scripted = HashMap::new();
+        scripted.insert(
+            "typo-cmd".to_string(),
+            Err(HookExecError::SpawnFailed {
+                command: "typo-cmd".to_string(),
+                message: "No such file or directory".to_string(),
+            }),
+        );
+        let runner = FakeHookRunner::new(scripted);
+        let hooks = Hooks {
+            session_start: Some(vec![HookMatcher {
+                matcher: None,
+                hooks: vec![HookAction::new("typo-cmd")],
+            }]),
+            ..Hooks::default()
+        };
+        let payload = HookPayload::session_start("/proj".to_string());
+        let out = run_hooks(&runner, Some(&hooks), &payload).await;
+        assert!(!out.blocked, "SessionStart never blocks");
+        assert_eq!(out.diagnostics.len(), 1);
+        assert!(
+            out.diagnostics[0].contains("typo-cmd") && out.diagnostics[0].contains("failed to run"),
+            "diagnostic must name the hook and the failure: {:?}",
+            out.diagnostics
+        );
     }
 
     #[tokio::test]

--- a/stella-core/src/loop_detect.rs
+++ b/stella-core/src/loop_detect.rs
@@ -43,10 +43,13 @@ pub struct LoopDetectionConfig {
 }
 
 impl Default for LoopDetectionConfig {
-    /// Three consecutive identical calls, or three full A-B cycles (12
-    /// calls of the 20-iteration cap in the interim CLI loop) — enough to
-    /// rule out coincidence without flagging a legitimately-repeated
-    /// read-then-fix-then-verify pattern.
+    /// Three consecutive identical calls, or three full A-B cycles (six
+    /// calls) — enough to rule out coincidence without flagging a
+    /// legitimately-repeated read-then-fix-then-verify pattern. These
+    /// thresholds are the PRIMARY stuck-turn defense and fire orders of
+    /// magnitude before the step-driver's belt-and-suspenders backstop
+    /// (`EngineConfig::max_steps`, 200 by default), so a stuck turn costs
+    /// a handful of wasted calls, never a whole cap's worth.
     fn default() -> Self {
         Self {
             exact_repeat_threshold: 3,


### PR DESCRIPTION
Closes #373 — the ten pinned nits from the 2026-07-23 agent-loop audit, batched into the one cleanup PR the issue calls for. Items 1 and 8 are **not** here: they already land in #375 (the driver-audit PR; its F6/F4 changes).

## Checklist

- [x] **1. Whitespace-only response emits contradictory events** — fixed in **#375** (trim-based `Text` guard)
- [x] **2. `--output-format json` one-shot emits no JSON on a hard pipeline error** — the `Err` arm now prints the same summary shape (`status: "error"`, `text: null`, `reason`, spend from the budget guard, the full `events` log, `reflection`)
- [x] **3. `/init` post-success refresh skipped on unrelated substep failure** — schema-index failure warns and falls through; graph-tool enable, memory reopen, and extensions reload always run
- [x] **4. `discover_configured_providers` called twice back-to-back** — verified identical inputs with no interleaved mutation; the shadowing second call is deleted, the first result reused
- [x] **5. Resume stale-lane downgrade iterates a `HashMap`** — downgrades now replay in first-appearance order (same convention as `journal_lanes`); new test drives 16 replays and pins the order
- [x] **6. SessionStart/PostToolUse hook failures vanish without a trace** — `HookRunOutcome.diagnostics` (new field) collects spawn failures and non-zero exits on non-blocking events; the dispatch path emits one `Error { retryable: true }` per affected call, session start prints a stderr warning. Still non-blocking; speculative executions pass `None` so a discarded attempt's hook noise never reaches the wire
- [x] **7. Interactive turns never reflect on failure** — REPL turn, REPL `/goal`, and the goal command now reflect on failure with the real `succeeded` flag (matching the one-shot paths); a user soft stop is excluded via the new `memory::should_reflect_on`
- [x] **8. Stale docs from the settlement refactor** — fixed in **#375** (`CommittedStep` / `handle_committed_result` doc rewrite)
- [x] **9. Stale "judge engine, built once and reused across rounds" comment** — rewritten to describe reality (`Engine::assess` builds a fresh inner engine per call); `assess` itself untouched
- [x] **10. `loop_detect` Default doc cites a dead constant** — rationale now names `max_steps = 200` as the belt-and-suspenders backstop; also corrects the old comment's cycle arithmetic (3 A-B cycles = 6 calls, not 12 — verified against `detect_short_cycle`'s `matched / 2`)

## Tests

- `stella-core`: 330/330 (new: `non_blocking_hook_failure_surfaces_as_one_retryable_error_event`, `clean_hooks_produce_no_diagnostics`, `session_start_spawn_failure_lands_in_diagnostics_not_silence`; extended: `never_blocks_on_post_tool_use_even_on_nonzero_exit` now pins the diagnostic)
- `stella-cli`: 482/482 (new: `stale_lane_downgrades_replay_in_first_appearance_order_deterministically`)
- `cargo fmt --check`, `clippy -D warnings` (core + cli, all targets), `cargo check --workspace --all-targets` all clean

## Interaction with #375 (updated after rebase)

#375 merged first; this branch is now rebased onto main at c962a0a (0.4.75) with #375 underneath. Full gate re-run post-rebase: fmt, clippy -D warnings, stella-core 336/336 (including all six of #375's audit_fixes tests), stella-cli 482/482, workspace check clean.
