### PR TITLE
stella-core: compaction pass-1 dedup keys on a call_id that recurs, stubbing distinct tool output

### DIFF
--- a/stella-core/src/compaction.rs
+++ b/stella-core/src/compaction.rs
@@ -145,17 +145,36 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
     let mut superseded_blocks: Vec<String> = Vec::new();
     let mut aged_blocks: Vec<String> = Vec::new();
     let mut evicted_blocks: Vec<String> = Vec::new();
-    // Each tool result's ORIGINAL block_id, captured before any pass mutates it,
-    // keyed by call_id (unique per result). A result aged then evicted in the
-    // same call must be recorded under the id the manifest cited, not the id of
-    // its intermediate aged content.
-    let original_ids: std::collections::HashMap<String, String> = messages
+    // Each tool result's ORIGINAL block_id, captured before any pass mutates
+    // it, indexed by POSITION: `original_ids[message_idx][result_idx]`. A
+    // result aged then evicted in the same call must be recorded under the id
+    // the manifest cited, not the id of its intermediate aged content, which is
+    // what capturing up front preserves.
+    //
+    // Deliberately NOT keyed by `call_id`. A call_id is unique only within ONE
+    // step — `driver.rs::snapshot_result_identities` says so and poisons any id
+    // it sees carrying two different outputs — and Gemini/Vertex mint theirs as
+    // `call_{ordinal}` counted per response, so `call_0` recurs on every
+    // assistant step. A `HashMap<call_id, block_id>` keeps only the LAST
+    // occurrence, which collapsed every result sharing a recurring id onto one
+    // identity: pass 1 then read three distinct outputs as duplicates of each
+    // other and stubbed the middle ones, and the receipt cited the wrong block.
+    let original_ids: Vec<Vec<String>> = messages
         .iter()
-        .filter(|m| m.role == MessageRole::Tool)
-        .flat_map(|m| &m.tool_results)
-        .map(|r| (r.call_id.clone(), tool_result_block_id(&r.output)))
+        .map(|m| {
+            m.tool_results
+                .iter()
+                .map(|r| tool_result_block_id(&r.output))
+                .collect()
+        })
         .collect();
-    let id_of = |call_id: &str| original_ids.get(call_id).cloned().unwrap_or_default();
+    let id_at = |message_idx: usize, result_idx: usize| -> String {
+        original_ids
+            .get(message_idx)
+            .and_then(|ids| ids.get(result_idx))
+            .cloned()
+            .unwrap_or_default()
+    };
 
     // Index of the last Tool message — its results answer the most recent
     // assistant tool calls and must never be evicted or deduped away.
@@ -170,24 +189,26 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
         // Keyed on the content-addressed block id `original_ids` already
         // computed above, not on a clone of the content: the id IS the
         // content identity (receipts.rs hashes the serialized output), so
