### PR TITLE
feat(deck): INSPECT overlay — see the context any recorded call was sent

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -296,6 +296,11 @@ pub async fn run_deck_session(
     let mut budget = agent::build_budget_guard(budget_limit);
     let store = agent::open_store(&cfg.workspace_root);
     let calibration = agent::seed_calibration(&store, cfg);
+    // The most recent execution this session opened — the INSPECT overlay's
+    // subject. `execution` itself is per-turn and out of scope at the idle
+    // service site, and the overlay is most useful precisely when no turn is
+    // running, so the id is retained here across the whole session loop.
+    let mut last_execution_id: Option<i64> = None;
 
     let system_prompt = agent::with_session_hook_context(
         agent::build_system_prompt(cfg, &cfg.workspace_root, &active_rules),
@@ -1063,6 +1068,7 @@ pub async fn run_deck_session(
                                 &workspace_path,
                                 &in_tx,
                             )
+                            && !service_inspect_action(&other, &store, last_execution_id, &in_tx)
                             && !handle_agents_input(&other, cfg, &in_tx)
                             && !handle_issues_input(&other, cfg, &issue_backend_cache, &in_tx)
                         {
@@ -1202,6 +1208,9 @@ pub async fn run_deck_session(
             cfg,
             Some(&session_record.id),
         );
+        if let Some((_, id)) = &execution {
+            last_execution_id = Some(*id);
+        }
         let files_before = registry.files_touched().len();
         let started_unix = crate::memory::unix_now_secs();
 
@@ -1537,6 +1546,15 @@ pub async fn run_deck_session(
                                 &workspace_path,
                                 &in_tx,
                             );
+                        }
+                        // INSPECT is answered mid-turn too: the receipts of
+                        // earlier steps are already durable, and watching the
+                        // context grow while a turn runs is the point.
+                        Some(
+                            input @ (WorkspaceInput::InspectRefresh
+                            | WorkspaceInput::InspectCall { .. }),
+                        ) => {
+                            service_inspect_action(&input, &store, last_execution_id, &in_tx);
                         }
                         // Navigation waits for the road to clear: switching
                         // sessions mid-turn would tear down live work, so the
@@ -2171,6 +2189,149 @@ fn service_registry_action(
         _ => return false,
     }
     true
+}
+
+/// The INSPECT overlay's driver half: answer the recorded-call index and the
+/// reconstruction of one call. Returns `false` for anything else so the caller
+/// can keep trying the other service handlers.
+///
+/// Both arms are blocking SQLite reads — `reconstruct_call` replays the block
+/// registry and the event journal — so they run on `spawn_blocking` and answer
+/// out of band, the same shape as [`WorkspaceInput::FocusGraphFile`]. Stalling
+/// the event pump to rebuild a prompt would stutter a live turn.
+fn service_inspect_action(
+    input: &WorkspaceInput,
+    store: &Option<Arc<Store>>,
+    execution_id: Option<i64>,
+    in_tx: &mpsc::UnboundedSender<Inbound>,
+) -> bool {
+    if !matches!(
+        input,
+        WorkspaceInput::InspectRefresh | WorkspaceInput::InspectCall { .. }
+    ) {
+        return false;
+    }
+    // No store (claim mode, or it failed to open) or no turn yet: answer with
+    // an empty index rather than silence, so the overlay renders its "nothing
+    // recorded yet" line instead of looking hung.
+    let (Some(store), Some(execution_id)) = (store.clone(), execution_id) else {
+        let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
+        return true;
+    };
+    let in_tx = in_tx.clone();
+    match input {
+        WorkspaceInput::InspectRefresh => {
+            tokio::task::spawn_blocking(move || {
+                let calls = store.recorded_calls(execution_id).unwrap_or_default();
+                let _ = in_tx.send(Inbound::RecordedCalls(
+                    calls.iter().map(recorded_call_info).collect(),
+                ));
+            });
+        }
+        WorkspaceInput::InspectCall {
+            turn_instance,
+            step,
+            call_seq,
+        } => {
+            let (turn_instance, step, call_seq) = (*turn_instance, *step, *call_seq);
+            tokio::task::spawn_blocking(move || {
+                let Ok(recon) = store.reconstruct_call(execution_id, turn_instance, step, call_seq)
+                else {
+                    let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
+                    return;
+                };
+                // Re-read the header so the detail can name the model/role that
+                // served this call; the reconstruction itself carries only the
+                // messages.
+                let call = store
+                    .recorded_calls(execution_id)
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|c| {
+                        (c.turn_instance, c.step, c.call_seq) == (turn_instance, step, call_seq)
+                    })
+                    .map(recorded_call_info)
+                    .unwrap_or_else(|| stella_tui::RecordedCallInfo {
+                        turn_instance,
+                        step,
+                        call_seq,
+                        call_role: "unknown".into(),
+                        provider: "unknown".into(),
+                        model: "unknown".into(),
+                        estimated_input_tokens: 0,
+                    });
+                let _ = in_tx.send(Inbound::InspectedCall(Box::new(stella_tui::InspectView {
+                    call,
+                    messages: recon
+                        .messages
+                        .iter()
+                        .map(|m| stella_tui::InspectMessage {
+                            role: message_role_tag(m.role).to_string(),
+                            content: inspect_message_body(m),
+                        })
+                        .collect(),
+                    verified: recon.is_verified(),
+                    unresolved: recon.unresolved.len(),
+                    digest_mismatches: recon.digest_mismatches.len(),
+                })));
+            });
+        }
+        _ => unreachable!("guarded by the matches! above"),
+    }
+    true
+}
+
+fn recorded_call_info(call: &stella_store::RecordedCall) -> stella_tui::RecordedCallInfo {
+    stella_tui::RecordedCallInfo {
+        turn_instance: call.turn_instance,
+        step: call.step,
+        call_seq: call.call_seq,
+        call_role: call.call_role.clone(),
+        provider: call.provider.clone(),
+        model: call.model.clone(),
+        estimated_input_tokens: call.estimated_input_tokens,
+    }
+}
+
+fn message_role_tag(role: stella_protocol::MessageRole) -> &'static str {
+    match role {
+        stella_protocol::MessageRole::System => "system",
+        stella_protocol::MessageRole::User => "user",
+        stella_protocol::MessageRole::Assistant => "assistant",
+        stella_protocol::MessageRole::Tool => "tool",
+    }
+}
+
+/// Flatten one reconstructed message for display: text plus a compact rendering
+/// of the tool calls/results it carried. They are separate blocks in the
+/// receipt but belong to one message on the wire, and the overlay shows wire
+/// shape. Mirrors `crate::inspect::message_body` — the CLI and the deck must
+/// not disagree about what a message looked like.
+fn inspect_message_body(message: &CompletionMessage) -> String {
+    let mut out = String::new();
+    if !message.content.is_empty() {
+        out.push_str(&message.content);
+    }
+    for call in &message.tool_calls {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "→ tool_call {} {} {}",
+            call.call_id, call.name, call.input
+        ));
+    }
+    for result in &message.tool_results {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "← tool_result {} {}",
+            result.call_id,
+            serde_json::to_string(&result.output).unwrap_or_default()
+        ));
+    }
+    out
 }
 
 /// The SESSIONS overlay snapshot: every registry record mapped to the deck's
