### PR TITLE
fix(model): treat clean stream EOF without a terminal event as a retryable disconnect

### DIFF
--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -350,8 +350,8 @@ fn attachment_blocks(message: &CompletionMessage) -> Vec<AnthropicContentBlock> 
 /// Streamed SSE payloads from the Messages API's `content_block_delta`
 /// events. Anthropic's stream sends several event *types*
 /// (`message_start`, `content_block_start`, `content_block_delta`,
-/// `message_delta`, `message_stop`); this adapter only needs to aggregate
-/// text deltas and the final usage block.
+/// `message_delta`, `message_stop`); this adapter aggregates text deltas
+/// and the final usage block, and requires the terminal `message_stop`.
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AnthropicStreamEvent {
@@ -388,6 +388,12 @@ enum AnthropicStreamEvent {
         delta: AnthropicMessageDeltaBody,
         usage: Option<AnthropicUsage>,
     },
+    /// The stream's terminal event — the Messages API always ends a healthy
+    /// stream with it. Modeled explicitly (not left to `Other`) because its
+    /// absence at EOF is the only evidence that a *clean* connection close
+    /// (close-delimited proxies, LB idle-reaps) cut the message short.
+    #[serde(rename = "message_stop")]
+    MessageStop,
     /// A mid-stream error event. The Messages API can send
     /// `event: error` / `data: {"type":"error","error":{...}}` after already
     /// streaming content — modeled explicitly so it aborts the turn with a
@@ -795,6 +801,7 @@ async fn aggregate_anthropic_stream(
     // sequentially, so only this block can have been cut off by the token
     // limit — a later block starting proves every earlier one closed.
     let mut last_block_index: Option<usize> = None;
+    let mut message_stop_seen = false;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = http::next_with_timeout(&mut stream, http::STREAM_IDLE_TIMEOUT).await? {
@@ -897,6 +904,9 @@ async fn aggregate_anthropic_stream(
                         usage.output_tokens = u.output_tokens;
                     }
                 }
+                Ok(AnthropicStreamEvent::MessageStop) => {
+                    message_stop_seen = true;
+                }
                 Ok(_) => {}
                 Err(_) => {
                     // Unrecognized event shape (e.g. ping/ack events with no
@@ -904,6 +914,18 @@ async fn aggregate_anthropic_stream(
                 }
             }
         }
+    }
+
+    // EOF without `message_stop` is a disconnect, not a completion — and
+    // nothing accumulated from a cut stream (text, stop_reason, tool
+    // fragments) is trustworthy enough to classify further. Retryable
+    // Transport, upholding the same "never a truncated Ok" promise as the
+    // in-stream error path above.
+    if !message_stop_seen {
+        return Err(http::stream_ended_before_terminal(
+            "Anthropic",
+            "message_stop",
+        ));
     }
 
     // The one content block the token limit could have cut: the last block

--- a/stella-model/src/anthropic/tests.rs
+++ b/stella-model/src/anthropic/tests.rs
@@ -117,7 +117,9 @@ async fn complete_reassembles_a_large_multi_fragment_tool_call() {
     }
     body.push_str(
             "event: message_delta\n\
-             data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":15}}\n\n",
+             data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":15}}\n\n\
+             event: message_stop\n\
+             data: {\"type\":\"message_stop\"}\n\n",
         );
 
     Mock::given(method("POST"))
