### PR TITLE
fix(pipeline): unbreak main — handle SpeculationDiscarded in replay event_signature

### DIFF
--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -205,6 +205,11 @@ pub fn event_signature(event: &AgentEvent) -> String {
         // exists only to keep this function total.
         AgentEvent::TextDelta { .. } => "text_delta".to_string(),
         AgentEvent::Reasoning { .. } => "reasoning".to_string(),
+        // A discarded speculation is timing-dependent — which stream attempt
+        // failed (and so which read-only pool is dropped) varies run to run —
+        // so, like `TextDelta`, [`structural_diff`] excludes it before
+        // comparing; the signature exists only to keep this function total.
+        AgentEvent::SpeculationDiscarded { .. } => "speculation_discarded".to_string(),
         AgentEvent::ToolStart { call } => format!("tool_start:{}", call.name),
         // A tool_result's structural identity is that it answered a call and
         // whether it errored — not its duration or output body.
@@ -307,6 +312,7 @@ pub fn structural_diff(left: &[AgentEvent], right: &[AgentEvent]) -> Vec<StreamD
             AgentEvent::TextDelta { .. }
                 | AgentEvent::BlockRegistered { .. }
                 | AgentEvent::StepManifest { .. }
+                | AgentEvent::SpeculationDiscarded { .. }
         )
     };
     let left: Vec<&AgentEvent> = left.iter().filter(keep).collect();


### PR DESCRIPTION
## Urgent: `main` does not compile

#415 (#370) added `AgentEvent::SpeculationDiscarded` to `stella-protocol` but did not extend `stella-pipeline`'s `event_signature` match, which enumerates every `AgentEvent` variant with **no wildcard arm**:

```
error[E0004]: non-exhaustive patterns: `&AgentEvent::SpeculationDiscarded { .. }` not covered
   --> stella-pipeline/src/replay.rs:197
```

`main` therefore fails to compile `stella-pipeline` (and everything downstream). The gap slipped through because #370's verification was scoped to `-p stella-core` and never built stella-pipeline — a cross-crate blind spot the per-crate gate doesn't catch.

## Fix

- Give `SpeculationDiscarded` a signature in `event_signature`, keeping the match total.
- Add it to `structural_diff`'s exclusion set alongside `TextDelta`: a discarded speculation is **timing-dependent** — which stream attempt fails, and so which read-only pool is dropped, varies run to run — so including it would shift every later position in the golden-replay comparison.

Two-line change, mirrors the existing `TextDelta`/receipt exclusions. Verified `cargo clippy -p stella-pipeline -p stella-core -p stella-protocol --all-targets -- -D warnings` clean on a branch carrying this change.

Not marked draft — should land ahead of the open budget PRs to green CI.
