### PR TITLE
feat(context): Phase 1 domain type layer — context-use, contracts, outcomes, representation, protocol events

### DIFF
--- a/stella-core/src/context_record.rs
+++ b/stella-core/src/context_record.rs
@@ -45,16 +45,33 @@
 //!    an `observed` directive. That narrowing is left as a **flagged validator,
 //!    not implemented here**, because it refines the "uniform 5" resolution.
 
+pub mod context_use;
+pub mod contract;
 pub mod hash;
 pub mod kind;
+pub mod outcome;
+pub mod representation;
 pub mod scope;
 pub mod temporal;
 
+pub use context_use::{
+    ContextEvaluationMethod, ContextInfluenceStage, ContextOutcomeRelation, ContextUse,
+    ContextUseEvaluation, ContextUseFeedback, ContextUseKind, EvidenceLink, MissingContextDetected,
+    MissingContextKind,
+};
+pub use contract::{
+    ArtifactContract, ContractValidation, Requirement, RequirementKind, RequirementResult,
+    RequirementStatus, ValidationStatus,
+};
 pub use hash::{RecordHashError, record_hash};
 pub use kind::{
     ConstraintEffect, ContextRecordKind, DirectiveEnforcement, DirectiveKind, DirectivePriority,
     EffectiveStatus, KnowledgeKind, MemoryKind, Origin, PromotionAction, RecordProposalKind,
     RecordProposalStatus, RecordStatus,
+};
+pub use outcome::{CompletionStatus, CorrectnessStatus, OutcomeAssessment, OutcomeAssessmentLevel};
+pub use representation::{
+    ContentFidelity, InlineContentRequirement, MinimumContentFidelity, Representation,
 };
 pub use scope::{Scope, SharingScope};
 pub use temporal::{TemporalInterval, TemporalQuery};
@@ -125,4 +142,20 @@ pub enum RecordValidationError {
         /// The `Scope` id it requires.
         required_id: &'static str,
     },
+    /// A named cross-field invariant was violated. `rule` is a stable dotted
+    /// identifier (e.g. `not_helpful.requires_observable_effect`) so the many
+    /// intra-record rules stay self-documenting and testable without a variant
+    /// each.
+    #[error("invariant violated: {rule}")]
+    Invariant {
+        /// The stable rule identifier that failed.
+        rule: &'static str,
+    },
+}
+
+impl RecordValidationError {
+    /// Shorthand for [`RecordValidationError::Invariant`].
+    pub(crate) fn invariant(rule: &'static str) -> Self {
+        Self::Invariant { rule }
+    }
 }

