### PR TITLE
fix(core): discard the speculation pool on the budget-abort path (#460)

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -245,6 +245,10 @@ const SPECULATION_DISCARD_ATTEMPT_FAILED: &str = "attempt_failed";
 /// dispatch because the committed call diverged from what was announced, or
 /// no committed call ever claimed it.
 const SPECULATION_DISCARD_HARVEST_MISMATCH: &str = "harvest_mismatch";
+/// `SpeculationDiscarded.reason` — a committed step's pool ran read-only I/O
+/// but the turn aborted on an enforced budget before `dispatch_completion`
+/// could harvest it, so it is discarded on the abort unwind instead (#460).
+const SPECULATION_DISCARD_BUDGET_ABORT: &str = "budget_abort";
 
 /// One committed model call plus the step-scoped context the phases after
 /// it consume: the pre-call raw token estimate (drift feedback + telemetry
@@ -507,6 +511,18 @@ impl<'a> Engine<'a> {
                 &mut budget_warnings,
                 events,
             ) {
+                // The budget-abort unwind never reaches `dispatch_completion`,
+                // which is where a committed step's speculation pool is
+                // otherwise harvested or discarded. Any read-only calls this
+                // step already speculated would drop silently here — account
+                // for them so #370's guarantee holds on the abort path too
+                // (#460). `handle_committed_result` only borrows `committed`,
+                // so the pool is still ours to move.
+                self.discard_speculation_pool(
+                    committed.speculation,
+                    SPECULATION_DISCARD_BUDGET_ABORT,
+                    events,
+                );
                 return aborted;
             }
 
@@ -1169,14 +1185,16 @@ impl<'a> Engine<'a> {
     }
 
     /// Emit `SpeculationDiscarded` for every entry a committed step's pool
-    /// left un-harvested — read-only calls that ran real I/O off a divergent
-    /// stream but never appeared in the committed transcript (#370).
-    fn discard_speculation_pool(&self, pool: SpeculationPool, events: &EventSender) {
+    /// left un-harvested — read-only calls that ran real I/O but never made it
+    /// into the committed transcript (#370). `reason` names why the pool was
+    /// dropped (harvest mismatch on the normal path, budget abort on the
+    /// enforced-limit unwind) so the accounting stays reconcilable per site.
+    fn discard_speculation_pool(&self, pool: SpeculationPool, reason: &str, events: &EventSender) {
         for (call_id, result) in pool {
             let _ = events.send(AgentEvent::SpeculationDiscarded {
                 call_id,
                 name: result.name,
-                reason: SPECULATION_DISCARD_HARVEST_MISMATCH.to_string(),
+                reason: reason.to_string(),
             });
         }
     }
@@ -1347,7 +1365,11 @@ impl<'a> Engine<'a> {
             // read-only calls off a divergent stream (announced, then dropped
             // from the commit): none are harvested here, so account for the
             // discarded I/O rather than dropping the pool silently (#370).
-            self.discard_speculation_pool(speculation, events);
+            self.discard_speculation_pool(
+                speculation,
+                SPECULATION_DISCARD_HARVEST_MISMATCH,
+                events,
+            );
             // A turn that produced neither a tool call NOR any visible text is
             // never a real completion: the model was cut off at its output
             // limit (usually mid-reasoning) or returned nothing at all.
@@ -1540,7 +1562,7 @@ impl<'a> Engine<'a> {
         }
         // Any pool entry no committed call ever claimed ran real I/O that
         // never reached the transcript — account for it, don't drop it (#370).
-        self.discard_speculation_pool(speculation, events);
+        self.discard_speculation_pool(speculation, SPECULATION_DISCARD_HARVEST_MISMATCH, events);
         indexed.sort_by_key(|(index, _)| *index);
         indexed.into_iter().map(|(_, result)| result).collect()
     }

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -338,6 +338,65 @@ async fn a_divergent_committed_call_emits_a_harvest_mismatch_discard() {
     );
 }
 
+/// #460: a step that speculates a read-only call and then trips an ENFORCED
+/// budget aborts the turn before `dispatch_completion` — the only place a
+/// committed step's pool is harvested or discarded — ever runs. The read that
+/// already executed would drop silently on the abort unwind; it must instead
+/// emit `SpeculationDiscarded(budget_abort)` so #370's accounting holds on the
+/// abort path too. Witness: this event is absent before the fix.
+#[tokio::test]
+async fn budget_abort_after_speculation_discards_the_pool() {
+    let executed = Arc::new(tokio::sync::Notify::new());
+    let calls = Arc::new(AtomicU32::new(0));
+    // announce == commit: on a non-aborting turn this read is *harvested*,
+    // never a harvest_mismatch — so a discard here can only be the budget path.
+    let provider = SpeculatingProvider {
+        announce: read_call(serde_json::json!({"path": "a.rs"})),
+        commit: read_call(serde_json::json!({"path": "a.rs"})),
+        executed: executed.clone(),
+        wait_for_execution: true,
+        step: AtomicU32::new(0),
+    };
+    let tools = NotifyingReadTools {
+        calls: calls.clone(),
+        executed,
+    };
+
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("read a.rs")];
+    // The step-0 cost ($0.0001) crosses the enforced $0.00005 turn limit, so
+    // `handle_committed_result` returns `AbortTurn` before the pool is harvested.
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(0.00005), None);
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await
+    .expect("a hung turn means speculation deadlocked the provider/pump join");
+    let events = drain_events(&mut rx);
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { .. }),
+        "the enforced budget aborts the turn: {outcome:?}"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the read really ran — its I/O is exactly what the discard must account for"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::SpeculationDiscarded { call_id, name, reason }
+                if call_id == "c1" && name == "read_file" && reason == "budget_abort"
+        )),
+        "the pool dropped on the budget-abort unwind must emit \
+         SpeculationDiscarded(budget_abort): {events:?}"
+    );
+}
+
 /// Announces `announce` during its stream, FAILS its first attempt with a
 /// retryable transport error (dropping that attempt's speculation pool),
 /// then on the retry commits `commit`; a final step returns plain text. On


