### PR TITLE
feat(memory): stella memory forget/restore, as a tombstone that survives re-learning

### DIFF
--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -720,6 +720,30 @@ enum MemoryCmd {
     /// memory is one whose referenced path no longer exists — a strong signal
     /// the memory is about refactored-away code and may mislead.
     Validate,
+    /// Forget a memory: stop it steering the agent, and stop the reflection
+    /// loop re-learning it. Reversible with `stella memory restore <id>`.
+    ///
+    /// This is a tombstone, not a delete. The reflection loop re-mines
+    /// paraphrases of lessons it has already learned, so removing the row
+    /// alone does not hold — the tombstone also suppresses restatements at
+    /// the point new lessons are recorded and at the point the log is mined
+    /// into skills.
+    Forget {
+        /// The memory's stable id (nod_…) as shown by `stella memory list`
+        id: String,
+        /// Optional note on why, shown by `stella memory forgotten`
+        #[arg(long, default_value = "")]
+        reason: String,
+    },
+    /// Lift a tombstone written by `stella memory forget`, letting the memory
+    /// be recalled again and be re-learnable.
+    Restore {
+        /// The memory's stable id (nod_…) as shown by `stella memory forgotten`
+        id: String,
+    },
+    /// List the tombstones in this workspace — what was forgotten, when, and
+    /// why.
+    Forgotten,
 }
 
 /// NUL boundaries prevent LLVM's string pooling from adjoining identifier
@@ -1330,6 +1354,9 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 MemoryCmd::List { format } => memory_cmd::run_memory_list(*format),
                 MemoryCmd::Promote { id } => memory_cmd::run_memory_promote(id),
                 MemoryCmd::Validate => memory_cmd::run_memory_validate(),
+                MemoryCmd::Forget { id, reason } => memory_cmd::run_memory_forget(id, reason),
+                MemoryCmd::Restore { id } => memory_cmd::run_memory_restore(id),
+                MemoryCmd::Forgotten => memory_cmd::run_memory_forgotten(),
             };
         }
         Some(Command::Mcp { cmd }) => {

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -501,6 +501,16 @@ impl SessionMemory {
             }
         };
         let (lessons, reflection_cost_usd, reflection_events) = lessons;
