### PR TITLE
ci(bench): gate the Python TB2.1 suites (adapter + analyzer)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,48 @@
+name: bench
+
+# The Python benchmark tooling (Terminal-Bench harbor adapter + claim analyzer)
+# is not covered by the Rust `ci.yml` gate, so it silently drifted red once
+# (adapter suite 224/2 — a posture-hash + stale-fixture drift caught only by hand
+# during TB2.1 run prep). This workflow gates those suites so it cannot recur.
+# Scoped to bench/ changes so ordinary Rust PRs don't pay for it.
+
+on:
+  pull_request:
+    paths:
+      - "bench/harbor_adapter/**"
+      - "bench/terminal_bench_analysis/**"
+      - ".github/workflows/bench.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bench/harbor_adapter/**"
+      - "bench/terminal_bench_analysis/**"
+      - ".github/workflows/bench.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: bench-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  pytest:
+    name: harbor_adapter + analyzer pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: harbor_adapter — sync (locked) + pytest
+        working-directory: bench/harbor_adapter
+        run: |
+          uv sync --locked --extra dev
+          uv run --no-sync pytest -q
+
+      - name: terminal_bench_analysis — sync (locked) + pytest
+        working-directory: bench/terminal_bench_analysis
+        run: |
+          uv sync --locked --extra dev
+          uv run --no-sync pytest -q

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ test-cli: ## Test stella-cli only (the shipping binary)
 test-protocol: ## Test stella-protocol only (shared types)
 	cargo test -p stella-protocol
 
+.PHONY: bench-test
+bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer)
+	cd bench/harbor_adapter && uv sync --locked --extra dev && uv run --no-sync pytest -q
+	cd bench/terminal_bench_analysis && uv sync --locked --extra dev && uv run --no-sync pytest -q
+
 .PHONY: gate
 gate: format-check lint test ## Full CI gate: fmt-check + clippy + test
 

--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -116,10 +116,11 @@ every other digest is an external dataset/comparator/fixture value, unchanged).
    `stella init` (code-graph indexing added after the fixture was written). Added
    the attribute. The posture assertion was updated to the recomputed hash.
 
-> ⚠️ **CI gap discovered:** stella's CI is Rust-only (`fmt + clippy + test`), so
-> the Python adapter/analyzer suites are **not CI-gated** — which is how the
-> adapter suite drifted red unnoticed. Recommend adding these `pytest` suites to
-> CI before or alongside publication.
+> ✅ **CI gap fixed:** stella's CI was Rust-only (`fmt + clippy + test`), so the
+> Python adapter/analyzer suites were **not gated** — which is how the adapter
+> suite drifted red unnoticed. Added `.github/workflows/bench.yml` (gates both
+> `pytest` suites on `bench/**` changes) and a `make bench-test` target for local
+> parity, so this drift class cannot recur silently.
 
 ---
 


### PR DESCRIPTION
Follow-up to #504. The Python Terminal-Bench tooling (harbor adapter + claim analyzer) was gated by **nothing** — stella's `ci.yml` and the local `make gate` are Rust-only. That's exactly how the adapter suite drifted **224/2** (post-`#301` posture-hash + a stale env fixture), caught only by hand during run prep.

## Fix
- **`.github/workflows/bench.yml`** — runs both `pytest` suites, scoped to `bench/**` changes so ordinary Rust PRs don't pay for it.
- **`make bench-test`** — local parity target.
- Updates `bench/READINESS.md` (CI-gap note → fixed).

Both suites green: **adapter 226, analyzer 234**. Closes the drift class so a frozen preregistration artifact can't silently rot again.

🤖 Prepared with Claude Code