--- a/stella-core/src/context_record/context_use.rs
+++ b/stella-core/src/context_record/context_use.rs
@@ -1,0 +1,682 @@
+//! The context-use / efficacy value types (lifecycle §8.x) — how a compiled
+//! frame's records were used, whether they helped, and what context was missing.
+//!
+//! **Purity boundary (important):** these are pure value types. Two spec
+//! invariants are inherently *referential* — "a `ContextUseFeedback` resolves to
+//! exactly one identity-consistent `ContextUse`" and the `not_rendered`
+//! selected-use back-reference resolution — and cannot be checked without the
+//! record set. This module validates only the **intra-record** parts (required
+//! ids present, internally consistent, non-empty evidence). Existence,
+//! uniqueness, and cross-record resolution are the Phase 2/3 repository's job.
+
+use serde::{Deserialize, Serialize};
+
+use super::{Confidence, RecordValidationError};
+
+/// How a context record was used within a task (lifecycle §). Closed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextUseKind {
+    Selected,
+    Rendered,
+    Cited,
+}
+
+impl ContextUseKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Selected => "selected",
+            Self::Rendered => "rendered",
+            Self::Cited => "cited",
+        }
+    }
+}
+
+/// A post-task judgement of whether a used record helped (lifecycle §). Closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextUseEvaluation {
+    Helpful,
+    NotHelpful,
+    Neutral,
+}
+
+impl ContextUseEvaluation {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Helpful => "helpful",
+            Self::NotHelpful => "not_helpful",
+            Self::Neutral => "neutral",
+        }
+    }
+}
+
+/// Which stage of a task a record influenced (lifecycle §). `none` means it had
+/// no opportunity to influence anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextInfluenceStage {
+    Planning,
+    Execution,
+    Verification,
+    FinalResponse,
+    None,
+}
+
+impl ContextInfluenceStage {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Planning => "planning",
+            Self::Execution => "execution",
+            Self::Verification => "verification",
+            Self::FinalResponse => "final_response",
+            Self::None => "none",
+        }
+    }
+}
+
+/// How a record related to the task outcome (lifecycle §). Closed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextOutcomeRelation {
+    Supported,
+    Contradicted,
+    Unrelated,
+    Unknown,
+}
+
+impl ContextOutcomeRelation {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Supported => "supported",
+            Self::Contradicted => "contradicted",
+            Self::Unrelated => "unrelated",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// The method by which a use was evaluated (lifecycle §). **Extensible** — a
+/// writer must emit a non-empty registered or versioned identifier, so this is a
+/// validated string newtype, not a closed enum. The seven recognized *core*
+/// methods are exposed as constants.
+///
+/// Two-tier policy: *recognized* ≠ *pruning-eligible*. `agent_self_report` is a
+/// recognized core method but is explicitly excluded from driving pruning, and
+/// unregistered extensions never contribute to automatic suppression until host
+/// policy trusts them. This type carries the recognition signal; the full
+/// pruning-eligibility decision is Phase 9 policy.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ContextEvaluationMethod(String);
+
+impl ContextEvaluationMethod {
+    /// Deterministic validator produced the verdict.
+    pub const DETERMINISTIC_VALIDATION: &'static str = "deterministic_validation";
+    /// A user gave explicit feedback.
+    pub const EXPLICIT_USER_FEEDBACK: &'static str = "explicit_user_feedback";
+    /// An external outcome (CI, deploy, ticket) confirmed it.
+    pub const EXTERNAL_OUTCOME: &'static str = "external_outcome";
+    /// The accepted repository state reflects it.
+    pub const ACCEPTED_REPOSITORY_STATE: &'static str = "accepted_repository_state";
+    /// A controlled comparison (A/B) established it.
+    pub const CONTROLLED_COMPARISON: &'static str = "controlled_comparison";
+    /// Correlated against a use trace.
+    pub const TRACE_CORRELATION: &'static str = "trace_correlation";
+    /// The agent's own post-task report — inferred evidence only; cannot drive
+    /// pruning.
+    pub const AGENT_SELF_REPORT: &'static str = "agent_self_report";
+
+    const RECOGNIZED_CORE: [&'static str; 7] = [
+        Self::DETERMINISTIC_VALIDATION,
+        Self::EXPLICIT_USER_FEEDBACK,
+        Self::EXTERNAL_OUTCOME,
+        Self::ACCEPTED_REPOSITORY_STATE,
+        Self::CONTROLLED_COMPARISON,
+        Self::TRACE_CORRELATION,
+        Self::AGENT_SELF_REPORT,
+    ];
+
+    /// Construct a method identifier, rejecting an empty string (a writer must
+    /// emit a non-empty registered or versioned identifier).
+    pub fn new(identifier: impl Into<String>) -> Result<Self, RecordValidationError> {
+        let identifier = identifier.into();
+        if identifier.is_empty() {
+            return Err(RecordValidationError::invariant(
+                "evaluation_method.must_be_nonempty",
+            ));
+        }
+        Ok(Self(identifier))
+    }
+
+    /// The identifier string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this is one of the seven recognized core methods (an extension
+    /// identifier returns `false` and is recognized only after host trust).
+    pub fn is_recognized_core(&self) -> bool {
+        Self::RECOGNIZED_CORE.contains(&self.0.as_str())
+    }
+
+    /// Whether this is `agent_self_report`, which alone cannot drive pruning.
+    pub fn is_agent_self_report(&self) -> bool {
+        self.0 == Self::AGENT_SELF_REPORT
+    }
+}
+
+impl<'de> Deserialize<'de> for ContextEvaluationMethod {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let identifier = String::deserialize(deserializer)?;
+        ContextEvaluationMethod::new(identifier).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A single missing-context kind (lifecycle §). Closed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingContextKind {
+    NotRetrieved,
+    NotSelected,
+    NotRendered,
+    Unavailable,
+    Unknown,
+}
+
+impl MissingContextKind {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotRetrieved => "not_retrieved",
+            Self::NotSelected => "not_selected",
+            Self::NotRendered => "not_rendered",
+            Self::Unavailable => "unavailable",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// A link from an observation to its supporting evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceLink {
+    /// The evidence record id.
+    pub evidence_id: String,
+    /// How the evidence relates to the observation.
+    pub relation: String,
+}
+
+/// A record that a compiled frame's context record was used (lifecycle §). The
+/// raw use event; the post-task judgement lives in [`ContextUseFeedback`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUse {
+    /// How it was used.
+    pub use_kind: ContextUseKind,
+    /// The context record that was used.
+    pub context_record_id: String,
+    /// The use-trace id tying this use to a task/invocation.
+    pub use_trace_id: String,
+    /// The task this use belongs to.
+    pub task_id: String,
+    /// Which stage it influenced.
+    pub influence_stage: ContextInfluenceStage,
+    /// When the use was observed (RFC 3339 UTC).
+    pub observed_at: String,
+}
+
+/// A post-task judgement of a [`ContextUse`] (lifecycle §).
+///
+/// `context_use_id` must resolve to exactly one identity-consistent `ContextUse`
+/// — that resolution is **referential** and enforced by the repository, not
+/// here. This type enforces the intra-record shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUseFeedback {
+    /// The `ContextUse` this feedback is about (referentially resolved later).
+    pub context_use_id: String,
+    /// The use-trace id (must match the referenced use — checked in the repo).
+    pub use_trace_id: String,
+    /// The task this feedback belongs to.
+    pub task_id: String,
+    /// The judgement.
+    pub evaluation: ContextUseEvaluation,
+    /// Whether the record had a real opportunity to influence the task.
+    pub had_opportunity: bool,
+    /// Which stage it influenced.
+    pub influence_stage: ContextInfluenceStage,
+    /// How it related to the outcome.
+    pub outcome_relation: ContextOutcomeRelation,
+    /// Observable-effect evidence references (post-task, observable only).
+    #[serde(default)]
+    pub observable_effect_refs: Vec<String>,
+    /// The evaluation method (required for a `not_helpful` verdict).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub evaluation_method: Option<ContextEvaluationMethod>,
+    /// Attribution confidence (`0..=100`, un-bypassable via [`Confidence`]).
+    pub attribution_confidence: Confidence,
+    /// The outcome assessment (required when supported/contradicted).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub outcome_assessment_id: Option<String>,
+    /// A bounded, post-task observable summary (≤ 500 Unicode scalar values).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub influence_statement: Option<String>,
+    /// When the feedback was observed (RFC 3339 UTC).
+    pub observed_at: String,
+}
+
+impl ContextUseFeedback {
+    /// Validate every intra-record invariant. (Referential resolution of
+    /// `context_use_id` is deferred to the repository.)
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        // not_helpful requires opportunity + observable effect + a method.
+        if self.evaluation == ContextUseEvaluation::NotHelpful {
+            if !self.had_opportunity {
+                return Err(RecordValidationError::invariant(
+                    "not_helpful.requires_opportunity",
+                ));
+            }
+            if self.observable_effect_refs.is_empty() {
+                return Err(RecordValidationError::invariant(
+                    "not_helpful.requires_observable_effect",
+                ));
+            }
+            if self.evaluation_method.is_none() {
+                return Err(RecordValidationError::invariant(
+                    "not_helpful.requires_evaluation_method",
+                ));
+            }
+        }
+        // No opportunity constrains the other axes.
+        if !self.had_opportunity {
+            if self.influence_stage != ContextInfluenceStage::None {
+                return Err(RecordValidationError::invariant(
+                    "no_opportunity.requires_influence_stage_none",
+                ));
+            }
+            if self.evaluation != ContextUseEvaluation::Neutral {
+                return Err(RecordValidationError::invariant(
+                    "no_opportunity.requires_neutral_evaluation",
+                ));
+            }
+            if !matches!(
+                self.outcome_relation,
+                ContextOutcomeRelation::Unrelated | ContextOutcomeRelation::Unknown
+            ) {
+                return Err(RecordValidationError::invariant(
+                    "no_opportunity.requires_unrelated_or_unknown_outcome",
+                ));
+            }
+        }
+        // supported/contradicted require an assessment and observable effects.
+        if matches!(
+            self.outcome_relation,
+            ContextOutcomeRelation::Supported | ContextOutcomeRelation::Contradicted
+        ) {
+            if self.outcome_assessment_id.is_none() {
+                return Err(RecordValidationError::invariant(
+                    "outcome_relation.requires_assessment",
+                ));
+            }
+            if self.observable_effect_refs.is_empty() {
+                return Err(RecordValidationError::invariant(
+                    "outcome_relation.requires_observable_effect",
+                ));
+            }
+        }
+        validate_influence_statement(self.influence_statement.as_deref())?;
+        Ok(())
+    }
+}
+
+/// A record that expected context was missing (lifecycle §).
+///
+/// The `not_rendered` selected-use back-references (`selected_context_use_id` /
+/// `selected_use_trace_id`) are validated for shape only; their identity-
+/// consistent resolution to the earlier selected `ContextUse`, and the
+/// "at least one present when selected-use telemetry is available" rule, are
+/// **referential** and enforced by the repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissingContextDetected {
+    /// Which kind of missing-context this is.
+    pub missing_context_kind: MissingContextKind,
+    /// The record that was expected (required for not_retrieved/selected/rendered).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expected_context_record_id: Option<String>,
+    /// The requirement that could not be met (required for `unavailable`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expected_requirement: Option<String>,
+    /// How the miss was detected.
+    pub detection_method: String,
+    /// Supporting evidence (must be non-empty).
+    #[serde(default)]
+    pub evidence_links: Vec<EvidenceLink>,
+    /// (not_rendered) the selected use that was not rendered.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub selected_context_use_id: Option<String>,
+    /// (not_rendered) the selected use's trace id.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub selected_use_trace_id: Option<String>,
+    /// The task this observation belongs to.
+    pub task_id: String,
+    /// When it was observed (RFC 3339 UTC).
+    pub observed_at: String,
+}
+
+impl MissingContextDetected {
+    /// Validate every intra-record invariant.
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        // Every missing-context observation needs non-empty evidence.
+        if self.evidence_links.is_empty() {
+            return Err(RecordValidationError::invariant(
+                "missing_context.requires_evidence_links",
+            ));
+        }
+        match self.missing_context_kind {
+            MissingContextKind::NotRetrieved
+            | MissingContextKind::NotSelected
+            | MissingContextKind::NotRendered => {
+                if self.expected_context_record_id.is_none() {
+                    return Err(RecordValidationError::invariant(
+                        "missing_context.requires_expected_record",
+                    ));
+                }
+            }
+            MissingContextKind::Unavailable => {
+                if self.expected_requirement.is_none() {
+                    return Err(RecordValidationError::invariant(
+                        "unavailable.requires_expected_requirement",
+                    ));
+                }
+                if self.expected_context_record_id.is_some() {
+                    return Err(RecordValidationError::invariant(
+                        "unavailable.forbids_expected_record",
+                    ));
+                }
+            }
+            MissingContextKind::Unknown => {
+                if self.expected_context_record_id.is_none() && self.expected_requirement.is_none()
+                {
+                    return Err(RecordValidationError::invariant(
+                        "unknown.requires_record_or_requirement",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// An `influence_statement`, when present, is at most 500 Unicode scalar values
+/// — one bounded, post-task observable sentence.
+pub fn validate_influence_statement(statement: Option<&str>) -> Result<(), RecordValidationError> {
+    if let Some(statement) = statement
+        && statement.chars().count() > 500
+    {
+        return Err(RecordValidationError::invariant(
+            "influence_statement.max_500_scalars",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base_feedback() -> ContextUseFeedback {
+        ContextUseFeedback {
+            context_use_id: "cxu_1".into(),
+            use_trace_id: "trace_1".into(),
+            task_id: "task_1".into(),
+            evaluation: ContextUseEvaluation::Helpful,
+            had_opportunity: true,
+            influence_stage: ContextInfluenceStage::Execution,
+            outcome_relation: ContextOutcomeRelation::Unrelated,
+            observable_effect_refs: vec![],
+            evaluation_method: None,
+            attribution_confidence: Confidence::new(80).unwrap(),
+            outcome_assessment_id: None,
+            influence_statement: None,
+            observed_at: "2026-07-20T18:30:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn enum_strings_are_canonical() {
+        assert_eq!(
+            serde_json::to_value(ContextUseKind::Cited).unwrap(),
+            json!("cited")
+        );
+        assert_eq!(
+            serde_json::to_value(ContextUseEvaluation::NotHelpful).unwrap(),
+            json!("not_helpful")
+        );
+        assert_eq!(
+            serde_json::to_value(ContextInfluenceStage::FinalResponse).unwrap(),
+            json!("final_response")
+        );
+        assert_eq!(
+            serde_json::to_value(ContextOutcomeRelation::Contradicted).unwrap(),
+            json!("contradicted")
+        );
+        assert_eq!(
+            serde_json::to_value(MissingContextKind::NotRendered).unwrap(),
+            json!("not_rendered")
+        );
+    }
+
+    #[test]
+    fn evaluation_method_recognition_and_extensibility() {
+        let core = ContextEvaluationMethod::new("deterministic_validation").unwrap();
+        assert!(core.is_recognized_core());
+        assert!(!core.is_agent_self_report());
+        let asr = ContextEvaluationMethod::new(ContextEvaluationMethod::AGENT_SELF_REPORT).unwrap();
+        assert!(asr.is_recognized_core());
+        assert!(asr.is_agent_self_report());
+        let ext = ContextEvaluationMethod::new("acme.custom_v2").unwrap();
+        assert!(
+            !ext.is_recognized_core(),
+            "extensions are not core-recognized"
+        );
+        assert!(
+            ContextEvaluationMethod::new("").is_err(),
+            "empty method rejected"
+        );
+        // serializes transparently as the string.
+        assert_eq!(
+            serde_json::to_value(&core).unwrap(),
+            json!("deterministic_validation")
+        );
+    }
+
+    #[test]
+    fn helpful_feedback_is_valid() {
+        assert!(base_feedback().validate().is_ok());
+    }
+
+    #[test]
+    fn not_helpful_requires_opportunity_effect_and_method() {
+        let mut fb = base_feedback();
+        fb.evaluation = ContextUseEvaluation::NotHelpful;
+        // missing opportunity
+        fb.had_opportunity = false;
+        // had_opportunity=false also trips its own rules first — set stage none etc.
+        fb.influence_stage = ContextInfluenceStage::None;
+        fb.outcome_relation = ContextOutcomeRelation::Unknown;
+        // not_helpful + no opportunity → not_helpful.requires_opportunity
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "not_helpful.requires_opportunity"
+            ))
+        );
+        // give opportunity but no observable effect
+        fb.had_opportunity = true;
+        fb.influence_stage = ContextInfluenceStage::Execution;
+        fb.outcome_relation = ContextOutcomeRelation::Unrelated;
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "not_helpful.requires_observable_effect"
+            ))
+        );
+        // add effect but no method
+        fb.observable_effect_refs = vec!["ev_1".into()];
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "not_helpful.requires_evaluation_method"
+            ))
+        );
+        // add method → valid
+        fb.evaluation_method =
+            Some(ContextEvaluationMethod::new("explicit_user_feedback").unwrap());
+        assert!(fb.validate().is_ok());
+    }
+
+    #[test]
+    fn no_opportunity_constrains_the_other_axes() {
+        let mut fb = base_feedback();
+        fb.had_opportunity = false;
+        fb.influence_stage = ContextInfluenceStage::Execution; // wrong
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "no_opportunity.requires_influence_stage_none"
+            ))
+        );
+        fb.influence_stage = ContextInfluenceStage::None;
+        fb.evaluation = ContextUseEvaluation::Helpful; // wrong
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "no_opportunity.requires_neutral_evaluation"
+            ))
+        );
+        fb.evaluation = ContextUseEvaluation::Neutral;
+        fb.outcome_relation = ContextOutcomeRelation::Supported; // wrong
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "no_opportunity.requires_unrelated_or_unknown_outcome"
+            ))
+        );
+        fb.outcome_relation = ContextOutcomeRelation::Unrelated;
+        assert!(fb.validate().is_ok());
+    }
+
+    #[test]
+    fn supported_requires_assessment_and_effects() {
+        let mut fb = base_feedback();
+        fb.outcome_relation = ContextOutcomeRelation::Supported;
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "outcome_relation.requires_assessment"
+            ))
+        );
+        fb.outcome_assessment_id = Some("oa_1".into());
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "outcome_relation.requires_observable_effect"
+            ))
+        );
+        fb.observable_effect_refs = vec!["ev_1".into()];
+        assert!(fb.validate().is_ok());
+    }
+
+    #[test]
+    fn influence_statement_is_bounded_to_500_scalars() {
+        let mut fb = base_feedback();
+        fb.influence_statement = Some("x".repeat(500));
+        assert!(fb.validate().is_ok(), "exactly 500 is allowed");
+        fb.influence_statement = Some("x".repeat(501));
+        assert_eq!(
+            fb.validate(),
+            Err(RecordValidationError::invariant(
+                "influence_statement.max_500_scalars"
+            ))
+        );
+    }
+
+    fn base_missing() -> MissingContextDetected {
+        MissingContextDetected {
+            missing_context_kind: MissingContextKind::NotRetrieved,
+            expected_context_record_id: Some("rec_1".into()),
+            expected_requirement: None,
+            detection_method: "coverage_gap".into(),
+            evidence_links: vec![EvidenceLink {
+                evidence_id: "ev_1".into(),
+                relation: "supports".into(),
+            }],
+            selected_context_use_id: None,
+            selected_use_trace_id: None,
+            task_id: "task_1".into(),
+            observed_at: "2026-07-20T18:30:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn missing_context_per_kind_rules() {
+        // evidence required for all kinds.
+        let mut m = base_missing();
+        m.evidence_links.clear();
+        assert_eq!(
+            m.validate(),
+            Err(RecordValidationError::invariant(
+                "missing_context.requires_evidence_links"
+            ))
+        );
+
+        // not_retrieved needs expected record.
+        let mut m = base_missing();
+        m.expected_context_record_id = None;
+        assert_eq!(
+            m.validate(),
+            Err(RecordValidationError::invariant(
+                "missing_context.requires_expected_record"
+            ))
+        );
+
+        // unavailable needs a requirement and forbids an expected record.
+        let mut m = base_missing();
+        m.missing_context_kind = MissingContextKind::Unavailable;
+        m.expected_context_record_id = None;
+        m.expected_requirement = None;
+        assert_eq!(
+            m.validate(),
+            Err(RecordValidationError::invariant(
+                "unavailable.requires_expected_requirement"
+            ))
+        );
+        m.expected_requirement = Some("brand_kit".into());
+        m.expected_context_record_id = Some("rec_1".into());
+        assert_eq!(
+            m.validate(),
+            Err(RecordValidationError::invariant(
+                "unavailable.forbids_expected_record"
+            ))
+        );
+        m.expected_context_record_id = None;
+        assert!(m.validate().is_ok());
+
+        // unknown needs at least one of the two.
+        let mut m = base_missing();
+        m.missing_context_kind = MissingContextKind::Unknown;
+        m.expected_context_record_id = None;
+        m.expected_requirement = None;
+        assert_eq!(
+            m.validate(),
+            Err(RecordValidationError::invariant(
+                "unknown.requires_record_or_requirement"
+            ))
+        );
+        m.expected_requirement = Some("something".into());
+        assert!(m.validate().is_ok());
+    }
+}