+
+        // Drop anything the user has already forgotten, BEFORE it reaches any
+        // of the three places this function persists to. Matching is by
+        // restatement, not equality: the loop re-learns paraphrases, so a
+        // lesson mined today can be the same lesson the user deleted last
+        // week wearing slightly different words. Suppressing here rather than
+        // at recall is what makes forgetting durable — an unsuppressed lesson
+        // would land in the log and stay re-mineable forever.
+        let lessons = self.retain_unforgotten(lessons);
+
         if lessons.is_empty() {
             return ReflectionReport {
                 cost_usd: reflection_cost_usd,
@@ -581,16 +591,60 @@ impl SessionMemory {
         }
     }
 
+    /// Drop lessons that restate something the user forgot.
+    ///
+    /// Best-effort in one direction only: if the tombstone table cannot be
+    /// read we keep every lesson rather than silently discarding the turn's
+    /// learning. That is the opposite posture from recall — there, an
+    /// unreadable suppression set means surface nothing; here it means
+    /// persist everything. Both choices fail toward the recoverable outcome:
+    /// a memory that should have been suppressed can be forgotten again,
+    /// whereas a lesson dropped on a transient read error is gone for good.
+    fn retain_unforgotten(&self, lessons: Vec<ReflectionLesson>) -> Vec<ReflectionLesson> {
+        let forgotten = match stella_store::Store::open(&self.workspace_root)
+            .and_then(|store| store.forgotten_texts(stella_store::ContextSurface::Memory))
+        {
+            Ok(texts) if !texts.is_empty() => texts,
+            _ => return lessons,
+        };
+        lessons
+            .into_iter()
+            .filter(|l| {
+                !stella_store::is_suppressed(&l.lesson, forgotten.iter().map(String::as_str))
+            })
+            .collect()
+    }
+
     /// Mine the whole reflection log for recurring lessons and auto-create
     /// skills for any that qualify (threshold + session cap + no-clobber
     /// enforced by `stella_core::skills`).
+    ///
+    /// The log is append-only and re-read in full every reflection turn, so
+    /// lines written before a tombstone existed are still in it. Filtering
+    /// the observations here is what stops a forgotten lesson from returning
+    /// as an auto-created skill — the second door that made a plain `DELETE`
+    /// insufficient.
     fn auto_create_skills(&mut self, log_path: &Path, quiet: bool) {
         let Ok(log) = std::fs::read_to_string(log_path) else {
             return;
         };
+        // Tombstones from BOTH surfaces: forgetting the memory should stop the
+        // lesson being promoted to a skill, and forgetting the skill should
+        // stop it being re-created from the same log lines it came from.
+        let forgotten: Vec<String> = stella_store::Store::open(&self.workspace_root)
+            .and_then(|store| {
+                let mut texts = store.forgotten_texts(stella_store::ContextSurface::Memory)?;
+                texts.extend(store.forgotten_texts(stella_store::ContextSurface::Skill)?);
+                Ok(texts)
+            })
+            .unwrap_or_default();
+
         let observations: Vec<SkillObservation> = log
             .lines()
             .filter_map(|line| serde_json::from_str::<ReflectionLesson>(line).ok())
+            .filter(|l| {
+                !stella_store::is_suppressed(&l.lesson, forgotten.iter().map(String::as_str))
+            })
             .map(|l| SkillObservation {
                 reference: format!("reflection:{}", l.occurred_at),
                 text: l.lesson,
@@ -674,13 +728,20 @@ impl SessionMemory {
             as_of: None,
             representation_preferences: vec![],
         };
-        let quarantined = match stella_store::Store::open(&self.workspace_root)
-            .and_then(|store| store.quarantined_memory_ids())
-        {
+        // Two independent suppression sets, read together and applied as one.
+        // Quarantine is *derived* — the model kept calling a memory untruthful;
+        // a tombstone is *stored* — a person read it and said remove it. Both
+        // are fail-closed for the same reason: if the state cannot be read,
+        // surfacing everything is the one outcome that is definitely wrong.
+        let quarantined = match stella_store::Store::open(&self.workspace_root).and_then(|store| {
+            let mut ids = store.quarantined_memory_ids()?;
+            ids.extend(store.forgotten_ids(stella_store::ContextSurface::Memory)?);
+            Ok(ids)
+        }) {
             Ok(ids) => ids,
             Err(error) => {
                 report(format!(
-                    "memory recall disabled: quarantine state unavailable: {error}"
+                    "memory recall disabled: suppression state unavailable: {error}"
                 ));
                 return Recall::default();
             }

--- a/stella-cli/src/memory/quarantine_tests.rs
+++ b/stella-cli/src/memory/quarantine_tests.rs
@@ -20,8 +20,11 @@ async fn assert_no_prompt_or_pipeline_frames(memory: &SessionMemory, lesson: &st
         .await;
     assert!(reported_frames.is_empty());
     assert_eq!(diagnostics.len(), 1, "failure emits one diagnostic");
+    // Recall reads two suppression sets together — derived quarantine and
+    // stored tombstones — so the diagnostic names the combined state rather
+    // than either half.
     assert!(
-        diagnostics[0].contains("quarantine") && diagnostics[0].contains("disabled"),
+        diagnostics[0].contains("suppression") && diagnostics[0].contains("disabled"),
         "diagnostic explains the fail-closed recall decision: {}",
         diagnostics[0]
     );
@@ -29,11 +32,11 @@ async fn assert_no_prompt_or_pipeline_frames(memory: &SessionMemory, lesson: &st
     let pipeline_frames = ContextRecallPort::recall(memory, lesson).await;
     assert!(
         pipeline_frames.is_empty(),
-        "pipeline recall must fail closed when quarantine state is unknown: {pipeline_frames:?}"
+        "pipeline recall must fail closed when suppression state is unknown: {pipeline_frames:?}"
     );
     assert!(
         memory.recall_block(lesson).await.is_none(),
-        "prompt recall must fail closed when quarantine state is unknown"
+        "prompt recall must fail closed when suppression state is unknown"
     );
 }
 

--- a/stella-cli/src/memory_cmd.rs
+++ b/stella-cli/src/memory_cmd.rs
@@ -314,27 +314,94 @@ pub fn run_memory_validate() -> Result<(), String> {
     Ok(())
 }
 
-/// Extract workspace-relative file-path anchors from memory text. A path
-/// anchor is a token matching the pattern `word/word[/word…]` with at least
-/// one slash and a recognized source extension, e.g. `stella-cli/src/agent.rs`,
-/// `src/lib.rs`, `docs/context-reuse.md`.
+/// Source extensions a token must end in to count as a file reference.
+const ANCHOR_EXTS: &[&str] = &[
+    "rs", "py", "ts", "tsx", "js", "jsx", "go", "md", "sql", "toml",
+];
+
+/// Extract file anchors from memory text. Two shapes count:
+///
+/// * **Rooted paths** — `word/word[/word…]` with a recognized source
+///   extension, e.g. `stella-cli/src/agent.rs`, `docs/context-reuse.md`.
+///   These resolve against the workspace root directly.
+/// * **Bare filenames** — a name with a recognized extension and no
+///   directory at all, e.g. `slash_models_witness.rs`, `Cargo.toml`.
+///
+/// Bare filenames matter because that is how reflections actually name
+/// files: a lesson mined from a turn says "in `slash_models_witness.rs`",
+/// not "in `stella-cli/tests/slash_models_witness.rs`". Requiring a slash
+/// meant the memories most likely to rot — the ones naming a single test
+/// file that later got deleted — were reported as `no-anchors` and never
+/// checked, which is the failure this function exists to catch.
 fn extract_path_anchors(text: &str) -> Vec<String> {
-    let exts = [
-        "rs", "py", "ts", "tsx", "js", "jsx", "go", "md", "sql", "toml",
-    ];
     text.split(|c: char| !(c.is_alphanumeric() || c == '/' || c == '.' || c == '-' || c == '_'))
-        .filter(|tok| {
+        .filter_map(|tok| {
             // Trim trailing dots — a sentence like "see src/lib.rs." would
             // otherwise produce token "src/lib.rs." with extension "rs.".
             let tok = tok.trim_end_matches('.');
-            tok.contains('/')
-                && tok
-                    .rsplit('.')
-                    .next()
-                    .is_some_and(|ext| exts.contains(&ext))
+            if tok.len() > 256 || tok.starts_with('/') || tok.split('/').any(|seg| seg == "..") {
+                return None;
+            }
+            let (stem, ext) = tok.rsplit_once('.')?;
+            // A bare `.rs` has no stem and names nothing; `graph_snapshot`
+            // has no extension. Both must stay out.
+            if stem.is_empty() || !ANCHOR_EXTS.contains(&ext) {
+                return None;
+            }
+            Some(tok.to_string())
         })
-        .map(|tok| tok.trim_end_matches('.').to_string())
         .collect()
+}
+
+/// Directories that never hold source a memory would meaningfully anchor to,
+/// and that dominate the walk cost when present.
+const ANCHOR_WALK_SKIP: &[&str] = &[
+    ".git",
+    ".stella",
+    "target",
+    "node_modules",
+    ".next",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "__pycache__",
+];
+
+/// Every file name present anywhere under the workspace, for resolving
+/// bare-filename anchors — they carry no directory to join onto the root, so
+/// existence is a "does the tree contain a file by this name" question.
+///
+/// Built once per `validate` run and bounded: a pathological or symlinked
+/// tree must not stall an inspection command.
+fn workspace_file_names(root: &std::path::Path) -> std::collections::HashSet<String> {
+    const MAX_FILES: usize = 200_000;
+    let mut names = std::collections::HashSet::new();
+    let mut queue = std::collections::VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(kind) = entry.file_type() else {
+                continue;
+            };
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // `is_dir`/`is_file` on the entry type does not follow symlinks,
+            // so a self-referential link cannot re-enter the walk.
+            if kind.is_dir() {
+                if !ANCHOR_WALK_SKIP.contains(&name.as_str()) {
+                    queue.push_back(entry.path());
+                }
+            } else if kind.is_file() {
+                names.insert(name);
+                if names.len() >= MAX_FILES {
+                    return names;
+                }
+            }
+        }
+    }
+    names
 }
 
 /// Validate all memories in a workspace against the current file tree.
@@ -351,6 +418,10 @@ fn validate_memories(workspace_root: &std::path::Path) -> Result<Vec<MemoryValid
         .memory_nodes()
         .map_err(|e| format!("cannot read memories: {e}"))?;
 
+    // Built lazily: a workspace whose memories name no bare filenames never
+    // pays for the walk.
+    let mut file_names: Option<std::collections::HashSet<String>> = None;
+
     let mut rows = Vec::new();
     for node in &memories {
         let anchors = extract_path_anchors(&node.content);
@@ -366,7 +437,15 @@ fn validate_memories(workspace_root: &std::path::Path) -> Result<Vec<MemoryValid
         }
         let missing = anchors
             .iter()
-            .filter(|p| !workspace_root.join(p).exists())
+            .filter(|anchor| {
+                if anchor.contains('/') {
+                    !workspace_root.join(anchor).exists()
+                } else {
+                    !file_names
+                        .get_or_insert_with(|| workspace_file_names(workspace_root))
+                        .contains(anchor.as_str())
+                }
+            })
             .count();
         let status = if missing > 0 { "stale" } else { "ok" };
         rows.push(MemoryValidationRow {
@@ -702,6 +781,73 @@ mod tests {
         assert!(anchors.contains(&"src/lib.rs".to_string()));
         // No false positives from bare words.
         assert!(!anchors.iter().any(|a| a == "graph_snapshot"));
+    }
+
+    #[test]
+    fn extract_path_anchors_finds_bare_filenames() {
+        // The shape reflections actually use: a file named with no directory.
+        let text = "In stella-cli witness tests (slash_models_witness.rs), prefer \
+                    updating assertions rather than changing the renderer.";
+        let anchors = extract_path_anchors(text);
+        assert!(
+            anchors.contains(&"slash_models_witness.rs".to_string()),
+            "bare filenames must anchor: {anchors:?}"
+        );
+    }
+
+    #[test]
+    fn extract_path_anchors_rejects_non_files() {
+        // A bare extension has no stem, version strings have no source
+        // extension, and prose words have no extension at all.
+        let anchors = extract_path_anchors("the .rs files in v0.4.47 use cargo test -- --exact");
+        assert!(anchors.is_empty(), "no false anchors: {anchors:?}");
+    }
+
+    #[test]
+    fn validate_flags_stale_bare_filename_anchors() {
+        // Regression: a memory naming a deleted test file by bare name was
+        // reported `no-anchors` and never checked, so recall kept surfacing
+        // it long after the file was gone.
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+        std::fs::create_dir_all(root.path().join("stella-cli/tests")).unwrap();
+        std::fs::write(
+            root.path().join("stella-cli/tests/live_witness.rs"),
+            "#[test] fn t() {}",
+        )
+        .unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let context = stella_context::ContextStore::open(&context_db).unwrap();
+            use stella_context::{ContextDelta, MemoryInput};
+            let delta = ContextDelta {
+                memories: vec![
+                    MemoryInput::reflection(
+                        "In witness tests (deleted_witness.rs), prefer updating assertions.",
+                        Vec::<String>::new(),
+                    ),
+                    MemoryInput::reflection(
+                        "In witness tests (live_witness.rs), prefer updating assertions.",
+                        Vec::<String>::new(),
+                    ),
+                ],
+                ..Default::default()
+            };
+            context.upsert(delta).await.unwrap();
+        });
+
+        let rows = validate_memories(root.path()).unwrap();
+        let stale = rows.iter().find(|r| r.status == "stale").expect(
+            "a memory naming a deleted file by bare name must be flagged stale, not no-anchors",
+        );
+        assert!(stale.memory.contains("deleted_witness.rs"));
+        let ok = rows
+            .iter()
+            .find(|r| r.status == "ok")
+            .expect("live file verifies");
+        assert!(ok.memory.contains("live_witness.rs"));
     }
 
     #[test]

--- a/stella-cli/src/memory_cmd.rs
+++ b/stella-cli/src/memory_cmd.rs
@@ -18,7 +18,7 @@ use colored::Colorize;
 use serde::Serialize;
 use stella_context::{ContextStore, NodeKind, NodeRow};
 use stella_core::rules::{self, PromoteStatus, RuleCandidate};
-use stella_store::{MemoryCitationStats, PROMOTION_CITATIONS_REQUIRED, Store};
+use stella_store::{ContextSurface, MemoryCitationStats, PROMOTION_CITATIONS_REQUIRED, Store};
 
 /// Output format for `stella memory list`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -312,6 +312,135 @@ pub fn run_memory_validate() -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+/// Entry point for `stella memory forget <id>`.
+///
+/// Resolves the id to its text first and stores that alongside the
+/// tombstone. The copy is the whole point: the reflection loop re-mines
+/// paraphrases under fresh ids, so suppressing only `id` would hold until
+/// the next reflection turn. Forgetting an id that is not live is still
+/// allowed — a memory may have gone by other means and the user may want the
+/// tombstone anyway — but it is reported, because the usual cause is a
+/// typo'd id that would otherwise silently do nothing.
+pub fn run_memory_forget(id: &str, reason: &str) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+
+    let content = memory_text(&workspace_root, id)?;
+    if content.is_none() {
+        eprintln!(
+            "  {} `{id}` is not a live memory — recording the tombstone anyway, but check the id \
+             against `stella memory list` if you expected a match",
+            "!".yellow()
+        );
+    }
+    let content = content.unwrap_or_default();
+
+    let store = Store::open(&workspace_root).map_err(|e| format!("cannot open store: {e}"))?;
+    store
+        .forget(ContextSurface::Memory, id, &content, reason)
+        .map_err(|e| format!("cannot record tombstone: {e}"))?;
+
+    println!("  {} forgot {id}", "✓".green());
+    if !content.is_empty() {
+        println!("    {}", clip(content.trim(), 72).dimmed());
+        println!(
+            "    {}",
+            "restatements of this will also be suppressed when the loop reflects".dimmed()
+        );
+    }
+    println!(
+        "    {}",
+        format!("undo: stella memory restore {id}").dimmed()
+    );
+    Ok(())
+}
+
+/// Entry point for `stella memory restore <id>`.
+pub fn run_memory_restore(id: &str) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let store = Store::open(&workspace_root).map_err(|e| format!("cannot open store: {e}"))?;
+    let lifted = store
+        .restore(ContextSurface::Memory, id)
+        .map_err(|e| format!("cannot lift tombstone: {e}"))?;
+    if lifted {
+        println!("  {} restored {id}", "✓".green());
+    } else {
+        println!(
+            "  {} `{id}` was not forgotten — nothing to restore",
+            "·".dimmed()
+        );
+    }
+    Ok(())
+}
+
+/// Entry point for `stella memory forgotten` — the tombstones in this
+/// workspace. Read-only politeness like `list`: a workspace with no store
+/// reads as "nothing forgotten", never a created database.
+pub fn run_memory_forgotten() -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    if stella_store::existing_workspace_private_sqlite_path(&workspace_root, "store.db")
+        .map_err(|e| format!("cannot resolve store: {e}"))?
+        .is_none()
+    {
+        println!("nothing forgotten in this workspace");
+        return Ok(());
+    }
+    let store = Store::open(&workspace_root).map_err(|e| format!("cannot open store: {e}"))?;
+    let rows = store
+        .forgotten_rows()
+        .map_err(|e| format!("cannot read tombstones: {e}"))?;
+    if rows.is_empty() {
+        println!("nothing forgotten in this workspace");
+        return Ok(());
+    }
+    for row in &rows {
+        println!(
+            "  {} {:<16} {:<30} {}",
+            "·".dimmed(),
+            row.surface,
+            row.item_id,
+            clip(row.content.trim(), 56).dimmed()
+        );
+        if !row.reason.is_empty() {
+            println!("      {}", row.reason.dimmed());
+        }
+    }
+    println!(
+        "\n  {} forgotten — `stella memory restore <id>` lifts one",
+        rows.len()
+    );
+    Ok(())
+}
+
+/// First `max` characters, ellipsised. Char-safe: a memory containing
+/// multi-byte text must not panic a listing on a byte-boundary slice.
+fn clip(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut clipped: String = text.chars().take(max.saturating_sub(1)).collect();
+    clipped.push('…');
+    clipped
+}
+
+/// The text of a memory by public id, or `None` when no such memory is live.
+fn memory_text(workspace_root: &std::path::Path, id: &str) -> Result<Option<String>, String> {
+    let Some(context_db) =
+        stella_store::existing_workspace_private_sqlite_path(workspace_root, "context.db")
+            .map_err(|e| format!("cannot resolve context store: {e}"))?
+    else {
+        return Ok(None);
+    };
+    let context =
+        ContextStore::open(&context_db).map_err(|e| format!("cannot open context store: {e}"))?;
+    let node = context
+        .node_by_public_id(id)
+        .map_err(|e| format!("cannot read memory `{id}`: {e}"))?;
+    Ok(node.map(|n| n.content))
 }
 
 /// Extract workspace-relative file-path anchors from memory text. A path

--- a/stella-store/src/ddl.rs
+++ b/stella-store/src/ddl.rs
@@ -12,8 +12,9 @@
 
 /// Every table the store owns — the allowlist for [`Store::count`](crate::Store::count) and the
 /// fresh-file probe in [`Store::migrate`](crate::Store::migrate).
-pub(crate) const TABLES: [&str; 20] = [
+pub(crate) const TABLES: [&str; 21] = [
     "executions",
+    "forgotten",
     "events",
     "telemetry",
     "files_touched",
@@ -207,6 +208,46 @@ pub(crate) const MEMORY_CITATIONS_DDL: &str = "CREATE TABLE IF NOT EXISTS memory
      );
      CREATE INDEX IF NOT EXISTS memory_citations_by_memory
        ON memory_citations(memory_id, execution_id);";
+
+/// `forgotten` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — explicit human
+/// tombstones over anything that steers the agent
+/// ([`ContextSurface`](crate::ContextSurface)).
+///
+/// This is a *stored* judgment, unlike quarantine, which
+/// [`Store::quarantined_memory_ids`](crate::Store::quarantined_memory_ids)
+/// derives from citation counts. A derivation can express "the model kept
+/// calling this untruthful"; it cannot express "a person read this and said
+/// remove it", which is why the state needs a table of its own rather than
+/// another fold over `memory_citations`.
+///
+/// It lives in `store.db` beside `memory_citations` rather than in
+/// `context.db` next to the memories themselves, because context nodes are
+/// mutable current-state (`upsert_node` overwrites in place, so there is no
+/// point-in-time reader), and a tombstone must outlive edits to the thing it
+/// buries — including the row being deleted entirely.
+///
+/// PRIMARY KEY (surface, item_id): one verdict per item, and re-forgetting
+/// is an idempotent upsert rather than a duplicate.
+///
+/// `content` is the forgotten text, copied in at forget time. It is what
+/// makes the tombstone survive re-learning: the reflection recorder and the
+/// skill miner compare *candidates* against it
+/// ([`forget::is_suppressed`](crate::forget::is_suppressed)), so a
+/// re-mined paraphrase with a brand-new id is still caught. Without the copy
+/// the check would depend on the original row, which forgetting may remove.
+///
+/// Restoring is a plain `DELETE` — the row's absence is the "not forgotten"
+/// state, so there is no tri-state to keep consistent.
+pub(crate) const FORGOTTEN_DDL: &str = "CREATE TABLE IF NOT EXISTS forgotten (
+       surface TEXT NOT NULL,
+       item_id TEXT NOT NULL,
+       content TEXT NOT NULL DEFAULT '',
+       reason TEXT NOT NULL DEFAULT '',
+       forgotten_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+       PRIMARY KEY (surface, item_id)
+     );
+     CREATE INDEX IF NOT EXISTS forgotten_by_surface
+       ON forgotten(surface, forgotten_at);";
 
 /// `agent_uses` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — the agent-invocation log
 /// ([`AgentUseRow`](crate::AgentUseRow)): one row per invocation of an installed agent

--- a/stella-store/src/forget.rs
+++ b/stella-store/src/forget.rs
@@ -1,0 +1,270 @@
+//! Reversible suppression of context that steers the agent — "forget".
+//!
+//! Every surface that feeds the model (memories, rules, skills, agents,
+//! commands) can acquire an entry the user wants gone. Until now the only
+//! removal path for a memory was citing it untruthful twice to trip
+//! [`crate::QUARANTINE_NEGATIVES_THRESHOLD`], which is an odd thing to ask of
+//! someone looking straight at the offending text.
+//!
+//! ## Why a tombstone and not a `DELETE`
+//!
+//! Deleting the row does not hold, because the reflection loop re-learns.
+//! Observed in this project's own store: two memories recorded two days
+//! apart, both naming a test file that had already been deleted —
+//!
+//! ```text
+//! id 51  "In stella-cli witness tests (slash_models_witness.rs), prefer
+//!         updating assertions to match the live renderer output … rather
+//!         than changing core CLI behavior."
+//! id 53  "In stella-cli witness tests (slash_models_witness.rs), prefer
+//!         updating assertions to match the live renderer output … rather
+//!         than changing the renderer."
+//! ```
+//!
+//! Node inserts do not dedupe on `content_hash`, and `auto_create_skills`
+//! mines the whole reflection log into skills that re-enter context through
+//! the skills half of the recall block. So a delete leaves two doors open:
+//! the miner writes the lesson back, or promotes it to a skill.
+//!
+//! A tombstone closes both. It records what was forgotten and is consulted
+//! at three points — recall, the reflection recorder, and the skill miner —
+//! so a forgotten lesson stays forgotten without being unrecoverable.
+//!
+//! ## Why lexical similarity, not equality
+//!
+//! The two memories above are not byte-identical, so a `content_hash` match
+//! would not have caught the second one. Measured over this project's real
+//! memory corpus, token-set Jaccard separates the cases with a wide margin:
+//!
+//! ```text
+//! 51 vs 53   0.641   the same lesson, re-learned
+//! 51 vs 55   0.058   |
+//! 51 vs 56   0.020   |  every unrelated pair
+//! 53 vs 57   0.095   |
+//! ```
+//!
+//! Roughly a sevenfold gap between signal and noise, which is why
+//! [`SIMILARITY_THRESHOLD`] sits at 0.5: far above the observed noise floor
+//! and far below the observed re-learning score. Cheap, deterministic, and
+//! needs no embedder on the record path — the alternative (embedding every
+//! candidate lesson to compare against tombstones) buys nothing here and
+//! puts a model call in the way of finishing a turn.
+
+use std::collections::BTreeSet;
+
+/// Token-set overlap above which a candidate counts as a restatement of
+/// something already forgotten. See the module docs for the measurements
+/// behind this number; it is a constant rather than a literal so the
+/// threshold can be tuned against a larger corpus without hunting call
+/// sites.
+pub const SIMILARITY_THRESHOLD: f64 = 0.5;
+
+/// A context surface a tombstone can apply to. The agent is steered by more
+/// than memories, and "forget this" should mean the same thing whichever
+/// surface the user is looking at, so the tombstone is keyed by surface plus
+/// that surface's own stable id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ContextSurface {
+    /// A mined reflection in `context.db`, keyed by its `nod_…` public id.
+    /// Reaches the model through the volatile recall block.
+    Memory,
+    /// A hand-written note at `.stella/memories/<name>.md`, keyed by
+    /// filename stem. Distinct from [`Self::Memory`]: these are authored,
+    /// not mined, and are pasted into the *system prompt* rather than
+    /// recalled — today with no filter of any kind in front of them.
+    WorkspaceMemory,
+    /// A project rule at `.stella/rules/<slug>.md`, keyed by rule id. Steers
+    /// twice — the rules section of the system prompt, and the tool-boundary
+    /// guards — which must never disagree, so one filter covers both.
+    Rule,
+    /// An installed skill, by name. Reaches the model three ways: the recall
+    /// block, explicit `/skill-name` invocation, and `skill_search` results.
+    Skill,
+    /// A subagent definition at `.stella/agents/<name>.md`, by name.
+    Agent,
+    /// A slash command at `.stella/commands/<name>.md`, by name.
+    Command,
+    /// A domain in `.stella/domains.toml`, by name. Steers indirectly: it is
+    /// both text in `project_overview` output and the selection signal that
+    /// decides which skills and memories are recalled at all.
+    Domain,
+}
+
+impl ContextSurface {
+    /// The wire/storage spelling. Stable — it is a primary-key component.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::WorkspaceMemory => "workspace-memory",
+            Self::Rule => "rule",
+            Self::Skill => "skill",
+            Self::Agent => "agent",
+            Self::Command => "command",
+            Self::Domain => "domain",
+        }
+    }
+
+    /// Parse the storage spelling back, for rows read out of SQLite and for
+    /// the CLI's surface argument.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "memory" => Some(Self::Memory),
+            "workspace-memory" => Some(Self::WorkspaceMemory),
+            "rule" => Some(Self::Rule),
+            "skill" => Some(Self::Skill),
+            "agent" => Some(Self::Agent),
+            "command" => Some(Self::Command),
+            "domain" => Some(Self::Domain),
+            _ => None,
+        }
+    }
+
+    /// Every surface, for enumeration in the CLI and the deck's browser.
+    pub fn all() -> [Self; 7] {
+        [
+            Self::Memory,
+            Self::WorkspaceMemory,
+            Self::Rule,
+            Self::Skill,
+            Self::Agent,
+            Self::Command,
+            Self::Domain,
+        ]
+    }
+
+    /// Whether a tombstone on this surface should also suppress *restatements*
+    /// of the forgotten text, not just the exact id.
+    ///
+    /// True only for the surfaces a background loop can regenerate on its own:
+    /// mined reflections, and the skills `auto_create_skills` mines out of the
+    /// reflection log. The rest are authored by a human — re-creating a rule
+    /// by hand is a deliberate act, and silently swallowing it because it
+    /// resembles something forgotten months ago would be its own bug.
+    pub fn suppresses_restatements(&self) -> bool {
+        matches!(self, Self::Memory | Self::Skill)
+    }
+}
+
+/// Comparison tokens: lowercased alphanumeric runs, keeping the characters
+/// that make identifiers and paths one token (`slash_models_witness.rs`
+/// must not shatter into `slash`/`models`/`witness`/`rs`, or two lessons
+/// about different files would look alike).
+fn tokens(text: &str) -> BTreeSet<String> {
+    text.split(|c: char| !(c.is_alphanumeric() || matches!(c, '_' | '.' | '-' | '/')))
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+/// Jaccard similarity of two texts' token sets, in `0.0..=1.0`. Two empty
+/// texts are 0.0, not 1.0 — an empty lesson is not a restatement of
+/// anything, and returning 1.0 would let one empty tombstone suppress every
+/// future empty-ish candidate.
+pub fn similarity(a: &str, b: &str) -> f64 {
+    let (a, b) = (tokens(a), tokens(b));
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let intersection = a.intersection(&b).count() as f64;
+    let union = a.union(&b).count() as f64;
+    intersection / union
+}
+
+/// Is `candidate` close enough to `forgotten` to be the same lesson wearing
+/// different words?
+pub fn is_restatement(candidate: &str, forgotten: &str) -> bool {
+    similarity(candidate, forgotten) >= SIMILARITY_THRESHOLD
+}
+
+/// Does `candidate` restate anything in `forgotten`? The question the
+/// reflection recorder and the skill miner both ask before persisting.
+pub fn is_suppressed<'a>(candidate: &str, forgotten: impl IntoIterator<Item = &'a str>) -> bool {
+    forgotten.into_iter().any(|f| is_restatement(candidate, f))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two real memories from this project's store, verbatim. They are
+    /// the reason this module exists: recorded two days apart, the same
+    /// lesson about a file that no longer existed.
+    const RELEARNED_A: &str = "In stella-cli witness tests (slash_models_witness.rs), prefer \
+         updating assertions to match the live renderer output (abbreviated column headers like \
+         'in'/'out'/'cached-i', actual seeded numeric formatting, and observed strings like \
+         'thinks') rather than changing core CLI behavior.";
+    const RELEARNED_B: &str = "In stella-cli witness tests (slash_models_witness.rs), prefer \
+         updating assertions to match the live renderer output (abbreviated column headers like \
+         'in'/'out'/'cached-i', actual seed values, etc.) rather than changing the renderer.";
+    const UNRELATED: &str = "For cargo test filters like --exact, always place them after the -- \
+         separator (cargo test -- --exact) to pass args to the test binary instead of Cargo.";
+
+    #[test]
+    fn a_relearned_lesson_is_recognized_as_a_restatement() {
+        assert!(
+            is_restatement(RELEARNED_B, RELEARNED_A),
+            "similarity was {}",
+            similarity(RELEARNED_B, RELEARNED_A)
+        );
+    }
+
+    #[test]
+    fn unrelated_lessons_are_not_restatements() {
+        assert!(!is_restatement(UNRELATED, RELEARNED_A));
+        assert!(!is_restatement(RELEARNED_A, UNRELATED));
+    }
+
+    /// The threshold is only defensible if signal and noise are far apart —
+    /// pin the margin so a future tweak that collapses it fails loudly.
+    #[test]
+    fn signal_and_noise_stay_far_apart() {
+        let signal = similarity(RELEARNED_A, RELEARNED_B);
+        let noise = similarity(RELEARNED_A, UNRELATED);
+        assert!(signal > 0.5, "re-learned pair scored {signal}");
+        assert!(noise < 0.2, "unrelated pair scored {noise}");
+        assert!(
+            signal > noise * 3.0,
+            "margin collapsed: signal {signal}, noise {noise}"
+        );
+    }
+
+    #[test]
+    fn identifiers_and_paths_stay_whole() {
+        // Two lessons about *different* files must not look alike just
+        // because they share sentence scaffolding.
+        let about_a = "In witness tests (alpha_witness.rs), prefer updating assertions.";
+        let about_b = "In witness tests (beta_witness.rs), prefer updating assertions.";
+        assert!(tokens(about_a).contains("alpha_witness.rs"));
+        // The filename stayed whole, so its parts are not tokens of their own.
+        assert!(!tokens(about_a).contains("alpha"));
+        assert!(
+            similarity(about_a, about_b) < 1.0,
+            "the differing filename must register"
+        );
+    }
+
+    #[test]
+    fn empty_text_matches_nothing() {
+        assert_eq!(similarity("", ""), 0.0);
+        assert_eq!(similarity("", RELEARNED_A), 0.0);
+        assert!(!is_restatement("", ""));
+    }
+
+    #[test]
+    fn suppression_scans_every_tombstone() {
+        let forgotten = [UNRELATED, RELEARNED_A];
+        assert!(is_suppressed(RELEARNED_B, forgotten));
+        assert!(!is_suppressed(
+            "An entirely new observation about graph queries.",
+            forgotten
+        ));
+    }
+
+    #[test]
+    fn surface_spellings_round_trip() {
+        for surface in ContextSurface::all() {
+            assert_eq!(ContextSurface::parse(surface.as_str()), Some(surface));
+        }
+        assert_eq!(ContextSurface::parse("nonsense"), None);
+    }
+}

