### PR TITLE
fix(stella-cli): refuse loader and interpreter names from a project .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,13 @@ into the environment at startup, most-specific file first. Template files
 (`.env.example`, `.env.sample`, `.env.dist`) and non-`.local` mode files
 (`.env.production`) are never read. **Your live shell always wins** — a value
 already exported (or `OPENROUTER_API_KEY=… stella …`) is never overwritten by a
-file, so unset a stale export if you mean to switch. Disable the whole mechanism
-with `STELLA_NO_ENV_FILE=1`; see what loaded with `STELLA_ENV_DEBUG=1`.
+file, so unset a stale export if you mean to switch. A small deny-list of
+loader, interpreter and VCS command-execution names (`LD_*`, `DYLD_*`,
+`BASH_ENV`, `NODE_OPTIONS`, `PYTHONPATH`, `GIT_SSH*`, `RUSTC_WRAPPER`, `PATH`, …)
+is **never applied** from a project file — a cloned repo must not be able to
+redirect which programs run — and `stella config` names anything it refused.
+Disable the whole mechanism with `STELLA_NO_ENV_FILE=1`; see what loaded with
+`STELLA_ENV_DEBUG=1`.
 
 ```bash
 stella models    # list providers, models, and key status

--- a/docs/design/enterprise-authority-telemetry.md
+++ b/docs/design/enterprise-authority-telemetry.md
@@ -118,8 +118,10 @@ references, allowed event classes, the closed provider/model catalog,
 process-free isolation, issue time, and expiry. The administrator-managed file
 is opened without following a terminal symlink and must be an owner/root-owned,
 single-link regular file that is not group/other writable. Privileged startup
-environment values and credential references are snapshotted before project
-dotenv loading and restored afterward. Invalid enrollment bytes cannot register
+environment values, credential references, and the exact
+loader/interpreter/VCS command-execution names a project dotenv file may never
+set are snapshotted before project dotenv loading and restored afterward.
+Invalid enrollment bytes cannot register
 arbitrary scrub names. Every delivery rechecks expiry and credential-domain
 separation.
 

--- a/stella-cli/src/credential_status.rs
+++ b/stella-cli/src/credential_status.rs
@@ -90,20 +90,28 @@ pub fn provider_config_for(id: &str, settings: &Settings) -> ProviderConfig {
 }
 
 /// A one-line summary of which project `.env*` files contributed which
-/// variable NAMES (never values) — the same information `STELLA_ENV_DEBUG`
-/// prints to stderr, but surfaced unconditionally in `stella config` rather
-/// than gated behind that flag. `None` when nothing was loaded.
+/// variable NAMES (never values), plus any name the deny-list refused to apply
+/// and the file that named it — the same information `STELLA_ENV_DEBUG` prints
+/// to stderr, but surfaced unconditionally in `stella config` rather than
+/// gated behind that flag. `None` when nothing was loaded and nothing was
+/// refused.
 pub fn env_files_summary(loaded: &Loaded) -> Option<String> {
-    if loaded.names.is_empty() {
-        return None;
+    let mut parts = Vec::new();
+    if !loaded.names.is_empty() {
+        let files = loaded
+            .files
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        parts.push(format!("{files} ({})", loaded.names.join(", ")));
     }
-    let files = loaded
-        .files
-        .iter()
-        .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    Some(format!("{files} ({})", loaded.names.join(", ")))
+    // A refused name is reported even when the file contributed nothing else,
+    // so "my .env is being ignored" always has a visible answer.
+    if let Some(refused) = loaded.refused_summary() {
+        parts.push(format!("refused (never applied): {refused}"));
+    }
+    (!parts.is_empty()).then(|| parts.join(" — "))
 }
 
 /// The display label for a resolved [`CredentialSource`]: which env var
@@ -247,6 +255,7 @@ mod tests {
             name_files: [("STELLA_TEST_LABEL_B_KEY".to_string(), local_file)]
                 .into_iter()
                 .collect(),
+            ..Default::default()
         };
         assert_eq!(
             label_for(&provider, CredentialSource::EnvVar, Some(&loaded)),
@@ -282,6 +291,7 @@ mod tests {
             ],
             names: vec!["OPENROUTER_API_KEY".to_string(), "FOO".to_string()],
             name_files: Default::default(),
+            refused: Default::default(),
         };
         let summary = env_files_summary(&loaded).unwrap();
         assert!(summary.contains(".env.local"));
@@ -293,6 +303,19 @@ mod tests {
     #[test]
     fn env_files_summary_is_none_when_nothing_loaded() {
         assert!(env_files_summary(&Loaded::default()).is_none());
+    }
+
+    #[test]
+    fn env_files_summary_reports_refusals_even_when_nothing_else_loaded() {
+        let loaded = Loaded {
+            refused: [("LD_PRELOAD".to_string(), PathBuf::from("/proj/.env.local"))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let summary = env_files_summary(&loaded).unwrap();
+        assert!(summary.contains("LD_PRELOAD"), "{summary}");
+        assert!(summary.contains(".env.local"), "{summary}");
     }
 
     // provider_config_for: unknown-id fallback for `stella auth list`

--- a/stella-cli/src/enterprise_telemetry.rs
+++ b/stella-cli/src/enterprise_telemetry.rs
@@ -437,9 +437,23 @@ pub(crate) struct StartupAuthoritySnapshot {
 }
 
 impl StartupAuthoritySnapshot {
+    /// The privileged control names, the loader/interpreter/VCS
+    /// command-execution names a project dotenv file may never set
+    /// (`env_files::DENIED_ENV_NAMES`), and any managed credential reference.
+    ///
+    /// The dotenv loader already refuses those names outright — the same trust
+    /// posture `.stella/mcp.toml` gets in `agent::load_mcp_plan` ("a cloned
+    /// repo's .stella/mcp.toml can name an arbitrary stdio command — RCE on
+    /// `git clone && stella`"). Snapshotting them as well means a *second*
+    /// loader, one that does not report the names it parsed, still cannot
+    /// reopen the hole. A snapshot is a concrete set of names, so it can only
+    /// cover the exact-name subset: the wildcard shapes (`LD_*`, `DYLD_*`,
+    /// `GIT_SSH*`, `GIT_CONFIG_*`, `CARGO_*_RUNNER`) are covered by
+    /// `env_files::is_denied_env_name` alone.
     pub(crate) fn capture(managed: Option<&Value>) -> Self {
         let mut names: BTreeSet<String> = PRIVILEGED_ENV_NAMES
             .iter()
+            .chain(crate::env_files::DENIED_ENV_NAMES.iter())
             .map(|name| (*name).to_string())
             .collect();
         if let Some(raw) = managed {

--- a/stella-cli/src/enterprise_telemetry_tests.rs
+++ b/stella-cli/src/enterprise_telemetry_tests.rs
@@ -472,6 +472,38 @@ fn pre_dotenv_snapshot_restores_every_privileged_control_and_credential_ref() {
 }
 
 #[test]
+fn pre_dotenv_snapshot_restores_loader_and_interpreter_control_names() {
+    let _env = crate::test_env::lock();
+    // Exact deny-list names only: a snapshot holds concrete names, so the
+    // wildcard shapes (`LD_*`, `CARGO_*_RUNNER`, …) are the dotenv loader's
+    // job, not this one.
+    let names = [
+        "BASH_ENV",
+        "SHELLOPTS",
+        "NODE_OPTIONS",
+        "PYTHONPATH",
+        "RUSTC_WRAPPER",
+        "GIT_ASKPASS",
+    ];
+    let _restore = EnvRestore::capture(&names);
+    for name in names {
+        unsafe { std::env::remove_var(name) };
+    }
+    let snapshot = StartupAuthoritySnapshot::capture(None);
+    for name in names {
+        unsafe { std::env::set_var(name, format!("project-{name}")) };
+    }
+    let rejected = snapshot.restore_after_project_env(&names.map(str::to_string));
+    assert_eq!(rejected.len(), names.len());
+    for name in names {
+        assert!(
+            std::env::var_os(name).is_none(),
+            "project value survived: {name}"
+        );
+    }
+}
+
+#[test]
 fn invalid_enrollment_cannot_register_arbitrary_scrub_names() {
     let arbitrary = "STELLA_ATTACKER_CHOSEN_SCRUB_TARGET";
     assert!(!stella_tools::exec::is_sensitive_env_name(arbitrary));

--- a/stella-cli/src/env_files.rs
+++ b/stella-cli/src/env_files.rs
@@ -23,6 +23,15 @@
 //!   is applied first and application never overwrites, so it wins over the
 //!   less specific. (Consequence worth knowing: a value still *exported* in
 //!   your shell shadows a project file — unset it if you mean to switch.)
+//! - **Never applied**: a small deny-list of loader, interpreter and VCS
+//!   command-execution names ([`is_denied_env_name`]) — `LD_*`, `DYLD_*`,
+//!   `BASH_ENV`, `NODE_OPTIONS`, `GIT_SSH*`, `RUSTC_WRAPPER`, `PATH`, … A
+//!   cloned repository's dotenv file is untrusted input, and those names
+//!   redirect which program runs rather than configure Stella, so applying
+//!   one would turn `git clone && stella` into code execution — the same
+//!   threat the `.stella/mcp.toml` trust gate closes (`agent.rs`
+//!   `load_mcp_plan`). Refusals are recorded on [`Loaded::refused`] and shown
+//!   by `stella config`; the rest of the file still loads.
 //!
 //! Loading is confined to the current project: the search walks up from the
 //! working directory to the nearest ancestor that actually contains a
@@ -34,13 +43,84 @@
 //!
 //! Set `STELLA_NO_ENV_FILE=1` to disable the whole mechanism.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
 use crate::OutputFormat;
+
+/// Environment variable names a project dotenv file may never set, as exact
+/// names. The wildcard shapes live in [`DENIED_ENV_PREFIXES`] and
+/// [`DENIED_ENV_PREFIX_SUFFIX`]; [`is_denied_env_name`] is the whole policy.
+///
+/// `pub(crate)` because `enterprise_telemetry::StartupAuthoritySnapshot` also
+/// snapshots these names across dotenv loading — one list, policed twice,
+/// rather than two lists that can drift apart.
+pub(crate) const DENIED_ENV_NAMES: &[&str] = &[
+    // Shell entry points: a value here runs code in every shell Stella (or a
+    // tool it spawns) starts.
+    "BASH_ENV",
+    "ENV",
+    "SHELLOPTS",
+    "IFS",
+    // Which binary a name resolves to at all.
+    "PATH",
+    // Tool configuration that names a command to execute.
+    "RIPGREP_CONFIG_PATH",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_PAGER",
+    "GIT_EDITOR",
+    "GIT_ASKPASS",
+    "GIT_PROXY_COMMAND",
+    "GIT_TEMPLATE_DIR",
+    "GIT_ATTR_NOSYSTEM",
+    // Interpreter pre-load / module-resolution hooks.
+    "NODE_OPTIONS",
+    "NODE_REPL_EXTERNAL_MODULE",
+    "PYTHONSTARTUP",
+    "PYTHONPATH",
+    "PERL5OPT",
+    "RUBYOPT",
+    "RUSTC_WRAPPER",
+];
+
+/// Denied name prefixes: dynamic-loader injection (`LD_PRELOAD`,
+/// `DYLD_INSERT_LIBRARIES`, …), git's ssh program (`GIT_SSH`,
+/// `GIT_SSH_COMMAND`) and git's config redirection (`GIT_CONFIG_GLOBAL`,
+/// `GIT_CONFIG_COUNT`, …, which can inject any of the exec-bearing config
+/// keys).
+const DENIED_ENV_PREFIXES: &[&str] = &["LD_", "DYLD_", "GIT_SSH", "GIT_CONFIG_"];
+
+/// Denied `<prefix>…<suffix>` shapes: cargo's per-target runner
+/// (`CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER`) names the program cargo
+/// executes for a built binary.
+const DENIED_ENV_PREFIX_SUFFIX: &[(&str, &str)] = &[("CARGO_", "_RUNNER")];
+
+/// Whether a project dotenv file is forbidden from setting `name`.
+///
+/// These names decide *which program runs*, not how Stella behaves, so a
+/// cloned repository naming one is asking for code execution rather than for
+/// configuration — refuse it and let the rest of the file load (a deny-list,
+/// not an allow-list, because the whole point of the feature is that a project
+/// may carry arbitrary credentials).
+///
+/// Matching is ASCII case-insensitive, for parity with
+/// `stella_tools::exec::is_sensitive_env_name` and with Windows environment
+/// semantics, where `Path` and `PATH` are one variable.
+pub(crate) fn is_denied_env_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    DENIED_ENV_NAMES.contains(&upper.as_str())
+        || DENIED_ENV_PREFIXES
+            .iter()
+            .any(|prefix| upper.starts_with(prefix))
+        || DENIED_ENV_PREFIX_SUFFIX.iter().any(|(prefix, suffix)| {
+            upper.len() >= prefix.len() + suffix.len()
+                && upper.starts_with(prefix)
+                && upper.ends_with(suffix)
+        })
+}
 
 /// What a load pass applied, for an optional diagnostic line. `files` are the
 /// dotenv files that actually contributed at least one variable (most-specific
@@ -54,12 +134,32 @@ pub struct Loaded {
     /// display surface (`stella config`) attribute e.g. `OPENROUTER_API_KEY`
     /// to `.env.local` by name, rather than only "loaded from a dotenv file"
     /// in aggregate.
-    pub name_files: std::collections::BTreeMap<String, PathBuf>,
+    pub name_files: BTreeMap<String, PathBuf>,
+    /// Names a dotenv file asked for that [`is_denied_env_name`] refused,
+    /// mapped to the file that named them, so a user can find the offending
+    /// file. Refused names are never applied to the process environment.
+    pub refused: BTreeMap<String, PathBuf>,
 }
 
 impl Loaded {
     fn is_empty(&self) -> bool {
-        self.names.is_empty()
+        self.names.is_empty() && self.refused.is_empty()
+    }
+
+    /// A value-free rendering of what was refused and where it came from —
+    /// `LD_PRELOAD (.env.local), NODE_OPTIONS (.env)`. `None` when a project's
+    /// dotenv files named nothing on the deny-list.
+    pub fn refused_summary(&self) -> Option<String> {
+        if self.refused.is_empty() {
+            return None;
+        }
+        Some(
+            self.refused
+                .iter()
+                .map(|(name, path)| format!("{name} ({})", file_name_of(path)))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
     }
 
     /// The dotenv file that contributed `name`, if any — `None` when `name`
@@ -91,8 +191,8 @@ pub fn maybe_load() -> Loaded {
 
     let mut names = Vec::new();
     let mut files: Vec<PathBuf> = Vec::new();
-    let mut name_files = std::collections::BTreeMap::new();
-    for (key, value, path) in plan {
+    let mut name_files = BTreeMap::new();
+    for (key, value, path) in plan.assignments {
         // SAFETY: called only from `main` during single-threaded process
         // startup, before the tokio runtime or any worker threads exist — no
         // concurrent `getenv`/`setenv` can race this write.
@@ -107,20 +207,26 @@ pub fn maybe_load() -> Loaded {
         files,
         names,
         name_files,
+        refused: plan.refused,
     }
 }
 
-/// The ordered list of assignments a load would apply, given a predicate for
-/// "this name is already set" (the live environment, in production). Pure over
-/// the filesystem + predicate — no process-environment mutation — so the
-/// precedence and shell-wins rules are unit-testable without env races.
-fn plan_from(
-    start: &Path,
-    home: Option<&Path>,
-    is_set: impl Fn(&str) -> bool,
-) -> Vec<(String, String, PathBuf)> {
+/// What a load pass would do: the ordered assignments to apply, and the names
+/// the deny-list refused (each mapped to the file that named it).
+#[derive(Debug, Default)]
+struct Plan {
+    assignments: Vec<(String, String, PathBuf)>,
+    refused: BTreeMap<String, PathBuf>,
+}
+
+/// The [`Plan`] a load would carry out, given a predicate for "this name is
+/// already set" (the live environment, in production). Pure over the
+/// filesystem + predicate — no process-environment mutation — so the
+/// precedence, shell-wins and deny-list rules are unit-testable without env
+/// races.
+fn plan_from(start: &Path, home: Option<&Path>, is_set: impl Fn(&str) -> bool) -> Plan {
     let Some(base) = find_base(start, home) else {
-        return Vec::new();
+        return Plan::default();
     };
     let files = collect_files(&base);
     plan_assignments(&files, is_set)
@@ -220,13 +326,11 @@ fn classify(name: &str) -> Option<u8> {
 /// the first (most-specific) file that defines it and that neither the
 /// environment (`is_set`) nor an earlier file has already claimed — so the live
 /// shell wins over every file, and a more specific file wins over a less
-/// specific one.
-fn plan_assignments(
-    files: &[(u8, PathBuf)],
-    is_set: impl Fn(&str) -> bool,
-) -> Vec<(String, String, PathBuf)> {
+/// specific one. A name [`is_denied_env_name`] rejects is never applied at all,
+/// and is recorded in [`Plan::refused`] instead.
+fn plan_assignments(files: &[(u8, PathBuf)], is_set: impl Fn(&str) -> bool) -> Plan {
     let mut claimed: HashSet<String> = HashSet::new();
-    let mut out: Vec<(String, String, PathBuf)> = Vec::new();
+    let mut plan = Plan::default();
     for (_rank, path) in files {
         // dotenvy's parser (quotes, escapes, multi-line values, `export`
         // prefixes, `#` comments) as a non-mutating iterator — we apply our own
