### PR TITLE
feat(context): complete Phase 1 installments 3-5 — contract/outcome validators, representation matrix, event JCS vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
  "thiserror 2.0.19",
 ]
 

--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -14,7 +14,6 @@ use crate::event_sender::EventSender;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
 
-
 /// Where an auxiliary call sits in the receipt coordinate space, so the context
 /// it sent is reconstructable alongside the engine's own steps. `call_seq` must
 /// be unique within the execution (see `AgentEvent::StepManifest::call_seq`).

--- a/stella-core/src/context_record.rs
+++ b/stella-core/src/context_record.rs
@@ -6,17 +6,28 @@
 //! types, cross-field validators, and canonical hashing. (Named `context_record`
 //! rather than `context` to stay unambiguous next to the `stella-context` crate.)
 //!
-//! ## Scope of this installment
+//! ## Scope
 //!
-//! Phase 1 is large; this is **installment 1 of N** — the foundational vertical:
-//! the record taxonomy enums, [`Scope`]/[`SharingScope`], the temporal
-//! primitives, canonical [`hash`]ing, and the cross-field validators that live
-//! entirely on those types. **Deferred to later installments** (their types are
-//! not here yet, so neither are the validators that span them): the
-//! context-use / efficacy web, artifact contracts + validation, outcome
-//! assessments, frame representation / content-fidelity, and the internal
-//! replay-safe events in `stella-protocol`. This module does **not** yet satisfy
-//! the full Phase 1 gate.
+//! The Phase 1 type layer is **complete**: the record taxonomy enums,
+//! [`Scope`]/[`SharingScope`], the temporal primitives and canonical [`hash`]ing
+//! (installment 1); the [`context_use`] efficacy web (2); [`contract`] +
+//! [`outcome`] (3); [`representation`] content fidelity (4); and the internal
+//! replay-safe events, which live in `stella-protocol::context_event` so the
+//! protocol crate stays free of a `stella-core` dependency (5).
+//!
+//! Two Phase 1 line items are deliberately **not** here, because they cannot be:
+//! the ingestion-boundary compatibility adapters (legacy `recorded_at` →
+//! `observed_at`, `valid_to` → `valid_until`, and the legacy memory/fact APIs)
+//! need the ingestion path, so they land with the Phase 2 migration that owns it.
+//!
+//! ## Where a validator lives
+//!
+//! Purity is about I/O, not about arity. A rule that spans two records is still
+//! pure when it needs only the two *values* — those are plain functions taking
+//! both (e.g. [`ContractValidation::validate_against`],
+//! [`OutcomeAssessment::validate_against`]). Only rules needing **identity
+//! resolution** — "does this id name a record that exists?" — are deferred to the
+//! Phase 2/3 repository, since a value layer cannot answer them.
 //!
 //! ## Relationship to the legacy `rules::metadata` types (coexist, do not merge)
 //!
@@ -60,8 +71,8 @@ pub use context_use::{
     MissingContextKind,
 };
 pub use contract::{
-    ArtifactContract, ContractValidation, Requirement, RequirementKind, RequirementResult,
-    RequirementStatus, ValidationStatus,
+    AppliesWhen, ArtifactContract, ContractValidation, Presentation, Requirement, RequirementKind,
+    RequirementResult, RequirementStatus, ValidationStatus,
 };
 pub use hash::{RecordHashError, record_hash};
 pub use kind::{
@@ -69,9 +80,13 @@ pub use kind::{
     EffectiveStatus, KnowledgeKind, MemoryKind, Origin, PromotionAction, RecordProposalKind,
     RecordProposalStatus, RecordStatus,
 };
-pub use outcome::{CompletionStatus, CorrectnessStatus, OutcomeAssessment, OutcomeAssessmentLevel};
+pub use outcome::{
+    CompletionAssessment, CompletionStatus, CorrectnessAssessment, CorrectnessStatus,
+    OutcomeAssessment, OutcomeAssessmentLevel, OutcomeReason,
+};
 pub use representation::{
-    ContentFidelity, InlineContentRequirement, MinimumContentFidelity, Representation,
+    ContentFidelity, FrameContentSpec, InlineContentRequirement, MinimumContentFidelity,
+    Representation, validate_directive_minimum_fidelity,
 };
 pub use scope::{Scope, SharingScope};
 pub use temporal::{TemporalInterval, TemporalQuery};

--- a/stella-core/src/context_record/contract.rs
+++ b/stella-core/src/context_record/contract.rs
@@ -7,17 +7,20 @@
 //! with "unknown kinds fail closed"). `validation_status` keeps its four named
 //! values; `requirement_status` gets its own enum.
 //!
-//! The "exactly one result for every requirement in the referenced contract
-//! version, no unknown ids" rule is **referential** (it spans the contract and
-//! the validation) — only the intra-record half (no *duplicate* result ids, and
-//! duplicates force `error`) is enforced here; coverage/unknown-id checks are the
-//! repository's job.
+//! The §8.13 coverage rule — "exactly one result for every requirement in the
+//! referenced contract version, with no duplicate or unknown requirement IDs;
+//! missing, duplicate, or unknown result IDs make validation_status error" —
+//! spans two records, but it is still **pure**: it needs only the contract value
+//! beside the validation value, never a repository. It therefore lives here as
+//! [`ContractValidation::validate_against`], with the id-only half a validation
+//! can check alone in [`ContractValidation::validate`].
 
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
 use super::RecordValidationError;
+use super::context_use::EvidenceLink;
 use super::kind::Origin;
 use super::scope::{Scope, SharingScope};
 
@@ -99,9 +102,12 @@ impl<'de> Deserialize<'de> for RequirementKind {
     }
 }
 
-/// One requirement of an [`ArtifactContract`]. Kind-specific parameters
-/// (`glob`/`minimum`, `argv`/`timeout_ms`, `rubric_ref`, …) are carried in
-/// `params` and interpreted by the executor in a later phase.
+/// One requirement of an [`ArtifactContract`]. Kind-specific fields
+/// (`path`, `glob`/`minimum`, `argv`/`timeout_ms`, `rubric_ref`, …) sit
+/// **inline beside** the three common fields on the wire (lifecycle §8.12), so
+/// `params` is `#[serde(flatten)]`ed rather than nested — the canonical record
+/// bytes must match the spec's shape exactly, since they enter the `record_hash`
+/// preimage. The executor interprets them in a later phase.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Requirement {
     /// Stable id, unique within the contract.
