### PR TITLE
docs: settle CLA vs DCO — the CLA governs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ Stella's definition of done is a test that **fails on the old code and passes on
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
 - [ ] `cargo test --workspace`
 - [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments)
-- [ ] Commits signed off for DCO (`git commit -s`)
+- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
 - [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
       the commit body from commit messages, so the description alone won't carry it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ get it merged. It's long because it's honest — but the short version is:
 - [The ground rules](#the-ground-rules)
 - [The definition of done — witness tests](#the-definition-of-done--witness-tests)
 - [Style](#style)
-- [Commits, DCO, and PRs](#commits-dco-and-prs)
+- [Commits, the CLA, and PRs](#commits-the-cla-and-prs)
 - [Issues and labels](#issues-and-labels)
 - [Security](#security)
 - [License](#license)
@@ -211,7 +211,7 @@ rendering), explain how you verified the change instead.
 - **Match the neighborhood.** Every crate has an established idiom — copy the
   patterns around you before inventing new ones.
 
-## Commits, DCO, and PRs
+## Commits, the CLA, and PRs
 
 **Commit format** — [Conventional Commits](https://www.conventionalcommits.org),
 with the crate (or surface) as scope, matching the existing history:
@@ -230,9 +230,11 @@ are needed because squash merges build the commit body from commit messages
 rather than the PR body, while the description drives GitHub's linked-issue
 close. Use `Refs #N` when a PR advances an issue without finishing it.
 
-**DCO, not CLA.** Sign every commit (`git commit -s`) to certify the
-[Developer Certificate of Origin](https://developercertificate.org/). You keep
-your copyright; no assignment, ever.
+**Sign the CLA once.** On your first PR a bot will ask you to sign the
+[Contributor License Agreement](CLA.md); it takes one comment and covers every
+PR you open afterwards. **You keep your copyright** — the CLA is a license
+grant, not an assignment. See [License](#license) below for what it grants and
+why. There is no per-commit sign-off step.
 
 **PR checklist** (the template walks you through it):
 
@@ -241,7 +243,7 @@ your copyright; no assignment, ever.
 3. A witness test, or a stated reason there isn't one.
 4. Docs updated in the same PR if behavior or flags changed (`README.md`,
    `--help` text, doc comments).
-5. Commits signed off (`-s`).
+5. CLA signed — the bot prompts you on your first PR.
 
 Maintainers aim for a first response within a few days. "Needs work" is a
 normal part of the loop here, not a rejection.
@@ -271,7 +273,7 @@ By contributing you agree to the [Contributor License Agreement](CLA.md). In
 short: **you keep your copyright**, your contribution is published under the
 AGPL, and Oxagen may also include it in commercially licensed builds. Without
 that last part a merged contribution would be AGPL-only and could never ship
-commercially — which is why the CLA replaced the old DCO-only policy.
+commercially — which is why this project uses a CLA rather than a DCO sign-off.
 
 If some clause in the CLA is a blocker for you, say so in the PR or email
 <licensing@oxagen.sh>. Better to talk about it than to lose the contribution.


### PR DESCRIPTION
Closes #650

**Decision: the CLA governs.** Confirmed with the owner before editing — this PR implements that call rather than inferring it.

## The contradiction

`CONTRIBUTING.md` asserted both policies, 37 lines apart:

| line | text |
|---|---|
| **233** | **"DCO, not CLA."** Sign every commit (`git commit -s`)… |
| **234-235** | "You keep your copyright; **no assignment, ever.**" |
| **272** | "By contributing you agree to the [Contributor License Agreement](CLA.md)." |
| **274** | "…which is why **the CLA replaced the old DCO-only policy**." |

## What actually gated a PR

Only the CLA. `.github/workflows/cla.yml:47` runs `contributor-assistant/github-action` against `macanderson/stella-cla-signatures`, and `CLA.md` exists. There was **zero** DCO enforcement — no `signed-off` / `commit -s` check in any workflow — yet the repo asked for DCO in four places (`CONTRIBUTING.md` L20, L214, L233, L244) plus an unenforced checkbox in `PULL_REQUEST_TEMPLATE.md:34`.

This wasn't a style nit. A contributor who read L233, signed off their commits, and opened a PR was then blocked by a CLA bot asking for terms the same document told them did not apply. *"No assignment, ever"* is a statement about what someone is agreeing to.

## What changed

- Section heading and TOC entry now name the CLA (`## Commits, the CLA, and PRs`)
- The "DCO, not CLA" paragraph → a pointer to the sign-once bot flow and to the License section
- PR checklist item 5 and the PR template's per-commit sign-off checkbox now reference the CLA

**The "you keep your copyright" promise survives verbatim.** It was always true under the CLA — a license grant, not an assignment. The License section (L266-277) already said exactly that, correctly; it just contradicted the section above it. That section is otherwise untouched.

## How this was verified

- Every remaining mention of DCO or sign-off is now a **negative** statement — "there is no per-commit sign-off step", "a CLA rather than a DCO sign-off" — so nothing asks for a policy that isn't enforced.
- **All 10 internal anchors in `CONTRIBUTING.md` still resolve** after the heading rename, checked programmatically against the heading set (the TOC link and the new `[License](#license)` cross-reference both land).

## Still needs you

One checkbox from the issue can't be done from a checkout: **make the `cla` check required in branch protection.** Until then the gate is advisory — `cla` currently reports `skipping` on PRs from you.

<sub>Third of the five tickets triaged out of #614. Siblings: #648 (action pins, PR #653), #652 (doc citations, PR #654), #649 (release signing), #651 (release cadence).</sub>