@@ -169,6 +171,8 @@ async fn complete_surfaces_a_truncated_tool_call_instead_of_silent_null() {
         "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README.md\\\",\\\"content\\\":\\\"# Title\\\\nlots of\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -222,6 +226,8 @@ async fn malformed_but_complete_tool_json_falls_back_to_the_null_repair_sentinel
         "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\": not json,}\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":40}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -259,6 +265,8 @@ async fn a_tool_call_with_no_arguments_cut_at_max_tokens_is_terminal() {
         "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"write_file\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -307,6 +315,8 @@ async fn truncation_is_blamed_on_the_call_that_was_cut_not_an_earlier_broken_one
         "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"README\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":8192}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -552,6 +562,8 @@ async fn fable5_sends_adaptive_shape_and_drops_budget_tokens_and_sampling() {
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"OK\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -607,6 +619,8 @@ async fn legacy_model_still_sends_budget_tokens_and_no_output_config() {
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"OK\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -656,6 +670,8 @@ async fn complete_streams_and_aggregates_text_deltas_from_a_mock_server() {
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"lo!\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":12,\"output_tokens\":2}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
 
     Mock::given(method("POST"))
@@ -708,6 +724,8 @@ async fn complete_reports_cache_write_tokens_from_the_usage_envelope() {
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":7}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -752,6 +770,8 @@ async fn complete_reassembles_a_streamed_tool_use_block() {
         "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"src/lib.rs\\\"}\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":15}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
 
     Mock::given(method("POST"))
@@ -826,6 +846,8 @@ async fn complete_observed_streams_answer_deltas_in_order_never_thinking() {
         "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel\"}}\n\n",
         "event: content_block_delta\n",
         "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"lo!\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -880,6 +902,8 @@ async fn complete_observed_announces_a_tool_call_at_its_block_stop() {
         "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\"}}\n\n",
         "event: content_block_delta\n",
         "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"reading it now\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -931,6 +955,8 @@ async fn complete_observed_never_announces_a_block_whose_json_is_broken() {
         "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\": not json,}\"}}\n\n",
         "event: content_block_stop\n",
         "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -1132,6 +1158,8 @@ async fn complete_computes_nonzero_cost_from_catalog_pricing() {
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
         "event: message_delta\n",
         "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":500}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -1173,6 +1201,8 @@ async fn complete_forwards_temperature_to_the_request_body() {
     let sse_body = concat!(
         "event: content_block_delta\n",
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
     );
     // Legacy models accept sampling params; the mock only matches if the
     // serialized body carries the temperature — proving it isn't dropped on
@@ -1263,6 +1293,51 @@ async fn complete_returns_err_on_mid_stream_error_event_not_truncated_ok() {
     assert!(err.is_retryable());
 }
 
+/// The clean-EOF twin of the test above: a well-formed stream that simply
+/// ENDS without `message_stop` (close-delimited HTTP/1.1 proxies, local
+/// gateways, and LB idle-reaps surface a dropped connection as clean EOF,
+/// not a reqwest error) must fail as a retryable Transport disconnect —
+/// never commit the partial "Hel" as a successful completion.
+#[tokio::test]
+async fn complete_returns_transport_err_on_clean_eof_without_message_stop() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel\"}}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":12,\"output_tokens\":2}}\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+        .with_base_url(server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let err = provider.complete(req).await.unwrap_err();
+    assert!(
+        matches!(err, ProviderError::Transport(_)),
+        "expected Transport, got {err:?}"
+    );
+    assert!(err.is_retryable(), "a disconnect must be retryable");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("message_stop"),
+        "names the missing terminal event: {msg}"
+    );
+}
+
 #[test]
 fn thinking_budgets_map_effort_tiers_and_default_to_medium() {
     use stella_protocol::ReasoningEffort::*;
@@ -1278,6 +1353,8 @@ fn thinking_budgets_map_effort_tiers_and_default_to_medium() {
 const OK_SSE: &str = concat!(
     "event: content_block_delta\n",
     "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+    "event: message_stop\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
 );
 
 async fn mock_ok(server: &MockServer) {

--- a/stella-model/src/http.rs
+++ b/stella-model/src/http.rs
@@ -270,6 +270,19 @@ pub(crate) fn truncated_tool_input_error(
     ))
 }
 
+/// Build the retryable error for a stream that reached EOF without its
+/// protocol's terminal event (`terminal_event` names it: `message_stop`,
+/// `response.completed`, `[DONE]`). A clean EOF is how close-delimited
+/// HTTP/1.1 proxies, local gateways, and idle-reaping load balancers surface
+/// a dropped connection — whatever accumulated is a half-answer, so it must
+/// never be committed as a successful completion. Shared by every streaming
+/// adapter so the disconnect classifies as retryable `Transport` uniformly.
+pub(crate) fn stream_ended_before_terminal(provider: &str, terminal_event: &str) -> ProviderError {
+    ProviderError::Transport(format!(
+        "{provider} stream ended before {terminal_event} — connection closed mid-response"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/stella-model/src/openai.rs
+++ b/stella-model/src/openai.rs
@@ -586,6 +586,7 @@ async fn aggregate_openai_stream(
     let mut text = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_calls: BTreeMap<usize, ToolCallAccumulator> = BTreeMap::new();
+    let mut completed_seen = false;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = http::next_with_timeout(&mut stream, http::STREAM_IDLE_TIMEOUT).await? {
@@ -623,6 +624,7 @@ async fn aggregate_openai_stream(
                         .push_str(&delta);
                 }
                 OpenAiStreamEvent::Completed { response } => {
+                    completed_seen = true;
                     if let Some(u) = response.usage {
                         usage.reported = true;
                         usage.input_tokens = u.input_tokens;
@@ -658,6 +660,17 @@ async fn aggregate_openai_stream(
                 OpenAiStreamEvent::Other => {}
             }
         }
+    }
+
+    // EOF without `response.completed` (and without the failed/incomplete/
+    // error events handled above) is a disconnect, not a completion —
+    // whatever accumulated is a half-answer. Retryable Transport, upholding
+    // the same "never a truncated Ok" promise as the mid-stream error paths.
+    if !completed_seen {
+        return Err(http::stream_ended_before_terminal(
+            "OpenAI",
+            "response.completed",
+        ));
     }
 
     let tool_calls = tool_calls
@@ -1285,6 +1298,50 @@ mod tests {
             ProviderError::Terminal(msg) => assert!(msg.contains("max_output_tokens"), "{msg}"),
             other => panic!("expected Terminal incomplete error, got {other:?}"),
         }
+    }
+
+    /// The clean-EOF twin of the tests above: a well-formed stream that
+    /// simply ENDS without `response.completed` (close-delimited proxies,
+    /// LM-Studio-style local gateways, LB idle-reaps surface a dropped
+    /// connection as clean EOF, not a reqwest error) must fail as a
+    /// retryable Transport disconnect — never commit the partial "Hel" as a
+    /// successful completion.
+    #[tokio::test]
+    async fn complete_returns_transport_err_on_clean_eof_without_completed() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let provider =
+            OpenAiProvider::new(ApiKey::new("sk-test"), "gpt-5.5").with_base_url(server.uri());
+        let req = CompletionRequest {
+            messages: vec![CompletionMessage::user("hi")],
+            max_output_tokens: None,
+            temperature: None,
+            effort: None,
+            tools: vec![],
+            reasoning: None,
+            params: None,
+        };
+
+        let err = provider.complete(req).await.unwrap_err();
+        assert!(
+            matches!(err, ProviderError::Transport(_)),
+            "expected Transport, got {err:?}"
+        );
+        assert!(err.is_retryable(), "a disconnect must be retryable");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("response.completed"),
+            "names the missing terminal event: {msg}"
+        );
     }
 
     /// Minimal happy-path SSE body for tests that only inspect the request.

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -1146,7 +1146,16 @@ async fn aggregate_zai_stream(
         }
     }
 
-    usage.reported = usage_seen && terminal_seen;
+    // EOF without the `[DONE]` sentinel is a disconnect, not a completion —
+    // whatever accumulated is a half-answer, and even a `finish_reason` seen
+    // earlier can't prove the stream wasn't cut after it. Retryable
+    // Transport, upholding the same "never a truncated Ok" promise as the
+    // mid-stream error-frame path above.
+    if !terminal_seen {
+        return Err(http::stream_ended_before_terminal(label, "[DONE]"));
+    }
+
+    usage.reported = usage_seen;
 
     // OpenAI-style tool calls stream sequentially by index, so when the
     // stream reports `finish_reason: "length"` only the highest-index call

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -840,6 +840,50 @@ async fn complete_returns_err_on_mid_stream_error_frame_not_truncated_ok() {
     assert!(err.is_retryable());
 }
 
+/// The clean-EOF twin of the test above: a well-formed stream that simply
+/// ENDS without the `[DONE]` sentinel (close-delimited HTTP/1.1 proxies,
+/// LM-Studio-style local gateways, and LB idle-reaps surface a dropped
+/// connection as clean EOF, not a reqwest error) must fail as a retryable
+/// Transport disconnect — never commit the partial "Hel" as a successful
+/// completion, even when a usage frame already arrived.
+#[tokio::test]
+async fn complete_returns_transport_err_on_clean_eof_without_done() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{}}],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":3}}\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider =
+        ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+
+    let err = provider.complete(req).await.unwrap_err();
+    assert!(
+        matches!(err, ProviderError::Transport(_)),
+        "expected Transport, got {err:?}"
+    );
+    assert!(err.is_retryable(), "a disconnect must be retryable");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("[DONE]"),
+        "names the missing terminal sentinel: {msg}"
+    );
+}
+
 /// Minimal happy-path SSE body for tests that only inspect the request.
 const OK_SSE: &str = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n";
 


