### PR TITLE
feat(stella-pipeline): gate golden trajectories and pin the reference-engine gap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,13 @@ test-cli: ## Test stella-cli only (the shipping binary)
 test-protocol: ## Test stella-protocol only (shared types)
 	cargo test -p stella-protocol
 
+.PHONY: record-golden
+record-golden: ## Re-record the golden replay trajectories (review the fixture diff!)
+	STELLA_REFRESH_GOLDEN=1 cargo test -p stella-pipeline --lib golden
+	@git --no-pager diff --stat -- stella-pipeline/tests/fixtures/golden || true
+	@echo "Golden trajectories re-recorded. A non-empty diff above is a change to"
+	@echo "the observable event contract — review it as such before committing."
+
 .PHONY: bench-test
 bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer)
 	cd bench/harbor_adapter && uv sync --locked --extra dev && uv run --no-sync pytest -q

--- a/docs/replay-golden-trajectories.md
+++ b/docs/replay-golden-trajectories.md
@@ -1,0 +1,159 @@
+# Golden replay trajectories
+
+How the golden-trajectory fixtures are recorded and refreshed, and what a
+**reference** engine has to do before its runs can join them.
+
+Machinery: `stella-pipeline/src/replay.rs` (`validate_stream`,
+`structural_diff`, `streams_equivalent`) and
+`stella-pipeline/src/replay/golden.rs` (the fixture format and its load gates).
+
+---
+
+## Two kinds of recording, deliberately not interchangeable
+
+A golden's manifest names its `source`, and the distinction is load-bearing:
+
+| Source | What it is | What it proves |
+|---|---|---|
+| `rust_stack` | Recorded from this workspace's own pipeline | **Drift baseline.** Catches a stage that stopped being emitted, a tool that changed name, an event that moved or vanished. Both sides are the same code, so it is not independent evidence. |
+| `reference` | Recorded from another engine through an adapter that emits this protocol | **Reference trajectory.** The only kind that answers "does the Rust stack agree with the reference implementation?" |
+
+Encoding this in the fixture rather than in prose is what stops a baseline from
+being cited later as a reference. `RecordingSource::is_reference()` is asserted
+in `stella-pipeline/src/pipeline/tests/golden.rs`.
+
+Today every committed golden is a `rust_stack` baseline. No `reference`
+recording exists — see [The reference-engine gap](#the-reference-engine-gap).
+
+---
+
+## The fixture format
+
+Two files per task under `stella-pipeline/tests/fixtures/golden/`:
+
+- `<task_id>.jsonl` — one `AgentEvent` per line, the same wire format
+  `stella run --output-format stream-json` emits.
+- `<task_id>.manifest.json` — `task_id`, a one-line `description`, the
+  `source`, and `event_count`.
+
+`event_count` is not decoration. `parse_jsonl` deliberately tolerates a torn
+final line (L-T1) — correct for a live reader recovering from a crashed writer,
+and exactly wrong for a committed fixture, where it would silently hand back a
+recording one event short and weaken every assertion made against it. The count
+turns that into a loud `GoldenError::Truncated`.
+
+`GoldenTrajectory::load` additionally refuses:
+
+- a recording that is not parseable as an `AgentEvent` stream
+  (`GoldenError::Recording`) — this is what a foreign wire format produces;
+- a manifest whose `task_id` disagrees with the file it was loaded as
+  (`GoldenError::TaskIdMismatch`);
+- a recording that violates the protocol's own structural invariants
+  (`GoldenError::NotWellFormed`). A golden is the yardstick other runs are
+  measured against; an ill-formed one would license ill-formed runs.
+
+---
+
+## Recording and refreshing
+
+```bash
+make record-golden        # re-record every golden from the current code
+```
+
+or directly:
+
+```bash
+STELLA_REFRESH_GOLDEN=1 cargo test -p stella-pipeline --lib golden
+```
+
+The recorders live in `stella-pipeline/src/pipeline/tests/golden.rs`. Each
+drives the real `Pipeline` over scripted model/test ports and records the
+stream it actually emits — deterministic, no API key, runnable in CI, which is
+the only reason a recording can be asserted on every `cargo test` instead of
+refreshed by hand and hoped over.
+
+**A non-empty fixture diff is a change to the observable event contract.**
+Review it as one. If the change is intended, commit the refreshed fixture with
+the change that caused it; if it is not, you have found a regression.
+
+### Adding a task
+
+1. Add a `#[tokio::test]` to `stella-pipeline/src/pipeline/tests/golden.rs`
+   that drives the pipeline over scripted ports and ends in `check_golden`.
+2. Run `make record-golden` to write the fixture.
+3. Read the recorded `.jsonl`. It is evidence — confirm it is the flow you
+   meant to capture.
+4. Keep the set discriminating: `the_recorded_flows_are_structurally_distinct`
+   fails if two goldens collapse into the same trajectory, because a golden set
+   whose members are indistinguishable passes no matter what the pipeline does.
+
+---
+
+## The reference-engine gap
+
+Issue #462 asks for reference trajectories recorded from the TS engine. The
+engine is reachable. **It does not emit this protocol**, and that — not access
+— is the blocker.
+
+Its `--output-format stream-json` emits five untyped envelope kinds:
+
+```jsonc
+{"type":"stage","label":"evaluating the prompt","detail":"single"}
+{"type":"text","delta":"..."}
+{"type":"reasoning","delta":"..."}
+{"type":"tool","phase":"start","name":"read_file"}
+{"type":"tool","phase":"end","name":"read_file","ok":true,"durationMs":12}
+{"type":"result","ok":true,"text":"done","steps":3,"model":"..."}
+```
+
+`AgentEvent` is a tagged enum of ~34 variants. The two do not line up, and the
+overlap is inverted from what a golden replay needs:
+
+| Reference event | Deserializes as `AgentEvent`? | Gap |
+|---|---|---|
+| `stage` | No | Carries a free-text `label`; the stage *kind* is dropped entirely. `AgentEvent::Stage` needs a typed `StageKind`. The two vocabularies also differ: the reference has `evaluate`/`enhance`/`route`/`revise`, this protocol has `ScopeReview`/`Witness`/`Verify`/`Reflect`/`ContextWrite`. |
+| `text` | **Yes** | — |
+| `reasoning` | **Yes** | — |
+| `tool` (start/end) | No | No `call_id` on either phase, so `validate_stream`'s tool-pairing invariant is not merely unmet — it is *unrepresentable*. |
+| `result` | No | The stream terminates with `result`; this protocol terminates with `complete`, which `validate_stream` requires to be last. |
+
+The two kinds that already parse (`text`, `reasoning`) are exactly the ones
+`event_signature` treats as structurally inert, and every event carrying
+structural identity fails. A half-imported reference recording would therefore
+be **all volatile content and no structure**: it would parse into something
+shaped like a trajectory that asserts nothing. That is why the loader gates
+instead of trusting a recording, and why
+`stella-pipeline/tests/reference_conformance.rs` pins the gap executably rather
+than leaving it as a comment that can rot.
+
+Note also that `structural_diff` is *positional* by design. Even with the wire
+format fixed, a reference stream would have to align stage-for-stage with the
+Rust stack's — and the reference emits no `Witness`, `ScopeReview`, `Reflect`,
+or `ContextWrite` stage at all.
+
+### What an adapter has to supply
+
+To produce a `reference` golden, an adapter must:
+
+1. Map the reference's free-text stage label onto a typed `StageKind`, and
+   decide what to emit for the stages this protocol has and the reference does
+   not (and vice versa).
+2. Synthesize a `call_id`, split `phase:"start"` into `tool_start`, and pair
+   `phase:"end"` back to the same id, mapping `ok` onto a `ToolOutput`.
+3. Translate the `result` envelope into a terminal `Complete` event.
+4. Emit the result as JSONL and record it with
+   `"source": {"kind": "reference", "engine": "...", "adapter": "..."}`.
+
+`reference_conformance.rs` is the executable statement of items 1–3; when an
+adapter lands, that file is where its output should be proven to satisfy the
+contract before any recording is committed.
+
+### The second blocker: provenance
+
+The reference engine lives in a **private** repository and its one-shot path
+routes model calls through a private platform (or a gateway API key). A public
+OSS repo's CI therefore cannot regenerate a reference fixture, so any such
+recording would be a committed artifact nobody downstream can reproduce or
+refresh. That needs an explicit decision before recordings land, not after —
+whether the adapter output is checked in as an opaque artifact, or the
+reference runs are reproduced some other way.

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1753,6 +1753,9 @@ mod verification_honesty {
 
 mod best_of_n;
 mod chaos;
+/// Golden-trajectory recordings of this pipeline's real event stream — a
+/// child module so it reaches the scripted ports above via `super::*`.
+mod golden;
 /// The orchestrator MCP pre-fetch hook (issue #248) — split out for
 /// the same file-size reason `tests.rs` itself was split from
 /// `pipeline.rs`; a child module, so it reaches the fakes above via

--- a/stella-pipeline/src/pipeline/tests/golden.rs
+++ b/stella-pipeline/src/pipeline/tests/golden.rs
@@ -1,0 +1,232 @@
+//! Golden trajectories recorded from **this pipeline**, on fixed tasks.
+//!
+//! These are real recordings: each test drives the actual [`Pipeline`] over
+//! scripted ports and records the `AgentEvent` stream it really emits — nothing
+//! here is hand-authored the way the synthetic fixtures under
+//! `tests/fixtures/` are. Scripted model/test doubles are what make them
+//! deterministic and runnable in CI with no API key, which is the only reason a
+//! recording can be asserted on every `cargo test` rather than refreshed by
+//! hand and hoped over.
+//!
+//! # What they do and do not prove
+//!
+//! Both sides of the comparison are the same code, so these are a **drift
+//! baseline**, not independent evidence: they catch a stage that stopped being
+//! emitted, a tool that changed name, an event that moved or disappeared —
+//! silent protocol regressions that no single-flow assertion notices. They do
+//! *not* establish that the Rust stack agrees with a reference implementation.
+//! That needs a [`RecordingSource::Reference`] recording, which is blocked on
+//! an adapter — see `tests/reference_conformance.rs` and
+//! `docs/replay-golden-trajectories.md`.
+//!
+//! # Refreshing
+//!
+//! `make record-golden` (or `STELLA_REFRESH_GOLDEN=1 cargo test -p
+//! stella-pipeline golden`) rewrites the fixtures from the current code. Review
+//! the diff: a change here is a change to the observable event contract, and
+//! that is exactly the thing that should be hard to do by accident.
+
+use std::path::PathBuf;
+
+use super::*;
+use crate::replay::golden::{GoldenManifest, GoldenTrajectory, RecordingSource};
+
+/// Set to rewrite the fixtures instead of asserting against them.
+const REFRESH_ENV: &str = "STELLA_REFRESH_GOLDEN";
+
+fn golden_dir() -> PathBuf {
+    [env!("CARGO_MANIFEST_DIR"), "tests", "fixtures", "golden"]
+        .iter()
+        .collect()
+}
+
+/// Gate a freshly-recorded stream, then either rewrite the fixture (refresh
+/// mode) or assert the committed golden is structurally equivalent to it.
+fn check_golden(task_id: &str, description: &str, events: Vec<AgentEvent>) {
+    let source = RecordingSource::RustStack {
+        recorded_by: format!("stella-pipeline::pipeline::tests::golden::{task_id}"),
+    };
+    let manifest = GoldenManifest::for_recording(task_id, description, source, &events);
+    // The recording must itself be a well-formed trajectory. If the pipeline
+    // ever emits a stream that violates its own invariants, that is a defect
+    // worth failing on here rather than quietly enshrining as the new golden.
+    let recorded = GoldenTrajectory::new(manifest, events)
+        .unwrap_or_else(|e| panic!("the recorded run is not a well-formed trajectory: {e}"));
+
+    let dir = golden_dir();
+    if std::env::var_os(REFRESH_ENV).is_some() {
+        recorded
+            .write(&dir)
+            .unwrap_or_else(|e| panic!("refreshing golden `{task_id}`: {e}"));
+        return;
+    }
+
+    let committed = GoldenTrajectory::load(&dir, task_id).unwrap_or_else(|e| {
+        panic!("loading golden `{task_id}`: {e}\nrun `make record-golden` to (re)record it")
+    });
+    let diff = committed.diff(recorded.events());
+    assert!(
+        diff.is_empty(),
+        "the recorded trajectory for `{task_id}` diverged from its golden.\n\
+         `left` is the golden, `right` is this run: {diff:#?}\n\
+         If the change is intended, refresh with `make record-golden` and \
+         review the fixture diff as an event-contract change."
+    );
+}
+
+/// The deterministic-flip path: a single-task goal whose test command flips
+/// fail→pass submits fast, so the model judge is never consulted (L-E11).
+#[tokio::test]
+async fn golden_single_task_deterministic_flip() {
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![false, true], "@@ -1 +1 @@\n-old\n+new");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    check_golden(
+        "single_task_deterministic_flip",
+        "A single-task goal whose test command flips fail->pass: deterministic \
+         verdict, model judge skipped.",
+        drain(&mut rx),
+    );
+}
+
+/// The judge-escalation path: no test command, so the deterministic ladder
+/// cannot conclude and a model judge is consulted — a materially different
+/// stage sequence from the flip path above.
+#[tokio::test]
+async fn golden_judge_escalation_without_a_test_command() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("lookup"),
+        text_result("done"),
+        text_result("PASS looks right"),
+    ]);
+    let resolver = OneProvider(&provider);
+    // A non-empty diff means files were touched, so the zero-diff guard revokes
+    // the lookup fast path's judge-skip.
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: None,
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    pipeline
+        .run("Explain the retry policy", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    check_golden(
+        "judge_escalation_without_a_test_command",
+        "A file-touching goal with no test command: the deterministic ladder \
+         cannot conclude, so the model judge is consulted.",
+        drain(&mut rx),
+    );
+}
+
+/// The two recorded flows must not collapse into the same trajectory — a
+/// golden set whose members are indistinguishable would pass no matter what
+/// the pipeline did, so the suite's own discriminating power is asserted here.
+#[test]
+fn the_recorded_flows_are_structurally_distinct() {
+    let dir = golden_dir();
+    let flip = GoldenTrajectory::load(&dir, "single_task_deterministic_flip")
+        .expect("the flip golden is committed");
+    let escalation = GoldenTrajectory::load(&dir, "judge_escalation_without_a_test_command")
+        .expect("the escalation golden is committed");
+    assert!(
+        !flip.diff(escalation.events()).is_empty(),
+        "a deterministic-flip run and a judge-escalation run must differ; \
+         identical goldens would assert nothing"
+    );
+}
+
+/// Every committed golden is a drift baseline, never independent evidence.
+/// The day a reference recording lands it will be a `Reference` source, and
+/// this test is where that distinction stops being a comment.
+#[test]
+fn the_committed_goldens_are_labelled_as_baselines_not_references() {
+    let dir = golden_dir();
+    for task_id in [
+        "single_task_deterministic_flip",
+        "judge_escalation_without_a_test_command",
+    ] {
+        let golden = GoldenTrajectory::load(&dir, task_id).expect("golden is committed");
+        assert!(
+            !golden.manifest().source.is_reference(),
+            "`{task_id}` claims to be a reference trajectory, but no reference \
+             adapter exists yet (see tests/reference_conformance.rs)"
+        );
+    }
+}

