### PR TITLE
refactor(tools): make adding a tool a one-place change (#450)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Every one of these is genuinely valued — pick the one that fits your energy:
 | 🐛 **A bug report with a repro** | [Bug report form](https://github.com/macanderson/stella/issues/new?template=bug_report.yml) | 10 minutes |
 | 🧭 **Docs & examples** — fix a lie in the README before it fools someone else | Any `*.md` file, `--help` text, doc comments | Small |
 | 🔌 **A new provider adapter** — Stella is BYOK; every model provider we speak makes it more useful | `stella-model/src/` — copy the shape of an existing adapter | Medium |
-| 🛠 **A new built-in tool** | `stella-tools/src/` — implement the tool trait, register it | Medium |
+| 🛠 **A new built-in tool** | `stella-tools/src/` — implement the tool trait, register it in `ToolRegistry`, then declare one line in [`catalog.rs`](stella-tools/src/catalog.rs) | Medium |
 | 🌐 **A Context Graph Protocol (CGP) provider** — implement it in your language and prove it green | [macanderson/context-graph-protocol](https://github.com/macanderson/context-graph-protocol) — its own repo, no Stella code required | Medium |
 | 🏗 **Core engine work** | `good first issue` / `help wanted` labels | Varies |
 

--- a/docs/design/scripts-index.md
+++ b/docs/design/scripts-index.md
@@ -17,8 +17,9 @@ the `stella graph` subcommand:
    `assemble_system_prompt` (`stella-cli/src/agent.rs:141`), computed once at
    session start, byte-stable within the session.
 2. **Tools** — `list_scripts` (read-only) and `run_script` in
-   `stella-tools`, registered in `ToolRegistry::with_backends` and added to
-   `custom::RESERVED_NAMES` (`stella-tools/src/custom.rs:93`).
+   `stella-tools`, registered in `ToolRegistry::with_backends` and declared in
+   the canonical `stella-tools/src/catalog.rs` (which `custom::RESERVED_NAMES`
+   now aliases).
 3. **CLI** — `stella scripts list` / `stella scripts run <id> [-- args]`,
    mirroring the `Graph` subcommand (`stella-cli/src/main.rs:238`), offline
    (short-circuits before provider resolution).

--- a/stella-cli/src/agent/prompt.rs
+++ b/stella-cli/src/agent/prompt.rs
@@ -338,3 +338,59 @@ pub(crate) fn render_file_tree(files: &str, max_lines: usize) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PIPELINE_SYSTEM_PROMPT, SYSTEM_PROMPT};
+
+    use std::collections::BTreeSet;
+
+    /// The issue-tool names both static prompts enumerate, parsed out of the
+    /// `issue tracking (a/b/c)` steering clause.
+    fn steered_issue_tools(prompt: &str) -> BTreeSet<&str> {
+        const OPEN: &str = "issue tracking (";
+        let start = prompt
+            .find(OPEN)
+            .expect("both prompts steer on issue tracking")
+            + OPEN.len();
+        let len = prompt[start..]
+            .find(')')
+            .expect("the steering clause closes its parenthesis");
+        prompt[start..start + len].split('/').collect()
+    }
+
+    /// Witness for #450: the steering line is duplicated verbatim across two
+    /// static prompts, so a new issue tool had to be hand-added in both — the
+    /// kind of duplicated name-list that merges cleanly while going stale.
+    /// Both are now pinned to the canonical catalog.
+    #[test]
+    fn both_prompts_steer_on_exactly_the_catalog_issue_tools() {
+        let expected: BTreeSet<&str> =
+            stella_tools::catalog::names_where(|a| a == stella_tools::catalog::Availability::Issue)
+                .into_iter()
+                .collect();
+
+        for (label, prompt) in [
+            ("SYSTEM_PROMPT", SYSTEM_PROMPT),
+            ("PIPELINE_SYSTEM_PROMPT", PIPELINE_SYSTEM_PROMPT),
+        ] {
+            assert_eq!(
+                steered_issue_tools(prompt),
+                expected,
+                "{label}'s issue-tracking steering line disagrees with \
+                 stella_tools::catalog"
+            );
+        }
+    }
+
+    /// The two prompts are separate string literals; the steering clause is
+    /// meant to be identical in both. Pin that directly so they cannot drift
+    /// apart independently of the catalog.
+    #[test]
+    fn the_two_prompts_agree_with_each_other() {
+        assert_eq!(
+            steered_issue_tools(SYSTEM_PROMPT),
+            steered_issue_tools(PIPELINE_SYSTEM_PROMPT)
+        );
+    }
+}

--- a/stella-docs/content/docs/agent-tools/index.mdx
+++ b/stella-docs/content/docs/agent-tools/index.mdx
@@ -110,7 +110,9 @@ These 42 tools register in every session — no configuration, no prerequisites.
 | `task_assign` | Delegate a board task to a parallel sub-agent — the briefing is passed verbatim, so write it self-contained. | Mutating |
 
 <Callout type="info">
-`verify_done` and `screenshot` are **mutating** in the permission model (`read_only: false`) even though `verify_done` never edits your working tree and `screenshot` only writes into `.stella/`. The read-only partition is exactly: `read_file`, `read_symbol`, `grep`, `glob`, `graph_query`, `project_overview`, `list_scripts`, `gather_context`, `explorations`, `ci_status`, `repo_status`, `task_list`, and (when present) `search_issues`, `get_issue`, `list_labels`, `list_members`, `web_search`, `web_fetch`, `web_extract_assets` — plus `search_skills`, `tool_search`, `skill_search`, and `mcp_search` at the session layer. (`web_download` writes a file, so it is mutating.)
+`verify_done` and `screenshot` are **mutating** in the permission model (`read_only: false`) even though `verify_done` never edits your working tree and `screenshot` only writes into `.stella/`. `web_download` is mutating for the same reason — it writes a file.
+
+The read-only partition is exactly: `read_file`, `read_symbol`, `grep`, `glob`, `graph_query`, `project_overview`, `gather_context`, `explorations`, `diagnostics`, `list_scripts`, `repo_status`, `repo_diff`, `ci_status`, `task_list`, and (when present) `search_issues`, `get_issue`, `list_labels`, `list_members`, `web_fetch`, `web_extract_assets`, `web_search` — plus `search_skills`, `tool_search`, `skill_search`, and `mcp_search` at the session layer.
 </Callout>
 
 ### Conditionally registered

--- a/stella-tools/src/catalog.rs
+++ b/stella-tools/src/catalog.rs
@@ -1,0 +1,310 @@
+//! The canonical tool table — the one place a new built-in is declared.
+//!
+//! Adding a tool used to be a ~6-file edit, and several of those edits were
+//! hardcoded counts or duplicated name-lists: two registry count pins, the
+//! read-only partition, [`crate::custom::RESERVED_NAMES`], and two counts in
+//! the docs. Parallel PRs each bumped the same integer off the same base, so
+//! squash-merging them back-to-back left the count off by N−1 with **no merge
+//! conflict** — a plausible-but-wrong number that only CI (or nothing at all,
+//! on the docs side) caught after the fact.
+//!
+//! This module is the fix. Every built-in — plus the six the CLI layers on
+//! top — is declared exactly once in the [`catalog!`] invocation below, with
+//! its read-only flag and what has to be true for it to register. Everything
+//! that used to be duplicated is now derived from it:
+//!
+//! - the registry's expected-name sets and their counts (`registry.rs` tests),
+//! - the read-only partition (same),
+//! - [`crate::custom::RESERVED_NAMES`] (aliased straight to [`ALL_NAMES`]),
+//! - the "N always-on / up to M native" counts and the read-only set listed in
+//!   the docs (`tests/docs_in_sync.rs`).
+//!
+//! **To add a tool:** register it in
+//! [`ToolRegistry::with_backends_and_options`](crate::registry::ToolRegistry),
+//! then add one line here. Nothing else needs a count bumped. Two PRs adding
+//! different tools now merge to the correct union instead of a wrong integer,
+//! and a tool registered but never declared here fails the registry tests by
+//! *name*, not by an off-by-one.
+
+/// What has to be true for a tool to be registered.
+///
+/// Everything but [`Availability::Session`] is registered by
+/// [`crate::registry::ToolRegistry`] itself; the session tools live in the
+/// CLI's interactive and discovery layers and are listed here only so
+/// [`ALL_NAMES`] can back `RESERVED_NAMES` — a custom manifest must not shadow
+/// them either.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Availability {
+    /// Registers in every session, with no configuration and no prerequisite.
+    Always,
+    /// The `"tools": {"bash": "on"}` settings opt-in.
+    Bash,
+    /// The `"tools": {"web": "on"}` settings opt-in.
+    Web,
+    /// The web opt-in *and* a BYOK search key (`BRAVE_API_KEY`/`TAVILY_API_KEY`).
+    WebSearch,
+    /// An image-capable BYOK media provider key.
+    Media,
+    /// A media provider whose key family also has a video adapter.
+    Video,
+    /// A configured issue backend (Linear/GitHub connection, or ambient `gh`).
+    Issue,
+    /// Layered on by the CLI rather than the native registry — never appears
+    /// in [`crate::registry::ToolRegistry::schemas`].
+    Session,
+}
+
+impl Availability {
+    /// Whether the native [`crate::registry::ToolRegistry`] is what registers
+    /// this tool. False only for [`Availability::Session`].
+    pub const fn is_native(self) -> bool {
+        !matches!(self, Availability::Session)
+    }
+}
+
+/// One row of the canonical table.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolEntry {
+    /// The exact dispatch name — what `schema().name` returns.
+    pub name: &'static str,
+    /// The schema's `read_only` flag. The engine parallelizes on this: a
+    /// mutating tool marked read-only would race writes.
+    pub read_only: bool,
+    /// What has to be true for it to register.
+    pub availability: Availability,
+}
+
+/// Declares the canonical table once and derives every flat name list from it,
+/// so the two can never disagree.
+macro_rules! catalog {
+    ($($name:literal => ($read_only:expr, $availability:expr)),* $(,)?) => {
+        /// Every tool Stella can dispatch by name, sorted, declared once.
+        ///
+        /// See the [module docs](self) for how to add one.
+        pub const CATALOG: &[ToolEntry] = &[
+            $(ToolEntry {
+                name: $name,
+                read_only: $read_only,
+                availability: $availability,
+            }),*
+        ];
+
+        /// Every name in [`CATALOG`], in the same order. Backs
+        /// [`crate::custom::RESERVED_NAMES`].
+        pub const ALL_NAMES: &[&str] = &[$($name),*];
+    };
+}
+
+use Availability::{Always, Bash, Issue, Media, Session, Video, Web, WebSearch};
+
+catalog! {
+    // ---- Always-on: registered in every session ----
+    // File CRUD
+    "read_file"           => (true,  Always),
+    // Graph-resolved span read (reads through the same `read_file` instance)
+    "read_symbol"         => (true,  Always),
+    "write_file"          => (false, Always),
+    "edit_file"           => (false, Always),
+    "apply_edits"         => (false, Always),
+    "delete_file"         => (false, Always),
+    // Search
+    "grep"                => (true,  Always),
+    "glob"                => (true,  Always),
+    "graph_query"         => (true,  Always),
+    // Context & memory
+    "project_overview"    => (true,  Always),
+    "gather_context"      => (true,  Always),
+    "explorations"        => (true,  Always),
+    "save_exploration"    => (false, Always),
+    "save_memory"         => (false, Always),
+    "cite_memory"         => (false, Always),
+    // The definition of done + build/test
+    "verify_done"         => (false, Always),
+    "build_project"       => (false, Always),
+    "run_tests"           => (false, Always),
+    "diagnostics"         => (true,  Always),
+    // Manifest-verb execution (argv, no shell)
+    "run_lint"            => (false, Always),
+    "format_code"         => (false, Always),
+    // The project scripts index (docs/design/scripts-index.md)
+    "list_scripts"        => (true,  Always),
+    "run_script"          => (false, Always),
+    // The long-running process group
+    "start_process"       => (false, Always),
+    "read_output"         => (false, Always),
+    "send_stdin"          => (false, Always),
+    "stop_process"        => (false, Always),
+    // Vendor-neutral repository tools
+    "repo_status"         => (true,  Always),
+    "repo_diff"           => (true,  Always),
+    "repo_commit"         => (false, Always),
+    "repo_push"           => (false, Always),
+    "repo_pull"           => (false, Always),
+    "repo_rollback"       => (false, Always),
+    // CI & evidence
+    "ci_status"           => (true,  Always),
+    "screenshot"          => (false, Always),
+    // generate_svg is client-side, so it needs no media key
+    "generate_svg"        => (false, Always),
+    // The session task board
+    "task_create"         => (false, Always),
+    "task_list"           => (true,  Always),
+    "task_start"          => (false, Always),
+    "task_complete"       => (false, Always),
+    "task_cancel"         => (false, Always),
+    "task_assign"         => (false, Always),
+
+    // ---- Conditionally registered ----
+    "bash"                => (false, Bash),
+    "web_fetch"           => (true,  Web),
+    "web_extract_assets"  => (true,  Web),
+    "web_download"        => (false, Web),
+    "web_search"          => (true,  WebSearch),
+    "generate_image"      => (false, Media),
+    "generate_video"      => (false, Video),
+    "poll_video"          => (false, Video),
+    // Issue tracking
+    "create_issue"        => (false, Issue),
+    "update_issue"        => (false, Issue),
+    "close_issue"         => (false, Issue),
+    "search_issues"       => (true,  Issue),
+    "get_issue"           => (true,  Issue),
+    "list_labels"         => (true,  Issue),
+    "list_members"        => (true,  Issue),
+    "start_work_on_issue" => (false, Issue),
+
+    // ---- CLI session layer (never in the native registry) ----
+    "ask_user"            => (false, Session),
+    "search_skills"       => (true,  Session),
+    "install_skill"       => (false, Session),
+    "tool_search"         => (true,  Session),
+    "skill_search"        => (true,  Session),
+    "mcp_search"          => (true,  Session),
+}
+
+/// Look up a tool's canonical row by dispatch name.
+pub fn get(name: &str) -> Option<&'static ToolEntry> {
+    CATALOG.iter().find(|entry| entry.name == name)
+}
+
+/// Names whose [`Availability`] satisfies `pred`, sorted.
+///
+/// Sorted so callers can compare against a registry's schemas directly —
+/// `schemas()` is name-sorted for prompt-cache stability.
+pub fn names_where(pred: impl Fn(Availability) -> bool) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = CATALOG
+        .iter()
+        .filter(|entry| pred(entry.availability))
+        .map(|entry| entry.name)
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// The tools that register in every session, with no prerequisite — the
+/// "always-on" count the docs quote.
+pub fn always_on() -> Vec<&'static str> {
+    names_where(|a| a == Availability::Always)
+}
+
+/// Every tool the native registry can register, with every opt-in enabled and
+/// every backend configured — the "up to M native" ceiling the docs quote.
+/// Excludes the CLI session layer.
+pub fn native() -> Vec<&'static str> {
+    names_where(Availability::is_native)
+}
+
+/// The always-on set plus the issue tools — what a registry with a configured
+/// issue backend and no opt-ins advertises.
+pub fn always_on_with_issues() -> Vec<&'static str> {
+    names_where(|a| matches!(a, Availability::Always | Availability::Issue))
+}
+
+/// The read-only partition across the whole catalog, sorted. The engine
+/// speculates exactly this set.
+pub fn read_only() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = CATALOG
+        .iter()
+        .filter(|entry| entry.read_only)
+        .map(|entry| entry.name)
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// A duplicated row would make every derived count silently too high and
+    /// let two rows disagree on `read_only` for the same dispatch name.
+    #[test]
+    fn catalog_names_are_unique() {
+        let mut seen = HashSet::new();
+        for entry in CATALOG {
+            assert!(
+                seen.insert(entry.name),
+                "duplicate catalog entry for `{}`",
+                entry.name
+            );
+        }
+        assert_eq!(seen.len(), ALL_NAMES.len());
+    }
+
+    /// `ALL_NAMES` is macro-derived from the same rows as `CATALOG`; this pins
+    /// that the macro keeps them aligned rather than merely equal in length.
+    #[test]
+    fn all_names_mirrors_the_catalog() {
+        let from_catalog: Vec<&str> = CATALOG.iter().map(|entry| entry.name).collect();
+        assert_eq!(from_catalog, ALL_NAMES);
+    }
+
+    /// The declaration order is the order a reader scans, and `names_where`
+    /// sorts anyway — but an alphabetized block is where a new tool goes
+    /// without thinking, so keep the availability blocks contiguous.
+    #[test]
+    fn availability_blocks_are_contiguous() {
+        let mut seen_blocks: Vec<Availability> = vec![];
+        for entry in CATALOG {
+            if seen_blocks.last() != Some(&entry.availability) {
+                assert!(
+                    !seen_blocks.contains(&entry.availability),
+                    "`{}` reopens the {:?} block — keep each availability \
+                     contiguous so a new tool has one obvious home",
+                    entry.name,
+                    entry.availability
+                );
+                seen_blocks.push(entry.availability);
+            }
+        }
+    }
+
+    #[test]
+    fn derived_views_partition_the_catalog() {
+        assert_eq!(
+            always_on().len() + names_where(|a| a != Availability::Always).len(),
+            CATALOG.len()
+        );
+        // Native + session is the whole table, with no overlap.
+        let native_count = native().len();
+        let session_count = names_where(|a| a == Availability::Session).len();
+        assert_eq!(native_count + session_count, CATALOG.len());
+        // The always-on set is a subset of the native set.
+        let native_set: HashSet<&str> = native().into_iter().collect();
+        for name in always_on() {
+            assert!(native_set.contains(name), "{name} must be native");
+        }
+    }
+
+    #[test]
+    fn lookup_finds_entries_by_dispatch_name() {
+        assert!(get("read_file").expect("read_file is canonical").read_only);
+        assert!(
+            !get("write_file")
+                .expect("write_file is canonical")
+                .read_only
+        );
+        assert!(get("no_such_tool").is_none());
+    }
+}

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -85,96 +85,18 @@ use stella_protocol::tool::{ToolOutput, ToolSchema};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-/// Tool names that a custom manifest may not claim. Mirrors every built-in
-/// registered in [`crate::registry::ToolRegistry`] (including the conditional
-/// issue tools) plus `ask_user`/`search_skills`/`install_skill` from the CLI's
-/// `interactive` layer — a custom tool must never shadow one, or the decorator
-/// chain (native ← custom ← mcp ← ask_user) would route the wrong executor and
-/// a manifest named e.g. `verify_done` or `delete_file` could silently replace
-/// a flagship built-in. Keep this in sync if either set changes.
-pub const RESERVED_NAMES: &[&str] = &[
-    "project_overview",
-    // File CRUD
-    "read_file",
-    // Graph-resolved span read (reads through the same `read_file` instance)
-    "read_symbol",
-    "write_file",
-    "edit_file",
-    "apply_edits",
-    "delete_file",
-    // Search
-    "grep",
-    "glob",
-    // Manifest-verb execution (argv, no shell)
-    "run_lint",
-    "format_code",
-    // The long-running process group
-    "start_process",
-    "read_output",
-    "send_stdin",
-    "stop_process",
-    // Vendor-neutral repository tools
-    "repo_status",
-    "repo_diff",
-    "repo_commit",
-    "repo_push",
-    "repo_pull",
-    "repo_rollback",
-    // Codebase maps & memory
-    "explorations",
-    "save_exploration",
-    "gather_context",
-    "save_memory",
-    "cite_memory",
-    // The definition of done + build/test
-    "verify_done",
-    "build_project",
-    "run_tests",
-    "diagnostics",
-    // The project scripts index (docs/design/scripts-index.md)
-    "list_scripts",
-    "run_script",
-    // CI & evidence
-    "ci_status",
-    "screenshot",
-    // Media generation: generate_svg is client-side and always registered.
-    "generate_svg",
-    // The session task board
-    "task_create",
-    "task_list",
-    "task_start",
-    "task_complete",
-    "task_cancel",
-    "task_assign",
-    // Conditionally registered tools: bash only when the settings opt-in
-    // (`tools.bash: "on"`) enabled it, graph_query only when a code-graph
-    // index exists, generate_image (and the video pair, when the key family
-    // has a video adapter) only when a media key is configured. The
-    // registry-driven drift test can't see these (a bare registry never
-    // advertises them), so they must be listed here by hand.
-    "bash",
-    "graph_query",
-    "generate_image",
-    "generate_video",
-    "poll_video",
-    // Issue tracking (registered only when a backend is configured)
-    "create_issue",
-    "update_issue",
-    "close_issue",
-    "search_issues",
-    "get_issue",
-    "list_labels",
-    "list_members",
-    "start_work_on_issue",
-    // CLI interactive layer
-    "ask_user",
-    "search_skills",
-    "install_skill",
-    // CLI discovery layer (tool/skill/MCP-server search — stella-cli::discovery)
-    "tool_search",
-    "skill_search",
-    "mcp_search",
-];
+/// Tool names that a custom manifest may not claim — every name in the
+/// canonical [`crate::catalog`], which covers every built-in registered in
+/// [`crate::registry::ToolRegistry`] (including the conditionally-registered
+/// bash/web/media/issue tools) plus the six the CLI layers on top. A custom
+/// tool must never shadow one, or the decorator chain
+/// (native ← custom ← mcp ← ask_user) would route the wrong executor and a
+/// manifest named e.g. `verify_done` or `delete_file` could silently replace a
+/// flagship built-in.
+///
+/// This is an alias, not a copy: declaring a tool in the catalog reserves its
+/// name automatically, so the two can no longer drift apart.
+pub const RESERVED_NAMES: &[&str] = crate::catalog::ALL_NAMES;
 
 /// Timeout applied when a manifest omits `timeout_ms`. Public so
 /// [`crate::validate`] can explain the defaulting it mirrors.

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod agent_use;
 pub mod apply_edits;
 pub mod bash;
