### PR TITLE
fix: three backlog wins — tool-timeout backstop (#367), SQLite family migration (#409), candidate policy plane (#441)

### DIFF
--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -241,6 +241,7 @@ async fn run_pipeline_one_shot(
             registry_options,
             active_rules.clone(),
             mcp.clone(),
+            Some(tx.clone()),
         )?;
 
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));

--- a/stella-cli/src/agent/goal.rs
+++ b/stella-cli/src/agent/goal.rs
@@ -590,6 +590,7 @@ async fn run_goal_pipeline_turn(
             registry_options,
             active_rules.clone(),
             mcp,
+            Some(stella_core::EventSender::new(tx.clone())),
         )?;
         let no_recall = NoContextRecall;
         let recall: &dyn ContextRecallPort = &no_recall;

--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -322,6 +322,7 @@ pub(crate) fn workspace_ports(
     registry_options: stella_tools::RegistryOptions,
     active_rules: crate::rules::ResolvedRules,
     mcp: Option<Arc<stella_mcp::McpToolSet>>,
+    events: Option<stella_core::EventSender>,
 ) -> Result<WorkspacePorts, String> {
     crate::enterprise_telemetry::authorize_execution_surface(
         crate::enterprise_telemetry::ExecutionSurface::WorkspacePorts,
@@ -347,6 +348,9 @@ pub(crate) fn workspace_ports(
     );
     if let Some(mcp) = &mcp {
         candidate_workspaces = candidate_workspaces.with_candidate_mcp(Arc::clone(mcp));
+    }
+    if let Some(events) = events {
+        candidate_workspaces = candidate_workspaces.with_events(events);
     }
     Ok(WorkspacePorts {
         repo_structure: GitRepoStructure { root: root.clone() },

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -869,6 +869,7 @@ async fn candidate_rules_reuse_the_parent_snapshot_after_source_removal() {
         stella_tools::RegistryOptions::default(),
         parent_rules.clone(),
         None,
+        None,
     )
     .unwrap();
     let candidate = ws_ports.candidate_workspaces.create().await.unwrap();
@@ -893,6 +894,87 @@ async fn candidate_rules_reuse_the_parent_snapshot_after_source_removal() {
         "prohibited candidate edit was adoptable: {adopted:?}"
     );
     assert!(!landed, "prohibited candidate edit reached the parent tree");
+}
+
+/// Witness for #441: a rule denial *inside a best-of-N candidate* must
+/// reach the journal as a typed `PolicyDecision`, not just as a tool error.
+/// Candidate workspaces are the primary real users of the rule-guard bus,
+/// so before this the typed record existed for the session and was missing
+/// exactly where most denials happen.
+#[tokio::test]
+async fn a_candidate_rule_denial_reaches_the_journal_as_a_policy_decision() {
+    let root = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root.path())
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "t@t.t"]);
+    git(&["config", "user.name", "t"]);
+    std::fs::write(root.path().join("base.txt"), "base\n").unwrap();
+    git(&["add", "base.txt"]);
+    git(&["commit", "-q", "-m", "base"]);
+
+    let rule_path = root.path().join(".stella/rules/protect-session.md");
+    std::fs::create_dir_all(rule_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &rule_path,
+        "---\nguard-tool: Write\nguard-deny-path: protected/**\n---\nSession guard.",
+    )
+    .unwrap();
+    let mut cfg = cfg_for("zai");
+    cfg.workspace_root = root.path().to_path_buf();
+    cfg.authority.project_prompts_allowed = true;
+    let parent_rules = crate::rules::load_workspace_rules(root.path(), &cfg.authority);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
+    let ws_ports = workspace_ports(
+        root.path().to_path_buf(),
+        &cfg,
+        stella_tools::RegistryOptions::default(),
+        parent_rules.clone(),
+        None,
+        Some(stella_core::EventSender::new(tx)),
+    )
+    .unwrap();
+
+    let candidate = ws_ports.candidate_workspaces.create().await.unwrap();
+    let output = candidate
+        .tools()
+        .execute(
+            "write_file",
+            &serde_json::json!({"path": "protected/candidate.txt", "content": "no\n"}),
+        )
+        .await;
+    candidate.remove().await;
+    drop(ws_ports);
+
+    assert!(
+        output.is_error(),
+        "precondition: the guard must still deny inside the candidate"
+    );
+
+    let mut decisions = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let AgentEvent::PolicyDecision { kind, subject, .. } = event {
+            decisions.push((kind, subject));
+        }
+    }
+    assert!(
+        decisions
+            .iter()
+            .any(|(kind, _)| *kind == stella_protocol::PolicyKind::Blocked),
+        "the candidate's denial never reached the journal: {decisions:?}"
+    );
 }
 
 #[test]

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -253,6 +253,11 @@ pub(crate) struct GitCandidateWorkspaces {
     /// phased tool surface" section). `None` when the session has no MCP
     /// servers connected, or hasn't opted any into `with_candidate_mcp`.
     candidate_mcp: Option<Arc<stella_mcp::McpToolSet>>,
+    /// The turn's event sink, used to bridge each candidate registry's
+    /// policy plane into the journal (#441). `None` leaves a candidate's
+    /// rule denials evaluating and blocking exactly as before — they simply
+    /// never land as typed `PolicyDecision` events.
+    events: Option<stella_core::EventSender>,
 }
 
 impl GitCandidateWorkspaces {
@@ -268,7 +273,18 @@ impl GitCandidateWorkspaces {
             custom_tools,
             active_rules,
             candidate_mcp: None,
+            events: None,
         }
+    }
+
+    /// Journal the policy decisions made inside every candidate this port
+    /// creates. Best-of-N candidates are the primary *actual* users of the
+    /// rule-guard bus, so without this the typed `PolicyDecision` record of
+    /// a denial exists for the session but not for the candidates where
+    /// most denials actually happen.
+    pub(crate) fn with_events(mut self, events: stella_core::EventSender) -> Self {
+        self.events = Some(events);
+        self
     }
 
     /// Share the session's connected MCP servers into every candidate this