--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -4,13 +4,24 @@
 //! ignoring volatile fields like durations and exact costs) so a Rust-stack
 //! trajectory can be asserted equivalent to a reference one.
 //!
-//! # Reference trajectories are a documented follow-up
+//! # Golden trajectories, and what is still missing
 //!
-//! The fixtures under `tests/fixtures/` are **synthetic** streams that exercise
-//! the invariants and the differ. *Recording real TS-engine trajectories* on
-//! fixed tasks and checking the Rust stack against them is the next step — it is
-//! deliberately not faked here. This module is the machinery those recordings
-//! will be validated with once they exist.
+//! [`golden`] adds the fixture format those comparisons are made against: a
+//! recorded stream plus a manifest naming what produced it, gated on load so a
+//! malformed or truncated recording fails loudly instead of becoming a weaker
+//! yardstick. `tests/fixtures/golden/` holds recordings made from this
+//! workspace's own pipeline — a **drift baseline**, which detects a stage that
+//! stopped being emitted or a tool that changed name, but is not independent
+//! evidence, because both sides are the same code.
+//!
+//! A **reference trajectory** — recorded from an independent engine — remains
+//! outstanding, and the blocker is not access: it is that the reference engine
+//! emits a different wire format (untyped stage labels, no tool `call_id`, a
+//! `result` terminator instead of `complete`). Recording it requires an adapter
+//! onto this protocol first. `docs/replay-golden-trajectories.md` specifies
+//! that adapter contract, and `tests/reference_conformance.rs` pins it
+//! executably. The synthetic fixtures directly under `tests/fixtures/` remain
+//! what they always were: exercises for the invariants and the differ.
 //!
 //! # Torn tails (L-T1)
 //!
