### PR TITLE
docs: add a CHANGELOG and roll it on every release

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -180,9 +180,30 @@ jobs:
           # Keep the local build-from-source formula pointing at the release.
           perl -pi -e 's/tag: "v[^"]*"/tag: "v$ENV{NEW_VERSION}"/; s/^  version "[^"]*"/  version "$ENV{NEW_VERSION}"/' packaging/homebrew/stella.rb
 
+          # Roll CHANGELOG.md: whatever contributors put under [Unreleased]
+          # becomes this version's section, and [Unreleased] is left empty for
+          # the next change. Inserting *after* the heading (rather than
+          # renaming it) is what carries the existing bullets down.
+          #
+          # Deliberately tolerant: a missing file or a missing [Unreleased]
+          # heading is skipped, not fatal. This job publishes releases, and a
+          # changelog bookkeeping slip must never be what stops one.
+          if [ -f CHANGELOG.md ] && grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+            RELEASE_DATE="$(date -u +%F)" \
+              perl -pi -e 's/^## \[Unreleased\]$/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] — $ENV{RELEASE_DATE}/' CHANGELOG.md
+            grep -q "^## \[${version}\] " CHANGELOG.md \
+              || echo "::warning::CHANGELOG.md roll did not take for ${version}"
+          else
+            echo "::warning::CHANGELOG.md missing or has no [Unreleased] heading; skipping the roll."
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock packaging/homebrew/stella.rb
+          # An `if`, not `[ -f … ] && git add …`: under `set -e` a false test
+          # in a bare `&&` chain is a non-zero status for the whole line and
+          # would abort the release job.
+          if [ -f CHANGELOG.md ]; then git add CHANGELOG.md; fi
           if git diff --cached --quiet; then
             echo "manifests already at ${version}; nothing to sync."
             exit 0
@@ -200,6 +221,7 @@ jobs:
           - \`[workspace.package].version\` in \`Cargo.toml\` (inherited by every crate)
           - the workspace-member entries in \`Cargo.lock\`
           - \`packaging/homebrew/stella.rb\` (build-from-source formula)
+          - \`CHANGELOG.md\` — whatever was under \`[Unreleased]\` now sits under \`[${version}]\`
 
           The workflow dispatches the required \`ci\` checks onto this branch and merges once they're green (past GitHub's phantom \`action_required\` check suite for this GITHUB_TOKEN-authored PR — see #275); no action is needed unless the dispatched run fails."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How this file works
+
+**Every merge to main cuts a release** (see [`RELEASING.md`](RELEASING.md)), so
+this file is written by contributors, not by the release job. Add a bullet under
+`## [Unreleased]` in the same PR as your change, whenever that change is
+something a user would notice — a new flag, a changed default, a fixed bug, a
+breaking rename.
+
+On release, `auto-tag.yml` moves whatever is under `## [Unreleased]` beneath a
+new version heading and leaves `## [Unreleased]` empty for the next change. It
+does not invent entries: a release with nothing under `## [Unreleased]` gets a
+version heading with no bullets, which is the honest record of a merge that
+changed nothing user-facing.
+
+Internal refactors, test-only changes, and CI work do not need an entry.
+
+Each GitHub Release additionally carries per-release notes generated at publish
+time from the commit range. Those are a summary of *commits*; this file is a
+record of *changes*, curated by the person who made them.
+
+## [Unreleased]
+
+## Before 0.5.27
+
+This file was introduced at 0.5.27. Earlier releases are recorded only in their
+generated GitHub Release notes, at
+<https://github.com/macanderson/stella/releases>. No attempt has been made to
+reconstruct them here — a hand-written history of releases nobody curated at the
+time would be a guess presented as a record.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,8 +29,32 @@ main and does everything — no manual steps:
    pass. Its commit carries `[skip release]`, so the sync itself never cuts a
    release. If a sync PR is ever left open (red check, race with another
    merge), the next release supersedes it automatically — no cleanup needed.
+   The same PR **rolls [`CHANGELOG.md`](CHANGELOG.md)**: whatever sits under
+   `## [Unreleased]` moves beneath a new version heading, and `[Unreleased]`
+   is left empty for the next change.
 
 Manual version bumps are therefore only needed for the hand-cut flows below.