@@ -327,6 +343,13 @@ impl GitCandidateWorkspaces {
                 // a plain `ToolRegistry`, before it moves into the `Arc`.
                 crate::agent::populate_schema_index(&registry, &ws_root).map_err(snap)?;
                 crate::rules::attach_rule_guards(&registry, &self.active_rules);
+                // `attach_rule_guards` is what gives this registry a live
+                // HookBus, so the bridge must follow it — and both must
+                // happen while `registry` is still a concrete `ToolRegistry`,
+                // before the `Arc<dyn ToolExecutor>` coercion below erases it.
+                if let Some(events) = &self.events {
+                    registry.bridge_policy_plane(events.clone());
+                }
                 // The candidate's tool surface: the snapshot-rooted registry
                 // plus the session's custom script tools, owned as one value
                 // (the workspace outlives every borrow). Custom tools re-root

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -3988,6 +3988,7 @@ async fn run_lead_pipeline_turn(
             registry_options.clone(),
             active_rules.clone(),
             mcp,
+            Some(stella_core::EventSender::new(tx.clone())),
         )?;
         let no_recall = NoContextRecall;
         let recall: &dyn ContextRecallPort = match memory {

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -703,6 +703,7 @@ async fn run_task(
                 registry_options,
                 active_rules.clone(),
                 None,
+                Some(stella_core::EventSender::new(tx.clone())),
             )?;
             let recall = NoContextRecall;
             let hook_runner = ShellHookRunner;

--- a/stella-core/Cargo.toml
+++ b/stella-core/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 rand = { workspace = true }

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -70,6 +70,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use futures_util::StreamExt;
 use stella_protocol::{
@@ -130,6 +131,29 @@ pub struct EngineConfig {
     /// and suspenders, never the *primary* stuck-loop defense (that's
     /// `crate::loop_detect`).
     pub max_steps: usize,
+    /// Hard backstop on how long one tool dispatch may run, independent of
+    /// each tool's own bound — the same belt-and-suspenders philosophy as
+    /// [`Self::max_steps`], and never the *primary* mechanism.
+    ///
+    /// Per-tool bounds are the real defense (bash clamps its own timeout,
+    /// scripts cap out, MCP bounds each call), but each is that tool's own
+    /// responsibility. A tool that misses its bound — a future native tool,
+    /// an MCP server that overrides its timeout upward, a wedged blocking
+    /// read — would otherwise park the step forever: loop detection, budget
+    /// checks and soft-stop all fire at *step boundaries*, so a headless
+    /// `stella run` hangs indefinitely with no way out but a hard cancel.
+    ///
+    /// When the ceiling trips, the call resolves to a `ToolOutput::Error`
+    /// the model can react to, turning "hung forever" into one failed call
+    /// the loop routes around. Deliberately generous (15 minutes) so it
+    /// never pre-empts a legitimately slow tool. `None` disables the
+    /// backstop entirely, restoring the unbounded await.
+    ///
+    /// Note this is the one place the engine may interrupt a tool in
+    /// flight; the budget-abort invariant (clean aborts at step boundaries,
+    /// never mid-tool) is unaffected, because a trip is surfaced as a tool
+    /// *result*, not as a turn abort.
+    pub tool_timeout: Option<Duration>,
     /// Working directory reported to lifecycle hooks (`crate::hooks`) as the
     /// `cwd` of every [`HookPayload`]. Kept here — rather than sniffed via
     /// `std::env::current_dir()` inside the engine — so `stella-core`
@@ -166,6 +190,7 @@ impl Default for EngineConfig {
             summarize_overflow: true,
             summarize_keep_recent: 8,
             max_steps: 200,
+            tool_timeout: Some(Duration::from_secs(15 * 60)),
             cwd: ".".to_string(),
             turn_instance: 0,
         }
@@ -1600,7 +1625,43 @@ impl<'a> Engine<'a> {
     /// stream as one non-fatal `Error` per call. `None` on the speculative
     /// path: speculation emits no events until harvest, and a failed
     /// attempt's hook noise must not reach the wire with it.
+    ///
+    /// The whole dispatch — hooks included — runs under
+    /// [`EngineConfig::tool_timeout`], the engine-level backstop for a tool
+    /// that blows past its own bound. On a trip the in-flight future is
+    /// dropped (so a `PostToolUse` hook does not fire, exactly as for a
+    /// tool that never returned) and the model sees a `ToolOutput::Error`
+    /// instead of the step parking forever. Dropping cancels at the next
+    /// await point: a tool already blocked inside `spawn_blocking` keeps
+    /// its thread until the process exits — the engine is unwedged, the
+    /// thread is not.
     async fn execute_with_repair(
+        &self,
+        call: &ToolCall,
+        events: Option<&EventSender>,
+    ) -> ToolOutput {
+        let Some(limit) = self.config.tool_timeout else {
+            return self.dispatch_tool_call(call, events).await;
+        };
+        match tokio::time::timeout(limit, self.dispatch_tool_call(call, events)).await {
+            Ok(output) => output,
+            Err(_) => ToolOutput::Error {
+                message: format!(
+                    "tool `{}` exceeded the engine's {}s dispatch ceiling and was abandoned \
+                     before it returned — it produced no result, and any work it had already \
+                     done outside this process may or may not have landed. This backstop fires \
+                     only when a tool overruns its own timeout, so an identical retry will \
+                     likely hang the same way: narrow the input, or reach the goal another way.",
+                    call.name,
+                    limit.as_secs()
+                ),
+            },
+        }
+    }
+
+    /// One tool dispatch, unbounded — the body [`Self::execute_with_repair`]
+    /// wraps in the timeout backstop.
+    async fn dispatch_tool_call(
         &self,
         call: &ToolCall,
         events: Option<&EventSender>,

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -2626,6 +2626,125 @@ fn read_tally_footer_does_not_blind_loop_detection() {
     );
 }
 
+/// A `ToolExecutor` that never returns — the wedged tool of #367. It
+/// awaits a future that can never complete, so nothing but the engine's
+/// own ceiling can end the step.
+struct WedgedTools;
+#[async_trait]
+impl ToolExecutor for WedgedTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        std::future::pending().await
+    }
+}
+
+/// Witness for #367: a tool that overruns its own bound must not park the
+/// turn forever. `EngineConfig::tool_timeout` is the engine-level backstop
+/// — it turns "hung forever" into one failed call the loop routes around,
+/// so the turn still reaches a clean `Completed`.
+///
+/// The clock is paused, so both timers below are virtual and the test
+/// costs no wall-clock. The outer guard is deliberately far longer than
+/// the engine's ceiling: with the backstop present the *inner* timer fires
+/// first and the turn recovers; without it (the pre-fix engine) the outer
+/// one is the only timer, and the test fails cleanly instead of hanging
+/// the suite.
+#[tokio::test(start_paused = true)]
+async fn a_wedged_tool_trips_the_dispatch_ceiling_instead_of_hanging() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("call_1", "bash")),
+            Ok(text_result("recovered")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        tool_timeout: Some(Duration::from_secs(900)),
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &WedgedTools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(4 * 3600),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await
+    .expect("the engine must bound a wedged tool itself — the turn hung past its own ceiling");
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "recovered".into(),
+            cost_usd: 0.0002
+        },
+        "the trip is a tool *result*, not a turn abort: the loop routes around it"
+    );
+    let result = messages
+        .iter()
+        .filter(|m| m.role == MessageRole::Tool)
+        .flat_map(|m| &m.tool_results)
+        .find(|r| r.call_id == "call_1")
+        .expect("the abandoned call must still answer the model with a result");
+    let ToolOutput::Error { message } = &result.output else {
+        panic!("a tripped ceiling is an error the model can react to: {result:?}");
+    };
+    assert!(
+        message.contains("dispatch ceiling") && message.contains("900s"),
+        "the model must be told the call was abandoned and why, not left guessing: {message}"
+    );
+}
+
+/// The backstop is opt-out: `None` restores the unbounded await, so a
+/// deployment that trusts its per-tool bounds keeps the old behavior.
+#[tokio::test(start_paused = true)]
+async fn a_none_ceiling_leaves_tool_dispatch_unbounded() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("call_1", "bash")),
+            Ok(text_result("unreachable")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        tool_timeout: None,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &WedgedTools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_secs(4 * 3600),
+            engine.run_turn(&mut messages, &mut budget, &tx),
+        )
+        .await
+        .is_err(),
+        "with no ceiling configured the wedged tool must still park the turn"
+    );
+}
+
 mod audit_fixes;
 mod task4;
 mod usage_completeness;

