### PR TITLE
fix(tui): drop duplicate SpeculationDiscarded match arms

### DIFF
--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -1005,10 +1005,6 @@ fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             TraceKind::Other,
             format!("steer: {}", text.chars().take(40).collect::<String>()),
         ),
-        AgentEvent::SpeculationDiscarded { name, reason, .. } => (
-            TraceKind::Other,
-            format!("speculation discarded: {name} ({reason})"),
-        ),
         AgentEvent::Compaction {
             before_tokens,
             after_tokens,

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -586,9 +586,6 @@ impl SessionModel {
             | AgentEvent::BlockRegistered { .. }
             | AgentEvent::StepManifest { .. }
             | AgentEvent::GoalVerdict { .. } => {}
-            // A discarded speculation pool (#415) is store/telemetry
-            // bookkeeping; no user-visible panel state depends on it.
-            AgentEvent::SpeculationDiscarded { .. } => {}
             AgentEvent::Error { message, retryable } => {
                 self.pending_scope_review = None;
                 self.pending_ask_user = None;


### PR DESCRIPTION
`#401` (compaction receipts) and `#422` ("unbreak main — handle SpeculationDiscarded") independently added `SpeculationDiscarded` arms to stella-tui's `model.rs` and `deck.rs` event matches. Both landed on main, so each match now has **two** arms — the second unreachable:

```
warning: unreachable pattern
  --> stella-tui/src/model.rs:618:13
  --> stella-tui/src/deck.rs:1008:9
```

Harmless as a `warn`, but it fails the `fmt + clippy + test` CI gate (`-D warnings`) and is noise in every local build.

**Fix:** remove the redundant arms that rode in from #401's merge, keeping #422's canonical versions (deck traces it as `TraceKind::Tool "discarded {name} ({reason})"`). `textline.rs` was unaffected — both fixes added `SpeculationDiscarded` to the same `| … => None` group, which git deduped automatically.

Verified: `cargo clippy -p stella-tui --all-targets -- -D warnings` clean; `cargo build` shows no remaining unreachable-pattern warnings.