### PR TITLE
feat(context): CGP context-reuse, usage reports, and the external-provider seam (#451, #452, #453)

### DIFF
--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -57,11 +57,13 @@ tempfile.workspace = true
 # Masked TTY prompt for `stella connect … --token` (same crate stella-model
 # uses for the interactive API-key prompt).
 rpassword.workspace = true
+# The protocol's own conformance suite (SPEC.md 3.6), pinned to the same rev as
+# the types/host we consume. A RUNTIME dependency, not just a dev one: #453
+# makes conformance an install/enable-time ADMISSION GATE for external
+# stdio/HTTP providers, so a non-conformant source is refused before it can
+# serve a turn. The same suite still audits the in-tree providers in tests.
+contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 rusqlite.workspace = true
-# The protocol's own conformance suite (§3.6), pinned to the same rev as the
-# types/host we consume. Wired into `contextgraph.rs` tests so "CGP-conformant"
-# is a checked claim about the providers this CLI ships, not a documented one.
-contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -212,6 +212,13 @@ async fn run_pipeline_one_shot(
         format == OutputFormat::Text,
         &cfg.authority,
     );
+    if let Some(m) = &mut memory {
+        // External CGP providers join the host before the first recall, so a
+        // configured source either passed conformance and serves this turn or
+        // is refused with a reason (#453).
+        m.register_external_providers(|message| eprintln!("  {} {message}", "!".yellow()))
+            .await;
+    }
     if let Some(m) = &memory {
         inject_recall_block(&mut messages, m.recall_block(prompt).await);
     }
@@ -593,6 +600,12 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     .await;
     let mut messages = vec![CompletionMessage::system(system_prompt.clone())];
     let mut memory = SessionMemory::open_with_authority(&cfg.workspace_root, true, &cfg.authority);
+    if let Some(m) = &mut memory {
+        // Conformance-gated external CGP providers join before the first
+        // recall, or are refused with a reason (#453).
+        m.register_external_providers(|message| println!("  {} {message}", "!".yellow()))
+            .await;
+    }
     // Custom extensions: â¡ commands/skills invocable as `/name args`, custom
     // agents behind `/agents`. Reloaded after `/init`, which may adopt new
     // ones from `.claude/`/`.agents/`. Load problems print up front so a

--- a/stella-cli/src/agent/goal.rs
+++ b/stella-cli/src/agent/goal.rs
@@ -83,6 +83,12 @@ pub(crate) async fn run_raw_one_shot(
         format == OutputFormat::Text,
         &cfg.authority,
     );
+    if let Some(m) = &mut memory {
+        // Conformance-gated external CGP providers join before the first
+        // recall, or are refused with a reason (#453).
+        m.register_external_providers(|message| eprintln!("  {} {message}", "!".yellow()))
+            .await;
+    }
     if let Some(m) = &memory {
         inject_recall_block(&mut messages, m.recall_block(prompt).await);
     }

--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -41,15 +41,21 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use contextgraph_host::{ContextProvider, Host, HostError, ProviderResult};
+use contextgraph_conformance::{ProviderTarget, run_conformance};
+use contextgraph_host::{
+    ConsentDecision, ConsentRecord, ContextProvider, Host, HostError, ProviderResult,
+};
 use contextgraph_types::{
-    Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, FrameId, ProviderInfo,
-    UsageReport, VerifyRequest, VerifyResponse, canonical_order,
+    Capabilities, ConsentReceipt, ContextFrame, ContextQuery, ContextQueryResult, DataFlow,
+    EgressScope, FrameId, Grantor, ProviderInfo, UsageReport, VerifyRequest, VerifyResponse,
+    canonical_order,
 };
 use stella_context::{
     ContextError, ContextProvider as PlaneProvider, ContextStore, ProviderRegistry,
 };
 use stella_protocol::{ContextProviderUsage, ContextUsage};
+
+use crate::settings::{ContextProviderSettings, ExternalContextProvider, ProviderEndpoint};
 
 /// Per-provider recall timeout. Recall runs before every turn, so a wedged
 /// source must cost bounded latency — the host isolates it and the other
@@ -258,6 +264,235 @@ pub fn session_host(
     host
 }
 
+/// What happened when the host was asked to admit an external provider.
+///
+/// A value rather than an error because refusing a provider is a *normal*,
+/// reportable outcome: the session continues on its remaining sources, and the
+/// operator is told exactly which contract the refused one failed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Admission {
+    /// Conformance passed, consent (if any was needed) is on file, and the
+    /// provider is registered on the host.
+    Registered { id: String },
+    /// The entry is present in config but not turned on.
+    Disabled { id: String },
+    /// The config entry cannot be turned into a transport target.
+    Misconfigured { id: String, reason: String },
+    /// The conformance suite failed. The provider is **not** registered.
+    NonConformant { id: String, failures: String },
+    /// The transport could not be established (spawn failed, handshake
+    /// refused, endpoint unreachable).
+    Unreachable { id: String, error: String },
+    /// The provider declares off-machine egress scopes with no recorded
+    /// consent.
+    ///
+    /// The transport is up (scopes are only knowable from the handshake), but
+    /// the host's own consent gate refuses every query to it and **the query
+    /// payload is never transmitted** (`docs/context-reuse.md` §3.5) — so it
+    /// contributes nothing to a turn and no workspace content reaches it. The
+    /// admission is reported as a refusal because that is what it is
+    /// operationally: a source that will serve no frames until consent exists.
+    NeedsEgressConsent { id: String, scopes: Vec<String> },
+}
+
+impl Admission {
+    /// The provider id this outcome concerns.
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Registered { id }
+            | Self::Disabled { id }
+            | Self::Misconfigured { id, .. }
+            | Self::NonConformant { id, .. }
+            | Self::Unreachable { id, .. }
+            | Self::NeedsEgressConsent { id, .. } => id,
+        }
+    }
+
+    /// Whether the provider was admitted to the host.
+    pub fn registered(&self) -> bool {
+        matches!(self, Self::Registered { .. })
+    }
+
+    /// A one-line operator-facing explanation, or `None` when the outcome
+    /// needs no explaining (registered, or simply not enabled).
+    pub fn refusal(&self) -> Option<String> {
+        match self {
+            Self::Registered { .. } | Self::Disabled { .. } => None,
+            Self::Misconfigured { id, reason } => Some(format!(
+                "context provider `{id}` is misconfigured: {reason}"
+            )),
+            Self::NonConformant { id, failures } => Some(format!(
+                "context provider `{id}` refused: it is not CGP-conformant ({failures})"
+            )),
+            Self::Unreachable { id, error } => {
+                Some(format!("context provider `{id}` is unreachable: {error}"))
+            }
+            Self::NeedsEgressConsent { id, scopes } => Some(format!(
+                "context provider `{id}` refused: it sends workspace content off this machine \
+                 under scope(s) {} — add them to `context_providers.{id}.egress_consent` to allow it",
+                scopes.join(", ")
+            )),
+        }
+    }
+}
+
+/// Register every **enabled** external CGP provider from user config onto
+/// `host`, gating each on the conformance suite and on egress consent.
+///
+/// Returns one [`Admission`] per configured entry, in config order, so a
+/// caller can report refusals without inspecting the host. One provider's
+/// refusal never affects another's — the same isolation the query fan-out
+/// gives, applied at admission time.
+pub async fn register_external_providers(
+    host: &mut Host,
+    configured: &ContextProviderSettings,
+) -> Vec<Admission> {
+    let mut admissions = Vec::with_capacity(configured.len());
+    for (id, config) in configured {
+        admissions.push(admit_external_provider(host, id, config).await);
+    }
+    admissions
+}
+
+/// Admit one configured provider: validate → conformance-gate → connect →
+/// consent-gate.
+///
+/// The order matters. Conformance runs on its **own** connection, before the
+/// session host holds one, so a provider that fails is never registered even
+/// transiently — "refuse before it serves a turn" is only true if the refusal
+/// happens before registration, not after.
+async fn admit_external_provider(
+    host: &mut Host,
+    id: &str,
+    config: &ExternalContextProvider,
+) -> Admission {
+    if !config.enabled {
+        return Admission::Disabled { id: id.to_string() };
+    }
+    let endpoint = match config.target() {
+        Ok(endpoint) => endpoint,
+        Err(reason) => {
+            return Admission::Misconfigured {
+                id: id.to_string(),
+                reason,
+            };
+        }
+    };
+    if let Some(refusal) = conformance_refusal(id, conformance_target(&endpoint)).await {
+        return refusal;
+    }
+    match connect(host, id, &endpoint).await {
+        Ok(()) => {}
+        Err(error) => {
+            return Admission::Unreachable {
+                id: id.to_string(),
+                error,
+            };
+        }
+    }
+    grant_declared_egress_consent(host, id, config)
+}
+
+/// The conformance suite's view of a validated endpoint.
+fn conformance_target(endpoint: &ProviderEndpoint) -> ProviderTarget {
+    match endpoint {
+        ProviderEndpoint::Stdio { program, args } => ProviderTarget::Stdio {
+            program: program.clone(),
+            args: args.clone(),
+        },
+        ProviderEndpoint::Http { url } => ProviderTarget::Http { url: url.clone() },
+    }
+}
+
+/// Run the conformance suite against `target`, returning the refusal to
+/// report when it fails and `None` when the provider is clean.
+///
+/// Split out from [`admit_external_provider`] so the gate is exercisable
+/// against an in-process target — a scripted misbehaving provider proves the
+/// gate bites without needing a fixture binary on disk.
+async fn conformance_refusal(id: &str, target: ProviderTarget) -> Option<Admission> {
+    let report = run_conformance(target).await;
+    if report.passed() {
+        return None;
+    }
+    Some(Admission::NonConformant {
+        id: id.to_string(),
+        failures: report
+            .failures()
+            .map(|check| format!("{}: {}", check.name, check.evidence))
+            .collect::<Vec<_>>()
+            .join("; "),
+    })
+}
+
+/// Establish the transport and register the provider on the session host.
+async fn connect(host: &mut Host, id: &str, endpoint: &ProviderEndpoint) -> Result<(), String> {
+    let result = match endpoint {
+        ProviderEndpoint::Stdio { program, args } => host.add_stdio(id, program, args).await,
+        ProviderEndpoint::Http { url } => host.add_http(id, url.clone()).await,
+    };
+    result.map_err(|error| error.to_string())
+}
+
+/// Record the operator's declared consent, then re-evaluate the host's own
+/// gate — and refuse the provider if anything it declares is still uncovered.
+///
+/// Consent is matched against the scopes the provider declared **at handshake
+/// time**, not the ones config guessed at: a provider that quietly widened its
+/// egress since consent was granted is refused rather than grandfathered.
+fn grant_declared_egress_consent(
+    host: &mut Host,
+    id: &str,
+    config: &ExternalContextProvider,
+) -> Admission {
+    let Some(info) = host.provider(id).map(|p| p.info().clone()) else {
+        return Admission::Unreachable {
+            id: id.to_string(),
+            error: "provider vanished immediately after registration".to_string(),
+        };
+    };
+    let grantor = match &config.consent_grantor {
+        Some(who) => Grantor::Human(who.clone()),
+        None => Grantor::Human("local-operator".to_string()),
+    };
+    let now = now_rfc3339();
+    for scope in &config.egress_consent {
+        let scope = EgressScope::from_wire(scope.as_str());
+        host.record_receipt(ConsentReceipt::new(
+            id,
+            &info,
+            scope,
+            grantor.clone(),
+            now.clone(),
+        ));
+    }
+    // The legacy boolean contract: a provider declaring `egress` with NO
+    // scopes is gated on a plain consent record, which any declared consent
+    // satisfies. With no consent declared at all it stays gated below.
+    if info.data_flow.egress
+        && info.data_flow.egress_scopes.is_empty()
+        && !config.egress_consent.is_empty()
+    {
+        host.record_consent(ConsentRecord::new(
+            id,
+            info.data_flow.clone(),
+            config.egress_consent.join(", "),
+        ));
+    }
+
+    match host.consent().evaluate(id, &info) {
+        ConsentDecision::Permitted => Admission::Registered { id: id.to_string() },
+        ConsentDecision::NeedsConsent => Admission::NeedsEgressConsent {
+            id: id.to_string(),
+            scopes: vec!["egress".to_string()],
+        },
+        ConsentDecision::NeedsReceipts(scopes) => Admission::NeedsEgressConsent {
+            id: id.to_string(),
+            scopes: scopes.iter().map(|s| s.as_str().to_string()).collect(),
+        },
+    }
+}
+
 /// The `workspace-memory` capability declaration, shared by `session_host` and
 /// the conformance tests so the suite audits what actually ships.
 fn memory_capabilities() -> Capabilities {
@@ -344,6 +579,7 @@ pub struct HostRecall {
 ///
 /// Failed, timed-out, or budget-lying providers contribute nothing — their
 /// isolation is the point of routing through the host.
+///
 /// It also returns the fan-out's **usage report** — the per-request roll-up of
 /// which providers served how many frames, at what token cost, against which
 /// budget (`docs/context-reuse.md` §2).
@@ -1051,6 +1287,206 @@ mod tests {
             ),
             "the missing citation label must surface as a frame-validity failure"
         );
+    }
+
+    // External-provider seam (#453)
+    //
+    // The admission gate is exercised against IN-PROCESS targets: the gate's
+    // contract — refuse a non-conformant provider before it can serve a turn —
+    // is transport-independent, and an in-process target proves it without a
+    // fixture binary on disk. The transport wiring itself is `Host::add_stdio`
+    // / `add_http`, already covered by the protocol's own suite at the pin.
+
+    use crate::settings::ExternalContextProvider;
+    use crate::settings::context_providers::ContextTransport;
+
+    fn stdio_config(command: &str) -> ExternalContextProvider {
+        ExternalContextProvider {
+            transport: ContextTransport::Stdio,
+            command: Some(command.to_string()),
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    /// WITNESS (#453): the conformance suite is an ADMISSION gate. A provider
+    /// that serves a frame with no citation label — a real §3.4 violation —
+    /// must be refused, and must not end up registered on the session host.
+    #[tokio::test]
+    async fn a_non_conformant_provider_is_refused_before_it_can_serve_a_turn() {
+        let mut bare_id = frame("bare-id", 0.9, 8);
+        bare_id.citation_label = None;
+        let target = ProviderTarget::InProcess(scripted("rogue", vec![bare_id]));
+
+        let refusal = conformance_refusal("rogue", target)
+            .await
+            .expect("a frame with no citation label must not be admitted");
+        match &refusal {
+            Admission::NonConformant { id, failures } => {
+                assert_eq!(id, "rogue");
+                assert!(
+                    failures.contains(CHECK_FRAME_VALIDITY),
+                    "the refusal must name the contract that broke: {failures}"
+                );
+            }
+            other => panic!("expected a conformance refusal, got {other:?}"),
+        }
+        assert!(!refusal.registered());
+        assert!(refusal.refusal().is_some(), "a refusal is explained");
+    }
+
+    /// The gate passes a genuinely conformant provider — otherwise "refused"
+    /// would be indistinguishable from "the gate rejects everything".
+    #[tokio::test]
+    async fn a_conformant_provider_clears_the_admission_gate() {
+        let target = ProviderTarget::InProcess(scripted("good", vec![frame("f1", 0.5, 4)]));
+        assert!(
+            conformance_refusal("good", target).await.is_none(),
+            "a conformant provider must not be refused"
+        );
+    }
+
+    /// WITNESS (#453): a declared-but-disabled provider is never spawned, never
+    /// conformance-probed, and never registered. `enabled` defaults false, so
+    /// merely appearing in config — including a merged-in org scope — cannot
+    /// put a provider in the recall path.
+    #[tokio::test]
+    async fn a_disabled_provider_is_never_reached() {
+        let mut host = Host::new();
+        let mut configured = ContextProviderSettings::new();
+        configured.insert("off".to_string(), {
+            let mut config = stdio_config("definitely-not-a-real-program-451");
+            config.enabled = false;
+            config
+        });
+        let admissions = register_external_providers(&mut host, &configured).await;
+        assert_eq!(admissions, vec![Admission::Disabled { id: "off".into() }]);
+        assert!(
+            host.provider_ids().is_empty(),
+            "a disabled entry must not register"
+        );
+    }
+
+    /// A malformed entry is reported as configuration — naming the missing
+    /// field — rather than surfacing later as a process that would not start.
+    #[tokio::test]
+    async fn a_transport_missing_its_required_field_is_a_config_refusal() {
+        let mut host = Host::new();
+        let mut configured = ContextProviderSettings::new();
+        configured.insert(
+            "broken".to_string(),
+            ExternalContextProvider {
+                transport: ContextTransport::Http,
+                enabled: true,
+                ..Default::default()
+            },
+        );
+        let admissions = register_external_providers(&mut host, &configured).await;
+        match &admissions[0] {
+            Admission::Misconfigured { id, reason } => {
+                assert_eq!(id, "broken");
+                assert!(reason.contains("`url`"), "{reason}");
+            }
+            other => panic!("expected a config refusal, got {other:?}"),
+        }
+        assert!(host.provider_ids().is_empty());
+    }
+
+    /// An unspawnable program is a per-provider refusal, not a session
+    /// failure: the remaining sources keep serving.
+    #[tokio::test]
+    async fn an_unreachable_provider_is_refused_without_taking_the_session_down() {
+        let mut host = Host::new();
+        let mut configured = ContextProviderSettings::new();
+        configured.insert(
+            "ghost".to_string(),
+            stdio_config("stella-no-such-cgp-provider-451"),
+        );
+        let admissions = register_external_providers(&mut host, &configured).await;
+        assert!(
+            !admissions[0].registered(),
+            "a program that cannot be reached must not be admitted: {:?}",
+            admissions[0]
+        );
+        assert_eq!(admissions[0].id(), "ghost");
+        assert!(admissions[0].refusal().is_some());
+        assert!(host.provider_ids().is_empty());
+    }
+
+    /// An egress provider with declared consent for every off-machine scope
+    /// it advertises is permitted; the same provider with no consent is not.
+    /// This is the path that has never fired, because every built-in is
+    /// `egress: false`.
+    #[tokio::test]
+    async fn egress_consent_gates_a_provider_that_sends_content_off_the_machine() {
+        use contextgraph_host::ConsentDecision;
+
+        let info = ProviderInfo {
+            name: "acme".to_string(),
+            version: "1".to_string(),
+            data_flow: DataFlow {
+                reads: true,
+                writes: false,
+                egress: true,
+                egress_scopes: vec![EgressScope::ThirdPartyIndex],
+            },
+        };
+
+        // No consent recorded: the host refuses to transmit, so the query
+        // payload — which carries workspace content — never leaves.
+        let bare = Host::new();
+        assert_eq!(
+            bare.consent().evaluate("acme", &info),
+            ConsentDecision::NeedsReceipts(vec![EgressScope::ThirdPartyIndex]),
+            "an unconsented egress scope must gate before any payload moves"
+        );
+
+        // The receipt the admission path writes from config unlocks exactly
+        // that scope, and nothing wider.
+        let mut consented = Host::new();
+        consented.record_receipt(ConsentReceipt::new(
+            "acme",
+            &info,
+            EgressScope::ThirdPartyIndex,
+            Grantor::Human("ada@acme.test".into()),
+            "2026-07-24T00:00:00Z",
+        ));
+        assert_eq!(
+            consented.consent().evaluate("acme", &info),
+            ConsentDecision::Permitted
+        );
+
+        // A receipt for a DIFFERENT scope does not unlock this one — consent
+        // is per-scope, never a blanket egress switch.
+        let mut wrong_scope = Host::new();
+        wrong_scope.record_receipt(ConsentReceipt::new(
+            "acme",
+            &info,
+            EgressScope::OrgTenant,
+            Grantor::Human("ada@acme.test".into()),
+            "2026-07-24T00:00:00Z",
+        ));
+        assert_eq!(
+            wrong_scope.consent().evaluate("acme", &info),
+            ConsentDecision::NeedsReceipts(vec![EgressScope::ThirdPartyIndex]),
+            "consent granted for one scope must not silently cover another"
+        );
+    }
+
+    /// Every built-in stays `egress: false`, which is why the consent prompt
+    /// has never fired — and must keep not firing.
+    #[tokio::test]
+    async fn the_in_tree_providers_still_declare_no_egress() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ContextStore::open(dir.path().join("context.db")).expect("store");
+        let host = session_host(Arc::new(store), vec![], dir.path().to_path_buf());
+        for id in host.provider_ids() {
+            let info = host.provider(id).expect("registered").info();
+            assert!(
+                !info.data_flow.egress,
+                "built-in `{id}` must never egress without consent"
+            );
+        }
     }
 
     #[test]

--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -44,11 +44,12 @@ use async_trait::async_trait;
 use contextgraph_host::{ContextProvider, Host, HostError, ProviderResult};
 use contextgraph_types::{
     Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, FrameId, ProviderInfo,
-    VerifyRequest, VerifyResponse, canonical_order,
+    UsageReport, VerifyRequest, VerifyResponse, canonical_order,
 };
 use stella_context::{
     ContextError, ContextProvider as PlaneProvider, ContextStore, ProviderRegistry,
 };
+use stella_protocol::{ContextProviderUsage, ContextUsage};
 
 /// Per-provider recall timeout. Recall runs before every turn, so a wedged
 /// source must cost bounded latency — the host isolates it and the other
@@ -315,6 +316,15 @@ impl AttributedContextFrame {
     }
 }
 