### PR DESCRIPTION
## Behavior change

The streaming aggregators in all three adapters looped until EOF and committed whatever text/tool-call fragments had accumulated. A mid-stream disconnect surfacing as a reqwest error was already a retryable `Transport`, but a **clean early EOF** (close-delimited HTTP/1.1 proxies, LM-Studio-style local gateways, LB idle-reaps) returned a half-answer as `Ok` with `finish_reason: None` — which the driver committed as `TurnOutcome::Completed` with no truncation warning, breaking the in-stream error path's "never a truncated Ok" promise.

Each aggregation loop now tracks whether its protocol's terminal stream event arrived; EOF without one returns `ProviderError::Transport` (retryable) via a new shared `http::stream_ended_before_terminal(provider, terminal_event)` helper, so the existing retry machinery treats it as the disconnect it is:

- `stella-model/src/anthropic.rs` — requires `message_stop`, now modeled as an explicit `AnthropicStreamEvent::MessageStop` variant instead of falling into `Other`
- `stella-model/src/openai.rs` — requires `response.completed` (the `failed`/`incomplete`/`error` events already abort in-stream, unchanged)
- `stella-model/src/zai.rs` — requires the `[DONE]` sentinel (`terminal_seen` was already tracked for usage accounting; `usage.reported = usage_seen && terminal_seen` simplifies to `usage_seen` past the new early return)

In-stream error-event handling and the idle-timeout path are untouched. The EOF check runs before tool-call assembly: a cut stream's accumulated `stop_reason`/tool fragments are not trustworthy enough to justify a non-retryable Terminal classification.

## Tests

- `anthropic::tests::complete_returns_transport_err_on_clean_eof_without_message_stop` (new)
- `openai::tests::complete_returns_transport_err_on_clean_eof_without_completed` (new)
- `zai::tests::complete_returns_transport_err_on_clean_eof_without_done` (new)
- Existing anthropic fixtures gained the `message_stop` event the real API always sends (they previously ended at `message_delta`); zai/openai fixtures were already protocol-complete and are unchanged.

Verified the new anthropic/zai tests FAIL against the unfixed aggregators (stashed source, reran); the openai test is inline with its source so it could not be run pre-fix, but it is structurally identical.

`CARGO_BUILD_JOBS=2 cargo test -p stella-model -- --test-threads=2`: 247 passed, 0 failed.
`CARGO_BUILD_JOBS=2 cargo clippy -p stella-model --all-targets -- -D warnings`: clean.

Fixes #362