--- a/stella-core/src/context_record/contract.rs
+++ b/stella-core/src/context_record/contract.rs
@@ -1,0 +1,358 @@
+//! Artifact-contract and contract-validation value types (lifecycle §8.12–8.13).
+//!
+//! Two spec points are handled per the flagged-decisions issue (#483) with a
+//! documented, non-freezing choice: **requirement kinds and the validation
+//! `method` are extensible strings**, not closed enums (the spec never names the
+//! semantic-judge method token, and requirement kinds are explicitly extensible
+//! with "unknown kinds fail closed"). `validation_status` keeps its four named
+//! values; `requirement_status` gets its own enum.
+//!
+//! The "exactly one result for every requirement in the referenced contract
+//! version, no unknown ids" rule is **referential** (it spans the contract and
+//! the validation) — only the intra-record half (no *duplicate* result ids, and
+//! duplicates force `error`) is enforced here; coverage/unknown-id checks are the
+//! repository's job.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+use super::kind::Origin;
+use super::scope::{Scope, SharingScope};
+
+/// A requirement kind. Extensible: the ten recognized core kinds are exposed as
+/// constants; an unrecognized kind is non-executable and fails closed when
+/// required (enforced by the executor in a later phase).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RequirementKind(String);
+
+impl RequirementKind {
+    /// A file exists at a path.
+    pub const FILE_EXISTS: &'static str = "file_exists";
+    /// A directory exists at a path.
+    pub const DIRECTORY_EXISTS: &'static str = "directory_exists";
+    /// At least N files match a glob.
+    pub const GLOB_MIN_COUNT: &'static str = "glob_min_count";
+    /// A file has an expected MIME type.
+    pub const MIME_TYPE: &'static str = "mime_type";
+    /// An image has expected dimensions.
+    pub const IMAGE_DIMENSIONS: &'static str = "image_dimensions";
+    /// A file is within a size bound.
+    pub const FILE_SIZE: &'static str = "file_size";
+    /// A JSON document matches a schema.
+    pub const JSON_SCHEMA: &'static str = "json_schema";
+    /// A Markdown document has required sections.
+    pub const MARKDOWN_SECTIONS: &'static str = "markdown_sections";
+    /// A command exits successfully (needs `execution_approval_ref`).
+    pub const COMMAND: &'static str = "command";
+    /// A semantic judge scores against a rubric.
+    pub const SEMANTIC_JUDGE: &'static str = "semantic_judge";
+
+    const RECOGNIZED: [&'static str; 10] = [
+        Self::FILE_EXISTS,
+        Self::DIRECTORY_EXISTS,
+        Self::GLOB_MIN_COUNT,
+        Self::MIME_TYPE,
+        Self::IMAGE_DIMENSIONS,
+        Self::FILE_SIZE,
+        Self::JSON_SCHEMA,
+        Self::MARKDOWN_SECTIONS,
+        Self::COMMAND,
+        Self::SEMANTIC_JUDGE,
+    ];
+
+    /// Construct a requirement kind, rejecting an empty identifier.
+    pub fn new(identifier: impl Into<String>) -> Result<Self, RecordValidationError> {
+        let identifier = identifier.into();
+        if identifier.is_empty() {
+            return Err(RecordValidationError::invariant(
+                "requirement_kind.must_be_nonempty",
+            ));
+        }
+        Ok(Self(identifier))
+    }
+
+    /// The identifier string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this is one of the ten recognized core kinds. An unrecognized
+    /// kind is non-executable (fails closed when required).
+    pub fn is_recognized(&self) -> bool {
+        Self::RECOGNIZED.contains(&self.0.as_str())
+    }
+
+    /// Whether this is the `command` kind (which forces
+    /// `execution_approval_ref` on the contract).
+    pub fn is_command(&self) -> bool {
+        self.0 == Self::COMMAND
+    }
+}
+
+impl<'de> Deserialize<'de> for RequirementKind {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let identifier = String::deserialize(deserializer)?;
+        RequirementKind::new(identifier).map_err(serde::de::Error::custom)
+    }
+}
+
+/// One requirement of an [`ArtifactContract`]. Kind-specific parameters
+/// (`glob`/`minimum`, `argv`/`timeout_ms`, `rubric_ref`, …) are carried in
+/// `params` and interpreted by the executor in a later phase.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Requirement {
+    /// Stable id, unique within the contract.
+    pub requirement_id: String,
+    /// The requirement kind.
+    pub requirement_kind: RequirementKind,
+    /// Whether the deliverable must satisfy this to be complete.
+    pub required: bool,
+    /// Kind-specific parameters (opaque here; validated by the executor).
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty", default)]
+    pub params: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A contract that a produced artifact must satisfy (lifecycle §8.12). Carries
+/// completion authority when selected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactContract {
+    /// Human name.
+    pub name: String,
+    /// Contract version.
+    pub version: String,
+    /// What it produces / checks.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+    /// Provenance.
+    pub origin: Origin,
+    /// Where it applies.
+    pub scope: Scope,
+    /// Who it is shared with.
+    pub sharing_scope: SharingScope,
+    /// Root under which outputs are checked.
+    pub output_root: String,
+    /// The requirements.
+    #[serde(default)]
+    pub requirements: Vec<Requirement>,
+    /// Required when any requirement is `command`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub execution_approval_ref: Option<String>,
+    /// When it was observed (RFC 3339 UTC).
+    pub observed_at: String,
+    /// Validity start (RFC 3339 UTC).
+    pub valid_from: String,
+}
+
+impl ArtifactContract {
+    /// Validate intra-record invariants: a `command` requirement forces an
+    /// `execution_approval_ref`.
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        let has_command = self
+            .requirements
+            .iter()
+            .any(|r| r.requirement_kind.is_command());
+        if has_command && self.execution_approval_ref.is_none() {
+            return Err(RecordValidationError::invariant(
+                "contract.command_requires_execution_approval_ref",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// The verdict of a whole contract validation (lifecycle §8.13). Four named
+/// values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationStatus {
+    Passed,
+    Failed,
+    Error,
+    Skipped,
+}
+
+impl ValidationStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+            Self::Error => "error",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// The verdict for a single requirement. Its own enum (per #483): `error` is a
+/// validation-level aggregate, not a per-requirement verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+impl RequirementStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// One requirement's result within a [`ContractValidation`]. `method` is an
+/// extensible identifier (e.g. `deterministic`, or a semantic-judge token).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequirementResult {
+    /// The requirement this result is for.
+    pub requirement_id: String,
+    /// The per-requirement verdict.
+    pub requirement_status: RequirementStatus,
+    /// How it was checked (extensible identifier).
+    pub method: String,
+    /// Optional human message.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub message: Option<String>,
+}
+
+/// A validation of an [`ArtifactContract`] (lifecycle §8.13).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContractValidation {
+    /// The contract this validated.
+    pub contract_record_id: String,
+    /// The exact contract version validated.
+    pub contract_version: String,
+    /// The overall verdict.
+    pub validation_status: ValidationStatus,
+    /// Per-requirement results.
+    #[serde(default)]
+    pub results: Vec<RequirementResult>,
+    /// When it was observed (RFC 3339 UTC).
+    pub observed_at: String,
+}
+
+impl ContractValidation {
+    /// Validate the intra-record half of the coverage rule: duplicate result
+    /// ids force `validation_status == error`. (Full coverage / unknown-id
+    /// checks against the referenced contract are the repository's job.)
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        let mut seen = HashSet::new();
+        let has_duplicate = self
+            .results
+            .iter()
+            .any(|r| !seen.insert(r.requirement_id.as_str()));
+        if has_duplicate && self.validation_status != ValidationStatus::Error {
+            return Err(RecordValidationError::invariant(
+                "contract_validation.duplicate_result_requires_error",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn contract(kinds: &[&str]) -> ArtifactContract {
+        ArtifactContract {
+            name: "brand-kit".into(),
+            version: "1".into(),
+            description: None,
+            origin: Origin::User,
+            scope: Scope {
+                repository_id: Some("repo_1".into()),
+                ..Default::default()
+            },
+            sharing_scope: SharingScope::Repository,
+            output_root: "out/".into(),
+            requirements: kinds
+                .iter()
+                .enumerate()
+                .map(|(i, k)| Requirement {
+                    requirement_id: format!("req_{i}"),
+                    requirement_kind: RequirementKind::new(*k).unwrap(),
+                    required: true,
+                    params: serde_json::Map::new(),
+                })
+                .collect(),
+            execution_approval_ref: None,
+            observed_at: "2026-07-20T18:30:00Z".into(),
+            valid_from: "2026-07-20T18:30:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn requirement_kind_recognition_and_extensibility() {
+        assert!(RequirementKind::new("file_exists").unwrap().is_recognized());
+        assert!(RequirementKind::new("command").unwrap().is_command());
+        assert!(!RequirementKind::new("acme.custom").unwrap().is_recognized());
+        assert!(RequirementKind::new("").is_err());
+    }
+
+    #[test]
+    fn command_requirement_forces_execution_approval_ref() {
+        let mut c = contract(&["file_exists", "command"]);
+        assert_eq!(
+            c.validate(),
+            Err(RecordValidationError::invariant(
+                "contract.command_requires_execution_approval_ref"
+            ))
+        );
+        c.execution_approval_ref = Some("approval_1".into());
+        assert!(c.validate().is_ok());
+        // No command → no approval needed.
+        assert!(contract(&["file_exists", "json_schema"]).validate().is_ok());
+    }
+
+    #[test]
+    fn duplicate_result_ids_force_error_status() {
+        let dup = |status| ContractValidation {
+            contract_record_id: "ctr_1".into(),
+            contract_version: "1".into(),
+            validation_status: status,
+            results: vec![
+                RequirementResult {
+                    requirement_id: "req_0".into(),
+                    requirement_status: RequirementStatus::Passed,
+                    method: "deterministic".into(),
+                    message: None,
+                },
+                RequirementResult {
+                    requirement_id: "req_0".into(),
+                    requirement_status: RequirementStatus::Failed,
+                    method: "deterministic".into(),
+                    message: None,
+                },
+            ],
+            observed_at: "2026-07-20T18:30:00Z".into(),
+        };
+        assert_eq!(
+            dup(ValidationStatus::Passed).validate(),
+            Err(RecordValidationError::invariant(
+                "contract_validation.duplicate_result_requires_error"
+            ))
+        );
+        assert!(dup(ValidationStatus::Error).validate().is_ok());
+    }
+
+    #[test]
+    fn status_strings_are_canonical() {
+        assert_eq!(
+            serde_json::to_value(ValidationStatus::Error).unwrap(),
+            json!("error")
+        );
+        assert_eq!(
+            serde_json::to_value(RequirementStatus::Skipped).unwrap(),
+            json!("skipped")
+        );
+    }
+}

--- a/stella-core/src/context_record/outcome.rs
+++ b/stella-core/src/context_record/outcome.rs
@@ -1,0 +1,147 @@
+//! Outcome-assessment value types (lifecycle §6.8 / §8.x). Two independent
+//! dimensions — completion and correctness — each carrying a status and the
+//! evidential level behind it.
+
+use serde::{Deserialize, Serialize};
+
+/// The evidential strength behind an assessment (lifecycle §6.8). Agent
+/// reflection alone supports only `inferred`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeAssessmentLevel {
+    Verified,
+    UserConfirmed,
+    ExternallyConfirmed,
+    Inferred,
+    Unknown,
+}
+
+impl OutcomeAssessmentLevel {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::UserConfirmed => "user_confirmed",
+            Self::ExternallyConfirmed => "externally_confirmed",
+            Self::Inferred => "inferred",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Whether a task's deliverable was completed (lifecycle §).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionStatus {
+    Complete,
+    Incomplete,
+    Unknown,
+}
+
+impl CompletionStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Incomplete => "incomplete",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Whether a task's deliverable was correct (lifecycle §). Independent of
+/// [`CompletionStatus`] — a task can be complete but incorrect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CorrectnessStatus {
+    Correct,
+    Incorrect,
+    Unknown,
+}
+
+impl CorrectnessStatus {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Correct => "correct",
+            Self::Incorrect => "incorrect",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// One assessed dimension: a status plus the level of evidence behind it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionAssessment {
+    /// The completion verdict.
+    pub status: CompletionStatus,
+    /// The evidence level.
+    pub assessment_level: OutcomeAssessmentLevel,
+}
+
+/// One assessed dimension: a status plus the level of evidence behind it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorrectnessAssessment {
+    /// The correctness verdict.
+    pub status: CorrectnessStatus,
+    /// The evidence level.
+    pub assessment_level: OutcomeAssessmentLevel,
+}
+
+/// A post-task assessment of an outcome across the two independent dimensions
+/// (lifecycle §). Referenced by a `ContextUseFeedback` when the outcome relation
+/// is supported/contradicted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeAssessment {
+    /// The completion dimension.
+    pub completion_assessment: CompletionAssessment,
+    /// The correctness dimension.
+    pub correctness_assessment: CorrectnessAssessment,
+    /// When it was observed (RFC 3339 UTC).
+    pub observed_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn level_and_status_strings_are_canonical() {
+        assert_eq!(
+            serde_json::to_value(OutcomeAssessmentLevel::ExternallyConfirmed).unwrap(),
+            json!("externally_confirmed")
+        );
+        assert_eq!(
+            serde_json::to_value(OutcomeAssessmentLevel::UserConfirmed).unwrap(),
+            json!("user_confirmed")
+        );
+        assert_eq!(
+            serde_json::to_value(CompletionStatus::Incomplete).unwrap(),
+            json!("incomplete")
+        );
+        assert_eq!(
+            serde_json::to_value(CorrectnessStatus::Incorrect).unwrap(),
+            json!("incorrect")
+        );
+    }
+
+    #[test]
+    fn the_two_dimensions_are_independent() {
+        // Complete but incorrect is a representable, valid combination.
+        let assessment = OutcomeAssessment {
+            completion_assessment: CompletionAssessment {
+                status: CompletionStatus::Complete,
+                assessment_level: OutcomeAssessmentLevel::Verified,
+            },
+            correctness_assessment: CorrectnessAssessment {
+                status: CorrectnessStatus::Incorrect,
+                assessment_level: OutcomeAssessmentLevel::Inferred,
+            },
+            observed_at: "2026-07-20T18:30:00Z".into(),
+        };
+        let round: OutcomeAssessment =
+            serde_json::from_value(serde_json::to_value(&assessment).unwrap()).unwrap();
+        assert_eq!(round, assessment);
+    }
+}

--- a/stella-core/src/context_record/representation.rs
+++ b/stella-core/src/context_record/representation.rs
@@ -1,0 +1,321 @@
+//! Frame representation and content-fidelity value types (lifecycle §10.1–10.3).
+//! Three **separate** enums — do not collapse them. These complete the Phase 1
+//! type layer that Phase 4 (compaction) wires into the compiler.
+//!
+//! Per the flagged-decisions issue (#483): the "blocking or **guarded** directive
+//! requires exact minimum fidelity" invariant is implemented only for `blocking`
+//! — both spec extractions agree `guarded` is a fidelity-policy category (a
+//! "guarded rule" defaults to exact), not an enforcement value. No `guarded`
+//! enforcement variant is introduced; the guarded-rule default policy is Phase 4.
+
+use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+use super::kind::DirectiveEnforcement;
+
+/// How a frame carries its content (lifecycle §10.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Representation {
+    /// Complete inline content (the legacy default).
+    #[default]
+    Full,
+    /// Shorter inline content linked to the canonical source.
+    Compact,
+    /// A stable reference + hash, no inline content.
+    Reference,
+}
+
+impl Representation {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Compact => "compact",
+            Self::Reference => "reference",
+        }
+    }
+}
+
+/// The fidelity of a frame's content to its canonical source (lifecycle §10.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentFidelity {
+    /// Byte/order exact — cannot be paraphrased.
+    Exact,
+    /// Lossless canonical reformatting.
+    Normalized,
+    /// A faithful shorter representation.
+    Summarized,
+    /// No inline content (used by `reference`).
+    Omitted,
+}
+
+impl ContentFidelity {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Normalized => "normalized",
+            Self::Summarized => "summarized",
+            Self::Omitted => "omitted",
+        }
+    }
+}
+
+/// The minimum acceptable fidelity for an item (lifecycle §10.3). A **distinct**
+/// enum from [`ContentFidelity`]: `omitted` is not a legal minimum, so the type
+/// makes it unrepresentable (no validator needed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MinimumContentFidelity {
+    Exact,
+    Normalized,
+    Summarized,
+}
+
+impl MinimumContentFidelity {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Normalized => "normalized",
+            Self::Summarized => "summarized",
+        }
+    }
+}
+
+/// Whether inline content is required or a resolvable reference is allowed
+/// (lifecycle §10.3). An availability choice, not a fidelity level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InlineContentRequirement {
+    Required,
+    ResolvableReferenceAllowed,
+}
+
+impl InlineContentRequirement {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Required => "required",
+            Self::ResolvableReferenceAllowed => "resolvable_reference_allowed",
+        }
+    }
+}
+
+/// The content-carrying fields of a frame, for validating the representation
+/// requirement matrix (lifecycle §10.1 table).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FrameContentSpec {
+    /// How content is carried.
+    pub representation: Representation,
+    /// Inline content (absent for `reference`; never an empty placeholder).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub content: Option<String>,
+    /// The fidelity of the carried content.
+    pub content_fidelity: ContentFidelity,
+    /// Hash of the canonical source content.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub canonical_content_hash: Option<String>,
+    /// A resolvable reference to the canonical content.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub content_ref: Option<String>,
+    /// The transform applied (required for `compact`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub transform: Option<String>,
+}
+
+impl FrameContentSpec {
+    /// Validate the representation requirement matrix and the
+    /// "reference has no inline-content placeholder" rule.
+    pub fn validate(&self) -> Result<(), RecordValidationError> {
+        let inv = RecordValidationError::invariant;
+        match self.representation {
+            Representation::Full => {
+                if self.content_fidelity != ContentFidelity::Exact {
+                    return Err(inv("representation.full_requires_exact_fidelity"));
+                }
+                if self.content.is_none() {
+                    return Err(inv("representation.full_requires_inline_content"));
+                }
+                if self.canonical_content_hash.is_none() {
+                    return Err(inv("representation.requires_canonical_content_hash"));
+                }
+            }
+            Representation::Compact => {
+                if self.content_fidelity == ContentFidelity::Omitted {
+                    return Err(inv("representation.compact_fidelity_not_omitted"));
+                }
+                if self.content.is_none() {
+                    return Err(inv("representation.compact_requires_inline_content"));
+                }
+                if self.canonical_content_hash.is_none() {
+                    return Err(inv("representation.requires_canonical_content_hash"));
+                }
+                if self.content_ref.is_none() {
+                    return Err(inv("representation.compact_requires_content_ref"));
+                }
+                if self.transform.is_none() {
+                    return Err(inv("representation.compact_requires_transform"));
+                }
+            }
+            Representation::Reference => {
+                // Never encode a reference as an empty inline content string.
+                if self.content.is_some() {
+                    return Err(inv("representation.reference_forbids_inline_content"));
+                }
+                if self.content_fidelity != ContentFidelity::Omitted {
+                    return Err(inv("representation.reference_requires_omitted_fidelity"));
+                }
+                if self.canonical_content_hash.is_none() {
+                    return Err(inv("representation.requires_canonical_content_hash"));
+                }
+                if self.content_ref.is_none() {
+                    return Err(inv("representation.reference_requires_content_ref"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A blocking directive requires an exact minimum fidelity (lifecycle §10.3
+/// default-policy table). See the module docs for the deferred `guarded` case.
+pub fn validate_directive_minimum_fidelity(
+    enforcement: DirectiveEnforcement,
+    minimum: MinimumContentFidelity,
+) -> Result<(), RecordValidationError> {
+    if enforcement == DirectiveEnforcement::Blocking && minimum != MinimumContentFidelity::Exact {
+        return Err(RecordValidationError::invariant(
+            "directive.blocking_requires_exact_minimum_fidelity",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn representation_missing_on_the_wire_is_full() {
+        // Absent representation ⇒ Full (legacy compatibility).
+        assert_eq!(Representation::default(), Representation::Full);
+        assert_eq!(
+            serde_json::to_value(Representation::Reference).unwrap(),
+            json!("reference")
+        );
+    }
+
+    #[test]
+    fn minimum_fidelity_cannot_be_omitted() {
+        // `omitted` is not a variant of MinimumContentFidelity — unrepresentable.
+        assert!(serde_json::from_value::<MinimumContentFidelity>(json!("omitted")).is_err());
+        assert!(serde_json::from_value::<ContentFidelity>(json!("omitted")).is_ok());
+    }
+
+    fn full() -> FrameContentSpec {
+        FrameContentSpec {
+            representation: Representation::Full,
+            content: Some("hello".into()),
+            content_fidelity: ContentFidelity::Exact,
+            canonical_content_hash: Some("sha256:aa".into()),
+            content_ref: None,
+            transform: None,
+        }
+    }
+
+    #[test]
+    fn full_representation_matrix() {
+        assert!(full().validate().is_ok());
+        let mut f = full();
+        f.content_fidelity = ContentFidelity::Summarized;
+        assert_eq!(
+            f.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.full_requires_exact_fidelity"
+            ))
+        );
+        let mut f = full();
+        f.content = None;
+        assert_eq!(
+            f.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.full_requires_inline_content"
+            ))
+        );
+    }
+
+    #[test]
+    fn reference_has_no_inline_content_placeholder() {
+        let good = FrameContentSpec {
+            representation: Representation::Reference,
+            content: None,
+            content_fidelity: ContentFidelity::Omitted,
+            canonical_content_hash: Some("sha256:aa".into()),
+            content_ref: Some("ref://x".into()),
+            transform: None,
+        };
+        assert!(good.validate().is_ok());
+        // An empty-string content is the exact anti-pattern the rule forbids.
+        let mut bad = good.clone();
+        bad.content = Some(String::new());
+        assert_eq!(
+            bad.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.reference_forbids_inline_content"
+            ))
+        );
+    }
+
+    #[test]
+    fn compact_requires_refs_and_transform() {
+        let base = FrameContentSpec {
+            representation: Representation::Compact,
+            content: Some("short".into()),
+            content_fidelity: ContentFidelity::Summarized,
+            canonical_content_hash: Some("sha256:aa".into()),
+            content_ref: Some("ref://x".into()),
+            transform: Some("truncate".into()),
+        };
+        assert!(base.validate().is_ok());
+        let mut no_transform = base.clone();
+        no_transform.transform = None;
+        assert_eq!(
+            no_transform.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.compact_requires_transform"
+            ))
+        );
+    }
+
+    #[test]
+    fn blocking_directive_requires_exact_minimum_fidelity() {
+        assert_eq!(
+            validate_directive_minimum_fidelity(
+                DirectiveEnforcement::Blocking,
+                MinimumContentFidelity::Summarized
+            ),
+            Err(RecordValidationError::invariant(
+                "directive.blocking_requires_exact_minimum_fidelity"
+            ))
+        );
+        assert!(
+            validate_directive_minimum_fidelity(
+                DirectiveEnforcement::Blocking,
+                MinimumContentFidelity::Exact
+            )
+            .is_ok()
+        );
+        // Advisory has no fidelity floor.
+        assert!(
+            validate_directive_minimum_fidelity(
+                DirectiveEnforcement::Advisory,
+                MinimumContentFidelity::Summarized
+            )
+            .is_ok()
+        );
+    }
+}

--- a/stella-protocol/src/context_event.rs
+++ b/stella-protocol/src/context_event.rs
@@ -1,0 +1,333 @@
+//! Internal, replay-safe adaptive-context events (Phase 1 installment 5).
+//!
+//! These are stella-internal lifecycle events — they do **not** change the
+//! Context Graph Exchange Protocol wire semantics. They carry only stable IDs
+//! (as strings), never the `stella-core` record structs: `stella-core` depends on
+//! `stella-protocol`, so importing core types here would be a dependency cycle.
+//!
+//! ## Forward compatibility (the whole point)
+//!
+//! The main [`crate::event::AgentEvent`] stream is an internally-tagged enum that
+//! **rejects unknown variants**, and the JSONL replay reader treats an
+//! unparseable interior line as fatal. So a NEW event must never be a new
+//! `AgentEvent` variant — an older binary replaying a mixed stream would break.
+//!
+//! Instead these events ride a **versioned envelope**: [`LifecycleEventEnvelope`]
+//! keeps the type-specific fields in a raw `payload`, so it always deserializes,
+//! even for an `event_type` the reader has never seen. [`LifecycleEventEnvelope::decode`]
+//! then maps a recognized `event_type` to a typed [`LifecycleEvent`], or preserves
+//! an unrecognized one as [`LifecycleEvent::Unknown`] with its payload intact —
+//! the exact tolerance the fatal `parse_jsonl` path lacks.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The canonical `event_type` tokens.
+pub mod event_type {
+    /// An observation was recorded.
+    pub const OBSERVATION_RECORDED: &str = "observation_recorded";
+    /// A record proposal was created.
+    pub const RECORD_PROPOSAL_CREATED: &str = "record_proposal_created";
+    /// A promotion event was recorded.
+    pub const PROMOTION_RECORDED: &str = "promotion_recorded";
+    /// A context use was recorded.
+    pub const CONTEXT_USE_RECORDED: &str = "context_use_recorded";
+    /// Feedback on a context use was recorded.
+    pub const CONTEXT_USE_FEEDBACK_RECORDED: &str = "context_use_feedback_recorded";
+    /// Missing context was detected.
+    pub const MISSING_CONTEXT_DETECTED: &str = "missing_context_detected";
+    /// An artifact contract was selected for a task.
+    pub const ARTIFACT_CONTRACT_SELECTED: &str = "artifact_contract_selected";
+    /// A contract validation completed.
+    pub const CONTRACT_VALIDATION_COMPLETED: &str = "contract_validation_completed";
+    /// An outcome was assessed.
+    pub const OUTCOME_ASSESSED: &str = "outcome_assessed";
+    /// A compiled context frame was built.
+    pub const COMPILED_CONTEXT_FRAME_BUILT: &str = "compiled_context_frame_built";
+}
+
+/// The versioned envelope every lifecycle event rides. Always deserializes: the
+/// event-specific fields live in `payload` as a raw value, so an unrecognized
+/// `event_type` is preserved rather than rejected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LifecycleEventEnvelope {
+    /// Envelope schema version (e.g. `1.0-draft`).
+    pub schema_version: String,
+    /// The event discriminator (see [`event_type`]).
+    pub event_type: String,
+    /// Unique id of this event.
+    pub event_id: String,
+    /// When the event was observed (RFC 3339 UTC).
+    pub observed_at: String,
+    /// The task this event belongs to, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub task_id: Option<String>,
+    /// The invocation this event belongs to, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub invocation_id: Option<String>,
+    /// Event-type-specific fields (stable IDs only). Raw so unknown event types
+    /// round-trip losslessly.
+    pub payload: Value,
+}
+
+impl LifecycleEventEnvelope {
+    /// Decode the payload into a typed [`LifecycleEvent`]. An unrecognized
+    /// `event_type`, or a payload that does not match a recognized type, is
+    /// preserved as [`LifecycleEvent::Unknown`] — decoding never fails.
+    pub fn decode(&self) -> LifecycleEvent {
+        fn typed<T: for<'de> Deserialize<'de>>(payload: &Value) -> Option<T> {
+            serde_json::from_value(payload.clone()).ok()
+        }
+        let unknown = || LifecycleEvent::Unknown {
+            event_type: self.event_type.clone(),
+            payload: self.payload.clone(),
+        };
+        match self.event_type.as_str() {
+            event_type::OBSERVATION_RECORDED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::ObservationRecorded)
+            }
+            event_type::RECORD_PROPOSAL_CREATED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::RecordProposalCreated)
+            }
+            event_type::PROMOTION_RECORDED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::PromotionRecorded)
+            }
+            event_type::CONTEXT_USE_RECORDED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::ContextUseRecorded)
+            }
+            event_type::CONTEXT_USE_FEEDBACK_RECORDED => typed(&self.payload)
+                .map_or_else(unknown, LifecycleEvent::ContextUseFeedbackRecorded),
+            event_type::MISSING_CONTEXT_DETECTED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::MissingContextDetected)
+            }
+            event_type::ARTIFACT_CONTRACT_SELECTED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::ArtifactContractSelected)
+            }
+            event_type::CONTRACT_VALIDATION_COMPLETED => typed(&self.payload)
+                .map_or_else(unknown, LifecycleEvent::ContractValidationCompleted),
+            event_type::OUTCOME_ASSESSED => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::OutcomeAssessed)
+            }
+            event_type::COMPILED_CONTEXT_FRAME_BUILT => {
+                typed(&self.payload).map_or_else(unknown, LifecycleEvent::CompiledContextFrameBuilt)
+            }
+            _ => unknown(),
+        }
+    }
+}
+
+/// A decoded lifecycle event. `Unknown` carries a forward-compatible event whose
+/// type this binary does not recognize, with its payload preserved.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LifecycleEvent {
+    /// An observation was recorded.
+    ObservationRecorded(ObservationRecorded),
+    /// A record proposal was created.
+    RecordProposalCreated(RecordProposalCreated),
+    /// A promotion event was recorded.
+    PromotionRecorded(PromotionRecorded),
+    /// A context use was recorded.
+    ContextUseRecorded(ContextUseRecorded),
+    /// Feedback on a context use was recorded.
+    ContextUseFeedbackRecorded(ContextUseFeedbackRecorded),
+    /// Missing context was detected.
+    MissingContextDetected(MissingContextDetected),
+    /// An artifact contract was selected.
+    ArtifactContractSelected(ArtifactContractSelected),
+    /// A contract validation completed.
+    ContractValidationCompleted(ContractValidationCompleted),
+    /// An outcome was assessed.
+    OutcomeAssessed(OutcomeAssessed),
+    /// A compiled context frame was built.
+    CompiledContextFrameBuilt(CompiledContextFrameBuilt),
+    /// A forward-compatible event this binary does not recognize.
+    Unknown {
+        /// The unrecognized event type.
+        event_type: String,
+        /// Its preserved payload.
+        payload: Value,
+    },
+}
+
+/// Stable-ID payload of `observation_recorded`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservationRecorded {
+    /// The observation record id.
+    pub observation_id: String,
+    /// Its observation kind (string; the typed enum lives in stella-core).
+    pub observation_kind: String,
+}
+
+/// Stable-ID payload of `record_proposal_created`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordProposalCreated {
+    /// The proposal record id.
+    pub proposal_id: String,
+    /// Its proposal kind (string).
+    pub proposal_kind: String,
+}
+
+/// Stable-ID payload of `promotion_recorded`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromotionRecorded {
+    /// The promotion event id.
+    pub promotion_event_id: String,
+    /// The source record.
+    pub source_record_id: String,
+    /// The resulting record (a new immutable revision).
+    pub result_record_id: String,
+    /// The promotion action (string).
+    pub action: String,
+}
+
+/// Stable-ID payload of `context_use_recorded`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUseRecorded {
+    /// The context-use record id.
+    pub context_use_id: String,
+    /// The record that was used.
+    pub context_record_id: String,
+    /// The use-trace id.
+    pub use_trace_id: String,
+}
+
+/// Stable-ID payload of `context_use_feedback_recorded`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUseFeedbackRecorded {
+    /// The feedback record id.
+    pub context_use_feedback_id: String,
+    /// The context use it is about.
+    pub context_use_id: String,
+}
+
+/// Stable-ID payload of `missing_context_detected`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissingContextDetected {
+    /// The missing-context observation id.
+    pub missing_context_id: String,
+    /// Its missing-context kind (string).
+    pub missing_context_kind: String,
+}
+
+/// Stable-ID payload of `artifact_contract_selected`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactContractSelected {
+    /// The selected contract record id.
+    pub contract_record_id: String,
+    /// The exact contract version selected.
+    pub contract_version: String,
+}
+
+/// Stable-ID payload of `contract_validation_completed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContractValidationCompleted {
+    /// The contract validation record id.
+    pub contract_validation_id: String,
+    /// The contract it validated.
+    pub contract_record_id: String,
+    /// The validation status (string).
+    pub validation_status: String,
+}
+
+/// Stable-ID payload of `outcome_assessed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeAssessed {
+    /// The outcome-assessment record id.
+    pub outcome_assessment_id: String,
+}
+
+/// Stable-ID payload of `compiled_context_frame_built`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledContextFrameBuilt {
+    /// The compiled frame id.
+    pub compiled_frame_id: String,
+    /// Its byte-stable frame hash (`sha256:<hex>`).
+    pub frame_hash: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn envelope(event_type: &str, payload: Value) -> LifecycleEventEnvelope {
+        LifecycleEventEnvelope {
+            schema_version: "1.0-draft".into(),
+            event_type: event_type.into(),
+            event_id: "evt_1".into(),
+            observed_at: "2026-07-20T18:30:00Z".into(),
+            task_id: Some("task_1".into()),
+            invocation_id: None,
+            payload,
+        }
+    }
+
+    #[test]
+    fn a_recognized_event_decodes_to_its_typed_form() {
+        let env = envelope(
+            event_type::COMPILED_CONTEXT_FRAME_BUILT,
+            json!({ "compiled_frame_id": "cf_1", "frame_hash": "sha256:aa" }),
+        );
+        assert_eq!(
+            env.decode(),
+            LifecycleEvent::CompiledContextFrameBuilt(CompiledContextFrameBuilt {
+                compiled_frame_id: "cf_1".into(),
+                frame_hash: "sha256:aa".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_future_event_type_round_trips_without_error() {
+        // THE witness: the exact failure mode Phase 0 found in parse_jsonl —
+        // an unknown interior event must NOT break the reader.
+        let wire = r#"{
+            "schema_version": "2.0",
+            "event_type": "future_event_v99",
+            "event_id": "evt_future",
+            "observed_at": "2027-01-01T00:00:00Z",
+            "payload": { "some_new_field": [1, 2, 3] }
+        }"#;
+        let env: LifecycleEventEnvelope =
+            serde_json::from_str(wire).expect("unknown event types must still deserialize");
+        // decode preserves it as Unknown with its payload intact.
+        match env.decode() {
+            LifecycleEvent::Unknown {
+                event_type,
+                payload,
+            } => {
+                assert_eq!(event_type, "future_event_v99");
+                assert_eq!(payload, json!({ "some_new_field": [1, 2, 3] }));
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+        // and re-serializes losslessly.
+        let back = serde_json::to_value(&env).unwrap();
+        assert_eq!(back["event_type"], json!("future_event_v99"));
+        assert_eq!(back["payload"], json!({ "some_new_field": [1, 2, 3] }));
+    }
+
+    #[test]
+    fn a_recognized_type_with_a_bad_payload_degrades_to_unknown_not_error() {
+        // Recognized event_type but payload missing required fields → preserved
+        // as Unknown rather than panicking the decoder.
+        let env = envelope(event_type::OBSERVATION_RECORDED, json!({ "wrong": true }));
+        assert!(matches!(env.decode(), LifecycleEvent::Unknown { .. }));
+    }
+
+    #[test]
+    fn envelope_omits_absent_identity_fields() {
+        let env = LifecycleEventEnvelope {
+            schema_version: "1.0-draft".into(),
+            event_type: event_type::OUTCOME_ASSESSED.into(),
+            event_id: "evt_1".into(),
+            observed_at: "2026-07-20T18:30:00Z".into(),
+            task_id: None,
+            invocation_id: None,
+            payload: json!({ "outcome_assessment_id": "oa_1" }),
+        };
+        let wire = serde_json::to_value(&env).unwrap();
+        assert!(wire.get("task_id").is_none(), "absent task_id omitted");
+        assert!(wire.get("invocation_id").is_none());
+    }
+}

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod attachment;
 pub mod cache;
 pub mod completion;
+pub mod context_event;
 pub mod error;
 pub mod event;
 pub mod provider;


### PR DESCRIPTION
## Phase 1 — domain type layer complete (installments 2–5)

Completes the **pure domain type layer** of Phase 1. Installment 1 (record taxonomy, `Scope`/`SharingScope`, temporal, JCS `record_hash`) already landed in `main` via the squash-merge of #423; this PR adds the rest. Rebased onto current `main` (0.5.0).

**Scope — what "complete" means here:** the plan's §5 types, validators, and internal events are done. The remaining §5 Phase-1 line items are **ingestion-boundary compatibility adapters** — accept legacy `recorded_at`→`observed_at` / `valid_to`→`valid_until` at ingestion, and keep the legacy memory/fact APIs working through adapters. Those cannot live in a pure, I/O-free type crate; they land with the Phase 2 migration (which owns the ingestion boundary). So: **domain types + validators + internal events complete; ingestion adapters are Phase 2.**

### Installment 2 — context-use / efficacy (`context_record::context_use`)
`ContextUseKind`, `ContextUseEvaluation`, `ContextInfluenceStage`, `ContextOutcomeRelation`, the extensible `ContextEvaluationMethod` (7 recognized core; `agent_self_report` flagged non-pruning), `MissingContextKind`, and the `ContextUse`/`ContextUseFeedback`/`MissingContextDetected` structs with their **intra-record** validators. Referential resolution (feedback→one use; not_rendered selected-use) is documented as deferred to the Phase 2/3 repository — a pure type layer can't check cross-record identity.

### Installment 3 — contracts + outcomes (`contract`, `outcome`)
`ArtifactContract` + extensible `RequirementKind` (10 core) + `ContractValidation`/`ValidationStatus`/`RequirementStatus`/`RequirementResult`; `OutcomeAssessmentLevel`/`CompletionStatus`/`CorrectnessStatus`/`OutcomeAssessment`. Validators: `command` requirement forces `execution_approval_ref`; duplicate result ids force `error`.

### Installment 4 — representation / fidelity (`representation`)
`Representation`/`ContentFidelity`/`MinimumContentFidelity` (`omitted` unrepresentable by type)/`InlineContentRequirement`; representation matrix, reference-no-inline, `blocking ⇒ exact-minimum-fidelity`.

### Installment 5 — internal events (`stella-protocol::context_event`)
The 10 replay-safe lifecycle events on a **versioned envelope** with an unknown-tolerant decoder (unrecognized `event_type` → `LifecycleEvent::Unknown`, payload preserved) — the tolerance the fatal `parse_jsonl` path lacks (Phase 0). Witness: a synthetic future event type round-trips without error. Stable-ID strings only — no `stella-core` import (avoids the core→protocol cycle).

### Flagged-decision choices (#483) — recorded, not resolved by fiat
"guarded" = fidelity category not an enforcement value (`blocking ⇒ exact` only; no `guarded` variant); contract `method` + `RequirementKind` are extensible strings; `requirement_status` its own enum; procedure order unique+increasing. Left open in #483: `Informational→advisory` and the directive-origin narrowing.

### Verification
- **Off-by-default / zero behavior change:** no production code imports the new modules (grep clean) — they are inert until a later phase wires them.
- **Local gate (scoped to the two crates this PR touches):** `cargo fmt --all --check` clean; `cargo clippy -p stella-core -p stella-protocol --all-targets -- -D warnings` clean; `cargo test -p stella-core` (41 `context_record`) + `cargo test -p stella-protocol` (incl. the future-event witness) green, on the 0.5.0 base.
- **Full workspace** fmt/clippy/test runs in this PR's CI.

Completes Epic #469's Phase 1 row. Closes #470, #471, #472, #473.