### PR DESCRIPTION
## What & why

`driver.rs::handle_committed_result` returns `BudgetOutcome::AbortTurn` when a committed step trips an **enforced** budget, and `run_turn` unwinds without reaching `dispatch_completion` — the only place a committed step's speculation pool is harvested or discarded. If that step speculatively executed a read-only call during the pump, its pool dropped silently, so event-log consumers reconstructing "what actually executed" **undercounted** the real read-only I/O. This was the one hole left in #370's (PR #415) otherwise-complete accounting; its author flagged the abort path as explicitly deferred ("that's budget code the brief said not to touch").

**Reachability confirmed:** `CommittedStep` carries the `speculation` pool, and `handle_committed_result` only *borrows* `committed`, so on the abort return the pool is still owned by the caller and dropped there. It is reachable and is a real bug (see the witness).

- Route `committed.speculation` through `discard_speculation_pool` at the abort call site, emitting `SpeculationDiscarded` per already-completed entry.
- Parameterize `discard_speculation_pool` by `reason` and add a distinct `budget_abort` token so the abort discard is reconcilable separately from the `harvest_mismatch` drops; the two existing call sites now pass `harvest_mismatch` explicitly.

Closes #460

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`budget_abort_after_speculation_discards_the_pool` (driver/tests.rs): a `SpeculatingProvider` announces == commits a read-only call (so on a normal turn it is *harvested*, never a `harvest_mismatch`), run under an `Enforced` budget whose limit the step's cost crosses. It asserts (a) the read really ran, and (b) `SpeculationDiscarded(budget_abort)` is emitted for it.

**Verified fails-on-main:** with the fix reverted, the event stream carries only a synthetic "not executed — turn aborted on budget" `ToolResult` for the call and **no** `SpeculationDiscarded` — exactly the undercount this fixes (the speculated read ran real I/O yet left no accounting trace). The two signals are complementary: the "not executed" result is the committed-transcript axis; `SpeculationDiscarded` is the "ran off-transcript, discarded" axis (#370's model).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated (new reason const doc; generalized `discard_speculation_pool` doc)
- [x] Commits signed off for DCO (`git commit -s`)

## Ground-rule check

- [x] No I/O added to `stella-core` — only reorders existing event emission on an already-reached branch
- [x] No new outbound network calls
- [x] Budget still aborts only at a safe boundary — this changes nothing about *when* the abort happens, only that the already-run pool is accounted as it unwinds

## Anything reviewers should know?

The abort branch already emits synthetic `ToolResult(not executed)` for the committed step's un-run tool_calls; this adds the *separate* speculation-accounting event for calls that ran speculatively. Same call_id can therefore appear in both — intentional and matches how the divergent path already behaves (a re-executed/synthetic result **and** a `SpeculationDiscarded`). Sequencing note from #459's filing still applies: any persistence of these events should sort by `sequence`, not arrival order. Follow-up to #370 (PR #415).