### PR TITLE
fix(stella-tools): stop run_tests interpolating a model-chosen filter into bash -c

### DIFF
--- a/stella-tools/src/project.rs
+++ b/stella-tools/src/project.rs
@@ -143,7 +143,7 @@ impl Tool for RunTests {
         // selection, or stands down to the full suite with a one-line note —
         // the note rides the report either way, so a widened run is never
         // mistaken for a narrowed one.
-        let mut filter = filter.to_string();
+        let mut filter = SafeFilter::from_input(filter);
         let mut note = String::new();
         if scope.is_some() {
             use crate::impact::ImpactSelection;
@@ -173,7 +173,7 @@ impl Tool for RunTests {
                             tests.len(),
                             changed
                         );
-                        filter = tests.join(" ");
+                        filter = SafeFilter::from_tokens(&tests);
                     } else {
                         // Composing a per-file filter for this runner is not
                         // confidently possible — widen loudly, never guess.
@@ -211,6 +211,72 @@ fn with_note(note: &str, out: ToolOutput) -> ToolOutput {
     }
 }
 
+/// Minimal POSIX single-quote escaping: wrap in `'…'` and close/reopen
+/// around any embedded quote, so the result is one shell word whose content
+/// is exactly `s`.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// A test filter that is safe to interpolate into a `bash -c` line.
+///
+/// Every constructor quotes **each token separately**, which is what lets
+/// this be safe without breaking the filter's documented multi-token
+/// contract: `cargo test --workspace foo bar` still reaches the runner as
+/// two arguments, and `scope:"impacted"`'s file list still arrives as N
+/// paths — but a token can no longer carry shell metacharacters out of its
+/// own word. Wrapping the *whole* filter in one pair of quotes would have
+/// collapsed it to a single argument and broken both.
+///
+/// The type is the enforcement: [`test_command`] takes only a `SafeFilter`,
+/// so an interpolation site cannot accidentally be handed a raw string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SafeFilter(String);
+
+impl SafeFilter {
+    /// A model-supplied filter. Split on whitespace — the same split `bash`
+    /// would have performed — then quote each token, so the token *count*
+    /// is preserved while `;`, `|`, `$(…)`, backticks and newlines lose
+    /// their meaning. Also fixes runner-native syntax that used to be eaten
+    /// by the shell: `go test -run 'TestA|TestB'` was a pipeline before.
+    fn from_input(raw: &str) -> Self {
+        SafeFilter(
+            raw.split_whitespace()
+                .map(shell_quote)
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
+    }
+
+    /// A filter composed from values whose token boundaries are already
+    /// known (`scope:"impacted"`'s selected test files). Strictly better
+    /// than joining on a space and re-splitting: a path *containing* a
+    /// space stays one argument instead of silently becoming two.
+    fn from_tokens<I, S>(tokens: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        SafeFilter(
+            tokens
+                .into_iter()
+                .map(|t| shell_quote(t.as_ref()))
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for SafeFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// The runner-native test command for `kind` + `filter`, or a named error.
 /// Pure over the detected index — separable from process spawning (the same
 /// discipline as [`lint_argv`]), which is what lets `scope:"impacted"`
@@ -219,7 +285,7 @@ fn test_command(
     index: &ScriptIndex,
     primary: &str,
     kind: &str,
-    filter: &str,
+    filter: &SafeFilter,
 ) -> Result<String, String> {
     Ok(match primary {
         "cargo" => match kind {
@@ -329,7 +395,13 @@ pub(crate) async fn resolve_command_for_gate(
         "run_tests" => {
             let kind = input.get("kind").and_then(|v| v.as_str()).unwrap_or("all");
             let filter = input.get("filter").and_then(|v| v.as_str()).unwrap_or("");
-            test_command(&index, index.primary_runner()?, kind, filter).ok()
+            test_command(
+                &index,
+                index.primary_runner()?,
+                kind,
+                &SafeFilter::from_input(filter),
+            )
+            .ok()
         }
         _ => None,
     }
@@ -517,6 +589,79 @@ impl Tool for FormatCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The security witness. Asserts BOTH halves on purpose: that the shape
+    /// the code used to have really is injectable (otherwise this test
+    /// would pass for the wrong reason and could not catch a regression),
+    /// and that routing the identical filter through `SafeFilter` closes
+    /// it. Deliberately runs a real `bash -c`, because the claim is about
+    /// what a shell does — asserting on the composed string alone would
+    /// only be testing my own idea of shell grammar.
+    #[tokio::test]
+    async fn a_hostile_filter_cannot_start_a_second_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join("pwned");
+        let hostile = format!("x; touch {}", sentinel.display());
+
+        // Pre-PR shape: the filter is interpolated raw.
+        let _ = crate::exec::run(&format!("echo {hostile}"), dir.path(), 30).await;
+        assert!(
+            sentinel.exists(),
+            "precondition: a raw interpolation must be injectable, or this test proves nothing"
+        );
+        std::fs::remove_file(&sentinel).unwrap();
+
+        // Fixed shape: same filter, quoted per token.
+        let safe = SafeFilter::from_input(&hostile);
+        let _ = crate::exec::run(&format!("echo {safe}"), dir.path(), 30).await;
+        assert!(
+            !sentinel.exists(),
+            "SafeFilter let `{hostile}` escape its word and start a new command"
+        );
+    }
+
+    /// The multi-token contract the original remediation was afraid of
+    /// breaking: quoting must not collapse a filter into one argument.
+    #[tokio::test]
+    async fn quoting_preserves_the_token_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let safe = SafeFilter::from_input("alpha beta gamma");
+        // `printf '%s\n'` prints one line per argument, so the line count
+        // IS the argument count the runner would have received.
+        let (_, out) = crate::exec::run(&format!("printf '%s\\n' {safe}"), dir.path(), 30)
+            .await
+            .unwrap();
+        let lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["alpha", "beta", "gamma"], "{out}");
+    }
+
+    /// A path containing a space stays ONE argument. The old
+    /// `tests.join(" ")` could not express this — it round-tripped through
+    /// a string and the shell re-split it.
+    #[tokio::test]
+    async fn impact_selection_keeps_a_spaced_path_whole() {
+        let dir = tempfile::tempdir().unwrap();
+        let safe = SafeFilter::from_tokens(["tests/a b.rs", "tests/c.rs"]);
+        let (_, out) = crate::exec::run(&format!("printf '%s\\n' {safe}"), dir.path(), 30)
+            .await
+            .unwrap();
+        let lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["tests/a b.rs", "tests/c.rs"], "{out}");
+    }
+
+    /// Runner-native syntax that the shell used to eat. `go test -run`
+    /// takes a regex, and `|` in an unquoted regex was a pipeline.
+    #[test]
+    fn a_regex_filter_is_no_longer_a_pipeline() {
+        let safe = SafeFilter::from_input("TestA|TestB");
+        assert_eq!(safe.to_string(), r"'TestA|TestB'");
+    }
+
+    #[test]
+    fn an_embedded_quote_is_escaped_not_dropped() {
+        assert_eq!(shell_quote("a'b"), r"'a'\''b'");
+        assert!(SafeFilter::from_input("").is_empty());
+    }
 
     #[tokio::test]
     async fn no_toolchain_is_a_named_error_and_command_overrides() {

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -2955,7 +2955,10 @@ mod tests {
             *commands.lock().unwrap(),
             vec![
                 "cargo build --workspace",
-                "cargo test --workspace --lib --bins my_test",
+                // The filter is shell-quoted per token, so the gated line is
+                // still byte-identical to what would have executed — which
+                // is the property this test exists to protect.
+                "cargo test --workspace --lib --bins 'my_test'",
             ],
             "the chain must see the index-composed command line"
         );


### PR DESCRIPTION
## The hole

`run_tests` read `filter` from the model and interpolated it into a command line that `exec::run` hands to **`bash -c`** (`exec.rs:88-97`). Six sites, not the two the audit cited:

| Site | Composed line |
|---|---|
| `project.rs:228` | `cargo test --workspace --lib --bins {filter}` |
| `project.rs:233` | `cargo test --workspace --test '*' {filter}` |
| `project.rs:236` | `cargo test --workspace {filter}` |
| `project.rs:257` | `{pm} run {script} -- {filter}` |
| `project.rs:264` | `go test ./... -run {filter}` |
| `project.rs:289` | `{entry.command} {filter}` |

`{"filter": "x; touch /tmp/pwned"}` ran `touch`. `scope:"impacted"` fed the same position from `tests.join(" ")`.

## Why it was deferred, and what that missed

The audit deferred this ([#615](https://github.com/macanderson/stella/issues/615), item 1) because both obvious fixes conflict with a real contract:

- **quoting** breaks the documented multi-token filter (`tests.join(" ")` relies on shell splitting), and
- **argv composition** is a cross-function signature change.

Both are true of the fixes as stated. But they share an assumption — that "quoting" means wrapping the *whole* filter in one pair of quotes. **Quoting each token separately** preserves the multi-token contract exactly:

```
--lib foo bar   ->   '--lib' 'foo' 'bar'      still three arguments
x; touch /tmp/p ->   'x;' 'touch' '/tmp/p'    still three arguments, none of them a command
```

Token *count* is preserved; token *content* loses its shell meaning.

## The change

`filter` becomes a `SafeFilter` newtype whose only constructors quote, and `test_command` accepts nothing else — so a future interpolation site cannot be handed a raw string by accident. The type is the enforcement, not a convention.

`SafeFilter::from_tokens` also fixes a latent bug the old join-then-resplit shape could not express: a selected test path **containing a space** now stays one argument instead of silently becoming two.

Two behaviours improve as a side effect:

- `go test -run 'TestA|TestB'` was a **shell pipeline** before; it is now a regex.
- A filter containing `$HOME`, backticks or `$(…)` is no longer expanded by the shell.

## Witness

`a_hostile_filter_cannot_start_a_second_command` asserts **both** halves on purpose — that the pre-PR shape really is injectable, and that the identical filter routed through `SafeFilter` is not. Without the first assertion the test could pass for the wrong reason and would not catch a regression. It runs a real `bash -c`, because the claim is about what a shell does.

Confirmed to fail on the unfixed code (reverting `from_input` to return the raw string):

```
test project::tests::a_hostile_filter_cannot_start_a_second_command ... FAILED
panicked at stella-tools/src/project.rs:612:
SafeFilter let `x; touch /var/.../pwned` escape its word and start a new command
```

Plus `quoting_preserves_the_token_count` (via `printf '%s\n'`, so the line count *is* the argument count), `impact_selection_keeps_a_spaced_path_whole`, and `a_regex_filter_is_no_longer_a_pipeline`.

## Note on the one changed expectation

`the_command_chain_gates_the_index_composed_build_and_test_commands` asserted the gate sees `… --lib --bins my_test`; it now sees `… --lib --bins 'my_test'`. `resolve_command_for_gate` quotes identically to `execute`, so the gated line remains **byte-identical to what runs** — which is precisely what that test protects. The expectation moved; the assertion did not weaken.

## Verification

- `cargo clippy -p stella-tools --all-targets -- -D warnings` — clean
- `cargo test -p stella-tools` — 441 pass, 0 fail
- `cargo check --workspace --all-targets` — clean
- `make no-scratch` — OK

`Refs #615` — this closes item 1 of that issue, not the whole issue.
