### PR TITLE
ci: run ci.yml on merge_group so a GitHub merge queue can gate main (#306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,32 @@ on:
       - "package.json"
       - "pnpm-workspace.yaml"
       - "pnpm-lock.yaml"
+  # Merge queue: GitHub tests each queued PR against the current queue tip
+  # before it lands, so two individually-green PRs can't combine into a red
+  # `main` (see #306). The queue evaluates the required checks on the
+  # `merge_group` event, so `check` and `supply-chain` — the two required
+  # contexts — must both fire here or the queue can never go green. Note
+  # `merge_group` does NOT honor `paths-ignore`, so a docs-only PR that skips
+  # the Rust gate on `pull_request` still runs the full gate once queued; that
+  # is deliberate — the required check must report on the merged result.
+  merge_group:
   workflow_dispatch:
 
 concurrency:
-  # PR pushes share a group keyed on the PR ref and cancel-in-progress, so a
-  # rapid string of pushes to the same PR only pays for the latest one. Pushes
-  # to main must NOT share a group across commits: GitHub only keeps one
-  # "in progress" and one "queued" run per concurrency group — a third push
-  # arriving while a prior main run is still queued silently cancels that
-  # queued run rather than running it, so a break can land without a single
-  # red run to point at. Keying the group on github.sha for non-PR events
-  # gives every commit to main its own group, so its full-repo check
-  # (fmt + clippy + test, over ALL tracked files) always runs to completion
-  # and a breaking union goes red within one run.
+  # Three event shapes, three behaviors — the ternary below routes each:
+  #
+  # - pull_request: group by PR ref, cancel-in-progress. A rapid string of
+  #   pushes to the same PR only pays for the latest one.
+  # - push to main: group by github.sha (per-commit), no cancel. GitHub keeps
+  #   only one "in progress" and one "queued" run per group — a third push
+  #   arriving while a prior main run is still queued would silently cancel
+  #   that queued run, so a break could land with no red run to point at.
+  #   Per-commit groups give every commit its own full-repo run to completion.
+  # - merge_group (merge queue, #306): github.sha is the queued merge-group
+  #   head, unique per queue entry, so each entry lands in its own group with
+  #   no cancel — exactly what we want, since cancelling a merge_group run
+  #   would fail that entry in the queue. The non-'pull_request' branch of the
+  #   ternary already covers this; do not fold merge_group into the PR branch.
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 


### PR DESCRIPTION
Closes part of #306 (the workflow half). **Enabling the queue is a repo-settings change and is intentionally left to a human — see below.**

## What this PR does

Adds the `merge_group` trigger to `.github/workflows/ci.yml` and rewrites the `concurrency` comment.

A GitHub merge queue tests each queued PR against the current queue tip and evaluates the branch's **required status checks on the `merge_group` event**. `main`'s required checks today are:

- `fmt + clippy + test` (the `check` job)
- `cargo deny + cargo audit` (the `supply-chain` job)

Both are jobs under this workflow's shared `on:`, so a single `merge_group:` trigger makes **both** report on queue runs. Without it, the queue could never go green — a required context that never runs on `merge_group` blocks every merge.

The `github.sha`-keyed concurrency branch from #270 **already** handles `merge_group` correctly: for a `merge_group` event `github.sha` is the queued merge-group head (unique per queue entry), so each entry gets its own group with `cancel-in-progress: false` — cancelling a `merge_group` run would fail that entry. I only rewrote the comment to document all three event shapes (PR / push-to-main / merge_group) instead of leaving it as pre-queue dead config, which #306 explicitly asks for.

`actionlint` passes. Live queue behavior **cannot** be tested from a workflow change alone — it only exercises once the queue is enabled (below).

## The human step — enabling the queue (NOT done here)

This PR is inert until someone flips the setting. `macanderson/stella`'s required checks live in **classic branch protection** (the one ruleset only blocks branch deletion), and the classic branch-protection REST API **cannot** toggle a merge queue. Enable it via:

**Settings → Branches → branch protection rule for `main` → check "Require merge queue"** (or add a `merge_queue` rule to a ruleset).

### Verify / decide before closing #306

1. **Docs-only PRs (the one real risk).** `merge_group` can't be path-filtered, so on the queue `check` always runs — good. But on `pull_request`, docs-only PRs (`stella-docs/**`, `package.json`, `pnpm-*`) skip `check` via `paths-ignore`, so `fmt + clippy + test` never reports on the PR head. **Verification item #1: queue a docs-only PR end-to-end and confirm it enqueues and merges.** The queue evaluates required checks on the merged result (where `check` runs), so this should work — but if a docs-only PR can't enter the queue, the one-commit fallback is to drop `paths-ignore` on the gate jobs (or split out an always-runs job that reports the required context). I kept `paths-ignore` deliberately: the maintainer's comment says not to spend an hour of Rust CI on docs PRs.
2. **`enforce_admins: false` is the actual hole.** A queue only blocks a red `main` if admins don't bypass it — the later comments on #306 ("main is unprotected", owner auto-merges landing red) are admin-bypass symptoms, not queue-absence symptoms. Adopting the queue means also deciding the admin-bypass policy.
3. **`strict: true` (require branches up to date)** is redundant with a queue and GitHub recommends turning it off once the queue is on.
4. **`--auto` (auto-merge --squash).** `auto-tag.yml` and every agent session land via `gh pr merge --squash --auto`. #306 explicitly says *don't assume* — verify whether enabling auto-merge enqueues the PR or whether it needs an explicit "Merge when ready". Flipping the queue on mid-flight can stall in-progress auto-merges, so pick a quiet moment.
5. **`dependency-review`** runs only on `pull_request` (the action needs PR context and can't run on `merge_group`). It is **not** a required check, so it won't hang the queue — just confirm it stays non-required.

## Note on the issue's "reorder the ratchet" mitigation

#306's first comment proposes reordering CI so the file-size ratchet runs after clippy/test (so a `sizes` failure can't mask a compile break). **That step no longer exists in `ci.yml`** — the current gate is `fmt → clippy → test → release-smoke build`, with no `check-file-sizes.sh` step anywhere in `.github/`. So that specific mitigation is already moot; nothing to reorder. Flagging it so a reviewer doesn't think it was skipped.
