### PR TITLE
docs: add a README to every crate, and remove claims that are no longer true

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,9 +390,13 @@ be closed by exactly one PR; if a fix spans several, close on the last and
 
 ## Testing approach
 
-- **Property tests** for pure engine logic (`proptest`): compaction,
-  loop detection, budget arithmetic, retry history, calibration drift.
-  These run on every `cargo test`.
+- **Property tests** for pure engine logic (`proptest`): loop detection,
+  retry history, skill selection, and the task board (`stella-core`), plus
+  retrieval fusion (`stella-context`), fleet planning (`stella-fleet`),
+  witness verification (`stella-pipeline`), and render/scroll (`stella-tui`).
+  These run on every `cargo test`. Compaction, eviction, and budget
+  arithmetic are covered by unit tests, not properties — a property test for
+  them is a welcome contribution.
 - **Witness tests** for features — see above.
 - **Wiremock-based adapter tests** for provider SSE parsing and HTTP error
   classification (`stella-model`, `stella-mcp`, `stella-media`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,25 +208,28 @@ loop, and the `/pipeline` deck toggle.
 
 ## Workspace layout — where a change goes
 
-Fifteen crates. The one-sentence rule of thumb:
+Fifteen crates. The one-sentence rule of thumb below routes you to the right
+one; **each crate's own `README.md`** (linked from the table) then covers its
+layout, invariants, gotchas, and extension recipe in depth. Read that before
+changing code inside a crate you don't already know.
 
 | You want to… | Crate | Notes |
 |---|---|---|
-| Change the agent loop (plan / retry / compact / budget / loop-detect / hooks / skills / rules) | `stella-core` | **No I/O allowed.** Decision logic only. |
-| Add/fix a model provider (SSE, tool-call dialect, pricing) | `stella-model` | One file per adapter (`anthropic.rs`, `openai.rs`, `gemini.rs`, `vertex.rs`, `bedrock.rs`, `zai.rs`). Copy an existing adapter's shape. |
-| Add/fix a built-in tool (`read_file`, `verify_done`, the opt-in `bash`, …) | `stella-tools` | Implement the `Tool` trait, register in `ToolRegistry`. |
-| Change CLI commands, flags, or agent wiring | `stella-cli` | This is the shipping binary. |
-| Change REPL rendering / panels / keybindings | `stella-tui` | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
-| Touch shared types crossing a crate boundary | `stella-protocol` | **Zero logic, zero I/O — types only.** |
-| Persistence: executions, events, telemetry (SQLite) | `stella-store` | |
-| Retrieval: graph, embeddings, episodic memory | `stella-context` | |
-| Tree-sitter code indexing | `stella-graph` | |
-| Triage → … → judge orchestration plane | `stella-pipeline` | |
-| MCP client (external tool servers) | `stella-mcp` | |
-| Multimodal generation | `stella-media` | |
-| Multi-agent fan-out, worktree isolation | `stella-fleet` | |
-| The Observatory telemetry dashboard (`stella observe`) | `stella-observatory` | Loopback-only, read-only, embedded HTML. |
-| The headless engine server a host process drives over the wire | `stella-serve` | Its **own binary**, not linked into `stella-cli`. Every model/tool call is remoted back to the host; the engine holds no ambient authority. Design: [`docs/design/serve-surface.md`](docs/design/serve-surface.md). |
+| Change the agent loop (plan / retry / compact / budget / loop-detect / hooks / skills / rules) | [`stella-core`](stella-core/README.md) | **No I/O allowed.** Decision logic only. |
+| Add/fix a model provider (SSE, tool-call dialect, pricing) | [`stella-model`](stella-model/README.md) | One file per adapter (`anthropic.rs`, `openai.rs`, `gemini.rs`, `vertex.rs`, `bedrock.rs`, `zai.rs`). Copy an existing adapter's shape. |
+| Add/fix a built-in tool (`read_file`, `verify_done`, the opt-in `bash`, …) | [`stella-tools`](stella-tools/README.md) | Implement the `Tool` trait, register in `ToolRegistry`. |
+| Change CLI commands, flags, or agent wiring | [`stella-cli`](stella-cli/README.md) | This is the shipping binary. |
+| Change REPL rendering / panels / keybindings | [`stella-tui`](stella-tui/README.md) | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
+| Touch shared types crossing a crate boundary | [`stella-protocol`](stella-protocol/README.md) | **Zero logic, zero I/O — types only.** |
+| Persistence: executions, events, telemetry (SQLite) | [`stella-store`](stella-store/README.md) | |
+| Retrieval: graph, embeddings, episodic memory | [`stella-context`](stella-context/README.md) | |
+| Tree-sitter code indexing | [`stella-graph`](stella-graph/README.md) | |
+| Triage → … → judge orchestration plane | [`stella-pipeline`](stella-pipeline/README.md) | |
+| MCP client (external tool servers) | [`stella-mcp`](stella-mcp/README.md) | |
+| Multimodal generation | [`stella-media`](stella-media/README.md) | |
+| Multi-agent fan-out, worktree isolation | [`stella-fleet`](stella-fleet/README.md) | |
+| The Observatory telemetry dashboard (`stella observe`) | [`stella-observatory`](stella-observatory/README.md) | Loopback-only, read-only, embedded HTML. |
+| The headless engine server a host process drives over the wire | [`stella-serve`](stella-serve/README.md) | Its **own binary**, not linked into [`stella-cli`](stella-cli/README.md). Every model/tool call is remoted back to the host; the engine holds no ambient authority. Design: [`docs/design/serve-surface.md`](docs/design/serve-surface.md). |
 | Context Graph Protocol (wire types / host / conformance) | external repo: [`context-graph-protocol`](https://github.com/macanderson/context-graph-protocol) | Split out of this workspace; Stella depends on it directly via git as `contextgraph-types`/`contextgraph-host` at a pinned rev. Stays dependency-light by contract. |
 
 **Status — what ships.** The live runtime path is
@@ -307,7 +310,7 @@ this before assuming two of them mean the same thing:
 | **turn** | `turn_instance` | `stella-protocol/src/event.rs` | One `run_turn` — a prompt through the model/tool loop to an answer. Monotonic per session; groups the steps of that turn in `step_manifest`/`step_receipt`. In the store one turn is one execution. |
 | **step** | `(step, call_seq)` | `stella-protocol/src/event.rs` | One iteration inside a turn: one model call plus the tools it requested. `call_seq` disambiguates the several calls that can share a `(turn_instance, step)` — the engine's worker call is 0, the overflow summarizer and the pipeline's triage/judge/plan/guidance roles take 1, 2, … |
 | **fleet run** | `run_id` | `stella-fleet/src/ledger.rs` | One multi-agent fan-out, top of the fleet hierarchy: run → task → attempt → commits/spend. **Not** an `execution_id` and **not** a session. |
-| **task** | `TaskId` / `tasks` row | `stella-fleet/src/plan.rs`, `stella-store` | Two things that share a word: in the fleet ledger, one unit of work dispatched to a worker within a run; in the store, one row of the agent's own task-board snapshot, keyed `(session, task id)` and mirrored from `TaskUpdate` events. |
+| **task** | `TaskId` / `tasks` row | `stella-fleet/src/plan.rs`, [`stella-store`](stella-store/README.md) | Two things that share a word: in the fleet ledger, one unit of work dispatched to a worker within a run; in the store, one row of the agent's own task-board snapshot, keyed `(session, task id)` and mirrored from `TaskUpdate` events. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -607,23 +607,27 @@ Fifteen `stella-*` crates make up the workspace. The Context Graph Protocol
 the retrieval abstraction Stella's recall routes through — now lives in its own
 repository and is pulled in as a pinned git dependency, not as workspace members.
 
+Every crate carries its own `README.md` — linked from the table below — with its
+file layout, the invariants it enforces, its gotchas, and the recipe for
+extending it.
+
 | Crate | Role |
 |---|---|
-| `stella-cli` | CLI binary — clap surface + agent loop wiring |
-| `stella-core` | The step-driver engine (no I/O): parallel tools, goal loop, budget, retry, compaction, loop detection, router |
-| `stella-tools` | The built-in tools (CRUD, `grep`/`glob`, build/test/lint/format, `run_script`, the process group, the `repo_*` tools, `verify_done`, issues, CI — plus the opt-in `bash`) |
-| `stella-model` | The `Provider` port's adapters: anthropic, openai, gemini, vertex, bedrock, zai (SSE, tool-call dialects, SigV4, pricing) |
-| `stella-store` | SQLite persistence — executions, events, telemetry, files-touched |
-| `stella-mcp` | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry |
-| `stella-protocol` | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports |
-| `stella-context` | The context plane: reflection-memory recall + embedding index, episodes, bi-temporal facts |
-| `stella-graph` | Tree-sitter symbol + import-edge indexer (Rust/TS/JS/Python/SQL) |
-| `stella-pipeline` | The orchestration plane above the engine — the default `stella run` path: triage → plan → scope review → witness → execute → verify → judge ([docs](https://stella.oxagen.sh/docs/inference-pipeline)) |
-| `stella-fleet` | The multi-agent fleet behind `stella fleet`: DAG planner + wave scheduling, a shared tree with cooperative file claims by default, opt-in git-worktree isolation per task |
-| `stella-media` | Multimodal generation behind one `MediaProvider` port — `generate_svg` always on; `generate_image` and `generate_video`/`poll_video` registered when a media-capable key is set (video behind a headless cost gate) |
-| `stella-tui` | The Command Deck — a pure event-fold core + thin crossterm shell |
-| `stella-observatory` | The Observatory — `stella observe`'s loopback-only telemetry dashboard over the local SQLite stores |
-| `stella-serve` | A separate headless binary (not part of the `stella` CLI): drives the engine over a wire protocol so a host process runs the Rust core, remoting every model and tool call back — the engine holds no ambient authority |
+| [`stella-cli`](stella-cli/README.md) | CLI binary — clap surface + agent loop wiring |
+| [`stella-core`](stella-core/README.md) | The step-driver engine (no I/O): parallel tools, goal loop, budget, retry, compaction, loop detection, router |
+| [`stella-tools`](stella-tools/README.md) | The built-in tools (CRUD, `grep`/`glob`, build/test/lint/format, `run_script`, the process group, the `repo_*` tools, `verify_done`, issues, CI — plus the opt-in `bash`) |
+| [`stella-model`](stella-model/README.md) | The `Provider` port's adapters: anthropic, openai, gemini, vertex, bedrock, zai (SSE, tool-call dialects, SigV4, pricing) |
+| [`stella-store`](stella-store/README.md) | SQLite persistence — executions, events, telemetry, files-touched |
+| [`stella-mcp`](stella-mcp/README.md) | MCP client (stdio + HTTP, protocol `2025-06-18`) merging external tools into the registry |
+| [`stella-protocol`](stella-protocol/README.md) | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports |
+| [`stella-context`](stella-context/README.md) | The context plane: reflection-memory recall + embedding index, episodes, bi-temporal facts |
+| [`stella-graph`](stella-graph/README.md) | Tree-sitter symbol + import-edge indexer (Rust/Python/JS/TS/TSX/SQL/Go/Java/C/PHP) |
+| [`stella-pipeline`](stella-pipeline/README.md) | The orchestration plane above the engine — the default `stella run` path: triage → plan → scope review → witness → execute → verify → judge ([docs](https://stella.oxagen.sh/docs/inference-pipeline)) |
+| [`stella-fleet`](stella-fleet/README.md) | The multi-agent fleet behind `stella fleet`: DAG planner + wave scheduling, a shared tree with cooperative file claims by default, opt-in git-worktree isolation per task |
+| [`stella-media`](stella-media/README.md) | Multimodal generation behind one `MediaProvider` port — `generate_svg` always on; `generate_image` and `generate_video`/`poll_video` registered when a media-capable key is set (video behind a headless cost gate) |
+| [`stella-tui`](stella-tui/README.md) | The Command Deck — a pure event-fold core + thin crossterm shell |
+| [`stella-observatory`](stella-observatory/README.md) | The Observatory — `stella observe`'s loopback-only telemetry dashboard over the local SQLite stores |
+| [`stella-serve`](stella-serve/README.md) | A separate headless binary (not part of the `stella` CLI): drives the engine over a wire protocol so a host process runs the Rust core, remoting every model and tool call back — the engine holds no ambient authority |
 | Context Graph Protocol | Its own project now: [macanderson/context-graph-protocol](https://github.com/macanderson/context-graph-protocol) — wire types, host runtime, and the public conformance suite. Stella is its reference host and depends on it via git. |
 
 The repo is a **monorepo**: alongside the Rust workspace, the documentation

--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -1,0 +1,90 @@
+# loop-bench
+
+An inexpensive turn-loop and context-query correctness harness over
+Terminal-Bench. The full benchmark measures *pass rate* — expensive, dominated
+by model quality. This measures what it hides and a **cheap** model exposes just
+as clearly: did the turn execute real work, or abort having done nothing? did it
+die without saying why? did `project_overview` / `graph_query` get used at all?
+
+It shells out to the `stella` binary and `harbor` with **no dependency on any
+stella crate** (`clap`, `serde`, `serde_json` only), so it compiles in seconds
+and never drags the workspace into a bench iteration. It is one file.
+
+> Wider benchmarking context — the Harbor adapter, the standalone SWE-bench
+> harness, the zero-cost smoke test, claim-run rules — lives in
+> **[`../README.md`](../README.md)**. Start there.
+
+## Running it
+
+Run it **from the workspace root**: harbor loads `stella_harbor:StellaAgent` by
+import path via the relative `PYTHONPATH` entry `bench/harbor_adapter` — wrong
+cwd gives a warning here, an opaque per-trial `ImportError` otherwise.
+
+```bash
+cargo run -p loop-bench -- --n 4                    # first 4 tasks of the default pool
+cargo run -p loop-bench -- --tasks fix-git,prove-plus-comm -m openrouter/z-ai/glm-5.2
+cargo run -p loop-bench -- --analyze-only --jobs-dir <dir> --job-name <name>   # free
+```
+
+Defaults: 4 tasks from `DEFAULT_POOL`, `openrouter/z-ai/glm-4.7-flash`,
+`--budget 0.20` USD/task (passed on as `STELLA_BUDGET`), `--concurrent 4`,
+`--dataset terminal-bench`, output under `loop-bench-jobs/loop-bench/`.
+`--stella-binary` / `$STELLA_BINARY` names the uploaded binary; `--json` emits
+the report for CI instead of the table.
+
+## Key concepts
+
+For each trial dir `<jobs-dir>/<job-name>/<task>__<id>/`, `distill_events` reads
+`agent/stella-events.jsonl`: `step_usage` counts model calls, `tool_start` tool
+calls (`write_file` / `edit_file` / `apply_edits` are writes — never
+`delete_file`, or a destructive loop would look productive; `project_overview` /
+`graph_query` are context queries), and a terminal event is `complete` or an
+`error` with `retryable: false`. The reward comes from `verifier/reward.txt`.
+
+`TrialReport::loop_verdict` collapses that into one word, in this order:
+
+| Verdict | Meaning |
+|---|---|
+| `solved` | reward `1.0` — a solved task did the work by definition, so reward beats every other signal |
+| `SILENT-DEATH` | zero tool calls *and* no terminal event — it vanished with no explanation, the worst mode |
+| `ZERO-WORK` | zero tool calls, but it said why |
+| `ran (unsolved)` | real work happened, the verifier said no — not a loop failure |
+
+**The gate is loop health, not pass rate.** `loop_broken()` is
+`zero_work && reward != Some(1.0)`; the process exits `1` if any trial matches —
+even when others passed, and also when no trial artifacts were found at all.
+Exit `2` means the task list resolved to nothing.
+
+## Gotchas
+
+- A trial whose event stream is missing or unreadable is **reported**, not
+  skipped: it lands as `zero_work` with a `no event stream` error. Skipping it
+  made a launch failure look like a clean run with fewer rows, gate still green.
+- `reward` is `Option<f64>`, and `None` is not zero — a trial that never reached
+  the verifier must not read as a verifier failure.
+- A non-positive or non-finite `--budget` denies the very first model call, so
+  every task reports as a loop failure: the harness manufacturing the signal it
+  gates on. It warns rather than proceeding silently.
+- `$STELLA_BINARY` must be a **Linux** build; the task containers are amd64.
+  Unset, it warns and falls back to `target/release/stella`.
+
+## Testing
+
+```bash
+cargo test -p loop-bench        # no make target; `make test` covers it via --workspace
+```
+
+Seven pure unit tests at the bottom of [`src/main.rs`](src/main.rs) feed JSONL to
+`distill_events` and assert the verdict — no Docker, no harbor, no key. Each
+pins a real defect: batched `apply_edits` reporting zero writes, an ellipsis
+past the column budget that shifted a whole row, a retryable warning read as
+terminal, a 177-tool *solved* run called silent. A new signal means a
+`TrialReport` field, an arm in `distill_events`, a `print_table` column
+(`TABLE_WIDTH`), and a test.
+
+## See also
+
+- [`../README.md`](../README.md) — benchmarking overview and claim-run rules
+- [`../harbor_adapter/README.md`](../harbor_adapter/README.md) — the adapter this
+  drives, and the `stella-events.jsonl` it writes
+- [`../../AGENTS.md`](../../AGENTS.md) — "Essential commands / The gate"

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -37,7 +37,8 @@
 //! Run it from the workspace root: the harbor adapter is put on `PYTHONPATH`
 //! by the relative path `ADAPTER_PYTHONPATH`.
 //!
-//! Exit codes, for the CI job that gates on this:
+//! Exit codes, for a caller that wants to gate on this (no CI job runs it
+//! today — it is invoked manually):
 //!
 //! - `0` — every trial that reported did real work (or passed).
 //! - `1` — the loop misbehaved on at least one trial, *or* no trial artifacts

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -1,9 +1,15 @@
 # Stella serve surface — the headless engine for Oxagen
 
-**Status:** Implemented as the `stella-serve` crate (`Session`, `ServerFrame`,
-the HTTP/SSE transport) — ADR-033 Option B, the Rust sidecar. It builds its own
-binary and nothing in `stella-cli` links it, so a change here never reaches a
-`stella` user. **Date:** 2026-07-20. **Owner:** Mac Anderson.
+**Status:** Partly implemented as the `stella-serve` crate (`Session`,
+`ServerFrame`, the HTTP/SSE transport, bearer auth, remoted tools) — ADR-033
+Option B, the Rust sidecar. It builds its own binary and nothing in
+`stella-cli` links it, so a change here never reaches a `stella` user.
+**This document describes the target surface, not all of it is built:** the
+code today serves one turn per registered id, with no sessions-over-turns, no
+steering, no pause/cancel, no approval gate, no SSE replay via `?after=<seq>`,
+no `Host`-header guard, and no SIGTERM drain. Sections below flag the gaps
+individually; treat `stella-serve/src/` as the state and this doc as the
+destination. **Date:** 2026-07-20. **Owner:** Mac Anderson.
 **Companion:** `oxagen-platform/docs/specs/agent-engine-v2/` (ADR-033 + spec) —
 the host side. That repository is private to Oxagen; this document is the
 *Stella* side of the same integration and is self-contained without it.
@@ -185,15 +191,18 @@ Oxagen's existing Firecracker/Modal sandbox** (the same isolation
 — the engine does not spawn its own shells server-side. `stella-serve` in server
 mode:
 
-- **binds to a token-gated port only** (no ambient trust); reuses the
-  Observatory's DNS-rebinding `Host`-header guard.
+- **binds to a token-gated port only** (no ambient trust). **Not yet built:**
+  reusing the Observatory's DNS-rebinding `Host`-header guard
+  (`stella-observatory/src/lib.rs::host_is_local`) — `stella-serve` performs no
+  `Host` validation today.
 - **disables the local shell/web tool surface by default** (`--tools remote`),
   delegating all execution to the host's `RemoteToolExecutor`.
 - **does not use `stella-store` or `stella-cli` shell hooks server-side** (per
   ADR-033 §4.1) — persistence and policy are the platform's.
-- adds the **graceful shutdown** the CLI lacks: SIGTERM drains in-flight turns to
-  the next step boundary (soft-stop), then exits; a per-session lifecycle tears
-  down cleanly (the CLI only has SIGPIPE + TUI-drop cleanup).
+- **Not yet built:** the **graceful shutdown** the CLI lacks — SIGTERM draining
+  in-flight turns to the next step boundary (soft-stop), then exiting. There is
+  no signal handling in `stella-serve/src/` today; only the per-session
+  lifecycle tears down cleanly (the CLI has SIGPIPE + TUI-drop cleanup).
 
 ## Metering parity
 
@@ -239,5 +248,5 @@ ADR-033 §7 names).
 
 See `serve-surface.fleet.toml` (this directory) — a `stella fleet --plan` file
 that fans the eight upstream items into gate-verified tasks, each of which passes
-`make gate` (fmt + file-size ratchet + clippy `-D warnings` + `cargo test`)
-before its commit lands.
+`make gate` (no-scratch + doc-citations + fmt `--check` + clippy `-D warnings`
++ `cargo test --workspace`) before its commit lands.

--- a/stella-cli/README.md
+++ b/stella-cli/README.md
@@ -1,0 +1,227 @@
+# stella-cli
+
+The shipping binary. `[[bin]] name = "stella"` over [`src/main.rs`](src/main.rs) —
+the clap surface, the credential/settings/provider resolution that has to happen
+before a turn can start, and the composition root that hands `stella-core` its
+ports and drives `stella-pipeline`, `stella-fleet`, `stella-tui`, and
+`stella-media`.
+
+This crate is **wiring, not decisions**. Anything that could be a pure function
+over owned data belongs in `stella-core`; a provider's wire dialect in
+`stella-model`; a tool's behaviour in `stella-tools`. What stays is the half that
+touches the process — the concrete `Clock`/`Sleeper` ([`src/runtime.rs`](src/runtime.rs)),
+the real-git `CandidateWorkspacePort` ([`src/candidate_ws.rs`](src/candidate_ws.rs)),
+the pipeline's ports ([`src/agent/tools.rs`](src/agent/tools.rs)), the
+directory-reading `RuleSource` ([`src/rules.rs`](src/rules.rs)). `rules.rs` and
+[`src/extensions.rs`](src/extensions.rs) say it outright in their module docs:
+the semantics live in `stella-core`, only the I/O is here.
+
+## Where it sits
+
+Top of the stack, depending on every other workspace crate except `stella-serve`,
+plus `contextgraph-types`/`-host`/`-trace`/`-conformance` from the external
+[`context-graph-protocol`](https://github.com/macanderson/context-graph-protocol)
+repo at a pinned rev. **Nothing depends on stella-cli** — no other `Cargo.toml`
+names it, and there is no `lib.rs`, only the binary. A change here reaches users
+immediately and reaches no other crate at all.
+
+## Layout
+
+| Path | What it holds |
+|---|---|
+| [`src/main.rs`](src/main.rs), [`src/main_tests.rs`](src/main_tests.rs) | The whole clap surface (`Cli`, `GlobalArgs`, `Command` and its nested subcommand enums) and the two-phase `run()` dispatch — open it to add a command or a global flag — plus the argument-surface fence that guards it. |
+| [`src/agent.rs`](src/agent.rs) + [`src/agent/`](src/agent) | Agent wiring: `run_one_shot` / `run_interactive` / `run_init`, and the submodules for engine tuning (`engine.rs`), judged rounds (`goal.rs`), the session code-graph (`graph.rs`), pipeline-status projection (`outcome.rs`), headless output (`output.rs`), event persistence (`persistence.rs`), prompt assembly (`prompt.rs`), registry/port construction (`tools.rs`). |
+| [`src/config.rs`](src/config.rs), [`src/settings.rs`](src/settings.rs) + [`src/settings/`](src/settings), [`src/engine_config.rs`](src/engine_config.rs), [`src/settings_check.rs`](src/settings_check.rs) | Which provider/model/key this invocation runs on; the three-scope `settings.json` merge behind it (`merge.rs`, `managed.rs`, `authority.rs`, `private.rs`, `context.rs`, `context_providers.rs`); `agent_engine_config` → per-agent resolution; and the launch-time slug validation that turns a typo into a startup warning instead of a provider `400`. |
+| [`src/env_files.rs`](src/env_files.rs) | Project-scoped `.env` loading with shell-wins precedence and the execution-hijack refusal list. |
+| [`src/memory.rs`](src/memory.rs) + [`src/memory/`](src/memory), [`src/contextgraph.rs`](src/contextgraph.rs) | `SessionMemory` (per-turn recall, post-turn reflection, skill auto-promotion, CGP→pipeline projection) and the session's `contextgraph-host`, which serves the in-tree workspace-memory and code-graph sources as real CGP providers. |
+| [`src/rules.rs`](src/rules.rs), [`src/domains.rs`](src/domains.rs), [`src/discovery.rs`](src/discovery.rs) | Workspace-rule wiring (Tier-2 guards armed at the tool boundary), `stella init`'s domain inference, and the `tool_search`/`skill_search`/`mcp_search` discovery tools. |
+| [`src/command_deck.rs`](src/command_deck.rs) + [`src/command_deck/`](src/command_deck), [`src/subsession.rs`](src/subsession.rs), [`src/session_persist.rs`](src/session_persist.rs), [`src/claims.rs`](src/claims.rs), [`src/cache_insight.rs`](src/cache_insight.rs) | The deck driver: bridges engine `AgentEvent`s into `stella-tui`'s `Inbound` fold, runs per-prompt sub-sessions, tees every fold-relevant envelope to the resume journal, and coordinates concurrent writers by claim-on-first-write. |
+| [`src/tui.rs`](src/tui.rs), [`src/interactive.rs`](src/interactive.rs), [`src/init_fx.rs`](src/init_fx.rs) | The non-deck surfaces: `render_event`'s plain streaming renderer, `ask_user`'s TTY implementation, and the `stella init` animation. |
+| [`src/auth_cmd.rs`](src/auth_cmd.rs), [`src/connect_cmd.rs`](src/connect_cmd.rs), [`src/mcp_cmd.rs`](src/mcp_cmd.rs), [`src/memory_cmd.rs`](src/memory_cmd.rs), [`src/usage_cmd.rs`](src/usage_cmd.rs), [`src/fleet_cmd.rs`](src/fleet_cmd.rs), [`src/inspect.rs`](src/inspect.rs), [`src/stats.rs`](src/stats.rs), [`src/export.rs`](src/export.rs) | One module per command family. Everything but `fleet_cmd` runs without a resolved provider. |
+| [`src/model_catalog.rs`](src/model_catalog.rs), [`src/credential_handoff.rs`](src/credential_handoff.rs), [`src/credential_status.rs`](src/credential_status.rs), [`src/enterprise_telemetry.rs`](src/enterprise_telemetry.rs) | The only place that knows both models.dev's provider ids and stella's (`bootstrap()` installs the catalog slug validation and pricing resolve against); launcher FD key handoff; the shared "where did this key come from" verdict for `models`/`config`/`auth list`; and the managed-only operational spool. |
+| [`src/arena.rs`](src/arena.rs), [`src/candidate_ws.rs`](src/candidate_ws.rs) | The arena-bench adapter (`--task-dir/--journal/--state-dir/--resume`) and best-of-N candidate isolation over detached git worktrees. |
+| [`src/skill_manager.rs`](src/skill_manager.rs), [`src/agents_installed.rs`](src/agents_installed.rs), [`src/extensions.rs`](src/extensions.rs) | Disk I/O for the deck's SKILLS and INSTALLED AGENTS panes, and the `.claude/`/`.agents/` adoption sync. |
+| [`src/attachments.rs`](src/attachments.rs), [`src/accounted_call.rs`](src/accounted_call.rs), [`src/runtime.rs`](src/runtime.rs), [`src/signals.rs`](src/signals.rs) | Prompt-text → multimodal attachments, cost accounting for paid calls outside a turn, the production time ports, and SIGINT/SIGTERM handling. |
+| [`build.rs`](build.rs), [`tests/inspect_cli.rs`](tests/inspect_cli.rs), [`tests/fixtures/`](tests/fixtures) | `STELLA_BUILD_VERSION` (package version, or `<version>-dev.<sha>` when `STELLA_BUILD_GIT_SHA` is set), and the only integration test — it spawns the real `stella` binary against a real store. Fixtures are also `include_str!`'d by `settings/context.rs` and `rules.rs`. |
+
+## Key concepts
+
+### The command surface is two dispatches, split by "does this need a key"
+
+`run()` in [`src/main.rs`](src/main.rs) matches `cli.command` **twice**. The first
+match returns early for every command that resolves no provider — `models`,
+`tools`, `graph`, `scripts`, `storage`, `inspect`, `stats`, `usage`, `cloud`,
+`telemetry`, `memory`, `mcp`, `connect`, `auth`, `observe`, `version`,
+`resume --list`. Only then does it run `model_catalog::bootstrap()`,
+`config::Config::load` (which can prompt for a key) and
+`settings_check::validate_at_launch`. The second match handles the rest (`run`,
+`arena`, `goal`, `monitor`, `fleet`, `chat`, `resume`, `config`) and lists the
+first group under `unreachable!("handled before provider resolution")` — so a new
+key-free command needs an arm in both places or it will not compile.
+
+A bare `stella` is `Command::Chat`, which picks the Command Deck when `use_deck()`
+holds (no `--plain`, no `STELLA_PLAIN`, both stdin and stdout TTYs); `resume`
+without `--list` is deck-only and errors rather than degrading, because durable
+session state is a deck feature.
+
+Every field of `GlobalArgs` must carry `global = true`. clap accepts a plain
+root-level flag only *before* the subcommand token, so a non-global field is
+silently unreachable where users actually type it — `stella fleet … --budget 5`
+died with "unexpected argument". `every_root_flag_is_global` in
+[`src/main_tests.rs`](src/main_tests.rs) fails the suite instead, and its
+corollary `no_subcommand_flag_reuses_a_global_name` reserves those names
+CLI-wide — which is why `connect linear` takes `--paste-key`, not `--api-key`.
+
+### Byte-stable prompt prefix (L-E8) — the discipline that costs money to break
+
+[`src/agent/prompt.rs`](src/agent/prompt.rs)'s `build_system_prompt` /
+`build_pipeline_system_prompt` funnel into `assemble_system_prompt`, which
+appends, in fixed order, the project scripts index, the project orientation
+block, the workspace memories, the exploration index, and the rendered rules
+section. Everything appended must be deterministic for a given workspace state:
+that prefix is what the provider's prompt cache keys on, so nondeterminism here
+is a re-billing regression, not a cosmetic one. Two consequences the code
+enforces on purpose:
+
+- `append_workspace_memories` reads `.stella/memories/*.md`, `files.sort()`s by
+  filename, and concatenates under a 16,000-char budget (`MEMORY_PROMPT_BUDGET_CHARS`);
+  overflow is dropped with a count, never reordered. The prompt is built **once
+  per session** and reused verbatim (including across `/clear`), so a memory
+  saved mid-session deliberately does not appear until the next session —
+  hot-injecting it would invalidate the cached prefix on every `save_memory`.
+- In-progress exploration drafts are excluded from `append_exploration_index`:
+  their line names the producing pid and its liveness, which flips mid-session —
+  a guaranteed cache miss on every call (#639).
+
+Both ride the volatile channel instead — [`src/memory.rs`](src/memory.rs)'s
+`inject_recall_block`, which builds a `MessageRole::User` message prefixed with
+`RECALL_MARKER` and inserts it at the conversation *tail* (just before the turn's
+prompt when that prompt is already last), skipping insertion when the newest
+marked block is byte-identical. The prefix — system prompt and replayed turns
+alike — is never rewritten. `SYSTEM_PROMPT` and `PIPELINE_SYSTEM_PROMPT` are
+`concat!` of literals, not `format!`, for the same reason.
+
+### The 3-scope settings merge, and the project scope as a trust boundary
+
+[`src/settings.rs`](src/settings.rs) merges per provider id, per field, ascending:
+user `~/.stella/settings.json` → org-managed
+(`/Library/Application Support/stella/settings.json` on macOS, `/etc/stella/settings.json`
+elsewhere, overridable with `STELLA_MANAGED_SETTINGS`) → project
+`<workspace>/.stella/settings.json`. Project wins per field. `Settings::load`
+reads each scope exactly once into an immutable snapshot and hands all three to
+`merge_captured_scopes`, which does **no I/O** — so the bytes that compute the
+authority ceilings are the same bytes that produce the merged config.
+
+The project scope is untrusted input from a cloned repo, so it is not a plain
+last-wins overlay. Without `STELLA_TRUST_PROJECT=1` (or `STELLA_PROJECT_HOOKS=1`
+for hooks alone), project `hooks`, `context_providers`, credential-routing fields
+(`providers.*.base_url` / `api_key` / `api_key_env`, `mcp.registry_url`), tool
+switches, and replacement prompts are restored from the trusted scopes, and
+stderr names what was ignored. Repointing a built-in provider's `base_url` would
+exfiltrate the real key on the first model call; an `enabled` stdio
+`context_providers` entry spawns its command at admission time. Managed denials
+in `ManagedAuthoritySettings` stay ceilings even after explicit trust —
+`AuthorityPolicy` is monotonic and `apply_tool_ceiling` runs last.
+
+Not everything merges per field: `context` is whole-block last-wins, and
+`context_providers` merges per **entry** — field-level merging there would let a
+project inherit the user scope's `egress_consent` while swapping the `url`.
+
+### `env_files.rs` — dotenvy as an iterator, so precedence stays ours
+
+`.env.<mode>.local` → `.env.local` → `.env`, most-specific first, from the
+nearest ancestor directory that has one (never crossing out of the git repo,
+never treating `$HOME` as a scope). Templates (`.env.example`, `.env.sample`,
+`.env.dist`) and committed non-`.local` `.env.<mode>` files are never read.
+
+The load path calls `dotenvy::from_path_iter` — a **non-mutating** iterator —
+rather than `dotenvy::from_path`, precisely so the CLI keeps its own precedence:
+`plan_assignments` skips any name already in the process environment and any name
+an earlier (more specific) file already claimed, and only then does `maybe_load`
+`set_var` the survivors. The live shell always wins; a malformed line is skipped
+without aborting the file. Names that redirect the loader, command lookup,
+interpreter startup, or the git/pager escapes (`LD_*`, `DYLD_*`, `PATH`,
+`NODE_OPTIONS`, `BASH_ENV`, `GIT_SSH_COMMAND`, `GIT_CONFIG_*`, …) are refused and
+reported by name — applying them would make `git clone && stella` arbitrary code
+execution on the first subprocess (#553). `STELLA_NO_ENV_FILE=1` disables it all.
+
+## Gotchas
+
+- **`main` resets SIGPIPE to `SIG_DFL`.** Rust masks it at startup, so
+  `stella tools | head` surfaces EPIPE as a `println!` panic — a SIGABRT and a
+  panic dump on a routine pipe. Don't tidy away the `unsafe` block.
+- **Startup order in `main` is load-bearing**: legacy `~/.stella` migration →
+  managed telemetry snapshot + `StartupAuthoritySnapshot::capture` →
+  `credential_handoff::consume_at_startup` (before any repo-controlled process
+  can read the FD) → `env_files::maybe_load` → `restore_after_project_env` →
+  `Cli::parse()`. Env-file loading must precede parsing (clap fields carry
+  `env = "STELLA_MODEL"` and friends) and must follow the authority snapshot, so
+  a project dotenv cannot redefine a privileged variable.
+- **`set_var` is only safe where it is called** — single-threaded startup, before
+  the tokio runtime exists. Tests that mutate env must hold
+  `crate::test_env::lock()` across the whole mutate-read-cleanup window:
+  concurrent `setenv`/`getenv` is UB on POSIX and the harness runs these modules
+  on parallel threads.
+- **Don't print a second error envelope.** `agent.rs` emits its JSON summary and
+  can still return `Err`; `note_json_summary_emitted()` is what stops `main`'s
+  catch-all from following it with a duplicate `{"status":"error",…}`. Text
+  output never gets an envelope on stdout at all.
+- **Adding a provider needs a parity row in the same PR** —
+  [`src/config/tests.rs`](src/config/tests.rs) asserts every seeded provider has
+  both a `CachePosture` and a `ReasoningPosture` row in
+  `stella-model/src/provider_parity.rs`.
+- **`registry_options` in [`src/agent/tools.rs`](src/agent/tools.rs) is the only
+  translation from settings to `RegistryOptions`**, so no path can quietly
+  re-enable the shell. Hand-build `RegistryOptions` elsewhere and you made one.
+
+## Testing
+
+```bash
+make test-cli            # = cargo test -p stella-cli
+```
+
+Almost all of it is in-crate unit tests, wired with `#[cfg(test)] #[path = …]`
+from the module they cover: [`src/main_tests.rs`](src/main_tests.rs) (argument
+surface), [`src/agent_tests.rs`](src/agent_tests.rs) (prompt assembly, provider
+routing, usage completeness), [`src/config/tests.rs`](src/config/tests.rs) (key
+resolution, the provider-parity matrix), plus the `settings`/`memory`
+private-state and quarantine suites. [`tests/inspect_cli.rs`](tests/inspect_cli.rs)
+is the sole integration test — it spawns `env!("CARGO_BIN_EXE_stella")` against a
+real store, needing a built binary but no API key. No feature flags, no fixture
+server; env-mutating tests must take `crate::test_env::lock()`.
+
+## Extending it
+
+**Add a subcommand:**
+
+1. Add the variant to `Command` in [`src/main.rs`](src/main.rs) (plus a nested
+   `Subcommand` enum if it has sub-verbs — follow `McpCmd`/`AuthCmd`).
+2. Put the implementation in its own `*_cmd.rs` module and `mod` it in `main.rs`.
+3. Wire the arm: if it needs no provider, the **first** match in `run()` *and* the
+   `unreachable!("handled before provider resolution")` list in the second; if it
+   needs one, the second match only.
+4. `cargo test -p stella-cli` — `clap_command_is_internally_consistent` and the
+   global-flag invariants run against the real `Command` tree — then document it
+   under [`../website/content/docs/commands/`](../website/content/docs/commands).
+
+**Add a `settings.json` field:** add it to the type in
+[`src/settings.rs`](src/settings.rs), then extend `overlay_scope` in
+[`src/settings/merge.rs`](src/settings/merge.rs) with its merge rule (per field,
+per entry, or whole-block — decide deliberately). If it can route credentials,
+run code, or grant egress, add it to the untrusted-project restoration in
+`merge_captured_scopes` and to the stderr notice too. Enums are "loud": an
+unrecognized value is a hard parse error, never a silent fallback.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions" (#7 is
+  the byte-stable-prompt rule this crate owns), "Workspace layout", and the
+  `.stella/` directory table. [`../README.md`](../README.md) is the user-facing
+  command and provider reference.
+- [`../website/content/docs/commands/`](../website/content/docs/commands),
+  [`../website/content/docs/configuration/settings.mdx`](../website/content/docs/configuration/settings.mdx),
+  [`../website/content/docs/inference-pipeline.mdx`](../website/content/docs/inference-pipeline.mdx)
+  — the published docs this crate's surfaces must stay honest to.
+- [`../docs/design/scripts-index.md`](../docs/design/scripts-index.md),
+  [`../docs/design/storage-map.md`](../docs/design/storage-map.md) — the contracts
+  behind `stella scripts` and `stella storage`.

--- a/stella-cli/README.md
+++ b/stella-cli/README.md
@@ -29,20 +29,20 @@ immediately and reaches no other crate at all.
 
 | Path | What it holds |
 |---|---|
-| [`src/main.rs`](src/main.rs), [`src/main_tests.rs`](src/main_tests.rs) | The whole clap surface (`Cli`, `GlobalArgs`, `Command` and its nested subcommand enums) and the two-phase `run()` dispatch — open it to add a command or a global flag — plus the argument-surface fence that guards it. |
-| [`src/agent.rs`](src/agent.rs) + [`src/agent/`](src/agent) | Agent wiring: `run_one_shot` / `run_interactive` / `run_init`, and the submodules for engine tuning (`engine.rs`), judged rounds (`goal.rs`), the session code-graph (`graph.rs`), pipeline-status projection (`outcome.rs`), headless output (`output.rs`), event persistence (`persistence.rs`), prompt assembly (`prompt.rs`), registry/port construction (`tools.rs`). |
-| [`src/config.rs`](src/config.rs), [`src/settings.rs`](src/settings.rs) + [`src/settings/`](src/settings), [`src/engine_config.rs`](src/engine_config.rs), [`src/settings_check.rs`](src/settings_check.rs) | Which provider/model/key this invocation runs on; the three-scope `settings.json` merge behind it (`merge.rs`, `managed.rs`, `authority.rs`, `private.rs`, `context.rs`, `context_providers.rs`); `agent_engine_config` → per-agent resolution; and the launch-time slug validation that turns a typo into a startup warning instead of a provider `400`. |
+| [`src/main.rs`](src/main.rs), [`src/main_tests.rs`](src/main_tests.rs) | The whole clap surface (`Cli`, `GlobalArgs`, `Command` and its nested subcommand enums) and the two-phase `run()` dispatch — open it to add a command or a global flag — plus the argument-surface fence guarding it. |
+| [`src/agent.rs`](src/agent.rs) + [`src/agent/`](src/agent) | Agent wiring: `run_one_shot` / `run_interactive` / `run_init`, and submodules for engine tuning (`engine.rs`), judged rounds (`goal.rs`), the session code-graph (`graph.rs`), pipeline-status projection (`outcome.rs`), headless output (`output.rs`), event persistence (`persistence.rs`), prompt assembly (`prompt.rs`), registry/port construction (`tools.rs`). |
+| [`src/config.rs`](src/config.rs), [`src/settings.rs`](src/settings.rs) + [`src/settings/`](src/settings), [`src/engine_config.rs`](src/engine_config.rs), [`src/settings_check.rs`](src/settings_check.rs) | Which provider/model/key this invocation runs on; the three-scope `settings.json` merge behind it; `agent_engine_config` → per-agent resolution; and the launch-time slug validation that turns a typo into a startup warning instead of a provider `400`. |
 | [`src/env_files.rs`](src/env_files.rs) | Project-scoped `.env` loading with shell-wins precedence and the execution-hijack refusal list. |
 | [`src/memory.rs`](src/memory.rs) + [`src/memory/`](src/memory), [`src/contextgraph.rs`](src/contextgraph.rs) | `SessionMemory` (per-turn recall, post-turn reflection, skill auto-promotion, CGP→pipeline projection) and the session's `contextgraph-host`, which serves the in-tree workspace-memory and code-graph sources as real CGP providers. |
-| [`src/rules.rs`](src/rules.rs), [`src/domains.rs`](src/domains.rs), [`src/discovery.rs`](src/discovery.rs) | Workspace-rule wiring (Tier-2 guards armed at the tool boundary), `stella init`'s domain inference, and the `tool_search`/`skill_search`/`mcp_search` discovery tools. |
+| [`src/rules.rs`](src/rules.rs), [`src/domains.rs`](src/domains.rs), [`src/discovery.rs`](src/discovery.rs) | Workspace-rule wiring (Tier-2 guards armed at the tool boundary), `stella init`'s domain inference, and the `tool_search`/`skill_search`/`mcp_search` tools. |
 | [`src/command_deck.rs`](src/command_deck.rs) + [`src/command_deck/`](src/command_deck), [`src/subsession.rs`](src/subsession.rs), [`src/session_persist.rs`](src/session_persist.rs), [`src/claims.rs`](src/claims.rs), [`src/cache_insight.rs`](src/cache_insight.rs) | The deck driver: bridges engine `AgentEvent`s into `stella-tui`'s `Inbound` fold, runs per-prompt sub-sessions, tees every fold-relevant envelope to the resume journal, and coordinates concurrent writers by claim-on-first-write. |
 | [`src/tui.rs`](src/tui.rs), [`src/interactive.rs`](src/interactive.rs), [`src/init_fx.rs`](src/init_fx.rs) | The non-deck surfaces: `render_event`'s plain streaming renderer, `ask_user`'s TTY implementation, and the `stella init` animation. |
 | [`src/auth_cmd.rs`](src/auth_cmd.rs), [`src/connect_cmd.rs`](src/connect_cmd.rs), [`src/mcp_cmd.rs`](src/mcp_cmd.rs), [`src/memory_cmd.rs`](src/memory_cmd.rs), [`src/usage_cmd.rs`](src/usage_cmd.rs), [`src/fleet_cmd.rs`](src/fleet_cmd.rs), [`src/inspect.rs`](src/inspect.rs), [`src/stats.rs`](src/stats.rs), [`src/export.rs`](src/export.rs) | One module per command family. Everything but `fleet_cmd` runs without a resolved provider. |
-| [`src/model_catalog.rs`](src/model_catalog.rs), [`src/credential_handoff.rs`](src/credential_handoff.rs), [`src/credential_status.rs`](src/credential_status.rs), [`src/enterprise_telemetry.rs`](src/enterprise_telemetry.rs) | The only place that knows both models.dev's provider ids and stella's (`bootstrap()` installs the catalog slug validation and pricing resolve against); launcher FD key handoff; the shared "where did this key come from" verdict for `models`/`config`/`auth list`; and the managed-only operational spool. |
+| [`src/model_catalog.rs`](src/model_catalog.rs), [`src/credential_handoff.rs`](src/credential_handoff.rs), [`src/credential_status.rs`](src/credential_status.rs), [`src/enterprise_telemetry.rs`](src/enterprise_telemetry.rs) | The only place that knows both models.dev's provider ids and stella's (`bootstrap()` installs the catalog slug validation and pricing resolve against); launcher FD key handoff; the shared "where did this key come from" verdict for `models`/`config`/`auth list`; the managed-only operational spool. |
 | [`src/arena.rs`](src/arena.rs), [`src/candidate_ws.rs`](src/candidate_ws.rs) | The arena-bench adapter (`--task-dir/--journal/--state-dir/--resume`) and best-of-N candidate isolation over detached git worktrees. |
 | [`src/skill_manager.rs`](src/skill_manager.rs), [`src/agents_installed.rs`](src/agents_installed.rs), [`src/extensions.rs`](src/extensions.rs) | Disk I/O for the deck's SKILLS and INSTALLED AGENTS panes, and the `.claude/`/`.agents/` adoption sync. |
-| [`src/attachments.rs`](src/attachments.rs), [`src/accounted_call.rs`](src/accounted_call.rs), [`src/runtime.rs`](src/runtime.rs), [`src/signals.rs`](src/signals.rs) | Prompt-text → multimodal attachments, cost accounting for paid calls outside a turn, the production time ports, and SIGINT/SIGTERM handling. |
-| [`build.rs`](build.rs), [`tests/inspect_cli.rs`](tests/inspect_cli.rs), [`tests/fixtures/`](tests/fixtures) | `STELLA_BUILD_VERSION` (package version, or `<version>-dev.<sha>` when `STELLA_BUILD_GIT_SHA` is set), and the only integration test — it spawns the real `stella` binary against a real store. Fixtures are also `include_str!`'d by `settings/context.rs` and `rules.rs`. |
+| [`src/attachments.rs`](src/attachments.rs), [`src/accounted_call.rs`](src/accounted_call.rs), [`src/runtime.rs`](src/runtime.rs), [`src/signals.rs`](src/signals.rs) | Prompt-text → multimodal attachments, cost accounting for paid calls outside a turn, the production time ports, SIGINT/SIGTERM handling. |
+| [`build.rs`](build.rs), [`tests/inspect_cli.rs`](tests/inspect_cli.rs), [`tests/fixtures/`](tests/fixtures) | `STELLA_BUILD_VERSION` (package version, or `<version>-dev.<sha>` when `STELLA_BUILD_GIT_SHA` is set) and the only integration test. Fixtures are also `include_str!`'d by `settings/context.rs` and `rules.rs`. |
 
 ## Key concepts
 
@@ -192,19 +192,17 @@ server; env-mutating tests must take `crate::test_env::lock()`.
 
 ## Extending it
 
-**Add a subcommand:**
+**A subcommand:** add the variant to `Command` in [`src/main.rs`](src/main.rs)
+(plus a nested `Subcommand` enum if it has sub-verbs — follow `McpCmd`/`AuthCmd`);
+put the implementation in its own `*_cmd.rs` module and `mod` it in `main.rs`;
+wire the arm into the **first** match in `run()` *and* the
+`unreachable!("handled before provider resolution")` list in the second if it
+needs no provider, or the second match alone if it does. Then
+`cargo test -p stella-cli` — `clap_command_is_internally_consistent` and the
+global-flag invariants run against the real `Command` tree — and document it
+under [`../website/content/docs/commands/`](../website/content/docs/commands).
 
-1. Add the variant to `Command` in [`src/main.rs`](src/main.rs) (plus a nested
-   `Subcommand` enum if it has sub-verbs — follow `McpCmd`/`AuthCmd`).
-2. Put the implementation in its own `*_cmd.rs` module and `mod` it in `main.rs`.
-3. Wire the arm: if it needs no provider, the **first** match in `run()` *and* the
-   `unreachable!("handled before provider resolution")` list in the second; if it
-   needs one, the second match only.
-4. `cargo test -p stella-cli` — `clap_command_is_internally_consistent` and the
-   global-flag invariants run against the real `Command` tree — then document it
-   under [`../website/content/docs/commands/`](../website/content/docs/commands).
-
-**Add a `settings.json` field:** add it to the type in
+**A `settings.json` field:** add it to the type in
 [`src/settings.rs`](src/settings.rs), then extend `overlay_scope` in
 [`src/settings/merge.rs`](src/settings/merge.rs) with its merge rule (per field,
 per entry, or whole-block — decide deliberately). If it can route credentials,

--- a/stella-cli/src/cache_insight.rs
+++ b/stella-cli/src/cache_insight.rs
@@ -1,6 +1,6 @@
 //! Derive [`stella_tui::Inbound::CacheInsight`] from a committed
 //! `AgentEvent::StepUsage` (issues #267/#269) — split out of
-//! `command_deck.rs` (already over its file-size ratchet; not a file to
+//! `command_deck.rs` (already oversized; not a file to
 //! grow) so `spawn_forwarder`, the one seam shared by every deck lane (the
 //! lead's turns and every `crate::subsession` worker), only needs a call
 //! site.

--- a/stella-context/README.md
+++ b/stella-context/README.md
@@ -1,0 +1,199 @@
+# stella-context
+
+The context plane: one SQLite file (`.stella/private/context.db`) and one engine
+([`ContextStore`](src/store.rs)) holding a bi-temporal property graph, a
+fingerprinted embedding index, and episodic memory — with a hybrid, budgeted,
+cited retrieval pipeline (`recall`) on top and a close-and-supersede write path
+(`upsert`) underneath. It is the single door between the engine and everything
+the agent knows that isn't already in the prompt.
+
+Two boundaries are deliberate. **Wire types are never redefined here**: frames,
+queries, capabilities and verdicts come from `contextgraph-types` and are
+re-exported from [`src/lib.rs`](src/lib.rs) so a consumer needs only this crate.
+And **external context sources do not register here** — third-party stdio/HTTP
+providers are admitted onto the CGP host by
+[`stella-cli/src/contextgraph.rs`](../stella-cli/src/contextgraph.rs), gated on
+the conformance suite and egress consent, which is why this crate takes no
+dependency on `contextgraph-host`. [`ProviderRegistry`](src/provider.rs) is the
+seam for *in-plane* sources that share the workspace store's lifetime. The
+built-in store declares `egress: false`: it reads and writes locally and nothing
+leaves the machine.
+
+## Where it sits
+
+No workspace crate is a dependency — only `contextgraph-types` (pinned by git
+rev), `rusqlite`, `tokio`, `serde`, `sha2`, `async-trait` and `thiserror`. It
+even formats its own RFC-3339 timestamps rather than pull a date-time crate
+([`src/clock.rs`](src/clock.rs)). It is a library, not a binary.
+
+`stella-cli` is the only crate that depends on it (`Cargo.toml` path dep):
+session recall, `stella memory`, and reflection write-back all flow through it.
+Despite what `stella-graph`'s package description says, **`stella-graph` does not
+link this crate** — it writes its own `.stella/private/codegraph.db`.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | Crate docs, the module list, and the whole public re-export surface. `#![warn(missing_docs)]` — with `make lint` at `-D warnings`, an undocumented public item is a build failure. |
+| [`src/store.rs`](src/store.rs) | `ContextStore`, the DDL and migrations, and every low-level `pub(crate)` SQL accessor retrieval and write-back share. Open this to change the schema, the pragmas, or warming. |
+| [`src/retrieval.rs`](src/retrieval.rs) | `recall` / `recall_scoped`: fusion, dedup, MMR, budget packing, the coverage gate, and `frame_from_node` (where a `ContextFrame` is actually minted). |
+| [`src/writeback.rs`](src/writeback.rs) | `ContextDelta` and `upsert`, plus bi-temporal fact supersession (`apply_fact`) and the `facts_as_of` audit read. |
+| [`src/provider.rs`](src/provider.rs) | The `ContextProvider` trait, `ContextStore`'s implementation of it (`info`/`capabilities`/`query`/`verify`), and `ProviderRegistry` fan-out. |
+| [`src/embed.rs`](src/embed.rs) | The `Embedder` seam, `EmbedderFingerprint`, and the offline `HashEmbedder` default. |
+| [`src/clock.rs`](src/clock.rs) | `Clock`, `SystemClock`, `FixedClock`, `format_rfc3339`. Inject `FixedClock` whenever a test needs an exact T1→T2 correction. |
+| [`src/error.rs`](src/error.rs) | `ContextError` — the typed failure set, including the invariants the plane refuses to violate. |
+
+## Key concepts
+
+**Vectors are keyed `(content_hash, fingerprint)`, never by node.** A
+fingerprint is `model_id@revision/dims/normalization` (`hash-ngram@1/256/l2` for
+the default). Retrieval reads only vectors under the *active* fingerprint, so
+swapping embedders is a new fingerprint plus an incremental re-embed on next
+touch — old vectors go invisible, they are never invalidated in place. Identical
+content is therefore never embedded twice; `UpsertReceipt::embeddings_reused`
+counts the skips.
+
+**Recall embeds the query and nothing else.** Indexing happens at mount:
+`open_and_warm` spawns `warm_index`, which embeds every live node missing a
+vector under the active fingerprint, 64 at a time, one transaction per chunk. A
+cold store degrades to lexical results; it never blocks the first prompt.
+
+**The pipeline is fuse → dedup → diversify → pack → report.** Reciprocal-rank
+fusion (`RRF_K = 60`) over four ranked lists — vector cosine, recency, 1-hop
+graph adjacency from anchors and the top vector seeds, and (when scoped) domain
+overlap — then dedup by content hash, an MMR pass (`MMR_LAMBDA = 0.7`), then
+`pack_to_budget`. Packing returns `(kept, dropped)` as a *partition* of the
+input: nothing may vanish silently, and every drop names its `token_cost` and
+`DropReason` so a caller can size a re-query instead of guessing.
+
+**Weak coverage is labeled, not disguised.** If mean top-5 cosine falls below
+`MIN_COVERAGE = 0.15`, recall abandons fusion and serves up to 8 bounded lexical
+matches, each stamped `stella-context/lexical-fallback` in its provenance chain
+(`is_lexical_fallback` reads it back). `RecallResult::used_lexical_fallback`
+says so at the result level.
+
+**Citation and digest are constructor invariants, not conventions.**
+`upsert_node` rejects a blank `display_name` at write time and `frame_from_node`
+returns `ContextError::MissingCitation` at read time, so an uncitable frame
+cannot reach a prompt from either direction. Every minted frame also declares
+`content_digest: sha256:<content_hash>` over exactly the bytes it serves, which
+is what lets `ContextProvider::verify` answer `Valid`/`Stale`/`Gone` by
+comparing hashes — no frame body moves in either direction. An identity
+presented with no digest is `Unknown`, never `Valid`.
+
+**Only edges are bi-temporal.** A single-valued fact correction calls
+`close_edge` (setting `superseded_at`, and `valid_to` if still open) and inserts
+a replacement linked through `edge.supersedes` — never a delete, so
+`facts_as_of(Some(t))` still reconstructs what was believed at `t`. Timestamps
+are fixed-width RFC-3339 precisely so that reconstruction is a string range scan
+(`recorded_at <= ?1 AND (superseded_at IS NULL OR superseded_at > ?1)`) with no
+parsing. Nodes are mutable current-state: `upsert_node` overwrites content in
+place.
+
+## Gotchas
+
+- **`context.db` is not `codegraph.db`.** The tree-sitter index used to share
+  this file with `code_graph_*`-prefixed tables; `MIGRATION_V3` drops any that
+  survive, and `stella-graph` opens its own `codegraph.db`. The witness is
+  `opening_drops_orphaned_code_graph_tables_from_context_db`
+  ([`src/store.rs`](src/store.rs), ~line 1385). Do not reintroduce graph tables here.
+- **`NodeRow::valid_from` is always `None`.** The columns exist on `node` but
+  `upsert_node` never writes them. Fact history is recoverable; node content
+  history is not.
+- **Nothing forgets.** There is no delete or tombstone path, and a node whose
+  uri changed (renamed or deleted file) is orphaned live forever, still serving
+  its last-known content. Recall reads *every* live node and *every* vector
+  under the active fingerprint on each query, so store size and recall latency
+  grow with the workspace's lifetime. This is the plane's first scaling wall.
+- **`await_warm()` returning `Ok(0)` does not mean "the index is complete."** It
+  means there is no warm left to join — the handle is taken, so a second call
+  also returns `Ok(0)`, as does a store opened outside a tokio runtime (where
+  `open_and_warm` silently returns un-warmed) or an in-memory store (which
+  `warm_index` skips outright).
+- **The store ignores two `ContextQuery` fields.** `kinds` is honored only at the
+  registry seam, so once the store is selected a `kinds: [Memory]` query can
+  come back with `File` frames; `representation_preferences` is ignored entirely
+  — every frame is `Representation::Full` with its body inline.
+- **Empty-content nodes are exempt from hash dedup.** They all share
+  `sha256("")` despite being distinct identities, so `DedupKey::Distinct` keys
+  them by node id — merging them would collapse graph and taxonomy recall on any
+  initialized workspace.
+- **Every ordering tie breaks explicitly on node id.** The cosine sort and the
+  dedup survivor both do it because the underlying query has no `ORDER BY` and
+  fusion runs through a `HashMap`; without the tiebreak the same store answers
+  the same query in a different order between runs.
+- **The builders are `#[must_use]` for a reason.** `NodeInput::with_content` and
+  friends consume and return `self`, so a dropped result is content or domain
+  tags that never reach the store, with no error to notice.
+- **`edge.public_id` has no `UNIQUE` constraint** and its disambiguating
+  sequence (`EDGE_SEQ`) is process-local, so two stella processes writing the
+  same db in the same second can mint the same `edg_…`. Tolerable only because
+  nothing reads an edge by public id — make it collision-proof before anything
+  does.
+- **A newer schema is a hard error, not a best-effort open.** `migrate` rejects
+  `user_version > SCHEMA_VERSION` with `ContextError::SchemaTooNew`: episodic
+  memory and the fact graph are not rebuildable, so an older binary must not
+  write into a schema it does not know.
+
+## Testing
+
+```bash
+cargo test -p stella-context
+```
+
+There is no `make test-context` target and no `tests/` directory — every test is
+an inline `#[cfg(test)] mod tests` at the bottom of its module, next to the code
+it pins. `tempfile` backs real on-disk stores (an in-memory one never warms, so
+warming tests must use a file), `proptest` covers the packer invariant
+(`packing_never_exceeds_budget_and_loses_nothing` in
+[`src/retrieval.rs`](src/retrieval.rs)), and async tests use `#[tokio::test]`.
+
+The tests worth reading before changing anything are the ones that encode a
+past defect: `kill_mid_index_rolls_back_to_a_consistent_store`,
+`rejects_a_context_db_written_by_a_newer_stella`, the `migrates_v1_/v2_…`
+replays that hand-build an old schema and assert the data survives (all in
+[`src/store.rs`](src/store.rs)), and the two `store_verifies_by_digest…` /
+`store_frames_declare_a_content_digest…` witnesses in
+[`src/provider.rs`](src/provider.rs).
+
+Note that `make gate` runs `make doc-citations`, which fails if a `docs/*.md`
+path cited from a doc comment in this crate does not resolve.
+
+## Extending it
+
+**Add a node kind.** 1. Add the variant to `NodeKind` in
+[`src/store.rs`](src/store.rs). 2. Extend `as_str`, `parse`, and
+`to_frame_kind` — the compiler catches all three. 3. Add it to `store_kinds()`
+in [`src/provider.rs`](src/provider.rs), or kind-filtered queries will be routed
+away from the store; omitting `Memory` there once did exactly that to memory
+queries. No migration is needed — `node.kind` is a TEXT column.
+
+**Add an embedder.** 1. Implement `Embedder` (`fingerprint` + `embed`) in a new
+module. 2. Return a fingerprint that differs in at least one field. 3. Pass it
+to `ContextStore::open_with` or `open_and_warm`. Nothing else changes: old
+vectors stay under the old fingerprint, invisible to retrieval, and warm
+re-embeds incrementally on the next mount.
+
+**Add a migration.** 1. Add a `MIGRATION_V<n>` const whose doc comment says
+*why*, not what the SQL says. 2. Bump `SCHEMA_VERSION`. 3. Add the
+`if version < n` arm inside `migrate`'s single transaction. 4. Add a replay
+test that builds the previous schema by hand and asserts the old data survives —
+copy `migrates_v2_context_db_preserving_memories`. Remember that shipping this
+makes older binaries refuse the workspace.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "The `.stella/` directory (per-workspace
+  state)" for where `context.db` sits and who else writes under `private/`, and
+  the Gotchas entry on `context.db` vs `codegraph.db`.
+- [`../docs/context-reuse.md`](../docs/context-reuse.md) — the frame identity
+  triple and the `context/verify` contract that `ContextProvider::verify`
+  implements.
+- [`../website/content/docs/context-engine.mdx`](../website/content/docs/context-engine.mdx)
+  — the user-facing view of the context engine and its stores.
+- [`../stella-cli/src/contextgraph.rs`](../stella-cli/src/contextgraph.rs) —
+  where this store is wrapped as the `workspace-memory` CGP provider and where
+  external providers are registered instead.
+- [`../stella-graph`](../stella-graph) — the tree-sitter code graph, a separate
+  crate writing a separate file.

--- a/stella-core/README.md
+++ b/stella-core/README.md
@@ -1,0 +1,213 @@
+# stella-core
+
+The step-driver. `Engine::run_turn` takes a message history, a budget guard and
+an event channel, and runs the model/tool loop to an answer: one model call per
+step, retry+backoff, context compaction, tool-output eviction, loop detection,
+USD metering. Alongside it live the workspace's other decision engines — rules,
+skills, routing, the goal loop, the task board, discovery ranking — which the
+CLI drives directly rather than through a turn.
+
+**No I/O.** This crate never imports a provider SDK, never touches the
+filesystem, never spawns a process, never opens a socket. Anything needing the
+outside world is a trait the caller implements: `ToolExecutor`, `Clock`,
+`TurnGate`, `TurnSteering` ([`src/ports.rs`](src/ports.rs)), `Sleeper`
+([`src/retry.rs`](src/retry.rs)), `HookRunner` ([`src/hooks.rs`](src/hooks.rs)),
+`RuleSource` ([`src/rules.rs`](src/rules.rs)), `SkillSource`
+([`src/skills.rs`](src/skills.rs)) — plus `Provider` from `stella-protocol`.
+Even the working directory is passed in (`EngineConfig::cwd`) rather than read
+from `std::env`. That is what makes compaction, eviction, loop detection and
+budget arithmetic plain synchronous functions over owned data, testable against
+fakes without a runtime. The one documented exception is reading a clock:
+[`src/bus.rs`](src/bus.rs) reads `SystemTime` to timestamp events and `Instant`
+to enforce the per-handler latency budget.
+
+## Where it sits
+
+Depends on exactly one workspace crate — `stella-protocol` (types) — plus
+`serde`, `tokio` (`sync` + `time` only), `async-trait`, `futures-util`, `rand`,
+`sha2` and `serde_json_canonicalizer`. Note what is absent: no `regex`, no
+HTTP client, no SQLite. `stella-cli`, `stella-tools`, `stella-mcp`,
+`stella-pipeline`, `stella-fleet` and `stella-serve` depend on it. Library only
+— it builds no binary.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | Module list and the crate's re-export surface. Read the `pub use` block to see what callers are meant to touch. |
+| [`src/driver.rs`](src/driver.rs) | `Engine`, `EngineConfig`, `TurnOutcome`, `run_turn`. The one file that sequences every other module against real I/O. Start here. |
+| [`src/driver/settlement.rs`](src/driver/settlement.rs) | The between-steps budget check and `BudgetTick`/warning emission, split out of the step loop. |
+| [`src/ports.rs`](src/ports.rs) | The port boundary: `ToolExecutor`, `ReadOnlyTools`, `Clock`, `TurnGate`, `TurnSteering`. |
+| [`src/budget.rs`](src/budget.rs) | `BudgetGuard` — USD spend against a turn and/or session cap. Returns `BudgetOutcome`; aborts nothing itself. |
+| [`src/compaction.rs`](src/compaction.rs) | `compact()` — dedup, supersession, aging, eviction. Open when the conversation is being rewritten wrongly. |
+| [`src/estimator.rs`](src/estimator.rs) | Conservative token estimate plus `Calibration`/`CalibrationMap`, the per-model drift correction fed by reported usage. |
+| [`src/loop_detect.rs`](src/loop_detect.rs) | `detect_loop()` — exact repeats and short cycles over `CallRecord`s. |
+| [`src/retry.rs`](src/retry.rs) | `RetryPolicy`, backoff computation, `retry_with_backoff*`, and the `Sleeper` port. |
+| [`src/speculation.rs`](src/speculation.rs) | Early execution of read-only tool calls announced mid-stream (`pub(crate)`). |
+| [`src/receipts.rs`](src/receipts.rs) | `ReceiptLedger` — `BlockRegistered` + `StepManifest` context receipts, content-free (digests, never payloads). |
+| [`src/accounted_call.rs`](src/accounted_call.rs), [`src/event_sender.rs`](src/event_sender.rs) | A one-shot accounted provider call for callers that are not the engine, and the channel wrapper that can journal an event durably before admitting it. |
+| [`src/bus.rs`](src/bus.rs) | The in-process extension bus: observers (`emit`) and policy hooks (`emit_blocking`) over a dotted event-name catalog. |
+| [`src/hooks.rs`](src/hooks.rs) | Settings-declared *shell* hooks — `SessionStart`/`PreToolUse`/`PostToolUse` matching and blocking decisions. |
+| [`src/rules.rs`](src/rules.rs), [`src/rules/metadata.rs`](src/rules/metadata.rs) | Rules engine: loading, precedence merge, Tier-1 rendering, Tier-2 `evaluate_guards`, candidate mining, metadata parse/render. |
+| [`src/skills.rs`](src/skills.rs) | Skills engine: `SKILL.md` loading, `select_skills`, `render_skills_section`, auto-creation mining, install vocabulary. |
+| [`src/glob.rs`](src/glob.rs), [`src/mining.rs`](src/mining.rs), [`src/summarize.rs`](src/summarize.rs) | Non-public shared helpers: the `*`-only glob matcher behind rule guards and hook matchers; the lexical mining primitives the rules and skills miners share (they were once two byte-identical copies); the overflow summarizer's prompt and span rendering. |
+| [`src/discovery.rs`](src/discovery.rs) | The ranker behind `tool_search`/`skill_search`/`mcp_search`: `select:` lookups, `+required` terms, field-weighted scoring. |
+| [`src/extensions.rs`](src/extensions.rs) | Custom commands and agents parsed from markdown, plus `plan_extension_sync` for adopting `.claude/`/`.agents/` definitions. |
+| [`src/goal.rs`](src/goal.rs) | The goal loop: worker turn → judge verdict → feedback, bounded by round cap, budget and turn abort. |
+| [`src/router.rs`](src/router.rs) | Role → model resolution over a caller-supplied `ProviderProfile`, plus the per-provider circuit breaker. |
+| [`src/tasks.rs`](src/tasks.rs) | `TaskBoard` — the transition rules behind the `task_*` tools; records `SpawnRequest`s rather than spawning. |
+| [`src/mcp_usage.rs`](src/mcp_usage.rs) | The MCP usage record/ledger types, homed here so `stella-mcp` and `stella-tools` need no edge between them. |
+| [`src/context_record.rs`](src/context_record.rs) + [`src/context_record/`](src/context_record) | The adaptive-context Phase 1 value layer: taxonomy enums, scope, temporal, canonical `record_hash`, context-use, contract, outcome, representation. Types and validators only. |
+
+## Key concepts
+
+**The step loop is a fixed phase sequence.** `run_turn`
+([`src/driver.rs:406`](src/driver.rs)) iterates up to `EngineConfig::max_steps`,
+and each step runs the same phases in the same order: pause gate → drain
+steering / check soft stop → budget check → snapshot tool-result identities →
+compaction pass → loop detection → model call (wrapped in retry+backoff) →
+committed-step bookkeeping → dispatch. Each phase is one sub-method
+(`run_compaction_pass`, `check_loop_detection`, `run_model_call`,
+`dispatch_completion`). The order is load-bearing, not stylistic: identities are
+snapshotted *before* compaction because the compaction pass rewrites tool
+results in place and loop detection then runs on the rewritten history in that
+same step (#554). The engine holds no conversation state — `messages` is
+borrowed `&mut`, so the caller owns persistence and can inspect history after an
+abort.
+
+**Everything that ends a turn ends it at a step boundary.** Budget aborts, the
+pause gate, the soft stop and loop-detection aborts all fire between steps,
+never mid-tool — killing a tool in flight leaves the workspace and the model's
+view of it inconsistent, a defect this codebase already shipped once in its
+TypeScript era. [`src/budget.rs`](src/budget.rs) is deliberately unable to abort
+anything: `BudgetGuard::evaluate`/`record_spend` return a
+`BudgetOutcome::AbortTurn` *recommendation*, and `check_budget`
+([`src/driver/settlement.rs`](src/driver/settlement.rs)) turns it into
+`TurnOutcome::Aborted`. The one place the engine may interrupt a running tool is
+`EngineConfig::tool_timeout` (15 minutes by default), and it surfaces as a
+`ToolOutput::Error` the model can route around — a tool result, not a turn abort.
+
+**Exactly-once is a guarantee about mutating tools only.**
+`retry_with_backoff_observed` wraps the model call together with that attempt's
+speculation pump. A mutating tool call runs *outside* the retried closure, after
+a model call has already succeeded, so a retried step structurally cannot
+re-execute it — proved by `retry_never_re_executes_a_tool_call`
+([`src/driver/tests.rs:1194`](src/driver/tests.rs)), which counts real executions
+against a flaky scripted provider. Read-only calls carry no such guarantee: they
+run inside the retried closure and inside speculation, so one can execute several
+times in a step. Do not assume a `read_only` tool with an observable side channel
+(a rate-limited API, a write to `codegraph.db`) runs at most once.
+
+**Speculation is fenced by the first mutating call.** Dispatch runs every
+mutating call as its own barrier in call order, so a read-only call appearing
+*after* a mutation must observe it. Calls stream in order, so
+[`src/speculation.rs`](src/speculation.rs) permanently stops speculating for the
+rest of the step at the first non-read-only call it sees — only the all-read-only
+prefix is ever run early. A speculative result is harvested only when the
+committed call is byte-identical (id, name, input) to what was announced;
+anything else is discarded and reported as an
+`AgentEvent::SpeculationDiscarded` so the I/O it already ran stays accountable
+(#370).
+
+**Compaction's four mechanisms pull in opposite directions on purpose.**
+`compact()` ([`src/compaction.rs:133`](src/compaction.rs)) applies, least-lossy
+first: dedup of byte-identical tool outputs, supersession of re-run calls, aging
+(middle-out truncation of old large outputs), then eviction. Dedup keeps the
+**earliest** copy — byte-identical content is position-independent, so stubbing
+the later ones keeps the provider's prompt-cache prefix byte-identical (#372).
+Supersession keeps the **latest**, because it is about staleness, not
+duplication. They look like the same rule with a sign error; they are not. The
+system message and the latest user message are never touched.
+
+## Gotchas
+
+- **Two unrelated things are called `HookEvent`.** `hooks::HookEvent` is the
+  settings-declared shell-hook lifecycle enum; `bus::HookEvent` is the
+  extension-bus envelope. Only the first is re-exported at the crate root; the
+  second stays module-qualified on purpose ([`src/lib.rs:41`](src/lib.rs)).
+- **Loop detection ignores `ToolCall::call_id`.** `ToolCall` derives `PartialEq`
+  over all fields including the id, which providers mint fresh per call — using
+  derived equality here would mean the detector silently never fires.
+  `same_record` in [`src/loop_detect.rs`](src/loop_detect.rs) is the one place
+  that distinction is made, comparing name + input + output.
+- **A repeat is only a loop when the *output* repeats too**, and compaction
+  rewrites those outputs in place. Identical input with changing output is
+  legitimate work (polling a process, re-running a shrinking test suite);
+  callers that can preserve what a call really produced pass it as
+  `CallRecord::identity` rather than let comparison see rewritten bytes.
+- **Bus observers must return `Err`, never panic.** `catch_unwind` contains a
+  panic only under an unwinding profile, and the workspace `release` profile sets
+  `panic = "abort"` ([`../Cargo.toml`](../Cargo.toml)).
+- **`run_session_start_hooks` is not called by `run_turn`.** `SessionStart` is a
+  session-level event and `run_turn` runs many times per session; the caller
+  invokes it once and folds the output into the system prompt it builds.
+- **`Engine::with_sleeper` is the only constructor.** The crate exports the
+  `Sleeper` port but no production implementation — wiring a real one is the
+  binary's job, and tests wire a no-op to run retries at zero wall-clock cost.
+- **`context_record` is not `stella-context`,** and it is not the live rules
+  path either: `rules::metadata` still drives that. The two coexist by decision —
+  do not merge them, and read the subsumption table in
+  [`src/context_record.rs`](src/context_record.rs) before assuming a mapping is
+  ratified (two edges are explicitly flagged as unratified).
+
+## Testing
+
+```bash
+make test-core           # cargo test -p stella-core
+make watch-core          # re-run on save (needs cargo-watch)
+```
+
+There is no `tests/` directory: every test is an inline `#[cfg(test)]` module in
+the file it covers, which is why the engine's own suite is split across
+[`src/driver/tests.rs`](src/driver/tests.rs) and
+[`src/driver/tests/`](src/driver/tests) (`audit_fixes.rs` holds the 2026-07
+turn-driver audit witnesses; also `budget_boundaries.rs`,
+`usage_completeness.rs`). `proptest!` blocks live in
+[`src/retry.rs`](src/retry.rs), [`src/loop_detect.rs`](src/loop_detect.rs),
+[`src/tasks.rs`](src/tasks.rs) and [`src/skills.rs`](src/skills.rs); past
+failing seeds are committed under
+[`proptest-regressions/`](proptest-regressions). No feature flag, no env var, no
+fixture server and no network — driver tests wire scripted `Provider`s, counting
+`ToolExecutor`s and no-op `Sleeper`s, so the suite runs in seconds. Keep it that
+way: a test here that needs a file or a socket means the logic under test is in
+the wrong crate.
+
+## Extending it
+
+**Adding an engine capability that needs the outside world:**
+
+1. Define the trait next to the decision it serves — [`src/ports.rs`](src/ports.rs)
+   for engine-wide seams, otherwise module-local like `rules::RuleSource`.
+2. Attach it with a `with_*` builder on `Engine` that stores an `Option`, so an
+   engine built without it takes exactly the old path
+   (`with_hooks`/`with_calibration`/`with_gate`/`with_steering` are the pattern).
+3. Implement it in `stella-cli` or `stella-tools`. Never here.
+4. Test it in-crate against a fake implementation.
+
+**Adding a compaction mechanism:** extend `compact()`
+([`src/compaction.rs`](src/compaction.rs)) in least-lossy-first order, add the
+counters to `CompactionReport`, and add a test beside
+`never_evicts_the_most_recent_tool_result` — plus check
+`dedups_identical_outputs_keeping_the_earliest` and
+`repeated_identical_call_supersedes_older_differing_results` still pass, since
+they pin the two opposing retention directions.
+
+**Adding a reason a turn can end:** return `Option<TurnOutcome>` from a check
+called at the top of the step loop in `run_turn`, next to `check_budget` and
+`check_loop_detection` — never from inside `dispatch_completion`, or you have
+built the mid-tool abort this crate exists to prevent.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions"
+  (invariants 1, 2 and 6 are this crate's contract) and "Testing approach".
+- [`../stella-protocol`](../stella-protocol) — `Provider`, `AgentEvent`,
+  `CompletionMessage`, `ToolCall`/`ToolOutput`. [`../stella-tools`](../stella-tools)
+  has `ToolRegistry`, the production `ToolExecutor`;
+  [`../stella-cli`](../stella-cli) wires the remaining ports.
+- [`../website/content/docs/agent-engine-paths.mdx`](../website/content/docs/agent-engine-paths.mdx)
+  — every caller that drives `run_turn`;
+  [`../website/content/docs/configuration/agent-engine-config.mdx`](../website/content/docs/configuration/agent-engine-config.mdx)
+  — the user-facing knobs behind `EngineConfig`.
+- [`../docs/design/session-telemetry-receipts-spec.md`](../docs/design/session-telemetry-receipts-spec.md)
+  — the receipt schema [`src/receipts.rs`](src/receipts.rs) emits.

--- a/stella-core/src/summarize.rs
+++ b/stella-core/src/summarize.rs
@@ -1,6 +1,6 @@
 //! The overflow summarizer's prompt and span rendering — the pure half of
 //! `driver.rs`'s summarize-on-overflow fallback, split out so the driver
-//! stays within the size ratchet and the render logic is testable alone.
+//! stays small and the render logic is testable alone.
 
 use stella_protocol::{CompletionMessage, MessageRole, ToolOutput};
 

--- a/stella-fleet/README.md
+++ b/stella-fleet/README.md
@@ -126,11 +126,15 @@ table-tested with an injected `Clock` instead of a real wait (L-E4).
   `finish_attempt` uses `unchecked_transaction`, which is sound *only* because
   that mutex is the borrow rusqlite would otherwise enforce and this is the one
   place a transaction is opened. A lock is never held across an `.await`.
-- **The schema is versioned; `ledger.rs`'s module header is stale on this
-  point.** The header still describes a stamp-free convergent DDL, but
-  `migrate` ([`ledger.rs:372`](src/ledger.rs)) stamps `PRAGMA user_version` in
-  the same transaction as the DDL, and `MIGRATION_V2` rebuilt `lineage` to add
-  the uniqueness constraint. Trust the code.
+- **An additive table or index is free; a *reshape* is not.** The base DDL is
+  convergent (`CREATE … IF NOT EXISTS`, replayed on every open), so a new table
+  reaches an existing ledger the next time it is opened. Altering or
+  backfilling a column does not — the `IF NOT EXISTS` guard silently skips it
+  on an existing file, which is exactly how a schema change becomes a runtime
+  `INSERT` failure. That change must land as a numbered `MIGRATION_V<n>` with a
+  matching `version < n` arm; `migrate` ([`ledger.rs:372`](src/ledger.rs))
+  stamps `PRAGMA user_version` in the same transaction as the DDL it applies,
+  the way `MIGRATION_V2` rebuilt `lineage` to add its uniqueness constraint.
 - **Nothing removes worktrees or branches.** `WorktreeManager::remove` exists
   but neither `Fleet` nor `fleet_cmd` calls it; isolated worktrees under
   `.stella/worktrees/<slug>` and their `fleet/<slug>-<hash>` branches are left

--- a/stella-fleet/README.md
+++ b/stella-fleet/README.md
@@ -1,0 +1,198 @@
+# stella-fleet
+
+The multi-agent fleet layer: it takes a DAG of tasks, dispatches them wave by
+wave to worker agents running in one shared repository tree (a dedicated git
+worktree only where a plan opts in), and records every attempt, commit and
+dollar in an embedded SQLite ledger. It is the engine behind `stella fleet`;
+the command wiring, the real worker, and the `--budget` split live in
+[`../stella-cli/src/fleet_cmd.rs`](../stella-cli/src/fleet_cmd.rs).
+
+The boundary *is* the seam: subagent fan-out goes through exactly one API,
+[`Fleet::dispatch`](src/fleet.rs) (L-E9). Nothing here spawns a process for an
+agent ad hoc — hand-rolled per-call-site fan-out is what lost lineage and left
+budgets uncounted in the TS era, so a caller gets claims, ledger rows, lineage
+and budget metering or it does not get a worker. Everything external is a port
+trait (`FleetWorker`, `GitCli`, `GhCli`, `Sleeper`, plus `stella_core::Clock`)
+so every test runs against fakes; `git`/`gh` are shelled out to through
+`tokio::process` rather than linking libgit2 (a deliberately-avoided heavy
+native build); and there is no `unwrap`/`panic` outside tests.
+
+## Where it sits
+
+Depends on `stella-protocol` (`AgentEvent`, `PrStatus`, `CiStatus`),
+`stella-core` (`BudgetGuard`, `Clock`), `stella-store` (the `file_locks` table
+that backs task claims) and `stella-tools` (`subprocess_env` scrubbing for the
+`git`/`gh` subprocesses). `stella-cli` is the only crate that depends on it,
+and this crate builds no binary of its own. It deliberately does **not** depend
+on `stella-model`: prompt-cache pricing and TTL *policy* stay on that side of
+the boundary, and only the scheduling *heuristic* lives here
+([`src/cache_schedule.rs:1`](src/cache_schedule.rs)).
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The five-pieces-one-seam overview and the crate's re-exports. Read it first. |
+| [`src/plan.rs`](src/plan.rs) | `Plan`/`Task`/`Isolation` and the pure DAG scheduling: `validate`, `topological_order`, `ready_tasks`, cycle detection. No I/O, no async — open it to change how waves are formed or what a plan may declare. |
+| [`src/fleet.rs`](src/fleet.rs) | `Fleet::dispatch` (the seam), `run_wave`, `run_plan`, the claim/control RAII guards, and the per-task pause/resume/stop verbs. The biggest file and the one that orders everything else. |
+| [`src/ledger.rs`](src/ledger.rs) | `fleet.db`: schema, migrations, and every read/write of runs, tasks, attempts, commits, lineage and spend. |
+| [`src/git.rs`](src/git.rs) | The `GitCli` port, `SystemGitCli`, and `WorktreeManager` — worktree create/remove/list plus the pathspec-only commit helper. |
+| [`src/monitor.rs`](src/monitor.rs) | The `GhCli` port and `Monitor`: live PR reconciliation, the CI poll loop, the pure `decide` cap state machine, and the `AgentEvent` emit-shape helpers. |
+| [`src/cache_schedule.rs`](src/cache_schedule.rs) | `warmest_first` — the pure, no-I/O ordering heuristic for equal-priority runnable sessions. |
+
+## Key concepts
+
+**The ledger hierarchy: run → task → attempt → commits/spend.** One
+`.stella/private/fleet.db` per workspace holds `runs`, `tasks`, `attempts`,
+`commits`, `spend` and `lineage`. An attempt row is opened *before* the worker
+runs ([`ledger.rs:174`](src/ledger.rs)) so a crash mid-attempt still leaves a
+row naming what was in flight; the closing half — outcome, commits and the
+spend row — is written all-or-nothing in one transaction
+([`Ledger::finish_attempt`, ledger.rs:193](src/ledger.rs)). Retries are extra
+`attempts` rows, never extra lineage edges: `record_lineage` is idempotent per
+`(parent_run_id, child_task_id)`. This is not a rebuildable cache like
+`codegraph.db` — it is the authoritative record of a subagent's commits and of
+real money spent, and nothing can reconstruct it once written. The in-memory
+`BudgetGuard` is the *gate*; the ledger is the *record*, and dispatch writes
+both.
+
+**A fleet `run_id` is not an `execution_id` and not a session id.** It is the
+top of the hierarchy above — one multi-agent fan-out — and it is owned by this
+crate. `execution_id` is one row of `stella-store`'s `executions` table (one
+goal/turn), and a session is one run of the CLI tracked under
+`~/.stella/sessions/`. The three join correctly today, so this is a naming
+hazard rather than a bug; see the *Glossary — the identifiers that look alike*
+table in [`../AGENTS.md`](../AGENTS.md) before assuming two of them mean the
+same thing. Note `task` is doubly loaded too: a fleet `TaskId` is a unit of
+work in a run, while a `tasks` row in `stella-store` is the agent's own
+task-board snapshot.
+
+**What `dispatch` does, in order** ([`fleet.rs:438`](src/fleet.rs)): check the
+aggregate parent budget; claim the task's declared paths; allocate the
+workspace (a worktree only for `Isolation::Isolated`, otherwise the repo root);
+record task + lineage + attempt-open; register the worker's control lines and
+run it; stamp the outcome atomically; meter the child's cost into the parent
+`BudgetGuard`. The claim rows and the control registration are held by
+`Drop`-scoped guards (`ClaimGuard`, [`fleet.rs:117`](src/fleet.rs);
+`ControlGuard`, [`fleet.rs:146`](src/fleet.rs)) rather than released at a
+statement, because a panicking worker or a dropped dispatch future skips the
+statement — and `file_locks` rows are durable, so a missed release outlives the
+process.
+
+**Share by default, isolate on purpose.** `Isolation::SharedTree` is the
+default: every worker runs in the one repository root, coordinated by
+cooperative claims, so conflicts surface at write time with the rival named and
+the build cache stays warm. `Isolation::Isolated` is the explicit opt-in for
+genuinely divergent work (best-of-N, checkout-state mutation) and costs a cold
+build cache plus conflicts deferred to integration time.
+
+**Long waits are capped, not global.** `Monitor::watch_ci`
+([`monitor.rs:576`](src/monitor.rs)) polls CI and extends the wait *only* on
+fresh evidence (a changed run-set fingerprint, or a job actively in progress).
+The arithmetic is a pure function, `decide` ([`monitor.rs:398`](src/monitor.rs)),
+so the 2h cumulative cap, the 20m stall window and the 10m startup grace are
+table-tested with an injected `Clock` instead of a real wait (L-E4).
+
+## Gotchas
+
+- **Fleet commits always name explicit pathspecs.** `WorktreeManager::commit_paths`
+  ([`git.rs:382`](src/git.rs)) runs `git add -- <paths>` then
+  `git commit -m <msg> -- <paths>`, never `-A`/`.`/`-a` and never a
+  pathspec-less commit — a blanket add in a shared tree sweeps another worker's
+  staged files, which is how work was lost in the TS monorepo. An empty
+  pathspec is `WorktreeError::EmptyPathspec`; a pathspec-less commit is not
+  expressible through this API.
+- **`SystemGitCli` strips `GIT_DIR` and friends on every invocation**
+  ([`git.rs:86`](src/git.rs)). Inside a git hook (the pre-push gate running
+  `cargo test`) those exported variables silently override `-C` — it once
+  rewrote the host repo's identity and committed test fixtures onto a real
+  branch.
+- **The pre-worker budget check is a snapshot, not a reservation.** Up to
+  `max_concurrency` workers can pass it before any of them records spend, so
+  worst-case overshoot is one in-flight window's cost. `fleet_cmd` divides the
+  cap by the concurrency width before handing each child its own guard; a
+  caller wiring this crate directly must do the same or accept the window.
+- **`run_plan` never cancels in flight.** When a child trips an enforced
+  parent budget the *remaining waves* are not launched, but running siblings
+  settle — same "safe boundaries only" contract as the engine.
+- **A failed task does not unblock its dependents**, and a dispatch error
+  (worktree creation, ledger I/O) is recorded as that task's failure rather
+  than an early return that would discard settled siblings' handles.
+- **Two `stella fleet` runs in one workspace open the same `fleet.db`.** WAL
+  plus `busy_timeout=5000` are set on every open
+  ([`ledger.rs:136`](src/ledger.rs)) — without the timeout a second writer's
+  `finish_attempt` fails after its worker already spent real money.
+- **`Ledger` is not `Sync`.** The fleet holds it behind a `Mutex` and
+  `finish_attempt` uses `unchecked_transaction`, which is sound *only* because
+  that mutex is the borrow rusqlite would otherwise enforce and this is the one
+  place a transaction is opened. A lock is never held across an `.await`.
+- **The schema is versioned; `ledger.rs`'s module header is stale on this
+  point.** The header still describes a stamp-free convergent DDL, but
+  `migrate` ([`ledger.rs:372`](src/ledger.rs)) stamps `PRAGMA user_version` in
+  the same transaction as the DDL, and `MIGRATION_V2` rebuilt `lineage` to add
+  the uniqueness constraint. Trust the code.
+- **Nothing removes worktrees or branches.** `WorktreeManager::remove` exists
+  but neither `Fleet` nor `fleet_cmd` calls it; isolated worktrees under
+  `.stella/worktrees/<slug>` and their `fleet/<slug>-<hash>` branches are left
+  for review. The slug hashes the run scope *and* the task id, so re-running a
+  plan with the same task ids does not collide with what the last run kept.
+- **`WatchConfig::run_list_limit` (default 50) is a truncation point.** A
+  branch with more CI runs than the limit can report `AllCompleted` while older
+  runs go unobserved.
+
+## Testing
+
+```bash
+cargo test -p stella-fleet
+```
+
+There is no `tests/` directory and no `make` target for this crate — every test
+is an inline `#[cfg(test)]` module next to the code it covers. `plan.rs` is
+proptested (acyclic-plan strategies assert that `topological_order` respects
+every edge, that wave scheduling drains the plan, and that injected 2-cycles
+are always detected). `fleet.rs`, `git.rs` and `monitor.rs` drive fakes through
+the ports: a fake `FleetWorker`, a `GitCli`/`GhCli` that records argv and
+returns canned `GitOutput`/`GhOutput`, and a `Sleeper` that advances an
+injected `Clock` instead of sleeping — which is how the 2h cap is proven in
+microseconds. `git.rs` also has real-`git` integration tests (worktree
+isolation, branch-preserving removal) that seed a throwaway repo in a tempdir
+and skip with a printed note when `git` is not on `PATH`.
+
+## Extending it
+
+Adding a ledger column, table or constraint — the case with a real footgun:
+
+1. Add a `MIGRATION_V<n>` const in [`src/ledger.rs`](src/ledger.rs) holding
+   only the new steps. Reshaping an existing table (a new column, a new
+   constraint) needs the full rebuild dance `MIGRATION_V2` shows —
+   `CREATE`/`INSERT … SELECT`/`DROP`/`RENAME`, plus recreating the indexes the
+   drop took with it.
+2. Add the matching `if version < n { … }` arm in `migrate` and bump
+   `SCHEMA_VERSION` in the same commit.
+3. Write the witness pair the existing tests model: a fresh ledger is stamped
+   at the current version, and a ledger seeded with the *old* schema migrates
+   in place without losing rows — `an_unversioned_ledger_migrates_in_place_without_losing_data`
+   is the template. Downgrades are unguarded by design: a file stamped by a
+   newer binary is opened as-is.
+
+A new `git`/`gh` interaction goes on `WorktreeManager`/`Monitor` and through
+the existing `GitCli`/`GhCli::run`, never as a fresh `Command` — that is what
+keeps the env scrubbing, `-C` pinning and fake-driven tests in force. A new
+kind of worker implements `FleetWorker` and is handed to `Fleet::new`; it must
+honor its `WorkerControls` (park on the pause watch at a safe step boundary
+only, treat a closed channel as "resumed"/"no stop coming").
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — *Glossary — the identifiers that look alike*
+  (why `run_id` is none of the other four ids) and *The `.stella/` directory*
+  (where `fleet.db` sits and what else shares that directory).
+- [`../stella-cli/src/fleet_cmd.rs`](../stella-cli/src/fleet_cmd.rs) — the only
+  consumer: plan parsing, the real worker, the per-child budget split, and the
+  `gh`-backed PR/CI pass.
+- [`../website/content/docs/commands/fleet.mdx`](../website/content/docs/commands/fleet.mdx)
+  — the user-facing `stella fleet` contract (flags, cleanup behavior).
+- [`../website/content/docs/agent-fleets.mdx`](../website/content/docs/agent-fleets.mdx)
+  — the fleet concept guide, including the plan-file schema.
+- [`../docs/design/fleet.plan.toml`](../docs/design/fleet.plan.toml) — a real
+  plan file that deserializes straight into `Plan`.

--- a/stella-fleet/src/ledger.rs
+++ b/stella-fleet/src/ledger.rs
@@ -15,18 +15,22 @@
 //! ([`Ledger::finish_attempt`]); WAL journaling is enabled at open so a
 //! reader is never blocked by an in-flight writer.
 //!
-//! Schema: `fleet.db` carries **no version stamp**. Its DDL is convergence —
-//! every statement is `CREATE … IF NOT EXISTS` and the whole batch replays on
-//! every open — so an additive table or index reaches an existing ledger the
-//! next time it is opened, and adding one is the migration. Unlike the
-//! rebuildable `codegraph.db` index, this is *not* a cache: it is the
-//! authoritative record of a subagent's commits and of real money spent, and
-//! nothing can reconstruct it once written. So the absence of a stamp is a
-//! known gap, not a justification: any change that *reshapes* an existing table
-//! (altering or backfilling a column, which the `IF NOT EXISTS` guard silently
-//! skips on an existing file) must introduce versioned migration machinery —
-//! `PRAGMA user_version` plus a stepwise list, as `stella_store::migrations`
-//! does — before it touches this schema.
+//! Schema: `fleet.db` is **versioned** by `SCHEMA_VERSION` and `migrate`,
+//! which stamps `PRAGMA user_version` in the same transaction as the DDL it
+//! applies. The base DDL is still convergence — every statement is
+//! `CREATE … IF NOT EXISTS` and the whole batch replays on every open — so an
+//! *additive* table or index reaches an existing ledger the next time it is
+//! opened, and adding one needs no migration step. What convergence cannot do
+//! is *reshape* an existing table: altering or backfilling a column is
+//! silently skipped by the `IF NOT EXISTS` guard on an existing file, so that
+//! change must land as a numbered `MIGRATION_V<n>` with a matching
+//! `version < n` arm, the way `MIGRATION_V2` rebuilt `lineage` to add its
+//! uniqueness constraint.
+//!
+//! This matters more here than in a rebuildable index: unlike `codegraph.db`,
+//! the ledger is *not* a cache. It is the authoritative record of a subagent's
+//! commits and of real money spent, and nothing can reconstruct it once
+//! written.
 
 use std::path::Path;
 

--- a/stella-graph/Cargo.toml
+++ b/stella-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stella-graph"
-description = "Code-graph indexer: tree-sitter parsers (native), symbol + import-edge extraction, incremental re-index on file change. Implemented AS a built-in CGP provider feeding stella-context."
+description = "Code-graph indexer: tree-sitter parsers (native), symbol + import-edge extraction, incremental re-index on file change. Implemented AS a built-in CGP provider; recall reaches it through the CGP host, and it owns codegraph.db independently of stella-context."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/stella-graph/README.md
+++ b/stella-graph/README.md
@@ -3,8 +3,8 @@
 The code-graph indexer: tree-sitter symbol and import-edge extraction over a
 workspace, persisted in SQLite at `.stella/private/codegraph.db`, and served
 back as `ContextFrame`s. It is implemented **as a built-in CGP provider**
-(`PROVIDER_ID = "code-graph"`) feeding `stella-context`, and `stella init` is
-what builds the index.
+(`PROVIDER_ID = "code-graph"`) that recall reaches through the CGP host, and
+`stella init` is what builds the index.
 
 The boundary is one-directional: this crate depends on `contextgraph-types`
 for the wire shape and **never on `stella-context`**, so the provider can be

--- a/stella-graph/README.md
+++ b/stella-graph/README.md
@@ -1,0 +1,198 @@
+# stella-graph
+
+The code-graph indexer: tree-sitter symbol and import-edge extraction over a
+workspace, persisted in SQLite at `.stella/private/codegraph.db`, and served
+back as `ContextFrame`s. It is implemented **as a built-in CGP provider**
+(`PROVIDER_ID = "code-graph"`) feeding `stella-context`, and `stella init` is
+what builds the index.
+
+The boundary is one-directional: this crate depends on `contextgraph-types`
+for the wire shape and **never on `stella-context`**, so the provider can be
+consumed without the retrieval plane depending back on it. Two smaller rules
+follow from the same discipline. Nothing here hard-codes the database
+location — `CodeGraph::open` takes a caller-supplied path, and the
+`.stella/private/codegraph.db` convention lives in the callers. And a
+tree-sitter parse failure on an arbitrary file is *not* a `GraphError`: it is
+skipped-with-record so one unparseable file never aborts an index batch
+(L-L1). `GraphError` is reserved for real infrastructure faults — SQLite, I/O,
+a malformed built-in query.
+
+## Where it sits
+
+No workspace crate is a dependency of this one; its only non-third-party
+dependency is `contextgraph-types`, pinned by git rev. It builds no binary.
+`stella-cli` and `stella-tools` both depend on it: the CLI mounts the graph
+for a session (`stella-cli/src/agent/graph.rs`) and `stella-tools` uses it for
+`read_symbol`, `code_map`, `impact`, `overview`, and the pre-write schema gate
+(`stella-tools/src/schema_gate.rs`).
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | Crate docs, the public re-export surface, and `load_storage_snapshot` — the pure read the gate calls per proposed write. |
+| [`src/graph.rs`](src/graph.rs) | `CodeGraph`, the public handle: `open` / `mount` / `index_all` / the query methods. Open this to change mount, shutdown, or connection behavior. |
+| [`src/lang.rs`](src/lang.rs) | `Language` and the extension → grammar + query mapping. First stop when adding a language. |
+| [`src/queries.rs`](src/queries.rs) | The tree-sitter S-expression queries as `const &str` compile-time data, one symbols/imports pair per language. |
+| [`src/parse.rs`](src/parse.rs) | `Grammars` (compiled once, shared by reference) and `parse_file`: tree → `Symbol`s + raw `ImportSpec`s. Pure and synchronous. |
+| [`src/symbol.rs`](src/symbol.rs) / [`src/import.rs`](src/import.rs) | `SymbolKind` (the cross-language superset, including SQL schema objects) and `ImportKind` plus the relative-specifier resolution ladder. |
+| [`src/store.rs`](src/store.rs) | SQLite: the `MIGRATION` DDL, `index_tree`, `apply_changes`, and every read query. The largest file and the one with the durability contract. |
+| [`src/walk.rs`](src/walk.rs) | The directory walk and `DENY_DIRS` — the cheap structural half of generated-file exclusion. |
+| [`src/generated.rs`](src/generated.rs) | The per-file half: `.gitattributes linguist-generated`, `*.min.*`, and the minified-content heuristic (issue #272). |
+| [`src/watch.rs`](src/watch.rs) | The live re-index pipeline: `notify` event source → debounce → one transactional apply, plus the `WatchInjector` test seam. |
+| [`src/frames.rs`](src/frames.rs) | Query → `ContextFrame` assembly: citation labels, provenance, score bands, budget packing. |
+| [`src/storage/mod.rs`](src/storage/mod.rs) | The storage map's canonical model (layer / namespace / relation / field) and `StorageExtractor`. |
+| [`src/storage/sql.rs`](src/storage/sql.rs), [`prisma.rs`](src/storage/prisma.rs), [`ts.rs`](src/storage/ts.rs), [`py.rs`](src/storage/py.rs) | One adapter per source family: SQL DDL; Prisma; Drizzle/TypeORM/Mongoose/DynamoDB; Django/SQLAlchemy. |
+| [`src/manifest.rs`](src/manifest.rs) | `stella.storage.toml` — the committed half of the storage map (layers, intent, redirects, stubs) merged at snapshot time. |
+| [`src/error.rs`](src/error.rs) | `GraphError`. |
+
+## Key concepts
+
+**Languages are wired in at compile time, natively.** Ten `Language` variants
+— Rust, Python, JavaScript, TypeScript, Tsx, Sql, Go, Java, C, Php — over nine
+grammar crates (`tree-sitter-typescript` supplies both `LANGUAGE_TYPESCRIPT`
+and `LANGUAGE_TSX`, which is why `Tsx` is a separate variant even though it
+shares TypeScript's query strings). Extensions map in
+[`Language::from_path`](src/lang.rs): `rs`; `py`/`pyi`; `js`/`jsx`/`mjs`/`cjs`;
+`ts`/`mts`/`cts`; `tsx`; `go`; `java`; `c`/`h`; `php`; `sql`. Grammars are
+linked in from their own crates, not loaded as WASM, and the queries are
+module `const`s rather than `.scm` assets — L-L2: built-in assets that resolve
+relative to the binary's install path broke the moment the artifact was
+bundled differently.
+
+**Every symbol query follows one capture convention** so `parse.rs` can decode
+matches uniformly: `@name` is the identifier whose text becomes the symbol
+name, and the *kind capture* (`@fn`, `@method`, `@struct`, `@enum`, `@trait`,
+`@class`, `@interface`, `@table`, …) captures the whole definition node — its
+line span becomes the symbol span and its capture name encodes the kind. Name
+fields use the `(_)` wildcard because `identifier` vs `type_identifier` vs
+`property_identifier` differ across grammars. Methods are deliberately
+double-captured and deduped by the name node's byte range, higher
+`SymbolKind::rank` winning.
+
+**`codegraph.db` is a cache versioned by convergence, not by a stamp.** Every
+statement in `MIGRATION` is `CREATE … IF NOT EXISTS` and the whole batch
+replays on every writer `open`, so adding a table or an index *is* the
+migration. That is only acceptable because the file is fully rebuildable by
+`stella init`. A change that needs a *reshape* — an altered or backfilled
+column, which `IF NOT EXISTS` silently skips on an existing store — would need
+versioned machinery introduced first. The `code_graph_` table prefix is a
+holdover from when this shared `stella-context`'s `context.db`; it stays so
+the two schemas cannot collide.
+
+**Mount is warm and non-blocking.** `CodeGraph::mount` opens the store
+synchronously so queries are immediately callable, then runs incremental
+catch-up and arms the watcher on a background task (L-C1) — building lazily on
+first query added seconds to the first real prompt. Indexing and queries use
+**separate connections to the same WAL file**, so a long catch-up transaction
+never blocks a read; the reader just sees the last committed snapshot. Every
+index batch is one transaction, so a kill mid-index commits nothing.
+
+**Frames are cited by human label, never by id (L-C4).** `title` and the
+mandatory `citation_label` are strings like `fn run_turn
+(stella-core/src/driver.rs:160)`; every frame's provenance ends in a
+derivation attributed to `code-graph`; each declares an exact `token_cost`
+and a `content_digest` over exactly the bytes it carries inline, and assembly
+respects `max_tokens`/`max_frames` (L-C5).
+
+## Gotchas
+
+- **Custom `.gitignore` patterns are not honored.** `walk.rs` is a deny-list
+  approximation of ripgrep semantics (hidden dirs, `target`, `node_modules`,
+  `dist`, `dist-standalone`, `build`, `out`, `.next`, `vendor`,
+  `__pycache__`, `venv`, …), not the `ignore` crate. The same gap applies to
+  `.gitattributes`: only the root-level file is read, per-directory ones are
+  not merged.
+- **Generated-file exclusion runs *before* the byte-compat skip.** Deliberate:
+  the sha256 skip would otherwise keep a file indexed before `generated.rs`
+  existed in the store forever, because its bytes never change.
+- **The read path must not run DDL.** `load_storage_snapshot` uses
+  `store::open_read` (pragmas only, no `MIGRATION`) because the pre-write gate
+  opens the store on *every* write an agent proposes; running the whole
+  `CREATE …` batch there is never free.
+- **`Language::tag()` is persisted** in `code_graph_files.language`. Renaming
+  a tag is a schema change the convergence migration cannot express.
+- **`Language::Php` uses `LANGUAGE_PHP`, not `LANGUAGE_PHP_ONLY`** — real
+  `.php` files open and close `<?php` around markup, which the PHP-only
+  grammar cannot parse at all.
+- **`.h` indexes as C** even in a C++ tree. Misreading a header still yields
+  useful struct/function symbols; skipping it loses every declaration.
+- **SQL has no `SQL_IMPORTS`** (the const is `""`), and `parse_file` returns an
+  empty import vector for it.
+- **`references()` is a linear text scan** over the indexed corpus, capped at
+  50 hits — best-effort retrieval, not an index.
+- **Import frames cap their listing at 50 edges** because `budget_pack` *skips*
+  an over-budget frame rather than truncating it: an uncapped barrel file
+  produced one multi-thousand-token frame and the caller silently got no
+  import context at all.
+
+## Testing
+
+```bash
+cargo test -p stella-graph                 # no crate-specific `make` target exists
+cargo test -p stella-graph -- --ignored    # adds the real-FS notify smoke test
+```
+
+Per-language extraction and the query-compile guard (`all_queries_compile`)
+live in `#[cfg(test)]` modules inside [`src/parse.rs`](src/parse.rs); the
+integration tests are fixture-driven over real files in tempdirs:
+[`tests/languages.rs`](tests/languages.rs) (end-to-end indexing, Python
+relative and TS `index.ts` resolution, byte-compat skip),
+[`tests/frames.rs`](tests/frames.rs) (citation labels, provenance, budgets,
+content digests), [`tests/generated_exclusion.rs`](tests/generated_exclusion.rs)
+(witness tests for issue #272), and
+[`tests/live_index.rs`](tests/live_index.rs).
+
+Live-index tests are deterministic by construction: they use
+`#[tokio::test(start_paused = true)]` (which needs tokio's `test-util` feature,
+already a dev-dependency) and drive the real debounce → `apply_changes`
+pipeline through `CodeGraph::watch_pipeline_for_tests`, replacing OS event
+*delivery* only. [`tests/watcher.rs`](tests/watcher.rs) is the one test that
+goes through `notify` end to end and is `#[ignore]`d — FSEvents/inotify timing
+would make it a flaky gate.
+
+## Extending it
+
+To add a language:
+
+1. Add the `tree-sitter-<lang>` crate to the workspace `[workspace.dependencies]`
+   in `../Cargo.toml` and to this crate's [`Cargo.toml`](Cargo.toml).
+2. Add `<LANG>_SYMBOLS` and `<LANG>_IMPORTS` to [`src/queries.rs`](src/queries.rs),
+   following the `@name` + kind-capture convention and matching name fields
+   with `(_)`.
+3. Add the `Language` variant in [`src/lang.rs`](src/lang.rs) and extend all
+   five matches: `from_path`, `tag`, `ts_language`, `symbol_query`,
+   `import_query`. They are exhaustive, so the compiler enumerates what is
+   missing.
+4. In [`src/parse.rs`](src/parse.rs), add a `LangPack` field to `Grammars`,
+   load it in `Grammars::load`, map it in `Grammars::pack`, and add an arm to
+   the import-decoder match in `parse_file` (each language decodes its own
+   specifier shape — see `extract_go_imports`, `extract_c_imports`).
+5. If specifiers resolve to files, extend [`src/import.rs`](src/import.rs);
+   otherwise record them as `ImportKind::Bare`/`Absolute`, which preserves the
+   edge even when the target is outside the tree.
+6. Add tests: `all_queries_compile` in `src/parse.rs` fails immediately if a
+   query string does not compile; add a symbols-and-imports test beside
+   `go_symbols_and_grouped_imports`, and extend `new_extensions_classify`
+   (`src/parse.rs`) and `extensions_map_to_languages` (`src/lang.rs`).
+
+To add a storage source, implement extraction in a new
+[`src/storage/`](src/storage) module, dispatch it from `StorageExtractor::extract`,
+and extend `is_storage_file`. Extraction is shared by the indexer and the
+pre-write gate, so the two cannot drift; an unrecognized pattern must yield
+nothing rather than garbage.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Workspace layout — where a change goes" for
+  the crate boundary, and its "Gotchas" entry on `context.db` vs `codegraph.db`
+  (they used to share one file; do not revert the split).
+- [`../docs/design/storage-map.md`](../docs/design/storage-map.md) — the spec
+  the `storage` adapters and `manifest` implement (§3 model, §4a sources).
+- [`../docs/design/schema-graph.md`](../docs/design/schema-graph.md) — the
+  earlier schema-aware design; its Phases 1–2 shipped here, the rest was
+  absorbed into `storage-map.md`.
+- [`../website/content/docs/context-engine.mdx`](../website/content/docs/context-engine.mdx)
+  — how the code graph fits the retrieval plane from a user's point of view.
+- [`../stella-tools/src/schema_gate.rs`](../stella-tools/src/schema_gate.rs) —
+  the pre-write gate that consumes `load_storage_snapshot`.

--- a/stella-mcp/README.md
+++ b/stella-mcp/README.md
@@ -1,0 +1,205 @@
+# stella-mcp
+
+An **MCP client**. It connects to external Model Context Protocol servers
+(stdio child processes and streamable-HTTP endpoints), discovers their tools,
+and merges them into the engine's tool registry so `stella-core::Engine` calls
+them exactly like a built-in tool.
+
+It is a client and nothing else. v1 drives `initialize` / `tools/list` /
+`tools/call` and deliberately ignores every server-initiated request or
+notification (sampling, roots, progress). It also does not decide *where*
+anything lives on disk: [`config.rs`](src/config.rs) owns the shape of
+`mcp.toml`, not its path, and [`TokenStore`](src/oauth.rs) is handed a path by
+its caller. Path resolution, the `STELLA_TRUST_PROJECT` gate that decides
+whether a cloned repo's `mcp.toml` may spawn processes at all, and every print
+belong to `stella-cli` ([`mcp_cmd.rs`](../stella-cli/src/mcp_cmd.rs),
+[`agent.rs`](../stella-cli/src/agent.rs)).
+
+## Where it sits
+
+It depends on `stella-protocol` (`ToolOutput`, `ToolSchema`) and `stella-core`
+(the [`ports::ToolExecutor`](../stella-core/src/ports.rs) trait it implements
+and the [`mcp_usage`](../stella-core/src/mcp_usage.rs) ledger it records calls
+into) — nothing else in the workspace. Only `stella-cli` depends on it. It also
+builds its own binary, `mcp-fixture-server`, which exists purely for
+`tests/` and is excluded from dist (`[package.metadata.dist] dist = false`).
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The crate's authoritative design notes and the flat re-export surface. Read this first. |
+| [`src/toolset.rs`](src/toolset.rs) | `McpToolSet` — the `ToolExecutor` impl, tool namespacing, routing, native fall-through, disabled servers, and the Best-of-N `CandidateMcpView`. Open it for anything the engine sees. |
+| [`src/client.rs`](src/client.rs) | `McpClient` — handshake, version negotiation, paginated discovery, `tools/call`, the reconnect/backoff state machine, and every ingest budget. The largest file and the one with the most invariants. |
+| [`src/transport.rs`](src/transport.rs) | The `Transport` trait (framing only, no MCP methods) plus the `ScriptedTransport` test double used by the unit tests. |
+| [`src/stdio.rs`](src/stdio.rs) / [`src/http.rs`](src/http.rs) / [`src/sse.rs`](src/sse.rs) | The two transports and the SSE decoder streamable-HTTP needs. `http.rs` also owns the shared `truncate` / `truncate_middle_out` helpers. |
+| [`src/config.rs`](src/config.rs) | `mcp.toml`'s shape: `McpConfig` / `McpServerEntry` / `McpTransport`, the redacting `Debug`, and the `candidate_safe` opt-in. |
+| [`src/oauth.rs`](src/oauth.rs) | OAuth 2.1 login (`login`), the on-disk `TokenStore`, and the runtime `OAuthManager` / `OAuthTokenSource` pair. |
+| [`src/registry.rs`](src/registry.rs) | The MCP Server Registry API client (`GET /v0.1/servers`) and the mapping from a registry entry to a writable `McpTransport` + the `AuthField`s still to fill. |
+| [`src/error.rs`](src/error.rs) | `McpError` and `user_message()` — the length-bounded, credential-free rendering that reaches the model. |
+| [`src/bin/mcp-fixture-server.rs`](src/bin/mcp-fixture-server.rs) | The canned MCP server the integration tests spawn, with its fault-injection flags. |
+
+## Key concepts
+
+**One integration point, one namespace.** `McpToolSet` implements the same
+`ToolExecutor` port `stella-tools`' `ToolRegistry` implements, so composing it
+over the native set (`McpToolSet::connect(...).wrapping(native)`) makes MCP
+tools indistinguishable from built-ins. Every MCP tool is advertised as
+`mcp__<server>__<tool>`; a server name that is empty or contains the reserved
+`__` separator is skipped into `failed_servers()` rather than producing an
+ambiguous prefix. A non-`mcp__` name falls through to the native executor; an
+`mcp__…` name that matches no route is a model-visible error and never falls
+through. `stella-cli` builds the set once per session
+(`load_mcp_plan` → `connect_mcp_servers` in
+[`agent.rs`](../stella-cli/src/agent.rs)), which is why config changes take a
+restart — but `schemas()` is re-read on every model call, so the shared
+`DisabledServers` set toggles a server's tools in and out live.
+
+**Everything a server can push at the model is capped at ingest** (#551).
+`stella-core`'s compaction only trims on a *later* turn, so by the time it runs
+the tokens are already paid for; the budgets therefore live in this crate.
+[`client.rs`](src/client.rs) caps a rendered `tools/call` result at
+`MAX_TOOL_RESULT_BYTES` (100 000, middle-out with a counted elision marker),
+the tools accepted from one server at `MAX_TOOLS_PER_SERVER` (256), a
+description at `MAX_TOOL_DESCRIPTION_CHARS` (2 000), and a serialized
+`inputSchema` at `MAX_TOOL_SCHEMA_BYTES` (16 384). A schema cannot be
+string-truncated and stay valid JSON Schema, so an over-budget one is *replaced*
+with `{"type": "object"}` and a note appended to the description. A JSON-RPC
+*error* response never reaches `decode_call_result`, so
+[`McpError::user_message`](src/error.rs) bounds that second door on the same
+budget.
+
+**Connection failures are data, never an aborted turn.** `McpClient::call_tool`
+classifies each bounded request into `RequestOutcome::{Ok, Dropped, Timeout,
+Protocol}`. A *drop* reconnects and — only when the tool advertised
+`readOnlyHint` or `idempotentHint` (`McpToolInfo::safe_to_retry`) — transparently
+re-sends; a drop is ambiguous, so re-sending a mutating tool risks double
+execution and instead surfaces a named error. A *timeout* already burned the
+whole budget, so it tears down and defers the reconnect. A *protocol* error is
+passed straight through: the server answered, it just answered badly.
+`backoff_delay` retries the first failure immediately (a single blip self-heals
+inside the turn) and then doubles from 1 s to a 30 s cap, so a long-dead server
+is still probed forever. `HealthState` (`Live` / `Reconnecting` / `Down`) is
+surfaced per server through `McpToolSet::health`.
+
+**A stdio server inherits no ambient credential.** `StdioTransport::spawn` uses
+`Command::env_clear`; only the keys in the server's config `env` reach the
+child, plus `PATH` — the one deliberate exception, because a bare runner
+(`npx`, `uvx`, `docker`) cannot resolve without it, and a config `env` may still
+override it. stderr is `Stdio::null` so a chatty server cannot corrupt the
+JSON-RPC framing on stdout.
+
+**OAuth is lazy and its state is secret.** `OAuthManager::source_for` hands
+every HTTP transport a per-server `OAuthTokenSource` unconditionally; a source
+with no stored tokens yields no header (static-header servers are untouched)
+and re-checks the store until tokens appear, so a login completed mid-session
+takes effect on the next tool call with no reconnect. Tokens live in the
+caller-chosen JSON file — `stella-cli` puts it at
+`.stella/private/mcp_oauth.json`, inside the gitignored `private/` directory.
+Persistence is **Unix-only**: every open is `O_NOFOLLOW | O_CLOEXEC` at `0600`
+under a `0700` parent, rejects a non-regular or multiply-linked file, and writes
+through a temp file + `rename` + parent `fsync`. Elsewhere `TokenStore` refuses
+to read or write rather than fall back to a world-readable file.
+
+## Gotchas
+
+- **`PATH` is the only inherited variable, and it is load-bearing.** Without
+  the pass-through, every registry-installed stdio server (`npx`/`uvx`/`docker`)
+  failed to spawn. `stdio.rs`'s `a_bare_runner_command_resolves_via_inherited_path`
+  is the witness.
+- **`McpTransport`'s `Debug` is hand-written to redact values.** A plain derive
+  prints an `Authorization` bearer or an API key verbatim into any log or panic
+  message. Keys stay visible, values become `<redacted>`. Note the asymmetry:
+  `McpConfig::to_toml_string` still writes those values to disk verbatim — the
+  pre-existing `mcp.toml` convention.
+- **The stdio transport never reconnects itself.** A dead child leaves it
+  permanently closed and drains every waiter with `McpError::Closed`; respawning
+  is `McpClient`'s job, so no `request` call hides a process restart. A client
+  built with `McpClient::new` (the shape tests use) has no reconnector at all —
+  dead stays dead.
+- **Only a genuine response fulfills a waiter.** `JsonRpcMessage::is_response()`
+  requires `result`/`error` and no `method`, because a server-initiated `ping`
+  whose id collides with an in-flight client id would otherwise be handed to
+  that caller as its answer.
+- **An over-cap stdout line has its tail drained too.** Reading only the capped
+  prefix and resuming would reparse the remainder as a fresh frame — a way to
+  smuggle a response past `MAX_LINE_BYTES` (8 MiB). `sse.rs` bounds an
+  unterminated event on the same reasoning.
+- **`over_advertising_servers()` is deliberately not folded into
+  `failed_servers()`.** Those servers are connected and their kept tools route
+  normally; callers render `failed_servers()` as "server unavailable", which
+  would be a lie. The dropped count is a floor — discovery stops at the cap.
+- **`candidate_safe` is never inferred.** A server's own `read_only_hint` is
+  untrusted and cannot distinguish "reads an external system" from "reads the
+  local tree", so the Best-of-N allowlist is a human-set flag in `mcp.toml`, and
+  `McpConfig::upsert` preserves it across a reinstall.
+- **Every MCP tool's `ToolSchema` is `read_only: false`.** External tools are
+  unknown, so they are treated as mutating and never auto-parallelized.
+- **The token store is not locked across processes.** Two concurrent logins each
+  rewrite from a pre-login snapshot and the later `rename` wins; one repeated
+  login is cheaper than a stale-lock failure mode.
+
+## Testing
+
+```bash
+cargo test -p stella-mcp
+```
+
+There is no `make` target for this crate — the root [`Makefile`](../Makefile)
+covers `core`/`model`/`tools`/`cli`/`protocol` only. Nothing needs a feature
+flag, an env var, or the network. Unit tests live inline in each module and
+drive the full protocol state machine over `transport::testkit::ScriptedTransport`
+— no process, no socket. The integration tests are the interesting half:
+
+- [`tests/stdio_integration.rs`](tests/stdio_integration.rs) spawns the real
+  [`mcp-fixture-server`](src/bin/mcp-fixture-server.rs) binary, located via
+  `env!("CARGO_BIN_EXE_mcp-fixture-server")` (cargo builds it automatically).
+  Its flags drive the resilience matrix: `--hang` (call timeout), `--die-after`
+  (mid-call death), `--garbage` (undecodable result), `--paginate` (cursor
+  pagination), `--protocol-version` (negotiation, both accept and reject). The
+  `env_probe` fixture tool is what makes the environment scrub testable from
+  the outside.
+- [`tests/http_integration.rs`](tests/http_integration.rs) and
+  [`tests/oauth_integration.rs`](tests/oauth_integration.rs) use `wiremock`.
+  The OAuth suite runs mock MCP *and* authorization servers and simulates the
+  browser by GETting the loopback redirect with a code and the right state.
+- [`tests/registry_integration.rs`](tests/registry_integration.rs) replays
+  recorded JSON in [`tests/fixtures/`](tests/fixtures) — deterministic and
+  offline.
+
+## Extending it
+
+**Add a transport.** 1. Add a variant to `McpTransport` in
+[`config.rs`](src/config.rs) (the enum is internally tagged on `transport`, so
+the discriminant is the TOML key) and cover it in `kind_label`,
+`credential_names`, `has_credentials`, `set_credential`, and the redacting
+`Debug`. 2. Implement `Transport` in a new `src/<name>.rs`. 3. Wire it into
+`build_transport` in [`client.rs`](src/client.rs) — that one function serves
+both the first connect and every reconnect. 4. Re-export it from
+[`lib.rs`](src/lib.rs) and add an integration test.
+
+**Bump the protocol revision.** Add it to `SUPPORTED_PROTOCOL_VERSIONS` (and
+move `PREFERRED_PROTOCOL_VERSION`) in [`protocol.rs`](src/protocol.rs). The
+negotiation tests in [`tests/stdio_integration.rs`](tests/stdio_integration.rs)
+drive both directions through the fixture server's `--protocol-version` flag,
+whose own default is `2025-06-18` and must move with it.
+
+**Add a fixture-server behavior.** New tools go in `all_tools()` /
+`tools_call_response`, new fault flags in `Flags::parse` — then document the
+flag in both the binary's `//!` header and the `[[bin]]` comment in
+[`Cargo.toml`](Cargo.toml).
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions"
+  (why `ToolExecutor` is the only seam), "The `.stella/` directory" (where
+  `mcp.toml` and `mcp_oauth.json` live), and "Testing approach".
+- [`../website/content/docs/agent-tools/mcp.mdx`](../website/content/docs/agent-tools/mcp.mdx)
+  — the user-facing `mcp.toml` reference.
+- [`../website/content/docs/commands/mcp.mdx`](../website/content/docs/commands/mcp.mdx)
+  — `stella mcp list|search|install|remove|login|logout|usage`.
+- [`../stella-cli/src/mcp_cmd.rs`](../stella-cli/src/mcp_cmd.rs) — where
+  `mcp.toml` and the token store actually live, and the atomic config write.
+- [`../stella-cli/src/candidate_ws.rs`](../stella-cli/src/candidate_ws.rs) —
+  the full rationale for `candidate_safe` and why every other server stays
+  withheld from Best-of-N candidates.

--- a/stella-media/README.md
+++ b/stella-media/README.md
@@ -1,0 +1,202 @@
+# stella-media
+
+Image, SVG, and video generation for Stella — client-side, BYOK, behind one
+[`MediaProvider`](src/provider.rs) port, with the same artifact discipline as
+the rest of the engine. It reaches users as the `generate_image`,
+`generate_svg`, `generate_video`, and `poll_video` tools, which live in
+[`stella-tools`](../stella-tools/src/media.rs) and drive this crate.
+
+The hard boundary is isolation from `stella-model`. The workstream spec
+nominally put vendor media HTTP clients next to the chat adapters; they live
+here instead so this crate does **not** depend on `stella-model`, which is why
+[`credential::ApiKey`](src/credential.rs) and
+[`error::MediaError`](src/error.rs) are minimal self-contained copies of that
+crate's `ApiKey`/`ProviderError` shapes rather than imports — folding the
+adapters into `stella-model`'s provider set is the recorded migration follow-up
+([`src/lib.rs`](src/lib.rs)). Three further boundaries: providers never touch
+the filesystem (they return in-memory `MediaArtifact` bytes for the caller to
+persist through `ArtifactStore`, so the artifact jail is enforced in one
+place); `emit` returns `AgentEvent` *values* because this crate has no channel
+dependency; `preview` builds strings and never writes to a TTY. Audio, 3D, and
+image *understanding* (the chat `vision` role) are out of scope.
+
+## Where it sits
+
+The only workspace dependency is `stella-protocol` (`MediaKind`,
+`MediaJobState`, `MediaArtifactRef`, and the media events, all re-exported from
+`lib.rs`). `stella-tools` and `stella-cli` depend on it; nothing else does, and
+it builds no binary. `libc` is a `cfg(unix)` dependency of the operation
+journal's secure-open discipline. `stella-cli` uses it directly only to open
+the SQLite operation journal; everything else arrives through the
+`stella-tools` media tools.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The authoritative crate description, the public re-export surface, and the recorded architecture deviation. Read it first. |
+| [`src/provider.rs`](src/provider.rs) | The `MediaProvider` trait, its request/response types, and `MediaCapabilities` rate-card estimation. Open it to change the port. |
+| [`src/adapters/`](src/adapters/mod.rs) | One file per vendor endpoint: `zai_image.rs` (CogView), `zai_video.rs` (CogVideoX), `openai_image.rs` (gpt-image). `mod.rs` also owns the live-smoke env gate. |
+| [`src/http.rs`](src/http.rs) | Private, shared adapter plumbing: the bounded `reqwest` client, `classify_http_error`, `Retry-After` parsing, and the size-capped `download_bytes`. |
+| [`src/artifact.rs`](src/artifact.rs) | `ArtifactStore` — the single writer to `.stella/artifacts/`, plus the `manifest.json` upsert. |
+| [`src/svg.rs`](src/svg.rs) | `SvgPipeline`: validate → sanitize → optimize, and the bounded model-repair loop. Pure text in, pure text out. |
+| [`src/jobs.rs`](src/jobs.rs) | `JobStore` (`jobs.json` beside the artifacts) and `resume`, the load-then-poll-live flow. |
+| [`src/operation_journal.rs`](src/operation_journal.rs) | `MediaOperationJournal` and its SQLite implementation — durable, cross-process idempotency for paid submissions. The largest file here, and mostly secure-open discipline. |
+| [`src/cost_gate.rs`](src/cost_gate.rs) | `MediaSpendGate`, the content-free `MediaSpendRequest`, and the deny-by-default implementation. |
+| [`src/preview.rs`](src/preview.rs) | The terminal preview ladder: kitty → iTerm2 → a plain path line, as pure string builders. |
+| [`src/emit.rs`](src/emit.rs) | Job transition → `AgentEvent` mapping, so a `MediaJobStatus` translates one way, not per call site. |
+| [`src/error.rs`](src/error.rs) / [`src/credential.rs`](src/credential.rs) | The `MediaError` category set with its retry classification, and the redacted `ApiKey`. |
+| [`tests/operation_journal.rs`](tests/operation_journal.rs) | The only integration test file: journal concurrency and Unix permission witnesses. |
+
+## Key concepts
+
+**One port, three wired adapters.** `ZaiImageProvider` (`cogview-4`, `POST
+/images/generations`, which may answer with a URL or inline `b64_json` — the
+adapter downloads the URL so the caller never holds an expiring link),
+`ZaiVideoProvider` (`cogvideox-3`, `POST /videos/generations` to submit, `GET
+/async-result/{id}` to poll), and `OpenAiImageProvider` (`gpt-image-1`, inline
+`b64_json`, no second round trip). Which one a user gets is decided *outside*
+this crate, in `detect_media_backend`
+([`../stella-tools/src/media/backend.rs`](../stella-tools/src/media/backend.rs)):
+`ZAI_API_KEY` wins when both are set and is the only backend with video;
+`OPENAI_API_KEY` yields an image-only backend. What an adapter cannot do
+returns `MediaError::CapabilityUnavailable` naming the env var that would
+enable it — never a panic or a silent no-op.
+
+**Money crosses two host-owned ports before the wire.** `MediaSpendGate`
+authorizes each submission from a content-free `MediaSpendRequest` (provider,
+kind, estimate — never the prompt or label), and callers without an injected
+host gate get `DenyMediaSpendGate`. `MediaOperationJournal` then makes the
+submission idempotent: `claim` returns `New`, `Existing(state)` to replay, or
+`Expired`. No bundled adapter exposes remote idempotency
+([`src/provider.rs:17`](src/provider.rs)), so the local claim is all that
+stands between a retry and a second charge. Relatedly, neither image adapter
+forwards `req.n` — a caller passing `n > 1` gets one image, priced exactly as
+the gate approved
+([`src/adapters/openai_image.rs:100`](src/adapters/openai_image.rs)). That is a
+recorded follow-up, not a supported flag.
+
+**A persisted job handle is never reported from cache (L-V3).** `jobs::resume`
+loads the handle and polls the provider; a `404` on the poll endpoint comes
+back as `MediaJobState::Failed` — a definite terminal "gone", not an error and
+not a stale `Running`. Unrecognized statuses map optimistically to `Running`,
+on the reasoning that a new status name is far more likely to be in-flight than
+terminal; the cost is that an unrecognized *terminal* status polls until the
+caller gives up, and the age bound belongs in that caller
+([`src/adapters/zai_video.rs:239`](src/adapters/zai_video.rs)).
+
+**LLM-authored SVG is untrusted code (L-V2).** `SvgPipeline::process` is pure
+and deterministic: parse with `roxmltree` under default options, which reject
+DTDs and so block XXE and billion-laughs before a renderer ever sees them;
+re-serialize through a deny-list (drop `<script>`, `<style>`,
+`<foreignObject>`, `<metadata>`; drop every `on*` attribute; keep only
+same-document `#fragment` hrefs; drop any value containing `//` or
+`javascript:`); then optimize lightly (comments/PIs dropped, whitespace
+collapsed, a `viewBox` backfilled from `width`/`height`). Depth is bounded
+twice against `MAX_NESTING_DEPTH` (256) — textually before parsing, because
+roxmltree's tokenizer recurses per level and would overflow the stack *inside*
+`Document::parse`, and again over the built tree, because this module's
+serializer recurses too.
+
+**`ArtifactStore` is the single writer to `.stella/artifacts/`.** Ids are
+generated here, never caller-supplied, and every filename component is reduced
+to `[a-z0-9_-]`, so no id, label, or extension can carry a separator or a `..`.
+Files are opened `create_new` (on unix, `O_EXCL|O_CREAT`, which also refuses a
+planted symlink), and the manifest row for a path is *replaced*, not appended.
+
+## Gotchas
+
+- **The operation journal is blocking and Unix-only.** Every method is SQLite
+  I/O behind a `Mutex`, plus bounded `thread::sleep` backoff on a contended
+  first open (~1s in `open`, ~2s in schema init), so an async caller must reach
+  it through `spawn_blocking`. The file-backed constructors fail closed off
+  unix rather than persist a weaker journal; `open_in_memory` is portable but
+  forgets every claim on a crash — which is the exact failure the persisted
+  journal exists to prevent.
+- **`MediaError::SidecarRace` is not caller-retryable.** `is_retryable()` is
+  `false`: the journal retries the benign concurrent-first-open race itself
+  (40 attempts × 25 ms), and the classifier keys on the *variant*, never on a
+  message substring (#456). It escapes only if the race never settles.
+- **Prompt-derived text never reaches disk here.** `jobs.json` persists
+  identifiers and money only, so a resumed job comes back labelled with its
+  artifact id rather than its prompt-derived label; the journal schema stores
+  hashed keys and opaque handles; `MediaSpendRequest` is content-free and uses
+  `deny_unknown_fields`. Tests assert the absence, not just the intent.
+- **Never build a `reqwest::Client` directly in an adapter** — use
+  `http::client()`. There is no outer tool-level timeout on the media path, so
+  an unbounded client turns a stalled provider into a turn that hangs forever.
+  Downloads are capped (64 MiB image / 256 MiB video); the overflow is
+  `Malformed`, non-retryable on purpose, since re-fetching an oversized asset
+  just repeats the memory exhaustion the cap prevents.
+- **Both Z.ai adapters report `id() == "zai"`.** A job's `provider_id` alone
+  does not say whether the image or the video adapter owns it.
+- **Two SVG holes are recorded, not fixed.** Rule 6 keys on `//` and
+  `javascript:`, so a `data:` URI in a non-`href` attribute survives, and a
+  `style="…"` *attribute* has no rule of its own (only the `<style>` element
+  does). Neither is reachable through the preview ladder, which never renders
+  SVG — both matter once an artifact is inlined into HTML.
+
+## Testing
+
+```bash
+cargo test -p stella-media
+```
+
+There is no `make` target for this crate — `make test` runs the workspace.
+Unit tests sit beside the code in `#[cfg(test)] mod tests`;
+[`tests/operation_journal.rs`](tests/operation_journal.rs) is the only
+integration file, covering cross-process claims, concurrent first-open, expiry
+pruning, and the Unix permission witnesses: a permissive parent or database, a
+symlinked or hardlinked database, and injected WAL/SHM sidecars are each
+refused, and refused without being repaired or mutated.
+
+Adapter coverage is **wiremock**: each test starts a `MockServer` and points
+the adapter at it with `with_base_url`, then pins both the happy path and the
+failure shapes — `401` → `Auth`, `429` with `Retry-After` →
+`RateLimited { retry_after_ms }`, a `400` whose body mentions safety →
+`ContentPolicy`, an empty or field-less payload → `Malformed`, and `404` on the
+video poll → `Failed` (gone). `http.rs` carries its own wiremock tests for the
+download caps (including the case where `Content-Length` lies or is absent) and
+proves a stalled response times out instead of hanging.
+
+Each adapter family also carries one **live smoke** that fires only when the
+vendor key *and* `STELLA_MEDIA_LIVE=1` are present, so CI never calls a paid
+API. The gate requires the literal `1` — `true`, `yes`, and `" 1"` all leave it
+skipped — because a CogVideoX submit spends real money; `live_smoke_armed_by`
+is the pure half, so the gate is witnessed without a `set_var` that would race
+every other test thread. (`OXAGEN_MEDIA_LIVE` is a deprecated alias.)
+
+## Extending it
+
+To add a provider:
+
+1. Add `src/adapters/<vendor>_<kind>.rs`, copying `zai_image.rs`'s shape, and
+   implement `MediaProvider`. Return `MediaError::CapabilityUnavailable`,
+   naming the enabling env var, for the methods this vendor does not serve.
+2. Build the HTTP client with `crate::http::client()` and route every
+   non-success response through `classify_http_error` — a per-adapter status
+   match is how a `401` starts meaning something different per vendor.
+3. Fill `MediaCapabilities` with the vendor's documented rates: those numbers
+   are what the spend gate shows the user before charging.
+4. Register the module in [`src/adapters/mod.rs`](src/adapters/mod.rs)
+   (`pub mod` + `pub use`).
+5. Add wiremock tests for the happy path plus 401 / 429 / content-policy /
+   malformed, and one live smoke behind `live_smoke_enabled()`.
+6. Wire it into `detect_media_backend` in
+   [`../stella-tools/src/media/backend.rs`](../stella-tools/src/media/backend.rs).
+   Until you do it compiles and tests green but never reaches `generate_image`
+   — this crate has no provider registry of its own.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions" (why
+  every vendor is an adapter behind `MediaProvider`) and "Testing approach",
+  whose wiremock-adapter-test line names this crate.
+- [`../stella-tools/src/media.rs`](../stella-tools/src/media.rs) — the tools
+  that drive this crate, their conditional registration, and where the spend
+  gate, operation ids, and journal are injected.
+- [`../stella-protocol/src/event.rs`](../stella-protocol/src/event.rs) —
+  `MediaKind`, `MediaJobState`, `MediaArtifactRef`, and the `MediaProgress` /
+  `MediaComplete` events `emit` builds.
+- [`../website/content/docs/agent-tools/index.mdx`](../website/content/docs/agent-tools/index.mdx)
+  — the user-facing tool table and each media tool's registration condition.

--- a/stella-media/src/jobs.rs
+++ b/stella-media/src/jobs.rs
@@ -1,7 +1,8 @@
 //! Persisted video-job state so a dollar-cost job is never orphaned by a
 //! dropped terminal. Submitted job handles are written
 //! to `jobs.json` inside the artifacts dir; after a Ctrl-C or a process
-//! restart, `stella gen video --resume <id>` reattaches.
+//! restart, [`resume`] reattaches — reached from the agent side by the
+//! `poll_video` tool. There is no `stella gen` subcommand.
 //!
 //! The truthfulness contract (L-V3): a persisted handle is **never** reported
 //! from cache. [`resume`] loads the handle and reconciles it *live* against

--- a/stella-model/README.md
+++ b/stella-model/README.md
@@ -1,0 +1,202 @@
+# stella-model
+
+Every byte stella sends to a model vendor and every byte it parses back: the
+concrete `Provider` adapters plus the vendor-neutral machinery they share — SSE
+decoding, tool-call dialect translation, request signing, credential resolution,
+model-catalog lookups.
+
+The `Provider` trait itself is deliberately **not** defined here — it lives in
+[`stella-protocol`](../stella-protocol/src/provider.rs) and is only re-exported
+by [`src/provider.rs`](src/provider.rs), so `stella-core` drives every model call
+through `&dyn Provider` without depending on any adapter. The other half of the
+boundary: the seam is one port and *five wire dialects*, not one adapter per
+vendor. Anything that genuinely speaks OpenAI Chat Completions — xAI, DeepSeek,
+OpenRouter, a local server, a settings-defined gateway — rides the one adapter in
+[`src/zai.rs`](src/zai.rs), re-identified through `ZaiProvider::with_identity`,
+so a new OpenAI-compatible endpoint costs a config row in `stella-cli` rather
+than a module here. A new module is justified by a structurally different
+request/response shape, never by a new vendor name.
+
+## Where it sits
+
+Depends on exactly one workspace crate, `stella-protocol` (`Provider`,
+`CompletionRequest`/`CompletionResult`, `ProviderError`, `Attachment`); the rest
+are third-party — `reqwest`/`tokio`/`futures-util` for transport, `hmac`+`sha2`
+for Bedrock SigV4, `rpassword` for the credential prompt, `toml` for
+`~/.stella/credentials.toml`. Only `stella-cli` depends on it (`stella-core`
+never does, by design), and it constructs adapters in exactly one place:
+`build_provider_parts` in
+[`../stella-cli/src/agent/engine.rs`](../stella-cli/src/agent/engine.rs). No
+binary of its own.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The crate map (read this first) and the public re-exports: `Provider`, `Catalog`, `ApiKey`, the cache-economics helpers. |
+| [`src/provider.rs`](src/provider.rs) | Two-line re-export of the port. Open it to be reminded where the trait actually lives. |
+| [`src/zai.rs`](src/zai.rs) (+ [`src/zai/tests.rs`](src/zai/tests.rs), [`src/zai/tests/error_classify_tests.rs`](src/zai/tests/error_classify_tests.rs)) | The shared OpenAI Chat Completions adapter. One adapter serving Z.ai/GLM, xAI, DeepSeek, OpenRouter, `local`, and settings-defined gateways; per-identity behavior (OpenRouter's root `cache_control` + sticky `session_id`, GLM's `thinking`, xAI's `reasoning_effort`) is gated on `self.id` inside it. |
+| [`src/anthropic.rs`](src/anthropic.rs) (+ [`src/anthropic/tests.rs`](src/anthropic/tests.rs)), [`src/openai.rs`](src/openai.rs), [`src/gemini.rs`](src/gemini.rs), [`src/vertex.rs`](src/vertex.rs), [`src/bedrock.rs`](src/bedrock.rs) | One adapter per structurally distinct wire dialect: Messages API, Responses API, `generateContent` (direct and Vertex's project-scoped enterprise path, sharing wire types and the stream aggregator), Bedrock Converse. All follow the same shape — `new(ApiKey, model)` capturing catalog pricing, `with_base_url`, `http::client()`, `SseDecoder`, `http::classify_http_status`, `impl Provider` (plus `complete_observed`, the mid-stream tool-call announcement the engine speculates on — every streaming adapter implements it; Bedrock inherits the no-op default). Open the one whose vendor you are debugging. |
+| [`src/catalog.rs`](src/catalog.rs) | `Catalog`, `CatalogEntry`, `Pricing`, `ToolDialect`, and the compile-time seed. The only sanctioned slug → model resolution. |
+| [`src/credential.rs`](src/credential.rs) | `ApiKey` (the non-`Display` secret wrapper), the flag → env → file → prompt chain, `CredentialsFile`, and the multi-variable resolvers `VertexAddressing` / `BedrockCredentials`. |
+| [`src/provider_parity.rs`](src/provider_parity.rs) | `CachePosture` / `ReasoningPosture` — the per-provider matrix. A new provider id lands here or tests fail. |
+| [`src/cache_economics.rs`](src/cache_economics.rs) | Cache savings arithmetic (`Pricing::cache_savings_usd`) and `diagnose_cache`, which reads the parity matrix to tell an opt-in bug from prefix instability. |
+| [`src/sse.rs`](src/sse.rs) | Dependency-free SSE line parser + incremental UTF-8 decoder every streaming adapter feeds. |
+| [`src/http.rs`](src/http.rs) | Crate-private plumbing: the timeout-bounded `reqwest` clients, `classify_http_status`, and the two shared stream-failure errors. Change error retryability here, not in an adapter. |
+| [`src/attachment.rs`](src/attachment.rs) | Crate-private. Turns `Attachment`s into dialect-neutral `WirePart`s once, so each adapter only maps parts onto its own JSON. |
+| [`src/modelsdev.rs`](src/modelsdev.rs), [`src/provider_listing.rs`](src/provider_listing.rs) | Fetch-and-parse only: the models.dev master list and provider-native `/models` discovery. Deciding what to store belongs to `stella-cli`. Best-effort by contract — a dead or shape-drifted endpoint returns an `Err(String)` the caller reports and moves past, so one provider can never fail a refresh of the others. |
+
+## Key concepts
+
+**One port, five dialects; identity is a field.** `ToolDialect`
+([`src/catalog.rs`](src/catalog.rs)) is the axis adapters are cut on — four
+vendors share `OpenaiJson`, two Google surfaces share `GeminiFunctions`.
+`ZaiProvider::with_identity(id, label)` exists because without it every gateway
+on the shared adapter misreported itself: an xAI 401 read "Z.ai rejected the API
+key", pointing the user at the wrong credential.
+
+**The catalog is a gate, not a hint.** A slug not in the catalog is an immediate,
+named `ProviderError::UnknownModel` — never a silent fallback to a default (the
+TS-era phantom `glm-5.2-turbo` lesson). Adapters call
+`Catalog::resolve_for(provider, slug)`, not `resolve`, because the same slug
+genuinely exists under several providers and an unscoped lookup takes whichever
+row sits first.
+
+**The parity matrix is the crate's law.**
+[`src/provider_parity.rs`](src/provider_parity.rs) records, per provider id, how
+its prompt cache is engaged/observed (`CachePosture`) and how reasoning is
+controlled on the wire (`ReasoningPosture`). Born from a real defect: Anthropic
+models routed through OpenRouter ran with zero prompt caching across a $2+
+session because Anthropic's cache is opt-in while most are implicit, and
+DeepSeek's cache-hit field was dropped the same week because it spells the
+telemetry differently; the reasoning axis was added after the same shape recurred
+for a pinned `effort`. Enforced from both sides — `stella-cli`'s config tests
+fail when a seeded provider has no row, this crate's tests fail when a row's
+witness test no longer exists.
+
+**Errors are classified once, centrally.** `http::classify_http_status` is the
+shared ladder every adapter applies after its vendor-specific pre-check: 401/403
+→ non-retryable `Auth` (403 split into credits / model-not-enabled / permission),
+402 → billing `Terminal`, 429 → `RateLimited` with `Retry-After`, 5xx → retryable
+`Transport`, everything else → non-retryable `Terminal`. EOF before a stream's
+terminal event is retryable; tool-call JSON truncated at the output-token limit
+is not, because retrying re-truncates identically.
+
+## Gotchas
+
+- **Adding a request field can be a cost regression.** Optional sampling params
+  carry `skip_serializing_if = "Option::is_none"` so a request without overrides
+  serializes byte-identical to what shipped before — prompt-cache hits depend on
+  a byte-stable prefix.
+- **Pricing is captured at construction**, not per request. `Catalog::install_runtime`
+  must run before any adapter is built, or every cost lands on seed pricing.
+- **Anthropic's `cache_control` goes on content blocks only** — the system block
+  and the last block of the final message. Never a top-level request field.
+- **Gemini has no wire call ids.** Calls correlate by function *name*, so the
+  adapter mints `call_0`, `call_1`, … and rides Gemini 3's `thoughtSignature`
+  inside the id after a `#` — `ToolCall` has no slot for a provider-private blob,
+  and omitting the signature degrades or rejects the next turn.
+- **Session ids are volatile by design.** OpenRouter's `session_id` and OpenAI's
+  `prompt_cache_key` pin a session to one cache shard but ride as request
+  parameters and must never enter the cached bytes. Distinct per adapter
+  construction, so fleet siblings don't serialize onto one shard.
+- **Bedrock is non-streaming `Converse`, not `ConverseStream`** — the streaming
+  variant speaks binary `application/vnd.amazon.eventstream`, a separate
+  transport decoder. Its SigV4 signing is pinned by golden vectors generated from
+  botocore, because signing code looks right while producing signatures a real
+  endpoint rejects.
+- **An attachment never fails a request.** One a dialect cannot ingest (audio on
+  Anthropic, video on OpenAI, an unreadable payload file) degrades to a text note
+  describing what was attached — the conversation replays every turn, so a hard
+  error there would brick the session permanently.
+- **`ZAI_GLM_CODING_PLAN=1` silently swaps the Z.ai base URL** to the coding-plan
+  endpoint, read from the environment inside `ZaiProvider::new`.
+
+## Testing
+
+```bash
+make test-model          # or: cargo test -p stella-model
+```
+
+Adapter tests are `wiremock`-based and live beside the code: inline
+`#[cfg(test)] mod tests` in `openai.rs`, `gemini.rs`, `bedrock.rs`, `vertex.rs`,
+out-of-line in [`src/anthropic/tests.rs`](src/anthropic/tests.rs) and
+[`src/zai/tests.rs`](src/zai/tests.rs). They assert both directions — the exact
+bytes that go out, and a `CompletionResult` reassembled from a canned SSE stream.
+No credential or network required.
+
+Two integration tests in [`tests/`](tests):
+
+- [`tests/live_smoke.rs`](tests/live_smoke.rs) — one minimal *real* call per
+  adapter, asserting wire-shape acceptance (200, and stella's own parser
+  reassembles the result), never model quality. A clean skip unless
+  `STELLA_LIVE_SMOKE=1` is set **and** that provider's credential resolves, so
+  `make gate` and CI never make a network call:
+  `STELLA_LIVE_SMOKE=1 ANTHROPIC_API_KEY=sk-… cargo test -p stella-model --test live_smoke`.
+- [`tests/credential_prompt_degrade.rs`](tests/credential_prompt_degrade.rs) —
+  the regression guard for "an interactive prompt that cannot read stdin degrades
+  to `NotFound`", never a hang and never a raw `PromptFailed`.
+
+## Extending it
+
+Adding a provider. **Step 0 is the one most new providers stop at.**
+
+0. **Does it speak OpenAI Chat Completions?** Then no code lands in this crate.
+   Add a row to `PROVIDERS` in
+   [`../stella-cli/src/config.rs`](../stella-cli/src/config.rs) with
+   `dialect: Dialect::OpenaiCompatible` (or let a user define one in
+   `settings.json`); `build_provider_parts` builds a `ZaiProvider` and calls
+   `with_identity(id, label)`. Skip to step 3 — the parity matrix still applies.
+1. **Genuinely different wire shape** → new module in `src/`, declared `pub mod`
+   in [`src/lib.rs`](src/lib.rs). Copy the closest adapter's shape rather than
+   inventing one: constructor resolving `Catalog::resolve_for(<id>, slug)`
+   pricing, `with_base_url`, `http::client()`, `SseDecoder`,
+   `http::classify_http_status`, `attachment::wire_parts` for user content,
+   `impl Provider` (+ `complete_observed` if it streams). Add a `ToolDialect`
+   variant in [`src/catalog.rs`](src/catalog.rs), and a matching `Dialect`
+   variant plus `build_provider_parts` arm in `stella-cli`.
+2. **Seed the catalog.** A row in `Catalog::seed()` for the provider's
+   `default_model`, or `every_provider_default_model_resolves_against_the_catalog_seed`
+   ([`../stella-cli/src/config/tests.rs`](../stella-cli/src/config/tests.rs))
+   fails — and the provider would hard-error on first use.
+3. **Declare both parity rows, in the same PR.** Add the provider id to *both*
+   `CACHE_POSTURE` and `REASONING_POSTURE` in
+   [`src/provider_parity.rs`](src/provider_parity.rs).
+   - Cache: `OptIn` when the adapter must SEND a marker, `Implicit` when it must
+     PARSE hit telemetry, `NotApplicable` only when no billed cache exists.
+     Reasoning: `Controllable` when the effort preference reaches the request
+     body, `Unsupported` when the adapter deliberately drops it (an honest
+     degradation — `stella-cli` surfaces a boot notice), `FixedOn`/`FixedOff` for
+     a model with no dial at all.
+   - `OptIn`, `Implicit`, and `Controllable` must name a `witness` — the exact
+     test function proving the behavior on the wire — and it must live in one of
+     the six files `adapter_sources()` embeds with `include_str!`
+     (`anthropic/tests.rs`, `bedrock.rs`, `openai.rs`, `gemini.rs`, `vertex.rs`,
+     `zai/tests.rs`); a witness in a *new* adapter's own test module is invisible
+     until you add that file there too. No-control variants carry a `note` instead.
+   - What fails if you skip it: `every_seeded_provider_declares_a_cache_posture`
+     / `every_seeded_provider_declares_a_reasoning_posture` (in `stella-cli`) on
+     a missing row, `both_axes_cover_the_same_provider_ids` if you add one axis
+     and forget the other, `provider_ids_are_unique` and its reasoning twin on a
+     duplicate, and `every_witness_test_exists_in_the_adapter_sources` — which
+     matches the literal `fn <witness>(` — the moment a witness is renamed.
+4. **Multi-variable credentials belong here**, not in `stella-cli` — follow
+   `VertexAddressing` / `BedrockCredentials` in
+   [`src/credential.rs`](src/credential.rs), so a second host of the engine gets
+   the same variable names, fallback order, and named errors without copying them.
+5. **Add a gated live-smoke test** to [`tests/live_smoke.rs`](tests/live_smoke.rs).
+
+A *new* per-provider divergence (attachment dialects, tool schemas) means a third
+axis in `provider_parity.rs` — record it as a matrix, not as adapter folklore.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions",
+  invariant 8 ("Provider feature parity is declared, not assumed"), and the
+  `stella-model` row in "Workspace layout — where a change goes".
+- [`../stella-protocol/src/provider.rs`](../stella-protocol/src/provider.rs) —
+  the `Provider` / `ToolCallObserver` contract every adapter here implements.
+- [`../website/content/docs/api-providers/`](../website/content/docs/api-providers)
+  — the user-facing page per provider id, and
+  [`../website/content/docs/configuration/credentials.mdx`](../website/content/docs/configuration/credentials.mdx)
+  for the resolution chain from the user's side.

--- a/stella-observatory/README.md
+++ b/stella-observatory/README.md
@@ -1,0 +1,213 @@
+# stella-observatory
+
+The crate behind `stella observe`: a tiny HTTP server that reads the
+workspace's own telemetry out of `.stella/private/*.db` and serves it as a
+single embedded HTML page.
+
+Three properties are security boundaries, not conveniences, and each is
+enforced by construction rather than policy: the listener binds `127.0.0.1`
+only, every database handle is opened `SQLITE_OPEN_READ_ONLY`, and the page is
+`include_str!`'d with zero external references. Outside its tests, nothing here
+opens an outbound connection, writes a file, or answers a method other than
+`GET`. The crate also links **no other workspace crate**, and must not.
+
+## Where it sits
+
+A leaf. [`Cargo.toml`](Cargo.toml) lists `rusqlite`, `serde`, `serde_json`,
+`sha2`, `thiserror`, `tokio` (the `net` feature only) and `toml` — no `stella-*`
+dependency at all. That is deliberate: `stella_store::Store::open` creates
+`.stella/` and runs schema migrations, and an observer that migrates what it
+observes is not an observer. The price is two acknowledged copies —
+`global::data_dir` and `project_id_for` ([`src/global.rs:27`](src/global.rs),
+`:48`) mirror `../stella-store/src/usage.rs`, and `/api/explorations` re-hashes
+exploration manifests itself.
+
+Only [`stella-cli`](../stella-cli) depends on it: `run_observe`
+([`../stella-cli/src/main.rs:847`](../stella-cli/src/main.rs)) preflights the
+private store paths and calls `serve` (`--port`, default `7787`; `0` picks a
+free one). This crate builds no binary —
+[`examples/serve.rs`](examples/serve.rs) is the dev harness. It reads two tiers:
+`<root>/.stella/private/{store,fleet,codegraph}.db` per workspace, and
+`~/.stella/usage.db`, the cross-project hub.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The HTTP responder: the route table, the `Host` and head-cap gates, the CSP, `serve`. Open it to add a route or to touch anything security-relevant. |
+| [`src/db.rs`](src/db.rs) | Every query against `.stella/private/store.db` and `fleet.db`. Open it when a panel needs a new aggregate; the SQL deliberately mirrors `stella stats` semantics (resolved = outcome `completed`, `off-grid` = provider `local`). |
+| [`src/global.rs`](src/global.rs) | The user-tier view over `~/.stella/usage.db`: the project switcher (`/api/projects`, `?project=`) and the hub-telemetry drill (org → workspace → repo → project). |
+| [`src/fsview.rs`](src/fsview.rs) | Views derived from files rather than SQL — skills, memories, rule files, `reflections.jsonl` lessons, `mcp.toml`, the settings scope chain, exploration maps — plus `redact`, the credential scrubber. |
+| [`src/codegraph.rs`](src/codegraph.rs) | `codegraph.db` flattened to `{nodes, edges, groups}` for the force-directed canvas, including the Rust module-path resolution the indexer doesn't do. |
+| [`src/assets/index.html`](src/assets/index.html) | The entire dashboard — markup, styles and script in one file, embedded at compile time. |
+| `src/assets/mark.svg`, `src/assets/wordmark.svg` | Favicon and header lockup, served from `/assets/`. |
+| [`examples/serve.rs`](examples/serve.rs) | `cargo run -p stella-observatory --example serve -- <root> <port>` — serve any workspace without building the CLI. |
+
+## Key concepts
+
+### The three boundaries, and what actually enforces each
+
+**Loopback-only** starts at `TcpListener::bind(("127.0.0.1", port))`
+(`src/lib.rs:270`), but the bind is not the boundary: a web page can resolve an
+attacker-controlled name to `127.0.0.1` and read this dashboard cross-origin.
+Three things close that. `host_is_local` (`src/lib.rs:291`) refuses any `Host`
+that does not *parse* as a loopback IP — never a prefix test, because
+`127.0.0.1.attacker.example` is a registrable name `starts_with("127.")` waves
+through. `handle` refuses an unterminated request head with `431` *before*
+routing (`src/lib.rs:342`): padding the request line past the 8 KiB cap used to
+push `Host` out of the buffer entirely, and the no-`Host` allowance then waved
+the rebound request through to a route that still parsed out of the truncated
+path. And `frame-ancestors 'none'` in the CSP stops that page framing it
+instead. The no-`Host` allowance itself is deliberate — a browser `fetch`
+always sends one, so its absence means raw curl or a test, not the attack.
+
+**Read-only** is `OpenFlags::SQLITE_OPEN_READ_ONLY` at all three open sites —
+`db::open_read_only` (`src/db.rs:716`), `global::open_usage`
+(`src/global.rs:59`), `codegraph::snapshot` (`src/codegraph.rs:38`) — each with
+a 5 s `busy_timeout`, so a checkpoint or a migration's exclusive lock makes a
+poll wait rather than 500. `Observatory::new` opens nothing, and each open
+returns `None` for a missing file rather than creating it. Outside
+`#[cfg(test)]` nothing here writes to the filesystem, and non-`GET` requests get
+`405` (`src/lib.rs:362`), so there is no mutation verb to reach.
+
+**Embedded** is three `include_str!`s (`src/lib.rs:47`–`51`).
+`dashboard_html_has_no_external_references` fails the suite if `index.html` ever
+contains `http://`, `https://`, `//cdn`, `@import` or `integrity=`, and the
+`CSP` constant (`src/lib.rs:63`) restates that to the browser (`default-src
+'self'`, `connect-src 'self'`, `img-src 'self'`). `'unsafe-inline'` on
+`script-src`/`style-src` is unavoidable and load-bearing: the page is one
+document with an inline `<script>`, an inline `<style>` and inline `style="…"`
+attributes, so dropping it from `style-src` would strip the layout silently.
+`csp_admits_everything_the_embedded_dashboard_actually_uses` pins both halves.
+
+### `respond` is pure; there is no server state
+
+`respond(workspace_root, path)` (`src/lib.rs:113`) maps a path to a `Response`
+and is what the unit tests drive — no sockets involved. Every request opens its
+own connections and drops them; the page re-polls every 5 s while its tab is
+visible. The one twist is `?project=<id>`, accepted by every `/api/*` route: the
+id is resolved by `global::resolve_project_root` (`src/global.rs:138`) against
+the rollup's own `projects` table — never a path supplied by the client — and
+that root replaces the serving root for the request. Unknown ids fall back to
+the serving workspace rather than erroring, so a stale dropdown cannot break the
+page. `/api/projects` and `/api/hub-telemetry` are cross-project by nature and
+keep the original root.
+
+### `execution_id` and `run_id` are different entities
+
+[`src/db.rs`](src/db.rs) joins both. `execution_id` is the store's unit of work
+— one row in `executions`, the foreign key `telemetry`, `tool_calls`,
+`files_touched` and `execution_reflection` hang off; every join in
+`Observatory::executions`, `execution`, `models` and `activity` is on it.
+`run_id` appears only in `Observatory::fleet` (`src/db.rs:658`), against a
+different file (`fleet.db`) and a different hierarchy: a fleet run fans out to
+tasks, then attempts, then commits. It is not an execution and not a session,
+and no query may join the two. AGENTS.md's glossary is the authority.
+
+### Missing is a state, never an error
+
+A workspace that has never run `stella` renders an empty dashboard, not a 500.
+An absent file yields `None` and an empty payload at the call site; an absent
+*table* is caught by `is_missing_table` (`src/db.rs:779`), degrading
+`collect_rows`/`or_empty` to `[]`/`{}`. `global.rs` goes further — `query_rows`
+treats any `prepare` failure as empty, because a `usage.db` predating the hub
+replica has no `telemetry` table at all.
+
+### Secrets never reach the browser
+
+`settings.json` and `mcp.toml` carry credentials, and both are served. `redact`
+(`src/fsview.rs:376`) replaces every string at or below a *credential scope* —
+a key `sensitive_key` matches, or an `env`/`headers` map whose values are
+credentials by position. The scope is **inherited, not recomputed per level**:
+settings are arbitrary user JSON, so a secret can sit a container below the key
+naming it (`{"api_keys": ["sk-live-…"]}`), and redacting only the direct string
+child leaked that. Keys ending `_env` are exempt — they name a variable, not
+its value. `mcp_servers` never reads env or header *values* at all.
+
+## Gotchas
+
+- **The page is embedded at compile time.** Editing
+  [`src/assets/index.html`](src/assets/index.html) does nothing until you
+  rebuild — `--example serve` included.
+- **The test schema is a hand-written copy.** `seeded_workspace` in `src/lib.rs`
+  spells out its own DDL for the subset of tables the observatory reads, and
+  nothing checks it against `../stella-store/src/ddl.rs`. A column renamed in
+  the store keeps this suite green and breaks the dashboard at runtime.
+- **Store paths are hardcoded**, `<root>/.stella/private/<name>` — this crate
+  can't use `stella-store`'s path resolver (see *Where it sits*), so a
+  workspace still in the pre-`private/` legacy layout renders empty.
+  `stella observe` sidesteps that: the CLI's `preflight_observatory_stores`
+  resolves and migrates first. `--example serve` does not.
+- **There is no server-side time filter.** The `24h`/`7d`/`30d` window is a
+  client-side constant. `/api/overview`, `/api/executions`, `/api/activity` and
+  `/api/tools` carry no `LIMIT`, and `Observatory::tools` sorts every
+  `tool_calls` row ever recorded for an exact p50 (leaderboards cap at 50–100).
+- **`percent_decode` (`src/lib.rs:229`) parses attacker-reachable bytes.** A
+  malformed escape (`%`, `%A`, `%ZZ`) must stay literal — never a panic, never
+  a dropped byte — and decoding runs over bytes before UTF-8 validation so a
+  multi-byte character split across escapes reassembles.
+- **`STELLA_DATA_DIR` is process-wide.** The two tests that set it serialize on
+  `DATA_DIR_LOCK`, poison-tolerantly; a third that mutates it without the lock
+  will flake the other two.
+- **The code graph is capped at 600 nodes** (`MAX_NODES`, `src/codegraph.rs:22`):
+  the highest-degree files are kept and the rest reported as `truncated`, so a
+  large workspace's graph is a sample, not the whole index.
+
+## Testing
+
+```bash
+cargo test -p stella-observatory
+```
+
+There is no crate-specific `make` target — the root `Makefile` has one only for
+core/model/tools/cli/protocol — so `make test` picks this up with the workspace.
+Every test is an inline `#[cfg(test)] mod tests`: no `tests/` directory, no
+fixture dir, feature flag or env var.
+
+The dominant shape: `seeded_workspace()` builds a `TempDir` with a `store.db`
+seeded from hand-written DDL, `seed_fs_surfaces()` layers on the file-backed
+surfaces (skills, memories, rules, `reflections.jsonl`, `mcp.toml`,
+`settings.json`, `codegraph.db`), then the test calls `respond()` and asserts on
+the parsed JSON. Two `#[tokio::test]`s use a real socket on port 0 for what
+`respond` cannot cover: the response head (CSP, `nosniff`) and the head-cap
+refusal. `empty_workspace_degrades_to_empty_payloads_not_errors` asserts
+`200 OK` for every route against a bare `TempDir` — a new route belongs in that
+list.
+
+## Extending it
+
+Adding an API route:
+
+1. Write the query or view function in the module that owns the source —
+   [`src/db.rs`](src/db.rs) for `store.db`/`fleet.db`,
+   [`src/global.rs`](src/global.rs) for `usage.db`,
+   [`src/fsview.rs`](src/fsview.rs) for files,
+   [`src/codegraph.rs`](src/codegraph.rs) for the graph. Degrade a missing
+   file or table to an empty payload; do not return an error.
+2. Add the arm to the `match route` in `respond` (`src/lib.rs:127`). Take
+   filters via `query_param`, never by splitting the query string yourself.
+3. Add the path to `empty_workspace_degrades_to_empty_payloads_not_errors`'s
+   list — it fails until step 1's degradation is right — then seed the table or
+   file in `seeded_workspace`/`seed_fs_surfaces` and assert the payload.
+4. Render it in [`src/assets/index.html`](src/assets/index.html) and add the
+   route to the refresh list. Everything you add to the page must be inline:
+   `dashboard_html_has_no_external_references` fails on the first external URL,
+   and the CSP would block it in the browser anyway.
+
+A new file or store also has to be audited for credentials first — route it
+through `redact`, or emit key names only, the way `mcp_servers` does.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Glossary — the identifiers that look alike"
+  (the `execution_id` / `run_id` distinction this crate joins across), "The
+  `.stella/` directory (per-workspace state)" for what each store holds, and
+  invariant 3, "Zero telemetry egress by default".
+- [`../docs/design/exploration-sharing.md`](../docs/design/exploration-sharing.md)
+  §4e — the exploration-map freshness verdict `fsview::explorations` computes.
+- [`../website/content/docs/commands/observe.mdx`](../website/content/docs/commands/observe.mdx)
+  and [`../website/content/docs/telemetry/dashboard.mdx`](../website/content/docs/telemetry/dashboard.mdx)
+  — the user-facing flags and a tour of each tab.
+- [`../stella-store`](../stella-store) writes everything this crate reads
+  (`src/ddl.rs`, `src/usage.rs`); [`../stella-graph`](../stella-graph) writes
+  `codegraph.db`; [`../stella-fleet`](../stella-fleet) writes `fleet.db`.

--- a/stella-observatory/README.md
+++ b/stella-observatory/README.md
@@ -170,9 +170,7 @@ surfaces (skills, memories, rules, `reflections.jsonl`, `mcp.toml`,
 `settings.json`, `codegraph.db`), then the test calls `respond()` and asserts on
 the parsed JSON. Two `#[tokio::test]`s use a real socket on port 0 for what
 `respond` cannot cover: the response head (CSP, `nosniff`) and the head-cap
-refusal. `empty_workspace_degrades_to_empty_payloads_not_errors` asserts
-`200 OK` for every route against a bare `TempDir` — a new route belongs in that
-list.
+refusal.
 
 ## Extending it
 
@@ -208,6 +206,6 @@ through `redact`, or emit key names only, the way `mcp_servers` does.
 - [`../website/content/docs/commands/observe.mdx`](../website/content/docs/commands/observe.mdx)
   and [`../website/content/docs/telemetry/dashboard.mdx`](../website/content/docs/telemetry/dashboard.mdx)
   — the user-facing flags and a tour of each tab.
-- [`../stella-store`](../stella-store) writes everything this crate reads
-  (`src/ddl.rs`, `src/usage.rs`); [`../stella-graph`](../stella-graph) writes
-  `codegraph.db`; [`../stella-fleet`](../stella-fleet) writes `fleet.db`.
+- [`../stella-store`](../stella-store) writes everything this crate reads;
+  [`../stella-graph`](../stella-graph) writes `codegraph.db`, and
+  [`../stella-fleet`](../stella-fleet) `fleet.db`.

--- a/stella-pipeline/README.md
+++ b/stella-pipeline/README.md
@@ -1,0 +1,201 @@
+# stella-pipeline
+
+The orchestration plane above `stella-core::Engine`. It drives one prompt through the
+staged turn flow — **evaluate → enhance → route → witness → execute → verify → judge →
+revise** — over injected ports, emitting an `AgentEvent` at every stage boundary. This is
+the default `stella run` path.
+
+Two boundaries define the crate. First, **no I/O**: it never imports a provider SDK, a
+shell, a context store, or a terminal — everything crosses the traits in
+[`src/ports.rs`](src/ports.rs), which the `stella-cli` glue implements against the real
+subsystems. Second, **no decisions in the async code**: [`src/pipeline.rs`](src/pipeline.rs)
+is I/O sequencing only, and every judgement it makes is delegated to a synchronous function
+over owned data in a sibling module (`triage`, `plan`, `scope`, `verify`, `witness`,
+`candidate`) — which is what keeps the hard logic property-testable.
+
+## Where it sits
+
+Depends on `stella-protocol` (wire types and `AgentEvent`) and `stella-core` (`Engine`,
+`Router`, `BudgetGuard`, `ToolExecutor`, `Sleeper`), plus `tokio`, `async-trait`, `serde`,
+`serde_json` and `thiserror`. Nothing in the workspace depends on it except `stella-cli`,
+which owns the port implementations and the `Router` itself. It builds no binary.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The index of design lessons the crate encodes (L-E2, L-E5–E8, L-E11, L-M4) and the public re-exports. Read it first — every claim below is stated there in one line. |
+| [`src/pipeline.rs`](src/pipeline.rs) | `Pipeline::run` and the whole stage sequence, `PipelineConfig`, `PipelineOutcome`. Open it when you need the *order* things happen in. |
+| [`src/pipeline/witness_stage.rs`](src/pipeline/witness_stage.rs) | The one stage that runs against the candidate's `witness_tools()` rather than the worker's executor: author → one bounded repair → artifact/invocation/identity acceptance. |
+| [`src/pipeline/raw_usage.rs`](src/pipeline/raw_usage.rs), [`src/pipeline/run_error.rs`](src/pipeline/run_error.rs), [`src/pipeline/stage_budget.rs`](src/pipeline/stage_budget.rs) | The metered direct-completion path for roles that bypass the engine (triage, judge, guidance) so their spend still lands in accounting; `PipelineError`/`PipelineRunError`; the budget-abort translation. |
+| [`src/ports.rs`](src/ports.rs) | Every trait the pipeline orchestrates over, plus the no-op defaults (`NoContextRecall`, `NoRepoStructure`, `NoRepoStatus`, `AutoApproveGate`, `AlwaysAbortGate`). |
+| [`src/triage.rs`](src/triage.rs) | `TaskClass`, `TaskAssessment`, the response parser, and the deterministic pattern floor. |
+| [`src/plan.rs`](src/plan.rs) | The planner's split context (`build_planner_prompt`) and the JSON-then-numbered-list `parse_plan`. |
+| [`src/scope.rs`](src/scope.rs) | `ScopeThresholds` and the pure `needs_scope_review` / `apply_trim` / `build_proposal`. |
+| [`src/witness.rs`](src/witness.rs) | Witness prompts, the closed test-command vocabulary, and the artifact/invocation/identity validators. |
+| [`src/verify.rs`](src/verify.rs) | `FlipOracle`, `ladder_decision`, judge prompting/parsing, `heuristic_fallback`, `guidance_prompt`. |
+| [`src/candidate.rs`](src/candidate.rs) | `CandidateScore` and `select_best_candidate` — best-of-N selection, pure. |
+| [`src/mcp_prefetch.rs`](src/mcp_prefetch.rs) | `fold`: shared MCP context gathered once at the top of a fan-out instead of N times. |
+| [`src/replay.rs`](src/replay.rs), [`src/replay/golden.rs`](src/replay/golden.rs) | `validate_stream` / `structural_diff` / `parse_jsonl`, and the golden fixture format with its provenance manifest. |
+
+## Key concepts
+
+**The stage flow, and who owns the terminal event.** `stella-core::Engine::run_turn` emits
+its own `Stage { Execute }`, `Stage { Complete }` and `Complete` — correct for one turn,
+wrong for a multi-step plan or a revise loop. So the pipeline gives each `run_turn` a
+private channel and forwards everything *except* the engine's `Stage`/`Complete`, then emits
+the terminal `Complete` or a non-retryable `Error` itself. Triage and context recall are
+overlapped with `tokio::join!` (no data dependency); the recall latency ceiling sits inside
+the recall future, but triage's ceiling deliberately still awaits the paid call so its usage
+cannot vanish from accounting through cancellation.
+
+**Triage decides how much ceremony to buy** ([`src/triage.rs`](src/triage.rs)). `TaskClass`
+is ordered `SimpleLookup < SingleTask < MultiStep` and the derived `Ord` is load-bearing:
+`deterministic_floor` takes the `max` of the model's class and a pattern floor, so the floor
+can only ever *add* planning. A misclassified task must still complete, just more slowly —
+that is why `SimpleLookup`'s judge-skip self-revokes through the zero-diff guard
+(`pipeline.rs:1529`: a lookup is verified after all if `file_changes > 0` or the diff is
+non-empty). `TaskAssessment` carries `conversational` on its own field rather than as a
+fourth class, because "is this even a task" is a different axis from "how big is it"; a bare
+`hi` takes one plain completion and skips plan → witness → execute → verify entirely.
+
+**The witness stage** ([`src/witness.rs`](src/witness.rs),
+[`src/pipeline/witness_stage.rs`](src/pipeline/witness_stage.rs)). When the user armed no
+`--test-command`, an independent model — the judge's resolution, so witness ≠ worker —
+authors a test that must fail *now* and pass once the goal is met. The pipeline runs the
+authored command immediately; if it passes on unmodified code it proves nothing, so one
+bounded repair prompt is sent into the same thread and a second pass discards the witness.
+Acceptance is mechanical, not prose-trusted: `validate_witness_artifact` requires exactly
+one *newly created* untracked test file and zero tracked mutations,
+`validate_witness_invocation` requires the command to name that exact artifact and a single
+test (`--exact`, a pytest node id, an exact `-run ^Test…$`), and `validate_witness_identity`
+pins it to a regular, single-link file read without following symlinks.
+
+**The flip oracle and tamper exclusion.** Only a fail→pass flip of the *same normalized
+command* counts (`FlipOracle` in [`src/verify.rs`](src/verify.rs)): `none → failing →
+flipped`, locking onto the first command it sees fail. A pass with no prior failure is
+`NoEvidence` and does not even lock a command. Whitespace is normalized; token order is not,
+because a pass of `cargo test -p a` must never be credited to a failure of `cargo test -p b`.
+The witness is deliberately **visible** to the worker — iterating against a failing test is
+where convergence comes from — so integrity comes from tamper exclusion instead: at verify
+time every recorded `ArtifactIdentity` is re-read and compared on bytes, type, mode and link
+count (`pipeline.rs:1637`). A mismatch aborts the candidate *before* the ladder runs. It is
+an authority boundary, not evidence for a model to weigh, and no judge can override it.
+
+**The evidence ladder decides before spending a judge call.** `ladder_decision` is a pure
+function of `(flip_achieved, touched_tests_passed, diff_lines, diff_budget)`: touched tests
+red → `Revise` (a red test is already deterministic; never pay a judge to confirm it); flip
++ green + within budget → `SubmitFast` with the judge skipped; anything else →
+`ModelJudge`. `touched_tests_passed: None` means "couldn't run" — inconclusive, never a
+pass. Linters and typecheckers are never fed to `FlipOracle::observe`. A judge call that
+fails or returns unparseable text falls back to `heuristic_fallback`, which passes only on
+observed-green tests, so an outage never degrades to a blanket pass. On the second
+consecutive deterministic failure, `distress_guidance` buys one judge call for
+course-correction that rides with the next revision prompt — event-triggered, never a fixed
+mid-run checkpoint.
+
+**Degrade, never do nothing.** `WitnessAbort` splits reasons into `degradable` (no witness
+could be authored) and `rejected` (a budget limit, or an artifact-integrity violation), and
+`Pipeline::run` re-runs a bare worker turn when a candidate aborted before the worker ever
+ran. Execution aborts (budget, loop, step-cap) keep their stop — the worker did run.
+
+## Gotchas
+
+- **An authored witness forces candidate isolation even at N=1**, so authoring can never
+  mutate the session tree. The decision is made once in `Pipeline::run` before the
+  single-shot/best-of-N split, because isolation needs a git working tree and discovering
+  that later would commit the run to machinery it cannot use. With `test_command` set (or
+  `witness_writer` off), N=1 runs directly on the session ports — and an explicit
+  `--test-command` always wins over an authored one (`effective_test_command`,
+  `pipeline.rs:1862`).
+- **The flip baseline is re-run per candidate**, even though the witness stage already saw
+  the command fail once — the observation must come from *that candidate's* surface, and a
+  seeded one would be fabricated.
+- **An empty diff is never reported as "nothing changed" when `FileChange` events fired.**
+  `verification_honest_diff` substitutes an explicit "the change is real; the diff is blind
+  to it" note, because a judge reading a bare empty string concludes the agent did nothing —
+  the failure mode that once drove an agent to reinitialize git to beat the check.
+- **A review waived by triage scores `Unverified`, not `DeterministicPass`** — claiming the
+  strongest score would let a waived candidate tie a flip-verified sibling in best-of-N and
+  then win the smaller-diff tiebreak.
+- **The pipeline holds `&Router`, so it reads resolutions but never feeds the breaker.**
+  `record_success`/`record_failure` need `&mut Router`; that feedback belongs to the glue
+  that owns the router. A headless run crossing the scope thresholds with no bypass is
+  likewise a named error (`PipelineError::ScopeReviewRequiredHeadless`), never a silent
+  auto-approve.
+- **`docs/*.md` paths cited from rustdoc here are gated.** `make doc-citations` fails if a
+  cited path — or a cited `§N` — does not resolve; `src/replay.rs` and
+  `src/replay/golden.rs` both cite `docs/replay-golden-trajectories.md`.
+
+## Testing
+
+```bash
+cargo test -p stella-pipeline
+make record-golden            # STELLA_REFRESH_GOLDEN=1 … --lib golden; review the diff
+```
+
+There is no `make test-pipeline` target. Everything runs offline against scripted provider
+and port doubles — no API key, no network.
+
+- **Unit tests** sit beside the code ([`src/pipeline/tests.rs`](src/pipeline/tests.rs) and
+  [`src/pipeline/tests/`](src/pipeline/tests)), split by concern: `witness_isolation`,
+  `best_of_n`, `terminal_outcomes`, `usage`, `telemetry`, `management_accounting`,
+  `mcp_prefetch`. They are child modules so they reach `CandidateSurface` and the other
+  private surface via `super::*`; the shared fakes (`run_isolated`, `FakeWorkspacePort`)
+  stay in the common ancestor `tests.rs`. `chaos.rs` enumerates the config × environment
+  cross-product — provider behavior × isolation × task class × single/multi-model × witness
+  on/off × budget × headless bypass — asserting the loop invariants for every combination;
+  exhaustive rather than `proptest`-driven because the space is small enough.
+- **Property tests** (`proptest`) cover the flip oracle in
+  [`src/verify.rs`](src/verify.rs) — `flip_requires_a_prior_failing_observation` is the one
+  proving `Flipped` is unreachable without a prior `Failing` of the same command.
+- **Replay fixtures** are two distinct things, deliberately kept apart.
+  [`tests/fixtures/`](tests/fixtures) holds *synthetic*, hand-authored streams
+  (`single_task_flip.jsonl`, `judge_escalation.jsonl`, `torn_tail.jsonl`) exercising the
+  invariants and the differ, driven from
+  [`tests/replay_fixtures.rs`](tests/replay_fixtures.rs).
+  [`tests/fixtures/golden/`](tests/fixtures/golden) holds real recordings of this
+  pipeline's own event stream, asserted by `src/pipeline/tests/golden.rs`. Both sides of
+  that comparison are the same code, so goldens are a **drift baseline** — they catch a
+  stage that stopped being emitted or a tool that changed name — not independent evidence.
+  A recording parsing to a different length than its manifest's `event_count` is a
+  `GoldenError::Truncated`: `parse_jsonl`'s torn-tail tolerance is right for a live reader
+  and wrong for a committed fixture.
+  [`tests/reference_conformance.rs`](tests/reference_conformance.rs) pins the adapter
+  contract an *independent* engine must satisfy before its runs could join them.
+
+## Extending it
+
+**Adding a test-runner form to the witness vocabulary** is the most common change, and it
+touches three functions in [`src/witness.rs`](src/witness.rs) that must agree:
+
+1. `parse_test_invocation` — accept the program/argv shape, and add its path-escape and
+   working-directory flags to `validate_local_args` (`--manifest-path`, `--cwd`, `--rootdir`
+   and friends are rejected so a test command cannot retarget another tree).
+2. `validate_witness_invocation` — require the command to name the accepted artifact and a
+   single exact test. A form that can run a whole suite would credit a flip the witness did
+   not earn.
+3. `is_witness_test_path` — teach it the language's test-file shape so the artifact is
+   recognized at all.
+
+**Adding a port**: define the trait in [`src/ports.rs`](src/ports.rs), add the field to
+`PipelinePorts`, and choose deliberately between a no-op default and an `Option` — a port
+that can honestly answer "nothing" gets a default; one whose absence *changes what the run
+does* (candidate isolation, MCP pre-fetch) is an `Option`, so degradation stays visible.
+
+**Adding a stage**: add the variant to `StageKind` in `stella-protocol`, give it a rank in
+`stage_rank` ([`src/replay.rs`](src/replay.rs)) — `validate_stream` rejects any backward
+transition that is not the Verify/Judge → Execute revise back-edge — then re-record the
+goldens and read the fixture diff, because a change there changes the observable event
+contract.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "The definition of done: witness tests" for the contract
+  this crate enforces at runtime; "Architecture: ports, not concretions" for the inherited
+  no-I/O and byte-stable-prompt rules.
+- [`../website/content/docs/inference-pipeline.mdx`](../website/content/docs/inference-pipeline.mdx)
+  — the full stage flow, the distress-triggered guidance loop, and the `/pipeline` deck toggle.
+- [`../docs/replay-golden-trajectories.md`](../docs/replay-golden-trajectories.md) — the
+  recording procedure and the reference-engine adapter contract.
+- [`../stella-core`](../stella-core) — `Engine::run_turn`, the loop this crate composes.

--- a/stella-pipeline/src/mcp_prefetch.rs
+++ b/stella-pipeline/src/mcp_prefetch.rs
@@ -2,7 +2,7 @@
 //! [`fold`] is called once at the top of a fan-out, folding shared context
 //! into every candidate's starting messages instead of each candidate
 //! independently paying to look it up. Split out of `pipeline.rs` to keep
-//! the orchestrator under the file-size ratchet.
+//! the orchestrator small.
 
 use stella_protocol::CompletionMessage;
 

--- a/stella-pipeline/src/pipeline/tests/best_of_n.rs
+++ b/stella-pipeline/src/pipeline/tests/best_of_n.rs
@@ -1,5 +1,5 @@
 //! Best-of-N candidate isolation tests — split out of `tests.rs` to keep it
-//! under the file-size ratchet; a child module, so it reaches `run_isolated`,
+//! small; a child module, so it reaches `run_isolated`,
 //! `isolated_config`, and the other fakes above via `super::*`. The shared
 //! infrastructure itself (`run_isolated`, `isolated_config`,
 //! `FakeWorkspacePort`, `FakeWorkspace`) stays in `tests.rs` — `mcp_prefetch`

--- a/stella-protocol/README.md
+++ b/stella-protocol/README.md
@@ -1,0 +1,201 @@
+# stella-protocol
+
+The serde types and port traits every other crate in the workspace speaks:
+agent events, tool schemas, multimodal attachments, model roles, provider
+request/response envelopes, and the `Provider` trait itself. `stella run
+--output-format stream-json` is a `serde_json` serialization of `AgentEvent`,
+one line per event, so this crate is the workspace's public wire contract.
+
+**Types only — zero logic, zero I/O.** Nothing here opens a socket, reads a
+file, or spawns a task. The only functions that exist are total, allocation-
+light helpers over their own data (`AgentEvent::type_tag`,
+`ProviderError::is_retryable`, `ContextUsage::is_consistent`,
+`classify_media_type`). The crate also depends on **no other workspace crate**,
+and must not: `stella-core` depends on `stella-protocol`, so importing a core
+type here is a dependency cycle. That is why several fields mirror a
+`stella-core` type instead of re-exporting it — `AgentEvent::LoopDetected::kind`
+is a `String` mirroring `loop_detect::LoopVerdict`, `BudgetScope` duplicates
+`budget::BudgetAxis`, and `AgentEvent::Compaction` is a flat struct rather than
+a re-exported `CompactionReport`.
+
+## Where it sits
+
+The bottom of the workspace. Its only dependencies are `serde`, `serde_json`,
+`thiserror`, and `async-trait`; eleven of the other fourteen crates depend on
+it (every crate except `stella-context`, `stella-graph`, and
+`stella-observatory`). It builds no binary. The `Provider` port lives here
+rather than in `stella-model` precisely so `stella-core` can drive every model
+call through `&dyn Provider` without linking a single vendor adapter.
+
+```
+stella-protocol ← stella-core ← stella-cli / stella-pipeline / stella-tui …
+       ↑ also: stella-model (implements Provider), stella-tools, stella-store,
+         stella-mcp, stella-media, stella-fleet, stella-serve
+```
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The crate's flat re-export surface, and the statement of the one-directional wire-compatibility rule. Read it first. |
+| [`src/event.rs`](src/event.rs) | `AgentEvent` and its supporting types — the stream-json vocabulary, 34 variants. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
+| [`src/context_event.rs`](src/context_event.rs) | `LifecycleEventEnvelope` / `LifecycleEvent` — the *other* event channel, the one an older binary can still read. Open it when a new event must survive replay by an older reader. |
+| [`src/completion.rs`](src/completion.rs) | `CompletionRequest` / `CompletionResult` / `CompletionUsage`, `GenerationParams`, `FinishReason`. The one envelope every provider adapter translates to and from. |
+| [`src/provider.rs`](src/provider.rs) | The `Provider` port and `ToolCallObserver`, the seam speculative tool execution hangs on. |
+| [`src/tool.rs`](src/tool.rs) | `ToolSchema`, `ToolCall`, `ToolOutput`, `ToolResult` — the engine's single internal tool dialect. |
+| [`src/attachment.rs`](src/attachment.rs) | Multimodal *input* attachments, plus `classify_media_type`, `media_type_for_path`, `human_bytes`. |
+| [`src/role.rs`](src/role.rs) | `Role` (worker/triage/plan/judge/embed/vision/image/video) and `ModelRef`. |
+| [`src/error.rs`](src/error.rs) | `ProviderError` and its retry classification. |
+| [`src/cache.rs`](src/cache.rs) | `CacheCause` and the one-line hint each carries, so the CLI receipt and the deck panel print identical wording. |
+
+## Key concepts
+
+**Additivity is directional, and the asymmetry is the whole design.** New
+*fields* ride `#[serde(default)]`, so a newer binary parses every older stream.
+New `AgentEvent` *variants* do not travel backwards: the enum is internally
+tagged (`#[serde(tag = "type")]`), so an older binary meets an unrecognized
+`"type"` with a hard deserialization error, and the JSONL replay reader treats
+an unparseable interior line as fatal. An event that must be readable by an
+older binary therefore rides `LifecycleEventEnvelope` instead, whose `payload`
+stays a raw `Value` and whose `decode()` degrades an unrecognized `event_type`
+to `LifecycleEvent::Unknown` with the payload intact. Picking the wrong channel
+is the single most expensive mistake available in this crate.
+
+**`AgentEvent::type_tag` is a compile-time guard, not a convenience.**
+`src/event.rs:712` matches every variant with no wildcard arm, so adding a
+variant fails `cargo build -p stella-protocol` with `E0004` right there. Its
+doc comment carries the full downstream checklist: which matchers the compiler
+will also stop you at (`stella-pipeline` `replay::event_signature`,
+`stella-tui` `model::Model::apply`, `textline::event_line`, `deck::trace_of`)
+and — the dangerous half — which ones it cannot (`replay::structural_diff`'s
+volatile keep-set, `deck::event_intensity`, `deck::status_from_event`). Read
+that list before you add a variant; it is maintained there, not here.
+
+**Content-freedom is a type-level property.** `UsageIncompleteReason` is a
+closed enum precisely so an error body cannot be represented;
+`AgentEvent::PolicyDecision` carries a `subject` and a short `outcome` token,
+never a secret value; `ContextUsage` / `ContextProviderUsage` are a provider id
+and three numbers. `AgentEvent::BlockRegistered::content` is the one deliberate
+exception — bytes for the two block kinds the journal cannot otherwise resolve
+(the system prefix, the assembled user/recall message) — and it is local-only,
+stripped by the content-free export projection. See AGENTS.md's "Zero telemetry
+egress by default".
+
+**Correctness predicates travel with the data.** A consumer never re-derives a
+classification a producer already made: `ProviderError::is_retryable` is the
+adapter's own verdict (`AgentEvent::Error` even carries `retryable` on the
+wire), `CompletionUsage::reported` proves the adapter saw the provider's
+terminal usage frame rather than inferring it from nonzero counters, and
+`ContextUsage::is_consistent` / `as_of_is_wellformed` let a metering pipeline
+check a receipt before trusting it.
+
+**`ToolCallObserver` is advisory but exact.** An adapter may announce all,
+some, or none of the calls it will return, but any call it does announce must
+be byte-identical (same `call_id`, `name`, parsed `input`) to the one in the
+final `CompletionResult` — consumers match speculated work back by exact
+equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
+
+## Gotchas
+
+- **`AgentEvent::Text { delta }` is not a delta.** The field name is
+  wire-frozen legacy; the value is the step's *full* answer text and is
+  authoritative. `AgentEvent::TextDelta { text }` is the live fragment stream.
+  Consumers must **replace** any accumulated preview with `Text`, never append
+  — a retried model call re-streams its deltas from the start and there is no
+  reset marker.
+- **`LifecycleEventEnvelope::decode` never fails, which cuts both ways.** A
+  *recognized* `event_type` whose payload doesn't deserialize degrades to
+  `LifecycleEvent::Unknown` rather than erroring, so a renamed payload field
+  looks exactly like a future event type. The `event_type` string constants are
+  a wire contract; renaming one silently reroutes the event to `Unknown`.
+- **The golden JCS vectors in `context_event.rs` are meant to break.** Renaming,
+  retyping, adding, or reordering a field in a lifecycle body breaks exactly one
+  golden line, because those canonical bytes are the preimage
+  `stella_core::context_record::hash` builds `record_hash` from. The dev-dep
+  pins the same canonicalizer crate *and version* core hashes with.
+- **`ToolSchema::read_only` defaults to `false`** — the safe direction. An MCP
+  tool or an older schema that doesn't know about the field is treated as
+  mutating and never speculated on.
+- **`CompletionUsage::cache_write_tokens` is not a subset of `input_tokens`.**
+  Providers report cache writes separately; folding them in would change cost
+  accounting, since `Pricing::cost_usd` carries no cache-write rate.
+- **Adding a field to `CompletionMessage` can be a prompt-cache regression.**
+  `attachments` carries `skip_serializing_if = "Vec::is_empty"` so a text-only
+  message serializes byte-for-byte as it did before the field existed. Anything
+  that perturbs the stable prefix breaks cache hits (AGENTS.md, "Byte-stable
+  prompts").
+- **There is no `"auto"` model slug.** Selection is `Option<ModelRef>`; `None`
+  *is* auto. `ModelRef` deliberately has no auto variant — the TS-era bug where
+  a pseudo-slug leaked into resolver paths is structurally excluded (L-M3).
+- **`ProviderError::RateLimited` interpolates its hint by hand.** The obvious
+  `{retry_after_ms:?}` renders "retry after Some(500)ms", or the nonsense
+  "retry after Nonems", into a message the user reads on the TUI.
+- **`ContextUsage`'s sums saturate rather than wrap** — these predicates run
+  over journal bytes the consumer did not write, and an audit check must answer
+  `false` on a corrupt report, never panic on a debug-build overflow.
+
+## Testing
+
+```bash
+make test-protocol        # = cargo test -p stella-protocol
+```
+
+There is no `tests/` directory — every test is an inline `#[cfg(test)] mod
+tests` at the bottom of the module it covers, and the suite needs no fixtures,
+network, or env vars. The dominant shape is the serde round-trip (AGENTS.md
+"Serde-first": every type crossing a crate boundary round-trips byte-for-byte),
+paired with a "legacy stream still parses" test for each `serde(default)` field
+— e.g. `completion_usage_without_cache_write_tokens_still_parses`,
+`step_usage_from_a_pre_drift_stream_still_parses`,
+`legacy_compaction_without_identities_still_parses`. The other shape is the
+golden-bytes test in `context_event.rs`, which needs the
+`serde_json_canonicalizer` dev-dependency.
+
+## Extending it
+
+**Adding a field to an existing type** — give it `#[serde(default)]` (plus
+`skip_serializing_if` if its absence should stay off the wire), and add a test
+that deserializes a hand-written pre-field JSON literal and asserts the
+default. Every `serde(default)` in this crate has one; match the neighborhood.
+
+**Adding an `AgentEvent` variant** — first ask whether it must be readable by an
+older binary. If yes, it belongs on `LifecycleEventEnvelope`, not here. If no:
+
+1. Add the variant to `AgentEvent` in [`src/event.rs`](src/event.rs).
+2. Add its arm to `type_tag` — `cargo build -p stella-protocol` fails with
+   `E0004` until you do.
+3. Add a round-trip test asserting the `"type"` tag serializes as you expect.
+4. Work the checklist in `type_tag`'s doc comment: the compile-enforced
+   matchers in `stella-pipeline` and `stella-tui` will stop you one crate at a
+   time, then hand-audit the wildcard matchers the compiler cannot catch. This
+   step is not optional bookkeeping — a variant landed on `main` past the
+   compile-enforced half and broke `stella-pipeline` (#421) and then
+   `stella-tui` (#422) on separate days.
+
+**Adding a lifecycle event** — add the token to `context_event::event_type`,
+the payload struct, the `LifecycleEvent` variant, the `decode` arm, and a
+golden JCS vector in the same PR. `the_event_type_tokens_are_canonical` and
+`golden_jcs_vectors_for_every_event_body` are the tests that fail until you do.
+
+**Adding a generation parameter** — put it on `GenerationParams` as an
+`Option`, with include-semantics: `None` leaves the provider default alone.
+Each adapter in `stella-model` forwards the subset its dialect supports and
+silently drops the rest; a parameter a provider cannot express must never fail
+the request. If it is a genuine capability divergence rather than a droppable
+knob, it also needs a row in `stella-model/src/provider_parity.rs`.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions"
+  (invariants 1 and 4), and the "Glossary" table, which disambiguates
+  `turn_instance` / `(step, call_seq)` from the store's `execution_id` and the
+  fleet's `run_id`.
+- [`../docs/design/session-telemetry-receipts-spec.md`](../docs/design/session-telemetry-receipts-spec.md)
+  — the spec `BlockRegistered`, `StepManifest`, `BlockKind`, and `CacheZone`
+  implement (§4, §5, §6.2–6.4).
+- [`../docs/context-reuse.md`](../docs/context-reuse.md) — §2 defines
+  `ContextUsage` / `ContextProviderUsage` and the arithmetic identity
+  `is_consistent` checks.
+- [`../stella-model`](../stella-model) implements `Provider`;
+  [`../stella-core/src/ports.rs`](../stella-core/src/ports.rs) holds the
+  sibling `ToolExecutor` port.

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -1,0 +1,200 @@
+# stella-serve
+
+The Stella engine as a headless, host-driven service. The host assembles a turn,
+the engine here orchestrates it, and every governed side effect — model
+completions and tool calls — is remoted back to the host over a wire protocol.
+This is ADR-033 Option B, the Rust sidecar; the design is
+[`../docs/design/serve-surface.md`](../docs/design/serve-surface.md).
+
+The hard boundary is **no ambient authority**. The engine running inside this
+server never calls a model and never executes a tool itself: `RemoteProvider` and
+`RemoteToolExecutor` ([`src/remote.rs`](src/remote.rs)) satisfy the `Provider` and
+`ToolExecutor` ports by emitting a request frame and parking on the host's answer,
+so every effect re-enters the host's own governance. A local tool surface is not a
+configuration option — `STELLA_SERVE_TOOLS` accepts only `remote`, and any other
+value is refused at startup rather than silently ignored
+([`src/main.rs`](src/main.rs)). Persistence is the host's as well: this crate does
+not depend on `stella-store`.
+
+## Where it sits
+
+It depends on exactly two workspace crates — [`stella-protocol`](../stella-protocol)
+for the wire types and [`stella-core`](../stella-core) for the engine — and
+**nothing in the workspace depends on it**. It is a leaf that builds its own
+binary from [`src/main.rs`](src/main.rs); `stella-cli` does not link it, and
+`make build-release` builds `-p stella-cli` only, so a change here never reaches a
+`stella` user. The corollary: `make smoke` runs the CLI and never exercises this
+crate — `make gate`'s `cargo test --workspace` is the only thing that does.
+
+The binary is meant to run containerized —
+[`../packaging/docker/Dockerfile.serve`](../packaging/docker/Dockerfile.serve)
+builds it with `--bin stella-serve`, runs it under a non-root numeric UID, binds
+`0.0.0.0:8080`, and uses the binary's own `stella-serve healthcheck` subcommand as
+the container HEALTHCHECK so the runtime image needs no `curl` or `wget`.
+
+```
+host  ──POST /v1/turns──►  stella-serve  ──►  Session (dedicated OS thread)
+  ▲                                                   │
+  └──GET .../events: SSE frames (agent events + reverse-RPC requests)──┘
+  └──POST .../tool-result, .../provider-result──► Pending ──unparks the engine step
+```
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The crate `//!` overview and the whole public surface: `Session`, `SessionSpec`, `ServerFrame`, `ServeConfig`, `serve`. Read this first. |
+| [`src/session.rs`](src/session.rs) | `Session::start` — one turn on a dedicated OS thread with its own current-thread runtime. Open it to change the turn lifecycle or frame ordering. |
+| [`src/remote.rs`](src/remote.rs) | The two remoted port impls, plus `TokioSleeper` for the engine's retry backoff. |
+| [`src/pending.rs`](src/pending.rs) | `Pending`, the `request_id` → one-shot registry shared across the two runtimes. Open it when a resolve POST returns 409. |
+| [`src/frame.rs`](src/frame.rs) | The wire vocabulary: `ServerFrame`, `TurnOutcomeWire`, `ToolResultIn`, `ProviderResultIn`, `ProviderErrorWire`. Every wire-shape change starts here. |
+| [`src/server.rs`](src/server.rs) | `serve` — accept loop, bearer auth, the four `/v1/turns` routes, the turn registry, and a rustdoc list of the operational limits the deployment must supply. |
+| [`src/http.rs`](src/http.rs) | A hand-rolled HTTP/1.1 + SSE layer following [`stella-observatory`](../stella-observatory)'s no-framework idiom, extended with request bodies, bearer auth, and long-lived responses. |
+| [`src/error.rs`](src/error.rs) | `ServeError` — the named failures at the boundary. |
+| [`src/main.rs`](src/main.rs) | The binary: env config (`STELLA_SERVE_BIND` / `_TOKEN` / `_TOOLS`) and the `healthcheck` subcommand. |
+
+## Key concepts
+
+**The reverse tool-call protocol.** Two deliberately asymmetric directions.
+Outbound is one stream of `ServerFrame`s: mostly `Event` (agent events for the
+UI), plus `ToolRequest` / `ProviderRequest` carrying a `request_id`, terminated by
+exactly one `TurnComplete`. Inbound is the host POSTing `ToolResultIn` /
+`ProviderResultIn` keyed by that same `request_id`, which fires the one-shot the
+engine step is parked on. Over HTTP the outbound stream is the SSE endpoint and
+the inbound direction is the two result POSTs; that transport is a thin layer, and
+`Session` is usable directly without it.
+
+**One turn, one OS thread.** The engine's `run_turn` future is deliberately
+`!Send` (it holds provider futures and the retry-jitter RNG across awaits — see
+[`../stella-cli/src/fleet_cmd.rs`](../stella-cli/src/fleet_cmd.rs)), so it cannot
+be `tokio::spawn`ed onto the server's multi-thread runtime. Each session instead
+gets a named OS thread running a *current-thread* runtime that `block_on`s the
+turn, and the server talks to it only through `Send` channels. `tokio::sync::oneshot`
+is runtime-agnostic, so a sender fired on the server runtime cleanly wakes a
+receiver awaited on the session runtime. This is the fleet's bridge, reused for a
+long-lived server; [`tests/bridge.rs`](tests/bridge.rs) exists to prove it in
+isolation, with no socket involved.
+
+**`Pending` register-before-emit, and its single-lock take.** A port registers its
+reply channel *before* sending the request frame, so the entry always exists by
+the time the host could answer. `take_tool` / `take_provider` do the kind check
+and the removal under one lock on purpose: removing first and re-inserting on a
+mismatch leaves a window where the id is absent, so a correctly kinded resolve
+racing a mis-kinded one is rejected as unknown — the host gets a 409 for a result
+it will not send twice, and the engine step stays parked forever.
+
+**Provider failures are classified by the host, not re-derived here.**
+`ProviderErrorWire` mirrors `ProviderError`'s taxonomy on the wire; the engine
+rebuilds a real `ProviderError` from it so retry behaves exactly as with a local
+provider. Sending `terminal` where the host meant `rate_limited` silently disables
+the engine's backoff.
+
+## Gotchas
+
+- **Event frames and reverse-RPC frames are not mutually ordered.** Agent events
+  reach the frame channel through a forwarder task; the ports write request frames
+  straight to it (so a starved forwarder cannot stall the turn). A `tool_request`
+  can therefore overtake the `ToolStart` event that logically precedes it. The one
+  guarantee `run_session` does enforce: the event channel is closed and the
+  forwarder awaited before `TurnComplete` is sent, so every event frame precedes
+  the terminal frame.
+- **Several tool requests can be outstanding at once.** The engine runs
+  consecutive `read_only` tool calls as a concurrent group (`stella-core`'s
+  `execute_tool_calls`), and the host's advertised `read_only` flags drive that
+  partitioning. Answer by `request_id`, in any order — a host that assumes one
+  outstanding request at a time will stall the group.
+- **`request_id`s are per-turn counters** (`prov-0`, `tool-0`), unique only within
+  a turn. They are safe because the resolve routes are scoped by turn id — do not
+  treat them as global handles.
+- **A turn's event stream is exclusive and one-shot.** The second
+  `GET /v1/turns/{id}/events` gets 409, and the registry entry is removed only
+  when a stream ends. A turn created and never streamed keeps its entry and its
+  thread indefinitely.
+- **`max_steps` from the wire is validated, not trusted.** `0` is a 400 (it would
+  produce a zero-iteration turn that aborts with the misleading "reached the step
+  cap (0)"), and anything above `MAX_SERVED_STEPS` (10 000, fifty times
+  `EngineConfig::default`'s 200) is clamped — the host also supplies the budget
+  mode, which may be `Off`, so an unclamped cap would remove the last bound on a
+  turn holding an OS thread.
+- **Chunked request bodies are not decoded.** A chunked POST parses as an empty
+  body and fails validation with a 400. That is safe rather than a smuggling hole
+  only because this layer serves one request per connection and then closes.
+- **The token comparison must stay constant-time.** `constant_time_eq` in
+  [`src/server.rs`](src/server.rs) exists because `==` on `&str` stops at the first
+  differing byte and leaks the shared secret to a caller timing its own 401s. A
+  missing `Authorization` header is a hard `false`, so an empty configured token
+  cannot authorize an anonymous request.
+- **`ToolExecutor::execute` never returns an error.** A tool failure is
+  model-visible data, so a host disconnect mid-tool becomes `ToolOutput::Error`,
+  not an engine error. The provider port is the opposite: a disconnect there is a
+  `ProviderError::Transport`.
+- **The server has no admission control, no per-turn deadline, and no read
+  timeout** — see the `# Operational limits` rustdoc on `serve`. A reverse request
+  the host never answers parks a thread indefinitely. Front it with a proxy on a
+  private network; it is a sidecar for one trusted host, not an internet-facing
+  server.
+
+## Testing
+
+```bash
+cargo test -p stella-serve
+```
+
+There is no `make test-serve` target — the Makefile only has per-crate targets for
+`core`, `model`, `tools`, `cli`, and `protocol`. No fixtures, env vars, or network
+access are needed; the suites either bind `127.0.0.1:0` or use no socket at all.
+
+- [`tests/bridge.rs`](tests/bridge.rs) drives a live `Session` from a mock host
+  with **no HTTP**, answering reverse-RPC requests in-process. It covers the full
+  model → tool → model loop, the no-tool path, and a classified provider failure
+  aborting cleanly. Because the bridge is the risky part, prove a change here
+  first.
+- [`tests/http.rs`](tests/http.rs) runs the same protocol end-to-end over a real
+  socket: `POST /v1/turns`, SSE, and the two result POSTs, plus the auth and
+  `max_steps` rejections.
+- Unit tests live beside the code in [`src/frame.rs`](src/frame.rs) (wire
+  round-trips, including that a legacy `aborted` payload without `cost_usd` still
+  deserializes) and [`src/server.rs`](src/server.rs) (the step-cap clamp).
+
+Both integration suites need `#[tokio::test(flavor = "multi_thread")]`: a
+current-thread test runtime cannot both drive the socket and let the session
+thread's replies land.
+
+## Extending it
+
+To add another remoted port (an approval gate, a command runner):
+
+1. Implement the port in [`src/remote.rs`](src/remote.rs), following
+   `RemoteToolExecutor`: allocate a `request_id`, **register the one-shot before**
+   sending the frame, and map a send failure onto whatever "the host is gone"
+   means for that port's contract.
+2. Add the outbound `ServerFrame` variant and the inbound `…In` type in
+   [`src/frame.rs`](src/frame.rs).
+3. Add a `PendingReply` variant plus its `register_*` / `resolve_*` / `take_*`
+   trio in [`src/pending.rs`](src/pending.rs), keeping the kind check and removal
+   under one lock.
+4. Construct the port in `run_session` in [`src/session.rs`](src/session.rs) and
+   pass it to the engine.
+5. Add the POST route to `handle_conn` in [`src/server.rs`](src/server.rs) and a
+   `ServeError` arm if the failure is new.
+6. Extend [`tests/bridge.rs`](tests/bridge.rs) first, then
+   [`tests/http.rs`](tests/http.rs).
+
+Adding a `ProviderError` variant in `stella-protocol` is smaller but easy to miss
+from the other crate: both `From` impls in [`src/frame.rs`](src/frame.rs) match
+exhaustively, so this crate fails to compile until `ProviderErrorWire` grows the
+matching arm — which is the intended forcing function, since a variant absent from
+the wire would be silently reclassified.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions" (why the
+  remoted ports are adapters, not a rewrite) and the "Workspace layout" row for
+  this crate, which states the own-binary/not-linked rule.
+- [`../docs/design/serve-surface.md`](../docs/design/serve-surface.md) — the full
+  design. Note it describes a larger target surface than what is implemented
+  (sessions rather than turns, steering, pause/cancel, an approval gate, and SSE
+  replay from `?after=<seq>`); the code today serves one turn per registered id
+  with no resume. Treat the doc as the destination, `src/` as the state.
+- [`../packaging/docker/Dockerfile.serve`](../packaging/docker/Dockerfile.serve) —
+  how the binary is actually deployed, and the constraints that shape `main.rs`.

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -192,9 +192,11 @@ the wire would be silently reclassified.
   remoted ports are adapters, not a rewrite) and the "Workspace layout" row for
   this crate, which states the own-binary/not-linked rule.
 - [`../docs/design/serve-surface.md`](../docs/design/serve-surface.md) — the full
-  design. Note it describes a larger target surface than what is implemented
-  (sessions rather than turns, steering, pause/cancel, an approval gate, and SSE
-  replay from `?after=<seq>`); the code today serves one turn per registered id
-  with no resume. Treat the doc as the destination, `src/` as the state.
+  design. Its status line now flags the gaps itself: it describes a larger
+  target surface than what is implemented (sessions rather than turns,
+  steering, pause/cancel, an approval gate, SSE replay from `?after=<seq>`, a
+  `Host`-header guard, and a SIGTERM drain); the code today serves one turn per
+  registered id with no resume. Treat the doc as the destination, `src/` as the
+  state.
 - [`../packaging/docker/Dockerfile.serve`](../packaging/docker/Dockerfile.serve) —
   how the binary is actually deployed, and the constraints that shape `main.rs`.

--- a/stella-store/README.md
+++ b/stella-store/README.md
@@ -1,0 +1,212 @@
+# stella-store
+
+Local SQLite persistence for everything a session produces: one row per
+execution, the COMPLETE `AgentEvent` stream (reasoning deltas included), per-call
+telemetry, context receipts, task boards, and cooperative file claims — all on
+the user's disk, no server and no account.
+
+The crate's hard boundary is **facts, not policy**. It deliberately does not
+depend on `stella-model`: no pricing table, no cache TTL, no diagnosis lives here
+— [`cache_gaps.rs`](src/cache_gaps.rs) and [`cache_trend.rs`](src/cache_trend.rs)
+surface the raw rows and the caller applies the policy. It does not parse the
+rule markdown it stores (`stella_core::rules` does). And it never takes a turn
+down: every method returns `Result` and the CLI treats a failed store as
+observability loss — warn once, keep running. A panic here would be a work
+stoppage, which is why `Store::migrate` rejects a negative `user_version` with an
+error rather than indexing `MIGRATIONS` with a wrapped `usize`.
+
+## Where it sits
+
+A leaf: its only workspace dependency is `stella-protocol` (`AgentEvent`,
+`TaskItem`, `ToolOutput`), plus `rusqlite` (bundled), serde, `base64`, `sha2`,
+`rand`, and `libc` on unix for the session registry's `kill(pid, 0)` liveness
+check. No binary. `stella-cli` is the main consumer (`Store::open`, the session
+registry, notifications, the journal); `stella-fleet` uses `Store` for its file
+claims; `stella-tools` uses only the private-path helpers, to reach `codegraph.db`.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The `Store` handle, `open`/`in_memory`/`migrate`, the row types, and most of the query surface. Start here. |
+| [`src/ddl.rs`](src/ddl.rs) | Every table and index as DDL at the **current** `SCHEMA_VERSION`, plus the `TABLES` allowlist. The one place today's shape is written down. |
+| [`src/migrations.rs`](src/migrations.rs) | The ordered `MIGRATIONS` list, the fresh-file bootstrap, and the transactional runner. Open it to add a version. |
+| [`src/content_free.rs`](src/content_free.rs) | The zero-egress guard: the reviewed hub-column allowlist and the sentinel harness every egress encoder registers with. |
+| [`src/usage.rs`](src/usage.rs) | `~/.stella/usage.db` — the cross-project hub: replication cursor, `prune`, and the cloud-drain staging/ack/quarantine surface. |
+| [`src/drain.rs`](src/drain.rs) | The versioned drain wire contract (`DrainBatch`/`DrainRow`), the `CloudIntake` seam, and `drain_org`'s poison-row bisection. |
+| [`src/enterprise_telemetry.rs`](src/enterprise_telemetry.rs) + [`src/enterprise_telemetry/`](src/enterprise_telemetry) | The closed-schema `StellaOperationalEventV1` and its bounded, at-least-once host-owned spool. Delivery is the CLI's job. |
+| [`src/catalog.rs`](src/catalog.rs) | `catalog.db` — model cards, append-only pricing versions, and the alias join table telemetry is resolved through. |
+| [`src/sessions.rs`](src/sessions.rs), [`src/journal.rs`](src/journal.rs), [`src/notify.rs`](src/notify.rs) | The file-backed stores: one JSON file per session / per notification, and the per-session sidecar (`journal.jsonl`, `history.json`, `queue.json`) that makes a session resumable. |
+| [`src/private.rs`](src/private.rs), [`src/home.rs`](src/home.rs), [`src/identity.rs`](src/identity.rs) | Where state is allowed to live (`.stella/private/`: 0700 dirs, 0600 files, atomic temp+fsync+rename; `~/.stella` resolution) and the `org_id`/`workspace_id`/`repo_id`/`project_id` scoping that is infallible by design. |
+| [`src/receipts.rs`](src/receipts.rs), [`src/reconstruct.rs`](src/reconstruct.rs) | Context-receipt writes (block registry, per-step manifest) and the byte-exact reconstruction of what a model actually saw. |
+| [`src/telemetry.rs`](src/telemetry.rs) | `TelemetryRow`, the per-call write path, and the execution-level accounting boundary. |
+| `src/tests.rs`, `src/private_state_tests.rs`, `src/quarantine_tests.rs`, `src/usage_completeness_tests.rs` | `#[cfg(test)]` modules; the last three are named witnesses for private-state permissions, quarantine behaviour, and fail-closed accounting. |
+
+## Key concepts
+
+### The schema lives in two files, and they answer different questions
+
+[`ddl.rs`](src/ddl.rs) says what the shape *is*; [`migrations.rs`](src/migrations.rs)
+says how an existing file *gets there*. A fresh database gets `create_latest_schema`
+in one shot and is stamped at `SCHEMA_VERSION` (`= MIGRATIONS.len()`, 13 today);
+an existing one runs each pending step. `PRAGMA user_version` 0 is ambiguous — it
+is both "fresh empty file" and "legacy pre-versioning file" — so `Store::migrate`
+disambiguates by probing `TABLES` via `any_store_table_exists`. A file stamped
+**newer** than this build knows is refused outright: older code writing into a
+newer shape would silently violate whatever that schema added.
+
+`apply_migration` opens the transaction, runs the step, runs
+`pragma_foreign_key_check`, stamps the new `user_version` *inside that same
+transaction*, and commits — so a crash mid-migration rolls back to the old
+version **and** the old shape, never a mix. It also suspends `PRAGMA foreign_keys`
+outside the transaction and restores it after commit-or-rollback, because SQLite
+silently ignores that pragma inside one: the full `lang_altertable` §7 procedure,
+followed even though no store table declares a foreign key today, so a future one
+cannot be corrupted by a rebuild.
+
+Two rules follow. **A shipped migration must keep producing its own era's shape**:
+`migrate_v0_to_v1` re-creates `executions` and `files_touched` with their v1
+columns *inline*, not from `ddl.rs`, because the v2 rebuild and the v8 `ALTER`
+run against them afterwards — editing an old migration to match today's DDL
+breaks every old file on disk. And **most DDL carries `IF NOT EXISTS`** so one
+constant serves both the fresh path and an additive migration; the three
+name-parameterized functions (`events_ddl`, `telemetry_ddl`, `files_touched_ddl`)
+exist because a §7 rebuild creates the new shape under a scratch name first.
+
+### `content_free.rs` — the egress allowlist is a privacy review
+
+AGENTS.md invariant #3 says prompts, paths, tool payloads/results, reasoning,
+errors, git state, memories, rules, and local identifiers are never exportable.
+That used to hold *by construction*; nothing prevented a future column or struct
+field from quietly carrying content. This module makes it a red gate, in two
+halves:
+
+1. **Schema allowlist.** `HUB_TELEMETRY_COLUMNS` is the reviewed column set of
+   the hub `telemetry` table — the only table a cloud drain reads.
+   `hub_telemetry_schema_matches_the_reviewed_allowlist` compares it against the
+   live `PRAGMA table_info`, so adding a column fails the build until the
+   allowlist is edited in the same PR. That edit *is* the forcing function.
+   `SUSPICIOUS_KEY_SUBSTRINGS` ("prompt", "path", "diff", "stderr", …) is the
+   second opinion: naming a column `prompt_preview` trips
+   `no_allowlisted_hub_column_reads_as_content` even after the allowlist edit landed.
+2. **Encoder sentinel harness.** Every encoder that puts bytes on the network
+   implements `ContentFreeEncoder` and joins `registered_encoders()` — today
+   `NativeDrainGuard` and `EnterpriseOperationalGuard`. `audit_encoder` feeds it
+   `poisoned_cloud_event()` / `poisoned_execution_rollup()`, whose content-bearing
+   fields carry `CONTENT_SENTINEL`, `PATH_SENTINEL`, and two UUID sentinels, then
+   substring-searches the encoded bytes. Those fixtures are **exhaustive struct
+   literals**, so adding a field to `CloudTelemetryEvent` or `ExecutionRollupRow`
+   fails to *compile* here until someone decides what the fixture puts in it.
+
+Two details keep the guard from passing vacuously. `PASSTHROUGH_MARKER` is an allowlisted
+value the encoder must echo — without it an encoder could pass every sentinel
+check by quietly encoding a clean hand-rolled fixture (`FixtureNotUsed`).
+`DRAIN_FORMATS` lists every drain `format` the epic names, so an unbuilt encoder
+is a `NotYetBuilt` **declared gap** — building it without registering a guard
+fails `every_built_drain_format_has_a_registered_encoder`. And the leak message
+is deliberate: *remove the field from the encoding — do not widen the allowlist*.
+A leak here is a privacy incident, not a test failure.
+
+### Which databases this crate owns
+
+| Path | Opened by | Versioning |
+|---|---|---|
+| `.stella/private/store.db` | `Store::open(workspace_root)` | `PRAGMA user_version` + the ordered `MIGRATIONS` list |
+| `~/.stella/usage.db` | `UsageStore::open_default()` | **Convergence**, not migrations — every table in `USAGE_SCHEMA` is `CREATE … IF NOT EXISTS` and the whole batch replays on open |
+| `~/.stella/catalog.db` | `CatalogStore::open_default()` | `CATALOG_SCHEMA` batch on open plus its own `migrate` |
+| The enterprise operational spool | `EnterpriseTelemetrySpool`, at an **already policy-checked path** the caller supplies (`stella-cli` picks `~/.stella/enterprise-telemetry.db`) | Its own `migrate_spool_schema` |
+
+Plus three file-backed stores under `~/.stella/`: `sessions/` (one JSON record
+per session, one writer per file), `sessions/<id>/` (the resume sidecar), and
+`notifications/`. [`home.rs`](src/home.rs) resolves `~/.stella` on every platform
+— no OS data-dir guessing — with `STELLA_HOME` moving the whole home and
+`STELLA_DATA_DIR` / `STELLA_CONFIG_DIR` as narrower overrides.
+
+Flow between the two SQLite tiers is **one-way**: `store.db` → `usage.db` via a
+durable per-project cursor; nothing writes back, and a missing or unopenable hub
+never blocks a turn. Not owned here: `context.db`, `codegraph.db`, and `fleet.db`
+belong to `stella-context`, `stella-graph`, and `stella-fleet` — but they reach
+their files through this crate's `workspace_private_sqlite_path`, so the
+`.stella/private/` hardening applies to them too.
+
+## Gotchas
+
+- Accounting is **fail-closed**: `executions.usage_complete`/`usage_status`
+  (v9/v10) make only an execution finalized via
+  `finish_execution_accounted(.., true)` rollupable — otherwise
+  `Store::execution_rollup` returns `None`, so a turn whose accounting never
+  closed out cannot become an operational event, and v8 → v9 backfills every
+  legacy row to *not* complete. Witnesses: `src/usage_completeness_tests.rs`.
+- The `UNIQUE (execution_id, seq)` / `(execution_id, step)` keys on `events`,
+  `telemetry`, `mcp_usage`, and `tool_calls` are **double-write guards, not
+  dedup**. The writers own monotonic counters, so a collision means one logical
+  record was persisted twice — for `telemetry` that double-counts money. Let it
+  error; do not turn it into an upsert.
+- `tasks` is keyed `UNIQUE(session_id, task_id)` and `session_id` is nullable.
+  SQL NULLs are pairwise distinct, so rows recorded without a session id **never
+  conflict** — the upsert dedup only holds per session.
+- `record_event` reads an event's `type` tag by *deserializing* a one-field
+  struct, never by string-scanning for the first `"type":"` — a scan silently
+  yields the wrong tag if serialization is ever pretty-printed or reordered.
+- Failures in `harden_workspace_dir` are **not** swallowed: if `.stella/` cannot
+  be made 0700, or given a `.gitignore` covering `private/`, `Store::open`
+  refuses to open — such a directory is one commit away from publishing a
+  session's transcripts. That ignore is deliberately not `*`; `settings.json`,
+  `mcp.toml`, `tools/`, and `skills/` are meant to be committable.
+- `acquire_file_lock` never refreshes `acquired_at`, so the age-based
+  `prune_stale_file_locks` sweep eventually sees a long healthy run's own live
+  claims as stale. `release_file_locks_of_dead_holders` is the exact check
+  (holder identities end their owner prefix in the minting pid), and an identity
+  that does not parse is assumed **alive**.
+
+## Testing
+
+```bash
+cargo test -p stella-store
+```
+
+No crate-specific `make` target exists; `make gate` runs `cargo test --workspace`.
+Most tests are `#[cfg(test)]` modules inside `src/` (`src/tests.rs` is the bulk),
+built on `Store::in_memory()` and `tempfile` — no fixtures, flags, or env vars
+needed. The one integration test,
+[`tests/enterprise_telemetry.rs`](tests/enterprise_telemetry.rs), exercises the
+spool's lease/quarantine/clock behaviour against a real file. The content-free
+gate's tests sit inside `src/content_free.rs` and include negative witnesses
+(`harness_catches_a_leaking_encoder`, `harness_catches_an_unreviewed_key`) that
+fail if the harness itself stops catching leaks.
+
+## Extending it
+
+**Add a migration** (any change to `store.db`'s shape):
+
+1. Add the new or changed DDL to [`src/ddl.rs`](src/ddl.rs) at the current shape,
+   wire it into `create_latest_schema` if it is a new table, and add the table
+   name to `TABLES` — that list gates `Store::count` and the fresh-file probe.
+2. Append `migrate_vN_to_vN+1` to `MIGRATIONS` in
+   [`src/migrations.rs`](src/migrations.rs) with a one-line comment saying what it
+   does. `SCHEMA_VERSION` follows automatically. Do not touch earlier entries.
+3. Additive changes are `CREATE TABLE IF NOT EXISTS` / column-guarded
+   `ADD COLUMN`. A constraint or primary-key change is a §7 rebuild (scratch name
+   → `INSERT SELECT` → `DROP` → `RENAME`) and needs a keep-rule for pre-existing
+   duplicates — see `migrate_v0_to_v1`.
+4. If the column reaches `usage.db`'s `telemetry` table, `HUB_TELEMETRY_COLUMNS`
+   in [`src/content_free.rs`](src/content_free.rs) must be edited in the same PR
+   or the build fails. That is the point.
+
+**Add an egress encoder:** implement `ContentFreeEncoder` (id, optional drain
+`format`, `allowed_keys`, and `encode_poisoned_sample` built from the harness
+fixtures), add it to `registered_encoders()`, and flip its `DRAIN_FORMATS` entry
+from `NotYetBuilt` to `Guarded`. `every_registered_encoder_is_content_free` and
+`every_built_drain_format_has_a_registered_encoder` fail until both are done.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions"
+  (invariant #3), "The `.stella/` directory", and the glossary of look-alike
+  identifiers (session vs execution vs run vs task).
+- [`../docs/design/session-telemetry-receipts-spec.md`](../docs/design/session-telemetry-receipts-spec.md)
+  — the spec behind `context_blocks` / `step_manifest` / `step_receipt`.
+- [`../docs/design/enterprise-authority-telemetry.md`](../docs/design/enterprise-authority-telemetry.md)
+  — the enrolled-seat operational rollup this crate spools.
+- [`../stella-protocol`](../stella-protocol) — `AgentEvent`, whose full stream
+  this crate persists.

--- a/stella-store/src/cache_gaps.rs
+++ b/stella-store/src/cache_gaps.rs
@@ -1,5 +1,5 @@
 //! Raw per-call cache-gap facts — [`Store::cache_call_gaps`] — split out of
-//! `lib.rs` to keep that file under its size ratchet.
+//! `lib.rs` to keep that file small.
 //!
 //! Every recorded model call, paired with the gap since its session's
 //! previous call, is the raw material a caller (`stella-cli`'s `stats.rs`,

--- a/stella-store/src/cache_trend.rs
+++ b/stella-store/src/cache_trend.rs
@@ -1,5 +1,5 @@
 //! Per-session cache-economics trend — [`Store::session_cache_trend`] —
-//! split out of `lib.rs` to keep that file under its size ratchet.
+//! split out of `lib.rs` to keep that file small.
 //!
 //! `telemetry` already carries every call's cache read/write tokens keyed by
 //! `execution_id`, and `executions.session_id` already chains a multi-turn

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -90,7 +90,7 @@ use stella_protocol::{AgentEvent, TaskItem, TaskStatus, ToolOutput};
 //   ddl         (crate-private) every table/index DDL at the CURRENT schema
 //   migrations  (crate-private) versioned upgrades + the fresh-file bootstrap
 //   cache_gaps  per-call cache-gap facts behind the `cache_expired_rewrite`
-//               counter (split out to keep this file under its size ratchet)
+//               counter (split out to keep this file small)
 //   cache_trend per-session cache trend — telemetry already persists these
 //               facts; this groups them by session for `stella stats`
 //   catalog     `catalog.db` — user-tier model catalog (slugs, pricing)
@@ -729,7 +729,7 @@ impl Store {
     }
 
     /// `pub(crate)`: [`crate::cache_gaps`] is a separate module (split out to
-    /// keep this file under its size ratchet) whose `impl Store` block needs
+    /// keep this file small) whose `impl Store` block needs
     /// the same connection access every query method here has.
     pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         // A poisoned mutex means a panic mid-write; the connection itself

--- a/stella-tools/README.md
+++ b/stella-tools/README.md
@@ -1,0 +1,213 @@
+# stella-tools
+
+The built-in tool set the agent loop calls. Every tool implements the [`Tool`](src/registry.rs)
+trait, takes model-produced JSON in, and returns a `ToolOutput` — success, or an error whose
+message names the failure. `ToolRegistry` is the crate's public face and the adapter behind
+`stella-core`'s `ToolExecutor` port.
+
+This is the I/O half of the runtime: the complement to `stella-core`'s "no I/O in the engine".
+Process spawning, filesystem access, and network egress belong here — and decision logic that
+needs none of them (what to run, when to compact, whether to retry) does not. Two boundaries run
+the other way. **No tool-specific code lives outside this crate** — the engine only ever sees
+`schemas()` and `execute(name, input)`, so a new tool is never an engine edit. And **no authority
+is ambient**: every tool is workspace-root-pinned, the shell and the web family are off by
+default in every settings scope, and media/issue tools do not register at all without a key or a
+configured backend.
+
+## Where it sits
+
+Depends on `stella-protocol` (`ToolOutput`/`ToolSchema`), `stella-core` (the `ToolExecutor`
+port, the hook bus, the task board, the MCP-usage ledger), `stella-graph` (code graph and the
+storage snapshot), `stella-store`, and `stella-media`. It builds no binary.
+
+`stella-cli` is the real consumer: it constructs the registry, layers custom script tools and
+MCP tools around it, and drives `stella connect`. `stella-tui` and `stella-fleet` depend on the
+crate for exactly one thing — `subprocess_env::scrub_sensitive_env`, so their own spawns share
+the single credential deny-list rather than growing a second one that drifts.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | Module list plus `resolve_within_root` — the one path-confinement primitive every tool resolves through. |
+| [`src/registry.rs`](src/registry.rs), [`src/registry/process_tools.rs`](src/registry/process_tools.rs) | The `Tool` trait, `ToolRegistry`, construction (which tools register under which conditions), and the single `execute` path all cross-cutting behaviour hangs off. `process_tools.rs` is the closed list of child-process-spawning built-ins. |
+| [`src/catalog.rs`](src/catalog.rs) | The canonical tool table. Open it to add a tool or to answer "is this name taken / is it read-only". |
+| [`src/verify.rs`](src/verify.rs) | `verify_done` — the shadow-worktree witness gate. See below. |
+| [`src/read.rs`](src/read.rs), [`src/read_symbol.rs`](src/read_symbol.rs), [`src/write.rs`](src/write.rs), [`src/edit.rs`](src/edit.rs), [`src/apply_edits.rs`](src/apply_edits.rs), [`src/delete.rs`](src/delete.rs) | File CRUD. They share one read-state ledger so an `old_string` miss can be attributed to out-of-band drift rather than to the model. |
+| [`src/atomic_write.rs`](src/atomic_write.rs) | Durable file replacement. Read the header before touching any write path. |
+| [`src/file_touch.rs`](src/file_touch.rs) | The CRUD event model and per-session ledger behind the "Files Touched" panel and its telemetry. |
+| [`src/grep.rs`](src/grep.rs), [`src/glob.rs`](src/glob.rs), [`src/graph.rs`](src/graph.rs), [`src/code_map.rs`](src/code_map.rs) | Text search, file search, code-graph query, and the code-map footer search results carry so the agent's next move is structural. |
+| [`src/overview.rs`](src/overview.rs), [`src/gather.rs`](src/gather.rs), [`src/exploration.rs`](src/exploration.rs), [`src/staleness.rs`](src/staleness.rs) | Orientation and reusable context: `project_overview`, the `gather_context` sweep, saved exploration maps, and the per-file sha256 staleness oracle they all share. |
+| [`src/exec.rs`](src/exec.rs) | The shared subprocess runner: process-group spawn, hard timeout with group kill, output truncation, and the env-scrub constants. |
+| [`src/subprocess_env.rs`](src/subprocess_env.rs) | The credential deny-list applied as the last env mutation before any model- or repo-controlled spawn. Downstream crates use this, never a copy. |
+| [`src/project.rs`](src/project.rs), [`src/scripts.rs`](src/scripts.rs), [`src/diagnostics.rs`](src/diagnostics.rs), [`src/impact.rs`](src/impact.rs) | Build/test/lint/format as thin verbs over the scripts index, structured typecheck output, and the importer-edge blast radius behind `run_tests` `scope: "impacted"`. |
+| [`src/process.rs`](src/process.rs) | The long-running process group (`start_process`/`read_output`/`send_stdin`/`stop_process`) for servers, REPLs, watchers. |
+| [`src/repo.rs`](src/repo.rs), [`src/ci.rs`](src/ci.rs) | Vendor-neutral `repo_*` tools behind the `RepoBackend` port (`GitCli` is the only adapter), and `ci_status` via `gh`. |
+| [`src/bash.rs`](src/bash.rs), [`src/sandbox.rs`](src/sandbox.rs) | The opt-in shell and its opt-in OS confinement (`sandbox-exec` / `bwrap`). |
+| [`src/web.rs`](src/web.rs), [`src/web_extract.rs`](src/web_extract.rs) | The opt-in web family, and the pure HTML/CSS extraction behind it (no I/O in `web_extract.rs`, so it unit-tests without a network). |
+| [`src/issues.rs`](src/issues.rs), [`src/issue_ops.rs`](src/issue_ops.rs), [`src/github_rest.rs`](src/github_rest.rs), [`src/tracker_auth.rs`](src/tracker_auth.rs) | Issue-tracker tools, the backend-dispatching operations shared with the Command Deck, a minimal GitHub REST client, and the `stella connect` OAuth store. |
+| [`src/media.rs`](src/media.rs), [`src/media/`](src/media) | `generate_image`/`generate_video`/`poll_video` over `stella-media`'s port, plus the always-on client-side `generate_svg` and the host-attested process-free authority marker. |
+| [`src/memory.rs`](src/memory.rs), [`src/tasks.rs`](src/tasks.rs), [`src/agent_use.rs`](src/agent_use.rs) | `save_memory`/`cite_memory`, the six `task_*` tools over the session board, and the per-session agent-invocation ledger. |
+| [`src/custom.rs`](src/custom.rs), [`src/validate.rs`](src/validate.rs) | Developer-defined TOML script tools — lenient discovery for a session, strict validation for `stella tools --validate`. |
+| [`src/schema_gate.rs`](src/schema_gate.rs) | The pre-write storage gate that makes duplicate or misplaced schema hard to write. |
+| [`src/hook_runner.rs`](src/hook_runner.rs) | The real-I/O half of the hooks framework (`stella-core` owns matching and blocking). |
+| [`src/screenshot.rs`](src/screenshot.rs) | `screenshot` — capture to `.stella/screenshots/` as visual evidence a judge can demand. |
+
+## Key concepts
+
+**One dispatch path.** `ToolRegistry::execute` ([`src/registry.rs:467`](src/registry.rs)) is the
+only way a tool runs, and everything cross-cutting lives in that one function, in order: the
+`tool.call.requested` blocking hook chain (a `modify` decision replaces the input, and every
+later stage must see the replacement); file-op classification, which happens *before* execution
+because create-vs-update depends on whether the file exists now, not after; the storage schema
+gate; the per-side-effect hook chains; execution; observer events; then the ledger drains and
+the exploration-coverage hint. New cross-cutting behaviour belongs here, not sprinkled into
+tools.
+
+**The catalog is the single declaration point.** [`src/catalog.rs`](src/catalog.rs) declares
+every dispatchable name once, with its `read_only` flag and what must be true for it to
+register. Everything else derives from it: the registry's expected-name pins, the read-only
+partition, `custom::RESERVED_NAMES` (aliased straight to `ALL_NAMES`, so a custom manifest
+cannot shadow a built-in), and the counts and access markers in the published docs. It exists
+because those used to be hand-maintained integers in six places: parallel PRs each bumped the
+same number off the same base and squash-merged to a plausible-but-wrong count with no
+conflict. The `read_only` flag is load-bearing, not documentation — `stella-core`'s speculation
+gate forwards exactly the read-only set and drops everything after the first mutating call, and
+`ReadOnlyTools` uses it to give a judge evidence-gathering power without write authority.
+
+**Root pinning.** `resolve_within_root` ([`src/lib.rs:81`](src/lib.rs)) is the only confinement
+check. It canonicalises the root and then normalises the join, because `Path::starts_with` is a
+*lexical* comparison that never resolves `..`. The existence walk uses `symlink_metadata`
+(lstat), not `exists()`: `exists()` follows symlinks and so reports `false` for a *dangling*
+link, which let the old code hand back `root/link` as a brand-new in-root file — the OS then
+followed the link on write and escaped the workspace. All four cases have witness tests at the
+bottom of `lib.rs`.
+
+**`verify_done` — the definition of done, as a tool.** A change is done when a witness test
+fails on the previous code and passes on the new code. Either half alone is worthless: a test
+that also passed before witnesses nothing. `verify_done` runs both halves and refuses anything
+else — `NOT DONE` when the new code fails, `VACUOUS TEST` when the old code passes.
+
+The half that needs care is producing "the previous version" without touching your tree. There
+is no stash and no checkout. Instead a **detached shadow git worktree** is created at `HEAD` in
+the temp dir, *only* the named test files are copied into it, the test command runs there, and
+the worktree is removed on every exit path. Three details are the difference between a correct
+verdict and a destroyed working tree:
+
+1. **Destinations come from the canonical root-relative path, never the model-supplied string.**
+   An absolute `test_files` entry would make `shadow.join(file)` discard the shadow prefix and
+   resolve straight back to the real file — and `fs::copy(src, src)` truncates it, silently
+   emptying the user's test file while violating the tool's central contract.
+2. **The shadow mirrors the git toplevel, not the workspace root.** Destinations are relative to
+   `git rev-parse --show-toplevel` and the shadow run's cwd is the corresponding subdirectory,
+   so a relative `test_cmd` resolves the same package it would in the real tree. Assuming
+   root == toplevel produced false `WITNESS CONFIRMED` and false `VACUOUS` verdicts whenever
+   `verify_done` ran from a repo subdirectory.
+3. **Shadow paths carry pid plus a process-wide counter**, because a timestamp alone can collide
+   when two `verify_done` calls run concurrently.
+
+Every `git` invocation goes through `git_in`, which strips the repo-targeting env vars and
+scrubs credentials, so a surrounding git hook cannot redirect it at the outer repository. The
+verdict always includes the previous-code output tail: a *compile* error is a much weaker
+witness than an assertion failure, and the reader — model or judge — is told to check which it
+got.
+
+## Gotchas
+
+- **`schemas()` is sorted by name deliberately.** The list is serialized verbatim at position 0
+  of the prompt prefix and `HashMap` iteration order is per-process randomized. Prompt caching
+  is a byte-level prefix match, so an unsorted list means every process writes a divergent cache
+  entry.
+- **`bash` is off by default in every scope** — user, org-managed, and project. It registers only
+  when settings say `tools.bash: "on"`; the default surface has no shell at all. The `web` family
+  has the same posture, because a fetched page is untrusted input *and* an uncontrolled egress
+  channel. Prefer the structured executors (`run_tests`, `run_script`, `repo_*`, the process
+  group), which spawn enumerable argv and never interpret a shell string.
+- **Don't reintroduce `tokio::fs::write` on a write path.** It opens with `O_TRUNC`, and a crash
+  in that window left the user's own source file empty. `atomic_write` picks its strategy per
+  target and deliberately rewrites in place for hard-linked or foreign-owned files, because
+  rename-over-target swaps the inode and would sever links or change the owner.
+- **Three env hygiene rules before any spawn**, all in [`src/exec.rs`](src/exec.rs) and
+  [`src/subprocess_env.rs`](src/subprocess_env.rs). Scrub `GIT_REPO_ENV_VARS`: when Stella runs
+  from inside a git hook (the pre-push gate), an inherited `GIT_DIR` aims every git call at the
+  *outer* repo, so a scratch `git init` re-inits the host repository — the `verify.rs` tests
+  scrub them for exactly this reason. Scrub `FORCED_COLOR_ENV_VARS`: everything here writes to a
+  captured pipe, so an inherited `CLICOLOR_FORCE=1` wraps `gh --json` in ANSI escapes and every
+  parse dies at column 1. And apply `scrub_sensitive_env` as the *final* env mutation on anything
+  that can run model- or repository-controlled code — a second credential list elsewhere drifts.
+- **No lock guard may cross an `.await`.** `execute` clones the `Arc<dyn Tool>` out of the
+  overlay before awaiting, and the storage-snapshot load awaits *before* the overlay merge takes
+  the `std` mutex — otherwise the future stops being `Send`.
+- **The opt-in `bash` tool does not go through `exec::run`.** It spawns its own child so the
+  sandbox wrapper can replace the program; a change to the shared runner will not reach it.
+- **`timeout_secs` is clamped.** `exec::timeout_from` treats 0 as "default" and caps at 600s, so
+  a model-supplied `u64::MAX` cannot disable a tool's own hang backstop.
+- **Process-free isolation omits a whole class, not a path.** When the host attests
+  `HostDataIsolation::ProcessFree`, every built-in that launches a child process is skipped
+  wholesale: all of `process_tools::builtins` (including `verify_done` and the `repo_*` tools),
+  plus `grep`, `glob`, `gather_context`, the exploration tools, and the issue backend probe. It is
+  not a filesystem sandbox and must never be inferred from path checks.
+
+## Testing
+
+```bash
+make test-tools          # or: cargo test -p stella-tools
+```
+
+Most coverage is inline `#[cfg(test)]` modules next to the code; `registry.rs` alone carries the
+hook-chain, schema-gate, and file-touch-ledger suites. Registry tests construct through
+`ToolRegistry::with_issue_backend` so tool counts depend on neither the host's `gh` auth nor its
+provider env keys nor any opt-in. Four integration suites live in [`tests/`](tests):
+`web_integration.rs` and `tracker_integration.rs` drive the full HTTP surface against `wiremock`
+(the OAuth "browser" round-trip is simulated by GETting the loopback redirect),
+`media_replay.rs` exercises the media authority rules against an in-test `MediaProvider`, and
+`docs_in_sync.rs` derives every expectation from `catalog.rs`. That last one skips when the
+`website/` tree is absent (a vendored copy of this crate ships without its siblings) but still
+fails on a missing file *inside* a present tree — renaming `index.mdx` must not silently disable
+the gate.
+
+## Extending it
+
+Adding a built-in tool:
+
+1. Add a module under `src/` with a `//!` header saying what the tool is *for* and why it exists.
+   Study a sibling of similar shape first.
+2. Implement `Tool`: `schema()` (name, model-facing description, JSON Schema, honest `read_only`)
+   and `execute(input, root)`. Resolve every path through `resolve_within_root`. Return
+   `ToolOutput::Error` with a message that names the failure — never panic on model input.
+3. Register it in `ToolRegistry::with_backends_and_options` ([`src/registry.rs`](src/registry.rs))
+   — or in [`src/registry/process_tools.rs`](src/registry/process_tools.rs) if it spawns a child
+   process, delegates to another agent, or reaches a process-backed adapter, since that list is
+   what a process-free registry omits wholesale.
+4. Add exactly one line to the `catalog!` invocation in [`src/catalog.rs`](src/catalog.rs), inside
+   the contiguous block for its `Availability`. Nothing else needs a count bumped.
+5. Document it in [`../website/content/docs/agent-tools/index.mdx`](../website/content/docs/agent-tools/index.mdx)
+   with the matching Read-only/Mutating marker.
+6. Write the witness test.
+
+Until steps 4 and 5 are done these fail, by name rather than by an off-by-one:
+`registry_advertises_exactly_the_catalog_tool_set`, `an_undeclared_tool_fails_the_catalog_pin_by_name`,
+`read_only_flags_partition_the_registry_correctly`, and
+`every_registry_tool_is_reserved_against_custom_shadowing` in `registry.rs`, plus
+`every_catalog_tool_is_documented_and_vice_versa` and `documented_access_markers_match_the_catalog`
+in `tests/docs_in_sync.rs`.
+
+A tool that needs no Rust at all is a **custom script tool** — a TOML manifest next to a script
+under `.stella/tools/` or `~/.stella/tools/`, discovered at startup with no registry edit. See
+[`src/custom.rs`](src/custom.rs) and
+[`../website/content/docs/agent-tools/custom-tools.mdx`](../website/content/docs/agent-tools/custom-tools.mdx).
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Architecture: ports, not concretions" (ports and the no-I/O
+  rule) and "The definition of done: witness tests" (the contract `verify_done` automates).
+- [`../stella-core/src/ports.rs`](../stella-core/src/ports.rs) — the `ToolExecutor` port this
+  crate implements, and the `ReadOnlyTools` view built from `read_only`.
+- Specs for the subsystems above: [`scripts-index.md`](../docs/design/scripts-index.md) (verb
+  detection), [`exploration-sharing.md`](../docs/design/exploration-sharing.md) (saved maps, the
+  staleness oracle, coverage hints), [`storage-map.md`](../docs/design/storage-map.md) (§8 is the
+  pre-write schema gate).
+- [`../website/content/docs/agent-tools/index.mdx`](../website/content/docs/agent-tools/index.mdx),
+  [`hooks.mdx`](../website/content/docs/agent-tools/hooks.mdx),
+  [`permissions.mdx`](../website/content/docs/agent-tools/permissions.mdx) — the user-facing tool
+  reference, the hook events the registry emits, and the permission model.

--- a/stella-tui/README.md
+++ b/stella-tui/README.md
@@ -1,0 +1,207 @@
+# stella-tui
+
+The `ratatui` terminal UI: the single-session event-log REPL and the multi-tab
+**Command Deck** it grew into — the default interactive surface when `stella`
+runs on a TTY. 47 source files, ~36k lines.
+
+The hard boundary is **no engine access**. This crate never calls a model, a
+tool, or the store. `AgentEvent`s (single session) or `Inbound` envelopes
+(deck) arrive over a channel; `UserInput` / `WorkspaceInput` flow back out.
+Everything drawn is derived from that inbound stream, with a small set of
+*labeled* exceptions listed in [`src/deck.rs`](src/deck.rs)'s module header.
+It also does not depend on `stella-graph`: the caller queries its own
+`CodeGraph` and hands the deck a plain [`GraphSnapshot`](src/graph.rs).
+
+## Where it sits
+
+Depends on `stella-protocol` (the `AgentEvent` / `Attachment` types it folds)
+and `stella-tools` for exactly one thing — `subprocess_env::scrub_sensitive_env`
+when running a `!` command ([`src/deck_shell.rs:208`](src/deck_shell.rs)).
+Third-party: `ratatui` + `crossterm`, `tachyonfx` (motion), `tui-big-text`
+(the splash wordmark), `sysinfo` (CPU/MEM), `arboard` + `png` (clipboard
+images). `stella-cli` is the only workspace crate that depends on it — it owns
+the driver side (`stella-cli/src/command_deck.rs`, `src/tui.rs`). This crate
+builds no binary; the runnable surface is `examples/deck_demo.rs`. The driver
+and the TUI communicate over two channels and never call each other directly.
+
+## Layout
+
+| File | What it holds |
+|---|---|
+| [`src/lib.rs`](src/lib.rs) | The authoritative design statement (pure core + thin shell) and the whole public re-export surface. Read it first. |
+| [`src/model.rs`](src/model.rs) | `SessionModel` — one agent's fold. `apply` (line 319) is the *only* mutator; `replay` (line 645) rebuilds it from a log. |
+| [`src/ui.rs`](src/ui.rs) | `UiState` (scroll, composer, focus — everything *not* derived from events) and the pure `handle_key` / `ingest`. |
+| [`src/render.rs`](src/render.rs) | `render(model, ui, frame)` for the single-session REPL, plus `guarded_panel` — the panel panic boundary. |
+| [`src/shell.rs`](src/shell.rs) | `run(...)`: terminal setup, crossterm loop, two channels, `RunOptions`, `DebugLog`. No decision logic. |
+| [`src/term.rs`](src/term.rs) | `TerminalGuard` + `PanicHookGuard`. Open this before touching anything about raw mode or panics. |
+| [`src/deck.rs`](src/deck.rs) | `WorkspaceModel` — N `SessionModel`s plus cross-agent read-models (file ledger, route log, prompt queue, unified trace). |
+| [`src/deck_ui.rs`](src/deck_ui.rs) | `DeckUi` and `handle_deck_key` — every deck keybinding, and the documented Esc precedence list (line 1222). The largest file here. |
+| [`src/deck_render.rs`](src/deck_render.rs) | `render_deck`: tab bar · active view · trace strip · progress bar · composer · footer · statline. |
+| [`src/deck_shell.rs`](src/deck_shell.rs) | `run_deck(...)`: the deck's `select!` loop, plus a third arm — a 33 ms tick that advances the clock and samples resources. |
+| [`src/envelope.rs`](src/envelope.rs) | The multi-agent wire types: `Inbound` in, `WorkspaceInput` out, and every out-of-band snapshot the driver pushes. |
+| [`src/composer.rs`](src/composer.rs) | The input model: textarea semantics, `classify_enter`, paste chips, and the slash popup shared by both surfaces. |
+| [`src/views/*.rs`](src/views) | One module per deck tab (session · agents · installed · traces · graph · files · skills · mcp · issues · settings), each exposing `render(model, ui, area, buf)`. `engine` is the exception: the config editor SETTINGS hosts, with its own `render_panel` and key handler. |
+| [`src/diff.rs`](src/diff.rs), [`src/syntax.rs`](src/syntax.rs), [`src/markdown.rs`](src/markdown.rs), [`src/textline.rs`](src/textline.rs) | Shared text presentation — one implementation each of "how a diff looks", source coloring, markdown, and the event→wording table (also consumed by `stella-cli`'s plain renderer). |
+| [`src/theme.rs`](src/theme.rs), [`src/palette.rs`](src/palette.rs) | Every color and glyph. `palette.rs` is **generated** from `docs/brand/tokens.json`; `theme.rs` is the only module allowed to reference it. |
+| [`src/progress.rs`](src/progress.rs), [`src/cache_panel.rs`](src/cache_panel.rs), [`src/splash.rs`](src/splash.rs), [`src/invaders.rs`](src/invaders.rs), [`src/fx.rs`](src/fx.rs) | Chrome widgets: the run progress bar, the statline's cache cells, the launch cinematic and its battle scene, and the shared `tachyonfx` constructors. |
+| [`src/scroll.rs`](src/scroll.rs), [`src/input.rs`](src/input.rs), [`src/graph.rs`](src/graph.rs), [`src/resource.rs`](src/resource.rs), [`src/attach.rs`](src/attach.rs), [`src/clipboard.rs`](src/clipboard.rs) | Small leaf modules: line-exact viewport math, the outbound message enum, the graph snapshot types, CPU/MEM sampling, pasted-path detection, `⌃V` clipboard capture. |
+| [`src/fleet_dashboard.rs`](src/fleet_dashboard.rs) | A separate full-screen surface for `stella fleet` — its own fold (`FleetMsg`), its own `run`, monotonic `Instant` clocks only. |
+| [`src/scenario.rs`](src/scenario.rs) | A deterministic scripted multi-agent scenario, driving both `examples/deck_demo.rs` and the snapshot test. |
+
+## Key concepts
+
+**"Pure fold" is a code-level split, not a slogan.** Verify it in three places:
+`SessionModel` has exactly one mutator, `apply` ([`src/model.rs:319`](src/model.rs)),
+and `replay` ([`src/model.rs:645`](src/model.rs)) is just `apply` in a loop.
+`render` ([`src/render.rs:46`](src/render.rs)) takes `&SessionModel` — the model
+is immutable during a draw; the `&mut UiState` exists solely so panels can
+record their viewport heights for the next keypress's scroll clamp. And
+`handle_key` ([`src/ui.rs:245`](src/ui.rs)) returns a `ShellAction` rather than
+performing anything. So every question a contributor has — "what does this key
+do", "what does the screen show after these events" — is answerable by calling
+a function with no terminal, no engine, and no tokio runtime.
+
+**Why that matters here.** AGENTS.md's [witness-test contract](../AGENTS.md)
+names TUI rendering as the case where a witness is "genuinely impractical" —
+you cannot assert on a real terminal. The fold/render split is how this crate
+gets one anyway: fold synthetic events into a model, render into a
+`ratatui::backend::TestBackend`, and assert on the flattened **cell buffer**,
+never on ANSI bytes. [`tests/progress_gold.rs`](tests/progress_gold.rs) is the
+shape to copy — its header states the goal, why it failed before the change,
+and what it asserts after. The determinism this rests on is itself
+property-tested: `replaying_a_log_renders_identical_buffers`
+([`src/render/tests.rs:1160`](src/render/tests.rs)) folds one event vector into
+two fresh models and asserts byte-identical backing buffers.
+
+**Two shells, one design.** [`shell::run`](src/shell.rs) drives one agent;
+[`deck_shell::run_deck`](src/deck_shell.rs) drives N. Both are near-logic-free
+`select!` loops over (inbound events, key events); the deck adds a third arm, a
+33 ms tick, because gauges and elapsed timers must repaint on a clock rather
+than only when the model streams. Anything you are tempted to write inside
+either loop belongs in `ui.rs` / `deck_ui.rs` instead.
+
+**Keys are a precedence chain, not a match arm.** `handle_deck_key`
+([`src/deck_ui.rs:1251`](src/deck_ui.rs)) runs modal contexts first (splash,
+help, installed-agent editors, issues forms, queue editor, graph picker, engine
+panel, overlays), then tab navigation, then focused-agent gates, then composer
+editing, then per-tab keys, then Esc. Two rules hold throughout: bare-letter
+hotkeys (`s`/`p`/`r` on AGENTS, `?` for help) only fire from an **empty
+composer**, so they never eat a keystroke meant for a prompt; and the composer
+never claims Esc, so a typed draft survives an interrupt.
+
+**Slash commands are an input, not a hard-coded set.** The vocabulary arrives
+as `RunOptions::slash_commands` / `DeckOptions::slash_commands`, so the CLI owns
+it; `SlashKind` only distinguishes built-in from user-authored rows by glyph.
+`handle_slash_key`
+([`src/deck_ui.rs:1634`](src/deck_ui.rs)) intercepts only the deck-local ones —
+`/files`, `/diff`, `/graph`, `/agents`, `/skills`, `/mcp`, `/mcp-search`,
+`/settings`, `/sessions`, `/context`, `/inspect`, `/inbox` — because they change
+view state the driver has no say over. Everything else, `/help` included, is
+enqueued as a prompt so the answer lands in the transcript.
+
+**Terminal restoration survives panics in raw mode** — read
+[`src/term.rs`](src/term.rs) before changing any of it. `TerminalGuard` is
+constructed *before* the first state is acquired and flags each one (raw, alt
+screen, bracketed paste, mouse, kitty) as it lands, so a failure partway through
+`enter` still rolls back exactly what was entered. Release builds set
+`panic = "abort"`, where destructors never run, so `PanicHookGuard::install`
+([`src/term.rs:194`](src/term.rs)) additionally restores from inside the panic
+hook — but **only** under `cfg!(panic = "abort")`, then delegating to the
+previous hook so the panic message prints on the real screen, not the alternate
+one. In unwind builds the hook deliberately does *not* restore: it fires for
+every panic on every thread, including panel panics the session survives.
+
+## Gotchas
+
+- `guarded_panel` is **single-session only**. Every `guarded_panel` call site is
+  in [`src/render.rs`](src/render.rs) (hud, transcript, files, diff,
+  scope-review, ask-user, composer, slash-menu). `render_deck` calls its view
+  modules directly, so a panic inside a deck tab is not caught and rendered as
+  an error card — it takes the process down. Do not assume the boundary covers
+  a new tab you add.
+- `deck_ui.rs`'s module header still says "Tab hotkeys (`1`–`5`)". The code
+  disagrees, on purpose: digits never switch tabs (they quick-pick `ask_user`
+  answers and must be typeable as a prompt's first character). Tab / Shift-Tab
+  are the only tab navigation ([`src/deck_ui.rs:1418`](src/deck_ui.rs)).
+- Mouse capture is off by default in both `RunOptions` and `DeckOptions` so
+  native terminal selection and copy keep working. The deck's event loop
+  discards mouse events entirely today — turning the flag on currently costs
+  selection and buys nothing.
+- Bracketed paste is always enabled. Without it a multi-line paste arrives as
+  raw key events and every newline acts as Enter, turning one paste into N
+  submissions ([`src/term.rs:101`](src/term.rs)).
+- `⌃G`, not `⌃I`, opens the INSPECT overlay: without the kitty keyboard
+  protocol (pushed only best-effort) `⌃I` is byte-identical to Tab, which is
+  bound to tab switching. The collision would be silent and terminal-dependent.
+- Animations are *scrubbed*, not stateful: `splash` / `fx` / `invaders` rebuild
+  a fresh seeded effect each frame and process it once with the total elapsed
+  time. That only stays deterministic because randomized effects pin their RNG
+  to `FX_SEED` — a new randomized effect that skips it breaks frame stability.
+- Do not add a color literal to a view. `theme.rs` is the only module that may
+  read `palette.rs`, and `palette.rs` is generated — edit `docs/brand/tokens.json`.
+- Anything you put on `WorkspaceModel` that is not folded from `Inbound` erodes
+  the purity boundary. The current exceptions are enumerated by name in
+  [`src/deck.rs`](src/deck.rs)'s header; extend that list deliberately or not
+  at all.
+
+## Testing
+
+```bash
+cargo test -p stella-tui                       # no make target exists for this crate
+cargo test -p stella-tui -- --ignored          # the TTY smoke test, on a real terminal
+cargo run -p stella-tui --example deck_demo    # interactive scripted deck
+```
+
+Unit tests live in `#[cfg(test)]` modules inside the source files (37 of the 47
+have one); four modules grew large enough to split theirs into a sibling
+`tests.rs` submodule (`src/render/`, `src/deck/`, `src/deck_render/`,
+`src/fleet_dashboard/`).
+Two integration tests sit in [`tests/`](tests): `deck_snapshot.rs` renders every
+tab through the real `render_deck` and writes a human-readable text "screenshot"
+to `CARGO_TARGET_TMPDIR` (deliberately outside the source tree, so a test run
+never dirties the working tree), and `progress_gold.rs` is a single-assertion
+witness. `proptest` covers the two determinism-critical modules,
+`src/scroll.rs` and `src/render/`. No fixtures, env vars, or feature flags are
+needed. The one uncovered path is `shell::run` itself: its smoke test is
+`#[ignore]`d because it needs a real TTY.
+
+## Extending it
+
+Adding a deck tab:
+
+1. Add the variant to `DeckTab` **and** to `DeckTab::ALL` in
+   [`src/deck.rs`](src/deck.rs). `ALL` is a fixed-length array driving `index`
+   / `next` / `prev`, so forgetting it silently drops the tab from Tab-cycling;
+   the exhaustive `title()` match is what the compiler catches. Labels are
+   UPPERCASE by convention.
+2. Write `src/views/<tab>.rs` exposing
+   `render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer)`,
+   pulling every color from `theme` and recording viewport metrics onto
+   `ui.metrics`. Register it in [`src/views/mod.rs`](src/views/mod.rs).
+3. Add the match arm in `render_deck` ([`src/deck_render.rs`](src/deck_render.rs)).
+4. Add a `handle_<tab>_key` in [`src/deck_ui.rs`](src/deck_ui.rs) and wire it
+   into the per-tab dispatch, taking `composer_empty` and honoring the
+   empty-composer rule for bare-letter hotkeys.
+5. `deck_renders_every_tab_with_real_content` in
+   [`tests/deck_snapshot.rs`](tests/deck_snapshot.rs) iterates the tabs — extend
+   it with the content your tab must show.
+
+Adding an event the deck reacts to: add the variant to `Inbound`
+([`src/envelope.rs`](src/envelope.rs)), fold it in
+`WorkspaceModel::apply_inbound` (or, if it is a driver-pushed snapshot rather
+than a fold, handle it in `ingest_inbound` and add it to the `deck.rs`
+exceptions list), then cover it in `src/deck/tests.rs`.
+
+## See also
+
+- [`../AGENTS.md`](../AGENTS.md) — "Workspace layout" for the routing rule, and
+  "The definition of done: witness tests" for why this crate is named as the
+  hard case.
+- [`../stella-protocol`](../stella-protocol) — `AgentEvent`, the type every fold
+  in here consumes.
+- [`../stella-cli`](../stella-cli) — the driver: `src/command_deck.rs` and
+  `src/tui.rs` own the slash vocabulary, the on-disk snapshots, and dispatch.
+- [`../website/content/docs/agent-modes.mdx`](../website/content/docs/agent-modes.mdx)
+  — the Command Deck from a user's point of view.
+- [`../website/content/docs/agent-tools/commands.mdx`](../website/content/docs/agent-tools/commands.mdx)
+  — how a user extends the slash menu this crate renders.

--- a/stella-tui/README.md
+++ b/stella-tui/README.md
@@ -119,10 +119,11 @@ every panic on every thread, including panel panics the session survives.
   modules directly, so a panic inside a deck tab is not caught and rendered as
   an error card — it takes the process down. Do not assume the boundary covers
   a new tab you add.
-- `deck_ui.rs`'s module header still says "Tab hotkeys (`1`–`5`)". The code
-  disagrees, on purpose: digits never switch tabs (they quick-pick `ask_user`
-  answers and must be typeable as a prompt's first character). Tab / Shift-Tab
-  are the only tab navigation ([`src/deck_ui.rs:1418`](src/deck_ui.rs)).
+- **Digits never switch tabs, deliberately.** They quick-pick `ask_user`
+  answers and must stay typeable as a prompt's first character, so `Tab` /
+  `Shift-Tab` are the only tab navigation
+  ([`src/deck_ui.rs:1418`](src/deck_ui.rs)). Adding a digit hotkey would eat a
+  keystroke meant for the composer.
 - Mouse capture is off by default in both `RunOptions` and `DeckOptions` so
   native terminal selection and copy keep working. The deck's event loop
   discards mouse events entirely today — turning the flag on currently costs

--- a/stella-tui/src/cache_panel.rs
+++ b/stella-tui/src/cache_panel.rs
@@ -6,7 +6,7 @@
 //! the pricing-aware CLI producer (see [`crate::envelope::Inbound::CacheInsight`])
 //! and was folded into each [`AgentEntry`]; this module reads those folded
 //! aggregates and turns them into the compact strings the deck renders. Kept
-//! out of `deck.rs` to keep that file under its size ratchet, and out of
+//! out of `deck.rs` to keep that file small, and out of
 //! `deck_render.rs` so the formatting is unit-testable without a full frame.
 
 use ratatui::style::Style;
@@ -126,7 +126,7 @@ pub fn fmt_warmth(remaining_secs: Option<u64>) -> String {
 // ── Statline cell span builders ─────────────────────────────────────────────
 //
 // Each returns the `Span`s for one statline cell, so `deck_render` stays thin
-// (and under its size ratchet) and the styling lives next to the formatting it
+// (and small) and the styling lives next to the formatting it
 // dresses. Colors come from [`crate::theme`], matching the surrounding cells.
 
 /// CACHE cell: hit% then the compact read/write token volumes behind it, or the
@@ -285,7 +285,7 @@ mod tests {
     // Complete states — the deck's snapshot-test idiom (assert on a rendered
     // `Buffer`'s flattened text, same pattern as `deck_render`'s own statline
     // tests). Kept here rather than in `deck_render.rs`'s test module purely
-    // to stay under that file's size ratchet; `render_status_bar` is
+    // to keep that file small; `render_status_bar` is
     // `pub(crate)` for exactly this reason.
 
     use ratatui::buffer::Buffer;

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -18,10 +18,12 @@
 //! the focused agent has a pending gate (scope review / ask-user), in which
 //! case the chord/the gate keys answer it. (On legacy terminals that can't
 //! report a modified Enter, plain `⏎` submits and `⌥⏎` is the line break —
-//! see [`crate::composer::classify_enter`].) Tab hotkeys (`1`–`5`) and agent
-//! controls (`p`/`s`/`r`) only fire when the composer is empty, so they never
-//! eat a keystroke meant for a prompt (the same "quick-pick only when nothing
-//! typed" gate `crate::ui` already uses).
+//! see [`crate::composer::classify_enter`].) Tabs are navigated with `Tab` /
+//! `Shift-Tab` only — digits deliberately never switch tabs, because they
+//! quick-pick `ask_user` answers and must stay typeable as a prompt's first
+//! character. Agent controls (`p`/`s`/`r`) only fire when the composer is
+//! empty, so they never eat a keystroke meant for a prompt (the same
+//! "quick-pick only when nothing typed" gate `crate::ui` already uses).
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! `stella-tui` — the ratatui event-log REPL (ADR-023).
+//! `stella-tui` — the ratatui event-log REPL.
 //!
 //! This crate renders **exclusively** from [`stella_protocol::AgentEvent`]s
 //! (L-T1). It never touches the engine directly: `AgentEvent`s flow in over a


### PR DESCRIPTION
## What

Adds a `README.md` to every crate: all fifteen `stella-*` crates plus
`bench/loop-bench`. 3,177 lines across 16 files.

Contributors landing in a crate directory — from a stack trace, a `git blame`,
or a GitHub file link — had no crate-level orientation. The only guidance was
the 703-line root README and the 415-line AGENTS.md, neither of which says
which file to open inside a crate or what will bite you there.

Each README follows the same seven sections, so they're skimmable once you've
read one:

**Where it sits** · **Layout** (file-by-file table) · **Key concepts** ·
**Gotchas** · **Testing** · **Extending it** · **See also**

Each was written against the crate's own source and `//!` module docs rather
than paraphrased from the root docs, and deliberately links to AGENTS.md for
workspace-wide rules instead of duplicating them.

## Also in this PR

- Links every crate name in the root README and AGENTS.md workspace-layout
  tables to its new README (31 table rows).
- Corrects the `stella-graph` row in the root README: the indexer wires ten
  `Language` variants over nine grammars — adding Go, Java, C, PHP, and TSX —
  not the five it claimed (`Rust/TS/JS/Python/SQL`).

## Part 2 — removing claims that are no longer true

Writing the READMEs surfaced twelve places where docs, module headers, and
design docs assert things the code does not do. **These are now fixed in this
PR** (second commit), each verified against the source first. Tracked as #667.

Closes #667

| Where | Claim | Reality |
|---|---|---|
| `AGENTS.md` (testing) | compaction has property tests | `proptest!` blocks exist only in `retry.rs`, `loop_detect.rs`, `tasks.rs`, `skills.rs`; compaction's are plain unit tests |
| module docs, several crates | a "file-size ratchet" gates CI | no such script in `scripts/` or `.github/workflows/`, and not in `make gate` |
| `stella-fleet/src/ledger.rs` header | `fleet.db` "carries no version stamp" | `SCHEMA_VERSION`, `migrate`, `PRAGMA user_version`, `MIGRATION_V1`/`V2` all exist |
| `stella-media/src/jobs.rs`, `src/lib.rs` | `stella gen image\|video --resume` | no such subcommand in `stella-cli`; resume is via `jobs::resume` / the `poll_video` tool |
| `docs/design/serve-surface.md` | `Host`-header/DNS-rebinding guard, graceful SIGTERM drain | neither is in `stella-serve/src/` — the doc is ahead of the code |
| `stella-tui/src/deck_ui.rs` header | `1`–`5` tab hotkeys | contradicted by the code at `deck_ui.rs:1418` |
| `stella-tui/src/lib.rs` | references ADR-023 | `docs/adr/` stops at 0009 |
| `stella-graph/Cargo.toml` description | links to `stella-context` | no Cargo dependency backs it |
| `bench/loop-bench` module doc | "the CI job that gates on this" | nothing in `.github/workflows/` references loop-bench |

One item is potentially a real bug rather than doc drift: in `stella-tui`,
`guarded_panel` is used only in `render.rs`, so a panic inside a deck **tab**
is not caught. Worth a look independently of this PR.

## Verification

Docs only — no Rust source touched, so no witness test (per the CONTRIBUTING
carve-out for docs changes).

- Custom link checker over all **622 relative links** in the new READMEs, plus
  39 in the edited root docs → **0 broken**. Negative-tested: injecting one bad
  link makes it report the break, so the pass is meaningful.
- `make gate` → **green** (no-scratch + doc-citations + fmt `--check` + clippy
  `-D warnings` + `cargo test --workspace`)
- Every added Rust line is a comment; the only non-comment edit is a
  `Cargo.toml` description string.
- Section structure verified identical across all 15 crate READMEs.


### A flaky test hit on the way (pre-existing, not from this PR)

The first `make gate` run failed in `stella-tools`:
`media::tests::poll_success_persists_the_video_and_forgets_the_job` and
`priced_and_unpriced_media_share_gate_then_provider_order`, both with
`operation key is already claimed with a conflicting media identity or expiry`.
They pass single-threaded and passed 3/3 on re-run; the gate is green.

Root cause, for whoever picks it up: the journal treats `expires_at` as part of
the operation identity **on purpose**
(`stella-media/src/operation_journal.rs:290`), but the test-only
`FixedOperationIds` fixture (`stella-tools/src/media.rs:580`) mints
`expires_at: unix_now + 3600` fresh on *every* call. When a test claims an
operation and then replays it, any run slow enough to cross a one-second
boundary presents a different expiry and is correctly rejected. It's the
fixture that's wrong, not the product code — the fixture should capture the
expiry once and return the same value.
