### PR TITLE
feat(stella-store): quarantine poison rows so the org cursor never stalls

### DIFF
--- a/stella-cli/src/usage_cmd.rs
+++ b/stella-cli/src/usage_cmd.rs
@@ -393,6 +393,56 @@ fn prune(
     Ok(())
 }
 
+/// Number of dead-lettered reason groups `cloud status` lists before folding
+/// the tail into a "+N more" line — enough to see the shape of a problem
+/// without turning status into a log dump.
+const QUARANTINE_REASONS_SHOWN: usize = 3;
+
+/// Report rows the cloud drain permanently could not deliver (#467).
+///
+/// A poison row is dead-lettered and the org cursor steps over it so newer rows
+/// keep flowing — which is exactly why it has to be *visible* here: the drain
+/// looks healthy afterwards, and this is the only place the silent casualty
+/// surfaces. Prints nothing when there is nothing to report.
+///
+/// Best-effort: `cloud status` answers about identity first, so an unopenable
+/// hub degrades to a one-line note instead of failing the command.
+fn print_quarantine(org: &str) {
+    let hub = match UsageStore::open_default() {
+        Ok(hub) => hub,
+        Err(e) => {
+            println!("{}   (hub unavailable: {e})", "quarantined:".bold());
+            return;
+        }
+    };
+    let (count, reasons) = match (
+        hub.cloud_quarantine_count(Some(org)),
+        hub.cloud_quarantine_reasons(Some(org)),
+    ) {
+        (Ok(count), Ok(reasons)) => (count, reasons),
+        _ => return,
+    };
+    if count == 0 {
+        return;
+    }
+    println!(
+        "{}   {}",
+        "quarantined:".bold(),
+        format!("{count} row(s) the cloud intake permanently rejected").yellow()
+    );
+    for (reason, status, n) in reasons.iter().take(QUARANTINE_REASONS_SHOWN) {
+        let status = status.map_or_else(String::new, |s| format!("HTTP {s}: "));
+        println!("              {n} x {status}{reason}");
+    }
+    if reasons.len() > QUARANTINE_REASONS_SHOWN {
+        println!(
+            "              +{} more reason(s)",
+            reasons.len() - QUARANTINE_REASONS_SHOWN
+        );
+    }
+    println!("              retained in the hub for inspection; the cursor advanced past them");
+}
+
 pub fn run_cloud(cmd: CloudCmd) -> Result<(), String> {
     match cmd {
         CloudCmd::Status => {
@@ -410,6 +460,9 @@ pub fn run_cloud(cmd: CloudCmd) -> Result<(), String> {
             );
             println!("{}   {}", "repo_id:".bold(), scope.repo_id);
             println!("{}   {}", "project:".bold(), scope.project_id);
+            if let Some(org) = scope.org_id.as_deref() {
+                print_quarantine(org);
+            }
             if scope.org_id.is_none() {
                 println!(
                     "\nregister with `stella cloud register --org <org-id>` — \

--- a/stella-store/src/drain.rs
+++ b/stella-store/src/drain.rs
@@ -28,9 +28,20 @@
 //!   non-poison reject**: the batch is malformed-by-contract, not a transient
 //!   failure, so the drain loop (#467) must classify it as terminal (do not
 //!   retry forever) — yet distinct from a poison *row*, because the whole batch
-//!   shares one version and bisecting rows cannot rescue it. This module
-//!   supplies the predicate; the reject/quarantine handling lives with the
-//!   drain loop that has a batch to act on.
+//!   shares one version and bisecting rows cannot rescue it. That distinction
+//!   is now [`RejectionClass::TerminalBatch`] vs [`RejectionClass::TerminalRow`].
+//!
+//! # Poison-row resilience (#467)
+//!
+//! The cursor is monotonic and advances only on a confirmed ack, so one row the
+//! intake refuses *forever* would wedge every newer row for that org — an
+//! offline-forever org from one bad row. [`drain_org`] closes that hole:
+//! rejections are classified ([`DrainRejection`]), a terminal row-attributable
+//! rejection is bisected down to the exact offending row, that row is
+//! dead-lettered with its reason
+//! ([`crate::usage::UsageStore::quarantine_cloud_row`]), and the cursor steps
+//! over it so the org keeps draining. The intake is an injected port
+//! ([`CloudIntake`]) — the transport itself lands with #404.
 //!
 //! # Bump-on-change discipline
 //!
@@ -52,7 +63,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::usage::CloudTelemetryEvent;
+use crate::Result;
+use crate::usage::{CloudTelemetryEvent, QuarantineReason, UsageStore};
 
 /// The native drain wire-format version this build speaks. Increment on any
 /// change to [`DrainRow`]'s field set or a field's semantics (see the module
@@ -166,6 +178,326 @@ impl From<&CloudTelemetryEvent> for DrainRow {
             tool_calls: t.tool_calls,
             usage_complete: t.usage_complete,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poison-row resilience (#467): rejection classification, the intake port, and
+// the bisecting drain loop.
+// ---------------------------------------------------------------------------
+
+/// How the drain must react to an intake refusing a batch.
+///
+/// Typed rather than stringly-typed because the three arms have *opposite*
+/// correct behaviors, and picking the wrong one is a data-loss or
+/// availability bug:
+///
+/// - [`Self::Transient`] — retry with the existing backoff. Quarantining here
+///   would dead-letter perfectly good rows over a blip.
+/// - [`Self::TerminalBatch`] — permanent, but a property of the *batch or the
+///   client*, not of any row: bad credentials, wrong endpoint, an unsupported
+///   [`DrainBatch::schema_version`]. Bisecting cannot rescue it and every row
+///   would look equally "poison", so the drain stops and surfaces it instead of
+///   silently dead-lettering the org's whole backlog.
+/// - [`Self::TerminalRow`] — permanent and attributable to row content the
+///   intake validated and refused. This is the poison row: bisect, quarantine,
+///   step the cursor over it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionClass {
+    /// Retry later with the existing backoff (5xx, network, timeout, throttle).
+    Transient,
+    /// Permanent and batch-wide — never attributable to one row.
+    TerminalBatch,
+    /// Permanent and attributable to one row's contents (validation reject).
+    TerminalRow,
+}
+
+impl RejectionClass {
+    /// Whether the drain should keep retrying this batch unchanged.
+    pub fn is_retryable(self) -> bool {
+        matches!(self, Self::Transient)
+    }
+}
+
+/// One intake refusal: its class plus the diagnostic to surface or persist.
+///
+/// `detail` is the intake's own message — data, not an error type — and is the
+/// only free-form field; the *decision* is carried by the typed
+/// [`Self::class`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrainRejection {
+    pub class: RejectionClass,
+    /// HTTP status, when the refusal arrived over HTTP. `None` for transport
+    /// failures (DNS, TLS, connect/read timeout) that never produced a status.
+    pub http_status: Option<u16>,
+    /// The intake's diagnostic.
+    pub detail: String,
+}
+
+impl DrainRejection {
+    /// A refusal to retry with backoff — 5xx, throttle, or a transport failure
+    /// that never produced a status.
+    pub fn transient(http_status: Option<u16>, detail: impl Into<String>) -> Self {
+        Self {
+            class: RejectionClass::Transient,
+            http_status,
+            detail: detail.into(),
+        }
+    }
+
+    /// A permanent refusal of the whole batch — auth, endpoint, or an
+    /// unsupported [`DrainBatch::schema_version`]. Never quarantines a row.
+    pub fn terminal_batch(http_status: Option<u16>, detail: impl Into<String>) -> Self {
+        Self {
+            class: RejectionClass::TerminalBatch,
+            http_status,
+            detail: detail.into(),
+        }
+    }
+
+    /// A permanent refusal attributable to row contents — the poison row the
+    /// drain bisects for and dead-letters.
+    pub fn terminal_row(http_status: Option<u16>, detail: impl Into<String>) -> Self {
+        Self {
+            class: RejectionClass::TerminalRow,
+            http_status,
+            detail: detail.into(),
+        }
+    }
+
+    /// Classify an HTTP status the intake returned.
+    ///
+    /// The split is deliberately conservative in both directions, because both
+    /// mistakes are expensive:
+    ///
+    /// - `408` / `429` / `5xx` are **transient**. A 4xx that means "slow down"
+    ///   or "try again" must never dead-letter a row.
+    /// - `400` / `422` are **terminal-row**: the intake parsed the payload and
+    ///   refused its contents. This is the only class that quarantines.
+    /// - Every other permanent 4xx (`401`, `403`, `404`, `409`, `413`, `426`, …)
+    ///   is **terminal-batch**. A revoked token or a mistyped endpoint returns
+    ///   4xx for *every* batch; treating that as a poison row would quietly
+    ///   dead-letter the org's entire backlog one row at a time. Stopping and
+    ///   surfacing it is the safe failure.
+    /// - `1xx`/`2xx`/`3xx` are not refusals; a caller that reaches here with one
+    ///   has an unexpected response, classified transient so nothing is dropped.
+    pub fn from_http_status(status: u16, detail: impl Into<String>) -> Self {
+        let class = match status {
+            408 | 429 => RejectionClass::Transient,
+            400 | 422 => RejectionClass::TerminalRow,
+            500..=599 => RejectionClass::Transient,
+            401..=499 => RejectionClass::TerminalBatch,
+            _ => RejectionClass::Transient,
+        };
+        Self {
+            class,
+            http_status: Some(status),
+            detail: detail.into(),
+        }
+    }
+
+    /// The dead-letter reason for this rejection — `Some` **only** for
+    /// [`RejectionClass::TerminalRow`].
+    ///
+    /// This is the single gate between "the intake said no" and "a row is
+    /// quarantined and the cursor steps over it": a transient blip or a
+    /// batch-wide refusal cannot produce a [`QuarantineReason`], so it cannot
+    /// reach [`crate::usage::UsageStore::quarantine_cloud_row`] by accident.
+    pub fn quarantine_reason(&self) -> Option<QuarantineReason> {
+        (self.class == RejectionClass::TerminalRow)
+            .then(|| QuarantineReason::terminal(self.http_status, &self.detail))
+    }
+}
+
+/// The remote org intake, as a **port**.
+///
+/// The transport (HTTPS, auth, backoff) lands with #404; this trait is the seam
+/// the drain loop talks to, so poison-row handling is real, tested behavior
+/// today — a test drives terminal and transient refusals with no network at
+/// all, and #404 slots its client in as one more adapter.
+///
+/// `Ok(())` is a **confirmed ack** for every row in the batch: the drain treats
+/// it as durable receipt and advances the cursor. An implementation that
+/// returns `Ok` optimistically breaks at-least-once delivery.
+///
+/// Batches are re-sent during bisection, so an implementation must tolerate
+/// duplicates — the wire contract's `(workspace_id, source_rowid)` dedup key
+/// makes that safe by construction.
+pub trait CloudIntake {
+    /// Deliver one batch, or say why it was refused.
+    fn deliver(&self, batch: &DrainBatch) -> std::result::Result<(), DrainRejection>;
+}
+
+/// What one [`drain_org`] pass did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DrainOutcome {
+    /// Rows the intake confirmed. Counts each hub row once even though
+    /// bisection may have re-sent it (the intake dedups).
+    pub delivered: u64,
+    /// Rows dead-lettered as poison and stepped over.
+    pub quarantined: u64,
+    /// Batches the intake accepted (excludes bisection probes).
+    pub batches: u64,
+    /// Why the pass stopped short of draining the backlog, if it did. `None`
+    /// means the org has no pending rows left. A [`RejectionClass::Transient`]
+    /// stop is the caller's cue to back off and retry; a
+    /// [`RejectionClass::TerminalBatch`] stop needs an operator.
+    pub stopped_by: Option<DrainRejection>,
+}
+
+impl DrainOutcome {
+    /// Whether the backlog was fully drained (nothing left, no stop).
+    pub fn is_complete(&self) -> bool {
+        self.stopped_by.is_none()
+    }
+}
+
+/// Drain one org's pending hub rows to `intake`, isolating poison rows so a
+/// permanently-rejected row can never stall the cursor (#467).
+///
+/// Pages `batch_size` rows at a time from
+/// [`UsageStore::cloud_pending`](crate::usage::UsageStore::cloud_pending) and
+/// ships each page. On success the cursor advances to the page's last row. On
+/// refusal:
+///
+/// - **transient** → stop and report; the caller retries with its backoff.
+///   Nothing is quarantined and the cursor does not move.
+/// - **terminal-batch** → stop and report. No row is attributable, so
+///   dead-lettering any would be silent loss.
+/// - **terminal-row** → [`bisect`] the page down to the exact row, dead-letter
+///   it with its reason, and advance the cursor past both the delivered prefix
+///   and the poison row — in one transaction — then keep draining. The org's
+///   newer rows flow again.
+///
+/// The cursor invariant is untouched: every advance goes through the same
+/// monotonic `MAX()` upsert, so it never rewinds.
+///
+/// `batch_size` is clamped to at least 1.
+pub fn drain_org(
+    hub: &UsageStore,
+    org_id: &str,
+    intake: &dyn CloudIntake,
+    batch_size: usize,
+) -> Result<DrainOutcome> {
+    let batch_size = batch_size.max(1);
+    let mut outcome = DrainOutcome::default();
+    loop {
+        let page = hub.cloud_pending(org_id, batch_size)?;
+        if page.is_empty() {
+            return Ok(outcome);
+        }
+        match intake.deliver(&DrainBatch::from_events(&page)) {
+            Ok(()) => {
+                let last = page[page.len() - 1].hub_rowid;
+                hub.ack_cloud_synced(org_id, last)?;
+                outcome.delivered += page.len() as u64;
+                outcome.batches += 1;
+            }
+            Err(rejection) => {
+                let Some(reason) = rejection.quarantine_reason() else {
+                    // Transient or batch-wide: nothing is attributable to a
+                    // row, so nothing is dead-lettered and the cursor holds.
+                    outcome.stopped_by = Some(rejection);
+                    return Ok(outcome);
+                };
+                match bisect(&page, intake, reason) {
+                    Bisection::Poison { index, reason } => {
+                        // `index` is also the confirmed-delivered prefix length,
+                        // and rows are rowid-ascending, so the poison row's own
+                        // `hub_rowid` is the single monotone advance that steps
+                        // over the prefix *and* the poison row. One transaction:
+                        // the row can never be skipped without a record.
+                        hub.quarantine_cloud_row(&page[index], &reason, page[index].hub_rowid)?;
+                        outcome.delivered += index as u64;
+                        outcome.quarantined += 1;
+                    }
+                    Bisection::Aborted {
+                        rejection,
+                        delivered_prefix,
+                    } => {
+                        // Bank whatever the probes confirmed before banking the
+                        // failure, so a mid-bisect blip still makes progress.
+                        if delivered_prefix > 0 {
+                            hub.ack_cloud_synced(org_id, page[delivered_prefix - 1].hub_rowid)?;
+                            outcome.delivered += delivered_prefix as u64;
+                        }
+                        outcome.stopped_by = Some(rejection);
+                        return Ok(outcome);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The result of narrowing a terminally-rejected page down to one row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Bisection {
+    /// `events[index]` is the poison row. `index` doubles as the length of the
+    /// prefix the intake confirmed while searching.
+    Poison {
+        index: usize,
+        reason: QuarantineReason,
+    },
+    /// A probe hit a transient or batch-wide failure; the search cannot
+    /// conclude, so nothing is dead-lettered.
+    Aborted {
+        rejection: DrainRejection,
+        delivered_prefix: usize,
+    },
+}
+
+/// Pinpoint the first poison row in a page the intake terminally row-rejected.
+///
+/// Binary-searches the **prefix length**: the smallest `k` in `1..=n` for which
+/// `events[..k]` is still terminally row-rejected. Row validation is per-row, so
+/// rejection is monotone in prefix length — a prefix containing the poison row
+/// rejects, and every longer one does too — which makes the search valid at
+/// `O(log n)` probes instead of `n`.
+///
+/// Searching prefixes rather than arbitrary halves is what makes the answer
+/// usable by a **monotonic** cursor. The loop invariant is that `lo - 1` is
+/// always a prefix length the intake just confirmed, so on termination
+/// `events[..k-1]` are delivered and `events[k-1]` is the poison row — one
+/// contiguous, rowid-ascending run the cursor steps over in a single advance.
+/// Re-sending an already-accepted prefix is safe by the wire contract's
+/// `(workspace_id, source_rowid)` dedup key.
+///
+/// `initial_reason` is the full-page refusal, which is the caller's
+/// precondition: `events` as a whole was terminally row-rejected. It stands as
+/// the answer when `events` holds a single row (no probe needed).
+fn bisect(
+    events: &[CloudTelemetryEvent],
+    intake: &dyn CloudIntake,
+    initial_reason: QuarantineReason,
+) -> Bisection {
+    debug_assert!(!events.is_empty(), "bisect requires a non-empty page");
+    let mut lo = 1usize;
+    let mut hi = events.len();
+    // The refusal that pinpointed the current `hi` prefix.
+    let mut culprit = initial_reason;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        match intake.deliver(&DrainBatch::from_events(&events[..mid])) {
+            // `lo - 1` stays a confirmed-delivered prefix length.
+            Ok(()) => lo = mid + 1,
+            Err(r) if r.class == RejectionClass::TerminalRow => {
+                culprit = QuarantineReason::terminal(r.http_status, &r.detail);
+                hi = mid;
+            }
+            Err(rejection) => {
+                return Bisection::Aborted {
+                    rejection,
+                    delivered_prefix: lo - 1,
+                };
+            }
+        }
+    }
+    // `lo == hi == k`, and `k <= events.len()` because every probe uses
+    // `mid < hi`: `events[..k-1]` were confirmed, `events[k-1]` is poison.
+    Bisection::Poison {
+        index: lo - 1,
+        reason: culprit,
     }
 }
 
@@ -310,5 +642,450 @@ mod tests {
             !schema_version_supported(DRAIN_SCHEMA_VERSION + 1),
             "an unknown newer version must be an explicit (terminal) reject"
         );
+    }
+
+    // ---- poison-row resilience (#467) --------------------------------------
+
+    mod poison {
+        use std::cell::RefCell;
+        use std::collections::VecDeque;
+
+        use super::*;
+        use crate::identity::TelemetryScope;
+        use crate::usage::UsageStore;
+
+        const ORG: &str = "acme";
+
+        /// An intake driven entirely from memory — the injected port that lets
+        /// these tests exercise terminal and transient refusals with no network
+        /// and no #404 transport. Its refusal message deliberately does **not**
+        /// name the offending row, so the bisect has to actually find it.
+        struct FakeIntake {
+            /// `source_rowid`s this intake permanently refuses as invalid.
+            poison: Vec<i64>,
+            /// Refusals returned ahead of any row inspection, oldest first —
+            /// how a test scripts a transient blip or an auth failure.
+            scripted: RefCell<VecDeque<DrainRejection>>,
+            /// `source_rowid`s the intake confirmed, in delivery order
+            /// (duplicates included — bisection re-sends prefixes).
+            accepted: RefCell<Vec<i64>>,
+            /// Every batch size the intake was handed, in order.
+            batch_sizes: RefCell<Vec<usize>>,
+        }
+
+        impl FakeIntake {
+            fn new(poison: &[i64]) -> Self {
+                Self {
+                    poison: poison.to_vec(),
+                    scripted: RefCell::new(VecDeque::new()),
+                    accepted: RefCell::new(Vec::new()),
+                    batch_sizes: RefCell::new(Vec::new()),
+                }
+            }
+
+            fn scripting(poison: &[i64], scripted: Vec<DrainRejection>) -> Self {
+                let intake = Self::new(poison);
+                *intake.scripted.borrow_mut() = scripted.into();
+                intake
+            }
+
+            /// Distinct `source_rowid`s the intake confirmed, ascending.
+            fn confirmed(&self) -> Vec<i64> {
+                let mut v = self.accepted.borrow().clone();
+                v.sort_unstable();
+                v.dedup();
+                v
+            }
+
+            fn calls(&self) -> usize {
+                self.batch_sizes.borrow().len()
+            }
+        }
+
+        impl CloudIntake for FakeIntake {
+            fn deliver(&self, batch: &DrainBatch) -> std::result::Result<(), DrainRejection> {
+                self.batch_sizes.borrow_mut().push(batch.rows.len());
+                if let Some(scripted) = self.scripted.borrow_mut().pop_front() {
+                    return Err(scripted);
+                }
+                if !schema_version_supported(batch.schema_version) {
+                    return Err(DrainRejection::terminal_batch(
+                        Some(400),
+                        format!("unsupported schema_version {}", batch.schema_version),
+                    ));
+                }
+                if batch
+                    .rows
+                    .iter()
+                    .any(|r| self.poison.contains(&r.source_rowid))
+                {
+                    // A real intake reports *that* validation failed, not which
+                    // row — pinpointing it is the drain's job.
+                    return Err(DrainRejection::from_http_status(
+                        400,
+                        "schema validation failed for one or more rows",
+                    ));
+                }
+                self.accepted
+                    .borrow_mut()
+                    .extend(batch.rows.iter().map(|r| r.source_rowid));
+                Ok(())
+            }
+        }
+
+        fn hub_with(source_rowids: &[i64]) -> UsageStore {
+            let hub = UsageStore::in_memory().expect("hub");
+            let scope = TelemetryScope {
+                org_id: Some(ORG.into()),
+                workspace_id: Some("ws-1".into()),
+                repo_id: "repo01".into(),
+                project_id: "proj_a".into(),
+            };
+            let rows: Vec<crate::SourceTelemetryRow> = source_rowids
+                .iter()
+                .map(|id| crate::SourceTelemetryRow {
+                    source_rowid: *id,
+                    execution_id: 1,
+                    recorded_at: "2026-07-23T10:00:00Z".into(),
+                    telemetry: TelemetryRow {
+                        step: *id as u64,
+                        provider: "zai".into(),
+                        call_role: "engine".into(),
+                        model: "glm-5.2".into(),
+                        input_tokens: 1_000,
+                        estimated_input_tokens: 900,
+                        output_tokens: 100,
+                        cache_read_tokens: 0,
+                        cache_miss_tokens: 0,
+                        cache_write_tokens: 0,
+                        cost_usd: 0.01,
+                        duration_ms: 1_200,
+                        retries: 0,
+                        tool_calls: 0,
+                        usage_complete: true,
+                    },
+                })
+                .collect();
+            hub.replicate_telemetry(&scope, &rows).expect("replicate");
+            hub
+        }
+
+        /// Hub `source_rowid`s still awaiting the cloud for this org.
+        fn pending(hub: &UsageStore) -> Vec<i64> {
+            hub.cloud_pending(ORG, 100)
+                .expect("pending")
+                .iter()
+                .map(|e| e.source_rowid)
+                .collect()
+        }
+
+        /// ACCEPTANCE (a) + (b): one terminally-rejected row must not stall the
+        /// org's newer rows, the quarantined row must be visible with its
+        /// reason, and the cursor must have advanced past it.
+        ///
+        /// On the pre-#467 drain this hangs the org forever: the cursor only
+        /// moves on a confirmed ack, so rows 3–5 never ship.
+        #[test]
+        fn a_poison_row_does_not_stall_the_org_cursor() {
+            let hub = hub_with(&[1, 2, 3, 4, 5]);
+            let intake = FakeIntake::new(&[2]);
+
+            let outcome = drain_org(&hub, ORG, &intake, 5).expect("drain");
+
+            assert_eq!(outcome.quarantined, 1);
+            assert_eq!(outcome.delivered, 4, "every non-poison row is delivered");
+            assert!(outcome.is_complete(), "the backlog drained: {outcome:?}");
+            assert_eq!(
+                intake.confirmed(),
+                vec![1, 3, 4, 5],
+                "the org's newer rows keep draining past the poison row"
+            );
+
+            // (b) the cursor advanced past the poison row — nothing is left
+            // pending, and it never rewinds on a re-drain.
+            assert!(pending(&hub).is_empty(), "cursor advanced past the poison");
+            let again = drain_org(&hub, ORG, &intake, 5).expect("re-drain");
+            assert_eq!(again.delivered, 0);
+            assert_eq!(again.quarantined, 0);
+
+            // (b) the quarantined row is visible: count + reason.
+            assert_eq!(hub.cloud_quarantine_count(Some(ORG)).unwrap(), 1);
+            let reasons = hub.cloud_quarantine_reasons(Some(ORG)).unwrap();
+            assert_eq!(reasons.len(), 1);
+            assert_eq!(reasons[0].1, Some(400), "the intake's status is retained");
+            assert_eq!(reasons[0].2, 1);
+            assert!(
+                reasons[0].0.contains("schema validation failed"),
+                "the intake's reason is retained: {:?}",
+                reasons[0].0
+            );
+
+            // ...and it is retained for inspection, not silently dropped.
+            let rows = hub.cloud_quarantined(Some(ORG), 10).unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].source_rowid, 2, "the exact offending row");
+            assert_eq!(rows[0].org_id, ORG);
+            assert_eq!(rows[0].workspace_id.as_deref(), Some("ws-1"));
+            assert_eq!(rows[0].provider, "zai");
+        }
+
+        /// The bisect must pinpoint the *right* row when a batch has several
+        /// good rows on both sides of one bad one — and must not dead-letter
+        /// its neighbors.
+        #[test]
+        fn bisect_pinpoints_the_poison_row_among_good_neighbors() {
+            let hub = hub_with(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+            let intake = FakeIntake::new(&[7]);
+
+            let outcome = drain_org(&hub, ORG, &intake, 12).expect("drain");
+
+            assert_eq!(outcome.quarantined, 1);
+            assert_eq!(outcome.delivered, 11);
+            let quarantined = hub.cloud_quarantined(Some(ORG), 10).unwrap();
+            assert_eq!(
+                quarantined
+                    .iter()
+                    .map(|q| q.source_rowid)
+                    .collect::<Vec<_>>(),
+                vec![7],
+                "only the offending row is dead-lettered"
+            );
+            assert_eq!(
+                intake.confirmed(),
+                vec![1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12],
+                "every good neighbor still reaches the intake"
+            );
+            // Bisection is logarithmic, not linear: the full page + ~log2(12)
+            // probes + the tail re-send, nowhere near one call per row.
+            assert!(
+                intake.calls() <= 8,
+                "bisect probed {} times for 12 rows — that is not a bisect",
+                intake.calls()
+            );
+        }
+
+        /// Several poison rows in one page are each isolated in turn, and the
+        /// good rows between them still ship.
+        #[test]
+        fn multiple_poison_rows_are_isolated_one_at_a_time() {
+            let hub = hub_with(&[1, 2, 3, 4, 5, 6, 7, 8]);
+            let intake = FakeIntake::new(&[3, 6]);
+
+            let outcome = drain_org(&hub, ORG, &intake, 8).expect("drain");
+
+            assert_eq!(outcome.quarantined, 2);
+            assert_eq!(outcome.delivered, 6);
+            assert!(outcome.is_complete());
+            let mut ids: Vec<i64> = hub
+                .cloud_quarantined(Some(ORG), 10)
+                .unwrap()
+                .iter()
+                .map(|q| q.source_rowid)
+                .collect();
+            ids.sort_unstable();
+            assert_eq!(ids, vec![3, 6]);
+            assert_eq!(intake.confirmed(), vec![1, 2, 4, 5, 7, 8]);
+            assert!(pending(&hub).is_empty());
+        }
+
+        /// A transient refusal must NOT quarantine anything and must NOT move
+        /// the cursor: the rows stay pending for the caller's backoff to retry,
+        /// and the same rows drain cleanly once the intake recovers.
+        #[test]
+        fn transient_rejection_never_quarantines_and_holds_the_cursor() {
+            let hub = hub_with(&[1, 2, 3]);
+            let intake = FakeIntake::scripting(
+                &[],
+                vec![
+                    DrainRejection::from_http_status(503, "upstream unavailable"),
+                    DrainRejection::transient(None, "connect timeout"),
+                ],
+            );
+
+            let first = drain_org(&hub, ORG, &intake, 3).expect("drain");
+            assert_eq!(first.delivered, 0);
+            assert_eq!(first.quarantined, 0);
+            assert_eq!(
+                first.stopped_by.as_ref().map(|r| r.class),
+                Some(RejectionClass::Transient),
+                "a 5xx is a retry, not a poison row"
+            );
+            assert_eq!(hub.cloud_quarantine_count(Some(ORG)).unwrap(), 0);
+            assert_eq!(pending(&hub), vec![1, 2, 3], "the cursor did not move");
+
+            // A bare transport failure (no HTTP status) is transient too.
+            let second = drain_org(&hub, ORG, &intake, 3).expect("drain");
+            assert_eq!(
+                second.stopped_by.as_ref().map(|r| r.class),
+                Some(RejectionClass::Transient)
+            );
+            assert_eq!(hub.cloud_quarantine_count(Some(ORG)).unwrap(), 0);
+
+            // Script exhausted — the same rows now drain untouched.
+            let third = drain_org(&hub, ORG, &intake, 3).expect("drain");
+            assert_eq!(third.delivered, 3);
+            assert_eq!(third.quarantined, 0);
+            assert!(third.is_complete());
+            assert_eq!(intake.confirmed(), vec![1, 2, 3]);
+        }
+
+        /// A permanent but batch-wide refusal (revoked token, wrong endpoint,
+        /// unsupported schema version) must stop the drain rather than
+        /// dead-letter the org's whole backlog one row at a time.
+        #[test]
+        fn terminal_batch_rejection_stops_without_quarantining() {
+            let hub = hub_with(&[1, 2, 3, 4]);
+            let intake = FakeIntake::scripting(
+                &[],
+                vec![DrainRejection::from_http_status(401, "token revoked")],
+            );
+
+            let outcome = drain_org(&hub, ORG, &intake, 4).expect("drain");
+
+            assert_eq!(outcome.quarantined, 0, "auth failure is not a poison row");
+            assert_eq!(outcome.delivered, 0);
+            assert_eq!(
+                outcome.stopped_by.as_ref().map(|r| r.class),
+                Some(RejectionClass::TerminalBatch)
+            );
+            assert_eq!(hub.cloud_quarantine_count(None).unwrap(), 0);
+            assert_eq!(pending(&hub), vec![1, 2, 3, 4], "the cursor did not move");
+            assert_eq!(intake.calls(), 1, "a batch-wide refusal is never bisected");
+        }
+
+        /// A transient blip *during* bisection aborts the search without
+        /// dead-lettering a row — but banks the prefix the probes confirmed, so
+        /// the next pass restarts from a shorter backlog.
+        #[test]
+        fn a_transient_blip_mid_bisect_quarantines_nothing_but_keeps_progress() {
+            let hub = hub_with(&[1, 2, 3, 4]);
+            // Full page rejects (row 4 is poison); the first *probe* blips.
+            let intake = FakeIntake::scripting(
+                &[4],
+                vec![
+                    DrainRejection::from_http_status(400, "schema validation failed"),
+                    DrainRejection::from_http_status(503, "upstream unavailable"),
+                ],
+            );
+
+            let outcome = drain_org(&hub, ORG, &intake, 4).expect("drain");
+            assert_eq!(
+                outcome.quarantined, 0,
+                "an aborted bisect dead-letters nothing"
+            );
+            assert_eq!(
+                outcome.stopped_by.as_ref().map(|r| r.class),
+                Some(RejectionClass::Transient)
+            );
+            assert_eq!(hub.cloud_quarantine_count(None).unwrap(), 0);
+
+            // Retrying finds the poison row and the org drains out.
+            let outcome = drain_org(&hub, ORG, &intake, 4).expect("re-drain");
+            assert_eq!(outcome.quarantined, 1);
+            assert!(pending(&hub).is_empty());
+            assert_eq!(
+                hub.cloud_quarantined(Some(ORG), 10).unwrap()[0].source_rowid,
+                4
+            );
+        }
+
+        /// Paging: a poison row in a later page is isolated just the same, and
+        /// each page's cursor advance is monotone.
+        #[test]
+        fn poison_row_in_a_later_page_is_isolated_too() {
+            let hub = hub_with(&[1, 2, 3, 4, 5, 6]);
+            let intake = FakeIntake::new(&[5]);
+
+            let outcome = drain_org(&hub, ORG, &intake, 2).expect("drain");
+
+            assert_eq!(outcome.quarantined, 1);
+            assert_eq!(outcome.delivered, 5);
+            assert!(pending(&hub).is_empty());
+            assert_eq!(intake.confirmed(), vec![1, 2, 3, 4, 6]);
+        }
+
+        #[test]
+        fn http_status_classification_splits_retry_from_poison_from_operator() {
+            let class = |s: u16| DrainRejection::from_http_status(s, "x").class;
+            // Retry with backoff.
+            for s in [408, 429, 500, 502, 503, 504] {
+                assert_eq!(class(s), RejectionClass::Transient, "{s} must retry");
+            }
+            // The only statuses that may ever dead-letter a row.
+            for s in [400, 422] {
+                assert_eq!(class(s), RejectionClass::TerminalRow, "{s} is a poison row");
+            }
+            // Permanent, but never attributable to a row.
+            for s in [401, 403, 404, 409, 413, 426] {
+                assert_eq!(
+                    class(s),
+                    RejectionClass::TerminalBatch,
+                    "{s} must not dead-letter rows"
+                );
+            }
+            assert!(RejectionClass::Transient.is_retryable());
+            assert!(!RejectionClass::TerminalRow.is_retryable());
+            assert!(!RejectionClass::TerminalBatch.is_retryable());
+        }
+
+        /// The gate between "refused" and "dead-lettered": only a terminal,
+        /// row-attributable rejection can produce a [`QuarantineReason`].
+        #[test]
+        fn only_a_terminal_row_rejection_can_become_a_quarantine_reason() {
+            assert!(
+                DrainRejection::transient(Some(503), "blip")
+                    .quarantine_reason()
+                    .is_none()
+            );
+            assert!(
+                DrainRejection::terminal_batch(Some(401), "token revoked")
+                    .quarantine_reason()
+                    .is_none()
+            );
+            let reason = DrainRejection::terminal_row(Some(422), "bad model id")
+                .quarantine_reason()
+                .expect("terminal-row rejections are quarantinable");
+            assert_eq!(reason.http_status, Some(422));
+            assert_eq!(reason.detail(), "bad model id");
+        }
+
+        /// An unsupported wire version is terminal but batch-wide — the whole
+        /// batch shares one `schema_version`, so bisecting rows cannot rescue
+        /// it and no row may be blamed for it.
+        #[test]
+        fn unsupported_schema_version_is_terminal_but_never_a_poison_row() {
+            let hub = hub_with(&[1, 2, 3]);
+            struct VersionPickyIntake;
+            impl CloudIntake for VersionPickyIntake {
+                fn deliver(&self, batch: &DrainBatch) -> std::result::Result<(), DrainRejection> {
+                    // Simulate an intake that only speaks a *newer* range.
+                    if schema_version_supported(batch.schema_version) {
+                        return Err(DrainRejection::terminal_batch(
+                            Some(400),
+                            format!("unsupported schema_version {}", batch.schema_version),
+                        ));
+                    }
+                    Ok(())
+                }
+            }
+            let outcome = drain_org(&hub, ORG, &VersionPickyIntake, 3).expect("drain");
+            assert_eq!(outcome.quarantined, 0);
+            assert_eq!(
+                outcome.stopped_by.as_ref().map(|r| r.class),
+                Some(RejectionClass::TerminalBatch)
+            );
+            assert_eq!(pending(&hub), vec![1, 2, 3]);
+        }
+
+        /// An empty backlog is a clean no-op — the drain never calls the intake
+        /// with an empty batch.
+        #[test]
+        fn draining_an_empty_backlog_never_touches_the_intake() {
+            let hub = UsageStore::in_memory().unwrap();
+            let intake = FakeIntake::new(&[]);
+            let outcome = drain_org(&hub, ORG, &intake, 10).expect("drain");
+            assert_eq!(outcome, DrainOutcome::default());
+            assert_eq!(intake.calls(), 0);
+        }
     }
 }

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -130,8 +130,9 @@ use migrations::{
 pub use cache_gaps::CacheCallGap;
 pub use catalog::CatalogStore;
 pub use drain::{
-    DRAIN_SCHEMA_VERSION, DrainBatch, DrainRow, MAX_SUPPORTED_SCHEMA_VERSION,
-    MIN_SUPPORTED_SCHEMA_VERSION, OTEL_SCHEMA_VERSION_ATTR, schema_version_supported,
+    CloudIntake, DRAIN_SCHEMA_VERSION, DrainBatch, DrainOutcome, DrainRejection, DrainRow,
+    MAX_SUPPORTED_SCHEMA_VERSION, MIN_SUPPORTED_SCHEMA_VERSION, OTEL_SCHEMA_VERSION_ATTR,
+    RejectionClass, drain_org, schema_version_supported,
 };
 // The sidecar journal's writer is deliberately NOT re-exported at the top
 // level: `SessionJournal` here names the DB read-model reassembled by

--- a/stella-store/src/usage.rs
+++ b/stella-store/src/usage.rs
@@ -17,6 +17,23 @@
 //! bounds that growth — by age, by a hard row ceiling, and by GC of unregistered
 //! projects whose checkout is gone — without ever dropping an org's un-acked
 //! cloud-drain rows (see [`UsageStore::prune`] and [`PrunePolicy`]).
+//!
+//! Cloud drain: [`UsageStore::cloud_pending`] stages an org's un-acked rows and
+//! [`UsageStore::ack_cloud_synced`] advances a monotonic per-org cursor that
+//! never rewinds. Because it advances only on a confirmed ack, one row the
+//! intake rejects *permanently* would wedge every newer row for that org — so
+//! [`UsageStore::quarantine_cloud_row`] dead-letters that row (with its
+//! rejection reason, retained for inspection) and steps the cursor over it in a
+//! single transaction (#467). The drain loop that pinpoints such a row lives in
+//! [`crate::drain`].
+//!
+//! Schema: `usage.db` is versioned by *convergence*, not by a `user_version`
+//! migration list (unlike `.stella/private/store.db`, see [`crate::migrations`]).
+//! Every table in [`USAGE_SCHEMA`] is `CREATE ... IF NOT EXISTS` and the whole
+//! batch replays on every open, so an additive table or index reaches an
+//! existing hub the next time it is opened. Adding a table here is the
+//! migration; a table that ever needs a *reshape* would need the versioned
+//! machinery introduced first.
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -176,6 +193,26 @@ CREATE TABLE IF NOT EXISTS cloud_sync_cursors (
     org_id         TEXT PRIMARY KEY,
     last_hub_rowid INTEGER NOT NULL DEFAULT 0
 );
+CREATE TABLE IF NOT EXISTS cloud_quarantine (
+    org_id         TEXT NOT NULL,
+    project_id     TEXT NOT NULL,
+    source_rowid   INTEGER NOT NULL,
+    workspace_id   TEXT,
+    repo_id        TEXT NOT NULL DEFAULT '',
+    hub_rowid      INTEGER NOT NULL,
+    recorded_at    TEXT NOT NULL DEFAULT '',
+    provider       TEXT NOT NULL DEFAULT '',
+    model          TEXT NOT NULL DEFAULT '',
+    input_tokens   INTEGER NOT NULL DEFAULT 0,
+    output_tokens  INTEGER NOT NULL DEFAULT 0,
+    cost_usd       REAL NOT NULL DEFAULT 0,
+    reason         TEXT NOT NULL,
+    http_status    INTEGER,
+    quarantined_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (org_id, project_id, source_rowid)
+);
+CREATE INDEX IF NOT EXISTS cloud_quarantine_by_org
+    ON cloud_quarantine(org_id, quarantined_at);
 ";
 
 /// The user-tier aggregate store. Read/write, loopback-local, no server.
@@ -496,6 +533,151 @@ impl UsageStore {
             params![org_id, up_to_hub_rowid],
         )?;
         Ok(())
+    }
+
+    /// Dead-letter one permanently-rejected hub row and advance the org cursor
+    /// past it — the head-of-line-blocking escape hatch (#467).
+    ///
+    /// The cursor never rewinds and never advances on an un-acked row, so a
+    /// single row the intake refuses *forever* would otherwise wedge every
+    /// newer row for that org. Once the drain has pinpointed that row
+    /// ([`crate::drain::drain_org`] bisects the batch), this records it with its
+    /// rejection reason and moves the cursor past it in **one transaction**:
+    /// quarantine-then-ack can only ever err toward re-quarantining the same
+    /// row (idempotent on `(org_id, project_id, source_rowid)`), never toward
+    /// skipping one without a record. A crash between the two halves is
+    /// impossible; a crash before the commit replays the whole step.
+    ///
+    /// The row is **never silently dropped**: the quarantine record keeps its
+    /// identity, its content-free telemetry, and why the intake refused it, and
+    /// it survives the retention prune that will eventually reclaim the acked
+    /// `telemetry` row itself (which is why the fields are copied, not joined).
+    ///
+    /// Content-free by construction (#466): the copied columns are identity +
+    /// addressing + per-call telemetry only. No prompt, completion, path, or
+    /// tool payload exists on a hub row to copy, and `reason` is the intake's
+    /// own diagnostic, truncated to [`MAX_QUARANTINE_REASON_BYTES`] so a
+    /// misbehaving intake cannot turn the dead-letter table into a content
+    /// channel.
+    ///
+    /// `advance_to_hub_rowid` is the highest row the caller has *settled* —
+    /// normally `event.hub_rowid`, or a later row when a delivered prefix is
+    /// being acked in the same step. It is clamped to at least the quarantined
+    /// row so the poison row can never be quarantined without being stepped
+    /// over.
+    pub fn quarantine_cloud_row(
+        &self,
+        event: &CloudTelemetryEvent,
+        reason: &QuarantineReason,
+        advance_to_hub_rowid: i64,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        let t = &event.telemetry;
+        tx.execute(
+            "INSERT INTO cloud_quarantine \
+             (org_id, project_id, source_rowid, workspace_id, repo_id, hub_rowid, recorded_at, \
+              provider, model, input_tokens, output_tokens, cost_usd, reason, http_status) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(org_id, project_id, source_rowid) DO UPDATE SET \
+               hub_rowid = excluded.hub_rowid, \
+               reason = excluded.reason, \
+               http_status = excluded.http_status",
+            params![
+                event.org_id,
+                event.project_id,
+                event.source_rowid,
+                event.workspace_id,
+                event.repo_id,
+                event.hub_rowid,
+                event.recorded_at,
+                t.provider,
+                t.model,
+                t.input_tokens as i64,
+                t.output_tokens as i64,
+                t.cost_usd,
+                reason.detail(),
+                reason.http_status,
+            ],
+        )?;
+        tx.execute(
+            "INSERT INTO cloud_sync_cursors (org_id, last_hub_rowid) VALUES (?1, ?2) \
+             ON CONFLICT(org_id) DO UPDATE SET \
+               last_hub_rowid = MAX(last_hub_rowid, excluded.last_hub_rowid)",
+            params![event.org_id, advance_to_hub_rowid.max(event.hub_rowid)],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// How many rows the cloud drain has dead-lettered for one org — the count
+    /// half of what `stella cloud status` surfaces. `None` counts every org.
+    pub fn cloud_quarantine_count(&self, org_id: Option<&str>) -> Result<i64> {
+        Ok(self.lock().query_row(
+            "SELECT COUNT(*) FROM cloud_quarantine WHERE (?1 IS NULL OR org_id = ?1)",
+            params![org_id],
+            |r| r.get(0),
+        )?)
+    }
+
+    /// Dead-lettered rows for one org, newest first — the inspection view
+    /// behind `stella cloud status`. `None` reports every org.
+    pub fn cloud_quarantined(
+        &self,
+        org_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<QuarantinedRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT org_id, project_id, source_rowid, workspace_id, repo_id, hub_rowid, \
+                    recorded_at, provider, model, cost_usd, reason, http_status, quarantined_at \
+             FROM cloud_quarantine \
+             WHERE (?1 IS NULL OR org_id = ?1) \
+             ORDER BY quarantined_at DESC, hub_rowid DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![org_id, limit as i64], |r| {
+            Ok(QuarantinedRow {
+                org_id: r.get(0)?,
+                project_id: r.get(1)?,
+                source_rowid: r.get(2)?,
+                workspace_id: r.get(3)?,
+                repo_id: r.get(4)?,
+                hub_rowid: r.get(5)?,
+                recorded_at: r.get(6)?,
+                provider: r.get(7)?,
+                model: r.get(8)?,
+                cost_usd: r.get(9)?,
+                reason: r.get(10)?,
+                http_status: r.get(11)?,
+                quarantined_at: r.get(12)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Dead-letter counts grouped by rejection reason, largest group first —
+    /// the "count + reason" rollup `stella cloud status` prints without dumping
+    /// every row. `None` reports every org.
+    pub fn cloud_quarantine_reasons(
+        &self,
+        org_id: Option<&str>,
+    ) -> Result<Vec<(String, Option<i64>, i64)>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT reason, http_status, COUNT(*) AS n FROM cloud_quarantine \
+             WHERE (?1 IS NULL OR org_id = ?1) \
+             GROUP BY reason, http_status ORDER BY n DESC, reason ASC",
+        )?;
+        let rows = stmt.query_map(params![org_id], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
     }
 
     /// Every project the hub knows: (project_id, name, root_path) — the
@@ -830,6 +1012,89 @@ pub struct CloudTelemetryEvent {
     pub telemetry: crate::TelemetryRow,
 }
 
+/// Hard cap on the bytes of intake diagnostic text a quarantine record keeps.
+///
+/// The reason is the *remote* intake's own words. A hub row is content-free by
+/// construction (#466), so a well-behaved intake has nothing sensitive to quote
+/// back — but the dead-letter table must not become an unbounded channel for
+/// whatever a misbehaving or compromised intake decides to echo, so the store
+/// truncates rather than trusting the peer.
+pub const MAX_QUARANTINE_REASON_BYTES: usize = 512;
+
+/// Why the cloud intake permanently refused one row, as persisted by
+/// [`UsageStore::quarantine_cloud_row`].
+///
+/// Deliberately distinct from the drain's [`crate::drain::DrainRejection`]: only
+/// a **terminal, row-attributable** rejection may ever become a quarantine
+/// record, and the named constructor says so. A transient failure must retry,
+/// and a terminal *batch* failure (bad auth, unsupported schema version) is not
+/// attributable to any one row — dead-lettering either would be silent data
+/// loss. [`crate::drain::DrainRejection::quarantine_reason`] is the only path
+/// the drain loop takes to build one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuarantineReason {
+    /// The intake's HTTP status, when the rejection came over HTTP.
+    pub http_status: Option<u16>,
+    detail: String,
+}
+
+impl QuarantineReason {
+    /// Build a reason for a rejection the caller has already established is
+    /// terminal **and** attributable to this single row. `detail` is truncated
+    /// to [`MAX_QUARANTINE_REASON_BYTES`] on a char boundary.
+    pub fn terminal(http_status: Option<u16>, detail: &str) -> Self {
+        Self {
+            http_status,
+            detail: truncate_on_char_boundary(detail.trim(), MAX_QUARANTINE_REASON_BYTES)
+                .to_string(),
+        }
+    }
+
+    /// The (truncated) intake diagnostic.
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+/// Longest prefix of `s` that fits in `max` bytes without splitting a `char`.
+fn truncate_on_char_boundary(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// One dead-lettered hub row, retained for inspection after the cloud drain
+/// stepped the org cursor past it (#467).
+///
+/// Content-free by construction (#466): identity, addressing, the per-call
+/// telemetry a `stella cloud status` reader needs to recognize the row, and the
+/// intake's rejection reason. No prompt, completion, path, or tool payload.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuarantinedRow {
+    pub org_id: String,
+    pub project_id: String,
+    /// Half of the intake's `(workspace_id, source_rowid)` identity — what an
+    /// operator quotes when asking the intake why it refused the row.
+    pub source_rowid: i64,
+    pub workspace_id: Option<String>,
+    pub repo_id: String,
+    /// The hub cursor address the drain advanced past.
+    pub hub_rowid: i64,
+    pub recorded_at: String,
+    pub provider: String,
+    pub model: String,
+    pub cost_usd: f64,
+    /// The intake's diagnostic, truncated to [`MAX_QUARANTINE_REASON_BYTES`].
+    pub reason: String,
+    pub http_status: Option<u16>,
+    pub quarantined_at: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1014,6 +1279,205 @@ mod tests {
             hub.cloud_pending("acme", 10).unwrap().is_empty(),
             "an out-of-order ack never rewinds the cursor"
         );
+    }
+
+    // ---- poison-row quarantine (#467) --------------------------------------
+
+    /// Seed one org row and hand back the hub plus its pending event.
+    fn hub_with_one_org_row() -> (UsageStore, CloudTelemetryEvent) {
+        let hub = UsageStore::in_memory().unwrap();
+        hub.replicate_telemetry(
+            &scope(Some("acme"), Some("ws-1")),
+            &[source_row(1, 0.05), source_row(2, 0.05)],
+        )
+        .unwrap();
+        let event = hub.cloud_pending("acme", 10).unwrap().remove(0);
+        (hub, event)
+    }
+
+    #[test]
+    fn quarantine_advances_the_cursor_past_the_poison_row_in_one_step() {
+        let (hub, poison) = hub_with_one_org_row();
+        assert_eq!(hub.cloud_pending("acme", 10).unwrap().len(), 2);
+
+        hub.quarantine_cloud_row(
+            &poison,
+            &QuarantineReason::terminal(Some(400), "unknown provider"),
+            poison.hub_rowid,
+        )
+        .unwrap();
+
+        // The org's newer row is now the only pending one — head-of-line
+        // blocking is gone.
+        let still_pending: Vec<i64> = hub
+            .cloud_pending("acme", 10)
+            .unwrap()
+            .iter()
+            .map(|e| e.source_rowid)
+            .collect();
+        assert_eq!(still_pending, vec![2]);
+        assert_eq!(hub.cloud_quarantine_count(Some("acme")).unwrap(), 1);
+    }
+
+    #[test]
+    fn quarantine_never_rewinds_the_monotonic_cursor() {
+        let (hub, first) = hub_with_one_org_row();
+        // Ack everything, then quarantine the *older* row: the cursor must not
+        // walk backwards and re-ship the row already confirmed.
+        let last = hub.cloud_pending("acme", 10).unwrap().pop().unwrap();
+        hub.ack_cloud_synced("acme", last.hub_rowid).unwrap();
+        assert!(hub.cloud_pending("acme", 10).unwrap().is_empty());
+
+        hub.quarantine_cloud_row(
+            &first,
+            &QuarantineReason::terminal(Some(422), "late reject"),
+            first.hub_rowid,
+        )
+        .unwrap();
+
+        assert!(
+            hub.cloud_pending("acme", 10).unwrap().is_empty(),
+            "quarantining an already-acked row must never rewind the cursor"
+        );
+    }
+
+    #[test]
+    fn quarantining_the_same_row_twice_is_idempotent_and_keeps_the_latest_reason() {
+        let (hub, poison) = hub_with_one_org_row();
+        hub.quarantine_cloud_row(
+            &poison,
+            &QuarantineReason::terminal(Some(400), "first diagnosis"),
+            poison.hub_rowid,
+        )
+        .unwrap();
+        hub.quarantine_cloud_row(
+            &poison,
+            &QuarantineReason::terminal(Some(422), "second diagnosis"),
+            poison.hub_rowid,
+        )
+        .unwrap();
+
+        assert_eq!(
+            hub.cloud_quarantine_count(Some("acme")).unwrap(),
+            1,
+            "a replayed quarantine must not double-count"
+        );
+        let rows = hub.cloud_quarantined(Some("acme"), 10).unwrap();
+        assert_eq!(rows[0].reason, "second diagnosis");
+        assert_eq!(rows[0].http_status, Some(422));
+    }
+
+    #[test]
+    fn quarantine_is_org_scoped_and_reports_counts_by_reason() {
+        let hub = UsageStore::in_memory().unwrap();
+        for (org, project) in [("acme", "proj_a"), ("globex", "proj_b")] {
+            let mut s = scope(Some(org), Some("ws-1"));
+            s.project_id = project.into();
+            hub.replicate_telemetry(&s, &[source_row(1, 0.05), source_row(2, 0.05)])
+                .unwrap();
+        }
+        for org in ["acme", "acme", "globex"] {
+            let e = hub.cloud_pending(org, 10).unwrap().remove(0);
+            hub.quarantine_cloud_row(
+                &e,
+                &QuarantineReason::terminal(Some(400), "unknown provider"),
+                e.hub_rowid,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(hub.cloud_quarantine_count(Some("acme")).unwrap(), 2);
+        assert_eq!(hub.cloud_quarantine_count(Some("globex")).unwrap(), 1);
+        assert_eq!(hub.cloud_quarantine_count(None).unwrap(), 3, "all orgs");
+        let reasons = hub.cloud_quarantine_reasons(Some("acme")).unwrap();
+        assert_eq!(
+            reasons,
+            vec![("unknown provider".to_string(), Some(400), 2)]
+        );
+        assert!(
+            hub.cloud_quarantined(Some("globex"), 10)
+                .unwrap()
+                .iter()
+                .all(|q| q.org_id == "globex"),
+            "the inspection view is org-scoped"
+        );
+    }
+
+    /// The hard invariant from #466 / AGENTS.md #3: the dead-letter store keeps
+    /// a row for inspection, so it must not become a content leak. The column
+    /// set is pinned to identity + addressing + content-free telemetry + the
+    /// intake's diagnostic — adding a prompt/completion/path column here fails
+    /// this test.
+    #[test]
+    fn the_quarantine_table_is_content_free_by_construction() {
+        let hub = UsageStore::in_memory().unwrap();
+        let conn = hub.lock();
+        let mut stmt = conn
+            .prepare("SELECT name FROM pragma_table_info('cloud_quarantine')")
+            .unwrap();
+        let mut columns: Vec<String> = stmt
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        columns.sort();
+        let mut allowed: Vec<String> = [
+            // identity + addressing
+            "org_id",
+            "project_id",
+            "source_rowid",
+            "workspace_id",
+            "repo_id",
+            "hub_rowid",
+            "recorded_at",
+            // content-free telemetry
+            "provider",
+            "model",
+            "input_tokens",
+            "output_tokens",
+            "cost_usd",
+            // why it was refused
+            "reason",
+            "http_status",
+            "quarantined_at",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        allowed.sort();
+        assert_eq!(
+            columns, allowed,
+            "cloud_quarantine columns drifted — a dead-letter record is \
+             identity + telemetry + rejection reason ONLY, never content"
+        );
+    }
+
+    #[test]
+    fn a_quarantine_reason_cannot_grow_without_bound() {
+        let (hub, poison) = hub_with_one_org_row();
+        // A hostile/buggy intake echoing megabytes back must not turn the
+        // dead-letter table into a channel.
+        // The leading ASCII byte puts every multi-byte char on odd offsets, so
+        // the cap lands mid-char and the boundary walk is genuinely exercised.
+        let flood = format!("x{}", "é".repeat(MAX_QUARANTINE_REASON_BYTES));
+        let reason = QuarantineReason::terminal(None, &flood);
+        assert!(reason.detail().len() < MAX_QUARANTINE_REASON_BYTES);
+        assert!(
+            flood.starts_with(reason.detail()),
+            "truncation keeps a valid prefix on a char boundary"
+        );
+
+        hub.quarantine_cloud_row(&poison, &reason, poison.hub_rowid)
+            .unwrap();
+        let stored = hub.cloud_quarantined(Some("acme"), 1).unwrap();
+        assert!(stored[0].reason.len() <= MAX_QUARANTINE_REASON_BYTES);
+    }
+
+    #[test]
+    fn quarantine_reason_trims_and_preserves_short_diagnostics() {
+        let r = QuarantineReason::terminal(Some(400), "  model id not recognized\n");
+        assert_eq!(r.detail(), "model id not recognized");
+        assert_eq!(r.http_status, Some(400));
     }
 
     // ---- retention / prune -------------------------------------------------


### PR DESCRIPTION
## What & why

The cloud drain's per-org cursor (`cloud_sync_cursors`) is monotonic and advances only on a confirmed ack. That is correct for ack loss and offline backfill (#404's acceptance) — but it means a single row the intake rejects **permanently** is head-of-line blocking: it wedges every newer row for that org indefinitely. An offline-forever org from one bad row.

This closes that hole at the **store layer**, driven through an **injected port**, so it is real tested behavior rather than a stub waiting on the syncer.

**Classify the rejection.** A typed `RejectionClass`, three-way rather than the obvious two, because the arms have opposite correct behaviors and picking wrong is a data-loss *or* availability bug:

| Class | Statuses | Behavior |
|---|---|---|
| `Transient` | 5xx, 408, 429, transport (no status) | retry with the existing backoff; never quarantines |
| `TerminalBatch` | 401, 403, 404, 409, 413, 426, unsupported `schema_version` | permanent but **not attributable to any row** — stop and surface |
| `TerminalRow` | 400, 422 | the poison row; the only class that may ever quarantine |

The `TerminalBatch` arm is the one that matters most for safety. A revoked token or a mistyped endpoint returns 4xx for *every* batch — treating that as a poison row would quietly dead-letter the org's entire backlog one row at a time. `DrainRejection::quarantine_reason` returns `Some` only for `TerminalRow`, so that is the single gate between "the intake said no" and "a row is dead-lettered and the cursor steps over it".

**Isolate the poison row.** `drain_org` bisects a terminally-row-rejected page by **prefix length** — the smallest `k` for which `events[..k]` still rejects. Prefixes rather than arbitrary halves is what makes the answer usable by a *monotonic* cursor: the loop invariant keeps `lo - 1` a just-confirmed prefix, so on termination the delivered rows and the poison row form one contiguous rowid-ascending run the cursor steps over in a single advance. `O(log n)` probes; re-sending an accepted prefix is safe by the wire contract's `(workspace_id, source_rowid)` dedup key.

**Quarantine and advance, atomically.** `UsageStore::quarantine_cloud_row` writes the dead-letter record and advances the cursor in **one transaction**, so the failure mode can only ever be re-quarantining the same row (idempotent on `(org_id, project_id, source_rowid)`), never skipping one without a record. New `cloud_quarantine` table. The row is retained for inspection and survives the retention prune that eventually reclaims the acked `telemetry` row — which is why the fields are copied, not joined.

**Surface it.** `stella cloud status` prints the count and the top reason groups, with the intake's HTTP status. This matters *because* the fix works: after a poison row is stepped over the drain looks perfectly healthy, and this is the only place the silent casualty shows up.

Closes #467

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The acceptance criteria map to two tests in `stella-store/src/drain.rs`:

- `a_poison_row_does_not_stall_the_org_cursor` — (a) a batch with one terminally-rejected row still delivers every other row for that org; (b) the quarantined row is visible (count + reason + HTTP status) and the cursor advanced past it (nothing left pending, and a re-drain is a no-op).
- `bisect_pinpoints_the_poison_row_among_good_neighbors` — 12 rows, one bad at index 7; only that row is dead-lettered, all 11 neighbors reach the intake, and the probe count asserts the search is logarithmic rather than linear.

Plus the negative-space coverage that keeps the fix from becoming a data-loss bug:

- `transient_rejection_never_quarantines_and_holds_the_cursor`
- `terminal_batch_rejection_stops_without_quarantining` (auth) and `unsupported_schema_version_is_terminal_but_never_a_poison_row`
- `a_transient_blip_mid_bisect_quarantines_nothing_but_keeps_progress`
- `multiple_poison_rows_are_isolated_one_at_a_time`, `poison_row_in_a_later_page_is_isolated_too`
- `quarantine_never_rewinds_the_monotonic_cursor`, `quarantining_the_same_row_twice_is_idempotent_and_keeps_the_latest_reason`
- `the_quarantine_table_is_content_free_by_construction`, `a_quarantine_reason_cannot_grow_without_bound`

**Proof of the fail->pass flip.** `drain_org`'s terminal-row branch was temporarily reverted to the pre-#467 behavior (any refusal just stops the drain) and the suite re-run:

```
test drain::tests::poison::a_poison_row_does_not_stall_the_org_cursor ... FAILED
test drain::tests::poison::bisect_pinpoints_the_poison_row_among_good_neighbors ... FAILED
test drain::tests::poison::multiple_poison_rows_are_isolated_one_at_a_time ... FAILED
test drain::tests::poison::poison_row_in_a_later_page_is_isolated_too ... FAILED
test drain::tests::poison::a_transient_blip_mid_bisect_quarantines_nothing_but_keeps_progress ... FAILED
test result: FAILED. 6 passed; 5 failed
```

with `assertion `left == right` failed / left: 0 / right: 1` on `outcome.quarantined` — i.e. the old drain wedges the org exactly as #467 describes. The six that still pass are the classification and guard tests, which is the right shape: they assert what must *not* happen, and the old code also does not do it.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (module docs on `usage.rs` + `drain.rs`, doc comments on every new public item)
- [x] Commits signed off for DCO (`git commit -s`)

`make gate` is green (exit 0).

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new deps**
- [x] No new outbound network calls — `CloudIntake` is a trait with no implementation in the shipping binary. This PR cannot send a byte anywhere; the transport lands with #404.
- [x] Ports, not concretions — the intake is injected, and the tests drive terminal and transient refusals entirely in memory.

**Content-free invariant (#466 / AGENTS.md #3).** The quarantined row is retained for inspection, so the dead-letter store must not become a content leak. It stores identity + addressing + content-free telemetry + the rejection reason, and nothing else:

- A hub row has no prompt, completion, path, or tool payload to copy in the first place.
- `the_quarantine_table_is_content_free_by_construction` pins the `cloud_quarantine` column set against an allowlist — adding a content column fails the test.
- `reason` is the *remote* intake's own words, so it is truncated to `MAX_QUARANTINE_REASON_BYTES` (512, on a char boundary). A well-behaved intake has nothing sensitive to quote back, but the store must not trust the peer to stay well-behaved.
- The `telemetry` table is untouched — quarantine is its own table.

## Anything reviewers should know?

**What is deferred until #404.** #404 is still open, so nothing ships a batch to a remote intake yet and there is no live producer of terminal rejections today. Deferred, honestly:

1. **The transport adapter.** `CloudIntake` has no production implementation here. #404 implements it over HTTPS (auth, timeouts, its own backoff) and calls `drain_org`. Until then `drain_org` is exercised only by tests.
2. **Wiring `drain_org` into the syncer's retry loop.** The `Transient` stop is *reported*, not slept on — `DrainOutcome::stopped_by` is the caller's cue and the backoff policy belongs with the transport in #404.
3. **The real intake's status vocabulary.** The 400/422-vs-other-4xx split is the correct conservative default (only "the intake parsed and refused the contents" can dead-letter a row), but the companion server is a separate repo and may want a body-level discriminator instead of a bare status. `DrainRejection::from_http_status` is a convenience over the explicit constructors, so #404 can classify from a response body without touching this logic.

**Where the migration went.** `usage.db` is versioned by *convergence*, not by the `user_version` list in `migrations.rs` — that list belongs to `.stella/private/store.db`. Every table in `USAGE_SCHEMA` is `CREATE ... IF NOT EXISTS` and the batch replays on every open, so an additive table reaches an existing hub the next time it is opened. Adding `cloud_quarantine` there *is* the migration; putting it in `migrations.rs` would have targeted the wrong database. I documented this on the `usage.rs` module so the next person does not have to rediscover it, and noted that a table needing a *reshape* would need the versioned machinery introduced first.

**Follow-up not taken here.** `prune` does not bound `cloud_quarantine`. Poison rows are rare by nature and "never silently dropped" is the issue's explicit requirement, so unbounded-by-default is the right default — but if an intake ever starts rejecting at volume, retention for the dead-letter table is worth its own issue rather than a guess bolted on here.

**Merge-collision note:** touches `stella-cli/src/usage_cmd.rs` (the `cloud status` surface) beyond `stella-store`. It does **not** touch `enterprise_telemetry.rs` and does **not** add columns to `telemetry`, so it should not collide with #466.