@@ -3273,6 +3434,10 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
         "/context",
         "this session's active skills + MCP servers (also: → on an empty prompt)",
     ),
+    (
+        "/inspect",
+        "the context sent to the model on any recorded call (also: ⌃g)",
+    ),
     ("/inbox", "notifications — messages persist until read"),
     ("/mcp-search", "search the MCP registry & install servers"),
     // The engine-config editor (per-agent models included) lives on the
@@ -3703,7 +3868,7 @@ async fn run_deck_command(
         // but a queued one reaches here — accept it as handled (a no-op)
         // rather than calling it "unknown".
         "/files" | "/diff" | "/graph" | "/agents" | "/skills" | "/mcp" | "/mcp-search"
-        | "/settings" | "/sessions" | "/context" | "/inbox" => {}
+        | "/settings" | "/sessions" | "/context" | "/inspect" | "/inbox" => {}
         _ => {
             // The `/models` argument forms first (see [`ModelsCommand`]):
             // handled model-free — a catalog refresh is part of digging out

--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -14,7 +14,6 @@ use crate::event_sender::EventSender;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
 
-
 /// Where an auxiliary call sits in the receipt coordinate space, so the context
 /// it sent is reconstructable alongside the engine's own steps. `call_seq` must
 /// be unique within the execution (see `AgentEvent::StepManifest::call_seq`).

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -228,6 +228,11 @@ async fn main() -> std::io::Result<()> {
                         status: Some("the demo has no settings on disk".to_string()),
                     });
                 }
+                // The demo has no store, so INSPECT answers an empty index —
+                // exactly what the real driver does when receipts are absent.
+                WorkspaceInput::InspectRefresh | WorkspaceInput::InspectCall { .. } => {
+                    let _ = react_tx.send(Inbound::RecordedCalls(Vec::new()));
+                }
                 WorkspaceInput::Quit => break,
             }
         }

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -478,6 +478,8 @@ impl WorkspaceModel {
             | Inbound::IssuesList { .. }
             | Inbound::IssueActDone { .. }
             | Inbound::EntityHits { .. }
+            | Inbound::RecordedCalls(_)
+            | Inbound::InspectedCall(_)
             | Inbound::ShowHelp
             | Inbound::Splash(_) => {}
         }

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -131,6 +131,9 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     if ui.context_open {
         render_context_overlay(ui, area, buf);
     }
+    if ui.inspect_open {
+        render_inspect_overlay(ui, area, buf);
+    }
     // (The former ENGINE overlay is gone: the engine panel is the full-width
     // body of the SETTINGS tab — see `views::settings::render`.)
 
@@ -594,6 +597,178 @@ fn render_context_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
         .block(block)
         .scroll((ui.context_scroll as u16, 0))
         .render(popup, buf);
