### PR TITLE
ci(deps): codify the pnpm minimumReleaseAge policy, retire the version pin (#457)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  baseline-browser-mapping: 2.11.0
-
 importers:
 
   .: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,10 +12,18 @@ allowBuilds:
   esbuild: true
   sharp: true
 
-# Pin this Next transitive dep to the previous patch: 2.11.1 (a browser-compat
-# DATA release) was published <24h before the `minimumReleaseAge` supply-chain
-# cutoff, which fails `pnpm install --frozen-lockfile`. 2.11.0 (published a day
-# earlier) is identical in kind and safely aged. Drop this override once Next
-# ships a baseline-browser-mapping that clears the release-age window.
-overrides:
-  baseline-browser-mapping: 2.11.0
+# Supply-chain policy: refuse any version published less than this many minutes
+# ago. A compromised release is typically yanked within hours, so waiting a day
+# before anything enters the lockfile is most of the protection for none of the
+# cost. This lives here — not in each developer's global pnpm config — so devs
+# and CI resolve under the same rule; docs.yml's `pnpm install --frozen-lockfile`
+# previously ran under whatever policy the runner happened to have.
+minimumReleaseAge: 1440
+
+# baseline-browser-mapping is exempt. Next depends on it as `^2.9.19`, and it is
+# a browser-compat DATA package that publishes near-daily (2.10.40 → 2.11.1 in
+# under a month), so a release-age gate rejects its newest version most of the
+# time — that is what forced the hand-pinned override this setting replaces.
+# Re-pinning it by hand every week is not a supply-chain control, just churn.
+minimumReleaseAgeExclude:
+  - baseline-browser-mapping


### PR DESCRIPTION
## What & why

The 24h release-age rule lived only in individual developers' **global** pnpm config, so devs and CI resolved under different policies — `docs.yml` runs `pnpm install --frozen-lockfile` with whatever the runner happened to have. This moves it into `pnpm-workspace.yaml`, where pnpm 11 reads it for everyone.

It also retires the `baseline-browser-mapping: 2.11.0` override in favour of a policy exclude. That override was never a supply-chain control:

- Next depends on the package as `^2.9.19`
- it is a browser-compat **data** package that publishes near-daily (`2.10.40 → 2.11.1` inside a month)

so the age gate rejects its newest version most of the time, and the pin has to be bumped by hand every week just to keep resolution unblocked. Exempting the package once replaces that recurring chore.

Closes #457

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is dependency-resolution policy, not code. It is verified against the real resolver instead:

**1. The setting is actually read, not silently ignored.** pnpm now prints a step that was absent before:

```
✓ Lockfile passes supply-chain policies (358 entries in 1.3s)
```

**2. CI's exact command passes.** `pnpm install --frozen-lockfile` → clean.

**3. The exclude is load-bearing.** A/B at a deliberately inflated cutoff, everything else held constant:

| | `baseline-browser-mapping@2.11.0` |
| --- | --- |
| without the exclude | rejected by name, `…and 88 more` |
| with the exclude | absent from the rejection list, `…and 87 more` |

Exactly one package differs, and it is the intended one.

## The gate

- [x] `cargo fmt --check` — n/a, no Rust touched
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust touched
- [x] `cargo test --workspace` — n/a, no Rust touched
- [x] Docs updated where behavior/flags changed — the policy is documented inline in `pnpm-workspace.yaml`, including why the exemption exists
- [x] Commits signed off for DCO

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

**The lockfile diff is only the 3-line `overrides:` block.** No package resolution changed — `baseline-browser-mapping` stays at 2.11.0 through normal lockfile stability — so the installed tree is byte-identical and the docs build cannot regress from this.

**`1440` is inferred, not documented anywhere.** The issue describes 2.11.1 as published "<24h before the cutoff", so 24h is the value the policy was already operating at. Change it if your global config actually said something else.

**The policy verifies the whole lockfile, not just new resolutions** — all 358 entries are checked on every install. That is the desired behaviour, but it means a future dependency bump can fail on an entry unrelated to the thing being bumped. The fix in that case is to wait out the window, not to widen the exclude list.

## Summary by Sourcery

Codify a shared pnpm minimum release-age policy in the workspace config and replace the ad‑hoc baseline-browser-mapping version pin with a policy-based exemption.

Build:
- Define a 24-hour (1440-minute) minimumReleaseAge supply-chain policy in pnpm-workspace.yaml so local development and CI resolve dependencies under the same rule.
- Add a minimumReleaseAgeExclude entry for baseline-browser-mapping and remove the previous explicit version override to avoid ongoing manual pin maintenance.

Documentation:
- Document the dependency release-age policy and the rationale for exempting baseline-browser-mapping inline in pnpm-workspace.yaml.