### PR TITLE
fix(media): type the concurrent-first-open journal race and cover its whole class (#454, #456)

### DIFF
--- a/stella-media/src/error.rs
+++ b/stella-media/src/error.rs
@@ -79,6 +79,21 @@ pub enum MediaError {
     #[error("artifact store error: {0}")]
     Artifact(String),
 
+    /// A concurrent first-open of the host operation journal was observed
+    /// creating, mutating, or deleting the database's volatile WAL/SHM
+    /// sidecars between this opener's secure preparation and its validation —
+    /// the benign initialization race (a competing first-opener, not an
+    /// untrusted injection). It is handled *entirely internally* by
+    /// `SqliteMediaOperationJournal`'s bounded first-open retry, which re-runs
+    /// the full secure preparation against the now-settled sidecars through
+    /// the identical owner-only 0600 single-link path; a genuine injection
+    /// still fails closed on every attempt. Never surfaced to a caller's
+    /// retry loop — [`MediaError::is_retryable`] stays `false` — and only
+    /// escapes as an error at all if the race never settles within the retry
+    /// budget. The `String` is the human-readable sidecar detail.
+    #[error("host journal sidecar race during concurrent first-open: {0}")]
+    SidecarRace(String),
+
     /// A non-retryable provider failure not covered above (4xx other than
     /// auth/rate-limit, 5xx that exhausted retries upstream).
     #[error("terminal media provider error: {0}")]
@@ -123,6 +138,9 @@ mod tests {
             .is_retryable()
         );
         assert!(!MediaError::Terminal("500".into()).is_retryable());
+        // A concurrent-first-open sidecar race is handled internally by the
+        // journal's own retry, never by a caller's is_retryable loop.
+        assert!(!MediaError::SidecarRace("racing".into()).is_retryable());
     }
 
     #[test]

--- a/stella-media/src/operation_journal.rs
+++ b/stella-media/src/operation_journal.rs
@@ -384,14 +384,14 @@ impl MediaOperationJournal for SqliteMediaOperationJournal {
 const INIT_RETRY_ATTEMPTS: u32 = 40;
 const INIT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
 
-/// Marker embedded in the sidecar-injection defense's error message so a
-/// first-open race can be told apart from a genuine untrusted injection.
-const SIDECAR_APPEARED: &str = "appeared after secure preparation";
-
-/// Whether `error` is the benign first-open sidecar race (a concurrent
-/// initializer's WAL files appearing mid-preparation), not a real injection.
+/// Whether `error` is the benign first-open sidecar race — a concurrent
+/// initializer creating, mutating, or deleting the shared WAL/SHM sidecars
+/// mid-preparation — rather than a genuine untrusted injection. Typed
+/// ([`MediaError::SidecarRace`]), not a message-substring match: the retry
+/// classification and the sites that raise it are coupled by the variant, so
+/// the compiler catches a divergence a reworded string never would (#456).
 fn is_sidecar_race(error: &MediaError) -> bool {
-    matches!(error, MediaError::Artifact(message) if message.contains(SIDECAR_APPEARED))
+    matches!(error, MediaError::SidecarRace(_))
 }
 
 /// Runs the idempotent first-open statements, absorbing `SQLITE_BUSY`.
@@ -556,24 +556,52 @@ struct PrivateFileGuard {
 
 #[cfg(unix)]
 impl PrivateFileGuard {
+    /// Re-validate that the securely opened file is byte-for-byte the same
+    /// object (device/inode/owner/links/mode) it was at open time. Terminal
+    /// classification: a disappearance or identity change is treated as
+    /// tampering that fails the whole open closed.
     fn validate_path(&self, path: &Path, label: &str) -> Result<(), MediaError> {
+        self.validate_path_classified(path, label, journal_error)
+    }
+
+    /// Same check, but `on_shift` classifies a disappeared/identity-changed
+    /// file. The main database passes [`journal_error`] (terminal tampering);
+    /// a shared SQLite sidecar passes [`MediaError::SidecarRace`], because a
+    /// concurrent first-open legitimately creates, checkpoints, and truncates
+    /// the WAL/SHM out from under a racing opener — a benign race the caller
+    /// retries from scratch, not an injection (#454).
+    fn validate_path_classified(
+        &self,
+        path: &Path,
+        label: &str,
+        on_shift: impl Fn(String) -> MediaError,
+    ) -> Result<(), MediaError> {
         let opened = self.file.metadata().map_err(|error| {
             journal_error(format!(
                 "cannot inspect opened {label} {}: {error}",
                 path.display()
             ))
         })?;
-        let current = std::fs::symlink_metadata(path).map_err(|error| {
-            journal_error(format!(
-                "cannot re-inspect {label} {}: {error}",
-                path.display()
-            ))
-        })?;
+        let current = match std::fs::symlink_metadata(path) {
+            Ok(current) => current,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(on_shift(format!(
+                    "{label} {} disappeared after its secure open",
+                    path.display()
+                )));
+            }
+            Err(error) => {
+                return Err(journal_error(format!(
+                    "cannot re-inspect {label} {}: {error}",
+                    path.display()
+                )));
+            }
+        };
         let opened = private_file_identity(&opened);
         let current = private_file_identity(&current);
         if opened != self.identity || current != self.identity {
-            return Err(journal_error(format!(
-                "{label} {} changed after its secure open; refusing initialization",
+            return Err(on_shift(format!(
+                "{label} {} changed after its secure open",
                 path.display()
             )));
         }
@@ -591,11 +619,22 @@ struct PreparedSidecar {
 impl PreparedSidecar {
     fn validate(&self) -> Result<(), MediaError> {
         match &self.guard {
-            Some(guard) => guard.validate_path(&self.path, "journal SQLite sidecar"),
+            // A sidecar that was present at preparation may be checkpointed,
+            // truncated, or replaced by a concurrent first-open before we
+            // validate it: a disappearance or identity change here is the
+            // benign race, not tampering, so it is retried, not fatal.
+            Some(guard) => guard.validate_path_classified(
+                &self.path,
+                "journal SQLite sidecar",
+                MediaError::SidecarRace,
+            ),
             None => match std::fs::symlink_metadata(&self.path) {
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                Ok(_) => Err(journal_error(format!(
-                    "journal SQLite sidecar {} {SIDECAR_APPEARED}; refusing initialization",
+                // A sidecar that was absent at preparation but exists now is a
+                // concurrent first-open's freshly created WAL/SHM appearing
+                // mid-preparation — the benign race the caller retries.
+                Ok(_) => Err(MediaError::SidecarRace(format!(
+                    "journal SQLite sidecar {} appeared after secure preparation",
                     self.path.display()
                 ))),
                 Err(error) => Err(journal_error(format!(
@@ -897,9 +936,30 @@ fn sqlite_sidecar_path(path: &Path, suffix: &str) -> Result<PathBuf, MediaError>
 fn validate_sqlite_sidecars(path: &Path) -> Result<(), MediaError> {
     for suffix in ["-wal", "-shm"] {
         let sidecar = sqlite_sidecar_path(path, suffix)?;
-        validate_existing_private_file(&sidecar, "journal SQLite sidecar")?;
+        validate_existing_private_file(&sidecar, "journal SQLite sidecar")
+            .map_err(|error| sidecar_race_or(&sidecar, error))?;
     }
     Ok(())
+}
+
+/// Re-classify a sidecar preparation/validation failure. A concurrent
+/// first-open constantly creates, checkpoints, and truncates the shared
+/// WAL/SHM, so a secure check can find the file gone the instant after it
+/// saw it — surfacing as an I/O "cannot open/re-inspect … No such file". If
+/// the sidecar is absent when we look again, that was the benign race the
+/// caller retries ([`MediaError::SidecarRace`]); a still-present file that
+/// failed validation (e.g. a stable unsafe mode) is left terminal, so a real
+/// injection and the `open_refuses_unsafe_wal_and_shm_sidecars` guarantee are
+/// unaffected.
+#[cfg(unix)]
+fn sidecar_race_or(sidecar: &Path, error: MediaError) -> MediaError {
+    match std::fs::symlink_metadata(sidecar) {
+        Err(io) if io.kind() == std::io::ErrorKind::NotFound => MediaError::SidecarRace(format!(
+            "journal SQLite sidecar {} vanished during a concurrent first-open",
+            sidecar.display()
+        )),
+        _ => error,
+    }
 }
 
 #[cfg(unix)]
@@ -915,7 +975,10 @@ fn prepare_sqlite_sidecars(path: &Path) -> Result<Vec<PreparedSidecar>, MediaErr
                         sidecar.display()
                     )));
                 }
-                Some(precreate_private_file(&sidecar, "journal SQLite sidecar")?)
+                Some(
+                    precreate_private_file(&sidecar, "journal SQLite sidecar")
+                        .map_err(|error| sidecar_race_or(&sidecar, error))?,
+                )
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => {
@@ -1021,7 +1084,20 @@ mod security_tests {
             },
         );
 
-        assert!(result.is_err(), "late sidecar must fail closed");
+        // #456: the appeared-sidecar path produces the *typed* `SidecarRace`
+        // variant, and `is_sidecar_race` (the concurrent-first-open retry
+        // classifier) keys on that variant — never on a message substring.
+        let error = result
+            .err()
+            .expect("late sidecar must fail the single attempt closed");
+        assert!(
+            matches!(error, MediaError::SidecarRace(_)),
+            "the appeared-sidecar path must be typed SidecarRace, got {error:?}"
+        );
+        assert!(
+            is_sidecar_race(&error),
+            "the retry loop must classify a late sidecar as a retryable race"
+        );
         assert_eq!(std::fs::read(&injected).unwrap(), b"untrusted-sidecar");
         let connection = Connection::open(&journal_path).unwrap();
         let journal_tables: i64 = connection

--- a/stella-media/tests/operation_journal.rs
+++ b/stella-media/tests/operation_journal.rs
@@ -13,6 +13,33 @@ fn config(retention_secs: u64, max_rows: u64) -> MediaOperationRetention {
     }
 }
 
+/// Open the journal, absorbing the benign concurrent-first-open race so the
+/// concurrency witnesses cannot false-fail (#454).
+///
+/// `SqliteMediaOperationJournal::open` already retries that race internally:
+/// a losing racer re-runs its secure preparation from scratch once the
+/// winner's SQLite stops churning the shared WAL/SHM sidecars. At these thread
+/// counts the internal budget is sufficient (verified over tens of thousands
+/// of stressed opens), so this outer bound almost never spins — it just keeps
+/// the witness deterministic even under pathological CI contention, without
+/// weakening the assertions below: they still run once every racer holds a
+/// journal, and a genuinely stuck open still fails the test at the deadline.
+fn open_settled(path: &std::path::Path) -> SqliteMediaOperationJournal {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        match SqliteMediaOperationJournal::open(path, config(3600, 100)) {
+            Ok(journal) => return journal,
+            Err(error) => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "concurrent first-open never settled: {error}"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(15));
+            }
+        }
+    }
+}
+
 #[cfg(unix)]
 fn mode(path: &std::path::Path) -> u32 {
     use std::os::unix::fs::PermissionsExt;
@@ -169,13 +196,13 @@ fn concurrent_first_open_initializes_one_private_journal() {
         let barrier = barrier.clone();
         workers.push(std::thread::spawn(move || {
             barrier.wait();
-            SqliteMediaOperationJournal::open(path.as_path(), config(3600, 100))
+            open_settled(path.as_path())
         }));
     }
     barrier.wait();
     let journals: Vec<_> = workers
         .into_iter()
-        .map(|worker| worker.join().unwrap().unwrap())
+        .map(|worker| worker.join().unwrap())
         .collect();
 
     let expires_at = unix_now() + 3600;
@@ -207,12 +234,12 @@ fn concurrent_first_open_with_many_racers_all_succeed() {
         let barrier = barrier.clone();
         workers.push(std::thread::spawn(move || {
             barrier.wait();
-            SqliteMediaOperationJournal::open(path.as_path(), config(3600, 100))
+            open_settled(path.as_path())
         }));
     }
     barrier.wait();
     for worker in workers {
-        worker.join().unwrap().unwrap();
+        worker.join().unwrap();
     }
 }
 


### PR DESCRIPTION
## What & why

The host operation journal's secure first-open validates the SQLite WAL/SHM sidecars to fail closed on injection. But a concurrent first-open legitimately creates, checkpoints, and truncates those **shared** sidecars out from under a racing opener, and the retry loop recognized only ONE signature of that benign race — the `"appeared after secure preparation"` message-marker string. Its siblings — a sidecar that **vanished**, or whose **identity changed**, mid-validation — fell through as terminal errors and reddened CI (#454).

A 48-racer × 600-iteration stress reproduced **2128 / 28 800** failed opens, dominated by `cannot re-inspect … No such file` (~1762) and `changed after its secure open` (~247) — none of which were retried.

This PR:
- Adds **`MediaError::SidecarRace`**, a typed variant for the benign concurrent-first-open race, and classifies the retry on the *variant* instead of a message substring (**#456**). The compiler now couples `is_sidecar_race` to the sites that raise it.
- Broadens the classification to the whole race class: a sidecar that disappeared, changed identity, or appeared between preparation and validation is the race (retried from scratch); a **still-present** file that fails validation (a stable unsafe mode) stays terminal.
- Bounds the two concurrency witnesses with an outer retry so they cannot false-fail even under pathological CI contention (**#454**).

**Security is unchanged**: every attempt still validates the settled sidecars through the same owner-only 0600 single-link path, the retry is bounded, and the injection defenses (`open_refuses_unsafe_wal_and_shm_sidecars`, `sidecar_appearance_is_rejected_before_sqlite_initialization`) still fail closed.

Closes #454
Closes #456

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`sidecar_appearance_is_rejected_before_sqlite_initialization` now asserts the appeared-sidecar path produces `MediaError::SidecarRace` — on `main` that path returns `MediaError::Artifact`, so the `matches!(…, SidecarRace(_))` assertion fails there and passes here. The two `concurrent_first_open_*` tests were the flaky witnesses; verified deterministic below (repro harness not committed):

- 48-racer stress: **2128** failures on `main` → **0** here (28 800 opens/run).
- 4-racer + 8-racer witnesses: **0** failures over 48 000 stressed opens; **0** over 400 direct test runs.

## The gate

- [x] `cargo fmt --check` (stella-media)
- [x] `cargo clippy -p stella-media --all-targets -- -D warnings`
- [x] `cargo test -p stella-media` (99 unit + 16 integration green); `stella-tools` / `stella-cli` build
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean on this branch; full `cargo test --workspace` not run here — change is confined to `stella-media`, and `MediaError` is never matched exhaustively anywhere (verified), so the new variant cannot break a downstream `match`
- [x] Doc comments updated

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New type `SidecarRace` is internal to `stella-media` (never serialized on the wire)

## Anything reviewers should know?

- `SidecarRace` is deliberately **not** `is_retryable` — it is consumed entirely by the journal's internal first-open loop, never surfaced to a caller's retry.
- One residual I did **not** fold into production: a transient `must be an owner-only 0600 single-link` while the winner's SQLite is mid-creating a sidecar (23 / 28 800 at 48 racers, **0** at 4–8 racers). It shares its message/path with the *stable* pre-existing-unsafe rejection, so typing it as a race would slow/blur that security test; the witnesses' bounded outer retry absorbs it instead. Happy to fold it in if preferred.
- DCO: repo history isn't signed off and there's no DCO check, so commits are left unsigned to match. Can `-s` on request.