+}
+
+/// The INSPECT overlay (`⌃g`): the model calls this execution recorded, and
+/// the reconstructed context of the one selected — what was actually sent,
+/// system prompt included, rebuilt from the receipts rather than from any live
+/// UI state. Two modes in one popup, keyed off `ui.inspect_view`.
+fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    let w = area.width.saturating_sub(6).min(120);
+    let h = area.height.saturating_sub(4).min(area.height);
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(popup, buf);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let title;
+
+    if ui.inspect_pending && ui.inspect_view.is_none() {
+        title = " inspect · reconstructing ";
+        lines.push(Line::from(Span::styled(
+            "  reconstructing the call's context from the recorded receipt…",
+            theme::muted(),
+        )));
+    } else if let Some(view) = ui.inspect_view.clone() {
+        title = " inspect · context sent ";
+        let call = &view.call;
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  turn {} · step {} · call-seq {} · {}",
+                call.turn_instance, call.step, call.call_seq, call.call_role
+            ),
+            theme::accent().add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  {} / {} · {} message(s)",
+                call.provider,
+                call.model,
+                view.messages.len()
+            ),
+            theme::muted(),
+        )));
+        // The two failure modes read very differently and are never merged:
+        // an unresolved block is a documented coverage gap, a digest mismatch
+        // means the journal is torn or was altered.
+        if view.unresolved > 0 {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  ! {} block(s) unresolved — synthetic results, discarded speculation, \
+                     or attachments",
+                    view.unresolved
+                ),
+                Style::default().fg(theme::WARN),
+            )));
+        }
+        if view.digest_mismatches > 0 {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  !! {} block(s) did not re-hash to the recorded digest — journal torn \
+                     or altered",
+                    view.digest_mismatches
+                ),
+                Style::default().fg(theme::DANGER),
+            )));
+        }
+        if view.verified {
+            lines.push(Line::from(Span::styled(
+                "  verified · every journal-resolved block re-hashed to its recorded digest",
+                Style::default().fg(theme::SUCCESS),
+            )));
+        }
+        for (index, message) in view.messages.iter().enumerate() {
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled(
+                format!("  ─── [{index}] {} ───", message.role),
+                theme::accent().add_modifier(Modifier::BOLD),
+            )));
+            // Wrap by hand: Paragraph's own wrap would fight the scroll offset
+            // (rows would no longer equal lines, so the clamp below would lie).
+            for raw in message.content.lines() {
+                for chunk in wrap_chars(raw, (w as usize).saturating_sub(6)) {
+                    lines.push(Line::from(Span::styled(
+                        format!("    {chunk}"),
+                        Style::default().fg(theme::INK),
+                    )));
+                }
+            }
+        }
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            " ↑/↓ pgup/pgdn scroll · esc/← back to calls · q close",
+            theme::muted(),
+        )));
+    } else {
+        title = " inspect · recorded calls ";
+        lines.push(Line::from(Span::styled(
+            "  every model call this execution recorded a receipt for",
+            theme::muted(),
+        )));
+        lines.push(Line::default());
+        if ui.inspect_calls.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "    no receipts for this execution yet — run a turn, then reopen",
+                theme::muted(),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "    TURN  STEP  SEQ  ROLE            PROVIDER    MODEL",
+                theme::muted(),
+            )));
+        }
+        for (index, call) in ui.inspect_calls.iter().enumerate() {
+            let selected = index == ui.inspect_sel;
+            let style = if selected {
+                theme::accent().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::INK)
+            };
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  {} {:>4}  {:>4}  {:>3}  {:<14}  {:<10}  {}",
+                    if selected { "›" } else { " " },
+                    call.turn_instance,
+                    call.step,
+                    call.call_seq,
+                    truncate_chars(&call.call_role, 14),
+                    truncate_chars(&call.provider, 10),
+                    truncate_chars(&call.model, 22),
+                ),
+                style,
+            )));
+        }
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            " ↑/↓ select · ⏎ show the context it was sent · r refresh · esc close",
+            theme::muted(),
+        )));
+    }
+
+    // Clamp the scroll to the measured content so ↓ can't run off the end.
+    let inner_h = (h as usize).saturating_sub(2);
+    let max_scroll = lines.len().saturating_sub(inner_h);
+    ui.inspect_scroll = ui.inspect_scroll.min(max_scroll);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(title);
+    Paragraph::new(lines)
+        .block(block)
+        .scroll((ui.inspect_scroll as u16, 0))
+        .render(popup, buf);
+}
+
+/// Hard-wrap one logical line to `width` characters, char-safe. Returns at
+/// least one (possibly empty) chunk so a blank source line still occupies a row
+/// — the scroll clamp counts rows, so dropping blanks would desync it.
+fn wrap_chars(s: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![String::new()];
+    }
+    let chars: Vec<char> = s.chars().collect();
+    if chars.is_empty() {
+        return vec![String::new()];
+    }
+    chars
+        .chunks(width)
+        .map(|chunk| chunk.iter().collect())
+        .collect()
 }
 
 /// Char-safe prefix truncation with an ellipsis.
@@ -1327,6 +1502,7 @@ fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
             ("↑", "with prompts queued: open the queue editor"),
             ("←", "SESSIONS overlay — every session on this machine"),
             ("→", "CONTEXT overlay — active skills + MCP servers"),
+            ("ctrl-g", "INSPECT — the context sent on any recorded call"),
         ],
         DeckTab::Agents => &[
             ("← →", "switch panes — executions / installed"),

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -737,6 +737,14 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
             " ↑/↓ select · ⏎ show the context it was sent · r refresh · esc close",
             theme::muted(),
         )));
