### PR TITLE
feat(receipts): record every model call's context, and expose it via stella inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ stella init      # infer this workspace's domain taxonomy (.stella/domains.toml)
 stella tools     # list every tool available to the agent this session
 stella stats     # cost, tokens, and $/resolved task per provider/model
                  # (--format table|json|csv, --provider <id>)
+stella inspect   # the exact context a past model call was sent, rebuilt from
+                 # recorded receipts (--step N, --call-seq S, --format json)
 ```
 
 ### Global flags

--- a/stella-cli/src/accounted_call.rs
+++ b/stella-cli/src/accounted_call.rs
@@ -64,6 +64,7 @@ pub(crate) async fn complete_standalone(
             retry_policy: RetryPolicy::deterministic(),
             timeout: Some(Duration::from_secs(120)),
             estimated_input_tokens: 0,
+            receipt: None,
         },
         &mut budget,
         &stella_core::EventSender::new(tx.clone()),

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -349,6 +349,7 @@ pub(crate) fn persist_event(
     } else if let AgentEvent::StepManifest {
         turn_instance,
         step,
+        call_seq,
         role,
         provider,
         model,
@@ -363,6 +364,7 @@ pub(crate) fn persist_event(
             &StepManifestRow {
                 turn_instance: *turn_instance,
                 step: *step as u64,
+                call_seq: *call_seq,
                 provider: provider.clone(),
                 model: model.clone(),
                 call_role: enum_tag(role),
@@ -596,6 +598,7 @@ mod stream_tests {
         let manifest = AgentEvent::StepManifest {
             turn_instance: 0,
             step: 0,
+            call_seq: 0,
             role: ModelCallRole::Worker,
             provider: "anthropic".into(),
             model: "opus".into(),
@@ -621,7 +624,7 @@ mod stream_tests {
 
         // The manifest reconstructs the step's ordered blocks, token_cost joined
         // back from context_blocks.
-        let entries = store.step_manifest(id, 0, 0).expect("manifest");
+        let entries = store.step_manifest(id, 0, 0, 0).expect("manifest");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].block_id, "blk_tool1");
         assert_eq!(entries[0].cache_zone, "volatile");
@@ -706,7 +709,9 @@ mod stream_tests {
         }
 
         // Reconstruct purely from the persisted store, and prove it byte-exact.
-        let recon = store.reconstruct_step(id, 0, 1).expect("reconstruct");
+        let recon = store
+            .reconstruct_worker_step(id, 0, 1)
+            .expect("reconstruct");
         assert!(
             recon.is_verified(),
             "unresolved={:?} mismatches={:?}",

--- a/stella-cli/src/arena.rs
+++ b/stella-cli/src/arena.rs
@@ -561,6 +561,7 @@ mod tests {
         AgentEvent::StepManifest {
             turn_instance: 1,
             step: 0,
+            call_seq: 0,
             role: ModelCallRole::default(),
             provider: "test".into(),
             model: "test-model".into(),

--- a/stella-cli/src/inspect.rs
+++ b/stella-cli/src/inspect.rs
@@ -1,0 +1,411 @@
+//! `stella inspect` — the read surface over the context receipts: show the
+//! exact `Vec<CompletionMessage>` a past model call was sent, rebuilt from the
+//! append-only fold rather than from any live engine state.
+//!
+//! The storage layer has been able to do this since the receipts plane landed
+//! ([`Store::reconstruct_call`]); until now nothing exposed it, so the honest
+//! answer to "what context did the model actually get?" was "it's in SQLite,
+//! write your own query." This is that query.
+//!
+//! Reads only — like `stella stats`, it refuses to create `.stella/` as a side
+//! effect of being asked a question, and needs no API key or provider.
+//!
+//! Three levels, narrowing as you supply more:
+//!
+//! - `stella inspect` — executions that have receipts, most recent first.
+//! - `stella inspect <id>` — every recorded model call of one execution.
+//! - `stella inspect <id> --step N` — the reconstructed context of one call.
+//!
+//! ## What "verified" means in the output
+//!
+//! Every block whose preimage came from the event journal is re-hashed and
+//! checked against the digest the receipt recorded at emission, so a torn
+//! journal or a fabricated block surfaces as a mismatch instead of a
+//! plausible-looking lie. The two gap kinds (the system prefix and the
+//! assembled user/recall message) are stored as local bytes, so their check is
+//! tautological and is deliberately not counted as evidence — see
+//! [`stella_store::Reconstruction`]. The banner reports both facts rather than
+//! flattening them into one word.
+
+use serde::Serialize;
+use stella_protocol::{CompletionMessage, MessageRole};
+use stella_store::{Reconstruction, RecordedCall, Store};
+
+/// How much of a message body the text format prints before eliding. The whole
+/// point of this command is seeing the real bytes, so the cap is generous and
+/// `--full` removes it entirely.
+const DEFAULT_BODY_LIMIT: usize = 4_000;
+
+/// Prompt preview width in the execution index.
+const PROMPT_PREVIEW: usize = 68;
+
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum InspectFormat {
+    /// Human-readable, role-delimited transcript.
+    Text,
+    /// The reconstructed messages plus the verification verdict, as JSON.
+    Json,
+}
+
+/// `stella inspect [id] [--turn T] [--step N] [--call-seq S]`.
+pub(crate) fn run_inspect(
+    execution_id: Option<i64>,
+    turn: u32,
+    step: Option<u64>,
+    call_seq: u64,
+    format: InspectFormat,
+    full: bool,
+) -> Result<(), String> {
+    let store = open_readonly_store()?;
+    match (execution_id, step) {
+        (None, _) => list_executions(&store, format),
+        (Some(id), None) => list_calls(&store, id, format),
+        (Some(id), Some(step)) => show_call(&store, id, turn, step, call_seq, format, full),
+    }
+}
+
+/// Open the workspace store without creating it. Mirrors `stella stats`: a
+/// question about recorded history must never write.
+fn open_readonly_store() -> Result<Store, String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let db_path = stella_store::existing_workspace_private_sqlite_path(&workspace_root, "store.db")
+        .map_err(|e| format!("cannot resolve local store: {e}"))?;
+    if db_path.is_none() {
+        return Err(
+            "no local store in this workspace yet — run something first, then inspect it".into(),
+        );
+    }
+    Store::open(&workspace_root).map_err(|e| format!("cannot open local store: {e}"))
+}
+
+fn list_executions(store: &Store, format: InspectFormat) -> Result<(), String> {
+    let rows = store
+        .inspectable_executions(40)
+        .map_err(|e| format!("cannot read receipts: {e}"))?;
+    if matches!(format, InspectFormat::Json) {
+        return print_json(&rows.iter().map(execution_json).collect::<Vec<_>>());
+    }
+    if rows.is_empty() {
+        println!(
+            "No reconstructable executions recorded yet.\n\
+             Receipts are written by builds carrying the context-receipts plane; \
+             executions from before it landed have none."
+        );
+        return Ok(());
+    }
+    println!("{:>8}  {:>5}  {:<20}  PROMPT", "EXEC", "CALLS", "STARTED");
+    for row in &rows {
+        println!(
+            "{:>8}  {:>5}  {:<20}  {}",
+            row.execution_id,
+            row.calls,
+            truncate(&row.started_at, 20),
+            truncate(row.prompt.lines().next().unwrap_or(""), PROMPT_PREVIEW),
+        );
+    }
+    println!("\nstella inspect <EXEC> to list that execution's model calls.");
+    Ok(())
+}
+
+fn list_calls(store: &Store, execution_id: i64, format: InspectFormat) -> Result<(), String> {
+    let calls = store
+        .recorded_calls(execution_id)
+        .map_err(|e| format!("cannot read receipts: {e}"))?;
+    if matches!(format, InspectFormat::Json) {
+        return print_json(&calls.iter().map(call_json).collect::<Vec<_>>());
+    }
+    if calls.is_empty() {
+        println!("Execution {execution_id} has no recorded receipts.");
+        return Ok(());
+    }
+    println!(
+        "{:>4}  {:>4}  {:>3}  {:<14}  {:<10}  {:>9}",
+        "TURN", "STEP", "SEQ", "ROLE", "PROVIDER", "EST TOK"
+    );
+    for call in &calls {
+        println!(
+            "{:>4}  {:>4}  {:>3}  {:<14}  {:<10}  {:>9}",
+            call.turn_instance,
+            call.step,
+            call.call_seq,
+            truncate(&call.call_role, 14),
+            truncate(&call.provider, 10),
+            call.estimated_input_tokens,
+        );
+    }
+    println!(
+        "\nstella inspect {execution_id} --step <STEP> [--turn <TURN>] [--call-seq <SEQ>] \
+         to see the context one call was sent."
+    );
+    Ok(())
+}
+
+fn show_call(
+    store: &Store,
+    execution_id: i64,
+    turn: u32,
+    step: u64,
+    call_seq: u64,
+    format: InspectFormat,
+    full: bool,
+) -> Result<(), String> {
+    let recon = store
+        .reconstruct_call(execution_id, turn, step, call_seq)
+        .map_err(|e| format!("cannot reconstruct: {e}"))?;
+    if recon.messages.is_empty() && recon.unresolved.is_empty() {
+        return Err(format!(
+            "no receipt for execution {execution_id} turn {turn} step {step} call-seq {call_seq} \
+             — `stella inspect {execution_id}` lists what was recorded"
+        ));
+    }
+    match format {
+        InspectFormat::Json => print_json(&reconstruction_json(&recon)),
+        InspectFormat::Text => {
+            print_reconstruction(&recon, execution_id, turn, step, call_seq, full);
+            Ok(())
+        }
+    }
+}
+
+fn print_reconstruction(
+    recon: &Reconstruction,
+    execution_id: i64,
+    turn: u32,
+    step: u64,
+    call_seq: u64,
+    full: bool,
+) {
+    println!("execution {execution_id} · turn {turn} · step {step} · call-seq {call_seq}");
+    println!(
+        "{} message(s){}",
+        recon.messages.len(),
+        if full { ", full bodies" } else { "" }
+    );
+    // Report the two failure modes separately: an unresolved block is a
+    // documented coverage gap, a digest mismatch is a tampering/torn-journal
+    // signal. Collapsing them into "unverified" would hide which one happened.
+    if !recon.unresolved.is_empty() {
+        println!(
+            "!  {} block(s) could not be resolved (synthetic results, discarded \
+             speculation, or attachments): {}",
+            recon.unresolved.len(),
+            recon.unresolved.join(", ")
+        );
+    }
+    if !recon.digest_mismatches.is_empty() {
+        println!(
+            "!! {} block(s) did NOT re-hash to their recorded digest — the journal is torn \
+             or was altered: {}",
+            recon.digest_mismatches.len(),
+            recon.digest_mismatches.join(", ")
+        );
+    }
+    if recon.is_verified() {
+        println!("verified: every journal-resolved block re-hashed to its recorded digest");
+    }
+    for (index, message) in recon.messages.iter().enumerate() {
+        println!("\n─── [{index}] {} ───", role_tag(message.role));
+        let body = message_body(message);
+        if full || body.len() <= DEFAULT_BODY_LIMIT {
+            println!("{body}");
+        } else {
+            let cut = floor_char_boundary(&body, DEFAULT_BODY_LIMIT);
+            println!(
+                "{}\n… {} more bytes (--full to print, --format json for the exact bytes)",
+                &body[..cut],
+                body.len() - cut
+            );
+        }
+    }
+}
+
+/// The message's printable body: text content, plus a compact rendering of any
+/// tool calls/results it carried (they are separate blocks in the receipt but
+/// belong to one message on the wire).
+fn message_body(message: &CompletionMessage) -> String {
+    let mut out = String::new();
+    if !message.content.is_empty() {
+        out.push_str(&message.content);
+    }
+    for call in &message.tool_calls {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "→ tool_call {} {} {}",
+            call.call_id, call.name, call.input
+        ));
+    }
+    for result in &message.tool_results {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "← tool_result {} {}",
+            result.call_id,
+            serde_json::to_string(&result.output).unwrap_or_default()
+        ));
+    }
+    out
+}
+
+fn role_tag(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
+    }
+}
+
+#[derive(Serialize)]
+struct ExecutionJson {
+    execution_id: i64,
+    kind: String,
+    prompt: String,
+    started_at: String,
+    calls: u64,
+}
+
+#[derive(Serialize)]
+struct CallJson {
+    turn_instance: u32,
+    step: u64,
+    call_seq: u64,
+    call_role: String,
+    provider: String,
+    model: String,
+    estimated_input_tokens: u64,
+}
+
+#[derive(Serialize)]
+struct MessageJson {
+    role: &'static str,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ReconstructionJson {
+    verified: bool,
+    unresolved: Vec<String>,
+    digest_mismatches: Vec<String>,
+    messages: Vec<MessageJson>,
+}
+
+fn execution_json(row: &stella_store::InspectableExecution) -> ExecutionJson {
+    ExecutionJson {
+        execution_id: row.execution_id,
+        kind: row.kind.clone(),
+        prompt: row.prompt.clone(),
+        started_at: row.started_at.clone(),
+        calls: row.calls,
+    }
+}
+
+fn call_json(call: &RecordedCall) -> CallJson {
+    CallJson {
+        turn_instance: call.turn_instance,
+        step: call.step,
+        call_seq: call.call_seq,
+        call_role: call.call_role.clone(),
+        provider: call.provider.clone(),
+        model: call.model.clone(),
+        estimated_input_tokens: call.estimated_input_tokens,
+    }
+}
+
+fn reconstruction_json(recon: &Reconstruction) -> ReconstructionJson {
+    ReconstructionJson {
+        verified: recon.is_verified(),
+        unresolved: recon.unresolved.clone(),
+        digest_mismatches: recon.digest_mismatches.clone(),
+        messages: recon
+            .messages
+            .iter()
+            .map(|m| MessageJson {
+                role: role_tag(m.role),
+                content: message_body(m),
+            })
+            .collect(),
+    }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), String> {
+    let rendered =
+        serde_json::to_string_pretty(value).map_err(|e| format!("cannot render json: {e}"))?;
+    println!("{rendered}");
+    Ok(())
+}
+
+fn truncate(s: &str, limit: usize) -> String {
+    if s.chars().count() <= limit {
+        return s.to_string();
+    }
+    let cut: String = s.chars().take(limit.saturating_sub(1)).collect();
+    format!("{cut}…")
+}
+
+/// Largest index `<= limit` that is a char boundary — slicing a UTF-8 body at a
+/// raw byte offset would panic on any multibyte character.
+fn floor_char_boundary(s: &str, limit: usize) -> usize {
+    let mut cut = limit.min(s.len());
+    while cut > 0 && !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    cut
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_counts_characters_not_bytes() {
+        assert_eq!(truncate("abc", 8), "abc");
+        assert_eq!(truncate("abcdefghij", 5), "abcd…");
+        // Multibyte input must not panic or split a character.
+        assert_eq!(truncate("ααααααα", 3), "αα…");
+    }
+
+    #[test]
+    fn body_cut_lands_on_a_char_boundary() {
+        let s = "α".repeat(100);
+        let cut = floor_char_boundary(&s, 51);
+        assert!(s.is_char_boundary(cut), "cut must be sliceable");
+        assert_eq!(cut, 50, "rounds down to the boundary below the limit");
+    }
+
+    #[test]
+    fn message_body_renders_tool_round_trips_not_just_text() {
+        use stella_protocol::{ToolCall, ToolOutput, ToolResult};
+        let message = CompletionMessage {
+            role: MessageRole::Assistant,
+            content: "reading the file".into(),
+            tool_calls: vec![ToolCall {
+                call_id: "c1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "a.rs"}),
+            }],
+            tool_results: vec![],
+            attachments: vec![],
+        };
+        let body = message_body(&message);
+        assert!(body.contains("reading the file"));
+        assert!(body.contains("→ tool_call c1 read_file"));
+
+        let tool = CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::Ok {
+                    content: "fn main() {}".into(),
+                },
+            }],
+            attachments: vec![],
+        };
+        assert!(message_body(&tool).contains("← tool_result c1"));
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -46,6 +46,7 @@ mod export;
 mod extensions;
 mod fleet_cmd;
 mod init_fx;
+mod inspect;
 mod interactive;
 mod mcp_cmd;
 mod memory;
@@ -368,6 +369,37 @@ enum Command {
     Models {
         #[command(subcommand)]
         cmd: Option<ModelsCmd>,
+    },
+
+    /// Show the exact context a past model call was sent — the reconstructed
+    /// message array, rebuilt from the recorded receipts and verified against
+    /// the digests taken at emission. With no arguments, lists executions that
+    /// have receipts; with an execution id, lists its model calls. Reads
+    /// .stella/private/store.db only; needs no API key and never writes.
+    Inspect {
+        /// Execution to inspect (omit to list recent executions)
+        execution_id: Option<i64>,
+
+        /// Turn instance within the execution
+        #[arg(long, default_value_t = 0)]
+        turn: u32,
+
+        /// Step to reconstruct (omit to list the execution's calls)
+        #[arg(long)]
+        step: Option<u64>,
+
+        /// Which model call at that step: 0 the worker, 1 the overflow
+        /// summarizer, 2+ a pipeline management role
+        #[arg(long = "call-seq", default_value_t = 0)]
+        call_seq: u64,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "text")]
+        format: inspect::InspectFormat,
+
+        /// Print message bodies in full instead of eliding long ones
+        #[arg(long)]
+        full: bool,
     },
 
     /// Summarize cost, tokens, and resolve rate per provider/model from
@@ -1204,6 +1236,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // Reads the local index + manifest only — zero API keys.
             return run_storage(cmd);
         }
+        Some(Command::Inspect {
+            execution_id,
+            turn,
+            step,
+            call_seq,
+            format,
+            full,
+        }) => {
+            // Reads the local receipt tables only — no provider, no API key.
+            return inspect::run_inspect(*execution_id, *turn, *step, *call_seq, *format, *full);
+        }
         Some(Command::Stats { format, provider }) => {
             // Reads local telemetry only — works with zero API keys.
             // `*format`: this match borrows `&cli.command` (the Tools arm
@@ -1438,6 +1481,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Graph { .. }
         | Command::Scripts { .. }
         | Command::Storage { .. }
+        | Command::Inspect { .. }
         | Command::Stats { .. }
         | Command::Usage { .. }
         | Command::Cloud { .. }

--- a/stella-cli/tests/inspect_cli.rs
+++ b/stella-cli/tests/inspect_cli.rs
@@ -1,0 +1,197 @@
+//! End-to-end witness for `stella inspect`: drive the real binary against a
+//! real store and check that the context a past call was sent comes back out.
+//!
+//! The receipts plane could reconstruct a step long before this command
+//! existed; what was missing was any way to ask it. These tests exercise the
+//! asking — argument parsing, the SQL, and the rendering — not the
+//! reconstruction algorithm (covered by `stella-store`'s own tests).
+
+use std::process::Command;
+
+use stella_store::{ContextBlockRow, ManifestBlockRow, StepManifestRow, Store};
+
+/// Digest helper matching `stella-core`'s block identity: the store verifies
+/// journal-resolved blocks against this, and skips the check for gap kinds
+/// (which carry their bytes locally), so a placeholder is fine here.
+fn block(block_id: &str, kind: &str, content: &str) -> ContextBlockRow {
+    ContextBlockRow {
+        block_id: block_id.into(),
+        kind: kind.into(),
+        origin_turn: 0,
+        origin_step: 0,
+        call_id: None,
+        memory_id: None,
+        token_cost: 10,
+        content_digest: format!("sha256:{block_id}"),
+        citation_label: None,
+        // Gap kinds carry their preimage locally — this is the field that makes
+        // a system prompt readable after the fact.
+        content: Some(content.into()),
+    }
+}
+
+fn entry(block_id: &str, message_index: u64) -> ManifestBlockRow {
+    ManifestBlockRow {
+        block_id: block_id.into(),
+        cache_zone: "cacheable".into(),
+        token_cost: 10,
+        resident_since_step: 0,
+        message_index,
+    }
+}
+
+/// A workspace whose store holds one execution with two model calls at the
+/// SAME step: the engine's worker (seq 0) and an overflow summarizer (seq 1).
+fn seeded_workspace() -> (tempfile::TempDir, i64) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(dir.path()).expect("store");
+    let id = store
+        .begin_execution("run", "fix the failing test", "anthropic", "opus")
+        .expect("execution");
+
+    store
+        .record_context_block(id, &block("blk_sys", "system_prefix", "You are Stella."))
+        .expect("system block");
+    store
+        .record_context_block(id, &block("blk_goal", "user_goal", "fix the failing test"))
+        .expect("goal block");
+    store
+        .record_context_block(
+            id,
+            &block("blk_sum", "system_prefix", "Condense this span faithfully."),
+        )
+        .expect("summarizer block");
+
+    store
+        .record_step_manifest(
+            id,
+            &StepManifestRow {
+                turn_instance: 0,
+                step: 0,
+                call_seq: 0,
+                provider: "anthropic".into(),
+                model: "opus".into(),
+                call_role: "worker".into(),
+                effective_budget_tokens: 136_363,
+                calibration_factor: 1.1,
+                estimated_input_tokens: 20,
+                blocks: vec![entry("blk_sys", 0), entry("blk_goal", 1)],
+            },
+        )
+        .expect("worker manifest");
+    store
+        .record_step_manifest(
+            id,
+            &StepManifestRow {
+                turn_instance: 0,
+                step: 0,
+                call_seq: 1,
+                provider: "anthropic".into(),
+                model: "haiku".into(),
+                call_role: "summarization".into(),
+                effective_budget_tokens: 136_363,
+                calibration_factor: 1.1,
+                estimated_input_tokens: 10,
+                blocks: vec![entry("blk_sum", 0)],
+            },
+        )
+        .expect("summarizer manifest");
+    (dir, id)
+}
+
+fn inspect(dir: &tempfile::TempDir, args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .arg("inspect")
+        .args(args)
+        .current_dir(dir.path())
+        .output()
+        .expect("run stella inspect");
+    assert!(
+        output.status.success(),
+        "stella inspect {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn inspect_lists_executions_then_calls_then_the_context_itself() {
+    let (dir, id) = seeded_workspace();
+
+    // Level 1: the execution index.
+    let index = inspect(&dir, &[]);
+    assert!(
+        index.contains(&id.to_string()),
+        "index lists the execution: {index}"
+    );
+    assert!(
+        index.contains("fix the failing test"),
+        "index previews the prompt: {index}"
+    );
+
+    // Level 2: both calls of the step are listed — the collision this fixes.
+    let calls = inspect(&dir, &[&id.to_string()]);
+    assert!(calls.contains("worker"), "worker call listed: {calls}");
+    assert!(
+        calls.contains("summarization"),
+        "the summarizer call is no longer overwritten by the worker: {calls}"
+    );
+
+    // Level 3: the worker's actual context.
+    let worker = inspect(&dir, &[&id.to_string(), "--step", "0"]);
+    assert!(
+        worker.contains("You are Stella."),
+        "the system prompt is readable: {worker}"
+    );
+    assert!(
+        worker.contains("fix the failing test"),
+        "the user goal is readable: {worker}"
+    );
+    assert!(
+        !worker.contains("Condense this span"),
+        "the worker call must not show the summarizer's prompt: {worker}"
+    );
+
+    // The summarizer's own context — previously unrecoverable entirely.
+    let summarizer = inspect(&dir, &[&id.to_string(), "--step", "0", "--call-seq", "1"]);
+    assert!(
+        summarizer.contains("Condense this span faithfully."),
+        "the summarizer's prompt is recorded and readable: {summarizer}"
+    );
+    assert!(
+        !summarizer.contains("You are Stella."),
+        "each call shows its own context: {summarizer}"
+    );
+}
+
+#[test]
+fn inspect_json_is_machine_readable_and_reports_verification() {
+    let (dir, id) = seeded_workspace();
+    let out = inspect(&dir, &[&id.to_string(), "--step", "0", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(parsed["verified"], true, "clean path verifies: {out}");
+    let messages = parsed["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 2, "system + user: {out}");
+    assert_eq!(messages[0]["role"], "system");
+    assert_eq!(messages[0]["content"], "You are Stella.");
+    assert_eq!(messages[1]["role"], "user");
+}
+
+#[test]
+fn inspect_names_a_missing_receipt_instead_of_printing_an_empty_transcript() {
+    let (dir, id) = seeded_workspace();
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .args(["inspect", &id.to_string(), "--step", "99"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run");
+    assert!(
+        !output.status.success(),
+        "an absent step is an error, not silence"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no receipt"),
+        "says what was missing: {stderr}"
+    );
+}

--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -11,7 +11,21 @@ use tokio::time::timeout;
 
 use crate::budget::{BudgetGuard, BudgetOutcome};
 use crate::event_sender::EventSender;
+use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
+
+/// Where an auxiliary call sits in the receipt coordinate space, so the context
+/// it sent is reconstructable alongside the engine's own steps. `call_seq` must
+/// be unique within the execution (see `AgentEvent::StepManifest::call_seq`).
+///
+/// `None` on an [`AccountedCall`] means "emit no receipt" — reserved for callers
+/// that are not part of a recorded execution (tests, one-off tooling).
+#[derive(Debug, Clone, Copy)]
+pub struct ReceiptContext {
+    pub turn_instance: u32,
+    pub step: usize,
+    pub call_seq: u64,
+}
 
 pub struct AccountedCall<'a> {
     pub provider: &'a dyn Provider,
@@ -21,6 +35,9 @@ pub struct AccountedCall<'a> {
     pub retry_policy: RetryPolicy,
     pub timeout: Option<Duration>,
     pub estimated_input_tokens: u64,
+    /// Receipt coordinates for this call. `Some` makes the exact context it
+    /// sent reconstructable after the fact; `None` records cost only.
+    pub receipt: Option<ReceiptContext>,
 }
 
 pub enum AccountedCallError {
@@ -99,6 +116,24 @@ pub async fn run_accounted_call(
     }
     let result = outcome.value;
     let provider = call.provider.id();
+    // The context receipt for this call, emitted just before `StepUsage` so the
+    // pair — what the model saw, what it cost — lands together at the settled
+    // boundary, exactly as the engine's step loop does it. Every role routed
+    // through here (the overflow summarizer, and the pipeline's triage / judge /
+    // plan / guidance / conversational roles) is otherwise reconstructable only
+    // as a cost line: without this the prompt it actually sent is unrecoverable.
+    // A fresh ledger per call is correct — these are one-shot contexts, so every
+    // block is first-seen and registers with its bytes.
+    if let Some(receipt) = call.receipt {
+        ReceiptLedger::with_call_seq(receipt.turn_instance, receipt.call_seq).emit_step_receipt(
+            &call.request.messages,
+            receipt.step,
+            call.role,
+            provider,
+            &result.model,
+            events,
+        );
+    }
     let _ = events.send(AgentEvent::StepUsage {
         step: 0,
         role: call.role,
@@ -240,6 +275,7 @@ mod tests {
                 retry_policy: RetryPolicy::new(1, 0, 0),
                 timeout: None,
                 estimated_input_tokens: 1,
+                receipt: None,
             },
             &mut budget,
             &EventSender::new(tx),
@@ -281,6 +317,154 @@ mod tests {
             !serde_json::to_string(&incomplete)
                 .expect("wire")
                 .contains("private failed body")
+        );
+    }
+
+    struct Succeeds;
+
+    #[async_trait]
+    impl Provider for Succeeds {
+        fn id(&self) -> &str {
+            "scripted"
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResult, ProviderError> {
+            Ok(CompletionResult {
+                text: "summary".into(),
+                tool_calls: Vec::new(),
+                usage: CompletionUsage::reported_zero(),
+                model: "scripted-model".into(),
+                cost_usd: 0.01,
+                finish_reason: None,
+            })
+        }
+    }
+
+    /// The gap this closes: every role routed through here — the overflow
+    /// summarizer, the pipeline's triage/judge/plan/guidance — used to leave a
+    /// cost line and nothing else, so the prompt it sent was unrecoverable.
+    /// A receipt context makes its system prefix a registered block carrying
+    /// its own bytes, keyed apart from the worker call by `call_seq`.
+    #[tokio::test]
+    async fn a_receipt_context_makes_an_auxiliary_call_reconstructable() {
+        let provider = Succeeds;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let _ = run_accounted_call(
+            AccountedCall {
+                provider: &provider,
+                role: ModelCallRole::Summarization,
+                model_hint: "configured-model".into(),
+                request: CompletionRequest {
+                    messages: vec![
+                        CompletionMessage::system("condense this span faithfully"),
+                        CompletionMessage::user("t0 t1 t2"),
+                    ],
+                    max_output_tokens: None,
+                    temperature: None,
+                    effort: None,
+                    tools: Vec::new(),
+                    reasoning: None,
+                    params: None,
+                },
+                retry_policy: RetryPolicy::new(1, 0, 0),
+                timeout: None,
+                estimated_input_tokens: 1,
+                receipt: Some(ReceiptContext {
+                    turn_instance: 4,
+                    step: 7,
+                    call_seq: crate::receipts::RECEIPT_SEQ_SUMMARIZER,
+                }),
+            },
+            &mut budget,
+            &EventSender::new(tx),
+            &NoopSleeper,
+        )
+        .await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        // The system prefix registers with its bytes — that is the whole point.
+        let carries_prompt = events.iter().any(|event| {
+            matches!(
+                event,
+                AgentEvent::BlockRegistered { content: Some(c), .. }
+                    if c == "condense this span faithfully"
+            )
+        });
+        assert!(
+            carries_prompt,
+            "the summarizer's own system prompt must be a registered block: {events:?}"
+        );
+        // The manifest is keyed at the auxiliary seat, not over the worker's.
+        let manifest = events
+            .iter()
+            .find(|event| matches!(event, AgentEvent::StepManifest { .. }))
+            .expect("a manifest is emitted");
+        assert!(matches!(
+            manifest,
+            AgentEvent::StepManifest {
+                turn_instance: 4,
+                step: 7,
+                call_seq: 1,
+                role: ModelCallRole::Summarization,
+                ..
+            }
+        ));
+        // Receipt precedes StepUsage, matching the engine's ordering.
+        let manifest_at = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::StepManifest { .. }))
+            .expect("manifest");
+        let usage_at = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::StepUsage { .. }))
+            .expect("usage");
+        assert!(
+            manifest_at < usage_at,
+            "receipt lands with, and before, usage"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_receipt_context_emits_no_manifest() {
+        let provider = Succeeds;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let _ = run_accounted_call(
+            AccountedCall {
+                provider: &provider,
+                role: ModelCallRole::SkillAuthor,
+                model_hint: "configured-model".into(),
+                request: CompletionRequest {
+                    messages: vec![CompletionMessage::system("secret standalone prompt")],
+                    max_output_tokens: None,
+                    temperature: None,
+                    effort: None,
+                    tools: Vec::new(),
+                    reasoning: None,
+                    params: None,
+                },
+                retry_policy: RetryPolicy::new(1, 0, 0),
+                timeout: None,
+                estimated_input_tokens: 1,
+                receipt: None,
+            },
+            &mut budget,
+            &EventSender::new(tx),
+            &NoopSleeper,
+        )
+        .await;
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                AgentEvent::StepManifest { .. } | AgentEvent::BlockRegistered { .. }
+            )),
+            "an opt-out caller records cost only, and never its prompt bytes"
         );
     }
 
@@ -336,6 +520,7 @@ mod tests {
                 retry_policy: RetryPolicy::new(3, 250, 250),
                 timeout: Some(Duration::from_millis(100)),
                 estimated_input_tokens: 1,
+                receipt: None,
             },
             &mut budget,
             &EventSender::new(tx),

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -487,6 +487,7 @@ impl<'a> Engine<'a> {
                     calibration_model.as_deref(),
                     budget,
                     &mut summarizer_health,
+                    step,
                     events,
                 )
                 .await;
@@ -615,6 +616,7 @@ impl<'a> Engine<'a> {
         calibration_model: Option<&str>,
         budget: &mut BudgetGuard,
         health: &mut SummarizerHealth,
+        step: usize,
         events: &EventSender,
     ) -> f64 {
         let (compaction_budget, factor) = self.effective_compaction_budget(calibration_model);
@@ -654,6 +656,7 @@ impl<'a> Engine<'a> {
                     compaction_budget,
                     factor,
                     health,
+                    step,
                     events,
                 )
                 .await;
@@ -663,6 +666,10 @@ impl<'a> Engine<'a> {
 
     /// Replace the oldest viable span with a model-written summary. Failures
     /// leave the conversation untouched. Returns the summarizer call's spend.
+    /// `step` is carried only to key this call's receipt against the step it
+    /// rides, the same way [`Self::apply_overflow_summary`] carries the budget
+    /// pair it reports.
+    #[allow(clippy::too_many_arguments)]
     async fn summarize_overflow_span(
         &self,
         messages: &mut Vec<CompletionMessage>,
@@ -670,6 +677,7 @@ impl<'a> Engine<'a> {
         compaction_budget: u64,
         factor: f64,
         health: &mut SummarizerHealth,
+        step: usize,
         events: &EventSender,
     ) -> f64 {
         let before_tokens = crate::estimator::estimate_conversation_tokens(messages);
@@ -735,6 +743,16 @@ impl<'a> Engine<'a> {
                 retry_policy: RetryPolicy::standard(),
                 timeout: None,
                 estimated_input_tokens,
+                // The summarizer rewrites the conversation it is called on, so
+                // its own input is the only record of what it was given to
+                // compress — and the span it replaces is gone from the history
+                // afterwards. Reserved seat 1 at this step; compaction runs at
+                // most once per step, so it collides with nothing.
+                receipt: Some(crate::ReceiptContext {
+                    turn_instance: self.config.turn_instance,
+                    step,
+                    call_seq: crate::receipts::RECEIPT_SEQ_SUMMARIZER,
+                }),
             },
             budget,
             events,

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -397,7 +397,15 @@ async fn overflow_summarizer_retries_a_transient_error() {
     let events = EventSender::new(tx);
 
     let cost = engine
-        .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            &events,
+        )
         .await;
 
     assert_eq!(
@@ -444,7 +452,15 @@ async fn budget_aborted_summary_is_applied_not_discarded() {
     let events = EventSender::new(tx);
 
     let cost = engine
-        .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            &events,
+        )
         .await;
 
     assert!(
@@ -533,7 +549,15 @@ async fn overflow_summary_names_the_folded_tool_result_blocks() {
     let events = EventSender::new(tx);
 
     let _ = engine
-        .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            &events,
+        )
         .await;
 
     assert_eq!(summary_markers(&messages), 1, "the summary was spliced in");
@@ -587,7 +611,15 @@ async fn repeated_summarizer_failures_emit_events_and_latch() {
     for _ in 0..SUMMARIZER_FAILURE_LATCH {
         let mut messages = overflow_messages();
         let cost = engine
-            .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+            .summarize_overflow_span(
+                &mut messages,
+                &mut budget,
+                500,
+                1.0,
+                &mut health,
+                0,
+                &events,
+            )
             .await;
         assert_eq!(cost, 0.0, "a failed summarizer is free and changes nothing");
         assert_eq!(summary_markers(&messages), 0, "nothing spliced on failure");
@@ -622,7 +654,15 @@ async fn repeated_summarizer_failures_emit_events_and_latch() {
     // the summarizer.
     let mut messages = overflow_messages();
     let cost = engine
-        .summarize_overflow_span(&mut messages, &mut budget, 500, 1.0, &mut health, &events)
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            &events,
+        )
         .await;
     assert_eq!(cost, 0.0, "the latched pass spends nothing");
     assert_eq!(

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -41,7 +41,7 @@ pub use budget::{BudgetGuard, BudgetOutcome};
 // `bus::HookEvent` (the extension-bus envelope) stays module-qualified: the
 // crate root already exports `hooks::HookEvent` (the shell-hook lifecycle
 // enum) and the two must never be confused at a glance.
-pub use accounted_call::{AccountedCall, AccountedCallError, run_accounted_call};
+pub use accounted_call::{AccountedCall, AccountedCallError, ReceiptContext, run_accounted_call};
 pub use bus::{
     ExtensionFailure, HookBus, HookDecision, HookEventDraft, HookSubscription, PolicyOutcome,
 };

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -25,6 +25,21 @@ use stella_protocol::{
 use crate::estimator::{CHARS_PER_TOKEN, estimate_conversation_tokens};
 use crate::event_sender::EventSender;
 
+/// `StepManifest::call_seq` of the engine's own worker call — the step loop's
+/// model call, the one that already had a receipt.
+pub const RECEIPT_SEQ_WORKER: u64 = 0;
+
+/// `StepManifest::call_seq` of the overflow summarizer. A constant rather than
+/// a counter because compaction runs at most once per step, so the summarizer
+/// can collide with nothing else at its `(turn_instance, step)`.
+pub const RECEIPT_SEQ_SUMMARIZER: u64 = 1;
+
+/// First `call_seq` available to callers that must allocate their own — the
+/// pipeline's management roles, which have no step loop to key against and so
+/// draw a monotonic sequence per execution. Starts above the reserved worker
+/// and summarizer seats.
+pub const RECEIPT_SEQ_ALLOCATED_BASE: u64 = 2;
+
 /// `sha256` hex of a string. Byte-wise hex (the sha2 0.11 output type does not
 /// implement `LowerHex` directly), matching the context store's `to_hex`.
 fn sha256_hex(s: &str) -> String {
@@ -215,15 +230,26 @@ fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
 /// emission directly against a message vector without standing up a full turn.
 pub struct ReceiptLedger {
     turn_instance: u32,
+    call_seq: u64,
     first_seen_step: HashMap<String, usize>,
     effective_budget_tokens: u64,
     calibration_factor: f64,
 }
 
 impl ReceiptLedger {
+    /// A ledger for the engine's own step loop — the worker call, `call_seq` 0.
     pub fn new(turn_instance: u32) -> Self {
+        ReceiptLedger::with_call_seq(turn_instance, 0)
+    }
+
+    /// A ledger for one auxiliary call riding an engine step (the overflow
+    /// summarizer, or a pipeline management role). `call_seq` must be non-zero
+    /// and unique within the execution, or the receipt overwrites another
+    /// call's row — see `AgentEvent::StepManifest::call_seq`.
+    pub fn with_call_seq(turn_instance: u32, call_seq: u64) -> Self {
         ReceiptLedger {
             turn_instance,
+            call_seq,
             first_seen_step: HashMap::new(),
             effective_budget_tokens: 0,
             calibration_factor: 1.0,
@@ -293,6 +319,7 @@ impl ReceiptLedger {
         let _ = events.send(AgentEvent::StepManifest {
             turn_instance: self.turn_instance,
             step,
+            call_seq: self.call_seq,
             role,
             provider: provider.to_string(),
             model: model.to_string(),

--- a/stella-docs/content/docs/commands/index.mdx
+++ b/stella-docs/content/docs/commands/index.mdx
@@ -29,6 +29,7 @@ stella chat
 | `stella scripts <list\|run>` | List and run the project's [package-manager scripts](/docs/commands/scripts) via canonical verbs (offline, no API key). |
 | `stella models` | List configured providers and available models. |
 | `stella stats` | Summarize cost, tokens, and resolve rate per provider/model from local telemetry. |
+| `stella inspect` | Show the exact context a past model call was sent — the [reconstructed message array](/docs/commands/inspect), verified against the digests recorded at emission. |
 | `stella observe` | Serve the [Observatory dashboard](/docs/telemetry/dashboard) — your local telemetry in the browser, loopback-only. |
 | `stella memory` | Inspect memories through the citation loop, and promote one to a project rule. |
 | `stella mcp` | Manage MCP servers — search a registry, install, list, OAuth login, and show usage telemetry. |

--- a/stella-docs/content/docs/commands/inspect.mdx
+++ b/stella-docs/content/docs/commands/inspect.mdx
@@ -1,0 +1,63 @@
+---
+title: stella inspect
+description: Show the exact context a past model call was sent, rebuilt from recorded receipts and verified against the digests taken at emission.
+---
+
+Answer "what did the model actually see?" for any past call. `stella inspect` rebuilds the exact message array a model was sent — system prompt included — from the receipts recorded at the time, and re-checks it against the digests taken at emission. Entirely local; no API key, no network, and it never writes.
+
+## Synopsis
+
+```bash
+stella inspect                                   # executions that have receipts
+stella inspect <EXEC>                            # that execution's model calls
+stella inspect <EXEC> --step <N> [--turn <T>] [--call-seq <S>]
+```
+
+## What it does
+
+Every model call records a **receipt**: the ordered list of context blocks it sent, plus the bytes of the blocks the event journal cannot otherwise resolve (the system prefix and the assembled user/recall message). `stella inspect` replays that receipt against the journal to reconstruct the call's `Vec<CompletionMessage>`.
+
+It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it refuses to create `.stella/` as a side effect of being asked a question — if there's no store yet, it says so.
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--turn <T>` | Turn instance within the execution. Default `0`. |
+| `--step <N>` | Step to reconstruct. Omit to list the execution's calls instead. |
+| `--call-seq <S>` | Which model call at that step. Default `0`. |
+| `--format <text\|json>` | `text` (default) prints a role-delimited transcript; `json` gives the messages plus the verification verdict. |
+| `--full` | Print message bodies in full instead of eliding long ones. |
+
+## Why `--call-seq` exists
+
+A single step can involve more than one model call. The engine's own worker call is always `0`; the overflow summarizer that may run during that step's compaction is `1`; the pipeline's management roles (triage, judge, plan, guidance, conversational) allocate `2` and up.
+
+These auxiliary calls assemble their own prompts — a role task prompt, an optional settings-supplied system override, and a rendered transcript that exists nowhere else — so their receipt is the only record of what they sent. `stella inspect <EXEC>` lists every recorded call with its role, so you rarely have to guess a sequence number.
+
+## Reading the verification banner
+
+```
+execution 42 · turn 0 · step 3 · call-seq 0
+7 message(s)
+verified: every journal-resolved block re-hashed to its recorded digest
+```
+
+Two failure modes are reported separately, because they mean very different things:
+
+| Line | Meaning |
+| --- | --- |
+| `! N block(s) could not be resolved` | A documented coverage gap — budget-abort synthetic tool results, discarded speculation, or attachments. The rest of the transcript is still faithful. |
+| `!! N block(s) did NOT re-hash to their recorded digest` | The journal is torn or was altered. Treat the reconstruction as untrustworthy. |
+
+The system prefix and the assembled user message are stored as local bytes rather than resolved from the journal, so their digest check is tautological and is deliberately **not** counted as evidence. The proof lives in the journal-resolved kinds.
+
+## What it can't show you
+
+- **Executions from before the receipts plane landed.** They have no receipt rows and are omitted from the index rather than listed as empty.
+- **The literal wire bytes.** Receipts are taken before the provider adapter runs, and adapters transform the system block on the way out — Anthropic keeps only the last system message and inserts cache breakpoints, OpenAI and Gemini join system messages with `\n\n`. A receipt is the canonical pre-adapter view of the call.
+- **Tool JSON schemas.** The manifest records the messages, not the tool definitions sent alongside them.
+
+<Callout type="info">
+Receipts never leave your machine. The content-free export boundary (`stella-store`'s egress guard) strips prompts, paths, and tool payloads from anything replicated off-box, and is enforced by a compile-time column allowlist plus a sentinel-poisoning test. See [Telemetry](/docs/telemetry).
+</Callout>

--- a/stella-docs/content/docs/commands/meta.json
+++ b/stella-docs/content/docs/commands/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Commands",
-  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "models", "stats", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "version"]
+  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "models", "stats", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "version"]
 }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -44,9 +44,10 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use stella_core::hooks::{HookRunner, Hooks};
