### PR TITLE
stella-tui: duplicate pids make the resource monitor delete live processes, zeroing the AGENTS tab

### DIFF
--- a/stella-tui/src/resource.rs
+++ b/stella-tui/src/resource.rs
@@ -70,12 +70,24 @@ impl ResourceMonitor {
         // enumerate and stat every process on the machine once per second for
         // the life of the session. Built before `&mut self.sys` is taken so the
         // borrow of `model` ends first.
-        let pids: Vec<Pid> = model
+        let mut pids: Vec<Pid> = model
             .agents
             .iter()
             .filter_map(|a| a.meta.pid)
             .map(Pid::from_u32)
             .collect();
+        // MUST be deduplicated. Agents in one workspace routinely share a pid
+        // — the lead and every subagent register `std::process::id()` — and
+        // sysinfo's `Some(..)` arm walks the caller's slice verbatim, flipping
+        // each process's one-shot `updated` flag. The second visit to a
+        // repeated pid sees the flag already consumed, reads it as "did not
+        // refresh", and (with `remove_dead_processes = true`) evicts a LIVE
+        // process from the table — so `process()` below returns `None` and
+        // every agent renders 0% / 0 B. The old `ProcessesToUpdate::All` path
+        // used `retain()`, which visits each process exactly once and was
+        // structurally immune. Witness: `duplicate_pids_still_report_memory`.
+        pids.sort_unstable();
+        pids.dedup();
         if !pids.is_empty() {
             self.sys.refresh_processes_specifics(
                 ProcessesToUpdate::Some(&pids),
@@ -138,5 +150,44 @@ mod tests {
         monitor.sample(&mut model);
 
         assert!(model.agents[0].res.mem_bytes > 0);
+    }
+
+    /// Witness for the duplicate-pid regression: a lead plus subagents all
+    /// register the SAME `std::process::id()`, so the refresh list arrives as
+    /// `[P, P, P]`. sysinfo's `ProcessesToUpdate::Some` arm walks that slice
+    /// verbatim and consumes each process's one-shot `updated` flag, so the
+    /// second visit to `P` reads as "stale" and — with `remove_dead_processes`
+    /// on — deletes the live process from the table. Every agent then resolves
+    /// to `None` and the AGENTS tab renders 0% / 0 B for the whole deck.
+    ///
+    /// The single-pid test above cannot catch this: n = 1 is the only arity
+    /// that behaves correctly. Deduplicating before the refresh is what keeps
+    /// this green.
+    #[test]
+    fn duplicate_pids_still_report_memory() {
+        let mut monitor = ResourceMonitor::new();
+        let mut model = WorkspaceModel::new();
+
+        // Three agents, one shared pid — exactly what `command_deck.rs` and
+        // `subsession.rs` produce for a lead with two subagents.
+        let self_pid = std::process::id();
+        for (i, id) in ["lead", "sub-a", "sub-b"].iter().enumerate() {
+            let mut meta = AgentMeta::new(*id, format!("agent {i}"), 0);
+            meta.pid = Some(self_pid);
+            model.apply_inbound(&Inbound::Register(meta));
+        }
+        assert_eq!(model.agents.len(), 3, "all three agents registered");
+
+        monitor.sample(&mut model);
+
+        for agent in &model.agents {
+            assert!(
+                agent.res.mem_bytes > 0,
+                "agent {} zeroed: duplicate pids evicted the live process from \
+                 the sysinfo table (sample = {:?})",
+                agent.meta.id,
+                agent.res,
+            );
+        }
     }
 }


### PR DESCRIPTION
## What & why

**The AGENTS tab shows 0% CPU / 0 B MEM for every agent as soon as a deck has more than one agent.** Not stale numbers — hard zeros, permanently.

Regressed by **PR #602 (issue #571)**.

### Inputs → wrong behaviour

PR #602 narrowed `ResourceMonitor::sample` from `ProcessesToUpdate::All` to `ProcessesToUpdate::Some(&pids)` so the per-second refresh scales with the number of agents instead of the size of the machine's process table. **That optimization is correct and is kept here.** What was missed is that the pid list can — and in practice always does — contain duplicates.

Every agent in a workspace registers the *same* pid, `std::process::id`:

| site | who |
| --- | --- |
| `stella-cli/src/command_deck.rs:449` | lead, at boot |
| `stella-cli/src/command_deck.rs:1027` | lead, re-register on resume |
| `stella-cli/src/subsession.rs:391` | every subagent |

So an ordinary deck — a lead plus one subagent — builds `pids = [P, P]` at `stella-tui/src/resource.rs:73-78`, with no sort or dedup, and hands it straight to `refresh_processes_specifics(ProcessesToUpdate::Some(&pids), /* remove_dead_processes */ true, ..)`.

In sysinfo 0.38.4 (pinned at `Cargo.lock:3503`), the `Some(..)` arm at `common/system.rs:385-393` iterates the **caller's raw slice** and calls `update_and_remove` per entry. That helper consumes a one-shot flag via `switch_updated`, which is exactly `std::mem::replace(&mut self.updated, false)`:

- 1st visit to `P` → `true` → process kept.
- 2nd visit to `P` → flag already consumed → `false` → **`processes.remove(&P)` evicts a LIVE process from the table.**
- 3rd+ visits → early-return, entry already gone.

The old `ProcessesToUpdate::All` arm used `retain`, which visits each process exactly once, so this was structurally impossible before #602.

The eviction happens *inside* the refresh call at `resource.rs:80`, which runs **before** the read loop at `resource.rs:89` — so the damage lands on the very same tick. `self.sys.process(Pid::from_u32(pid))` returns `None`, `agent.res` falls back to `ResourceSample::default`, and `stella-tui/src/views/agents.rs:209-213` renders those zeros directly. It never self-heals: the inner refresh re-adds `P` every second and the outer loop evicts it again. The scripted demo (`scenario.rs:171`, `examples/deck_demo.rs:70`) stamps `self_pid` on all its lanes and is broken identically.

### The fix

`pids.sort_unstable; pids.dedup;` before the refresh — two lines, in the one place the list is built. Sorting is what makes `dedup` total rather than adjacent-only. I chose this over setting `remove_dead_processes = false` because dead-process eviction is real behaviour worth keeping; the duplicate list was the actual defect.

Refs #571

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-tui/src/resource.rs` → `resource::tests::duplicate_pids_still_report_memory`. It registers **three** agents sharing `std::process::id` — exactly the shape `command_deck.rs` + `subsession.rs` produce for a lead with two subagents — samples once, and asserts every agent reports non-zero memory.

**Confirmed to fail without the fix.** I removed only the two dedup lines, left the test in place, and re-ran:

```
running 4 tests
test resource::tests::sample_dead_or_missing_pid_zeroes_the_sample ... ok
test resource::tests::sample_on_empty_model_does_not_panic ... ok
test resource::tests::sample_current_process_reports_nonzero_memory ... ok
test resource::tests::duplicate_pids_still_report_memory ... FAILED

---- resource::tests::duplicate_pids_still_report_memory stdout ----
panicked at stella-tui/src/resource.rs:183:13:
agent lead zeroed: duplicate pids evicted the live process from the sysinfo
table (sample = ResourceSample { cpu_pct: 0.0, mem_bytes: 0 })

test result: FAILED. 3 passed; 1 failed
```

Then restored the two lines and all 4 pass.

### Why CI was green through #602

Worth calling out, because it explains the blind spot rather than just the bug. PR #602's own commit message cites `sample_current_process_reports_nonzero_memory` as "the de-facto witness [that] stays green" — but that test registers **exactly one** pid, and `n = 1` is the only arity that behaves correctly. No test in the suite registered two agents, so the suite was *structurally incapable* of catching this. That's visible in the run above: with the fix removed, the three pre-existing resource tests all stay green while only the new one goes red.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui` — 527 passed, 0 failed, 1 ignored (+ 5 + 1 in the integration targets)
- [x] `make no-scratch`
- [x] Doc comment on the refresh explains the invariant and names the witness

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

The comment above the dedup is deliberately long for two lines of code. This is a silent, non-obvious coupling to a sysinfo implementation detail — a future reader trimming "redundant" sort/dedup would re-open the hole with no visible symptom in review, so the comment states the mechanism and names the witness test that guards it.