+
+## What records a change
+
+Two things, and they are not the same thing:
+
+- **[`CHANGELOG.md`](CHANGELOG.md)** — written by contributors, in the PR that
+  makes the change. This is the durable, curated record. Add a bullet under
+  `## [Unreleased]` whenever a user would notice the change; skip it for
+  internal refactors, tests, and CI.
+- **GitHub Release notes** — generated at publish time by `release.yml` from
+  the commit range. A summary of commits, not a curated record, and not
+  something to edit by hand.
+
+Because every merge releases, most individual releases are small and some have
+no user-facing change at all. Those get a version heading with no bullets. That
+is the correct output, not a gap to fill in: it says the release happened and
+changed nothing a user would notice.
+
+The changelog roll is deliberately non-fatal. If `CHANGELOG.md` is missing or
+has no `## [Unreleased]` heading, `auto-tag.yml` logs a warning and continues —
+a bookkeeping slip must never be the reason a release fails to ship.
 
 ## One-time setup
 


### PR DESCRIPTION
Closes #651

**Decision: keep the cadence, add a CHANGELOG.** Confirmed with the owner before editing.

## The gap

Every merge to main cuts a release (`auto-tag.yml:3`), the project is at **0.5.27**, and **no CHANGELOG existed anywhere in the tree**. The only record of what changed between versions was per-release notes generated at publish time from the commit range — a summary of *commits*, not a curated record.

## What landed

**`CHANGELOG.md`** — Keep a Changelog format, written by contributors in the PR that makes the change, not by the release job.

**`auto-tag.yml` rolls it on release.** The existing version-sync PR — already bumping `Cargo.toml`, `Cargo.lock`, and the Homebrew formula — now also moves whatever sits under `## [Unreleased]` beneath a new version heading and leaves `[Unreleased]` empty. Putting it in that PR means the changelog cannot drift from the version it describes.

**`RELEASING.md`** now distinguishes the two records — the curated file vs. the generated release notes — and documents the roll.

## Two judgment calls worth flagging

**The file is seeded honestly.** Releases before 0.5.27 point at their generated GitHub Release notes rather than being reconstructed. A hand-written history of releases nobody curated at the time would be a guess presented as a record.

**Empty releases get a bare version heading.** Because every merge releases, some releases change nothing user-facing. That heading is the correct output, not a gap to backfill: it says the release happened and changed nothing a user would notice. The alternative — inventing an entry — is how a changelog becomes noise.

## How this was verified

`auto-tag.yml` only runs on a merge to main, so a PR cannot exercise it. What I could do instead:

- **Ran the exact roll logic through two consecutive simulated releases.** An entry under `[Unreleased]` lands under the new version heading; a second release with an empty `[Unreleased]` produces a bare heading; prior versions stay in reverse-chronological order.
- **`auto-tag.yml` re-parses as YAML**, and the edited `run:` block was extracted and passed through **`bash -n`**.

## One `set -e` hazard caught on the way in

My first draft ended the step with:

```sh
[ -f CHANGELOG.md ] && git add CHANGELOG.md
```

Under `set -euo pipefail`, a false test in a bare `&&` chain is a non-zero status for the whole line — which would **abort the release job** whenever the file was absent. It is now an `if`. Flagging it because this job is the release path, and that failure would have been invisible until the first release after someone deleted the file.

The roll itself is deliberately non-fatal for the same reason: a missing file or missing `[Unreleased]` heading logs a `::warning::` and continues.

## Not addressed here

The issue also flagged `auto-tag.yml:228-298` — the `RELEASE_ADMIN_TOKEN` admin-merge that pushes the version-sync PR past branch protection on every release. That is a standing bypass on the most-trafficked path in the repo and deserves its own review; it is independent of the changelog decision and out of scope for this PR.

<sub>Fourth of the five tickets triaged out of #614. Siblings: #648 (action pins, PR #653), #652 (doc citations, PR #654), #650 (CLA, PR #655), #649 (release signing).</sub>