+use stella_core::receipts::RECEIPT_SEQ_ALLOCATED_BASE;
 use stella_core::retry::{RetryPolicy, Sleeper};
 use stella_core::router::FallbackInfo;
 use stella_core::{BudgetGuard, Engine, EngineConfig, EventSender, Router, TurnOutcome};
@@ -448,6 +449,13 @@ pub struct Pipeline<'a> {
     events: EventSender,
     config: PipelineConfig,
     configured_test: Result<Option<TestInvocation>, crate::witness::TestInvocationError>,
+    /// Monotonic `StepManifest::call_seq` for the management roles that call
+    /// providers directly (`metered_raw_call`). They sit outside any step loop,
+    /// so nothing else keys their receipts apart — several judge calls in one
+    /// run would otherwise all land on the same primary key and overwrite each
+    /// other. Starts at [`RECEIPT_SEQ_ALLOCATED_BASE`], above the seats the
+    /// engine's worker and summarizer reserve.
+    raw_call_seq: AtomicU64,
 }
 
 impl<'a> Pipeline<'a> {
@@ -480,6 +488,7 @@ impl<'a> Pipeline<'a> {
             events: events.into(),
             config,
             configured_test,
+            raw_call_seq: AtomicU64::new(RECEIPT_SEQ_ALLOCATED_BASE),
         }
     }
 