@@ -110,19 +116,40 @@ pub struct Requirement {
     pub requirement_kind: RequirementKind,
     /// Whether the deliverable must satisfy this to be complete.
     pub required: bool,
-    /// Kind-specific parameters (opaque here; validated by the executor).
-    #[serde(skip_serializing_if = "serde_json::Map::is_empty", default)]
+    /// Kind-specific fields, inline on the wire (opaque here).
+    #[serde(flatten)]
     pub params: serde_json::Map<String, serde_json::Value>,
 }
 
-/// A contract that a produced artifact must satisfy (lifecycle §8.12). Carries
-/// completion authority when selected.
+/// The selection predicate for a contract — when it applies (lifecycle §8.12).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AppliesWhen {
+    /// Task intents this contract applies to.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub task_intents: Vec<String>,
+}
+
+/// Presentation hints for a contract's output (lifecycle §8.12). Advisory: it
+/// orders how a satisfied deliverable is shown, never what is required.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Presentation {
+    /// The order output directories are presented in.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub directory_order: Vec<String>,
+}
+
+/// A contract that a produced artifact must satisfy (lifecycle §8.12).
+///
+/// A contract is **data, never execution authorization**: `execution_approval_ref`
+/// is a required *reference* for a `command` requirement, and resolving it is a
+/// separate authorization step that this type layer does not perform.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactContract {
     /// Human name.
     pub name: String,
-    /// Contract version.
-    pub version: String,
+    /// Contract version — an integer on the wire (lifecycle §8.12), so the
+    /// canonical bytes are `"version":3`, never `"version":"3"`.
+    pub version: u32,
     /// What it produces / checks.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
@@ -132,11 +159,17 @@ pub struct ArtifactContract {
     pub scope: Scope,
     /// Who it is shared with.
     pub sharing_scope: SharingScope,
+    /// When this contract applies.
+    #[serde(default)]
+    pub applies_when: AppliesWhen,
     /// Root under which outputs are checked.
     pub output_root: String,
     /// The requirements.
     #[serde(default)]
     pub requirements: Vec<Requirement>,
+    /// Presentation hints for the produced output.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub presentation: Option<Presentation>,
     /// Required when any requirement is `command`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub execution_approval_ref: Option<String>,
@@ -147,9 +180,19 @@ pub struct ArtifactContract {
 }
 
 impl ArtifactContract {
-    /// Validate intra-record invariants: a `command` requirement forces an
-    /// `execution_approval_ref`.
+    /// Validate intra-record invariants: `requirement_id` is unique within the
+    /// contract, and a `command` requirement forces an `execution_approval_ref`.
     pub fn validate(&self) -> Result<(), RecordValidationError> {
+        let mut seen = HashSet::new();
+        if self
+            .requirements
+            .iter()
+            .any(|r| !seen.insert(r.requirement_id.as_str()))
+        {
+            return Err(RecordValidationError::invariant(
+                "contract.requirement_ids_must_be_unique",
+            ));
+        }
         let has_command = self
             .requirements
             .iter()
@@ -160,6 +203,18 @@ impl ArtifactContract {
             ));
         }
         Ok(())
+    }
+
+    /// The ids of `required` requirements whose kind is **not** recognized.
+    /// Such a requirement is non-executable, so it fails closed: it can never be
+    /// reported `passed` (lifecycle §8.12, enforced by
+    /// [`ContractValidation::validate_against`]).
+    pub fn non_executable_required_ids(&self) -> Vec<&str> {
+        self.requirements
+            .iter()
+            .filter(|r| r.required && !r.requirement_kind.is_recognized())
+            .map(|r| r.requirement_id.as_str())
+            .collect()
     }
 }
 
