### PR TITLE
ci: pin all 34 workflow actions to commit SHAs, and guard it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,9 @@ updates:
       cargo:
         update-types: [minor, patch]
 
-  # GitHub Actions pinned in workflows.
+  # GitHub Actions. Every `uses:` in .github/workflows/ is pinned to a commit
+  # SHA with the human-readable tag in a trailing comment; dependabot bumps the
+  # SHA and the comment together. Keep it that way — see scripts/check-action-pins.sh.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -76,7 +76,7 @@ jobs:
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Tag the exact commit CI validated, not whatever main is now.
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Install Rust (Cargo.lock sync)
         if: steps.ver.outputs.skip != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Open the version-sync PR
         if: steps.ver.outputs.skip != 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: harbor_adapter — sync (locked) + pytest
         working-directory: bench/harbor_adapter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     # heavy C compiles on a cold cache; rust-cache keeps warm runs fast.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Cheap and toolchain-free, so it runs before the Rust setup: a tracked
       # file that matches .gitignore means agent scratch reached the remote
@@ -77,12 +77,18 @@ jobs:
       - name: no tracked file is gitignored
         run: ./scripts/check-no-scratch.sh
 
+      # Also toolchain-free, so it runs before the Rust setup: a floating
+      # `uses:` ref lets the action's owner change what runs with this job's
+      # secrets. Pinning is only durable if something re-checks it (#648).
+      - name: every workflow action is pinned to a commit SHA
+        run: ./scripts/check-action-pins.sh
+
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: cargo fmt --check
         run: cargo fmt --check
@@ -101,12 +107,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-deny + cargo-audit
         run: cargo install --locked cargo-deny cargo-audit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -44,7 +44,7 @@ jobs:
           && github.event.pull_request.user.type != 'Bot')
     steps:
       - name: Check or record CLA signature
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,9 +12,9 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         # Version comes from the root package.json's packageManager field.
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Vertex only: exchange the long-lived service-account key for a
       # short-lived bearer token, freshly minted this run. The `secrets`
@@ -104,13 +104,13 @@ jobs:
 
       - name: Authenticate to Google Cloud (Vertex)
         if: steps.vertex_creds.outputs.present == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
       - name: Set up gcloud (Vertex)
         if: steps.vertex_creds.outputs.present == 'true'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
 
       - name: Mint VERTEX_ACCESS_TOKEN
         if: steps.vertex_creds.outputs.present == 'true'

--- a/.github/workflows/normative-home.yml
+++ b/.github/workflows/normative-home.yml
@@ -31,6 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check NORMATIVE-HOME pins match the CGP rev stella builds against
         run: bash scripts/check-normative-home.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,14 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -135,7 +135,7 @@ jobs:
           echo "asset=${stem}.tar.gz" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stella-${{ matrix.target }}
           path: ${{ steps.package.outputs.asset }}
@@ -151,13 +151,13 @@ jobs:
       contents: write
     steps:
       # Full history + tags so the notes step can diff against the prior tag.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: stella-*
@@ -218,7 +218,7 @@ jobs:
           echo "----- notes.md -----"; cat notes.md
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             artifacts/stella-*.tar.gz
@@ -241,10 +241,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout (for the formula template)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: stella-*

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,16 +22,16 @@ jobs:
       security-events: write # upload SARIF to code scanning
       id-token: write # publish results to the OpenSSF API
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: results.sarif

--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,15 @@ bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer)
 no-scratch: ## Assert no tracked file is gitignored (agent scratch guard, #448)
 	@./scripts/check-no-scratch.sh
 
+.PHONY: action-pins
+action-pins: ## Assert every workflow `uses:` is pinned to a commit SHA (#648)
+	@./scripts/check-action-pins.sh
+
 .PHONY: gate
-gate: no-scratch format-check lint test ## Full CI gate: no-scratch + fmt-check + clippy + test
+gate: no-scratch action-pins format-check lint test ## Full CI gate: no-scratch + action-pins + fmt-check + clippy + test
 
 .PHONY: check