--- a/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/stella-pipeline/src/pipeline/raw_usage.rs
@@ -1,9 +1,12 @@
 //! Complete per-call accounting for pipeline roles that call providers directly.
 
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use stella_core::retry::RetryPolicy;
-use stella_core::{AccountedCall, AccountedCallError, BudgetGuard, run_accounted_call};
+use stella_core::{
+    AccountedCall, AccountedCallError, BudgetGuard, ReceiptContext, run_accounted_call,
+};
 use stella_protocol::{CompletionMessage, CompletionRequest, CompletionResult, ModelCallRole};
 
 use super::stage_budget::{PipelineBudgetAbort, budget_abort};
@@ -65,6 +68,15 @@ impl<'a> Pipeline<'a> {
                 retry_policy: call.policy,
                 timeout: call.timeout,
                 estimated_input_tokens: 0,
+                // Management roles assemble their own prompts — the role's task
+                // prompt, an optional settings-supplied system override, and a
+                // rendered transcript that exists nowhere else. This receipt is
+                // the only record of what any of them actually sent.
+                receipt: Some(ReceiptContext {
+                    turn_instance: 0,
+                    step: 0,
+                    call_seq: self.raw_call_seq.fetch_add(1, Ordering::Relaxed),
+                }),
             },
             budget,
             &self.events,

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -536,6 +536,16 @@ pub enum AgentEvent {
         /// Monotonic per session — groups the steps of one `run_turn`.
         turn_instance: u32,
         step: usize,
+        /// Disambiguates the several model calls that can share one
+        /// `(turn_instance, step)`. The engine's own worker call is always 0;
+        /// auxiliary calls that ride the same step — the overflow summarizer,
+        /// and the pipeline's triage/judge/plan/guidance roles — take 1, 2, …
+        /// from a per-execution counter. Without it a summarizer receipt and
+        /// the worker receipt it precedes collide on the primary key and the
+        /// auxiliary one is silently replaced. `serde(default)` so manifests
+        /// persisted before this field existed still decode (as the worker 0).
+        #[serde(default)]
+        call_seq: u64,
         role: ModelCallRole,
         provider: String,
         model: String,
@@ -1782,6 +1792,7 @@ mod tests {
         let event = AgentEvent::StepManifest {
             turn_instance: 1,
             step: 3,
+            call_seq: 0,
             role: ModelCallRole::Worker,
             provider: "anthropic".into(),
             model: "claude-opus".into(),

--- a/stella-store/src/ddl.rs
+++ b/stella-store/src/ddl.rs
@@ -393,19 +393,22 @@ pub(crate) const CONTEXT_BLOCKS_DDL: &str = "CREATE TABLE IF NOT EXISTS context_
 /// — the per-step request manifest, normalized one row per (step, block) in
 /// wire order (v11, spec §5). This is the receipt that makes any past step
 /// reconstructable: replaying the fold + this ordering yields exactly what the
-/// model saw. PRIMARY KEY (execution_id, turn_instance, step, ordinal) is the
-/// wire position; the second index is the reverse lookup (every step a given
-/// block was resident) that cost-of-carry and eviction analysis read.
+/// model saw. PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal)
+/// is the wire position; `call_seq` separates the several model calls that can
+/// share one step (worker 0, overflow summarizer 1, allocated management roles
+/// 2+ — v13). The second index is the reverse lookup (every step a given block
+/// was resident) that cost-of-carry and eviction analysis read.
 pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_manifest (
        execution_id INTEGER NOT NULL,
        turn_instance INTEGER NOT NULL,
        step INTEGER NOT NULL,
+       call_seq INTEGER NOT NULL DEFAULT 0,
        ordinal INTEGER NOT NULL,
        block_id TEXT NOT NULL,
        cache_zone TEXT NOT NULL,
        resident_since_step INTEGER NOT NULL,
        message_index INTEGER NOT NULL DEFAULT 0,
-       PRIMARY KEY (execution_id, turn_instance, step, ordinal)
+       PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal)
      );
      CREATE INDEX IF NOT EXISTS step_manifest_by_block
        ON step_manifest(execution_id, block_id);";
@@ -416,16 +419,19 @@ pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_mani
 /// against (raw budget / calibration factor), so the receipt's numbers line up
 /// with the decision that was made. The per-zone cache columns (spec §7) are
 /// added additively by a later migration; this is the increment-1 header only.
-/// PRIMARY KEY (execution_id, turn_instance, step): one receipt per step.
+/// PRIMARY KEY (execution_id, turn_instance, step, call_seq): one receipt per
+/// model call, not per step — a step can carry the worker call plus the
+/// auxiliary calls that ride it (v13).
 pub(crate) const STEP_RECEIPT_DDL: &str = "CREATE TABLE IF NOT EXISTS step_receipt (
        execution_id INTEGER NOT NULL,
        turn_instance INTEGER NOT NULL,
        step INTEGER NOT NULL,
+       call_seq INTEGER NOT NULL DEFAULT 0,
        provider TEXT NOT NULL,
        model TEXT NOT NULL,
        call_role TEXT NOT NULL,
        effective_budget_tokens INTEGER NOT NULL,
        calibration_factor REAL NOT NULL,
        estimated_input_tokens INTEGER NOT NULL,
-       PRIMARY KEY (execution_id, turn_instance, step)
+       PRIMARY KEY (execution_id, turn_instance, step, call_seq)
      );";

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -158,7 +158,9 @@ pub(crate) use private::{
     ensure_private_dir, ensure_workspace_generated_ignore, ensure_workspace_state_dir,
     open_private_file, open_private_sqlite, read_private_to_string, write_private_atomic,
 };
-pub use receipts::{ContextBlockRow, ManifestBlockRow, StepManifestRow};
+pub use receipts::{
+    ContextBlockRow, InspectableExecution, ManifestBlockRow, RecordedCall, StepManifestRow,
+};
 pub use reconstruct::Reconstruction;
 pub use sessions::{SessionRecord, SessionRegistry, SessionStatus};
 pub use telemetry::{SourceTelemetryRow, TelemetryRow};

--- a/stella-store/src/migrations.rs
+++ b/stella-store/src/migrations.rs
@@ -28,7 +28,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 12] = [
+pub(crate) const MIGRATIONS: [Migration; 13] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -67,6 +67,13 @@ pub(crate) const MIGRATIONS: [Migration; 12] = [
     // `step_manifest` grows `message_index` (regroups event-granular blocks into
     // exact messages). Both additive ADD COLUMNs, column-guarded.
     migrate_v11_to_v12,
+    // v12 → v13: receipt coverage for the calls that are not engine steps —
+    // the overflow summarizer and the pipeline's management roles. Both
+    // receipt tables grow `call_seq` and take it into the primary key, so a
+    // summarizer receipt no longer collides with (and is replaced by) the
+    // worker receipt of the step it precedes. A PK change is a table rebuild;
+    // existing rows are all worker calls and backfill to seq 0.
+    migrate_v12_to_v13,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -413,8 +420,100 @@ fn migrate_v9_to_v10(tx: &rusqlite::Transaction<'_>) -> Result<()> {
 /// also tolerates a partial file that somehow already grew them.
 fn migrate_v10_to_v11(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(CONTEXT_BLOCKS_DDL)?;
-    tx.execute_batch(STEP_MANIFEST_DDL)?;
-    tx.execute_batch(STEP_RECEIPT_DDL)?;
+    // The receipt tables changed shape in v13 (the `call_seq` key column), so
+    // they left the shared DDL constants — but a v11 database has its ERA's
+    // shape, which this step must keep producing (the v13 rebuild later in the
+    // chain runs against it).
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS step_manifest (
+           execution_id INTEGER NOT NULL,
+           turn_instance INTEGER NOT NULL,
+           step INTEGER NOT NULL,
+           ordinal INTEGER NOT NULL,
+           block_id TEXT NOT NULL,
+           cache_zone TEXT NOT NULL,
+           resident_since_step INTEGER NOT NULL,
+           PRIMARY KEY (execution_id, turn_instance, step, ordinal)
+         );
+         CREATE INDEX IF NOT EXISTS step_manifest_by_block
+           ON step_manifest(execution_id, block_id);",
+    )?;
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS step_receipt (
+           execution_id INTEGER NOT NULL,
+           turn_instance INTEGER NOT NULL,
+           step INTEGER NOT NULL,
+           provider TEXT NOT NULL,
+           model TEXT NOT NULL,
+           call_role TEXT NOT NULL,
+           effective_budget_tokens INTEGER NOT NULL,
+           calibration_factor REAL NOT NULL,
+           estimated_input_tokens INTEGER NOT NULL,
+           PRIMARY KEY (execution_id, turn_instance, step)
+         );",
+    )?;
+    Ok(())
+}
+
+/// v12 → v13: `call_seq` joins the primary key of both receipt tables so the
+/// auxiliary calls that share a step with the worker (overflow summarizer,
+/// pipeline management roles) each keep their own receipt instead of replacing
+/// one another. SQLite cannot alter a primary key, so both tables are rebuilt;
+/// every pre-existing row is a worker call and backfills to seq 0.
+fn migrate_v12_to_v13(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !column_exists(tx, "step_manifest", "call_seq")? {
+        tx.execute_batch(
+            "CREATE TABLE step_manifest_v13 (
+               execution_id INTEGER NOT NULL,
+               turn_instance INTEGER NOT NULL,
+               step INTEGER NOT NULL,
+               call_seq INTEGER NOT NULL DEFAULT 0,
+               ordinal INTEGER NOT NULL,
+               block_id TEXT NOT NULL,
+               cache_zone TEXT NOT NULL,
+               resident_since_step INTEGER NOT NULL,
+               message_index INTEGER NOT NULL DEFAULT 0,
+               PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal)
+             );
+             INSERT INTO step_manifest_v13
+               (execution_id, turn_instance, step, call_seq, ordinal, block_id,
+                cache_zone, resident_since_step, message_index)
+             SELECT execution_id, turn_instance, step, 0, ordinal, block_id,
+                    cache_zone, resident_since_step, message_index
+               FROM step_manifest;
+             DROP TABLE step_manifest;
+             ALTER TABLE step_manifest_v13 RENAME TO step_manifest;
+             CREATE INDEX IF NOT EXISTS step_manifest_by_block
+               ON step_manifest(execution_id, block_id);",
+        )?;
+    }
+    if !column_exists(tx, "step_receipt", "call_seq")? {
+        tx.execute_batch(
+            "CREATE TABLE step_receipt_v13 (
+               execution_id INTEGER NOT NULL,
+               turn_instance INTEGER NOT NULL,
+               step INTEGER NOT NULL,
+               call_seq INTEGER NOT NULL DEFAULT 0,
+               provider TEXT NOT NULL,
+               model TEXT NOT NULL,
+               call_role TEXT NOT NULL,
+               effective_budget_tokens INTEGER NOT NULL,
+               calibration_factor REAL NOT NULL,
+               estimated_input_tokens INTEGER NOT NULL,
+               PRIMARY KEY (execution_id, turn_instance, step, call_seq)
+             );
+             INSERT INTO step_receipt_v13
+               (execution_id, turn_instance, step, call_seq, provider, model,
+                call_role, effective_budget_tokens, calibration_factor,
+                estimated_input_tokens)
+             SELECT execution_id, turn_instance, step, 0, provider, model,
+                    call_role, effective_budget_tokens, calibration_factor,
+                    estimated_input_tokens
+               FROM step_receipt;
+             DROP TABLE step_receipt;
+             ALTER TABLE step_receipt_v13 RENAME TO step_receipt;",
+        )?;
+    }
     Ok(())
 }
 