--- a/stella-store/src/forget_tests.rs
+++ b/stella-store/src/forget_tests.rs
@@ -1,0 +1,175 @@
+//! Round-trip tests for the explicit-tombstone table.
+//!
+//! The behaviour under test is the one that motivated the feature: a
+//! forgotten lesson must stay forgotten even when the reflection loop
+//! re-mines it under a brand-new id, and it must be recoverable when the
+//! user changes their mind.
+
+use crate::{ContextSurface, Store, forget};
+
+/// The two real memories from this project's store — the same lesson mined
+/// twice, two days apart, both naming a file that had already been deleted.
+const RELEARNED_A: &str = "In stella-cli witness tests (slash_models_witness.rs), prefer updating \
+     assertions to match the live renderer output (abbreviated column headers like \
+     'in'/'out'/'cached-i', actual seeded numeric formatting, and observed strings like 'thinks') \
+     rather than changing core CLI behavior.";
+const RELEARNED_B: &str = "In stella-cli witness tests (slash_models_witness.rs), prefer updating \
+     assertions to match the live renderer output (abbreviated column headers like \
+     'in'/'out'/'cached-i', actual seed values, etc.) rather than changing the renderer.";
+
+#[test]
+fn forget_then_read_back_by_surface() {
+    let store = Store::in_memory().expect("in-memory store");
+    store
+        .forget(ContextSurface::Memory, "nod_aaa", RELEARNED_A, "stale file")
+        .expect("forget");
+
+    let ids = store.forgotten_ids(ContextSurface::Memory).expect("ids");
+    assert!(ids.contains("nod_aaa"));
+
+    // Surfaces are independent namespaces — a forgotten memory must not
+    // suppress a rule that happens to share an id.
+    assert!(
+        store
+            .forgotten_ids(ContextSurface::Rule)
+            .expect("rule ids")
+            .is_empty()
+    );
+}
+
+#[test]
+fn forgetting_twice_updates_instead_of_erroring() {
+    let store = Store::in_memory().expect("in-memory store");
+    store
+        .forget(ContextSurface::Memory, "nod_aaa", RELEARNED_A, "first")
+        .expect("first forget");
+    store
+        .forget(ContextSurface::Memory, "nod_aaa", RELEARNED_B, "second")
+        .expect("re-forget must be idempotent, not an error");
+
+    let rows = store.forgotten_rows().expect("rows");
+    assert_eq!(rows.len(), 1, "one verdict per item, not a duplicate");
+    assert_eq!(rows[0].reason, "second");
+    assert_eq!(rows[0].content, RELEARNED_B, "content refreshed");
+}
+
+#[test]
+fn restore_reports_whether_anything_was_lifted() {
+    let store = Store::in_memory().expect("in-memory store");
+    store
+        .forget(ContextSurface::Skill, "witness-tests", "some text", "")
+        .expect("forget");
+
+    assert!(
+        store
+            .restore(ContextSurface::Skill, "witness-tests")
+            .expect("restore"),
+        "restoring a live tombstone reports true"
+    );
+    assert!(
+        !store
+            .restore(ContextSurface::Skill, "witness-tests")
+            .expect("restore again"),
+        "restoring something never forgotten reports false, not success"
+    );
+    assert!(
+        store
+            .forgotten_ids(ContextSurface::Skill)
+            .expect("ids")
+            .is_empty()
+    );
+}
+
+/// The point of the whole design: forgetting memory `nod_aaa` must also
+/// suppress the paraphrase the miner writes back under `nod_bbb`.
+#[test]
+fn a_forgotten_lesson_suppresses_its_relearned_paraphrase() {
+    let store = Store::in_memory().expect("in-memory store");
+    store
+        .forget(ContextSurface::Memory, "nod_aaa", RELEARNED_A, "stale")
+        .expect("forget");
+
+    let forgotten = store
+        .forgotten_texts(ContextSurface::Memory)
+        .expect("forgotten texts");
+
+    assert!(
+        forget::is_suppressed(RELEARNED_B, forgotten.iter().map(String::as_str)),
+        "the re-mined paraphrase must be caught by the tombstone"
+    );
+    assert!(
+        !forget::is_suppressed(
+            "For cargo test filters like --exact, place them after the -- separator.",
+            forgotten.iter().map(String::as_str)
+        ),
+        "an unrelated lesson must still be allowed through"
+    );
+}
+
+#[test]
+fn forgotten_texts_skips_rows_with_no_recorded_content() {
+    let store = Store::in_memory().expect("in-memory store");
+    // A surface whose id IS its whole identity (a domain name) may carry no
+    // body; such a row must not contribute an empty string to the
+    // restatement check, or it would match nothing and cost a comparison.
+    store
+        .forget(ContextSurface::Domain, "stella-cli", "", "")
+        .expect("forget");
+    assert!(
+        store
+            .forgotten_texts(ContextSurface::Domain)
+            .expect("texts")
+            .is_empty()
+    );
+    assert!(
+        store
+            .forgotten_ids(ContextSurface::Domain)
+            .expect("ids")
+            .contains("stella-cli"),
+        "the id is still tombstoned even with no body"
+    );
+}
+
+/// Same posture as [`Store::quarantined_memory_ids`]: a missing table is an
+/// error the caller must handle, never a silent empty set that would read as
+/// "nothing is forgotten" and surface everything.
+#[test]
+fn a_missing_tombstone_table_is_an_error_not_an_empty_set() {
+    let store = Store::in_memory().expect("in-memory store");
+    store
+        .lock()
+        .execute("DROP TABLE forgotten", [])
+        .expect("remove tombstone table");
+    assert!(store.forgotten_ids(ContextSurface::Memory).is_err());
+    assert!(store.forgotten_texts(ContextSurface::Memory).is_err());
+    assert!(store.forgotten_rows().is_err());
+}
+
+/// An existing database must gain the table by migration, not only fresh
+/// ones via `create_latest_schema`.
+#[test]
+fn the_table_arrives_by_migration_on_an_existing_database() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(root.path()).expect("open");
+    // Simulate a pre-v14 file: drop the table and wind the version back.
+    store
+        .lock()
+        .execute("DROP TABLE forgotten", [])
+        .expect("drop");
+    store
+        .lock()
+        .pragma_update(None, "user_version", 13i64)
+        .expect("rewind version");
+    drop(store);
+
+    let store = Store::open(root.path()).expect("reopen runs migrations");
+    store
+        .forget(ContextSurface::Memory, "nod_aaa", RELEARNED_A, "")
+        .expect("table exists after migration");
+    assert!(
+        store
+            .forgotten_ids(ContextSurface::Memory)
+            .expect("ids")
+            .contains("nod_aaa")
+    );
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -102,6 +102,8 @@ use stella_protocol::{AgentEvent, TaskItem, TaskStatus, ToolOutput};
 //   sessions    cross-process session registry (one JSON file per session)
 //   usage       `usage.db` — user-tier cross-project telemetry aggregate
 mod ddl;
