### PR TITLE
feat(context): Phase 1 (installment 1) — record taxonomy, scope, temporal, JCS hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +2917,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3124,6 +3141,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
  "sha2 0.11.0",
  "stella-protocol",
  "thiserror 2.0.19",
@@ -3505,7 +3523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ publish = false
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# RFC 8785 JSON Canonicalization Scheme — pinned to the SAME version the Context
+# Graph Exchange Protocol crates use (contextgraph-conformance), so stella's
+# record_hash preimage is byte-identical to CGEP's for future export interop.
+serde_json_canonicalizer = "0.3.2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "fs", "io-util", "sync"] }
 async-trait = "0.1"

--- a/docs/adaptive-context/phase-0-baseline.md
+++ b/docs/adaptive-context/phase-0-baseline.md
@@ -272,14 +272,17 @@ defined in the protocol types but **unused** here. Phase 4 wires them.
 
 ## 8. Open questions carried into later phases
 
-- **SharingScope arity** (→ ADR 0002): canonical pair disagrees (4 values vs 3).
-  Roadmap resolution: 4-value set authoritative (`workspace` first-class). Needs
-  human sign-off before the Phase 1 enum freeze.
-- **`Origin` arity**: §7.1 lists five (`user`, `system`, `observed`, `inferred`,
-  `imported`); the §8.6 directive example permits four (drops `observed`).
-  Verify the per-kind narrowing is deliberate before freezing.
-- **Enforcement 4→2 mapping** (→ ADR 0007): `context-prs-spec` uses 4 levels,
-  the plan uses 2. Lock the mapping before Phase 6.
+- ~~**SharingScope arity**~~ (→ ADR 0002): **Resolved 2026-07-23** — owner
+  ratified the 4-value set (`user, repository, workspace, organization`); §21's
+  3-value line superseded. Phase 1 enum freezes on four.
+- ~~**`Origin` arity**~~: **Resolved 2026-07-23 (spec-verified)** — the full
+  5-value set (`user, system, observed, inferred, imported`) is authoritative for
+  all families; the normative origin→derivation_kind table (§ line 952) is
+  family-uniform and admits `observed`. The §8.6 directive example (four values)
+  is illustrative, not a per-kind narrowing.
+- ~~**Enforcement 4→2 mapping**~~ (→ ADR 0007): **Resolved 2026-07-23** — owner
+  ratified the 4→2 mapping; `DirectiveEnforcement` is 2-value (`advisory`,
+  `blocking`); the four levels survive only as UI labels.
 - **World-time columns**: `valid_from`/`valid_to` are written but never read.
   Decide in Phase 3 whether to make the store truly bi-temporal (valid-time
   queries) or document them as advisory metadata.

