### PR TITLE
feat: context receipts — increment 2 (byte-exact step reconstruction)

### DIFF
--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -305,12 +305,14 @@ pub(crate) fn persist_event(
         token_cost,
         content_digest,
         citation_label,
+        content,
     } = event
     {
         // Context receipts (spec §4). Best-effort — a receipt write failure
         // never fails the paid-call accounting boundary (these rows are
         // observability, not billing), and the block also survives verbatim in
-        // the generic `events` table via record_event above.
+        // the generic `events` table via record_event above. `content` is the
+        // local-only gap preimage (spec §5.3), present only for gap kinds.
         let _ = store.record_context_block(
             execution_id,
             &ContextBlockRow {
@@ -323,6 +325,7 @@ pub(crate) fn persist_event(
                 token_cost: *token_cost,
                 content_digest: content_digest.clone(),
                 citation_label: citation_label.clone(),
+                content: content.clone(),
             },
         );
     } else if let AgentEvent::StepManifest {
@@ -355,6 +358,7 @@ pub(crate) fn persist_event(
                         cache_zone: enum_tag(&b.cache_zone),
                         token_cost: b.token_cost,
                         resident_since_step: b.resident_since_step as u64,
+                        message_index: b.message_index as u64,
                     })
                     .collect(),
             },
@@ -485,6 +489,7 @@ mod stream_tests {
             token_cost: 40,
             content_digest: "sha256:abc".into(),
             citation_label: None,
+            content: None,
         };
         assert!(persist_event(&store, id, 0, &registered, "anthropic"));
 
@@ -499,6 +504,7 @@ mod stream_tests {
                 cache_zone: CacheZone::Volatile,
                 token_cost: 40,
                 resident_since_step: 0,
+                message_index: 0,
             }],
             effective_budget_tokens: 136_363,
             calibration_factor: 1.1,
@@ -520,5 +526,93 @@ mod stream_tests {
         assert_eq!(entries[0].block_id, "blk_tool1");
         assert_eq!(entries[0].cache_zone, "volatile");
         assert_eq!(entries[0].token_cost, 40);
+    }
+
+    #[test]
+    fn end_to_end_receipt_reconstructs_the_step_byte_exact_from_the_persisted_store() {
+        // The increment-2 gate: the REAL emitter produces a receipt that, once
+        // persisted, reconstructs byte-exact what the model saw — resolved from
+        // the fold (tool I/O, assistant text) + local gaps (system/user), never
+        // from the emitter's in-memory state. Exercises a full tool round-trip.
+        use stella_core::event_sender::EventSender;
+        use stella_core::receipts::ReceiptLedger;
+        use stella_protocol::{CompletionMessage, MessageRole, ToolCall, ToolOutput, ToolResult};
+
+        let call = ToolCall {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            input: serde_json::json!({ "path": "a.rs" }),
+        };
+        let output = ToolOutput::Ok {
+            content: "fn a() {}".into(),
+        };
+        // The step-1 input: system, user, assistant (text + tool call), result.
+        let original = vec![
+            CompletionMessage::system("you are a careful engineer"),
+            CompletionMessage::user("fix the failing test"),
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: "let me read the file".into(),
+                tool_calls: vec![call.clone()],
+                tool_results: vec![],
+                attachments: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    call_id: "c1".into(),
+                    output: output.clone(),
+                }],
+                attachments: vec![],
+            },
+        ];
+
+        // Drive the REAL emitter + the journal events the driver would emit.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let events = EventSender::new(tx);
+        let _ = events.send(AgentEvent::Text {
+            delta: "let me read the file".into(),
+        });
+        let _ = events.send(AgentEvent::ToolStart { call: call.clone() });
+        let _ = events.send(AgentEvent::ToolResult {
+            call_id: "c1".into(),
+            output: output.clone(),
+            duration_ms: 5,
+            speculated: false,
+        });
+        let mut ledger = ReceiptLedger::new(0);
+        ledger.set_effective_budget(136_363, 1.1);
+        ledger.emit_step_receipt(
+            &original,
+            1,
+            stella_protocol::ModelCallRole::Worker,
+            "anthropic",
+            "opus",
+            &events,
+        );
+        drop(events);
+
+        // Persist the whole stream exactly as the renderer would.
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "fix the failing test", "anthropic", "opus")
+            .expect("exec");
+        let mut seq = 0u64;
+        while let Ok(event) = rx.try_recv() {
+            persist_event(&store, id, seq, &event, "anthropic");
+            seq += 1;
+        }
+
+        // Reconstruct purely from the persisted store, and prove it byte-exact.
+        let recon = store.reconstruct_step(id, 0, 1).expect("reconstruct");
+        assert!(
+            recon.is_verified(),
+            "unresolved={:?} mismatches={:?}",
+            recon.unresolved,
+            recon.digest_mismatches
+        );
+        assert_eq!(recon.messages, original);
     }
 }

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod loop_detect;
 pub mod mcp_usage;
 pub(crate) mod mining;
 pub mod ports;
-pub(crate) mod receipts;
+pub mod receipts;
 pub mod retry;
 pub mod router;
 pub mod rules;

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -74,6 +74,22 @@ fn estimate_tokens(content: &str) -> u32 {
     (content.chars().count() as f64 / CHARS_PER_TOKEN).ceil() as u32
 }
 
