### PR TITLE
chore(model): satisfy cargo fmt in vertex.rs (post-#512 fmt gate) [skip release]

### DIFF
--- a/stella-model/src/vertex.rs
+++ b/stella-model/src/vertex.rs
@@ -289,7 +289,10 @@ mod tests {
         );
         assert!(err.is_retryable(), "a disconnect must be retryable");
         let msg = err.to_string();
-        assert!(msg.contains("Vertex AI"), "names the adapter, not Gemini: {msg}");
+        assert!(
+            msg.contains("Vertex AI"),
+            "names the adapter, not Gemini: {msg}"
+        );
         assert!(
             msg.contains("finishReason"),
             "names the missing terminal event: {msg}"


### PR DESCRIPTION
Main is red on the required `fmt + clippy + test` check: #512 merged a single-line `assert!` in `stella-model/src/vertex.rs` that rustfmt 1.9.0 (pinned 1.97.0) wants wrapped. This blocks every open PR (strict up-to-date pulls main's tree into the merge check). Pure `cargo fmt` output — behavior-identical, 4-line reformat, no logic change.

## Summary by Sourcery

Enhancements:
- Apply cargo fmt style wrapping to a long assert message in the Vertex AI tests for consistency with the pinned rustfmt version.