@@ -238,14 +342,22 @@ fn plan_assignments(
             let Ok((key, value)) = item else {
                 continue; // a malformed line must not abort the whole file
             };
+            // Deliberately ahead of the `is_set` filter: `PATH` and `IFS` are
+            // exported in every real shell, so testing "already set" first
+            // would drop them into the silent skip path and report nothing —
+            // a refusal the user never sees is not a refusal they can act on.
+            if is_denied_env_name(&key) {
+                plan.refused.entry(key).or_insert_with(|| path.clone());
+                continue;
+            }
             if is_set(&key) || claimed.contains(&key) {
                 continue;
             }
             claimed.insert(key.clone());
-            out.push((key, value, path.clone()));
+            plan.assignments.push((key, value, path.clone()));
         }
     }
-    out
+    plan
 }
 
 /// Emit a concise, value-free confirmation of what [`maybe_load`] applied —
@@ -262,17 +374,35 @@ pub fn announce(loaded: &Loaded, format: OutputFormat) {
     {
         return;
     }
-    let file_list = loaded
-        .files
-        .iter()
-        .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    eprintln!(
-        "{} {}",
-        "env:".dimmed(),
-        format!("loaded {} from {file_list}", loaded.names.join(", ")).dimmed(),
-    );
+    if !loaded.names.is_empty() {
+        let file_list = loaded
+            .files
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "{} {}",
+            "env:".dimmed(),
+            format!("loaded {} from {file_list}", loaded.names.join(", ")).dimmed(),
+        );
+    }
+    if let Some(refused) = loaded.refused_summary() {
+        eprintln!(
+            "{} {}",
+            "env:".dimmed(),
+            format!("refused (never applied): {refused}").dimmed(),
+        );
+    }
+}
+
+/// A dotenv file's bare name for display (`.env.local`), degrading to the full
+/// path when it has no valid-UTF-8 file name.
+fn file_name_of(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string())
 }
 
 #[cfg(test)]
