### PR TITLE
chore(stella-core): restore rustfmt cleanliness on main

### DIFF
--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -14,7 +14,6 @@ use crate::event_sender::EventSender;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
 
-
 /// Where an auxiliary call sits in the receipt coordinate space, so the context
 /// it sent is reconstructable alongside the engine's own steps. `call_seq` must
 /// be unique within the execution (see `AgentEvent::StepManifest::call_seq`).


### PR DESCRIPTION
main is currently red on `cargo fmt --check` (run 30170531715) because of a stray double blank line in `stella-core/src/accounted_call.rs`. Every branch cut from main inherits the red gate, so this lands first to give the epic #546 remediation PRs a green baseline.

No behavior change — whitespace only.

## Summary by Sourcery

Chores:
- Clean up formatting in stella-core to satisfy rustfmt / cargo fmt checks.