+        // The whole popup scrolls by `inspect_scroll`, and the list-mode key
+        // handler only moves `inspect_sel` — it never touches the scroll. Track
+        // the selection here so the `›` row stays on-screen when the call list
+        // is taller than the popup. The rows are preceded by three fixed lines
+        // (title · blank · header), so the selected row is at `3 + inspect_sel`.
+        let inner_h = (h as usize).saturating_sub(2);
+        let sel_line = 3 + ui.inspect_sel;
+        ui.inspect_scroll = scroll_window_start(lines.len(), sel_line, inner_h);
     }
 
     // Clamp the scroll to the measured content so ↓ can't run off the end.

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -654,6 +654,26 @@ pub struct DeckUi {
     pub notifications: Vec<crate::envelope::NotificationInfo>,
     /// Selected row in the inbox overlay.
     pub inbox_sel: usize,
+    /// Whether the INSPECT overlay is open (`⌃g`, `/inspect`): the model calls
+    /// this execution recorded, and the reconstructed context of the one
+    /// selected. Two modes in one overlay — the list, and the detail once
+    /// [`DeckUi::inspect_view`] is filled.
+    pub inspect_open: bool,
+    /// The recorded-call index ([`Inbound::RecordedCalls`]), in wire order.
+    /// Empty after a refresh is a real answer, not a pending state — an
+    /// execution predating the receipts plane has no rows.
+    pub inspect_calls: Vec<crate::envelope::RecordedCallInfo>,
+    /// Selected row in the call list.
+    pub inspect_sel: usize,
+    /// The reconstructed call being shown ([`Inbound::InspectedCall`]).
+    /// `None` = the overlay is on the list; `Some` = on the detail.
+    pub inspect_view: Option<Box<crate::envelope::InspectView>>,
+    /// Vertical scroll offset (rows) for the detail; render clamps.
+    pub inspect_scroll: usize,
+    /// True between sending [`WorkspaceInput::InspectCall`] and its answer, so
+    /// the detail can say "reconstructing…" instead of rendering an empty
+    /// transcript that reads like "the model was sent nothing".
+    pub inspect_pending: bool,
     /// Driver requests queued by handlers/ingest beyond the one action a key
     /// can return (e.g. opening CONTEXT refreshes both skills and MCP; a
     /// finished OAuth login refreshes the MCP snapshot). The shell drains
@@ -715,6 +735,12 @@ impl Default for DeckUi {
             sessions_sel: 0,
             context_open: false,
             context_scroll: 0,
+            inspect_open: false,
+            inspect_calls: Vec::new(),
+            inspect_sel: 0,
+            inspect_view: None,
+            inspect_scroll: 0,
+            inspect_pending: false,
             inbox_open: false,
             notifications: Vec::new(),
             inbox_sel: 0,
@@ -999,6 +1025,21 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
     if let Inbound::Sessions(sessions) = inbound {
         ui.sessions = sessions.clone();
         ui.sessions_sel = ui.sessions_sel.min(sessions.len().saturating_sub(1));
+        return;
+    }
+    // The recorded-call index for the INSPECT overlay. Kept even while the
+    // overlay is shut so reopening renders instantly off the last snapshot.
+    if let Inbound::RecordedCalls(calls) = inbound {
+        ui.inspect_calls = calls.clone();
+        ui.inspect_sel = ui.inspect_sel.min(calls.len().saturating_sub(1));
+        return;
+    }
+    // One reconstructed call. Landing it clears the pending flag; the detail
+    // renders from here until Esc returns to the list.
+    if let Inbound::InspectedCall(view) = inbound {
+        ui.inspect_view = Some(view.clone());
+        ui.inspect_pending = false;
+        ui.inspect_scroll = 0;
         return;
     }
     // The persist-until-read notification snapshot: feeds the footer badge
@@ -1302,6 +1343,14 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
         return DeckAction::Handled;
     }
 
+    // Ctrl-G opens the INSPECT overlay from anywhere. Deliberately NOT ctrl+i:
+    // that is byte-identical to Tab on terminals without the kitty keyboard
+    // protocol (which `term.rs` pushes only best-effort), and Tab is bound to
+    // tab-switching — the collision would be silent and terminal-dependent.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('g')) {
+        return open_inspect_overlay(ui);
+    }
+
     // Ctrl-T toggles the queue editor from anywhere.
     if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('t')) {
         ui.queue_open = !ui.queue_open;
@@ -1343,6 +1392,9 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     }
     if ui.context_open {
         return handle_context_key(key, ui);
+    }
+    if ui.inspect_open {
+        return handle_inspect_key(key, ui);
     }
 
     let composer_empty = ui.composer.buffer().is_empty();
@@ -1626,6 +1678,7 @@ fn handle_slash_key(key: KeyEvent, matches: &[String], ui: &mut DeckUi) -> Optio
             // empty-prompt `←` / `→`, and the footer's ✉ badge for the inbox).
             "/sessions" => open_sessions_overlay(ui),
             "/context" => open_context_overlay(ui),
+            "/inspect" => open_inspect_overlay(ui),
             "/inbox" => open_inbox_overlay(ui),
             // `/mcp-search` jumps straight into the MCP tab's registry
             // search — THE way to begin looking for a server from anywhere
