### PR TITLE
feat(tools): read→edit drift — attribute and correct stale-content edits (#331)

### DIFF
--- a/stella-core/src/loop_detect.rs
+++ b/stella-core/src/loop_detect.rs
@@ -644,6 +644,42 @@ mod tests {
     }
 
     #[test]
+    fn drift_attributed_edit_recovery_is_not_a_loop() {
+        // #331: when `edit_file` attributes a match failure to an
+        // out-of-band file change, the error embeds the CURRENT content —
+        // so as long as the file keeps changing, the outputs differ and the
+        // legitimate read→edit-retry recovery is progress by construction.
+        // Only when the file stops changing (and the model keeps replaying
+        // the same failing edit verbatim) do outputs repeat byte-identically
+        // and detection rightly fires. Pins the contract that the drift echo
+        // is what keeps recovery progress-eligible.
+        let drift_fail = |content: &str| {
+            record(
+                "edit_file",
+                serde_json::json!({ "path": "a.rs", "old": "x", "new": "y" }),
+                Some(ToolOutput::Error {
+                    message: format!("old_string not found — the file CHANGED; current: {content}"),
+                }),
+            )
+        };
+        let read_v = |content: &str| {
+            call("read_file", serde_json::json!({ "path": "a.rs" }), content)
+        };
+        let records = vec![
+            read_v("v1"),
+            drift_fail("v2"),
+            read_v("v2"),
+            drift_fail("v3"),
+            read_v("v3"),
+            drift_fail("v4"),
+        ];
+        assert_eq!(
+            detect_loop(&records, LoopDetectionConfig::default()),
+            LoopVerdict::NoLoop
+        );
+    }
+
+    #[test]
     fn healthy_varied_sequence_is_not_a_loop() {
         // A realistic productive trajectory: no false positives.
         let records = vec![

--- a/stella-core/src/loop_detect.rs
+++ b/stella-core/src/loop_detect.rs
@@ -662,9 +662,8 @@ mod tests {
                 }),
             )
         };
