### PR TITLE
feat: context receipts — increment 1 (block registry + per-step manifest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,6 +3124,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "stella-protocol",
  "thiserror 2.0.19",
  "tokio",

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -28,7 +28,7 @@ use stella_pipeline::{
 };
 use stella_protocol::event::BudgetMode;
 use stella_protocol::{AgentEvent, CompletionMessage, ModelRef, Role, ToolOutput};
-use stella_store::{Store, TelemetryRow};
+use stella_store::{ContextBlockRow, ManifestBlockRow, StepManifestRow, Store, TelemetryRow};
 use stella_tools::ToolRegistry;
 use stella_tools::custom::{self, CustomTool, CustomToolSet};
 use stella_tools::hook_runner::ShellHookRunner;

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -460,4 +460,65 @@ mod stream_tests {
                     && (*cost_usd - 1.25).abs() < f64::EPSILON
         ));
     }
+
+    #[test]
+    fn receipt_events_persist_into_queryable_block_and_manifest_rows() {
+        // The increment-1 promise, end to end: a BlockRegistered + StepManifest
+        // pair flowing through persist_event lands as queryable receipt rows,
+        // and the manifest reconstructs the step's block order with token_cost
+        // joined back from the block registry.
+        use stella_protocol::{BlockKind, BlockOrigin, CacheZone, ManifestEntry, ModelCallRole};
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "anthropic", "opus")
+            .expect("exec");
+
+        let registered = AgentEvent::BlockRegistered {
+            block_id: "blk_tool1".into(),
+            kind: BlockKind::ToolResult,
+            origin: BlockOrigin {
+                turn_instance: 0,
+                step: 0,
+                call_id: Some("c1".into()),
+                memory_id: None,
+            },
+            token_cost: 40,
+            content_digest: "sha256:abc".into(),
+            citation_label: None,
+        };
+        assert!(persist_event(&store, id, 0, &registered, "anthropic"));
+
+        let manifest = AgentEvent::StepManifest {
+            turn_instance: 0,
+            step: 0,
+            role: ModelCallRole::Worker,
+            provider: "anthropic".into(),
+            model: "opus".into(),
+            blocks: vec![ManifestEntry {
+                block_id: "blk_tool1".into(),
+                cache_zone: CacheZone::Volatile,
+                token_cost: 40,
+                resident_since_step: 0,
+            }],
+            effective_budget_tokens: 136_363,
+            calibration_factor: 1.1,
+            estimated_input_tokens: 40,
+        };
+        assert!(persist_event(&store, id, 1, &manifest, "anthropic"));
+
+        // The block registry row, with its call_id join key and snake_case kind.
+        let blocks = store.context_blocks(id).expect("blocks");
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block_id, "blk_tool1");
+        assert_eq!(blocks[0].call_id.as_deref(), Some("c1"));
+        assert_eq!(blocks[0].kind, "tool_result");
+
+        // The manifest reconstructs the step's ordered blocks, token_cost joined
+        // back from context_blocks.
+        let entries = store.step_manifest(id, 0, 0).expect("manifest");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].block_id, "blk_tool1");
+        assert_eq!(entries[0].cache_zone, "volatile");
+        assert_eq!(entries[0].token_cost, 40);
+    }
 }

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -217,6 +217,17 @@ fn memory_citation_rows(registry: &ToolRegistry) -> Vec<stella_store::MemoryCita
         .collect()
 }
 