@@ -1716,6 +1769,19 @@ pub(crate) fn open_context_overlay(ui: &mut DeckUi) -> DeckAction {
     ui.context_scroll = 0;
     ui.pending_inputs.push(WorkspaceInput::McpRefresh);
     DeckAction::Send(WorkspaceInput::Skill(SkillOp::List))
+}
+
+/// Open the INSPECT overlay (`⌃g`, `/inspect`) on its call list and ask the
+/// driver for a fresh index. Opens on the list, never straight into a detail:
+/// which call produced a given transcript line is not knowable from UI state
+/// yet (transcript entries carry no step coordinate), so a human picks.
+pub(crate) fn open_inspect_overlay(ui: &mut DeckUi) -> DeckAction {
+    ui.inspect_open = true;
+    ui.inspect_sel = 0;
+    ui.inspect_view = None;
+    ui.inspect_scroll = 0;
+    ui.inspect_pending = false;
+    DeckAction::Send(WorkspaceInput::InspectRefresh)
 }
 
 /// Open the INBOX overlay (`/inbox`). The driver's poller keeps the
@@ -1889,6 +1955,81 @@ fn handle_context_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             ui.context_scroll = ui.context_scroll.saturating_add(10);
             DeckAction::Handled
         }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// The INSPECT overlay key map. Two modes: on the LIST, ↑/↓ move and Enter
+/// reconstructs the selected call; on the DETAIL, ↑/↓/PageUp/PageDown scroll
+/// and Esc/`←` returns to the list (rather than closing outright — stepping
+/// between calls is the common motion). Esc on the list closes. Modal.
+fn handle_inspect_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if ui.inspect_view.is_some() || ui.inspect_pending {
+        return match key.code {
+            KeyCode::Esc | KeyCode::Left => {
+                // Back to the list, not out of the overlay.
+                ui.inspect_view = None;
+                ui.inspect_pending = false;
+                ui.inspect_scroll = 0;
+                DeckAction::Handled
+            }
+            KeyCode::Char('q') => {
+                ui.inspect_open = false;
+                ui.inspect_view = None;
+                ui.inspect_pending = false;
+                DeckAction::Handled
+            }
+            KeyCode::Up => {
+                ui.inspect_scroll = ui.inspect_scroll.saturating_sub(1);
+                DeckAction::Handled
+            }
+            KeyCode::Down => {
+                // Render clamps to the content height it measures.
+                ui.inspect_scroll = ui.inspect_scroll.saturating_add(1);
+                DeckAction::Handled
+            }
+            KeyCode::PageUp => {
+                ui.inspect_scroll = ui.inspect_scroll.saturating_sub(10);
+                DeckAction::Handled
+            }
+            KeyCode::PageDown => {
+                ui.inspect_scroll = ui.inspect_scroll.saturating_add(10);
+                DeckAction::Handled
+            }
+            _ => DeckAction::Handled,
+        };
+    }
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            ui.inspect_open = false;
+            DeckAction::Handled
+        }
+        KeyCode::Up => {
+            ui.inspect_sel = ui.inspect_sel.saturating_sub(1);
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            // Clamp here (unlike the scroll offsets): the selection indexes a
+            // vec the render must be able to trust.
+            let last = ui.inspect_calls.len().saturating_sub(1);
+            ui.inspect_sel = ui.inspect_sel.saturating_add(1).min(last);
+            DeckAction::Handled
+        }
+        KeyCode::Enter | KeyCode::Right => match ui.inspect_calls.get(ui.inspect_sel) {
+            Some(call) => {
+                let (turn_instance, step, call_seq) = call.coordinate();
+                ui.inspect_pending = true;
+                ui.inspect_scroll = 0;
+                DeckAction::Send(WorkspaceInput::InspectCall {
+                    turn_instance,
+                    step,
+                    call_seq,
+                })
+            }
+            // Enter on an empty list is a no-op, not a request for call 0.
+            None => DeckAction::Handled,
+        },
+        KeyCode::Char('r') => DeckAction::Send(WorkspaceInput::InspectRefresh),
         _ => DeckAction::Handled,
     }
 }