@@ -321,6 +451,7 @@ mod tests {
         let plan = plan_assignments(&files, |k| shell.contains(k));
 
         let map: std::collections::HashMap<_, _> = plan
+            .assignments
             .iter()
             .map(|(k, v, _)| (k.clone(), v.clone()))
             .collect();
@@ -350,6 +481,7 @@ mod tests {
         let files = collect_files(d);
         let plan = plan_assignments(&files, |_| false);
         let map: std::collections::HashMap<_, _> = plan
+            .assignments
             .iter()
             .map(|(k, v, _)| (k.clone(), v.clone()))
             .collect();
@@ -393,6 +525,112 @@ mod tests {
         assert_eq!(find_base(home, Some(home)), None);
     }
 
+    // The deny-list: a cloned repo's dotenv file must not be able to redirect
+    // which program Stella (or anything it spawns) executes.
+
+    #[test]
+    fn loader_interpreter_and_vcs_exec_names_are_refused_while_the_rest_still_loads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path();
+        write(
+            d,
+            ".env",
+            "LD_PRELOAD=/tmp/evil.so\n\
+             DYLD_INSERT_LIBRARIES=/tmp/evil.dylib\n\
+             BASH_ENV=/tmp/evil.sh\n\
+             GIT_SSH_COMMAND=/tmp/evil\n\
+             GIT_CONFIG_COUNT=1\n\
+             NODE_OPTIONS=\"--require /tmp/evil.js\"\n\
+             PYTHONPATH=/tmp/evil\n\
+             RUSTC_WRAPPER=/tmp/evil\n\
+             CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=/tmp/evil\n\
+             PATH=/tmp/evil/bin\n\
+             ld_preload=/tmp/evil-lowercase.so\n\
+             OPENROUTER_API_KEY=sk-project\n",
+        );
+
+        let files = collect_files(d);
+        // `PATH` is exported in every real shell — the deny check must still
+        // report it, so it cannot hide behind the "already set" filter.
+        let plan = plan_assignments(&files, |k| k == "PATH");
+
+        let applied: Vec<&str> = plan
+            .assignments
+            .iter()
+            .map(|(k, _, _)| k.as_str())
+            .collect();
+        assert_eq!(
+            applied,
+            ["OPENROUTER_API_KEY"],
+            "only the credential may be applied"
+        );
+
+        for name in [
+            "LD_PRELOAD",
+            "DYLD_INSERT_LIBRARIES",
+            "BASH_ENV",
+            "GIT_SSH_COMMAND",
+            "GIT_CONFIG_COUNT",
+            "NODE_OPTIONS",
+            "PYTHONPATH",
+            "RUSTC_WRAPPER",
+            "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER",
+            "PATH",
+            "ld_preload",
+        ] {
+            assert!(
+                plan.refused.contains_key(name),
+                "{name} must be reported as refused"
+            );
+        }
+
+        let loaded = Loaded {
+            refused: plan.refused,
+            ..Default::default()
+        };
+        let summary = loaded.refused_summary().unwrap();
+        // Names and the offending file, never values.
+        assert!(summary.contains("LD_PRELOAD (.env)"), "{summary}");
+        assert!(!summary.contains("evil.so"), "{summary}");
+    }
+
+    #[test]
+    fn deny_list_matches_exact_prefix_and_wrapped_shapes_but_not_ordinary_names() {
+        for denied in [
+            "PATH",
+            "path",
+            "IFS",
+            "ENV",
+            "SHELLOPTS",
+            "LD_LIBRARY_PATH",
+            "DYLD_LIBRARY_PATH",
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_ASKPASS",
+            "RIPGREP_CONFIG_PATH",
+            "PERL5OPT",
+            "RUBYOPT",
+            "NODE_REPL_EXTERNAL_MODULE",
+            "PYTHONSTARTUP",
+            "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER",
+        ] {
+            assert!(is_denied_env_name(denied), "{denied} must be denied");
+        }
+        for allowed in [
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DATABASE_URL",
+            "STELLA_MODEL",
+            "LDAP_URL", // `LD_` is a prefix, `LDAP` is not
+            "GIT_AUTHOR_NAME",
+            "CARGO_TERM_COLOR",
+            "NODE_ENV",
+        ] {
+            assert!(!is_denied_env_name(allowed), "{allowed} must load");
+        }
+    }
+
     // Loaded::file_for (stella config's "which file, which name")
 
     #[test]
@@ -404,6 +642,7 @@ mod tests {
             name_files: [("OPENROUTER_API_KEY".to_string(), local.clone())]
                 .into_iter()
                 .collect(),
+            ..Default::default()
         };
         assert_eq!(loaded.file_for("OPENROUTER_API_KEY"), Some(local.as_path()));
         // A name that was never loaded from a dotenv file (a real shell

--- a/stella-core/src/accounted_call.rs
+++ b/stella-core/src/accounted_call.rs
@@ -14,7 +14,6 @@ use crate::event_sender::EventSender;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryPolicy, Sleeper, retry_with_backoff_observed};
 
