### PR TITLE
feat(tools): diagnostics — structured fast-typecheck records from native JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ are also accepted case-insensitively.
 | `grep` · `glob` | Regex content search (ripgrep) · glob file discovery (fd) |
 | `graph_query` | Query the indexed code graph: symbol definitions/references, file imports/importers/neighborhood — auto-built at session start, refreshed live |
 | `build_project` · `run_tests` | Build/test with the workspace's toolchain (cargo/npm/go/make) |
+| `diagnostics` | Fast typecheck: the toolchain's native machine-readable check (`cargo check` / `tsc` / `eslint` / `ruff`) parsed into structured file:line:col records, grouped by file |
 | `run_lint` · `format_code` | The project's own linter/formatter (cargo clippy/fmt, or package.json `lint`/`format` scripts), spawned argv-style — no shell |
 | `run_script` | Run a verb the project itself declares (Makefile target, package.json script, cargo alias); unknown names list the discovered vocabulary |
 | `start_process` · `read_output` · `send_stdin` · `stop_process` | Long-running processes (dev servers, REPLs, watchers) from an argv vector — capped output ring, SIGTERM-then-kill stop, reaped at session end |

--- a/docs/design/*/scripts-index.md
+++ b/docs/design/*/scripts-index.md
@@ -1,7 +1,7 @@
 # Project scripts index
 
-Every workspace has the same six jobs — install, build, start, test, lint,
-format — spelled differently by every package manager. Today the agent
+Every workspace has the same seven jobs — install, build, check, start,
+test, lint, format — spelled differently by every package manager. Today the agent
 rediscovers that spelling with model calls: read `package.json`, guess the
 package manager, compose a `bash` command. This spec makes the mapping a
 deterministic index computed by Stella itself, so listing and running a
@@ -40,7 +40,7 @@ code path in the workspace.
   because tree-sitter over the tree is expensive; manifest parsing is not.
   Nothing persisted means nothing to go stale or be lost.)
 - **Byte-stable output.** Canonical verbs render in the fixed order
