### PR TITLE
ci: scope workflow permissions and drop the dead cross build branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,6 +24,10 @@ concurrency:
   group: bench-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Checkout + uv sync + pytest only.
+permissions:
+  contents: read
+
 jobs:
   pytest:
     name: harbor_adapter + analyzer pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ concurrency:
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Both jobs only check out, build, and test — nothing here writes to the repo.
+# Without the key, GITHUB_TOKEN falls back to the repository default, which on
+# repos created before the 2023 default change is read/write on every scope.
+permissions:
+  contents: read
+
 jobs:
   check:
     name: fmt + clippy + test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Typecheck + build only — there is no Pages deploy here, so read is enough.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: typecheck + build

--- a/.github/workflows/normative-home.yml
+++ b/.github/workflows/normative-home.yml
@@ -21,6 +21,10 @@ on:
       - ".github/workflows/normative-home.yml"
   workflow_dispatch:
 
+# Checkout + one read-only shell check.
+permissions:
+  contents: read
+
 jobs:
   check:
     name: normative-home pin check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,15 +103,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release \
-              --target ${{ matrix.target }} \
-              --package stella-cli --bin stella
-          else
-            cargo build --release \
-              --target ${{ matrix.target }} \
-              --package stella-cli --bin stella
-          fi
+          # Every target builds with plain cargo: the two Apple targets share
+          # one universal Apple toolchain, and aarch64-linux builds natively on
+          # ubuntu-24.04-arm. `cross` was tried and abandoned (see the matrix
+          # comments above) and is installed by no step here.
+          cargo build --release \
+            --target ${{ matrix.target }} \
+            --package stella-cli --bin stella
 
       - name: Package tarball
         id: package


### PR DESCRIPTION
Closes #556

Two of the seven `area:ci` audit findings. Three more were **already fixed on `main`** before this branch was cut, and two are **deferred** — details below.

## What changed

### 1. Least-privilege `GITHUB_TOKEN` — item 5

Added a top-level `permissions: contents: read` block to `ci.yml`, `docs.yml`, `bench.yml`, and `normative-home.yml`.

I YAML-parsed all ten workflows: these were the only four with no `permissions` key at *any* level (top or job), so `GITHUB_TOKEN` fell back to the repository default — read/write on every scope for repos created before the 2023 default change.

None of the four needs more than read:

| Workflow | What its jobs actually do |
|---|---|
| `ci.yml` | checkout, `no-scratch`, fmt, clippy, test, release smoke build; `cargo deny` + `cargo audit` |
| `docs.yml` | checkout, pnpm install, `pnpm typecheck`, `pnpm build` — **no Pages deploy step**, the file ends at the build |
| `bench.yml` | checkout, `uv sync`, `pytest` |
| `normative-home.yml` | checkout, `bash scripts/check-normative-home.sh` |

The block is placed **top-level** (after `concurrency`, before `jobs:`), not per-job, so a future job inherits it by default. The shape matches `release.yml`, `live-smoke.yml`, and `dependency-review.yml` rather than inventing a new one.

### 2. Dead `cross` branch in the release build — item 7

Deleted the unreachable `if [ "${{ matrix.cross }}" = "true" ]` / `cross build` branch in `release.yml`'s "Build stella" step, keeping the plain `cargo build`.

No row in `strategy.matrix.include` defines a `cross` key, so the expression always interpolated to the empty string and the branch never ran. It was also a trap: a maintainer who added `cross: true` to a matrix row would have hit `cross: command not found`, since no step installs it — and the matrix comments directly above already explain at length why `cross` was abandoned for both targets. The surviving `cargo build` is unindented back out of the `if` body; `set -euo pipefail` is kept.

## Verification