-
 /// Where an auxiliary call sits in the receipt coordinate space, so the context
 /// it sent is reconstructable alongside the engine's own steps. `call_seq` must
 /// be unique within the execution (see `AgentEvent::StepManifest::call_seq`).

--- a/stella-docs/content/docs/getting-started/providers.mdx
+++ b/stella-docs/content/docs/getting-started/providers.mdx
@@ -70,7 +70,11 @@ For the selected provider, Stella resolves the API key in this order — **first
   **nearest-scope-wins** — confined to the enclosing git repository (never the home
   directory or above). It never loads `.env.example` or a committed `.env.<mode>`, an
   exported shell value always overrides a file value, and `STELLA_NO_ENV_FILE=1` disables
-  the whole mechanism.
+  the whole mechanism. A small deny-list of loader, interpreter and VCS
+  command-execution names (`LD_*`, `DYLD_*`, `BASH_ENV`, `NODE_OPTIONS`, `PYTHONPATH`,
+  `GIT_SSH*`, `RUSTC_WRAPPER`, `PATH`, ...) is **never applied** from a project file — a
+  cloned repo must not be able to redirect which programs run — and `stella config` names
+  anything it refused.
 </Callout>
 
 See [Credentials](/docs/configuration/credentials) for the file format and precedence


### PR DESCRIPTION
## What & why

