### PR TITLE
feat(agent): pre-inject byte-stable orientation map at session start (zero-call orientation)

### DIFF
--- a/stella-cli/src/agent/prompt.rs
+++ b/stella-cli/src/agent/prompt.rs
@@ -182,8 +182,10 @@ fn append_project_scripts(prompt: &mut String, workspace_root: &std::path::Path)
 }
 
 /// The project-map section of [`assemble_system_prompt`]: the graph-derived
-/// languages, entry points, and storage — the complement of the scripts
-/// section above. Read-only (`stella_tools::overview::render_orientation_block`
+/// languages, top-level layout, entry points, and storage — the complement
+/// of the scripts section above, and bounded by construction so it stays
+/// useful on monorepos far past a few hundred files (issue #328). Read-only
+/// (`stella_tools::overview::render_orientation_block`
 /// opens an existing index and never builds one), so it adds nothing to
 /// first-response latency; it appears once the session's background index
 /// build has completed (or immediately when the workspace was pre-indexed,

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -122,6 +122,37 @@ fn assemble_system_prompt_carries_a_byte_stable_scripts_section() {
     );
 }
 
+/// Zero-call orientation (issue #328): over a pre-indexed workspace, the
+/// interactive system prompt carries the project map — languages, layout,
+/// entry points — baked into the byte-stable prefix, so orientation costs no
+/// model round-trip and is unconditional rather than left to the model's
+/// discretion. Two assemblies over the same index state must be
+/// byte-identical: that is the invariant that lets the whole prefix ride the
+/// provider's prompt cache (AGENTS.md invariant #7).
+#[test]
+fn assemble_system_prompt_bakes_a_byte_stable_orientation_map() {
+    let root = graph_fixture();
+
+    let authority = crate::settings::AuthorityPolicy {
+        project_prompts_allowed: true,
+        ..crate::settings::AuthorityPolicy::default()
+    };
+    let rules = crate::rules::ResolvedRules::default();
+    let first = assemble_system_prompt(SYSTEM_PROMPT, root.path(), &authority, &rules);
+    let second = assemble_system_prompt(SYSTEM_PROMPT, root.path(), &authority, &rules);
+    assert_eq!(
+        first, second,
+        "same index state ⇒ identical bytes (the prompt-cache invariant)"
+    );
+    assert!(first.contains("## Project map"), "{first}");
+    assert!(first.contains("Languages: rust"), "{first}");
+    assert!(
+        first.contains("Layout (2 indexed files): 2 at the root"),
+        "the slow-churning skeleton includes the top-level layout: {first}"
+    );
+    assert!(first.contains("Entry points:"), "{first}");
+}
+
 /// Build a real code-graph index in a tempdir: `hub.rs` (three symbols) is
 /// busiest, `leaf.rs` (one) is not. Returns the workspace root tempdir.
 fn graph_fixture() -> tempfile::TempDir {

--- a/stella-graph/src/graph.rs
+++ b/stella-graph/src/graph.rs
@@ -278,6 +278,18 @@ impl CodeGraph {
         store::busiest_file(&self.inner.read_guard())
     }
 
+    /// Up to `limit` files nothing imports — binaries, scripts, tests, dead
+    /// code: exactly the set worth reading first when orienting in an
+    /// unfamiliar tree. Computed as one SQL anti-join, so the cost is
+    /// independent of index size — callers need no file-count cap, unlike
+    /// the per-file [`importers_of`] scan this replaces. Shallowest path
+    /// first, then lexicographic; empty on an empty index.
+    ///
+    /// [`importers_of`]: CodeGraph::importers_of
+    pub fn entry_points(&self, limit: usize) -> Result<Vec<String>, GraphError> {
+        store::entry_points(&self.inner.read_guard(), limit)
+    }
+
     /// Every indexed file path (root-relative, forward-slash), sorted. The
     /// deck's Graph tab lists these in its file picker so a user can re-root
     /// the neighborhood on any file, not only the [`busiest_file`] default.
@@ -484,5 +496,43 @@ mod tests {
     fn all_files_is_empty_on_an_empty_index() {
         let (graph, _ws, _dbdir) = open_graph();
         assert!(graph.all_files().unwrap().is_empty());
+    }
+
+    /// `entry_points` is the single-query anti-join orientation relies on: a
+    /// file some resolved import edge points at is excluded, the rest come
+    /// back shallowest-first, and `limit` truncates that stable order.
+    #[test]
+    fn entry_points_excludes_imported_files_and_orders_shallowest_first() {
+        let ws = TempDir::new().unwrap();
+        let dbdir = TempDir::new().unwrap();
+        std::fs::create_dir_all(ws.path().join("lib")).unwrap();
+        std::fs::write(
+            ws.path().join("main.ts"),
+            "import { help } from \"./lib/helper\";\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.path().join("lib").join("helper.ts"),
+            "export function help() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.path().join("lib").join("lonely.ts"),
+            "export function alone() {}\n",
+        )
+        .unwrap();
+        let graph = CodeGraph::open(ws.path(), &dbdir.path().join("context.db")).unwrap();
+        graph.index_all().unwrap();
+
+        assert_eq!(
+            graph.entry_points(12).unwrap(),
+            vec!["main.ts".to_string(), "lib/lonely.ts".to_string()],
+            "imported files excluded, roots before nested files"
+        );
+        assert_eq!(
+            graph.entry_points(1).unwrap(),
+            vec!["main.ts".to_string()],
+            "the limit truncates the same stable order"
+        );
     }
 }

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -680,6 +680,23 @@ pub(crate) fn importers_of(conn: &Connection, rel: &str) -> Result<Vec<String>, 
     Ok(rows.collect::<Result<_, _>>()?)
 }
 