No Rust, TypeScript, or Python source is touched, so there is no witness test to write (AGENTS.md: CI-only changes don't need one). What I ran instead:

- **All ten workflows re-parsed as YAML**, asserting the expected top-level `permissions` on each and that `matrix.cross` no longer appears anywhere in `release.yml`.
- **`release.yml`'s rewritten `run:` block rendered** with the `${{ matrix.target }}` expression substituted, then `bash -n` — the release path can't be exercised without cutting a tag, so this is the closest local proof that the re-indent didn't break the heredoc-style block.
- `cargo fmt --check` — pass.
- `make no-scratch` — pass.
- `make bench-test` — 226 passed (harbor_adapter) + 234 passed (terminal_bench_analysis).
- `pnpm install --frozen-lockfile && pnpm typecheck` — pass (exit 0).

Nice property of this diff: `docs.yml`, `bench.yml`, and `normative-home.yml` each trigger on their own path, so **this PR's own CI run exercises three of the four new permissions blocks**. `ci.yml` runs too, since `.github/workflows/**` is not in its `paths-ignore`.

## Rebase note

This branch was originally cut from a base that predated #575. Three items had already landed on `main` by the time I verified, and #575 renamed `stella-docs/` → `website/`, so the stale base would have reverted that rename inside `ci.yml`/`docs.yml`. I reset onto current `origin/main` and re-applied only what is genuinely still missing. The branch is now exactly one commit on top of `b5a99b4`.

## Issue checklist

- [x] **`.github/ISSUE_TEMPLATE/config.yml:4`** — docs contact link → `https://stella.oxagen.sh/docs`. **Already on `main`** — the link reads `https://stella.oxagen.sh/docs` today and `docs.oxagen.sh` has zero occurrences tree-wide (`rg -uu`). Nothing to change.
- [x] **`.github/ISSUE_TEMPLATE/config.yml:4`** (duplicate filing of the above) — same one-line fix, already on `main`.
-  **`.github/dependabot.yml:15`** — SHA-pin all 34 GitHub Actions refs + correct the "pinned in workflows" comment. **Deferred** — see below.
- [x] **`.github/workflows/ci.yml:7`** — add `docs/**`, `*.md`, `.github/ISSUE_TEMPLATE/**` to both `paths-ignore` blocks. **Already on `main`** — both blocks carry all three (plus `website/**` after the #575 rename), and the comment already documents that GitHub's `*` stops at `/`. Nothing to change.
- [x] **`.github/workflows/ci.yml:1`** — top-level `permissions: contents: read` on `ci.yml`, `docs.yml`, `bench.yml`, `normative-home.yml`. **Done in this PR.**
-  **`.github/workflows/release.yml:166`** — release signing / build provenance attestation. **Deferred** — see below.
- [x] **`.github/workflows/release.yml:105`** — delete the unreachable `cross build` branch. **Done in this PR.**

## Deferred

**SHA-pinning all 34 action references (+ the `dependabot.yml:15` comment).** The finding is accurate — I confirmed 34 of 34 `uses:` refs are floating tags or branches, `dtolnay/rust-toolchain@stable` being the sharpest — but it is not locally verifiable. A wrong SHA, or one that points at a tag object rather than a commit, fails every workflow at startup, and the blast radius covers `release.yml`, `live-smoke.yml` (secret-gated, cannot be exercised here), and `scorecard.yml`. Nothing in a local checkout can run a workflow to prove the pins resolve, and the repo has no actionlint target. The two halves are coupled: fixing the `dependabot.yml:15` comment alone either states a falsehood or documents the un-pinned status quo. This belongs in its own PR where a real CI run validates every pin.

**Build provenance attestation on the release job.** The `release` job only runs on `refs/tags/*`, so an `actions/attest-build-provenance` step can only be proven by publishing a real release. It also changes what a release *ships* (a new attestation artifact) and grants write-scoped OIDC to the publishing job. Whether to adopt provenance attestation, cosign, or minisign — and which version of the attest action to pin — is an owner/security-policy decision, and the issue's own rationale ties it to the unpinned-actions finding above. The cited state is accurate: `SHA256SUMS` is generated inside the same job that publishes, and that job's only permission is `contents: write`.
