### PR TITLE
fix(tui): unbreak main — handle SpeculationDiscarded in stella-tui's three exhaustive event matches

### DIFF
--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -133,6 +133,10 @@ fn config_debug_never_leaks_the_api_key() {
 
 #[test]
 fn resolved_config_carries_the_authority_computed_during_settings_load() {
+    // `load_with_settings` reads the process-wide trusted-engine-config env
+    // var; hold the binary env lock so a concurrent test setting it to a
+    // malformed value can't make this load fail (setenv races any getenv).
+    let _env = crate::test_env::lock();
     let authority = crate::settings::AuthorityPolicy {
         project_prompts_allowed: true,
         project_custom_tools_allowed: false,

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -932,6 +932,9 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
         AgentEvent::TextDelta { text } => (TraceKind::Text, snip(text)),
         AgentEvent::Reasoning { delta } => (TraceKind::Reasoning, snip(delta)),
         AgentEvent::ToolStart { call } => (TraceKind::Tool, format!("{}()", call.name)),
+        AgentEvent::SpeculationDiscarded { name, reason, .. } => {
+            (TraceKind::Tool, format!("discarded {name} ({reason})"))
+        }
         AgentEvent::ToolResult {
             output,
             duration_ms,

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -610,6 +610,9 @@ impl SessionModel {
                     cost_usd: *cost_usd,
                 });
             }
+            // Internal accounting for read-only speculation that never
+            // committed — no visible model state to update.
+            AgentEvent::SpeculationDiscarded { .. } => {}
         }
         self.evict_transcript_overflow();
     }

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -418,7 +418,10 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
         // Context receipts (spec §4/§5) are observability, not transcript
         // narration — they never produce a rendered line.
         | AgentEvent::BlockRegistered { .. }
-        | AgentEvent::StepManifest { .. } => None,
+        | AgentEvent::StepManifest { .. }
+        // A discarded speculation is internal accounting for read-only work
+        // that never reached the transcript — observability, not narration.
+        | AgentEvent::SpeculationDiscarded { .. } => None,
         AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
         AgentEvent::Steered { text } => Some(steered(text)),
         AgentEvent::Compaction {


### PR DESCRIPTION
## Urgent: `main` still does not compile (stella-tui)

Follow-up to #421. #415 (#370) added `AgentEvent::SpeculationDiscarded`; #421 fixed stella-pipeline's `event_signature`, but **three more exhaustive matches** on `AgentEvent` in `stella-tui` were missed — none has a wildcard arm:

```
error[E0004]: non-exhaustive patterns: `AgentEvent::SpeculationDiscarded { .. }` not covered
  --> stella-tui/src/model.rs:312     (apply_event)
  --> stella-tui/src/textline.rs:410  (event_line)
  --> stella-tui/src/deck.rs:927      (trace_of)
```

CI got past the pipeline error (now that #421 merged) and fails here. The gap survived because #370 and #421 both verified with scoped `-p <crate>` builds that never compiled stella-tui — a full `cargo check --workspace` catches it; the per-crate gate does not.

## Fix

Each match handled per its return type:
- **model.rs** — no-op arm (a discarded speculation changes no visible model state).
- **textline.rs** — joins the observability None-group (like receipts/`TextDelta`, never a rendered transcript line).
- **deck.rs** — a `TraceKind::Tool` row: `discarded <name> (<reason>)`.

Verified `cargo check --workspace --all-targets` compiles clean, and `clippy -p stella-tui --all-targets -- -D warnings` clean.

Not draft — should land to green CI across all open PRs.