-        let read_v = |content: &str| {
-            call("read_file", serde_json::json!({ "path": "a.rs" }), content)
-        };
+        let read_v =
+            |content: &str| call("read_file", serde_json::json!({ "path": "a.rs" }), content);
         let records = vec![
             read_v("v1"),
             drift_fail("v2"),

--- a/stella-tools/src/edit.rs
+++ b/stella-tools/src/edit.rs
@@ -1,13 +1,61 @@
 //! `edit_file` — replace an exact substring in a file. Surgical edits, not
 //! full rewrites. Supports `replace_all` for multi-occurrence.
+//!
+//! The tool shares the session's read-state ledger (#331): when `old_string`
+//! fails to match, it compares current disk bytes against the hash of what
+//! the model last saw (recorded by `read_file`/`read_symbol` and by the
+//! model's own edits/writes) and *attributes* the failure — a drifted file
+//! gets a drift-named error carrying the fresh content so the model can
+//! re-issue the edit against current bytes, instead of a generic not-found
+//! that sends it back into a read→edit-fail thrash. Because the drift echo
+//! embeds the changed content, a legitimate recovery never produces
+//! byte-identical outputs, so the loop detector (which requires identical
+//! outputs to flag a loop) keeps treating it as progress.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 
+use crate::read::ReadLedger;
 use crate::registry::Tool;
 
-pub struct EditFile;
+/// Ceiling on the fresh-content echo inside a drift-attributed error, so a
+/// huge drifted file doesn't flood the context through an error message.
+const DRIFT_ECHO_MAX_LINES: usize = 400;
+
+#[derive(Default)]
+pub struct EditFile {
+    ledger: Arc<ReadLedger>,
+}
+
+impl EditFile {
+    /// Construct sharing the registry's read-state ledger, so match failures
+    /// can be attributed against what the model last saw.
+    pub fn with_ledger(ledger: Arc<ReadLedger>) -> Self {
+        Self { ledger }
+    }
+}
+
+/// Render the fresh content echoed inside a drift-attributed error:
+/// line-numbered like `read_file` output (so the model can re-anchor
+/// edits), capped at [`DRIFT_ECHO_MAX_LINES`].
+fn drift_echo(content: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let shown = lines.len().min(DRIFT_ECHO_MAX_LINES);
+    let mut numbered = String::new();
+    for (i, line) in lines[..shown].iter().enumerate() {
+        numbered.push_str(&format!("{:>6}\t{line}\n", i + 1));
+    }
+    if shown < lines.len() {
+        numbered.push_str(&format!(
+            "(first {shown} of {} lines — use read_file for the rest)\n",
+            lines.len()
+        ));
+    }
+    numbered
+}
 
 #[async_trait]
 impl Tool for EditFile {
@@ -93,10 +141,45 @@ impl Tool for EditFile {
 
         let count = content.matches(old_string).count();
         if count == 0 {
-            return ToolOutput::Error {
-                message: format!(
-                    "old_string not found in `{path}` — check for exact whitespace/newline differences"
-                ),
+            // Attribute the miss (#331): compare current bytes against what
+            // the model last saw. Three distinguishable causes, three
+            // different recoveries — a generic not-found forces the model to
+            // guess which one it is.
+            let current_sha = crate::staleness::hex_sha256(content.as_bytes());
+            return match self.ledger.last_seen_sha(root, path) {
+                Some(seen) if seen != current_sha => {
+                    // Drift: the file changed after the model last saw it.
+                    // Echo the fresh content so the model can re-issue the
+                    // edit without a round-trip — and record it as seen, so
+                    // a repeat failure against these same bytes is reported
+                    // as unchanged (not re-attributed as drift forever).
+                    // The echo is capped, so the recorded hash may cover
+                    // more than was shown; the unchanged-file message below
+                    // still steers a confused model back to read_file.
+                    self.ledger.record_known(root, path, &content);
+                    ToolOutput::Error {
+                        message: format!(
+                            "old_string not found in `{path}` — the file CHANGED after you last \
+                             read it (out-of-band modification); the copy in your context is \
+                             stale. Current content follows — re-issue the edit against these \
+                             bytes.\n\n--- {path} (current) ---\n{}",
+                            drift_echo(&content)
+                        ),
+                    }
+                }
+                Some(_) => ToolOutput::Error {
+                    message: format!(
+                        "old_string not found in `{path}` — the file is unchanged since you last \
+                         saw it, so the copy in your context matches disk; check for exact \
+                         whitespace/newline differences"
+                    ),
+                },
+                None => ToolOutput::Error {
+                    message: format!(
+                        "old_string not found in `{path}` — no read of this file is recorded \
+                         this session; read it first and copy old_string byte-exact"
+                    ),
+                },
             };
         }
         if count > 1 && !replace_all {
@@ -115,6 +198,9 @@ impl Tool for EditFile {
 
         match tokio::fs::write(&full_path, &new_content).await {
             Ok(()) => {
+                // The model knows the bytes it just produced — record them so
+                // its own edit is never later misattributed as drift.
+                self.ledger.record_known(root, path, &new_content);
                 let replaced = if replace_all { count } else { 1 };
                 ToolOutput::Ok {
                     content: format!("replaced {replaced} occurrence(s) in {path}"),
@@ -130,6 +216,7 @@ impl Tool for EditFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::read::ReadFile;
 
     #[tokio::test]
     async fn replaces_unique_substring() {
@@ -138,7 +225,7 @@ mod tests {
         let full = dir.join(&path);
         tokio::fs::write(&full, "fn main() { old }").await.unwrap();
 
-        let result = EditFile
+        let result = EditFile::default()
             .execute(
                 &serde_json::json!({"path": path, "old_string": "old", "new_string": "new"}),
                 &dir,
@@ -160,7 +247,7 @@ mod tests {
         let full = dir.join(&path);
         tokio::fs::write(&full, "a a a").await.unwrap();
 
-        let result = EditFile
+        let result = EditFile::default()
             .execute(
                 &serde_json::json!({"path": path, "old_string": "a", "new_string": "b"}),
                 &dir,
@@ -177,7 +264,7 @@ mod tests {
         let full = dir.join(&path);
         tokio::fs::write(&full, "a a a").await.unwrap();
 
-        let result = EditFile
+        let result = EditFile::default()
             .execute(
                 &serde_json::json!({"path": path, "old_string": "a", "new_string": "b", "replace_all": true}),
                 &dir,
@@ -193,19 +280,210 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn not_found_gives_diagnostic() {
+    async fn not_found_without_a_read_names_the_missing_read() {
         let dir = std::env::temp_dir();
         let path = format!("stella_edit_nf_{}.rs", std::process::id());
         let full = dir.join(&path);
         tokio::fs::write(&full, "hello world").await.unwrap();
 
-        let result = EditFile
+        let result = EditFile::default()
             .execute(
                 &serde_json::json!({"path": path, "old_string": "xyz", "new_string": "abc"}),
                 &dir,
             )
             .await;
-        assert!(result.is_error());
+        match result {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("old_string not found"), "got: {message}");
+                assert!(
+                    message.contains("no read of this file is recorded"),
+                    "an unread file must be attributed as such: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected error, got: {content}"),
+        }
         let _ = tokio::fs::remove_file(&full).await;
+    }
+
+    /// The #331 witness: read a file, mutate it out-of-band, then edit with
+    /// an `old_string` that no longer matches — the error must name the
+    /// concurrent change (not the generic not-found) and carry the fresh
+    /// content so the model can re-issue the edit without a round-trip.
+    #[tokio::test]
+    async fn drift_is_attributed_and_fresh_content_echoed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "original contents\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        let read = ReadFile::with_ledger(ledger.clone());
+        let edit = EditFile::with_ledger(ledger.clone());
+
+        let seen = read
+            .execute(&serde_json::json!({"path": "a.rs"}), dir.path())
+            .await;
+        assert!(!seen.is_error(), "{seen:?}");
+
+        // Out-of-band change (another process, the user, a subagent).
+        std::fs::write(dir.path().join("a.rs"), "rewritten elsewhere\n").unwrap();
+
+        let result = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "original", "new_string": "x"}),
+                dir.path(),
+            )
+            .await;
+        match result {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("CHANGED after you last read it"),
+                    "drift must be attributed: {message}"
+                );
+                assert!(
+                    message.contains("rewritten elsewhere"),
+                    "fresh content must be echoed: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected drift error, got: {content}"),
+        }
+
+        // The echo counts as seen: a repeat failure against the SAME bytes is
+        // reported as unchanged, not re-attributed as drift forever.
+        let repeat = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "original", "new_string": "x"}),
+                dir.path(),
+            )
+            .await;
+        match repeat {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("unchanged since you last saw it"),
+                    "got: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected error, got: {content}"),
+        }
+
+        // And the recovery works: an edit against current bytes succeeds.
+        let recovered = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "rewritten", "new_string": "fixed"}),
+                dir.path(),
+            )
+            .await;
+        assert!(!recovered.is_error(), "{recovered:?}");
+    }
+
+    #[tokio::test]
+    async fn unchanged_file_failure_is_not_drift_attributed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "hello world\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        let read = ReadFile::with_ledger(ledger.clone());
+        let edit = EditFile::with_ledger(ledger.clone());
+
+        let seen = read
+            .execute(&serde_json::json!({"path": "a.rs"}), dir.path())
+            .await;
+        assert!(!seen.is_error());
+
+        let result = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "helo world", "new_string": "x"}),
+                dir.path(),
+            )
+            .await;
+        match result {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("unchanged since you last saw it"),
+                    "an unchanged file must not be blamed on drift: {message}"
+                );
+                assert!(
+                    message.contains("whitespace/newline"),
+                    "the classic hint stays: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected error, got: {content}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn own_successful_edit_is_not_later_misattributed_as_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "one two three\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        let read = ReadFile::with_ledger(ledger.clone());
+        let edit = EditFile::with_ledger(ledger.clone());
+
+        let seen = read
+            .execute(&serde_json::json!({"path": "a.rs"}), dir.path())
+            .await;
+        assert!(!seen.is_error());
+
+        // The model's own edit changes the file relative to the read…
+        let first = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "two", "new_string": "2"}),
+                dir.path(),
+            )
+            .await;
+        assert!(!first.is_error(), "{first:?}");
+
+        // …but a subsequent bad old_string is the model's mistake, not drift.
+        let second = edit
+            .execute(
+                &serde_json::json!({"path": "a.rs", "old_string": "bogus", "new_string": "x"}),
+                dir.path(),
+            )
+            .await;
+        match second {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.contains("unchanged since you last saw it"),
+                    "own edits must update the seen hash: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected error, got: {content}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn drift_echo_is_capped_for_huge_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("big.txt"), "seed\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        let read = ReadFile::with_ledger(ledger.clone());
+        let edit = EditFile::with_ledger(ledger.clone());
+
+        let seen = read
+            .execute(&serde_json::json!({"path": "big.txt"}), dir.path())
+            .await;
+        assert!(!seen.is_error());
+
+        let big: String = (1..=1000).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(dir.path().join("big.txt"), &big).unwrap();
+
+        let result = edit
+            .execute(
+                &serde_json::json!({"path": "big.txt", "old_string": "seed", "new_string": "x"}),
+                dir.path(),
+            )
+            .await;
+        match result {
+            ToolOutput::Error { message } => {
+                assert!(message.contains("CHANGED after you last read it"));
+                assert!(message.contains("line 400"), "echo shows the cap window");
+                assert!(
+                    !message.contains("line 401"),
+                    "echo must stop at the cap: {}",
+                    &message[message.len().saturating_sub(200)..]
+                );
+                assert!(
+                    message.contains("first 400 of 1000 lines"),
+                    "truncation must be named: {message}"
+                );
+            }
+            ToolOutput::Ok { content } => panic!("expected drift error, got: {content}"),
+        }
     }
 }

