### PR TITLE
feat(tui): render GoalVerdict as a transcript entry (#463)

### DIFF
--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -220,6 +220,14 @@ pub enum TranscriptEntry {
         summary: String,
         deterministic: bool,
     },
+    /// A goal-check verdict from the judge loop (`AgentEvent::GoalVerdict`) —
+    /// the symmetric scrollback row to [`Self::JudgeVerdict`]. `met` is the
+    /// pass/fail; `round` is the judge iteration it settled on.
+    GoalVerdict {
+        met: bool,
+        round: usize,
+        reasoning: String,
+    },
     /// A scope-review gate was presented (the actionable card is driven off
     /// [`SessionModel::pending_scope_review`]; this line is the scrollback
     /// record of it).
@@ -572,20 +580,29 @@ impl SessionModel {
                         .map(|t| t.subject.clone()),
                 });
             }
+            AgentEvent::GoalVerdict {
+                met, round, reasoning, ..
+            } => {
+                // Symmetric to `JudgeVerdict` above — a scrollback row. The
+                // event's own `cost_usd` is already accounted against the
+                // budget when it fires, so it is dropped here (folding it would
+                // double-count the HUD spend, which `BudgetTick` drives).
+                self.transcript.push(TranscriptEntry::GoalVerdict {
+                    met: *met,
+                    round: *round,
+                    reasoning: reasoning.clone(),
+                });
+            }
             // `StepUsage` is a metering/billing record consumed by
             // `stella-store`; the HUD's live spend is driven by `BudgetTick`,
-            // so folding it here would double-count. `GoalVerdict`'s own
-            // `cost_usd` is likewise already accounted against the budget when
-            // it fires. Neither mutates TUI state today (a goal-verdict
-            // transcript row is a display enhancement, tracked as follow-up).
+            // so folding it here would double-count.
             AgentEvent::StepUsage { .. }
             | AgentEvent::UsageIncomplete { .. }
             // Context receipts (spec §4/§5) are consumed by the store/inspector,
             // not folded into TUI panel state — the model stays a pure function
             // of the user-visible event sequence.
             | AgentEvent::BlockRegistered { .. }
-            | AgentEvent::StepManifest { .. }
-            | AgentEvent::GoalVerdict { .. } => {}
+            | AgentEvent::StepManifest { .. } => {}
             AgentEvent::Error { message, retryable } => {
                 self.pending_scope_review = None;
                 self.pending_ask_user = None;
@@ -1397,6 +1414,38 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Witness for #463: a `GoalVerdict` event lands as its own transcript row
+    /// (it used to fold as a no-op, leaving the transcript empty) — symmetric
+    /// to `JudgeVerdict`. Its `cost_usd` is *not* double-counted into HUD spend.
+    #[test]
+    fn goal_verdict_lands_on_the_transcript_without_touching_spend() {
+        let mut model = SessionModel::new();
+        model.apply(&AgentEvent::GoalVerdict {
+            round: 3,
+            met: true,
+            reasoning: "the witness test passes now".into(),
+            cost_usd: 0.02,
+        });
+        assert_eq!(model.transcript.len(), 1, "goal verdict is recorded");
+        match &model.transcript[0] {
+            TranscriptEntry::GoalVerdict {
+                met,
+                round,
+                reasoning,
+            } => {
+                assert!(*met);
+                assert_eq!(*round, 3);
+                assert_eq!(reasoning, "the witness test passes now");
+            }
+            other => panic!("expected GoalVerdict, got {other:?}"),
+        }
+        // `cost_usd` is billing state, not HUD state (`BudgetTick` drives spend).
+        assert_eq!(
+            model.hud.spent_usd, 0.0,
+            "goal-verdict cost is not folded here"
+        );
     }
 
     #[test]

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -1297,6 +1297,34 @@ pub(crate) fn entry_lines(
                 out,
             );
         }