+/// Whether a block kind's preimage lives in the event journal (resolved at
+/// reconstruction time) or must be captured locally at emission. Tool I/O and
+/// assistant text ride the journal (`ToolStart`/`ToolResult`/`Text`); the
+/// system prefix and the assembled user/recall/steer/summary messages do not,
+/// so their bytes are carried as local-only block content (spec §5.3).
+fn is_gap_kind(kind: BlockKind) -> bool {
+    matches!(
+        kind,
+        BlockKind::SystemPrefix
+            | BlockKind::UserGoal
+            | BlockKind::RecalledFrame
+            | BlockKind::Steered
+            | BlockKind::Summary
+    )
+}
+
 /// One decomposed context block, before it becomes a manifest entry.
 struct BlockDraft {
     block_id: String,
@@ -82,10 +98,15 @@ struct BlockDraft {
     token_cost: u32,
     call_id: Option<String>,
     cache_zone: CacheZone,
+    /// Which sent `CompletionMessage` this block belonged to — its position in
+    /// the message vector — so reconstruction regroups exactly (spec §5.1).
+    message_index: usize,
+    /// Local-only preimage for gap kinds; `None` for journal-resolvable kinds.
+    content: Option<String>,
 }
 
 impl BlockDraft {
-    fn new(kind: BlockKind, content: &str, call_id: Option<String>) -> Self {
+    fn new(kind: BlockKind, content: &str, call_id: Option<String>, message_index: usize) -> Self {
         BlockDraft {
             block_id: block_id(kind, content),
             kind,
@@ -93,30 +114,39 @@ impl BlockDraft {
             token_cost: estimate_tokens(content),
             call_id,
             cache_zone: CacheZone::Cacheable,
+            message_index,
+            content: is_gap_kind(kind).then(|| content.to_string()),
         }
     }
 }
 
 /// Decompose the live message vector into event-granular blocks, in wire order,
-/// and stamp each a structural cache zone. The zone is a hint at emission — the
-/// system prefix is the stable-cached head (L-E8) and the final message is the
-/// live tail that is recomputed each step; cache attribution (spec §7, A3)
-/// refines these against reported usage.
+/// tagging each with its source message index (for reconstruction regrouping)
+/// and a structural cache zone. The zone is a hint at emission — the system
+/// prefix is the stable-cached head (L-E8) and the final message is the live
+/// tail that is recomputed each step; cache attribution (spec §7, A3) refines
+/// these against reported usage.
 fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
     let mut drafts = Vec::new();
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
         match message.role {
             MessageRole::System => {
                 drafts.push(BlockDraft::new(
                     BlockKind::SystemPrefix,
                     &message.content,
                     None,
+                    message_index,
                 ));
             }
             MessageRole::User => {
                 // The recalled frames live inside this message; splitting them
                 // into per-frame blocks is the memory-join increment (§9).
-                drafts.push(BlockDraft::new(BlockKind::UserGoal, &message.content, None));
+                drafts.push(BlockDraft::new(
+                    BlockKind::UserGoal,
+                    &message.content,
+                    None,
+                    message_index,
+                ));
             }
             MessageRole::Assistant => {
                 if !message.content.is_empty() {
@@ -124,6 +154,7 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
                         BlockKind::AssistantText,
                         &message.content,
                         None,
+                        message_index,
                     ));
                 }
                 for call in &message.tool_calls {
@@ -132,6 +163,7 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
                         BlockKind::ToolCall,
                         &content,
                         Some(call.call_id.clone()),
+                        message_index,
                     ));
                 }
             }
@@ -142,6 +174,7 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
                         BlockKind::ToolResult,
                         &content,
                         Some(result.call_id.clone()),
+                        message_index,
                     ));
                 }
             }
@@ -165,7 +198,10 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
 /// budget the driver computed for the step about to run. Lives on the stack in
 /// `run_turn`, threaded into the model call by reference — the engine holds no
 /// receipt state of its own.