--- a/stella-tools/src/read.rs
+++ b/stella-tools/src/read.rs
@@ -5,16 +5,21 @@
 //! the file is read into memory first, so a single pathologically long line is
 //! still read in full.
 //!
-//! The tool also keeps the session's per-file read tally: every successful
-//! read increments a counter keyed by the file's normalized
+//! The tool also keeps the session's read-state ledger ([`ReadLedger`]): every
+//! successful read records a per-file tally (reported in the tool output) and
+//! the sha256 of the bytes that were current at read time. The hash is the
+//! read→edit drift oracle's baseline (#331): `edit_file` compares it against
+//! current disk bytes to attribute a failed match to an out-of-band change
+//! instead of a generic not-found. Reads are keyed by the file's normalized
 //! workspace-relative path (so `src/./a.rs` and `src/a.rs` count as one
-//! file), and the running count is reported in the tool output. One
-//! [`ReadFile`] instance lives per registry, so the tally is per session by
-//! construction; the audit-grade equivalent (one `R` event per read) lands in
-//! the registry's file-touch ledger.
+//! file). One ledger lives per registry, shared by `read_file`, `read_symbol`
+//! (which reads through this same tool), `edit_file`, and `write_file` — so
+//! the ledger tracks the content the model last *saw*, whichever surface
+//! showed (or produced) it. The audit-grade equivalent (one `R` event per
+//! read) lands in the registry's file-touch ledger.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -26,30 +31,93 @@ use crate::registry::Tool;
 /// the cap honestly when a symbol's span exceeds it.
 pub(crate) const MAX_LINES: usize = 2000;
 
