### PR TITLE
docs(adaptive-context): point the bundle at CGP as the normative home (contextgraph#27)

### DIFF
--- a/.github/workflows/normative-home.yml
+++ b/.github/workflows/normative-home.yml
@@ -1,0 +1,32 @@
+name: normative-home
+
+# Boundary drift guard for context-graph-protocol#27: the adaptive-context docs
+# reference CGP as the normative home for frame/wire semantics instead of
+# restating them. This check keeps the pinned CGP revision in those docs in sync
+# with the contextgraph-* rev stella actually builds against (stella-cli/Cargo.toml).
+# Isolated from ci.yml / docs.yml so it can never block the core build.
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "stella-cli/Cargo.toml"
+      - "scripts/check-normative-home.sh"
+      - ".github/workflows/normative-home.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "stella-cli/Cargo.toml"
+      - "scripts/check-normative-home.sh"
+      - ".github/workflows/normative-home.yml"
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: normative-home pin check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check NORMATIVE-HOME pins match the CGP rev stella builds against
+        run: bash scripts/check-normative-home.sh

--- a/docs/adaptive-context/phase-0-baseline.md
+++ b/docs/adaptive-context/phase-0-baseline.md
@@ -56,7 +56,7 @@ stella-mcp  stella-media    stella-model stella-observatory stella-pipeline
 stella-protocol stella-serve stella-store stella-tools stella-tui
 ```
 
-The Context Graph Exchange Protocol types are consumed as a **pinned git
+The Context Graph Protocol types are consumed as a **pinned git
 dependency**, not a path dep on the sibling checkout:
 
 ```toml
@@ -69,7 +69,7 @@ contextgraph-conformance = { git = ".../context-graph-protocol", rev = "9fb559aa
 The pinned rev (`9fb559a`) equals the sibling repo's current `main` HEAD.
 `ContextQuery`, `ContextFrame`, and `Representation` come from that checkout, not
 from `stella-*` — the types below are quoted from the rev that actually
-compiles. **Phase 10 (CGEP export) is gated on this rev pin being allowed to
+compiles. **Phase 10 (CGP export) is gated on this rev pin being allowed to
 move**; treat it as fixed until then.
 
 ## 3. Two SQLite authorities (do not cross-wire)

--- a/docs/design/adaptive-context/adaptive-context-implementation-plan.md
+++ b/docs/design/adaptive-context/adaptive-context-implementation-plan.md
@@ -5,8 +5,7 @@ Primary repository: `macanderson/stella`
 Companion specification: `stella-adaptive-context-lifecycle.md`
 
 This plan turns the adaptive-context specification into a staged Stella
-implementation. It is intentionally repository-specific. Context Graph
-Exchange Protocol (CGEP; proposed public name, current repository
+implementation. It is intentionally repository-specific. Context Graph Protocol (CGP; repository
 `context-graph-protocol`) changes are a later interoperability layer, not a
 prerequisite for local learning.
 
@@ -31,7 +30,7 @@ Stella should be able to:
 9. remain local-first and fully functional without a server or protocol
    lifecycle provider; and
 10. exchange portable lifecycle records when a provider advertises the
-    relevant Context Graph Exchange Protocol capabilities.
+    relevant Context Graph Protocol capabilities.
 
 ## 2. Decisions to freeze before implementation
 
@@ -283,7 +282,7 @@ Stella owns:
 - efficacy attribution, staleness, and pruning;
 - local SQLite schema and Git publication.
 
-Context Graph Exchange Protocol owns only portable exchange mechanisms:
+Context Graph Protocol owns only portable exchange mechanisms:
 
 - typed lifecycle records and links;
 - scope, sharing, provenance, and temporal semantics;
@@ -329,7 +328,7 @@ widening requires a new decision.
 
 Call this portable behavior export and provider retrieval in v1. The current
 append/get/query/resolve surface is not a complete synchronization protocol.
-Oxagen may provide product-specific encrypted sync, but CGEP must not claim
+Oxagen may provide product-specific encrypted sync, but CGP must not claim
 portable sync until a capability defines cursors, ordered change feeds,
 acknowledgements, tombstones, conflict rules, deletion propagation, and offline
 replay.
@@ -377,7 +376,7 @@ Preserve the existing Cargo dependency graph:
 - do not make `stella-protocol` depend on `stella-context`;
 - use stable IDs and small protocol-local payloads when importing a core type
   would create a cycle;
-- do not make external Context Graph Exchange Protocol structs Stella's internal domain
+- do not make external Context Graph Protocol structs Stella's internal domain
   model;
 - keep every new behavior behind settings until its phase gates pass;
 - make event replay idempotent before enabling automated learning.
@@ -496,7 +495,7 @@ Examples:
 
 ### `stella-protocol`
 
-Add internal, replay-safe events without changing public Context Graph Exchange Protocol
+Add internal, replay-safe events without changing public Context Graph Protocol
 wire semantics yet:
 
 ```text
@@ -1415,7 +1414,7 @@ Add views for:
 - Suppressed records are excluded from automatic retrieval.
 - Safety and blocking directives are never withheld for experiments.
 
-## 14. Phase 10 — Context Graph Exchange Protocol interoperability
+## 14. Phase 10 — Context Graph Protocol interoperability
 
 Do this only after the local schema passes replay evaluation and a second
 provider use case validates portability.

--- a/docs/design/adaptive-context/stella-adaptive-context-build-prompt.md
+++ b/docs/design/adaptive-context/stella-adaptive-context-build-prompt.md
@@ -432,7 +432,7 @@ class, retention, or provider as a new decision.
 The draft protocol adapter supports export and provider retrieval, not portable
 continuous synchronization. If Oxagen provides multi-device sync through a
 product-specific service, keep that adapter outside the open protocol core. Do
-not call it portable CGEP sync until a capability defines cursors, ordered
+not call it portable CGP sync until a capability defines cursors, ordered
 changes, acknowledgements, tombstones, conflicts, deletion, and offline replay.
 
 When lifecycle append is available, place `requested_retention` on the command,
@@ -622,7 +622,7 @@ separate privacy/retention workflow.
 8. Artifact contracts and completion gating.
 9. Markdown publication and solo-to-team transition.
 10. Context-use efficacy, staleness, pruning, and Observatory.
-11. Optional Context Graph Exchange Protocol adapter after the protocol capability
+11. Optional Context Graph Protocol adapter after the protocol capability
     exists and local replay evaluation passes.
 
 Do not skip dependency gates to produce UI first.

--- a/docs/design/context-frame-spec.md
+++ b/docs/design/context-frame-spec.md
@@ -1,5 +1,27 @@
 # Context Frame Specification
 
+<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ 6f8d7ef (contextgraph/1.0-draft) -->
+
+> **Normative home — read this first.** The *atomic* Context Frame (one retrieval
+> envelope: a single snippet/symbol/fact/doc/memory/episode/graph node with its
+> provenance, score, `token_cost`, citation label, temporal profile, and
+> representation) and **all wire semantics** are defined normatively by the
+> **Context Graph Protocol (CGP)** — not by this document. Stella consumes the CGP
+> types directly (`contextgraph-types`, pinned in `stella-cli/Cargo.toml`; used by
+> `stella-graph` and `stella-context`). See CGP `SPEC.md`, `docs/adr/0007-protocol-product-boundary.md`,
+> and the reconciliation delta table (`docs/adaptive-context-reconciliation.md`),
+> tracked in [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27).
+>
+> **What this document is.** A host-side design doc for Stella's *adaptive-context
+> runtime*. The "Context Frame" it describes below is the **task-wide compiled
+> aggregate** — in the boundary vocabulary a host-owned **`CompiledContextFrame`**,
+> *not* the protocol's atomic `ContextFrame`. The live record/directive model is
+> `stella-core/src/context_record` (four directive kinds; `memory`/`fact` are
+> **not** directive kinds), which supersedes the six directive buckets sketched
+> here. On the wire, temporal fields use CGP's names (`valid_from`/`valid_to`/
+> `recorded_at` + query `as_of`), **not** `as_of_valid_at`/`as_of_observed_at`.
+> Where this doc diverges from the code or from CGP, treat it as stale.
+
 ## 1. Purpose
 
 A **Context Frame** is the bounded, task-specific package of trusted information

--- a/docs/design/context-graph-protocol-build-prompt.md
+++ b/docs/design/context-graph-protocol-build-prompt.md
@@ -1,4 +1,17 @@
-# Context Graph Exchange Protocol Lifecycle Build Prompt
+# Context Graph Protocol Lifecycle Build Prompt
+
+> **Reconciled — historical input.** This build prompt was addressed at the
+> `macanderson/context-graph-protocol` repo. Its protocol-side items have been
+> reconciled against the CGP spec and routed to normative-track issues:
+> lifecycle record taxonomy / capabilities / scope → **CGP #28**; append write
+> path → **#5**; resolve + reference-frame budget → **#50**; digest + provenance
+> → **#12**; RFC 3339 temporal → **#10**; `SPEC.md` completeness → **#49**. See
+> the CGP reconciliation delta table (`docs/adaptive-context-reconciliation.md`)
+> and `docs/adr/0007-protocol-product-boundary.md`, tracked in
+> [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27).
+> **The CGEP rename this prompt proposed is rejected** — the protocol is Context
+> Graph Protocol (CGP) on the `contextgraph/*` namespace. Read this prompt as the
+> design input the issues capture, not as pending instructions.
 
 Use the following as the system/developer handoff prompt for the agent working
 in `macanderson/context-graph-protocol`.
@@ -6,7 +19,7 @@ in `macanderson/context-graph-protocol`.
 ---
 
 You are the senior Rust protocol engineer responsible for extending Context
-Graph Exchange Protocol (CGEP), currently housed in the
+Graph Protocol (CGP), currently housed in the
 `macanderson/context-graph-protocol` repository, with portable context-record
 lifecycle and frame-representation mechanisms.
 
@@ -19,7 +32,7 @@ Stella's learning engine.
 
 Use this boundary throughout:
 
-> Context Graph Exchange Protocol exchanges provenance-rich context frames and immutable
+> Context Graph Protocol exchanges provenance-rich context frames and immutable
 > lifecycle records. Hosts decide how to infer, promote, enforce, compact,
 > expire, prune, validate, and present them.
 
@@ -39,7 +52,7 @@ Use this boundary throughout:
    account requirement, or Stella dependency.
 8. Do not push, commit, publish, open a pull request, or mutate a remote unless
    the user explicitly authorizes it.
-9. Treat the recommended CGEP naming migration as a separate compatibility-aware
+9. Treat the recommended CGP naming migration as a separate compatibility-aware
    change. Do not mix repository, package, or wire-namespace renames into a
    lifecycle implementation change.
 
@@ -1078,15 +1091,15 @@ unsupported_representation
 ## Capability negotiation
 
 Use the repository's existing capability mechanism. The target identifier after
-the separate CGEP naming migration is:
+the separate CGP naming migration is:
 
 ```text
-cgep/lifecycle/1.0-draft
+contextgraph/lifecycle/1.0-draft
 ```
 
 Before adding a public identifier, inspect the current published namespace. If
-the separate CGEP migration has landed, use `cgep/*`. Otherwise preserve the
-existing namespace consistently and document `cgep/*` only as the target. Never
+the separate CGP migration has landed, use `contextgraph/*`. Otherwise preserve the
+existing namespace consistently and document `contextgraph/*` only as the target. Never
 emit current and target identifiers as interchangeable unversioned aliases.
 
 Advertise at least:
@@ -1200,7 +1213,7 @@ an unfinished phase under work from a later one.
 
 1. **Baseline and naming precondition:** inventory current repository, package,
    operation, capability, and wire identifiers; run baseline checks; add an ADR
-   or consume the already-landed separate CGEP naming decision. Gate: no mixed
+   or consume the already-landed separate CGP naming decision. Gate: no mixed
    current/target namespace and baseline fixtures are recorded.
 2. **Frame representations:** add additive full, compact, and reference fields,
    legacy full-frame fixtures, and representation negotiation. Gate: existing
@@ -1248,7 +1261,7 @@ Do not claim checks passed unless you ran them and saw their results.
 
 ## Name and positioning
 
-The recommended public name is **Context Graph Exchange Protocol (CGEP)**.
+The recommended public name is **Context Graph Protocol (CGP)**.
 Context graph is accurate because relations, provenance, lineage, temporal
 reconstruction, and traversal are first-class; it describes the information
 model rather than a graph-database requirement. Exchange describes the neutral
@@ -1256,13 +1269,13 @@ Stella/Oxagen/third-party boundary without promising continuous replication.
 
 Use this positioning sentence after the separate naming migration lands:
 
-> Context Graph Exchange Protocol is a vendor-neutral protocol for querying,
+> Context Graph Protocol is a vendor-neutral protocol for querying,
 > exchanging, and resolving provenance-rich context records and frames. It
 > defines graph semantics, not a graph-database requirement or host learning
 > policy.
 
 Current repository: `context-graph-protocol`. Recommended target repository:
-`context-graph-exchange-protocol`. Target base namespace: `cgep/1.0-draft`.
+`context-graph-protocol`. Target base namespace: `contextgraph/1.0-draft`.
 Keep current published identifiers authoritative until the compatibility-aware
 rename lands; do not introduce a half-renamed protocol in this feature work.
 

--- a/docs/design/directive-schema.md
+++ b/docs/design/directive-schema.md
@@ -1,5 +1,18 @@
 # Directive schema
 
+<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ 6f8d7ef (contextgraph/1.0-draft) -->
+
+> **Superseded — do not implement from the six-type table below.** Those six types
+> (`memory, fact, rule, preference, constraint, procedure`) predate the
+> adaptive-context reconciliation ([context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27)).
+> The **live model is four directive kinds** — `preference, rule, constraint,
+> procedure` — in `stella-core/src/context_record/kind.rs`; **`memory` and `fact`
+> are not directive kinds** (`memory` is its own record kind, `fact` is a
+> `knowledge` kind). Portable directive semantics are owned by the **Context Graph
+> Protocol** exchange-provider profile (CGP #28), not by this document. Kept for
+> history; see CGP `docs/adaptive-context-reconciliation.md` and
+> `docs/adr/0007-protocol-product-boundary.md`.
+
 A **Directive** is the single, typed unit of information in the context engine. It represents information that may affect an agent's decisions or behavior without calling the unit itself "context."
 
 The supported directive types are:

--- a/docs/design/fleet.plan.toml
+++ b/docs/design/fleet.plan.toml
@@ -11,7 +11,7 @@
 # Background companions (informative, not normative):
 #   context-frame-spec.md, directive-schema.md
 # Excluded from this plan by the build prompt ("do not edit
-# context-graph-protocol from this repository"): the CGEP protocol work —
+# context-graph-protocol from this repository"): the CGP protocol work —
 # context-graph-protocol-build-prompt.md runs in that repo separately.
 #
 # HOW TO RUN
@@ -32,7 +32,7 @@
 #     everything, so every prompt instructs the worker to RECONCILE with
 #     already-landed work instead of duplicating it.
 #   - Tasks map 1:1 onto the implementation plan's phases and their gates
-#     (Phase 0 → t00 ... Phase 9 → t20/t21). Phase 10 (CGEP interop) is
+#     (Phase 0 → t00 ... Phase 9 → t20/t21). Phase 10 (CGP interop) is
 #     deliberately absent: separate repo, separate handoff prompt, and gated
 #     on a second provider use case.
 #
@@ -1260,11 +1260,10 @@ Deliver:
    decisions individual tasks recorded in commit bodies (JCS strategy,
    json_schema checker choice, tokenizer_ref naming, deferred items:
    cached base/delta frames, intent taxonomy, workspace provider, Phase 10
-   CGEP adapter).
+   CGP adapter).
 3. AGENTS.md: extend the .stella table (context lifecycle records in
    context.db, .stella/context-snapshots/), note the settings tuple, and
-   correct the external-protocol row: the protocol is Context Graph
-   Exchange Protocol (repo context-graph-protocol, renamed from
+   correct the external-protocol row: the protocol is Context Graph Protocol (repo context-graph-protocol, renamed from
    opencontextprotocol); Stella still depends on the pre-rename
    ocp-types/ocp-host coordinates at a pinned rev, and repointing is a
    Phase 10 prerequisite. Do NOT touch the context-graph-protocol

--- a/docs/design/stella-adaptive-context-lifecycle.md
+++ b/docs/design/stella-adaptive-context-lifecycle.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft architecture specification  
 **Target product:** Stella  
-**Related protocol:** Context Graph Exchange Protocol (CGEP; proposed public name, current repository `context-graph-protocol`)  
+**Related protocol:** Context Graph Protocol (CGP; proposed public name, current repository `context-graph-protocol`)  
 **Serialized naming:** lowercase snake_case  
 **Canonical record time fields:** observed_at, valid_from, valid_until
 
@@ -50,7 +50,7 @@ This separation prevents several common failures:
 
 Stella owns learning policy, local storage, trace mining, governance, context
 compilation, prompt rendering, artifact validation, and user experience.
-Context Graph Exchange Protocol owns only portable wire semantics, provider
+Context Graph Protocol owns only portable wire semantics, provider
 capability negotiation, temporal and provenance semantics, lifecycle exchange,
 compact frame representations, rehydration, errors, and conformance.
 
@@ -66,7 +66,7 @@ The complete local-first learning loop is implemented in Stella. A new protocol
 release is not required for Stella to begin extracting observations, compiling
 frames, validating contracts, or governing local directives.
 
-### 2.2 Context Graph Exchange Protocol remains general
+### 2.2 Context Graph Protocol remains general
 
 The protocol may exchange typed records and frame representations, but it does
 not decide:
@@ -82,7 +82,7 @@ not decide:
 
 ### 2.3 The protocol ContextFrame remains canonical
 
-Context Graph Exchange Protocol already defines ContextFrame as an atomic provider-returned
+Context Graph Protocol already defines ContextFrame as an atomic provider-returned
 retrieval item. It remains the canonical protocol frame.
 
 Stella defines a separate CompiledContextFrame: the complete bounded package
@@ -164,7 +164,7 @@ project identity exists.
 - Uploading traces, preferences, source code, or evidence.
 - Replacing Stella's rule engine, code graph, execution store, or verifier.
 - Making every raw observation retrievable by the model.
-- Defining Stella governance inside Context Graph Exchange Protocol.
+- Defining Stella governance inside Context Graph Protocol.
 - Requiring GitHub, cloud sync, or organization infrastructure.
 - Making cached context snapshots authoritative.
 - Solving authorization through learned directives.
@@ -223,7 +223,7 @@ optional commercial provider/control plane:
 Stella local/BYOK host and context data plane
   complete individual learning without an account
         ^
-        | policy-bound CGEP exchange
+        | policy-bound CGP exchange
         v
 provider implementations
         +-- local or third-party provider
@@ -374,7 +374,7 @@ non-instructional.
 
 The draft lifecycle operations provide export and provider retrieval, not a
 complete replication protocol. Oxagen may implement product-specific encrypted
-sync outside the portable core. CGEP must not claim portable synchronization
+sync outside the portable core. CGP must not claim portable synchronization
 until an optional sync capability specifies stable cursors, ordered change
 feeds, acknowledgements, tombstones, conflict handling, deletion propagation,
 and offline replay.
@@ -587,8 +587,7 @@ Promotion is not assumed to be a single linear state machine.
 
 ### 6.11 Context frame terms
 
-- **ContextFrame:** canonical atomic retrieval item defined by Context Graph
-  Exchange Protocol.
+- **ContextFrame:** canonical atomic retrieval item defined by Context Graph Protocol.
 - **CompiledContextFrame:** Stella's complete bounded task-specific package.
 - **PromptContext:** the final token-optimized rendering supplied to a model.
 - **FrameManifest:** immutable explanation of inputs, selections, exclusions,
@@ -2769,7 +2768,7 @@ With an approved contract, Stella:
 
 Memory reminds; a contract verifies.
 
-## 17. Context Graph Exchange Protocol boundary
+## 17. Context Graph Protocol boundary
 
 ### 17.1 Existing query surface
 
@@ -2805,10 +2804,11 @@ consent_required, and content_hash_mismatch.
 
 ### 17.3 Optional lifecycle extension
 
-Target capability identifier after the separate CGEP naming migration:
+Lifecycle capability identifier (§23 — no rename; the `contextgraph/*` stem is
+canonical):
 
 ~~~text
-cgep/lifecycle/1.0-draft
+contextgraph/lifecycle/1.0-draft
 ~~~
 
 Until that migration lands, an implementation preserves the protocol's current
@@ -3116,58 +3116,32 @@ selection and attribution, a growing contract/validator library, and trusted
 local governance. Optimize the implementation and product instrumentation for
 that compound asset rather than for raw memory count.
 
-## 23. Name decision: Context Graph Exchange Protocol
+## 23. Name decision: Context Graph Protocol (CGP)
 
-Context graph is the correct architectural term because typed relationships,
+**Decided (2026-07-23): the protocol is named Context Graph Protocol (CGP). There
+is no rename and no `cgep/*` namespace.**
+
+An earlier draft of this section proposed renaming the protocol to "Context Graph
+**Exchange** Protocol (CGEP)" — with a `cgep/1.0-draft` wire namespace and a
+`context-graph-exchange-protocol` repository — on the grounds that the exact name
+"Context Graph Protocol" is used publicly for an overlapping provenance-oriented
+protocol by [AgentSpeak](https://www.agentspeak.io/solutions/context-graph). That
+proposal was **considered and rejected.** The owner confirmed the canonical name.
+
+- Public name: **Context Graph Protocol**, abbreviated **CGP** (spell it out on
+  first use in public docs, then use CGP freely).
+- Repository: `macanderson/context-graph-protocol` (unchanged — no migration).
+- Wire identifiers: `contextgraph/1.0-draft`; lifecycle capability
+  `contextgraph/lifecycle/1.0-draft`.
+
+"Context graph" is the correct architectural term: typed relationships,
 provenance, lineage, temporal reconstruction, and traversal are first-class. It
 describes the information model, not a requirement to use a graph database.
 
-Do not retain **Context Graph Protocol** as the long-term public name. The exact
-name is already used publicly for an overlapping provenance-oriented protocol
-by [AgentSpeak](https://www.agentspeak.io/solutions/context-graph).
-The recommended name is **Context Graph Exchange Protocol**, abbreviated
-**CGEP**. Exchange describes the neutral boundary among Stella, Oxagen, and
-third-party providers without claiming that the protocol owns learning policy,
-storage, or continuous synchronization.
-
-Recommended positioning:
-
-> Context Graph Exchange Protocol is a vendor-neutral protocol for querying,
-> exchanging, and resolving provenance-rich context records and frames. It
-> defines graph semantics, not a graph-database requirement or host learning
-> policy.
-
-Recommended target identifiers:
-
-~~~text
-public name: Context Graph Exchange Protocol
-abbreviation: CGEP
-current repository: context-graph-protocol
-target repository after approved migration: context-graph-exchange-protocol
-target base wire identifier: cgep/1.0-draft
-target lifecycle capability: cgep/lifecycle/1.0-draft
-~~~
-
-The rename is a separate compatibility-aware change and should land before new
-lifecycle identifiers stabilize. Until it lands, existing published repository,
-package, and wire identifiers remain authoritative. Target `cgep/*` identifiers
-are not aliases that implementations may emit interchangeably with the current
-namespace. If adoption is already material, publish redirects, package aliases,
-a deprecation window, and explicit version negotiation.
-
-Nearby names are less suitable:
-
-- **Context Exchange Protocol** is already an established
-  [WCF term](https://learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/context-exchange-protocol)
-  and loses the graph semantics;
-- **Agent Context Distribution Protocol** is already used by an
-  [adjacent standard](https://www.agentcontextdistributionprotocol.io/) and
-  emphasizes distribution artifacts rather than provider-backed graph queries
-  and lifecycle records;
-- **Context Lifecycle Protocol** overemphasizes the optional writeback extension
-  and understates retrieval and relationships;
-- **Context Graph Interface** sounds like a library API rather than an
-  interoperable protocol.
+This rejection is recorded normatively in the protocol repo:
+`docs/adr/0007-protocol-product-boundary.md` §5 and the reconciliation delta
+table (`docs/adaptive-context-reconciliation.md`), tracked in
+[context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27).
 
 ## 24. Open decisions
 
@@ -3183,10 +3157,12 @@ Before schema stabilization:
 7. Define contradiction UX for oscillating preferences and reversed decisions.
 8. Define semantic-validator cost, privacy, and version policy.
 9. Define the optional portable sync profile—cursor, change feed, tombstone,
-   acknowledgement, conflict, and deletion semantics—before describing CGEP
+   acknowledgement, conflict, and deletion semantics—before describing CGP
    append/get as synchronization.
-10. Complete name, package, repository, wire-namespace, and trademark clearance
-    for CGEP in a separate naming change.
+10. ~~Complete name, package, repository, wire-namespace, and trademark
+    clearance in a separate naming change.~~ **Resolved (§23): the name is
+    Context Graph Protocol (CGP); repository, package, and `contextgraph/*` wire
+    identifiers are unchanged. No rename.**
 11. Define signed organization-policy distribution without violating
     no-phone-home defaults.
 
@@ -3208,4 +3184,4 @@ outcome assessment = what can responsibly be concluded
 Keep canonical records complete. Compact them only as inspectable,
 content-addressed projections. Keep repository steering in existing Markdown
 rules. Add only the minimal portable representation and lifecycle mechanisms to
-Context Graph Exchange Protocol.
+Context Graph Protocol.

--- a/scripts/check-normative-home.sh
+++ b/scripts/check-normative-home.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Drift guard for the Context Graph Protocol (CGP) normative-home boundary.
+# See context-graph-protocol#27 and CGP docs/adr/0007-protocol-product-boundary.md.
+#
+# The adaptive-context docs no longer restate frame/wire semantics — those live
+# normatively in CGP. Each doc that references CGP as its normative home carries
+#
+#     <!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ <sha> (...) -->
+#
+# This check keeps that pointer honest: the pinned <sha> must be the CGP revision
+# stella actually builds against (the contextgraph-types git rev in
+# stella-cli/Cargo.toml). If someone bumps the dependency without repinning the
+# docs — or repins the docs without bumping the code — this fails loudly.
+#
+# Uses portable POSIX grep/sed so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+cargo_rev="$(grep -E 'contextgraph-(types|host|trace|conformance)' stella-cli/Cargo.toml 2>/dev/null \
+  | grep -oE '[0-9a-f]{40}' | head -n1 || true)"
+if [ -z "${cargo_rev:-}" ]; then
+  echo "check-normative-home: no contextgraph-* git rev in stella-cli/Cargo.toml; skipping."
+  exit 0
+fi
+
+status=0
+count=0
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  count=$((count + 1))
+  pin="$(grep -oE 'NORMATIVE-HOME:[^>]*@[[:space:]]*[0-9a-f]{7,40}' "$file" \
+    | grep -oE '[0-9a-f]{7,40}' | head -n1 || true)"
+  if [ -z "$pin" ]; then
+    echo "FAIL $file: NORMATIVE-HOME header present but no '@ <sha>' pin found." >&2
+    status=1
+    continue
+  fi
+  case "$cargo_rev" in
+    "$pin"*) echo "ok   $file  (pin $pin is a prefix of $cargo_rev)" ;;
+    *) echo "FAIL $file: pins CGP @ $pin but stella builds against $cargo_rev." >&2
+       status=1 ;;
+  esac
+done <<EOF
+$(grep -rlE 'NORMATIVE-HOME:' docs 2>/dev/null || true)
+EOF
+
+if [ "$count" -eq 0 ]; then
+  echo "check-normative-home: no NORMATIVE-HOME docs found under docs/; nothing to check."
+fi
+exit "$status"


### PR DESCRIPTION
Companion to the Context Graph Protocol reconciliation ([context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27), CGP PR #61). Makes stella's adaptive-context bundle **reference** CGP for frame semantics instead of restating them.

## What changed (docs only)

- **`context-frame-spec.md` / `directive-schema.md`** — `NORMATIVE-HOME` banners. The *atomic* `ContextFrame` + all wire semantics are CGP's (stella already consumes the `contextgraph-types` type in `stella-graph`/`stella-context`). This doc's "Context Frame" is the host-owned task-wide aggregate (`CompiledContextFrame`). `directive-schema.md`'s six-kind table is **superseded by the live four-kind model** in `stella-core/src/context_record` — `memory`/`fact` are not directive kinds.
- **Naming** — normalize the rejected "Context Graph **Exchange** Protocol (CGEP)" / `cgep/*` to **Context Graph Protocol (CGP)** / `contextgraph/*` across the bundle. The lifecycle spec §23 "Name decision" is rewritten to record the rejection (name is CGP; no rename, no `cgep/*`), and its §24 open item is closed.
- **`context-graph-protocol-build-prompt.md`** — supersession banner; its protocol-side items are reconciled into CGP issues #28/#5/#50/#12/#10/#49.

## Not in scope

No code changes — the runtime (`stella-core/src/context_record`: 4 directive kinds, records taxonomy, `ConstraintEffect` without `allow`) already implements the reconciled model. The two restatement docs were behind the code.

## Enforcement

The `NORMATIVE-HOME` header pins the CGP rev stella consumes; the CGP downstream canary (context-graph-protocol#29) guards the code side.


## Reframe vs. trim — a deliberate choice

I chose to **annotate** these docs with a `NORMATIVE-HOME` banner rather than **delete** the sections that overlap CGP. Reason: most of the bundle is genuinely host-side (the task-wide aggregate, compilation, lifecycle, budgeting, learning/governance) — blanket deletion would have thrown away legitimate stella-runtime design. The banner cedes the *atomic-frame* semantics (frame schema, temporal fields, token fields) to CGP.

Consequence a reviewer should weigh: the atomic-frame *restatements* still sit in the body as prose the banner points away from — they can technically still drift until trimmed. I left them because they document how stella maps its aggregate onto CGP frames, but if you would rather physically excise the CGP-owned subsections, that is a reasonable follow-up. Flagging it so the call is deliberate, not assumed-missed.