A cloned repository's `.env` / `.env.local` was applied name-for-name into stella's own
process environment at startup (`env_files::maybe_load`, before `Cli::parse`), filtered
only on "already set in the live shell". Names such as `LD_PRELOAD`, `BASH_ENV`,
`GIT_SSH_COMMAND`, `NODE_OPTIONS`, `RUSTC_WRAPPER` and `PATH` do not configure Stella —
they decide *which program runs* — so `git clone && stella` was code execution for
anything Stella or a tool it spawns later exec'd. The privileged snapshot taken around the
load covered `STELLA_*`/proxy names only, and `is_sensitive_env_name` matches credential
suffixes, so neither clawed these back.

Closes #553

### Changed

- **`stella-cli/src/env_files.rs`** — added the deny-list the issue enumerates:
  `DENIED_ENV_NAMES` (exact names), `DENIED_ENV_PREFIXES` (`LD_`, `DYLD_`, `GIT_SSH`,
  `GIT_CONFIG_`) and `DENIED_ENV_PREFIX_SUFFIX` (`CARGO_*_RUNNER`), behind
  `is_denied_env_name`. Matching is ASCII case-insensitive, for parity with
  `stella_tools::exec::is_sensitive_env_name`.
  `plan_assignments` consults it **before** the existing `is_set(&key) || claimed` filter —
  `PATH` and `IFS` are exported in every real shell, so testing "already set" first would
  send them down the silent skip path and report nothing. The module doc comment now states
  the rule alongside the other three.
