### PR TITLE
fix(core): loop detection sees through read_file's session-tally footer

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -1796,7 +1796,7 @@ fn recent_call_records(messages: &[CompletionMessage]) -> Vec<CallRecord> {
                         .rev()
                         .find(|r| r.output.is_none() && r.call.call_id == result.call_id)
                     {
-                        record.output = Some(result.output.clone());
+                        record.output = Some(comparable_output(&result.output));
                     }
                 }
             }
@@ -1804,6 +1804,27 @@ fn recent_call_records(messages: &[CompletionMessage]) -> Vec<CallRecord> {
         }
     }
     records
+}
+
+/// Normalize one tool output for loop comparison: strip `read_file`'s
+/// volatile session-tally footer (`\n\n(N/M lines shown · read K× this
+/// session)`). The footer changes on EVERY read by design — it is the
+/// model-facing "you already read this" nudge — but the loop detector
+/// requires byte-identical outputs, so the footer made every reread unique
+/// and blinded detection to the exact thrash it exists to catch (the
+/// read → failing-edit → read cycle the `loop_detect` module doc names).
+/// Comparison-only: the transcript and history keep the footer untouched.
+fn comparable_output(output: &ToolOutput) -> ToolOutput {
+    if let ToolOutput::Ok { content } = output
+        && content.ends_with("\u{d7} this session)")
+        && let Some(idx) = content.rfind("\n\n(")
+        && content[idx..].contains(" lines shown \u{b7} read ")
+    {
+        return ToolOutput::Ok {
+            content: content[..idx].to_string(),
+        };
+    }
+    output.clone()
 }
 
 /// The [`TurnOutcome::Aborted`] reason of a user-requested soft stop —

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -2457,6 +2457,77 @@ async fn session_start_hooks_run_via_the_helper_not_per_turn() {
     assert!(payloads[0].contains("\"event\":\"SessionStart\""));
 }
 
+#[test]
+fn read_tally_footer_does_not_blind_loop_detection() {
+    // `read_file` appends "read K\u{d7} this session" — different bytes on
+    // EVERY read of an unchanged file. Comparison must see through the
+    // footer, or the module-doc thrash (read → failing edit → read, and a
+    // bare reread spiral) can never satisfy the byte-identical-output
+    // requirement and detection is structurally blind for read_file.
+    let read_call = |id: &str| CompletionMessage {
+        role: MessageRole::Assistant,
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: id.into(),
+            name: "read_file".into(),
+            input: serde_json::json!({ "path": "a.rs" }),
+        }],
+        tool_results: Vec::new(),
+        attachments: Vec::new(),
+    };
+    let read_result = |id: &str, body: &str, count: usize| CompletionMessage {
+        role: MessageRole::Tool,
+        content: String::new(),
+        tool_calls: Vec::new(),
+        tool_results: vec![stella_protocol::ToolResult {
+            call_id: id.into(),
+            output: ToolOutput::Ok {
+                content: format!(
+                    "     1\tfn {body}() {{}}\n\n(1/1 lines shown \u{b7} read {count}\u{d7} this session)"
+                ),
+            },
+        }],
+        attachments: Vec::new(),
+    };
+
+    // Unchanged file reread four times: only the tally differs → a loop.
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("go"),
+    ];
+    for count in 1..=4usize {
+        let id = format!("c{count}");
+        messages.push(read_call(&id));
+        messages.push(read_result(&id, "same", count));
+    }
+    let verdict = detect_loop(
+        &recent_call_records(&messages),
+        LoopDetectionConfig::default(),
+    );
+    assert!(
+        verdict.is_loop(),
+        "identical rereads must be a loop despite the tally footer: {verdict:?}"
+    );
+
+    // Content that genuinely changes between reads stays progress.
+    let mut changing = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("go"),
+    ];
+    for count in 1..=4usize {
+        let id = format!("d{count}");
+        changing.push(read_call(&id));
+        changing.push(read_result(&id, &format!("v{count}"), count));
+    }
+    assert_eq!(
+        detect_loop(
+            &recent_call_records(&changing),
+            LoopDetectionConfig::default()
+        ),
+        crate::loop_detect::LoopVerdict::NoLoop
+    );
+}
+
 mod audit_fixes;
 mod task4;
 mod usage_completeness;


### PR DESCRIPTION
## The bug

`read_file` appends `(N/M lines shown · read K× this session)` to every output — deliberately, as the model-facing anti-loop nudge. But the loop detector requires **byte-identical outputs** to rule out progress (correctly — that's what keeps polling legit). The tally changes on every read, so every reread of an *unchanged* file was byte-unique → `same_record` never matched → **loop detection could never fire on `read_file`**. The `loop_detect` module doc's own motivating example — the read → failing-edit → read thrash — was structurally undetectable; a bare reread spiral ran to the 200-step cap.

## The fix

`recent_call_records` (which exists precisely to build comparison records) normalizes outputs before comparison: the exact footer shape (`\n\n(` … ` lines shown · read ` … `× this session)`) is stripped. Comparison-only — transcript, history, and the model-facing output keep the footer untouched.

## Tests

New `read_tally_footer_does_not_blind_loop_detection`: four rereads of an unchanged file differing only in tally → **loop** (fails before this fix); four reads with genuinely changing content → `NoLoop`. Full stella-core suite green (394); fmt + clippy clean.

Found during the #364/#331 work while pinning the drift-recovery/loop-detection contract.
