### PR TITLE
fix(core): harden the overflow summarizer's failure paths

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -389,6 +389,9 @@ impl<'a> Engine<'a> {
         // by reference into each model call. Stack-local — the engine holds no
         // receipt state of its own.
         let mut receipts = ReceiptLedger::new(self.config.turn_instance);
+        // Per-turn overflow-summarizer latch: stops a persistently failing
+        // cheap summarizer re-firing every step for the rest of the turn.
+        let mut summarizer_health = SummarizerHealth::default();
 
         for step in 0..self.config.max_steps {
             // Pause parks HERE — after the previous step fully settled and
@@ -422,7 +425,13 @@ impl<'a> Engine<'a> {
                 return aborted;
             }
             total_cost_usd += self
-                .run_compaction_pass(messages, calibration_model.as_deref(), budget, events)
+                .run_compaction_pass(
+                    messages,
+                    calibration_model.as_deref(),
+                    budget,
+                    &mut summarizer_health,
+                    events,
+                )
                 .await;
             // The manifest reports the budget compaction just compared against.
             let (effective_budget, calibration_factor) =
@@ -520,6 +529,7 @@ impl<'a> Engine<'a> {
         messages: &mut Vec<CompletionMessage>,
         calibration_model: Option<&str>,
         budget: &mut BudgetGuard,
+        health: &mut SummarizerHealth,
         events: &EventSender,
     ) -> f64 {
         let (compaction_budget, _factor) = self.effective_compaction_budget(calibration_model);
@@ -541,7 +551,9 @@ impl<'a> Engine<'a> {
         if self.config.summarize_overflow
             && crate::estimator::estimate_conversation_tokens(messages) > compaction_budget
         {
-            return self.summarize_overflow_span(messages, budget, events).await;
+            return self
+                .summarize_overflow_span(messages, budget, health, events)
+                .await;
         }
         0.0
     }
@@ -552,6 +564,7 @@ impl<'a> Engine<'a> {
         &self,
         messages: &mut Vec<CompletionMessage>,
         budget: &mut BudgetGuard,
+        health: &mut SummarizerHealth,
         events: &EventSender,
     ) -> f64 {
         let before_tokens = crate::estimator::estimate_conversation_tokens(messages);
@@ -584,6 +597,13 @@ impl<'a> Engine<'a> {
         if end <= start || end - start < 4 {
             return 0.0;
         }
+        // Give-up latch: once the summarizer has failed this many steps in a
+        // row this turn, stop re-firing it — each attempt is a completion and
+        // its latency. The next model call overflows and surfaces one clear
+        // failure instead of one per remaining step.
+        if health.is_latched() {
+            return 0.0;
+        }
         let rendered = crate::summarize::render_span_for_summary(&messages[start..end]);
         let request = CompletionRequest {
             messages: vec![
@@ -604,7 +624,10 @@ impl<'a> Engine<'a> {
                 role: stella_protocol::ModelCallRole::Summarization,
                 model_hint: "unknown".into(),
                 request,
-                retry_policy: RetryPolicy::deterministic(),
+                // The last line of defense before a terminal context
+                // overflow — a transient blip here must be retried, not
+                // fast-failed into an oversized, doomed next call.
+                retry_policy: RetryPolicy::standard(),
                 timeout: None,
                 estimated_input_tokens,
             },
@@ -615,18 +638,73 @@ impl<'a> Engine<'a> {
         .await
         {
             Ok(result) => result,
-            Err(AccountedCallError::Budget { result, .. }) => return result.cost_usd,
-            Err(AccountedCallError::Provider(_) | AccountedCallError::Timeout) => return 0.0,
+            // The summary was generated and paid for before the budget
+            // tripped. Splicing it in only shrinks the context the resumed
+            // session reloads, so apply it rather than discard the spend.
+            Err(AccountedCallError::Budget { result, .. }) => {
+                let text = result.text.trim();
+                if !text.is_empty() {
+                    self.apply_overflow_summary(messages, start, end, before_tokens, text, events);
+                }
+                return result.cost_usd;
+            }
+            // A silent 0.0 hid a failing summarizer that re-fired every step
+            // until the provider hard-failed. Surface it and count it toward
+            // the give-up latch.
+            Err(AccountedCallError::Provider(e)) => {
+                health.record_failure();
+                let _ = events.send(AgentEvent::Error {
+                    message: format!("overflow summarizer failed ({e}); context left intact"),
+                    retryable: true,
+                });
+                return 0.0;
+            }
+            Err(AccountedCallError::Timeout) => {
+                health.record_failure();
+                let _ = events.send(AgentEvent::Error {
+                    message: "overflow summarizer timed out; context left intact".to_string(),
+                    retryable: true,
+                });
+                return 0.0;
+            }
         };
         let cost_usd = result.cost_usd;
-        if result.text.trim().is_empty() {
+        let text = result.text.trim();
+        if text.is_empty() {
+            // An empty summary shrinks nothing, so the next step re-fires on
+            // the same span — the same non-progress the error paths latch
+            // against, and just as invisible if left unannounced.
+            health.record_failure();
+            let _ = events.send(AgentEvent::Error {
+                message: "overflow summarizer returned an empty summary; context left intact"
+                    .to_string(),
+                retryable: true,
+            });
             return cost_usd;
         }
+        health.reset();
+        self.apply_overflow_summary(messages, start, end, before_tokens, text, events);
+        cost_usd
+    }
+
+    /// Splice `text` (trimmed, non-empty) over `messages[start..end]` as the
+    /// overflow summary and announce the resulting shrink. Shared by the
+    /// normal path and the budget-abort path: a paid summary is applied even
+    /// when the turn is about to abort, since it only shrinks the context the
+    /// resumed session reloads.
+    fn apply_overflow_summary(
+        &self,
+        messages: &mut Vec<CompletionMessage>,
+        start: usize,
+        end: usize,
+        before_tokens: u64,
+        text: &str,
+        events: &EventSender,
+    ) {
         let replaced = end - start;
         let summary = CompletionMessage::user(format!(
             "{SUMMARY_MARKER_PREFIX} to fit context — full detail was compacted away; \
-             re-read files or re-run tools for specifics]\n\n{}",
-            result.text.trim()
+             re-read files or re-run tools for specifics]\n\n{text}"
         ));
         messages.splice(start..end, std::iter::once(summary));
         let _ = events.send(AgentEvent::Compaction {
@@ -638,7 +716,6 @@ impl<'a> Engine<'a> {
             aged: 0,
             summarized: replaced,
         });
-        cost_usd
     }
 
     /// Loop detection, before spending a model call on a step that's
@@ -1384,6 +1461,37 @@ impl Drop for CancelUsageGuard {
 /// the marker is User-role on the wire, but it is NOT a real user turn and
 /// must not act as a loop-detection window boundary.
 const SUMMARY_MARKER_PREFIX: &str = "[earlier history summarized";
+
+/// Consecutive overflow-summarizer failures this turn that trip the give-up
+/// latch ([`SummarizerHealth`]). Each failed attempt is a wasted completion
+/// and its latency; past this many in a row the pass stops re-firing and
+/// lets the next model call surface one clear overflow instead of N.
+const SUMMARIZER_FAILURE_LATCH: u32 = 2;
+
+/// Per-turn health of the overflow summarizer. A cheap summarizer model that
+/// keeps erroring, timing out, or returning nothing must not re-fire every
+/// remaining step of the turn: this latches after
+/// [`SUMMARIZER_FAILURE_LATCH`] consecutive non-progress results, and a
+/// successful splice clears it. Stack-local to [`Engine::run_turn`] — the
+/// engine holds no summarizer state of its own, so the latch is per-turn.
+#[derive(Default)]
+struct SummarizerHealth {
+    consecutive_failures: u32,
+}
+
+impl SummarizerHealth {
+    fn record_failure(&mut self) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
+
+    fn reset(&mut self) {
+        self.consecutive_failures = 0;
+    }
+
+    fn is_latched(&self) -> bool {
+        self.consecutive_failures >= SUMMARIZER_FAILURE_LATCH
+    }
+}
 
 /// Flatten the tool calls of the CURRENT turn — assistant messages after
 /// the last user message — in chronological order, for

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -322,3 +322,198 @@ async fn hard_cancel_mid_stream_emits_a_cancelled_usage_envelope() {
         "the envelope must stay content-free: {wire}"
     );
 }
+
+/// A conversation whose oldest span (after the task statement, before the
+/// kept tail) is a summarizable ≥4-message run — the input every direct
+/// `summarize_overflow_span` witness below needs.
+fn overflow_messages() -> Vec<CompletionMessage> {
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    for i in 0..8 {
+        messages.push(big_assistant_text(&format!("t{i}")));
+    }
+    messages
+}
+
+fn summary_markers(messages: &[CompletionMessage]) -> usize {
+    messages
+        .iter()
+        .filter(|m| m.content.starts_with(SUMMARY_MARKER_PREFIX))
+        .count()
+}
+
+/// #368.2: the summarizer is the last line of defense before a terminal
+/// context overflow, so a transient blip must be retried (standard policy),
+/// not fast-failed (deterministic policy, which discarded the recovery).
+#[tokio::test]
+async fn overflow_summarizer_retries_a_transient_error() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Err(ProviderError::Transport("429 blip".into())),
+            Ok(text_result("SUMMARY")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let calls = provider.calls.clone();
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let mut messages = overflow_messages();
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let mut health = SummarizerHealth::default();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    let cost = engine
+        .summarize_overflow_span(&mut messages, &mut budget, &mut health, &events)
+        .await;
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "the transient error must be retried, not fast-failed"
+    );
+    assert!(cost > 0.0, "the successful retry is paid for: {cost}");
+    assert_eq!(
+        summary_markers(&messages),
+        1,
+        "the summary lands after the retry"
+    );
+    assert_eq!(health.consecutive_failures, 0, "a success clears the latch");
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, AgentEvent::Error { .. })),
+        "a recovered blip surfaces no failure: {events:?}"
+    );
+}
+
+/// #368.3: a summary generated and paid for right as the budget trips must
+/// still be spliced in — applying it only shrinks the context the resumed
+/// session reloads. Discarding it lost paid work for no benefit.
+#[tokio::test]
+async fn budget_aborted_summary_is_applied_not_discarded() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("SUMMARY"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let mut messages = overflow_messages();
+    let before_len = messages.len();
+    // The single summarizer call overruns the enforced limit → budget abort
+    // with the paid result in hand.
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(0.00005), None);
+    let mut health = SummarizerHealth::default();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    let cost = engine
+        .summarize_overflow_span(&mut messages, &mut budget, &mut health, &events)
+        .await;
+
+    assert!(
+        (cost - 0.0001).abs() < f64::EPSILON,
+        "the paid cost is still returned: {cost}"
+    );
+    assert_eq!(
+        summary_markers(&messages),
+        1,
+        "the paid summary must be spliced in, not dropped"
+    );
+    assert!(
+        messages.len() < before_len,
+        "the span shrank: {} !< {before_len}",
+        messages.len()
+    );
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Compaction { summarized, .. } if *summarized > 0
+        )),
+        "the applied summary is announced: {events:?}"
+    );
+}
+
+/// #368.4: a summarizer that keeps failing must surface each failure and,
+/// after enough consecutive misses, latch — a persistently-timing-out cheap
+/// summarizer can't be allowed to re-fire (and re-pay) every remaining step.
+#[tokio::test]
+async fn repeated_summarizer_failures_emit_events_and_latch() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Err(ProviderError::Transport("down".into()))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let calls = provider.calls.clone();
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let mut health = SummarizerHealth::default();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    // Every over-budget step this turn hits the same dead summarizer.
+    for _ in 0..SUMMARIZER_FAILURE_LATCH {
+        let mut messages = overflow_messages();
+        let cost = engine
+            .summarize_overflow_span(&mut messages, &mut budget, &mut health, &events)
+            .await;
+        assert_eq!(cost, 0.0, "a failed summarizer is free and changes nothing");
+        assert_eq!(summary_markers(&messages), 0, "nothing spliced on failure");
+    }
+    assert!(
+        health.is_latched(),
+        "consecutive failures must latch the summarizer"
+    );
+    let calls_while_unlatched = calls.load(Ordering::SeqCst);
+    assert!(
+        calls_while_unlatched > 0,
+        "the summarizer actually ran before latching"
+    );
+    let failures = drain_events(&mut rx)
+        .into_iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AgentEvent::Error {
+                    retryable: true,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        failures, SUMMARIZER_FAILURE_LATCH as usize,
+        "each failure surfaces exactly one retryable error"
+    );
+
+    // Latched: a further over-budget step must NOT re-fire (or re-pay for)
+    // the summarizer.
+    let mut messages = overflow_messages();
+    let cost = engine
+        .summarize_overflow_span(&mut messages, &mut budget, &mut health, &events)
+        .await;
+    assert_eq!(cost, 0.0, "the latched pass spends nothing");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        calls_while_unlatched,
+        "latched: the provider is not called again"
+    );
+    assert!(
+        drain_events(&mut rx).is_empty(),
+        "latched: no further events are emitted"
+    );
+}


