### PR TITLE
feat(core): name the overflow-summary spliced blocks in the compaction receipt (#461)

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -592,6 +592,9 @@ impl<'a> Engine<'a> {
                 deduped_blocks: report.deduped_blocks,
                 superseded_blocks: report.superseded_blocks,
                 aged_blocks: report.aged_blocks,
+                // The pure passes never summarize — the overflow fallback below
+                // owns that path and its block identities.
+                summarized_blocks: Vec::new(),
                 effective_budget_tokens: compaction_budget,
                 calibration_factor: factor,
             });
@@ -784,6 +787,18 @@ impl<'a> Engine<'a> {
         events: &EventSender,
     ) {
         let replaced = end - start;
+        // Name which blocks left context (spec §6.2): the identity-bearing
+        // tool-result blocks in the span the summary folds away, keyed the same
+        // way the pure passes key theirs (`receipts::tool_result_block_id`), so
+        // a receipt consumer can reconcile the summary splice against the
+        // manifest. Captured before the splice mutates `messages`. Text
+        // messages in the span carry no block identity, so this is a subset of
+        // the `summarized` count, not a one-for-one list.
+        let summarized_blocks: Vec<String> = messages[start..end]
+            .iter()
+            .flat_map(|m| m.tool_results.iter())
+            .map(|r| crate::receipts::tool_result_block_id(&r.output))
+            .collect();
         let summary = CompletionMessage::user(format!(
             "{SUMMARY_MARKER_PREFIX} to fit context — full detail was compacted away; \
              re-read files or re-run tools for specifics]\n\n{text}"
@@ -797,13 +812,14 @@ impl<'a> Engine<'a> {
             superseded: 0,
             aged: 0,
             summarized: replaced,
-            // The summary splices a new block rather than stubbing existing
-            // ones; naming that summary block is deferred (spec §6.2). It
-            // targets the same effective budget as the pure passes.
+            // The summary path runs none of the pure passes, so their block
+            // vectors stay empty; the folded blocks are named in
+            // `summarized_blocks`. It targets the same effective budget.
             evicted_blocks: Vec::new(),
             deduped_blocks: Vec::new(),
             superseded_blocks: Vec::new(),
             aged_blocks: Vec::new(),
+            summarized_blocks,
             effective_budget_tokens: compaction_budget,
             calibration_factor: factor,
         });

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -471,6 +471,97 @@ async fn budget_aborted_summary_is_applied_not_discarded() {
     );
 }
 
+/// #461: the overflow-summary splice names *which* tool-result blocks it
+/// folded away in its `Compaction` receipt (spec §6.2). Before the fix
+/// `summarized_blocks` was hard-coded empty, so the one compaction path that
+/// most changes context reported no block identities. Witness: a tool-result
+/// block in the folded span leaves context and is named in the receipt.
+#[tokio::test]
+async fn overflow_summary_names_the_folded_tool_result_blocks() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("SUMMARY"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+
+    // A tool-result block sits in the interior of the summarizable span,
+    // paired with its assistant tool_call and surrounded by big assistant
+    // texts so neither span bound walks onto a Tool message.
+    let folded_output = ToolOutput::Ok {
+        content: "read 4096 bytes from src/main.rs".into(),
+    };
+    let expected_block = crate::receipts::tool_result_block_id(&folded_output);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+        big_assistant_text("a0"),
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: "c1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({ "path": "src/main.rs" }),
+            }],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        },
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "c1".into(),
+                output: folded_output.clone(),
+            }],
+            attachments: Vec::new(),
+        },
+        big_assistant_text("a1"),
+        big_assistant_text("a2"),
+        big_assistant_text("a3"),
+        big_assistant_text("a4"),
+    ];
+
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let mut health = SummarizerHealth::default();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    let _ = engine
+        .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+        .await;
+
+    assert_eq!(summary_markers(&messages), 1, "the summary was spliced in");
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.tool_results.iter().any(|r| r.call_id == "c1")),
+        "the tool-result message was folded into the summary, so it left context"
+    );
+
+    let events = drain_events(&mut rx);
+    let summarized_blocks = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::Compaction {
+                summarized,
+                summarized_blocks,
+                ..
+            } if *summarized > 0 => Some(summarized_blocks.clone()),
+            _ => None,
+        })
+        .expect("a summary compaction event was emitted");
+    assert!(
+        summarized_blocks.contains(&expected_block),
+        "summarized_blocks {summarized_blocks:?} must name the folded block {expected_block}"
+    );
+}
+
 /// #368.4: a summarizer that keeps failing must surface each failure and,
 /// after enough consecutive misses, latch — a persistently-timing-out cheap
 /// summarizer can't be allowed to re-fire (and re-pay) every remaining step.

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -324,8 +324,9 @@ pub enum AgentEvent {
         /// The `block_id`s each pass stubbed (spec §6.2) — identities, not just
         /// counts, so the receipt records *which* blocks left context and a
         /// later pass can prove a block was evicted before it was ever cited or
-        /// referenced (the wasted-carry signal). Each vec's length equals its
-        /// count field. `serde(default)` — absent on pre-identity journals.
+        /// referenced (the wasted-carry signal). For the pure passes each vec's
+        /// length equals its count field (`summarized_blocks` is the documented
+        /// exception). `serde(default)` — absent on pre-identity journals.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         evicted_blocks: Vec<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -334,6 +335,16 @@ pub enum AgentEvent {
         superseded_blocks: Vec<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         aged_blocks: Vec<String>,
+        /// The `block_id`s of the tool-result blocks folded into an
+        /// overflow-summary splice (spec §6.2). Unlike the pure passes — which
+        /// stub tool-result blocks one-for-one, so their vec length equals the
+        /// count — the summary replaces a whole message span whose `summarized`
+        /// count also covers user/assistant text carrying no block identity;
+        /// this vector is the identity-bearing (tool-result) subset that left
+        /// context, so `summarized_blocks.len()` may be less than `summarized`.
+        /// `serde(default)` — absent on pre-identity journals.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        summarized_blocks: Vec<String>,
         /// The budget this pass actually compared against — the raw compaction
         /// budget divided by the model's calibration factor — and that factor.
         /// The event's `before/after_tokens` are raw estimates; these are the
@@ -994,11 +1005,14 @@ mod tests {
             deduped: 1,
             superseded: 1,
             aged: 1,
-            summarized: 0,
+            summarized: 3,
             evicted_blocks: vec!["blk_ev1".into(), "blk_ev2".into()],
             deduped_blocks: vec!["blk_dd1".into()],
             superseded_blocks: vec!["blk_sup".into()],
             aged_blocks: vec!["blk_age".into()],
+            // Fewer identities than the `summarized` count: the summary folded
+            // three messages but only two were identity-bearing tool results.
+            summarized_blocks: vec!["blk_sum1".into(), "blk_sum2".into()],
             effective_budget_tokens: 136_363,
             calibration_factor: 1.1,
         };
@@ -1010,12 +1024,18 @@ mod tests {
                 before_tokens,
                 after_tokens,
                 evicted_blocks,
+                summarized,
+                summarized_blocks,
                 effective_budget_tokens,
                 ..
             } => {
                 assert!(after_tokens < before_tokens);
                 // Identities, not just counts — which blocks left context.
                 assert_eq!(evicted_blocks, vec!["blk_ev1", "blk_ev2"]);
+                // The summary names its folded tool-result blocks, and the vec
+                // may be shorter than the message count it replaced.
+                assert_eq!(summarized_blocks, vec!["blk_sum1", "blk_sum2"]);
+                assert!(summarized_blocks.len() < summarized);
                 assert_eq!(effective_budget_tokens, 136_363);
             }
             other => panic!("unexpected variant: {other:?}"),

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -838,6 +838,7 @@ mod tests {
                 deduped_blocks: vec![],
                 superseded_blocks: vec![],
                 aged_blocks: vec![],
+                summarized_blocks: vec![],
                 effective_budget_tokens: 0,
                 calibration_factor: 0.0,
             },


### PR DESCRIPTION
## What & why

`driver.rs::apply_overflow_summary` splices a model-written history summary over `messages[start..end]` and emits `AgentEvent::Compaction`, but the block-identity vectors on that path were all empty (`evicted_blocks: Vec::new`, …). The pure passes (evict/dedup/supersede/age) populate their `*_blocks`, so the receipt reconstructs what they did — but the **overflow-summary fallback**, the path that most changes context (it replaces messages with a *paid* model summary), reported no block identities. §6.2's promise is "which blocks left context," so that path was a hole.

- Add `summarized_blocks: Vec<String>` to `AgentEvent::Compaction` (`serde(default, skip_serializing_if = "Vec::is_empty")` — pre-identity journals still parse byte-for-byte, and the legacy-parse test still passes).
- Populate it in `apply_overflow_summary` from the tool-result blocks in the folded span, keyed via `receipts::tool_result_block_id` — the same identity scheme the pure passes use — captured **before** the splice mutates `messages`. The pure-pass emit site sets it empty (that path never summarizes).

Closes #461

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`overflow_summary_names_the_folded_tool_result_blocks` (driver/tests/audit_fixes.rs): puts a tool-result block in the interior of the summarizable span, runs `summarize_overflow_span`, and asserts the emitted `Compaction` names that block in `summarized_blocks`. On `main` the field is hard-coded empty, so the assertion fails there. The stella-protocol round-trip test `compaction_event_carries_counts_and_block_identities` is also extended to cover a non-empty `summarized_blocks` whose length is *less* than the `summarized` count (the documented span-vs-identity semantics).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed (field doc comment spells out the length-vs-count semantics; updated the deferred inline comment in `apply_overflow_summary`)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core` — `summarized_blocks` is computed from owned message data by a pure function
- [x] No new outbound network calls
- [x] New cross-boundary field round-trips through serde (test included; additive/back-compat with `serde(default)`)

## Anything reviewers should know?

**Semantics choice:** unlike the pure passes (one identity per stubbed tool-result block, so `vec.len == count`), the summary replaces a whole message span whose `summarized` count also covers user/assistant text that carries no block identity. So `summarized_blocks` is the identity-bearing (tool-result) *subset* that left context, and `summarized_blocks.len` may be `< summarized`. This is documented on the field and asserted in both tests. Naming a stable identity for the *new* summary block that entered (vs. the folded blocks that left) is a possible follow-up — §6.2's core promise is "which blocks left," which this delivers. Child of the receipts epic #364; deferred from PR #401.