@@ -6605,5 +6746,135 @@ mod tests {
         // "any key closes" made the long content unreadable).
         handle_deck_key(ch('x'), &model, &mut ui);
         assert!(ui.help_open, "a random key does not close the overlay");
+    }
+
+    fn call(step: u64, call_seq: u64, role: &str) -> crate::envelope::RecordedCallInfo {
+        crate::envelope::RecordedCallInfo {
+            turn_instance: 0,
+            step,
+            call_seq,
+            call_role: role.into(),
+            provider: "anthropic".into(),
+            model: "opus".into(),
+            estimated_input_tokens: 100,
+        }
+    }
+
+    #[test]
+    fn ctrl_g_opens_inspect_and_asks_the_driver_for_the_call_index() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        assert!(!ui.inspect_open);
+        let action = handle_deck_key(ctrl('g'), &model, &mut ui);
+        assert!(ui.inspect_open, "⌃g opens the INSPECT overlay");
+        assert!(
+            matches!(action, DeckAction::Send(WorkspaceInput::InspectRefresh)),
+            "opening asks for a fresh index: {action:?}"
+        );
+    }
+
+    #[test]
+    fn enter_on_a_call_requests_that_calls_coordinate_not_the_first() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        handle_deck_key(ctrl('g'), &model, &mut ui);
+        ingest_inbound(
+            &Inbound::RecordedCalls(vec![
+                call(0, 0, "worker"),
+                call(3, 1, "summarization"),
+                call(3, 0, "worker"),
+            ]),
+            &mut WorkspaceModel::new(),
+            &mut ui,
+        );
+        handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert!(
+            matches!(
+                action,
+                DeckAction::Send(WorkspaceInput::InspectCall {
+                    turn_instance: 0,
+                    step: 3,
+                    call_seq: 1,
+                })
+            ),
+            "⏎ reconstructs the SELECTED call — the summarizer here: {action:?}"
+        );
+        assert!(ui.inspect_pending, "the detail shows a pending state");
+    }
+
+    #[test]
+    fn enter_on_an_empty_index_is_a_no_op_not_a_request_for_call_zero() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        handle_deck_key(ctrl('g'), &model, &mut ui);
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert!(
+            matches!(action, DeckAction::Handled),
+            "no calls recorded — ⏎ must not fabricate a coordinate: {action:?}"
+        );
+        assert!(!ui.inspect_pending);
+    }
+
+    #[test]
+    fn esc_steps_back_from_the_detail_to_the_list_before_closing() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        handle_deck_key(ctrl('g'), &model, &mut ui);
+        ingest_inbound(
+            &Inbound::InspectedCall(Box::new(crate::envelope::InspectView {
+                call: call(0, 0, "worker"),
+                messages: vec![crate::envelope::InspectMessage {
+                    role: "system".into(),
+                    content: "You are Stella.".into(),
+                }],
+                verified: true,
+                unresolved: 0,
+                digest_mismatches: 0,
+            })),
+            &mut WorkspaceModel::new(),
+            &mut ui,
+        );
+        assert!(ui.inspect_view.is_some());
+        assert!(!ui.inspect_pending, "the answer clears the pending flag");
+
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert!(ui.inspect_view.is_none(), "esc returns to the call list");
+        assert!(ui.inspect_open, "…and does NOT close the overlay");
+
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+        assert!(!ui.inspect_open, "a second esc closes it");
+    }
+
+    #[test]
+    fn inspect_selection_cannot_run_past_the_last_call() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        handle_deck_key(ctrl('g'), &model, &mut ui);
+        ingest_inbound(
+            &Inbound::RecordedCalls(vec![call(0, 0, "worker"), call(1, 0, "worker")]),
+            &mut WorkspaceModel::new(),
+            &mut ui,
+        );
+        for _ in 0..10 {
+            handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+        }
+        assert_eq!(
+            ui.inspect_sel, 1,
+            "the selection indexes a real row — render must be able to trust it"
+        );
+    }
+
+    #[test]
+    fn inspect_is_modal_and_does_not_leak_keys_to_the_composer() {
+        let model = WorkspaceModel::new();
+        let mut ui = ready_ui();
+        handle_deck_key(ctrl('g'), &model, &mut ui);
+        handle_deck_key(ch('x'), &model, &mut ui);
+        assert!(
+            ui.composer.buffer().is_empty(),
+            "a letter typed over the overlay must not reach the composer"
+        );
+        assert!(ui.inspect_open, "…and must not close it either");
     }
 }

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -311,6 +311,65 @@ pub enum Inbound {
         query: String,
         hits: Vec<EntityHit>,
     },
+    /// INSPECT overlay: every model call this execution recorded a receipt for,
+    /// in wire order. Answers [`WorkspaceInput::InspectRefresh`]. An empty vec
+    /// is a real answer — an execution whose receipts predate the receipts
+    /// plane has none — and the overlay says so rather than hanging.
+    RecordedCalls(Vec<RecordedCallInfo>),
+    /// INSPECT overlay: the reconstructed context of one call, answering
+    /// [`WorkspaceInput::InspectCall`]. Boxed — the message bodies are whole
+    /// prompts, far larger than any other `Inbound` payload, and this variant
+    /// would otherwise set the size of every channel send.
+    InspectedCall(Box<InspectView>),
+}
+
+/// One recorded model call — the INSPECT overlay's row. Mirrors
+/// `stella_store::RecordedCall`; the TUI never links the store crate, so the
+/// driver maps one to the other (same contract as [`IssueRow`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordedCallInfo {
+    pub turn_instance: u32,
+    pub step: u64,
+    /// Which call at this step: 0 the engine's worker, 1 the overflow
+    /// summarizer, 2+ a pipeline management role.
+    pub call_seq: u64,
+    pub call_role: String,
+    pub provider: String,
+    pub model: String,
+    pub estimated_input_tokens: u64,
+}
+
+impl RecordedCallInfo {
+    /// The coordinate triple, for the detail header and the request echo.
+    pub fn coordinate(&self) -> (u32, u64, u64) {
+        (self.turn_instance, self.step, self.call_seq)
+    }
+}
+
+/// One message of a reconstructed call, flattened for display: tool calls and
+/// results are already rendered into `content` by the driver, so the overlay
+/// never needs the protocol types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectMessage {
+    pub role: String,
+    pub content: String,
+}
+
+/// The reconstructed context of one model call — what the INSPECT overlay
+/// shows. Carries the verification verdict alongside the bytes, because a
+/// transcript you cannot vouch for is worse than none.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectView {
+    pub call: RecordedCallInfo,
+    pub messages: Vec<InspectMessage>,
+    /// Every journal-resolved block re-hashed to its recorded digest.
+    pub verified: bool,
+    /// Blocks with no recoverable preimage — a documented coverage gap
+    /// (synthetic results, discarded speculation, attachments).
+    pub unresolved: usize,
+    /// Blocks whose bytes did NOT re-hash — a torn or altered journal. Kept
+    /// distinct from `unresolved`: the two mean very different things.
+    pub digest_mismatches: usize,
 }
 
 /// One row of the ISSUES tab's browse list — a tracker-agnostic mirror of
