### PR TITLE
fix(tui): drop unreachable duplicate SpeculationDiscarded arms (red main)

### DIFF
--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -1005,10 +1005,6 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             TraceKind::Other,
             format!("steer: {}", text.chars().take(40).collect::<String>()),
         ),
-        AgentEvent::SpeculationDiscarded { name, reason, .. } => (
-            TraceKind::Other,
-            format!("speculation discarded: {name} ({reason})"),
-        ),
         AgentEvent::Compaction {
             before_tokens,
             after_tokens,

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -613,9 +613,6 @@ impl SessionModel {
                     cost_usd: *cost_usd,
                 });
             }
-            // Internal accounting for read-only speculation that never
-            // committed — no visible model state to update.
-            AgentEvent::SpeculationDiscarded { .. } => {}
         }
         self.evict_transcript_overflow();
     }


### PR DESCRIPTION
Main CI has been red since 20:55Z (every push: #420, #423, #425) with two `unreachable pattern` errors under `clippy -D warnings`: the merge train left duplicate `AgentEvent::SpeculationDiscarded` arms in `stella-tui/src/model.rs` (591 vs 618) and `stella-tui/src/deck.rs` (935 vs 1008).

This removes the **later, unreachable** arm of each pair, so runtime behavior is exactly what main already does today (model: no panel-state change; deck: the `TraceKind::Tool` "discarded name (reason)" rendering).

Verified: `cargo clippy --workspace --all-targets -- -D warnings` green, `cargo test -p stella-tui` green, `cargo fmt --all --check` clean. Ready to merge — marked draft only by convention.