+/// Serialize a serde enum (BlockKind / CacheZone / ModelCallRole) to its stable
+/// snake_case tag for storage, falling back to `"unknown"` if it somehow does
+/// not serialize to a string. Keeps the store string-typed while the wire
+/// carries the real enum.
+fn enum_tag<T: serde::Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "unknown".into())
+}
+
 pub(crate) fn warn_store_write_failed(what: &str) {
     eprintln!(
         "  {} store write failed — {what} for this execution is incomplete",
@@ -287,6 +298,67 @@ pub(crate) fn persist_event(
         crate::model_catalog::note_wire_model(actual_provider, model);
     } else if matches!(event, AgentEvent::UsageIncomplete { .. }) {
         usage_complete = false;
+    } else if let AgentEvent::BlockRegistered {
+        block_id,
+        kind,
+        origin,
+        token_cost,
+        content_digest,
+        citation_label,
+    } = event
+    {
+        // Context receipts (spec §4). Best-effort — a receipt write failure
+        // never fails the paid-call accounting boundary (these rows are
+        // observability, not billing), and the block also survives verbatim in
+        // the generic `events` table via record_event above.
+        let _ = store.record_context_block(
+            execution_id,
+            &ContextBlockRow {
+                block_id: block_id.clone(),
+                kind: enum_tag(kind),
+                origin_turn: origin.turn_instance,
+                origin_step: origin.step as u64,
+                call_id: origin.call_id.clone(),
+                memory_id: origin.memory_id.clone(),
+                token_cost: *token_cost,
+                content_digest: content_digest.clone(),
+                citation_label: citation_label.clone(),
+            },
+        );
+    } else if let AgentEvent::StepManifest {
+        turn_instance,
+        step,
+        role,
+        provider,
+        model,
+        blocks,
+        effective_budget_tokens,
+        calibration_factor,
+        estimated_input_tokens,
+    } = event
+    {
+        let _ = store.record_step_manifest(
+            execution_id,
+            &StepManifestRow {
+                turn_instance: *turn_instance,
+                step: *step as u64,
+                provider: provider.clone(),
+                model: model.clone(),
+                call_role: enum_tag(role),
+                effective_budget_tokens: *effective_budget_tokens,
+                calibration_factor: *calibration_factor,
+                estimated_input_tokens: *estimated_input_tokens,
+                blocks: blocks
+                    .iter()
+                    .map(|b| ManifestBlockRow {
+                        block_id: b.block_id.clone(),
+                        cache_zone: enum_tag(&b.cache_zone),
+                        token_cost: b.token_cost,
+                        resident_since_step: b.resident_since_step as u64,
+                    })
+                    .collect(),
+            },
+        );
     }
     let complete = recorded && telemetry_ok && usage_complete;
     if !complete {

--- a/stella-core/Cargo.toml
+++ b/stella-core/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { workspace = true, features = ["sync"] }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 rand = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -74,6 +74,7 @@ use crate::event_sender::EventSender;
 use crate::hooks::{HookPayload, HookRunner, Hooks, run_hooks};
 use crate::loop_detect::{LoopDetectionConfig, detect_loop};
 use crate::ports::ToolExecutor;
+use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, retry_with_backoff_observed};
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::{AccountedCall, AccountedCallError, run_accounted_call};
@@ -127,6 +128,13 @@ pub struct EngineConfig {
     /// the `"."` default keeps hook-free turns unaffected. Only read when
     /// hooks are actually configured.
     pub cwd: String,
+    /// Monotonic per-session turn index stamped onto this turn's context
+    /// receipts (`BlockRegistered`/`StepManifest`, spec §3). Groups a
+    /// `run_turn`'s steps across executions in one session without an
+    /// event-order correlation. `0` when the caller does not track turns
+    /// (the receipt is still valid — `(execution_id, step)` disambiguates
+    /// within an execution).
+    pub turn_instance: u32,
 }
 
 impl Default for EngineConfig {
@@ -149,6 +157,7 @@ impl Default for EngineConfig {
             summarize_keep_recent: 8,
             max_steps: 200,
             cwd: ".".to_string(),
+            turn_instance: 0,
         }
     }
 }
@@ -376,6 +385,10 @@ impl<'a> Engine<'a> {
         // `CalibrationMap::factor` then falls back to the session's single
         // seeded entry.
         let mut calibration_model: Option<String> = None;
+        // Per-turn context-receipt state: block registry + residency, carried
+        // by reference into each model call. Stack-local — the engine holds no
+        // receipt state of its own.
+        let mut receipts = ReceiptLedger::new(self.config.turn_instance);
 
         for step in 0..self.config.max_steps {
             // Pause parks HERE — after the previous step fully settled and
@@ -411,6 +424,10 @@ impl<'a> Engine<'a> {
             total_cost_usd += self
                 .run_compaction_pass(messages, calibration_model.as_deref(), budget, events)
                 .await;
+            // The manifest reports the budget compaction just compared against.
+            let (effective_budget, calibration_factor) =
+                self.effective_compaction_budget(calibration_model.as_deref());
+            receipts.set_effective_budget(effective_budget, calibration_factor);
 
             if let Some(aborted) = self.check_loop_detection(messages, total_cost_usd, events) {
                 return aborted;
@@ -419,7 +436,10 @@ impl<'a> Engine<'a> {
                 return aborted;
             }
 
-            let committed = match self.run_model_call(step, messages, budget, events).await {
+            let committed = match self
+                .run_model_call(step, messages, budget, &mut receipts, events)
+                .await
+            {
                 Ok(committed) => committed,
                 Err(reason) => {
                     return TurnOutcome::Aborted {
@@ -476,6 +496,25 @@ impl<'a> Engine<'a> {
     ///
     /// Returns the summarizer's spend (0.0 on the overwhelmingly common
     /// no-summarization path) so `run_turn` folds it into the turn total.
+    /// The compaction budget this turn's next step will actually compare
+    /// against, and the calibration factor that produced it. Single source of
+    /// truth for both the compaction pass and the step manifest, so the
+    /// receipt's `effective_budget_tokens` is exactly the number the decision
+    /// used (#364 item 1). Returns the configured budget with factor `1.0`
+    /// when calibration is off.
+    fn effective_compaction_budget(&self, calibration_model: Option<&str>) -> (u64, f64) {
+        match self.calibration {
+            Some(calibration) => {
+                let factor = calibration.factor(calibration_model);
+                (
+                    (self.config.compaction_budget_tokens as f64 / factor) as u64,
+                    factor,
+                )
+            }
+            None => (self.config.compaction_budget_tokens, 1.0),
+        }
+    }
+
     async fn run_compaction_pass(
         &self,
         messages: &mut Vec<CompletionMessage>,
@@ -483,13 +522,7 @@ impl<'a> Engine<'a> {
         budget: &mut BudgetGuard,
         events: &EventSender,
     ) -> f64 {
-        let compaction_budget = match self.calibration {
-            Some(calibration) => {
-                (self.config.compaction_budget_tokens as f64
-                    / calibration.factor(calibration_model)) as u64
-            }
-            None => self.config.compaction_budget_tokens,
-        };
+        let (compaction_budget, _factor) = self.effective_compaction_budget(calibration_model);
         if let Some(report) = compact(messages, compaction_budget) {
             let _ = events.send(AgentEvent::Compaction {
                 before_tokens: report.before_tokens,
@@ -651,6 +684,7 @@ impl<'a> Engine<'a> {
         step: usize,
         messages: &[CompletionMessage],
         budget: &mut BudgetGuard,
+        receipts: &mut ReceiptLedger,
         events: &EventSender,
     ) -> Result<CommittedStep, String> {
         let tools_schema = self.tools.schemas();
@@ -770,6 +804,21 @@ impl<'a> Engine<'a> {
                 reason: attempt.reason.clone(),
             });
         }
+
+        // The context receipt for this step: register any newly-seen blocks,
+        // then the ordered manifest of exactly what was sent. Emitted just
+        // before StepUsage so the pair — what the model saw, what it cost —
+        // lands together at the settled boundary, and the served model/provider
+        // are already known.
+        receipts.emit_step_receipt(
+            messages,
+            step,
+            self.call_role,
+            self.provider.id(),
+            &result.model,
+            estimated_input_tokens,
+            events,
+        );
 
         // Cost and usage settle at one no-await boundary. Speculative tool
         // work may still be draining; cancellation in that interval must not

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -816,7 +816,6 @@ impl<'a> Engine<'a> {
             self.call_role,
             self.provider.id(),
             &result.model,
-            estimated_input_tokens,
             events,
         );
 

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod loop_detect;
 pub mod mcp_usage;
 pub(crate) mod mining;
 pub mod ports;
+pub(crate) mod receipts;
 pub mod retry;
 pub mod router;
 pub mod rules;

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -22,7 +22,7 @@ use stella_protocol::{
     ModelCallRole,
 };
 
-use crate::estimator::CHARS_PER_TOKEN;
+use crate::estimator::{CHARS_PER_TOKEN, estimate_conversation_tokens};
 use crate::event_sender::EventSender;
 
 /// `sha256` hex of a string. Byte-wise hex (the sha2 0.11 output type does not
@@ -107,7 +107,11 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
     for message in messages {
         match message.role {
             MessageRole::System => {
-                drafts.push(BlockDraft::new(BlockKind::SystemPrefix, &message.content, None));
+                drafts.push(BlockDraft::new(
+                    BlockKind::SystemPrefix,
+                    &message.content,
+                    None,
+                ));
             }
             MessageRole::User => {
                 // The recalled frames live inside this message; splitting them
@@ -148,10 +152,10 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
     if let Some(last) = drafts.last_mut() {
         last.cache_zone = CacheZone::Volatile;
     }
-    if let Some(first) = drafts.first_mut() {
-        if first.kind == BlockKind::SystemPrefix {
-            first.cache_zone = CacheZone::StablePrefix;
-        }
+    if let Some(first) = drafts.first_mut()
+        && first.kind == BlockKind::SystemPrefix
+    {
+        first.cache_zone = CacheZone::StablePrefix;
     }
     drafts
 }
@@ -197,9 +201,12 @@ impl ReceiptLedger {
         role: ModelCallRole,
         provider: &str,
         model: &str,
-        estimated_input_tokens: u64,
         events: &EventSender,
     ) {
+        // The manifest's estimate is the same conversation estimate the driver
+        // pairs with `StepUsage` (a drift sample), computed here from the same
+        // messages so the two events always agree.
+        let estimated_input_tokens = estimate_conversation_tokens(messages);
         let drafts = decompose(messages);
         let mut blocks = Vec::with_capacity(drafts.len());
         for draft in &drafts {
@@ -297,7 +304,14 @@ mod tests {
         let mut ledger = ReceiptLedger::new(0);
         ledger.set_effective_budget(136_363, 1.1);
         let messages = convo();
-        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "anthropic", "opus", 42, &events);
+        ledger.emit_step_receipt(
+            &messages,
+            0,
+            ModelCallRole::Worker,
+            "anthropic",
+            "opus",
+            &events,
+        );
 
         let evts = drain(&mut rx);
         let manifest = evts
@@ -326,11 +340,11 @@ mod tests {
         let mut ledger = ReceiptLedger::new(0);
         let messages = convo();
 
-        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "p", "m", 1, &events);
+        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "p", "m", &events);
         let _ = drain(&mut rx);
         // Same conversation on the next step: no NEW registrations, and the
         // blocks report resident_since_step == 0 (they arrived on step 0).
-        ledger.emit_step_receipt(&messages, 1, ModelCallRole::Worker, "p", "m", 1, &events);
+        ledger.emit_step_receipt(&messages, 1, ModelCallRole::Worker, "p", "m", &events);
         let evts = drain(&mut rx);
 
         let new_registrations = evts
@@ -355,7 +369,10 @@ mod tests {
     fn identical_tool_output_resolves_to_the_same_block_id() {
         // Two tool results with byte-identical output share a content-addressed
         // id — the property dedup/supersession identities rely on.
-        let a = serde_json::to_string(&ToolOutput::Ok { content: "same".into() }).unwrap();
+        let a = serde_json::to_string(&ToolOutput::Ok {
+            content: "same".into(),
+        })
+        .unwrap();
         let id1 = block_id(BlockKind::ToolResult, &a);
         let id2 = block_id(BlockKind::ToolResult, &a);
         assert_eq!(id1, id2);

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -1,0 +1,365 @@
+//! Context-receipts emission (spec §4/§5), kept out of the driver body so the
+//! step loop calls one helper and the emission logic stays independently
+//! testable. Produces, per step: a `BlockRegistered` event for each context
+//! block the model has not seen before (content-addressed, emitted once), then
+//! a `StepManifest` naming the blocks it saw this step in wire order.
+//!
+//! Content-free by construction: blocks carry a `content_digest`, never the
+//! payload bytes — the preimage already lives in the originating event in the
+//! journal, so this is an index over the fold, not a second content store.
+//!
+//! Granularity is event-level (increment 1): the engine decomposes what it can
+//! see in the message vec — the system prefix, each assistant text and
+//! tool-call, and each tool result by `call_id`. Splitting the recalled user
+//! message into per-frame `RecalledFrame` blocks (with `memory_id`) is the
+//! memory-join increment (spec §9), where the pipeline participates.
+
+use std::collections::HashMap;
+
+use sha2::{Digest, Sha256};
+use stella_protocol::{
+    AgentEvent, BlockKind, BlockOrigin, CacheZone, CompletionMessage, ManifestEntry, MessageRole,
+    ModelCallRole,
+};
+
+use crate::estimator::CHARS_PER_TOKEN;
+use crate::event_sender::EventSender;
+
+/// `sha256` hex of a string. Byte-wise hex (the sha2 0.11 output type does not
+/// implement `LowerHex` directly), matching the context store's `to_hex`.
+fn sha256_hex(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in h.finalize() {
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// The content-addressed id of a block: `blk_` + the first 24 hex chars of
+/// `sha256(kind_tag \0 content)`. Mirrors the context store's `nod_…` shape.
+/// Byte-identical blocks of the same kind share an id — the property that makes
+/// dedup/supersession identities and lets residency track a block across steps.
+fn block_id(kind: BlockKind, content: &str) -> String {
+    format!(
+        "blk_{}",
+        &sha256_hex(&format!("{}\0{}", kind_tag(kind), content))[..24]
+    )
+}
+
+/// The stable snake_case tag for a block kind — kept in lockstep with the
+/// protocol enum's `rename_all = "snake_case"` so a block's id and its stored
+/// `kind` string agree.
+fn kind_tag(kind: BlockKind) -> &'static str {
+    match kind {
+        BlockKind::SystemPrefix => "system_prefix",
+        BlockKind::UserGoal => "user_goal",
+        BlockKind::RecalledFrame => "recalled_frame",
+        BlockKind::AssistantText => "assistant_text",
+        BlockKind::ToolCall => "tool_call",
+        BlockKind::ToolResult => "tool_result",
+        BlockKind::Steered => "steered",
+        BlockKind::Summary => "summary",
+        BlockKind::Attachment => "attachment",
+        BlockKind::Other => "other",
+    }
+}
+
+/// The engine's raw per-block token estimate — the same char heuristic the
+/// conversation estimator uses, applied to one block's content, so a block's
+/// cost is on the same scale as `StepUsage.estimated_input_tokens`.
+fn estimate_tokens(content: &str) -> u32 {
+    (content.chars().count() as f64 / CHARS_PER_TOKEN).ceil() as u32
+}
+
+/// One decomposed context block, before it becomes a manifest entry.
+struct BlockDraft {
+    block_id: String,
+    kind: BlockKind,
+    content_digest: String,
+    token_cost: u32,
+    call_id: Option<String>,
+    cache_zone: CacheZone,
+}
+
+impl BlockDraft {
+    fn new(kind: BlockKind, content: &str, call_id: Option<String>) -> Self {
+        BlockDraft {
+            block_id: block_id(kind, content),
+            kind,
+            content_digest: format!("sha256:{}", sha256_hex(content)),
+            token_cost: estimate_tokens(content),
+            call_id,
+            cache_zone: CacheZone::Cacheable,
+        }
+    }
+}
+
+/// Decompose the live message vector into event-granular blocks, in wire order,
+/// and stamp each a structural cache zone. The zone is a hint at emission — the
+/// system prefix is the stable-cached head (L-E8) and the final message is the
+/// live tail that is recomputed each step; cache attribution (spec §7, A3)
+/// refines these against reported usage.
+fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
+    let mut drafts = Vec::new();
+    for message in messages {
+        match message.role {
+            MessageRole::System => {
+                drafts.push(BlockDraft::new(BlockKind::SystemPrefix, &message.content, None));
+            }
+            MessageRole::User => {
+                // The recalled frames live inside this message; splitting them
+                // into per-frame blocks is the memory-join increment (§9).
+                drafts.push(BlockDraft::new(BlockKind::UserGoal, &message.content, None));
+            }
+            MessageRole::Assistant => {
+                if !message.content.is_empty() {
+                    drafts.push(BlockDraft::new(
+                        BlockKind::AssistantText,
+                        &message.content,
+                        None,
+                    ));
+                }
+                for call in &message.tool_calls {
+                    let content = serde_json::to_string(call).unwrap_or_default();
+                    drafts.push(BlockDraft::new(
+                        BlockKind::ToolCall,
+                        &content,
+                        Some(call.call_id.clone()),
+                    ));
+                }
+            }
+            MessageRole::Tool => {
+                for result in &message.tool_results {
+                    let content = serde_json::to_string(&result.output).unwrap_or_default();
+                    drafts.push(BlockDraft::new(
+                        BlockKind::ToolResult,
+                        &content,
+                        Some(result.call_id.clone()),
+                    ));
+                }
+            }
+        }
+    }
+    // Structural zones: the head is the stable prefix, the tail is volatile.
+    // Set the tail first so a single-block conversation ends StablePrefix.
+    if let Some(last) = drafts.last_mut() {
+        last.cache_zone = CacheZone::Volatile;
+    }
+    if let Some(first) = drafts.first_mut() {
+        if first.kind == BlockKind::SystemPrefix {
+            first.cache_zone = CacheZone::StablePrefix;
+        }
+    }
+    drafts
+}
+
+/// Per-turn receipt state: which blocks have been registered (and at which
+/// step they first appeared, for residency), plus the effective compaction
+/// budget the driver computed for the step about to run. Lives on the stack in
+/// `run_turn`, threaded into the model call by reference — the engine holds no
+/// receipt state of its own.
+pub(crate) struct ReceiptLedger {
+    turn_instance: u32,
+    first_seen_step: HashMap<String, usize>,
+    effective_budget_tokens: u64,
+    calibration_factor: f64,
+}
+
+impl ReceiptLedger {
+    pub(crate) fn new(turn_instance: u32) -> Self {
+        ReceiptLedger {
+            turn_instance,
+            first_seen_step: HashMap::new(),
+            effective_budget_tokens: 0,
+            calibration_factor: 1.0,
+        }
+    }
+
+    /// Record the effective compaction budget and calibration factor the
+    /// driver computed for the next step — the values the compaction pass
+    /// actually compared against, carried onto the manifest so the receipt's
+    /// numbers line up with the decision that was made (#364 item 1).
+    pub(crate) fn set_effective_budget(&mut self, budget_tokens: u64, factor: f64) {
+        self.effective_budget_tokens = budget_tokens;
+        self.calibration_factor = factor;
+    }
+
+    /// Emit the receipt for one committed step: a `BlockRegistered` for every
+    /// block first seen this step, then the ordered `StepManifest`. Called at
+    /// the settled boundary where the served model/provider are known.
+    pub(crate) fn emit_step_receipt(
+        &mut self,
+        messages: &[CompletionMessage],
+        step: usize,
+        role: ModelCallRole,
+        provider: &str,
+        model: &str,
+        estimated_input_tokens: u64,
+        events: &EventSender,
+    ) {
+        let drafts = decompose(messages);
+        let mut blocks = Vec::with_capacity(drafts.len());
+        for draft in &drafts {
+            let resident_since_step = match self.first_seen_step.get(&draft.block_id) {
+                Some(first) => *first,
+                None => {
+                    self.first_seen_step.insert(draft.block_id.clone(), step);
+                    // Durable-before-visible: register the block before the
+                    // manifest cites it.
+                    let _ = events.send(AgentEvent::BlockRegistered {
+                        block_id: draft.block_id.clone(),
+                        kind: draft.kind,
+                        origin: BlockOrigin {
+                            turn_instance: self.turn_instance,
+                            step,
+                            call_id: draft.call_id.clone(),
+                            memory_id: None,
+                        },
+                        token_cost: draft.token_cost,
+                        content_digest: draft.content_digest.clone(),
+                        citation_label: None,
+                    });
+                    step
+                }
+            };
+            blocks.push(ManifestEntry {
+                block_id: draft.block_id.clone(),
+                cache_zone: draft.cache_zone,
+                token_cost: draft.token_cost,
+                resident_since_step,
+            });
+        }
+        let _ = events.send(AgentEvent::StepManifest {
+            turn_instance: self.turn_instance,
+            step,
+            role,
+            provider: provider.to_string(),
+            model: model.to_string(),
+            blocks,
+            effective_budget_tokens: self.effective_budget_tokens,
+            calibration_factor: self.calibration_factor,
+            estimated_input_tokens,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::{ToolCall, ToolOutput, ToolResult};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn drain(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            out.push(ev);
+        }
+        out
+    }
+
+    fn convo() -> Vec<CompletionMessage> {
+        vec![
+            CompletionMessage::system("you are a careful engineer"),
+            CompletionMessage::user("fix the failing test"),
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: "c1".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({"path": "a.rs"}),
+                }],
+                tool_results: vec![],
+                attachments: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    call_id: "c1".into(),
+                    output: ToolOutput::Ok {
+                        content: "fn a() {}".into(),
+                    },
+                }],
+                attachments: vec![],
+            },
+        ]
+    }
+
+    #[test]
+    fn manifest_names_every_block_in_wire_order_with_structural_zones() {
+        let (tx, mut rx) = unbounded_channel();
+        let events = EventSender::new(tx);
+        let mut ledger = ReceiptLedger::new(0);
+        ledger.set_effective_budget(136_363, 1.1);
+        let messages = convo();
+        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "anthropic", "opus", 42, &events);
+
+        let evts = drain(&mut rx);
+        let manifest = evts
+            .iter()
+            .find_map(|e| match e {
+                AgentEvent::StepManifest { blocks, .. } => Some(blocks.clone()),
+                _ => None,
+            })
+            .expect("a manifest was emitted");
+        // system prefix, user goal, one tool_call, one tool_result = 4 blocks.
+        assert_eq!(manifest.len(), 4);
+        assert_eq!(manifest[0].cache_zone, CacheZone::StablePrefix);
+        assert_eq!(manifest[3].cache_zone, CacheZone::Volatile);
+        // A BlockRegistered was emitted for each, before the manifest.
+        let registered = evts
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::BlockRegistered { .. }))
+            .count();
+        assert_eq!(registered, 4);
+    }
+
+    #[test]
+    fn a_block_carried_across_steps_registers_once_and_ages_its_residency() {
+        let (tx, mut rx) = unbounded_channel();
+        let events = EventSender::new(tx);
+        let mut ledger = ReceiptLedger::new(0);
+        let messages = convo();
+
+        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "p", "m", 1, &events);
+        let _ = drain(&mut rx);
+        // Same conversation on the next step: no NEW registrations, and the
+        // blocks report resident_since_step == 0 (they arrived on step 0).
+        ledger.emit_step_receipt(&messages, 1, ModelCallRole::Worker, "p", "m", 1, &events);
+        let evts = drain(&mut rx);
+
+        let new_registrations = evts
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::BlockRegistered { .. }))
+            .count();
+        assert_eq!(new_registrations, 0, "carried blocks re-register 0 times");
+        let manifest = evts
+            .iter()
+            .find_map(|e| match e {
+                AgentEvent::StepManifest { blocks, .. } => Some(blocks.clone()),
+                _ => None,
+            })
+            .expect("manifest");
+        assert!(
+            manifest.iter().all(|b| b.resident_since_step == 0),
+            "every block has been resident since step 0"
+        );
+    }
+
+    #[test]
+    fn identical_tool_output_resolves_to_the_same_block_id() {
+        // Two tool results with byte-identical output share a content-addressed
+        // id — the property dedup/supersession identities rely on.
+        let a = serde_json::to_string(&ToolOutput::Ok { content: "same".into() }).unwrap();
+        let id1 = block_id(BlockKind::ToolResult, &a);
+        let id2 = block_id(BlockKind::ToolResult, &a);
+        assert_eq!(id1, id2);
+        assert!(id1.starts_with("blk_"));
+        assert_eq!(id1.len(), 4 + 24);
+    }
+}

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -2014,6 +2014,11 @@ impl<'a> Pipeline<'a> {
                 uri: f.uri.clone(),
                 method: f.method.clone(),
                 token_cost: f.token_cost,
+                // Frame-granular block ids are populated in the memory-join
+                // increment (spec §9). Engine-level receipts (increment 1) do
+                // not split the recalled user message into per-frame blocks.
+                block_id: None,
+                content_digest: None,
             })
             .collect();
         self.emit(AgentEvent::ContextRecall {

--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -256,6 +256,15 @@ pub fn event_signature(event: &AgentEvent) -> String {
             let done = tasks.iter().filter(|t| !t.status.is_open()).count();
             format!("task_update:tasks={},resolved={done}", tasks.len())
         }
+        // Context receipts are additive observability (spec §4/§5), excluded
+        // from the structural comparison below just like TextDelta — a golden
+        // stream recorded before receipts existed has none, so they must not
+        // shift the aligned positions. The signatures exist only to keep this
+        // function total; they capture occurrence + shape, never volatile ids.
+        AgentEvent::BlockRegistered { kind, .. } => format!("block_registered:{kind:?}"),
+        AgentEvent::StepManifest { blocks, .. } => {
+            format!("step_manifest:blocks={}", blocks.len())
+        }
     }
 }
 
@@ -289,7 +298,17 @@ pub fn structural_diff(left: &[AgentEvent], right: &[AgentEvent]) -> Vec<StreamD
     // is volatile — the authoritative `Text` event that follows them is the
     // structural record. Diff indices therefore address the delta-free
     // sequence.
-    let keep = |e: &&AgentEvent| !matches!(e, AgentEvent::TextDelta { .. });
+    // Context receipts (BlockRegistered/StepManifest) join TextDelta in the
+    // exclusion set: they are additive observability a pre-receipt golden
+    // stream does not carry, so keeping them would shift every later position.
+    let keep = |e: &&AgentEvent| {
+        !matches!(
+            e,
+            AgentEvent::TextDelta { .. }
+                | AgentEvent::BlockRegistered { .. }
+                | AgentEvent::StepManifest { .. }
+        )
+    };
     let left: Vec<&AgentEvent> = left.iter().filter(keep).collect();
     let right: Vec<&AgentEvent> = right.iter().filter(keep).collect();
     let mut diffs = Vec::new();

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -91,6 +91,60 @@ pub enum UsageIncompleteReason {
     Cancelled,
 }
 
+/// The semantic kind of one context block — one durable, individually
+/// attributable unit that can enter the model's prompt. Finer-grained than a
+/// `CompletionMessage`: a tool message holding several results decomposes into
+/// one `ToolResult` block per `call_id`. See the session-telemetry-receipts
+/// spec (`docs/design/session-telemetry-receipts-spec.md`, §4). Forward-compat:
+/// an unknown kind read from a newer emitter deserializes to [`BlockKind::Other`]
+/// rather than failing the whole event.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockKind {
+    /// Message index 0 — the stable system prefix, never compacted.
+    SystemPrefix,
+    /// The user's task text.
+    UserGoal,
+    /// A context frame injected by recall (memory/graph/file).
+    RecalledFrame,
+    /// Model prose.
+    AssistantText,
+    /// An assistant tool-call request.
+    ToolCall,
+    /// A tool output (Ok or Error).
+    ToolResult,
+    /// A mid-turn injected user (steering) message.
+    Steered,
+    /// An overflow-summarizer replacement span.
+    Summary,
+    /// A multimodal attachment (image/doc/audio/video).
+    Attachment,
+    /// A kind this reader does not recognize (written by a newer emitter).
+    #[default]
+    #[serde(other)]
+    Other,
+}
+
+/// A block's cache position relative to the provider's prompt-cache
+/// breakpoints. Stella keeps the system prefix byte-stable and places volatile
+/// recall after it (L-E8), so a block's zone is computable from its position at
+/// manifest time. A structural hint at emission; reconciled against reported
+/// usage by cache attribution (spec §7). Forward-compat via [`CacheZone::Other`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheZone {
+    /// At/before the system-block breakpoint — should cache-hit every step.
+    StablePrefix,
+    /// Before the conversation-tail breakpoint — cacheable across steps.
+    #[default]
+    Cacheable,
+    /// After the last breakpoint — recomputed every step by construction.
+    Volatile,
+    /// A zone this reader does not recognize (written by a newer emitter).
+    #[serde(other)]
+    Other,
+}
+
 /// One event in the turn's stream. Every stage boundary emits an event;
 /// nothing user-visible is derived from internal state that isn't also in
 /// this stream.
@@ -281,6 +335,52 @@ pub enum AgentEvent {
         upserts: u32,
         superseded: u32,
     },
+    /// A context block first became eligible to enter the prompt (spec §4).
+    /// Content-free on the wire: carries a digest + provenance, never the
+    /// payload bytes — the bytes already live in the originating event
+    /// (`ToolResult`, `Text`, …) or, for recalled frames, the local block
+    /// registry. This is the birth record that makes the per-step manifest an
+    /// index over the fold rather than a parallel content store. Additive:
+    /// consumers recorded before receipts existed simply never see it.
+    BlockRegistered {
+        /// `blk_<24 hex of sha256(kind \0 content)>`. Byte-identical blocks
+        /// share an id, so dedup/supersession become identities not counts.
+        block_id: String,
+        kind: BlockKind,
+        origin: BlockOrigin,
+        /// Estimated tokens at birth (the engine's estimator).
+        token_cost: u32,
+        /// `"sha256:<full hex>"` — verifies the preimage on reconstruction.
+        content_digest: String,
+        /// Human label for recall frames / memory nodes, when the block has one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        citation_label: Option<String>,
+    },
+    /// The ordered receipt of exactly what the model saw on one step (spec §5):
+    /// the block sequence sent, in wire order, plus the budget the compaction
+    /// pass actually compared against this step. Emitted immediately before the
+    /// step's model call commits. Content-free (block ids + small ints); the
+    /// preimages are resolved from the fold at inspection time. This is the
+    /// record that makes any past step reconstructable and auditable.
+    StepManifest {
+        /// Monotonic per session — groups the steps of one `run_turn`.
+        turn_instance: u32,
+        step: usize,
+        role: ModelCallRole,
+        provider: String,
+        model: String,
+        /// Blocks in wire order; index 0 is the system prefix.
+        blocks: Vec<ManifestEntry>,
+        /// The budget the compaction pass actually compared against THIS step —
+        /// the raw budget divided by the model's calibration factor. Evented so
+        /// the receipt's numbers line up with the decision that was made (the
+        /// `Compaction` event's raw before/after do not, on their own — #364).
+        effective_budget_tokens: u64,
+        /// The per-model calibration factor applied to the raw budget.
+        calibration_factor: f64,
+        /// Sum of block token costs, pre-call (the engine's raw estimate).
+        estimated_input_tokens: u64,
+    },
     /// A verification verdict — from the deterministic ladder (flip oracle,
     /// touched-tests-green) or the model judge (L-E11: deterministic-first;
     /// model judges handle only inconclusive evidence).
@@ -409,6 +509,48 @@ pub struct ContextFrameRef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
     pub token_cost: u32,
+    /// The registry id (`blk_…`) of this frame as a context block, when
+    /// receipts are enabled. Joins the frame to its manifest membership and,
+    /// for memory frames, to the write→citation loop (spec §5.3, §9). Absent on
+    /// streams recorded before receipts existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    /// `"sha256:<hex>"` of the exact injected text. The digest rides the wire;
+    /// the content itself is journaled only locally (never exported), closing
+    /// the recall-content gap G1 without widening the content-free export.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_digest: Option<String>,
+}
+
+/// Where a context block came from — the provenance stamped once at a block's
+/// birth (spec §4). The join hub: a `RecalledFrame` carries the `memory_id` it
+/// was recalled from; a `ToolResult`/`ToolCall` carries its `call_id`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockOrigin {
+    /// Monotonic per session — the `run_turn` that produced the block.
+    pub turn_instance: u32,
+    /// The step within that turn.
+    pub step: usize,
+    /// Tool-call correlation id, for `ToolCall`/`ToolResult` blocks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    /// The `nod_…` memory node id, for a `RecalledFrame` that is a memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_id: Option<String>,
+}
+
+/// One block's membership in a step's manifest (spec §5): its id, its cache
+/// zone at that step, its estimated token cost, and how long it has been
+/// resident. Residency × cost is what makes cost-of-carry a real number.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    pub block_id: String,
+    /// Cache position class relative to the last stable breakpoint.
+    #[serde(default)]
+    pub cache_zone: CacheZone,
+    pub token_cost: u32,
+    /// The step this block first entered a manifest — drives cost-of-carry.
+    pub resident_since_step: usize,
 }
 
 /// One provider's share of a recall's frame mix.
@@ -719,6 +861,8 @@ mod tests {
                 uri: Some("file:///repo/stella-core/src/driver.rs".into()),
                 method: Some("tree-sitter/symbol-extract".into()),
                 token_cost: 120,
+                block_id: None,
+                content_digest: None,
             }],
             provider_mix: vec![ProviderShare {
                 provider: "code-graph".into(),
@@ -1072,5 +1216,102 @@ mod tests {
         assert_eq!(roundtrip["type"], "usage_incomplete");
         assert_eq!(roundtrip["reason"], "timeout");
         assert_eq!(roundtrip.as_object().unwrap().len(), 7);
+    }
+
+    #[test]
+    fn block_registered_roundtrips_and_is_content_free() {
+        let event = AgentEvent::BlockRegistered {
+            block_id: "blk_0123456789abcdef01234567".into(),
+            kind: BlockKind::ToolResult,
+            origin: BlockOrigin {
+                turn_instance: 2,
+                step: 5,
+                call_id: Some("call_9".into()),
+                memory_id: None,
+            },
+            token_cost: 480,
+            content_digest: "sha256:deadbeef".into(),
+            citation_label: None,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["type"], "block_registered");
+        assert_eq!(value["kind"], "tool_result");
+        assert_eq!(value["origin"]["call_id"], "call_9");
+        // Content-free: the payload bytes never appear, only a digest.
+        assert!(
+            value.get("content").is_none() && value.get("output").is_none(),
+            "block_registered must not carry payload bytes: {value}"
+        );
+        let back: AgentEvent = serde_json::from_str(&value.to_string()).unwrap();
+        match back {
+            AgentEvent::BlockRegistered { block_id, kind, .. } => {
+                assert_eq!(block_id, "blk_0123456789abcdef01234567");
+                assert_eq!(kind, BlockKind::ToolResult);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_manifest_preserves_block_order_and_the_effective_budget() {
+        let event = AgentEvent::StepManifest {
+            turn_instance: 1,
+            step: 3,
+            role: ModelCallRole::Worker,
+            provider: "anthropic".into(),
+            model: "claude-opus".into(),
+            blocks: vec![
+                ManifestEntry {
+                    block_id: "blk_sys".into(),
+                    cache_zone: CacheZone::StablePrefix,
+                    token_cost: 1200,
+                    resident_since_step: 0,
+                },
+                ManifestEntry {
+                    block_id: "blk_tail".into(),
+                    cache_zone: CacheZone::Volatile,
+                    token_cost: 90,
+                    resident_since_step: 3,
+                },
+            ],
+            effective_budget_tokens: 136_363,
+            calibration_factor: 1.1,
+            estimated_input_tokens: 1290,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["type"], "step_manifest");
+        // Order is load-bearing — the manifest IS the wire sequence.
+        assert_eq!(value["blocks"][0]["block_id"], "blk_sys");
+        assert_eq!(value["blocks"][1]["block_id"], "blk_tail");
+        assert_eq!(value["effective_budget_tokens"], 136_363);
+        let back: AgentEvent = serde_json::from_str(&value.to_string()).unwrap();
+        match back {
+            AgentEvent::StepManifest { blocks, .. } => {
+                assert_eq!(blocks.len(), 2);
+                assert_eq!(blocks[0].cache_zone, CacheZone::StablePrefix);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn context_frame_ref_without_receipt_fields_still_parses() {
+        // A recall frame recorded before receipts existed carries no block_id
+        // or content_digest — it must still deserialize (additive contract).
+        let old = r#"{"citation_label":"auth module","source":"stella-context","token_cost":42}"#;
+        let frame: ContextFrameRef = serde_json::from_str(old).unwrap();
+        assert_eq!(frame.citation_label, "auth module");
+        assert!(frame.block_id.is_none());
+        assert!(frame.content_digest.is_none());
+    }
+
+    #[test]
+    fn unknown_block_kind_degrades_to_other_not_a_parse_error() {
+        // A newer emitter may name a block kind this reader has never heard of.
+        // The additive contract requires it to degrade, not reject the event.
+        let kind: BlockKind = serde_json::from_str("\"some_future_kind\"").unwrap();
+        assert_eq!(kind, BlockKind::Other);
+        let zone: CacheZone = serde_json::from_str("\"some_future_zone\"").unwrap();
+        assert_eq!(zone, CacheZone::Other);
     }
 }

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -27,9 +27,10 @@ pub use completion::{
 };
 pub use error::ProviderError;
 pub use event::{
-    AgentEvent, BudgetMode, CiStatus, ContextFrameRef, FileChangeKind, JudgeEvidence,
-    MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole, PrStatus, ProviderShare,
-    ScopeProposal, StageKind, TaskItem, TaskStatus, UsageIncompleteReason,
+    AgentEvent, BlockKind, BlockOrigin, BudgetMode, CacheZone, CiStatus, ContextFrameRef,
+    FileChangeKind, JudgeEvidence, ManifestEntry, MediaArtifactRef, MediaJobState, MediaKind,
+    ModelCallRole, PrStatus, ProviderShare, ScopeProposal, StageKind, TaskItem, TaskStatus,
+    UsageIncompleteReason,
 };
 pub use provider::{Provider, ToolCallObserver};
 pub use role::{ModelRef, Role};

--- a/stella-store/src/ddl.rs
+++ b/stella-store/src/ddl.rs
@@ -12,7 +12,7 @@
 
 /// Every table the store owns — the allowlist for [`Store::count`](crate::Store::count) and the
 /// fresh-file probe in [`Store::migrate`](crate::Store::migrate).
-pub(crate) const TABLES: [&str; 17] = [
+pub(crate) const TABLES: [&str; 20] = [
     "executions",
     "events",
     "telemetry",
@@ -30,6 +30,9 @@ pub(crate) const TABLES: [&str; 17] = [
     "reflections",
     "tasks",
     "pull_requests",
+    "context_blocks",
+    "step_manifest",
+    "step_receipt",
 ];
 
 /// `executions` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — the spine every other table
@@ -356,4 +359,71 @@ pub(crate) const PULL_REQUESTS_DDL: &str = "CREATE TABLE IF NOT EXISTS pull_requ
        ci_status TEXT,
        updated_at INTEGER NOT NULL,
        UNIQUE(url)
+     );";
+
+/// `context_blocks` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION)
+/// — the context-receipts block registry (v11, spec §4). One row per durable,
+/// individually attributable unit that entered a step's prompt, born once and
+/// keyed by its content-addressed `block_id` (`blk_…`). Content-free: it stores
+/// a `content_digest`, never the payload bytes — the preimage lives in the
+/// originating event in the journal. `call_id`/`memory_id` are the join keys
+/// back to the tool call or memory node that produced the block.
+/// UNIQUE via PRIMARY KEY (execution_id, block_id): a block is registered once
+/// per execution; a byte-identical block re-entering context resolves to the
+/// same id, so the second registration is an idempotent no-op, not data.
+pub(crate) const CONTEXT_BLOCKS_DDL: &str = "CREATE TABLE IF NOT EXISTS context_blocks (
+       execution_id INTEGER NOT NULL,
+       block_id TEXT NOT NULL,
+       kind TEXT NOT NULL,
+       origin_turn INTEGER NOT NULL,
+       origin_step INTEGER NOT NULL,
+       call_id TEXT,
+       memory_id TEXT,
+       token_cost INTEGER NOT NULL,
+       content_digest TEXT NOT NULL,
+       citation_label TEXT,
+       first_seen_ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+       PRIMARY KEY (execution_id, block_id)
+     );
+     CREATE INDEX IF NOT EXISTS context_blocks_by_memory
+       ON context_blocks(memory_id, execution_id);";
+
+/// `step_manifest` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION)
+/// — the per-step request manifest, normalized one row per (step, block) in
+/// wire order (v11, spec §5). This is the receipt that makes any past step
+/// reconstructable: replaying the fold + this ordering yields exactly what the
+/// model saw. PRIMARY KEY (execution_id, turn_instance, step, ordinal) is the
+/// wire position; the second index is the reverse lookup (every step a given
+/// block was resident) that cost-of-carry and eviction analysis read.
+pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_manifest (
+       execution_id INTEGER NOT NULL,
+       turn_instance INTEGER NOT NULL,
+       step INTEGER NOT NULL,
+       ordinal INTEGER NOT NULL,
+       block_id TEXT NOT NULL,
+       cache_zone TEXT NOT NULL,
+       resident_since_step INTEGER NOT NULL,
+       PRIMARY KEY (execution_id, turn_instance, step, ordinal)
+     );
+     CREATE INDEX IF NOT EXISTS step_manifest_by_block
+       ON step_manifest(execution_id, block_id);";
+
+/// `step_receipt` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION)
+/// — the manifest header, one row per committed step (v11, spec §5/§12): which
+/// model served it, and the budget the compaction pass actually compared
+/// against (raw budget / calibration factor), so the receipt's numbers line up
+/// with the decision that was made. The per-zone cache columns (spec §7) are
+/// added additively by a later migration; this is the increment-1 header only.
+/// PRIMARY KEY (execution_id, turn_instance, step): one receipt per step.
+pub(crate) const STEP_RECEIPT_DDL: &str = "CREATE TABLE IF NOT EXISTS step_receipt (
+       execution_id INTEGER NOT NULL,
+       turn_instance INTEGER NOT NULL,
+       step INTEGER NOT NULL,
+       provider TEXT NOT NULL,
+       model TEXT NOT NULL,
+       call_role TEXT NOT NULL,
+       effective_budget_tokens INTEGER NOT NULL,
+       calibration_factor REAL NOT NULL,
+       estimated_input_tokens INTEGER NOT NULL,
+       PRIMARY KEY (execution_id, turn_instance, step)
      );";

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -98,6 +98,7 @@ use stella_protocol::{AgentEvent, TaskItem, TaskStatus, ToolOutput};
 mod ddl;
 mod migrations;
 mod private;
+mod receipts;
 #[cfg(test)]
 mod private_state_tests;
 #[cfg(test)]
@@ -142,6 +143,7 @@ pub(crate) use private::{
     open_private_file, open_private_sqlite, read_private_to_string, write_private_atomic,
 };
 pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
+pub use receipts::{ContextBlockRow, ManifestBlockRow, StepManifestRow};
 pub use telemetry::TelemetryRow;
 
 /// FNV-1a/64 hex — a stable, dependency-free digest for prompt hashes and

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -98,11 +98,11 @@ use stella_protocol::{AgentEvent, TaskItem, TaskStatus, ToolOutput};
 mod ddl;
 mod migrations;
 mod private;
-mod receipts;
 #[cfg(test)]
 mod private_state_tests;
 #[cfg(test)]
 mod quarantine_tests;
+mod receipts;
 mod telemetry;
 #[cfg(test)]
 mod tests;
@@ -142,8 +142,8 @@ pub(crate) use private::{
     ensure_private_dir, ensure_workspace_generated_ignore, ensure_workspace_state_dir,
     open_private_file, open_private_sqlite, read_private_to_string, write_private_atomic,
 };
-pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
 pub use receipts::{ContextBlockRow, ManifestBlockRow, StepManifestRow};
+pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
 pub use telemetry::TelemetryRow;
 
 /// FNV-1a/64 hex — a stable, dependency-free digest for prompt hashes and

--- a/stella-store/src/migrations.rs
+++ b/stella-store/src/migrations.rs
@@ -11,10 +11,10 @@
 use rusqlite::{Connection, params};
 
 use crate::ddl::{
-    AGENT_USES_DDL, EXECUTION_REFLECTION_DDL, EXECUTIONS_DDL, MCP_USAGE_DDL, MEMORY_CITATIONS_DDL,
-    PULL_REQUESTS_DDL, REFLECTIONS_DDL, RULES_TABLE, SKILL_USAGE_DDL, TABLES, TASKS_DDL,
-    TELEMETRY_INDEX, TOOL_CALLS_DDL, UNCHANGED_TABLES, events_ddl, files_touched_ddl,
-    telemetry_ddl,
+    AGENT_USES_DDL, CONTEXT_BLOCKS_DDL, EXECUTION_REFLECTION_DDL, EXECUTIONS_DDL, MCP_USAGE_DDL,
+    MEMORY_CITATIONS_DDL, PULL_REQUESTS_DDL, REFLECTIONS_DDL, RULES_TABLE, SKILL_USAGE_DDL,
+    STEP_MANIFEST_DDL, STEP_RECEIPT_DDL, TABLES, TASKS_DDL, TELEMETRY_INDEX, TOOL_CALLS_DDL,
+    UNCHANGED_TABLES, events_ddl, files_touched_ddl, telemetry_ddl,
 };
 use crate::{Result, StoreError};
 
@@ -28,7 +28,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 10] = [
+pub(crate) const MIGRATIONS: [Migration; 11] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -57,6 +57,11 @@ pub(crate) const MIGRATIONS: [Migration; 10] = [
     migrate_v8_to_v9,
     // v9 → v10: explicit pending/complete/incomplete execution lifecycle.
     migrate_v9_to_v10,
+    // v10 → v11: the context-receipts plane — `context_blocks` (the block
+    // registry), `step_manifest` (per-step ordered receipt), and `step_receipt`
+    // (the manifest header). All purely additive; no existing table changes
+    // shape.
+    migrate_v10_to_v11,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -85,6 +90,9 @@ pub(crate) fn create_latest_schema(tx: &rusqlite::Transaction<'_>) -> Result<()>
     tx.execute_batch(REFLECTIONS_DDL)?;
     tx.execute_batch(TASKS_DDL)?;
     tx.execute_batch(PULL_REQUESTS_DDL)?;
+    tx.execute_batch(CONTEXT_BLOCKS_DDL)?;
+    tx.execute_batch(STEP_MANIFEST_DDL)?;
+    tx.execute_batch(STEP_RECEIPT_DDL)?;
     Ok(())
 }
 
@@ -394,6 +402,17 @@ fn migrate_v9_to_v10(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     Ok(())
 }
 
+/// v10 → v11: the context-receipts plane (spec §4/§5). Three purely additive
+/// tables — `context_blocks`, `step_manifest`, `step_receipt` — and their
+/// indexes. No existing table changes shape, so no §7 rebuild; `IF NOT EXISTS`
+/// also tolerates a partial file that somehow already grew them.
+fn migrate_v10_to_v11(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    tx.execute_batch(CONTEXT_BLOCKS_DDL)?;
+    tx.execute_batch(STEP_MANIFEST_DDL)?;
+    tx.execute_batch(STEP_RECEIPT_DDL)?;
+    Ok(())
+}
+
 /// Run one migration in its own transaction, stamping `user_version` before
 /// commit so version and shape can never disagree on disk. The caller has
 /// already suspended foreign-key enforcement (a no-op inside a
@@ -492,5 +511,53 @@ mod tests {
                 ("incomplete".into(), false),
             ]
         );
+    }
+
+    #[test]
+    fn v11_migration_adds_the_receipts_tables_additively_to_an_existing_store() {
+        // Start from a minimal v10-shaped file with a live execution row: the
+        // migration must add the three receipts tables without touching it.
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE executions (id INTEGER PRIMARY KEY, kind TEXT);
+             INSERT INTO executions (id, kind) VALUES (1, 'run');",
+        )
+        .expect("v10 schema");
+
+        apply_migration(&mut conn, migrate_v10_to_v11, 11).expect("migrate");
+
+        // The pre-existing row is untouched.
+        let kind: String = conn
+            .query_row("SELECT kind FROM executions WHERE id = 1", [], |r| r.get(0))
+            .expect("execution preserved");
+        assert_eq!(kind, "run");
+
+        // All three tables now exist and accept a row at the new shape.
+        for table in ["context_blocks", "step_manifest", "step_receipt"] {
+            assert!(table_exists(&conn, table).unwrap(), "{table} missing");
+        }
+        conn.execute_batch(
+            "INSERT INTO context_blocks
+               (execution_id, block_id, kind, origin_turn, origin_step, token_cost, content_digest)
+               VALUES (1, 'blk_x', 'tool_result', 0, 2, 40, 'sha256:ab');
+             INSERT INTO step_manifest
+               (execution_id, turn_instance, step, ordinal, block_id, cache_zone, resident_since_step)
+               VALUES (1, 0, 2, 0, 'blk_x', 'cacheable', 2);
+             INSERT INTO step_receipt
+               (execution_id, turn_instance, step, provider, model, call_role,
+                effective_budget_tokens, calibration_factor, estimated_input_tokens)
+               VALUES (1, 0, 2, 'anthropic', 'opus', 'worker', 136363, 1.1, 40);",
+        )
+        .expect("new tables accept rows at the v11 shape");
+    }
+
+    #[test]
+    fn v11_migration_is_idempotent_on_a_partial_file() {
+        // A partial file that somehow already grew one receipts table must not
+        // fail the migration (IF NOT EXISTS tolerance).
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(CONTEXT_BLOCKS_DDL).expect("pre-grown");
+        apply_migration(&mut conn, migrate_v10_to_v11, 11).expect("migrate is idempotent");
+        assert!(table_exists(&conn, "step_manifest").unwrap());
     }
 }

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -1,0 +1,313 @@
+//! Context-receipts persistence (spec §4/§5): the block registry and the
+//! per-step request manifest. Content-free — these rows carry digests, ids,
+//! and small ints, never payload bytes. The preimage of any block lives in the
+//! originating event in the journal; these tables are the queryable index over
+//! it that makes any past step reconstructable and auditable.
+
+use rusqlite::params;
+
+use crate::{Result, Store, sqlite_i64};
+
+/// One context block as registered at birth (`context_blocks`, spec §4).
+/// `kind`/`cache_zone` are the wire enums already serialized to their
+/// snake_case strings by the caller — the store stays string-typed and never
+/// depends on the protocol enum shapes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextBlockRow {
+    pub block_id: String,
+    pub kind: String,
+    pub origin_turn: u32,
+    pub origin_step: u64,
+    pub call_id: Option<String>,
+    pub memory_id: Option<String>,
+    pub token_cost: u32,
+    pub content_digest: String,
+    pub citation_label: Option<String>,
+}
+
+/// One block's membership in a step's manifest (`step_manifest`, spec §5),
+/// in wire order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestBlockRow {
+    pub block_id: String,
+    pub cache_zone: String,
+    pub token_cost: u32,
+    pub resident_since_step: u64,
+}
+
+/// A full per-step manifest: the header (`step_receipt`) plus its ordered
+/// blocks (`step_manifest`). Persisted atomically so a receipt is never
+/// half-written.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StepManifestRow {
+    pub turn_instance: u32,
+    pub step: u64,
+    pub provider: String,
+    pub model: String,
+    pub call_role: String,
+    pub effective_budget_tokens: u64,
+    pub calibration_factor: f64,
+    pub estimated_input_tokens: u64,
+    pub blocks: Vec<ManifestBlockRow>,
+}
+
+impl Store {
+    /// Register one context block. Idempotent: a byte-identical block
+    /// re-entering context resolves to the same `block_id`, so a repeat
+    /// registration is a no-op (`INSERT OR IGNORE`), never an error or a
+    /// double-count — matching the content-addressed identity contract.
+    pub fn record_context_block(&self, execution_id: i64, row: &ContextBlockRow) -> Result<()> {
+        let origin_step = sqlite_i64("context block origin step", row.origin_step)?;
+        let token_cost = i64::from(row.token_cost);
+        self.lock().execute(
+            "INSERT OR IGNORE INTO context_blocks
+               (execution_id, block_id, kind, origin_turn, origin_step, call_id, memory_id,
+                token_cost, content_digest, citation_label)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                execution_id,
+                row.block_id,
+                row.kind,
+                i64::from(row.origin_turn),
+                origin_step,
+                row.call_id,
+                row.memory_id,
+                token_cost,
+                row.content_digest,
+                row.citation_label,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Persist one step's full manifest — the header row plus every ordered
+    /// block row — atomically. `INSERT OR REPLACE` so a re-emitted manifest for
+    /// the same (turn_instance, step) overwrites cleanly rather than colliding
+    /// on the primary key (the engine emits one manifest per step, but a caller
+    /// that replays must be able to re-persist idempotently).
+    pub fn record_step_manifest(&self, execution_id: i64, row: &StepManifestRow) -> Result<()> {
+        let step = sqlite_i64("manifest step", row.step)?;
+        let turn = i64::from(row.turn_instance);
+        let budget = sqlite_i64("manifest effective budget", row.effective_budget_tokens)?;
+        let estimated = sqlite_i64("manifest estimated input", row.estimated_input_tokens)?;
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT OR REPLACE INTO step_receipt
+               (execution_id, turn_instance, step, provider, model, call_role,
+                effective_budget_tokens, calibration_factor, estimated_input_tokens)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                execution_id,
+                turn,
+                step,
+                row.provider,
+                row.model,
+                row.call_role,
+                budget,
+                row.calibration_factor,
+                estimated,
+            ],
+        )?;
+        // Clear any prior ordinals for this step before rewriting, so a
+        // shorter re-emitted manifest cannot leave stale tail rows behind.
+        tx.execute(
+            "DELETE FROM step_manifest
+             WHERE execution_id = ? AND turn_instance = ? AND step = ?",
+            params![execution_id, turn, step],
+        )?;
+        // token_cost is a property of the block (context_blocks.token_cost),
+        // not of a manifest entry, so step_manifest stores only ordering, zone,
+        // and residency; the reader joins token_cost back from context_blocks.
+        for (ordinal, block) in row.blocks.iter().enumerate() {
+            let ordinal = sqlite_i64("manifest ordinal", ordinal as u64)?;
+            let resident = sqlite_i64("manifest residency", block.resident_since_step)?;
+            tx.execute(
+                "INSERT INTO step_manifest
+                   (execution_id, turn_instance, step, ordinal, block_id, cache_zone,
+                    resident_since_step)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    execution_id,
+                    turn,
+                    step,
+                    ordinal,
+                    block.block_id,
+                    block.cache_zone,
+                    resident,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Every block registered for an execution, insertion order.
+    pub fn context_blocks(&self, execution_id: i64) -> Result<Vec<ContextBlockRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT block_id, kind, origin_turn, origin_step, call_id, memory_id,
+                    token_cost, content_digest, citation_label
+             FROM context_blocks WHERE execution_id = ? ORDER BY rowid",
+        )?;
+        let rows = stmt
+            .query_map(params![execution_id], |r| {
+                Ok(ContextBlockRow {
+                    block_id: r.get(0)?,
+                    kind: r.get(1)?,
+                    origin_turn: r.get::<_, i64>(2)? as u32,
+                    origin_step: r.get::<_, i64>(3)? as u64,
+                    call_id: r.get(4)?,
+                    memory_id: r.get(5)?,
+                    token_cost: r.get::<_, i64>(6)? as u32,
+                    content_digest: r.get(7)?,
+                    citation_label: r.get(8)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// The ordered blocks of one step's manifest — the receipt of exactly what
+    /// the model saw, in wire order.
+    pub fn step_manifest(
+        &self,
+        execution_id: i64,
+        turn_instance: u32,
+        step: u64,
+    ) -> Result<Vec<ManifestBlockRow>> {
+        let step = sqlite_i64("manifest step", step)?;
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT sm.block_id, sm.cache_zone, cb.token_cost, sm.resident_since_step
+             FROM step_manifest sm
+             LEFT JOIN context_blocks cb
+               ON cb.execution_id = sm.execution_id AND cb.block_id = sm.block_id
+             WHERE sm.execution_id = ? AND sm.turn_instance = ? AND sm.step = ?
+             ORDER BY sm.ordinal",
+        )?;
+        let rows = stmt
+            .query_map(params![execution_id, i64::from(turn_instance), step], |r| {
+                Ok(ManifestBlockRow {
+                    block_id: r.get(0)?,
+                    cache_zone: r.get(1)?,
+                    // token_cost may be NULL if the block row is missing (a
+                    // manifest referencing an unregistered block — a bug worth
+                    // surfacing, not crashing on); default 0.
+                    token_cost: r.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
+                    resident_since_step: r.get::<_, i64>(3)? as u64,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(id: &str, step: u64) -> ContextBlockRow {
+        ContextBlockRow {
+            block_id: id.into(),
+            kind: "tool_result".into(),
+            origin_turn: 0,
+            origin_step: step,
+            call_id: Some(format!("call_{step}")),
+            memory_id: None,
+            token_cost: 100 + step as u32,
+            content_digest: format!("sha256:{id}"),
+            citation_label: None,
+        }
+    }
+
+    #[test]
+    fn block_registration_is_idempotent_on_the_content_addressed_id() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
+        store.record_context_block(id, &block("blk_a", 0)).unwrap();
+        // Re-registering the same block (identical content re-enters context)
+        // must be a silent no-op, never an error or a duplicate row.
+        store.record_context_block(id, &block("blk_a", 0)).unwrap();
+        store.record_context_block(id, &block("blk_b", 1)).unwrap();
+        let blocks = store.context_blocks(id).unwrap();
+        assert_eq!(blocks.len(), 2, "identical block must collapse to one row");
+        assert_eq!(blocks[0].block_id, "blk_a");
+        assert_eq!(blocks[1].call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn manifest_round_trips_in_wire_order_with_its_header() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
+        store.record_context_block(id, &block("blk_sys", 0)).unwrap();
+        store.record_context_block(id, &block("blk_tail", 3)).unwrap();
+        let manifest = StepManifestRow {
+            turn_instance: 0,
+            step: 3,
+            provider: "anthropic".into(),
+            model: "opus".into(),
+            call_role: "worker".into(),
+            effective_budget_tokens: 136_363,
+            calibration_factor: 1.1,
+            estimated_input_tokens: 203,
+            blocks: vec![
+                ManifestBlockRow {
+                    block_id: "blk_sys".into(),
+                    cache_zone: "stable_prefix".into(),
+                    token_cost: 100,
+                    resident_since_step: 0,
+                },
+                ManifestBlockRow {
+                    block_id: "blk_tail".into(),
+                    cache_zone: "volatile".into(),
+                    token_cost: 103,
+                    resident_since_step: 3,
+                },
+            ],
+        };
+        store.record_step_manifest(id, &manifest).unwrap();
+
+        let back = store.step_manifest(id, 0, 3).unwrap();
+        assert_eq!(back.len(), 2);
+        // Order is the receipt — index 0 is the system prefix.
+        assert_eq!(back[0].block_id, "blk_sys");
+        assert_eq!(back[0].cache_zone, "stable_prefix");
+        assert_eq!(back[0].resident_since_step, 0);
+        assert_eq!(back[1].block_id, "blk_tail");
+        // token_cost is joined back from context_blocks (the block's property).
+        assert_eq!(back[1].token_cost, 103);
+    }
+
+    #[test]
+    fn re_emitting_a_shorter_manifest_leaves_no_stale_tail_rows() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
+        let three = StepManifestRow {
+            turn_instance: 1,
+            step: 2,
+            provider: "anthropic".into(),
+            model: "opus".into(),
+            call_role: "worker".into(),
+            effective_budget_tokens: 100,
+            calibration_factor: 1.0,
+            estimated_input_tokens: 3,
+            blocks: (0..3)
+                .map(|i| ManifestBlockRow {
+                    block_id: format!("blk_{i}"),
+                    cache_zone: "cacheable".into(),
+                    token_cost: 1,
+                    resident_since_step: 0,
+                })
+                .collect(),
+        };
+        store.record_step_manifest(id, &three).unwrap();
+        let shorter = StepManifestRow {
+            blocks: three.blocks[..1].to_vec(),
+            ..three.clone()
+        };
+        store.record_step_manifest(id, &shorter).unwrap();
+        let back = store.step_manifest(id, 1, 2).unwrap();
+        assert_eq!(back.len(), 1, "a shorter re-emission must replace, not append");
+    }
+}

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -224,7 +224,9 @@ mod tests {
     #[test]
     fn block_registration_is_idempotent_on_the_content_addressed_id() {
         let store = Store::in_memory().unwrap();
-        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
+        let id = store
+            .begin_execution("run", "p", "anthropic", "opus")
+            .unwrap();
         store.record_context_block(id, &block("blk_a", 0)).unwrap();
         // Re-registering the same block (identical content re-enters context)
         // must be a silent no-op, never an error or a duplicate row.
@@ -239,9 +241,15 @@ mod tests {
     #[test]
     fn manifest_round_trips_in_wire_order_with_its_header() {
         let store = Store::in_memory().unwrap();
-        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
-        store.record_context_block(id, &block("blk_sys", 0)).unwrap();
-        store.record_context_block(id, &block("blk_tail", 3)).unwrap();
+        let id = store
+            .begin_execution("run", "p", "anthropic", "opus")
+            .unwrap();
+        store
+            .record_context_block(id, &block("blk_sys", 0))
+            .unwrap();
+        store
+            .record_context_block(id, &block("blk_tail", 3))
+            .unwrap();
         let manifest = StepManifestRow {
             turn_instance: 0,
             step: 3,
@@ -282,7 +290,9 @@ mod tests {
     #[test]
     fn re_emitting_a_shorter_manifest_leaves_no_stale_tail_rows() {
         let store = Store::in_memory().unwrap();
-        let id = store.begin_execution("run", "p", "anthropic", "opus").unwrap();
+        let id = store
+            .begin_execution("run", "p", "anthropic", "opus")
+            .unwrap();
         let three = StepManifestRow {
             turn_instance: 1,
             step: 2,
@@ -308,6 +318,10 @@ mod tests {
         };
         store.record_step_manifest(id, &shorter).unwrap();
         let back = store.step_manifest(id, 1, 2).unwrap();
-        assert_eq!(back.len(), 1, "a shorter re-emission must replace, not append");
+        assert_eq!(
+            back.len(),
+            1,
+            "a shorter re-emission must replace, not append"
+        );
     }
 }

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -945,9 +945,10 @@ fn skill_usage_records_per_execution_version_rows() {
     // skill_usage lands at v5; mcp_usage takes v6; the data-plane tables
     // (tool_calls / execution_reflection / reflections) take v7; the
     // session plane (executions.session_id / tasks / pull_requests)
-    // takes v8; v9 adds fail-closed call-role/completeness and v10 adds lifecycle
-    // accounting for execution/telemetry rows.
-    assert_eq!(SCHEMA_VERSION, 10);
+    // takes v8; v9 adds fail-closed call-role/completeness, v10 adds lifecycle
+    // accounting for execution/telemetry rows, and v11 adds the context-receipts
+    // plane (context_blocks / step_manifest / step_receipt).
+    assert_eq!(SCHEMA_VERSION, 11);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -598,8 +598,16 @@ impl WorkspaceModel {
         }
         // Streaming previews never reach the trace: one row per token would
         // churn the whole capped ring during a single answer, and the
-        // authoritative `Text` event lands the same content as one row.
-        if !matches!(event, AgentEvent::TextDelta { .. }) {
+        // authoritative `Text` event lands the same content as one row. Context
+        // receipts (spec §4/§5) are excluded for the same reason — one
+        // BlockRegistered per block per step would swamp the ring — and are
+        // consumed by the store/inspector, not the live deck.
+        if !matches!(
+            event,
+            AgentEvent::TextDelta { .. }
+                | AgentEvent::BlockRegistered { .. }
+                | AgentEvent::StepManifest { .. }
+        ) {
             let (kind, summary) = trace_of(event);
             self.trace.push(TraceRow {
                 ts: now,
@@ -955,6 +963,15 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             superseded,
             ..
         } => (TraceKind::Context, format!("+{upserts} ~{superseded}")),
+        // Receipts are filtered out of the trace ring above (apply_event's
+        // guard); these arms exist only to keep this mapping total.
+        AgentEvent::BlockRegistered { kind, .. } => {
+            (TraceKind::Context, format!("block {kind:?}").to_lowercase())
+        }
+        AgentEvent::StepManifest { step, blocks, .. } => (
+            TraceKind::Context,
+            format!("manifest step {step}: {} blocks", blocks.len()),
+        ),
         AgentEvent::JudgeVerdict { passed, .. } => (
             TraceKind::Verdict,
             if *passed {

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -579,6 +579,11 @@ impl SessionModel {
             // transcript row is a display enhancement, tracked as follow-up).
             AgentEvent::StepUsage { .. }
             | AgentEvent::UsageIncomplete { .. }
+            // Context receipts (spec §4/§5) are consumed by the store/inspector,
+            // not folded into TUI panel state — the model stays a pure function
+            // of the user-visible event sequence.
+            | AgentEvent::BlockRegistered { .. }
+            | AgentEvent::StepManifest { .. }
             | AgentEvent::GoalVerdict { .. } => {}
             AgentEvent::Error { message, retryable } => {
                 self.pending_scope_review = None;

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -1251,6 +1251,8 @@ mod tests {
                 uri: None,
                 method: None,
                 token_cost: 100,
+                block_id: None,
+                content_digest: None,
             }],
             provider_mix: vec![ProviderShare {
                 provider: "code-graph".into(),

--- a/stella-tui/src/scenario.rs
+++ b/stella-tui/src/scenario.rs
@@ -127,8 +127,8 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(lead, AgentEvent::Stage { name: StageKind::Triage }),
         ev(lead, AgentEvent::ContextRecall {
             frames: vec![
-                ContextFrameRef { id: None, citation_label: "engine step-driver (driver.rs)".into(), provider: "code-graph".into(), source: "code-graph".into(), kind: "symbol".into(), uri: None, method: None, token_cost: 120 },
-                ContextFrameRef { id: None, citation_label: "ADR-023 event-log REPL".into(), provider: "workspace-memory".into(), source: "stella-context".into(), kind: "memory".into(), uri: None, method: None, token_cost: 90 },
+                ContextFrameRef { id: None, citation_label: "engine step-driver (driver.rs)".into(), provider: "code-graph".into(), source: "code-graph".into(), kind: "symbol".into(), uri: None, method: None, token_cost: 120, block_id: None, content_digest: None },
+                ContextFrameRef { id: None, citation_label: "ADR-023 event-log REPL".into(), provider: "workspace-memory".into(), source: "stella-context".into(), kind: "memory".into(), uri: None, method: None, token_cost: 90, block_id: None, content_digest: None },
             ],
             provider_mix: vec![ProviderShare { provider: "code-graph".into(), frames: 1 }, ProviderShare { provider: "memory".into(), frames: 1 }],
             tokens: 210,

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -414,7 +414,11 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
         | AgentEvent::Reasoning { .. }
         | AgentEvent::ToolStart { .. }
         | AgentEvent::ToolResult { .. }
-        | AgentEvent::UsageIncomplete { .. } => None,
+        | AgentEvent::UsageIncomplete { .. }
+        // Context receipts (spec §4/§5) are observability, not transcript
+        // narration — they never produce a rendered line.
+        | AgentEvent::BlockRegistered { .. }
+        | AgentEvent::StepManifest { .. } => None,
         AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
         AgentEvent::Steered { text } => Some(steered(text)),
         AgentEvent::Compaction {

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -865,6 +865,8 @@ mod tests {
                     uri: None,
                     method: None,
                     token_cost: 1,
+                    block_id: None,
+                    content_digest: None,
                 }],
                 provider_mix: vec![],
                 tokens: 1,
@@ -977,6 +979,8 @@ mod tests {
                 uri: None,
                 method: None,
                 token_cost: 120,
+                block_id: None,
+                content_digest: None,
             }],
             provider_mix: vec![ProviderShare {
                 provider: "code-graph".into(),


### PR DESCRIPTION
Implements **Tier A / increment 1** of the session-telemetry-receipts spec (`docs/design/session-telemetry-receipts-spec.md`, §4–§5), the verifiable core of epic #364. Builds on the spec merged in #374 and reconciles cleanly on top of #375 (driver audit).

## What this delivers

A **content-addressed context-block registry** + **per-step request manifest**, emitted from the engine and persisted as queryable rows — the foundation that makes any past step of a turn reconstructable and auditable.

- **`BlockRegistered`** — emitted once per context block the model has not seen before. Content-free: a `blk_<24hex>` content-addressed id + `content_digest` + provenance (`call_id`/`memory_id`), never payload bytes. The preimage already lives in the originating event in the journal, so this is an *index over the fold*, not a second content store.
- **`StepManifest`** — the ordered receipt of exactly what the model saw on a step: blocks in wire order, each with its cache zone and how long it's been resident, plus the **effective compaction budget** the step actually compared against.

## Layers (one commit each, each green on its own)

| Layer | What |
| --- | --- |
| `stella-protocol` | Additive `BlockRegistered`/`StepManifest` variants + `BlockKind`/`CacheZone`/`BlockOrigin`/`ManifestEntry`; `block_id`/`content_digest` on `ContextFrameRef` (closes G1's wire side). All `serde(default)`; unknown kinds degrade to `Other`. |
| `stella-store` | Schema **v10 → v11**: `context_blocks`, `step_manifest`, `step_receipt` + idempotent writers and a reader that joins `token_cost` back from the block. Migration applies additively on an existing v10 store. |
| `stella-core` | New `crate::receipts` helper (kept out of `driver.rs` so a driver split reconciles as a move): decomposes the message vec into event-granular blocks, emits the receipt per step, threads `turn_instance`. |
| `stella-cli`/`stella-tui` | Normalizes the events into the store; adds the variants to the exhaustive renderer/replay matches (excluded from golden `structural_diff` like `TextDelta`, no transcript line, no trace-ring churn). |

## Bug fixed in path (#364 item 1)

Extracted `effective_compaction_budget` as the **single source** for the budget the compaction pass compares against, so the manifest's `effective_budget_tokens` is exactly the number the decision used — the mismatch #364 called out.

## Design fidelity

- **Content-free / no parallel store** (invariant §2): blocks carry digests + ids only; preimages stay in the journal.
- **Replay equivalence preserved**: receipt events are excluded from `structural_diff`, so pre-receipt golden streams still match.
- **Event-granular** (not message-granular): tool results are keyed by `call_id`, so compaction identities and the future memory-join (§9) land on real units.

## Not in this PR (deferred per the spec's staged plan)

Increment 2 (byte-exact reconstruction behind its own gate), cache attribution / cost-of-carry (§7–§8, A3), and everything in Tier B. Frame-granular `RecalledFrame` blocks with `memory_id` come with the §9 memory-join increment.

## Verification

Full workspace **build + test + clippy + fmt green** on top of current `main` (post-#374/#375). New tests: protocol round-trip/legacy-parse/content-free, store v11-migration + idempotent writes, core emission (order/residency/zones/dedup), and an **end-to-end** `persist_event → queryable rows` test.