@@ -227,21 +282,31 @@ pub struct RequirementResult {
 pub struct ContractValidation {
     /// The contract this validated.
     pub contract_record_id: String,
-    /// The exact contract version validated.
-    pub contract_version: String,
+    /// The exact contract version validated (integer, matching
+    /// [`ArtifactContract::version`]).
+    pub contract_version: u32,
+    /// The hash of the exact contract revision validated.
+    pub contract_hash: String,
     /// The overall verdict.
     pub validation_status: ValidationStatus,
     /// Per-requirement results.
     #[serde(default)]
     pub results: Vec<RequirementResult>,
+    /// Evidence supporting the verdict.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub evidence_links: Vec<EvidenceLink>,
+    /// Where the validation applies.
+    pub scope: Scope,
+    /// Who it is shared with.
+    pub sharing_scope: SharingScope,
     /// When it was observed (RFC 3339 UTC).
     pub observed_at: String,
 }
 
 impl ContractValidation {
-    /// Validate the intra-record half of the coverage rule: duplicate result
-    /// ids force `validation_status == error`. (Full coverage / unknown-id
-    /// checks against the referenced contract are the repository's job.)
+    /// The half of the §8.13 coverage rule a validation can check **alone**:
+    /// duplicate result ids force `validation_status == error`. Missing and
+    /// unknown ids need the contract — see [`Self::validate_against`].
     pub fn validate(&self) -> Result<(), RecordValidationError> {
         let mut seen = HashSet::new();
         let has_duplicate = self
@@ -255,6 +320,73 @@ impl ContractValidation {
         }
         Ok(())
     }
+
+    /// The **whole** §8.13 coverage rule, against the contract this validation
+    /// references: exactly one result for every requirement, with no duplicate
+    /// or unknown requirement ids. Missing, duplicate, or unknown result ids
+    /// make `validation_status` `error` — any other status with broken coverage
+    /// is invalid.
+    ///
+    /// Also enforces fail-closed non-executability: a `required` requirement
+    /// whose kind is unrecognized cannot be reported `passed`, and its presence
+    /// keeps the whole validation from passing (lifecycle §8.12).
+    ///
+    /// Pure: it compares two values and touches no repository. The caller is
+    /// responsible for supplying the contract revision that
+    /// `contract_record_id`/`contract_hash` actually name.
+    pub fn validate_against(
+        &self,
+        contract: &ArtifactContract,
+    ) -> Result<(), RecordValidationError> {
+        if self.contract_version != contract.version {
+            return Err(RecordValidationError::invariant(
+                "contract_validation.version_must_match_contract",
+            ));
+        }
+
+        let required_ids: HashSet<&str> = contract
+            .requirements
+            .iter()
+            .map(|r| r.requirement_id.as_str())
+            .collect();
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut coverage_broken = false;
+        for result in &self.results {
+            let id = result.requirement_id.as_str();
+            // Duplicate, or naming a requirement the contract does not have.
+            if !seen.insert(id) || !required_ids.contains(id) {
+                coverage_broken = true;
+            }
+        }
+        // Missing: a requirement with no result at all.
+        if seen.len() != required_ids.len() {
+            coverage_broken = true;
+        }
+        if coverage_broken && self.validation_status != ValidationStatus::Error {
+            return Err(RecordValidationError::invariant(
+                "contract_validation.broken_coverage_requires_error",
+            ));
+        }
+
+        let non_executable = contract.non_executable_required_ids();
+        if !non_executable.is_empty() {
+            let passed_non_executable = self.results.iter().any(|r| {
+                r.requirement_status == RequirementStatus::Passed
+                    && non_executable.contains(&r.requirement_id.as_str())
+            });
+            if passed_non_executable {
+                return Err(RecordValidationError::invariant(
+                    "contract_validation.unrecognized_required_kind_cannot_pass",
+                ));
+            }
+            if self.validation_status == ValidationStatus::Passed {
+                return Err(RecordValidationError::invariant(
+                    "contract_validation.non_executable_requirement_fails_closed",
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -265,7 +397,7 @@ mod tests {
     fn contract(kinds: &[&str]) -> ArtifactContract {
         ArtifactContract {
             name: "brand-kit".into(),
-            version: "1".into(),
+            version: 1,
             description: None,
             origin: Origin::User,
             scope: Scope {
@@ -273,6 +405,9 @@ mod tests {
                 ..Default::default()
             },
             sharing_scope: SharingScope::Repository,
+            applies_when: AppliesWhen {
+                task_intents: vec!["create_brand_kit".into()],
+            },
             output_root: "out/".into(),
             requirements: kinds
                 .iter()
@@ -284,9 +419,37 @@ mod tests {
                     params: serde_json::Map::new(),
                 })
                 .collect(),
+            presentation: None,
             execution_approval_ref: None,
             observed_at: "2026-07-20T18:30:00Z".into(),
             valid_from: "2026-07-20T18:30:00Z".into(),
+        }
+    }
+
+    /// A validation covering every requirement of `contract`, all passed.
+    fn validation_for(contract: &ArtifactContract) -> ContractValidation {
+        ContractValidation {
+            contract_record_id: "ctr_1".into(),
+            contract_version: contract.version,
+            contract_hash: "sha256:contract".into(),
+            validation_status: ValidationStatus::Passed,
+            results: contract
+                .requirements
+                .iter()
+                .map(|r| RequirementResult {
+                    requirement_id: r.requirement_id.clone(),
+                    requirement_status: RequirementStatus::Passed,
+                    method: "deterministic".into(),
+                    message: None,
+                })
+                .collect(),
+            evidence_links: Vec::new(),
+            scope: Scope {
+                repository_id: Some("repo_1".into()),
+                ..Default::default()
+            },
+            sharing_scope: SharingScope::Repository,
+            observed_at: "2026-07-20T18:30:00Z".into(),
         }
     }
 
@@ -314,26 +477,30 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_requirement_ids_are_rejected() {
+        let mut c = contract(&["file_exists", "file_exists"]);
+        c.requirements[1].requirement_id = "req_0".into();
+        assert_eq!(
+            c.validate(),
+            Err(RecordValidationError::invariant(
+                "contract.requirement_ids_must_be_unique"
+            ))
+        );
+    }
+
+    #[test]
     fn duplicate_result_ids_force_error_status() {
-        let dup = |status| ContractValidation {
-            contract_record_id: "ctr_1".into(),
-            contract_version: "1".into(),
-            validation_status: status,
-            results: vec![
-                RequirementResult {
-                    requirement_id: "req_0".into(),
-                    requirement_status: RequirementStatus::Passed,
-                    method: "deterministic".into(),
-                    message: None,
-                },
-                RequirementResult {
-                    requirement_id: "req_0".into(),
-                    requirement_status: RequirementStatus::Failed,
-                    method: "deterministic".into(),
-                    message: None,
-                },
-            ],
-            observed_at: "2026-07-20T18:30:00Z".into(),
+        let c = contract(&["file_exists"]);
+        let dup = |status| {
+            let mut v = validation_for(&c);
+            v.validation_status = status;
+            v.results.push(RequirementResult {
+                requirement_id: "req_0".into(),
+                requirement_status: RequirementStatus::Failed,
+                method: "deterministic".into(),
+                message: None,
+            });
+            v
         };
         assert_eq!(
             dup(ValidationStatus::Passed).validate(),
@@ -342,6 +509,130 @@ mod tests {
             ))
         );
         assert!(dup(ValidationStatus::Error).validate().is_ok());
+    }
+
+    #[test]
+    fn coverage_requires_exactly_one_result_per_requirement() {
+        let c = contract(&["file_exists", "json_schema"]);
+        // The complete, correct covering validation passes.
+        assert!(validation_for(&c).validate_against(&c).is_ok());
+
+        // Missing a result for req_1.
+        let mut missing = validation_for(&c);
+        missing.results.pop();
+        assert_eq!(
+            missing.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.broken_coverage_requires_error"
+            ))
+        );
+        // ...unless the status already admits the breakage.
+        missing.validation_status = ValidationStatus::Error;
+        assert!(missing.validate_against(&c).is_ok());
+
+        // A result naming a requirement the contract does not have.
+        let mut unknown = validation_for(&c);
+        unknown.results[1].requirement_id = "req_does_not_exist".into();
+        assert_eq!(
+            unknown.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.broken_coverage_requires_error"
+            ))
+        );
+
+        // A duplicate that also leaves a requirement uncovered.
+        let mut duplicate = validation_for(&c);
+        duplicate.results[1].requirement_id = "req_0".into();
+        assert_eq!(
+            duplicate.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.broken_coverage_requires_error"
+            ))
+        );
+    }
+
+    #[test]
+    fn a_validation_must_name_the_contract_version_it_validated() {
+        let c = contract(&["file_exists"]);
+        let mut v = validation_for(&c);
+        v.contract_version = 99;
+        assert_eq!(
+            v.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.version_must_match_contract"
+            ))
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_required_kind_fails_closed() {
+        let c = contract(&["acme.custom"]);
+        assert_eq!(c.non_executable_required_ids(), vec!["req_0"]);
+
+        // It can never be reported passed.
+        let v = validation_for(&c);
+        assert_eq!(
+            v.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.unrecognized_required_kind_cannot_pass"
+            ))
+        );
+
+        // Even reported failed, the whole validation cannot pass.
+        let mut failed_requirement = validation_for(&c);
+        failed_requirement.results[0].requirement_status = RequirementStatus::Failed;
+        assert_eq!(
+            failed_requirement.validate_against(&c),
+            Err(RecordValidationError::invariant(
+                "contract_validation.non_executable_requirement_fails_closed"
+            ))
+        );
+        failed_requirement.validation_status = ValidationStatus::Failed;
+        assert!(failed_requirement.validate_against(&c).is_ok());
+
+        // An unrecognized kind that is NOT required does not fail closed.
+        let mut optional = contract(&["acme.custom"]);
+        optional.requirements[0].required = false;
+        assert!(optional.non_executable_required_ids().is_empty());
+        assert!(
+            validation_for(&optional)
+                .validate_against(&optional)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn requirement_kind_fields_are_inline_on_the_wire() {
+        // The spec puts kind-specific fields beside the common ones, not nested
+        // under `params` — the canonical bytes must match.
+        let mut c = contract(&["file_exists"]);
+        c.requirements[0]
+            .params
+            .insert("path".into(), json!("README.md"));
+        let wire = serde_json::to_value(&c.requirements[0]).unwrap();
+        assert_eq!(
+            wire,
+            json!({
+                "requirement_id": "req_0",
+                "requirement_kind": "file_exists",
+                "required": true,
+                "path": "README.md"
+            })
+        );
+        let back: Requirement = serde_json::from_value(wire).unwrap();
+        assert_eq!(back, c.requirements[0]);
+    }
+
+    #[test]
+    fn contract_version_is_an_integer_on_the_wire() {
+        let wire = serde_json::to_value(contract(&["file_exists"])).unwrap();
+        assert_eq!(wire["version"], json!(1));
+        assert_eq!(
+            wire["applies_when"],
+            json!({"task_intents": ["create_brand_kit"]})
+        );
+        // Absent presentation is omitted, not null.
+        assert!(wire.get("presentation").is_none());
     }
 
     #[test]

--- a/stella-core/src/context_record/outcome.rs
+++ b/stella-core/src/context_record/outcome.rs
@@ -1,8 +1,19 @@
-//! Outcome-assessment value types (lifecycle §6.8 / §8.x). Two independent
+//! Outcome-assessment value types (lifecycle §6.8 / §8.14). Two independent
 //! dimensions — completion and correctness — each carrying a status and the
 //! evidential level behind it.
+//!
+//! The completion dimension is not free-standing when a contract governs the
+//! task: §8.13 ("completion cannot pass") and §8.12 ("do not declare completion
+//! until the artifact contract passes") tie it to the contract verdict. That
+//! cross-record rule is pure — two values, no repository — and lives here as
+//! [`OutcomeAssessment::validate_against`].
 
 use serde::{Deserialize, Serialize};
+
+use super::RecordValidationError;
+use super::context_use::EvidenceLink;
+use super::contract::{ContractValidation, ValidationStatus};
+use super::scope::{Scope, SharingScope};
 
 /// The evidential strength behind an assessment (lifecycle §6.8). Agent
 /// reflection alone supports only `inferred`.
@@ -88,17 +99,71 @@ pub struct CorrectnessAssessment {
     pub assessment_level: OutcomeAssessmentLevel,
 }
 
+/// Why an outcome was assessed the way it was (lifecycle §8.14). `reason_kind`
+/// is an extensible identifier (e.g. `contract_failure`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeReason {
+    /// The reason kind (extensible identifier).
+    pub reason_kind: String,
+    /// The record this reason points at (e.g. a `ContractValidation`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub record_ref: Option<String>,
+}
+
+impl OutcomeReason {
+    /// The reason kind naming a contract validation that did not pass.
+    pub const CONTRACT_FAILURE: &'static str = "contract_failure";
+}
+
 /// A post-task assessment of an outcome across the two independent dimensions
-/// (lifecycle §). Referenced by a `ContextUseFeedback` when the outcome relation
-/// is supported/contradicted.
+/// (lifecycle §8.14). Referenced by a `ContextUseFeedback` when the outcome
+/// relation is supported/contradicted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OutcomeAssessment {
+    /// The task assessed.
+    pub task_id: String,
     /// The completion dimension.
     pub completion_assessment: CompletionAssessment,
     /// The correctness dimension.
     pub correctness_assessment: CorrectnessAssessment,
+    /// Why it was assessed this way.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reasons: Vec<OutcomeReason>,
+    /// Evidence supporting the assessment.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub evidence_links: Vec<EvidenceLink>,
+    /// Where the assessment applies.
+    pub scope: Scope,
+    /// Who it is shared with.
+    pub sharing_scope: SharingScope,
     /// When it was observed (RFC 3339 UTC).
     pub observed_at: String,
+}
+
+impl OutcomeAssessment {
+    /// Completion cannot pass on a contract that did not (lifecycle §8.13:
+    /// broken coverage "make[s] validation_status error, and completion cannot
+    /// pass"; §8.12: "do not declare completion until the artifact contract
+    /// passes").
+    ///
+    /// `error` and `failed` both block a `complete` verdict. `skipped` does not:
+    /// a contract that did not apply says nothing about completion. Correctness
+    /// is untouched — the two dimensions stay independent.
+    pub fn validate_against(
+        &self,
+        validation: &ContractValidation,
+    ) -> Result<(), RecordValidationError> {
+        let blocks_completion = matches!(
+            validation.validation_status,
+            ValidationStatus::Error | ValidationStatus::Failed
+        );
+        if blocks_completion && self.completion_assessment.status == CompletionStatus::Complete {
+            return Err(RecordValidationError::invariant(
+                "outcome.completion_cannot_pass_an_unpassed_contract",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -126,22 +191,96 @@ mod tests {
         );
     }
 
-    #[test]
-    fn the_two_dimensions_are_independent() {
-        // Complete but incorrect is a representable, valid combination.
-        let assessment = OutcomeAssessment {
+    fn assessment(completion: CompletionStatus) -> OutcomeAssessment {
+        OutcomeAssessment {
+            task_id: "task_1".into(),
             completion_assessment: CompletionAssessment {
-                status: CompletionStatus::Complete,
+                status: completion,
                 assessment_level: OutcomeAssessmentLevel::Verified,
             },
             correctness_assessment: CorrectnessAssessment {
                 status: CorrectnessStatus::Incorrect,
                 assessment_level: OutcomeAssessmentLevel::Inferred,
             },
+            reasons: Vec::new(),
+            evidence_links: Vec::new(),
+            scope: Scope {
+                repository_id: Some("repo_1".into()),
+                ..Default::default()
+            },
+            sharing_scope: SharingScope::Repository,
             observed_at: "2026-07-20T18:30:00Z".into(),
-        };
+        }
+    }
+
+    fn validation(status: ValidationStatus) -> ContractValidation {
+        ContractValidation {
+            contract_record_id: "ctr_1".into(),
+            contract_version: 1,
+            contract_hash: "sha256:contract".into(),
+            validation_status: status,
+            results: Vec::new(),
+            evidence_links: Vec::new(),
+            scope: Scope {
+                repository_id: Some("repo_1".into()),
+                ..Default::default()
+            },
+            sharing_scope: SharingScope::Repository,
+            observed_at: "2026-07-20T18:30:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn the_two_dimensions_are_independent() {
+        // Complete but incorrect is a representable, valid combination.
+        let a = assessment(CompletionStatus::Complete);
         let round: OutcomeAssessment =
-            serde_json::from_value(serde_json::to_value(&assessment).unwrap()).unwrap();
-        assert_eq!(round, assessment);
+            serde_json::from_value(serde_json::to_value(&a).unwrap()).unwrap();
+        assert_eq!(round, a);
+    }
+
+    #[test]
+    fn completion_cannot_pass_an_unpassed_contract() {
+        for blocking in [ValidationStatus::Error, ValidationStatus::Failed] {
+            assert_eq!(
+                assessment(CompletionStatus::Complete).validate_against(&validation(blocking)),
+                Err(RecordValidationError::invariant(
+                    "outcome.completion_cannot_pass_an_unpassed_contract"
+                )),
+                "{blocking:?} must block a complete verdict"
+            );
+            // Not complete is fine against the same verdict.
+            assert!(
+                assessment(CompletionStatus::Incomplete)
+                    .validate_against(&validation(blocking))
+                    .is_ok()
+            );
+            assert!(
+                assessment(CompletionStatus::Unknown)
+                    .validate_against(&validation(blocking))
+                    .is_ok()
+            );
+        }
+        // A passed contract permits completion; a skipped one says nothing.
+        for permitted in [ValidationStatus::Passed, ValidationStatus::Skipped] {
+            assert!(
+                assessment(CompletionStatus::Complete)
+                    .validate_against(&validation(permitted))
+                    .is_ok(),
+                "{permitted:?} must not block completion"
+            );
+        }
+    }
+
+    #[test]
+    fn correctness_is_unconstrained_by_the_contract_verdict() {
+        // The dimensions stay independent: a passing contract does not make the
+        // outcome correct, and an incorrect outcome is still representable.
+        let mut a = assessment(CompletionStatus::Complete);
+        a.correctness_assessment.status = CorrectnessStatus::Incorrect;
+        assert!(
+            a.validate_against(&validation(ValidationStatus::Passed))
+                .is_ok()
+        );
     }
 }

--- a/stella-core/src/context_record/representation.rs
+++ b/stella-core/src/context_record/representation.rs
@@ -105,7 +105,7 @@ impl InlineContentRequirement {
 }
 
 /// The content-carrying fields of a frame, for validating the representation
-/// requirement matrix (lifecycle §10.1 table).
+/// requirement matrix (lifecycle §10.2 table).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FrameContentSpec {
     /// How content is carried.
@@ -115,22 +115,41 @@ pub struct FrameContentSpec {
     pub content: Option<String>,
     /// The fidelity of the carried content.
     pub content_fidelity: ContentFidelity,
-    /// Hash of the canonical source content.
+    /// Hash of the inline content as carried (absent for `reference`, which
+    /// carries none).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub content_hash: Option<String>,
+    /// Hash of the canonical source content. Required for every representation
+    /// — it is what makes a compacted or referenced item verifiable.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub canonical_content_hash: Option<String>,
     /// A resolvable reference to the canonical content.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_ref: Option<String>,
-    /// The transform applied (required for `compact`).
+    /// The transform applied (required for `compact`, absent otherwise).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub transform: Option<String>,
 }
 
 impl FrameContentSpec {
-    /// Validate the representation requirement matrix and the
-    /// "reference has no inline-content placeholder" rule.
+    /// Validate the §10.2 representation requirement matrix — **both** its
+    /// *required* and its *omitted* cells — plus the "a reference representation
+    /// has no inline-content placeholder" rule.
+    ///
+    /// | property | full | compact | reference |
+    /// |---|---|---|---|
+    /// | `content_fidelity` | exact | exact/normalized/summarized | omitted |
+    /// | `content` | required | required | omitted |
+    /// | `content_hash` | required | required | omitted |
+    /// | `canonical_content_hash` | required | required | required |
+    /// | `content_ref` | optional | required | required |
+    /// | `transform` | omitted | required | omitted |
     pub fn validate(&self) -> Result<(), RecordValidationError> {
         let inv = RecordValidationError::invariant;
+        // Required for every representation.
+        if self.canonical_content_hash.is_none() {
+            return Err(inv("representation.requires_canonical_content_hash"));
+        }
         match self.representation {
             Representation::Full => {
                 if self.content_fidelity != ContentFidelity::Exact {
@@ -139,8 +158,11 @@ impl FrameContentSpec {
                 if self.content.is_none() {
                     return Err(inv("representation.full_requires_inline_content"));
                 }
-                if self.canonical_content_hash.is_none() {
-                    return Err(inv("representation.requires_canonical_content_hash"));
+                if self.content_hash.is_none() {
+                    return Err(inv("representation.full_requires_content_hash"));
+                }
+                if self.transform.is_some() {
+                    return Err(inv("representation.full_forbids_transform"));
                 }
             }
             Representation::Compact => {
@@ -150,8 +172,8 @@ impl FrameContentSpec {
                 if self.content.is_none() {
                     return Err(inv("representation.compact_requires_inline_content"));
                 }
-                if self.canonical_content_hash.is_none() {
-                    return Err(inv("representation.requires_canonical_content_hash"));
+                if self.content_hash.is_none() {
+                    return Err(inv("representation.compact_requires_content_hash"));
                 }
                 if self.content_ref.is_none() {
                     return Err(inv("representation.compact_requires_content_ref"));
@@ -168,11 +190,14 @@ impl FrameContentSpec {
                 if self.content_fidelity != ContentFidelity::Omitted {
                     return Err(inv("representation.reference_requires_omitted_fidelity"));
                 }
-                if self.canonical_content_hash.is_none() {
-                    return Err(inv("representation.requires_canonical_content_hash"));
+                if self.content_hash.is_some() {
+                    return Err(inv("representation.reference_forbids_content_hash"));
                 }
                 if self.content_ref.is_none() {
                     return Err(inv("representation.reference_requires_content_ref"));
+                }
+                if self.transform.is_some() {
+                    return Err(inv("representation.reference_forbids_transform"));
                 }
             }
         }
@@ -221,8 +246,33 @@ mod tests {
             representation: Representation::Full,
             content: Some("hello".into()),
             content_fidelity: ContentFidelity::Exact,
+            content_hash: Some("sha256:bb".into()),
             canonical_content_hash: Some("sha256:aa".into()),
             content_ref: None,
+            transform: None,
+        }
+    }
+
+    fn compact() -> FrameContentSpec {
+        FrameContentSpec {
+            representation: Representation::Compact,
+            content: Some("short".into()),
+            content_fidelity: ContentFidelity::Summarized,
+            content_hash: Some("sha256:bb".into()),
+            canonical_content_hash: Some("sha256:aa".into()),
+            content_ref: Some("ref://x".into()),
+            transform: Some("truncate".into()),
+        }
+    }
+
+    fn reference() -> FrameContentSpec {
+        FrameContentSpec {
+            representation: Representation::Reference,
+            content: None,
+            content_fidelity: ContentFidelity::Omitted,
+            content_hash: None,
+            canonical_content_hash: Some("sha256:aa".into()),
+            content_ref: Some("ref://x".into()),
             transform: None,
         }
     }
@@ -246,21 +296,21 @@ mod tests {
                 "representation.full_requires_inline_content"
             ))
         );
+        let mut f = full();
+        f.content_hash = None;
+        assert_eq!(
+            f.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.full_requires_content_hash"
+            ))
+        );
     }
 
     #[test]
     fn reference_has_no_inline_content_placeholder() {
-        let good = FrameContentSpec {
-            representation: Representation::Reference,
-            content: None,
-            content_fidelity: ContentFidelity::Omitted,
-            canonical_content_hash: Some("sha256:aa".into()),
-            content_ref: Some("ref://x".into()),
-            transform: None,
-        };
-        assert!(good.validate().is_ok());
+        assert!(reference().validate().is_ok());
         // An empty-string content is the exact anti-pattern the rule forbids.
-        let mut bad = good.clone();
+        let mut bad = reference();
         bad.content = Some(String::new());
         assert_eq!(
             bad.validate(),
@@ -272,16 +322,8 @@ mod tests {
 
     #[test]
     fn compact_requires_refs_and_transform() {
-        let base = FrameContentSpec {
-            representation: Representation::Compact,
-            content: Some("short".into()),
-            content_fidelity: ContentFidelity::Summarized,
-            canonical_content_hash: Some("sha256:aa".into()),
-            content_ref: Some("ref://x".into()),
-            transform: Some("truncate".into()),
-        };
-        assert!(base.validate().is_ok());
-        let mut no_transform = base.clone();
+        assert!(compact().validate().is_ok());
+        let mut no_transform = compact();
         no_transform.transform = None;
         assert_eq!(
             no_transform.validate(),
@@ -289,6 +331,65 @@ mod tests {
                 "representation.compact_requires_transform"
             ))
         );
+        let mut no_hash = compact();
+        no_hash.content_hash = None;
+        assert_eq!(
+            no_hash.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.compact_requires_content_hash"
+            ))
+        );
+        // Compact keeps its fidelity freedom: exact is as legal as summarized.
+        let mut exact = compact();
+        exact.content_fidelity = ContentFidelity::Exact;
+        assert!(exact.validate().is_ok());
+    }
+
+    #[test]
+    fn the_matrix_omitted_cells_are_enforced_not_just_the_required_ones() {
+        // A cell the table marks "omitted" must actually be rejected when
+        // present — otherwise half the matrix is unenforced.
+        let mut full_with_transform = full();
+        full_with_transform.transform = Some("truncate".into());
+        assert_eq!(
+            full_with_transform.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.full_forbids_transform"
+            ))
+        );
+
+        let mut reference_with_transform = reference();
+        reference_with_transform.transform = Some("truncate".into());
+        assert_eq!(
+            reference_with_transform.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.reference_forbids_transform"
+            ))
+        );
+
+        let mut reference_with_content_hash = reference();
+        reference_with_content_hash.content_hash = Some("sha256:bb".into());
+        assert_eq!(
+            reference_with_content_hash.validate(),
+            Err(RecordValidationError::invariant(
+                "representation.reference_forbids_content_hash"
+            ))
+        );
+    }
+
+    #[test]
+    fn every_representation_requires_a_canonical_content_hash() {
+        for mut spec in [full(), compact(), reference()] {
+            let representation = spec.representation;
+            spec.canonical_content_hash = None;
+            assert_eq!(
+                spec.validate(),
+                Err(RecordValidationError::invariant(
+                    "representation.requires_canonical_content_hash"
+                )),
+                "{representation:?} must require canonical_content_hash"
+            );
+        }
     }
 
     #[test]

--- a/stella-protocol/Cargo.toml
+++ b/stella-protocol/Cargo.toml
@@ -16,3 +16,6 @@ async-trait.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+# Test-only: pins the golden RFC 8785 (JCS) bytes of the lifecycle event bodies.
+# Same crate + version stella-core hashes with, so the preimages agree.
+serde_json_canonicalizer.workspace = true

--- a/stella-protocol/src/context_event.rs
+++ b/stella-protocol/src/context_event.rs
@@ -214,8 +214,10 @@ pub struct MissingContextDetected {
 pub struct ArtifactContractSelected {
     /// The selected contract record id.
     pub contract_record_id: String,
-    /// The exact contract version selected.
-    pub contract_version: String,
+    /// The exact contract version selected. An integer, matching the record's
+    /// own `version` — the identity is only stable if both sides agree on the
+    /// type, so this is the one non-string id here.
+    pub contract_version: u32,
 }
 
 /// Stable-ID payload of `contract_validation_completed`.
@@ -313,6 +315,140 @@ mod tests {
         // as Unknown rather than panicking the decoder.
         let env = envelope(event_type::OBSERVATION_RECORDED, json!({ "wrong": true }));
         assert!(matches!(env.decode(), LifecycleEvent::Unknown { .. }));
+    }
+
+    /// The RFC 8785 (JCS) canonical bytes of a value — the same canonicalizer
+    /// crate + version `stella-core::context_record::hash` builds `record_hash`
+    /// preimages with, so an event body's bytes here and there agree.
+    fn jcs<T: Serialize>(value: &T) -> String {
+        serde_json_canonicalizer::to_string(value).expect("canonicalizes")
+    }
+
+    #[test]
+    fn golden_jcs_vectors_for_every_event_body() {
+        // Golden vectors: the exact canonical bytes of each event body. Keys are
+        // sorted and whitespace minimal, so these are hand-verifiable. Renaming,
+        // retyping, adding, or reordering a field breaks exactly one line —
+        // which is the point: these bodies are a wire contract across replays.
+        assert_eq!(
+            jcs(&ObservationRecorded {
+                observation_id: "obs_1".into(),
+                observation_kind: "tool_failure".into(),
+            }),
+            r#"{"observation_id":"obs_1","observation_kind":"tool_failure"}"#
+        );
+        assert_eq!(
+            jcs(&RecordProposalCreated {
+                proposal_id: "prop_1".into(),
+                proposal_kind: "new_record".into(),
+            }),
+            r#"{"proposal_id":"prop_1","proposal_kind":"new_record"}"#
+        );
+        assert_eq!(
+            jcs(&PromotionRecorded {
+                promotion_event_id: "pev_1".into(),
+                source_record_id: "rec_1".into(),
+                result_record_id: "rec_2".into(),
+                action: "accept".into(),
+            }),
+            r#"{"action":"accept","promotion_event_id":"pev_1","result_record_id":"rec_2","source_record_id":"rec_1"}"#
+        );
+        assert_eq!(
+            jcs(&ContextUseRecorded {
+                context_use_id: "cu_1".into(),
+                context_record_id: "rec_1".into(),
+                use_trace_id: "ut_1".into(),
+            }),
+            r#"{"context_record_id":"rec_1","context_use_id":"cu_1","use_trace_id":"ut_1"}"#
+        );
+        assert_eq!(
+            jcs(&ContextUseFeedbackRecorded {
+                context_use_feedback_id: "cuf_1".into(),
+                context_use_id: "cu_1".into(),
+            }),
+            r#"{"context_use_feedback_id":"cuf_1","context_use_id":"cu_1"}"#
+        );
+        assert_eq!(
+            jcs(&MissingContextDetected {
+                missing_context_id: "mc_1".into(),
+                missing_context_kind: "absent_directive".into(),
+            }),
+            r#"{"missing_context_id":"mc_1","missing_context_kind":"absent_directive"}"#
+        );
+        assert_eq!(
+            jcs(&ArtifactContractSelected {
+                contract_record_id: "ctr_1".into(),
+                contract_version: 3,
+            }),
+            r#"{"contract_record_id":"ctr_1","contract_version":3}"#
+        );
+        assert_eq!(
+            jcs(&ContractValidationCompleted {
+                contract_validation_id: "cv_1".into(),
+                contract_record_id: "ctr_1".into(),
+                validation_status: "passed".into(),
+            }),
+            r#"{"contract_record_id":"ctr_1","contract_validation_id":"cv_1","validation_status":"passed"}"#
+        );
+        assert_eq!(
+            jcs(&OutcomeAssessed {
+                outcome_assessment_id: "oa_1".into(),
+            }),
+            r#"{"outcome_assessment_id":"oa_1"}"#
+        );
+        assert_eq!(
+            jcs(&CompiledContextFrameBuilt {
+                compiled_frame_id: "cf_1".into(),
+                frame_hash: "sha256:aa".into(),
+            }),
+            r#"{"compiled_frame_id":"cf_1","frame_hash":"sha256:aa"}"#
+        );
+    }
+
+    #[test]
+    fn golden_jcs_vector_for_the_envelope() {
+        // The envelope's own canonical bytes, with an absent identity field
+        // omitted (never serialized as null, which would change the preimage).
+        let env = envelope(
+            event_type::OUTCOME_ASSESSED,
+            json!({ "outcome_assessment_id": "oa_1" }),
+        );
+        assert_eq!(
+            jcs(&env),
+            r#"{"event_id":"evt_1","event_type":"outcome_assessed","observed_at":"2026-07-20T18:30:00Z","payload":{"outcome_assessment_id":"oa_1"},"schema_version":"1.0-draft","task_id":"task_1"}"#
+        );
+    }
+
+    #[test]
+    fn the_event_type_tokens_are_canonical() {
+        // The discriminator strings are a wire contract: a reader matches on
+        // them, so a rename silently reroutes an event to Unknown.
+        assert_eq!(
+            [
+                event_type::OBSERVATION_RECORDED,
+                event_type::RECORD_PROPOSAL_CREATED,
+                event_type::PROMOTION_RECORDED,
+                event_type::CONTEXT_USE_RECORDED,
+                event_type::CONTEXT_USE_FEEDBACK_RECORDED,
+                event_type::MISSING_CONTEXT_DETECTED,
+                event_type::ARTIFACT_CONTRACT_SELECTED,
+                event_type::CONTRACT_VALIDATION_COMPLETED,
+                event_type::OUTCOME_ASSESSED,
+                event_type::COMPILED_CONTEXT_FRAME_BUILT,
+            ],
+            [
+                "observation_recorded",
+                "record_proposal_created",
+                "promotion_recorded",
+                "context_use_recorded",
+                "context_use_feedback_recorded",
+                "missing_context_detected",
+                "artifact_contract_selected",
+                "contract_validation_completed",
+                "outcome_assessed",
+                "compiled_context_frame_built",
+            ]
+        );
     }
 
     #[test]

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -39,6 +39,7 @@ pub use completion::{
     CompletionMessage, CompletionRequest, CompletionResult, CompletionUsage, FinishReason,
     GenerationParams, MessageRole, ReasoningEffort, ServiceTier, Verbosity,
 };
+pub use context_event::{LifecycleEvent, LifecycleEventEnvelope};
 pub use error::ProviderError;
 pub use event::{
     AgentEvent, BlockKind, BlockOrigin, BudgetMode, BudgetScope, CacheZone, CiStatus,


### PR DESCRIPTION
## Why these issues were still open

PR #498 landed the installment 3–5 type layer with a single `Closes #470, #471, #472, #473`. GitHub honors the closing keyword only on the **first** reference, so #470 closed and #471/#472/#473 stayed open. This PR uses the keyword on each.

They were right to stay open. Auditing the landed code against the three issue bodies and the normative spec (`stella-adaptive-context-lifecycle.md` §8.12–8.14, §10.2) turned up deliverables each issue explicitly asks for that were not there.

## Installment 3 — artifact contracts + outcome assessments (#471)

| issue asks for | was | now |
|---|---|---|
| `ArtifactContract(… applies_when … presentation …)` | both fields absent | added |
| "exactly one result per requirement, no duplicate/unknown ids ⇒ else `error`" | duplicates only; coverage deferred as "the repository's job" | enforced whole, purely |
| unknown kinds "non-executable and **fail closed** when required" | `is_recognized` predicate, no rule | enforced |
| "(completion cannot pass)" | no link at all between the two records | enforced |

**The deferral was unnecessary.** Coverage was documented as referential and pushed to a future repository, but purity is about I/O, not arity: the rule needs only the contract *value* beside the validation *value*. It is now `ContractValidation::validate_against(&contract)` — still pure, still I/O-free. Only rules needing identity *resolution* ("does this id name a record that exists?") genuinely belong to Phase 2/3, and the module docs now draw that line explicitly.

**Two wire-shape divergences fixed while the types are still inert** — both change the `record_hash` JCS preimage, so they are free now and expensive after anything persists:
- `version` was a `String`; the spec writes `"version": 3`. A string version silently forks the digest from every other producer.
- `Requirement`'s kind-specific fields (`path`, `glob`, `argv`, …) were nested under `params`; the spec puts them inline beside the common fields. Now `#[serde(flatten)]`.

Also: `ContractValidation`/`OutcomeAssessment` gain the record fields their siblings already carry (`contract_hash`, `scope`, `sharing_scope`, `evidence_links`, `task_id`, `reasons`), and a contract now rejects duplicate `requirement_id`s — the precondition that makes the coverage rule meaningful.

On "completion cannot pass": `error` and `failed` both block a `complete` verdict (§8.13 for error; §8.12 "do not declare completion until the artifact contract passes" for failed). `skipped` deliberately does not — a contract that did not apply says nothing about completion. Correctness is untouched; the dimensions stay independent.

## Installment 4 — frame representation / content fidelity (#472)

The §10.2 matrix was **half enforced**: the required cells were checked, the *omitted* cells were not, so a `full` frame carrying a `transform`, or a `reference` carrying a `content_hash`, validated clean. The `content_hash` field was missing from the struct entirely.

Now: `content_hash` added; `transform` forbidden on `full` and `reference`; `content_hash` forbidden on `reference`; `canonical_content_hash` required for all three (it is what makes a compacted or referenced item verifiable). The matrix is reproduced as a doc table on the validator.

## Installment 5 — protocol events (#473)

The envelope, the unknown-tolerant decoder, and the future-event witness all landed correctly. Missing was the issue's last clause: **"Golden JCS vectors for the event bodies."** Added — canonical bytes pinned for all ten bodies plus the envelope, using the same canonicalizer crate + version `stella-core` hashes with (added test-only, so the crate's public dependency surface is unchanged), so an event body's preimage agrees across both crates.

Also pins the ten `event_type` discriminator tokens: a rename there does not fail loudly, it silently reroutes a known event to `Unknown` — exactly the failure the tolerant decoder is designed to absorb, and therefore the one a test has to catch. `ArtifactContractSelected.contract_version` becomes an integer to match the record it names.

## Incidental

- The `context_record` module docs still announced installments 2–5 as "not here yet" and the module as not satisfying the Phase 1 gate. Refreshed, including which Phase 1 line items remain (the ingestion-boundary adapters, which need the ingestion path and land with the Phase 2 migration).
- Re-exported `FrameContentSpec`, `validate_directive_minimum_fidelity`, `CompletionAssessment`/`CorrectnessAssessment`/`OutcomeReason`, `AppliesWhen`/`Presentation`, and `LifecycleEvent`/`LifecycleEventEnvelope` — the main validator type of installment 4 was reachable only by full path while all its sibling enums were re-exported.
- **`cargo fmt --all --check` was already red on `main`** (a double blank line in `stella-core/src/accounted_call.rs`, from 0500d25). `cargo fmt` fixed it as a side effect; the one-line whitespace change is included so the gate is green.

## Verification

| check | result |
|---|---|
| `cargo fmt --all --check` | clean (was **red on main** before this PR) |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean, exit 0 |
| `cargo test --workspace` | green, 0 failures |
| `context_record` tests | 41 → **51** |
| `stella-protocol` tests | 64 → **67** |

**Zero behavior change:** no production code imports `context_record` or `context_event` — they stay inert until a later phase wires them. Verified by grep; the only non-test references are the module declarations themselves.

Closes #471. Closes #472. Closes #473.