-check: no-scratch format-check lint ## Fast pre-push check (scratch + fmt + clippy, no tests)
+check: no-scratch action-pins format-check lint ## Fast pre-push check (scratch + pins + fmt + clippy, no tests)
 
 .PHONY: hooks
 hooks: ## Install the pre-push gate hook (runs `make gate` on every push)

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Guard: every `uses:` in .github/workflows/ must name a 40-hex commit SHA.
+#
+# Before this guard, 34 of 34 action references were floating tags or branches,
+# and .github/dependabot.yml claimed the opposite. A tag is mutable: the owner
+# of any of those 15 actions could repoint it at new code, and it would run
+# with whatever secrets the job holds. `dtolnay/rust-toolchain@stable` was not
+# even a tag but a *branch*, which moves with no release event at all.
+#
+# Two of the un-pinned refs sat on the paths where that matters most:
+# softprops/action-gh-release publishes the release artifacts, and
+# contributor-assistant/github-action is the gate deciding who may contribute.
+#
+# The tag is kept in a trailing comment (`@<sha> # v7`) because the SHA alone
+# is unreadable and un-reviewable. Dependabot bumps the SHA and that comment
+# together, so pinning does not freeze the actions in place.
+#
+# Matching is anchored to a `uses:` *key* rather than a bare substring, because
+# `statuses: write` (cla.yml) ends in "uses:" and a naive grep flags it.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner (no ripgrep).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+workflows=".github/workflows"
+if [ ! -d "$workflows" ]; then
+  echo "check-action-pins: no $workflows directory; skipping."
+  exit 0
+fi
+
+# A `uses:` key: optional leading list dash, then `uses:` and whitespace.
+uses_key='^[[:space:]]*-?[[:space:]]*uses:[[:space:]]'
+# A correctly pinned value: <action>@<40 lowercase hex>, then EOL or a comment.
+pinned='uses:[[:space:]]*[^[:space:]]+@[0-9a-f]{40}([[:space:]]|$)'
+
+all_uses="$(grep -rnE "$uses_key" "$workflows" || true)"
+
+if [ -z "$all_uses" ]; then
+  echo "check-action-pins: no 'uses:' references found; skipping."
+  exit 0
+fi
+
+unpinned="$(printf '%s\n' "$all_uses" | grep -vE "$pinned" || true)"
+
+if [ -n "$unpinned" ]; then
+  echo "check-action-pins: these 'uses:' references are not pinned to a commit SHA:" >&2
+  echo >&2
+  printf '%s\n' "$unpinned" >&2
+  echo >&2
+  echo "Pin each one to a 40-hex commit SHA, keeping the tag in a comment:" >&2
+  echo >&2
+  echo "    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7" >&2
+  echo >&2
+  echo "Resolve a tag to its commit with:" >&2
+  echo >&2
+  echo "    gh api repos/<owner>/<repo>/commits/<tag> --jq .sha" >&2
+  echo >&2
+  echo "Use the API rather than 'git ls-remote': for an annotated tag, ls-remote" >&2
+  echo "prints the tag object's SHA, and a workflow pinned to a tag object fails" >&2
+  echo "at startup." >&2
+  exit 1
+fi
+
+total="$(printf '%s\n' "$all_uses" | wc -l | tr -d '[:space:]')"
+
+# Not fatal: a missing tag comment is a readability problem, not a security one.
+no_comment="$(printf '%s\n' "$all_uses" | grep -vE '@[0-9a-f]{40}[[:space:]]*#' || true)"
+if [ -n "$no_comment" ]; then
+  echo "check-action-pins: pinned, but with no '# <tag>' comment to say what version this is:"
+  printf '%s\n' "$no_comment"
+fi
+
+echo "check-action-pins: OK — all $total 'uses:' references are pinned to a commit SHA."


### PR DESCRIPTION
Closes #648

## What changed

All **34** `uses:` references across the 10 files in `.github/workflows/` are now pinned to 40-hex commit SHAs, with the human-readable tag preserved in a trailing comment:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

Before this, **0 of 34** were pinned — 15 distinct actions, all on mutable tags, and `dtolnay/rust-toolchain@stable` on a *branch*, which moves with no release event at all.

Two of them sat where a silent upstream change is worst: `softprops/action-gh-release` publishes the release artifacts, and `contributor-assistant/github-action` is the gate that decides who may contribute.

## The `dependabot.yml` half

`.github/dependabot.yml:15` claimed `# GitHub Actions pinned in workflows.` while none were. It now describes what is true and points at the guard. The `github-actions` ecosystem was already configured weekly with `patterns: ["*"]`, and dependabot bumps a pinned SHA *and* its trailing comment together — so this does not freeze the actions in place.

## The guard

`scripts/check-action-pins.sh`, wired into `ci.yml` (before the Rust setup, since it is toolchain-free) and into `make gate` / `make check`. Pinning that nothing re-checks decays on the next PR.

It matches an **anchored `uses:` key** rather than a substring, because `statuses: write` in `cla.yml:32` ends in the letters "uses:" — a naive `grep uses:` reports 35 refs and flags a permission line. That off-by-one is also why #614 recorded "35 of 35"; the real figure is 34.

## How this was verified

- **Every SHA resolved via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`**, then re-queried as `repos/<repo>/commits/<sha>` to confirm it names a **commit**, not an annotated tag object. All 15 confirmed. This is the failure the issue flagged: a workflow pinned to a tag object fails at startup.
- **All 10 workflow files + `dependabot.yml` re-parsed as YAML** after rewriting.
- **The guard was negative-tested**, not just run: it exits 1 on a floating tag (`actions/checkout@v7`), exits 1 on a 39-char truncated SHA, exits 0 on the real tree, and does not flag `statuses: write`.
- `make action-pins` green.

## What this PR cannot prove

`release.yml` and `live-smoke.yml` do not run on a pull request — the first is tag-triggered, the second is secret-gated. Their **14 pinned refs** (9 + 5) are verified only by the commit-object check above, not by execution.

The other 20 refs are in `ci.yml`, `docs.yml`, `dependency-review.yml`, `cla.yml`, `scorecard.yml`, and `normative-home.yml`, which do exercise on this PR — so a green check here is real evidence for those.

`auto-tag.yml` and `bench.yml` are `workflow_run`/schedule-triggered and likewise unexercised here.

## Follow-on

#649 adds a release attestation step and therefore a new action ref; landing this first means it gets pinned on arrival rather than in a second pass over `release.yml`.

<sub>First of the five tickets triaged out of #614. Sibling tickets: #649 (release signing), #650 (CLA vs DCO), #651 (release cadence), #652 (dangling `docs/context-reuse.md` citations).</sub>