-#[derive(Default)]
-pub struct ReadFile {
-    /// Per-session read counts by normalized workspace-relative path.
-    counts: Mutex<HashMap<String, u64>>,
+/// Per-file record of what the model last saw: how many times the file was
+/// read, and the sha256 of the file's full content the last time the model
+/// saw it (via a read, or via its own successful edit/write).
+#[derive(Debug, Clone, Default)]
+struct ReadState {
+    reads: u64,
+    sha256: String,
 }
 
-impl ReadFile {
+/// Session-scoped ledger of the last file content the model has *seen*.
+///
+/// Updated by successful reads (`read_file` and `read_symbol`) and by the
+/// model's own successful mutations (`edit_file`, `write_file` — the model
+/// knows the content it just produced). A mismatch between an entry's hash
+/// and current disk bytes therefore means the file changed out-of-band since
+/// the model last looked — the read→edit drift signal (#331).
+#[derive(Default)]
+pub struct ReadLedger {
+    states: Mutex<HashMap<String, ReadState>>,
+}
+
+impl ReadLedger {
+    /// Record one successful read of `path` whose full content was `content`,
+    /// returning the new per-file read count.
+    pub fn record_read(&self, root: &std::path::Path, path: &str, content: &str) -> u64 {
+        let mut states = self.states.lock().unwrap_or_else(|p| p.into_inner());
+        let state = states.entry(normalized_key(root, path)).or_default();
+        state.reads += 1;
+        state.sha256 = crate::staleness::hex_sha256(content.as_bytes());
+        state.reads
+    }
+
+    /// Record content the model produced or was shown for `path` without
+    /// counting a read — a successful `edit_file`/`write_file`, or the fresh
+    /// content echoed inside a drift-attributed error.
+    pub fn record_known(&self, root: &std::path::Path, path: &str, content: &str) {
+        let mut states = self.states.lock().unwrap_or_else(|p| p.into_inner());
+        let state = states.entry(normalized_key(root, path)).or_default();
+        state.sha256 = crate::staleness::hex_sha256(content.as_bytes());
+    }
+
     /// How many times `path` (under any workspace-relative spelling) has been
     /// successfully read this session.
     pub fn read_count(&self, root: &std::path::Path, path: &str) -> u64 {
-        self.counts
+        self.states
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .get(&normalized_key(root, path))
-            .copied()
+            .map(|s| s.reads)
             .unwrap_or(0)
     }
 
-    /// Record one successful read of `path`, returning the new total.
-    fn tally(&self, root: &std::path::Path, path: &str) -> u64 {
-        let mut counts = self.counts.lock().unwrap_or_else(|p| p.into_inner());
-        let count = counts.entry(normalized_key(root, path)).or_insert(0);
-        *count += 1;
-        *count
+    /// sha256 of the content the model last saw for `path` — `None` when the
+    /// file was never read (or written) through the ledger this session.
+    pub fn last_seen_sha(&self, root: &std::path::Path, path: &str) -> Option<String> {
+        self.states
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(&normalized_key(root, path))
+            .map(|s| s.sha256.clone())
+            .filter(|sha| !sha.is_empty())
+    }
+}
+
+pub struct ReadFile {
+    ledger: Arc<ReadLedger>,
+}
+
+impl Default for ReadFile {
+    fn default() -> Self {
+        Self {
+            ledger: Arc::default(),
+        }
+    }
+}
+
+impl ReadFile {
+    /// Construct sharing the registry's read-state ledger, so edits and
+    /// writes see the hashes this tool records.
+    pub fn with_ledger(ledger: Arc<ReadLedger>) -> Self {
+        Self { ledger }
+    }
+
+    /// How many times `path` (under any workspace-relative spelling) has been
+    /// successfully read this session.
+    pub fn read_count(&self, root: &std::path::Path, path: &str) -> u64 {
+        self.ledger.read_count(root, path)
     }
 }
 
@@ -115,8 +183,11 @@ impl Tool for ReadFile {
             Ok(content) => {
                 // Count every successful read — including a past-end offset,
                 // which still read the file — so the tally matches the
-                // ledger's one-R-event-per-successful-read rule.
-                let reads = self.tally(root, path);
+                // ledger's one-R-event-per-successful-read rule. The hash is
+                // of the FULL content (even for a ranged read): drift asks
+                // "has the file changed since the model looked", and the
+                // whole file was current at that moment.
+                let reads = self.ledger.record_read(root, path, &content);
                 let lines: Vec<&str> = content.lines().collect();
                 let start = offset.unwrap_or(1).saturating_sub(1);
                 let end = start.saturating_add(limit).min(lines.len());
@@ -242,6 +313,45 @@ mod tests {
             .await;
         assert!(missing.is_error());
         assert_eq!(tool.read_count(dir.path(), "ghost.rs"), 0);
+    }
+
+    #[tokio::test]
+    async fn read_records_last_seen_hash_even_for_ranged_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "one\ntwo\nthree\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        let tool = ReadFile::with_ledger(ledger.clone());
+
+        assert_eq!(ledger.last_seen_sha(dir.path(), "a.rs"), None);
+        let out = tool
+            .execute(
+                &serde_json::json!({"path": "a.rs", "offset": 2, "limit": 1}),
+                dir.path(),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        // The hash covers the FULL file content current at read time, not
+        // just the displayed range — drift asks about the file, not the view.
+        assert_eq!(
+            ledger.last_seen_sha(dir.path(), "a.rs"),
+            Some(crate::staleness::hex_sha256(b"one\ntwo\nthree\n")),
+        );
+
+        // An out-of-band change is visible as a hash mismatch…
+        std::fs::write(dir.path().join("a.rs"), "rewritten\n").unwrap();
+        assert_ne!(
+            ledger.last_seen_sha(dir.path(), "a.rs"),
+            Some(crate::staleness::hex_sha256(b"rewritten\n")),
+        );
+        // …until the next read refreshes the baseline.
+        let again = tool
+            .execute(&serde_json::json!({"path": "a.rs"}), dir.path())
+            .await;
+        assert!(!again.is_error());
+        assert_eq!(
+            ledger.last_seen_sha(dir.path(), "a.rs"),
+            Some(crate::staleness::hex_sha256(b"rewritten\n")),
+        );
     }
 
     #[tokio::test]

--- a/stella-tools/src/read.rs
+++ b/stella-tools/src/read.rs
@@ -95,16 +95,9 @@ impl ReadLedger {
     }
 }
 
+#[derive(Default)]
 pub struct ReadFile {
     ledger: Arc<ReadLedger>,
-}
-
-impl Default for ReadFile {
-    fn default() -> Self {
-        Self {
-            ledger: Arc::default(),
-        }
-    }
 }
 
 impl ReadFile {

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -233,15 +233,18 @@ impl ToolRegistry {
         let mcp_usage: stella_core::mcp_usage::McpUsageLedger = Arc::default();
         let task_board: crate::tasks::TaskBoardHandle = Arc::default();
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
-        // `read_symbol` reads through this same instance, so the per-file
-        // read tally ("read N× this session") counts both surfaces as one.
-        let read_file = Arc::new(crate::read::ReadFile::default());
+        // One read-state ledger per registry (#331): `read_file` and
+        // `read_symbol` (which reads through the same instance) record what
+        // the model saw; `edit_file` attributes match failures against it and
+        // `write_file`/`edit_file` record the content the model produced.
+        let read_ledger: Arc<crate::read::ReadLedger> = Arc::default();
+        let read_file = Arc::new(crate::read::ReadFile::with_ledger(read_ledger.clone()));
         let span_reads: crate::read_symbol::SpanReadLedger = Arc::default();
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
         let mut entries: Vec<Arc<dyn Tool>> = vec![
             read_file.clone(),
-            Arc::new(crate::write::WriteFile),
-            Arc::new(crate::edit::EditFile),
+            Arc::new(crate::write::WriteFile::with_ledger(read_ledger.clone())),
+            Arc::new(crate::edit::EditFile::with_ledger(read_ledger.clone())),
             Arc::new(crate::delete::DeleteFile),
             // Search results carry a code-map footer; a symbol-shaped grep
             // pattern additionally carries the graph_query pointer, decided

--- a/stella-tools/src/write.rs
+++ b/stella-tools/src/write.rs
@@ -1,12 +1,28 @@
 //! `write_file` — create or overwrite a file, creating parent dirs.
+//! Successful writes record the written bytes in the session's read-state
+//! ledger (#331): the model knows the content it just produced, so its own
+//! write must never be misattributed later as out-of-band drift.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 
+use crate::read::ReadLedger;
 use crate::registry::Tool;
 
-pub struct WriteFile;
+#[derive(Default)]
+pub struct WriteFile {
+    ledger: Arc<ReadLedger>,
+}
+
+impl WriteFile {
+    /// Construct sharing the registry's read-state ledger.
+    pub fn with_ledger(ledger: Arc<ReadLedger>) -> Self {
+        Self { ledger }
+    }
+}
 
 #[async_trait]
 impl Tool for WriteFile {
@@ -66,6 +82,7 @@ impl Tool for WriteFile {
 
         match tokio::fs::write(&full_path, content).await {
             Ok(()) => {
+                self.ledger.record_known(root, path, content);
                 let bytes = content.len();
                 ToolOutput::Ok {
                     content: format!("wrote {bytes} bytes to {path}"),
@@ -86,7 +103,7 @@ mod tests {
     async fn writes_file_and_creates_parent_dirs() {
         let dir = std::env::temp_dir();
         let path = format!("stella_write_test_{}/sub/dir/file.txt", std::process::id());
-        let result = WriteFile
+        let result = WriteFile::default()
             .execute(
                 &serde_json::json!({"path": path, "content": "hello stella"}),
                 &dir,
@@ -107,7 +124,7 @@ mod tests {
     #[tokio::test]
     async fn path_escape_returns_error() {
         let dir = std::env::temp_dir();
-        let result = WriteFile
+        let result = WriteFile::default()
             .execute(
                 &serde_json::json!({"path": "../../etc/bad", "content": "x"}),
                 &dir,
@@ -119,7 +136,7 @@ mod tests {
     #[tokio::test]
     async fn missing_content_returns_error() {
         let dir = std::env::temp_dir();
-        let result = WriteFile
+        let result = WriteFile::default()
             .execute(&serde_json::json!({"path": "ok.txt"}), &dir)
             .await;
         assert!(result.is_error());


### PR DESCRIPTION
## Summary

Implements #331 (epic #336, drift axis): the sha256 staleness oracle finally guards the read→edit path.

## What changed

**`ReadLedger`** (stella-tools/src/read.rs) — the previously dead per-file read tally becomes a session read-state ledger: read count + sha256 of the full file content current at read time. One ledger per registry, shared by:
- `read_file` / `read_symbol` (reads through the same instance) — record what the model **saw**
- `edit_file` / `write_file` — record what the model **produced**, so its own mutations are never misattributed as drift

**`edit_file` attribution** — a failed `old_string` match now names its cause instead of the generic not-found:
1. **Drift**: file changed after last seen → error says so and **echoes current content** (line-numbered, capped at 400 lines), so the model re-issues the edit against fresh bytes without a round-trip. The echo is recorded as seen, so a repeat failure against the same bytes reports as unchanged rather than re-attributing drift forever.
2. **Unchanged since last seen** → the model's own mistake; the whitespace/newline hint stays.
3. **Never read this session** → read it first.

**Loop detection** (part 3 of the issue) needs no core change: the detector only flags byte-identical outputs, and the drift echo embeds the changed content — so a legitimate recovery always produces differing outputs and stays progress-eligible, while a verbatim replay against an unchanged file still (rightly) trips detection. Added `drift_attributed_edit_recovery_is_not_a_loop` to pin that contract.

## Witness (from the issue)

`drift_is_attributed_and_fresh_content_echoed`: read a file, mutate it out-of-band, then `edit_file` with a stale `old_string` — asserts the error names the concurrent change and carries the fresh content. Fails before this change.

## Tests

- stella-tools: 379 passed (new: drift witness, unchanged-not-drift, own-edit-not-drift, capped echo, ranged-read hashes full content)
- stella-core: loop_detect 29 passed; full workspace `cargo check --all-targets` + clippy clean
