### PR TITLE
fix(tui): drop duplicate SpeculationDiscarded arms — unbreak clippy gate on main

### DIFF
--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -1005,10 +1005,6 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             TraceKind::Other,
             format!("steer: {}", text.chars().take(40).collect::<String>()),
         ),
-        AgentEvent::SpeculationDiscarded { name, reason, .. } => (
-            TraceKind::Other,
-            format!("speculation discarded: {name} ({reason})"),
-        ),
         AgentEvent::Compaction {
             before_tokens,
             after_tokens,

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -586,9 +586,6 @@ impl SessionModel {
             | AgentEvent::BlockRegistered { .. }
             | AgentEvent::StepManifest { .. }
             | AgentEvent::GoalVerdict { .. } => {}
-            // A discarded speculation pool (#415) is store/telemetry
-            // bookkeeping; no user-visible panel state depends on it.
-            AgentEvent::SpeculationDiscarded { .. } => {}
             AgentEvent::Error { message, retryable } => {
                 self.pending_scope_review = None;
                 self.pending_ask_user = None;


### PR DESCRIPTION
## Why main is red

CI's `fmt + clippy + test` job has failed for the last 6 runs on main (since `4ead0b5`). The cause is a merge collision between two PRs that each added `AgentEvent::SpeculationDiscarded` handling to stella-tui's exhaustive matches:

- **#401** merged first (13:42) carrying its own arms → CI green at `480949a`
- **#422** ("unbreak main"), authored against the older still-broken base, merged ten minutes later (13:52) and added a second set of arms

Duplicate match arms are only a *warning* to rustc, so the merge didn't conflict and `cargo test` stayed green — but `cargo clippy -D warnings` has been red ever since with `unreachable_patterns` in `stella-tui/src/model.rs` and `stella-tui/src/deck.rs`.

## Fix

Pure deletion (7 lines): keep #422's arms, drop #401's shadowed duplicates.

- `deck.rs`: the surviving arm (`TraceKind::Tool`, "discarded {name} ({reason})") is the **first** arm, i.e. the one that already executes on main today — zero runtime behavior change. It's also the better mapping (speculation = speculative read-only tool execution) and sits grouped with the tool arms.
- `model.rs`: both arms were identical no-ops; kept #422's.

## Verification (local, at `fef8e4b` + this commit)

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (was exit 101 on bare `fef8e4b`)
- `cargo test --workspace` ✅ — 55 suites, 2908 passed, 0 failed