### PR DESCRIPTION
The overflow summarizer is the last line of defense before a terminal context-overflow 400. Three of its failure paths degraded it silently; this hardens them. (Issue item 1, the `keep_recent==0` OOB panic, was already fixed upstream in #375 — see below.)

## Behavior changes (`stella-core/src/driver.rs`)

- **Retries (#368.2):** the summarizer ran `RetryPolicy::deterministic` (zero retries), so one transient 429/blip fast-failed and let the turn proceed oversized into a terminal overflow. Now uses `RetryPolicy::standard` — this is not a triage fast path.
- **Paid summary on budget abort (#368.3):** a summary generated and paid for right as the budget tripped was discarded (`return result.cost_usd`). It is now spliced in (via the new `apply_overflow_summary` helper, shared with the normal path) before returning the cost — applying it only shrinks the context the resumed session reloads.
- **Invisible failure + give-up latch (#368.4):** `Provider`/`Timeout` errors returned `0.0` with no event, and an empty-text "success" re-fired (and re-paid) every step. Each non-progress result now emits a retryable `AgentEvent::Error`, and a per-turn `SummarizerHealth` latch stops the summarizer re-firing after `SUMMARIZER_FAILURE_LATCH` (2) consecutive failures. The latch is stack-local to `run_turn` (peer of `receipts`), so it is genuinely per-turn.

Empty-text results are treated as a latch failure and surfaced too — the issue calls out the "empty-text 'success' pays and re-fires every step" pathology explicitly. The "always a clean abort" contract is preserved: the new events are informational and no path panics.

### Issue item 1 (OOB panic) — already fixed upstream
The `summarize_keep_recent == 0` out-of-bounds panic was fixed in #375 by the `end < messages.len` sentinel-walk guard, pinned by the existing `summarize_keep_recent_zero_does_not_panic` test, which establishes `keep_recent==0` as a legal "summarize the whole span" config. No clamp to `>= 1` is added, as that would reverse that merged, tested contract. Verified the panic returns if the guard is removed (`index out of bounds: the len is 8 but the index is 8`), then restored the guard unchanged.

## Tests added (`stella-core/src/driver/tests/audit_fixes.rs`)
- `overflow_summarizer_retries_a_transient_error` — a transient transport error is retried (provider called twice) and the summary lands; no failure event.
- `budget_aborted_summary_is_applied_not_discarded` — a budget-aborted summary is spliced in (marker present, span shrank, `Compaction` announced) and its cost still returned.
- `repeated_summarizer_failures_emit_events_and_latch` — each failure emits exactly one retryable `Error`; after N consecutive failures the pass latches and no longer calls the provider or emits events.

## Verification (scoped, `-p stella-core`, `CARGO_BUILD_JOBS=2`, `--test-threads=2`)
- `cargo test -p stella-core`: 342 passed, 0 failed (cargo exit 0).
- `cargo test -p stella-core audit_fixes`: 9 passed, 0 failed.
- `cargo clippy -p stella-core --all-targets -- -D warnings`: clean.
- `cargo fmt -p stella-core -- --check`: clean.

Fixes #368