- **`stella-cli/src/env_files.rs`** — `Loaded` gains `refused: BTreeMap<String, PathBuf>`
  (name → the file that named it) and `refused_summary`; `is_empty` and `announce` were
  widened so a dotenv file containing *only* denied names is still reported rather than
  printing nothing. `plan_assignments`/`plan_from` now return a small `Plan` struct so the
  refusals travel with the assignments; they remain pure over the filesystem + an `is_set`
  predicate, so the tests still need no env lock.
- **`stella-cli/src/credential_status.rs`** — `env_files_summary` appends
  `refused (never applied): LD_PRELOAD (.env.local)` and no longer short-circuits on
  `names.is_empty`. Names and filenames only, never values — the function's existing
  contract. `stella config` picks this up through the existing call site, so `config.rs`
  needed no change.
- **`stella-cli/src/enterprise_telemetry.rs`** — `StartupAuthoritySnapshot::capture` now
  snapshots `PRIVILEGED_ENV_NAMES` **plus** `env_files::DENIED_ENV_NAMES`, so a second
  loader that does not report the names it parsed cannot reopen the hole. The doc comment
  references the `.stella/mcp.toml` gate (`agent::load_mcp_plan`) as the issue asks, and
  says plainly that a snapshot holds concrete names — the wildcard shapes (`LD_*`,
  `GIT_CONFIG_*`, `CARGO_*_RUNNER`) are covered by `is_denied_env_name` alone, not by the
  snapshot.