+#[cfg(test)]
+mod forget_tests;
 mod migrations;
 mod private;
 #[cfg(test)]
@@ -122,6 +124,7 @@ pub mod catalog;
 pub mod content_free;
 pub mod drain;
 pub mod enterprise_telemetry;
+pub mod forget;
 pub mod home;
 pub mod identity;
 pub mod journal;
@@ -141,6 +144,7 @@ pub use drain::{
     MAX_SUPPORTED_SCHEMA_VERSION, MIN_SUPPORTED_SCHEMA_VERSION, OTEL_SCHEMA_VERSION_ATTR,
     RejectionClass, drain_org, schema_version_supported,
 };
+pub use forget::{ContextSurface, is_restatement, is_suppressed};
 // The sidecar journal's writer is deliberately NOT re-exported at the top
 // level: `SessionJournal` here names the DB read-model reassembled by
 // [`Store::session_events`] (read-only replay), while
@@ -276,6 +280,29 @@ pub const QUARANTINE_NEGATIVES_THRESHOLD: i64 = 2;
 /// resets the streak to zero, disqualifying the memory until it re-earns
 /// MORE THAN 10 fresh all-positive citations. A memory that was never cited
 /// negatively has `positive_streak == citations`.
+/// One tombstone as stored — what a person chose to forget, the text it
+/// carried at the time, and when.
+///
+/// `surface` stays a `String` rather than a [`ContextSurface`] so a row
+/// written by a newer build (naming a surface this binary has never heard
+/// of) reads back as data instead of failing the whole query. Callers that
+/// need the typed form go through [`ContextSurface::parse`] and decide for
+/// themselves what to do with an unknown one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForgottenRow {
+    /// Storage spelling of the surface — see [`ContextSurface::as_str`].
+    pub surface: String,
+    /// The surface's own stable id: `nod_…`, a rule id, a skill name.
+    pub item_id: String,
+    /// The item's text when it was forgotten, copied so the restatement
+    /// check outlives the original row.
+    pub content: String,
+    /// Optional free-text note on why.
+    pub reason: String,
+    /// SQLite `CURRENT_TIMESTAMP` at forget time.
+    pub forgotten_at: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct MemoryCitationStats {
     pub memory_id: String,
@@ -937,6 +964,97 @@ impl Store {
             .filter(|s| s.quarantined)
             .map(|s| s.memory_id)
             .collect())
+    }
+
+    /// Tombstone one item so it stops steering the agent, recording the text
+    /// it carried at the time. Idempotent: re-forgetting refreshes the copied
+    /// content and the reason rather than erroring, so forgetting a memory
+    /// that was re-learned under a new id behaves the way a user expects.
+    ///
+    /// `content` is what makes this survive re-learning — the reflection
+    /// recorder and the skill miner compare candidates against it, so a
+    /// paraphrase with a fresh id is still caught. Pass the item's text, not
+    /// its id.
+    pub fn forget(
+        &self,
+        surface: crate::ContextSurface,
+        item_id: &str,
+        content: &str,
+        reason: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO forgotten (surface, item_id, content, reason)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(surface, item_id) DO UPDATE SET
+               content = excluded.content,
+               reason = excluded.reason",
+            rusqlite::params![surface.as_str(), item_id, content, reason],
+        )?;
+        Ok(())
+    }
+
+    /// Lift a tombstone. Returns whether a row was actually removed, so a
+    /// caller can tell "restored" from "was never forgotten" instead of
+    /// reporting success either way.
+    pub fn restore(&self, surface: crate::ContextSurface, item_id: &str) -> Result<bool> {
+        let conn = self.lock();
+        let removed = conn.execute(
+            "DELETE FROM forgotten WHERE surface = ?1 AND item_id = ?2",
+            rusqlite::params![surface.as_str(), item_id],
+        )?;
+        Ok(removed > 0)
+    }
+
+    /// Tombstoned ids for one surface — the filter every loader applies. Like
+    /// [`Self::quarantined_memory_ids`], a query failure is explicit: an empty
+    /// set means "nothing is forgotten", and callers are expected to treat an
+    /// unreadable tombstone table as fail-closed rather than as permission to
+    /// surface everything.
+    pub fn forgotten_ids(
+        &self,
+        surface: crate::ContextSurface,
+    ) -> Result<std::collections::HashSet<String>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare("SELECT item_id FROM forgotten WHERE surface = ?1")?;
+        let ids = stmt
+            .query_map([surface.as_str()], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+        Ok(ids)
+    }
+
+    /// The forgotten *texts* for one surface, for the restatement check that
+    /// keeps a re-mined paraphrase from walking back in under a new id.
+    pub fn forgotten_texts(&self, surface: crate::ContextSurface) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt =
+            conn.prepare("SELECT content FROM forgotten WHERE surface = ?1 AND content <> ''")?;
+        let texts = stmt
+            .query_map([surface.as_str()], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<String>, _>>()?;
+        Ok(texts)
+    }
+
+    /// Every tombstone, newest first — the read behind `stella context
+    /// forgotten` and the deck's restore affordance.
+    pub fn forgotten_rows(&self) -> Result<Vec<ForgottenRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT surface, item_id, content, reason, forgotten_at
+               FROM forgotten ORDER BY forgotten_at DESC, surface, item_id",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(ForgottenRow {
+                    surface: row.get::<_, String>(0)?,
+                    item_id: row.get::<_, String>(1)?,
+                    content: row.get::<_, String>(2)?,
+                    reason: row.get::<_, String>(3)?,
+                    forgotten_at: row.get::<_, String>(4)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Persist the MCP tool calls recorded during an execution: one row per

