### PR TITLE
fix(media): restore journal-init symbols dropped in the #390/#391 merge (main does not compile)

### DIFF
--- a/stella-media/src/operation_journal.rs
+++ b/stella-media/src/operation_journal.rs
@@ -486,6 +486,25 @@ fn journal_error(message: impl Into<String>) -> MediaError {
     MediaError::Artifact(message.into())
 }
 
+/// How many times [`OperationJournal::open_private`] retries when it loses the
+/// first-open sidecar race — a concurrent initializer's freshly created WAL
+/// sidecars appearing between this open's secure preparation and validation.
+const INIT_RETRY_ATTEMPTS: u32 = 40;
+/// Backoff between those retries.
+const INIT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
+/// The validation-failure phrase [`PreparedSidecar::validate`] emits when a
+/// sidecar appears after preparation; [`is_sidecar_race`] keys the retry on it.
+const SIDECAR_APPEARED: &str = "appeared after secure preparation";
+
+/// Whether an open failed because a concurrent first-open's sidecars appeared
+/// mid-preparation (the recoverable race) rather than a genuine untrusted
+/// injection (which must still fail closed). Restored with its three constants
+/// after the #390/#391 merge dropped their definitions while leaving
+/// `open_private`'s references to them (main did not compile).
+fn is_sidecar_race(error: &MediaError) -> bool {
+    matches!(error, MediaError::Artifact(message) if message.contains(SIDECAR_APPEARED))
+}
+
 struct PreparedPrivateSqlite {
     path: PathBuf,
     #[cfg(unix)]


### PR DESCRIPTION
## P0 — `main` does not compile

`stella-media/src/operation_journal.rs` references four symbols that are **defined nowhere** on `main`, so `cargo build --workspace` fails with four `E0425` errors:

```
error[E0425]: cannot find value `INIT_RETRY_ATTEMPTS` in this scope
error[E0425]: cannot find value `INIT_RETRY_DELAY` in this scope
error[E0425]: cannot find value `SIDECAR_APPEARED` in this scope
error[E0425]: cannot find function `is_sidecar_race` in this scope
```

## Root cause

Two PRs fixed **different** first-open journal races and their merge dropped one's definitions:

- **#390** added `open_private`'s *sidecar-injection-race* retry, defining `INIT_RETRY_ATTEMPTS` / `INIT_RETRY_DELAY` / `SIDECAR_APPEARED` / `is_sidecar_race`.
- **#391** (merged second) fixed the *SQLITE_BUSY* first-open race with its own local `BUSY_ATTEMPTS` / `is_transient_lock_error`, and in doing so **removed** #390's four definitions — but `open_private` (lines 140–142) and `PreparedSidecar::validate` (line 580) still reference them.

The conflict resolution kept #391's approach for its loop but left #390's references orphaned.

## Fix

Restore the four definitions verbatim (they belong to `open_private`'s sidecar-race loop, which is still present and correct). #391's SQLITE_BUSY retry is untouched — the two loops handle distinct races and don't share state.

## Verification

`cargo build --workspace` finishes clean; **115 stella-media tests green** (including the sidecar-race security tests that pin `open_private`'s behavior). No other crate changed.

Found while rebasing unrelated work onto current `main`.