@@ -20,6 +31,8 @@
 //! additive-only, so parsing is forward-tolerant by construction (serde
 //! ignores unknown fields on the structs that opt in; unknown *variants* are
 //! the one thing that can't be tolerated and surface as an interior error).
+
+pub mod golden;
 
 use stella_protocol::{AgentEvent, StageKind};
 

--- a/stella-pipeline/src/replay/golden.rs
+++ b/stella-pipeline/src/replay/golden.rs
@@ -1,0 +1,484 @@
+//! Golden trajectories: a recorded `AgentEvent` stream on a fixed task, the
+//! manifest that says *what produced it*, and a loader that refuses anything
+//! which is not a well-formed recording of **this** protocol.
+//!
+//! [`super`] supplies the comparison machinery (`validate_stream`,
+//! `structural_diff`). This module supplies the thing that machinery is
+//! pointed at: a fixture format with provenance, so a committed golden can
+//! never be silently mistaken for something it isn't.
+//!
+//! # Why a manifest, and why it carries a count
+//!
+//! [`parse_jsonl`] deliberately tolerates a torn final line (L-T1) — the right
+//! posture for a *live* reader recovering from a crashed writer, and exactly
+//! the wrong posture for a *committed fixture*, where a truncated recording
+//! would load one event short and quietly weaken every assertion made against
+//! it. The manifest's `event_count` closes that hole: a recording that parses
+//! to a different length than it was recorded at is a
+//! [`GoldenError::Truncated`], not a slightly smaller golden.
+//!
+//! # Provenance is part of the fixture, not a comment
+//!
+//! [`RecordingSource`] distinguishes a recording made from this workspace's own
+//! pipeline from one made through an independent reference engine. The two
+//! answer different questions and must never be confused:
+//!
+//! - [`RecordingSource::RustStack`] is a **self-recorded baseline**. Replaying
+//!   the Rust stack against it detects *protocol drift* — a stage that stopped
+//!   being emitted, a tool that changed name, an event that moved. It is not
+//!   independent evidence of correctness, because both sides are the same code.
+//! - [`RecordingSource::Reference`] is a **reference trajectory** recorded from
+//!   another engine through an adapter that emits this protocol. Only this one
+//!   answers "does the Rust stack agree with the reference implementation?".
+//!
+//! Encoding the distinction in the fixture (rather than in prose) is what stops
+//! a baseline from being cited as a reference later. See
+//! `docs/replay-golden-trajectories.md` for the recording procedure and for the
+//! adapter contract a reference engine has to satisfy.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use stella_protocol::AgentEvent;
+
+use super::{
+    JsonlError, StreamDiff, StreamViolation, parse_jsonl, structural_diff, to_jsonl,
+    validate_stream,
+};
+
+/// What produced a recording. Serialized as an internally-tagged enum so the
+/// manifest reads as prose (`"kind": "rust_stack"`), and so adding a future
+/// source is additive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RecordingSource {
+    /// Recorded from this workspace's own `stella-pipeline`. A drift baseline,
+    /// **not** independent evidence — see the module doc.
+    RustStack {
+        /// How the run was driven, so a refresh can reproduce it (e.g. the
+        /// name of the test that records it, or the CLI invocation).
+        recorded_by: String,
+    },
+    /// Recorded from an independent reference engine through an adapter that
+    /// emits this protocol.
+    Reference {
+        /// The engine that ran the task.
+        engine: String,
+        /// The adapter that mapped that engine's native events onto
+        /// `AgentEvent`. Named because the mapping is where the fidelity of a
+        /// reference trajectory actually lives.
+        adapter: String,
+    },
+}
+
+impl RecordingSource {
+    /// Whether this recording is independent evidence (a reference engine) as
+    /// opposed to a self-recorded drift baseline.
+    pub fn is_reference(&self) -> bool {
+        matches!(self, RecordingSource::Reference { .. })
+    }
+}
+
+/// The sidecar describing one golden trajectory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoldenManifest {
+    /// Stable id; also the fixture's file stem.
+    pub task_id: String,
+    /// What the fixed task is, in one line.
+    pub description: String,
+    /// What produced the recording.
+    pub source: RecordingSource,
+    /// How many events the recording held when it was written. Guards against
+    /// a silently truncated fixture — see the module doc.
+    pub event_count: usize,
+}
+
+impl GoldenManifest {
+    /// Build a manifest for a freshly-recorded stream, deriving `event_count`
+    /// from the recording so the two can never disagree at authoring time.
+    pub fn for_recording(
+        task_id: impl Into<String>,
+        description: impl Into<String>,
+        source: RecordingSource,
+        events: &[AgentEvent],
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            description: description.into(),
+            source,
+            event_count: events.len(),
+        }
+    }
+}
+
+/// A recording that failed to load as a golden trajectory. Every variant names
+/// the task, because a failure surfaces from a fixture directory where one
+/// bad file among many is the usual case.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GoldenError {
+    /// A fixture file could not be read.
+    #[error("reading golden `{task_id}` from {path}: {message}")]
+    Io {
+        task_id: String,
+        path: PathBuf,
+        message: String,
+    },
+    /// The manifest sidecar was not valid `GoldenManifest` JSON.
+    #[error("manifest for golden `{task_id}` is not valid: {message}")]
+    Manifest { task_id: String, message: String },
+    /// The manifest's `task_id` disagrees with the file it was loaded as — a
+    /// copy-paste that would otherwise attribute a recording to the wrong task.
+    #[error("golden `{task_id}` has a manifest claiming task `{declared}`")]
+    TaskIdMismatch { task_id: String, declared: String },
+    /// The recording is not parseable as an `AgentEvent` stream. This is the
+    /// error a recording in *another* engine's wire format produces.
+    #[error("recording for golden `{task_id}` is not an AgentEvent stream: {source}")]
+    Recording {
+        task_id: String,
+        #[source]
+        source: JsonlError,
+    },
+    /// The recording parsed to a different length than the manifest declares —
+    /// a torn tail, a truncated copy, or a stale manifest.
+    #[error(
+        "golden `{task_id}` is truncated: the manifest declares {declared} events, \
+         the recording parsed {parsed}"
+    )]
+    Truncated {
+        task_id: String,
+        declared: usize,
+        parsed: usize,
+    },
+    /// The recording parsed but violates the protocol's structural invariants.
+    /// A golden is the yardstick other runs are measured against, so it must
+    /// itself be well-formed — an ill-formed one would license ill-formed runs.
+    #[error("golden `{task_id}` violates the protocol's structural invariants: {violations:?}")]
+    NotWellFormed {
+        task_id: String,
+        violations: Vec<StreamViolation>,
+    },
+}
+
+/// A loaded golden trajectory: a well-formed `AgentEvent` recording plus its
+/// provenance. Constructing one is the only way to get a golden, so every
+/// golden in the process has already passed the gates in [`GoldenTrajectory::new`].
+// `AgentEvent` is deliberately not `PartialEq` — structural equivalence
+// ([`GoldenTrajectory::matches`]), not field equality, is what a golden is
+// compared by — so this type isn't either.
+#[derive(Debug, Clone)]
+pub struct GoldenTrajectory {
+    manifest: GoldenManifest,
+    events: Vec<AgentEvent>,
+}
+
+impl GoldenTrajectory {
+    /// Gate a manifest + recording into a golden. Rejects a truncated recording
+    /// and one that violates the structural invariants; both would otherwise
+    /// become a weaker yardstick rather than a loud failure.
+    pub fn new(manifest: GoldenManifest, events: Vec<AgentEvent>) -> Result<Self, GoldenError> {
+        if manifest.event_count != events.len() {
+            return Err(GoldenError::Truncated {
+                task_id: manifest.task_id,
+                declared: manifest.event_count,
+                parsed: events.len(),
+            });
+        }
+        let violations = validate_stream(&events);
+        if !violations.is_empty() {
+            return Err(GoldenError::NotWellFormed {
+                task_id: manifest.task_id,
+                violations,
+            });
+        }
+        Ok(Self { manifest, events })
+    }
+
+    /// Parse a golden from in-memory documents — the pure core of
+    /// [`GoldenTrajectory::load`], so callers (and tests) can exercise every
+    /// gate without touching the filesystem.
+    ///
+    /// `task_id` is the identity the caller is loading *as*; a manifest that
+    /// declares a different one is a [`GoldenError::TaskIdMismatch`].
+    pub fn parse(task_id: &str, manifest_json: &str, recording: &str) -> Result<Self, GoldenError> {
+        let manifest: GoldenManifest =
+            serde_json::from_str(manifest_json).map_err(|e| GoldenError::Manifest {
+                task_id: task_id.to_string(),
+                message: e.to_string(),
+            })?;
+        if manifest.task_id != task_id {
+            return Err(GoldenError::TaskIdMismatch {
+                task_id: task_id.to_string(),
+                declared: manifest.task_id,
+            });
+        }
+        let events = parse_jsonl(recording).map_err(|source| GoldenError::Recording {
+            task_id: task_id.to_string(),
+            source,
+        })?;
+        Self::new(manifest, events)
+    }
+
+    /// Load `<dir>/<task_id>.manifest.json` + `<dir>/<task_id>.jsonl`.
+    pub fn load(dir: &Path, task_id: &str) -> Result<Self, GoldenError> {
+        let read = |path: PathBuf| -> Result<String, GoldenError> {
+            fs::read_to_string(&path).map_err(|e| GoldenError::Io {
+                task_id: task_id.to_string(),
+                path,
+                message: e.to_string(),
+            })
+        };
+        let manifest_json = read(manifest_path(dir, task_id))?;
+        let recording = read(recording_path(dir, task_id))?;
+        Self::parse(task_id, &manifest_json, &recording)
+    }
+
+    /// The recorded stream.
+    pub fn events(&self) -> &[AgentEvent] {
+        &self.events
+    }
+
+    /// The recording's provenance.
+    pub fn manifest(&self) -> &GoldenManifest {
+        &self.manifest
+    }
+
+    /// Structurally diff a candidate run against this golden — the golden is
+    /// the left-hand side, so a diff's `left` is what was expected and `right`
+    /// is what the run produced.
+    pub fn diff(&self, run: &[AgentEvent]) -> Vec<StreamDiff> {
+        structural_diff(&self.events, run)
+    }
+
+    /// Whether a candidate run is structurally equivalent to this golden.
+    pub fn matches(&self, run: &[AgentEvent]) -> bool {
+        self.diff(run).is_empty()
+    }
+
+    /// Render the two fixture documents (manifest JSON, recording JSONL) —
+    /// the inverse of [`GoldenTrajectory::parse`], used by the refresh path.
+    pub fn render(&self) -> (String, String) {
+        // The manifest is a plain struct of owned, always-serializable fields;
+        // `expect` documents that invariant rather than hiding a fallible path.
+        let manifest = serde_json::to_string_pretty(&self.manifest)
+            .expect("GoldenManifest is always serializable");
+        (format!("{manifest}\n"), to_jsonl(&self.events))
+    }
+
+    /// Write this golden into `dir`, creating it if needed. Used by the
+    /// refresh target; ordinary test runs only ever read.
+    pub fn write(&self, dir: &Path) -> Result<(), GoldenError> {
+        let io = |path: PathBuf, e: std::io::Error| GoldenError::Io {
+            task_id: self.manifest.task_id.clone(),
+            path,
+            message: e.to_string(),
+        };
+        fs::create_dir_all(dir).map_err(|e| io(dir.to_path_buf(), e))?;
+        let (manifest, recording) = self.render();
+        let manifest_path = manifest_path(dir, &self.manifest.task_id);
+        fs::write(&manifest_path, manifest).map_err(|e| io(manifest_path, e))?;
+        let recording_path = recording_path(dir, &self.manifest.task_id);
+        fs::write(&recording_path, recording).map_err(|e| io(recording_path, e))?;
+        Ok(())
+    }
+}
+
+/// Path of a golden's manifest sidecar.
+pub fn manifest_path(dir: &Path, task_id: &str) -> PathBuf {
+    dir.join(format!("{task_id}.manifest.json"))
+}
+
+/// Path of a golden's recording.
+pub fn recording_path(dir: &Path, task_id: &str) -> PathBuf {
+    dir.join(format!("{task_id}.jsonl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::StageKind;
+
+    fn stage(name: StageKind) -> AgentEvent {
+        AgentEvent::Stage { name }
+    }
+    fn complete() -> AgentEvent {
+        AgentEvent::Complete {
+            model: "scripted/only".into(),
+            cost_usd: 0.0,
+        }
+    }
+    fn events() -> Vec<AgentEvent> {
+        vec![
+            stage(StageKind::Triage),
+            stage(StageKind::Execute),
+            complete(),
+        ]
+    }
+    fn source() -> RecordingSource {
+        RecordingSource::RustStack {
+            recorded_by: "a_test".into(),
+        }
+    }
+    fn golden() -> GoldenTrajectory {
+        let events = events();
+        let manifest = GoldenManifest::for_recording("t", "a task", source(), &events);
+        GoldenTrajectory::new(manifest, events).expect("well-formed")
+    }
+
+    // manifest serde
+
+    #[test]
+    fn the_manifest_round_trips_through_serde_json() {
+        for src in [
+            source(),
+            RecordingSource::Reference {
+                engine: "reference-engine".into(),
+                adapter: "adapters/reference.rs".into(),
+            },
+        ] {
+            let manifest = GoldenManifest::for_recording("t", "a task", src, &events());
+            let json = serde_json::to_string(&manifest).unwrap();
+            let back: GoldenManifest = serde_json::from_str(&json).unwrap();
+            assert_eq!(manifest, back);
+        }
+    }
+
+    #[test]
+    fn only_a_reference_recording_counts_as_independent_evidence() {
+        assert!(!source().is_reference());
+        assert!(
+            RecordingSource::Reference {
+                engine: "e".into(),
+                adapter: "a".into(),
+            }
+            .is_reference()
+        );
+    }
+
+    // the gates
+
+    #[test]
+    fn a_well_formed_recording_loads_and_matches_itself() {
+        let g = golden();
+        assert_eq!(g.events().len(), 3);
+        assert!(g.matches(&events()));
+        assert!(g.diff(&events()).is_empty());
+    }
+
+    #[test]
+    fn a_truncated_recording_is_rejected_rather_than_loaded_short() {
+        // The manifest was written against three events; the recording lost
+        // its tail. `parse_jsonl` alone would happily return the short prefix.
+        let manifest = GoldenManifest::for_recording("t", "a task", source(), &events());
+        let mut short = events();
+        short.pop();
+        match GoldenTrajectory::new(manifest, short) {
+            Err(GoldenError::Truncated {
+                declared, parsed, ..
+            }) => {
+                assert_eq!((declared, parsed), (3, 2));
+            }
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_torn_tail_in_a_fixture_is_truncation_not_tolerance() {
+        // A writer that died partway through the final event. L-T1 tolerance is
+        // right for a live reader — keep the clean prefix — and wrong for a
+        // committed fixture, where it would silently shrink the yardstick by an
+        // event. Without the manifest's count this parses cleanly to 2 events.
+        let g = golden();
+        let (manifest_json, full) = g.render();
+        let mut lines: Vec<&str> = full.lines().collect();
+        let torn = &lines.pop().expect("a final line")[..12];
+        let recording = format!("{}\n{torn}", lines.join("\n"));
+        assert_eq!(
+            parse_jsonl(&recording)
+                .expect("a torn tail still parses")
+                .len(),
+            2,
+            "the tolerant parser alone would hand back a short stream"
+        );
+        match GoldenTrajectory::parse("t", &manifest_json, &recording) {
+            Err(GoldenError::Truncated { .. }) => {}
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_ill_formed_recording_cannot_become_a_yardstick() {
+        // Two Completes — a stream terminates once. A golden that violates the
+        // invariants would license runs that violate them too.
+        let events = vec![complete(), complete()];
+        let manifest = GoldenManifest::for_recording("t", "a task", source(), &events);
+        match GoldenTrajectory::new(manifest, events) {
+            Err(GoldenError::NotWellFormed { violations, .. }) => {
+                assert!(!violations.is_empty());
+            }
+            other => panic!("expected NotWellFormed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_manifest_for_another_task_is_rejected() {
+        let (manifest_json, recording) = golden().render();
+        match GoldenTrajectory::parse("other", &manifest_json, &recording) {
+            Err(GoldenError::TaskIdMismatch { declared, .. }) => assert_eq!(declared, "t"),
+            other => panic!("expected TaskIdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_malformed_manifest_names_the_task_it_failed_for() {
+        match GoldenTrajectory::parse("t", "{ not json }", "") {
+            Err(GoldenError::Manifest { task_id, .. }) => assert_eq!(task_id, "t"),
+            other => panic!("expected Manifest, got {other:?}"),
+        }
+    }
+
+    // round-trip through the filesystem
+
+    #[test]
+    fn a_golden_round_trips_through_render_and_parse() {
+        let g = golden();
+        let (manifest_json, recording) = g.render();
+        let back = GoldenTrajectory::parse("t", &manifest_json, &recording).expect("re-parses");
+        assert_eq!(back.manifest(), g.manifest());
+        assert!(back.matches(g.events()));
+    }
+
+    #[test]
+    fn a_golden_round_trips_through_write_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = golden();
+        g.write(dir.path()).expect("writes");
+        let back = GoldenTrajectory::load(dir.path(), "t").expect("loads");
+        assert_eq!(back.manifest(), g.manifest());
+        assert!(back.matches(g.events()));
+    }
+
+    #[test]
+    fn a_missing_fixture_names_the_path_it_looked_for() {
+        let dir = tempfile::tempdir().unwrap();
+        match GoldenTrajectory::load(dir.path(), "absent") {
+            Err(GoldenError::Io { path, .. }) => {
+                assert!(path.ends_with("absent.manifest.json"), "got {path:?}");
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+
+    // divergence
+
+    #[test]
+    fn a_diverging_run_reports_the_golden_on_the_left() {
+        let g = golden();
+        let mut run = events();
+        run[1] = stage(StageKind::Judge);
+        let diff = g.diff(&run);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff[0].left.as_deref(), Some("stage:Execute"));
+        assert_eq!(diff[0].right.as_deref(), Some("stage:Judge"));
+    }
+}

--- a/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.jsonl
+++ b/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.jsonl
@@ -1,0 +1,18 @@
+{"type":"stage","name":"triage"}
+{"type":"step_usage","step":0,"role":"triage","provider":"scripted","output_text":"lookup","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":0,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
+{"type":"budget_tick","spent_usd":0.0001,"limit_usd":null,"mode":"off","session_spent_usd":0.0001,"session_limit_usd":null}
+{"type":"stage","name":"context_recall"}
+{"type":"stage","name":"execute"}
+{"type":"budget_tick","spent_usd":0.0002,"limit_usd":null,"mode":"off","session_spent_usd":0.0002,"session_limit_usd":null}
+{"type":"block_registered","block_id":"blk_2496dfcf7ecfbc59286039dc","kind":"system_prefix","origin":{"turn_instance":0,"step":0},"token_cost":1,"content_digest":"sha256:518b67e652531c5fe7e25d6b2c3b4ef6224e7d90da2091967dd47eb082b26a19","content":"sys"}
+{"type":"block_registered","block_id":"blk_ae1103d1e8911d1745407182","kind":"user_goal","origin":{"turn_instance":0,"step":0},"token_cost":7,"content_digest":"sha256:8ec4c21e156039b6bb5f56475fc8f6447a999e4254b7f9a28de1cca10034eafd","content":"Explain the retry policy"}
+{"type":"step_manifest","turn_instance":0,"step":0,"role":"worker","provider":"scripted","model":"scripted","blocks":[{"block_id":"blk_2496dfcf7ecfbc59286039dc","cache_zone":"stable_prefix","token_cost":1,"resident_since_step":0,"message_index":0},{"block_id":"blk_ae1103d1e8911d1745407182","cache_zone":"volatile","token_cost":7,"resident_since_step":0,"message_index":1}],"effective_budget_tokens":150000,"calibration_factor":1.0,"estimated_input_tokens":16}
+{"type":"step_usage","step":0,"role":"worker","provider":"scripted","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":16,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
+{"type":"text","delta":"done"}
+{"type":"stage","name":"verify"}
+{"type":"stage","name":"judge"}
+{"type":"step_usage","step":0,"role":"judge","provider":"scripted","output_text":"PASS looks right","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":0,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
+{"type":"budget_tick","spent_usd":0.00030000000000000003,"limit_usd":null,"mode":"off","session_spent_usd":0.00030000000000000003,"session_limit_usd":null}
+{"type":"judge_verdict","passed":true,"evidence":{"summary":"PASS looks right","deterministic":false}}
+{"type":"stage","name":"complete"}
+{"type":"complete","model":"scripted/worker","cost_usd":0.00030000000000000003}

--- a/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.manifest.json
+++ b/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.manifest.json
@@ -1,0 +1,9 @@
+{
+  "task_id": "judge_escalation_without_a_test_command",
+  "description": "A file-touching goal with no test command: the deterministic ladder cannot conclude, so the model judge is consulted.",
+  "source": {
+    "kind": "rust_stack",
+    "recorded_by": "stella-pipeline::pipeline::tests::golden::judge_escalation_without_a_test_command"
+  },
+  "event_count": 18
+}

--- a/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.jsonl
+++ b/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.jsonl
@@ -1,0 +1,15 @@
+{"type":"stage","name":"triage"}
+{"type":"step_usage","step":0,"role":"triage","provider":"scripted","output_text":"single","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":0,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
+{"type":"budget_tick","spent_usd":0.0001,"limit_usd":null,"mode":"off","session_spent_usd":0.0001,"session_limit_usd":null}
+{"type":"stage","name":"context_recall"}
+{"type":"stage","name":"execute"}
+{"type":"budget_tick","spent_usd":0.0002,"limit_usd":null,"mode":"off","session_spent_usd":0.0002,"session_limit_usd":null}
+{"type":"block_registered","block_id":"blk_2496dfcf7ecfbc59286039dc","kind":"system_prefix","origin":{"turn_instance":0,"step":0},"token_cost":1,"content_digest":"sha256:518b67e652531c5fe7e25d6b2c3b4ef6224e7d90da2091967dd47eb082b26a19","content":"sys"}
+{"type":"block_registered","block_id":"blk_b501fd519971df515ced55c3","kind":"user_goal","origin":{"turn_instance":0,"step":0},"token_cost":6,"content_digest":"sha256:caedf2c0a1b485cb0ba3b135056262a3bce5d8b63510726dc9977b09b1fda648","content":"Fix the failing test"}
+{"type":"step_manifest","turn_instance":0,"step":0,"role":"worker","provider":"scripted","model":"scripted","blocks":[{"block_id":"blk_2496dfcf7ecfbc59286039dc","cache_zone":"stable_prefix","token_cost":1,"resident_since_step":0,"message_index":0},{"block_id":"blk_b501fd519971df515ced55c3","cache_zone":"volatile","token_cost":6,"resident_since_step":0,"message_index":1}],"effective_budget_tokens":150000,"calibration_factor":1.0,"estimated_input_tokens":15}
+{"type":"step_usage","step":0,"role":"worker","provider":"scripted","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":15,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
+{"type":"text","delta":"done"}
+{"type":"stage","name":"verify"}
+{"type":"judge_verdict","passed":true,"evidence":{"summary":"flip oracle: fail→pass of `cargo test -p x`; touched tests green; diff 2 lines within budget","deterministic":true}}
+{"type":"stage","name":"complete"}
+{"type":"complete","model":"scripted/worker","cost_usd":0.0002}

--- a/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.manifest.json
+++ b/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.manifest.json
@@ -1,0 +1,9 @@
+{
+  "task_id": "single_task_deterministic_flip",
+  "description": "A single-task goal whose test command flips fail->pass: deterministic verdict, model judge skipped.",
+  "source": {
+    "kind": "rust_stack",
+    "recorded_by": "stella-pipeline::pipeline::tests::golden::single_task_deterministic_flip"
+  },
+  "event_count": 15
+}

--- a/stella-pipeline/tests/reference_conformance.rs
+++ b/stella-pipeline/tests/reference_conformance.rs
@@ -1,0 +1,169 @@
+//! The adapter contract a **reference** engine has to satisfy before its runs
+//! can be recorded as golden trajectories — pinned executably.
+//!
+//! Issue #462 asks for reference trajectories recorded from the TS engine. The
+//! engine is reachable, but it does not speak this protocol: its
+//! `--output-format stream-json` emits a five-kind, untyped envelope
+//! (`stage`/`text`/`reasoning`/`tool`/`result`) while `AgentEvent` is a
+//! tagged enum of ~34 variants. Recording it therefore needs an adapter, and
+//! this file specifies what that adapter must fix.
+//!
+//! The samples below are the reference emitter's wire shapes transcribed from
+//! its source — they are **not** a recording, and nothing here is dressed up as
+//! one. Their only job is to hold the gap still so it cannot be forgotten or
+//! quietly papered over.
+//!
+//! # The finding this file exists to pin
+//!
+//! The overlap between the two formats is exactly inverted from what a golden
+//! replay needs. The reference events that *do* deserialize as `AgentEvent`
+//! (`text`, `reasoning`) are precisely the ones [`event_signature`] treats as
+//! structurally inert; every event that carries structural identity — the stage
+//! kind, the tool call pairing, the terminator — either fails to parse or has
+//! no counterpart at all. A half-imported reference recording would thus be
+//! *all* volatile content and *no* structure: it would parse into something
+//! that looks like a trajectory and asserts nothing. That is why
+//! [`GoldenTrajectory`] gates on load instead of trusting a recording.
+
+use stella_pipeline::replay::event_signature;
+use stella_pipeline::replay::golden::{GoldenError, GoldenTrajectory};
+use stella_protocol::AgentEvent;
+
+/// One line of the reference engine's `stream-json` output, with the reason it
+/// cannot serve as an `AgentEvent`.
+struct ReferenceLine {
+    /// The reference engine's wire shape.
+    json: &'static str,
+    /// What an adapter has to supply for this line to become an `AgentEvent`.
+    adapter_must: &'static str,
+}
+
+/// Every event kind the reference engine's `stream-json` emitter produces.
+fn reference_stream() -> Vec<ReferenceLine> {
+    vec![
+        ReferenceLine {
+            // The reference emits a human-readable label and drops the stage
+            // kind entirely; `AgentEvent::Stage` needs a typed `StageKind`.
+            json: r#"{"type":"stage","label":"evaluating the prompt","detail":"single"}"#,
+            adapter_must: "map the reference's free-text stage label onto a typed StageKind",
+        },
+        ReferenceLine {
+            json: r#"{"type":"text","delta":"Reading the file."}"#,
+            adapter_must: "nothing — this one already parses, which is the hazard",
+        },
+        ReferenceLine {
+            json: r#"{"type":"reasoning","delta":"The test asserts..."}"#,
+            adapter_must: "nothing — this one already parses, which is the hazard",
+        },
+        ReferenceLine {
+            // No `call_id` on either phase, so `validate_stream`'s tool-pairing
+            // invariant is not merely unmet — it is unrepresentable.
+            json: r#"{"type":"tool","phase":"start","name":"read_file"}"#,
+            adapter_must: "synthesize a call_id and split phase=start into tool_start",
+        },
+        ReferenceLine {
+            json: r#"{"type":"tool","phase":"end","name":"read_file","ok":true,"durationMs":12}"#,
+            adapter_must: "pair phase=end back to its call_id and map ok onto a ToolOutput",
+        },
+        ReferenceLine {
+            // The reference terminates with `result`; this protocol terminates
+            // with `complete`, and `validate_stream` requires it to be last.
+            json: r#"{"type":"result","ok":true,"text":"done","steps":3,"model":"m"}"#,
+            adapter_must: "translate the result envelope into a terminal Complete event",
+        },
+    ]
+}
+
+/// The kinds that already deserialize — recorded here so the list cannot grow
+/// silently. Both are volatile-content events.
+const ALREADY_PARSES: [&str; 2] = ["text", "reasoning"];
+
+fn kind(json: &str) -> String {
+    let value: serde_json::Value = serde_json::from_str(json).expect("sample is valid JSON");
+    value["type"]
+        .as_str()
+        .expect("sample is tagged")
+        .to_string()
+}
+
+#[test]
+fn the_reference_wire_format_is_not_this_protocol() {
+    let mut unparseable = Vec::new();
+    for line in reference_stream() {
+        let parsed = serde_json::from_str::<AgentEvent>(line.json);
+        let kind = kind(line.json);
+        if ALREADY_PARSES.contains(&kind.as_str()) {
+            assert!(
+                parsed.is_ok(),
+                "`{kind}` was expected to already parse; if it stopped, this \
+                 file's account of the gap is stale: {}",
+                line.json
+            );
+        } else {
+            assert!(
+                parsed.is_err(),
+                "`{kind}` parsed as an AgentEvent — the reference format and \
+                 this protocol have converged, so the adapter contract needs \
+                 revisiting (adapter must: {})",
+                line.adapter_must
+            );
+            unparseable.push(kind);
+        }
+    }
+    assert_eq!(
+        unparseable,
+        vec!["stage", "tool", "tool", "result"],
+        "every structurally-identifying reference event must be accounted for"
+    );
+}
+
+#[test]
+fn the_reference_events_that_do_parse_carry_no_structural_identity() {
+    // The damning half of the finding: the overlap is exactly the events the
+    // differ ignores. Importing only what parses yields a trajectory that
+    // asserts nothing about stages, tools, or termination.
+    for line in reference_stream() {
+        let Ok(event) = serde_json::from_str::<AgentEvent>(line.json) else {
+            continue;
+        };
+        let signature = event_signature(&event);
+        assert!(
+            matches!(signature.as_str(), "text" | "reasoning"),
+            "a reference event that parses must be structurally inert, got `{signature}`"
+        );
+    }
+}
+
+#[test]
+fn a_reference_recording_is_rejected_as_a_golden_rather_than_half_imported() {
+    let recording: String = reference_stream()
+        .iter()
+        .map(|l| format!("{}\n", l.json))
+        .collect();
+    let manifest = r#"{
+        "task_id": "reference_smoke",
+        "description": "a reference-engine run recorded verbatim",
+        "source": { "kind": "reference", "engine": "ts-engine", "adapter": "none" },
+        "event_count": 6
+    }"#;
+    match GoldenTrajectory::parse("reference_smoke", manifest, &recording) {
+        Err(GoldenError::Recording { task_id, .. }) => assert_eq!(task_id, "reference_smoke"),
+        other => panic!(
+            "a raw reference recording must be refused with a typed error, got {other:?} — \
+             silently accepting one is the failure mode this gate exists to prevent"
+        ),
+    }
+}
+
+#[test]
+fn every_reference_event_kind_has_a_stated_adapter_obligation() {
+    // The contract is only useful if it stays complete: a new reference event
+    // kind added to the sample set without a stated obligation fails here.
+    for line in reference_stream() {
+        assert!(
+            !line.adapter_must.is_empty(),
+            "reference event `{}` has no stated adapter obligation",
+            kind(line.json)
+        );
+    }
+}

--- a/stella-pipeline/tests/replay_fixtures.rs
+++ b/stella-pipeline/tests/replay_fixtures.rs
@@ -1,9 +1,15 @@
 //! Golden-trajectory replay harness, driven against synthetic fixtures.
-//! These fixtures are **synthetic** streams
-//! that exercise the harness's invariants and its structural differ; recording
-//! real TS-engine trajectories on fixed tasks and replaying the Rust stack
-//! against them is the documented next step (see `replay.rs`'s module doc) —
-//! deliberately not faked here.
+//! These fixtures are **synthetic** streams that exercise the harness's
+//! invariants and its structural differ — hand-authored to hit specific edges
+//! (a torn tail, a judge escalation) that a recording may not happen to
+//! contain.
+//!
+//! Real recordings live elsewhere and are kept distinct on purpose:
+//! `tests/fixtures/golden/` holds trajectories actually recorded from this
+//! pipeline (see `src/pipeline/tests/golden.rs`), and
+//! `tests/reference_conformance.rs` pins what an independent reference engine
+//! must emit before its runs can join them. See
+//! `docs/replay-golden-trajectories.md`.
 
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
## What & why

Refs #462 — **partial.** The issue asks for reference trajectories recorded from the TS engine. This PR delivers everything around that recording and states plainly why the recordings themselves are blocked. It does **not** close the issue.

### The feasibility finding

I located the reference engine. It is reachable (`packages/agent-engine` + `apps/cli` in the private `oxagen-platform` monorepo — the same code `stella-core/src/ports.rs`, `hooks.rs`, `rules.rs`, and `budget.rs` cite as "ported from"). So the blocker is **not access**.

The blocker is that **it does not emit this protocol.** Its `--output-format stream-json` emits five untyped envelope kinds against `AgentEvent`'s ~34 tagged variants:

| Reference event | Parses as `AgentEvent`? | Gap |
|---|---|---|
| `stage` | No | Carries a free-text `label`; the stage *kind* is dropped entirely. The vocabularies also differ (`evaluate`/`enhance`/`route`/`revise` vs `ScopeReview`/`Witness`/`Verify`/`Reflect`/`ContextWrite`). |
| `text`, `reasoning` | **Yes** | — |
| `tool` (start/end) | No | No `call_id` on either phase — the tool-pairing invariant is not merely unmet, it is *unrepresentable*. |
| `result` | No | Terminates with `result`; this protocol requires a terminal `complete`. |

The overlap is exactly inverted from what a golden replay needs: the two kinds that already deserialize are precisely the ones `event_signature` treats as structurally inert, while every event carrying structural identity fails. A half-imported reference recording would be **all volatile content and no structure** — it would parse into something shaped like a trajectory that asserts nothing. Recording the engine as-is would have produced exactly the fake the issue explicitly forbids, so I did not.

### What this PR does deliver

- **`replay::golden`** — `GoldenTrajectory`: a recording plus a manifest naming what produced it, gated on load. `event_count` is in the manifest because `parse_jsonl` deliberately tolerates a torn tail (L-T1): right for a live reader, wrong for a committed fixture, where it would silently hand back a short recording. The loader also refuses an unparseable recording, a mismatched task id, and a recording that violates the protocol's own invariants (a golden is the yardstick — an ill-formed one would license ill-formed runs).
- **`RecordingSource`** — separates a self-recorded *drift baseline* from an independent *reference trajectory*, in the fixture rather than in prose, so a baseline cannot later be cited as a reference. Asserted, not just documented.
- **Two real recordings** of this pipeline's actual event stream (deterministic-flip and judge-escalation paths), driven through the real `Pipeline` over scripted ports — deterministic, no API key, CI-runnable.
- **`make record-golden`** for refresh, and `docs/replay-golden-trajectories.md` with the procedure plus the adapter contract a reference engine must satisfy.
- **`tests/reference_conformance.rs`** — the gap pinned executably so it cannot rot into a stale comment.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

**Behavioral proof, not just "new code has new tests".** I deleted the `Stage { name: Verify }` emission in `pipeline.rs` and ran the crate:

```
test result: FAILED. 177 passed; 2 failed
    pipeline::tests::golden::golden_single_task_deterministic_flip
    pipeline::tests::golden::golden_judge_escalation_without_a_test_command
```

**Only the two new golden tests caught it.** All 177 other tests passed a pipeline that had silently stopped emitting a stage. The diff was precise:

```
StreamDiff { index: 8, left: Some("stage:Verify"),
             right: Some("judge_verdict:passed=true,deterministic=true") }
```

That class of silent event-contract regression was previously invisible to the entire suite. Mutation reverted; suite green.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated (`docs/replay-golden-trajectories.md`; stale module docs in `replay.rs` and `replay_fixtures.rs` corrected)
- [x] Commits signed off for DCO

`make gate` exits 0 — 57 suites, zero warnings.

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies** (`serde`/`serde_json`/`thiserror`/`tempfile` were already there)
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde — `the_manifest_round_trips_through_serde_json` covers both `RecordingSource` variants

## Anything reviewers should know?

**Please do not read the committed goldens as reference trajectories.** They are `rust_stack` baselines: both sides of the comparison are the same code, so they detect protocol *drift*, not correctness against an independent implementation. The manifest says so and a test enforces it. Calling them more than that is precisely the failure mode #462 warns against.

**What remains for #462:**

1. An adapter mapping the reference engine's `stream-json` onto `AgentEvent` (obligations enumerated in `reference_conformance.rs` and the docs).
2. A decision on provenance: the reference engine is in a **private** repo and routes model calls through a private platform, so a public OSS repo's CI cannot regenerate a reference fixture. Any such recording would be an artifact nobody downstream can reproduce or refresh. That needs deciding *before* recordings land.
3. Note `structural_diff` is positional by design — even with the wire format fixed, a reference stream must align stage-for-stage, and the reference emits no `Witness`, `ScopeReview`, `Reflect`, or `ContextWrite` stage at all. That may warrant its own discussion on the issue.