-        // byte-identical outputs still collide exactly, while the map stops
-        // paying a full heap copy of every >200-byte output plus a second
-        // full hash pass over it on lookup. Pass 2 already compares
-        // identities the same way.
+        // byte-identical outputs still collide exactly — and only those do —
+        // while the map stops paying a full heap copy of every >200-byte
+        // output plus a second full hash pass over it on lookup. The id is
+        // read by POSITION, never through the result's call_id: two results
+        // that merely share a recurring call_id are different content and
+        // must keep different identities here, or dedup destroys one of them.
         let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
         // First record positions of the earliest occurrence.
         for (idx, message) in messages.iter().enumerate() {
             if message.role != MessageRole::Tool {
                 continue;
             }
-            for result in &message.tool_results {
+            for (ridx, result) in message.tool_results.iter().enumerate() {
                 if let ToolOutput::Ok { content } = &result.output
                     && content.len() > 200
                 {
-                    // `id_of` yields "" for a call_id absent from the map;
-                    // an unidentifiable result is skipped rather than made
-                    // to collide with every other unidentifiable one.
-                    let id = id_of(&result.call_id);
+                    // `id_at` yields "" only for an out-of-range position; an
+                    // unidentifiable result is skipped rather than made to
+                    // collide with every other unidentifiable one.
+                    let id = id_at(idx, ridx);
                     if !id.is_empty() {
                         seen.entry(id).or_insert(idx);
                     }
@@ -201,11 +222,11 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
             if Some(idx) == last_tool_idx || message.role != MessageRole::Tool {
                 continue;
             }
-            for result in &mut message.tool_results {
+            for (ridx, result) in message.tool_results.iter_mut().enumerate() {
                 if let ToolOutput::Ok { content } = &result.output
                     && content.len() > 200
                 {
-                    let id = id_of(&result.call_id);
+                    let id = id_at(idx, ridx);
                     if !id.is_empty() && seen.get(&id).is_some_and(|&kept_at| kept_at < idx) {
                         deduped_blocks.push(id);
                         result.output = ToolOutput::Ok {
@@ -226,38 +247,63 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
     // calls because results themselves only carry a call_id.
     {
         use std::collections::HashMap;
-        // call_id -> invocation key. Input serialization is deterministic
-        // for a given call because it round-trips the same serde_json Value.
-        let mut invocation: HashMap<&str, String> = HashMap::new();
-        for message in messages.iter() {
-            for call in &message.tool_calls {
-                invocation.insert(
-                    call.call_id.as_str(),
-                    format!("{}\u{0}{}", call.name, call.input),
+        // The invocation key (tool name + byte-identical input) behind each
+        // tool result, indexed by POSITION like `original_ids`. Resolved by
+        // walking the conversation FORWARD and reading the most recent call
+        // bearing that call_id, so a result is matched to the call it actually
+        // answered. A conversation-wide `call_id -> invocation` map would bind
+        // an old result to a NEWER, unrelated call whenever a provider reuses a
+        // call_id across steps (Gemini/Vertex do, by construction) — and then
+        // stub a live, distinct output as "stale". Input serialization is
+        // deterministic for a given call because it round-trips the same
+        // serde_json Value.
+        let invocation_of: Vec<Vec<Option<String>>> = {
+            let mut pending: HashMap<&str, String> = HashMap::new();
+            let mut per_message: Vec<Vec<Option<String>>> = Vec::with_capacity(messages.len());
+            for message in messages.iter() {
+                for call in &message.tool_calls {
+                    pending.insert(
+                        call.call_id.as_str(),
+                        format!("{}\u{0}{}", call.name, call.input),
+                    );
+                }
+                per_message.push(
+                    message
+                        .tool_results
+                        .iter()
+                        .map(|r| pending.get(r.call_id.as_str()).cloned())
+                        .collect(),
                 );
             }
-        }
-        // Latest tool-message index — and that result's call_id — per
-        // invocation key. The call_id lets the staleness check below compare
-        // ORIGINAL content identities even after pass 1 stubbed a copy.
-        let mut latest: HashMap<&str, (usize, String)> = HashMap::new();
+            per_message
+        };
+        let invocation_at = |message_idx: usize, result_idx: usize| -> Option<&str> {
+            invocation_of
+                .get(message_idx)
+                .and_then(|keys| keys.get(result_idx))
+                .and_then(|key| key.as_deref())
+        };
+        // Latest tool result POSITION per invocation key. The position lets the
+        // staleness check below compare ORIGINAL content identities even after
+        // pass 1 stubbed a copy.
+        let mut latest: HashMap<&str, (usize, usize)> = HashMap::new();
         for (idx, message) in messages.iter().enumerate() {
             if message.role != MessageRole::Tool {
                 continue;
             }
-            for result in &message.tool_results {
-                if let Some(key) = invocation.get(result.call_id.as_str()) {
-                    latest.insert(key.as_str(), (idx, result.call_id.clone()));
+            for ridx in 0..message.tool_results.len() {
+                if let Some(key) = invocation_at(idx, ridx) {
+                    latest.insert(key, (idx, ridx));
                 }
             }
         }
-        let mut stale: Vec<(usize, String)> = Vec::new();
+        let mut stale: Vec<(usize, usize)> = Vec::new();
         for (idx, message) in messages.iter().enumerate() {
             if Some(idx) == last_tool_idx || message.role != MessageRole::Tool {
                 continue;
             }
-            for result in &message.tool_results {
-                let Some(key) = invocation.get(result.call_id.as_str()) else {
+            for (ridx, result) in message.tool_results.iter().enumerate() {
+                let Some(key) = invocation_at(idx, ridx) else {
                     continue;
                 };
                 // Supersession only restubs Ok results. A superseded error is
@@ -267,7 +313,7 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
                 let ToolOutput::Ok { content } = &result.output else {
                     continue;
                 };
-                let Some((latest_idx, latest_call)) = latest.get(key.as_str()) else {
+                let Some(&(latest_idx, latest_ridx)) = latest.get(key) else {
                     continue;
                 };
                 // A later run whose output was byte-identical is redundancy,
@@ -276,22 +322,20 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
                 // ORIGINAL content identities (captured before pass 1 could
                 // replace the later copy with a stub).
                 if content.len() > 200
-                    && *latest_idx > idx
-                    && id_of(latest_call) != id_of(&result.call_id)
+                    && latest_idx > idx
+                    && id_at(latest_idx, latest_ridx) != id_at(idx, ridx)
                 {
-                    stale.push((idx, result.call_id.clone()));
+                    stale.push((idx, ridx));
                 }
             }
         }
-        for (idx, call_id) in stale {
-            for result in &mut messages[idx].tool_results {
-                if result.call_id == call_id {
-                    superseded_blocks.push(id_of(&result.call_id));
-                    result.output = ToolOutput::Ok {
-                        content: supersession_stub(),
-                    };
-                    superseded += 1;
-                }
+        for (idx, ridx) in stale {
+            if let Some(result) = messages[idx].tool_results.get_mut(ridx) {
+                superseded_blocks.push(id_at(idx, ridx));
+                result.output = ToolOutput::Ok {
+                    content: supersession_stub(),
+                };
+                superseded += 1;
             }
         }
     }
@@ -307,7 +351,7 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
                 continue;
             }
             let before = estimate_message_tokens(message);
-            for result in &mut message.tool_results {
+            for (ridx, result) in message.tool_results.iter_mut().enumerate() {
                 let (payload, is_error) = match &result.output {
                     ToolOutput::Ok { content } => (content, false),
                     ToolOutput::Error { message } => (message, true),
@@ -323,7 +367,7 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
                             content: aged_payload,
                         }
                     };
-                    aged_blocks.push(id_of(&result.call_id));
+                    aged_blocks.push(id_at(idx, ridx));
                     aged += 1;
                 }
             }
@@ -349,13 +393,13 @@ pub fn compact(messages: &mut [CompletionMessage], budget_tokens: u64) -> Option
                 continue;
             }
             let before = estimate_message_tokens(message);
-            for result in &mut message.tool_results {
+            for (ridx, result) in message.tool_results.iter_mut().enumerate() {
                 let (payload_len, is_error) = match &result.output {
                     ToolOutput::Ok { content } => (content.len(), false),
                     ToolOutput::Error { message } => (message.len(), true),
                 };
                 if payload_len > 400 {
-                    evicted_blocks.push(id_of(&result.call_id));
+                    evicted_blocks.push(id_at(idx, ridx));
                     result.output = if is_error {
                         ToolOutput::Error {
                             message: EVICTION_STUB.to_string(),
@@ -593,6 +637,95 @@ mod tests {
             ToolOutput::Ok { content } => assert_eq!(content, &repeated),
             _ => panic!("earliest copy must survive intact"),
         }
+        match &messages[4].tool_results[0].output {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("earlier tool result"), "got: {content}")
+            }
+            _ => panic!("expected a dedup stub on the later copy"),
+        }
+    }
+
+    #[test]
+    fn recurring_call_id_never_dedups_distinct_outputs() {
+        // Witness for the pass-1 regression in PR #595 (issue #560). Dedup was
+        // keyed on an identity resolved through a `HashMap<call_id, block_id>`,
+        // so a call_id that RECURS collapsed every result carrying it onto the
+        // LAST occurrence's id and they all compared equal. Gemini and Vertex
+        // mint ids as `call_{ordinal}` counted per RESPONSE
+        // (`stella-model/src/gemini.rs`), so `call_0` comes back on every
+        // assistant step: below, three reads of three different files return
+        // three different outputs, all answering `call_0`. The middle one was
+        // replaced by the dedup stub — text asserting the model has already
+        // seen content that was never in the transcript.
+        //
+        // Sized so no other pass can confound the result: each payload is >200
+        // chars (pass 1 considers it) but <=400 (eviction's floor) and far
+        // under AGE_THRESHOLD_CHARS, so even an impossible budget reclaims
+        // nothing and `compact` correctly reports a no-op.
+        let out = |tag: char| tag.to_string().repeat(300);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            assistant_with_call_on("call_0", "src/a.rs"),
+            tool_msg("call_0", out('a')),
+            assistant_with_call_on("call_0", "src/b.rs"),
+            tool_msg("call_0", out('b')),
+            assistant_with_call_on("call_0", "src/c.rs"),
+            tool_msg("call_0", out('c')),
+        ];
+        let report = compact(&mut messages, 1);
+        assert_eq!(
+            report.as_ref().map_or(0, |r| r.deduped),
+            0,
+            "distinct outputs sharing a recurring call_id are not duplicates: {report:?}"
+        );
+        assert_eq!(
+            report.as_ref().map_or(0, |r| r.superseded),
+            0,
+            "three different files are three invocations — none is stale: {report:?}"
+        );
+        for (idx, tag) in [(2usize, 'a'), (4, 'b'), (6, 'c')] {
+            match &messages[idx].tool_results[0].output {
+                ToolOutput::Ok { content } => {
+                    assert_eq!(content, &out(tag), "message {idx} lost its output")
+                }
+                _ => panic!("message {idx}: expected its untouched Ok output"),
+            }
+        }
+    }
+
+    #[test]
+    fn byte_identical_outputs_still_dedup_under_a_recurring_call_id() {
+        // The other half of the contract, and a witness for the receipt half of
+        // the same regression: keying identities by position must not turn
+        // dedup off, and the id it reports must be the id of the block it
+        // actually stubbed. Under the call_id-keyed map both copies resolved to
+        // the LAST result's id, so `deduped_blocks` cited a block that was
+        // never touched.
+        let repeated = "same big output ".repeat(20);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            assistant_with_call_on("call_0", "src/a.rs"),
+            tool_msg("call_0", repeated.clone()),
+            assistant_with_call_on("call_0", "src/b.rs"),
+            tool_msg("call_0", repeated.clone()),
+            assistant_with_call_on("call_0", "src/c.rs"),
+            tool_msg("call_0", "tail".into()),
+        ];
+        let report = compact(&mut messages, 1).expect("should compact");
+        assert_eq!(report.deduped, 1, "{report:?}");
+        assert_eq!(
+            report.deduped_blocks,
+            vec![tool_result_block_id(&ToolOutput::Ok {
+                content: repeated.clone()
+            })],
+            "the receipt must cite the identity of the block it stubbed"
+        );
+        // The EARLIEST copy survives byte-identical (#372)…
+        match &messages[2].tool_results[0].output {
+            ToolOutput::Ok { content } => assert_eq!(content, &repeated),
+            _ => panic!("earliest copy must survive intact"),
+        }
+        // …and only the later duplicate is stubbed.
         match &messages[4].tool_results[0].output {
             ToolOutput::Ok { content } => {
                 assert!(content.contains("earlier tool result"), "got: {content}")


### PR DESCRIPTION
## What & why

Compaction pass 1 (dedup of byte-identical tool outputs) could **destroy distinct tool output and replace it with a stub that tells the model it already saw content that was never in the transcript.**

Refs #560 — this is a *new* defect found by review of the merged work, not a listed audit item, so nothing is closed here.

### The failure mode, concretely

Pass 1 resolved each tool result's identity through

```rust
let original_ids: HashMap<String, String> = /* call_id -> block_id, over ALL tool results */;
let id_of = |call_id: &str| original_ids.get(call_id).cloned.unwrap_or_default;
...
let id = id_of(&result.call_id);
seen.entry(id).or_insert(idx);
```

A `HashMap` keeps only the **last** value written for a key. So when a `call_id`
**recurs**, every result carrying it resolves to one and the same identity — and
pass 1 concludes they are byte-identical copies of each other.

Concrete input → wrong behaviour, three assistant steps, three different files,
three different outputs, all answering `call_0`:

| step | tool call | output | after `compact` (before this PR) |
|---|---|---|---|
| 1 | `read_file {"path":"src/a.rs"}` as `call_0` | `"aaa…"` (300 B) | survives |
| 2 | `read_file {"path":"src/b.rs"}` as `call_0` | `"bbb…"` (300 B) | **`[identical output repeated — the full content already appears in an earlier tool result]`** |
| 3 | `read_file {"path":"src/c.rs"}` as `call_0` | `"ccc…"` (300 B) | survives (last tool message is protected) |

`CompactionReport { deduped: 1, deduped_blocks: ["blk_8d5725…"] }`. Two things are wrong:

1. **Step 2's content is gone**, and the stub asserts the full content "already
   appears in an earlier tool result". It does not. The model is told it has
   seen bytes that were never in the transcript.
2. **The receipt cites the wrong block.** `deduped_blocks` records the id the
   collapsed map held — the *last* occurrence's — so the manifest names a block
   that was never stubbed. (With exactly two occurrences last-wins happens to
   coincide with the stubbed result; from three on it does not.)

### Why call ids recur

`stella-model/src/gemini.rs` mints them per response:

```rust
let ordinal = tool_calls.len;
let call_id = match &part.thought_signature {
    Some(sig) => format!("call_{ordinal}{SIGNATURE_SEPARATOR}{sig}"),
    None => format!("call_{ordinal}"),
};
```

`tool_calls` is local to one `aggregate_gemini_stream` invocation, so the
ordinals restart at `call_0` on **every** assistant step. `stella-model/src/vertex.rs`
calls the same aggregator, so Vertex inherits it. Thinking models that return a
`thought_signature` get an effectively-unique id; the no-signature branch — live
code for non-thinking Gemini/Vertex configurations — does not. Nothing between
the provider and `compact` uniquifies ids: `driver.rs` clones `call_id`
straight onto the `ToolResult`.

Nothing about the defect is Gemini-specific, either. `driver.rs` already says so
and already defends against it: `snapshot_result_identities` **poisons** (`None`)
any `call_id` it sees carrying two different real outputs, because
*"a WRONG identity is far worse than none: it can make two genuinely different
outputs compare equal"*. Pass 1 was doing exactly the thing that guard exists to
prevent. And `compact` runs on the live conversation every step
(`driver.rs::run_turn`), so this is the hot path.

### Where it came from

**PR #595 (issue #560)** re-keyed pass 1 from the tool output CONTENT onto
`id_of(&result.call_id)`:

```
-  seen.entry(content.clone).or_insert(idx);
+  let id = id_of(&result.call_id);
+  ... seen.entry(id).or_insert(idx);
```

on the premise stated in the comment it leaned on — *"keyed by call_id (unique
per result)"* — which is false. The content-keyed pass it replaced was
byte-exact and could not misfire. (`original_ids`/`id_of` themselves predate
#595: they arrived with #588 for the passes 2–4 receipts. #595's contribution
was routing pass 1 through them.)

### The fix

Index identities by **position** — `original_ids[message_idx][result_idx]` —
instead of by `call_id`. This keeps the good part of #595: byte-identical
outputs still hash to the same content-addressed `block_id`, so dedup remains
exactly as byte-exact as the content-keyed pass, and #595's actual point (no
full heap copy of every >200-byte output into a map key, no second full hash
pass on lookup) is preserved. The ids were already being computed once up front.

**Pass 2 (supersession) is moved with it, deliberately.** Its
`call_id -> "name\0input"` map has the same shape, and the collapse was the only
thing keeping it inert: `id_of(latest_call) != id_of(&result.call_id)` is
*always false* when both resolve through one map entry. Fixing `original_ids`
alone would have un-masked a second data-destroying misfire — a conversation-wide
map binds an OLD result to a NEWER, unrelated call whenever an id recurs, and
would stub a live distinct output with *"[stale result of a repeated call…]"*.
Pass 2 now resolves each result against the most recent call bearing its
`call_id` by walking the conversation forward, and compares positions. Genuine
supersession (same tool, byte-identical input, re-run) is unaffected — the
existing `repeated_identical_call_supersedes_older_differing_results` and
`identical_rerun_is_deduped_not_superseded` tests still pass unchanged.

Passes 3 (aging) and 4 (eviction) read the same positional ids, so their
`aged_blocks` / `evicted_blocks` receipts stop mis-citing under a recurring id too.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, in `stella-core/src/compaction.rs`:

**`recurring_call_id_never_dedups_distinct_outputs`** — the table above, as a
test. Payloads are sized >200 chars (pass 1 considers them) but <=400 (eviction's
floor) and far under `AGE_THRESHOLD_CHARS`, so no other pass can confound the
result: on fixed code even an impossible budget reclaims nothing and `compact`
correctly returns the no-op `None`. Asserts `deduped == 0`, `superseded == 0`,
and that all three outputs survive byte-identical.

**`byte_identical_outputs_still_dedup_under_a_recurring_call_id`** — the other
half of the contract, so the fix cannot be "turn dedup off": two genuinely
byte-identical outputs under a recurring `call_0` are still deduped, earliest
copy kept intact (#372). It is also the witness for the *receipt* half of the
defect: it asserts `deduped_blocks` names the id of the block that was actually
stubbed.

### How I confirmed they fail without the fix

Spliced both new tests onto `HEAD`'s (unfixed) `compaction.rs`, ran, then
restored the fixed file:

```
test compaction::tests::byte_identical_outputs_still_dedup_under_a_recurring_call_id ... FAILED
test compaction::tests::recurring_call_id_never_dedups_distinct_outputs ... FAILED
test result: FAILED. 13 passed; 2 failed
```

```
---- recurring_call_id_never_dedups_distinct_outputs ----
assertion `left == right` failed: distinct outputs sharing a recurring call_id are not duplicates:
  Some(CompactionReport { deduped: 1, deduped_blocks: ["blk_8d5725889c1a6227cf279d56"], .. })
  left: 1   right: 0

---- byte_identical_outputs_still_dedup_under_a_recurring_call_id ----
assertion `left == right` failed: the receipt must cite the identity of the block it stubbed
  left: ["blk_dc37686fefd044ec0d0cad2f"]     <- the third, untouched result
 right: ["blk_4da3f541bb914fc7ce136916"]     <- the block that was actually stubbed
```

Every one of the 13 pre-existing compaction tests passes on the unfixed code —
which is the point: this regression was invisible to the whole existing suite,
because every test used distinct call ids.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core --all-targets -- -D warnings`
- [x] `cargo test -p stella-core` — 444 passed, 0 failed
- [x] `cargo test --workspace` — green, with one caveat below
- [x] `make no-scratch`

> Caveat, flagged rather than hidden: on the first `--workspace` run,
> `stella-tools`'s `media::tests::priced_and_unpriced_media_share_gate_then_provider_order`
> failed. It passes alone and passes on a re-run of the whole `stella-tools`
> lib suite (411/411), so it looks order-dependent, and it cannot be downstream
> of this change — the only file touched is `stella-core/src/compaction.rs`,
> whose public API is unchanged and which that test does not exercise. Worth a
> separate look.
- [x] Commits signed off for DCO (`git commit -s`)
- [x] Docs: the stale `// keyed by call_id (unique per result)` comment that
      justified the bug is replaced with the actual invariant and why it holds

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] Public API unchanged (`compact` signature and `CompactionReport` untouched)

## Anything reviewers should know?

- **Scope call.** The pass-2 change is larger than the one-line pass-1 revert
  would be, and I want it flagged rather than buried: fixing pass 1 alone leaves
  a loaded gun. See "The fix" above. Reverting #595 outright was the other
  option; it throws away a real allocation/hash win for a bug that keying by
  position fixes cleanly.
- `original_ids` is now built over all messages rather than filtered to
  `MessageRole::Tool`. Non-Tool messages contribute an empty inner vec, so it is
  the same work; every pass still skips non-Tool messages.
- Positional lookup is total by construction (no pass adds or removes messages
  or results), but `id_at`/`invocation_at` still go through `.get` rather than
  indexing — `stella-core` does not panic on runtime data.