- **Docs** — README's "Project `.env` files" paragraph, the providers-doc dotenv callout,
  and the one design-doc sentence in `docs/design/enterprise-authority-telemetry.md` now
  state the rule, in wording consistent with the module doc.

The constant is shared `pub(crate)` rather than duplicated, so the loader and the snapshot
cannot drift apart. `stella-cli` is bin-only, so `Loaded` has no out-of-crate consumers.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, both in `stella-cli`:

- `env_files::tests::loader_interpreter_and_vcs_exec_names_are_refused_while_the_rest_still_loads`
  — a `.env` declaring `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`,
  `GIT_SSH_COMMAND`, `GIT_CONFIG_COUNT`, `NODE_OPTIONS`, `PYTHONPATH`, `RUSTC_WRAPPER`,
  `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER`, `PATH` and lowercase `ld_preload` plans
  **no** assignment for any of them, reports each as refused with its file, and still loads
  `OPENROUTER_API_KEY` from the same file. `PATH` is passed as already-set to pin the
  check-order decision. The summary is asserted to carry the name and the filename and
  **not** the value.
- `enterprise_telemetry_tests::pre_dotenv_snapshot_restores_loader_and_interpreter_control_names`
  — a project value for `BASH_ENV` / `SHELLOPTS` / `NODE_OPTIONS` / `PYTHONPATH` /
  `RUSTC_WRAPPER` / `GIT_ASKPASS` does not survive `restore_after_project_env`. Modelled on
  the existing `pre_dotenv_snapshot_restores_every_privileged_control_and_credential_ref`,
  including `test_env::lock` + `EnvRestore::capture`.

