### PR TITLE
stella-mcp: a JSON-RPC error response bypasses every context bound #551 added

### DIFF
--- a/stella-mcp/src/client.rs
+++ b/stella-mcp/src/client.rs
@@ -783,10 +783,16 @@ async fn fetch_all_tools(
 
 /// Map a raw `tools/call` result value into the engine's [`ToolOutput`].
 ///
-/// This is the seam where an untrusted result is bounded (#551): the rendered
-/// string is capped at [`MAX_TOOL_RESULT_BYTES`] middle-out, on both the `Ok`
-/// and the `Error` branch, so a server cannot evict the conversation with one
-/// enormous answer. [`render_content`] itself stays pure and zero-copy.
+/// This is the seam where an untrusted *result* is bounded (#551): the
+/// rendered string is capped at [`MAX_TOOL_RESULT_BYTES`] middle-out, on both
+/// the `Ok` and the `isError: true` branch, so a server cannot evict the
+/// conversation with one enormous answer. [`render_content`] itself stays pure
+/// and zero-copy.
+///
+/// It bounds **only** the two branches below. A server that answers
+/// `tools/call` with a JSON-RPC *error object* fails the request before it
+/// gets here (`RequestOutcome::Protocol` → `Err`), and that route is bounded
+/// by [`McpError::user_message`] at the same budget.
 fn decode_call_result(tool: &str, raw: Value) -> Result<ToolOutput, McpError> {
     let result: CallToolResult = serde_json::from_value(raw)
         .map_err(|e| McpError::Protocol(format!("could not decode tools/call result: {e}")))?;

--- a/stella-mcp/src/error.rs
+++ b/stella-mcp/src/error.rs
@@ -6,6 +6,9 @@
 
 use thiserror::Error;
 
+use crate::client::MAX_TOOL_RESULT_BYTES;
+use crate::http::truncate_middle_out;
+
 /// Everything that can go wrong talking to an MCP server.
 #[derive(Debug, Error)]
 pub enum McpError {
@@ -55,11 +58,86 @@ pub enum McpError {
 }
 
 impl McpError {
-    /// A one-line, credential-free summary safe to surface to the model as a
-    /// `ToolOutput::Error` message. (No `McpError` variant ever carries a
-    /// secret — credentials are never logged nor forwarded,
-    /// §8 — so this is just the `Display` form, named for intent.)
+    /// A credential-free, **length-bounded** summary safe to surface to the
+    /// model as a `ToolOutput::Error` message. (No `McpError` variant ever
+    /// carries a secret — credentials are never logged nor forwarded,
+    /// §8 — so this is the `Display` form, named for intent.)
+    ///
+    /// # Bounded, because half of this string is the server's
+    ///
+    /// Several variants interpolate text the *server* chose and this client
+    /// only relayed: [`McpError::JsonRpc`]'s `message` is the wire error
+    /// object's own, and [`McpError::Transport`]/[`McpError::Protocol`] wrap
+    /// decoder and HTTP-body text. That makes the rendered string untrusted
+    /// input on the same footing as a `tools/call` result, and it reaches the
+    /// model through exactly the same door — `McpToolSet::execute_mcp` turns
+    /// this into a `ToolOutput::Error`.
+    ///
+    /// [`crate::client`]'s result cap (#551) sits in `decode_call_result`,
+    /// which a JSON-RPC *error* response never reaches — the request fails
+    /// before it, so the cap there bounds only the `isError: true` content
+    /// route. This is the seam that covers the rest, at the same
+    /// [`MAX_TOOL_RESULT_BYTES`] budget and with the same middle-out elision
+    /// marker, so a server cannot evict the conversation by answering
+    /// `tools/call` with a gigabyte-long error message instead of a
+    /// gigabyte-long result. An under-budget message is returned verbatim.
     pub fn user_message(&self) -> String {
-        self.to_string()
+        let rendered = self.to_string();
+        // Under budget stays byte-identical (and pays for no second pass) —
+        // only a hostile or badly-behaved server's message is rebuilt.
+        if rendered.len() > MAX_TOOL_RESULT_BYTES {
+            truncate_middle_out(&rendered, MAX_TOOL_RESULT_BYTES)
+        } else {
+            rendered
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_under_budget_message_is_the_display_form_verbatim() {
+        let err = McpError::JsonRpc {
+            code: -32602,
+            message: "unknown argument `pth`".into(),
+            data: None,
+        };
+        assert_eq!(err.user_message(), err.to_string());
+        assert_eq!(
+            err.user_message(),
+            "json-rpc error -32602: unknown argument `pth`"
+        );
+    }
+
+    /// The bound is on the *rendered* string, so it holds for every variant
+    /// that relays server-chosen text — not just [`McpError::JsonRpc`].
+    #[test]
+    fn every_variant_relaying_server_text_is_bounded() {
+        let flood = "Z".repeat(MAX_TOOL_RESULT_BYTES * 4);
+        let cases = [
+            McpError::JsonRpc {
+                code: -32000,
+                message: flood.clone(),
+                data: None,
+            },
+            McpError::Transport(flood.clone()),
+            McpError::Protocol(flood.clone()),
+            McpError::Closed(flood.clone()),
+            McpError::Auth(flood),
+        ];
+        for err in cases {
+            let msg = err.user_message();
+            assert!(
+                msg.len() < MAX_TOOL_RESULT_BYTES + 128,
+                "{err:?} rendered {} bytes",
+                msg.len()
+            );
+            assert!(
+                msg.contains("... [truncated ") && msg.contains(" bytes] ..."),
+                "the elision is explicit and counted"
+            );
+        }
     }
 }

--- a/stella-mcp/src/lib.rs
+++ b/stella-mcp/src/lib.rs
@@ -50,9 +50,12 @@
 //!   marker, the number of tools accepted from one server is capped (the
 //!   overflow surfacing via [`McpToolSet::over_advertising_servers`], a
 //!   non-fatal diagnostic — the server still works), and each tool's
-//!   description and input schema are bounded. Without this a single verbose
-//!   or hostile server could evict the real conversation, since the engine's
-//!   compaction only trims on a *later* turn.
+//!   description and input schema are bounded. A *failed* call is bounded on
+//!   the same budget by [`McpError::user_message`] ([`error`]) — a JSON-RPC
+//!   error object is server-chosen text that reaches the model through the
+//!   same door as a result. Without this a single verbose or hostile server
+//!   could evict the real conversation, since the engine's compaction only
+//!   trims on a *later* turn.
 //! - **Resilience.** Per-call timeouts; a dead/hung server yields a
 //!   server-named `ToolOutput::Error` and never poisons its siblings or the
 //!   native tools. A dropped connection **auto-reconnects with bounded

--- a/stella-mcp/src/toolset.rs
+++ b/stella-mcp/src/toolset.rs
@@ -1001,6 +1001,92 @@ mod tests {
         }
     }
 
+    /// Witness for the hole PR #586 left in #551's context bound. The result
+    /// cap lives in `decode_call_result`, which a JSON-RPC **error object**
+    /// never reaches: the request fails first, and `execute_mcp`'s `Err` arm
+    /// used to interpolate the server's `error.message` verbatim. That is the
+    /// cheapest possible hostile payload — no content array, no `isError`,
+    /// just a huge string in the error field — and it landed in model context
+    /// whole. Distinct from `an_oversized_error_result_is_capped_too` above,
+    /// which exercises the `isError: true` *content* route.
+    #[tokio::test]
+    async fn an_oversized_json_rpc_error_message_is_capped_before_the_model() {
+        let transport = ScriptedTransport::new();
+        transport.push_ok(
+            "initialize",
+            serde_json::json!({ "protocolVersion": PREFERRED_PROTOCOL_VERSION }),
+        );
+        transport.push_ok(
+            "tools/list",
+            serde_json::json!({ "tools": [{ "name": "boom", "inputSchema": { "type": "object" } }] }),
+        );
+        transport.push_err(
+            "tools/call",
+            McpError::JsonRpc {
+                code: -32000,
+                message: "Z".repeat(MAX_TOOL_RESULT_BYTES * 10),
+                data: None,
+            },
+        );
+        let mut client = McpClient::new("flood", Box::new(transport));
+        client.initialize().await.unwrap();
+        let set = McpToolSet::from_clients(vec![client]);
+
+        match set.execute("mcp__flood__boom", &Value::Null).await {
+            ToolOutput::Error { message } => {
+                assert!(
+                    message.len() < MAX_TOOL_RESULT_BYTES + 256,
+                    "a {}-byte server-chosen error message must not reach the model whole \
+                     (got {} bytes)",
+                    MAX_TOOL_RESULT_BYTES * 10,
+                    message.len()
+                );
+                assert!(
+                    message.contains("mcp server `flood` failed calling `boom`"),
+                    "the server is still named"
+                );
+                assert!(
+                    message.contains("... [truncated ") && message.contains(" bytes] ..."),
+                    "the elision is explicit and counted"
+                );
+            }
+            other => panic!("expected a tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_under_budget_json_rpc_error_message_is_passed_through_verbatim() {
+        let transport = ScriptedTransport::new();
+        transport.push_ok(
+            "initialize",
+            serde_json::json!({ "protocolVersion": PREFERRED_PROTOCOL_VERSION }),
+        );
+        transport.push_ok(
+            "tools/list",
+            serde_json::json!({ "tools": [{ "name": "boom", "inputSchema": { "type": "object" } }] }),
+        );
+        transport.push_err(
+            "tools/call",
+            McpError::JsonRpc {
+                code: -32602,
+                message: "unknown argument `pth`".into(),
+                data: None,
+            },
+        );
+        let mut client = McpClient::new("files", Box::new(transport));
+        client.initialize().await.unwrap();
+        let set = McpToolSet::from_clients(vec![client]);
+
+        assert_eq!(
+            set.execute("mcp__files__boom", &Value::Null).await,
+            ToolOutput::Error {
+                message: "mcp server `files` failed calling `boom`: json-rpc error -32602: \
+                          unknown argument `pth`"
+                    .into()
+            }
+        );
+    }
+
     #[tokio::test]
     async fn an_under_budget_result_is_byte_identical() {
         let set = McpToolSet::from_clients(vec![


### PR DESCRIPTION
## What & why

An MCP server can put unbounded, server-chosen text into the model's context by
failing a `tools/call` instead of answering it.

PR #586 (issue #551) bounded MCP results at ingest — but it put the cap inside
`decode_call_result`, and a JSON-RPC **error response** never reaches that
function. The whole chain, on today's `main`:

1. Server answers `tools/call` with `{"error":{"code":-32000,"message":"<huge>"}}`.
2. `protocol.rs::into_result` moves the wire `message` verbatim into
   `McpError::JsonRpc { code, message, data }`. No length check.
3. `client.rs::request_once` — `is_connection_death` matches only
   `Transport`/`Closed`, so a `JsonRpc` error classifies as
   `RequestOutcome::Protocol`, and `call_tool`'s arm for it is
   `RequestOutcome::Protocol(err) => Err(err)`. `decode_call_result` (where
   #586's cap lives) is only ever called on `RequestOutcome::Ok`, so the error
   never passes through it.
4. `McpError::user_message` was literally `self.to_string`, and the
   `#[error("json-rpc error {code}: {message}")]` Display interpolates the
   whole message.
5. `toolset.rs::execute_mcp`'s `Err` arm builds
   `ToolOutput::Error { message: format!("mcp server `{}` failed calling `{raw_tool}`: {}", …, err.user_message) }`
   — uncapped — and `stella-model`'s Anthropic adapter passes
   `ToolOutput::Error { message }` straight into a `tool_result` block.

**Inputs → wrong behaviour:** a server that returns a 1 MB `error.message` for
one `tools/call` lands a 1,000,065-byte `ToolOutput::Error` in the model's
context — 10× `MAX_TOOL_RESULT_BYTES` (100 KB). This is the *cheapest* hostile
payload in the protocol: no content array, no `isError: true`, just a big
string in the error field. The realistic ceiling is transport-dependent —
8 MiB over stdio (`MAX_LINE_BYTES`) and SSE (`MAX_BUFFERED_BYTES`), and
effectively unbounded over streamable HTTP, where `http.rs` reads the body with
an uncapped `response.text.await`. Precisely the eviction vector #551
describes, through a door #586 left open.

### The fix

Cap in `McpError::user_message` — one seam, same budget, same helper:

```rust
let rendered = self.to_string;
if rendered.len > MAX_TOOL_RESULT_BYTES {
    truncate_middle_out(&rendered, MAX_TOOL_RESULT_BYTES)
} else {
    rendered
}
```

Chosen over capping at the `execute_mcp` call site because it covers, in one
place, every variant that relays server-chosen text (`Transport` and `Protocol`
wrap decoder and HTTP-body text too — and `call_tool`'s dropped-connection arm
interpolates a nested `{err}` into a fresh `Transport`) and every consumer:
the model-visible `ToolOutput::Error`, `McpToolSet::failed_servers` (CLI
display), and `ServerHealth::last_error` (CLI/TUI/telemetry). An under-budget
message is returned byte-identical and pays for no extra pass.

`decode_call_result`'s doc comment is corrected too: "capped … on both the `Ok`
and the `Error` branch" was scoped-true for that function's two branches, but
it reads as a global guarantee — which is exactly the reading under which this
hole went unnoticed. It now says what it does and does not bound, and points at
the seam that covers the rest.

Refs #551

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-mcp/src/toolset.rs::an_oversized_json_rpc_error_message_is_capped_before_the_model`
drives the real `McpClient` state machine (`ScriptedTransport::push_err` with
`McpError::JsonRpc { code: -32000, message: "Z".repeat(MAX_TOOL_RESULT_BYTES * 10), … }`)
through `McpToolSet::execute`, and asserts the resulting `ToolOutput::Error` is
under budget, still names the server, and carries the explicit elision marker.
It is deliberately distinct from #586's `an_oversized_error_result_is_capped_too`,
which exercises the `isError: true` **content** route — the one that was already
capped.

**Confirmed it fails without the fix.** With the test in place and
`user_message` reverted to `self.to_string`:

```
test toolset::tests::an_oversized_json_rpc_error_message_is_capped_before_the_model ... FAILED
test error::tests::every_variant_relaying_server_text_is_bounded ... FAILED

a 1000000-byte server-chosen error message must not reach the model whole (got 1000065 bytes)

test result: FAILED. 94 passed; 2 failed
```

With the fix restored: `96 passed; 0 failed`.

Two supporting tests guard the other half of the contract — that this does not
become a truncating-everything change:
`an_under_budget_json_rpc_error_message_is_passed_through_verbatim` (asserts the
full expected `ToolOutput::Error` string for a normal `-32602`) and
`error::tests::an_under_budget_message_is_the_display_form_verbatim`. Both pass
on old and new code, as they should. `every_variant_relaying_server_text_is_bounded`
is a second witness proving the bound is not `JsonRpc`-specific.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-mcp --all-targets -- -D warnings`
- [x] `cargo test -p stella-mcp` (96 lib + 22 integration + 1 doc, all green)
- [x] `cargo check --workspace --all-targets`
- [x] `make no-scratch`
- [x] Docs updated (`user_message` rustdoc, `decode_call_result` rustdoc, the
      crate-level "Bounded context" bullet in `lib.rs`)
- [x] Commit signed off for DCO

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

- **This is a coverage gap, not a regression.** The JSON-RPC error path was
  equally uncapped before #586 — #586 simply did not close it, and its
  "Deferred" section reproduces #551's remediation checklist without mentioning
  this route. Nothing in #586 is reverted here; the result cap it added stays
  exactly as it was.
- **Budget choice.** `MAX_TOOL_RESULT_BYTES` (100 KB) rather than a new,
  smaller error-specific constant: a JSON-RPC error *is* the tool's answer on
  the wire, and an `isError: true` result already lands on that budget, so the
  two failure shapes now cost the model the same. Introducing a second constant
  is a product decision, and #551 already parks budget configurability as an
  owner API question.
- **Slack in the assertion.** The witness allows `MAX_TOOL_RESULT_BYTES + 256`
  rather than `+ 128`, because this message carries the
  ``mcp server `x` failed calling `y`: `` prefix on top of the cap plus the
  elision marker — the same "budget is for the kept text" contract
  `truncate_middle_out` documents.