+/// Up to `limit` files that no resolved import edge points at — the
+/// entry-point set. One query whatever the index size (the anti-join rides
+/// the `code_graph_imports_to` index), unlike the per-file `importers_of`
+/// scan this replaces, which forced callers to cap orientation at a few
+/// hundred files. Shallowest path first, then lexicographic, so the
+/// truncated list is stable and leads with the roots worth reading first.
+pub(crate) fn entry_points(conn: &Connection, limit: usize) -> Result<Vec<String>, GraphError> {
+    let mut stmt = conn.prepare(
+        "SELECT f.path FROM code_graph_files f \
+         WHERE NOT EXISTS (SELECT 1 FROM code_graph_imports i WHERE i.to_path = f.path) \
+         ORDER BY LENGTH(f.path) - LENGTH(REPLACE(f.path, '/', '')), f.path \
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![limit as i64], |row| row.get::<_, String>(0))?;
+    Ok(rows.collect::<Result<_, _>>()?)
+}
+
 /// All indexed file paths (used by the linear reference scan).
 pub(crate) fn all_files(conn: &Connection) -> Result<Vec<String>, GraphError> {
     let mut stmt = conn.prepare("SELECT path FROM code_graph_files ORDER BY path")?;

--- a/stella-tools/src/overview.rs
+++ b/stella-tools/src/overview.rs
@@ -12,7 +12,7 @@
 //! detection), the code graph, the storage/schema snapshot, and the domain
 //! taxonomy. No model call, no shell, no grep.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use async_trait::async_trait;
@@ -22,13 +22,16 @@ use stella_protocol::{ToolOutput, ToolSchema};
 use crate::registry::Tool;
 use crate::scripts::ScriptIndex;
 
-/// Deriving entry points costs one `importers_of` query per file, so it is
-/// bounded: past this many files the roots list is omitted rather than
-/// silently truncated into a half-truth.
-const ENTRY_POINT_SCAN_LIMIT: usize = 400;
-
-/// Entry points reported at most, newest-shallowest first.
+/// Entry points reported at most, shallowest first. The derivation is one
+/// SQL anti-join (`CodeGraph::entry_points`) whatever the repository size,
+/// so this bounds the rendered list, never the scan — a monorepo past a few
+/// hundred files gets the same roots a small tree does.
 const MAX_ENTRY_POINTS: usize = 12;
+
+/// Top-level directories named in the layout summary at most. Past this the
+/// remainder collapses to a count, so a monorepo with hundreds of packages
+/// still renders a few dozen deterministic tokens.
+const MAX_TOP_LEVEL_DIRS: usize = 12;
 
 pub struct ProjectOverview;
 
@@ -81,10 +84,16 @@ impl Tool for ProjectOverview {
 /// `project_overview` explicitly.
 ///
 /// Deliberately the complement of the script index (which the prompt already
-/// injects separately): languages, entry points, and storage — the shape of
-/// the code the model would otherwise spend grep/glob/read_file turns
-/// discovering. Kept to a few lines so it stays cheap in the cache-stable
-/// system prefix.
+/// injects separately): languages, top-level layout, entry points, and
+/// storage — the slow-churning skeleton the model would otherwise spend
+/// grep/glob/read_file turns discovering. Fine detail that changes within a
+/// session stays with `graph_query`/`read_file`; everything here is derived
+/// from `codegraph.db`, so the block is byte-stable for a given index state
+/// and kept to a few lines so it stays cheap in the cache-stable system
+/// prefix. Every line is bounded by construction (issue #328): entry points
+/// come from one SQL anti-join and the layout collapses past
+/// [`MAX_TOP_LEVEL_DIRS`], so a monorepo far beyond a few hundred files
+/// renders the same useful map a small tree does.
 pub fn render_orientation_block(root: &Path) -> Option<String> {
     let path = stella_store::existing_workspace_private_sqlite_path(root, "codegraph.db")
         .ok()
@@ -113,14 +122,13 @@ pub fn render_orientation_block(root: &Path) -> Option<String> {
         ));
     }
 
-    // Same bound as `code_section`: deriving entry points costs one
-    // `importers_of` query per file, so past the scan limit we skip the line
-    // rather than pay an unbounded per-file scan on the first-response path.
-    if all_files.len() <= ENTRY_POINT_SCAN_LIMIT {
-        let entry_points = entry_point_paths(&graph, &all_files);
-        if !entry_points.is_empty() {
-            lines.push(format!("Entry points: {}", entry_points.join(", ")));
-        }
+    if let Some(layout) = top_level_summary(&all_files) {
+        lines.push(layout);
+    }
+
+    let entry_points = graph.entry_points(MAX_ENTRY_POINTS).unwrap_or_default();
+    if !entry_points.is_empty() {
+        lines.push(format!("Entry points: {}", entry_points.join(", ")));
     }
 
     let storage = graph.storage_snapshot();
@@ -210,28 +218,12 @@ fn code_section(graph: &stella_graph::CodeGraph) -> Value {
         }
     }
 
-    let mut section = json!({
+    json!({
         "languages": languages.into_iter().collect::<Vec<_>>(),
         "busiest_file": graph.busiest_file().unwrap_or(None),
-    });
-    let map = section.as_object_mut().expect("object literal");
-
-    if files.len() > ENTRY_POINT_SCAN_LIMIT {
-        map.insert(
-            "entry_points".into(),
-            json!(format!(
-                "omitted — {} indexed files exceeds the {} scan limit; \
-                 use graph_query importers to check a specific file",
-                files.len(),
-                ENTRY_POINT_SCAN_LIMIT
-            )),
-        );
-        return section;
-    }
-
-    let roots = entry_point_paths(graph, &files);
-    map.insert("entry_points".into(), json!(roots));
-    section
+        "top_level": top_level_summary(&files),
+        "entry_points": graph.entry_points(MAX_ENTRY_POINTS).unwrap_or_default(),
+    })
 }
 
 fn storage_section(snapshot: &stella_graph::StorageSnapshot) -> Value {
@@ -302,23 +294,44 @@ fn domains_section(root: &Path) -> Value {
     json!(names)
 }
 
-/// Files nothing imports — a binary, a script, a test, or dead code, which is
-/// exactly the set worth reading first. Bounded and stably ordered
-/// (shallowest path first) so both the tool and the prompt block agree.
-fn entry_point_paths(graph: &stella_graph::CodeGraph, files: &[String]) -> Vec<String> {
-    let mut roots: Vec<String> = files
-        .iter()
-        .filter(|file| {
-            graph
-                .importers_of(Path::new(file))
-                .map(|importers| importers.is_empty())
-                .unwrap_or(false)
-        })
-        .cloned()
+/// One line summarizing where the code lives: top-level directories by
+/// indexed-file count (largest first, ties by name), the remainder and any
+/// root-level files collapsed to counts. Derived from the index's sorted
+/// file list, so it is deterministic for a given index state — and it never
+/// degrades: past [`MAX_TOP_LEVEL_DIRS`] the summary collapses instead of
+/// disappearing, which is what keeps the injected map useful on a monorepo.
+fn top_level_summary(files: &[String]) -> Option<String> {
+    if files.is_empty() {
+        return None;
+    }
+    let mut dir_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut root_files = 0usize;
+    for file in files {
+        match file.split_once('/') {
+            Some((dir, _)) => *dir_counts.entry(dir).or_default() += 1,
+            None => root_files += 1,
+        }
+    }
+    let mut dirs: Vec<(&str, usize)> = dir_counts.into_iter().collect();
+    dirs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let omitted = dirs.len().saturating_sub(MAX_TOP_LEVEL_DIRS);
+    dirs.truncate(MAX_TOP_LEVEL_DIRS);
+
+    let mut parts: Vec<String> = dirs
+        .into_iter()
+        .map(|(dir, count)| format!("{dir}/ ({count})"))
         .collect();
-    roots.sort_by_key(|path| (path.matches('/').count(), path.clone()));
-    roots.truncate(MAX_ENTRY_POINTS);
-    roots
+    if omitted > 0 {
+        parts.push(format!("+{omitted} more dirs"));
+    }
+    if root_files > 0 {
+        parts.push(format!("{root_files} at the root"));
+    }
+    Some(format!(
+        "Layout ({} indexed files): {}",
+        files.len(),
+        parts.join(", ")
+    ))
 }
 
 /// Extension → language label, matching the grammars the indexer actually
@@ -445,8 +458,50 @@ mod tests {
         assert!(block.contains("Project map"), "{block}");
         assert!(block.contains("Languages: rust"), "{block}");
         assert!(
+            block.contains("Layout (2 indexed files): 2 at the root"),
+            "the layout line summarizes where the code lives: {block}"
+        );
+        assert!(
             block.contains("Entry points:"),
             "a file nothing imports is an entry point: {block}"
+        );
+    }
+
+    /// Issue #328 witness: past the old 400-file scan limit the map must stay
+    /// useful — entry points are still derived (one SQL anti-join, no
+    /// file-count cap) and the bounded layout line is still present, in both
+    /// the tool output and the injected prompt block. Pre-#328, this fixture
+    /// rendered no entry points anywhere and an "omitted" note in the tool.
+    #[test]
+    fn orientation_stays_useful_past_the_old_400_file_scan_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(dir.path().join("main.rs"), "pub fn main() {}\n").unwrap();
+        for i in 0..420 {
+            std::fs::write(src.join(format!("f{i:03}.rs")), "pub fn f() {}\n").unwrap();
+        }
+
+        let out = build_overview(dir.path());
+        assert!(
+            out["index"]["files"].as_u64().unwrap_or(0) > 400,
+            "the fixture must exceed the old scan limit: {}",
+            out["index"]
+        );
+        let entry_points = out["code"]["entry_points"]
+            .as_array()
+            .expect("entry points stay a real list, never an 'omitted' note");
+        assert_eq!(
+            entry_points.first(),
+            Some(&serde_json::json!("main.rs")),
+            "shallowest first: {entry_points:?}"
+        );
+
+        let block = render_orientation_block(dir.path()).expect("an indexed workspace renders");
+        assert!(block.contains("Entry points: main.rs"), "{block}");
+        assert!(
+            block.contains("Layout (421 indexed files): src/ (420), 1 at the root"),
+            "{block}"
         );
     }
 


### PR DESCRIPTION
## What & why

Completes #328 (epic #336). The pre-injection itself — `project_overview`'s deterministic map baked into the byte-stable system-prompt prefix — shipped in #343; this PR closes the remaining gap: **the injected map degraded on large monorepos**. Entry points were derived with one `importers_of` query per file, so past `ENTRY_POINT_SCAN_LIMIT = 400` files the roots list was silently omitted from both the tool output and the baked map — exactly the repositories where zero-call orientation pays most.

- **stella-graph**: new `CodeGraph::entry_points(limit)` — files no resolved import edge points at, computed as one SQL anti-join riding the existing `code_graph_imports_to` index, shallowest path first, then lexicographic. Cost is independent of repository size, so orientation needs no file-count cap. No schema change.
- **stella-tools**: `project_overview` and the injected map both use the single query; the scan limit and its "omitted" degradation are deleted. New bounded **Layout** line — top-level directories by indexed-file count, collapsing past 12 to a `+N more dirs` count — so the baked skeleton also names where the code lives on any size tree.
- **stella-cli**: the interactive prefix now carries the fuller map; doc comments chased.

**Freshness-tension resolution (as the issue recommends):** only the slow-churning skeleton is baked into the stable prefix — languages, top-level layout, entry points, storage (build/test verbs already ride the adjacent scripts section). Every line is derived from `codegraph.db`, so the block is byte-stable for a given index state; fine detail that churns within a session stays with the already-steered `graph_query`/`project_overview`/`read_file`. Deviation from the issue's `render_file_tree` suggestion, per its own smallest-honest-version escape hatch: the bounded layout is derived from the graph's file list at assembly time (same source as the rest of the map, byte-stable by construction) rather than re-rendering the pipeline planner's `git ls-files` tree, and no index schema change was needed.

Closes #328 — part of epic #336.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Verified artisanally: with the pre-#328 behavior temporarily restored (400-file gate, no layout line), the new tests fail; with the change they pass.

- `stella_tools::overview::tests::orientation_stays_useful_past_the_old_400_file_scan_limit` — 421-file fixture: entry points stay a real list (never an "omitted" note) and the bounded layout line renders, in both the tool output and the injected block.
- `stella_cli::agent::tests::assemble_system_prompt_bakes_a_byte_stable_orientation_map` — the interactive first-turn prompt contains the injected map for an indexed fixture repo, and two assemblies over the same index state are byte-identical (the prompt-cache invariant, AGENTS.md #7).
- `stella_graph::graph::tests::entry_points_excludes_imported_files_and_orders_shallowest_first` — the anti-join excludes imported files, orders shallowest-first, and truncates stably.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-graph -p stella-tools -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-graph -p stella-tools -p stella-cli` (87+~390 and 482 tests, all green)
- [x] Docs updated where behavior changed (doc comments on every touched seam)
- [x] Commits signed off for DCO (`git commit -s`)

Note: the full `make gate` (workspace-wide) is being run serially by the session coordinator before un-drafting.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

The old per-file scan and its constant are fully deleted, not gated — the single-query derivation makes the cap meaningless. `code_section` now also reports `top_level`, keeping tool output and prompt block in agreement via one shared helper.
