### PR TITLE
feat(store): version the drain wire contract — schema_version on the batch payload (#468)

### DIFF
--- a/stella-store/src/drain.rs
+++ b/stella-store/src/drain.rs
@@ -1,0 +1,314 @@
+//! The versioned drain wire contract — what a cloud syncer ships off the hub.
+//!
+//! The hub (`~/.stella/usage.db`) stages org-scoped, content-free telemetry
+//! rows for upload (`UsageStore::cloud_pending`). A drain — the native syncer
+//! built in #404, or the OTLP encoder in #427 — pages those rows and ships them
+//! to a remote intake. This module defines the *native* (`format = "stella"`)
+//! wire payload and stamps it with a **schema version** so the intake can tell
+//! client versions apart as the payload evolves.
+//!
+//! # Why version now
+//!
+//! The [`DrainRow`] field set is a contract between every deployed client and
+//! the intake. Once real clients are in the field, renaming a key or changing a
+//! field's meaning silently breaks older/newer peers. A version stamp is cheap
+//! to add before the transport lands (#404) and expensive to retrofit after —
+//! the same reasoning that shipped the drain config's `format` discriminator
+//! ahead of the OTLP encoder (#427). Ship the seam now, fill it in later.
+//!
+//! # Compatibility contract
+//!
+//! - Every native batch carries [`DrainBatch::schema_version`]; the version
+//!   this build speaks is [`DRAIN_SCHEMA_VERSION`].
+//! - The OTLP export (#427) carries the same value as a resource/scope
+//!   attribute keyed [`OTEL_SCHEMA_VERSION_ATTR`], so a collector reads the
+//!   version the same way regardless of format.
+//! - The intake accepts a **known version range** — [`schema_version_supported`]
+//!   is the single source of truth. An unknown version is a **terminal,
+//!   non-poison reject**: the batch is malformed-by-contract, not a transient
+//!   failure, so the drain loop (#467) must classify it as terminal (do not
+//!   retry forever) — yet distinct from a poison *row*, because the whole batch
+//!   shares one version and bisecting rows cannot rescue it. This module
+//!   supplies the predicate; the reject/quarantine handling lives with the
+//!   drain loop that has a batch to act on.
+//!
+//! # Bump-on-change discipline
+//!
+//! Any change to [`DrainRow`]'s field set or a field's semantics **must**
+//! increment [`DRAIN_SCHEMA_VERSION`] and widen [`schema_version_supported`]
+//! to match. The `wire_contract_is_frozen` test pins the serialized key set to
+//! this version: change the fields without bumping and it fails, forcing the
+//! version bump into the same change rather than a silent wire break.
+//!
+//! # Content-free by construction (#466)
+//!
+//! [`DrainRow`] enumerates only identity + addressing + telemetry keys — never
+//! prompt or completion text. It deliberately drops internal-only columns the
+//! hub row carries: the cursor address (`hub_rowid`), execution grouping
+//! (`execution_id`, `step`, `call_role`), and the local drift-analysis estimate
+//! (`estimated_input_tokens`) are not part of the enterprise rollup contract.
+//! Adding any of them is a v2 decision made on purpose, not a side effect of a
+//! blanket `derive(Serialize)` over the internal struct.
+
+use serde::{Deserialize, Serialize};
+
+use crate::usage::CloudTelemetryEvent;
+
+/// The native drain wire-format version this build speaks. Increment on any
+/// change to [`DrainRow`]'s field set or a field's semantics (see the module
+/// docs' bump-on-change discipline).
+pub const DRAIN_SCHEMA_VERSION: u32 = 1;
+
+/// Oldest wire version this build's intake contract still accepts.
+pub const MIN_SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+/// Newest wire version this build understands — always [`DRAIN_SCHEMA_VERSION`].
+pub const MAX_SUPPORTED_SCHEMA_VERSION: u32 = DRAIN_SCHEMA_VERSION;
+
+/// OTLP resource/scope attribute key carrying [`DrainBatch::schema_version`] on
+/// the `format = "otel"` export (#427). The native and OTLP encoders stamp the
+/// same value under this key so a collector can tell client versions apart.
+pub const OTEL_SCHEMA_VERSION_ATTR: &str = "stella.schema_version";
+
+/// Whether the intake accepts wire version `v` — the single source of truth for
+/// the "known version range" half of the compatibility contract. `false` is a
+/// **terminal, non-poison** reject (see the module docs), never a transient
+/// error the drain loop should retry.
+pub fn schema_version_supported(v: u32) -> bool {
+    (MIN_SUPPORTED_SCHEMA_VERSION..=MAX_SUPPORTED_SCHEMA_VERSION).contains(&v)
+}
+
+/// The native (`format = "stella"`) batch envelope: a schema-versioned run of
+/// content-free telemetry rows. This is the wire payload a cloud syncer (#404)
+/// POSTs to the org intake; the intake reads [`Self::schema_version`] first and
+/// rejects an unsupported version before decoding [`Self::rows`].
+///
+/// The version is an **integer** so the intake can accept a *range*
+/// ([`schema_version_supported`]) and bump-on-change is a simple increment —
+/// distinct from the enterprise spool's string `schema` discriminator
+/// (`"stella.operational.batch.v1"`), a different sink with a different
+/// (single-id, not range) contract. `deny_unknown_fields` matches that sink's
+/// wire posture: within a supported version the field set is exact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DrainBatch {
+    /// Wire-format version — see [`DRAIN_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// The staged hub rows, oldest first (the order `cloud_pending` returns).
+    pub rows: Vec<DrainRow>,
+}
+
+impl DrainBatch {
+    /// Wrap a page of hub rows in the current-version envelope — the native
+    /// encoder the `format = "stella"` drain (#404) serializes and POSTs.
+    pub fn from_events(events: &[CloudTelemetryEvent]) -> Self {
+        Self {
+            schema_version: DRAIN_SCHEMA_VERSION,
+            rows: events.iter().map(DrainRow::from).collect(),
+        }
+    }
+}
+
+/// One telemetry row on the wire: org/workspace/repo/project identity, the
+/// `(workspace_id, source_rowid)` idempotency key, `recorded_at`, and the
+/// content-free per-call telemetry. Content-free by construction (#466) — this
+/// field set *is* what [`DRAIN_SCHEMA_VERSION`] pins.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DrainRow {
+    // --- identity ---
+    pub org_id: String,
+    pub workspace_id: Option<String>,
+    pub repo_id: String,
+    pub project_id: String,
+
+    // --- addressing / idempotency ---
+    /// Per-project source rowid. `(workspace_id, source_rowid)` is the intake's
+    /// dedup key, so a re-send after a lost ack lands idempotently (#404).
+    pub source_rowid: i64,
+    pub recorded_at: String,
+
+    // --- telemetry (content-free) ---
+    pub provider: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_miss_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub cost_usd: f64,
+    pub duration_ms: u64,
+    pub retries: u32,
+    pub tool_calls: u64,
+    pub usage_complete: bool,
+}
+
+impl From<&CloudTelemetryEvent> for DrainRow {
+    fn from(e: &CloudTelemetryEvent) -> Self {
+        let t = &e.telemetry;
+        Self {
+            org_id: e.org_id.clone(),
+            workspace_id: e.workspace_id.clone(),
+            repo_id: e.repo_id.clone(),
+            project_id: e.project_id.clone(),
+            source_rowid: e.source_rowid,
+            recorded_at: e.recorded_at.clone(),
+            provider: t.provider.clone(),
+            model: t.model.clone(),
+            input_tokens: t.input_tokens,
+            output_tokens: t.output_tokens,
+            cache_read_tokens: t.cache_read_tokens,
+            cache_miss_tokens: t.cache_miss_tokens,
+            cache_write_tokens: t.cache_write_tokens,
+            cost_usd: t.cost_usd,
+            duration_ms: t.duration_ms,
+            retries: t.retries,
+            tool_calls: t.tool_calls,
+            usage_complete: t.usage_complete,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TelemetryRow;
+    use serde_json::Value;
+
+    /// A hub row whose internal-only ids differ from its wire ids, so the tests
+    /// can prove the wire carries `source_rowid` (the dedup key), not the
+    /// internal `hub_rowid`.
+    fn sample_event() -> CloudTelemetryEvent {
+        CloudTelemetryEvent {
+            hub_rowid: 42,
+            org_id: "acme".into(),
+            workspace_id: Some("ws-1".into()),
+            repo_id: "repo-1".into(),
+            project_id: "proj-1".into(),
+            execution_id: 7,
+            source_rowid: 99,
+            recorded_at: "2026-07-23T00:00:00Z".into(),
+            telemetry: TelemetryRow {
+                step: 3,
+                provider: "zai".into(),
+                call_role: "lead".into(),
+                model: "glm-5.2".into(),
+                input_tokens: 100,
+                estimated_input_tokens: 90,
+                output_tokens: 20,
+                cache_read_tokens: 10,
+                cache_miss_tokens: 5,
+                cache_write_tokens: 2,
+                cost_usd: 0.01,
+                duration_ms: 1234,
+                retries: 1,
+                tool_calls: 4,
+                usage_complete: true,
+            },
+        }
+    }
+
+    /// The frozen wire-contract field set for schema v1. Editing this list
+    /// without bumping [`DRAIN_SCHEMA_VERSION`] is exactly what
+    /// `wire_contract_is_frozen` catches. Compared as a set (order-independent).
+    const V1_ROW_KEYS: &[&str] = &[
+        "org_id",
+        "workspace_id",
+        "repo_id",
+        "project_id",
+        "source_rowid",
+        "recorded_at",
+        "provider",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_miss_tokens",
+        "cache_write_tokens",
+        "cost_usd",
+        "duration_ms",
+        "retries",
+        "tool_calls",
+        "usage_complete",
+    ];
+
+    #[test]
+    fn batch_carries_schema_version() {
+        let batch = DrainBatch::from_events(&[sample_event()]);
+        assert_eq!(batch.schema_version, DRAIN_SCHEMA_VERSION);
+        let v: Value = serde_json::to_value(&batch).unwrap();
+        assert_eq!(v["schema_version"], DRAIN_SCHEMA_VERSION);
+        assert_eq!(v["rows"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn wire_contract_is_frozen() {
+        // Serialize a row and assert its key set equals the frozen v1 allowlist.
+        // This is the bump-on-change guard: add / remove / rename a DrainRow
+        // field and this fails until V1_ROW_KEYS is updated *and* the version
+        // bumped in the same change.
+        let row = DrainRow::from(&sample_event());
+        let obj = serde_json::to_value(&row).unwrap();
+        let obj = obj.as_object().unwrap();
+        let mut got: Vec<&str> = obj.keys().map(String::as_str).collect();
+        got.sort_unstable();
+        let mut want: Vec<&str> = V1_ROW_KEYS.to_vec();
+        want.sort_unstable();
+        assert_eq!(
+            got, want,
+            "DrainRow wire keys drifted from the v1 contract — bump \
+             DRAIN_SCHEMA_VERSION and update V1_ROW_KEYS in the same change"
+        );
+    }
+
+    #[test]
+    fn drain_row_excludes_internal_fields() {
+        // The internal columns the hub row carries but the contract excludes
+        // must never leak onto the wire (cursor address, execution grouping,
+        // local drift estimate).
+        let obj = serde_json::to_value(DrainRow::from(&sample_event())).unwrap();
+        let obj = obj.as_object().unwrap();
+        for excluded in [
+            "hub_rowid",
+            "execution_id",
+            "step",
+            "call_role",
+            "estimated_input_tokens",
+        ] {
+            assert!(
+                !obj.contains_key(excluded),
+                "internal field `{excluded}` leaked onto the wire"
+            );
+        }
+    }
+
+    #[test]
+    fn source_rowid_is_the_dedup_key() {
+        // The wire carries source_rowid (the intake's (workspace_id,
+        // source_rowid) dedup key), not the hub's internal rowid.
+        let e = sample_event();
+        assert_ne!(
+            e.source_rowid, e.hub_rowid,
+            "fixture must distinguish the two ids for this test to mean anything"
+        );
+        assert_eq!(DrainRow::from(&e).source_rowid, e.source_rowid);
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let batch = DrainBatch::from_events(&[sample_event(), sample_event()]);
+        let bytes = serde_json::to_vec(&batch).unwrap();
+        let back: DrainBatch = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(batch, back);
+    }
+
+    #[test]
+    fn version_support_range_is_closed_and_current() {
+        assert!(schema_version_supported(DRAIN_SCHEMA_VERSION));
+        assert!(!schema_version_supported(0));
+        assert!(
+            !schema_version_supported(DRAIN_SCHEMA_VERSION + 1),
+            "an unknown newer version must be an explicit (terminal) reject"
+        );
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -113,6 +113,7 @@ mod usage_completeness_tests;
 pub mod cache_gaps;
 pub mod cache_trend;
 pub mod catalog;
+pub mod drain;
 pub mod enterprise_telemetry;
 pub mod home;
 pub mod identity;
@@ -128,6 +129,10 @@ use migrations::{
 
 pub use cache_gaps::CacheCallGap;
 pub use catalog::CatalogStore;
+pub use drain::{
+    DRAIN_SCHEMA_VERSION, DrainBatch, DrainRow, MAX_SUPPORTED_SCHEMA_VERSION,
+    MIN_SUPPORTED_SCHEMA_VERSION, OTEL_SCHEMA_VERSION_ATTR, schema_version_supported,
+};
 // The sidecar journal's writer is deliberately NOT re-exported at the top
 // level: `SessionJournal` here names the DB read-model reassembled by
 // [`Store::session_events`] (read-only replay), while

--- a/stella-store/src/usage.rs
+++ b/stella-store/src/usage.rs
@@ -437,7 +437,7 @@ impl UsageStore {
                     t.step, t.recorded_at, t.provider, t.call_role, t.model, t.input_tokens, \
                     t.estimated_input_tokens, t.output_tokens, t.cache_read_tokens, \
                     t.cache_miss_tokens, t.cache_write_tokens, t.cost_usd, t.duration_ms, \
-                    t.retries, t.tool_calls, t.usage_complete \
+                    t.retries, t.tool_calls, t.usage_complete, t.source_rowid \
              FROM telemetry t \
              WHERE t.org_id = ?1 \
                AND t.rowid > COALESCE((SELECT last_hub_rowid FROM cloud_sync_cursors \
@@ -452,6 +452,7 @@ impl UsageStore {
                 repo_id: r.get(3)?,
                 project_id: r.get(4)?,
                 execution_id: r.get(5)?,
+                source_rowid: r.get(22)?,
                 recorded_at: r.get(7)?,
                 telemetry: crate::TelemetryRow {
                     step: r.get::<_, i64>(6)? as u64,
@@ -524,6 +525,12 @@ pub struct GlobalTelemetryRow {
 }
 
 /// One org-scoped hub row awaiting cloud acknowledgement.
+///
+/// `hub_rowid` addresses the row for the monotonic cloud cursor
+/// ([`UsageStore::ack_cloud_synced`]); `source_rowid` is the per-project id the
+/// wire contract ships as half of the intake's `(workspace_id, source_rowid)`
+/// dedup key (see [`crate::drain`]). They are distinct: the cursor is a hub
+/// concern, the dedup key a wire concern.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CloudTelemetryEvent {
     pub hub_rowid: i64,
@@ -532,6 +539,7 @@ pub struct CloudTelemetryEvent {
     pub repo_id: String,
     pub project_id: String,
     pub execution_id: i64,
+    pub source_rowid: i64,
     pub recorded_at: String,
     pub telemetry: crate::TelemetryRow,
 }


### PR DESCRIPTION
Closes #468. Part of #403; hardens the wire contract that #404 / #427 will carry.

## Problem

The hub (`~/.stella/usage.db`) stages org-scoped, content-free telemetry rows for the cloud drain (`cloud_pending` → POST → `ack_cloud_synced`), but nothing stamps a protocol/schema version. As the payload evolves (new telemetry fields, renamed keys, changed semantics), the intake can't tell client versions apart and old/new clients can't be handled gracefully. Cheap to add now, expensive to retrofit once real clients are in the field.

## What this ships

New `stella-store::drain` module — the native (`format = "stella"`) wire contract:

- **`DrainBatch`** — the versioned envelope: `{ schema_version, rows }`. `DrainBatch::from_events(&[CloudTelemetryEvent])` is the ready-made native encoder #404 can serialize + POST.
- **`DrainRow`** — a **deliberate wire DTO** whose field set *is* what v1 pins: identity (`org_id`/`workspace_id`/`repo_id`/`project_id`) + the `(workspace_id, source_rowid)` dedup key + `recorded_at` + content-free per-call telemetry (provider/model/tokens/cache/cost/duration/retries/tool_calls/usage_complete). Mapped explicitly from the internal `CloudTelemetryEvent` via `From`, so a blanket `derive(Serialize)` can't freeze the wrong field set at v1 or leak content.
- **`schema_version_supported(v)`** — single source of truth for the accepted version *range*. An unknown version is documented as a **terminal, non-poison reject** (the drain loop in #467 owns the actual reject/quarantine handling — this just supplies the predicate).
- **`OTEL_SCHEMA_VERSION_ATTR`** (`"stella.schema_version"`) — the resource/scope attribute key the OTLP export (#427) stamps with the same value.

Supporting change: `CloudTelemetryEvent` gains `source_rowid` (the hub table already preserves it under PK `(project_id, source_rowid)`; `cloud_pending` now selects it) so the wire carries the intake's real dedup key, not the hub's internal cursor `rowid`.

## Bump-on-change discipline (acceptance)

`wire_contract_is_frozen` pins the serialized `DrainRow` key set to a frozen v1 allowlist: change the field set without updating the allowlist (and bumping `DRAIN_SCHEMA_VERSION`) and the test fails. Six unit tests cover: envelope carries `schema_version`, the frozen key set, exclusion of internal-only columns, `source_rowid` is the wire dedup key (not `hub_rowid`), JSON round-trip, and the closed support range.

## Seams I invented — flag if you'd redraw them

1. **`DrainBatch` / `DrainRow` envelope boundary.** #468 says to stamp the version on "the native batch envelope (issue #404)" — but #404 isn't landed, so this issue introduces the versioned envelope type + DTO. If you'd rather **#404 own the DTO**, the seam is one module; easy to move. What lives here vs #404: this PR = the versioned wire *type* + contract + tests; #404 = the pager/HTTP transport that carries it.
2. **`stella.schema_version` OTLP attr key.** #427 will consume it. Deliberately **distinct from OTLP's native `schema_url`** (which versions the OTel schema itself, not our app payload) — please don't conflate them in #427.
3. **Integer `schema_version` vs the enterprise sink's string `schema`.** The enterprise spool's wire batch uses `schema: "stella.operational.batch.v1"` (a single string id). The drain uses an **integer** `schema_version` because #468 calls for a version *range* the intake accepts and an *increment* on change — range/increment semantics want an integer, not a string URI. Both wire structs share the `#[serde(deny_unknown_fields)]` posture. Deliberate divergence, documented in the module rustdoc.

## Out of scope (later issues)

No HTTP pager, no OTLP encoder, no drain-loop validator — those are #404 / #427 / #467. This ships the versioned seam so they slot in without a breaking wire change.

## Verification

- `cargo test -p stella-store` → 126 lib + 31 integration, 0 failures (incl. the pre-existing `cloud_pending` test, which exercises the new `source_rowid` SELECT).
- `cargo clippy -p stella-store --all-targets -- -D warnings` → clean.