@@ -700,6 +759,18 @@ pub enum WorkspaceInput {
         field: EntityField,
         query: String,
         seq: u64,
+    },
+    /// INSPECT overlay: list the model calls this execution recorded, so a
+    /// human can pick one. Answered with [`Inbound::RecordedCalls`].
+    InspectRefresh,
+    /// INSPECT overlay: reconstruct one call's context. Answered with
+    /// [`Inbound::InspectedCall`]. A blocking SQLite read on the driver side —
+    /// it replays the block registry and the event journal — so it is served
+    /// off the pump, like [`WorkspaceInput::FocusGraphFile`].
+    InspectCall {
+        turn_instance: u32,
+        step: u64,
+        call_seq: u64,
     },
     /// Tear down the deck.
     Quit,

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -93,10 +93,10 @@ pub use deck_ui::{
 };
 pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
-    EngineConfigState, EngineRole, EntityField, EntityHit, Inbound, InstalledAgentEntry,
-    IssueAction, IssueRow, McpSearchItem, McpSearchOutcome, McpServerInfo, NotificationInfo,
-    Secret, SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView,
-    SplashCue, WorkspaceInput,
+    EngineConfigState, EngineRole, EntityField, EntityHit, Inbound, InspectMessage, InspectView,
+    InstalledAgentEntry, IssueAction, IssueRow, McpSearchItem, McpSearchOutcome, McpServerInfo,
+    NotificationInfo, RecordedCallInfo, Secret, SessionInfo, SessionPhase, SkillOp, SkillRow,
+    SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 pub use fleet_dashboard::{
     FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,

--- a/stella-tui/tests/deck_snapshot.rs
+++ b/stella-tui/tests/deck_snapshot.rs
@@ -173,3 +173,103 @@ fn help_overlay_shows_only_the_active_tabs_shortcuts() {
     assert!(skills.contains("search skills"), "{skills}");
     assert!(!skills.contains("cycle the per-agent filter"), "{skills}");
 }
+
+/// The INSPECT overlay in both of its modes, through the real `render_deck`
+/// entrypoint. This is the closest headless equivalent of opening it in a TTY:
+/// if the prompt bytes are not on the screen, the feature does not work.
+#[test]
+fn inspect_overlay_renders_the_call_list_then_the_context_sent() {
+    use stella_tui::{InspectMessage, InspectView, RecordedCallInfo};
+
+    let model = folded_model();
+    let call = |step: u64, call_seq: u64, role: &str| RecordedCallInfo {
+        turn_instance: 0,
+        step,
+        call_seq,
+        call_role: role.into(),
+        provider: "anthropic".into(),
+        model: "claude-opus".into(),
+        estimated_input_tokens: 1234,
+    };
+
+    let render = |ui: &mut DeckUi| {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal.draw(|f| render_deck(&model, ui, f)).unwrap();
+        let buf = terminal.backend().buffer();
+        let area = *buf.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // Mode 1: the call list. Both calls of step 3 must be distinguishable —
+    // that is the whole point of keying receipts on call_seq.
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    ui.inspect_open = true;
+    ui.inspect_calls = vec![
+        call(0, 0, "worker"),
+        call(3, 1, "summarization"),
+        call(3, 0, "worker"),
+    ];
+    ui.inspect_sel = 1;
+    let list = render(&mut ui);
+    assert!(list.contains("recorded calls"), "titled:\n{list}");
+    assert!(
+        list.contains("summarization"),
+        "the auxiliary call is listed:\n{list}"
+    );
+    assert!(list.contains("worker"), "{list}");
+    assert!(
+        list.contains("show the context it was sent"),
+        "the footer says what ⏎ does:\n{list}"
+    );
+
+    // Mode 2: the reconstructed context. The system prompt must be readable.
+    ui.inspect_view = Some(Box::new(InspectView {
+        call: call(3, 1, "summarization"),
+        messages: vec![
+            InspectMessage {
+                role: "system".into(),
+                content: "Condense this span faithfully.".into(),
+            },
+            InspectMessage {
+                role: "user".into(),
+                content: "t0 t1 t2".into(),
+            },
+        ],
+        verified: true,
+        unresolved: 0,
+        digest_mismatches: 0,
+    }));
+    let detail = render(&mut ui);
+    assert!(detail.contains("context sent"), "titled:\n{detail}");
+    assert!(
+        detail.contains("Condense this span faithfully."),
+        "the system prompt is on screen — the feature:\n{detail}"
+    );
+    assert!(
+        detail.contains("turn 0 · step 3 · call-seq 1"),
+        "the coordinate is shown:\n{detail}"
+    );
+    assert!(
+        detail.contains("verified"),
+        "the verdict is shown:\n{detail}"
+    );
+
+    // A torn journal must read differently from a coverage gap.
+    if let Some(view) = ui.inspect_view.as_mut() {
+        view.verified = false;
+        view.digest_mismatches = 2;
+    }
+    let torn = render(&mut ui);
+    assert!(
+        torn.contains("did not re-hash"),
+        "a digest mismatch is called out, not folded into 'unverified':\n{torn}"
+    );
+}


### PR DESCRIPTION
> Follow-up to #544, which merged while this was in flight — rebased onto main, so this branch is just the deck surface.

## What it does

`⌃g` (or `/inspect`) opens the INSPECT overlay on the execution's recorded-call index. `⏎` on a row reconstructs that call and shows the messages it was actually sent — system prompt included — with the verification verdict. `Esc` steps back to the list rather than closing, since walking between calls is the common motion.

**The call list** — both calls of step 3 are distinguishable, which is the whole point of keying receipts on `call_seq`:

```
┌ inspect · recorded calls ──────────────────────────────────────────────┐
│  every model call this execution recorded a receipt for                │
│                                                                        │
│    TURN  STEP  SEQ  ROLE            PROVIDER    MODEL                  │
│       0     0    0  worker          anthropic   claude-opus            │
│  ›    0     3    1  summarization   anthropic   claude-opus            │
│       0     3    0  worker          anthropic   claude-opus            │
│                                                                        │
│ ↑/↓ select · ⏎ show the context it was sent · r refresh · esc close     │
└────────────────────────────────────────────────────────────────────────┘
```

**The context sent:**

```
┌ inspect · context sent ────────────────────────────────────────────────┐
│  turn 0 · step 3 · call-seq 1 · summarization                          │
│  anthropic / claude-opus · 2 message(s)                                │
│  verified · every journal-resolved block re-hashed to its digest       │
│                                                                        │
│  ─── [0] system ───                                                    │
│    Condense this span faithfully.                                      │
│                                                                        │
│  ─── [1] user ───                                                      │
│    t0 t1 t2                                                            │
│                                                                        │
│ ↑/↓ pgup/pgdn scroll · esc/← back to calls · q close                   │
└────────────────────────────────────────────────────────────────────────┘
```

(Both frames above are the real `render_deck` output, captured by the render test.)

## Why ⌃g and not ⌃i

The obvious binding is a trap. **Ctrl-I is byte-identical to Tab** (0x09) on terminals without the kitty keyboard protocol — which `term.rs:115` pushes only best-effort — and Tab is bound to deck tab-switching (`deck_ui.rs:1371`). On Ghostty/kitty it would work; on Terminal.app it would silently switch tabs instead. `⌃g` is unambiguous.

## Plumbing

`stella-tui` doesn't link `stella-store`, by design (`envelope.rs:561` documents the round-trip contract), so this is a request/answer pair: two `WorkspaceInput` variants, two `Inbound` variants, with payload types mirrored in the envelope the way `IssueRow` mirrors the tools crate's `IssueSummary`.

Both driver arms are **blocking SQLite reads** — `reconstruct_call` replays the block registry and the event journal — so they run on `spawn_blocking` and answer out of band, the same shape as `FocusGraphFile`. Stalling the event pump to rebuild a prompt would stutter a live turn.

The deck now retains the last execution id across the session loop: the per-turn `execution` binding is out of scope at the idle service site, and the overlay is most useful precisely when no turn is running. No store (claim mode) or no turn yet answers an **empty index rather than silence**, so the overlay renders its empty state instead of looking hung.

## Scope: this is the picker, not line-precise correlation

`TranscriptEntry` carries no step coordinate today — `StepManifest` is discarded in all three fold paths (`model.rs:606`, `deck.rs:609`, `textline.rs:421`) — so "the call that produced *this* transcript line" isn't knowable from UI state yet. A human picks from the list.

The follow-up is stamping entries with their step: the event order at step N is `summarizer manifest → worker text/tool deltas → worker manifest (call_seq 0) → StepUsage`, so "the next `call_seq == 0` manifest" is exactly the call that produced the entries before it. The fiddly part is keeping a parallel coordinate vec in sync with `evict_transcript_overflow`.

## Testing

- **State machine** (`deck_ui.rs`): opening requests the index; `⏎` sends the *selected* coordinate, not the first; `⏎` on an empty index fabricates nothing; `Esc` steps list-ward before closing; selection clamps to a real row; modal keys don't leak to the composer.
- **Render** (`deck_snapshot.rs`): through the real `render_deck` entrypoint, asserting the prompt bytes reach the screen in both modes — and that a digest mismatch reads differently from a coverage gap.
- `make check` clean; full suite **3135 passed, 0 failed**.


## Note on main

`cargo fmt --check` fails on `origin/main` as of 3e925ce — the #544 squash left a stray blank line in `stella-core/src/accounted_call.rs`. A one-line commit here unbreaks the gate; happy to split it out if you would rather land it separately.
