### PR TITLE
ci: attest release provenance, and verify it in install.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      # Provenance attestation (#649). `id-token: write` mints the short-lived
+      # OIDC token Sigstore signs against; `attestations: write` stores the
+      # resulting bundle on the repo. No signing key is involved, so there is
+      # no key to rotate or leak — which is what made this landable.
+      id-token: write
+      attestations: write
     steps:
       # Full history + tags so the notes step can diff against the prior tag.
       - uses: actions/checkout@v7
@@ -171,6 +177,22 @@ jobs:
           sha256sum stella-*.tar.gz > SHA256SUMS
           echo "----- SHA256SUMS -----"
           cat SHA256SUMS
+
+      # Attest the tarballs *and* SHA256SUMS. Attesting the sums file is the
+      # point: install.sh trusts it to vouch for the tarball, but it was
+      # fetched over the same channel from the same release, so anything able
+      # to replace one could replace the other. A provenance bundle is bound to
+      # this workflow at this commit and cannot be reissued by whoever holds
+      # the release.
+      #
+      # Pinned by SHA because that is the invariant #648 established; adding a
+      # floating ref here would be the first thing to break its CI guard.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: |
+            artifacts/stella-*.tar.gz
+            artifacts/SHA256SUMS
 
       # Draft the release notes from the diff since the previous tag using the
       # AI Gateway. Falls back to a plain commit list if the key is unset or the

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,24 @@
 #   STELLA_VERSION      install a specific version (e.g. "0.1.0" or "v0.1.0")
 #                       instead of the latest release.
 #   STELLA_INSTALL_DIR  install directory (default: $HOME/.local/bin).
+#   STELLA_REQUIRE_PROVENANCE=1
+#                       refuse to install unless the build-provenance
+#                       attestation verifies. Requires `gh`. Off by default
+#                       because `curl | sh` cannot assume gh is present, and
+#                       releases published before provenance was introduced
+#                       carry no attestation.
 #
 # Behavior: detects your OS/arch, downloads the matching prebuilt tarball from
-# the GitHub Release, verifies its SHA-256 against SHA256SUMS, and installs the
+# the GitHub Release, verifies its SHA-256 against SHA256SUMS, verifies the
+# build-provenance attestation when `gh` is available, and installs the
 # `stella` binary. If no prebuilt binary matches your platform, it falls back to
 # `cargo install`.
+#
+# Note the checksum and the attestation answer different questions: SHA256SUMS
+# proves the download was not corrupted, and is fetched over the same channel
+# as the artifact it vouches for. The attestation proves the artifact was built
+# by this repo's release workflow. A verifier that runs and *rejects* an
+# artifact is always fatal, regardless of STELLA_REQUIRE_PROVENANCE.
 #
 # POSIX sh — no bashisms.
 
@@ -130,6 +143,70 @@ sha256_of() {
   fi
 }
 
