### PR TITLE
fix(core): don't misattribute a per-call timeout that expires during backoff (#371)

### DIFF
--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -1,5 +1,6 @@
 //! I/O-free one-shot provider accounting shared by non-engine callers.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use stella_protocol::{
@@ -38,10 +39,25 @@ pub async fn run_accounted_call(
     sleeper: &dyn Sleeper,
 ) -> Result<CompletionResult, AccountedCallError> {
     let started = Instant::now();
+    // True only while a provider dispatch is actually being polled — cleared
+    // for the backoff sleeps between attempts. A per-call timeout wraps the
+    // whole retry future (sleeps included), so its expiry must not attribute a
+    // Timeout envelope to a moment when nothing was in flight: the attempt that
+    // preceded a sleep already reported its own per-attempt envelope.
+    let attempt_in_flight = AtomicBool::new(false);
     let future = retry_with_backoff_observed(
         &call.retry_policy,
         sleeper,
-        || call.provider.complete(call.request.clone()),
+        || {
+            let call_fut = call.provider.complete(call.request.clone());
+            let in_flight = &attempt_in_flight;
+            async move {
+                in_flight.store(true, Ordering::SeqCst);
+                let result = call_fut.await;
+                in_flight.store(false, Ordering::SeqCst);
+                result
+            }
+        },
         // Per-attempt duration (retry.rs times each dispatch individually):
         // the failed call's own latency, never cumulative across attempts.
         |attempt, _error, attempt_duration| {
@@ -60,7 +76,13 @@ pub async fn run_accounted_call(
                 return Err(AccountedCallError::Provider(error));
             }
             Err(_) => {
-                emit_incomplete(&call, events, started.elapsed(), None);
+                // The per-call deadline fired. Attribute a Timeout envelope only
+                // if a paid attempt was genuinely in flight — an expiry during a
+                // backoff sleep would double-report a failure the per-attempt
+                // observer already accounted for.
+                if attempt_in_flight.load(Ordering::SeqCst) {
+                    emit_incomplete(&call, events, started.elapsed(), None);
+                }
                 return Err(AccountedCallError::Timeout);
             }
         },
@@ -257,6 +279,92 @@ mod tests {
             !serde_json::to_string(&incomplete)
                 .expect("wire")
                 .contains("private failed body")
+        );
+    }
+
+    /// A [`Sleeper`] backed by real (here, paused-virtual) tokio time so a
+    /// caller-supplied per-call timeout can expire *during* a backoff sleep.
+    struct TokioSleeper;
+
+    #[async_trait]
+    impl Sleeper for TokioSleeper {
+        async fn sleep(&self, duration_ms: u64) {
+            tokio::time::sleep(Duration::from_millis(duration_ms)).await;
+        }
+    }
+
+    struct AlwaysRetryable;
+
+    #[async_trait]
+    impl Provider for AlwaysRetryable {
+        fn id(&self) -> &str {
+            "scripted"
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResult, ProviderError> {
+            Err(ProviderError::Transport("private failed body".into()))
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_during_backoff_does_not_emit_a_spurious_timeout_envelope() {
+        // Deadline (100ms) shorter than the first backoff floor (250ms): the
+        // per-call timeout expires while the retry loop is sleeping between
+        // attempts, not while a paid dispatch is in flight.
+        let provider = AlwaysRetryable;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let result = run_accounted_call(
+            AccountedCall {
+                provider: &provider,
+                role: ModelCallRole::SkillAuthor,
+                model_hint: "configured-model".into(),
+                request: CompletionRequest {
+                    messages: vec![CompletionMessage::user("work")],
+                    max_output_tokens: None,
+                    temperature: None,
+                    effort: None,
+                    tools: Vec::new(),
+                    reasoning: None,
+                    params: None,
+                },
+                retry_policy: RetryPolicy::new(3, 250, 250),
+                timeout: Some(Duration::from_millis(100)),
+                estimated_input_tokens: 1,
+            },
+            &mut budget,
+            &EventSender::new(tx),
+            &TokioSleeper,
+        )
+        .await;
+
+        assert!(matches!(result, Err(AccountedCallError::Timeout)));
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let incomplete: Vec<_> = events
+            .iter()
+            .filter(|event| matches!(event, AgentEvent::UsageIncomplete { .. }))
+            .collect();
+        // The one failed attempt reported its own per-attempt `ProviderError`
+        // envelope; no `Timeout` envelope may follow, because the deadline fired
+        // mid-backoff with nothing in flight (that would double-report the
+        // already-accounted failure).
+        assert_eq!(
+            incomplete.len(),
+            1,
+            "exactly the single failed attempt's envelope, no spurious timeout: {incomplete:?}"
+        );
+        assert!(
+            incomplete.iter().all(|event| matches!(
+                event,
+                AgentEvent::UsageIncomplete {
+                    reason: UsageIncompleteReason::ProviderError,
+                    ..
+                }
+            )),
+            "the deadline fired during a backoff sleep, so no Timeout envelope is owed: {incomplete:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Issue #371 lists three usage-attribution gaps. **Two of them (#1 per-attempt `duration_ms`, and #3 the hard-cancel `Cancelled` envelope) were already fixed on `main` by the merged turn-driver audit (PR #375, commit `e131505`)** — per-attempt `Duration` is threaded through `observe_failure` in `retry.rs`/`driver.rs`/`accounted_call.rs`, and `CancelUsageGuard` + the `Cancelled` `UsageIncompleteReason` + test `hard_cancel_mid_stream_emits_a_cancelled_usage_envelope` (F9) all landed there.

This PR closes the **one remaining gap, #2**: `accounted_call.rs`'s per-call `timeout` wraps the whole retry future (backoff sleeps included). When the deadline expires *during a backoff sleep* — not while a dispatch is in flight — the code emitted a `UsageIncomplete { reason: Timeout }` for a moment when no attempt existed, double-reporting the failure the per-attempt observer had already accounted for.

## Behavior change

- Arm an `AtomicBool` inside the attempt wrapper — true only while a provider dispatch is being polled, cleared across backoff sleeps.
- On outer timeout expiry, emit the `Timeout` envelope **only if an attempt was genuinely in flight**. An expiry mid-sleep now returns `AccountedCallError::Timeout` with no spurious envelope.
- The per-call timeout budget and the `Timeout` error return are unchanged; callers (`stella-cli`, `stella-pipeline` triage) are unaffected. Scope is `accounted_call.rs` only — `driver.rs::run_model_call` has no timeout wrapping its retry future, so it has nothing to fix.

## Tests

- `timeout_during_backoff_does_not_emit_a_spurious_timeout_envelope` (new, `#[tokio::test(start_paused = true)]`): a retryable-always provider with `max_retries=3, base_delay=250ms` and `timeout=100ms`. Paused virtual time fires the deadline while the first backoff sleep is pending. Asserts the result is `Err(Timeout)` and exactly one `UsageIncomplete` — the failed attempt's `ProviderError` envelope — with no `Timeout` envelope.
- Regression-verified: temporarily reverting the in-flight guard makes this test fail with two envelopes (`ProviderError` + spurious `Timeout { retries: None }`), confirming it pins the fix.

## Deliberate deviation from the issue's suggested fix

Issue #2 also suggests "flush the accumulated `Retry` events" on outer expiry. I **did not** do this: both `accounted_call.rs` and `driver.rs` flush `Retry` events **only on the commit path** (L-E10 — speculative side effects flush only when the step commits), and the sibling terminal path (`Ok(Err(error)) => Provider`) already drops retry history without flushing. The retry *history* is already durably preserved via the per-attempt `UsageIncomplete { ProviderError }` envelopes the observer emits (added by #375); flushing `Retry` events on a non-commit would contradict that documented invariant for no accounting gain. Fixing the unambiguous defect (the spurious envelope) is sufficient.

## Note on latency

Both call sites that pass a `timeout` today use `RetryPolicy::deterministic` (`max_retries = 0`), so no production caller currently combines backoff with a per-call timeout — the defect is latent. This hardens the invariant for any future caller that does, per "fix the class of bug."

Fixes #371