-pub(crate) struct ReceiptLedger {
+///
+/// Public so reconstruction tests and inspect tooling can drive receipt
+/// emission directly against a message vector without standing up a full turn.
+pub struct ReceiptLedger {
     turn_instance: u32,
     first_seen_step: HashMap<String, usize>,
     effective_budget_tokens: u64,
@@ -173,7 +209,7 @@ pub(crate) struct ReceiptLedger {
 }
 
 impl ReceiptLedger {
-    pub(crate) fn new(turn_instance: u32) -> Self {
+    pub fn new(turn_instance: u32) -> Self {
         ReceiptLedger {
             turn_instance,
             first_seen_step: HashMap::new(),
@@ -186,7 +222,7 @@ impl ReceiptLedger {
     /// driver computed for the next step — the values the compaction pass
     /// actually compared against, carried onto the manifest so the receipt's
     /// numbers line up with the decision that was made (#364 item 1).
-    pub(crate) fn set_effective_budget(&mut self, budget_tokens: u64, factor: f64) {
+    pub fn set_effective_budget(&mut self, budget_tokens: u64, factor: f64) {
         self.effective_budget_tokens = budget_tokens;
         self.calibration_factor = factor;
     }
@@ -194,7 +230,7 @@ impl ReceiptLedger {
     /// Emit the receipt for one committed step: a `BlockRegistered` for every
     /// block first seen this step, then the ordered `StepManifest`. Called at
     /// the settled boundary where the served model/provider are known.
-    pub(crate) fn emit_step_receipt(
+    pub fn emit_step_receipt(
         &mut self,
         messages: &[CompletionMessage],
         step: usize,
@@ -215,7 +251,8 @@ impl ReceiptLedger {
                 None => {
                     self.first_seen_step.insert(draft.block_id.clone(), step);
                     // Durable-before-visible: register the block before the
-                    // manifest cites it.
+                    // manifest cites it. Gap kinds carry their local-only bytes
+                    // (spec §5.3); journal-resolvable kinds carry only a digest.
                     let _ = events.send(AgentEvent::BlockRegistered {
                         block_id: draft.block_id.clone(),
                         kind: draft.kind,
@@ -228,6 +265,7 @@ impl ReceiptLedger {
                         token_cost: draft.token_cost,
                         content_digest: draft.content_digest.clone(),
                         citation_label: None,
+                        content: draft.content.clone(),
                     });
                     step
                 }
@@ -237,6 +275,7 @@ impl ReceiptLedger {
                 cache_zone: draft.cache_zone,
                 token_cost: draft.token_cost,
                 resident_since_step,
+                message_index: draft.message_index,
             });
         }
         let _ = events.send(AgentEvent::StepManifest {

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -336,12 +336,19 @@ pub enum AgentEvent {
         superseded: u32,
     },
     /// A context block first became eligible to enter the prompt (spec §4).
-    /// Content-free on the wire: carries a digest + provenance, never the
-    /// payload bytes — the bytes already live in the originating event
-    /// (`ToolResult`, `Text`, …) or, for recalled frames, the local block
-    /// registry. This is the birth record that makes the per-step manifest an
-    /// index over the fold rather than a parallel content store. Additive:
-    /// consumers recorded before receipts existed simply never see it.
+    /// The birth record that makes the per-step manifest an index over the fold.
+    ///
+    /// Digest, not bytes, for the kinds the journal already carries whole
+    /// (`ToolResult`, `ToolCall`/`ToolStart`, assistant `Text`): those preimages
+    /// are resolved from the originating event at reconstruction time, never
+    /// re-stored. For the two kinds the fold does NOT carry — the system prefix
+    /// and the assembled user/recall message — `content` carries the bytes so
+    /// the step is reconstructable (spec §5.3). That content is **local-only**:
+    /// it is stripped by the content-free enterprise export projection and never
+    /// leaves the local journal. So "content-free" means content-free *on
+    /// export*, and content-free *on the wire for journal-resolvable kinds* —
+    /// gap-kind blocks deliberately carry their bytes locally. Additive:
+    /// consumers recorded before receipts existed simply never see this event.
     BlockRegistered {
         /// `blk_<24 hex of sha256(kind \0 content)>`. Byte-identical blocks
         /// share an id, so dedup/supersession become identities not counts.
@@ -355,6 +362,12 @@ pub enum AgentEvent {
         /// Human label for recall frames / memory nodes, when the block has one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         citation_label: Option<String>,
+        /// Local-only preimage for gap kinds the journal cannot resolve (the
+        /// system prefix, the assembled user/recall message). `None` for
+        /// journal-resolvable kinds (tool I/O, assistant text) — those never
+        /// carry bytes here. Redacted by the content-free export projection.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        content: Option<String>,
     },
     /// The ordered receipt of exactly what the model saw on one step (spec §5):
     /// the block sequence sent, in wire order, plus the budget the compaction
@@ -551,6 +564,14 @@ pub struct ManifestEntry {
     pub token_cost: u32,
     /// The step this block first entered a manifest — drives cost-of-carry.
     pub resident_since_step: usize,
+    /// Which `CompletionMessage` this block belonged to, by position in the
+    /// sent sequence. Event-granular blocks (a tool message's several results,
+    /// an assistant message's text + calls) share one `message_index`, so
+    /// reconstruction regroups them back into the exact message boundaries
+    /// rather than inferring them from kinds (spec §5.1). `0` on manifests
+    /// recorded before reconstruction existed.
+    #[serde(default)]
+    pub message_index: usize,
 }
 
 /// One provider's share of a recall's frame mix.
@@ -1219,8 +1240,10 @@ mod tests {
     }
 
     #[test]
-    fn block_registered_roundtrips_and_is_content_free() {
-        let event = AgentEvent::BlockRegistered {
+    fn block_registered_carries_bytes_only_for_gap_kinds() {
+        // Journal-resolvable kinds (tool I/O, assistant text) carry NO content —
+        // their preimage is resolved from the originating event, never re-stored.
+        let tool = AgentEvent::BlockRegistered {
             block_id: "blk_0123456789abcdef01234567".into(),
             kind: BlockKind::ToolResult,
             origin: BlockOrigin {
@@ -1232,21 +1255,42 @@ mod tests {
             token_cost: 480,
             content_digest: "sha256:deadbeef".into(),
             citation_label: None,
+            content: None,
         };
-        let value = serde_json::to_value(&event).unwrap();
+        let value = serde_json::to_value(&tool).unwrap();
         assert_eq!(value["type"], "block_registered");
         assert_eq!(value["kind"], "tool_result");
         assert_eq!(value["origin"]["call_id"], "call_9");
-        // Content-free: the payload bytes never appear, only a digest.
         assert!(
             value.get("content").is_none() && value.get("output").is_none(),
-            "block_registered must not carry payload bytes: {value}"
+            "a journal-resolvable block must not carry payload bytes: {value}"
         );
+
+        // Gap kinds the journal cannot resolve (the system prefix, the assembled
+        // user message) DO carry their bytes — local-only, stripped on export —
+        // so the step stays reconstructable (spec §5.3).
+        let system = AgentEvent::BlockRegistered {
+            block_id: "blk_sys0000000000000000000".into(),
+            kind: BlockKind::SystemPrefix,
+            origin: BlockOrigin {
+                turn_instance: 0,
+                step: 0,
+                call_id: None,
+                memory_id: None,
+            },
+            token_cost: 300,
+            content_digest: "sha256:beef".into(),
+            citation_label: None,
+            content: Some("you are a careful engineer".into()),
+        };
+        let value = serde_json::to_value(&system).unwrap();
+        assert_eq!(value["content"], "you are a careful engineer");
+
         let back: AgentEvent = serde_json::from_str(&value.to_string()).unwrap();
         match back {
-            AgentEvent::BlockRegistered { block_id, kind, .. } => {
-                assert_eq!(block_id, "blk_0123456789abcdef01234567");
-                assert_eq!(kind, BlockKind::ToolResult);
+            AgentEvent::BlockRegistered { kind, content, .. } => {
+                assert_eq!(kind, BlockKind::SystemPrefix);
+                assert_eq!(content.as_deref(), Some("you are a careful engineer"));
             }
             other => panic!("unexpected variant: {other:?}"),
         }
@@ -1266,12 +1310,14 @@ mod tests {
                     cache_zone: CacheZone::StablePrefix,
                     token_cost: 1200,
                     resident_since_step: 0,
+                    message_index: 0,
                 },
                 ManifestEntry {
                     block_id: "blk_tail".into(),
                     cache_zone: CacheZone::Volatile,
                     token_cost: 90,
                     resident_since_step: 3,
+                    message_index: 3,
                 },
             ],
             effective_budget_tokens: 136_363,

--- a/stella-store/src/ddl.rs
+++ b/stella-store/src/ddl.rs
@@ -382,6 +382,7 @@ pub(crate) const CONTEXT_BLOCKS_DDL: &str = "CREATE TABLE IF NOT EXISTS context_
        token_cost INTEGER NOT NULL,
        content_digest TEXT NOT NULL,
        citation_label TEXT,
+       content TEXT,
        first_seen_ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
        PRIMARY KEY (execution_id, block_id)
      );
@@ -403,6 +404,7 @@ pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_mani
        block_id TEXT NOT NULL,
        cache_zone TEXT NOT NULL,
        resident_since_step INTEGER NOT NULL,
+       message_index INTEGER NOT NULL DEFAULT 0,
        PRIMARY KEY (execution_id, turn_instance, step, ordinal)
      );
      CREATE INDEX IF NOT EXISTS step_manifest_by_block

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -103,6 +103,7 @@ mod private_state_tests;
 #[cfg(test)]
 mod quarantine_tests;
 mod receipts;
+mod reconstruct;
 mod telemetry;
 #[cfg(test)]
 mod tests;
@@ -143,6 +144,7 @@ pub(crate) use private::{
     open_private_file, open_private_sqlite, read_private_to_string, write_private_atomic,
 };
 pub use receipts::{ContextBlockRow, ManifestBlockRow, StepManifestRow};
+pub use reconstruct::Reconstruction;
 pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
 pub use telemetry::TelemetryRow;
 

--- a/stella-store/src/migrations.rs
+++ b/stella-store/src/migrations.rs
@@ -28,7 +28,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 11] = [
+pub(crate) const MIGRATIONS: [Migration; 12] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -62,6 +62,11 @@ pub(crate) const MIGRATIONS: [Migration; 11] = [
     // (the manifest header). All purely additive; no existing table changes
     // shape.
     migrate_v10_to_v11,
+    // v11 → v12: reconstruction support — `context_blocks` grows the local-only
+    // `content` column (gap-kind preimages the journal cannot resolve), and
+    // `step_manifest` grows `message_index` (regroups event-granular blocks into
+    // exact messages). Both additive ADD COLUMNs, column-guarded.
+    migrate_v11_to_v12,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -413,6 +418,26 @@ fn migrate_v10_to_v11(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     Ok(())
 }
 
+/// v11 → v12: reconstruction support (spec §5, increment 2). `context_blocks`
+/// grows a nullable local-only `content` column — the preimage of gap kinds the
+/// journal cannot resolve (system prefix, assembled user/recall message);
+/// `step_manifest` grows `message_index` so event-granular blocks regroup into
+/// the exact `CompletionMessage`s that were sent. Both are plain additive
+/// ADD COLUMNs; column-guarded so this is a no-op on a store whose v11 tables
+/// were already created at the v12 shape (fresh files, or a v10→v11 upgrade run
+/// by this build's [`CONTEXT_BLOCKS_DDL`]/[`STEP_MANIFEST_DDL`]).
+fn migrate_v11_to_v12(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !column_exists(tx, "context_blocks", "content")? {
+        tx.execute_batch("ALTER TABLE context_blocks ADD COLUMN content TEXT;")?;
+    }
+    if !column_exists(tx, "step_manifest", "message_index")? {
+        tx.execute_batch(
+            "ALTER TABLE step_manifest ADD COLUMN message_index INTEGER NOT NULL DEFAULT 0;",
+        )?;
+    }
+    Ok(())
+}
+
 /// Run one migration in its own transaction, stamping `user_version` before
 /// commit so version and shape can never disagree on disk. The caller has
 /// already suspended foreign-key enforcement (a no-op inside a
@@ -559,5 +584,35 @@ mod tests {
         conn.execute_batch(CONTEXT_BLOCKS_DDL).expect("pre-grown");
         apply_migration(&mut conn, migrate_v10_to_v11, 11).expect("migrate is idempotent");
         assert!(table_exists(&conn, "step_manifest").unwrap());
+    }
+
+    #[test]
+    fn v12_migration_adds_reconstruction_columns_and_is_idempotent() {
+        // Build v11-shaped receipts tables WITHOUT the v12 columns (the shape a
+        // store created on the increment-1 branch has), then upgrade.
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE context_blocks (
+               execution_id INTEGER NOT NULL, block_id TEXT NOT NULL, kind TEXT NOT NULL,
+               origin_turn INTEGER NOT NULL, origin_step INTEGER NOT NULL, call_id TEXT,
+               memory_id TEXT, token_cost INTEGER NOT NULL, content_digest TEXT NOT NULL,
+               citation_label TEXT, first_seen_ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+               PRIMARY KEY (execution_id, block_id));
+             CREATE TABLE step_manifest (
+               execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL, step INTEGER NOT NULL,
+               ordinal INTEGER NOT NULL, block_id TEXT NOT NULL, cache_zone TEXT NOT NULL,
+               resident_since_step INTEGER NOT NULL,
+               PRIMARY KEY (execution_id, turn_instance, step, ordinal));",
+        )
+        .expect("v11 receipts shape");
+        assert!(!column_exists(&conn, "context_blocks", "content").unwrap());
+
+        apply_migration(&mut conn, migrate_v11_to_v12, 12).expect("migrate");
+        assert!(column_exists(&conn, "context_blocks", "content").unwrap());
+        assert!(column_exists(&conn, "step_manifest", "message_index").unwrap());
+
+        // Idempotent on tables already at the v12 shape (fresh files, or a
+        // v10→v11 upgrade run by this build's DDL).
+        apply_migration(&mut conn, migrate_v11_to_v12, 12).expect("idempotent");
     }
 }

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -23,6 +23,10 @@ pub struct ContextBlockRow {
     pub token_cost: u32,
     pub content_digest: String,
     pub citation_label: Option<String>,
+    /// Local-only preimage for gap kinds the journal cannot resolve (system
+    /// prefix, assembled user/recall message); `None` for journal-resolvable
+    /// kinds (spec §5.3). Never leaves the local store.
+    pub content: Option<String>,
 }
 
 /// One block's membership in a step's manifest (`step_manifest`, spec §5),
@@ -33,6 +37,9 @@ pub struct ManifestBlockRow {
     pub cache_zone: String,
     pub token_cost: u32,
     pub resident_since_step: u64,
+    /// The sent-message this block belonged to; reconstruction regroups blocks
+    /// sharing a `message_index` back into one `CompletionMessage` (spec §5.1).
+    pub message_index: u64,
 }
 
 /// A full per-step manifest: the header (`step_receipt`) plus its ordered
@@ -62,8 +69,8 @@ impl Store {
         self.lock().execute(
             "INSERT OR IGNORE INTO context_blocks
                (execution_id, block_id, kind, origin_turn, origin_step, call_id, memory_id,
-                token_cost, content_digest, citation_label)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                token_cost, content_digest, citation_label, content)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
                 row.block_id,
@@ -75,6 +82,7 @@ impl Store {
                 token_cost,
                 row.content_digest,
                 row.citation_label,
+                row.content,
             ],
         )?;
         Ok(())
@@ -122,11 +130,12 @@ impl Store {
         for (ordinal, block) in row.blocks.iter().enumerate() {
             let ordinal = sqlite_i64("manifest ordinal", ordinal as u64)?;
             let resident = sqlite_i64("manifest residency", block.resident_since_step)?;
+            let message_index = sqlite_i64("manifest message index", block.message_index)?;
             tx.execute(
                 "INSERT INTO step_manifest
                    (execution_id, turn_instance, step, ordinal, block_id, cache_zone,
-                    resident_since_step)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    resident_since_step, message_index)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     execution_id,
                     turn,
@@ -135,6 +144,7 @@ impl Store {
                     block.block_id,
                     block.cache_zone,
                     resident,
+                    message_index,
                 ],
             )?;
         }
@@ -147,7 +157,7 @@ impl Store {
         let conn = self.lock();
         let mut stmt = conn.prepare(
             "SELECT block_id, kind, origin_turn, origin_step, call_id, memory_id,
-                    token_cost, content_digest, citation_label
+                    token_cost, content_digest, citation_label, content
              FROM context_blocks WHERE execution_id = ? ORDER BY rowid",
         )?;
         let rows = stmt
@@ -162,6 +172,7 @@ impl Store {
                     token_cost: r.get::<_, i64>(6)? as u32,
                     content_digest: r.get(7)?,
                     citation_label: r.get(8)?,
+                    content: r.get(9)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -179,7 +190,8 @@ impl Store {
         let step = sqlite_i64("manifest step", step)?;
         let conn = self.lock();
         let mut stmt = conn.prepare(
-            "SELECT sm.block_id, sm.cache_zone, cb.token_cost, sm.resident_since_step
+            "SELECT sm.block_id, sm.cache_zone, cb.token_cost, sm.resident_since_step,
+                    sm.message_index
              FROM step_manifest sm
              LEFT JOIN context_blocks cb
                ON cb.execution_id = sm.execution_id AND cb.block_id = sm.block_id
@@ -196,6 +208,7 @@ impl Store {
                     // surfacing, not crashing on); default 0.
                     token_cost: r.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
                     resident_since_step: r.get::<_, i64>(3)? as u64,
+                    message_index: r.get::<_, i64>(4)? as u64,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -218,6 +231,7 @@ mod tests {
             token_cost: 100 + step as u32,
             content_digest: format!("sha256:{id}"),
             citation_label: None,
+            content: None,
         }
     }
 
@@ -265,12 +279,14 @@ mod tests {
                     cache_zone: "stable_prefix".into(),
                     token_cost: 100,
                     resident_since_step: 0,
+                    message_index: 0,
                 },
                 ManifestBlockRow {
                     block_id: "blk_tail".into(),
                     cache_zone: "volatile".into(),
                     token_cost: 103,
                     resident_since_step: 3,
+                    message_index: 1,
                 },
             ],
         };
@@ -308,6 +324,7 @@ mod tests {
                     cache_zone: "cacheable".into(),
                     token_cost: 1,
                     resident_since_step: 0,
+                    message_index: 0,
                 })
                 .collect(),
         };

--- a/stella-store/src/reconstruct.rs
+++ b/stella-store/src/reconstruct.rs
@@ -1,0 +1,467 @@
+//! Byte-exact step reconstruction (spec §5.1, increment 2). Given a persisted
+//! receipt — the per-step manifest + the block registry — rebuild the exact
+//! `Vec<CompletionMessage>` the model saw on that step, resolving each block's
+//! preimage from the event journal (tool I/O by `call_id`, assistant text by
+//! digest) and, only for the two kinds the fold cannot carry (the system prefix
+//! and the assembled user/recall message), from the block's local-only content.
+//!
+//! This is the payoff of the whole receipts design: proof, after the fact, of
+//! exactly what a model saw — reconstructed from the append-only fold, not from
+//! any live engine state. What makes it *verifiable* rather than merely stored:
+//! every journal-resolved block's recovered bytes are re-hashed and checked
+//! against the digest the receipt recorded, so a torn journal or a fabricated
+//! block surfaces as a mismatch instead of a plausible-looking lie.
+//!
+//! # Reconstructable boundary (clean path only)
+//!
+//! Byte-exact reconstruction holds for the ordinary turn: system prompt, user
+//! goal, assistant text, and real tool round-trips. It does NOT cover blocks
+//! with no journal preimage — budget-abort synthetic tool results and
+//! discarded-speculation results (spec §6.4, deferred) — nor `Attachment`
+//! blocks (not decomposed yet). Those surface in [`Reconstruction::unresolved`]
+//! rather than silently corrupting the output.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+use rusqlite::params;
+use sha2::{Digest, Sha256};
+use stella_protocol::{
+    AgentEvent, CompletionMessage, MessageRole, ToolCall, ToolOutput, ToolResult,
+};
+
+use crate::{Result, Store};
+
+/// The outcome of reconstructing one step: the rebuilt messages plus the honest
+/// accounting of anything the fold could not fully vouch for.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reconstruction {
+    /// The rebuilt message sequence, in wire order.
+    pub messages: Vec<CompletionMessage>,
+    /// Block ids whose preimage could not be resolved from the journal or the
+    /// local gap store — the documented non-reconstructable cases (synthetic
+    /// results, discarded speculation, attachments). Empty on the clean path.
+    pub unresolved: Vec<String>,
+    /// Block ids whose resolved preimage did NOT re-hash to the recorded digest
+    /// — a torn-journal or tampering signal. Empty on the clean path.
+    pub digest_mismatches: Vec<String>,
+}
+
+impl Reconstruction {
+    /// Whether every block resolved and every journal-resolved digest matched —
+    /// the step is a faithful, verified reconstruction of what the model saw.
+    pub fn is_verified(&self) -> bool {
+        self.unresolved.is_empty() && self.digest_mismatches.is_empty()
+    }
+}
+
+/// `sha256` hex of a string (byte-wise; the sha2 0.11 output does not `LowerHex`).
+fn sha256_hex(s: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in h.finalize() {
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// Per-execution preimage index built once from the event journal: tool calls
+/// and outputs by `call_id`, and assistant text keyed by its content digest.
+#[derive(Default)]
+struct JournalPreimages {
+    tool_calls: HashMap<String, ToolCall>,
+    tool_outputs: HashMap<String, ToolOutput>,
+    /// `content_digest` ("sha256:<hex>") → the assistant text bytes.
+    text_by_digest: HashMap<String, String>,
+}
+
+impl Store {
+    /// Reconstruct the exact messages sent on one step from its persisted
+    /// receipt + the event journal. See the module docs for the reconstructable
+    /// boundary; callers should check [`Reconstruction::is_verified`].
+    pub fn reconstruct_step(
+        &self,
+        execution_id: i64,
+        turn_instance: u32,
+        step: u64,
+    ) -> Result<Reconstruction> {
+        let manifest = self.step_manifest(execution_id, turn_instance, step)?;
+        let blocks: HashMap<String, crate::ContextBlockRow> = self
+            .context_blocks(execution_id)?
+            .into_iter()
+            .map(|b| (b.block_id.clone(), b))
+            .collect();
+        let preimages = self.journal_preimages(execution_id)?;
+
+        let mut messages: Vec<CompletionMessage> = Vec::new();
+        let mut unresolved = Vec::new();
+        let mut digest_mismatches = Vec::new();
+        let mut current: Option<u64> = None;
+
+        for entry in &manifest {
+            let Some(block) = blocks.get(&entry.block_id) else {
+                // A manifest cited a block never registered — cannot resolve.
+                unresolved.push(entry.block_id.clone());
+                continue;
+            };
+            let Some(content) = resolve_content(block, &preimages) else {
+                unresolved.push(entry.block_id.clone());
+                continue;
+            };
+            // Verify journal-resolved bytes against the recorded digest. Gap
+            // content is stored locally, so its digest-check is tautological and
+            // deliberately skipped as evidence — the proof lives in the
+            // journal-resolved kinds.
+            if block.content.is_none() {
+                let expected = block
+                    .content_digest
+                    .strip_prefix("sha256:")
+                    .unwrap_or(&block.content_digest);
+                if sha256_hex(&content) != expected {
+                    digest_mismatches.push(entry.block_id.clone());
+                }
+            }
+            // Regroup: a change in message_index starts a new CompletionMessage,
+            // whose role is fixed by the first block that opens it.
+            if current != Some(entry.message_index) {
+                messages.push(empty_message_for(&block.kind));
+                current = Some(entry.message_index);
+            }
+            let message = messages
+                .last_mut()
+                .expect("a message was just pushed for this group");
+            append_block(message, block, &content, &mut unresolved);
+        }
+
+        Ok(Reconstruction {
+            messages,
+            unresolved,
+            digest_mismatches,
+        })
+    }
+
+    /// Index the execution's `tool_start` / `tool_result` / `text` events into a
+    /// preimage lookup. Mirrors [`Store::materialize_tool_calls`]'s read shape.
+    fn journal_preimages(&self, execution_id: i64) -> Result<JournalPreimages> {
+        let payloads: Vec<String> = {
+            let conn = self.lock();
+            let mut stmt = conn.prepare(
+                "SELECT payload FROM events \
+                 WHERE execution_id = ?1 AND event_type IN ('tool_start', 'tool_result', 'text') \
+                 ORDER BY seq ASC",
+            )?;
+            let rows = stmt.query_map(params![execution_id], |row| row.get::<_, String>(0))?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        let mut out = JournalPreimages::default();
+        for payload in &payloads {
+            let Ok(event) = serde_json::from_str::<AgentEvent>(payload) else {
+                continue;
+            };
+            match event {
+                AgentEvent::ToolStart { call } => {
+                    out.tool_calls.insert(call.call_id.clone(), call);
+                }
+                AgentEvent::ToolResult {
+                    call_id, output, ..
+                } => {
+                    out.tool_outputs.insert(call_id, output);
+                }
+                AgentEvent::Text { delta } => {
+                    out.text_by_digest
+                        .insert(format!("sha256:{}", sha256_hex(&delta)), delta);
+                }
+                _ => {}
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Resolve one block's exact content: gap kinds carry it locally; every other
+/// kind is recovered from the journal preimage index. `None` means the fold
+/// does not carry this block's preimage (a documented non-reconstructable case).
+fn resolve_content(block: &crate::ContextBlockRow, preimages: &JournalPreimages) -> Option<String> {
+    if let Some(content) = &block.content {
+        return Some(content.clone());
+    }
+    match block.kind.as_str() {
+        "tool_result" => {
+            let call_id = block.call_id.as_ref()?;
+            let output = preimages.tool_outputs.get(call_id)?;
+            serde_json::to_string(output).ok()
+        }
+        "tool_call" => {
+            let call_id = block.call_id.as_ref()?;
+            let call = preimages.tool_calls.get(call_id)?;
+            serde_json::to_string(call).ok()
+        }
+        "assistant_text" => preimages.text_by_digest.get(&block.content_digest).cloned(),
+        _ => None,
+    }
+}
+
+/// An empty `CompletionMessage` with the role the given block kind opens.
+fn empty_message_for(kind: &str) -> CompletionMessage {
+    let role = match kind {
+        "system_prefix" => MessageRole::System,
+        "user_goal" | "steered" => MessageRole::User,
+        "tool_result" => MessageRole::Tool,
+        // assistant_text, tool_call, summary, and anything else open an
+        // assistant message (the summary is spliced as assistant-authored).
+        _ => MessageRole::Assistant,
+    };
+    CompletionMessage {
+        role,
+        content: String::new(),
+        tool_calls: Vec::new(),
+        tool_results: Vec::new(),
+        attachments: Vec::new(),
+    }
+}
+
+/// Fold one resolved block into the message it belongs to.
+fn append_block(
+    message: &mut CompletionMessage,
+    block: &crate::ContextBlockRow,
+    content: &str,
+    unresolved: &mut Vec<String>,
+) {
+    match block.kind.as_str() {
+        "system_prefix" | "user_goal" | "steered" | "assistant_text" | "summary" => {
+            message.content = content.to_string();
+        }
+        "tool_call" => match serde_json::from_str::<ToolCall>(content) {
+            Ok(call) => message.tool_calls.push(call),
+            Err(_) => unresolved.push(block.block_id.clone()),
+        },
+        "tool_result" => match serde_json::from_str::<ToolOutput>(content) {
+            Ok(output) => message.tool_results.push(ToolResult {
+                call_id: block.call_id.clone().unwrap_or_default(),
+                output,
+            }),
+            Err(_) => unresolved.push(block.block_id.clone()),
+        },
+        _ => unresolved.push(block.block_id.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContextBlockRow, ManifestBlockRow, StepManifestRow};
+
+    fn digest(s: &str) -> String {
+        format!("sha256:{}", sha256_hex(s))
+    }
+
+    fn gap(block_id: &str, kind: &str, mi: u64, content: &str) -> ContextBlockRow {
+        ContextBlockRow {
+            block_id: block_id.into(),
+            kind: kind.into(),
+            origin_turn: 0,
+            origin_step: mi,
+            call_id: None,
+            memory_id: None,
+            token_cost: 10,
+            content_digest: digest(content),
+            citation_label: None,
+            content: Some(content.into()),
+        }
+    }
+
+    fn journal(
+        block_id: &str,
+        kind: &str,
+        call_id: Option<&str>,
+        content: &str,
+    ) -> ContextBlockRow {
+        ContextBlockRow {
+            block_id: block_id.into(),
+            kind: kind.into(),
+            origin_turn: 0,
+            origin_step: 0,
+            call_id: call_id.map(str::to_owned),
+            memory_id: None,
+            token_cost: 10,
+            content_digest: digest(content),
+            citation_label: None,
+            content: None,
+        }
+    }
+
+    fn entry(block_id: &str, mi: u64) -> ManifestBlockRow {
+        ManifestBlockRow {
+            block_id: block_id.into(),
+            cache_zone: "cacheable".into(),
+            token_cost: 10,
+            resident_since_step: 0,
+            message_index: mi,
+        }
+    }
+
+    #[test]
+    fn reconstructs_a_tool_round_trip_byte_exact_and_verified_from_the_fold() {
+        // The step-1 input the model saw: system, user, an assistant tool call,
+        // and its tool result. Exactly the shape a real turn produces.
+        let call = ToolCall {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            input: serde_json::json!({ "path": "a.rs" }),
+        };
+        let output = ToolOutput::Ok {
+            content: "fn a() {}".into(),
+        };
+        let call_json = serde_json::to_string(&call).unwrap();
+        let output_json = serde_json::to_string(&output).unwrap();
+
+        let original = vec![
+            CompletionMessage {
+                role: MessageRole::System,
+                content: "you are careful".into(),
+                tool_calls: vec![],
+                tool_results: vec![],
+                attachments: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::User,
+                content: "fix it".into(),
+                tool_calls: vec![],
+                tool_results: vec![],
+                attachments: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![call.clone()],
+                tool_results: vec![],
+                attachments: vec![],
+            },
+            CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    call_id: "c1".into(),
+                    output: output.clone(),
+                }],
+                attachments: vec![],
+            },
+        ];
+
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("run", "p", "anthropic", "opus")
+            .unwrap();
+
+        // The journal: the events whose preimages the tool blocks resolve from.
+        store
+            .record_event(id, 0, &AgentEvent::ToolStart { call: call.clone() })
+            .unwrap();
+        store
+            .record_event(
+                id,
+                1,
+                &AgentEvent::ToolResult {
+                    call_id: "c1".into(),
+                    output: output.clone(),
+                    duration_ms: 5,
+                    speculated: false,
+                },
+            )
+            .unwrap();
+
+        // The receipt: gap blocks carry local content; tool blocks carry only a
+        // digest and resolve from the journal above.
+        store
+            .record_context_block(id, &gap("blk_sys", "system_prefix", 0, "you are careful"))
+            .unwrap();
+        store
+            .record_context_block(id, &gap("blk_user", "user_goal", 1, "fix it"))
+            .unwrap();
+        store
+            .record_context_block(
+                id,
+                &journal("blk_call", "tool_call", Some("c1"), &call_json),
+            )
+            .unwrap();
+        store
+            .record_context_block(
+                id,
+                &journal("blk_res", "tool_result", Some("c1"), &output_json),
+            )
+            .unwrap();
+
+        store
+            .record_step_manifest(
+                id,
+                &StepManifestRow {
+                    turn_instance: 0,
+                    step: 1,
+                    provider: "anthropic".into(),
+                    model: "opus".into(),
+                    call_role: "worker".into(),
+                    effective_budget_tokens: 100,
+                    calibration_factor: 1.0,
+                    estimated_input_tokens: 40,
+                    blocks: vec![
+                        entry("blk_sys", 0),
+                        entry("blk_user", 1),
+                        entry("blk_call", 2),
+                        entry("blk_res", 3),
+                    ],
+                },
+            )
+            .unwrap();
+
+        let recon = store.reconstruct_step(id, 0, 1).unwrap();
+        assert!(
+            recon.is_verified(),
+            "unresolved={:?} mismatches={:?}",
+            recon.unresolved,
+            recon.digest_mismatches
+        );
+        // Byte-exact via PartialEq (order-independent for ToolCall.input Value).
+        assert_eq!(recon.messages, original);
+    }
+
+    #[test]
+    fn a_block_with_no_journal_preimage_surfaces_as_unresolved_not_a_lie() {
+        // A tool_result block whose ToolResult event is absent (the deferred
+        // synthetic/speculation cases) must be reported, never fabricated.
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "z", "m").unwrap();
+        store
+            .record_context_block(
+                id,
+                &journal(
+                    "blk_orphan",
+                    "tool_result",
+                    Some("missing"),
+                    "{\"ok\":{\"content\":\"x\"}}",
+                ),
+            )
+            .unwrap();
+        store
+            .record_step_manifest(
+                id,
+                &StepManifestRow {
+                    turn_instance: 0,
+                    step: 0,
+                    provider: "z".into(),
+                    model: "m".into(),
+                    call_role: "worker".into(),
+                    effective_budget_tokens: 1,
+                    calibration_factor: 1.0,
+                    estimated_input_tokens: 1,
+                    blocks: vec![entry("blk_orphan", 0)],
+                },
+            )
+            .unwrap();
+
+        let recon = store.reconstruct_step(id, 0, 0).unwrap();
+        assert!(!recon.is_verified());
+        assert_eq!(recon.unresolved, vec!["blk_orphan".to_string()]);
+    }
+}

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -946,9 +946,10 @@ fn skill_usage_records_per_execution_version_rows() {
     // (tool_calls / execution_reflection / reflections) take v7; the
     // session plane (executions.session_id / tasks / pull_requests)
     // takes v8; v9 adds fail-closed call-role/completeness, v10 adds lifecycle
-    // accounting for execution/telemetry rows, and v11 adds the context-receipts
-    // plane (context_blocks / step_manifest / step_receipt).
-    assert_eq!(SCHEMA_VERSION, 11);
+    // accounting for execution/telemetry rows, v11 adds the context-receipts
+    // plane (context_blocks / step_manifest / step_receipt), and v12 adds
+    // reconstruction support (context_blocks.content / step_manifest.message_index).
+    assert_eq!(SCHEMA_VERSION, 12);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
Implements **increment 2** of the session-telemetry-receipts spec (§5.1) — the reconstruction half of Tier A, gated by a byte-exact test. Stacks on increment 1 (#380, merged).

## What this delivers

`Store::reconstruct_step(execution, turn, step)` → the **exact `Vec<CompletionMessage>` the model saw** on that step, rebuilt from the append-only fold — the payoff of the whole receipts design: verifiable proof, after the fact, of exactly what a model saw and could act on.

- **Resolve from the journal, don't re-store.** Tool calls/results resolve from the `tool_start`/`tool_result` events by `call_id`; assistant text resolves from the `text` event by content digest. Nothing is duplicated — this is an index over the fold (invariant §2).
- **Two gaps captured locally.** Only the system prefix and the assembled user/recall message — the kinds the fold genuinely cannot carry — are stored as `BlockRegistered.content` (local-only, stripped on export).
- **Verifiable, not just stored.** Every journal-resolved block's recovered bytes are re-hashed against the digest the receipt recorded. A torn journal or fabricated block surfaces as a `digest_mismatch`, never a plausible-looking lie. Gap-content digest checks are tautological and deliberately excluded as evidence.
- **Exact regrouping.** A new `message_index` on each manifest entry regroups event-granular blocks back into the exact message boundaries, instead of inferring them from kinds (which would merge e.g. a `UserGoal` + a later `Steered` into one message).

## The gate (has teeth)

`end_to_end_receipt_reconstructs_the_step_byte_exact_from_the_persisted_store` drives the **real emitter** + the journal events the driver emits, persists the whole stream via `persist_event`, then reconstructs step 1 **purely from the persisted store** and asserts **byte-exact `PartialEq`** — through a full tool round-trip with assistant text. Plus store-level tests for the DB path and the orphan-block case.

## Honest scope boundary

Byte-exact reconstruction holds for the **clean path** (system, user, assistant text, real tool round-trips). It does **not** cover blocks with no journal preimage — budget-abort synthetic results and discarded-speculation results (spec §6.4, deferred) — nor `Attachment` blocks (not decomposed yet). Those surface in `Reconstruction.unresolved` rather than corrupting output; the controlled gate never hits them, production can.

## Honesty fix to increment 1's claim

Increment 1 advertised `BlockRegistered` as "content-free by construction." That's now precise: **content-free on export**, and **content-free on the wire for journal-resolvable kinds** — gap-kind blocks deliberately carry their bytes locally. The protocol test was rewritten to assert exactly this (a `ToolResult` block carries no content; a `SystemPrefix` block does), rather than coincidentally passing on a no-content example.

## Layers (one commit each)

| Layer | Change |
| --- | --- |
| `stella-protocol` | `ManifestEntry.message_index`; `BlockRegistered.content` (Option, gap-only); honest content-free test |
| `stella-store` | schema **v11→v12** (column-guarded ALTERs); `reconstruct.rs` |
| `stella-core` | `decompose` tags message_index + captures gap content; `ReceiptLedger` made `pub` |
| `stella-cli` | persistence stores the new fields; the end-to-end byte-exact gate |

## Verification

Full workspace **build + test + clippy + fmt green** on top of current `main` (post-#380 squash + #381–#387). Additive: schema v11→v12 is column-guarded so it composes with a v11-created store; new event fields are `serde(default)`.