### PR TITLE
style: rustfmt the fleet dashboard (green main after #501)

### DIFF
--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -46,9 +46,9 @@ use stella_fleet::{
     WatchConfig, WorkerControls, WorkerOutcome, WorktreeManager,
 };
 use stella_protocol::{AgentEvent, CompletionMessage, PrStatus};
-use stella_tui::{FleetDashResult, FleetMsg, FleetStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::ShellHookRunner;
+use stella_tui::{FleetDashResult, FleetMsg, FleetStatus};
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::agent;

--- a/stella-tui/src/fleet_dashboard.rs
+++ b/stella-tui/src/fleet_dashboard.rs
@@ -379,10 +379,8 @@ impl FleetBoard {
                     .clone()
                     .unwrap_or_else(|| file_verb(*kind).to_string());
                 row.last_diff = diff.clone();
-                row.action = LastAction::Tool(format!(
-                    "{verb}  {}  +{added}-{removed}",
-                    short_path(path)
-                ));
+                row.action =
+                    LastAction::Tool(format!("{verb}  {}  +{added}-{removed}", short_path(path)));
             }
             AgentEvent::ToolResult { output, .. } => {
                 let preview = match output {
@@ -524,7 +522,8 @@ fn display_order(board: &FleetBoard, sort: SortKey, now: Instant) -> Vec<usize> 
         SortKey::ToolAgo => order.sort_by(|&a, &b| {
             let ta = board.rows[a].tool_ago(now).unwrap_or(Duration::ZERO);
             let tb = board.rows[b].tool_ago(now).unwrap_or(Duration::ZERO);
-            tb.cmp(&ta).then_with(|| board.rows[a].id.cmp(&board.rows[b].id))
+            tb.cmp(&ta)
+                .then_with(|| board.rows[a].id.cmp(&board.rows[b].id))
         }),
         SortKey::Elapsed => order.sort_by(|&a, &b| {
             board.rows[b]
@@ -922,7 +921,10 @@ fn render_detail(
             Style::default().add_modifier(Modifier::BOLD),
         ),
         Span::raw("   "),
-        Span::styled(entry.status.label(), Style::default().fg(entry.status.color())),
+        Span::styled(
+            entry.status.label(),
+            Style::default().fg(entry.status.color()),
+        ),
         Span::styled(format!(" · tool-ago {tool_ago}"), theme::muted()),
     ]));
     // last: <tool> <arg>
@@ -946,13 +948,19 @@ fn render_detail(
                 theme::TEXT_TERTIARY
             };
             lines.push(Line::from(Span::styled(
-                format!("         {}", truncate(l, area.width.saturating_sub(10) as usize)),
+                format!(
+                    "         {}",
+                    truncate(l, area.width.saturating_sub(10) as usize)
+                ),
                 Style::default().fg(color),
             )));
         }
     } else if let Some(out) = &entry.last_output {
         lines.push(Line::from(Span::styled(
-            format!("         {}", truncate(out, area.width.saturating_sub(10) as usize)),
+            format!(
+                "         {}",
+                truncate(out, area.width.saturating_sub(10) as usize)
+            ),
             theme::muted(),
         )));
     }

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -83,9 +83,6 @@ pub use deck::{
 };
 pub use deck_render::render_deck;
 pub use deck_shell::{DeckOptions, run_deck};
-pub use fleet_dashboard::{
-    FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,
-};
 pub use deck_ui::{
     DeckAction, DeckUi, IssueField, IssuesMode, IssuesPanel, ScopeAction, SkillPrompt, SkillsFocus,
     SkillsPanel, TypeAhead, handle_deck_key, ingest_inbound,
@@ -96,6 +93,9 @@ pub use envelope::{
     IssueAction, IssueRow, McpSearchItem, McpSearchOutcome, McpServerInfo, NotificationInfo,
     Secret, SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView,
     SplashCue, WorkspaceInput,
+};
+pub use fleet_dashboard::{
+    FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;


### PR DESCRIPTION
## Why

PR #501 (the `stella fleet` live dashboard) was squash-merged at its **pre-format** commit, racing the rustfmt fix that was pushed to the branch moments later. The fix landed on the merged feature branch but never reached main, so main's `fmt + clippy + test` CI is now **red on `cargo fmt --check`** ([run](https://github.com/macanderson/stella/actions/runs/30063161797)).

## What

Applies the identical rustfmt formatting on top of main — import ordering + a few line-wraps in:
- `stella-tui/src/fleet_dashboard.rs`
- `stella-tui/src/lib.rs`
- `stella-cli/src/fleet_cmd.rs`

**No behavior change.** Zero-risk, fmt-only.

## Verified (off current main)

- `cargo fmt --check` — clean
- `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` — clean
- fleet dashboard tests — 7 passed

Ready to merge to un-red main.
