### PR TITLE
release:minor: stella 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,7 +3100,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-cli"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "contextgraph-types",
  "notify",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "stella-mcp"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "stella-pipeline"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "base64",
  "libc",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui"
-version = "0.4.91"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.91"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT OR Apache-2.0"

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.4.91"
-  version "0.4.91"
+  url "https://github.com/macanderson/stella.git", tag: "v0.5.0"
+  version "0.5.0"
   license "MIT OR Apache-2.0"
   head "https://github.com/macanderson/stella.git", branch: "main"
 


### PR DESCRIPTION
## stella 0.5.0 — minor release

Cuts the **0.5.0** minor release, following the accumulated feature work landed on `main` since the 0.4.x line (read→edit drift oracle #331, transactional `apply_edits` #333, graph-driven test-impact selection #334, graph-derived planner context #342, typed decision events / policy-plane journal bridge #364, org/hub observatory dashboard #410, plus loop-detection, compaction, and TUI fixes).

### What this PR does
- Bumps `[workspace.package].version` → **0.5.0** (inherited by all 15 crates)
- Syncs the `Cargo.lock` workspace-member entries
- Bumps the build-from-source Homebrew formula (`packaging/homebrew/stella.rb`) → 0.5.0

### Release mechanics
The `release:minor` title prefix drives `auto-tag.yml`:
1. computes the next version as a **minor** bump from the latest tag → `v0.5.0`
2. creates + pushes tag `v0.5.0`
3. dispatches `release.yml` → builds binaries for all 4 targets, publishes the GitHub Release (with generated notes + SHA256SUMS), and pushes the rendered formula to `macanderson/homebrew-tap`

Manifests are pre-synced here, so the automated post-release version-sync write-back is a no-op.

Verified locally: `cargo fmt --check` clean, `cargo build --workspace` green.