Verified as witnesses by disabling the deny branch in `plan_assignments` and removing the
`DENIED_ENV_NAMES` chain in `capture`: both tests fail (`549 passed; 2 failed`), and pass
once restored (`551 passed; 0 failed`).

Also added `deny_list_matches_exact_prefix_and_wrapped_shapes_but_not_ordinary_names`
(unit coverage of the three matcher shapes, including that `LDAP_URL`, `NODE_ENV`,
`GIT_AUTHOR_NAME` and `CARGO_TERM_COLOR` still load) and
`env_files_summary_reports_refusals_even_when_nothing_else_loaded`.

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli` — 551 passed + 3 integration, 0 failed
- [x] `make no-scratch` — OK
- [x] Docs updated (README, providers doc, design doc, module doc comment)
- [x] Commits signed off for DCO
- [x] `Closes #553` appears both above and as a commit trailer

Crate-scoped rather than workspace-wide: the only Rust changes are in `stella-cli`, which
is a bin-only crate that nothing depends on, and the remaining changes are Markdown/MDX.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Deferred

Everything the triage pass identified as out of scope, and why:

-  **Gating project `.env` loading behind `project_code_execution_trusted`** the way
  `.stella/mcp.toml` is. The issue's Summary frames the absent trust gate as the root
  cause, but its own Remediation deliberately does not ask for one — *"A deny-list is the
  pragmatic shape here because the whole point of the feature is arbitrary project
  credentials."* Adding the gate would silently stop loading every user's project API keys
  until they set `STELLA_TRUST_PROJECT=1`, breaking the behaviour README.md and the
  providers doc advertise. Product judgment, not a local fix.
-  **Broadening `is_sensitive_env_name`** (`stella-tools/src/subprocess_env.rs`) to also
  match loader/interpreter/VCS-exec names. The issue cites its narrow coverage as context
  but does not ask to change it, and that function drives what `scrub_sensitive_env`
  *removes* from every subprocess environment — adding `PATH` / `NODE_OPTIONS` / `LD_*`
  there would strip legitimate environment from every bash, hook, MCP stdio and custom-tool
  spawn in the workspace.
-  **Acting on the discarded `_rejected_privileged` return value** at `main.rs:1173`
  (e.g. warning when a repo tried to overwrite a privileged name). New unconditional
  startup output the issue does not request; it scopes reporting to the dotenv refusals via
  `Loaded` and `stella config`.
-  **Expanding the deny-list beyond the enumerated names** (Windows loader variables,
  `JAVA_TOOL_OPTIONS`, `LD_AUDIT` variants, `MallocLogFile`, …). Each addition is a
  judgment call about which legitimate project configurations to break. Implemented exactly
  the enumerated set; anything further is the owner's call in review.

## Anything reviewers should know?

The snapshot half is deliberately partial and documented as such: `capture` builds a
concrete `BTreeSet` of names, so it cannot express `LD_*` or `CARGO_*_RUNNER`. The
deny-list in `plan_assignments` is what covers the patterns; the snapshot is the belt to
its braces for the exact names. Adding `PATH` to the snapshot means it is restored to its
captured value after dotenv loading — a no-op in practice, since the loader now refuses to
set it in the first place.

`config.rs` and `main.rs` are untouched: the refusals ride inside the string
`env_files_summary` already returns, which keeps this PR's hunks clear of the other
in-flight branches touching those files.