+/// One recall through the host: the frames that won selection, plus the CGP
+/// usage report for the request that produced them.
+pub struct HostRecall {
+    /// Selected frames, in canonical render order (`docs/context-reuse.md` §1).
+    pub frames: Vec<AttributedContextFrame>,
+    /// The per-request cost roll-up (`docs/context-reuse.md` §2).
+    pub usage: ContextUsage,
+}
+
 /// Fan `query` out through the host, **select** by score, and **render** in
 /// canonical order.
 ///
@@ -334,8 +344,21 @@ impl AttributedContextFrame {
 ///
 /// Failed, timed-out, or budget-lying providers contribute nothing — their
 /// isolation is the point of routing through the host.
-pub async fn recall_via_host(host: &Host, query: &ContextQuery) -> Vec<AttributedContextFrame> {
+/// It also returns the fan-out's **usage report** — the per-request roll-up of
+/// which providers served how many frames, at what token cost, against which
+/// budget (`docs/context-reuse.md` §2).
+///
+/// The report is taken from the fan-out **before** fusion, so it accounts for
+/// what each provider actually served and what the host rejected — a budget
+/// liar's dropped frames, a consent-gated or failed leg — not merely what
+/// survived the merge into the prompt. That distinction is what makes it an
+/// accounting record rather than a debug counter: a provider that is expensive
+/// but always loses fusion is invisible in the frame mix and perfectly visible
+/// here. `as_of` is the accounting-event time this host stamps, never the
+/// query's bi-temporal retrieval pin — two different clocks (§2).
+pub async fn recall_via_host(host: &Host, query: &ContextQuery) -> HostRecall {
     let fanout = host.query_all(query).await;
+    let usage = to_context_usage(&fanout.usage_report(query, now_rfc3339()));
     let mut frames: Vec<AttributedContextFrame> = Vec::new();
     for outcome in fanout.outcomes {
         if let ProviderResult::Frames(result) = outcome.result {
@@ -380,7 +403,48 @@ pub async fn recall_via_host(host: &Host, query: &ContextQuery) -> Vec<Attribute
     let mut ids: Vec<FrameId> = kept.iter().map(AttributedContextFrame::identity).collect();
     canonical_order(&mut ids);
     kept.sort_by_cached_key(|frame| ids.binary_search(&frame.identity()).unwrap_or(usize::MAX));
-    kept
+    HostRecall {
+        frames: kept,
+        usage,
+    }
+}
+
+/// Project the CGP [`UsageReport`] onto the telemetry envelope
+/// (`stella_protocol::ContextUsage`).
+///
+/// Deliberately **lossy in one direction only**: the spec's `served_frames`
+/// drill-down is dropped here because the sibling `frames` field of the same
+/// `ContextRecall` event already records frame-granular identities locally.
+/// What survives is counts, costs, and a timestamp — no titles, no bodies, no
+/// query text, so the event stays content-free (AGENTS.md invariant 3, #466).
+fn to_context_usage(report: &UsageReport) -> ContextUsage {
+    ContextUsage {
+        budget_requested: report.budget_requested,
+        budget_consumed: report.budget_consumed,
+        as_of: report.as_of.clone(),
+        providers: report
+            .providers
+            .iter()
+            .map(|provider| ContextProviderUsage {
+                provider_id: provider.provider_id.clone(),
+                frames_served: provider.frames_served,
+                frames_rejected: provider.frames_rejected,
+                token_cost: provider.token_cost,
+            })
+            .collect(),
+    }
+}
+
+/// The accounting-event timestamp stamped on a usage report (RFC 3339 UTC),
+/// via the context plane's dependency-free formatter. A clock before the epoch
+/// renders as the epoch rather than panicking — a report is an accounting
+/// record, and no timestamp is worth aborting a turn over.
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default();
+    stella_context::format_rfc3339(secs)
 }
 
 #[cfg(test)]
@@ -479,7 +543,7 @@ mod tests {
             "b",
             vec![frame("high", 0.9, 10), frame("shared", 0.5, 10)],
         ));
-        let kept = recall_via_host(&host, &query(10, 1_000)).await;
+        let kept = recall_via_host(&host, &query(10, 1_000)).await.frames;
         // Canonical order (§1 D2): by provider id, then frame id — NOT by
         // score, which is query-dependent and must not move rendered bytes.
         let rendered: Vec<(&str, &str)> = kept
@@ -541,7 +605,7 @@ mod tests {
             vec![frame("alpha", 0.9, 10), frame("beta", 0.1, 10)],
         ));
         first.register(scripted("graph", vec![frame("gamma", 0.5, 10)]));
-        let turn_one = render(&recall_via_host(&first, &query(10, 1_000)).await);
+        let turn_one = render(&recall_via_host(&first, &query(10, 1_000)).await.frames);
 
         // Same three frames, same content, completely inverted relevance —
         // and the graph leg registered first this time, so arrival order
@@ -552,12 +616,74 @@ mod tests {
             "mem",
             vec![frame("beta", 0.99, 10), frame("alpha", 0.02, 10)],
         ));
-        let turn_two = render(&recall_via_host(&second, &query(10, 1_000)).await);
+        let turn_two = render(&recall_via_host(&second, &query(10, 1_000)).await.frames);
 
         assert_eq!(
             turn_one, turn_two,
             "an unchanged frame set must render byte-identically across turns (§1 D2/D3)"
         );