-  `install, build, start, test, lint, format`; all other entries sort by
+  `install, build, check, start, test, lint, format`; all other entries sort by
   `id`. Same workspace state ⇒ byte-identical prompt section, tool frame,
   and CLI output. The prompt section is computed once at session start and
   never mutated mid-session (same contract as memories, `AGENTS.md`
@@ -74,7 +74,7 @@ in the fixed order below; **all** matching ecosystems contribute entries
 
 | # | Marker (in package dir) | Runner | Script enumeration (static parse) | Synthesized verbs |
 | --- | --- | --- | --- | --- |
-| 1 | `Cargo.toml` | `cargo` | `[alias]` entries from `.cargo/config.toml` (root only) | install→`cargo fetch`, build→`cargo build --workspace`, start→`cargo run` (only if a default-run binary exists), test→`cargo test --workspace`, lint→`cargo clippy --workspace --all-targets`, format→`cargo fmt` |
+| 1 | `Cargo.toml` | `cargo` | `[alias]` entries from `.cargo/config.toml` (root only) | install→`cargo fetch`, build→`cargo build --workspace`, check→`cargo check --workspace`, start→`cargo run` (only if a default-run binary exists), test→`cargo test --workspace`, lint→`cargo clippy --workspace --all-targets`, format→`cargo fmt` |
 | 2 | `package.json` | `pnpm` if `pnpm-lock.yaml`, `yarn` if `yarn.lock`, `bun` if `bun.lock`/`bun.lockb`, else `npm` | the `scripts` object → `<pm> run <name>` | install→`<pm> install` |
 | 3 | `deno.json` / `deno.jsonc` | `deno` | the `tasks` object → `deno task <name>` | install→`deno install` |
 | 4 | `pyproject.toml` | `uv` if `uv.lock` or `[tool.uv]`, `poetry` if `poetry.lock` or `[tool.poetry]`, else `uv` | `[project.scripts]` entry points → `<runner> run <name>` | install→`uv sync` / `poetry install`; test→`<runner> run pytest`, lint→`<runner> run ruff check`, format→`<runner> run ruff format` — each only if that tool appears in the declared dependencies (incl. dependency groups) |
@@ -95,13 +95,14 @@ member packages carry their `dir` and execute with cwd = that directory.
 
 ### Canonical verb resolution
 
-The six verbs are a resolution layer over qualified ids, computed
+The seven verbs are a resolution layer over qualified ids, computed
 deterministically per package:
 
 | Verb | Explicit script names matched (exact, first match wins) | Fallback |
 | --- | --- | --- |
 | `install` | `install`, `setup`, `bootstrap` | synthesized install of each ecosystem |
 | `build` | `build`, `compile`, `dist` | synthesized (cargo/go) |
+| `check` | `check`, `typecheck`, `type-check` | synthesized (`cargo check`) |
 | `start` | `start`, `dev`, `serve` | synthesized (`cargo run`) |
 | `test` | `test`, `tests` | synthesized (cargo/go/uv) |
 | `lint` | `lint` | synthesized (clippy/vet/ruff) |
@@ -137,7 +138,7 @@ below.
   "type": "object",
   "required": ["script"],
   "properties": {
-    "script": { "type": "string", "description": "Canonical verb (install|build|start|test|lint|format), qualified id like pnpm:build, or unique declared script/target/alias name" },
+    "script": { "type": "string", "description": "Canonical verb (install|build|check|start|test|lint|format), qualified id like pnpm:build, or unique declared script/target/alias name" },
     "dir": { "type": "string", "description": "Package dir when the id exists in several packages; default workspace root" },
     "args": { "type": "array", "items": { "type": "string" }, "description": "Appended runner-natively (after `--` for npm-family)" },
     "timeout_secs": { "type": "integer" }
@@ -171,7 +172,7 @@ format  → cargo fmt
 23 more scripts (make:docs, pnpm:deck, …): call list_scripts.
 ```
 
-Only the six verb bindings render inline; everything else is a count plus
+Only the verb bindings render inline; everything else is a count plus
 up to three sorted teaser ids. The section is capped at 1,500 characters
 (oversized verb commands truncate with `…`), keeping the stable prefix
 cheap. An empty index renders nothing — no section, no noise.
@@ -179,7 +180,7 @@ cheap. An empty index renders nothing — no section, no noise.
 ## Index JSON Schema
 
 Emitted by `stella scripts list --json`; `schema_version` bumps on any
-shape change.
+shape change (2 = the `check` verb joined the set).
 
 ```json
 {
@@ -189,12 +190,13 @@ shape change.
   "additionalProperties": false,
   "required": ["schema_version", "verbs", "scripts"],
   "properties": {
-    "schema_version": { "const": 1 },
+    "schema_version": { "const": 2 },
     "verbs": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "install": { "type": "string" }, "build": { "type": "string" },
+        "check": { "type": "string" },
         "start": { "type": "string" }, "test": { "type": "string" },
         "lint": { "type": "string" }, "format": { "type": "string" }
       },
@@ -213,7 +215,7 @@ shape change.
           "command": { "type": "string", "minLength": 1, "description": "Exact command run_script executes, cwd = dir" },
           "dir": { "type": "string", "description": "Workspace-relative package dir; \".\" = root" },
           "source": { "type": "string", "description": "Workspace-relative manifest path, or \"synthesized\"" },
-          "verb": { "type": "string", "enum": ["install", "build", "start", "test", "lint", "format"], "description": "Present only on the entry each verb binds to" },
+          "verb": { "type": "string", "enum": ["install", "build", "check", "start", "test", "lint", "format"], "description": "Present only on the entry each verb binds to" },
           "raw": { "type": "string", "description": "The manifest's own definition (e.g. the package.json script body), when one exists" }
         }
       }
@@ -228,8 +230,8 @@ Stella's own workspace (`Cargo.toml` + `package.json`/pnpm + `Makefile`):
 
 ```json
 {
-  "schema_version": 1,
-  "verbs": { "install": "cargo:install", "build": "cargo:build", "test": "cargo:test", "lint": "cargo:lint", "format": "cargo:format" },
+  "schema_version": 2,
+  "verbs": { "install": "cargo:install", "build": "cargo:build", "check": "cargo:check", "test": "cargo:test", "lint": "cargo:lint", "format": "cargo:format" },
   "scripts": [
     { "id": "cargo:build", "runner": "cargo", "name": "build", "command": "cargo build --workspace", "dir": ".", "source": "synthesized", "verb": "build" },
     { "id": "cargo:test", "runner": "cargo", "name": "test", "command": "cargo test --workspace", "dir": ".", "source": "synthesized", "verb": "test" },

--- a/stella-cli/src/agent/prompt.rs
+++ b/stella-cli/src/agent/prompt.rs
@@ -16,7 +16,7 @@ You have these tools available:
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
 - run_lint / format_code: Run the project's own linter/formatter (cargo clippy/fmt, or the package.json lint/format scripts)
-- run_script: Run a script the project itself declares, by canonical verb (install/build/start/test/lint/format), qualified id (pnpm:build, make:lint), or declared name; args are passed argv-style and an unknown name lists the declared vocabulary
+- run_script: Run a script the project itself declares, by canonical verb (install/build/check/start/test/lint/format), qualified id (pnpm:build, make:lint), or declared name; args are passed argv-style and an unknown name lists the declared vocabulary
 - list_scripts: The full project scripts index — every detected script and its canonical verb binding; read-only, nothing executes
 - start_process / read_output / send_stdin / stop_process: Manage long-running processes (dev servers, REPLs, watchers) from an argv vector; one-shot commands belong in build_project/run_tests/run_script
 - repo_status / repo_commit / repo_push / repo_pull / repo_rollback: Version-control status, pathspec-explicit commits, guarded pushes (never the default branch, never forced), fast-forward-only pulls, and restoring named files to their last committed state
@@ -24,6 +24,7 @@ You have these tools available:
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
 - build_project: Build with the workspace's own toolchain (cargo/npm/go/make)
+- diagnostics: Fast typecheck — runs the toolchain's native machine-readable check (cargo check / tsc / eslint / ruff) and returns structured file:line:col records with severity and rule code, grouped by file; much cheaper than build_project when you only need to know what broke
 - run_tests: Run the workspace's test suite
 - verify_done: The definition of done — replays a new test against the previous code in a shadow worktree; it must fail there and pass on your change (WITNESS CONFIRMED). Use it to prove a change actually works, not just that the suite is green.
 - ask_user: Ask the user a multiple-choice question when a decision is genuinely theirs to make (2-6 options; the UI always adds a free-text option automatically — never add an "Other" option yourself)
@@ -55,7 +56,7 @@ You have these tools available:
 - edit_file: Replace an exact substring in a file (use replace_all for multiple)
 - delete_file: Delete a file within the workspace
 - run_lint / format_code: Run the project's own linter/formatter (cargo clippy/fmt, or the package.json lint/format scripts)
-- run_script: Run a script the project itself declares, by canonical verb (install/build/start/test/lint/format), qualified id (pnpm:build, make:lint), or declared name; args are passed argv-style and an unknown name lists the declared vocabulary
+- run_script: Run a script the project itself declares, by canonical verb (install/build/check/start/test/lint/format), qualified id (pnpm:build, make:lint), or declared name; args are passed argv-style and an unknown name lists the declared vocabulary
 - list_scripts: The full project scripts index — every detected script and its canonical verb binding; read-only, nothing executes
 - start_process / read_output / send_stdin / stop_process: Manage long-running processes (dev servers, REPLs, watchers) from an argv vector; one-shot commands belong in build_project/run_tests/run_script
 - repo_status / repo_commit / repo_push / repo_pull / repo_rollback: Version-control status, pathspec-explicit commits, guarded pushes (never the default branch, never forced), fast-forward-only pulls, and restoring named files to their last committed state
@@ -64,6 +65,7 @@ You have these tools available:
 - grep: Search file contents with regex (shells to ripgrep)
 - glob: Find files matching a glob pattern
 - build_project: Build with the workspace's own toolchain (cargo/npm/go/make)
+- diagnostics: Fast typecheck — runs the toolchain's native machine-readable check (cargo check / tsc / eslint / ruff) and returns structured file:line:col records with severity and rule code, grouped by file; much cheaper than build_project when you only need to know what broke
 - run_tests: Run the workspace's test suite
 - verify_done: The definition of done, replays a new test against the previous code in a shadow worktree; it must fail there and pass on your change (WITNESS CONFIRMED). Use it to prove a change actually works, not just that the suite is green.
 - ask_user: Ask the user a multiple-choice question when a decision is genuinely theirs to make (2-6 options; the UI always adds a free-text option automatically, never add an "Other" option yourself)

--- a/stella-cli/src/claims.rs
+++ b/stella-cli/src/claims.rs
@@ -22,8 +22,8 @@
 //!    process cannot release its own).
 //!
 //! The build lane is the one **transient** claim: `run_tests` /
-//! `build_project` — and the manifest-verb executors that can rewrite the
-//! tree (`run_lint`, `format_code`, `run_script`) — serialize under the
+//! `build_project` / `diagnostics` — and the manifest-verb executors that
+//! can rewrite the tree (`run_lint`, `format_code`, `run_script`) — serialize under the
 //! well-known pseudo-path [`BUILD_CLAIM`] for the duration of the call
 //! only (with a bounded wait, not a hard refusal — build contention is
 //! routine, edit contention is signal). This kills the phantom-failure
@@ -175,7 +175,12 @@ impl ToolExecutor for ClaimTap<'_> {
         // never observes a formatter/linter/script mid-rewrite.
         if matches!(
             name,
-            "run_tests" | "build_project" | "run_lint" | "format_code" | "run_script"
+            "run_tests"
+                | "build_project"
+                | "diagnostics"
+                | "run_lint"
+                | "format_code"
+                | "run_script"
         ) {
             let mut waited = 0u64;
             let acquired = loop {
@@ -287,10 +292,13 @@ mod tests {
         let inner = Passthrough(std::sync::Mutex::new(Vec::new()));
         let tap = ClaimTap::new(&inner, Some(store.clone()), "ses-1/lead");
         let input = serde_json::json!({});
-        // Every tree-rewriting executor rides the lane, not just tests.
+        // Every tree-rewriting executor rides the lane, not just tests —
+        // and `diagnostics`, which rewrites nothing but must never observe
+        // a sibling's half-written tree (phantom errors).
         for tool in [
             "run_tests",
             "build_project",
+            "diagnostics",
             "run_lint",
             "format_code",
             "run_script",

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -311,7 +311,7 @@ enum Command {
 
     /// List or run the project's package-manager scripts — deterministic
     /// static detection (cargo/npm/uv/go/make/just/…) mapped onto canonical
-    /// verbs (install/build/start/test/lint/format). Offline: manifest
+    /// verbs (install/build/check/start/test/lint/format). Offline: manifest
     /// parsing plus a local subprocess, needs no API key.
     Scripts {
         #[command(subcommand)]
@@ -764,7 +764,7 @@ enum ScriptsCmd {
     },
     /// Run a script by canonical verb or qualified id (e.g. test, pnpm:build)
     Run {
-        /// install|build|start|test|lint|format, or a qualified id
+        /// install|build|check|start|test|lint|format, or a qualified id
         script: String,
 
         /// Package dir when the id exists in several packages

--- a/stella-docs/content/docs/agent-tools/index.mdx
+++ b/stella-docs/content/docs/agent-tools/index.mdx
@@ -62,6 +62,7 @@ These 38 tools register in every session — no configuration, no prerequisites.
 | `verify_done` | Prove a change is done: the test command must pass on the new code and fail on `git HEAD`. Runs in a shadow worktree and never edits your working tree. | Mutating |
 | `build_project` | Build the workspace with its own toolchain (cargo/npm/go/make), or a custom command. | Mutating |
 | `run_tests` | Run the project's tests with its own runner — `kind` picks unit/e2e/all, `filter` is runner-native. | Mutating |
+| `diagnostics` | Fast typecheck: run the toolchain's native machine-readable check (`cargo check` / `tsc` / `eslint` / `ruff`) and return structured file:line:col diagnostics with severity and rule code, grouped by file. | Read-only |
 | `run_lint` | Run the project's own linter (cargo clippy, or the `lint` script); `fix` applies automatic fixes. | Mutating |
 | `format_code` | Run the project's own formatter (cargo fmt, or the `format` script); `check` verifies without rewriting. | Mutating |
 | `list_scripts` | List the verbs the project declares (Makefile targets, package.json scripts, cargo aliases) — the index `run_script` draws from. | Read-only |

--- a/stella-docs/content/docs/commands/scripts.mdx
+++ b/stella-docs/content/docs/commands/scripts.mdx
@@ -3,7 +3,7 @@ title: stella scripts
 description: List and run the project's package-manager scripts through Stella's canonical-verb index — the same frames the agent sees.
 ---
 
-`stella scripts` lists and runs the project's package-manager scripts. Detection is deterministic static parsing of your manifests (cargo, npm/pnpm/yarn, uv, go, make, just, …), mapped onto canonical verbs — `install`, `build`, `start`, `test`, `lint`, `format`. It mirrors the [`list_scripts` and `run_script` tools](/docs/agent-tools) one-for-one, so a human at the CLI and the model inside a turn see the same script index. Offline: manifest parsing plus a local subprocess, no API key.
+`stella scripts` lists and runs the project's package-manager scripts. Detection is deterministic static parsing of your manifests (cargo, npm/pnpm/yarn, uv, go, make, just, …), mapped onto canonical verbs — `install`, `build`, `check`, `start`, `test`, `lint`, `format`. It mirrors the [`list_scripts` and `run_script` tools](/docs/agent-tools) one-for-one, so a human at the CLI and the model inside a turn see the same script index. Offline: manifest parsing plus a local subprocess, no API key.
 
 ## Synopsis
 
@@ -36,7 +36,7 @@ Run a script by canonical verb or by qualified id (e.g. `test`, `pnpm:build`).
 
 | Flag / arg | Default | Meaning |
 | --- | --- | --- |
-| `<script>` | — | `install` \| `build` \| `start` \| `test` \| `lint` \| `format`, or a qualified id like `pnpm:build`. |
+| `<script>` | — | `install` \| `build` \| `check` \| `start` \| `test` \| `lint` \| `format`, or a qualified id like `pnpm:build`. |
 | `--dir <path>` | — | Package dir when the id exists in several packages. |
 | `--timeout-secs <n>` | `600` | Abort the subprocess after this many seconds. |
 | `-- <args...>` | — | Extra args appended runner-natively (after `--` for npm-family runners). |

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -126,6 +126,7 @@ pub const RESERVED_NAMES: &[&str] = &[
     "verify_done",
     "build_project",
     "run_tests",
+    "diagnostics",
     // The project scripts index (docs/design/scripts-index.md)
     "list_scripts",
     "run_script",

--- a/stella-tools/src/diagnostics.rs
+++ b/stella-tools/src/diagnostics.rs
@@ -1,0 +1,869 @@
+//! `diagnostics` — fast typecheck via the toolchain's native
+//! machine-readable diagnostics.
+//!
+//! `build_project`/`run_tests` return prose that gets middle-truncated at
+//! 30 KB; the model re-parses it and misses errors buried in the cut. This
+//! tool runs the detected toolchain's own structured-output mode —
+//! `cargo check --message-format=json`, `tsc --pretty false`,
+//! `eslint --format json`, `ruff check --output-format=json` — and parses
+//! the FULL stream into typed [`Diagnostic`] records rendered compactly:
+//! grouped by file, error-bearing files first, capped with a loud elision.
+//! The raw stream is never truncated (`exec::run_argv_untruncated`) — the
+//! *render* is bounded, so no record is silently severed mid-JSON-line.
+//!
+//! Detection mirrors the script index's ecosystem ranks (cargo → node →
+//! python) and reuses its primitives (`scripts::node_pm`,
+//! `scripts::python_runner`, `scripts::has_python_dep`); the command is a
+//! fixed argv per toolchain — no shell, no free-form command surface, same
+//! posture as `run_lint`/`format_code`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+use crate::exec;
+use crate::registry::Tool;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 600;
+
+/// Rendered-record cap. The elision line carries the exact counts left out,
+/// so a giant break is loud, never silently shortened.
+const MAX_RENDERED_DIAGNOSTICS: usize = 100;
+
+/// Severity of one record. `Error < Warning` so sorting puts errors first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+impl Severity {
+    fn label(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
+}
+
+/// One structured diagnostic: exactly the fields the model needs to act —
+/// where (`file`, `line`, `col`), how bad (`severity`), which rule
+/// (`code`), and what (`message`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Diagnostic {
+    pub file: String,
+    pub line: u32,
+    pub col: u32,
+    pub severity: Severity,
+    pub code: Option<String>,
+    pub message: String,
+}
+
+/// The machine-readable dialects this tool parses, one per toolchain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticsFormat {
+    /// `cargo check --message-format=json` (clippy shares the shape).
+    CargoJson,
+    /// `tsc --pretty false`: line-stable `file(l,c): error TSnnnn: msg`.
+    Tsc,
+    /// `eslint --format json`.
+    EslintJson,
+    /// `ruff check --output-format=json`.
+    RuffJson,
+}
+
+/// The resolved run: an exact argv (no shell anywhere) plus the parser for
+/// its output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsPlan {
+    pub argv: Vec<String>,
+    pub format: DiagnosticsFormat,
+}
+
+/// Resolve the workspace's diagnostics command, in the script index's
+/// ecosystem-rank order (cargo → node → python). Static marker reads only —
+/// nothing is executed here.
+pub fn resolve_plan(root: &Path) -> Result<DiagnosticsPlan, String> {
+    if root.join("Cargo.toml").exists() {
+        return Ok(DiagnosticsPlan {
+            argv: to_argv(&["cargo", "check", "--workspace", "--message-format=json"]),
+            format: DiagnosticsFormat::CargoJson,
+        });
+    }
+    if root.join("package.json").exists() {
+        let pm = crate::scripts::node_pm(root, None);
+        if root.join("tsconfig.json").exists() {
+            let mut argv = pm_exec(pm);
+            // `--noEmit` keeps the run non-mutating even when the project's
+            // tsconfig would emit JS.
+            argv.extend(to_argv(&["tsc", "--noEmit", "--pretty", "false"]));
+            return Ok(DiagnosticsPlan {
+                argv,
+                format: DiagnosticsFormat::Tsc,
+            });
+        }
+        if has_eslint_config(root) {
+            let mut argv = pm_exec(pm);
+            argv.extend(to_argv(&["eslint", "--format", "json", "."]));
+            return Ok(DiagnosticsPlan {
+                argv,
+                format: DiagnosticsFormat::EslintJson,
+            });
+        }
+    }
+    if let Ok(text) = std::fs::read_to_string(root.join("pyproject.toml"))
+        && let Ok(doc) = toml::from_str::<toml::Value>(&text)
+        && crate::scripts::has_python_dep(&doc, "ruff")
+    {
+        let runner = crate::scripts::python_runner(root, &doc);
+        return Ok(DiagnosticsPlan {
+            argv: to_argv(&[runner, "run", "ruff", "check", "--output-format=json"]),
+            format: DiagnosticsFormat::RuffJson,
+        });
+    }
+    Err(
+        "no diagnostics toolchain detected — looked for Cargo.toml (cargo check), \
+         package.json + tsconfig.json (tsc), an ESLint config (eslint), and a \
+         pyproject.toml declaring ruff; run the project's own check script via \
+         run_script instead"
+            .into(),
+    )
+}
+
+fn to_argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|p| (*p).to_string()).collect()
+}
+
+/// The package manager's binary-exec prefix (`pnpm exec tsc …`), matching
+/// the lockfile-detected pm the script index uses.
+fn pm_exec(pm: &str) -> Vec<String> {
+    match pm {
+        "pnpm" => to_argv(&["pnpm", "exec"]),
+        "yarn" => to_argv(&["yarn"]),
+        "bun" => to_argv(&["bunx"]),
+        _ => to_argv(&["npx"]),
+    }
+}
+
+/// Whether the workspace configures ESLint: a dedicated config file (flat
+/// or legacy) or the `eslintConfig` key in `package.json`.
+fn has_eslint_config(root: &Path) -> bool {
+    const CONFIG_FILES: &[&str] = &[
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        ".eslintrc.yml",
+        ".eslintrc.yaml",
+    ];
+    if CONFIG_FILES.iter().any(|name| root.join(name).exists()) {
+        return true;
+    }
+    std::fs::read_to_string(root.join("package.json"))
+        .ok()
+        .and_then(|text| serde_json::from_str::<Value>(&text).ok())
+        .is_some_and(|pkg| pkg.get("eslintConfig").is_some())
+}
+
+/// Dispatch to the per-format parser. Each parser is a pure, deterministic
+/// function of the captured output — unit-tested per format on captured
+/// fixtures, no toolchain required.
+pub fn parse(format: DiagnosticsFormat, output: &str) -> Vec<Diagnostic> {
+    match format {
+        DiagnosticsFormat::CargoJson => parse_cargo_json(output),
+        DiagnosticsFormat::Tsc => parse_tsc(output),
+        DiagnosticsFormat::EslintJson => parse_eslint_json(output),
+        DiagnosticsFormat::RuffJson => parse_ruff_json(output),
+    }
+}
+
+/// `cargo check --message-format=json`: one JSON object per line; rustc
+/// diagnostics ride `reason: "compiler-message"`. Span-less messages
+/// ("aborting due to N previous errors") are summaries, not locations —
+/// skipped. Note/help levels ride as children of their parent and are
+/// skipped as top-level records.
+fn parse_cargo_json(output: &str) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+    for line in output.lines() {
+        let Ok(record) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if record.get("reason").and_then(|r| r.as_str()) != Some("compiler-message") {
+            continue;
+        }
+        let Some(message) = record.get("message") else {
+            continue;
+        };
+        let severity = match message.get("level").and_then(|l| l.as_str()) {
+            Some("warning") => Severity::Warning,
+            // "error" and "error: internal compiler error".
+            Some(level) if level.starts_with("error") => Severity::Error,
+            _ => continue,
+        };
+        let Some(span) = message
+            .get("spans")
+            .and_then(|s| s.as_array())
+            .and_then(|spans| {
+                spans.iter().find(|s| {
+                    s.get("is_primary")
+                        .and_then(|p| p.as_bool())
+                        .unwrap_or(false)
+                })
+            })
+        else {
+            continue;
+        };
+        let Some(file) = span.get("file_name").and_then(|f| f.as_str()) else {
+            continue;
+        };
+        out.push(Diagnostic {
+            file: file.to_string(),
+            line: span.get("line_start").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+            col: span
+                .get("column_start")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            severity,
+            code: message
+                .get("code")
+                .and_then(|c| c.get("code"))
+                .and_then(|c| c.as_str())
+                .map(String::from),
+            message: flatten(
+                message
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or(""),
+            ),
+        });
+    }
+    out
+}
+
+/// `tsc --pretty false`: `src/a.ts(12,5): error TS2322: message`, plus
+/// file-less project errors (`error TS18003: message`). Non-matching lines
+/// (continuations, summaries) contribute nothing.
+fn parse_tsc(output: &str) -> Vec<Diagnostic> {
+    output
+        .lines()
+        .filter_map(|line| parse_tsc_line(line.trim_end()))
+        .collect()
+}
+
+fn parse_tsc_line(line: &str) -> Option<Diagnostic> {
+    if let Some(idx) = line.find("): ")
+        && let Some(diag) = parse_tsc_located(&line[..idx], &line[idx + 3..])
+    {
+        return Some(diag);
+    }
+    let (severity, code, message) = parse_tsc_tail(line)?;
+    Some(Diagnostic {
+        file: String::new(),
+        line: 0,
+        col: 0,
+        severity,
+        code: Some(code),
+        message,
+    })
+}
+
+/// `head` = `src/a.ts(12,5` (closing paren stripped), `tail` = the
+/// `error TSnnnn: message` remainder.
+fn parse_tsc_located(head: &str, tail: &str) -> Option<Diagnostic> {
+    let open = head.rfind('(')?;
+    let (line, col) = head[open + 1..].split_once(',')?;
+    let (severity, code, message) = parse_tsc_tail(tail)?;
+    Some(Diagnostic {
+        file: head[..open].to_string(),
+        line: line.trim().parse().ok()?,
+        col: col.trim().parse().ok()?,
+        severity,
+        code: Some(code),
+        message,
+    })
+}
+
+/// `error TS2322: message` → (severity, code, message); `None` for any
+/// other shape.
+fn parse_tsc_tail(tail: &str) -> Option<(Severity, String, String)> {
+    let (word, rest) = tail.split_once(' ')?;
+    let severity = match word {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        _ => return None,
+    };
+    let (code, message) = rest.split_once(": ")?;
+    let digits = code.strip_prefix("TS")?;
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some((severity, code.to_string(), flatten(message)))
+}
+
+/// `eslint --format json`: one array of file entries, each with a
+/// `messages` list (`severity` 2 = error, 1 = warning; `ruleId` null on
+/// fatal parse errors).
+fn parse_eslint_json(output: &str) -> Vec<Diagnostic> {
+    let Some(files) = first_json_value(output) else {
+        return Vec::new();
+    };
+    let Some(files) = files.as_array().cloned() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in &files {
+        let Some(file) = entry.get("filePath").and_then(|f| f.as_str()) else {
+            continue;
+        };
+        let Some(messages) = entry.get("messages").and_then(|m| m.as_array()) else {
+            continue;
+        };
+        for m in messages {
+            let severity = if m.get("severity").and_then(|s| s.as_u64()) == Some(2) {
+                Severity::Error
+            } else {
+                Severity::Warning
+            };
+            out.push(Diagnostic {
+                file: file.to_string(),
+                line: m.get("line").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                col: m.get("column").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                severity,
+                code: m.get("ruleId").and_then(|r| r.as_str()).map(String::from),
+                message: flatten(m.get("message").and_then(|s| s.as_str()).unwrap_or("")),
+            });
+        }
+    }
+    out
+}
+
+/// `ruff check --output-format=json`: one array of violations with
+/// `filename`, `location {row, column}`, `code` (null on syntax errors),
+/// `message`. Ruff carries no per-record severity; every violation fails
+/// the run (exit 1), so they map to errors.
+fn parse_ruff_json(output: &str) -> Vec<Diagnostic> {
+    let Some(list) = first_json_value(output) else {
+        return Vec::new();
+    };
+    let Some(list) = list.as_array().cloned() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for v in &list {
+        let Some(file) = v.get("filename").and_then(|f| f.as_str()) else {
+            continue;
+        };
+        let location = v.get("location");
+        out.push(Diagnostic {
+            file: file.to_string(),
+            line: location
+                .and_then(|l| l.get("row"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            col: location
+                .and_then(|l| l.get("column"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            severity: Severity::Error,
+            code: v.get("code").and_then(|c| c.as_str()).map(String::from),
+            message: flatten(v.get("message").and_then(|m| m.as_str()).unwrap_or("")),
+        });
+    }
+    out
+}
+
+/// The first JSON value at or after the first `[`/`{` — package-manager
+/// wrappers (yarn's `yarn run v1…` banner) and interleaved stderr surround
+/// the formatter's document with non-JSON lines.
+fn first_json_value(output: &str) -> Option<Value> {
+    let start = output.find(['[', '{'])?;
+    serde_json::Deserializer::from_str(&output[start..])
+        .into_iter::<Value>()
+        .next()?
+        .ok()
+}
+
+/// Newlines inside a message would break the one-record-per-line render.
+fn flatten(message: &str) -> String {
+    message.replace('\n', " ").trim().to_string()
+}
+
+/// Make paths workspace-relative (eslint/ruff print absolute paths), then
+/// sort and dedup — cargo emits the same diagnostic once per target
+/// (lib + test), and duplicates would double-count.
+fn normalize(diags: &mut Vec<Diagnostic>, root: &Path) {
+    let mut prefixes = vec![root.display().to_string()];
+    if let Ok(canonical) = root.canonicalize() {
+        let canonical = canonical.display().to_string();
+        if !prefixes.contains(&canonical) {
+            prefixes.push(canonical);
+        }
+    }
+    for diag in diags.iter_mut() {
+        for prefix in &prefixes {
+            if let Some(rest) = diag.file.strip_prefix(prefix.as_str()) {
+                diag.file = rest.trim_start_matches('/').to_string();
+                break;
+            }
+        }
+    }
+    diags.sort();
+    diags.dedup();
+}
+
+/// Render the report: a PASSED/FAILED first line with exact counts, then
+/// records grouped by file — error-bearing files first, errors before
+/// warnings within a file — capped at [`MAX_RENDERED_DIAGNOSTICS`] with an
+/// elision line that names what was left out.
+fn render_report(display: &str, exit_code: i32, diags: &[Diagnostic]) -> String {
+    let errors = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    let warnings = diags.len() - errors;
+    let verdict = if exit_code == 0 {
+        format!("`{display}` PASSED (exit 0)")
+    } else {
+        format!("`{display}` FAILED (exit {exit_code})")
+    };
+    if diags.is_empty() {
+        return format!("{verdict} — no diagnostics");
+    }
+
+    // Group by file; error-bearing files first (then by path), and within
+    // a file errors before warnings (then by line) — so the cap can only
+    // ever elide errors when there are more than the cap OF errors.
+    let mut groups: BTreeMap<&str, Vec<&Diagnostic>> = BTreeMap::new();
+    for diag in diags {
+        groups.entry(diag.file.as_str()).or_default().push(diag);
+    }
+    let mut ordered: Vec<(&str, Vec<&Diagnostic>)> = groups.into_iter().collect();
+    for (_, group) in ordered.iter_mut() {
+        group.sort_by_key(|d| (d.severity, d.line, d.col));
+    }
+    ordered.sort_by_key(|(file, group)| (group[0].severity, *file));
+
+    let files = ordered.len();
+    let mut report =
+        format!("{verdict} — {errors} error(s), {warnings} warning(s) in {files} file(s)\n");
+    let mut rendered = 0usize;
+    let mut rendered_errors = 0usize;
+    'render: for (file, group) in &ordered {
+        if rendered == MAX_RENDERED_DIAGNOSTICS {
+            break 'render;
+        }
+        report.push('\n');
+        report.push_str(if file.is_empty() { "(project)" } else { file });
+        report.push('\n');
+        for diag in group {
+            if rendered == MAX_RENDERED_DIAGNOSTICS {
+                break 'render;
+            }
+            let code = diag
+                .code
+                .as_deref()
+                .map(|c| format!("[{c}]"))
+                .unwrap_or_default();
+            report.push_str(&format!(
+                "  {}{code} {}:{} {}\n",
+                diag.severity.label(),
+                diag.line,
+                diag.col,
+                diag.message
+            ));
+            rendered += 1;
+            if diag.severity == Severity::Error {
+                rendered_errors += 1;
+            }
+        }
+    }
+    if rendered < diags.len() {
+        let elided = diags.len() - rendered;
+        let elided_errors = errors - rendered_errors;
+        report.push_str(&format!(
+            "\n[!] {elided} more diagnostic(s) NOT shown ({elided_errors} error(s), {} \
+             warning(s)) — fix the ones above and rerun diagnostics\n",
+            elided - elided_errors
+        ));
+    }
+    report.trim_end().to_string()
+}
+
+/// `diagnostics` — the fast-typecheck tool. Read-only in the flag's sense:
+/// it mutates no workspace state the model sees (cargo/tsc caches land in
+/// their own build dirs; `--noEmit` pins tsc).
+pub struct Diagnostics;
+
+#[async_trait]
+impl Tool for Diagnostics {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "diagnostics".into(),
+            description: "Fast typecheck: run the toolchain's native machine-readable check \
+                          (cargo check / tsc / eslint / ruff) and return structured \
+                          file:line:col diagnostics with severity and rule code, grouped by \
+                          file. Much cheaper than build_project — use it after edits to see \
+                          exactly what broke."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "timeout_secs": { "type": "integer" }
+                }
+            }),
+            read_only: true,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &std::path::Path) -> ToolOutput {
+        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
+        let plan = {
+            // Manifest reads on the blocking pool, like `ScriptIndex::detect`.
+            let root = root.to_path_buf();
+            tokio::task::spawn_blocking(move || resolve_plan(&root))
+                .await
+                .unwrap_or_else(|_| Err("diagnostics detection was cancelled".into()))
+        };
+        let plan = match plan {
+            Ok(plan) => plan,
+            Err(message) => return ToolOutput::Error { message },
+        };
+        let display = plan.argv.join(" ");
+        match exec::run_argv_untruncated(&plan.argv[0], &plan.argv[1..], root, timeout_secs).await {
+            Ok((code, raw)) => {
+                let mut diags = parse(plan.format, &raw);
+                normalize(&mut diags, root);
+                if code != 0 && diags.is_empty() {
+                    // A failing run with nothing parseable (broken manifest,
+                    // missing binary shim, tool crash) must not report an
+                    // empty success-shaped frame — surface the raw evidence.
+                    return ToolOutput::Error {
+                        message: format!(
+                            "`{display}` FAILED (exit {code}) — no structured diagnostics \
+                             parsed; raw output:\n{}",
+                            exec::truncate_middle(raw)
+                        ),
+                    };
+                }
+                let report = render_report(&display, code, &diags);
+                if code == 0 {
+                    ToolOutput::Ok { content: report }
+                } else {
+                    ToolOutput::Error { message: report }
+                }
+            }
+            Err(e) => ToolOutput::Error { message: e },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, content: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    /// THE WITNESS for the structured-diagnostics tool: a known-bad crate
+    /// through the real cargo yields a record with the exact
+    /// {file, line, col, severity, code} — not a prose dump.
+    #[tokio::test]
+    async fn cargo_check_on_a_known_bad_crate_yields_exact_structured_records() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[package]\nname = \"known_bad\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        write(
+            dir.path(),
+            "src/lib.rs",
+            "pub fn answer() -> u32 {\n    \"forty-two\"\n}\n",
+        );
+        let out = Diagnostics
+            .execute(&serde_json::json!({}), dir.path())
+            .await;
+        match &out {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("FAILED"), "{message}");
+                assert!(message.contains("src/lib.rs"), "{message}");
+                assert!(
+                    message.contains("error[E0308] 2:5"),
+                    "exact severity[code] line:col record: {message}"
+                );
+                assert!(message.contains("mismatched types"), "{message}");
+            }
+            other => panic!("a bad crate must FAIL with structured records, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cargo_check_on_a_clean_crate_passes_with_no_diagnostics() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[package]\nname = \"known_good\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        write(
+            dir.path(),
+            "src/lib.rs",
+            "pub fn answer() -> u32 {\n    42\n}\n",
+        );
+        let out = Diagnostics
+            .execute(&serde_json::json!({}), dir.path())
+            .await;
+        match &out {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("PASSED"), "{content}");
+                assert!(content.contains("no diagnostics"), "{content}");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_empty_workspace_is_a_named_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = Diagnostics
+            .execute(&serde_json::json!({}), dir.path())
+            .await;
+        match &out {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("no diagnostics toolchain detected"),
+                    "{message}"
+                );
+                assert!(message.contains("Cargo.toml"), "{message}");
+                assert!(message.contains("run_script"), "{message}");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_resolution_is_marker_driven_and_rank_ordered() {
+        let join = |plan: &DiagnosticsPlan| plan.argv.join(" ");
+
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Cargo.toml", "[package]\nname = \"x\"\n");
+        let plan = resolve_plan(dir.path()).unwrap();
+        assert_eq!(join(&plan), "cargo check --workspace --message-format=json");
+        assert_eq!(plan.format, DiagnosticsFormat::CargoJson);
+
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", "{}");
+        write(dir.path(), "pnpm-lock.yaml", "");
+        write(dir.path(), "tsconfig.json", "{}");
+        let plan = resolve_plan(dir.path()).unwrap();
+        assert_eq!(join(&plan), "pnpm exec tsc --noEmit --pretty false");
+        assert_eq!(plan.format, DiagnosticsFormat::Tsc);
+
+        // No tsconfig, but an ESLint flat config: eslint via npx (no
+        // lockfile → npm).
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", "{}");
+        write(dir.path(), "eslint.config.js", "module.exports = [];");
+        let plan = resolve_plan(dir.path()).unwrap();
+        assert_eq!(join(&plan), "npx eslint --format json .");
+        assert_eq!(plan.format, DiagnosticsFormat::EslintJson);
+
+        // Ruff only when pyproject declares it; uv from its lockfile.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "pyproject.toml",
+            "[project]\nname = \"y\"\n\n[dependency-groups]\ndev = [\"ruff\"]\n",
+        );
+        write(dir.path(), "uv.lock", "");
+        let plan = resolve_plan(dir.path()).unwrap();
+        assert_eq!(join(&plan), "uv run ruff check --output-format=json");
+        assert_eq!(plan.format, DiagnosticsFormat::RuffJson);
+
+        // A ruff-less pyproject resolves nothing.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "pyproject.toml", "[project]\nname = \"z\"\n");
+        assert!(resolve_plan(dir.path()).is_err());
+    }
+
+    /// Captured `cargo check --message-format=json` shapes: the duplicate
+    /// per-target record dedups, span-less summaries and note levels are
+    /// skipped, and non-JSON lines contribute nothing.
+    #[test]
+    fn cargo_json_parses_dedups_and_skips_summaries() {
+        let record = r#"{"reason":"compiler-message","package_id":"path+file:///tmp/x#0.1.0","message":{"$message_type":"diagnostic","message":"mismatched types","code":{"code":"E0308","explanation":null},"level":"error","spans":[{"file_name":"src/lib.rs","line_start":2,"line_end":2,"column_start":5,"column_end":16,"is_primary":true}],"children":[],"rendered":"error[E0308]: mismatched types\n"}}"#;
+        let summary = r#"{"reason":"compiler-message","message":{"$message_type":"diagnostic","message":"aborting due to 1 previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to 1 previous error\n"}}"#;
+        let note = r#"{"reason":"compiler-message","message":{"$message_type":"diagnostic","message":"required by a bound","code":null,"level":"note","spans":[{"file_name":"src/lib.rs","line_start":9,"line_end":9,"column_start":1,"column_end":2,"is_primary":true}],"children":[],"rendered":"note\n"}}"#;
+        let finished = r#"{"reason":"build-finished","success":false}"#;
+        let output = format!(
+            "{record}\n{record}\n{summary}\n{note}\n{finished}\nerror: could not compile `x` (lib)\n"
+        );
+
+        let mut diags = parse(DiagnosticsFormat::CargoJson, &output);
+        normalize(&mut diags, Path::new("/nonexistent-root"));
+        assert_eq!(
+            diags,
+            vec![Diagnostic {
+                file: "src/lib.rs".into(),
+                line: 2,
+                col: 5,
+                severity: Severity::Error,
+                code: Some("E0308".into()),
+                message: "mismatched types".into(),
+            }]
+        );
+    }
+
+    /// Captured `tsc --pretty false` output: located records, a warning,
+    /// a file-less project error, and noise lines.
+    #[test]
+    fn tsc_output_parses_located_and_project_level_records() {
+        let output = "src/app.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.\n\
+                      src/util.ts(3,10): warning TS6133: 'x' is declared but its value is never read.\n\
+                      error TS18003: No inputs were found in config file 'tsconfig.json'.\n\
+                      Found 3 errors in 2 files.\n";
+        let diags = parse(DiagnosticsFormat::Tsc, output);
+        assert_eq!(diags.len(), 3, "{diags:?}");
+        assert_eq!(
+            diags[0],
+            Diagnostic {
+                file: "src/app.ts".into(),
+                line: 12,
+                col: 5,
+                severity: Severity::Error,
+                code: Some("TS2322".into()),
+                message: "Type 'string' is not assignable to type 'number'.".into(),
+            }
+        );
+        assert_eq!(diags[1].severity, Severity::Warning);
+        assert_eq!(diags[1].code.as_deref(), Some("TS6133"));
+        // The project-level error keeps its code but has no location.
+        assert_eq!(diags[2].file, "");
+        assert_eq!(diags[2].code.as_deref(), Some("TS18003"));
+    }
+
+    /// Captured `eslint --format json` output, wrapped in the yarn-classic
+    /// banner noise the pm-exec path can prepend.
+    #[test]
+    fn eslint_json_parses_severities_and_null_rule_ids() {
+        let output = "yarn run v1.22.19\n$ eslint --format json .\n\
+            [{\"filePath\":\"/repo/src/a.js\",\"messages\":[\
+            {\"ruleId\":\"no-unused-vars\",\"severity\":2,\"message\":\"'x' is defined but never used.\",\"line\":1,\"column\":7},\
+            {\"ruleId\":\"eqeqeq\",\"severity\":1,\"message\":\"Expected '===' and instead saw '=='.\",\"line\":4,\"column\":9},\
+            {\"ruleId\":null,\"severity\":2,\"fatal\":true,\"message\":\"Parsing error: Unexpected token\",\"line\":9,\"column\":1}\
+            ],\"errorCount\":2,\"warningCount\":1}]\n";
+        let diags = parse(DiagnosticsFormat::EslintJson, output);
+        assert_eq!(diags.len(), 3, "{diags:?}");
+        assert_eq!(
+            diags[0],
+            Diagnostic {
+                file: "/repo/src/a.js".into(),
+                line: 1,
+                col: 7,
+                severity: Severity::Error,
+                code: Some("no-unused-vars".into()),
+                message: "'x' is defined but never used.".into(),
+            }
+        );
+        assert_eq!(diags[1].severity, Severity::Warning);
+        assert_eq!(diags[2].code, None, "fatal parse errors have no ruleId");
+    }
+
+    /// Captured `ruff check --output-format=json` output — records carry no
+    /// severity of their own; every violation fails the run.
+    #[test]
+    fn ruff_json_parses_location_and_null_codes() {
+        let output = r#"[{"cell":null,"code":"F401","end_location":{"column":10,"row":1},"filename":"/repo/pkg/a.py","fix":null,"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"},{"cell":null,"code":null,"end_location":{"column":1,"row":4},"filename":"/repo/pkg/b.py","fix":null,"location":{"column":5,"row":3},"message":"SyntaxError: Expected an expression","noqa_row":3,"url":null}]"#;
+        let diags = parse(DiagnosticsFormat::RuffJson, output);
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert_eq!(
+            diags[0],
+            Diagnostic {
+                file: "/repo/pkg/a.py".into(),
+                line: 1,
+                col: 8,
+                severity: Severity::Error,
+                code: Some("F401".into()),
+                message: "`os` imported but unused".into(),
+            }
+        );
+        assert_eq!(diags[1].code, None, "syntax errors carry a null code");
+    }
+
+    #[test]
+    fn normalize_relativizes_absolute_paths_under_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let abs = dir.path().canonicalize().unwrap().join("src/a.py");
+        let mut diags = vec![Diagnostic {
+            file: abs.display().to_string(),
+            line: 1,
+            col: 1,
+            severity: Severity::Error,
+            code: None,
+            message: "m".into(),
+        }];
+        normalize(&mut diags, dir.path());
+        assert_eq!(diags[0].file, "src/a.py");
+    }
+
+    #[test]
+    fn render_groups_by_file_orders_error_files_first_and_elides_loudly() {
+        let diag = |file: &str, line: u32, severity: Severity| Diagnostic {
+            file: file.into(),
+            line,
+            col: 1,
+            severity,
+            code: Some("X1".into()),
+            message: "m".into(),
+        };
+        // a.rs has only a warning; z.rs has an error — z.rs must render
+        // first so the cap can never elide errors in favor of warnings.
+        let mut diags = vec![
+            diag("a.rs", 1, Severity::Warning),
+            diag("z.rs", 2, Severity::Error),
+        ];
+        diags.sort();
+        let report = render_report("cmd", 101, &diags);
+        assert!(report.contains("FAILED (exit 101) — 1 error(s), 1 warning(s) in 2 file(s)"));
+        let z = report.find("z.rs").unwrap();
+        let a = report.find("a.rs").unwrap();
+        assert!(z < a, "error-bearing file renders first:\n{report}");
+
+        // 40 errors in one file + 100 warnings in another: the render caps
+        // at MAX_RENDERED_DIAGNOSTICS and the elision line counts the rest.
+        let mut many = Vec::new();
+        for line in 0..40 {
+            many.push(diag("bad.rs", line, Severity::Error));
+        }
+        for line in 0..100 {
+            many.push(diag("warn.rs", line, Severity::Warning));
+        }
+        many.sort();
+        let report = render_report("cmd", 101, &many);
+        assert!(
+            report.contains("[!] 40 more diagnostic(s) NOT shown (0 error(s), 40 warning(s))"),
+            "{report}"
+        );
+        // Every error is visible; only warnings were elided.
+        assert_eq!(report.matches("error[X1]").count(), 40, "{report}");
+
+        // Warnings-only with exit 0 is a PASS that still shows the records.
+        let warn_only = vec![diag("w.rs", 1, Severity::Warning)];
+        let report = render_report("cmd", 0, &warn_only);
+        assert!(
+            report.contains("PASSED (exit 0) — 0 error(s), 1 warning(s)"),
+            "{report}"
+        );
+        assert!(report.contains("warning[X1] 1:1"), "{report}");
+    }
+}

--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -3,7 +3,7 @@
 //! truncation. Two entry points: [`run`] shells out via `bash -c`
 //! (`verify_done`, `build_project`, `run_tests`, the opt-in `bash` tool);
 //! [`run_argv`] execs an argv vector directly with NO shell anywhere
-//! (`run_script`, `run_lint`, `format_code`).
+//! (`run_script`, `run_lint`, `format_code`, `diagnostics`).
 
 use std::time::Duration;
 
@@ -91,7 +91,9 @@ pub(crate) async fn run(
 ) -> Result<(i32, String), String> {
     let mut cmd = Command::new("bash");
     cmd.arg("-c").arg(command);
-    drive(cmd, command, dir, timeout_secs, &[]).await
+    drive(cmd, command, dir, timeout_secs, &[])
+        .await
+        .map(|(code, output)| (code, truncate_middle(output)))
 }
 
 /// Run a repository-owned GitHub CLI command while preserving only GitHub
@@ -113,6 +115,7 @@ pub(crate) async fn run_github(
         crate::subprocess_env::GITHUB_CLI_AUTH_ENV_VARS,
     )
     .await
+    .map(|(code, output)| (code, truncate_middle(output)))
 }
 
 /// Run `program` with `args` DIRECTLY — argv exec, no shell anywhere — in
@@ -121,6 +124,23 @@ pub(crate) async fn run_github(
 /// model-supplied string is ever shell-interpreted. Same process-group
 /// spawn, timeout kill, and truncation as [`run`].
 pub(crate) async fn run_argv(
+    program: &str,
+    args: &[String],
+    dir: &std::path::Path,
+    timeout_secs: u64,
+) -> Result<(i32, String), String> {
+    run_argv_untruncated(program, args, dir, timeout_secs)
+        .await
+        .map(|(code, output)| (code, truncate_middle(output)))
+}
+
+/// [`run_argv`] without the middle-out truncation — for callers that PARSE
+/// the full output into a bounded structure of their own (`diagnostics`
+/// consuming a `--message-format=json` stream: truncating the raw stream
+/// would sever JSON lines and silently drop the very records the parse
+/// exists to keep). Peak memory is unchanged — `wait_with_output` buffers
+/// everything before truncation would apply anyway.
+pub(crate) async fn run_argv_untruncated(
     program: &str,
     args: &[String],
     dir: &std::path::Path,
@@ -159,8 +179,10 @@ impl Drop for GroupKillGuard {
     }
 }
 
-/// Shared spawn/wait/kill/truncate body of [`run`] and [`run_argv`] —
-/// `command` is the human-readable command line for error messages.
+/// Shared spawn/wait/kill body of [`run`] and [`run_argv`] — `command` is
+/// the human-readable command line for error messages. Output is returned
+/// UNTRUNCATED; the wrappers apply [`truncate_middle`] except
+/// [`run_argv_untruncated`], whose callers parse the full stream.
 async fn drive(
     mut cmd: Command,
     command: &str,
@@ -230,10 +252,7 @@ async fn drive(
         }
         combined.push_str(&stderr);
     }
-    Ok((
-        output.status.code().unwrap_or(-1),
-        truncate_middle(combined),
-    ))
+    Ok((output.status.code().unwrap_or(-1), combined))
 }
 
 /// [`run`] with the PASSED/FAILED framing shared by `build_project`,

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ci;
 pub mod code_map;
 pub mod custom;
 pub mod delete;
+pub mod diagnostics;
 pub mod edit;
 pub mod exec;
 pub mod exploration;

--- a/stella-tools/src/overview.rs
+++ b/stella-tools/src/overview.rs
@@ -257,15 +257,14 @@ fn scripts_section(scripts: &ScriptIndex) -> Value {
     if scripts.is_empty() {
         return json!({ "detected": false });
     }
-    let verbs: serde_json::Map<String, Value> =
-        ["install", "build", "start", "test", "lint", "format"]
-            .iter()
-            .filter_map(|verb| {
-                scripts
-                    .verb_entry(verb)
-                    .map(|entry| ((*verb).to_string(), json!(entry.command.clone())))
-            })
-            .collect();
+    let verbs: serde_json::Map<String, Value> = crate::scripts::VERBS
+        .iter()
+        .filter_map(|verb| {
+            scripts
+                .verb_entry(verb)
+                .map(|entry| ((*verb).to_string(), json!(entry.command.clone())))
+        })
+        .collect();
     json!({
         "detected": true,
         "runners": scripts.detected_runners(),
@@ -392,6 +391,13 @@ mod tests {
                 .iter()
                 .any(|r| r == "cargo"),
             "cargo detected from the manifest alone: {scripts}"
+        );
+        // The fast-typecheck path is discoverable from the overview: the
+        // `check` verb rides the same index the diagnostics tool uses.
+        assert_eq!(
+            scripts["verbs"]["check"],
+            serde_json::json!("cargo check --workspace"),
+            "{scripts}"
         );
     }
 

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -1467,6 +1467,7 @@ mod tests {
             "verify_done",
             "build_project",
             "run_tests",
+            "diagnostics",
             "run_lint",
             "format_code",
             "list_scripts",
@@ -1504,7 +1505,7 @@ mod tests {
         }
         // `bash` is NOT in the default surface — it is the settings opt-in.
         assert!(!names.contains(&"bash".to_string()), "{names:?}");
-        assert_eq!(names.len(), 46, "unexpected tool count: {names:?}");
+        assert_eq!(names.len(), 47, "unexpected tool count: {names:?}");
     }
 
     // bash opt-in (default OFF everywhere)
@@ -1629,7 +1630,7 @@ mod tests {
     fn issue_tools_absent_without_a_configured_backend() {
         let (_root, reg) = bare_registry(None);
         let names: Vec<String> = reg.schemas().iter().map(|s| s.name.clone()).collect();
-        assert_eq!(names.len(), 38, "unexpected tool count: {names:?}");
+        assert_eq!(names.len(), 39, "unexpected tool count: {names:?}");
         for absent in [
             "create_issue",
             "update_issue",
@@ -1764,6 +1765,7 @@ mod tests {
                     | "glob"
                     | "gather_context"
                     | "explorations"
+                    | "diagnostics"
                     | "list_scripts"
                     | "ci_status"
                     | "search_issues"

--- a/stella-tools/src/registry/process_tools.rs
+++ b/stella-tools/src/registry/process_tools.rs
@@ -16,6 +16,7 @@ pub(super) fn builtins(
         Arc::new(crate::verify::VerifyDone),
         Arc::new(crate::project::BuildProject),
         Arc::new(crate::project::RunTests),
+        Arc::new(crate::diagnostics::Diagnostics),
         Arc::new(crate::project::RunLint),
         Arc::new(crate::project::FormatCode),
         Arc::new(crate::scripts::RunScript),

--- a/stella-tools/src/scripts.rs
+++ b/stella-tools/src/scripts.rs
@@ -1,6 +1,6 @@
 //! Project scripts index — static, deterministic detection of
-//! package-manager scripts across ecosystems, mapped onto six canonical
-//! verbs (`install`, `build`, `start`, `test`, `lint`, `format`).
+//! package-manager scripts across ecosystems, mapped onto seven canonical
+//! verbs (`install`, `build`, `check`, `start`, `test`, `lint`, `format`).
 //!
 //! Spec: `docs/design/scripts-index.md`. Three surfaces share this module:
 //! the byte-stable `## Project scripts` prompt section, the
@@ -22,7 +22,9 @@ use crate::exec;
 use crate::registry::Tool;
 
 /// The canonical verbs, in the fixed render/resolution order.
-pub const VERBS: [&str; 6] = ["install", "build", "start", "test", "lint", "format"];
+pub const VERBS: [&str; 7] = [
+    "install", "build", "check", "start", "test", "lint", "format",
+];
 
 const DEFAULT_TIMEOUT_SECS: u64 = 600;
 /// Workspace-member enumeration cap — overflow is counted, not enumerated.
@@ -100,6 +102,7 @@ fn verb_aliases(verb: &str) -> &'static [&'static str] {
     match verb {
         "install" => &["install", "setup", "bootstrap"],
         "build" => &["build", "compile", "dist"],
+        "check" => &["check", "typecheck", "type-check"],
         "start" => &["start", "dev", "serve"],
         "test" => &["test", "tests"],
         "lint" => &["lint"],
@@ -349,11 +352,12 @@ impl ScriptIndex {
         s.trim_end().to_string()
     }
 
-    /// The machine frame (`stella scripts list --json`), schema_version 1 —
-    /// shape pinned by `docs/design/scripts-index.md`.
+    /// The machine frame (`stella scripts list --json`), schema_version 2
+    /// (2 = the `check` verb joined the set) — shape pinned by
+    /// `docs/design/scripts-index.md`.
     pub fn to_json(&self) -> Value {
         serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "verbs": self.verbs,
             "scripts": self.scripts,
         })
@@ -528,8 +532,9 @@ fn quoted_name(name: &str) -> String {
 
 /// The package manager for a dir with `package.json`, from its lockfile —
 /// falling back to the workspace root's pm for lockfile-less members
-/// (hoisted-lockfile monorepos).
-fn node_pm(dir: &Path, inherited: Option<&'static str>) -> &'static str {
+/// (hoisted-lockfile monorepos). Shared with `crate::diagnostics`, which
+/// composes its tsc/eslint exec command from the same pm choice.
+pub(crate) fn node_pm(dir: &Path, inherited: Option<&'static str>) -> &'static str {
     if dir.join("pnpm-lock.yaml").exists() {
         "pnpm"
     } else if dir.join("yarn.lock").exists() {
@@ -600,14 +605,7 @@ fn detect_python(dir: &Path, rel: &str, out: &mut Vec<ScriptEntry>) {
     let Ok(doc) = toml::from_str::<toml::Value>(&text) else {
         return;
     };
-    let tool = |name: &str| doc.get("tool").and_then(|t| t.get(name));
-    let runner: &'static str = if dir.join("uv.lock").exists() || tool("uv").is_some() {
-        "uv"
-    } else if dir.join("poetry.lock").exists() || tool("poetry").is_some() {
-        "poetry"
-    } else {
-        "uv"
-    };
+    let runner = python_runner(dir, &doc);
     let source = manifest_path(rel, "pyproject.toml");
     if let Some(scripts) = doc
         .get("project")
@@ -657,11 +655,25 @@ fn detect_python(dir: &Path, rel: &str, out: &mut Vec<ScriptEntry>) {
     }
 }
 
+/// The Python script runner for a dir with a parsed `pyproject.toml`: `uv`
+/// on a uv marker, `poetry` on a poetry marker, `uv` by default. Shared
+/// with `crate::diagnostics`.
+pub(crate) fn python_runner(dir: &Path, doc: &toml::Value) -> &'static str {
+    let tool = |name: &str| doc.get("tool").and_then(|t| t.get(name));
+    if dir.join("uv.lock").exists() || tool("uv").is_some() {
+        "uv"
+    } else if dir.join("poetry.lock").exists() || tool("poetry").is_some() {
+        "poetry"
+    } else {
+        "uv"
+    }
+}
+
 /// Whether `pyproject.toml` declares `tool_name` anywhere dependencies live:
 /// `[project] dependencies`, `[project.optional-dependencies]`,
 /// `[dependency-groups]`, `[tool.poetry.dependencies]`, or
 /// `[tool.poetry.group.*.dependencies]`.
-fn has_python_dep(doc: &toml::Value, tool_name: &str) -> bool {
+pub(crate) fn has_python_dep(doc: &toml::Value, tool_name: &str) -> bool {
     let mut names: Vec<String> = Vec::new();
     let mut push_reqs = |value: Option<&toml::Value>| {
         if let Some(reqs) = value.and_then(|v| v.as_array()) {
@@ -771,6 +783,12 @@ fn detect_cargo(root: &Path, out: &mut Vec<ScriptEntry>) {
         "cargo",
         "build",
         "cargo build --workspace",
+        ".",
+    ));
+    out.push(synthesized(
+        "cargo",
+        "check",
+        "cargo check --workspace",
         ".",
     ));
     out.push(synthesized("cargo", "test", "cargo test --workspace", "."));
@@ -1122,7 +1140,7 @@ fn expand_member_pattern(root: &Path, pattern: &str, dirs: &mut BTreeSet<String>
 
 // Verb resolution
 
-/// Bind the six canonical verbs over the sorted entries (root package only):
+/// Bind the canonical verbs over the sorted entries (root package only):
 /// (1) an explicit script in the first-ranked ecosystem, (2) that
 /// ecosystem's synthesized default, (3) explicit scripts of later-ranked
 /// ecosystems. Synthesized defaults of later ecosystems never bind.
@@ -1183,8 +1201,9 @@ impl Tool for ListScripts {
         ToolSchema {
             name: "list_scripts".into(),
             description: "List the project's indexed package-manager scripts and their \
-                          canonical verb bindings (install/build/start/test/lint/format). \
-                          Static manifest detection — nothing is executed."
+                          canonical verb bindings \
+                          (install/build/check/start/test/lint/format). Static manifest \
+                          detection — nothing is executed."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -1213,9 +1232,9 @@ impl Tool for RunScript {
         ToolSchema {
             name: "run_script".into(),
             description: "Run an indexed project script by canonical verb \
-                          (install|build|start|test|lint|format) or qualified id (e.g. \
-                          pnpm:build, make:lint — see list_scripts). Executes only indexed \
-                          entries; for arbitrary shell, use bash."
+                          (install|build|check|start|test|lint|format) or qualified id \
+                          (e.g. pnpm:build, make:lint — see list_scripts). Executes only \
+                          indexed entries; for arbitrary shell, use bash."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -1309,6 +1328,35 @@ mod tests {
         assert_eq!(alias.command, "cargo xt");
         assert_eq!(alias.raw.as_deref(), Some("test --workspace"));
         assert_eq!(alias.source, ".cargo/config.toml");
+    }
+
+    #[test]
+    fn check_verb_synthesizes_for_cargo_and_binds_explicit_typecheck() {
+        // Cargo: the synthesized fast typecheck binds `check`.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+        );
+        let index = ScriptIndex::detect_blocking(dir.path());
+        assert_eq!(index.verbs.get("check").unwrap(), "cargo:check");
+        assert_eq!(
+            index.verb_entry("check").unwrap().command,
+            "cargo check --workspace"
+        );
+
+        // Node: an explicit `typecheck` script binds the verb via its alias,
+        // and `run_script {"script": "check"}` resolves to it.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts": {"typecheck": "tsc --noEmit"}}"#,
+        );
+        let index = ScriptIndex::detect_blocking(dir.path());
+        assert_eq!(index.verbs.get("check").unwrap(), "npm:typecheck");
+        assert_eq!(index.resolve("check", None).unwrap().id, "npm:typecheck");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Adds a first-class `diagnostics` tool (read-only, non-mutating): it runs the detected toolchain's **native machine-readable check** — `cargo check --message-format=json` (mandatory path), `tsc --pretty false`, `eslint --format json`, `ruff check --output-format=json` — and returns **structured `{file, line, col, severity, code, message}` records** instead of raw prose. Rendered grouped by file, error-bearing files first, capped at 100 records with a loud elision that names the exact counts left out. The raw stream is parsed **untruncated** (new `exec::run_argv_untruncated`) so no record is severed mid-JSON-line — only the render is bounded, replacing the 30 KB middle-truncated dumps that today bury errors.

- One deterministic parser per format; `tsc`/`eslint`/`ruff` are fixture-tested and never assumed installed.
- Detection reuses the script index's primitives (`node_pm`, `python_runner`, `has_python_dep`) in the same ecosystem-rank order; fixed argv per toolchain, no shell, no free-form command surface (same posture as `run_lint`/`format_code`).
- New `check` canonical verb in the script index (aliases `check`/`typecheck`/`type-check`; cargo synthesizes `cargo check --workspace`), surfaced by `project_overview` via `scripts::VERBS`; scripts JSON `schema_version` bumped to 2 per the spec's shape-change rule.
- Registered in the process-tool builtins, `RESERVED_NAMES`, both system prompts, and the CLI claim tap's build lane (a checker must never observe a sibling's half-written tree).

Closes #329 — part of epic #336.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`diagnostics::tests::cargo_check_on_a_known_bad_crate_yields_exact_structured_records` — feeds a known-bad fixture crate through the **real cargo** and asserts the exact `error[E0308] 2:5` record for `src/lib.rs`. On `main` the module, tool, and registry entry are genuinely absent (the registry count tests there pin 46 tools; here they pin 47), so the test cannot exist, let alone pass. Per-format parser fixtures (`tsc`/`eslint`/`ruff`), plan resolution, render/elision, and `check`-verb binding are covered by dedicated unit tests in the same module.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings` and `-p stella-cli` (touched crates; the session coordinator runs the full `make gate` serially before un-drafting)
- [x] `cargo test -p stella-tools` (374 tests) and `cargo test -p stella-cli` (481 tests) green
- [x] Docs updated (README tool table, agent-tools + scripts docs pages, `docs/design/*/scripts-index.md`, CLI `--help` strings)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (the JSON formats are emitted by the native toolchains; parsing uses the existing serde/toml stack)
- [x] No new outbound network calls

## Anything reviewers should know?

- Ruff records carry no per-record severity in its JSON; they map to `error` (every violation fails the run, matching its exit code and `--output-format=github` behavior). ESLint severity 1/2 maps to warning/error; cargo note/help child levels are skipped as top-level records.
- `tsc` runs with `--noEmit` appended so the check can never emit JS (keeps the tool honestly read-only).
- Full `make gate` is being run by the session coordinator before un-drafting.