--- a/stella-store/src/migrations.rs
+++ b/stella-store/src/migrations.rs
@@ -11,10 +11,10 @@
 use rusqlite::{Connection, params};
 
 use crate::ddl::{
-    AGENT_USES_DDL, CONTEXT_BLOCKS_DDL, EXECUTION_REFLECTION_DDL, EXECUTIONS_DDL, MCP_USAGE_DDL,
-    MEMORY_CITATIONS_DDL, PULL_REQUESTS_DDL, REFLECTIONS_DDL, RULES_TABLE, SKILL_USAGE_DDL,
-    STEP_MANIFEST_DDL, STEP_RECEIPT_DDL, TABLES, TASKS_DDL, TELEMETRY_INDEX, TOOL_CALLS_DDL,
-    UNCHANGED_TABLES, events_ddl, files_touched_ddl, telemetry_ddl,
+    AGENT_USES_DDL, CONTEXT_BLOCKS_DDL, EXECUTION_REFLECTION_DDL, EXECUTIONS_DDL, FORGOTTEN_DDL,
+    MCP_USAGE_DDL, MEMORY_CITATIONS_DDL, PULL_REQUESTS_DDL, REFLECTIONS_DDL, RULES_TABLE,
+    SKILL_USAGE_DDL, STEP_MANIFEST_DDL, STEP_RECEIPT_DDL, TABLES, TASKS_DDL, TELEMETRY_INDEX,
+    TOOL_CALLS_DDL, UNCHANGED_TABLES, events_ddl, files_touched_ddl, telemetry_ddl,
 };
 use crate::{Result, StoreError};
 
