### PR TITLE
fix(media): unbreak main — restore journal init-race helpers dropped by #390/#391 merge collision

### DIFF
--- a/stella-media/src/operation_journal.rs
+++ b/stella-media/src/operation_journal.rs
@@ -376,6 +376,24 @@ impl MediaOperationJournal for SqliteMediaOperationJournal {
     }
 }
 
+/// Attempts a losing first-open racer retries before giving up, and the
+/// pause between them. A concurrent first-open can momentarily expose the
+/// winner's freshly created WAL sidecars to the loser's security validation;
+/// retrying from scratch lets the loser re-run its preparation against the
+/// now-settled sidecars instead of failing closed on the transient overlap.
+const INIT_RETRY_ATTEMPTS: u32 = 40;
+const INIT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// Marker embedded in the sidecar-injection defense's error message so a
+/// first-open race can be told apart from a genuine untrusted injection.
+const SIDECAR_APPEARED: &str = "appeared after secure preparation";
+
+/// Whether `error` is the benign first-open sidecar race (a concurrent
+/// initializer's WAL files appearing mid-preparation), not a real injection.
+fn is_sidecar_race(error: &MediaError) -> bool {
+    matches!(error, MediaError::Artifact(message) if message.contains(SIDECAR_APPEARED))
+}
+
 /// Runs the idempotent first-open statements, absorbing `SQLITE_BUSY`.
 ///
 /// Converting a fresh rollback-journal database into WAL needs an exclusive


### PR DESCRIPTION
## Urgent: `main` does not compile

PRs #390 and #391 **both** fixed the concurrent first-open journal race (#385), branched from the same base, and merged one after the other. The text-level merge succeeded with no conflict markers but produced a **non-compiling `main`**: `stella-media/src/operation_journal.rs` references four symbols #390 introduced whose definitions landed in a region #391 rewrote, so they were dropped in the merge.

```
error[E0425]: cannot find value `INIT_RETRY_ATTEMPTS` in this scope
error[E0425]: cannot find value `INIT_RETRY_DELAY` in this scope
error[E0425]: cannot find value `SIDECAR_APPEARED` in this scope
error[E0425]: cannot find function `is_sidecar_race` in this scope
```

Because CI builds every PR merged against `main`, this reddens CI on **all** open PRs (e.g. #394, #395) — not a defect in any of them.

## Fix

Restore the four dropped definitions. The two fixes are complementary and now coexist:
- **`open_private`** retries the security **sidecar-validation race** — a losing first-opener transiently observing the winner's freshly created WAL sidecars mid-preparation (#390's contribution).
- **`init` → `initialize_journal_database`** retries **`SQLITE_BUSY`** during the rollback→WAL conversion, which SQLite's busy handler deliberately skips (#391's contribution).

`is_sidecar_race` matches the `MediaError::Artifact` message the sidecar-injection defense emits (`… appeared after secure preparation …`), so a benign race is told apart from a genuine untrusted injection.

## Verification

- `cargo clippy -p stella-media --all-targets -- -D warnings` — clean
- `cargo test -p stella-media` — **116 passed, 0 failed**
- `concurrent_first_open_initializes_one_private_journal` — **15/15** in a loop

Not marked draft — this should land ahead of the other open PRs to green CI.