+        TranscriptEntry::GoalVerdict {
+            met,
+            round,
+            reasoning,
+        } => {
+            let (glyph, color) = if *met {
+                ("✓", theme::OK)
+            } else {
+                ("○", theme::WARN)
+            };
+            push_labeled(
+                &format!("{glyph} goal"),
+                Style::new().fg(color).add_modifier(Modifier::BOLD),
+                vec![
+                    Span::styled(
+                        format!("[round {round}] "),
+                        Style::new().fg(Color::DarkGray),
+                    ),
+                    Span::raw(if *met {
+                        format!("goal met — {reasoning}")
+                    } else {
+                        format!("not yet met — {reasoning}")
+                    }),
+                ],
+                width,
+                out,
+            );
+        }
         TranscriptEntry::ScopeReview {
             summary,
             steps,

--- a/stella-tui/src/render/tests.rs
+++ b/stella-tui/src/render/tests.rs
@@ -126,6 +126,11 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
             summary: "ok".into(),
             deterministic: true,
         },
+        TranscriptEntry::GoalVerdict {
+            met: false,
+            round: 2,
+            reasoning: "tests still red".into(),
+        },
         TranscriptEntry::ScopeReview {
             summary: "auth".into(),
             steps: 2,
@@ -183,6 +188,7 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
             | TranscriptEntry::MediaProgress { .. }
             | TranscriptEntry::MediaComplete { .. }
             | TranscriptEntry::JudgeVerdict { .. }
+            | TranscriptEntry::GoalVerdict { .. }
             | TranscriptEntry::ScopeReview { .. }
             | TranscriptEntry::AskUser { .. }
             | TranscriptEntry::Commit { .. }


### PR DESCRIPTION
## What & why

`SessionModel::apply` folded `AgentEvent::GoalVerdict` as a no-op, grouped with the metering/receipt events that don't mutate TUI panel state — the inline comment called that omission a tracked follow-up, but nothing tracked it. `JudgeVerdict` already produces a `TranscriptEntry::JudgeVerdict` scrollback row, so a goal-verdict row is the symmetric treatment.

- **`model.rs`** — add `TranscriptEntry::GoalVerdict { met, round, reasoning }`; fold `GoalVerdict` into it, mirroring `JudgeVerdict`. `cost_usd` is intentionally dropped (already accounted against the budget; the HUD's live spend is driven by `BudgetTick`, so folding it would double-count).
- **`render.rs`** — render through the shared label gutter: `OK`/`✓` "goal met — …" when met, `WARN`/`○` "not yet met — …" otherwise, matching `textline::goal_verdict` wording (the CLI annotation line already handled `GoalVerdict`; only the TUI transcript lagged).

Closes #463

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`goal_verdict_lands_on_the_transcript_without_touching_spend` (model.rs): applies a `GoalVerdict` event and asserts it lands as a `TranscriptEntry::GoalVerdict` row — on `main` the no-op fold leaves the transcript empty, so it fails there. Also asserts `hud.spent_usd` stays `0` (cost is not double-counted). The exhaustive render-coverage test `every_transcript_entry_renders_in_the_label_gutter` is extended with a sample + match arm, so the new variant is proven to render through the gutter.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (doc comments on the new variant + updated the no-op-fold comment)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core` (change is entirely in `stella-tui`); no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `GoalVerdict` already exists in `stella-protocol` (with its own round-trip test); `TranscriptEntry` is a TUI-internal derived record, not a wire type

## Anything reviewers should know?

Symmetric to the existing `JudgeVerdict` handling end-to-end. `deck.rs` (command deck) and `textline.rs` (CLI) already rendered `GoalVerdict`; this closes the one remaining surface — the TUI `SessionModel` transcript. Colors follow `textline::goal_verdict` semantics (met → success, not-yet-met → warn) rather than `JudgeVerdict`'s cyan/magenta, since "not yet met" is a pending state, not a failure.