--- a/docs/adaptive-context/phase-0-baseline.md
+++ b/docs/adaptive-context/phase-0-baseline.md
@@ -1,0 +1,290 @@
+# Phase 0 — Baseline & Characterization
+
+Status: baseline of record for the adaptive-context work
+Date: 2026-07-23
+Branch: `feat/phase-0-adaptive-context-baseline` (off `main` @ `1a8d872`)
+
+This document is the **frozen baseline** the adaptive-context lifecycle is built
+on: the current toolchain, the reusable persistence substrate, the exact
+read/write paths a migration must not break, and — most importantly — the
+**characterized semantics of today's `as_of`** (which the plan forbids
+*assuming*). Every claim is grounded in a `file:line` reference against the tree
+at `1a8d872`.
+
+Its companion decision records live in [`../adr/`](../adr/README.md).
+
+---
+
+## 1. Toolchain & baseline checks
+
+| | |
+|---|---|
+| Rust toolchain (`rust-toolchain.toml`) | `1.97.0` (+ `clippy`, `rustfmt`) |
+| Edition | 2024 |
+| Workspace version (`Cargo.toml`) | `0.4.77` |
+| `cargo fmt --all --check` | clean at baseline |
+
+**Nominal per-phase gate** (the plan's non-negotiable witnesses):
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+For this purely-additive phase the effectively-load-bearing subset is the two
+crates it touches — `stella-context` and `stella-cli`:
+
+```sh
+cargo test -p stella-context
+cargo test -p stella-cli
+```
+
+> Honesty note: a full `cargo test --workspace` on this repo (15 crates, a 133 GB
+> warm `target/`) is expensive. The phase-0 change adds only tests, an inert
+> settings schema, fixtures, and docs; the scoped `stella-context` /
+> `stella-cli` runs are what was actually executed for this branch. Do not
+> record the full-workspace gate as passed unless it was run.
+
+## 2. Cargo dependency graph
+
+15 workspace members:
+
+```
+stella-cli  stella-context  stella-core  stella-fleet  stella-graph
+stella-mcp  stella-media    stella-model stella-observatory stella-pipeline
+stella-protocol stella-serve stella-store stella-tools stella-tui
+```
+
+The Context Graph Exchange Protocol types are consumed as a **pinned git
+dependency**, not a path dep on the sibling checkout:
+
+```toml
+# stella-context/Cargo.toml, stella-cli/Cargo.toml
+contextgraph-types  = { git = ".../context-graph-protocol", rev = "9fb559aa4d3ec4cf062e59dab113eae4e175c5fa" }
+contextgraph-host   = { git = ".../context-graph-protocol", rev = "9fb559aa4d3ec4cf062e59dab113eae4e175c5fa" }
+contextgraph-conformance = { git = ".../context-graph-protocol", rev = "9fb559aa4d3ec4cf062e59dab113eae4e175c5fa" } # dev-dep
+```
+
+The pinned rev (`9fb559a`) equals the sibling repo's current `main` HEAD.
+`ContextQuery`, `ContextFrame`, and `Representation` come from that checkout, not
+from `stella-*` — the types below are quoted from the rev that actually
+compiles. **Phase 10 (CGEP export) is gated on this rev pin being allowed to
+move**; treat it as fixed until then.
+
+## 3. Two SQLite authorities (do not cross-wire)
+
+Two independent databases, each with its own `SCHEMA_VERSION` constant of the
+same name in a different crate:
+
+| DB | Owner crate | `SCHEMA_VERSION` | Holds |
+|---|---|---|---|
+| `.stella/private/context.db` | `stella-context` | **3** (`store.rs:28`) | graph plane: `node`, `edge`, `episode`, `memory`, `embedding`, `domain*` |
+| `.stella/private/store.db` | `stella-store` | **12** (`migrations.rs:76` = `MIGRATIONS.len()`) | telemetry/rules plane: `rules`, `memory_citations`, executions, … |
+
+### 3a. `context.db` schema & migrations (`stella-context/src/store.rs`)
+
+`migrate()` (`store.rs:526`) reads `PRAGMA user_version`, early-returns if `>= 3`,
+applies each pending step in **one transaction**, then stamps `user_version = 3`
+(`store.rs:541`). This is the harness Phase 2 extends.
+
+- **v0→v1** `MIGRATION_V1` (`store.rs:38-104`): `node`, `edge`, `embedding`,
+  `episode`, `embedder_fingerprint` + indexes. Both `node` and `edge` carry the
+  four bitemporal columns `valid_from`, `valid_to`, `recorded_at`,
+  `superseded_at`.
+- **v1→v2** `MIGRATION_V2` (`store.rs:113-144`): `domain`, `node_domains`,
+  `edge_domains`, and the `memory` record table (+ `idx_memory_kind`).
+- **v2→v3** `MIGRATION_V3` (`store.rs:155-159`): `DROP TABLE IF EXISTS
+  code_graph_{symbols,imports,files}` — evicts orphaned tree-sitter tables (the
+  code graph now lives in its own `codegraph.db`).
+
+### 3b. `context.db` read/write paths (the migration must preserve these)
+
+**No `DELETE` exists on any of `node`/`edge`/`episode`/`memory`.** Nodes
+overwrite in place; edges "close" via supersede-UPDATE; the only drop is the V3
+`code_graph_*` eviction.
+
+- `node` — `upsert_node` (`store.rs:667`, `INSERT … ON CONFLICT(public_id) DO
+  UPDATE`, content-on-touch). Readers: `node_count` (`:450`), `memory_nodes`
+  (`:471`, reads `node WHERE kind='memory'`, **not** the `memory` table),
+  `node_by_public_id` (`:488`), `live_nodes` (`:720`, `WHERE superseded_at IS
+  NULL`), `node_ids_for_uris` (`:734`), `node_by_id` (`:774`).
+- `edge` — `insert_edge` (`:889`), `close_edge` (`:940`, `UPDATE … SET
+  superseded_at=?, valid_to=COALESCE(valid_to,?)` — the supersession mechanism,
+  never a delete), `currently_valid_edge` (`:920`), `neighbors` (`:789`),
+  `edges_as_of` (`:956`).
+- `episode` / `memory` — **write-only tables.** `insert_episode` (`:996`),
+  `insert_memory` (`:1024`) both `INSERT … ON CONFLICT DO UPDATE`. There is **no
+  `SELECT` and no `DELETE`** on either table anywhere; read-back is exclusively
+  through the mirror `node` row (`episode://<id>`, `memory://<id>`) written in
+  the same transaction.
+- The one persist entry point is `ContextStore::upsert(delta)` (async,
+  `writeback.rs:343`): one transaction — domains → nodes → episodes (+mirror) →
+  memories (+mirror) → facts via `apply_fact` (`:503`) → embeddings → commit.
+
+> **Migration consequence:** every memory/episode is stored twice (canonical row
+> + mirror node), and the mirror node is the only thing ever read. `node`
+> content history is unrecoverable (`upsert_node` overwrites in place). Phase 2
+> must migrate memories losslessly and decide whether the write-only
+> `memory`/`episode` tables survive as projections.
+
+### 3c. `store.db` rules & citations (`stella-store`)
+
+- `rules` table — DDL `RULES_TABLE` (`ddl.rs:172-178`): `rule_id` PK, `contents`
+  (the full `.stella/rules/*.md` markdown, opaque), `source`, timestamps. Added
+  in store.db migration v2→v3 (`migrations.rs:306-310`). Writes:
+  `Store::upsert_rule` (`lib.rs:1518`), `Store::delete_rule` (`lib.rs:1529`, a
+  **real** `DELETE` — unlike context.db). Reads: `Store::list_rules`
+  (`lib.rs:1539`), consumed by `stella-cli/src/rules.rs:117` as
+  `store://rules/<id>.md`.
+- `memory_citations` table — DDL (`ddl.rs:196-206`): `UNIQUE(execution_id,
+  memory_id)`. Write `Store::record_memory_citations` (`lib.rs:740`) is a **plain
+  INSERT** (not an upsert) — a second drain under the same `execution_id` errors
+  on the UNIQUE constraint; dedup relies on the in-memory `CitationLedger`
+  (`stella-tools/src/memory.rs:124`, `retain` keep-latest at `:210`) and
+  per-execution drain (`stella-cli/src/agent/persistence.rs:145`). Read:
+  `memory_citation_stats` (`lib.rs:801`) → per-memory promotion eligibility.
+
+### 3d. Rules live in two surfaces
+
+Hand-authored / promoted Markdown `.stella/rules/*.md` (+ `.claude/rules`, user
+`~/.config/stella/rules`) **and** extension-authored rows in `store.db.rules`.
+They merge at load time in `stella-cli/src/rules.rs` (`SessionRuleSource`, store
+rules lowest precedence). `stella-core/src/rules/` is I/O-free and operates on an
+injected `RuleSource`; `render_rule_markdown` (`rules.rs:786`) and
+`rule_from_file` (`:300`) are mirror encode/decode. `RuleRecordKind` currently
+has a **single** variant, `Directive` (`metadata.rs:8-12`) — Phase 1 subsumes it.
+
+The `stella memory promote` command writes `.stella/rules/<id>.md`
+(`memory_cmd.rs:185`) and refuses to clobber an existing file. (Distinct from the
+lesson→`SKILL.md` auto-promotion at `memory.rs:571` — do not conflate.)
+
+## 4. Characterized: what `as_of` means today
+
+**Finding (pinned by tests, not assumed): `as_of` filters on
+TRANSACTION / BELIEF time only** — the half-open interval
+`[recorded_at, superseded_at)`. It **never** consults world-validity
+(`valid_from` / `valid_to`).
+
+The two temporal readers (`neighbors` `Some` arm `store.rs:802-808`;
+`edges_as_of` `Some` arm `store.rs:981-985`) share one filter:
+
+```sql
+WHERE recorded_at <= ?t AND (superseded_at IS NULL OR superseded_at > ?t)
+```
+
+- start is **inclusive** (`t == recorded_at` → visible);
+- end is **exclusive** (`t == superseded_at` → not visible);
+- `as_of = None` collapses to `superseded_at IS NULL` ("currently believed").
+
+An exhaustive grep confirms **no `WHERE` clause in `stella-context/src` ever
+references `valid_from`/`valid_to`** — those columns are written (`insert_edge`,
+`close_edge`) but **dead on read**. The store's practical shape is therefore
+**uni-temporal on transaction time, edges only** (node time columns are inert
+because `upsert_node` overwrites in place).
+
+This contract is pinned by three tests added in this phase
+(`store.rs`, `mod tests`):
+
+- `as_of_none_returns_only_currently_believed_edges`
+- `as_of_reconstructs_half_open_transaction_interval` (the boundary test:
+  inclusive start, exclusive end)
+- `as_of_ignores_world_validity_valid_from_valid_to` (**the discriminator** —
+  an edge whose `valid_to` closed in the past but which is still believed
+  remains visible; this is what distinguishes "transaction time" from "world
+  validity / both")
+
+**Load-bearing nuance for Phase 3:** inside `recall`, `as_of` time-travels
+**only the 1-hop graph-adjacency signal** (`retrieval.rs:256` → `neighbors`).
+Vector similarity, recency, domain overlap, and the lexical fallback all draw
+from *current* `live_nodes` (`WHERE superseded_at IS NULL`). So "recall as-of T"
+is **not** a true historical snapshot today. See ADR
+[`0003-bitemporal-semantics`](../adr/0003-bitemporal-semantics.md): the new API
+must separate `known_at` (transaction/belief) from `valid_at` (world validity),
+with `as_of` mapping to `known_at`.
+
+## 5. Characterized: event decoder forward-compatibility
+
+`stella-protocol/src/event.rs` — the top-level `AgentEvent` (`event.rs:151`) is a
+Serde **internally-tagged** enum (`#[serde(tag = "type", rename_all =
+"snake_case")]`) with **no `#[serde(other)]` / catch-all variant**. Therefore:
+
+- **Adding a field** to an existing variant is bidirectionally safe (unknown
+  fields ignored on read; `#[serde(default)]` fills missing) — extensively
+  tested.
+- **Adding a variant** is safe for new-code-reads-old-data, but **old code
+  hard-fails on new data**: the only in-tree JSONL reader, `parse_jsonl`
+  (`stella-pipeline/src/replay.rs:349`), treats an unparseable interior line as a
+  **fatal** `MalformedLine`.
+
+**Phase 1 consequence:** before adding `AgentEvent` variants (the internal
+`ObservationRecorded`, `RecordProposalCreated`, … events), add a versioned
+unknown-event envelope / reader tolerance, or the change breaks replay of mixed
+streams. The plan already flags "characterize the existing decoder" — this is
+the answer: it rejects unknown tags.
+
+## 6. Characterized: frame representations
+
+`Representation` (`contextgraph-types … frame.rs:47`) is `{ Full (default),
+Compact, Reference }`. stella emits **`Full` exclusively** — a grep of
+`Representation::` across all `.rs` finds only `::Full` (production emitters
+`retrieval.rs:370`, `stella-graph/src/frames.rs:302`). `Compact`/`Reference` and
+the `content_fidelity` / `canonical_content_hash` / `ContentRef` machinery are
+defined in the protocol types but **unused** here. Phase 4 wires them.
+
+## 7. Artifacts added in this phase
+
+- **Characterization tests** — `stella-context/src/store.rs` `mod tests` (the
+  three `as_of_*` tests above).
+- **Disabled settings schema** — `stella-cli/src/settings/context.rs`
+  (`ContextSettings` and friends), wired into `Settings` as an inert
+  `Option<ContextSettings>` (whole-block last-wins across scopes). `off` /
+  `record_only` / `advisory` learning modes and `solo` / `team` / `regulated`
+  governance modes are kept as distinct dimensions; enums are loud on typos.
+  `context.lifecycle.enabled` defaults `false` — the value that preserves
+  behavior. **Nothing reads these settings yet.**
+- **Canonical settings fixture** — `stella-cli/tests/fixtures/context_settings.json`
+  (the plan's suggested block). `.stella/` is gitignored, so the canonical
+  example is a committed fixture, round-trip-tested against the code defaults so
+  the two cannot drift.
+- **ADRs** — [`docs/adr/`](../adr/README.md) (8 records; `0002` SharingScope
+  arity and `0007` enforcement 4→2 carry open questions requiring human
+  confirmation).
+- **Schema-version fixtures** — `stella-context/src/store.rs` `mod tests`:
+  `migrates_v1_context_db_preserving_bitemporal_edges` and
+  `migrates_v2_context_db_preserving_memories` build a legacy v1/v2 `context.db`
+  carrying representative rows (a superseded edge, an edge whose world-validity
+  closed in the past, a memory + mirror node), open it through
+  `ContextStore::open`, and assert the migration to `SCHEMA_VERSION` is a
+  lossless, idempotent replay.
+- **Rule-markdown fixtures** — `stella-cli/tests/fixtures/rules/`
+  (`no-hand-edited-migrations.md` = a promoted guard rule;
+  `api-integration-coverage.md` = a full context-as-code directive with
+  inferred/advisory metadata). Parsed under today's `stella_core::rules` parser
+  by `rules::tests::{guard,directive}_rule_fixture_*` so the format Phase 2's
+  importer reads is pinned.
+
+> **Scope note (no silent cap):** schema-version DB fixtures cover `context.db`
+> (the Phase 2 migration authority) at v1→v3 and v2→v3. `store.db`'s 12-version
+> migration harness (`stella-store`, gated at `lib.rs:615` with a version-gap
+> error) is owned and tested inside `stella-store`; per-version `store.db`
+> fixtures are deferred to the phase that actually touches `store.db` rows.
+
+## 8. Open questions carried into later phases
+
+- **SharingScope arity** (→ ADR 0002): canonical pair disagrees (4 values vs 3).
+  Roadmap resolution: 4-value set authoritative (`workspace` first-class). Needs
+  human sign-off before the Phase 1 enum freeze.
+- **`Origin` arity**: §7.1 lists five (`user`, `system`, `observed`, `inferred`,
+  `imported`); the §8.6 directive example permits four (drops `observed`).
+  Verify the per-kind narrowing is deliberate before freezing.
+- **Enforcement 4→2 mapping** (→ ADR 0007): `context-prs-spec` uses 4 levels,
+  the plan uses 2. Lock the mapping before Phase 6.
+- **World-time columns**: `valid_from`/`valid_to` are written but never read.
+  Decide in Phase 3 whether to make the store truly bi-temporal (valid-time
+  queries) or document them as advisory metadata.
+- **Point-in-time recall is edges-only**: making "recall as-of T" a true
+  snapshot requires versioned node content, which the current schema cannot
+  provide.
+- **Contextgraph rev pin**: whether the `9fb559a` pin is meant to move is a
+  Phase 10 question; keep fixed until then.

--- a/docs/adr/0001-semantic-taxonomy.md
+++ b/docs/adr/0001-semantic-taxonomy.md
@@ -44,7 +44,11 @@ kinds is a regression to reject in review.
 
 ## Open questions
 
-Related open item (do not resolve here): `Origin` arity disagrees inside the
-canonical pair — §7.1 lists five (`user, system, observed, inferred, imported`)
-but the §8.6 directive example permits four (drops `observed`). Likely a
-deliberate per-kind narrowing; verify before the enum freezes in Phase 1.
+Resolved (spec-verified 2026-07-23): `Origin` has the **five** portable values
+`user, system, observed, inferred, imported` for **all** record families,
+including directives. Lifecycle §7.1 lists all five (line 628), and the normative
+origin→derivation_kind table (§ line 952) is family-uniform and explicitly
+admits `observed`. The §8.6 directive example using only four is **illustrative,
+not a per-kind narrowing** — there is no rule forbidding an `observed` directive.
+Freeze the 5-value enum in Phase 1. (Any future directive-specific narrowing
+would be a new decision, not implied by the current spec.)

--- a/docs/adr/0001-semantic-taxonomy.md
+++ b/docs/adr/0001-semantic-taxonomy.md
@@ -1,0 +1,50 @@
+# ADR 0001: Semantic Taxonomy
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+The adaptive-context work needs one typed record taxonomy that every later phase
+(migration, compilation, learning, governance) builds on. Two incompatible
+taxonomies exist in the planning corpus. The canonical pair
+(`adaptive-context-implementation-plan.md` §5 and `stella-adaptive-context-lifecycle.md`)
+defines separate record families; the older `directive-schema.md` (Jul 20)
+defines a single flat `kind` list. These cannot both be implemented — they
+assign different meanings to the same words.
+
+This ADR RECORDS the taxonomy decision already made by the canonical pair. It
+does not open a new question.
+
+## Decision
+
+Adopt the plan's taxonomy: separate `knowledge`, `memory`, and `directive`
+families, typed as `ContextRecordKind` with per-family `KnowledgeKind`,
+`MemoryKind`, and `DirectiveKind`. Confidence is an integer `0..=100`
+(lifecycle §7.6). `constraint_effect` is `require` or `forbid` — **never**
+`allow` (plan §5, lifecycle §11 "forbid").
+
+The older `directive-schema.md` taxonomy — `kind: memory|fact|rule|preference|
+constraint|procedure`, confidence `0–1`, `priority low|normal|high|critical` —
+is **SUPERSEDED and must not be implemented**. Per the roadmap §2, `memory` and
+`fact` must not be restored as directive kinds. Mine that doc for lifecycle
+*ideas* only (citation stats, archive ratios), never its type shapes.
+
+The existing `stella-core/src/rules/metadata.rs` `RuleRecordKind::Directive`
+(carrying `scope_paths`/`enforcement`/`confidence`) is subsumed and renamed
+into this taxonomy in Phase 1; it is not deleted in Phase 0.
+
+## Consequences
+
+Phase 1 introduces these as pure I/O-free types in `stella-core`. Migration
+(Phase 2) maps ambiguous legacy memories losslessly as `memory`, never
+reclassifying by LLM. Any code or doc reaching for the flat `directive-schema`
+kinds is a regression to reject in review.
+
+## Open questions
+
+Related open item (do not resolve here): `Origin` arity disagrees inside the
+canonical pair — §7.1 lists five (`user, system, observed, inferred, imported`)
+but the §8.6 directive example permits four (drops `observed`). Likely a
+deliberate per-kind narrowing; verify before the enum freezes in Phase 1.

--- a/docs/adr/0002-scope-vs-sharing.md
+++ b/docs/adr/0002-scope-vs-sharing.md
@@ -1,8 +1,8 @@
 # ADR 0002: Scope vs. Sharing
 
-- Status: Proposed — needs human confirmation
+- Status: Accepted — ratified by repository owner 2026-07-23 (was: Proposed)
 - Date: 2026-07-23
-- Deciders: (Phase 0 baseline)
+- Deciders: repository owner (ratified 2026-07-23)
 
 ## Context
 
@@ -29,8 +29,9 @@ user, repository, and organization") is judged stale. Repository and workspace
 are not synonyms: a repository is a VCS/Git identity; a workspace is a
 provider-managed security principal spanning resources (§7.3).
 
-This resolution is **not** ratified. It requires human sign-off before the enum
-is frozen in Phase 1.
+**Ratified by the repository owner on 2026-07-23:** the four-value set is
+authoritative and the enum may be frozen on it in Phase 1. §21's three-value
+line is superseded.
 
 ## Consequences
 
@@ -41,5 +42,6 @@ reviewer instead confirms the three-value set, the `workspace` publication path
 
 ## Open questions
 
-**Needs human confirmation:** ratify the 4-value `SharingScope` (accepting §21
-as stale) versus the 3-value set, before the enum is frozen in Phase 1.
+Resolved 2026-07-23: the repository owner ratified the **4-value** `SharingScope`
+(`user, repository, workspace, organization`); §21's 3-value line is superseded.
+The Phase 1 enum freezes on the four values.

--- a/docs/adr/0002-scope-vs-sharing.md
+++ b/docs/adr/0002-scope-vs-sharing.md
@@ -1,0 +1,45 @@
+# ADR 0002: Scope vs. Sharing
+
+- Status: Proposed — needs human confirmation
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+Two orthogonal dimensions are easy to conflate and must stay separate. `Scope`
+answers *where a record applies* (which repository, workspace, user, or
+organization it is about). `SharingScope` answers *who may receive or inherit
+it* (lifecycle §7.3). Authority is derived from origin and evidence, not from
+sharing rank (§13.2) — so the two cannot be collapsed into a single ladder.
+
+This ADR FLAGS an open decision. The canonical pair disagrees with itself on
+`SharingScope` arity, and this value set becomes a `context_records.sharing_scope`
+column the Phase 1/2 implementer hits immediately, so it must be resolved
+before the enum is frozen.
+
+## Decision
+
+Keep `Scope` and `SharingScope` as distinct types (plan §5).
+
+For `SharingScope` arity, record the roadmap's **provisional** resolution: treat
+the **four-value** set — `user`, `repository`, `workspace`, `organization`
+(lifecycle §7.3) — as authoritative. `workspace` is first-class in §13.4
+workspace publication, and the §21 acceptance line ("SharingScope contains only
+user, repository, and organization") is judged stale. Repository and workspace
+are not synonyms: a repository is a VCS/Git identity; a workspace is a
+provider-managed security principal spanning resources (§7.3).
+
+This resolution is **not** ratified. It requires human sign-off before the enum
+is frozen in Phase 1.
+
+## Consequences
+
+Records carry both a `scope_json` and a `sharing_scope`. Audience changes are
+always explicit — sharing never widens automatically (roadmap M-B gate). If a
+reviewer instead confirms the three-value set, the `workspace` publication path
+(§13.4) must be re-scoped and the column value set narrowed.
+
+## Open questions
+
+**Needs human confirmation:** ratify the 4-value `SharingScope` (accepting §21
+as stale) versus the 3-value set, before the enum is frozen in Phase 1.

--- a/docs/adr/0003-bitemporal-semantics.md
+++ b/docs/adr/0003-bitemporal-semantics.md
@@ -1,0 +1,46 @@
+# ADR 0003: Bitemporal Semantics
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+The plan forbids guessing what today's `as_of` means before migrating off the
+live graph (roadmap §2, plan §4). It must be characterized, not assumed.
+
+The current `stella-context` behavior is now characterized. `edges_as_of`/
+`neighbors` in `stella-context/src/store.rs` filter on **transaction/belief time
+only**: `recorded_at <= t AND (superseded_at IS NULL OR superseded_at > t)`
+(store.rs:806-807). This is a half-open `[recorded_at, superseded_at)` belief
+interval — it selects which beliefs were *held* at `t`. It does **not** filter
+world-validity (`valid_from`/`valid_to`); those columns exist on `node`/`edge`
+but are never consulted by `as_of`. The store's own doc comment confirms
+`as_of` is "transaction time" pinning "which beliefs are visible" (store.rs:787).
+
+This ADR RECORDS the observed semantics and the target separation. A Phase 0
+characterization test pins this behavior against `store.rs` `neighbors`/
+`edges_as_of` so the migration cannot silently change it.
+
+## Decision
+
+The new bitemporal API separates two axes explicitly (lifecycle §7.5):
+
+- `known_at` — transaction/belief (provider-local knowledge) time;
+- `valid_at` — world validity.
+
+Both use half-open intervals. Reconstruction is prefix-safe: restrict to
+knowledge `<= known_at`, then apply `valid_at`/`valid_overlaps` per lineage
+(§7.5). The legacy single-axis `as_of` maps to `known_at` — never silently to
+`valid_at`, which would produce false historical results.
+
+## Consequences
+
+Callers of legacy `as_of` keep belief-time behavior through the `known_at`
+mapping and the characterization fixture. Any query needing world-validity must
+opt into `valid_at`; conflating the two is a correctness bug. Phase 3 supersedes
+the single `as_of` filter with the typed two-axis temporal query.
+
+## Open questions
+
+None.

--- a/docs/adr/0004-record-revision-identity.md
+++ b/docs/adr/0004-record-revision-identity.md
@@ -1,0 +1,48 @@
+# ADR 0004: Record Revision Identity
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+An accountable, self-correcting store must be able to reconstruct exactly what
+was believed at any past point and prove a record has not been tampered with.
+Mutating rows in place destroys both properties. The canonical spec therefore
+makes records immutable and content-addressed (lifecycle §7.6). This ADR RECORDS
+that decision; it opens no question.
+
+## Decision
+
+Records are **immutable**. Three identity fields (lifecycle §7.6):
+
+- `record_id` — identifies **one immutable revision**;
+- `lineage_id` — the stable conceptual record across revisions;
+- `supersedes_record_id` — links a revision to its immediate predecessor.
+
+Records are never mutated in place. Corrections, retractions, and archival each
+create a **new revision** that supersedes the prior one; earlier bytes and
+hashes are left unchanged. `superseded` is therefore a *derived* EffectiveStatus
+of the predecessor, never written back into it.
+
+`record_hash` is `sha256:<64 lowercase hex>` over the RFC 8785 JCS bytes of the
+record, with `record_hash` **omitted from its own preimage** (§7.6). Before
+canonicalization: resolve input aliases, omit absent optionals, normalize
+input nulls, and normalize timestamps to UTC `Z` with trailing fractional-second
+zeros removed. All semantic fields, provenance, links, and extensions
+participate; transport/ingestion metadata (e.g. append idempotency keys) do not.
+`EffectiveStatus` is excluded from `record_hash`.
+
+## Consequences
+
+Phase 1 ships golden JCS hash vectors (real 64-char digests, never ellipsized
+`sha256:...` placeholders). Phase 2 stores `canonical_json` + `record_hash` per
+revision. History reconstruction (ADR 0003) and immutable promotion history
+(ADR 0007) depend on this: a later revision learned after `known_at` cannot
+alter an earlier reconstruction. Content hashes (`content_hash`,
+`canonical_content_hash`) are separate SHA-256 over exact UTF-8 bytes, not
+record JCS.
+
+## Open questions
+
+None.

--- a/docs/adr/0005-storage-authority.md
+++ b/docs/adr/0005-storage-authority.md
@@ -1,0 +1,47 @@
+# ADR 0005: Storage Authority
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+Today `context.db` is a bi-temporal knowledge graph — `node`/`edge`/`memory`/
+`episode` tables managed by `stella-context/src/store.rs` (`migrate()` +
+`SCHEMA_VERSION`, currently v3) — **not** a record authority. The live `recall`
+path, `memory promote`, and the code graph all read these tables. The roadmap
+names Phase 2 the single riskiest step: it evolves a live authoritative store,
+so it cannot be greenfielded.
+
+This ADR RECORDS the authority model already decided by the plan (§6) and
+roadmap. It opens no question, but Phase 2 execution carries a human-decision
+gate (confirm the model on a copy of a real `context.db`).
+
+## Decision
+
+A new immutable `context_records` table becomes the canonical **local**
+authority (Phase 2). Today's `node`/`edge`/`memory`/`episode` tables become
+**transactionally-rebuilt projections / compatibility views** derived from it.
+The canonical row and its projections commit in **one transaction**; a
+projection-rebuild command reproduces them byte-for-byte.
+
+Hard migration constraints:
+
+- Must not lose a memory or break the live `recall` path.
+- **No LLM or semantic reclassification inside a migration.** Ambiguous
+  memories migrate losslessly as `memory` (per ADR 0001); reclassification is a
+  later reviewable proposal, never a migration side effect.
+- Extend the existing `store.rs` migration harness — do not create a replacement
+  database. Fixtures for every schema version (v1/v2/v3) must prove replay is a
+  no-op.
+
+## Consequences
+
+`context_records` holds `record_hash` + `canonical_json` (ADR 0004) as the
+source of truth; legacy tables become derived read paths kept working through
+adapters. Front-loaded fixtures and a tested rollback are mandatory before the
+migration runs against real data.
+
+## Open questions
+
+None.

--- a/docs/adr/0006-contextframe-vs-compiledcontextframe.md
+++ b/docs/adr/0006-contextframe-vs-compiledcontextframe.md
@@ -1,0 +1,45 @@
+# ADR 0006: ContextFrame vs. CompiledContextFrame
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+Stella already consumes provider-emitted `ContextFrame`s: `contextgraph-types`
+defines `ContextFrame`, and `stella-cli/src/contextgraph.rs` hosts in-tree
+providers. Today `recall` returns frames with honest token budgeting and
+drop-reports, but there is no immutable *compiled* aggregate, no manifest, and
+no byte-stable hash — so an invocation's context is not reproducible or
+inspectable after the fact.
+
+This ADR RECORDS the distinction the plan draws (Phase 3, roadmap Layer 1). It
+opens no question.
+
+## Decision
+
+Keep two distinct concepts:
+
+- `ContextFrame` — the **provider-emitted input**, from `contextgraph-types`.
+- `CompiledContextFrame` — a new, deterministic, inspectable aggregate stella
+  builds, carrying a `FrameManifest` and a byte-stable `frame_hash` (Phase 3).
+
+Compilation is **deterministic**: identical inputs produce a byte-identical
+frame body and identical `frame_hash`. Required items **cannot be evicted by
+ranking** — precedence is category-aware, and budget packing may drop only
+non-required items, always with a drop-report (reusing today's honest
+budgeting discipline from `retrieval.rs`, never silent truncation).
+
+## Consequences
+
+Phase 3 emits `CompiledContextFrameBuilt` events and persists compiled frames +
+manifests. Gate: identical inputs → byte-identical frame/hash; required items
+survive ranking; scope-leakage tests pass at every dimension. This is the
+"accountable" milestone (M-A) — every invocation gets a deterministic,
+provenance-bearing frame with honest costs. Compaction (Phase 4) then wires the
+CGP `Compact`/`Reference` representations stella defines but never emits, under
+per-item minimum fidelity so compaction can never weaken a blocking constraint.
+
+## Open questions
+
+None.

--- a/docs/adr/0007-immutable-promotion-history.md
+++ b/docs/adr/0007-immutable-promotion-history.md
@@ -1,8 +1,8 @@
 # ADR 0007: Immutable Promotion History
 
-- Status: Proposed — needs human confirmation
+- Status: Accepted — ratified by repository owner 2026-07-23 (was: Proposed)
 - Date: 2026-07-23
-- Deciders: (Phase 0 baseline)
+- Deciders: repository owner (ratified 2026-07-23)
 
 ## Context
 
@@ -28,7 +28,11 @@ mapping — `observe`/`advisory` → `advisory`; `required`/`blocking` → `bloc
 enforcement states. Also frame "Context PR" as UX over the
 `record_proposal → promotion_event` pipeline, not a second mechanism.
 
-This mapping requires human sign-off before Phase 6.
+**Ratified by the repository owner on 2026-07-23:** adopt the 4→2 mapping
+(`observe`/`advisory` → `advisory`; `required`/`blocking` → `blocking`).
+`DirectiveEnforcement` has exactly two values (`advisory`, `blocking`); the four
+levels may survive only as UI labels over those two enforcement states, never as
+a second enforcement enum.
 
 ## Consequences
 
@@ -40,6 +44,6 @@ locked first.
 
 ## Open questions
 
-**Needs human confirmation:** ratify the 4→2 enforcement mapping (vs. retaining
-four levels as a UI ramp) before Phase 6, since it freezes the
-`DirectiveEnforcement` enum.
+Resolved 2026-07-23: the repository owner ratified the **4→2** enforcement
+mapping. `DirectiveEnforcement` freezes on two values (`advisory`, `blocking`);
+the four levels may appear only as UI labels over them.

--- a/docs/adr/0007-immutable-promotion-history.md
+++ b/docs/adr/0007-immutable-promotion-history.md
@@ -1,0 +1,45 @@
+# ADR 0007: Immutable Promotion History
+
+- Status: Proposed — needs human confirmation
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+The adaptive loop promotes observations into proposals into governed records.
+For that loop to be auditable and reversible, the promotion trail cannot be
+editable after the fact. The canonical plan makes promotions immutable, driven
+by a governance state machine. This ADR RECORDS that decision — and FLAGS one
+surface conflict between the canonical plan and `context-prs-spec.md` that must
+be resolved before Phase 6, because it fixes an enforcement enum.
+
+## Decision
+
+Promotions (`promotion_event`) are **append-only and immutable**. A governance
+state machine with modes `solo`, `team`, and `regulated` records every
+transition; state changes create new immutable events (consistent with ADR
+0004), never in-place edits.
+
+**Enforcement-level mapping (proposed, not ratified):** `context-prs-spec.md`
+uses four levels (`observe | advisory | required | blocking`); the canonical
+plan uses two (`advisory | blocking`). Record the roadmap's proposed 4→2
+mapping — `observe`/`advisory` → `advisory`; `required`/`blocking` → `blocking`
+— while leaving open the alternative of keeping four as a UI ramp over two
+enforcement states. Also frame "Context PR" as UX over the
+`record_proposal → promotion_event` pipeline, not a second mechanism.
+
+This mapping requires human sign-off before Phase 6.
+
+## Consequences
+
+Phase 6 emits immutable `PromotionRecorded` events with a re-proposal cooldown;
+no inferred directive may auto-activate as blocking, and no sharing widens
+automatically (M-B gate). Whichever enforcement resolution is ratified fixes the
+`DirectiveEnforcement` value set and the proposal-review UX, so it must be
+locked first.
+
+## Open questions
+
+**Needs human confirmation:** ratify the 4→2 enforcement mapping (vs. retaining
+four levels as a UI ramp) before Phase 6, since it freezes the
+`DirectiveEnforcement` enum.

--- a/docs/adr/0008-markdown-canonical-rules.md
+++ b/docs/adr/0008-markdown-canonical-rules.md
@@ -1,0 +1,44 @@
+# ADR 0008: Markdown Repository Rules Remain Canonical
+
+- Status: Accepted (Phase 0)
+- Date: 2026-07-23
+- Deciders: (Phase 0 baseline)
+
+## Context
+
+Repository rules are human-governed policy. The plan's Phase 8 model treats Git
+as the authoritative policy ledger and the database as a derived read-only
+mirror. The live code already seeds this: `stella memory promote` writes rules
+as Markdown to `.stella/rules/*.md` after citation thresholds. `context-prs-spec.md`
+proposes a `.stella/rules/*.yaml` surface instead — a *surface* conflict, since
+its thesis (Git canonical, graph derived) is the same model.
+
+This ADR RECORDS the format decision (roadmap §2 reconciliation table) and
+REJECTS the YAML surface. Its one open item is a deferral, not a confirmation
+gate — so this ADR is Accepted, not Proposed.
+
+## Decision
+
+Repository rules remain **Markdown** (`.stella/rules/*.md`) as the canonical,
+human-governed authority. The database is a **derived, read-only mirror** of
+that Markdown (Phase 8 model). Do **not** introduce YAML as a second authority;
+`context-prs-spec.md`'s `.yaml` rule surface is rejected. A single source of
+truth avoids two governance ledgers drifting.
+
+Migration imports legacy `.stella/rules/*.md` (including guard frontmatter and
+aliases) as read-only mirror rows; it never promotes the DB above Markdown.
+
+## Consequences
+
+Phase 8 maps rule frontmatter to/from records and keeps the DB mirror in sync on
+read, never authoritative. The existing `memory promote` Markdown seam is reused,
+not replaced. "Context PR" remains UX over proposal → publish (see ADR 0007), so
+no YAML tooling is needed. Confirming Markdown-canonical is itself a Phase 8
+human-decision gate per the roadmap.
+
+## Open questions
+
+Owner-routing policy (which reviewers/teams gate which rule kinds and paths,
+per `context-prs-spec.md`'s ownership map) is **deferred to Phase 8**. This is a
+deferral, not a blocking confirmation gate — it does not affect the Markdown-
+canonical decision above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,19 +3,23 @@
 These ADRs capture the baseline decisions for Phase 0 of the adaptive-context
 work in stella. Most RECORD decisions already made by the canonical planning
 pair (`adaptive-context-implementation-plan.md` and
-`stella-adaptive-context-lifecycle.md`); two FLAG open questions that require
-human sign-off before the enums they touch are frozen in later phases, and must
-not be resolved by fiat. Each ADR grounds its claims in the source docs and, where
-relevant, the current stella code. The two marked below carry open questions
-requiring human confirmation before their gating phase.
+`stella-adaptive-context-lifecycle.md`). Each ADR grounds its claims in the
+source docs and, where relevant, the current stella code.
+
+ADRs 0002 and 0007 originally FLAGGED open questions for human sign-off; the
+repository owner **ratified both on 2026-07-23**, so all Phase 0 ADRs are now
+Accepted. The ratified resolutions: `SharingScope` is the 4-value set
+(`user, repository, workspace, organization`); `DirectiveEnforcement` is the
+2-value set from the 4→2 mapping. The related `Origin`-arity item (ADR 0001) was
+spec-verified as the full 5-value set for all families.
 
 | # | Title | Status |
 |---|---|---|
 | [0001](0001-semantic-taxonomy.md) | Semantic Taxonomy | Accepted (Phase 0) |
-| [0002](0002-scope-vs-sharing.md) | Scope vs. Sharing | **Proposed — needs human confirmation** (SharingScope arity, before Phase 1) |
+| [0002](0002-scope-vs-sharing.md) | Scope vs. Sharing | Accepted — ratified 2026-07-23 (4-value SharingScope) |
 | [0003](0003-bitemporal-semantics.md) | Bitemporal Semantics | Accepted (Phase 0) |
 | [0004](0004-record-revision-identity.md) | Record Revision Identity | Accepted (Phase 0) |
 | [0005](0005-storage-authority.md) | Storage Authority | Accepted (Phase 0) |
 | [0006](0006-contextframe-vs-compiledcontextframe.md) | ContextFrame vs. CompiledContextFrame | Accepted (Phase 0) |
-| [0007](0007-immutable-promotion-history.md) | Immutable Promotion History | **Proposed — needs human confirmation** (enforcement 4→2 mapping, before Phase 6) |
+| [0007](0007-immutable-promotion-history.md) | Immutable Promotion History | Accepted — ratified 2026-07-23 (enforcement 4→2) |
 | [0008](0008-markdown-canonical-rules.md) | Markdown Repository Rules Remain Canonical | Accepted (Phase 0) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records — Phase 0 (Adaptive Context)
+
+These ADRs capture the baseline decisions for Phase 0 of the adaptive-context
+work in stella. Most RECORD decisions already made by the canonical planning
+pair (`adaptive-context-implementation-plan.md` and
+`stella-adaptive-context-lifecycle.md`); two FLAG open questions that require
+human sign-off before the enums they touch are frozen in later phases, and must
+not be resolved by fiat. Each ADR grounds its claims in the source docs and, where
+relevant, the current stella code. The two marked below carry open questions
+requiring human confirmation before their gating phase.
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-semantic-taxonomy.md) | Semantic Taxonomy | Accepted (Phase 0) |
+| [0002](0002-scope-vs-sharing.md) | Scope vs. Sharing | **Proposed — needs human confirmation** (SharingScope arity, before Phase 1) |
+| [0003](0003-bitemporal-semantics.md) | Bitemporal Semantics | Accepted (Phase 0) |
+| [0004](0004-record-revision-identity.md) | Record Revision Identity | Accepted (Phase 0) |
+| [0005](0005-storage-authority.md) | Storage Authority | Accepted (Phase 0) |
+| [0006](0006-contextframe-vs-compiledcontextframe.md) | ContextFrame vs. CompiledContextFrame | Accepted (Phase 0) |
+| [0007](0007-immutable-promotion-history.md) | Immutable Promotion History | **Proposed — needs human confirmation** (enforcement 4→2 mapping, before Phase 6) |
+| [0008](0008-markdown-canonical-rules.md) | Markdown Repository Rules Remain Canonical | Accepted (Phase 0) |

--- a/stella-cli/src/rules.rs
+++ b/stella-cli/src/rules.rs
@@ -720,4 +720,60 @@ mod tests {
             .await;
         assert!(!allowed.is_error(), "a non-matching command runs normally");
     }
+
+    // Phase 0: representative `.stella/rules/*.md` fixtures must parse under the
+    // CURRENT `stella_core::rules` parser — the format Phase 2's importer will
+    // read back as read-only mirrors. Captures both a promoted guard rule and a
+    // full context-as-code directive (inferred, advisory).
+    const GUARD_RULE_FIXTURE: &str =
+        include_str!("../tests/fixtures/rules/no-hand-edited-migrations.md");
+    const DIRECTIVE_RULE_FIXTURE: &str =
+        include_str!("../tests/fixtures/rules/api-integration-coverage.md");
+
+    #[test]
+    fn guard_rule_fixture_parses_as_a_guarded_rule_without_metadata() {
+        let rule = stella_core::rules::rule_from_file(
+            ".stella/rules/no-hand-edited-migrations.md",
+            GUARD_RULE_FIXTURE,
+        )
+        .expect("guard rule parses");
+        assert_eq!(rule.id, "no-hand-edited-migrations");
+        assert_eq!(
+            rule.description,
+            "Never hand-edit an already-applied migration file."
+        );
+        let guard = rule.guard.expect("guard frontmatter present");
+        assert_eq!(guard.tool.as_deref(), Some("Edit"));
+        assert_eq!(
+            guard.deny_path_glob.as_deref(),
+            Some("migrations/*-applied/**")
+        );
+        assert!(guard.deny_command_glob.is_none());
+        // A pure guard rule declares no lifecycle metadata and so has no errors.
+        assert!(rule.metadata.is_none());
+        assert!(rule.metadata_errors.is_empty());
+    }
+
+    #[test]
+    fn directive_rule_fixture_parses_with_context_metadata() {
+        let rule = stella_core::rules::rule_from_file(
+            ".stella/rules/api-integration-coverage.md",
+            DIRECTIVE_RULE_FIXTURE,
+        )
+        .expect("directive rule parses");
+        assert_eq!(rule.id, "api-integration-coverage");
+        // Empty errors proves every enum (record_kind/enforcement/origin) and
+        // timestamp in the frontmatter parsed to a valid value.
+        assert!(
+            rule.metadata_errors.is_empty(),
+            "unexpected metadata errors: {:?}",
+            rule.metadata_errors
+        );
+        let meta = rule.metadata.expect("context metadata present");
+        assert_eq!(meta.record_id, "dir_api_integration_coverage_v1");
+        assert_eq!(meta.confidence, 88);
+        // `scope_paths` is canonicalized (sorted, deduped) by the parser.
+        assert_eq!(meta.scope_paths, vec!["docs/api/**", "src/api/**"]);
+        assert_eq!(meta.supporting_evidence_ids.len(), 3);
+    }
 }

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -36,6 +36,7 @@ use stella_protocol::{ReasoningEffort, ServiceTier, Verbosity};
 use crate::config::Dialect;
 
 mod authority;
+mod context;
 mod managed;
 mod merge;
 mod private;
@@ -43,6 +44,10 @@ mod private;
 #[path = "settings/private_state_tests.rs"]
 mod private_state_tests;
 pub use authority::{AuthorityPolicy, ManagedAuthoritySettings};
+// Only `ContextSettings` is consumed today (the inert `Settings::context`
+// field). The nested types (`LearningMode`, `GovernanceMode`, …) live in
+// `settings::context`; a later phase re-exports them here as it wires them in.
+pub use context::ContextSettings;
 
 /// One `providers.<id>` entry. Every field is optional at the schema level;
 /// which ones are *required* depends on whether the id names a built-in
@@ -129,6 +134,14 @@ pub struct Settings {
     /// changed, beside the file and cost panels. No model call. Default off.
     #[serde(default)]
     pub enable_recap: Option<Toggle>,
+    /// Adaptive-context lifecycle configuration (the `context` block). INERT
+    /// in Phase 0: deserialized, round-tripped, and merged, but read by no
+    /// code yet — `context.lifecycle.enabled` defaults `false`, which is what
+    /// preserves current behavior. `None` = the block was absent. Whole-block
+    /// last-wins across scopes (see [`Settings::overlay_scope`]). See
+    /// [`ContextSettings`].
+    #[serde(default)]
+    pub context: Option<ContextSettings>,
     /// Authority ceilings are honored only from the org-managed settings
     /// file. The serde name is intentionally short because the containing
     /// file is already the policy source.

--- a/stella-cli/src/settings/context.rs
+++ b/stella-cli/src/settings/context.rs
@@ -1,0 +1,331 @@
+//! `context.*` — adaptive-context lifecycle configuration (Phase 0 scaffold).
+//!
+//! This block is **entirely inert in Phase 0**: every field deserializes and
+//! round-trips, but no code reads it yet. The single value that preserves
+//! current behavior is [`LifecycleSettings::enabled`], which defaults to
+//! `false`; while it is off, the learning, governance, promotion, efficacy,
+//! and retention knobs are ignored. The schema exists now so a later phase can
+//! turn the loop on without a settings migration, and so the vocabulary is
+//! pinned by round-trip tests.
+//!
+//! Two dimensions are kept deliberately separate (do not collapse them):
+//!
+//! * **learning mode** — `off` | `record_only` | `advisory`. `off` disables
+//!   mining, proposal induction, and efficacy learning; `record_only` captures
+//!   observations, proposals, uses, and outcomes without selecting or promoting
+//!   inferred records; `advisory` enables governed inferred *advisory* use.
+//! * **governance mode** — `solo` | `team` | `regulated`.
+//!
+//! Enums are "loud": an unrecognized value is a hard parse error (as with
+//! [`crate::settings::Toggle`]), never a silent fallback. Omitted fields fall
+//! back to the documented defaults below.
+
+use serde::{Deserialize, Serialize};
+
+/// The `context` block of `settings.json`. All fields default, so `"context":
+/// {}` — or an absent block — yields the behavior-preserving defaults
+/// (lifecycle disabled, learning off, governance solo).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct ContextSettings {
+    pub lifecycle: LifecycleSettings,
+    pub learning: LearningSettings,
+    pub governance: GovernanceSettings,
+    pub promotion: PromotionSettings,
+    pub efficacy: EfficacySettings,
+    pub retention: RetentionSettings,
+}
+
+/// Master switch for the whole adaptive-context lifecycle.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct LifecycleSettings {
+    /// `false` (default) preserves all pre-adaptive-context behavior: every
+    /// other field in the `context` block is ignored while this is off.
+    pub enabled: bool,
+}
+
+/// How much of the learning loop runs. Orthogonal to [`GovernanceMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LearningMode {
+    /// Disables mining, proposal induction, and efficacy learning.
+    #[default]
+    Off,
+    /// Captures observations, proposals, uses, and outcomes without selecting
+    /// or promoting inferred records.
+    RecordOnly,
+    /// Enables governed inferred *advisory* use.
+    Advisory,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct LearningSettings {
+    pub mode: LearningMode,
+}
+
+/// Who governs promotions. Orthogonal to [`LearningMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceMode {
+    #[default]
+    Solo,
+    Team,
+    Regulated,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct GovernanceSettings {
+    pub mode: GovernanceMode,
+}
+
+/// The enforcement a directive carries. Only two states exist (`advisory` and
+/// `blocking`); an inferred directive may only *start* advisory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InitialEnforcement {
+    #[default]
+    Advisory,
+    Blocking,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PromotionSettings {
+    pub inferred_directive: InferredDirectivePromotion,
+    pub blocking_directive: BlockingDirectivePromotion,
+}
+
+/// Thresholds gating when a set of observations may become an inferred
+/// directive. `confidence` values are on the `0..=100` scale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InferredDirectivePromotion {
+    pub min_observations: u32,
+    pub min_distinct_tasks: u32,
+    /// `0..=100`.
+    pub auto_activate_at_confidence: u8,
+    /// An inferred directive can never *start* blocking; the default and only
+    /// sensible value here is `advisory`.
+    pub initial_enforcement: InitialEnforcement,
+}
+
+impl Default for InferredDirectivePromotion {
+    fn default() -> Self {
+        Self {
+            min_observations: 3,
+            min_distinct_tasks: 3,
+            auto_activate_at_confidence: 85,
+            initial_enforcement: InitialEnforcement::Advisory,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BlockingDirectivePromotion {
+    /// A blocking directive always requires an explicit human confirmation;
+    /// this is `true` by default and should not be turned off lightly.
+    pub requires_explicit_confirmation: bool,
+}
+
+impl Default for BlockingDirectivePromotion {
+    fn default() -> Self {
+        Self {
+            requires_explicit_confirmation: true,
+        }
+    }
+}
+
+/// Efficacy-attribution thresholds. `confidence` values are on the `0..=100`
+/// scale; `not_helpful_ratio_threshold` is a `0.0..=1.0` ratio.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EfficacySettings {
+    pub min_attributable_uses: u32,
+    pub not_helpful_ratio_threshold: f64,
+    /// `0..=100`.
+    pub min_attribution_confidence: u8,
+    /// `0..=100`.
+    pub receipt_display_min_attribution_confidence: u8,
+}
+
+impl Default for EfficacySettings {
+    fn default() -> Self {
+        Self {
+            min_attributable_uses: 5,
+            not_helpful_ratio_threshold: 0.8,
+            min_attribution_confidence: 80,
+            receipt_display_min_attribution_confidence: 80,
+        }
+    }
+}
+
+/// How long raw observations, proposals, and inferred directives are retained
+/// before review/expiry (in days).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RetentionSettings {
+    pub raw_observation_days: u32,
+    pub proposal_days: u32,
+    pub inferred_directive_review_days: u32,
+}
+
+impl Default for RetentionSettings {
+    fn default() -> Self {
+        Self {
+            raw_observation_days: 30,
+            proposal_days: 30,
+            inferred_directive_review_days: 180,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+
+    /// The canonical committed fixture (`.stella/settings.json` is gitignored,
+    /// so the canonical example lives as a test fixture).
+    const FIXTURE: &str = include_str!("../../tests/fixtures/context_settings.json");
+
+    #[test]
+    fn absent_context_block_is_none_and_preserves_behavior() {
+        // No `context` key at all — the field is absent, not defaulted-on.
+        let s: Settings = serde_json::from_str("{}").expect("empty settings parse");
+        assert_eq!(s.context, None, "absent context must stay None");
+        // And the workspace default carries no context block either.
+        assert_eq!(Settings::default().context, None);
+    }
+
+    #[test]
+    fn empty_context_block_yields_behavior_preserving_defaults() {
+        let s: Settings = serde_json::from_str(r#"{"context":{}}"#).expect("empty context parse");
+        let ctx = s.context.expect("context present");
+        // The one field that gates behavior: disabled by default.
+        assert!(!ctx.lifecycle.enabled, "lifecycle must default disabled");
+        assert_eq!(ctx.learning.mode, LearningMode::Off);
+        assert_eq!(ctx.governance.mode, GovernanceMode::Solo);
+        assert_eq!(ctx, ContextSettings::default());
+    }
+
+    #[test]
+    fn canonical_fixture_deserializes_to_the_documented_defaults() {
+        let s: Settings = serde_json::from_str(FIXTURE).expect("fixture parse");
+        let ctx = s.context.expect("fixture has a context block");
+        // Disabled-by-default lifecycle is what keeps behavior unchanged.
+        assert!(!ctx.lifecycle.enabled);
+        assert_eq!(ctx.learning.mode, LearningMode::Off);
+        assert_eq!(ctx.governance.mode, GovernanceMode::Solo);
+        assert_eq!(ctx.promotion.inferred_directive.min_observations, 3);
+        assert_eq!(ctx.promotion.inferred_directive.min_distinct_tasks, 3);
+        assert_eq!(
+            ctx.promotion.inferred_directive.auto_activate_at_confidence,
+            85
+        );
+        assert_eq!(
+            ctx.promotion.inferred_directive.initial_enforcement,
+            InitialEnforcement::Advisory
+        );
+        assert!(
+            ctx.promotion
+                .blocking_directive
+                .requires_explicit_confirmation
+        );
+        assert_eq!(ctx.efficacy.min_attributable_uses, 5);
+        assert_eq!(ctx.efficacy.not_helpful_ratio_threshold, 0.8);
+        assert_eq!(ctx.efficacy.min_attribution_confidence, 80);
+        assert_eq!(ctx.efficacy.receipt_display_min_attribution_confidence, 80);
+        assert_eq!(ctx.retention.raw_observation_days, 30);
+        assert_eq!(ctx.retention.proposal_days, 30);
+        assert_eq!(ctx.retention.inferred_directive_review_days, 180);
+        // The whole block equals the code-level defaults: the fixture and the
+        // Default impls cannot silently drift apart.
+        assert_eq!(ctx, ContextSettings::default());
+    }
+
+    #[test]
+    fn context_round_trips_through_json() {
+        let original = ContextSettings::default();
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: ContextSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn modes_are_loud_on_unknown_values() {
+        // A typo'd mode is a hard error, not a silent fallback.
+        let err =
+            serde_json::from_str::<Settings>(r#"{"context":{"learning":{"mode":"advisary"}}}"#);
+        assert!(err.is_err(), "unknown learning mode must fail to parse");
+        let err = serde_json::from_str::<Settings>(r#"{"context":{"governance":{"mode":"duo"}}}"#);
+        assert!(err.is_err(), "unknown governance mode must fail to parse");
+    }
+
+    #[test]
+    fn every_key_binds_to_its_field() {
+        // Because every field is `#[serde(default)]` and the structs do not
+        // `deny_unknown_fields`, a misspelled key would be silently ignored and
+        // default to its usual value — so a fixture whose values equal the
+        // defaults cannot catch a typo. This test gives EVERY key a DISTINCT
+        // non-default value and asserts it reads back, proving each JSON key
+        // actually reaches its field (and none reads another's value).
+        let json = r#"{"context":{
+            "lifecycle":{"enabled":true},
+            "learning":{"mode":"record_only"},
+            "governance":{"mode":"regulated"},
+            "promotion":{
+                "inferred_directive":{
+                    "min_observations":7,
+                    "min_distinct_tasks":4,
+                    "auto_activate_at_confidence":42,
+                    "initial_enforcement":"blocking"
+                },
+                "blocking_directive":{"requires_explicit_confirmation":false}
+            },
+            "efficacy":{
+                "min_attributable_uses":9,
+                "not_helpful_ratio_threshold":0.25,
+                "min_attribution_confidence":70,
+                "receipt_display_min_attribution_confidence":60
+            },
+            "retention":{
+                "raw_observation_days":15,
+                "proposal_days":45,
+                "inferred_directive_review_days":200
+            }
+        }}"#;
+        let s: Settings = serde_json::from_str(json).expect("parse");
+        let ctx = s.context.expect("present");
+
+        assert!(ctx.lifecycle.enabled);
+        assert_eq!(ctx.learning.mode, LearningMode::RecordOnly);
+        assert_eq!(ctx.governance.mode, GovernanceMode::Regulated);
+
+        let inf = &ctx.promotion.inferred_directive;
+        assert_eq!(inf.min_observations, 7);
+        assert_eq!(inf.min_distinct_tasks, 4);
+        assert_eq!(inf.auto_activate_at_confidence, 42);
+        // Deserializing "blocking" here is a schema check; the "inferred may
+        // not START blocking" invariant is a Phase 1 validator, not a parse
+        // constraint.
+        assert_eq!(inf.initial_enforcement, InitialEnforcement::Blocking);
+        assert!(
+            !ctx.promotion
+                .blocking_directive
+                .requires_explicit_confirmation
+        );
+
+        assert_eq!(ctx.efficacy.min_attributable_uses, 9);
+        assert_eq!(ctx.efficacy.not_helpful_ratio_threshold, 0.25);
+        assert_eq!(ctx.efficacy.min_attribution_confidence, 70);
+        assert_eq!(ctx.efficacy.receipt_display_min_attribution_confidence, 60);
+
+        assert_eq!(ctx.retention.raw_observation_days, 15);
+        assert_eq!(ctx.retention.proposal_days, 45);
+        assert_eq!(ctx.retention.inferred_directive_review_days, 200);
+    }
+}

--- a/stella-cli/src/settings/merge.rs
+++ b/stella-cli/src/settings/merge.rs
@@ -76,6 +76,13 @@ impl Settings {
         if let Some(authority) = scope.managed_authority {
             self.managed_authority = Some(authority);
         }
+        // Adaptive-context config: whole-block last-wins (a higher-precedence
+        // scope that declares `context` replaces a lower one's). Inert in
+        // Phase 0 — nothing reads it — so no trust restoration is needed (it
+        // carries no credential or egress authority).
+        if let Some(context) = &scope.context {
+            self.context = Some(context.clone());
+        }
     }
 
     fn merge_snapshots(scopes: &[&Settings]) -> Self {

--- a/stella-cli/tests/fixtures/context_settings.json
+++ b/stella-cli/tests/fixtures/context_settings.json
@@ -1,0 +1,35 @@
+{
+  "context": {
+    "lifecycle": {
+      "enabled": false
+    },
+    "learning": {
+      "mode": "off"
+    },
+    "governance": {
+      "mode": "solo"
+    },
+    "promotion": {
+      "inferred_directive": {
+        "min_observations": 3,
+        "min_distinct_tasks": 3,
+        "auto_activate_at_confidence": 85,
+        "initial_enforcement": "advisory"
+      },
+      "blocking_directive": {
+        "requires_explicit_confirmation": true
+      }
+    },
+    "efficacy": {
+      "min_attributable_uses": 5,
+      "not_helpful_ratio_threshold": 0.8,
+      "min_attribution_confidence": 80,
+      "receipt_display_min_attribution_confidence": 80
+    },
+    "retention": {
+      "raw_observation_days": 30,
+      "proposal_days": 30,
+      "inferred_directive_review_days": 180
+    }
+  }
+}

--- a/stella-cli/tests/fixtures/rules/api-integration-coverage.md
+++ b/stella-cli/tests/fixtures/rules/api-integration-coverage.md
@@ -1,0 +1,22 @@
+---
+name: api-integration-coverage
+description: API endpoint changes require integration coverage.
+schema_version: 1.0-draft
+record_id: dir_api_integration_coverage_v1
+record_kind: directive
+scope_paths:
+  - src/api/**
+  - docs/api/**
+enforcement: advisory
+confidence: 88
+origin: inferred
+supporting_evidence_ids:
+  - ev_task_118
+  - ev_task_101
+  - ev_task_094
+observed_at: 2026-07-20T18:30:00Z
+valid_from: 2026-07-20T18:30:00Z
+---
+
+When changing an API endpoint under `src/api/`, add or update an integration
+test that exercises the endpoint end to end before considering the change done.

--- a/stella-cli/tests/fixtures/rules/no-hand-edited-migrations.md
+++ b/stella-cli/tests/fixtures/rules/no-hand-edited-migrations.md
@@ -1,0 +1,9 @@
+---
+description: Never hand-edit an already-applied migration file.
+guard-tool: Edit
+guard-deny-path: migrations/*-applied/**
+---
+
+Applied migrations are immutable history. To change the schema, add a NEW
+migration rather than editing one under `migrations/*-applied/`. Hand-editing an
+applied migration desynchronizes environments that already ran it.

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -1673,4 +1673,308 @@ mod tests {
         // A second warm is a no-op — the vector already exists.
         assert_eq!(store.warm_now().await.unwrap(), 0);
     }
+
+    // ==================================================================
+    // Phase 0 characterization: `ContextQuery.as_of` bitemporal semantics
+    // ==================================================================
+    //
+    // The adaptive-context plan forbids *assuming* what `as_of` means
+    // (knowledge cutoff, world validity, or both). These tests PIN the
+    // observed contract of the two temporal readers that back it —
+    // `edges_as_of` (the public `facts_as_of`) and `neighbors` (the only
+    // consumer of `ContextQuery.as_of` inside `recall`). The characterized
+    // contract, which any future bitemporal API must preserve or migrate
+    // deliberately:
+    //
+    //   `as_of` filters on TRANSACTION / BELIEF time ONLY — the half-open
+    //   interval `[recorded_at, superseded_at)`:
+    //     * `as_of = None`      -> currently believed (`superseded_at IS NULL`)
+    //     * `as_of = Some(t)`   -> `recorded_at <= t AND
+    //                              (superseded_at IS NULL OR superseded_at > t)`
+    //   The start is INCLUSIVE (`t == recorded_at` is visible); the end is
+    //   EXCLUSIVE (`t == superseded_at` is NOT visible).
+    //
+    //   `as_of` DOES NOT consult world-validity (`valid_from` / `valid_to`).
+    //   An edge whose world-validity window has closed in the past is still
+    //   returned as long as it remains believed. This is the decisive
+    //   discriminator between "transaction time" and "world validity / both".
+
+    // Fixed, equal-length UTC instants so lexicographic order over the TEXT
+    // columns matches chronological order (the store compares timestamps as
+    // strings).
+    const T0: &str = "2026-01-01T00:00:00Z"; // before anything is recorded
+    const T1: &str = "2026-02-01T00:00:00Z"; // edge recorded (== recorded_at)
+    const T1_5: &str = "2026-02-15T00:00:00Z"; // strictly inside [T1, T2)
+    const T2: &str = "2026-03-01T00:00:00Z"; // edge superseded (== superseded_at)
+    const T3: &str = "2026-04-01T00:00:00Z"; // after supersession / world-validity
+
+    fn concept(conn: &Connection, name: &str) -> i64 {
+        upsert_node(conn, &NodeInput::new(NodeKind::Concept, name), T1).unwrap()
+    }
+
+    /// Sorted `(src_id, dst_id)` pairs visible to `edges_as_of` at `as_of`.
+    fn edge_pairs(conn: &Connection, as_of: Option<&str>) -> Vec<(i64, i64)> {
+        let mut v: Vec<(i64, i64)> = edges_as_of(conn, as_of)
+            .unwrap()
+            .into_iter()
+            .map(|e| (e.src_id, e.dst_id))
+            .collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Sorted neighbor ids of `seed` visible to `neighbors` at `as_of`.
+    fn neighbor_ids(conn: &Connection, seed: i64, as_of: Option<&str>) -> Vec<i64> {
+        let mut v: Vec<i64> = neighbors(conn, &[seed], as_of)
+            .unwrap()
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        v.sort_unstable();
+        v
+    }
+
+    #[test]
+    fn as_of_none_returns_only_currently_believed_edges() {
+        let (_dir, store) = tmp_store();
+        let conn = store.conn();
+        let (a, b, c) = (
+            concept(&conn, "a"),
+            concept(&conn, "b"),
+            concept(&conn, "c"),
+        );
+        let props = serde_json::json!({});
+        // Two beliefs recorded at T1: a->b and a->c.
+        let e_ab =
+            insert_edge(&conn, "relates_to", a, b, 1.0, &props, None, None, T1, None).unwrap();
+        insert_edge(&conn, "relates_to", a, c, 1.0, &props, None, None, T1, None).unwrap();
+        // a->b is later corrected away (superseded at T2). Never deleted.
+        close_edge(&conn, e_ab, T2, T2).unwrap();
+
+        // `None` == "currently believed": a->b is gone, a->c remains.
+        assert_eq!(edge_pairs(&conn, None), vec![(a, c)]);
+        assert_eq!(neighbor_ids(&conn, a, None), vec![c]);
+        // Undirected: c still sees a; b no longer does.
+        assert_eq!(neighbor_ids(&conn, c, None), vec![a]);
+        assert_eq!(neighbor_ids(&conn, b, None), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn as_of_reconstructs_half_open_transaction_interval() {
+        let (_dir, store) = tmp_store();
+        let conn = store.conn();
+        let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
+        let props = serde_json::json!({});
+        // a->b believed from T1, superseded at T2: valid transaction interval
+        // is the half-open [T1, T2).
+        let e = insert_edge(&conn, "relates_to", a, b, 1.0, &props, None, None, T1, None).unwrap();
+        close_edge(&conn, e, T2, T2).unwrap();
+
+        // Before it was recorded: not yet believed.
+        assert_eq!(edge_pairs(&conn, Some(T0)), Vec::<(i64, i64)>::new());
+        assert_eq!(neighbor_ids(&conn, a, Some(T0)), Vec::<i64>::new());
+
+        // At exactly recorded_at (T1): INCLUSIVE start -> visible.
+        assert_eq!(edge_pairs(&conn, Some(T1)), vec![(a, b)]);
+        assert_eq!(neighbor_ids(&conn, a, Some(T1)), vec![b]);
+
+        // Strictly inside [T1, T2): visible.
+        assert_eq!(edge_pairs(&conn, Some(T1_5)), vec![(a, b)]);
+        assert_eq!(neighbor_ids(&conn, a, Some(T1_5)), vec![b]);
+
+        // At exactly superseded_at (T2): EXCLUSIVE end -> NOT visible.
+        // This is the line that pins the interval as half-open, not closed.
+        assert_eq!(edge_pairs(&conn, Some(T2)), Vec::<(i64, i64)>::new());
+        assert_eq!(neighbor_ids(&conn, a, Some(T2)), Vec::<i64>::new());
+
+        // After supersession: still not visible.
+        assert_eq!(edge_pairs(&conn, Some(T3)), Vec::<(i64, i64)>::new());
+        assert_eq!(neighbor_ids(&conn, a, Some(T3)), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn as_of_ignores_world_validity_valid_from_valid_to() {
+        // THE DISCRIMINATOR. An edge whose world-validity window closed in the
+        // past (`valid_to = T1`) but which is still BELIEVED (`superseded_at IS
+        // NULL`) must remain visible to every `as_of` query at or after its
+        // `recorded_at`. If `as_of` consulted world validity (or "both"), a
+        // query at T3 > valid_to would hide it — it does not. Proves the filter
+        // is transaction/belief time only.
+        let (_dir, store) = tmp_store();
+        let conn = store.conn();
+        let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
+        let props = serde_json::json!({});
+        // Recorded at T1, world-valid only across [T0, T1], never superseded.
+        insert_edge(
+            &conn,
+            "relates_to",
+            a,
+            b,
+            1.0,
+            &props,
+            Some(T0), // valid_from
+            Some(T1), // valid_to — world-validity ends in the past
+            T1,       // recorded_at
+            None,     // supersedes -> superseded_at stays NULL (still believed)
+        )
+        .unwrap();
+
+        // Still believed now, despite a closed world-validity window.
+        assert_eq!(edge_pairs(&conn, None), vec![(a, b)]);
+        assert_eq!(neighbor_ids(&conn, a, None), vec![b]);
+
+        // And still visible as-of T3, long after valid_to (T1): as_of never
+        // reads valid_to.
+        assert_eq!(edge_pairs(&conn, Some(T3)), vec![(a, b)]);
+        assert_eq!(neighbor_ids(&conn, a, Some(T3)), vec![b]);
+
+        // Only transaction time gates it: before recorded_at it is invisible.
+        assert_eq!(edge_pairs(&conn, Some(T0)), Vec::<(i64, i64)>::new());
+    }
+
+    // ============================================================
+    // Phase 0 fixtures: schema-version migration is a lossless,
+    // idempotent replay carrying representative rows
+    // ============================================================
+    //
+    // `open`-ing a legacy `context.db` must migrate it to `SCHEMA_VERSION`
+    // without losing data, and re-opening must be a no-op. These fixtures carry
+    // the SAME representative rows the `as_of_*` tests characterize (a
+    // superseded edge, an edge whose world-validity closed in the past, a
+    // memory) so the migration is shown to preserve both the data AND the
+    // transaction-time semantics — not just an empty schema.
+
+    /// A raw connection migrated up to `version` with `user_version` stamped,
+    /// so `ContextStore::open` sees a legacy db to upgrade. The `node`/`edge`
+    /// tables are identical across v1..v3, so the crate's writers apply to any
+    /// version >= 1; the `memory` table requires v2.
+    fn open_legacy(path: &std::path::Path, version: i64) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(MIGRATION_V1).unwrap();
+        if version >= 2 {
+            conn.execute_batch(MIGRATION_V2).unwrap();
+        }
+        conn.pragma_update(None, "user_version", version).unwrap();
+        conn
+    }
+
+    #[test]
+    fn migrates_v1_context_db_preserving_bitemporal_edges() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("context.db");
+        let (a, b, c) = {
+            let conn = open_legacy(&path, 1);
+            let props = serde_json::json!({});
+            let a = upsert_node(&conn, &NodeInput::new(NodeKind::Concept, "a"), T1).unwrap();
+            let b = upsert_node(&conn, &NodeInput::new(NodeKind::Concept, "b"), T1).unwrap();
+            let c = upsert_node(&conn, &NodeInput::new(NodeKind::Concept, "c"), T1).unwrap();
+            // A belief a->b that was later corrected away (superseded at T2).
+            let e_ab =
+                insert_edge(&conn, "relates_to", a, b, 1.0, &props, None, None, T1, None).unwrap();
+            close_edge(&conn, e_ab, T2, T2).unwrap();
+            // A still-believed belief a->c whose world-validity window closed in
+            // the past (valid_to = T1) — the `as_of` discriminator row.
+            insert_edge(
+                &conn,
+                "relates_to",
+                a,
+                c,
+                1.0,
+                &props,
+                Some(T0),
+                Some(T1),
+                T1,
+                None,
+            )
+            .unwrap();
+            let v: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v, 1, "fixture really is a v1 db before open");
+            (a, b, c)
+        };
+
+        // Open through the store: migrate v1 -> SCHEMA_VERSION.
+        let store = ContextStore::open(&path).unwrap();
+        store.integrity_check().unwrap();
+        {
+            let conn = store.conn();
+            let v: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v, SCHEMA_VERSION, "v1 db upgraded to current");
+            // Currently believed = only a->c (a->b superseded; a->c's past
+            // valid_to is ignored by transaction-time queries).
+            assert_eq!(edge_pairs(&conn, None), vec![(a, c)]);
+            // Both edges still physically present, reconstructable as-of T1.
+            assert_eq!(edge_pairs(&conn, Some(T1)), vec![(a, b), (a, c)]);
+        }
+
+        // Re-open: replay is a no-op — same version, same data.
+        drop(store);
+        let store2 = ContextStore::open(&path).unwrap();
+        let conn = store2.conn();
+        let v: i64 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION);
+        assert_eq!(edge_pairs(&conn, None), vec![(a, c)]);
+    }
+
+    #[test]
+    fn migrates_v2_context_db_preserving_memories() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("context.db");
+        let mem_public = "mem_phase0fixturememory0001";
+        {
+            let conn = open_legacy(&path, 2);
+            // Production writes a memory as a canonical `memory` row plus a
+            // retrievable mirror `node` in one transaction; reproduce both.
+            insert_memory(
+                &conn,
+                mem_public,
+                "reflection",
+                "prefer rg over grep",
+                0.5,
+                T1,
+            )
+            .unwrap();
+            upsert_node(
+                &conn,
+                &NodeInput::new(NodeKind::Memory, "prefer rg over grep")
+                    .with_content("prefer rg over grep")
+                    .with_uri(format!("memory://{mem_public}")),
+                T1,
+            )
+            .unwrap();
+            let v: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v, 2, "fixture really is a v2 db before open");
+        }
+
+        let store = ContextStore::open(&path).unwrap();
+        store.integrity_check().unwrap();
+        {
+            let conn = store.conn();
+            let v: i64 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v, SCHEMA_VERSION, "v2 db upgraded to current");
+            // The canonical memory row survived the migration.
+            let content: String = conn
+                .query_row(
+                    "SELECT content FROM memory WHERE public_id = ?1",
+                    params![mem_public],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(content, "prefer rg over grep");
+        }
+        // And it is still retrievable through the mirror node (the recall
+        // surface behind `stella memory`).
+        let mem_nodes = store.memory_nodes().unwrap();
+        assert_eq!(mem_nodes.len(), 1);
+        assert_eq!(mem_nodes[0].content, "prefer rg over grep");
+    }
 }

--- a/stella-core/Cargo.toml
+++ b/stella-core/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 stella-protocol = { path = "../stella-protocol" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_json_canonicalizer = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 async-trait = { workspace = true }

--- a/stella-core/src/context_record.rs
+++ b/stella-core/src/context_record.rs
@@ -1,0 +1,128 @@
+//! Adaptive-context domain model — pure, I/O-free types and validators.
+//!
+//! This is the typed record taxonomy every later adaptive-context phase
+//! (migration, compilation, learning, governance) builds on. It is deliberately
+//! **pure**: no I/O, no persistence, no `stella-context` dependency — only value
+//! types, cross-field validators, and canonical hashing. (Named `context_record`
+//! rather than `context` to stay unambiguous next to the `stella-context` crate.)
+//!
+//! ## Scope of this installment
+//!
+//! Phase 1 is large; this is **installment 1 of N** — the foundational vertical:
+//! the record taxonomy enums, [`Scope`]/[`SharingScope`], the temporal
+//! primitives, canonical [`hash`]ing, and the cross-field validators that live
+//! entirely on those types. **Deferred to later installments** (their types are
+//! not here yet, so neither are the validators that span them): the
+//! context-use / efficacy web, artifact contracts + validation, outcome
+//! assessments, frame representation / content-fidelity, and the internal
+//! replay-safe events in `stella-protocol`. This module does **not** yet satisfy
+//! the full Phase 1 gate.
+//!
+//! ## Relationship to the legacy `rules::metadata` types (coexist, do not merge)
+//!
+//! `stella-core::rules::metadata` already carries types that drive the **live**
+//! Markdown rules path. Those are left untouched here — editing them would be a
+//! behavior change. The new types coexist; a later phase migrates the rules path
+//! onto them. The intended subsumption mapping:
+//!
+//! | legacy (`rules::metadata`)                     | new (`context_record`)                          |
+//! |------------------------------------------------|-------------------------------------------------|
+//! | `RuleRecordKind::Directive`                    | `ContextRecordKind::Directive` + `DirectiveKind`|
+//! | `RuleEnforcement` = {Informational,Advisory,Blocking} | `DirectiveEnforcement` = {Advisory,Blocking} |
+//! | `RuleOrigin` = {User,System,Inferred,Imported} | `Origin` = {User,System,Observed,Inferred,Imported} |
+//!
+//! **Two mapping edges are NOT covered by the ratified decisions and are flagged
+//! for confirmation before the legacy path is migrated:**
+//!
+//! 1. `RuleEnforcement::Informational` has no target in the 2-value
+//!    `DirectiveEnforcement`. The ratified 4→2 mapping (ADR 0007) was over the
+//!    `context-prs-spec` vocabulary (`observe|advisory|required|blocking`), a
+//!    *different* set than `Informational|Advisory|Blocking`. `Informational →
+//!    advisory` is the likely intent but is **unratified**.
+//! 2. `Origin` is a uniform 5-value enum (ratified). However the directive
+//!    record schema (lifecycle §, directive allowed-values) enumerates only
+//!    `user, system, inferred, imported` — a per-family narrowing that forbids
+//!    an `observed` directive. That narrowing is left as a **flagged validator,
+//!    not implemented here**, because it refines the "uniform 5" resolution.
+
+pub mod hash;
+pub mod kind;
+pub mod scope;
+pub mod temporal;
+
+pub use hash::{RecordHashError, record_hash};
+pub use kind::{
+    ConstraintEffect, ContextRecordKind, DirectiveEnforcement, DirectiveKind, DirectivePriority,
+    EffectiveStatus, KnowledgeKind, MemoryKind, Origin, PromotionAction, RecordProposalKind,
+    RecordProposalStatus, RecordStatus,
+};
+pub use scope::{Scope, SharingScope};
+pub use temporal::{TemporalInterval, TemporalQuery};
+
+/// A `0..=100` confidence score. The newtype makes the range invariant
+/// un-bypassable: there is no way to hold an out-of-range confidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize)]
+pub struct Confidence(u8);
+
+impl Confidence {
+    /// Construct a confidence, rejecting anything outside `0..=100`.
+    pub fn new(value: u16) -> Result<Self, RecordValidationError> {
+        if value > 100 {
+            return Err(RecordValidationError::ConfidenceOutOfRange(value));
+        }
+        Ok(Self(value as u8))
+    }
+
+    /// The score as `0..=100`.
+    pub fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Confidence {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = u16::deserialize(deserializer)?;
+        Confidence::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A cross-field domain invariant was violated. These are the "explicit
+/// constructor / validation function" errors the plan requires so an invalid
+/// record cannot be silently constructed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RecordValidationError {
+    /// Confidence must be an integer in `0..=100`.
+    #[error("confidence {0} is out of range (must be 0..=100)")]
+    ConfidenceOutOfRange(u16),
+    /// An inferred directive may not START blocking (lifecycle §: inferred
+    /// directives begin advisory and never become blocking without explicit
+    /// confirmation).
+    #[error("an inferred directive may not be created with blocking enforcement")]
+    InferredDirectiveBlocking,
+    /// An inferred record must carry a non-empty [`Scope`].
+    #[error("an inferred record must have a non-empty scope")]
+    InferredRecordEmptyScope,
+    /// A `constraint` directive's effect must be `require` or `forbid`. (The
+    /// type system already excludes `allow`; this variant exists for callers
+    /// that parse effects from untyped input.)
+    #[error("a constraint effect must be require or forbid, never allow")]
+    ConstraintEffectAllow,
+    /// A temporal interval must be non-empty and forward: `until` strictly
+    /// after `from`.
+    #[error("valid_until ({until}) must be strictly later than valid_from ({from})")]
+    NonForwardInterval {
+        /// The interval start.
+        from: String,
+        /// The interval end (must be strictly greater).
+        until: String,
+    },
+    /// A [`SharingScope`] audience requires the matching id to be present in the
+    /// record's [`Scope`].
+    #[error("sharing scope `{audience}` requires scope.{required_id} to be set")]
+    SharingScopeMissingId {
+        /// The audience that was declared.
+        audience: &'static str,
+        /// The `Scope` id it requires.
+        required_id: &'static str,
+    },
+}

--- a/stella-core/src/context_record/hash.rs
+++ b/stella-core/src/context_record/hash.rs
@@ -1,0 +1,188 @@
+//! Canonical record hashing — `record_hash = sha256:<64 hex>` over the RFC 8785
+//! (JCS) canonical bytes of the record's preimage.
+//!
+//! The preimage pipeline (the part that must be deterministic across producers):
+//!
+//! 1. serialize the record to a JSON object;
+//! 2. **drop `record_hash`** — a record never hashes its own hash;
+//! 3. **input-null normalization** — recursively remove `null`-valued object
+//!    keys, so an explicit `null` and an absent field hash identically (this
+//!    complements the `#[serde(skip_serializing_if = "Option::is_none")]`
+//!    absent-option omission on the record types);
+//! 4. **RFC 8785 JCS** — sort keys, minimal whitespace, canonical numbers, via
+//!    `serde_json_canonicalizer` (the same crate + version CGEP uses, so the
+//!    preimage bytes are byte-identical to CGEP's for export interop);
+//! 5. sha256, lowercase hex, `sha256:` prefix.
+//!
+//! Two normalization steps are the *caller's* responsibility before hashing and
+//! are intentionally NOT redone here: **alias normalization** (legacy field
+//! aliases like `recorded_at`→`observed_at`, `valid_to`→`valid_until` are mapped
+//! at ingestion) and **UTC timestamp normalization** (timestamps are stored in
+//! canonical UTC form). Records built from the typed model already satisfy both.
+
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Hashing failed. Distinct from validation: a record can be valid yet fail to
+/// serialize/canonicalize (or not be an object).
+#[derive(Debug, thiserror::Error)]
+pub enum RecordHashError {
+    /// The record could not be serialized to JSON.
+    #[error("record could not be serialized to JSON: {0}")]
+    Serialize(#[from] serde_json::Error),
+    /// The record's JSON could not be RFC 8785-canonicalized.
+    #[error("record could not be canonicalized (RFC 8785): {0}")]
+    Canonicalize(String),
+    /// Records must serialize to a JSON object; this one did not.
+    #[error("a context record must serialize to a JSON object")]
+    NotAnObject,
+}
+
+/// The canonical `record_hash` for `record`: `sha256:<64 lowercase hex>` over the
+/// JCS preimage. Deterministic for identical logical content regardless of field
+/// order or a pre-existing `record_hash`.
+pub fn record_hash<T: Serialize>(record: &T) -> Result<String, RecordHashError> {
+    let preimage = canonical_preimage(record)?;
+    let digest = Sha256::digest(preimage.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        // infallible on String
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(format!("sha256:{hex}"))
+}
+
+/// The exact bytes that get hashed — the RFC 8785 canonical JSON of the record
+/// after dropping `record_hash` and normalizing nulls. Private, but exercised
+/// directly by the golden tests so the preimage is pinned, not just the digest.
+fn canonical_preimage<T: Serialize>(record: &T) -> Result<String, RecordHashError> {
+    let mut value = serde_json::to_value(record)?;
+    match &mut value {
+        Value::Object(map) => {
+            map.remove("record_hash");
+        }
+        _ => return Err(RecordHashError::NotAnObject),
+    }
+    strip_nulls(&mut value);
+    serde_json_canonicalizer::to_string(&value)
+        .map_err(|e| RecordHashError::Canonicalize(e.to_string()))
+}
+
+/// Recursively remove `null`-valued keys from every object (and recurse into
+/// arrays), so an explicit `null` is indistinguishable from an absent field.
+fn strip_nulls(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|_, v| !v.is_null());
+            for v in map.values_mut() {
+                strip_nulls(v);
+            }
+        }
+        Value::Array(items) => {
+            for v in items.iter_mut() {
+                strip_nulls(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn preimage_sorts_keys_drops_record_hash_and_omits_nulls() {
+        // A focused, hand-verifiable pipeline vector: unsorted keys, a nested
+        // object, an explicit null, and a bogus record_hash.
+        let record = json!({
+            "b_num": 88,
+            "a_str": "x",
+            "nested": { "y": "2", "x": "1" },
+            "z_null": null,
+            "record_hash": "sha256:deadbeef"
+        });
+        // record_hash dropped, z_null omitted, all keys sorted, no whitespace.
+        assert_eq!(
+            canonical_preimage(&record).unwrap(),
+            r#"{"a_str":"x","b_num":88,"nested":{"x":"1","y":"2"}}"#
+        );
+    }
+
+    #[test]
+    fn hash_has_the_canonical_shape() {
+        let h = record_hash(&json!({"a": 1})).unwrap();
+        assert!(h.starts_with("sha256:"), "prefix: {h}");
+        let hex = h.strip_prefix("sha256:").unwrap();
+        assert_eq!(hex.len(), 64, "digest is 64 hex chars: {h}");
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+            "lowercase hex only: {h}"
+        );
+    }
+
+    #[test]
+    fn hash_is_independent_of_key_order() {
+        let a = record_hash(&json!({"a": 1, "b": 2})).unwrap();
+        let b = record_hash(&json!({"b": 2, "a": 1})).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_ignores_a_preexisting_record_hash_field() {
+        let without = record_hash(&json!({"a": 1})).unwrap();
+        let with_bogus = record_hash(&json!({"a": 1, "record_hash": "sha256:0000"})).unwrap();
+        assert_eq!(without, with_bogus, "record_hash must not hash itself");
+    }
+
+    #[test]
+    fn hash_treats_explicit_null_as_absent() {
+        let absent = record_hash(&json!({"a": 1})).unwrap();
+        let explicit_null = record_hash(&json!({"a": 1, "b": null})).unwrap();
+        assert_eq!(absent, explicit_null);
+    }
+
+    #[test]
+    fn non_object_records_are_rejected() {
+        assert!(matches!(
+            record_hash(&json!([1, 2, 3])),
+            Err(RecordHashError::NotAnObject)
+        ));
+    }
+
+    #[test]
+    fn golden_directive_record_hash_is_stable() {
+        // A representative directive record run through the whole pipeline. The
+        // canonical preimage is hand-verifiable (keys sorted, record_hash and
+        // absent fields gone); the digest is pinned so any drift is caught.
+        let record = json!({
+            "schema_version": "1.0-draft",
+            "record_kind": "directive",
+            "record_id": "dir_example_v1",
+            "lineage_id": "lin_example",
+            "directive_kind": "rule",
+            "origin": "inferred",
+            "enforcement": "advisory",
+            "confidence": 88,
+            "scope": { "repository_id": "repo_1" },
+            "sharing_scope": "repository",
+            "observed_at": "2026-07-20T18:30:00Z",
+            "valid_from": "2026-07-20T18:30:00Z",
+            "record_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        });
+        assert_eq!(
+            canonical_preimage(&record).unwrap(),
+            r#"{"confidence":88,"directive_kind":"rule","enforcement":"advisory","lineage_id":"lin_example","observed_at":"2026-07-20T18:30:00Z","origin":"inferred","record_id":"dir_example_v1","record_kind":"directive","schema_version":"1.0-draft","scope":{"repository_id":"repo_1"},"sharing_scope":"repository","valid_from":"2026-07-20T18:30:00Z"}"#
+        );
+        assert_eq!(record_hash(&record).unwrap(), GOLDEN_DIRECTIVE_HASH);
+    }
+
+    // Pinned from the canonical preimage asserted just above. Any change to the
+    // hashing pipeline or the record's canonical bytes will break this.
+    const GOLDEN_DIRECTIVE_HASH: &str =
+        "sha256:761d3d24d908aa31946a09d2fab3ab329c7504cfdb508b5f7d4832d23bd18499";
+}

--- a/stella-core/src/context_record/kind.rs
+++ b/stella-core/src/context_record/kind.rs
@@ -1,0 +1,459 @@
+//! The record-taxonomy enums. Every variant's canonical wire form is the
+//! lowercase `snake_case` token asserted by the tests at the bottom of this
+//! file — those strings are load-bearing (they enter `record_hash` preimages),
+//! so `as_str()` and the serde form are pinned to each other.
+
+use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+
+/// Top-level `record_kind` discriminator (lifecycle §6.1) — a flat discriminated
+/// union: the value selects the type-specific schema whose fields live at the
+/// record top level. Only `directive` carries instruction authority;
+/// `artifact_contract` carries completion authority when selected; all others
+/// carry none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextRecordKind {
+    Observation,
+    Knowledge,
+    Memory,
+    Directive,
+    RecordProposal,
+    Evidence,
+    ArtifactContract,
+    ContractValidation,
+    OutcomeAssessment,
+    PromotionEvent,
+    ContextUse,
+    ContextUseFeedback,
+}
+
+impl ContextRecordKind {
+    /// The canonical `snake_case` string stored on the wire.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Observation => "observation",
+            Self::Knowledge => "knowledge",
+            Self::Memory => "memory",
+            Self::Directive => "directive",
+            Self::RecordProposal => "record_proposal",
+            Self::Evidence => "evidence",
+            Self::ArtifactContract => "artifact_contract",
+            Self::ContractValidation => "contract_validation",
+            Self::OutcomeAssessment => "outcome_assessment",
+            Self::PromotionEvent => "promotion_event",
+            Self::ContextUse => "context_use",
+            Self::ContextUseFeedback => "context_use_feedback",
+        }
+    }
+}
+
+/// `knowledge` sub-kind (lifecycle §6.3). "Do not create a new kind for every
+/// noun" — the set is deliberately tiny.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeKind {
+    Fact,
+    Assumption,
+    Decision,
+}
+
+impl KnowledgeKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fact => "fact",
+            Self::Assumption => "assumption",
+            Self::Decision => "decision",
+        }
+    }
+}
+
+/// `memory` sub-kind (lifecycle §6.4).
+///
+/// NOTE: this is the spec taxonomy (`episode`, `summary`), which differs from
+/// the current `stella-context` `MemoryKind` (`Reflection`/`Note`/`Insight`).
+/// The two coexist; migration is a later phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    /// A bounded recollection of one task, session, or event.
+    Episode,
+    /// A lossy synthesis across multiple episodes.
+    Summary,
+}
+
+impl MemoryKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Episode => "episode",
+            Self::Summary => "summary",
+        }
+    }
+}
+
+/// `directive` sub-kind (lifecycle §6.5). `memory` and `fact` are explicitly
+/// forbidden as directive kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectiveKind {
+    Preference,
+    Rule,
+    Constraint,
+    Procedure,
+}
+
+impl DirectiveKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+            Self::Rule => "rule",
+            Self::Constraint => "constraint",
+            Self::Procedure => "procedure",
+        }
+    }
+}
+
+/// A `constraint` directive's effect (lifecycle §6.5). `allow` is **deliberately
+/// excluded** — learned context cannot grant authorization. The type therefore
+/// makes an `allow` constraint unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstraintEffect {
+    Require,
+    Forbid,
+}
+
+impl ConstraintEffect {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Require => "require",
+            Self::Forbid => "forbid",
+        }
+    }
+}
+
+/// Semantic source class for a record (lifecycle §7.1). Ratified as a uniform
+/// 5-value set across all families.
+///
+/// NOTE (flagged, not enforced here): the directive record schema narrows a
+/// directive's origin to `user, system, inferred, imported` (no `observed`).
+/// That per-family validator is deferred pending confirmation — see the module
+/// docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Origin {
+    User,
+    System,
+    Observed,
+    Inferred,
+    Imported,
+}
+
+impl Origin {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::System => "system",
+            Self::Observed => "observed",
+            Self::Inferred => "inferred",
+            Self::Imported => "imported",
+        }
+    }
+}
+
+/// A directive's enforcement level (lifecycle §). Exactly two values (the
+/// ratified 4→2 mapping, ADR 0007); any richer UI vocabulary is a label over
+/// these two, never a second enforcement enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectiveEnforcement {
+    Advisory,
+    Blocking,
+}
+
+impl DirectiveEnforcement {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Advisory => "advisory",
+            Self::Blocking => "blocking",
+        }
+    }
+}
+
+/// A directive's priority band (lifecycle §, directive allowed-values).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectivePriority {
+    Low,
+    Normal,
+    High,
+    Critical,
+}
+
+impl DirectivePriority {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Normal => "normal",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// The STORED lifecycle status of a record (lifecycle §7.6, §15.1). Exactly
+/// three; every change creates a new immutable revision. Staleness is NOT a
+/// status (it is a separate derived selection-health value). Contrast
+/// [`EffectiveStatus`], which is a query-time derivation and is excluded from
+/// `record_hash`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordStatus {
+    Active,
+    Retracted,
+    Archived,
+}
+
+impl RecordStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Retracted => "retracted",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+/// The DERIVED effective status computed at query time from the historical
+/// prefix (lifecycle §15.1). Excluded from `record_hash` — it is a projection,
+/// not stored canonical state. `superseded` comes from a later revision's
+/// `supersedes_record_id`; `expired` from `valid_until`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectiveStatus {
+    Active,
+    Superseded,
+    Retracted,
+    Archived,
+    Expired,
+}
+
+impl EffectiveStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Superseded => "superseded",
+            Self::Retracted => "retracted",
+            Self::Archived => "archived",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+/// The kind of record a proposal proposes (lifecycle §6.9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordProposalKind {
+    Knowledge,
+    Directive,
+    ContractAmendment,
+}
+
+impl RecordProposalKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Knowledge => "knowledge",
+            Self::Directive => "directive",
+            Self::ContractAmendment => "contract_amendment",
+        }
+    }
+}
+
+/// A proposal's status (lifecycle §8.9). Activation and rejection are
+/// PromotionEvent outcomes, NOT proposal states — do not add them here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordProposalStatus {
+    Collecting,
+    Eligible,
+    Dismissed,
+    Expired,
+}
+
+impl RecordProposalStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Collecting => "collecting",
+            Self::Eligible => "eligible",
+            Self::Dismissed => "dismissed",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+/// The action recorded on an immutable `promotion_event` (lifecycle §6.10).
+/// `auto_activated` is permitted only for an advisory directive under the active
+/// governance policy. Promotion is not assumed to be one linear state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionAction {
+    Proposed,
+    AutoActivated,
+    Confirmed,
+    Published,
+    Rejected,
+    Retired,
+    Reverted,
+}
+
+impl PromotionAction {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Proposed => "proposed",
+            Self::AutoActivated => "auto_activated",
+            Self::Confirmed => "confirmed",
+            Self::Published => "published",
+            Self::Rejected => "rejected",
+            Self::Retired => "retired",
+            Self::Reverted => "reverted",
+        }
+    }
+}
+
+/// Validate the enforcement a directive is *created* with against its origin: an
+/// inferred directive may not START blocking (lifecycle §). Spans `origin` and
+/// `enforcement`.
+pub fn validate_directive_creation_enforcement(
+    origin: Origin,
+    enforcement: DirectiveEnforcement,
+) -> Result<(), RecordValidationError> {
+    if origin == Origin::Inferred && enforcement == DirectiveEnforcement::Blocking {
+        return Err(RecordValidationError::InferredDirectiveBlocking);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    /// Assert that a variant's `as_str()` equals its serde wire form, and that
+    /// the wire form round-trips back to the same variant. This double-locks the
+    /// canonical string used in `record_hash` preimages.
+    fn assert_canonical<T>(variant: T, expected: &str)
+    where
+        T: Serialize + for<'de> Deserialize<'de> + PartialEq + std::fmt::Debug + Copy,
+    {
+        let wire = serde_json::to_value(variant).unwrap();
+        assert_eq!(wire, json!(expected), "serde wire form");
+        let back: T = serde_json::from_value(Value::String(expected.to_string())).unwrap();
+        assert_eq!(back, variant, "round-trip");
+    }
+
+    #[test]
+    fn context_record_kind_strings_are_canonical() {
+        use ContextRecordKind::*;
+        for (v, s) in [
+            (Observation, "observation"),
+            (Knowledge, "knowledge"),
+            (Memory, "memory"),
+            (Directive, "directive"),
+            (RecordProposal, "record_proposal"),
+            (Evidence, "evidence"),
+            (ArtifactContract, "artifact_contract"),
+            (ContractValidation, "contract_validation"),
+            (OutcomeAssessment, "outcome_assessment"),
+            (PromotionEvent, "promotion_event"),
+            (ContextUse, "context_use"),
+            (ContextUseFeedback, "context_use_feedback"),
+        ] {
+            assert_eq!(v.as_str(), s);
+            assert_canonical(v, s);
+        }
+    }
+
+    #[test]
+    fn small_taxonomy_strings_are_canonical() {
+        assert_canonical(KnowledgeKind::Fact, "fact");
+        assert_canonical(KnowledgeKind::Assumption, "assumption");
+        assert_canonical(KnowledgeKind::Decision, "decision");
+        assert_canonical(MemoryKind::Episode, "episode");
+        assert_canonical(MemoryKind::Summary, "summary");
+        assert_canonical(DirectiveKind::Preference, "preference");
+        assert_canonical(DirectiveKind::Rule, "rule");
+        assert_canonical(DirectiveKind::Constraint, "constraint");
+        assert_canonical(DirectiveKind::Procedure, "procedure");
+        assert_canonical(ConstraintEffect::Require, "require");
+        assert_canonical(ConstraintEffect::Forbid, "forbid");
+        assert_canonical(Origin::User, "user");
+        assert_canonical(Origin::System, "system");
+        assert_canonical(Origin::Observed, "observed");
+        assert_canonical(Origin::Inferred, "inferred");
+        assert_canonical(Origin::Imported, "imported");
+        assert_canonical(DirectiveEnforcement::Advisory, "advisory");
+        assert_canonical(DirectiveEnforcement::Blocking, "blocking");
+        assert_canonical(DirectivePriority::Low, "low");
+        assert_canonical(DirectivePriority::Critical, "critical");
+    }
+
+    #[test]
+    fn status_and_promotion_strings_are_canonical() {
+        assert_canonical(RecordStatus::Active, "active");
+        assert_canonical(RecordStatus::Retracted, "retracted");
+        assert_canonical(RecordStatus::Archived, "archived");
+        assert_canonical(EffectiveStatus::Superseded, "superseded");
+        assert_canonical(EffectiveStatus::Expired, "expired");
+        assert_canonical(RecordProposalKind::ContractAmendment, "contract_amendment");
+        assert_canonical(RecordProposalStatus::Collecting, "collecting");
+        assert_canonical(RecordProposalStatus::Eligible, "eligible");
+        assert_canonical(PromotionAction::AutoActivated, "auto_activated");
+        assert_canonical(PromotionAction::Reverted, "reverted");
+    }
+
+    #[test]
+    fn constraint_effect_cannot_represent_allow() {
+        // `allow` is not a variant, so it cannot even deserialize.
+        let parsed: Result<ConstraintEffect, _> = serde_json::from_value(json!("allow"));
+        assert!(
+            parsed.is_err(),
+            "constraint effect `allow` must be unrepresentable"
+        );
+    }
+
+    #[test]
+    fn inferred_directive_may_not_start_blocking() {
+        assert_eq!(
+            validate_directive_creation_enforcement(
+                Origin::Inferred,
+                DirectiveEnforcement::Blocking
+            ),
+            Err(RecordValidationError::InferredDirectiveBlocking)
+        );
+        // Inferred + advisory is fine; user + blocking is fine.
+        assert!(
+            validate_directive_creation_enforcement(
+                Origin::Inferred,
+                DirectiveEnforcement::Advisory
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_directive_creation_enforcement(Origin::User, DirectiveEnforcement::Blocking)
+                .is_ok()
+        );
+    }
+}

--- a/stella-core/src/context_record/scope.rs
+++ b/stella-core/src/context_record/scope.rs
@@ -1,0 +1,198 @@
+//! `Scope` (where a record applies) and `SharingScope` (who may receive it) —
+//! two independent concepts (lifecycle §7.2 / §7.3). Do not collapse them.
+
+use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+use super::kind::Origin;
+
+/// Where a record applies. A struct of optional identifiers, **conjunctive**
+/// when populated (a record scoped to a repository AND a workspace applies only
+/// where both match). `project` is intentionally not a core field — it is a
+/// namespaced extension only. Scope never widens automatically.
+///
+/// Optional fields are omitted (never `null`) on the wire, which is what keeps
+/// the `record_hash` preimage stable across present-vs-absent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Scope {
+    /// The user the record is about / applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub user_id: Option<String>,
+    /// The organization the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub organization_id: Option<String>,
+    /// The repository (VCS/Git identity) the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub repository_id: Option<String>,
+    /// The workspace (provider-managed security principal) the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub workspace_id: Option<String>,
+    /// The environment the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub environment_id: Option<String>,
+    /// The session the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub session_id: Option<String>,
+    /// The task the record applies to.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub task_id: Option<String>,
+}
+
+impl Scope {
+    /// True when no scope dimension is populated. An unscoped **inferred** record
+    /// is invalid (see [`validate_inferred_scope`]).
+    pub fn is_empty(&self) -> bool {
+        self.user_id.is_none()
+            && self.organization_id.is_none()
+            && self.repository_id.is_none()
+            && self.workspace_id.is_none()
+            && self.environment_id.is_none()
+            && self.session_id.is_none()
+            && self.task_id.is_none()
+    }
+}
+
+/// Who may receive or inherit a record (lifecycle §7.3) — a 4-value audience,
+/// ratified 2026-07-23 (ADR 0002). NOT a linear hierarchy; every audience change
+/// is explicit. Each audience requires its matching [`Scope`] id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingScope {
+    User,
+    Repository,
+    Workspace,
+    Organization,
+}
+
+impl SharingScope {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Repository => "repository",
+            Self::Workspace => "workspace",
+            Self::Organization => "organization",
+        }
+    }
+
+    /// The `Scope` id this audience requires to be present.
+    pub fn required_scope_id(self) -> &'static str {
+        match self {
+            Self::User => "user_id",
+            Self::Repository => "repository_id",
+            Self::Workspace => "workspace_id",
+            Self::Organization => "organization_id",
+        }
+    }
+
+    fn scope_id_present(self, scope: &Scope) -> bool {
+        match self {
+            Self::User => scope.user_id.is_some(),
+            Self::Repository => scope.repository_id.is_some(),
+            Self::Workspace => scope.workspace_id.is_some(),
+            Self::Organization => scope.organization_id.is_some(),
+        }
+    }
+}
+
+/// A sharing audience requires its matching scope id (`user → user_id`,
+/// `repository → repository_id`, `workspace → workspace_id`, `organization →
+/// organization_id`).
+pub fn validate_sharing_scope(
+    sharing: SharingScope,
+    scope: &Scope,
+) -> Result<(), RecordValidationError> {
+    if sharing.scope_id_present(scope) {
+        Ok(())
+    } else {
+        Err(RecordValidationError::SharingScopeMissingId {
+            audience: sharing.as_str(),
+            required_id: sharing.required_scope_id(),
+        })
+    }
+}
+
+/// An inferred record must carry a non-empty scope (lifecycle §7.2).
+pub fn validate_inferred_scope(origin: Origin, scope: &Scope) -> Result<(), RecordValidationError> {
+    if origin == Origin::Inferred && scope.is_empty() {
+        return Err(RecordValidationError::InferredRecordEmptyScope);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_scope_serializes_to_an_empty_object() {
+        // Every field is None → omitted, so the wire form is `{}` (no nulls).
+        let json = serde_json::to_value(Scope::default()).unwrap();
+        assert_eq!(json, json!({}));
+        assert!(Scope::default().is_empty());
+    }
+
+    #[test]
+    fn populated_scope_omits_absent_ids() {
+        let scope = Scope {
+            repository_id: Some("repo_42".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_value(&scope).unwrap(),
+            json!({"repository_id": "repo_42"})
+        );
+        assert!(!scope.is_empty());
+    }
+
+    #[test]
+    fn sharing_scope_strings_and_required_ids() {
+        for (s, name, id) in [
+            (SharingScope::User, "user", "user_id"),
+            (SharingScope::Repository, "repository", "repository_id"),
+            (SharingScope::Workspace, "workspace", "workspace_id"),
+            (
+                SharingScope::Organization,
+                "organization",
+                "organization_id",
+            ),
+        ] {
+            assert_eq!(s.as_str(), name);
+            assert_eq!(s.required_scope_id(), id);
+            assert_eq!(serde_json::to_value(s).unwrap(), json!(name));
+        }
+    }
+
+    #[test]
+    fn sharing_requires_matching_scope_id() {
+        let repo_scope = Scope {
+            repository_id: Some("repo_1".into()),
+            ..Default::default()
+        };
+        assert!(validate_sharing_scope(SharingScope::Repository, &repo_scope).is_ok());
+        // Sharing to the workspace audience needs workspace_id, which is absent.
+        assert_eq!(
+            validate_sharing_scope(SharingScope::Workspace, &repo_scope),
+            Err(RecordValidationError::SharingScopeMissingId {
+                audience: "workspace",
+                required_id: "workspace_id",
+            })
+        );
+    }
+
+    #[test]
+    fn inferred_record_requires_nonempty_scope() {
+        assert_eq!(
+            validate_inferred_scope(Origin::Inferred, &Scope::default()),
+            Err(RecordValidationError::InferredRecordEmptyScope)
+        );
+        let scoped = Scope {
+            task_id: Some("task_9".into()),
+            ..Default::default()
+        };
+        assert!(validate_inferred_scope(Origin::Inferred, &scoped).is_ok());
+        // A non-inferred record may be unscoped.
+        assert!(validate_inferred_scope(Origin::User, &Scope::default()).is_ok());
+    }
+}

--- a/stella-core/src/context_record/temporal.rs
+++ b/stella-core/src/context_record/temporal.rs
@@ -1,0 +1,157 @@
+//! Temporal primitives. Two axes, kept explicitly separate (lifecycle §7.5):
+//! `known_at` = provider-local knowledge/transaction (belief) time; `valid_at` =
+//! world validity. This is the typed successor to today's single `as_of` filter,
+//! which the Phase 0 characterization pinned as **transaction-time only** — it
+//! maps to `known_at`, never silently to `valid_at`.
+//!
+//! Intervals are **half-open `[from, until)`**: `from` inclusive, `until`
+//! exclusive. This installment defines the value types and the ordering
+//! invariant; the prefix-safe historical *reconstruction* over these lives in the
+//! Phase 3 repository, not here.
+//!
+//! Timestamps are RFC 3339 strings. The ordering check compares them
+//! lexicographically, which is correct **only for normalized UTC timestamps of
+//! equal precision** (the form the canonicalization pipeline's UTC normalization
+//! produces). Real instant parsing is deferred to Phase 3; callers must pass
+//! normalized timestamps until then.
+
+use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+
+/// A half-open time interval `[from, until)`. `until = None` is an open-ended
+/// interval (e.g. a record valid from `from` with no known end).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalInterval {
+    /// Inclusive start (RFC 3339, normalized UTC).
+    pub from: String,
+    /// Exclusive end (RFC 3339, normalized UTC). `None` = open-ended.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub until: Option<String>,
+}
+
+impl TemporalInterval {
+    /// Construct a validated interval: when `until` is present it must be
+    /// strictly after `from` (a non-empty forward interval). This is the
+    /// `valid_until` > `valid_from` invariant.
+    pub fn new(
+        from: impl Into<String>,
+        until: Option<String>,
+    ) -> Result<Self, RecordValidationError> {
+        let interval = Self {
+            from: from.into(),
+            until,
+        };
+        interval.validate()?;
+        Ok(interval)
+    }
+
+    /// An open-ended interval starting at `from` (no end).
+    pub fn open(from: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            until: None,
+        }
+    }
+
+    /// Re-check the ordering invariant (useful after deserialization, which
+    /// bypasses [`TemporalInterval::new`]).
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        if let Some(until) = &self.until
+            && *until <= self.from
+        {
+            return Err(RecordValidationError::NonForwardInterval {
+                from: self.from.clone(),
+                until: until.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// The parameters of a bi-temporal query (lifecycle §7.5). A pure value type —
+/// its *execution* (prefix-safe reconstruction) is the Phase 3 repository's job;
+/// this installment only carries the parameters.
+///
+/// A provider that cannot reconstruct durable local ingestion history must
+/// reject a query that sets `known_at`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalQuery {
+    /// Knowledge/transaction-time cutoff: consider only what was known at or
+    /// before this instant. (Maps to today's `as_of`.)
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub known_at: Option<String>,
+    /// World-validity instant: select records whose validity interval contains
+    /// this instant.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub valid_at: Option<String>,
+    /// Filter on canonical-origin `observed_at ∈ [from, until)`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub observed: Option<TemporalInterval>,
+    /// Select records whose validity overlaps this interval.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub valid_overlaps: Option<TemporalInterval>,
+    /// Include event-only records that carry no validity when a `valid_at` /
+    /// `valid_overlaps` filter is present (default `false` excludes them).
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub include_records_without_validity: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const T1: &str = "2026-02-01T00:00:00Z";
+    const T2: &str = "2026-03-01T00:00:00Z";
+
+    #[test]
+    fn forward_interval_is_accepted_and_empty_or_reversed_is_rejected() {
+        assert!(TemporalInterval::new(T1, Some(T2.into())).is_ok());
+        assert!(TemporalInterval::open(T1).validate().is_ok());
+        // until == from is empty (half-open) → rejected.
+        assert_eq!(
+            TemporalInterval::new(T1, Some(T1.into())),
+            Err(RecordValidationError::NonForwardInterval {
+                from: T1.into(),
+                until: T1.into(),
+            })
+        );
+        // until < from → rejected.
+        assert!(TemporalInterval::new(T2, Some(T1.into())).is_err());
+    }
+
+    #[test]
+    fn open_interval_omits_until_on_the_wire() {
+        assert_eq!(
+            serde_json::to_value(TemporalInterval::open(T1)).unwrap(),
+            json!({ "from": T1 })
+        );
+    }
+
+    #[test]
+    fn empty_temporal_query_is_all_absent() {
+        // Every field defaults absent / false, so the wire form is `{}`.
+        assert_eq!(
+            serde_json::to_value(TemporalQuery::default()).unwrap(),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn temporal_query_carries_both_axes() {
+        let q = TemporalQuery {
+            known_at: Some(T2.into()),
+            valid_at: Some(T1.into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_value(&q).unwrap(),
+            json!({ "known_at": T2, "valid_at": T1 })
+        );
+    }
+}

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod accounted_call;
 pub mod budget;
 pub mod bus;
 pub mod compaction;
+pub mod context_record;
 pub mod discovery;
 pub mod driver;
 pub mod estimator;


### PR DESCRIPTION
## Phase 1 — pure domain types (installment 1 of N)

Stacked on #420 (Phase 0). Introduces the pure, I/O-free adaptive-context domain model in a new `stella-core::context_record` module. **This is the first installment of Phase 1 — it does NOT yet satisfy the full Phase 1 gate** (deferred pieces listed below).

### In this installment

- **Taxonomy enums** with exact spec members, canonical `snake_case` pinned by round-trip tests (the strings enter `record_hash` preimages): `ContextRecordKind` (12), `KnowledgeKind` (3), `MemoryKind` (2), `DirectiveKind` (4), `ConstraintEffect` (`require|forbid` — `allow` is *unrepresentable*), `Origin` (5, ratified), `DirectiveEnforcement` (2, ratified 4→2), `DirectivePriority` (4), `RecordStatus` (3 stored) + `EffectiveStatus` (5 derived), `RecordProposalKind` (3), `RecordProposalStatus` (4), `PromotionAction` (7).
- **`Scope`** (7 optional conjunctive ids, omitted-when-`None`) + **`SharingScope`** (4, ratified).
- **`TemporalInterval`** (half-open `[from, until)`) + **`TemporalQuery`** (`known_at`/`valid_at`; the typed successor to today's transaction-time `as_of`, which maps to `known_at`). Reconstruction execution is Phase 3.
- **`Confidence`** newtype (`0..=100`, un-bypassable).
- **Validators** living entirely on these types: confidence range; inferred directive may not *start* blocking; inferred record needs non-empty scope; sharing audience requires its matching scope id; `valid_until` strictly after `valid_from`.
- **Canonical hashing** (`context_record::hash`): `record_hash = sha256:<64 hex>` over RFC 8785 JCS bytes via `serde_json_canonicalizer` **0.3.2 — the same crate + version CGEP uses**, so the preimage is byte-identical for future export interop. Pipeline: drop `record_hash` from its own preimage → strip nulls (explicit `null` == absent) → JCS → sha256. Golden vectors pin a **hand-verified canonical preimage** *and* the digest; determinism / key-order / null-omission all tested.

### Coexists with legacy types (does not touch the live path)

The new types sit beside `rules::metadata` (`RuleEnforcement`, `RuleOrigin`, `RuleRecordKind`), which drives the live Markdown rules path — untouched here (editing it would be a behavior change). Two mapping edges are **flagged, not silently resolved**:
1. `RuleEnforcement::Informational` has no target in the 2-value `DirectiveEnforcement` (`→ advisory` is likely but **unratified** — the ratified 4→2 mapping was over a different vocabulary).
2. The directive schema narrows `Origin` to 4 (no `observed`) — a per-family validator left **deferred**, since it refines the ratified uniform-5.

### Deferred to later Phase 1 installments (NOT covered by this PR)

context-use / efficacy web, artifact contracts + validation, outcome assessments, frame representation / content-fidelity, and the `stella-protocol` internal replay-safe events (which need an unknown-tolerant decoder — `AgentEvent` rejects unknown variants, per the Phase 0 finding). ~2/3 of the ~18 Phase 1 validators span those deferred types and ship with them.

Follow-up worth doing: cross-pin one `record_hash` against CGEP's own hasher for provable byte-interop (the crate/version match already makes the JCS step identical).

### Gate (stella-core — the only crate touched)

| check | result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy -p stella-core --all-targets -- -D warnings` | clean |
| `cargo test -p stella-core` | 360 passed |