+    }
+
+    /// WITNESS (#452, §2): the fan-out's usage report is surfaced — per
+    /// provider, how many frames it served, how many the host rejected, and
+    /// what that cost — against the query's budget, and it re-sums.
+    #[tokio::test]
+    async fn recall_reports_per_provider_frame_counts_and_token_costs() {
+        let mut host = Host::new();
+        host.register(scripted(
+            "mem",
+            vec![frame("m1", 0.9, 4), frame("m2", 0.5, 4)],
+        ));
+        host.register(scripted("graph", vec![frame("g1", 0.7, 4)]));
+
+        let recall = recall_via_host(&host, &query(10, 1_000)).await;
+        let usage = &recall.usage;
+        assert!(
+            usage.is_consistent(),
+            "the report must re-sum from the frames it itemizes: {usage:?}"
+        );
+        assert_eq!(usage.budget_requested, 1_000, "the query's max_tokens");
+        assert_eq!(usage.total_frames_served(), 3);
+        assert!(!usage.as_of.is_empty(), "an accounting snapshot is stamped");
+
+        let mem = usage
+            .providers
+            .iter()
+            .find(|p| p.provider_id == "mem")
+            .expect("every provider the query reached is itemized");
+        assert_eq!(mem.frames_served, 2);
+        assert_eq!(mem.frames_rejected, 0);
+        assert_eq!(mem.token_cost, 8);
+        assert_eq!(usage.budget_consumed, 12, "8 from mem + 4 from graph");
+    }
+
+    /// WITNESS (#452, §2): the report is taken from the fan-out **before**
+    /// fusion, so a provider whose frames the host threw out for lying about
+    /// cost is accounted as `frames_rejected` rather than vanishing. A report
+    /// built from the surviving prompt frames could never show this.
+    #[tokio::test]
+    async fn a_budget_lying_provider_is_reported_as_rejected_not_forgotten() {
+        let mut host = Host::new();
+        host.register(scripted("honest", vec![frame("h1", 0.5, 4)]));
+        // Declares far more than the query's whole budget: the host drops the
+        // leg wholesale, so it contributes nothing to the prompt.
+        host.register(scripted("liar", vec![frame("l1", 0.9, 9_999)]));
+
+        let recall = recall_via_host(&host, &query(10, 1_000)).await;
+        assert!(
+            recall.frames.iter().all(|f| f.provider != "liar"),
+            "a budget liar's frames must never reach the prompt"
+        );
+        let liar = recall
+            .usage
+            .providers
+            .iter()
+            .find(|p| p.provider_id == "liar")
+            .expect("a rejected provider is still itemized");
+        assert_eq!(liar.frames_served, 0);
+        assert_eq!(liar.frames_rejected, 1, "the drop is counted, not lost");
+        assert_eq!(liar.token_cost, 0, "a rejected frame contributes no cost");
+        assert!(recall.usage.is_consistent());
     }
 
     /// WITNESS (#451, §1): selection is still by score — the highest-scoring
