### PR TITLE
witness: keep the authored witness out of the user's tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,10 @@ The staged pipeline enforces the same contract at runtime: when no
 `--test-command` is configured, its **witness stage** has an independent model
 (the judge's resolution, never the worker) author the failing witness test up
 front, tracks its fail→pass flip in the flip oracle, and refuses to credit the
-flip if the worker modified the witness files (tamper exclusion). See
+flip if the worker modified the witness files (tamper exclusion). The witness
+is **scaffolding for that one run**: it lives in the candidate workspace and is
+discarded with it, so an already-satisfied test is never left behind in the
+project's test tree. `stella run --keep-witness` promotes it instead. See
 `website/content/docs/inference-pipeline.mdx` for the full stage flow, the distress-triggered guidance
 loop, and the `/pipeline` deck toggle.
 

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -98,7 +98,9 @@ fn skill_registry_for_run(workspace_root: std::path::PathBuf) -> Option<SkillReg
 /// default) vs the raw step-loop (`--no-pipeline`). `test_command`, when
 /// given, arms the pipeline's deterministic verification ladder (the
 /// fail→pass flip oracle); without it, verification falls back to the model
-/// judge on every iteration.
+/// judge on every iteration. `keep_witness` promotes an authored witness into
+/// the working tree instead of letting it die with the candidate workspace.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_one_shot(
     cfg: &Config,
     prompt: &str,
@@ -106,13 +108,22 @@ pub async fn run_one_shot(
     format: OutputFormat,
     use_pipeline: bool,
     test_command: Option<&str>,
+    keep_witness: bool,
 ) -> Result<(), String> {
     // A benchmark's durable sink is part of the accounting boundary. Prove the exact mounted file
     // is writable before provider construction or any code path that can make a paid call.
     preflight_durable_stream(format)?;
     crate::enterprise_telemetry::authorize_one_shot(use_pipeline)?;
     if use_pipeline {
-        run_pipeline_one_shot(cfg, prompt, budget_limit, format, test_command).await
+        run_pipeline_one_shot(
+            cfg,
+            prompt,
+            budget_limit,
+            format,
+            test_command,
+            keep_witness,
+        )
+        .await
     } else {
         run_raw_one_shot(cfg, prompt, budget_limit, format).await
     }
@@ -164,6 +175,7 @@ async fn run_pipeline_one_shot(
     budget_limit: Option<f64>,
     format: OutputFormat,
     test_command: Option<&str>,
+    keep_witness: bool,
 ) -> Result<(), String> {
     let provider = build_provider(cfg)?;
     let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
@@ -311,6 +323,10 @@ async fn run_pipeline_one_shot(
             &wiring.worker_model,
         );
         pipeline_config.role_overrides = wiring.role_overrides.clone();
+        // Set here rather than in `pipeline_config_for_approval_capability`:
+        // that helper is shared with the deck, fleet, and goal loops, and
+        // witness promotion is a one-shot `--keep-witness` concern only.
+        pipeline_config.keep_witness = keep_witness;
 
         let stdio_gate = StdioApprovalGate;
         let no_recall = NoContextRecall;

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -881,7 +881,7 @@ async fn candidate_rules_reuse_the_parent_snapshot_after_source_removal() {
         )
         .await;
     candidate.seal().await.unwrap();
-    let adopted = candidate.adopt().await.unwrap();
+    let adopted = candidate.adopt(&[]).await.unwrap();
     let landed = root.path().join("protected/candidate.txt").exists();
     candidate.remove().await;
 

--- a/stella-cli/src/arena.rs
+++ b/stella-cli/src/arena.rs
@@ -99,6 +99,9 @@ pub(crate) async fn run_arena(mut cfg: Config, args: ArenaArgs) -> Result<(), St
         OutputFormat::StreamJson,
         !args.no_pipeline,
         args.test_command.as_deref(),
+        // The arena judges the task result, not the scaffolding that proved
+        // it — a witness left in the tree would show up as unexplained work.
+        false,
     )
     .await;
 

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -642,7 +642,7 @@ impl GitCandidateWorkspace {
     /// apply that patch to the REAL tree in one atomic
     /// `git apply` — no `--index`, so the user's index is untouched and the
     /// adopted files land exactly as uncommitted working-tree changes.
-    async fn adopt_inner(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+    async fn adopt_inner(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
         let fail = |reason: String, paths: Vec<String>| WorkspaceError::Adopt {
             reason,
             paths,
@@ -664,19 +664,42 @@ impl GitCandidateWorkspace {
                 Vec::new(),
             ));
         }
-        let names = git(
-            &self.dir,
-            &[
-                "diff",
-                "--name-status",
-                "--no-renames",
-                "-z",
-                &self.baseline,
-                &sealed,
-            ],
-        )
-        .await
-        .map_err(|e| fail(e, Vec::new()))?;
+        // Withheld paths drop out via git pathspec magic, appended identically
+        // to the name-status listing and to the binary patch below — the
+        // reported changes and the applied bytes must never disagree, or the
+        // event stream would claim a file the user's tree does not have.
+        // `literal` disables glob interpretation: a path is a path, never a
+        // pattern, so a witness filename containing `*` or `[` cannot widen
+        // the exclusion into production code.
+        let exclusions: Vec<String> = withhold
+            .iter()
+            .map(|path| format!(":(exclude,literal){path}"))
+            .collect();
+        let mut name_args = vec![
+            "diff",
+            "--name-status",
+            "--no-renames",
+            "-z",
+            self.baseline.as_str(),
+            sealed.as_str(),
+        ];
+        let mut patch_args = vec![
+            "diff",
+            "--binary",
+            "--no-renames",
+            self.baseline.as_str(),
+            sealed.as_str(),
+        ];
+        if !exclusions.is_empty() {
+            for args in [&mut name_args, &mut patch_args] {
+                args.push("--");
+                args.push(".");
+                args.extend(exclusions.iter().map(String::as_str));
+            }
+        }
+        let names = git(&self.dir, &name_args)
+            .await
+            .map_err(|e| fail(e, Vec::new()))?;
         let changes = parse_name_status(&names);
         if changes.is_empty() {
             return Ok(Vec::new());
@@ -688,13 +711,9 @@ impl GitCandidateWorkspace {
             SHADOW_SEQ.fetch_add(1, Ordering::Relaxed)
         ));
         let all_paths = || changes.iter().map(|c| c.path.clone()).collect::<Vec<_>>();
-        git_stdout_to_file(
-            &self.dir,
-            &["diff", "--binary", "--no-renames", &self.baseline, &sealed],
-            &patch_file,
-        )
-        .await
-        .map_err(|e| fail(e, all_paths()))?;
+        git_stdout_to_file(&self.dir, &patch_args, &patch_file)
+            .await
+            .map_err(|e| fail(e, all_paths()))?;
         let patch_str = match patch_file.to_str() {
             Some(s) => s,
             None => {
@@ -756,8 +775,8 @@ impl CandidateWorkspace for GitCandidateWorkspace {
         self.sealed_unchanged_inner().await
     }
 
-    async fn adopt(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
-        self.adopt_inner().await
+    async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        self.adopt_inner(withhold).await
     }
 
     async fn remove(&self) {
@@ -1030,12 +1049,90 @@ mod tests {
             verified.as_ref()
         ));
 
-        let adopted = ws.adopt().await.unwrap();
+        let adopted = ws.adopt(&[]).await.unwrap();
         assert_eq!(adopted.len(), 1);
         assert_eq!(
             read(&root.join("tests/authority_witness.rs")),
             "#[test] fn authority_witness() {}\n"
         );
+        ws.remove().await;
+        assert_no_candidate_worktrees(&root);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Withholding the witness must remove ONLY the witness. The whole risk of
+    /// filtering the adoption patch is that an over-broad pathspec silently
+    /// swallows real work, which would look like the model simply not doing
+    /// the task — so this asserts both halves: the witness is absent from the
+    /// real tree AND from the reported change list, while the production edit
+    /// beside it lands byte-exactly.
+    #[tokio::test]
+    async fn withholding_the_witness_still_adopts_the_work_it_verified() {
+        let root = scaffold("witness-withhold");
+        let port = GitCandidateWorkspaces::new(
+            root.clone(),
+            RegistryOptions::default(),
+            Vec::new(),
+            crate::rules::ResolvedRules::default(),
+        );
+        let ws = port.create_workspace().await.unwrap();
+        std::fs::create_dir_all(ws.dir().join("tests")).unwrap();
+        std::fs::write(
+            ws.dir().join("tests/authority_witness.rs"),
+            "#[test] fn authority_witness() {}\n",
+        )
+        .unwrap();
+        // The real work the witness exists to prove.
+        std::fs::write(ws.dir().join("tracked.txt"), "the actual fix\n").unwrap();
+        ws.seal().await.unwrap();
+
+        let withhold = vec!["tests/authority_witness.rs".to_string()];
+        let adopted = ws.adopt(&withhold).await.unwrap();
+
+        assert_eq!(
+            adopted.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+            vec!["tracked.txt"],
+            "the withheld witness must not be reported as adopted"
+        );
+        assert_eq!(read(&root.join("tracked.txt")), "the actual fix\n");
+        assert!(
+            !root.join("tests/authority_witness.rs").exists(),
+            "the witness must never reach the real tree"
+        );
+        ws.remove().await;
+        assert_no_candidate_worktrees(&root);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A witness whose filename contains glob metacharacters must exclude
+    /// exactly itself. `:(exclude)` without `literal` would treat `[` and `*`
+    /// as a pattern and could withhold production files that happen to match.
+    #[tokio::test]
+    async fn withholding_treats_the_path_literally_not_as_a_glob() {
+        let root = scaffold("witness-glob");
+        let port = GitCandidateWorkspaces::new(
+            root.clone(),
+            RegistryOptions::default(),
+            Vec::new(),
+            crate::rules::ResolvedRules::default(),
+        );
+        let ws = port.create_workspace().await.unwrap();
+        std::fs::create_dir_all(ws.dir().join("tests")).unwrap();
+        // `t*.rs` as a glob would also match `tracked_rs.rs`; as a literal it
+        // matches only the file actually named `t*.rs`.
+        std::fs::write(ws.dir().join("tests/t*.rs"), "#[test] fn w() {}\n").unwrap();
+        std::fs::write(ws.dir().join("tests/tracked_rs.rs"), "// real work\n").unwrap();
+        ws.seal().await.unwrap();
+
+        let adopted = ws.adopt(&["tests/t*.rs".to_string()]).await.unwrap();
+
+        assert_eq!(
+            adopted.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+            vec!["tests/tracked_rs.rs"],
+            "only the literally-named witness may be withheld"
+        );
+        assert!(root.join("tests/tracked_rs.rs").exists());
+        assert!(!root.join("tests/t*.rs").exists());
         ws.remove().await;
         assert_no_candidate_worktrees(&root);
         std::fs::remove_dir_all(&root).ok();
@@ -1212,7 +1309,7 @@ mod tests {
             )
             .await;
         ws.seal().await.unwrap();
-        let adopted = ws.adopt().await.unwrap();
+        let adopted = ws.adopt(&[]).await.unwrap();
         let landed = root.join("protected/store.txt").exists();
         ws.remove().await;
         assert_no_candidate_worktrees(&root);
@@ -1264,7 +1361,7 @@ mod tests {
             )
             .await;
         ws.seal().await.unwrap();
-        let adopted = ws.adopt().await.unwrap();
+        let adopted = ws.adopt(&[]).await.unwrap();
         let landed = root.join("protected/ignored.txt").exists();
         ws.remove().await;
         assert_no_candidate_worktrees(&root);
@@ -1306,7 +1403,7 @@ mod tests {
         let (_, before_cached, before_stash, before_head) = tree_state(&root);
         loser.remove().await;
 
-        let mut adopted = winner.adopt().await.unwrap();
+        let mut adopted = winner.adopt(&[]).await.unwrap();
         adopted.sort_by(|a, b| a.path.cmp(&b.path));
         let described: Vec<(String, FileChangeKind)> =
             adopted.into_iter().map(|c| (c.path, c.kind)).collect();
@@ -1360,7 +1457,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = ws.adopt().await.expect_err("drift must reject adoption");
+        let error = ws.adopt(&[]).await.expect_err("drift must reject adoption");
         assert!(
             error.to_string().contains("changed after verification"),
             "{error}"
@@ -1394,7 +1491,7 @@ mod tests {
         // The user edits the same file while the candidate runs.
         std::fs::write(root.join("tracked.txt"), "base\nuser-edit\n").unwrap();
 
-        match ws.adopt().await.unwrap_err() {
+        match ws.adopt(&[]).await.unwrap_err() {
             WorkspaceError::Adopt {
                 paths, workspace, ..
             } => {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -250,6 +250,14 @@ enum Command {
         /// judge.
         #[arg(long, value_name = "CMD")]
         test_command: Option<String>,
+
+        /// Keep the authored witness test as a file in your working tree.
+        /// By default the witness is scaffolding: it proves this run's goal
+        /// inside the candidate workspace and is discarded with it, so an
+        /// already-satisfied test is never left behind in your test tree.
+        /// Pass this to promote it to a real test you can commit.
+        #[arg(long)]
+        keep_witness: bool,
     },
 
     /// arena-bench adapter: run the task in --task-dir (prompt in TASK.md)
@@ -1424,6 +1432,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             prompt,
             no_pipeline,
             test_command,
+            keep_witness,
         } => {
             signals::block_on_interruptible(
                 rt()?,
@@ -1434,6 +1443,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                     cli.globals.output_format,
                     !no_pipeline,
                     test_command.as_deref(),
+                    keep_witness,
                 ),
             )?;
         }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -201,6 +201,23 @@ pub struct PipelineConfig {
     /// oracle, with tamper exclusion at verify time ([`crate::witness`]).
     /// Costs one engine turn + up to two test runs per pipeline run.
     pub witness_writer: bool,
+    /// Whether an authored witness is adopted into the real tree along with
+    /// the work it verified. Off by default: the witness is scaffolding for
+    /// one run, not a change the user asked for.
+    ///
+    /// A witness is written to *fail* — it encodes a moment ("this code does
+    /// not do X yet"), not an invariant, which is the opposite of what a
+    /// durable regression test encodes. Adopting one by default dropped an
+    /// untracked, already-satisfied test into the project's real test tree,
+    /// where the runner picks it up forever and nobody reviews it because it
+    /// was never in a diff. They accumulate: the witness executor creates
+    /// exclusively (`create_new`), so each run that lands on a taken filename
+    /// simply picks another.
+    ///
+    /// Turning this on is the explicit promotion step — the run's verdict is
+    /// unchanged either way, since the witness has already done its job by
+    /// the time adoption happens.
+    pub keep_witness: bool,
     /// Distress-triggered course-correction: on the *second consecutive*
     /// deterministic verification failure, spend one judge call for guidance
     /// that rides with the next revision prompt ([`crate::verify::guidance_prompt`]).
@@ -242,6 +259,7 @@ impl Default for PipelineConfig {
             headless_bypass_scope_review: false,
             test_command: None,
             witness_writer: true,
+            keep_witness: false,
             distress_guidance: true,
             diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
             diff_budget_lines: 400,
@@ -439,6 +457,21 @@ struct CandidateSurface<'c> {
     cwd: Option<&'c str>,
     hook_runner: Option<&'c dyn HookRunner>,
     workspace: Option<&'c dyn CandidateWorkspace>,
+}
+
+/// One candidate's live workspace plus the witness paths authored inside it.
+///
+/// They travel together because adoption needs both and indexes by candidate:
+/// a parallel `Vec<Vec<String>>` would have to be kept aligned by hand at
+/// every early `continue` in the candidate loop, and a single missed push
+/// would silently shift every later candidate's witness onto the wrong
+/// workspace. Pairing them makes that misalignment unrepresentable.
+struct CandidateSlot {
+    workspace: Box<dyn CandidateWorkspace>,
+    /// Workspace-relative paths of the accepted witness artifact(s). Withheld
+    /// from adoption unless [`PipelineConfig::keep_witness`]; empty when the
+    /// candidate authored no witness.
+    witness_paths: Vec<String>,
 }
 
 /// The staged orchestrator. Holds only borrowed ports + an owned event sender
@@ -1325,8 +1358,11 @@ impl<'a> Pipeline<'a> {
         };
 
         let mut candidates: Vec<CandidateResult> = Vec::with_capacity(n as usize);
-        let mut workspaces: Vec<Option<Box<dyn CandidateWorkspace>>> =
-            Vec::with_capacity(n as usize);
+        // The witness paths ride WITH their workspace rather than in a parallel
+        // vector: adoption indexes by candidate, and every early `continue`
+        // below would otherwise have to remember to keep a second vector
+        // aligned. Carrying them together makes drift unrepresentable.
+        let mut workspaces: Vec<Option<CandidateSlot>> = Vec::with_capacity(n as usize);
         for i in 0..n {
             let ws = match port.create().await {
                 Ok(ws) => ws,
@@ -1343,7 +1379,7 @@ impl<'a> Pipeline<'a> {
                     continue;
                 }
             };
-            let result = {
+            let (result, witness_paths) = {
                 let bound_hook_runner = self.hooks.map(|(_, runner)| BoundHookRunner {
                     inner: runner,
                     cwd: ws.root(),
@@ -1379,13 +1415,27 @@ impl<'a> Pipeline<'a> {
                                 CandidateResult::aborted(base_messages.to_vec(), abort.reason)
                             };
                             candidates.push(candidate);
-                            workspaces.push(Some(ws));
+                            // No accepted witness, so nothing to withhold. This
+                            // candidate cannot be adopted anyway (adoption
+                            // requires a passing verdict, and this one aborted),
+                            // but the slot must still be pushed to keep indices
+                            // aligned with `candidates`.
+                            workspaces.push(Some(CandidateSlot {
+                                workspace: ws,
+                                witness_paths: Vec::new(),
+                            }));
                             continue;
                         }
                     }
                 } else {
                     None
                 };
+                // Captured before `witness` is handed to the candidate: these
+                // are the paths withheld from adoption unless `keep_witness`.
+                let witness_paths: Vec<String> = witness
+                    .as_ref()
+                    .map(|w| w.files.keys().cloned().collect())
+                    .unwrap_or_default();
                 let mut engine = Engine::with_sleeper(
                     worker.provider,
                     ws.tools(),
@@ -1398,36 +1448,55 @@ impl<'a> Pipeline<'a> {
                 if let Some(steering) = self.steering {
                     engine = engine.with_steering(steering);
                 }
-                self.run_candidate(
-                    goal,
-                    base_messages,
-                    plan,
-                    assessment,
-                    witness.as_ref(),
-                    &engine,
-                    surface,
-                    budget,
-                    total,
-                )
-                .await
+                let result = self
+                    .run_candidate(
+                        goal,
+                        base_messages,
+                        plan,
+                        assessment,
+                        witness.as_ref(),
+                        &engine,
+                        surface,
+                        budget,
+                        total,
+                    )
+                    .await;
+                (result, witness_paths)
             };
             candidates.push(result);
-            workspaces.push(Some(ws));
+            workspaces.push(Some(CandidateSlot {
+                workspace: ws,
+                witness_paths,
+            }));
         }
 
         let best_idx = best_index(&candidates);
         // Winner adoption + cleanup. An aborted winner adopts nothing — an
         // aborted best-of-N run leaves the real tree untouched.
         let mut adopt_failure: Option<WorkspaceError> = None;
-        for (i, ws) in workspaces.into_iter().enumerate() {
-            let Some(ws) = ws else { continue };
+        for (i, slot) in workspaces.into_iter().enumerate() {
+            let Some(CandidateSlot {
+                workspace: ws,
+                witness_paths,
+            }) = slot
+            else {
+                continue;
+            };
             if i == best_idx
                 && candidates[best_idx]
                     .verdict
                     .as_ref()
                     .is_some_and(|verdict| verdict.passed)
             {
-                match ws.adopt().await {
+                // The witness has already done its whole job by now — it armed
+                // the flip oracle and the flip was observed — so withholding it
+                // cannot change the verdict, only what lands in the tree.
+                let withhold: &[String] = if self.config.keep_witness {
+                    &[]
+                } else {
+                    &witness_paths
+                };
+                match ws.adopt(withhold).await {
                     Ok(adopted) => {
                         // Surface the adopted paths on the event stream: the
                         // winner's edits happened inside the snapshot, so no

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -397,8 +397,16 @@ impl CandidateWorkspace for FakeWorkspace {
     async fn sealed_is_unchanged(&self) -> Result<bool, WorkspaceError> {
         Ok(self.sealed_unchanged)
     }
-    async fn adopt(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
-        self.log.lock().unwrap().push(format!("adopt:{}", self.id));
+    async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        // The withheld set is logged so tests can assert that an authored
+        // witness never reaches the real tree, without reaching for real git.
+        // Unchanged shape when nothing is withheld, so every pre-existing
+        // `adopt:<id>` assertion still reads the same.
+        self.log.lock().unwrap().push(if withhold.is_empty() {
+            format!("adopt:{}", self.id)
+        } else {
+            format!("adopt:{}:withhold={}", self.id, withhold.join(","))
+        });
         self.adopt_result.clone()
     }
     async fn remove(&self) {

--- a/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -247,6 +247,48 @@ async fn authored_witness_degrades_when_judge_is_worker() {
     assert!(!stages(&events).contains(&StageKind::Witness));
 }
 
+/// `keep_witness` is the explicit promotion step: the same run, opted in,
+/// adopts the witness alongside the work. Paired with the default-path
+/// assertion in `authored_witness_with_one_candidate_uses_one_disposable_snapshot`,
+/// this pins BOTH directions of the flag — a default-only test would still
+/// pass if the flag were ignored entirely.
+#[tokio::test]
+async fn keep_witness_promotes_the_authored_witness_into_the_real_tree() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result(
+            "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
+        ),
+        text_result("done"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/authority_witness.rs", "sha256:test")],
+        ]));
+    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+
+    let (outcome, _, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig {
+            candidates: Some(1),
+            keep_witness: true,
+            ..PipelineConfig::default()
+        },
+        "Fix the failing test",
+    )
+    .await;
+    let outcome = outcome.expect("run succeeds inside the snapshot");
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["create", "seal:0", "adopt:0", "remove:0"],
+        "keep_witness withholds nothing — the witness is adopted with the work"
+    );
+}
+
 #[tokio::test]
 async fn authored_witness_with_one_candidate_uses_one_disposable_snapshot() {
     let provider = ScriptedProvider::new(vec![
@@ -278,8 +320,14 @@ async fn authored_witness_with_one_candidate_uses_one_disposable_snapshot() {
     assert_eq!(outcome.status, PipelineStatus::Completed);
     assert_eq!(
         *log.lock().unwrap(),
-        vec!["create", "seal:0", "adopt:0", "remove:0"],
-        "authoring, worker verification, and adoption share one workspace"
+        vec![
+            "create",
+            "seal:0",
+            "adopt:0:withhold=tests/authority_witness.rs",
+            "remove:0"
+        ],
+        "authoring, worker verification, and adoption share one workspace, \
+         and the witness is withheld from the real tree by default"
     );
 }
 
@@ -328,7 +376,12 @@ async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_
     assert_eq!(outcome.status, PipelineStatus::Completed);
     assert_eq!(
         *log.lock().unwrap(),
-        vec!["create", "seal:0", "adopt:0", "remove:0"]
+        vec![
+            "create",
+            "seal:0",
+            "adopt:0:withhold=tests/authority_witness.rs",
+            "remove:0"
+        ]
     );
 }
 

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -331,7 +331,15 @@ pub trait CandidateWorkspace: Send + Sync {
     /// byte-identical and the error names the conflicting paths
     /// ([`WorkspaceError::Adopt`]); the user's index and stash are never
     /// touched on any path.
-    async fn adopt(&self) -> Result<Vec<AdoptedChange>, WorkspaceError>;
+    ///
+    /// `withhold` names workspace-relative paths to leave behind — they are
+    /// excluded from both the returned change list and the applied patch, so
+    /// the two can never disagree. This is how an authored witness stays
+    /// ephemeral: it must exist inside the candidate (it *is* the test the
+    /// flip oracle runs), but it is scaffolding for the run, not a change the
+    /// user asked for, so by default it dies with the workspace instead of
+    /// being copied into the real tree. Empty means adopt everything.
+    async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError>;
     /// Remove the workspace. Best-effort and infallible — the cleanup
     /// discipline is the pipeline's (every workspace is removed on every
     /// path, except a winner whose adoption failed, which is preserved for

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -75,6 +75,14 @@ the **witness author**, never the worker — writes a minimal *failing* test
 that pins down the intended behavior. Witness files are watched for tampering:
 a worker that edits the witness test doesn't get credit for "passing" it.
 
+The witness is scaffolding for one run, not a test you inherit. It is written
+to *fail* — it encodes a moment ("this code doesn't do X yet"), not an
+invariant, which is the opposite of what a durable regression test encodes. So
+it lives and dies inside the candidate workspace and is **not** adopted into
+your tree: you never find an already-satisfied test sitting in `tests/` that
+nobody reviewed. Pass `--keep-witness` to promote it into your working tree
+when the test is worth keeping.
+
 ### 5. Execute
 
 The worker runs the step loop against the plan — reading, editing, building,


### PR DESCRIPTION
Follow-up to #668. That PR stopped one shape of useless witness from being *born*; this one fixes the lifecycle that turns any witness into a landmine.

## The defect

`adopt_inner` diffed `baseline..sealed` and applied the whole patch with **no path filter**, so every authored witness was copied into the user's real tree — and `candidate_ws.rs` asserted exactly that behavior.

What that produces: an untracked, already-satisfied test sitting in the project's test tree. The runner picks it up forever. Nobody reviews it, because it was never in a diff. And they accumulate — the witness executor creates exclusively (`create_new`), so a run that lands on a taken filename just picks another name.

The underlying category error: **a witness is written to fail.** It encodes a moment ("this code doesn't do X yet"), not an invariant — the opposite of what a durable regression test encodes. Different artifact, different lifetime; they shouldn't silently share a directory.

## The fix

`adopt` takes a `withhold` list, applied as git pathspec exclusions to **both** the `--name-status` listing and the `--binary` patch, so the reported changes and the applied bytes can't disagree. `:(exclude,literal)` — without `literal`, a witness filename containing `*` or `[` could widen the exclusion over production code.

The pipeline withholds the winner's witness paths unless `PipelineConfig::keep_witness` (CLI: `stella run --keep-witness`) is set. That flag **is** the explicit promotion step.

Withholding cannot change a verdict: by adoption time the witness has already armed the flip oracle and the flip has been observed. Tamper exclusion, verification, and the judge are all untouched.

Witness paths ride *with* their workspace in a new `CandidateSlot` rather than a parallel vector — adoption indexes by candidate, and every early `continue` in the candidate loop would otherwise have to keep a second vector aligned by hand.

## Correction to #668

I claimed tamper protection persisted across runs and needed scoping. **That was wrong.** It was already run-scoped: `Witness::files` is in-memory only, and `validate_witness_artifact` structurally cannot admit a pre-existing file (`!untracked_before.contains_key(path)`). A previous run's witness is an ordinary file to a new run. No change was needed, and none was made.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` — clean, 58 test binaries
- `withholding_the_witness_still_adopts_the_work_it_verified` — the real risk of filtering a patch is silently swallowing real work, so this asserts the production edit lands byte-exactly *and* the witness is absent from both the tree and the reported change list
- `withholding_treats_the_path_literally_not_as_a_glob` — a witness named `t*.rs` must not withhold `tracked_rs.rs`
- `keep_witness_promotes_the_authored_witness_into_the_real_tree` — pins the opt-in direction; without it the suite would still pass if the flag were ignored entirely

## Still open

A witness is also unwritable for work that has no testable surface — a TUI keybinding, a dialog layout. That corners the author the same way a deletion does, and the ceiling in #668 doesn't cover it. Separate change.