@@ -28,7 +28,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 13] = [
+pub(crate) const MIGRATIONS: [Migration; 14] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -74,6 +74,9 @@ pub(crate) const MIGRATIONS: [Migration; 13] = [
     // worker receipt of the step it precedes. A PK change is a table rebuild;
     // existing rows are all worker calls and backfill to seq 0.
     migrate_v12_to_v13,
+    // v13 → v14: `forgotten` — explicit, reversible human tombstones over any
+    // context surface. Purely additive; no existing table changes shape.
+    migrate_v13_to_v14,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -105,6 +108,7 @@ pub(crate) fn create_latest_schema(tx: &rusqlite::Transaction<'_>) -> Result<()>
     tx.execute_batch(CONTEXT_BLOCKS_DDL)?;
     tx.execute_batch(STEP_MANIFEST_DDL)?;
     tx.execute_batch(STEP_RECEIPT_DDL)?;
+    tx.execute_batch(FORGOTTEN_DDL)?;
     Ok(())
 }
 
@@ -411,6 +415,14 @@ fn migrate_v9_to_v10(tx: &rusqlite::Transaction<'_>) -> Result<()> {
                 END;",
         )?;
     }
+    Ok(())
+}
+
+/// v13 → v14: `forgotten`, the explicit-tombstone table. Purely additive —
+/// one new table plus its by-surface index, so no §7 rebuild. `IF NOT EXISTS`
+/// in the shared DDL also tolerates a partial file that already grew it.
+fn migrate_v13_to_v14(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    tx.execute_batch(FORGOTTEN_DDL)?;
     Ok(())
 }
 

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -949,10 +949,11 @@ fn skill_usage_records_per_execution_version_rows() {
     // accounting for execution/telemetry rows, v11 adds the context-receipts
     // plane (context_blocks / step_manifest / step_receipt), v12 adds
     // reconstruction support (context_blocks.content / step_manifest.message_index),
-    // and v13 rekeys both receipt tables on call_seq so the auxiliary calls
+    // v13 rekeys both receipt tables on call_seq so the auxiliary calls
     // sharing a step (overflow summarizer, pipeline management roles) each keep
-    // their own receipt.
-    assert_eq!(SCHEMA_VERSION, 13);
+    // their own receipt, and v14 adds `forgotten` — explicit, reversible human
+    // tombstones over any context surface.
+    assert_eq!(SCHEMA_VERSION, 14);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
Adds `stella memory forget <id>` / `restore <id>` / `forgotten`, built as a
reversible tombstone rather than a delete.

## Why not a DELETE

Because a delete does not hold. This project's own store contained two
memories, recorded **two days apart**, that are the same lesson about a test
file that had already been removed:

| id | recorded | text |
|---|---|---|
| `nod_2c6a…` | 2026-07-23 | "In stella-cli witness tests (`slash_models_witness.rs`), … rather than changing core CLI behavior." |
| `nod_9485…` | 2026-07-25 | "In stella-cli witness tests (`slash_models_witness.rs`), … rather than changing the renderer." |

Node inserts do not dedupe on `content_hash`, and `auto_create_skills`
(`memory.rs:587`) re-mines the entire append-only `reflections.jsonl` on every
reflection turn, promoting clusters into `SKILL.md` files that re-enter
context through the skills half of the recall block — a path with no
suppression filter at all.

So a deleted memory has two doors back in: re-recorded as a memory, or
promoted to a skill. The tombstone closes both.

## Why not extend quarantine

`quarantined_memory_ids` is **derived**, not stored — it folds
`memory_citations`. A derivation can express "the model kept calling this
untruthful". It cannot express "a person read this and said remove it".
There is nowhere to write that verdict, which is why this needs its own
table.

## Design

**Storage.** New `forgotten` table (schema v14), keyed `(surface, item_id)`,
in `store.db` beside `memory_citations` — deliberately *not* `context.db`,
whose nodes are mutable current-state (`upsert_node` overwrites in place, no
point-in-time reader). A tombstone must outlive edits to the thing it
buries, including the row's deletion. Restore is a plain `DELETE`, so
absence is the "not forgotten" state and there is no tri-state to keep
consistent.

**Matching is by restatement, not equality.** The two memories above are not
byte-identical, so a `content_hash` check would have missed the second one.
Token-set Jaccard over the real corpus separates the cases with a wide
margin:

```
51 vs 53   0.641   the same lesson, re-learned
51 vs 55   0.058   |
51 vs 56   0.020   |  every unrelated pair
53 vs 57   0.095   |
```

`SIMILARITY_THRESHOLD = 0.5` sits ~7x above the observed noise floor. Cheap,
deterministic, and needs no embedder on the record path.

Restatement suppression applies only to surfaces a background loop can
regenerate (memories, mined skills) — `suppresses_restatements`.
Re-creating a rule by hand is a deliberate act and silently swallowing it
because it resembles something forgotten months ago would be its own bug.

**Three enforcement points**, so forgetting is durable rather than cosmetic:
1. `recalled_frames_reporting` — the forgotten set joins the quarantine set.
2. `reflect_and_record` — `retain_unforgotten` drops restatements *before*
   any of the three places that function persists to.
3. `auto_create_skills` — observations are filtered before mining.

**Fail-closed posture** matches quarantine at recall (unreadable state →
surface nothing) and deliberately **inverts** at the record path (unreadable
state → keep the lesson). Both fail toward the recoverable outcome: a memory
that should have been suppressed can be forgotten again, whereas a lesson
dropped on a transient read error is gone for good. That asymmetry is
documented at the call site.

## Verification

Round-tripped end to end against a copy of this workspace's real
`context.db`:

```
$ stella memory forget nod_2c6a… --reason "names a deleted file"
  ✓ forgot nod_2c6a6d1b55d6c55ea35c7de1
    In stella-cli witness tests (slash_models_witness.rs), prefer updating …
    restatements of this will also be suppressed when the loop reflects
    undo: stella memory restore nod_2c6a…

$ stella memory forgotten
  · memory  nod_2c6a…  In stella-cli witness tests (slash_models_witness.rs)…
      names a deleted file
  1 forgotten — `stella memory restore <id>` lifts one

$ stella memory restore nod_2c6a…   →  ✓ restored
$ stella memory restore nod_2c6a…   →  · was not forgotten — nothing to restore
```

`cargo test -p stella-cli -p stella-store`: **561 + 186 + 31 + 3 + 1 passed,
0 failed**. `cargo fmt --all --check` and `cargo clippy --all-targets` clean.
`cargo build --workspace` clean.

21 new tests, including `a_forgotten_lesson_suppresses_its_relearned_paraphrase`
(the pair above, verbatim), `the_table_arrives_by_migration_on_an_existing_database`,
and `a_missing_tombstone_table_is_an_error_not_an_empty_set`.

Two existing tests updated rather than worked around: the `SCHEMA_VERSION`
pin (13 → 14, with the running commentary extended), and the quarantine
fail-closed assertion, whose diagnostic now names the combined suppression
state because recall reads both sets together.

## Scope

`ContextSurface` enumerates all seven steering surfaces and the table is
keyed by surface, but **only `Memory` is wired end to end here**. The mapping
found that just 1 of 7 re-entry paths is filtered today; the loaders for
rules, skills, agents, commands, domains, and `.stella/memories/*.md` (which
is pasted into the system prompt with no filter of any kind) are the
follow-up, along with the deck UI.