@@ -614,5 +713,82 @@ mod tests {
         // Idempotent on tables already at the v12 shape (fresh files, or a
         // v10→v11 upgrade run by this build's DDL).
         apply_migration(&mut conn, migrate_v11_to_v12, 12).expect("idempotent");
+    }
+
+    #[test]
+    fn v13_migration_rekeys_receipts_on_call_seq_preserving_existing_rows_as_worker_calls() {
+        // A v12-shaped file with one recorded worker step. The rebuild must
+        // keep that row verbatim, backfill it to seq 0, and then accept a
+        // SECOND row at the same (turn, step) — the summarizer receipt that
+        // the old primary key silently replaced.
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE step_manifest (
+               execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL, step INTEGER NOT NULL,
+               ordinal INTEGER NOT NULL, block_id TEXT NOT NULL, cache_zone TEXT NOT NULL,
+               resident_since_step INTEGER NOT NULL, message_index INTEGER NOT NULL DEFAULT 0,
+               PRIMARY KEY (execution_id, turn_instance, step, ordinal));
+             CREATE TABLE step_receipt (
+               execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL, step INTEGER NOT NULL,
+               provider TEXT NOT NULL, model TEXT NOT NULL, call_role TEXT NOT NULL,
+               effective_budget_tokens INTEGER NOT NULL, calibration_factor REAL NOT NULL,
+               estimated_input_tokens INTEGER NOT NULL,
+               PRIMARY KEY (execution_id, turn_instance, step));
+             INSERT INTO step_manifest
+               (execution_id, turn_instance, step, ordinal, block_id, cache_zone,
+                resident_since_step, message_index)
+               VALUES (1, 0, 2, 0, 'blk_sys', 'stable_prefix', 0, 0);
+             INSERT INTO step_receipt
+               (execution_id, turn_instance, step, provider, model, call_role,
+                effective_budget_tokens, calibration_factor, estimated_input_tokens)
+               VALUES (1, 0, 2, 'anthropic', 'opus', 'worker', 136363, 1.1, 40);",
+        )
+        .expect("v12 receipts shape");
+        assert!(!column_exists(&conn, "step_receipt", "call_seq").unwrap());
+
+        apply_migration(&mut conn, migrate_v12_to_v13, 13).expect("migrate");
+
+        assert!(column_exists(&conn, "step_receipt", "call_seq").unwrap());
+        assert!(column_exists(&conn, "step_manifest", "call_seq").unwrap());
+
+        // The pre-existing worker row survives the rebuild, at seq 0.
+        let (role, seq, budget): (String, i64, i64) = conn
+            .query_row(
+                "SELECT call_role, call_seq, effective_budget_tokens FROM step_receipt
+                 WHERE execution_id = 1 AND turn_instance = 0 AND step = 2",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("worker receipt preserved");
+        assert_eq!((role.as_str(), seq, budget), ("worker", 0, 136363));
+        let block: String = conn
+            .query_row(
+                "SELECT block_id FROM step_manifest WHERE execution_id = 1 AND call_seq = 0",
+                [],
+                |r| r.get(0),
+            )
+            .expect("manifest row preserved");
+        assert_eq!(block, "blk_sys");
+
+        // The regression this migration exists for: a summarizer receipt at the
+        // SAME (turn, step) now coexists instead of replacing the worker's.
+        conn.execute_batch(
+            "INSERT INTO step_receipt
+               (execution_id, turn_instance, step, call_seq, provider, model, call_role,
+                effective_budget_tokens, calibration_factor, estimated_input_tokens)
+               VALUES (1, 0, 2, 1, 'anthropic', 'haiku', 'summarization', 136363, 1.1, 900);",
+        )
+        .expect("an auxiliary call at the same step is no longer a key collision");
+        let calls: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM step_receipt WHERE execution_id = 1 AND step = 2",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count");
+        assert_eq!(calls, 2, "both calls of the step are recorded");
+
+        // Idempotent on a file already at the v13 shape.
+        apply_migration(&mut conn, migrate_v12_to_v13, 13).expect("idempotent");
     }
 }

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -49,6 +49,10 @@ pub struct ManifestBlockRow {
 pub struct StepManifestRow {
     pub turn_instance: u32,
     pub step: u64,
+    /// Which model call at this step: 0 the engine's worker, 1 the overflow
+    /// summarizer, 2+ an allocated management role. See
+    /// `AgentEvent::StepManifest::call_seq`.
+    pub call_seq: u64,
     pub provider: String,
     pub model: String,
     pub call_role: String,
@@ -100,15 +104,17 @@ impl Store {
         let estimated = sqlite_i64("manifest estimated input", row.estimated_input_tokens)?;
         let mut conn = self.lock();
         let tx = conn.transaction()?;
+        let call_seq = sqlite_i64("manifest call seq", row.call_seq)?;
         tx.execute(
             "INSERT OR REPLACE INTO step_receipt
-               (execution_id, turn_instance, step, provider, model, call_role,
+               (execution_id, turn_instance, step, call_seq, provider, model, call_role,
                 effective_budget_tokens, calibration_factor, estimated_input_tokens)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
                 turn,
                 step,
+                call_seq,
                 row.provider,
                 row.model,
                 row.call_role,
@@ -117,12 +123,13 @@ impl Store {
                 estimated,
             ],
         )?;
-        // Clear any prior ordinals for this step before rewriting, so a
+        // Clear any prior ordinals for this call before rewriting, so a
         // shorter re-emitted manifest cannot leave stale tail rows behind.
+        // Scoped by call_seq: the auxiliary calls sharing this step keep theirs.
         tx.execute(
             "DELETE FROM step_manifest
-             WHERE execution_id = ? AND turn_instance = ? AND step = ?",
-            params![execution_id, turn, step],
+             WHERE execution_id = ? AND turn_instance = ? AND step = ? AND call_seq = ?",
+            params![execution_id, turn, step, call_seq],
         )?;
         // token_cost is a property of the block (context_blocks.token_cost),
         // not of a manifest entry, so step_manifest stores only ordering, zone,
@@ -133,13 +140,14 @@ impl Store {
             let message_index = sqlite_i64("manifest message index", block.message_index)?;
             tx.execute(
                 "INSERT INTO step_manifest
-                   (execution_id, turn_instance, step, ordinal, block_id, cache_zone,
-                    resident_since_step, message_index)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                   (execution_id, turn_instance, step, call_seq, ordinal, block_id,
+                    cache_zone, resident_since_step, message_index)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     execution_id,
                     turn,
                     step,
+                    call_seq,
                     ordinal,
                     block.block_id,
                     block.cache_zone,
@@ -186,8 +194,10 @@ impl Store {
         execution_id: i64,
         turn_instance: u32,
         step: u64,
+        call_seq: u64,
     ) -> Result<Vec<ManifestBlockRow>> {
         let step = sqlite_i64("manifest step", step)?;
+        let call_seq = sqlite_i64("manifest call seq", call_seq)?;
         let conn = self.lock();
         let mut stmt = conn.prepare(
             "SELECT sm.block_id, sm.cache_zone, cb.token_cost, sm.resident_since_step,
@@ -196,24 +206,105 @@ impl Store {
              LEFT JOIN context_blocks cb
                ON cb.execution_id = sm.execution_id AND cb.block_id = sm.block_id
              WHERE sm.execution_id = ? AND sm.turn_instance = ? AND sm.step = ?
+               AND sm.call_seq = ?
              ORDER BY sm.ordinal",
         )?;
         let rows = stmt
-            .query_map(params![execution_id, i64::from(turn_instance), step], |r| {
-                Ok(ManifestBlockRow {
-                    block_id: r.get(0)?,
-                    cache_zone: r.get(1)?,
-                    // token_cost may be NULL if the block row is missing (a
-                    // manifest referencing an unregistered block — a bug worth
-                    // surfacing, not crashing on); default 0.
-                    token_cost: r.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
-                    resident_since_step: r.get::<_, i64>(3)? as u64,
-                    message_index: r.get::<_, i64>(4)? as u64,
+            .query_map(
+                params![execution_id, i64::from(turn_instance), step, call_seq],
+                |r| {
+                    Ok(ManifestBlockRow {
+                        block_id: r.get(0)?,
+                        cache_zone: r.get(1)?,
+                        // token_cost may be NULL if the block row is missing (a
+                        // manifest referencing an unregistered block — a bug worth
+                        // surfacing, not crashing on); default 0.
+                        token_cost: r.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
+                        resident_since_step: r.get::<_, i64>(3)? as u64,
+                        message_index: r.get::<_, i64>(4)? as u64,
+                    })
+                },
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Executions with at least one recorded receipt, most recent first.
+    pub fn inspectable_executions(&self, limit: u32) -> Result<Vec<InspectableExecution>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT e.id, e.kind, e.prompt, e.started_at, COUNT(*) AS calls
+             FROM executions e
+             JOIN step_receipt sr ON sr.execution_id = e.id
+             GROUP BY e.id, e.kind, e.prompt, e.started_at
+             ORDER BY e.id DESC LIMIT ?",
+        )?;
+        let rows = stmt
+            .query_map(params![i64::from(limit)], |r| {
+                Ok(InspectableExecution {
+                    execution_id: r.get(0)?,
+                    kind: r.get(1)?,
+                    prompt: r.get(2)?,
+                    started_at: r.get(3)?,
+                    calls: r.get::<_, i64>(4)? as u64,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(rows)
     }
+
+    /// Every recorded model call of an execution, in wire order — the index
+    /// `stella inspect` lists and walks. One row per call, not per step: a step
+    /// that ran the worker plus an overflow summarizer appears twice, keyed
+    /// apart by `call_seq`.
+    pub fn recorded_calls(&self, execution_id: i64) -> Result<Vec<RecordedCall>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT turn_instance, step, call_seq, call_role, provider, model,
+                    estimated_input_tokens
+             FROM step_receipt WHERE execution_id = ?
+             ORDER BY turn_instance, step, call_seq",
+        )?;
+        let rows = stmt
+            .query_map(params![execution_id], |r| {
+                Ok(RecordedCall {
+                    turn_instance: r.get::<_, i64>(0)? as u32,
+                    step: r.get::<_, i64>(1)? as u64,
+                    call_seq: r.get::<_, i64>(2)? as u64,
+                    call_role: r.get(3)?,
+                    provider: r.get(4)?,
+                    model: r.get(5)?,
+                    estimated_input_tokens: r.get::<_, i64>(6)? as u64,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+}
+
+/// One execution that has at least one reconstructable model call — the index
+/// `stella inspect` shows when given no arguments. Executions predating the
+/// receipt plane (or run with the store disabled) have no rows and are omitted
+/// rather than listed as empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectableExecution {
+    pub execution_id: i64,
+    pub kind: String,
+    pub prompt: String,
+    pub started_at: String,
+    pub calls: u64,
+}
+
+/// One recorded model call — the header of a receipt, without its blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedCall {
+    pub turn_instance: u32,
+    pub step: u64,
+    pub call_seq: u64,
+    pub call_role: String,
+    pub provider: String,
+    pub model: String,
+    pub estimated_input_tokens: u64,
 }
 
 #[cfg(test)]
@@ -267,6 +358,7 @@ mod tests {
         let manifest = StepManifestRow {
             turn_instance: 0,
             step: 3,
+            call_seq: 0,
             provider: "anthropic".into(),
             model: "opus".into(),
             call_role: "worker".into(),
@@ -292,7 +384,7 @@ mod tests {
         };
         store.record_step_manifest(id, &manifest).unwrap();
 
-        let back = store.step_manifest(id, 0, 3).unwrap();
+        let back = store.step_manifest(id, 0, 3, 0).unwrap();
         assert_eq!(back.len(), 2);
         // Order is the receipt — index 0 is the system prefix.
         assert_eq!(back[0].block_id, "blk_sys");
@@ -312,6 +404,7 @@ mod tests {
         let three = StepManifestRow {
             turn_instance: 1,
             step: 2,
+            call_seq: 0,
             provider: "anthropic".into(),
             model: "opus".into(),
             call_role: "worker".into(),
@@ -334,7 +427,7 @@ mod tests {
             ..three.clone()
         };
         store.record_step_manifest(id, &shorter).unwrap();
-        let back = store.step_manifest(id, 1, 2).unwrap();
+        let back = store.step_manifest(id, 1, 2, 0).unwrap();
         assert_eq!(
             back.len(),
             1,

--- a/stella-store/src/reconstruct.rs
+++ b/stella-store/src/reconstruct.rs
@@ -77,16 +77,32 @@ struct JournalPreimages {
 }
 
 impl Store {
-    /// Reconstruct the exact messages sent on one step from its persisted
-    /// receipt + the event journal. See the module docs for the reconstructable
-    /// boundary; callers should check [`Reconstruction::is_verified`].
-    pub fn reconstruct_step(
+    /// Reconstruct the engine's own worker call at this step — the common case,
+    /// [`Store::reconstruct_call`] at `call_seq` 0.
+    pub fn reconstruct_worker_step(
         &self,
         execution_id: i64,
         turn_instance: u32,
         step: u64,
     ) -> Result<Reconstruction> {
-        let manifest = self.step_manifest(execution_id, turn_instance, step)?;
+        self.reconstruct_call(execution_id, turn_instance, step, 0)
+    }
+
+    /// Reconstruct the exact messages sent on one model call from its persisted
+    /// receipt + the event journal. See the module docs for the reconstructable
+    /// boundary; callers should check [`Reconstruction::is_verified`].
+    ///
+    /// `call_seq` selects which call at this step: 0 is the engine's worker
+    /// (see [`Store::reconstruct_worker_step`]), 1 the overflow summarizer, 2+
+    /// an allocated management role. [`Store::recorded_calls`] enumerates them.
+    pub fn reconstruct_call(
+        &self,
+        execution_id: i64,
+        turn_instance: u32,
+        step: u64,
+        call_seq: u64,
+    ) -> Result<Reconstruction> {
+        let manifest = self.step_manifest(execution_id, turn_instance, step, call_seq)?;
         let blocks: HashMap<String, crate::ContextBlockRow> = self
             .context_blocks(execution_id)?
             .into_iter()
@@ -399,6 +415,7 @@ mod tests {
                 &StepManifestRow {
                     turn_instance: 0,
                     step: 1,
+                    call_seq: 0,
                     provider: "anthropic".into(),
                     model: "opus".into(),
                     call_role: "worker".into(),
@@ -415,7 +432,7 @@ mod tests {
             )
             .unwrap();
 
-        let recon = store.reconstruct_step(id, 0, 1).unwrap();
+        let recon = store.reconstruct_worker_step(id, 0, 1).unwrap();
         assert!(
             recon.is_verified(),
             "unresolved={:?} mismatches={:?}",
@@ -449,6 +466,7 @@ mod tests {
                 &StepManifestRow {
                     turn_instance: 0,
                     step: 0,
+                    call_seq: 0,
                     provider: "z".into(),
                     model: "m".into(),
                     call_role: "worker".into(),
@@ -460,7 +478,7 @@ mod tests {
             )
             .unwrap();
 
-        let recon = store.reconstruct_step(id, 0, 0).unwrap();
+        let recon = store.reconstruct_worker_step(id, 0, 0).unwrap();
         assert!(!recon.is_verified());
         assert_eq!(recon.unresolved, vec!["blk_orphan".to_string()]);
     }

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -947,9 +947,12 @@ fn skill_usage_records_per_execution_version_rows() {
     // session plane (executions.session_id / tasks / pull_requests)
     // takes v8; v9 adds fail-closed call-role/completeness, v10 adds lifecycle
     // accounting for execution/telemetry rows, v11 adds the context-receipts
-    // plane (context_blocks / step_manifest / step_receipt), and v12 adds
-    // reconstruction support (context_blocks.content / step_manifest.message_index).
-    assert_eq!(SCHEMA_VERSION, 12);
+    // plane (context_blocks / step_manifest / step_receipt), v12 adds
+    // reconstruction support (context_blocks.content / step_manifest.message_index),
+    // and v13 rekeys both receipt tables on call_seq so the auxiliary calls
+    // sharing a step (overflow summarizer, pipeline management roles) each keep
+    // their own receipt.
+    assert_eq!(SCHEMA_VERSION, 13);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
## Why

The receipts plane can already reconstruct a step byte-exactly (`Store::reconstruct_call`), but two gaps meant you couldn't actually answer *"what context did the model get?"*:

1. **The calls that aren't engine steps recorded nothing.** `emit_step_receipt` had exactly one call site — `driver.rs`, the worker loop. The overflow summarizer and the pipeline's management roles went through `run_accounted_call` and left a cost line only. Their prompts were unrecoverable.
2. **Nothing exposed the reconstruction.** No `stella inspect`; the Observatory shows `executions.prompt` (the user task string), never the assembled system prompt.

## What changed

**Emission coverage.** `run_accounted_call` is the chokepoint every non-engine call routes through, so the receipt is emitted there — just before `StepUsage`, matching the engine's ordering. One change covers the summarizer *and* triage / judge / plan / guidance / conversational. Callers opt in with a `ReceiptContext`; `None` keeps the old cost-only behaviour (used by standalone tooling).

**Keying — the load-bearing fix.** A step can carry several model calls, but the tables were keyed `(execution_id, turn_instance, step)`. A summarizer receipt therefore collided with the worker receipt of the step it precedes and was silently `INSERT OR REPLACE`d away. Both tables grow `call_seq` into the primary key:

| seq | call |
| --- | --- |
| `0` | engine worker |
| `1` | overflow summarizer (compaction runs at most once per step, so a constant suffices) |
| `2+` | pipeline management roles, allocated per execution |

Migration **v12 → v13** rebuilds both tables (SQLite can't alter a PK) and backfills existing rows to seq 0 — the worker call they must have been.

**Read surface.** `stella inspect` narrows in three levels:

```
stella inspect                    # executions that have receipts
stella inspect 42                 # that execution's model calls
stella inspect 42 --step 3        # the reconstructed message array
stella inspect 42 --step 3 --call-seq 1   # ...the summarizer that rode that step
```

```
execution 1 · turn 0 · step 0 · call-seq 0
2 message(s)
verified: every journal-resolved block re-hashed to its recorded digest

─── [0] system ───
You are Stella.

─── [1] user ───
fix the failing test
```

Unresolved blocks and digest mismatches are reported separately — a documented coverage gap and a torn journal mean very different things. `--format json` for piping, `--full` to disable eliding.

## Privacy

Unchanged: receipts are local-only. The content-free egress guard is untouched and its column-allowlist test still passes over the rekeyed tables.

## Scope / known limits

- Receipts are taken **pre-provider-adapter**, so this is the canonical pre-adapter view, not literal wire bytes (Anthropic keeps only the last system message and adds cache breakpoints; OpenAI/Gemini join with `\n\n`).
- Tool JSON schemas still aren't recorded — the manifest covers messages only.
- Executions predating the receipts plane have no rows and are omitted from the index rather than listed as empty.

## Testing

- `migrations.rs` — v13 preserves existing rows at seq 0, then accepts a second call at the same `(turn, step)`: the exact collision this fixes.
- `accounted_call.rs` — an auxiliary call registers its system prompt as a block, keys its manifest at the auxiliary seat, and emits the receipt before `StepUsage`; opting out emits neither.
- `stella-cli/tests/inspect_cli.rs` — drives the **built binary** against a real store through all three levels and reads the prompts back out.
- `make check` clean; full suite **3128 passed, 0 failed**.

## Summary by Sourcery

Record context receipts for all model calls and expose them via a new `stella inspect` CLI command.

New Features:
- Add optional `ReceiptContext` to auxiliary model calls so their prompts are recorded alongside costs.
- Introduce the `stella inspect` CLI command to list executions and reconstruct past model call contexts in text or JSON.

Bug Fixes:
- Fix receipt collisions where auxiliary model call receipts overwrote worker receipts by rekeying tables on `(execution_id, turn_instance, step, call_seq)`.

Enhancements:
- Extend receipt storage schema and reconstruction APIs to distinguish multiple model calls per step using a `call_seq` key.
- Ensure pipeline management roles and overflow summarizer allocate unique receipt slots so their prompts are reconstructable.
- Expose new store APIs to enumerate inspectable executions and recorded calls for use by the CLI.

Documentation:
- Document the new `stella inspect` command in README and command reference, including scope and limitations of reconstruction.

Tests:
- Add end-to-end CLI tests for `stella inspect` against a real store and binary.
- Add migration tests ensuring v13 schema preserves existing receipts and allows multiple calls per step.
- Add tests verifying auxiliary calls emit receipts when opted in and that opt-out calls remain cost-only.