--- a/stella-store/src/home.rs
+++ b/stella-store/src/home.rs
@@ -59,6 +59,17 @@ fn legacy_config_dir() -> Option<PathBuf> {
     home_dir().map(|home| home.join(".config").join("stella"))
 }
 
+/// The sidecars SQLite keeps beside a database in WAL mode. They are
+/// meaningless without their base file, so they never travel alone.
+const SQLITE_SIDECARS: [&str; 2] = ["-wal", "-shm"];
+
+/// If `name` is a WAL/SHM sidecar, the database file it belongs to.
+fn sqlite_base_of(name: &str) -> Option<&str> {
+    SQLITE_SIDECARS
+        .iter()
+        .find_map(|suffix| name.strip_suffix(suffix))
+}
+
 /// Move every entry of `legacy` that does not already exist under `target`.
 /// Prefers `fs::rename` (atomic, same-volume); on a cross-device (`EXDEV`)
 /// or other rename failure it falls back to a recursive copy that leaves the
@@ -66,6 +77,15 @@ fn legacy_config_dir() -> Option<PathBuf> {
 /// of a user's settings/credentials, and the next run retries. Returns the
 /// number of entries it could neither move nor copy, so the caller can
 /// surface a partial migration instead of silently reporting an empty home.
+///
+/// A SQLite database and its `-wal`/`-shm` sidecars are one **family**, not
+/// three independent entries (#409). Moving them separately is what the
+/// per-entry loop used to do, and it has two failure modes: the family can
+/// be split across a crash, and — worse — the `dest.exists()` skip could
+/// drop a legacy `-wal` beside a *different*, already-migrated database.
+/// Families are therefore prepared and moved as a unit, and an orphan
+/// sidecar whose base is absent is left where it is rather than migrated
+/// next to a database it does not describe.
 fn merge_dir_into(legacy: &std::path::Path, target: &std::path::Path) -> u64 {
     let Ok(entries) = std::fs::read_dir(legacy) else {
         return 0;
@@ -73,25 +93,160 @@ fn merge_dir_into(legacy: &std::path::Path, target: &std::path::Path) -> u64 {
     if std::fs::create_dir_all(target).is_err() {
         return 1;
     }
+    let names: Vec<std::ffi::OsString> = entries.flatten().map(|e| e.file_name()).collect();
+    let present: std::collections::HashSet<&std::ffi::OsStr> =
+        names.iter().map(std::ffi::OsString::as_os_str).collect();
+
     let mut failures = 0u64;
-    for entry in entries.flatten() {
-        let dest = target.join(entry.file_name());
-        if dest.exists() {
+    for name in &names {
+        // Sidecars are handled with their base — or, orphaned, not at all.
+        if let Some(base) = name.to_str().and_then(sqlite_base_of) {
+            if present.contains(std::ffi::OsStr::new(base)) {
+                continue;
+            }
+            // An orphan `-wal`/`-shm` carries nothing recoverable on its
+            // own; migrating it could only confuse a database at the target
+            // that it has no relationship to.
             continue;
         }
-        if std::fs::rename(entry.path(), &dest).is_ok() {
+
+        let sidecars: Vec<std::ffi::OsString> = name
+            .to_str()
+            .map(|name| {
+                SQLITE_SIDECARS
+                    .iter()
+                    .map(|suffix| std::ffi::OsString::from(format!("{name}{suffix}")))
+                    .filter(|sidecar| present.contains(sidecar.as_os_str()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if !sidecars.is_empty() {
+            failures += move_sqlite_family(legacy, target, name, &sidecars);
             continue;
         }
-        // Cross-device or racing rename: copy instead, leaving the legacy
-        // original untouched. A failed copy removes its own partial output
-        // so the retry starts clean.
-        if copy_into(&entry.path(), &dest).is_err() {
-            let _ = std::fs::remove_dir_all(&dest);
-            let _ = std::fs::remove_file(&dest);
-            failures += 1;
-        }
+
+        failures += move_entry(&legacy.join(name), &target.join(name));
     }
     failures
+}
+
+/// Move one legacy entry, skipping anything already present at the target.
+/// Returns 1 when the entry could be neither renamed nor copied.
+fn move_entry(src: &std::path::Path, dest: &std::path::Path) -> u64 {
+    if dest.exists() {
+        return 0;
+    }
+    if std::fs::rename(src, dest).is_ok() {
+        return 0;
+    }
+    // Cross-device or racing rename: copy instead, leaving the legacy
+    // original untouched. A failed copy removes its own partial output
+    // so the retry starts clean.
+    if copy_into(src, dest).is_err() {
+        let _ = std::fs::remove_dir_all(dest);
+        let _ = std::fs::remove_file(dest);
+        return 1;
+    }
+    0
+}
+
+/// Migrate a SQLite database together with its live sidecars.
+///
+/// The database is checkpointed (`wal_checkpoint(TRUNCATE)`) and closed
+/// first, so in the common case the `-wal` folds back into the base and
+/// there is no live sidecar left to move at all. If another stella process
+/// is actively writing the database, the whole family is **deferred** to the
+/// next run rather than half-moved — the migration is idempotent and
+/// resumable, so deferring costs nothing and a torn family costs data.
+fn move_sqlite_family(
+    legacy: &std::path::Path,
+    target: &std::path::Path,
+    name: &std::ffi::OsStr,
+    sidecars: &[std::ffi::OsString],
+) -> u64 {
+    let db = legacy.join(name);
+    // Any member already at the target means a previous run (or another
+    // install) owns this family there. Never merge into it: a stale legacy
+    // `-wal` beside a foreign database is the corruption this guards.
+    if target.join(name).exists() || sidecars.iter().any(|s| target.join(s).exists()) {
+        return 0;
+    }
+    if checkpoint_for_move(&db) == Checkpoint::Busy {
+        // Live writer — leave every member in place and report it, so the
+        // "rerun to retry" advice is the accurate remedy.
+        return 1;
+    }
+    // Move the base first: a crash between renames then leaves the target
+    // holding a database with no sidecars (which SQLite opens cleanly)
+    // rather than sidecars with no database.
+    let failures = move_entry(&db, &target.join(name));
+    if failures > 0 {
+        return failures;
+    }
+    sidecars
+        .iter()
+        // Checkpoint + close usually deletes these; only survivors move.
+        .filter(|sidecar| legacy.join(sidecar).exists())
+        .map(|sidecar| move_entry(&legacy.join(sidecar), &target.join(sidecar)))
+        .sum()
+}
+
+/// Whether a database could be quiesced before moving it.
+#[derive(Debug, PartialEq)]
+enum Checkpoint {
+    /// Safe to move — either checkpointed, or not a database we can drive
+    /// (in which case the family still moves together, which is what makes
+    /// it recoverable).
+    Movable,
+    /// Another connection holds the database; defer the whole family.
+    Busy,
+}
+
+/// Fold the WAL back into `db` and close it, so the family reduces to a
+/// single closed file before the move.
+fn checkpoint_for_move(db: &std::path::Path) -> Checkpoint {
+    use rusqlite::{Connection, ErrorCode, OpenFlags};
+
+    // Don't open *through* a symlink — it could point anywhere. Renaming
+    // the link itself is still safe, so this is `Movable`, not a failure.
+    //
+    // Deliberately checked here rather than with `SQLITE_OPEN_NOFOLLOW`:
+    // that flag also rejects a symlinked *ancestor*, which is ordinary
+    // (`/var` → `/private/var` on macOS), and would defer every family
+    // forever for anyone whose home sits behind a link.
+    match std::fs::symlink_metadata(db) {
+        Ok(meta) if meta.file_type().is_symlink() => return Checkpoint::Movable,
+        Ok(_) => {}
+        Err(_) => return Checkpoint::Movable,
+    }
+
+    // Never CREATE: this path must not conjure a database that wasn't there.
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    let Ok(conn) = Connection::open_with_flags(db, flags) else {
+        // Cannot even open it — assume someone else can, and defer.
+        return Checkpoint::Busy;
+    };
+    // An exclusive transaction is the precise probe for "another process is
+    // using this": it is the one operation that must fail with BUSY while a
+    // live writer holds the database.
+    if let Err(err) = conn.execute_batch("BEGIN EXCLUSIVE; COMMIT;") {
+        if matches!(
+            err.sqlite_error_code(),
+            Some(ErrorCode::DatabaseBusy) | Some(ErrorCode::DatabaseLocked)
+        ) {
+            return Checkpoint::Busy;
+        }
+        // Not a database, or otherwise not drivable by us. Moving the family
+        // as a group is still correct — that is the recoverable shape.
+        return Checkpoint::Movable;
+    }
+    let _ = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()));
+    // Leaving WAL mode retires the sidecars outright, so the family really
+    // does reduce to one file. Stella re-enables WAL on its next open, so
+    // this is a migration-window state, not a lasting change.
+    let _ = conn.pragma_update(None, "journal_mode", "DELETE");
+    Checkpoint::Movable
 }
 
 /// Recursively copy a file or directory tree `src` → `dest`. Used only as
@@ -194,6 +349,158 @@ mod tests {
         assert_eq!(
             std::fs::read(target.join("installation-id")).unwrap(),
             b"new-id"
+        );
+    }
+
+    /// A WAL-mode database at `path` holding one row, closed cleanly.
+    fn seed_db(path: &std::path::Path, value: &str) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        conn.execute_batch("CREATE TABLE IF NOT EXISTS t (v TEXT);")
+            .unwrap();
+        conn.execute("INSERT INTO t (v) VALUES (?1)", [value])
+            .unwrap();
+    }
+
+    fn read_back(path: &std::path::Path) -> Vec<String> {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        let mut stmt = conn.prepare("SELECT v FROM t ORDER BY v").unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    /// Witness for #409: a database and its sidecars are one unit. The
+    /// family must arrive intact and must not leave sidecars stranded in
+    /// the legacy dir.
+    #[test]
+    fn a_sqlite_family_migrates_as_one_unit_with_its_data() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let target = tmp.path().join("home/.stella");
+        std::fs::create_dir_all(&legacy).unwrap();
+        seed_db(&legacy.join("usage.db"), "kept");
+        // The shape a crash leaves behind: sidecars still on disk beside
+        // the base at migration time.
+        std::fs::write(legacy.join("usage.db-wal"), b"").unwrap();
+        std::fs::write(legacy.join("usage.db-shm"), b"").unwrap();
+
+        assert_eq!(merge_dir_into(&legacy, &target), 0, "a closed family moves");
+
+        assert_eq!(
+            read_back(&target.join("usage.db")),
+            vec!["kept".to_string()],
+            "zero data loss: the migrated database still answers for its rows"
+        );
+        for sidecar in ["usage.db-wal", "usage.db-shm"] {
+            assert!(
+                !legacy.join(sidecar).exists(),
+                "{sidecar} must not be stranded in the legacy dir"
+            );
+        }
+        assert!(
+            !legacy.join("usage.db").exists(),
+            "the base moved, so the family is gone from legacy"
+        );
+    }
+
+    /// Witness for #409's sharpest edge: the per-entry loop could skip an
+    /// already-migrated `usage.db` and then move the legacy `-wal` in
+    /// beside it — a stale WAL describing a database it has no relationship
+    /// to. The family must be skipped whole.
+    #[test]
+    fn a_legacy_sidecar_never_lands_beside_a_foreign_database() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let target = tmp.path().join("home/.stella");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        seed_db(&legacy.join("usage.db"), "legacy");
+        std::fs::write(legacy.join("usage.db-wal"), b"stale-wal").unwrap();
+        seed_db(&target.join("usage.db"), "already-migrated");
+
+        assert_eq!(merge_dir_into(&legacy, &target), 0);
+
+        assert!(
+            !target.join("usage.db-wal").exists(),
+            "a legacy WAL must never be dropped beside a database it does not describe"
+        );
+        assert_eq!(
+            read_back(&target.join("usage.db")),
+            vec!["already-migrated".to_string()],
+            "the already-migrated database is untouched"
+        );
+        assert!(
+            legacy.join("usage.db").exists() && legacy.join("usage.db-wal").exists(),
+            "the skipped family stays whole in the legacy dir"
+        );
+    }
+
+    /// An orphan sidecar describes nothing; migrating it could only
+    /// confuse the target. It stays put.
+    #[test]
+    fn an_orphan_sidecar_is_left_behind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let target = tmp.path().join("home/.stella");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("usage.db-wal"), b"orphan").unwrap();
+
+        assert_eq!(merge_dir_into(&legacy, &target), 0);
+
+        assert!(
+            !target.join("usage.db-wal").exists(),
+            "orphan does not move"
+        );
+        assert!(legacy.join("usage.db-wal").exists(), "orphan stays put");
+    }
+
+    /// The one genuinely unhandled window in #409: another stella process
+    /// actively writing a legacy database *during* the first migration.
+    /// The family must be deferred whole, never half-moved.
+    #[test]
+    fn a_live_writer_defers_the_whole_family() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let target = tmp.path().join("home/.stella");
+        std::fs::create_dir_all(&legacy).unwrap();
+        let db = legacy.join("usage.db");
+        seed_db(&db, "in-flight");
+
+        // A live writer: an open connection holding the write lock, exactly
+        // as a concurrent stella process would.
+        let writer = rusqlite::Connection::open(&db).unwrap();
+        writer.pragma_update(None, "journal_mode", "WAL").unwrap();
+        writer.execute_batch("BEGIN EXCLUSIVE;").unwrap();
+        assert!(
+            legacy.join("usage.db-shm").exists(),
+            "precondition: the live writer has real sidecars on disk"
+        );
+
+        assert_eq!(
+            merge_dir_into(&legacy, &target),
+            1,
+            "a busy family is reported, so `rerun to retry` is accurate advice"
+        );
+        assert!(
+            !target.join("usage.db").exists(),
+            "nothing moved: a half-moved family is the data loss this prevents"
+        );
+        assert!(
+            db.exists(),
+            "the database stays where the live writer left it"
+        );
+
+        writer.execute_batch("COMMIT;").unwrap();
+        drop(writer);
+
+        // Resumable: once the writer is gone, the next run migrates it.
+        assert_eq!(merge_dir_into(&legacy, &target), 0, "the retry succeeds");
+        assert_eq!(
+            read_back(&target.join("usage.db")),
+            vec!["in-flight".to_string()],
+            "deferring cost nothing: the data arrives intact on the next run"
         );
     }
 


### PR DESCRIPTION
## Summary

Three backlog fixes, picked from the 42 open issues for impact-per-line. Each is independently reviewable and carries its own witness test.

| Issue | Class | What it prevents |
|---|---|---|
| #367 | Reliability | A wedged tool hanging a headless run forever |
| #409 | Data loss | A SQLite family torn apart by the `~/.stella` migration |
| #441 | Auditability | Candidate rule denials never reaching the journal |

---

### #367 — engine-level tool dispatch timeout backstop

Neither dispatch layer bounded tool execution. Per-tool bounds exist and are good — bash clamps its own timeout, scripts cap out, MCP bounds each call — but each is that tool's *own* responsibility. A tool that misses its bound parks the step forever, and loop detection, budget checks and soft-stop all fire only at **step boundaries**, so a headless `stella run` hangs indefinitely with no way out but a hard cancel.

Adds `EngineConfig::tool_timeout`: a generous 15-minute ceiling around the whole dispatch (hooks included), in the same belt-and-suspenders spirit as `max_steps`. A trip resolves to a `ToolOutput::Error` the model can react to, so "hung forever" becomes one failed call the loop routes around — the turn still reaches a clean `Completed`. `None` restores the unbounded await.

The budget-abort invariant is unaffected: a trip is surfaced as a tool *result*, never as a mid-tool turn abort.

Scoped to the engine ceiling the issue asks for. Still unbounded and worth separate issues: `stella-tools`' `ToolRegistry::execute`, `stella-serve`'s `RemoteToolExecutor`, and any `settings.json` surface for tuning the value.

### #409 — migrate SQLite families as one unit

`merge_dir_into` moved every top-level entry independently, so a database and its `-wal`/`-shm` sidecars migrated as three unrelated files in `read_dir` order. Two sharp edges followed.

The first is the one the issue names: the move was not a single atomic step, and a concurrent writer during the first migration was entirely unhandled.

**The second is worse and was not filed:** the `dest.exists` skip could *split* a family. An already-migrated `usage.db` at the target was skipped, and then the legacy `usage.db-wal` moved in beside it — a stale WAL sitting next to a database it does not describe.

Families are now prepared and moved as a unit: checkpointed (`wal_checkpoint(TRUNCATE)`) and taken out of WAL mode so the family collapses to one closed file; a live writer detected via `BEGIN EXCLUSIVE` defers the whole family to the next run (the migration is already idempotent and resumable, so deferring costs nothing and a torn family costs data); any member already at the target skips the family whole; an orphan sidecar is left where it is; and the base renames before its sidecars so a crash mid-move leaves a database with no sidecars rather than the reverse.

One deliberate deviation from the sibling precedent in `private.rs`: the open does **not** use `SQLITE_OPEN_NOFOLLOW`. That flag also rejects a symlinked *ancestor*, which is ordinary (`/var` → `/private/var` on macOS) — it would have deferred every family forever for anyone whose home sits behind a link, printing a migration failure on every startup. Caught by a test; the symlink risk it guards is covered directly by refusing to open through a symlinked database file.

### #441 — bridge the policy plane for candidate workspaces

PR #437 wired `bridge_policy_plane` into both main CLI run paths, but best-of-N candidate workspaces — today's primary *actual* users of the rule-guard bus — run through their own per-candidate event channels that were never bridged. A rule denial inside a candidate still evaluated and blocked correctly; it just never landed in the journal as a typed `PolicyDecision`.

Threads the turn's `EventSender` through `workspace_ports` into `GitCandidateWorkspaces` (a `with_events` builder, mirroring the existing `with_candidate_mcp`), and bridges each candidate registry right after `attach_rule_guards` creates its bus — while the registry is still a concrete `ToolRegistry`, before the `Arc<dyn ToolExecutor>` coercion erases it. `None` preserves today's behavior exactly.

---

## Witness tests

Per `AGENTS.md`, each behavior change carries a test that fails on the old code and passes on the new. Every one below was verified fail-before / pass-after by reverting the corresponding production change in place.

| Test | Proves |
|---|---|
| `a_wedged_tool_trips_the_dispatch_ceiling_instead_of_hanging` | A tool awaiting a never-completing future ends as one failed call, not a hung turn |
| `a_none_ceiling_leaves_tool_dispatch_unbounded` | The backstop is genuinely opt-out |
| `a_legacy_sidecar_never_lands_beside_a_foreign_database` | The split-family corruption is gone |
| `a_live_writer_defers_the_whole_family` | A busy family is deferred whole, and the retry succeeds with data intact |
| `an_orphan_sidecar_is_left_behind` | An orphan sidecar never migrates |
| `a_candidate_rule_denial_reaches_the_journal_as_a_policy_decision` | A candidate denial arrives as a typed `PolicyDecision` |

`a_sqlite_family_migrates_as_one_unit_with_its_data` is a **regression guard**, not a witness — it pins the issue's zero-data-loss acceptance criterion, which the old loop happened to satisfy when nothing conflicted at the target.

The two `#367` tests run on a paused clock, so they cost no wall-clock. Their outer guard is deliberately longer than the engine's ceiling, so the pre-fix engine fails them cleanly instead of hanging the suite.

## Verification

`make gate` (no-scratch + `fmt --check` + `clippy --workspace --all-targets -D warnings` + `test --workspace`) passes locally.

No new dependencies. `stella-core`'s `tokio` gains an explicit `"time"` feature — it was already resolving via workspace feature union, and the crate now genuinely uses `tokio::time`.

## Also found

**#446 is already fixed on `main`** and can be closed — commit c7a018a ("name the overflow-summary spliced blocks in the compaction receipt") added `summarized_blocks` to `AgentEvent::Compaction` and populates it in `apply_overflow_summary`, with a witness at `driver/tests/audit_fixes.rs:480`. The four remaining `Vec::new`s there are correct by construction: the pure passes never ran on that path. No code change needed.

**#445 is largely resolved too** — PR #514 landed a compile-enforced exhaustiveness guard for `AgentEvent` variants, which is the design half of that issue.