@@ -572,7 +698,7 @@ mod tests {
         // budget-honest and only the merge has to choose.
         host.register(scripted("a", vec![frame("aaa", 0.1, 600)]));
         host.register(scripted("z", vec![frame("zzz", 0.9, 600)]));
-        let kept = recall_via_host(&host, &query(10, 1_000)).await;
+        let kept = recall_via_host(&host, &query(10, 1_000)).await.frames;
         assert_eq!(kept.len(), 1, "only one frame fits the budget");
         assert_eq!(
             kept[0].frame.id, "zzz",
@@ -587,7 +713,7 @@ mod tests {
         host.register(scripted("b", vec![frame("b1", 0.8, 600)]));
         // Each provider individually fits 1000 tokens; the merged set must
         // not exceed it either.
-        let kept = recall_via_host(&host, &query(10, 1_000)).await;
+        let kept = recall_via_host(&host, &query(10, 1_000)).await.frames;
         assert_eq!(kept.len(), 1, "second frame would blow the merged budget");
         assert_eq!(kept[0].frame.id, "a1");
         assert_eq!(kept[0].provider, "a");
@@ -642,7 +768,7 @@ mod tests {
         q.query_text = Some("open the sqlite connection in wal mode".to_string());
         // Host → workspace-memory → plane registry → store: the full
         // production path, end to end.
-        let kept = recall_via_host(&host, &q).await;
+        let kept = recall_via_host(&host, &q).await.frames;
         assert!(
             kept.iter()
                 .any(|f| f.frame.content.as_deref().unwrap_or("").contains("sqlite")),
@@ -838,7 +964,7 @@ mod tests {
 
         let mut q = query(5, 4_000);
         q.query_text = Some("conformance probe".to_string());
-        let kept = recall_via_host(&host, &q).await;
+        let kept = recall_via_host(&host, &q).await.frames;
         let held: Vec<FrameId> = kept
             .iter()
             .filter(|f| f.provider == "workspace-memory")

--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -21,6 +21,21 @@
 //!
 //! Both are local, `egress: false` sources — the consent store passes them
 //! without a prompt; only an egress provider would gate.
+//!
+//! ## Context reuse (`docs/context-reuse.md`)
+//!
+//! Recall also honors the protocol's reuse guarantees, which is what makes a
+//! multi-turn session cheap rather than merely correct:
+//!
+//! - **§1 deterministic composition.** [`recall_via_host`] *selects* by score
+//!   and *renders* in canonical `FrameId` order, so a turn whose underlying
+//!   frames did not change emits byte-identical prompt text and rides the
+//!   provider's prompt cache instead of busting it every turn.
+//! - **§4 `context/verify`.** `workspace-memory` advertises and answers
+//!   verify by comparing digests against the live store, so a host can
+//!   revalidate held frames for bytes instead of re-querying them for tokens.
+//!   `code-graph` does not advertise it and is re-queried — the conformant
+//!   fallback (V3).
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,7 +43,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use contextgraph_host::{ContextProvider, Host, HostError, ProviderResult};
 use contextgraph_types::{
-    Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo,
+    Capabilities, ContextFrame, ContextQuery, ContextQueryResult, DataFlow, FrameId, ProviderInfo,
+    VerifyRequest, VerifyResponse, canonical_order,
 };
 use stella_context::{
     ContextError, ContextProvider as PlaneProvider, ContextStore, ProviderRegistry,
@@ -72,6 +88,12 @@ impl PlaneProvider for ScopedStore {
     }
     async fn query(&self, query: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
         Ok(self.store.recall_scoped(query, &self.domains).await?.into())
+    }
+    /// Domain scoping narrows *retrieval*, never *identity*: a frame this
+    /// wrapper served is the store's frame, so revalidation is the store's
+    /// answer, unmodified (`docs/context-reuse.md` §4).
+    async fn verify(&self, request: &VerifyRequest) -> Result<VerifyResponse, ContextError> {
+        PlaneProvider::verify(self.store.as_ref(), request).await
     }
 }
 
@@ -134,6 +156,21 @@ impl ContextProvider for MemoryProvider {
             dropped_estimate: result.dropped_estimate,
             frames,
         })
+    }
+
+    /// Revalidate held identities through the same plane registry that served
+    /// them (`docs/context-reuse.md` §4). Every store-minted frame declares
+    /// `sha256:<content_hash>`, so the plane compares digests against the live
+    /// rows and the host reuses only what verifies `valid` — no frame body
+    /// travels in either direction.
+    async fn verify(&self, request: &VerifyRequest) -> Result<VerifyResponse, HostError> {
+        self.plane
+            .verify_all(request)
+            .await
+            .map_err(|e| HostError::Transport {
+                id: "workspace-memory".to_string(),
+                message: e.to_string(),
+            })
     }
 }
 
@@ -210,27 +247,52 @@ pub fn session_host(
     host.register(Box::new(MemoryProvider {
         plane: memory_plane(store, domains),
         info: local_info("workspace-memory"),
-        caps: Capabilities {
-            query: contextgraph_types::capability::QueryCapability {
-                kinds: ["memory", "episode", "fact", "snippet", "symbol", "doc"]
-                    .map(String::from)
-                    .to_vec(),
-            },
-            ..Capabilities::default()
-        },
+        caps: memory_capabilities(),
     }));
     host.register(Box::new(GraphProvider {
         workspace_root,
         info: local_info("code-graph"),
-        caps: Capabilities {
-            graph: true,
-            query: contextgraph_types::capability::QueryCapability {
-                kinds: ["symbol", "snippet", "graph"].map(String::from).to_vec(),
-            },
-            ..Capabilities::default()
-        },
+        caps: graph_capabilities(),
     }));
     host
+}
+
+/// The `workspace-memory` capability declaration, shared by `session_host` and
+/// the conformance tests so the suite audits what actually ships.
+fn memory_capabilities() -> Capabilities {
+    Capabilities {
+        query: contextgraph_types::capability::QueryCapability {
+            kinds: ["memory", "episode", "fact", "snippet", "symbol", "doc"]
+                .map(String::from)
+                .to_vec(),
+        },
+        // `docs/context-reuse.md` §4: the plane compares each presented digest
+        // against the live node's `content_hash`, so held memory frames are
+        // revalidated instead of re-queried — and an unchanged set keeps
+        // rendering byte-identically (§1).
+        verify: true,
+        ..Capabilities::default()
+    }
+}
+
+/// The `code-graph` capability declaration.
+///
+/// Deliberately **without** `verify`. A graph frame's digest covers the
+/// *rendered* frame body (a quoted snippet, an import neighborhood), not a file
+/// the index already hashes, so answering `valid`/`stale` honestly would mean
+/// re-deriving the frame — which is the re-query the host performs anyway. Per
+/// §4 V3 a provider that does not advertise `verify` has its frames re-queried,
+/// which is the correct, conformant degradation. Advertising it without an
+/// honest answer would be worse than not advertising it at all: the suite's
+/// `verify-honesty` check fails a provider that can never vouch for anything.
+fn graph_capabilities() -> Capabilities {
+    Capabilities {
+        graph: true,
+        query: contextgraph_types::capability::QueryCapability {
+            kinds: ["symbol", "snippet", "graph"].map(String::from).to_vec(),
+        },
+        ..Capabilities::default()
+    }
 }
 
 /// A frame paired with the CGP provider leg that returned it. Provider
@@ -243,11 +305,35 @@ pub struct AttributedContextFrame {
     pub frame: ContextFrame,
 }
 
-/// Fan `query` out through the host and fuse the surviving frames: highest
-/// score first, deduped by frame id, re-capped to the query's own frame and
-/// token budget (each provider already respected it individually; the merge
-/// must too). Failed, timed-out, or budget-lying providers contribute
-/// nothing — their isolation is the point of routing through the host.
+/// The identity triple that names a frame's exact bytes
+/// (`docs/context-reuse.md` §1) — the sort key for canonical composition and
+/// the payload of a `context/verify` request.
+impl AttributedContextFrame {
+    /// This frame's stable `(provider id, frame id, content digest)` identity.
+    pub fn identity(&self) -> FrameId {
+        self.frame.identity(&self.provider)
+    }
+}
+
+/// Fan `query` out through the host, **select** by score, and **render** in
+/// canonical order.
+///
+/// The split is the whole point of `docs/context-reuse.md` §1. Selection is
+/// query-dependent: the highest-scoring frames win the frame and token budget,
+/// deduped by identity and re-capped across providers (each provider already
+/// respected the budget individually; the merge must too). Rendering is not:
+/// the surviving set is returned in the protocol's canonical `FrameId` order —
+/// `(provider id, frame id, content digest)` — so a turn whose *underlying
+/// frames did not change* emits byte-identical prompt text even when retrieval
+/// re-ranked them, and the provider's prompt-cache prefix survives (D2/D3).
+/// Score is what got a frame in; it must never decide where it renders.
+///
+/// Every downstream prompt builder consumes this order — the recall block, the
+/// planner prompt, the witness prompt — so ordering here is the single seam
+/// that makes them all cache-stable.
+///
+/// Failed, timed-out, or budget-lying providers contribute nothing — their
+/// isolation is the point of routing through the host.
 pub async fn recall_via_host(host: &Host, query: &ContextQuery) -> Vec<AttributedContextFrame> {
     let fanout = host.query_all(query).await;
     let mut frames: Vec<AttributedContextFrame> = Vec::new();
@@ -287,6 +373,13 @@ pub async fn recall_via_host(host: &Host, query: &ContextQuery) -> Vec<Attribute
         spent_tokens += frame.frame.token_cost;
         kept.push(frame);
     }
+    // Selection is finished; how the survivors *render* must now be free of
+    // score and cost (§1 D2/D3). `canonical_order` puts the identities in the
+    // protocol's total order, and the frames follow their identity — so an
+    // unchanged frame set emits identical bytes however this turn ranked it.
+    let mut ids: Vec<FrameId> = kept.iter().map(AttributedContextFrame::identity).collect();
+    canonical_order(&mut ids);
+    kept.sort_by_cached_key(|frame| ids.binary_search(&frame.identity()).unwrap_or(usize::MAX));
     kept
 }
 
@@ -376,7 +469,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn merges_providers_by_score_and_dedupes_only_within_a_provider() {
+    async fn merges_providers_and_dedupes_only_within_a_provider() {
         let mut host = Host::new();
         host.register(scripted(
             "a",
@@ -387,9 +480,22 @@ mod tests {
             vec![frame("high", 0.9, 10), frame("shared", 0.5, 10)],
         ));
         let kept = recall_via_host(&host, &query(10, 1_000)).await;
-        let ids: Vec<&str> = kept.iter().map(|f| f.frame.id.as_str()).collect();
-        assert_eq!(ids.first(), Some(&"high"), "highest score remains first");
-        assert_eq!(ids.last(), Some(&"low"), "lowest score remains last");
+        // Canonical order (§1 D2): by provider id, then frame id — NOT by
+        // score, which is query-dependent and must not move rendered bytes.
+        let rendered: Vec<(&str, &str)> = kept
+            .iter()
+            .map(|f| (f.provider.as_str(), f.frame.id.as_str()))
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("a", "low"),
+                ("a", "shared"),
+                ("b", "high"),
+                ("b", "shared")
+            ],
+            "frames render in canonical identity order"
+        );
         let mut shared_providers: Vec<&str> = kept
             .iter()
             .filter(|f| f.frame.id == "shared")
@@ -401,13 +507,76 @@ mod tests {
             vec!["a", "b"],
             "provider-local ids must not collide across host legs"
         );
-        assert_eq!(kept[0].provider, "b", "host provider identity survives");
         assert_eq!(
             kept.iter()
-                .find(|f| f.frame.id == "low")
+                .find(|f| f.frame.id == "high")
                 .map(|f| f.provider.as_str()),
-            Some("a"),
+            Some("b"),
             "each frame keeps its own leg"
+        );
+    }
+
+    /// WITNESS (#451, §1 D2/D3): selection stays score-driven, rendering does
+    /// not. Two turns that surface the same frames with re-ranked scores — what
+    /// vector search does on every re-query — must produce byte-identical
+    /// prompt text, or the provider's cached prefix is forfeited every turn.
+    #[tokio::test]
+    async fn a_rerank_of_an_unchanged_frame_set_renders_byte_identically() {
+        let render = |kept: &[AttributedContextFrame]| -> String {
+            kept.iter()
+                .map(|f| {
+                    format!(
+                        "{}|{}|{}\n",
+                        f.provider,
+                        f.frame.id,
+                        f.frame.content.as_deref().unwrap_or("")
+                    )
+                })
+                .collect()
+        };
+
+        let mut first = Host::new();
+        first.register(scripted(
+            "mem",
+            vec![frame("alpha", 0.9, 10), frame("beta", 0.1, 10)],
+        ));
+        first.register(scripted("graph", vec![frame("gamma", 0.5, 10)]));
+        let turn_one = render(&recall_via_host(&first, &query(10, 1_000)).await);
+
+        // Same three frames, same content, completely inverted relevance —
+        // and the graph leg registered first this time, so arrival order
+        // differs too.
+        let mut second = Host::new();
+        second.register(scripted("graph", vec![frame("gamma", 0.95, 10)]));
+        second.register(scripted(
+            "mem",
+            vec![frame("beta", 0.99, 10), frame("alpha", 0.02, 10)],
+        ));
+        let turn_two = render(&recall_via_host(&second, &query(10, 1_000)).await);
+
+        assert_eq!(
+            turn_one, turn_two,
+            "an unchanged frame set must render byte-identically across turns (§1 D2/D3)"
+        );
+    }
+
+    /// WITNESS (#451, §1): selection is still by score — the highest-scoring
+    /// frames win a tight budget, even though they render canonically.
+    /// Guards the fix against the trivial "sort canonically before selecting"
+    /// mistake, which would silently make recall pick alphabetically.
+    #[tokio::test]
+    async fn selection_still_prefers_the_highest_scoring_frames() {
+        let mut host = Host::new();
+        // `zzz` scores highest but sorts LAST canonically; `aaa` sorts first
+        // but is the least relevant. One leg each, so both are individually
+        // budget-honest and only the merge has to choose.
+        host.register(scripted("a", vec![frame("aaa", 0.1, 600)]));
+        host.register(scripted("z", vec![frame("zzz", 0.9, 600)]));
+        let kept = recall_via_host(&host, &query(10, 1_000)).await;
+        assert_eq!(kept.len(), 1, "only one frame fits the budget");
+        assert_eq!(
+            kept[0].frame.id, "zzz",
+            "the budget must be spent on the most relevant frame, not the alphabetically first"
         );
     }
 
@@ -562,7 +731,8 @@ mod tests {
     // cleanly turns this suite red.
 
     use contextgraph_conformance::{
-        CHECK_FRAME_VALIDITY, CheckStatus, ConformanceReport, ProviderTarget, run_conformance,
+        CHECK_FRAME_VALIDITY, CHECK_VERIFY_HONESTY, CheckStatus, ConformanceReport, ProviderTarget,
+        run_conformance, sample_query,
     };
 
     /// Render a report's failures for a panic message, so a red run names the
@@ -575,24 +745,58 @@ mod tests {
             .join("; ")
     }
 
+    /// The status of one named check, for non-vacuity assertions.
+    fn check_status(report: &ConformanceReport, name: &str) -> CheckStatus {
+        report
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .unwrap_or_else(|| panic!("report has no `{name}` check"))
+            .status
+    }
+
+    /// A store seeded so the **conformance suite's own probe query** retrieves
+    /// something.
+    ///
+    /// This is what turns the gate from decorative into real. The suite probes
+    /// with `sample_query()` ("conformance probe"), and zero frames is a
+    /// *permitted* answer — so a store seeded only with unrelated content made
+    /// `frame-validity` pass on an empty set and skipped `verify-honesty`
+    /// entirely. Every check that inspects a frame was inspecting nothing.
+    async fn probe_seeded_store(dir: &tempfile::TempDir) -> Arc<ContextStore> {
+        let store = seeded_store(dir).await;
+        let probe = sample_query();
+        let text = probe.query_text.clone().unwrap_or(probe.goal);
+        store
+            .upsert(
+                ContextDelta::new().with_node(
+                    NodeInput::new(NodeKind::Memory, "cgp conformance probe fixture")
+                        .with_uri("file:///repo/.stella/memories/cgp-probe.md")
+                        // Derived from the suite's own query text, so a pin
+                        // bump that reworded the probe cannot silently return
+                        // this gate to a vacuous pass.
+                        .with_content(format!(
+                            "{text}: this memory exists so the CGP conformance suite has a real \
+                             frame to validate and revalidate."
+                        )),
+                ),
+            )
+            .await
+            .expect("seed probe fixture");
+        store
+    }
+
     #[tokio::test]
     async fn workspace_memory_provider_is_cgp_conformant() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = seeded_store(&dir).await;
+        let store = probe_seeded_store(&dir).await;
         // Constructed exactly as `session_host` builds the shipped
         // `workspace-memory` provider: the store behind the plane registry,
-        // advertising the kinds it serves.
+        // advertising the kinds and the `verify` capability it ships with.
         let provider = MemoryProvider {
             plane: memory_plane(store, vec![]),
             info: local_info("workspace-memory"),
-            caps: Capabilities {
-                query: contextgraph_types::capability::QueryCapability {
-                    kinds: ["memory", "episode", "fact", "snippet", "symbol", "doc"]
-                        .map(String::from)
-                        .to_vec(),
-                },
-                ..Capabilities::default()
-            },
+            caps: memory_capabilities(),
         };
         let report = run_conformance(ProviderTarget::InProcess(Box::new(provider))).await;
         assert!(
@@ -600,6 +804,80 @@ mod tests {
             "workspace-memory is not CGP-conformant: {}",
             conformance_failures(&report)
         );
+
+        // WITNESS (#451): the gate has teeth. Before the probe-matching seed,
+        // the suite surfaced 0 frames and every frame-level check was a
+        // free pass — `frame-validity` on an empty set, `verify-honesty`
+        // skipped. Asserting the *evidence* is what pins that shut.
+        let validity = report
+            .checks
+            .iter()
+            .find(|check| check.name == CHECK_FRAME_VALIDITY)
+            .expect("frame-validity check present");
+        assert!(
+            !validity.evidence.contains("0 frames"),
+            "the conformance probe surfaced no frames — the gate is passing vacuously: {}",
+            validity.evidence
+        );
+        assert_eq!(
+            check_status(&report, CHECK_VERIFY_HONESTY),
+            CheckStatus::Pass,
+            "verify-honesty must actually run (not skip): the shipped provider advertises \
+             `verify` and its frames must carry digests it can vouch for"
+        );
+    }
+
+    /// WITNESS (#451, §4 V1/V2): `context/verify` is implemented, not just
+    /// advertised. A frame the plane just served verifies `valid`; the same
+    /// identity with a digest the store never minted must NOT be retained.
+    #[tokio::test]
+    async fn workspace_memory_verifies_its_own_frames_and_refuses_a_foreign_digest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = probe_seeded_store(&dir).await;
+        let host = session_host(store, vec![], dir.path().to_path_buf());
+
+        let mut q = query(5, 4_000);
+        q.query_text = Some("conformance probe".to_string());
+        let kept = recall_via_host(&host, &q).await;
+        let held: Vec<FrameId> = kept
+            .iter()
+            .filter(|f| f.provider == "workspace-memory")
+            .map(AttributedContextFrame::identity)
+            .collect();
+        assert!(
+            !held.is_empty(),
+            "the probe fixture must surface through the shipped recall path"
+        );
+        assert!(
+            held.iter().all(FrameId::is_verifiable),
+            "every store-minted frame must declare a content_digest (§1 D4)"
+        );
+
+        let unchanged = host.verify_frames(&held).await;
+        assert_eq!(
+            unchanged.retained.len(),
+            held.len(),
+            "unchanged frames must verify `valid`, not be re-queried: {:?}",
+            unchanged.dropped
+        );
+
+        // A digest the store never served: default-deny must evict it.
+        let forged: Vec<FrameId> = held
+            .iter()
+            .map(|id| {
+                FrameId::new(
+                    &id.provider_id,
+                    &id.frame_id,
+                    Some(format!("sha256:{}", "0".repeat(64))),
+                )
+            })
+            .collect();
+        let changed = host.verify_frames(&forged).await;
+        assert!(
+            changed.retained.is_empty(),
+            "a digest the provider never minted must never verify `valid` (§4 V1)"
+        );
+        assert_eq!(changed.dropped.len(), forged.len(), "every forgery evicted");
     }
 
     #[tokio::test]

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -168,6 +168,53 @@ impl SessionMemory {
         }
     }
 
+    /// Register every enabled external CGP context provider from settings onto
+    /// this session's host (#453).
+    ///
+    /// Async and separate from [`SessionMemory::open`] because admission does
+    /// real I/O — it spawns or connects to each provider and runs the
+    /// protocol's conformance suite against it — and `open` is called from
+    /// synchronous paths. A refusal is reported, never fatal: the session
+    /// continues on its in-tree sources, which is the same crash-isolation
+    /// discipline the query fan-out applies, moved to admission time.
+    ///
+    /// With no `context_providers` configured (the shipping default) this
+    /// costs one settings read and registers nothing.
+    pub async fn register_external_providers(
+        &mut self,
+        report: impl Fn(String),
+    ) -> Vec<crate::contextgraph::Admission> {
+        let configured = match crate::settings::Settings::load(&self.workspace_root) {
+            Ok(settings) => settings.context_providers,
+            Err(error) => {
+                report(format!(
+                    "external context providers disabled: settings unreadable: {error}"
+                ));
+                return Vec::new();
+            }
+        };
+        if configured.is_empty() {
+            return Vec::new();
+        }
+        let admissions =
+            crate::contextgraph::register_external_providers(&mut self.host, &configured).await;
+        let admitted: Vec<&str> = admissions
+            .iter()
+            .filter(|a| a.registered())
+            .map(|a| a.id())
+            .collect();
+        if !admitted.is_empty() {
+            report(format!(
+                "external context providers admitted: {}",
+                admitted.join(", ")
+            ));
+        }
+        for refusal in admissions.iter().filter_map(|a| a.refusal()) {
+            report(refusal);
+        }
+        admissions
+    }
+
     fn workspace_skills_dir(&self) -> String {
         workspace_skills_dir(&self.workspace_root)
     }

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -36,7 +36,7 @@ use stella_core::skills::{
     self, AutoCreateConfig, AutoCreateDecision, SelectionConfig, Skill, SkillMineConfig,
     SkillObservation,
 };
-use stella_pipeline::{ContextRecallPort, RecalledFrame};
+use stella_pipeline::{ContextRecallPort, Recall, RecalledFrame};
 use stella_protocol::{CompletionMessage, MessageRole, Provider};
 
 use crate::domains::Domains;
@@ -198,7 +198,7 @@ impl SessionMemory {
             return None;
         }
         let mut sections: Vec<String> = Vec::new();
-        let frames = self.recalled_frames(prompt).await;
+        let frames = self.recalled_frames(prompt).await.frames;
         if let Some(section) = render_context_section(&frames) {
             sections.push(section);
         }
@@ -587,7 +587,7 @@ impl SessionMemory {
 
     /// Authoritative prompt and pipeline recall, including a fresh quarantine
     /// read so prior-turn feedback applies immediately.
-    async fn recalled_frames(&self, goal: &str) -> Vec<RecalledFrame> {
+    async fn recalled_frames(&self, goal: &str) -> Recall {
         self.recalled_frames_reporting(goal, |message| eprintln!("  {} {message}", "!".yellow()))
             .await
     }
@@ -596,9 +596,9 @@ impl SessionMemory {
         &self,
         goal: &str,
         mut report: impl FnMut(String),
-    ) -> Vec<RecalledFrame> {
+    ) -> Recall {
         if self.ab_suppressed {
-            return Vec::new();
+            return Recall::default();
         }
         let query = ContextQuery {
             goal: goal.to_string(),
@@ -626,15 +626,24 @@ impl SessionMemory {
                 report(format!(
                     "memory recall disabled: quarantine state unavailable: {error}"
                 ));
-                return Vec::new();
+                return Recall::default();
             }
         };
-        crate::contextgraph::recall_via_host(&self.host, &query)
-            .await
-            .into_iter()
-            .filter_map(project_recalled_frame)
-            .filter(|frame| !is_quarantined_local_memory(frame, &quarantined))
-            .collect()
+        // The usage report accounts for the fan-out that produced this turn's
+        // context, so it is captured even when quarantine or the citation-label
+        // filter later drops every frame: a provider still spent the tokens,
+        // and a cost that vanishes because the host discarded the frames is
+        // exactly the unmeterable cost #452 exists to surface.
+        let recalled = crate::contextgraph::recall_via_host(&self.host, &query).await;
+        Recall {
+            frames: recalled
+                .frames
+                .into_iter()
+                .filter_map(project_recalled_frame)
+                .filter(|frame| !is_quarantined_local_memory(frame, &quarantined))
+                .collect(),
+            usage: Some(recalled.usage),
+        }
     }
 }
 
@@ -682,7 +691,7 @@ fn goal_path_anchors(goal: &str, root: &std::path::Path) -> Vec<String> {
 /// failed recall, including quarantine verification, degrades to no frames (L-C6).
 #[async_trait::async_trait]
 impl ContextRecallPort for SessionMemory {
-    async fn recall(&self, goal: &str) -> Vec<RecalledFrame> {
+    async fn recall(&self, goal: &str) -> Recall {
         self.recalled_frames(goal).await
     }
 }
@@ -1149,7 +1158,7 @@ mod tests {
             .await
             .unwrap();
 
-        let before = ContextRecallPort::recall(&memory, lesson).await;
+        let before = ContextRecallPort::recall(&memory, lesson).await.frames;
         let memory_id = before
             .iter()
             .find(|frame| frame.content.contains("frobnicator"))
@@ -1176,7 +1185,7 @@ mod tests {
                 .unwrap();
         }
 
-        let pipeline_after = ContextRecallPort::recall(&memory, lesson).await;
+        let pipeline_after = ContextRecallPort::recall(&memory, lesson).await.frames;
         assert!(
             pipeline_after
                 .iter()

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -37,6 +37,7 @@ use crate::config::Dialect;
 
 mod authority;
 mod context;
+pub(crate) mod context_providers;
 mod managed;
 mod merge;
 mod private;
@@ -48,6 +49,7 @@ pub use authority::{AuthorityPolicy, ManagedAuthoritySettings};
 // field). The nested types (`LearningMode`, `GovernanceMode`, …) live in
 // `settings::context`; a later phase re-exports them here as it wires them in.
 pub use context::ContextSettings;
+pub use context_providers::{ContextProviderSettings, ExternalContextProvider, ProviderEndpoint};
 
 /// One `providers.<id>` entry. Every field is optional at the schema level;
 /// which ones are *required* depends on whether the id names a built-in
@@ -142,6 +144,13 @@ pub struct Settings {
     /// [`ContextSettings`].
     #[serde(default)]
     pub context: Option<ContextSettings>,
+    /// `context_providers.<id>` — third-party CGP context sources reached over
+    /// stdio/HTTP (#453). Merged per-entry across scopes like `providers`, so
+    /// a project may enable a provider the user scope declared without
+    /// restating its transport. Empty (the shipping default) registers
+    /// nothing and leaves recall exactly as it is today.
+    #[serde(default)]
+    pub context_providers: ContextProviderSettings,
     /// Authority ceilings are honored only from the org-managed settings
     /// file. The serde name is intentionally short because the containing
     /// file is already the policy source.

--- a/stella-cli/src/settings/context_providers.rs
+++ b/stella-cli/src/settings/context_providers.rs
@@ -1,0 +1,218 @@
+//! `context_providers.*` — third-party CGP context sources registered from
+//! user config.
+//!
+//! Until now every context provider was in-process (`workspace-memory`,
+//! `code-graph`) and `stella-context/src/provider.rs` documented the external
+//! seam as "designed here but not yet built". The pinned CGP rev ships
+//! `contextgraph-host`'s stdio and HTTP transports, so a third-party provider
+//! is now a config entry rather than a fork.
+//!
+//! Two properties are load-bearing and deliberately **not** optional:
+//!
+//! * **Conformance is an admission gate, not a badge.** A provider is run
+//!   through the protocol's own conformance suite *before* it is registered on
+//!   the session host, so a source that lies about token cost, serves frames
+//!   with no citation label, or cannot shut down cleanly never serves a turn.
+//!   The alternative — register first, discover later — means the first
+//!   evidence of non-conformance is a corrupted prompt.
+//! * **Egress is consented, never assumed.** Every built-in is
+//!   `egress: false`, so the consent store has never had occasion to prompt.
+//!   An external provider is the first thing that can send workspace content
+//!   off the machine, and it stays gated until the config records consent for
+//!   every off-machine scope it declares.
+//!
+//! Enums are "loud": an unrecognized `transport` is a hard parse error, never
+//! a silent fallback to something that happens to work.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The `context_providers` block: provider id → declaration. The map key is
+/// the host's routing **and consent** key, so renaming an entry is a new
+/// provider whose consent must be granted afresh — which is the point.
+pub type ContextProviderSettings = BTreeMap<String, ExternalContextProvider>;
+
+/// How the host reaches an external provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextTransport {
+    /// A child process speaking the protocol over stdio.
+    #[default]
+    Stdio,
+    /// A remote endpoint over HTTP.
+    Http,
+}
+
+/// One externally-served context provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct ExternalContextProvider {
+    /// Which transport carries the protocol.
+    pub transport: ContextTransport,
+    /// The program to spawn (`transport: "stdio"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Arguments for `command`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// The endpoint to connect to (`transport: "http"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Whether the entry is live. Defaults **false**: adding a provider to
+    /// config is a declaration, turning it on is a separate, deliberate act —
+    /// and a merged-in org-managed entry must never start serving a turn
+    /// because a lower scope happened to define it.
+    pub enabled: bool,
+    /// Off-machine egress scopes the operator has consented to for this
+    /// provider, as CGP scope strings (`org_tenant`, `third_party_index`,
+    /// `third_party_model`, or a namespaced `acme:vector-store`).
+    ///
+    /// A provider that declares an off-machine scope with no matching entry
+    /// here stays gated: the host refuses to transmit, and the query payload
+    /// — which carries workspace content — never leaves.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub egress_consent: Vec<String>,
+    /// Who granted the consent above, for the audit ledger. Free text (a user
+    /// id, email, or policy name); absent means the local operator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consent_grantor: Option<String>,
+}
+
+impl ExternalContextProvider {
+    /// The declaration's transport target, or a typed reason it is unusable.
+    ///
+    /// Validated here rather than at spawn time so a malformed entry is
+    /// reported as configuration — naming the missing field — instead of
+    /// surfacing later as a process that would not start.
+    pub fn target(&self) -> Result<ProviderEndpoint, String> {
+        match self.transport {
+            ContextTransport::Stdio => match self.command.as_deref() {
+                Some(command) if !command.trim().is_empty() => Ok(ProviderEndpoint::Stdio {
+                    program: command.to_string(),
+                    args: self.args.clone(),
+                }),
+                _ => Err("transport `stdio` requires a non-empty `command`".to_string()),
+            },
+            ContextTransport::Http => match self.url.as_deref() {
+                Some(url) if !url.trim().is_empty() => Ok(ProviderEndpoint::Http {
+                    url: url.to_string(),
+                }),
+                _ => Err("transport `http` requires a non-empty `url`".to_string()),
+            },
+        }
+    }
+}
+
+/// A validated transport target — the config shape reduced to exactly what the
+/// host and the conformance suite both need, with no `Option`s left to check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderEndpoint {
+    Stdio { program: String, args: Vec<String> },
+    Http { url: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+
+    #[test]
+    fn absent_block_registers_nothing() {
+        let s: Settings = serde_json::from_str("{}").expect("parse");
+        assert!(
+            s.context_providers.is_empty(),
+            "no config means no external providers — the shipping default"
+        );
+    }
+
+    #[test]
+    fn a_declared_provider_defaults_to_disabled_and_unconsented() {
+        let s: Settings =
+            serde_json::from_str(r#"{"context_providers":{"acme":{"command":"acme-cgp"}}}"#)
+                .expect("parse");
+        let acme = s.context_providers.get("acme").expect("entry");
+        assert_eq!(acme.transport, ContextTransport::Stdio);
+        assert!(
+            !acme.enabled,
+            "declaring a provider must not turn it on — that is a separate act"
+        );
+        assert!(
+            acme.egress_consent.is_empty(),
+            "consent is never implied by declaration"
+        );
+    }
+
+    #[test]
+    fn every_key_binds_to_its_field() {
+        let json = r#"{"context_providers":{"acme":{
+            "transport":"http",
+            "url":"https://ctx.acme.test/cgp",
+            "enabled":true,
+            "egress_consent":["org_tenant","acme:vector-store"],
+            "consent_grantor":"ada@acme.test"
+        }}}"#;
+        let s: Settings = serde_json::from_str(json).expect("parse");
+        let acme = s.context_providers.get("acme").expect("entry");
+        assert_eq!(acme.transport, ContextTransport::Http);
+        assert_eq!(acme.url.as_deref(), Some("https://ctx.acme.test/cgp"));
+        assert!(acme.enabled);
+        assert_eq!(acme.egress_consent, vec!["org_tenant", "acme:vector-store"]);
+        assert_eq!(acme.consent_grantor.as_deref(), Some("ada@acme.test"));
+        assert!(acme.command.is_none());
+    }
+
+    #[test]
+    fn transport_is_loud_on_an_unknown_value() {
+        let err = serde_json::from_str::<Settings>(
+            r#"{"context_providers":{"acme":{"transport":"grpc"}}}"#,
+        );
+        assert!(err.is_err(), "an unknown transport must fail to parse");
+    }
+
+    #[test]
+    fn a_transport_without_its_required_field_is_a_typed_config_error() {
+        let stdio = ExternalContextProvider {
+            transport: ContextTransport::Stdio,
+            ..Default::default()
+        };
+        assert!(stdio.target().unwrap_err().contains("`command`"));
+
+        let http = ExternalContextProvider {
+            transport: ContextTransport::Http,
+            url: Some("   ".into()),
+            ..Default::default()
+        };
+        assert!(http.target().unwrap_err().contains("`url`"));
+
+        let good = ExternalContextProvider {
+            transport: ContextTransport::Stdio,
+            command: Some("acme-cgp".into()),
+            args: vec!["--serve".into()],
+            ..Default::default()
+        };
+        assert_eq!(
+            good.target().expect("valid"),
+            ProviderEndpoint::Stdio {
+                program: "acme-cgp".into(),
+                args: vec!["--serve".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn context_providers_round_trip_through_json() {
+        let original = ExternalContextProvider {
+            transport: ContextTransport::Http,
+            command: None,
+            args: vec![],
+            url: Some("https://ctx.acme.test/cgp".into()),
+            enabled: true,
+            egress_consent: vec!["third_party_index".into()],
+            consent_grantor: Some("policy:security-review".into()),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: ExternalContextProvider = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, back);
+    }
+}

--- a/stella-cli/src/settings/merge.rs
+++ b/stella-cli/src/settings/merge.rs
@@ -83,6 +83,15 @@ impl Settings {
         if let Some(context) = &scope.context {
             self.context = Some(context.clone());
         }
+        // External CGP providers merge per-ENTRY (like `providers`), so a
+        // project scope can enable an entry the user scope declared without
+        // restating its transport — but a higher scope's entry replaces the
+        // lower one's wholesale. Field-level merging here would let a project
+        // file inherit a user's `egress_consent` while swapping the `url`,
+        // silently reusing consent granted for a different endpoint.
+        for (id, entry) in &scope.context_providers {
+            self.context_providers.insert(id.clone(), entry.clone());
+        }
     }
 
     fn merge_snapshots(scopes: &[&Settings]) -> Self {

--- a/stella-context/src/provider.rs
+++ b/stella-context/src/provider.rs
@@ -4,10 +4,16 @@
 //! the primary backend and a first-class provider), and the shipping CLI's
 //! session recall flows through this registry (`stella-cli/src/contextgraph.rs` wraps
 //! it as the `workspace-memory` CGP provider, registering the store domain-
-//! scoped). Wiring further sources through this seam — a `stella-graph`
-//! code-graph provider at this layer, a git-history provider, and external CGP
-//! providers adapted from `contextgraph-host` — is designed here but not yet built;
-//! this crate does not depend on `contextgraph-host`.
+//! scoped).
+//!
+//! **External providers register on the CGP host, not here.** Third-party
+//! stdio/HTTP sources are admitted by `stella-cli/src/contextgraph.rs`
+//! (`register_external_providers`, #453) straight onto the
+//! `contextgraph_host::Host`, gated on the protocol's conformance suite and on
+//! egress consent. This registry stays the seam for *in-plane* sources that
+//! share the workspace store's lifetime — a git-history provider, a future
+//! reflection source — which is why this crate still takes no dependency on
+//! `contextgraph-host`.
 
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/stella-context/src/provider.rs
+++ b/stella-context/src/provider.rs
@@ -14,7 +14,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use contextgraph_types::capability::QueryCapability;
-use contextgraph_types::{Capabilities, ContextQuery, ContextQueryResult, DataFlow, ProviderInfo};
+use contextgraph_types::{
+    Capabilities, ContextQuery, ContextQueryResult, DataFlow, FrameVerdict, ProviderInfo, Verdict,
+    VerifyRequest, VerifyResponse,
+};
 
 use crate::error::ContextError;
 use crate::store::{ContextStore, NodeKind};
@@ -36,6 +39,26 @@ pub trait ContextProvider: Send + Sync {
     /// frame list would erase the truncation report). Budgeting/fusion across
     /// providers is the host's job.
     async fn query(&self, q: &ContextQuery) -> Result<ContextQueryResult, ContextError>;
+
+    /// Revalidate frame identities a host already holds, without any frame
+    /// body travelling in either direction (`docs/context-reuse.md` §4,
+    /// `context/verify`).
+    ///
+    /// The digest is the ground truth: a provider compares the digest the host
+    /// presents against the digest its source carries *now* — equal is
+    /// [`Verdict::Valid`], different is [`Verdict::Stale`], a vanished source
+    /// is [`Verdict::Gone`], and anything it cannot judge is
+    /// [`Verdict::Unknown`].
+    ///
+    /// Defaults to `Unknown` for every identity, mirroring
+    /// `contextgraph_host::ContextProvider::verify`: a plane provider that
+    /// implements nothing can never accidentally bless a stale frame, and the
+    /// host degrades to re-querying (V3). A provider that overrides this
+    /// **MUST** also advertise [`Capabilities::verify`], since the host only
+    /// asks providers that declare support.
+    async fn verify(&self, request: &VerifyRequest) -> Result<VerifyResponse, ContextError> {
+        Ok(VerifyResponse::uniform(request, Verdict::Unknown))
+    }
 }
 
 /// Every frame kind the built-in store can serve.
@@ -96,6 +119,10 @@ impl ContextProvider for ContextStore {
             },
             graph: true,
             embeddings_fingerprint: Some(self.fingerprint().id()),
+            // The store can answer `context/verify` honestly: every frame it
+            // mints declares `sha256:<node.content_hash>`, and the same hash is
+            // re-read from the live row (`docs/context-reuse.md` §4).
+            verify: true,
             ..Default::default()
         }
     }
@@ -103,6 +130,37 @@ impl ContextProvider for ContextStore {
     async fn query(&self, q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
         // The CGP-shaped adapter over the rich `recall` pipeline.
         Ok(self.recall(q).await?.into())
+    }
+
+    /// Compare each presented digest against the live node's `content_hash`
+    /// (`docs/context-reuse.md` §4, requirement V1).
+    ///
+    /// The store mints `content_digest` as `sha256:<content_hash>` over exactly
+    /// the bytes it serves as `content`, so re-reading the row is a faithful
+    /// "what am I serving now?" — no frame body is read, sent, or compared.
+    /// A superseded or deleted node is `Gone`; an identity presented without a
+    /// digest is `Unknown` (nothing to compare), never `Valid`.
+    async fn verify(&self, request: &VerifyRequest) -> Result<VerifyResponse, ContextError> {
+        let mut verdicts = Vec::with_capacity(request.frames.len());
+        for frame in &request.frames {
+            let verdict = match self.node_by_public_id(&frame.frame_id)? {
+                None => Verdict::Gone,
+                Some(node) => {
+                    let current = format!("sha256:{}", node.content_hash);
+                    match frame.content_digest.as_deref() {
+                        Some(presented) if presented == current => Verdict::Valid,
+                        Some(_) => Verdict::Stale {
+                            replacement_digest: Some(current),
+                        },
+                        // Silence is not validity: an identity with no digest
+                        // is unverifiable, so the host re-queries it (§1 D4).
+                        None => Verdict::Unknown,
+                    }
+                }
+            };
+            verdicts.push(FrameVerdict::new(frame.clone(), verdict));
+        }
+        Ok(VerifyResponse::new(verdicts))
     }
 }
 
@@ -189,6 +247,58 @@ impl ProviderRegistry {
             truncated,
             dropped_estimate,
         })
+    }
+
+    /// Fan a `context/verify` request out to the plane providers that advertise
+    /// the capability and merge their verdicts (`docs/context-reuse.md` §4).
+    ///
+    /// Plane provider ids are not part of a `FrameId` — the whole plane is one
+    /// CGP provider (`workspace-memory`) to the host — so an identity is
+    /// offered to every verify-capable provider and the **first definite**
+    /// answer wins. `Unknown` is not definite: a provider that cannot judge an
+    /// identity must not shadow one that can. An identity no provider can
+    /// judge stays `Unknown`, which the host treats as "do not reuse" (V2).
+    pub async fn verify_all(
+        &self,
+        request: &VerifyRequest,
+    ) -> Result<VerifyResponse, ContextError> {
+        let mut resolved: Vec<Option<Verdict>> = vec![None; request.frames.len()];
+        for provider in &self.providers {
+            if !provider.capabilities().verify {
+                continue;
+            }
+            // Only ask about identities still unresolved, so a provider never
+            // re-judges a frame another already vouched for.
+            let pending: Vec<_> = request
+                .frames
+                .iter()
+                .zip(resolved.iter())
+                .filter(|(_, verdict)| verdict.is_none())
+                .map(|(frame, _)| frame.clone())
+                .collect();
+            if pending.is_empty() {
+                break;
+            }
+            let response = provider.verify(&VerifyRequest::new(pending)).await?;
+            for (frame, slot) in request.frames.iter().zip(resolved.iter_mut()) {
+                if slot.is_some() {
+                    continue;
+                }
+                match response.verdict_for(frame) {
+                    Some(Verdict::Unknown) | None => {}
+                    Some(verdict) => *slot = Some(verdict.clone()),
+                }
+            }
+        }
+        let verdicts = request
+            .frames
+            .iter()
+            .zip(resolved)
+            .map(|(frame, verdict)| {
+                FrameVerdict::new(frame.clone(), verdict.unwrap_or(Verdict::Unknown))
+            })
+            .collect();
+        Ok(VerifyResponse::new(verdicts))
     }
 }
 
@@ -358,5 +468,166 @@ mod tests {
             Some(5),
             "estimates sum over the providers that reported one (L-C5)"
         );
+    }
+
+    /// WITNESS (#451, `docs/context-reuse.md` §1): every store-minted frame
+    /// declares a `content_digest` naming exactly the bytes it serves. A frame
+    /// without one is unverifiable and a host must re-query rather than reuse
+    /// it (D4), which is precisely the cache-busting this issue removes.
+    #[tokio::test]
+    async fn store_frames_declare_a_content_digest_over_their_own_content() {
+        let (_dir, store) = seeded_store().await;
+        let result = store
+            .query(&query("open the sqlite connection"))
+            .await
+            .unwrap();
+        assert!(!result.frames.is_empty(), "seeded node must surface");
+        for frame in &result.frames {
+            let digest = frame
+                .content_digest
+                .as_deref()
+                .unwrap_or_else(|| panic!("frame `{}` declares no content_digest", frame.id));
+            let expected = format!(
+                "sha256:{}",
+                crate::store::sha256_hex(frame.content.as_deref().unwrap_or_default())
+            );
+            assert_eq!(
+                digest, expected,
+                "the declared digest must name the bytes actually served (§1 D1)"
+            );
+        }
+    }
+
+    /// WITNESS (#451, §4 V1): the store answers `context/verify` by comparing
+    /// digests — `valid` for what it still serves, `stale` for a digest that
+    /// differs, `gone` for a node that no longer exists. A provider that
+    /// rubber-stamped everything `valid` would let a host cite stale evidence.
+    #[tokio::test]
+    async fn store_verifies_by_digest_and_never_rubber_stamps() {
+        use contextgraph_types::FrameId;
+
+        let (_dir, store) = seeded_store().await;
+        assert!(
+            store.capabilities().verify,
+            "the store must advertise `verify`, or the host will never ask (V3)"
+        );
+
+        let served = store
+            .query(&query("open the sqlite connection"))
+            .await
+            .unwrap();
+        let frame = served.frames.first().expect("a served frame");
+        let real = FrameId::new("workspace-memory", &frame.id, frame.content_digest.clone());
+        let mutated = FrameId::new(
+            "workspace-memory",
+            &frame.id,
+            Some(format!("sha256:{}", "0".repeat(64))),
+        );
+        let absent = FrameId::new(
+            "workspace-memory",
+            "nod_does_not_exist",
+            Some("sha256:whatever".to_string()),
+        );
+        let undigested = FrameId::new("workspace-memory", &frame.id, None);
+
+        let response = store
+            .verify(&VerifyRequest::new(vec![
+                real.clone(),
+                mutated.clone(),
+                absent.clone(),
+                undigested.clone(),
+            ]))
+            .await
+            .unwrap();
+
+        assert_eq!(response.verdict_for(&real), Some(&Verdict::Valid));
+        assert!(
+            matches!(
+                response.verdict_for(&mutated),
+                Some(Verdict::Stale { replacement_digest: Some(d) })
+                    if Some(d.as_str()) == frame.content_digest.as_deref()
+            ),
+            "a differing digest must be `stale`, carrying the current digest and no body (V4)"
+        );
+        assert_eq!(response.verdict_for(&absent), Some(&Verdict::Gone));
+        assert_eq!(
+            response.verdict_for(&undigested),
+            Some(&Verdict::Unknown),
+            "an identity with no digest is unverifiable, never `valid` (§1 D4)"
+        );
+    }
+
+    /// A plane provider that cannot judge must not shadow one that can: the
+    /// registry fan-out takes the first *definite* verdict, and leaves an
+    /// identity nobody can judge as `Unknown` (default-deny, V2).
+    #[tokio::test]
+    async fn verify_fan_out_prefers_a_definite_verdict_over_unknown() {
+        use contextgraph_types::FrameId;
+
+        let (_dir, store) = seeded_store().await;
+        let mut registry = ProviderRegistry::new();
+        // The abstaining provider is registered FIRST, so a naive
+        // first-response-wins merge would report `Unknown` for everything.
+        registry.register(Arc::new(Abstaining));
+        registry.register(store.clone());
+
+        let served = store
+            .query(&query("open the sqlite connection"))
+            .await
+            .unwrap();
+        let frame = served.frames.first().expect("a served frame");
+        let real = FrameId::new("workspace-memory", &frame.id, frame.content_digest.clone());
+
+        let response = registry
+            .verify_all(&VerifyRequest::new(vec![real.clone()]))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.verdict_for(&real),
+            Some(&Verdict::Valid),
+            "the abstaining provider must not shadow the one that can vouch"
+        );
+
+        // And with nobody able to judge, the answer stays `Unknown` — which
+        // the host treats as "do not reuse" (V2), never as silent assent.
+        let mut abstainers = ProviderRegistry::new();
+        abstainers.register(Arc::new(Abstaining));
+        let response = abstainers
+            .verify_all(&VerifyRequest::new(vec![real.clone()]))
+            .await
+            .unwrap();
+        assert_eq!(response.verdict_for(&real), Some(&Verdict::Unknown));
+    }
+
+    /// A verify-capable provider that abstains on everything.
+    struct Abstaining;
+
+    #[async_trait]
+    impl ContextProvider for Abstaining {
+        fn info(&self) -> ProviderInfo {
+            ProviderInfo {
+                name: "abstaining".to_string(),
+                version: "0".to_string(),
+                data_flow: DataFlow {
+                    reads: true,
+                    writes: false,
+                    egress: false,
+                    egress_scopes: vec![],
+                },
+            }
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                verify: true,
+                ..Capabilities::default()
+            }
+        }
+        async fn query(&self, _q: &ContextQuery) -> Result<ContextQueryResult, ContextError> {
+            Ok(ContextQueryResult {
+                frames: vec![],
+                truncated: false,
+                dropped_estimate: None,
+            })
+        }
     }
 }

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -366,7 +366,13 @@ pub(crate) fn frame_from_node(
         // no tolerance — the title is NOT part of the inline content, so it is
         // not counted here. `pack_to_budget` packs against this same value.
         token_cost: contextgraph_types::budget_tokens(&node.content),
-        content_digest: None,
+        // `docs/context-reuse.md` §1: the frame's identity triple is
+        // `(provider id, frame id, content digest)`, and a frame that declares
+        // no digest is *not verifiable* — a host must re-query it rather than
+        // reuse it (D4). `node.content_hash` is already the sha256 of exactly
+        // the bytes that become `content`, so declaring it here costs nothing
+        // and makes every store-minted frame revalidatable by `context/verify`.
+        content_digest: Some(format!("sha256:{}", node.content_hash)),
         representation: Representation::Full,
         content_fidelity: None,
         canonical_content_hash: None,

--- a/stella-graph/src/frames.rs
+++ b/stella-graph/src/frames.rs
@@ -290,6 +290,10 @@ fn frame(
     // content, exact (`budget_tokens` = ceil(bytes/4)), so a host that meters
     // or budgets these frames is told the truth.
     let token_cost = contextgraph_types::budget_tokens(&content);
+    // `docs/context-reuse.md` §1: declare the digest of exactly the bytes this
+    // frame carries inline. Without one the frame is unverifiable and a host
+    // must re-query it (D4) instead of reusing the cached, byte-stable block.
+    let content_digest = Some(format!("sha256:{}", store::sha256_hex(content.as_bytes())));
     ContextFrame {
         id,
         kind,
@@ -298,7 +302,7 @@ fn frame(
         uri,
         score,
         token_cost,
-        content_digest: None,
+        content_digest,
         representation: Representation::Full,
         content_fidelity: None,
         canonical_content_hash: None,

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -783,7 +783,7 @@ fn rel_path(root: &Path, abs: &Path) -> String {
     }
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     let digest = hasher.finalize();

--- a/stella-graph/tests/frames.rs
+++ b/stella-graph/tests/frames.rs
@@ -157,3 +157,73 @@ fn file_neighborhood_round_trips_through_serde() {
     let back: stella_graph::FileNeighborhood = serde_json::from_str(&json).unwrap();
     assert_eq!(hood, back);
 }
+
+/// WITNESS (#451, `docs/context-reuse.md` §1): every graph frame declares a
+/// `content_digest` over exactly the bytes it carries inline. Without one the
+/// frame is *not verifiable* and a host must re-query it rather than reuse it
+/// (D4) — forfeiting the byte-stable prefix canonical composition buys.
+#[test]
+fn frames_declare_a_content_digest_over_their_inline_content() {
+    let (_ws, _db, graph) = fixture();
+    let frames = graph.query(&query("run_turn", 10, 4_000)).unwrap();
+    assert!(!frames.is_empty(), "fixture must produce frames");
+    for frame in &frames {
+        let digest = frame
+            .content_digest
+            .as_deref()
+            .unwrap_or_else(|| panic!("frame `{}` declares no content_digest", frame.id));
+        let hex = digest
+            .strip_prefix("sha256:")
+            .unwrap_or_else(|| panic!("digest `{digest}` is not `sha256:<hex>`"));
+        assert_eq!(hex.len(), 64, "digest `{digest}` is not 64 hex chars");
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "digest `{digest}` must be lowercase hex"
+        );
+        // The digest must name the bytes actually served: recompute it.
+        let content = frame.content.as_deref().unwrap_or_default();
+        let expected = sha256_hex(content.as_bytes());
+        assert_eq!(
+            hex, expected,
+            "frame `{}` digest does not match its own content — identity would be a lie (§1 D1)",
+            frame.id
+        );
+    }
+}
+
+/// Editing the source must change the digest, or §4's staleness detection
+/// cannot work (§1 D1).
+#[test]
+fn changing_a_file_changes_its_frames_content_digest() {
+    let (ws, _db, graph) = fixture();
+    let before = graph.definitions("run_turn").unwrap()[0]
+        .content_digest
+        .clone()
+        .expect("digest");
+    fs::write(
+        ws.path().join("driver.rs"),
+        "pub fn run_turn() {\n    // drive one turn, differently\n}\npub struct Engine;\n",
+    )
+    .unwrap();
+    graph.index_all().unwrap();
+    let after = graph.definitions("run_turn").unwrap()[0]
+        .content_digest
+        .clone()
+        .expect("digest");
+    assert_ne!(
+        before, after,
+        "changed content MUST change content_digest (§1 D1)"
+    );
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -76,7 +76,7 @@ pub use ports::{
     AdoptedChange, AlwaysAbortGate, ApprovalGate, ArtifactIdentity, ArtifactKind, AutoApproveGate,
     CandidateWorkspace, CandidateWorkspacePort, CmdOutcome, ContextRecallPort,
     DiagnosticInvocation, DiagnosticRunner, McpPrefetchPort, NoContextRecall, NoRepoStatus,
-    NoRepoStructure, PipelinePorts, ProviderResolver, RecalledFrame, RepoStatusPort,
+    NoRepoStructure, PipelinePorts, ProviderResolver, Recall, RecalledFrame, RepoStatusPort,
     RepoStructurePort, ScopeDecision, StdioApprovalGate, TestInvocation, TestRunner,
     WorkspaceError,
 };

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -51,8 +51,8 @@ use stella_core::retry::{RetryPolicy, Sleeper};
 use stella_core::router::FallbackInfo;
 use stella_core::{BudgetGuard, Engine, EngineConfig, EventSender, Router, TurnOutcome};
 use stella_protocol::{
-    AgentEvent, CompletionMessage, ContextFrameRef, JudgeEvidence, ModelCallRole, ModelRef,
-    Provider, ProviderShare, Role, StageKind,
+    AgentEvent, CompletionMessage, ContextFrameRef, ContextUsage, JudgeEvidence, ModelCallRole,
+    ModelRef, Provider, ProviderShare, Role, StageKind,
 };
 
 use crate::candidate::{
@@ -527,9 +527,10 @@ impl<'a> Pipeline<'a> {
             });
             self.recall.recall(goal).await
         };
-        let (assessment, frames) =
+        let (assessment, recalled) =
             tokio::join!(self.triage(goal, budget, &mut total_cost), recall_future);
-        self.emit_context_recall(&frames);
+        self.emit_context_recall(&recalled.frames, recalled.usage.clone());
+        let frames = recalled.frames;
         let assessment = match assessment {
             Ok(assessment) => assessment,
             Err(abort) => {
@@ -2120,7 +2121,7 @@ impl<'a> Pipeline<'a> {
         (lines, text)
     }
 
-    fn emit_context_recall(&self, frames: &[RecalledFrame]) {
+    fn emit_context_recall(&self, frames: &[RecalledFrame], usage: Option<ContextUsage>) {
         if frames.is_empty() {
             return;
         }
@@ -2158,6 +2159,7 @@ impl<'a> Pipeline<'a> {
             frames: frame_refs,
             provider_mix: mix,
             tokens,
+            usage,
         });
     }
 

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -23,10 +23,11 @@ use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
 use crate::ports::{
-    AdoptedChange, ArtifactIdentity, ArtifactKind, AutoApproveGate, CmdOutcome,
-    DiagnosticInvocation, DiagnosticRunner, NoContextRecall, NoRepoStatus, NoRepoStructure,
+    AdoptedChange, ArtifactIdentity, ArtifactKind, AutoApproveGate, CmdOutcome, ContextRecallPort,
+    DiagnosticInvocation, DiagnosticRunner, NoContextRecall, NoRepoStatus, NoRepoStructure, Recall,
     TestInvocation, TestRunner,
 };
+use stella_protocol::{ContextProviderUsage, ContextUsage};
 
 // test doubles
 
@@ -1800,4 +1801,128 @@ async fn headless_scope_bypass_proceeds_instead_of_asking_a_gate_that_always_abo
         s.contains(&StageKind::Execute),
         "the run reaches execute rather than ending at the gate: {s:?}"
     );
+}
+
+/// A recall port whose plane reports what the fan-out spent — the shape
+/// `stella-cli`'s `SessionMemory` produces from a real CGP host.
+struct MeteredRecall;
+
+#[async_trait::async_trait]
+impl ContextRecallPort for MeteredRecall {
+    async fn recall(&self, _goal: &str) -> Recall {
+        Recall {
+            frames: vec![RecalledFrame {
+                citation_label: "driver.rs".into(),
+                provider: "code-graph".into(),
+                source: "code-graph".into(),
+                kind: "symbol".into(),
+                uri: None,
+                method: None,
+                content: "run_turn".into(),
+                token_cost: 120,
+                id: None,
+            }],
+            usage: Some(ContextUsage {
+                budget_requested: 1200,
+                budget_consumed: 210,
+                as_of: "2026-07-24T00:00:00Z".into(),
+                providers: vec![
+                    ContextProviderUsage {
+                        provider_id: "code-graph".into(),
+                        frames_served: 1,
+                        frames_rejected: 0,
+                        token_cost: 120,
+                    },
+                    // Served frames that lost fusion — invisible in the frame
+                    // mix, and the whole reason the report is taken pre-fusion.
+                    ContextProviderUsage {
+                        provider_id: "workspace-memory".into(),
+                        frames_served: 2,
+                        frames_rejected: 1,
+                        token_cost: 90,
+                    },
+                ],
+            }),
+        }
+    }
+}
+
+/// WITNESS (#452): the CGP usage report reaches telemetry. Before this, the
+/// `ContextRecall` event carried only the *selected* frames' token sum and a
+/// per-provider frame count — so a provider that served expensive frames which
+/// lost fusion, or whose frames the host rejected outright, cost real tokens
+/// that no event ever recorded. Context cost was visible, not meterable.
+#[tokio::test]
+async fn the_context_recall_event_carries_the_cgp_usage_report() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: no"),
+        text_result("done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
+    let repo_status = SeqRepoStatus::new(vec![vec![]]);
+    let tools = EmptyTools;
+    let recall = MeteredRecall;
+    let repo = NoRepoStructure;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let _ = pipeline
+        .run("Fix the retry bug", &mut messages, &mut budget)
+        .await;
+
+    let events = drain(&mut rx);
+    let usage = events
+        .iter()
+        .find_map(|event| match event {
+            AgentEvent::ContextRecall { usage, .. } => usage.clone(),
+            _ => None,
+        })
+        .expect("the ContextRecall event must carry the CGP usage report");
+
+    assert!(
+        usage.is_consistent(),
+        "a metering pipeline must be able to re-sum the total: {usage:?}"
+    );
+    assert_eq!(usage.budget_requested, 1200);
+    assert_eq!(usage.budget_consumed, 210);
+    assert_eq!(usage.total_frames_served(), 3);
+
+    let memory = usage
+        .providers
+        .iter()
+        .find(|p| p.provider_id == "workspace-memory")
+        .expect("every provider the query reached is itemized");
+    assert_eq!(
+        memory.frames_served, 2,
+        "frames served must be counted even when they lose fusion and never reach the prompt"
+    );
+    assert_eq!(
+        memory.frames_rejected, 1,
+        "a host-rejected frame is accounted, not silently forgotten"
+    );
+    assert_eq!(memory.token_cost, 90);
 }

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use stella_core::Router;
 use stella_core::hooks::{HookRunner, Hooks};
 use stella_core::retry::Sleeper;
-use stella_protocol::{FileChangeKind, ModelRef, Provider, ScopeProposal};
+use stella_protocol::{ContextUsage, FileChangeKind, ModelRef, Provider, ScopeProposal};
 
 /// Maps a router-resolved [`ModelRef`] to the concrete provider adapter that
 /// serves it. This is the one seam that connects `stella-core`'s
@@ -79,11 +79,45 @@ pub struct RecalledFrame {
 /// [`NoContextRecall`].
 #[async_trait]
 pub trait ContextRecallPort: Send + Sync {
-    /// Recall material relevant to `goal`. Returns an empty vec when nothing
-    /// is relevant or no plane is configured — never an error the pipeline
-    /// has to special-case (weak/absent context degrades to "no frames",
-    /// L-C6).
-    async fn recall(&self, goal: &str) -> Vec<RecalledFrame>;
+    /// Recall material relevant to `goal`. Returns an empty frame list when
+    /// nothing is relevant or no plane is configured — never an error the
+    /// pipeline has to special-case (weak/absent context degrades to "no
+    /// frames", L-C6).
+    async fn recall(&self, goal: &str) -> Recall;
+}
+
+/// The outcome of one context recall: the frames that reached the prompt, and
+/// what producing them cost.
+///
+/// The two travel together because they are answers to different questions
+/// about the same request — "what will the model see?" and "what did this turn
+/// spend on context, and which providers drove it?" — and separating them
+/// would mean either re-running recall to bill it or losing the cost entirely,
+/// which is how context cost stayed unmeterable.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Recall {
+    /// The frames selected for this turn, in the host's canonical render
+    /// order.
+    pub frames: Vec<RecalledFrame>,
+    /// The CGP usage report for the request (`docs/context-reuse.md` §2).
+    /// `None` when the port has no CGP host behind it to report one.
+    pub usage: Option<ContextUsage>,
+}
+
+impl Recall {
+    /// A recall of `frames` with no usage report — the shape a port without a
+    /// CGP host behind it produces.
+    pub fn frames(frames: Vec<RecalledFrame>) -> Self {
+        Self {
+            frames,
+            usage: None,
+        }
+    }
+
+    /// Whether nothing was recalled.
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
 }
 
 /// A repository-structure summary for the planner's **split context** (L-E6):
@@ -367,8 +401,8 @@ pub struct NoContextRecall;
 
 #[async_trait]
 impl ContextRecallPort for NoContextRecall {
-    async fn recall(&self, _goal: &str) -> Vec<RecalledFrame> {
-        Vec::new()
+    async fn recall(&self, _goal: &str) -> Recall {
+        Recall::default()
     }
 }
 
@@ -538,6 +572,10 @@ mod tests {
     #[tokio::test]
     async fn no_op_ports_are_inert() {
         assert!(NoContextRecall.recall("anything").await.is_empty());
+        assert!(
+            NoContextRecall.recall("anything").await.usage.is_none(),
+            "a port with no CGP host behind it reports no usage"
+        );
         assert!(NoRepoStructure.structure_summary().await.is_empty());
         let proposal = ScopeProposal {
             summary: "x".into(),

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -475,6 +475,14 @@ pub enum AgentEvent {
         frames: Vec<ContextFrameRef>,
         provider_mix: Vec<ProviderShare>,
         tokens: u32,
+        /// The CGP usage report for this recall (`docs/context-reuse.md` §2):
+        /// per-provider frame counts and token costs against the requested
+        /// budget, so context cost is meterable rather than merely visible.
+        /// Optional and defaulted — streams recorded before the report existed
+        /// still deserialize (the additive contract), and a recall path with
+        /// no CGP host behind it has none to report.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<ContextUsage>,
     },
     /// Context write-back completed: episode summaries, fact upserts,
     /// supersession (bi-temporal,
@@ -803,6 +811,70 @@ pub struct ManifestEntry {
 pub struct ProviderShare {
     pub provider: String,
     pub frames: u32,
+}
+
+/// One provider's contribution to a recall's cost, as the CGP usage report
+/// defines it (`docs/context-reuse.md` §2 `ProviderUsage`).
+///
+/// Distinct from [`ProviderShare`], which counts only the frames that *won*
+/// fusion and reached the prompt. This counts what the provider **served to
+/// the host** and what the host **rejected** (a budget lie, a consent gate, a
+/// failed leg), with the token cost behind each — the difference between "what
+/// did the model see?" and "what did this turn cost, and who drove it?".
+///
+/// Content-free by construction: a provider id, three numbers. No frame
+/// titles, bodies, URIs, or query text ever enter this type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextProviderUsage {
+    /// The host's routing/consent key for the serving provider.
+    pub provider_id: String,
+    /// Frames accepted — they passed consent, the timeout, and the
+    /// budget-honesty audit.
+    pub frames_served: u32,
+    /// Frames the host dropped whole, e.g. a provider that misdeclared cost.
+    pub frames_rejected: u32,
+    /// This provider's contribution to `budget_consumed`.
+    pub token_cost: u64,
+}
+
+/// The per-request roll-up of what one context recall cost
+/// (`docs/context-reuse.md` §2 `UsageReport`) — the envelope a metering
+/// pipeline bills from, and the answer to "what did this turn's context cost,
+/// and which sources drove it?".
+///
+/// Deliberately **content-free**: budget scalars, an accounting timestamp, and
+/// per-provider counts and costs. The spec's `served_frames` drill-down is
+/// *not* duplicated here — the sibling `frames: Vec<ContextFrameRef>` on the
+/// same [`AgentEvent::ContextRecall`] already records the frame-granular
+/// identities locally, so an auditor still walks from a total to its frames
+/// without this type ever carrying one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUsage {
+    /// The query's `max_tokens` — the budget this recall was allowed.
+    pub budget_requested: u32,
+    /// The summed `token_cost` of every served frame.
+    pub budget_consumed: u64,
+    /// The report's accounting snapshot (RFC 3339), stamped by the host. This
+    /// is the *accounting event* time, never the query's bi-temporal `as_of`
+    /// retrieval pin — two different clocks.
+    pub as_of: String,
+    /// One entry per provider the query reached.
+    pub providers: Vec<ContextProviderUsage>,
+}
+
+impl ContextUsage {
+    /// Whether the report re-sums: `budget_consumed` must equal the summed
+    /// per-provider `token_cost` (`docs/context-reuse.md` §2, the arithmetic
+    /// identity). A metering pipeline checks this before trusting a total, so
+    /// a corrupted number is a checkable failure rather than a silent misbill.
+    pub fn is_consistent(&self) -> bool {
+        self.budget_consumed == self.providers.iter().map(|p| p.token_cost).sum::<u64>()
+    }
+
+    /// Total frames served across every provider the query reached.
+    pub fn total_frames_served(&self) -> u64 {
+        self.providers.iter().map(|p| p.frames_served as u64).sum()
+    }
 }
 
 /// Evidence backing a `JudgeVerdict`. `deterministic` distinguishes the
@@ -1207,6 +1279,7 @@ mod tests {
                 frames: 1,
             }],
             tokens: 120,
+            usage: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("citation_label"), "{json}");
@@ -1227,6 +1300,97 @@ mod tests {
                 );
                 assert_eq!(frame.method.as_deref(), Some("tree-sitter/symbol-extract"));
             }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// WITNESS (#452): the usage-report envelope rides the recall event and
+    /// round-trips byte-for-byte (AGENTS.md invariant 4), so context cost is a
+    /// meterable record rather than a number that dies with the turn.
+    #[test]
+    fn context_usage_report_round_trips_and_stays_content_free() {
+        let usage = ContextUsage {
+            budget_requested: 1200,
+            budget_consumed: 210,
+            as_of: "2026-07-24T00:00:00Z".into(),
+            providers: vec![
+                ContextProviderUsage {
+                    provider_id: "workspace-memory".into(),
+                    frames_served: 2,
+                    frames_rejected: 0,
+                    token_cost: 90,
+                },
+                ContextProviderUsage {
+                    provider_id: "code-graph".into(),
+                    frames_served: 1,
+                    frames_rejected: 3,
+                    token_cost: 120,
+                },
+            ],
+        };
+        assert!(
+            usage.is_consistent(),
+            "budget_consumed must re-sum from the per-provider costs"
+        );
+        assert_eq!(usage.total_frames_served(), 3);
+
+        let event = AgentEvent::ContextRecall {
+            frames: vec![],
+            provider_mix: vec![],
+            tokens: 210,
+            usage: Some(usage.clone()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: AgentEvent = serde_json::from_str(&json).unwrap();
+        match &back {
+            AgentEvent::ContextRecall { usage: round, .. } => {
+                assert_eq!(round.as_ref(), Some(&usage), "byte-for-byte round trip")
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+        assert_eq!(
+            json,
+            serde_json::to_string(&back).unwrap(),
+            "re-serialization must be byte-identical"
+        );
+
+        // Content-free by construction: the envelope carries provider ids,
+        // counts, costs, and a timestamp — never frame text, titles, URIs, or
+        // query text (AGENTS.md invariant 3, #466).
+        let value = serde_json::to_value(&usage).unwrap();
+        let mut fields: Vec<String> = value.as_object().unwrap().keys().cloned().collect();
+        fields.sort();
+        assert_eq!(
+            fields,
+            ["as_of", "budget_consumed", "budget_requested", "providers"],
+            "no field may be added to the usage envelope without a content review"
+        );
+    }
+
+    /// An inconsistent total is *checkable*, never a silent misbill (§2).
+    #[test]
+    fn a_tampered_usage_total_fails_the_arithmetic_identity() {
+        let usage = ContextUsage {
+            budget_requested: 1200,
+            budget_consumed: 999,
+            as_of: "2026-07-24T00:00:00Z".into(),
+            providers: vec![ContextProviderUsage {
+                provider_id: "workspace-memory".into(),
+                frames_served: 1,
+                frames_rejected: 0,
+                token_cost: 90,
+            }],
+        };
+        assert!(!usage.is_consistent());
+    }
+
+    /// A recall event recorded before the usage report existed must still
+    /// deserialize — the additive contract.
+    #[test]
+    fn a_recall_event_without_a_usage_report_still_parses() {
+        let legacy = r#"{"type":"context_recall","frames":[],"provider_mix":[],"tokens":0}"#;
+        match serde_json::from_str::<AgentEvent>(legacy).unwrap() {
+            AgentEvent::ContextRecall { usage, .. } => assert!(usage.is_none()),
             other => panic!("unexpected variant: {other:?}"),
         }
     }

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -29,9 +29,9 @@ pub use completion::{
 pub use error::ProviderError;
 pub use event::{
     AgentEvent, BlockKind, BlockOrigin, BudgetMode, BudgetScope, CacheZone, CiStatus,
-    ContextFrameRef, FileChangeKind, JudgeEvidence, ManifestEntry, MediaArtifactRef, MediaJobState,
-    MediaKind, ModelCallRole, PolicyKind, PrStatus, ProviderShare, ScopeProposal, StageKind,
-    TaskItem, TaskStatus, UsageIncompleteReason,
+    ContextFrameRef, ContextProviderUsage, ContextUsage, FileChangeKind, JudgeEvidence,
+    ManifestEntry, MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole, PolicyKind, PrStatus,
+    ProviderShare, ScopeProposal, StageKind, TaskItem, TaskStatus, UsageIncompleteReason,
 };
 pub use provider::{Provider, ToolCallObserver};
 pub use role::{ModelRef, Role};

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -477,6 +477,7 @@ impl SessionModel {
                 frames,
                 provider_mix: _,
                 tokens,
+                ..
             } => {
                 let labels = frames.iter().map(|f| f.citation_label.clone()).collect();
                 self.transcript.push(TranscriptEntry::ContextRecall {
@@ -1297,6 +1298,7 @@ mod tests {
                 frames: 1,
             }],
             tokens: 100,
+            usage: None,
         });
         match model.transcript.last() {
             Some(TranscriptEntry::ContextRecall { labels, .. }) => {

--- a/stella-tui/src/scenario.rs
+++ b/stella-tui/src/scenario.rs
@@ -132,6 +132,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
             ],
             provider_mix: vec![ProviderShare { provider: "code-graph".into(), frames: 1 }, ProviderShare { provider: "memory".into(), frames: 1 }],
             tokens: 210,
+            usage: None,
         }),
         ev(lead, AgentEvent::Stage { name: StageKind::Plan }),
         ev(lead, AgentEvent::Text { delta: "Planning the automations cluster: list, editor, triggers, workflows.".into() }),

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -494,6 +494,7 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
             frames,
             provider_mix,
             tokens,
+            ..
         } => Some(context_recall(
             frames.len(),
             *tokens,
@@ -897,6 +898,7 @@ mod tests {
                 }],
                 provider_mix: vec![],
                 tokens: 1,
+                usage: None,
             },
             AgentEvent::ContextWrite {
                 provider: "p".into(),
@@ -1014,6 +1016,7 @@ mod tests {
                 frames: 1,
             }],
             tokens: 120,
+            usage: None,
         })
         .expect("recall is an annotation");
         assert_eq!(


### PR DESCRIPTION
Three interlocking CGP issues that all touch `stella-cli/src/contextgraph.rs`. Shipped as one branch, three commits, in dependency order — as parallel PRs they would have produced overlapping hunks that squash-merge into broken code.

Closes #451
Closes #452
Closes #453

---

## #451 — adopt the context-reuse guarantees

Stella consumed none of the guarantees the pinned CGP rev ships (`docs/context-reuse.md`): every frame set `content_digest: None`, and recall assembled the prompt in **score** order — so an unchanged context set rendered differently every turn and forfeited the provider prompt cache, the exact cost the protocol exists to make honest.

- **`content_digest` on every minted frame.** `stella-context/src/retrieval.rs` declares `sha256:<node.content_hash>` (already the sha256 of exactly the bytes served as `content`); `stella-graph/src/frames.rs` hashes the rendered frame body. Without one a frame is unverifiable and a host must re-query it (§1 D4).
- **Selection by score, rendering in canonical order.** `recall_via_host` still picks the highest-scoring frames under the frame/token budget, then returns them in canonical `FrameId` order — `(provider id, frame id, content digest)` — so a re-rank of an unchanged set is byte-stable (§1 D2/D3). This is the single seam every downstream prompt builder consumes (recall block, planner prompt, witness prompt), so ordering here makes them all cache-stable at once.
- **`context/verify` advertised and implemented** for `workspace-memory`: the plane compares each presented digest against the live node's `content_hash` — valid / stale / gone / unknown, default-deny, no frame body in either direction.
- **The CLI conformance gate now has teeth.** `workspace_memory_provider_is_cgp_conformant` was passing **vacuously**: the suite probes with `"conformance probe"` and the fixture seeded unrelated content, so it surfaced 0 frames — a *permitted* answer that made frame-validity a free pass and skipped verify-honesty entirely. Proof, from the pre-fix run:
  > `the conformance probe surfaced no frames — the gate is passing vacuously: provider returned 0 frames (permitted — nothing relevant to the probe)`

  The fixture now seeds a probe-matching frame derived from `sample_query` itself, so a pin bump that rewords the probe cannot silently re-vacuum the gate, and the test asserts the evidence is non-empty and that verify-honesty actually ran.

**Scope honesty.** `compose_context`'s *renderer* is deliberately not adopted verbatim. Stella's recall block must carry the `[nod_…]` handles the `cite_memory` feedback loop binds to, which the reference renderer (bare `<frame>` fences) does not emit. The **guarantee** `compose_context` exists to provide — canonical order, score/cost-free bytes — is adopted via `canonical_order` at the seam and witness-tested end-to-end through the real renderer.

`code-graph` deliberately does **not** advertise `verify`: a graph frame's digest covers a rendered body, not a file the index already hashes, so an honest answer would mean re-deriving the frame — which is the re-query the host performs anyway. It takes the §4 V3 fallback. Advertising without an honest answer would be worse than not advertising: the suite's `verify-honesty` check fails a provider that can never vouch for anything.

## #452 — the usage-report envelope

Context cost was visible but not **meterable**: `ContextRecall` carried only the *selected* frames' token sum and a per-provider frame count, so a provider that served expensive frames which lost fusion — or whose frames the host rejected outright — spent real tokens no event ever recorded.

- `recall_via_host` returns `HostRecall { frames, usage }`, taking the report from `FanOut::usage_report` **before** fusion. That is what makes it an accounting record rather than a debug counter: a budget liar's dropped frames land in `frames_rejected`, and a consent-gated or failed leg is itemized as having served nothing.
- New `stella_protocol::ContextUsage` / `ContextProviderUsage`, carried as an optional `usage` field on `AgentEvent::ContextRecall`. `is_consistent` is the spec's arithmetic identity, so a corrupted total is a checkable failure, never a silent misbill.
- `ContextRecallPort::recall` returns `Recall { frames, usage }` so the report reaches the event emitter without re-running recall.

**Content-free by construction** (AGENTS.md invariant 3, #466): provider ids, counts, costs, and an accounting timestamp — no frame titles, bodies, URIs, or query text. The spec's `served_frames` drill-down is deliberately **not** duplicated: the sibling `frames` field of the same event already records frame-granular identities locally, so an auditor still walks a total back to its frames. A round-trip test pins the envelope's field set so no field is added without a content review.

## #453 — the external-provider seam

`stella-context/src/provider.rs` documented the stdio/HTTP seam as "designed here but not yet built". It is built now.

- **New `context_providers.<id>` settings block.** `enabled` defaults **false** — declaring a provider is not turning it on, so a merged-in org-managed entry can never start serving a turn because a lower scope happened to define it. Entries merge per-entry *wholesale*: field-level merging would let a project file inherit a user's consent while swapping the url, silently reusing consent granted for a different endpoint.
- **Conformance is an admission gate, not a badge.** `register_external_providers` runs the protocol's suite on its **own** connection, *before* the session host holds one — "refuse before it serves a turn" is only true if the refusal precedes registration. A refusal is a value (`Admission`), never fatal: the session continues on its in-tree sources and the operator is told which contract broke.
- **Egress consent surfaced for the first time.** Every built-in is `egress: false`, so the consent store has never had occasion to prompt. Consent is matched against the scopes the provider declared **at handshake time**, not the ones config guessed at — a provider that quietly widened its egress since consent was granted is refused rather than grandfathered — and is per-scope, never a blanket switch.

**Deferred, stated plainly:** an unconsented egress provider stays **registered**. Scopes are only knowable from the handshake, and `contextgraph_host::Host` exposes no unregister. It is inert — the host's own consent gate refuses every query and the payload is never transmitted (§3.5) — so no workspace content reaches it, but the admission is reported as a refusal because that is what it is operationally. Removing the registration cleanly needs an upstream `Host::unregister`.

**New dependency:** `contextgraph-conformance` promoted from dev- to runtime dependency of `stella-cli`. Same crate, same pin — the suite is now an admission gate, not only a test-time audit.

---

## Verification

`make gate` (fmt-check + clippy `-D warnings` + `test --workspace`) is **green**.

Every witness below was proven by reverting the source change while keeping the test, confirming red, then restoring.

| Issue | Witness test | Crate |
|---|---|---|
| 451 | `store_frames_declare_a_content_digest_over_their_own_content` | stella-context |
| 451 | `store_verifies_by_digest_and_never_rubber_stamps` | stella-context |
| 451 | `verify_fan_out_prefers_a_definite_verdict_over_unknown` | stella-context |
| 451 | `frames_declare_a_content_digest_over_their_inline_content` | stella-graph |
| 451 | `changing_a_file_changes_its_frames_content_digest` | stella-graph |
| 451 | `a_rerank_of_an_unchanged_frame_set_renders_byte_identically` | stella-cli |
| 451 | `selection_still_prefers_the_highest_scoring_frames` | stella-cli |
| 451 | `merges_providers_and_dedupes_only_within_a_provider` | stella-cli |
| 451 | `workspace_memory_verifies_its_own_frames_and_refuses_a_foreign_digest` | stella-cli |
| 451 | `workspace_memory_provider_is_cgp_conformant` (non-vacuity assertions) | stella-cli |
| 452 | `recall_reports_per_provider_frame_counts_and_token_costs` | stella-cli |
| 452 | `a_budget_lying_provider_is_reported_as_rejected_not_forgotten` | stella-cli |
| 452 | `the_context_recall_event_carries_the_cgp_usage_report` | stella-pipeline |
| 452 | `context_usage_report_round_trips_and_stays_content_free` | stella-protocol |
| 452 | `a_tampered_usage_total_fails_the_arithmetic_identity` | stella-protocol |
| 452 | `a_recall_event_without_a_usage_report_still_parses` | stella-protocol |
| 453 | `a_non_conformant_provider_is_refused_before_it_can_serve_a_turn` | stella-cli |
| 453 | `a_conformant_provider_clears_the_admission_gate` | stella-cli |
| 453 | `a_disabled_provider_is_never_reached` | stella-cli |
| 453 | `a_transport_missing_its_required_field_is_a_config_refusal` | stella-cli |
| 453 | `an_unreachable_provider_is_refused_without_taking_the_session_down` | stella-cli |
| 453 | `egress_consent_gates_a_provider_that_sends_content_off_the_machine` | stella-cli |
| 453 | `the_in_tree_providers_still_declare_no_egress` | stella-cli |

**Flake note.** Two `make gate` runs went red on `stella-tools` (`custom::tests::*` 5s spawn timeouts, then `media::tests::poll_success_persists_the_video_and_forgets_the_job` journal identity conflict) under peak load right after a clippy rebuild. `stella-tools` depends on none of the changed behavior; the crate passed 3/3 in isolation and the workspace suite passed 3/3 with these changes applied. Consistent with the tracked flakes in #454/#456.