+pub mod catalog;
 pub mod ci;
 pub mod code_map;
 pub mod custom;

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -1555,102 +1555,78 @@ mod tests {
 
     #[test]
     fn every_registry_tool_is_reserved_against_custom_shadowing() {
-        // RESERVED_NAMES (custom.rs) hand-mirrors the registry so a custom
-        // manifest can never shadow a built-in. Its comment says "keep this
-        // in sync if either set changes" — this test IS that sync: a new
-        // built-in that isn't reserved would be silently shadowable.
+        // RESERVED_NAMES is now an alias for catalog::ALL_NAMES rather than a
+        // hand-mirrored copy (#450), so declaring a tool reserves it. What
+        // still needs proving is the *other* direction: a tool that registers
+        // but was never declared is shadowable by a custom manifest.
         let (_root, reg) = bare_registry(Some(IssueBackend::GitHub));
         for schema in reg.schemas() {
             assert!(
                 crate::custom::RESERVED_NAMES.contains(&schema.name.as_str()),
                 "built-in tool `{}` is missing from custom::RESERVED_NAMES — \
-                 a custom manifest could shadow it",
+                 declare it in stella-tools/src/catalog.rs, or a custom \
+                 manifest could shadow it",
                 schema.name
             );
         }
 
         // Conditionally-registered tools never show up in a bare registry's
-        // schemas (graph_query needs an index on disk, the media tools need a
-        // capable key), so the registry-driven loop above can't catch them
-        // drifting out of RESERVED_NAMES. Pin them explicitly — if you add a
-        // new conditionally-registered tool, add its name to this array.
-        const CONDITIONALLY_REGISTERED: &[&str] = &[
-            "bash",
-            "graph_query",
-            "generate_image",
-            "generate_video",
-            "poll_video",
-        ];
-        for name in CONDITIONALLY_REGISTERED {
+        // schemas (the media tools need a capable key, the web tools an
+        // opt-in), so the registry-driven loop above can't reach them. The
+        // catalog declares them, and the alias reserves them — assert the
+        // conditional half of the table is genuinely covered.
+        for name in crate::catalog::names_where(|a| {
+            a != crate::catalog::Availability::Always && a.is_native()
+        }) {
             assert!(
-                crate::custom::RESERVED_NAMES.contains(name),
-                "conditionally-registered tool `{name}` is missing from \
-                 custom::RESERVED_NAMES — a custom manifest could shadow it"
+                crate::custom::RESERVED_NAMES.contains(&name),
+                "conditionally-registered tool `{name}` is not reserved"
             );
+        }
+        // The CLI's session layer is reserved too — it is not in any registry.
+        for name in ["ask_user", "tool_search", "install_skill"] {
+            assert!(crate::custom::RESERVED_NAMES.contains(&name), "{name}");
         }
     }
 
+    /// Witness for #450: the advertised set is pinned as an exact **name set**
+    /// against the canonical catalog, not as a count. A magic-number pin
+    /// (`names.len() == 50`) merges to a plausible-but-wrong integer when two
+    /// parallel PRs each bump it off the same base — this fails by name
+    /// instead, naming exactly what was added or dropped.
     #[test]
-    fn registry_advertises_the_full_tool_set() {
+    fn registry_advertises_exactly_the_catalog_tool_set() {
         let (_root, reg) = bare_registry(Some(IssueBackend::GitHub));
-        let names: Vec<String> = reg.schemas().iter().map(|s| s.name.clone()).collect();
-        for expected in [
-            "read_file",
-            "read_symbol",
-            "write_file",
-            "edit_file",
-            "apply_edits",
-            "delete_file",
-            "grep",
-            "glob",
-            "gather_context",
-            "explorations",
-            "save_exploration",
-            "save_memory",
-            "cite_memory",
-            "verify_done",
-            "build_project",
-            "run_tests",
-            "diagnostics",
-            "run_lint",
-            "format_code",
-            "list_scripts",
-            "run_script",
-            "start_process",
-            "read_output",
-            "send_stdin",
-            "stop_process",
-            "repo_status",
-            "repo_diff",
-            "repo_commit",
-            "repo_push",
-            "repo_pull",
-            "repo_rollback",
-            "ci_status",
-            "screenshot",
-            "generate_svg",
-            "task_create",
-            "task_list",
-            "task_start",
-            "task_complete",
-            "task_cancel",
-            "task_assign",
-            "create_issue",
-            "update_issue",
-            "close_issue",
-            "search_issues",
-            "get_issue",
-            "list_labels",
-            "list_members",
-            "start_work_on_issue",
-            "project_overview",
-            "graph_query",
-        ] {
-            assert!(names.contains(&expected.to_string()), "missing {expected}");
-        }
+        let schemas = reg.schemas();
+        let names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            crate::catalog::always_on_with_issues(),
+            "registry disagrees with catalog::CATALOG — register the tool, or \
+             add/remove its line in stella-tools/src/catalog.rs"
+        );
         // `bash` is NOT in the default surface — it is the settings opt-in.
-        assert!(!names.contains(&"bash".to_string()), "{names:?}");
-        assert_eq!(names.len(), 50, "unexpected tool count: {names:?}");
+        assert!(!names.contains(&"bash"), "{names:?}");
+    }
+
+    /// Witness for #450: a tool that registers but was never declared in the
+    /// catalog is caught by *name*. Simulated here by dropping a name from the
+    /// expectation — the same failure a real unregistered tool produces.
+    #[test]
+    fn an_undeclared_tool_fails_the_catalog_pin_by_name() {
+        let (_root, reg) = bare_registry(Some(IssueBackend::GitHub));
+        let schemas = reg.schemas();
+        let live: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
+        let mut catalog_missing_one = crate::catalog::always_on_with_issues();
+        let dropped = catalog_missing_one.pop().expect("catalog is non-empty");
+        assert_ne!(
+            live, catalog_missing_one,
+            "a catalog missing `{dropped}` must not compare equal to the live \
+             registry — otherwise the pin cannot catch an undeclared tool"
+        );
+        // And the difference is reported as a name, not an arity.
+        assert!(!catalog_missing_one.contains(&dropped));
+        assert!(live.contains(&dropped));
     }
 
     // bash opt-in (default OFF everywhere)
@@ -1774,22 +1750,17 @@ mod tests {
     #[test]
     fn issue_tools_absent_without_a_configured_backend() {
         let (_root, reg) = bare_registry(None);
-        let names: Vec<String> = reg.schemas().iter().map(|s| s.name.clone()).collect();
-        assert_eq!(names.len(), 42, "unexpected tool count: {names:?}");
-        for absent in [
-            "create_issue",
-            "update_issue",
-            "close_issue",
-            "search_issues",
-            "get_issue",
-            "list_labels",
-            "list_members",
-            "start_work_on_issue",
-        ] {
-            assert!(
-                !names.contains(&absent.to_string()),
-                "{absent} must be absent"
-            );
+        let schemas = reg.schemas();
+        let names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
+        // The no-backend surface is a *filtered view* of the same canonical
+        // table, not a second count to keep in sync (#450).
+        assert_eq!(
+            names,
+            crate::catalog::always_on(),
+            "the no-backend registry must be exactly the always-on catalog"
+        );
+        for absent in crate::catalog::names_where(|a| a == crate::catalog::Availability::Issue) {
+            assert!(!names.contains(&absent), "{absent} must be absent");
         }
     }
 
@@ -1955,31 +1926,18 @@ mod tests {
         // The engine parallelizes on this flag — a mutating tool marked
         // read-only would race writes; a read-only tool marked mutating
         // just loses concurrency. Pin the partition explicitly.
+        // The expectation is the canonical catalog's flag, so the partition
+        // lives in one place rather than being restated here (#450).
         let (_root, reg) = bare_registry(Some(IssueBackend::GitHub));
         for schema in reg.schemas() {
-            let expected = matches!(
-                schema.name.as_str(),
-                "read_file"
-                    | "read_symbol"
-                    | "grep"
-                    | "glob"
-                    | "gather_context"
-                    | "explorations"
-                    | "diagnostics"
-                    | "list_scripts"
-                    | "ci_status"
-                    | "search_issues"
-                    | "task_list"
-                    | "project_overview"
-                    | "graph_query"
-                    | "get_issue"
-                    | "list_labels"
-                    | "list_members"
-                    | "repo_status"
-                    | "repo_diff"
-            );
+            let entry = crate::catalog::get(&schema.name).unwrap_or_else(|| {
+                panic!(
+                    "`{}` registers but is not declared in catalog::CATALOG",
+                    schema.name
+                )
+            });
             assert_eq!(
-                schema.read_only, expected,
+                schema.read_only, entry.read_only,
                 "read_only flag wrong for {}",
                 schema.name
             );

--- a/stella-tools/tests/docs_in_sync.rs
+++ b/stella-tools/tests/docs_in_sync.rs
@@ -1,0 +1,297 @@
+//! Witness for #450: the docs cannot silently drift from the tool registry.
+//!
+//! The counts in `agent-tools/index.mdx` ("N always-on tools, up to M native")
+//! used to be hand-maintained integers. Two parallel PRs each bumping them off
+//! the same base merge without a conflict marker and land a
+//! plausible-but-wrong number — and unlike the registry's own pins, nothing
+//! caught it: the docs just drifted. (They had. Before this test, the
+//! read-only partition prose in `index.mdx` was missing `diagnostics` and
+//! `repo_diff`.)
+//!
+//! Every assertion here derives its expectation from
+//! [`stella_tools::catalog`], the one place a tool is declared. Adding a tool
+//! without documenting it — or documenting it with the wrong access marker —
+//! fails this test by name.
+
+use stella_tools::catalog::{self, Availability};
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// The docs live in a sibling crate, so resolve up out of this one.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("stella-tools has a parent directory")
+        .to_path_buf()
+}
+
+/// The docs tree, or `None` when it isn't present — a packaged/vendored
+/// `stella-tools` ships without its sibling crates, and this suite is a
+/// repo-hygiene gate, not a runtime invariant.
+///
+/// Note the granularity: a *missing tree* skips, but a missing **file inside
+/// a present tree** still fails. Renaming `index.mdx` must not silently
+/// disable the gate.
+fn docs_root() -> Option<PathBuf> {
+    let dir = repo_root().join("stella-docs");
+    dir.is_dir().then_some(dir)
+}
+
+fn read_doc(relative: &str) -> Option<String> {
+    let path = docs_root()?.join(relative);
+    Some(
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} is missing or unreadable: {e}", path.display())),
+    )
+}
+
+/// Every `` `name` `` span in `text`, in order, with the backticks stripped.
+fn backticked(text: &str) -> Vec<String> {
+    let mut out = vec![];
+    let mut rest = text;
+    while let Some(open) = rest.find('`') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('`') else { break };
+        out.push(after[..close].to_string());
+        rest = &after[close + 1..];
+    }
+    out
+}
+
+/// The tool names the docs enumerate in a prose sentence — everything
+/// backticked between `marker` and the end of that line.
+fn names_in_sentence(text: &str, marker: &str) -> BTreeSet<String> {
+    let start = text
+        .find(marker)
+        .unwrap_or_else(|| panic!("the docs no longer contain the marker {marker:?}"));
+    let line = text[start..].lines().next().expect("a marker has a line");
+    backticked(line).into_iter().collect()
+}
+
+/// The integer written as `{before}N{after}`.
+///
+/// Both sides are required so the needle can't drift onto an unrelated
+/// sentence: `"These "` alone would happily match new prose added above the
+/// catalog and then fail with a baffling message. Scans every occurrence and
+/// takes the first that satisfies the whole shape.
+fn count_between(text: &str, before: &str, after: &str) -> usize {
+    for (offset, _) in text.match_indices(before) {
+        let rest = &text[offset + before.len()..];
+        let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        if digits.is_empty() || !rest[digits.len()..].starts_with(after) {
+            continue;
+        }
+        return digits.parse().expect("a run of ASCII digits parses");
+    }
+    panic!("the docs no longer contain the phrase {before:?}<number>{after:?}")
+}
+
+/// Every markdown table row whose first cell is a single backticked name,
+/// paired with that row's access marker. Splitting on `|` is safe because the
+/// helper demands the access cell be *exactly* `Read-only` or `Mutating`, so a
+/// pipe inside a description can only ever cause a loud miss, never a false
+/// pass.
+fn documented_tools(text: &str) -> Vec<(String, bool)> {
+    let mut out = vec![];
+    for line in text.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
+        let Some(first) = cells.first() else { continue };
+        // The name cell is exactly one backticked identifier.
+        let names = backticked(first);
+        if names.len() != 1 || first.trim_matches('`') != names[0] {
+            continue;
+        }
+        let reads = cells.iter().filter(|c| **c == "Read-only").count();
+        let mutates = cells.iter().filter(|c| **c == "Mutating").count();
+        let read_only = match reads + mutates {
+            1 => reads == 1,
+            n => panic!(
+                "row for `{}` has {n} access cells — expected exactly one \
+                 `Read-only` or `Mutating`",
+                names[0]
+            ),
+        };
+        out.push((names[0].clone(), read_only));
+    }
+    out
+}
+
+const INDEX: &str = "content/docs/agent-tools/index.mdx";
+const PERMISSIONS: &str = "content/docs/agent-tools/permissions.mdx";
+
+/// The headline counts are derived, not typed. This is the exact failure the
+/// #336 wave-1 merge produced: four PRs, each +1, landing as +1.
+#[test]
+fn docs_counts_match_the_catalog() {
+    let Some(index) = read_doc(INDEX) else { return };
+
+    let always_on = catalog::always_on().len();
+    let native = catalog::native().len();
+
+    assert_eq!(
+        count_between(&index, "These ", " tools register in every session"),
+        always_on,
+        "the \"These N tools register in every session\" count is stale — \
+         catalog::always_on() has {always_on}"
+    );
+    assert_eq!(
+        count_between(&index, "All told: ", " always-on tools"),
+        always_on,
+        "the \"All told: N always-on tools\" count is stale — \
+         catalog::always_on() has {always_on}"
+    );
+    assert_eq!(
+        count_between(&index, "up to ", " native tools"),
+        native,
+        "the \"up to M native tools\" ceiling is stale — catalog::native() \
+         has {native}"
+    );
+}
+
+/// Adding a tool to the registry without adding its docs row fails here, by
+/// name — the second failure class from the #336 wave-1 merge.
+#[test]
+fn every_catalog_tool_is_documented_and_vice_versa() {
+    let Some(index) = read_doc(INDEX) else { return };
+
+    let documented: BTreeSet<String> = documented_tools(&index)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    let declared: BTreeSet<String> = catalog::CATALOG
+        .iter()
+        .map(|entry| entry.name.to_string())
+        .collect();
+
+    let undocumented: Vec<&String> = declared.difference(&documented).collect();
+    assert!(
+        undocumented.is_empty(),
+        "declared in catalog.rs but absent from {INDEX}: {undocumented:?}"
+    );
+    let unknown: Vec<&String> = documented.difference(&declared).collect();
+    assert!(
+        unknown.is_empty(),
+        "documented in {INDEX} but not declared in catalog.rs: {unknown:?}"
+    );
+}
+
+/// The docs' per-tool Read-only/Mutating marker is the same partition the
+/// engine speculates on. A row that disagrees tells a reader a mutating tool
+/// is safe to run.
+#[test]
+fn documented_access_markers_match_the_catalog() {
+    let Some(index) = read_doc(INDEX) else { return };
+
+    for (name, documented_read_only) in documented_tools(&index) {
+        let entry = catalog::get(&name)
+            .unwrap_or_else(|| panic!("`{name}` is documented but not declared in catalog.rs"));
+        assert_eq!(
+            documented_read_only,
+            entry.read_only,
+            "{INDEX} marks `{name}` as {} but the catalog says {}",
+            if documented_read_only {
+                "Read-only"
+            } else {
+                "Mutating"
+            },
+            if entry.read_only {
+                "read_only: true"
+            } else {
+                "read_only: false"
+            },
+        );
+    }
+}
+
+/// The prose partition in `index.mdx` covers the whole surface, session layer
+/// included. It was missing `diagnostics` and `repo_diff` when this test was
+/// written — exactly the silent doc drift #450 is about.
+#[test]
+fn index_read_only_prose_matches_the_catalog() {
+    let Some(index) = read_doc(INDEX) else { return };
+
+    let documented = names_in_sentence(&index, "The read-only partition is exactly:");
+    let expected: BTreeSet<String> = catalog::read_only()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        documented, expected,
+        "the read-only prose in {INDEX} disagrees with catalog::read_only()"
+    );
+}
+
+/// `permissions.mdx` scopes its list to the built-in catalog — the native
+/// registry, without the CLI's session layer.
+#[test]
+fn permissions_read_only_prose_matches_the_native_catalog() {
+    let Some(permissions) = read_doc(PERMISSIONS) else {
+        return;
+    };
+
+    let documented = names_in_sentence(&permissions, "The authoritative read-only set");
+    let expected: BTreeSet<String> = catalog::CATALOG
+        .iter()
+        .filter(|entry| entry.read_only && entry.availability.is_native())
+        .map(|entry| entry.name.to_string())
+        .collect();
+    assert_eq!(
+        documented, expected,
+        "the read-only prose in {PERMISSIONS} disagrees with the native \
+         read-only catalog"
+    );
+}
+
+/// The session layer is counted in prose as a word, so it needs its own pin.
+#[test]
+fn session_tool_count_prose_matches_the_catalog() {
+    let Some(index) = read_doc(INDEX) else { return };
+
+    let session = catalog::names_where(|a| a == Availability::Session).len();
+    let spelled = match session {
+        6 => "**six**",
+        n => panic!(
+            "the session-tool count changed to {n} — update the prose in \
+             {INDEX} (\"layers **six** more tools\", \"plus the six session \
+             tools\") and this test's spelling table"
+        ),
+    };
+    assert!(
+        index.contains(&format!("layers {spelled} more tools")),
+        "{INDEX} no longer spells the session-tool count as {spelled}"
+    );
+    assert!(
+        index.contains("plus the six session tools"),
+        "{INDEX} no longer spells the session-tool count in the summary line"
+    );
+}
+
+/// The parser is what makes the rest of this file meaningful: if it silently
+/// matched nothing, every set-equality above would pass vacuously.
+#[test]
+fn the_table_parser_actually_finds_rows() {
+    let sample = "\
+| Tool | Description | Access |
+| --- | --- | --- |
+| `read_file` | Read a file. | Read-only |
+| `write_file` | Write a file. | Mutating |
+| not a tool | filler | Read-only |
+";
+    assert_eq!(
+        documented_tools(sample),
+        vec![
+            ("read_file".to_string(), true),
+            ("write_file".to_string(), false),
+        ]
+    );
+    assert_eq!(backticked("a `b` c `d`"), vec!["b", "d"]);
+    // The decoy `up to 9 native things` must be skipped for the real phrase.
+    let prose = "up to 9 native things. All told: 42 always-on tools, up to 58 native tools.";
+    assert_eq!(count_between(prose, "up to ", " native tools"), 58);
+    assert_eq!(count_between(prose, "All told: ", " always-on tools"), 42);
+}


### PR DESCRIPTION
## What & why

Adding a built-in tool was a ~6-file edit whose worst parts were **hardcoded counts and duplicated name-lists that merge cleanly while going wrong** — exactly the failure that left `main` red after epic #336 wave 1 and needed reconcile PR #387.

This makes it a one-place change. New `stella-tools/src/catalog.rs` declares every tool exactly once — name, `read_only` flag, and what has to be true for it to register. A small macro emits both `CATALOG` and `ALL_NAMES` from the *same rows*, so the two cannot disagree. Everything that used to be duplicated now derives from it:

| Was | Now |
|---|---|
| `assert_eq!(names.len, 50)` and `== 42` in `registry.rs` | exact **name-set** equality against the catalog |
| an 18-arm `matches!` restating the read-only partition | each tool's canonical `read_only` flag |
| `custom::RESERVED_NAMES`, hand-mirrored | `pub const RESERVED_NAMES: &[&str] = catalog::ALL_NAMES;` |
| `CONDITIONALLY_REGISTERED`, a hand-kept sub-list | derived filter over the catalog |
| the issue-tool steering clause, duplicated in **both** static prompts | both pinned to the catalog, and to each other |
| "42 always-on / up to 58 native" typed into `index.mdx` | derived and asserted in a test |

New `stella-tools/tests/docs_in_sync.rs` checks the docs against the same table: both headline counts, every tool table row (set equality both directions), each row's Read-only/Mutating marker, and the read-only prose in `index.mdx` **and** `permissions.mdx`. It's a plain `#[test]`, so it rides the existing `cargo test --workspace` gate — no new CI wiring.

**Adding a tool is now: register it in `ToolRegistry`, then add one line to `catalog.rs`.** Two PRs adding different tools merge to the correct union instead of a wrong integer, and a tool registered but never declared fails by *name*, not by an off-by-N.

Closes #450

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`index_read_only_prose_matches_the_catalog` **fails on `main`**: the read-only partition prose in `agent-tools/index.mdx` was missing `diagnostics` and `repo_diff`. That is live, already-shipped doc drift of exactly the class #450 describes — found by writing the test, fixed in this PR.

The registry-side change is a refactor (`main` was internally consistent at the time), so it converts a *failure mode* rather than fixing a present bug. I verified it discriminates with a negative control: deleting one row from `catalog.rs` while the registry still registers the tool fails 7 tests, each naming `diagnostics` —

```
registry disagrees with catalog::CATALOG — register the tool, or add/remove its line in stella-tools/src/catalog.rs
`diagnostics` registers but is not declared in catalog::CATALOG
documented in content/docs/agent-tools/index.mdx but not declared in catalog.rs: ["diagnostics"]
```

— versus the old pin, which would have said only `unexpected tool count`. Simulating the #336 outcome (four +1 PRs landing as +1) in the docs fails with `left: 43 / right: 42`.

Two tests guard the harness itself so nothing passes vacuously: `an_undeclared_tool_fails_the_catalog_pin_by_name` and `the_table_parser_actually_finds_rows`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 56 test binaries, 0 failures
- [x] Docs updated (`index.mdx` drift fixed; `CONTRIBUTING.md` and `docs/design/scripts-index.md` now point at the catalog)
- [x] Commits signed off for DCO — not signed off, matching current practice on `main`; say the word and I'll redo it

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies** — the `.mdx` parsing is plain `str` work specifically to avoid adding `regex` as a dev-dep (it would be new to the workspace and subject to `cargo deny check bans sources`)
- [x] No new outbound network calls

## Anything reviewers should know?

- **First test in the repo that reads a sibling crate's files.** It resolves `CARGO_MANIFEST_DIR/../stella-docs`. If that directory is absent (a packaged/vendored crate) the tests skip; if the directory is present but a file inside it is missing, they **fail** — so renaming `index.mdx` can't silently disable the gate.
- **The count markers are two-sided** (`count_between("These ", " tools register in every session")`) rather than a bare needle, so new prose can't drift the match onto an unrelated sentence.
- `catalog.rs` also carries the CLI's six session tools (`ask_user`, `tool_search`, …). They're not registered by `ToolRegistry` — they're there because `RESERVED_NAMES` must still reserve them, and `Availability::Session` keeps them out of the native counts.
- **Rejected alternative:** deriving `RESERVED_NAMES` via a `const fn` — you can't build a `&[&str]` of dynamic length in const context. The declarative macro emitting both consts from one row-set was the way to get a genuine single source rather than a test asserting two lists match.
- Prose that spells counts as *words* ("layers **six** more tools") can't be templated, so `session_tool_count_prose_matches_the_catalog` panics with instructions if the session count ever changes.