+# ---- provenance ----------------------------------------------------------
+
+# Verify the GitHub build-provenance attestation for a downloaded artifact.
+#
+# Three outcomes, and the distinction between them is the whole design:
+#
+#   verified      -> continue
+#   contradicted  -> die, always, no override
+#   unverifiable  -> warn and continue, unless STELLA_REQUIRE_PROVENANCE=1
+#
+# "Unverifiable" means no `gh` on PATH, or a gh too old for `attestation
+# verify`. Requiring gh outright would break `curl | sh` for most people, which
+# is the install path this script exists to serve; silently skipping when gh
+# *is* present would waste a guarantee that costs nothing to check.
+verify_provenance() {
+  artifact="$1"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    if [ "${STELLA_REQUIRE_PROVENANCE:-0}" = "1" ]; then
+      die "STELLA_REQUIRE_PROVENANCE=1 but gh is not installed; cannot verify provenance"
+    fi
+    info "provenance not verified (gh not installed) — checksum only"
+    info "  to verify: install gh, then STELLA_REQUIRE_PROVENANCE=1 re-run this installer"
+    return 0
+  fi
+
+  if ! gh attestation verify --help >/dev/null 2>&1; then
+    if [ "${STELLA_REQUIRE_PROVENANCE:-0}" = "1" ]; then
+      die "STELLA_REQUIRE_PROVENANCE=1 but this gh has no 'attestation verify'; upgrade gh"
+    fi
+    info "provenance not verified (gh too old for 'attestation verify') — checksum only"
+    return 0
+  fi
+
+  info "verifying provenance"
+  if out="$(gh attestation verify "$artifact" --repo "$REPO" 2>&1)"; then
+    info "provenance ok"
+    return 0
+  fi
+
+  # Every release published before provenance was added carries no attestation
+  # at all, and so does any release cut from a fork. That is "unverifiable",
+  # not "forged" — treating it as a hard failure would break `curl | sh` for
+  # every older version the moment this landed. Distinguish the two by gh's
+  # own wording rather than collapsing them into one exit code.
+  if printf '%s' "$out" | grep -qi 'no attestation'; then
+    if [ "${STELLA_REQUIRE_PROVENANCE:-0}" = "1" ]; then
+      die "STELLA_REQUIRE_PROVENANCE=1 but ${version} carries no attestation.
+     Releases published before provenance was introduced have none. Install a
+     newer version, or unset STELLA_REQUIRE_PROVENANCE to accept checksum-only."
+    fi
+    info "provenance not verified (no attestation for ${version}) — checksum only"
+    return 0
+  fi
+
+  # Reached only when a verifier ran and actively rejected the artifact.
+  # Never soft, never overridable.
+  die "provenance verification FAILED for $(basename "$artifact") — refusing to install.
+     The checksum matched, but the artifact does not carry a valid build
+     attestation from ${REPO}. Do not install this binary. To see why:
+       gh attestation verify \"$artifact\" --repo ${REPO}
+     Please report it at https://github.com/${REPO}/security"
+}
+
 # ---- cargo fallback ------------------------------------------------------
 
 cargo_fallback() {
@@ -230,6 +307,20 @@ main() {
     die "checksum mismatch for ${asset}: expected ${expected}, got ${actual}"
   fi
   info "checksum ok"
+
+  # SHA256SUMS proves the tarball was not corrupted in transit. It does not
+  # prove where the tarball came from: it is fetched over the same channel,
+  # from the same release, so anything able to replace one could replace both.
+  # The provenance attestation closes that gap — it is bound to the release
+  # workflow at a specific commit and cannot be reissued by whoever holds the
+  # release.
+  #
+  # Verification needs `gh`, which a `curl | sh` install cannot assume. So:
+  # verify whenever gh is present, and let anyone who requires the guarantee
+  # demand it with STELLA_REQUIRE_PROVENANCE=1. A *failed* verification is
+  # always fatal — the soft path is "no verifier available", never "verifier
+  # said no".
+  verify_provenance "${tmpdir}/${asset}"
 
   # Extract. The tarball contains a top-level "stella-<version>-<target>/" dir.
   tar -C "$tmpdir" -xzf "${tmpdir}/${asset}"


### PR DESCRIPTION
Closes #649

**Decision: `actions/attest-build-provenance`.** Confirmed with the owner. It needs no signing key — only OIDC — which is exactly what made this landable; the original deferral (#587) assumed a repository signing key and a rotation story.

## The gap

`SHA256SUMS` shipped unsigned. `install.sh` verified it, but the sums file is fetched **over the same TLS channel, from the same GitHub Release**, as the tarball it vouches for. Anything able to replace one could replace both. The release defended against corruption, not against a compromised release.

## Production side

`release.yml`'s publish job gains `id-token: write` + `attestations: write`, and an attestation step covering **both** `artifacts/stella-*.tar.gz` and `artifacts/SHA256SUMS`.

Attesting the sums file is the point — that is the file `install.sh` actually trusts.

The action is **pinned by SHA** (`977bb373…` # v3). A floating ref here would be the first thing to break the guard #648 adds, whichever order the two land in.

## Consumption side — three outcomes, not two

This is the part that needed care. `install.sh` now distinguishes:

| outcome | behaviour |
|---|---|
| verified | continue |
| **contradicted** | **die — always, not overridable** |
| unverifiable | warn and continue, unless `STELLA_REQUIRE_PROVENANCE=1` |

**The third row is what keeps this from breaking every user the day it lands.** Two situations are *unverifiable* rather than forged:

1. A host with no `gh` — and `curl \| sh` cannot assume one.
2. **Any release published before provenance existed — which is every release so far.**

My first draft collapsed those into the failure path. That version would have made the installer **refuse every currently-published version** for anyone who happens to have `gh` installed. They're now told apart by gh's own `no attestation` wording, since gh returns non-zero for both.

## How this was verified

The attestation step itself **cannot be exercised from a PR** — `release.yml`'s publish job only runs on `refs/tags/*`. So I tested what I could:

- **Stubbed `gh` and exercised all six paths.** No gh → soft. No gh + `STELLA_REQUIRE_PROVENANCE=1` → dies. Valid attestation → passes. No attestation → soft. No attestation + `=1` → dies. **Invalid attestation → dies even with `STELLA_REQUIRE_PROVENANCE=0`**, because a verifier that ran and said *no* is never advisory.
- `install.sh` passes `sh -n`, `bash -n`, and shellcheck clean. It is still POSIX `sh` — no bashisms added.
- `release.yml` re-parses with the expected permissions and step.

## What proves it for real

The first tagged release after this merges. The check to run:

```sh
gh attestation verify stella-<target>.tar.gz --repo macanderson/stella
```

Given #651 established that every merge to main cuts a release, that will happen immediately on merge — which is a reason to review the `release.yml` hunk closely rather than rely on the draft status.

## Note on default

The issue asked install.sh to "fail closed". It does for the case that matters — a verifier that rejects an artifact — but not for "no verifier available", for the compatibility reason above. Flipping `STELLA_REQUIRE_PROVENANCE` to default-on becomes reasonable once a few attested releases exist; that's a one-line change and deliberately left to you.

<sub>Last of the five tickets triaged out of #614. Siblings: #648 (action pins, PR #653), #652 (doc citations, PR #654), #650 (CLA, PR #655), #651 (CHANGELOG, PR #656).</sub>
