### PR TITLE
protocol: make AgentEvent forward-compatible with newer event vocabularies

### DIFF
--- a/docs/adaptive-context/phase-0-baseline.md
+++ b/docs/adaptive-context/phase-0-baseline.md
@@ -223,6 +223,24 @@ unknown-event envelope / reader tolerance, or the change breaks replay of mixed
 streams. The plan already flags "characterize the existing decoder" — this is
 the answer: it rejects unknown tags.
 
+> **Resolved — the decoder is now forward-tolerant.** `AgentEvent` carries an
+> `Unknown { event_type, payload }` variant: an unrecognized `"type"` is
+> preserved whole instead of failing the line, so old code no longer hard-fails
+> on new data and `parse_jsonl` replays mixed streams intact. The tolerance is
+> scoped to the *tag* — a recognized tag with a body that does not fit its
+> variant is still a fatal `MalformedLine`, because that is corruption rather
+> than version skew.
+>
+> The characterization above stands as the record of why
+> `LifecycleEventEnvelope` was introduced. That envelope is still the right
+> home for internal lifecycle events, but now for its `schema_version` and to
+> keep stella-internal vocabulary off the public cross-language event
+> contract — not because the main stream would break.
+>
+> See `stella-protocol/src/event.rs` (`KNOWN_TYPE_TAGS`, the hand-written
+> codec) and the conformance fixture
+> `stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl`.
+
 ## 6. Characterized: frame representations
 
 `Representation` (`contextgraph-types … frame.rs:47`) is `{ Full (default),

--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -28,9 +28,15 @@
 //! A crashed writer must never poison a reader: [`parse_jsonl`] tolerates a
 //! single unparseable *final* line (a torn tail) by dropping it, while a
 //! malformed *interior* line is a real error. Envelope evolution is
-//! additive-only, so parsing is forward-tolerant by construction (serde
-//! ignores unknown fields on the structs that opt in; unknown *variants* are
-//! the one thing that can't be tolerated and surface as an interior error).
+//! additive-only, so parsing is forward-tolerant by construction: serde
+//! ignores unknown fields on the structs that opt in, and an unknown event
+//! *variant* is preserved as [`stella_protocol::AgentEvent::Unknown`] rather
+//! than failing the line — so a stream from a newer stella replays here
+//! intact. `tests/fixtures/from_a_newer_stella.jsonl` pins that.
+//!
+//! What remains fatal is real damage: a line that is not valid JSON, or one
+//! whose `"type"` this build *does* know but whose body does not fit that
+//! variant. Both mean the record is wrong, not merely newer.
 
 pub mod golden;
 
@@ -263,6 +269,14 @@ pub fn event_signature(event: &AgentEvent) -> String {
         AgentEvent::UsageIncomplete { reason, .. } => {
             format!("usage_incomplete:{reason:?}")
         }
+        // An event from a newer stella. Its tag is the only part this build
+        // can honestly read, and two different unknown tags are genuinely
+        // different events — so keep the tag and nothing else. Excluded from
+        // `structural_diff` below regardless (see the keep-set), so this
+        // signature exists mainly to keep the function total and to make an
+        // unknown event legible in a diff that is printed rather than
+        // compared.
+        AgentEvent::Unknown { event_type, .. } => format!("unknown:{event_type}"),
         // A goal verdict's structural identity is whether the goal was met
         // (mirrors `judge_verdict`); the reasoning text and cost are volatile.
         AgentEvent::GoalVerdict { met, .. } => format!("goal_verdict:met={met}"),
@@ -337,6 +351,14 @@ pub fn structural_diff(left: &[AgentEvent], right: &[AgentEvent]) -> Vec<StreamD
     // `SpeculationDiscarded` (#415) joins them: it is a run-to-run scheduling
     // artifact absent from pre-speculation goldens, so it too must not shift
     // aligned positions.
+    // `Unknown` is the general case of that same rule. An event this build
+    // cannot decode came from a different stella, so it is present in exactly
+    // one of the two streams by construction — keeping it would shift every
+    // later position and report drift that says nothing about behaviour. The
+    // comparison is therefore over the vocabulary both sides share, which is
+    // the only vocabulary either side can reason about. Unknown events are
+    // still counted and still validated; they are only excluded from
+    // *positional* structural comparison.
     let keep = |e: &&AgentEvent| {
         !matches!(
             e,
@@ -344,6 +366,7 @@ pub fn structural_diff(left: &[AgentEvent], right: &[AgentEvent]) -> Vec<StreamD
                 | AgentEvent::BlockRegistered { .. }
                 | AgentEvent::StepManifest { .. }
                 | AgentEvent::SpeculationDiscarded { .. }
+                | AgentEvent::Unknown { .. }
         )
     };
     let left: Vec<&AgentEvent> = left.iter().filter(keep).collect();
@@ -383,6 +406,11 @@ pub enum JsonlError {
 /// non-empty line fails to parse — the signature of a writer that crashed
 /// mid-line — it is dropped rather than failing the whole parse. A malformed
 /// *interior* line is a [`JsonlError::MalformedLine`].
+///
+/// A line carrying an event type this build does not recognize is **not**
+/// malformed: it parses into [`stella_protocol::AgentEvent::Unknown`] with its
+/// payload preserved. Only genuinely broken JSON, or a recognized `"type"`
+/// with a body that does not fit it, is an error.
 pub fn parse_jsonl(input: &str) -> Result<Vec<AgentEvent>, JsonlError> {
     // Collect (1-indexed line number, content) for every non-blank line.
     let lines: Vec<(usize, &str)> = input

--- a/stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl
+++ b/stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl
@@ -1,0 +1,10 @@
+{"type":"stage","name":"triage"}
+{"type":"budget_tick","spent_usd":0.0001,"limit_usd":null,"mode":"observed"}
+{"type":"stage","name":"execute"}
+{"type":"quantum_reticulation","call_id":"q_1","splines":["alpha","beta"],"nested":{"depth":3}}
+{"type":"tool_start","call":{"call_id":"call_1","name":"edit_file","input":{"path":"src/lib.rs"}}}
+{"type":"tool_result","call_id":"call_1","output":{"ok":{"content":"edited"}},"duration_ms":8}
+{"type":"holographic_verdict","confidence":0.91}
+{"type":"text","delta":"Made the change."}
+{"type":"stage","name":"complete"}
+{"type":"complete","model":"m","cost_usd":0.002}

--- a/stella-pipeline/tests/fixtures/from_a_newer_stella_baseline.jsonl
+++ b/stella-pipeline/tests/fixtures/from_a_newer_stella_baseline.jsonl
@@ -1,0 +1,8 @@
+{"type":"stage","name":"triage"}
+{"type":"budget_tick","spent_usd":0.0002,"limit_usd":null,"mode":"observed"}
+{"type":"stage","name":"execute"}
+{"type":"tool_start","call":{"call_id":"call_9","name":"edit_file","input":{"path":"src/lib.rs"}}}
+{"type":"tool_result","call_id":"call_9","output":{"ok":{"content":"edited"}},"duration_ms":31}
+{"type":"text","delta":"Made the change."}
+{"type":"stage","name":"complete"}
+{"type":"complete","model":"other-model","cost_usd":0.004}

--- a/stella-pipeline/tests/reference_conformance.rs
+++ b/stella-pipeline/tests/reference_conformance.rs
@@ -16,14 +16,24 @@
 //! # The finding this file exists to pin
 //!
 //! The overlap between the two formats is exactly inverted from what a golden
-//! replay needs. The reference events that *do* deserialize as `AgentEvent`
-//! (`text`, `reasoning`) are precisely the ones [`event_signature`] treats as
-//! structurally inert; every event that carries structural identity — the stage
-//! kind, the tool call pairing, the terminator — either fails to parse or has
-//! no counterpart at all. A half-imported reference recording would thus be
-//! *all* volatile content and *no* structure: it would parse into something
-//! that looks like a trajectory and asserts nothing. That is why
-//! [`GoldenTrajectory`] gates on load instead of trusting a recording.
+//! replay needs. The reference events that deserialize into a *typed*
+//! `AgentEvent` (`text`, `reasoning`) are precisely the ones
+//! [`event_signature`] treats as structurally inert; every event that carries
+//! structural identity — the stage kind, the tool call pairing, the terminator
+//! — lands in one of two buckets, neither of which is usable:
+//!
+//!   - `tool` and `result` are tags this protocol has never heard of, so
+//!     forward compatibility preserves them as `AgentEvent::Unknown`.
+//!     Preserved is not understood: an `Unknown` carries no structural
+//!     identity and is excluded from the structural diff entirely.
+//!   - `stage` collides with a tag this protocol *does* define, so it reaches
+//!     the typed decoder and is rejected on its body. That rejection is the
+//!     forward-compat rule working as designed, not a gap in it.
+//!
+//! A half-imported reference recording would thus be *all* volatile content
+//! and *no* structure: it would parse into something that looks like a
+//! trajectory and asserts nothing. That is why [`GoldenTrajectory`] gates on
+//! load instead of trusting a recording.
 
 use stella_pipeline::replay::event_signature;
 use stella_pipeline::replay::golden::{GoldenError, GoldenTrajectory};
@@ -74,9 +84,18 @@ fn reference_stream() -> Vec<ReferenceLine> {
     ]
 }
 
-/// The kinds that already deserialize — recorded here so the list cannot grow
-/// silently. Both are volatile-content events.
+/// The kinds that deserialize into a *typed* variant — recorded here so the
+/// list cannot grow silently. Both are volatile-content events.
 const ALREADY_PARSES: [&str; 2] = ["text", "reasoning"];
+
+/// The kinds this protocol also names, so they reach the typed decoder and are
+/// rejected on their *body*. `stage` collides by name only: the reference
+/// sends a free-text `label`, `AgentEvent::Stage` needs a typed `StageKind`.
+///
+/// This is the forward-compat rule's other branch, and the reason the rule is
+/// scoped to tags alone: a recognized tag carrying a foreign body is a real
+/// mismatch that must stay loud, not a version skew to be absorbed.
+const REJECTED_ON_BODY: [&str; 1] = ["stage"];
 
 fn kind(json: &str) -> String {
     let value: serde_json::Value = serde_json::from_str(json).expect("sample is valid JSON");
@@ -88,47 +107,71 @@ fn kind(json: &str) -> String {
 
 #[test]
 fn the_reference_wire_format_is_not_this_protocol() {
-    let mut unparseable = Vec::new();
+    let mut foreign = Vec::new();
+    let mut rejected = Vec::new();
     for line in reference_stream() {
         let parsed = serde_json::from_str::<AgentEvent>(line.json);
         let kind = kind(line.json);
         if ALREADY_PARSES.contains(&kind.as_str()) {
             assert!(
-                parsed.is_ok(),
-                "`{kind}` was expected to already parse; if it stopped, this \
-                 file's account of the gap is stale: {}",
+                parsed.is_ok_and(|e| !e.is_unknown()),
+                "`{kind}` was expected to parse as a typed variant; if it \
+                 stopped, this file's account of the gap is stale: {}",
                 line.json
             );
-        } else {
+        } else if REJECTED_ON_BODY.contains(&kind.as_str()) {
             assert!(
                 parsed.is_err(),
-                "`{kind}` parsed as an AgentEvent — the reference format and \
-                 this protocol have converged, so the adapter contract needs \
-                 revisiting (adapter must: {})",
+                "`{kind}` is a tag this protocol knows, so a foreign body must \
+                 be a hard error rather than being absorbed as Unknown \
+                 (adapter must: {})",
                 line.adapter_must
             );
-            unparseable.push(kind);
+            rejected.push(kind);
+        } else {
+            // A tag this protocol has never heard of. It is preserved rather
+            // than rejected — but preserved is not understood: it lands as
+            // `Unknown`, which carries no structural identity.
+            let event = parsed.expect("an unrecognized tag must be preserved, not rejected");
+            assert!(
+                event.is_unknown(),
+                "`{kind}` deserialized into a typed variant — the reference \
+                 format and this protocol have converged, so the adapter \
+                 contract needs revisiting (adapter must: {})",
+                line.adapter_must
+            );
+            foreign.push(kind);
         }
     }
     assert_eq!(
-        unparseable,
-        vec!["stage", "tool", "tool", "result"],
+        rejected,
+        vec!["stage"],
+        "the name-collision case must stay accounted for"
+    );
+    assert_eq!(
+        foreign,
+        vec!["tool", "tool", "result"],
         "every structurally-identifying reference event must be accounted for"
     );
 }
 
 #[test]
-fn the_reference_events_that_do_parse_carry_no_structural_identity() {
-    // The damning half of the finding: the overlap is exactly the events the
-    // differ ignores. Importing only what parses yields a trajectory that
-    // asserts nothing about stages, tools, or termination.
+fn no_reference_event_yields_structural_identity() {
+    // The damning half of the finding, and it survives the open enum intact.
+    // Whether a reference line parses as a typed variant (`text`/`reasoning`)
+    // or is preserved as `Unknown` (`tool`/`result`), the signature it
+    // produces is one the differ treats as inert. Importing a reference
+    // recording therefore yields a trajectory that asserts nothing about
+    // stages, tool pairing, or termination — exactly as before.
     for line in reference_stream() {
         let Ok(event) = serde_json::from_str::<AgentEvent>(line.json) else {
             continue;
         };
         let signature = event_signature(&event);
+        let inert =
+            matches!(signature.as_str(), "text" | "reasoning") || signature.starts_with("unknown:");
         assert!(
-            matches!(signature.as_str(), "text" | "reasoning"),
+            inert,
             "a reference event that parses must be structurally inert, got `{signature}`"
         );
     }

--- a/stella-pipeline/tests/replay_fixtures.rs
+++ b/stella-pipeline/tests/replay_fixtures.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use stella_pipeline::replay::{parse_jsonl, streams_equivalent, structural_diff, validate_stream};
+use stella_protocol::AgentEvent;
 
 fn fixture(name: &str) -> String {
     let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "tests", "fixtures", name]
@@ -60,6 +61,66 @@ fn a_judge_escalation_diverges_from_a_deterministic_pass() {
     );
     // And the escalation stream is itself well-formed.
     assert!(validate_stream(&escalation).is_empty());
+}
+
+#[test]
+fn a_stream_from_a_newer_stella_parses_and_stays_valid() {
+    // The conformance fixture: a well-formed turn carrying two event types
+    // this build has never heard of. An older reader must take the whole
+    // stream, not choke on the first line it does not recognize.
+    //
+    // Any client in any language that claims to consume stella's event stream
+    // should be held to exactly this: parse it, skip what you cannot decode,
+    // and keep going. A client that errors on `from_a_newer_stella.jsonl` is
+    // not forward compatible, however well it handles today's vocabulary.
+    let events = parse_jsonl(&fixture("from_a_newer_stella.jsonl"))
+        .expect("future events must not be fatal");
+    assert_eq!(
+        events.len(),
+        10,
+        "every line is kept, including the unknown"
+    );
+
+    let unknown: Vec<&str> = events
+        .iter()
+        .filter(|e| e.is_unknown())
+        .map(AgentEvent::type_tag)
+        .collect();
+    assert_eq!(unknown, vec!["quantum_reticulation", "holographic_verdict"]);
+
+    // The known vocabulary around them still validates: stage ordering, tool
+    // pairing, and the terminal `complete` are unaffected by their presence.
+    let violations = validate_stream(&events);
+    assert!(
+        violations.is_empty(),
+        "unknown events must not break stream invariants, got: {violations:?}"
+    );
+
+    // Payloads survive intact, so this reader could re-export the stream
+    // without dropping what it could not interpret.
+    let reticulation = events.iter().find(|e| e.is_unknown()).unwrap();
+    let AgentEvent::Unknown { payload, .. } = reticulation else {
+        unreachable!("filtered above")
+    };
+    assert_eq!(payload["splines"][1], "beta");
+    assert_eq!(payload["nested"]["depth"], 3);
+}
+
+#[test]
+fn a_newer_stream_is_structurally_equivalent_to_its_older_recording() {
+    // The point of the whole exercise, stated as a comparison: the same run
+    // recorded by a newer stella (with two extra event types) and by an older
+    // one must be judged structurally equivalent. If unknown events counted
+    // toward the positional diff, every golden trajectory would break the
+    // moment the vocabulary grew — which is precisely the failure the
+    // `structural_diff` keep-set exists to prevent.
+    let newer = parse_jsonl(&fixture("from_a_newer_stella.jsonl")).unwrap();
+    let older = parse_jsonl(&fixture("from_a_newer_stella_baseline.jsonl")).unwrap();
+    let diff = structural_diff(&newer, &older);
+    assert!(
+        streams_equivalent(&newer, &older),
+        "a vocabulary addition must not read as behavioural drift; got: {diff:?}"
+    );
 }
 
 #[test]

--- a/stella-protocol/README.md
+++ b/stella-protocol/README.md
@@ -50,26 +50,39 @@ stella-protocol ← stella-core ← stella-cli / stella-pipeline / stella-tui �
 
 ## Key concepts
 
-**Additivity is directional, and the asymmetry is the whole design.** New
-*fields* ride `#[serde(default)]`, so a newer binary parses every older stream.
-New `AgentEvent` *variants* do not travel backwards: the enum is internally
-tagged (`#[serde(tag = "type")]`), so an older binary meets an unrecognized
-`"type"` with a hard deserialization error, and the JSONL replay reader treats
-an unparseable interior line as fatal. An event that must be readable by an
-older binary therefore rides `LifecycleEventEnvelope` instead, whose `payload`
-stays a raw `Value` and whose `decode()` degrades an unrecognized `event_type`
-to `LifecycleEvent::Unknown` with the payload intact. Picking the wrong channel
-is the single most expensive mistake available in this crate.
+**Additivity holds in both directions, and the boundary between "newer" and
+"broken" is the whole design.** New *fields* ride `#[serde(default)]`, so a
+newer binary parses every older stream. New `AgentEvent` *variants* travel
+backwards via `AgentEvent::Unknown { event_type, payload }`: an older binary
+meets an unrecognized `"type"` by preserving the event whole and moving on, and
+the JSONL replay reader keeps the line.
 
-**`AgentEvent::type_tag` is a compile-time guard, not a convenience.**
-`src/event.rs:712` matches every variant with no wildcard arm, so adding a
-variant fails `cargo build -p stella-protocol` with `E0004` right there. Its
-doc comment carries the full downstream checklist: which matchers the compiler
-will also stop you at (`stella-pipeline` `replay::event_signature`,
-`stella-tui` `model::Model::apply`, `textline::event_line`, `deck::trace_of`)
-and — the dangerous half — which ones it cannot (`replay::structural_diff`'s
-volatile keep-set, `deck::event_intensity`, `deck::status_from_event`). Read
-that list before you add a variant; it is maintained there, not here.
+The tolerance is scoped to the **tag alone**. A `"type"` this build knows,
+carrying a body that does not fit its variant, is still a hard error — that is
+corruption or an encoder bug, not a version skew, and laundering it into
+`Unknown` would convert a loud failure into silent data loss. `KNOWN_TYPE_TAGS`
+is the exact boundary, and it is generated from the same macro list as
+`type_tag()` so the two cannot drift.
+
+`LifecycleEventEnvelope` remains the right channel for stella-*internal*
+lifecycle events — it adds an explicit `schema_version`, and it keeps internal
+vocabulary off the public cross-language event contract. It is no longer the
+only way to stay readable by an older binary.
+
+**The `agent_event_tags!` list is a compile-time guard, not a convenience.**
+It generates both `type_tag()` and `KNOWN_TYPE_TAGS` from one variant→tag
+mapping, and the generated match has no wildcard arm — so adding a variant
+fails `cargo build -p stella-protocol` with `E0004` right at the invocation.
+The comment directly below it carries the full downstream checklist: which
+matchers the compiler will also stop you at (`stella-pipeline`
+`replay::event_signature`, `stella-tui` `model::Model::apply`,
+`textline::event_line`, `deck::trace_of`) and — the dangerous half — which ones
+it cannot (`replay::structural_diff`'s volatile keep-set,
+`deck::event_intensity`, `deck::status_from_event`). Read that list before you
+add a variant; it is maintained there, not here.
+
+Note the guard is now about *this workspace's* renderers staying complete, not
+about wire safety: external readers survive a new variant on their own.
 
 **Content-freedom is a type-level property.** `UsageIncompleteReason` is a
 closed enum precisely so an error body cannot be represented;

--- a/stella-protocol/src/context_event.rs
+++ b/stella-protocol/src/context_event.rs
@@ -5,19 +5,30 @@
 //! (as strings), never the `stella-core` record structs: `stella-core` depends on
 //! `stella-protocol`, so importing core types here would be a dependency cycle.
 //!
-//! ## Forward compatibility (the whole point)
+//! ## Forward compatibility
 //!
-//! The main [`crate::event::AgentEvent`] stream is an internally-tagged enum that
-//! **rejects unknown variants**, and the JSONL replay reader treats an
-//! unparseable interior line as fatal. So a NEW event must never be a new
-//! `AgentEvent` variant — an older binary replaying a mixed stream would break.
+//! These events ride a **versioned envelope**: [`LifecycleEventEnvelope`] keeps
+//! the type-specific fields in a raw `payload`, so it always deserializes, even
+//! for an `event_type` the reader has never seen.
+//! [`LifecycleEventEnvelope::decode`] then maps a recognized `event_type` to a
+//! typed [`LifecycleEvent`], or preserves an unrecognized one as
+//! [`LifecycleEvent::Unknown`] with its payload intact.
 //!
-//! Instead these events ride a **versioned envelope**: [`LifecycleEventEnvelope`]
-//! keeps the type-specific fields in a raw `payload`, so it always deserializes,
-//! even for an `event_type` the reader has never seen. [`LifecycleEventEnvelope::decode`]
-//! then maps a recognized `event_type` to a typed [`LifecycleEvent`], or preserves
-//! an unrecognized one as [`LifecycleEvent::Unknown`] with its payload intact —
-//! the exact tolerance the fatal `parse_jsonl` path lacks.
+//! This envelope predates the same tolerance existing on the main event
+//! stream. [`crate::event::AgentEvent`] now carries its own
+//! [`crate::event::AgentEvent::Unknown`] fallback, so "an older binary would
+//! break on a new variant" is no longer the reason to stay off that enum.
+//!
+//! Two reasons remain, and they are the ones that matter now:
+//!
+//!   1. **Explicit versioning.** The envelope carries a `schema_version`
+//!      field. `AgentEvent` has no per-event version, only the additive
+//!      vocabulary rule — so an event whose *shape* is still moving belongs
+//!      here, where readers can branch on the version.
+//!   2. **Vocabulary hygiene.** `AgentEvent` is the public, cross-language
+//!      contract that `--output-format stream-json` and the serve SSE surface
+//!      both publish. Internal adaptive-context lifecycle records are not part
+//!      of that contract and should not enlarge it.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -6,17 +6,34 @@
 //! The vocabulary is additive-only: later variants are appended as the
 //! context/media/fleet crates land, never a breaking rename.
 //!
-//! "Additive" is directional, and the asymmetry matters. New *fields* ride
-//! `serde(default)`, so a newer reader parses every older stream. New
-//! *variants* do not survive the other direction: this enum is internally
-//! tagged (`tag = "type"`), so an older binary meets an unrecognized `"type"`
-//! with a hard deserialization error, and the JSONL replay reader treats an
-//! unparseable interior line as fatal. An event that must be readable by an
-//! older binary therefore belongs on the versioned
-//! [`crate::context_event::LifecycleEventEnvelope`], whose payload stays a raw
-//! `Value` — never on this enum.
+//! "Additive" is directional, but both directions are now survivable. New
+//! *fields* ride `serde(default)`, so a newer reader parses every older
+//! stream. New *variants* travel backwards through
+//! [`AgentEvent::Unknown`]: an unrecognized `"type"` deserializes into that
+//! variant with the original JSON object preserved whole in `payload`, and
+//! re-serializes without losing a key or a value. An older binary therefore
+//! *skips* an event from the future instead of failing the whole stream.
+//!
+//! Round-tripping an unknown event preserves its *content*, not its exact
+//! bytes: [`serde_json::Value`] holds object keys in a `BTreeMap`, so they
+//! come back sorted rather than in their original order. JSON object key
+//! order carries no meaning (RFC 8259 §4), so nothing downstream may depend
+//! on it — but a consumer diffing raw lines should compare parsed values.
+//!
+//! The tolerance is deliberately narrow, and the line matters: the fallback
+//! fires **only for an unrecognized tag**. A *recognized* tag whose body does
+//! not match its variant is still a hard error, because that is a real
+//! encoder bug or a corrupt record — silently degrading it to `Unknown` would
+//! turn data corruption into a shrug. See [`KNOWN_TYPE_TAGS`].
+//!
+//! Note this makes `AgentEvent`'s `Deserialize` impl specific to
+//! self-describing formats (it buffers through [`serde_json::Value`] to read
+//! the tag before dispatching). That is the format this type has always been
+//! defined against — `--output-format stream-json` *is* `serde_json` — so the
+//! constraint costs nothing in practice.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 use crate::tool::{ToolCall, ToolOutput};
 
@@ -182,8 +199,14 @@ pub enum CacheZone {
 /// One event in the turn's stream. Every stage boundary emits an event;
 /// nothing user-visible is derived from internal state that isn't also in
 /// this stream.
+///
+/// `remote = "Self"` keeps the derived codec as a pair of *inherent*
+/// associated functions instead of the trait impls, so the hand-written
+/// [`Serialize`]/[`Deserialize`] impls below can delegate to it after routing
+/// [`AgentEvent::Unknown`] around it. Without that indirection the forward-
+/// compat fallback would mean hand-writing a visitor for all 34 variants.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", remote = "Self")]
 pub enum AgentEvent {
     /// The turn entered a new pipeline stage. Every stage boundary emits one,
     /// in the order the pipeline walks them.
@@ -671,80 +694,195 @@ pub enum AgentEvent {
         model: String,
         cost_usd: f64,
     },
+    /// An event whose `"type"` this binary does not recognize — almost always
+    /// one emitted by a NEWER stella than the one reading. The whole original
+    /// JSON object is preserved in `payload` (tag included), so a proxy,
+    /// recorder, or replay tool can pass a future event through without
+    /// understanding it. Object keys may come back sorted; no value is lost.
+    ///
+    /// This is the variant that makes the vocabulary safe to extend. Consumers
+    /// should treat it as inert: count it, log it, pass it on — never fail on
+    /// it, and never try to guess its semantics from `event_type`.
+    ///
+    /// `serde(skip)` keeps it out of the derived codec entirely; the
+    /// hand-written impls below construct and flatten it. It therefore has no
+    /// wire tag of its own and can never be produced by a literal
+    /// `{"type":"unknown"}` — that input is an unknown tag like any other and
+    /// round-trips as `event_type: "unknown"`.
+    #[serde(skip)]
+    Unknown {
+        /// The unrecognized `"type"` value, lifted out for cheap matching.
+        event_type: String,
+        /// The complete original object, including its `"type"` field.
+        payload: Value,
+    },
 }
 
+/// The single source of truth for the variant ↔ wire-tag mapping.
+///
+/// [`AgentEvent::type_tag`] and [`KNOWN_TYPE_TAGS`] both expand from this one
+/// list, so the two can never disagree. That matters more than it looks: the
+/// deserializer decides "is this tag from the future?" by consulting
+/// `KNOWN_TYPE_TAGS`, so a real tag missing from it would quietly demote every
+/// one of its events to [`AgentEvent::Unknown`] — data loss with no error.
+/// Generating both from one list makes that class of bug unrepresentable.
+///
+/// The `E0004` tripwire survives the move: the generated match is still
+/// exhaustive, so adding a variant without adding it here fails
+/// `cargo build -p stella-protocol` at the invocation below.
+macro_rules! agent_event_tags {
+    ($($variant:ident => $tag:literal,)*) => {
+        impl AgentEvent {
+            /// The stable discriminant tag for this event — identical to the
+            /// string `serde` writes as the `"type"` field on the stream-json
+            /// wire. Allocation-free, so logs, metrics, and tests can name an
+            /// event without serializing it.
+            ///
+            /// For [`AgentEvent::Unknown`] this returns the *preserved
+            /// original* tag, not a placeholder — an unrecognized event still
+            /// reports truthfully what it was on the wire.
+            #[must_use]
+            pub fn type_tag(&self) -> &str {
+                match self {
+                    $(AgentEvent::$variant { .. } => $tag,)*
+                    AgentEvent::Unknown { event_type, .. } => event_type.as_str(),
+                }
+            }
+        }
+
+        /// Every `"type"` tag this build decodes into a typed variant.
+        ///
+        /// The deserializer's forward-compat fallback keys off exactly this
+        /// list: a tag present here must parse into its variant or fail loudly;
+        /// a tag absent from it becomes [`AgentEvent::Unknown`]. Consumers can
+        /// also use it to detect that a stream came from a newer stella.
+        pub const KNOWN_TYPE_TAGS: &[&str] = &[$($tag,)*];
+    };
+}
+
+agent_event_tags! {
+    Stage => "stage",
+    Text => "text",
+    TextDelta => "text_delta",
+    Reasoning => "reasoning",
+    ToolStart => "tool_start",
+    ToolResult => "tool_result",
+    SpeculationDiscarded => "speculation_discarded",
+    Retry => "retry",
+    Steered => "steered",
+    LoopDetected => "loop_detected",
+    BudgetDenied => "budget_denied",
+    RetriesExhausted => "retries_exhausted",
+    PolicyDecision => "policy_decision",
+    Compaction => "compaction",
+    BudgetTick => "budget_tick",
+    StepUsage => "step_usage",
+    UsageIncomplete => "usage_incomplete",
+    GoalVerdict => "goal_verdict",
+    ProviderFallback => "provider_fallback",
+    FileChange => "file_change",
+    ContextRecall => "context_recall",
+    ContextWrite => "context_write",
+    BlockRegistered => "block_registered",
+    StepManifest => "step_manifest",
+    JudgeVerdict => "judge_verdict",
+    ScopeReview => "scope_review",
+    AskUser => "ask_user",
+    MediaProgress => "media_progress",
+    MediaComplete => "media_complete",
+    Commit => "commit",
+    Pr => "pr",
+    TaskUpdate => "task_update",
+    Error => "error",
+    Complete => "complete",
+}
+
+// Adding a variant? The `E0004` at `agent_event_tags!` above is the first
+// tripwire. Add the tag there, then propagate the variant to every downstream
+// matcher — the tag table alone is not enough:
+//
+// **Compile-enforced** — also exhaustive, so they will not build until you add
+// an arm; but each break surfaces one crate at a time (CI stops at the first
+// failing crate), which is exactly how #415's variant reached `main` before
+// breaking `stella-pipeline` (#421) then `stella-tui` (#422):
+//   - `stella-pipeline` `replay::event_signature`
+//   - `stella-tui` `model::Model::apply`
+//   - `stella-tui` `textline::event_line`
+//   - `stella-tui` `deck::trace_of`
+//
+// **Silent** — wildcard / `matches!` arms the compiler CANNOT catch, so a new
+// variant falls through to a default and is wrong only at runtime. These are
+// the real trap; audit them by hand:
+//   - `stella-pipeline` `replay::structural_diff` volatile keep-set: add the
+//     variant if it is a run-to-run artifact absent from older golden streams,
+//     or it will shift every aligned position of the diff.
+//   - `stella-tui` `deck::event_intensity` and `deck::status_from_event`: give
+//     the variant an intensity / agent status if it should register on the
+//     fleet deck.
+//
+// The same duty applies to the other exhaustively-matched cross-crate enums
+// this pattern warns about (`ToolOutput`, `BudgetOutcome`).
+//
+// Note that none of this is about *wire* safety any more — an older reader
+// survives your new variant via `AgentEvent::Unknown`. It is about this
+// workspace's own renderers staying complete.
+
 impl AgentEvent {
-    /// The stable discriminant tag for this event — identical to the string
-    /// `serde` writes as the `"type"` field on the stream-json wire (this enum
-    /// is `#[serde(tag = "type", rename_all = "snake_case")]`). Allocation-free,
-    /// so logs, metrics, and tests can name an event without serializing it.
-    ///
-    /// This match is deliberately **exhaustive, with no wildcard arm**: it is
-    /// the cheap compile-time guard for the additive-only `AgentEvent`
-    /// vocabulary. Adding a variant fails `cargo build -p stella-protocol` (and
-    /// `-p stella-core`, which compiles this crate) with `E0004` right here — a
-    /// scoped per-crate build, not only a full `--workspace` build discovered
-    /// post-merge (#455). When that fires, add the arm AND propagate the new
-    /// variant to every downstream matcher:
-    ///
-    /// **Compile-enforced** — also exhaustive, so they will not build until you
-    /// add an arm; but each break surfaces one crate at a time (CI stops at the
-    /// first failing crate), which is exactly how #415's variant reached `main`
-    /// before breaking `stella-pipeline` (#421) then `stella-tui` (#422):
-    ///   - `stella-pipeline` `replay::event_signature`
-    ///   - `stella-tui` `model::Model::apply`
-    ///   - `stella-tui` `textline::event_line`
-    ///   - `stella-tui` `deck::trace_of`
-    ///
-    /// **Silent** — wildcard / `matches!` arms the compiler CANNOT catch, so a
-    /// new variant falls through to a default and is wrong only at runtime.
-    /// These are the real trap; audit them by hand:
-    ///   - `stella-pipeline` `replay::structural_diff` volatile keep-set: add
-    ///     the variant if it is a run-to-run artifact absent from older golden
-    ///     streams, or it will shift every aligned position of the diff.
-    ///   - `stella-tui` `deck::event_intensity` and `deck::status_from_event`:
-    ///     give the variant an intensity / agent status if it should register
-    ///     on the fleet deck.
-    ///
-    /// The same duty applies to the other exhaustively-matched cross-crate
-    /// enums this pattern warns about (`ToolOutput`, `BudgetOutcome`).
+    /// Whether this event arrived with a `"type"` this build does not know —
+    /// i.e. it was emitted by a newer stella. Consumers that want to surface
+    /// "there is something here I cannot render" ask this rather than matching
+    /// the variant directly.
     #[must_use]
-    pub fn type_tag(&self) -> &'static str {
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, AgentEvent::Unknown { .. })
+    }
+}
+
+impl Serialize for AgentEvent {
+    /// Every known variant delegates to the derived codec, so the wire format
+    /// is unchanged. [`AgentEvent::Unknown`] bypasses it and re-emits the
+    /// object it was parsed from — a future event therefore survives a
+    /// decode/encode round-trip with every key and value intact (though
+    /// possibly reordered), which is what lets a recorder, a proxy, or
+    /// `replay::to_jsonl` handle a stream it only partly understands without
+    /// corrupting the part it does not.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         match self {
-            AgentEvent::Stage { .. } => "stage",
-            AgentEvent::Text { .. } => "text",
-            AgentEvent::TextDelta { .. } => "text_delta",
-            AgentEvent::Reasoning { .. } => "reasoning",
-            AgentEvent::ToolStart { .. } => "tool_start",
-            AgentEvent::ToolResult { .. } => "tool_result",
-            AgentEvent::SpeculationDiscarded { .. } => "speculation_discarded",
-            AgentEvent::Retry { .. } => "retry",
-            AgentEvent::Steered { .. } => "steered",
-            AgentEvent::LoopDetected { .. } => "loop_detected",
-            AgentEvent::BudgetDenied { .. } => "budget_denied",
-            AgentEvent::RetriesExhausted { .. } => "retries_exhausted",
-            AgentEvent::PolicyDecision { .. } => "policy_decision",
-            AgentEvent::Compaction { .. } => "compaction",
-            AgentEvent::BudgetTick { .. } => "budget_tick",
-            AgentEvent::StepUsage { .. } => "step_usage",
-            AgentEvent::UsageIncomplete { .. } => "usage_incomplete",
-            AgentEvent::GoalVerdict { .. } => "goal_verdict",
-            AgentEvent::ProviderFallback { .. } => "provider_fallback",
-            AgentEvent::FileChange { .. } => "file_change",
-            AgentEvent::ContextRecall { .. } => "context_recall",
-            AgentEvent::ContextWrite { .. } => "context_write",
-            AgentEvent::BlockRegistered { .. } => "block_registered",
-            AgentEvent::StepManifest { .. } => "step_manifest",
-            AgentEvent::JudgeVerdict { .. } => "judge_verdict",
-            AgentEvent::ScopeReview { .. } => "scope_review",
-            AgentEvent::AskUser { .. } => "ask_user",
-            AgentEvent::MediaProgress { .. } => "media_progress",
-            AgentEvent::MediaComplete { .. } => "media_complete",
-            AgentEvent::Commit { .. } => "commit",
-            AgentEvent::Pr { .. } => "pr",
-            AgentEvent::TaskUpdate { .. } => "task_update",
-            AgentEvent::Error { .. } => "error",
-            AgentEvent::Complete { .. } => "complete",
+            AgentEvent::Unknown { payload, .. } => payload.serialize(serializer),
+            known => AgentEvent::serialize(known, serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentEvent {
+    /// Reads the `"type"` tag, then dispatches.
+    ///
+    /// An unrecognized tag becomes [`AgentEvent::Unknown`] with the whole
+    /// original object preserved. Everything else — including an object with
+    /// no `"type"` at all, or a non-string one — goes to the derived codec and
+    /// keeps its original error behaviour.
+    ///
+    /// The asymmetry is the point. A tag we have never seen is a newer stella
+    /// talking to an older reader, which is normal and must not break the
+    /// stream. A tag we *do* know carrying a body that does not fit is an
+    /// encoder bug or a corrupt record, and laundering that into `Unknown`
+    /// would convert a loud failure into silent data loss.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        let value = Value::deserialize(deserializer)?;
+        match value.get("type").and_then(Value::as_str) {
+            Some(tag) if !KNOWN_TYPE_TAGS.contains(&tag) => Ok(AgentEvent::Unknown {
+                event_type: tag.to_owned(),
+                payload: value,
+            }),
+            _ => AgentEvent::deserialize(value).map_err(D::Error::custom),
         }
     }
 }
@@ -2127,5 +2265,141 @@ mod tests {
             .type_tag(),
             "speculation_discarded"
         );
+    }
+
+    // ---- forward compatibility: events from a newer stella ----------------
+
+    #[test]
+    fn an_unrecognized_type_tag_degrades_to_unknown_rather_than_failing() {
+        // The whole point of the change. A reader built before this variant
+        // existed must not fail the line — it must keep going.
+        let line = r#"{"type":"quantum_entangled","turn":7,"nested":{"a":[1,2]}}"#;
+        let event: AgentEvent = serde_json::from_str(line).expect("future event must parse");
+        let AgentEvent::Unknown {
+            event_type,
+            payload,
+        } = &event
+        else {
+            panic!("expected Unknown, got {event:?}");
+        };
+        assert_eq!(event_type, "quantum_entangled");
+        assert_eq!(payload["turn"], 7);
+        assert_eq!(payload["nested"]["a"][1], 2);
+        assert!(event.is_unknown());
+    }
+
+    #[test]
+    fn an_unknown_event_round_trips_without_losing_data() {
+        // A recorder or proxy must be able to pass a future event through
+        // without corrupting it. Compare parsed values, not raw bytes: object
+        // key order is not preserved (and is not meaningful).
+        let line = r#"{"type":"from_the_future","alpha":1,"beta":["x",null,true]}"#;
+        let event: AgentEvent = serde_json::from_str(line).unwrap();
+        let reserialized = serde_json::to_string(&event).unwrap();
+
+        let before: Value = serde_json::from_str(line).unwrap();
+        let after: Value = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(before, after, "round-trip changed the event's content");
+        // The tag must survive: it lives only inside `payload`.
+        assert_eq!(after["type"], "from_the_future");
+    }
+
+    #[test]
+    fn a_known_tag_with_a_malformed_body_is_still_a_hard_error() {
+        // The load-bearing negative test. Forward compatibility is scoped to
+        // *unrecognized tags only*; a recognized tag whose body does not fit
+        // is an encoder bug or a corrupt record, and must stay loud. If this
+        // ever degrades to Unknown, corruption becomes indistinguishable from
+        // a version skew and the store's `skipped` counter starts lying.
+        let err = serde_json::from_str::<AgentEvent>(r#"{"type":"text"}"#)
+            .expect_err("`text` without `delta` must not parse");
+        assert!(
+            !format!("{err}").is_empty(),
+            "a known tag with a bad body must produce a real error"
+        );
+
+        // Same for a wrong field type under a known tag.
+        assert!(
+            serde_json::from_str::<AgentEvent>(r#"{"type":"retry","attempt":"one","reason":"x"}"#)
+                .is_err(),
+            "`retry.attempt` is a u32; a string must not be laundered into Unknown"
+        );
+
+        // And an object with no tag at all keeps the derived error path.
+        assert!(serde_json::from_str::<AgentEvent>(r#"{"delta":"hi"}"#).is_err());
+    }
+
+    #[test]
+    fn every_known_type_tag_resolves_to_a_typed_variant() {
+        // Proves the variant→tag list in `agent_event_tags!` has no typo.
+        //
+        // Combined with two structural facts this is airtight: the generated
+        // match is exhaustive (so every variant is listed) and duplicate arms
+        // would be unreachable (so each is listed once) — meaning
+        // `KNOWN_TYPE_TAGS.len()` equals the variant count. If every listed tag
+        // is additionally a *real* serde name, as asserted here, the mapping is
+        // a bijection and no real tag can be missing from the list. A missing
+        // one would silently demote all of its events to `Unknown`.
+        for tag in KNOWN_TYPE_TAGS {
+            let probe = serde_json::json!({ "type": tag });
+            // Most variants have required fields, so this usually errors —
+            // that is fine and expected. What must never happen is the tag
+            // being treated as unrecognized.
+            if let Ok(event) = serde_json::from_value::<AgentEvent>(probe) {
+                assert!(
+                    !event.is_unknown(),
+                    "`{tag}` is in KNOWN_TYPE_TAGS but deserialized as Unknown — \
+                     the tag string does not match any serde variant name"
+                );
+            }
+        }
+
+        let mut sorted = KNOWN_TYPE_TAGS.to_vec();
+        sorted.sort_unstable();
+        let before = sorted.len();
+        sorted.dedup();
+        assert_eq!(before, sorted.len(), "duplicate tag in KNOWN_TYPE_TAGS");
+    }
+
+    #[test]
+    fn type_tag_of_an_unknown_event_is_the_preserved_wire_tag() {
+        // `type_tag()` tells the truth even for an event it cannot decode, so
+        // logs and metrics can name a future event correctly.
+        let event: AgentEvent = serde_json::from_str(r#"{"type":"newer_thing"}"#).unwrap();
+        assert_eq!(event.type_tag(), "newer_thing");
+        assert!(!KNOWN_TYPE_TAGS.contains(&event.type_tag()));
+    }
+
+    #[test]
+    fn a_literal_unknown_tag_is_not_privileged() {
+        // `Unknown` is `serde(skip)`, so it has no wire tag of its own. An
+        // event literally tagged `"unknown"` is just another unrecognized tag
+        // and must round-trip as one rather than being mistaken for the
+        // fallback variant's own encoding.
+        let line = r#"{"type":"unknown","event_type":"spoof","payload":{}}"#;
+        let event: AgentEvent = serde_json::from_str(line).unwrap();
+        assert_eq!(event.type_tag(), "unknown");
+
+        // It round-trips as the opaque object it is — the decoy `event_type`
+        // and `payload` keys stay ordinary payload data, not the variant's
+        // own fields.
+        let after: Value = serde_json::from_str(&serde_json::to_string(&event).unwrap()).unwrap();
+        assert_eq!(after, serde_json::from_str::<Value>(line).unwrap());
+        assert_eq!(after["event_type"], "spoof");
+    }
+
+    #[test]
+    fn a_known_event_wire_format_is_unchanged_by_the_fallback() {
+        // The hand-written codec must be a pass-through for known variants —
+        // no tag rename, no extra wrapper, no reordering.
+        let event = AgentEvent::Text {
+            delta: "hello".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            r#"{"type":"text","delta":"hello"}"#
+        );
+        let back: AgentEvent = serde_json::from_str(r#"{"type":"text","delta":"hello"}"#).unwrap();
+        assert!(matches!(back, AgentEvent::Text { delta } if delta == "hello"));
     }
 }

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -10,13 +10,22 @@
 //! round-trip through `serde_json` byte-for-byte (see the round-trip tests in
 //! each module).
 //!
-//! Wire compatibility is additive, but in exactly **one** direction. New
-//! *fields* ride `serde(default)`, so a newer binary parses every older
-//! stream. New [`AgentEvent`] *variants* do not travel backwards: the enum is
-//! internally tagged, so an older binary meets an unrecognized `"type"` with a
-//! hard deserialization error. An event that must survive being read by an
-//! older binary rides the versioned
-//! [`context_event::LifecycleEventEnvelope`] instead, whose payload stays raw.
+//! Wire compatibility is additive, and it now holds in **both** directions.
+//! New *fields* ride `serde(default)`, so a newer binary parses every older
+//! stream. New [`AgentEvent`] *variants* travel backwards via
+//! [`AgentEvent::Unknown`]: an older binary meets an unrecognized `"type"` by
+//! preserving the event whole and moving on, instead of failing the stream.
+//!
+//! The tolerance is scoped to the tag alone. A `"type"` this build *does*
+//! know, carrying a body that does not fit its variant, is still a hard
+//! error — that is corruption or an encoder bug, not a version skew, and it
+//! must not be laundered into [`AgentEvent::Unknown`]. [`KNOWN_TYPE_TAGS`] is
+//! the exact boundary between the two cases.
+//!
+//! [`context_event::LifecycleEventEnvelope`] remains the right home for
+//! internal lifecycle events: it adds an explicit `schema_version` and keeps
+//! stella-internal vocabulary off the public event stream. It is no longer
+//! the *only* way to stay readable by an older binary.
 
 #![forbid(unsafe_code)]
 
@@ -44,8 +53,9 @@ pub use error::ProviderError;
 pub use event::{
     AgentEvent, BlockKind, BlockOrigin, BudgetMode, BudgetScope, CacheZone, CiStatus,
     ContextFrameRef, ContextProviderUsage, ContextUsage, FileChangeKind, JudgeEvidence,
-    ManifestEntry, MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole, PolicyKind, PrStatus,
-    ProviderShare, ScopeProposal, StageKind, TaskItem, TaskStatus, UsageIncompleteReason,
+    KNOWN_TYPE_TAGS, ManifestEntry, MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole,
+    PolicyKind, PrStatus, ProviderShare, ScopeProposal, StageKind, TaskItem, TaskStatus,
+    UsageIncompleteReason,
 };
 pub use provider::{Provider, ToolCallObserver};
 pub use role::{ModelRef, Role};

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -734,7 +734,7 @@ fn pull_request_upsert_is_keyed_by_url() {
 }
 
 #[test]
-fn session_events_reassembles_the_journal_and_skips_corrupt_payloads() {
+fn session_events_keeps_unknown_variants_and_skips_only_corrupt_payloads() {
     let store = Store::in_memory().unwrap();
     let turn_one = store
         .begin_execution("run", "one", "zai", "glm-5.2")
@@ -765,8 +765,10 @@ fn session_events_reassembles_the_journal_and_skips_corrupt_payloads() {
     store
         .record_event(elsewhere, 0, &AgentEvent::Text { delta: "z".into() })
         .unwrap();
-    // A payload whose variant this build no longer knows — inserted raw,
-    // exactly as an older stream would have left it on disk.
+    // A payload whose variant this build does not know — inserted raw,
+    // exactly as a NEWER stella would have left it on disk. This is a version
+    // skew, not damage, so it must survive as `AgentEvent::Unknown` and stay
+    // in the journal rather than being counted as a loss.
     {
         let conn = store.lock();
         conn.execute(
@@ -776,11 +778,21 @@ fn session_events_reassembles_the_journal_and_skips_corrupt_payloads() {
         )
         .unwrap();
     }
+    // Genuine damage: not JSON at all. This is what `skipped` exists to count.
+    {
+        let conn = store.lock();
+        conn.execute(
+            "INSERT INTO events (execution_id, seq, event_type, payload) \
+             VALUES (?, 1, 'text', '{ this is not json')",
+            params![turn_two],
+        )
+        .unwrap();
+    }
 
     let journal = store.session_events("ses-j").unwrap();
     assert_eq!(
         journal.skipped, 1,
-        "an unparseable row is counted, never fatal"
+        "only the corrupt row is counted — an unknown variant is not a loss"
     );
     assert_eq!(
         journal
@@ -788,12 +800,25 @@ fn session_events_reassembles_the_journal_and_skips_corrupt_payloads() {
             .iter()
             .map(|r| (r.execution_id, r.seq))
             .collect::<Vec<_>>(),
-        vec![(turn_one, 0), (turn_one, 1), (turn_two, 0)],
-        "ordered by (execution_id, seq) across the session's turns"
+        vec![(turn_one, 0), (turn_one, 1), (turn_one, 2), (turn_two, 0)],
+        "ordered by (execution_id, seq); the unknown-variant row is kept"
     );
     match &journal.events[0].event {
         AgentEvent::Reasoning { delta } => assert_eq!(delta, "think"),
         other => panic!("unexpected first event: {other:?}"),
+    }
+    // The row from the future round-trips with its payload intact, so a
+    // journal written by a newer stella can still be read, rendered, and
+    // re-exported by this one without dropping events on the floor.
+    match &journal.events[2].event {
+        AgentEvent::Unknown {
+            event_type,
+            payload,
+        } => {
+            assert_eq!(event_type, "ghost");
+            assert_eq!(payload["volume"], 11);
+        }
+        other => panic!("expected the ghost row to survive as Unknown: {other:?}"),
     }
     let empty = store.session_events("ses-unknown").unwrap();
     assert!(empty.events.is_empty());

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -894,6 +894,12 @@ fn event_intensity(ev: &AgentEvent) -> u8 {
         AgentEvent::Commit { .. } | AgentEvent::Pr { .. } => 230,
         AgentEvent::BudgetTick { .. } | AgentEvent::StepUsage { .. } => 60,
         AgentEvent::Error { .. } => 255,
+        // Explicit rather than falling through the wildcard: an undecodable
+        // event is real activity, so it should register on the sparkline, but
+        // this build cannot know whether it was hot (an edit) or cool (a
+        // metering tick). Cool-but-present is the honest reading, and it keeps
+        // a burst of future events from impersonating heavy edit activity.
+        AgentEvent::Unknown { .. } => 60,
         _ => 110,
     }
 }
@@ -927,6 +933,10 @@ fn status_from_event(ev: &AgentEvent) -> Option<AgentStatus> {
 fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
     use stella_protocol::ToolOutput;
     match ev {
+        // An event from a newer stella: name it, claim nothing about it.
+        AgentEvent::Unknown { event_type, .. } => {
+            (TraceKind::Other, format!("unrecognized `{event_type}`"))
+        }
         AgentEvent::Stage { name } => (TraceKind::Stage, format!("{name:?}").to_lowercase()),
         AgentEvent::Text { delta } => (TraceKind::Text, snip(delta)),
         // Mapped for completeness; `apply_event` never traces deltas (one

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -318,6 +318,13 @@ impl SessionModel {
     /// replaying the same log yields an identical model (L-T1).
     pub fn apply(&mut self, event: &AgentEvent) {
         match event {
+            // An event from a newer stella. The fold stays a pure function of
+            // events it understands: guessing at state from an undecodable
+            // payload would make the model disagree with the transcript that
+            // rendered it. The transcript still shows the event (see
+            // `textline::unknown_event`), so nothing is hidden — the model
+            // just declines to invent state for it.
+            AgentEvent::Unknown { .. } => {}
             AgentEvent::Stage { name } => {
                 // A stage after a Complete means a new turn has started —
                 // clear the completion flag so the progress bar and HUD read

--- a/stella-tui/src/textline.rs
+++ b/stella-tui/src/textline.rs
@@ -128,6 +128,24 @@ pub fn compaction(
 /// The spend line. Visibility policy stays surface-side (the plain surface
 /// suppresses ticks in `BudgetMode::Off`; the deck shows every tick and may
 /// append the mode as detail).
+/// An event this build cannot decode, emitted by a newer stella.
+///
+/// Rendered rather than dropped: the realistic way the TUI meets one of these
+/// is replaying a session journal written by a newer binary (`stella resume`),
+/// and silently omitting events would leave unexplained holes in a transcript
+/// the user is reading as a record. Muted, one line, tag only — enough to show
+/// that something happened and that this build is the reason it is not
+/// legible, without pretending to know what it was.
+pub fn unknown_event(event_type: &str) -> EventLine {
+    EventLine {
+        glyph: "?",
+        tone: Tone::Muted,
+        strong: false,
+        body: format!("unrecognized event `{event_type}`"),
+        detail: Some("emitted by a newer stella".to_string()),
+    }
+}
+
 pub fn budget_tick(spent_usd: f64, limit_usd: Option<f64>) -> EventLine {
     EventLine {
         glyph: "$",
@@ -430,6 +448,7 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
         | AgentEvent::BudgetDenied { .. }
         | AgentEvent::RetriesExhausted { .. }
         | AgentEvent::PolicyDecision { .. } => None,
+        AgentEvent::Unknown { event_type, .. } => Some(unknown_event(event_type)),
         AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
         AgentEvent::Steered { text } => Some(steered(text)),
         AgentEvent::Compaction {

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -1,0 +1,166 @@
+---
+title: Event stream compatibility
+description: The versioning contract behind Stella's event stream — what stays stable, what may change, and what a client in any language must do to keep working across upgrades.
+---
+
+Every machine-readable surface Stella exposes carries the same event objects:
+
+- [`--output-format stream-json`](/docs/scripting) — one event per line on stdout
+- `--output-format json` — the same objects, batched under an `events` key
+- the session journal Stella writes to `.stella/private/` and replays on `stella resume`
+
+So there is one compatibility contract to learn, and it applies everywhere. This
+page is that contract, stated for someone writing a client in a language other
+than Rust.
+
+## The guarantee
+
+**A client written against one version of Stella keeps working against later
+versions, without changes.** Concretely, upgrading Stella will not make your
+parser fail on a stream it used to handle.
+
+That holds in both directions:
+
+| Change | Older client, newer stream | Newer client, older stream |
+| --- | --- | --- |
+| A new field on an existing event | Ignored | Filled with its default |
+| A brand-new event type | Preserved, reported as unrecognized | Never appears |
+| A renamed or removed event type | **Does not happen** — the vocabulary is additive only | — |
+
+Event type names and field names are never renamed or repurposed once shipped.
+Growth is by addition.
+
+## The two rules that matter
+
+Everything above reduces to a single distinction that your client should mirror,
+because Stella's own reader enforces it exactly:
+
+**1. An event `type` you do not recognize is normal. Skip it and keep going.**
+
+It means the stream came from a newer Stella than your client knows about. It is
+not an error, and it is not a reason to stop reading. Stella's own decoder
+preserves such events whole rather than failing the line.
+
+**2. A `type` you *do* recognize, carrying a body that does not fit, is a real
+error. Fail loudly.**
+
+That is not a version skew — it is corruption, or a bug in whatever produced the
+stream. Treating it as "probably just something new" converts a loud failure into
+silent data loss, which is how a bad record ends up in your database instead of
+in your logs.
+
+<Callout type="warn">
+  The tempting shortcut is a single `try { parse } catch { skip }` around each
+  line. Do not do that. It collapses both rules into rule 1 and will quietly
+  swallow malformed events that you needed to hear about. Branch on whether the
+  `type` is one you know, *then* parse.
+</Callout>
+
+## What a client must do
+
+A conforming client:
+
+1. Reads the stream **line by line** and parses each line as an independent JSON
+   object. Never buffer the whole stream and parse it as one document.
+2. Dispatches on the `"type"` string.
+3. On an unrecognized `"type"`: does not fail, does not warn loudly, and does not
+   guess at semantics from the name. Count it, log it at debug level, or pass it
+   through — nothing more.
+4. On a recognized `"type"` whose body does not parse: surfaces a real error.
+5. Ignores unknown *fields* on events it does recognize.
+6. Tolerates a torn final line. A writer killed mid-line leaves a partial JSON
+   object; the clean prefix before it is still valid.
+
+Point 6 matters more than it sounds — a crashed or cancelled run is a normal
+occurrence, not an exceptional one.
+
+```ts
+// TypeScript: the shape the contract asks for.
+const KNOWN = new Set(["stage", "text", "text_delta", "tool_start", "tool_result", "complete", /* … */]);
+
+for (const line of stream) {
+  if (!line.trim()) continue;
+
+  let event: { type?: string };
+  try {
+    event = JSON.parse(line);
+  } catch {
+    // Not JSON. Only forgivable as the final line of a killed run.
+    if (isFinalLine) break;
+    throw new Error(`corrupt event line: ${line}`);
+  }
+
+  if (typeof event.type !== "string" || !KNOWN.has(event.type)) {
+    // Rule 1: from a newer Stella. Inert, not fatal.
+    onUnrecognized?.(event);
+    continue;
+  }
+
+  // Rule 2: a type we know — a body that does not fit is a real error.
+  handle(parseKnownEvent(event));
+}
+```
+
+## Unrecognized events in practice
+
+Suppose a future Stella adds a `spline_reticulated` event. A client built before
+it existed sees:
+
+```json
+{"type":"stage","name":"execute"}
+{"type":"spline_reticulated","call_id":"q_1","splines":["alpha","beta"]}
+{"type":"text","delta":"Done."}
+{"type":"complete","model":"m","cost_usd":0.002}
+```
+
+It processes `stage`, `text`, and `complete` exactly as before, and treats line 2
+as inert. The run is fully usable. Nothing is lost that the client could have
+understood anyway.
+
+If your client re-emits or stores events, keep unrecognized ones **whole**. A
+proxy or recorder that drops them silently degrades the stream for whatever reads
+it next, which may be a newer client that would have understood them.
+
+<Callout type="info">
+  Object key order is not part of the contract and may change — JSON object keys
+  are unordered by definition. Compare parsed values, never raw lines.
+</Callout>
+
+## What is *not* guaranteed
+
+- **Ordering between event types** beyond what the pipeline documents. `text_delta`
+  lines interleave with other events.
+- **That every event has a stable meaning to you.** `text_delta` is an explicit
+  best-effort preview: the `text` event that follows carries the authoritative
+  step text, and you must *replace* accumulated deltas with it rather than append
+  (a retried model call re-streams its deltas from the start). See
+  [Scripting & automation](/docs/scripting).
+- **Internal lifecycle events.** Stella's adaptive-context machinery emits its own
+  versioned envelope, deliberately kept off this stream. Do not build on it.
+- **Byte-level stability.** Whitespace and key order may vary.
+
+## Conformance
+
+The repository ships a fixture whose only purpose is to break clients that get
+rule 1 wrong:
+
+```
+stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl
+```
+
+It is a well-formed turn containing two event types that do not exist. A client
+that parses it end to end, reports two unrecognized events, and reconstructs the
+run from the rest is forward compatible. A client that throws is not — however
+well it handles today's vocabulary.
+
+If you maintain a Stella client, run it against that file in CI. It is the
+cheapest possible guard against the failure mode this contract exists to
+prevent, and it costs one test.
+
+## Detecting a version gap
+
+You do not need to know Stella's version to consume the stream correctly — that
+is the point of rule 1. But if you want to *report* a gap ("this run used
+features your dashboard cannot display"), count unrecognized types and surface
+the count. Stella's Rust decoder exposes the same information through the
+`KNOWN_TYPE_TAGS` list in `stella-protocol`.

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -22,6 +22,7 @@
     "commands",
     "extensions",
     "scripting",
+    "event-stream-compatibility",
     "showcase",
     "release-notes",
     "donate"

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -20,8 +20,14 @@ an environment-variable equivalent for CI.
 `stream-json` is a line-per-event serialization of Stella's internal event enum — a stable
 machine interface you can parse incrementally. Each line is one event object tagged
 `"type"` in snake_case (`stage`, `text`, `reasoning`, `tool_start`, `tool_result`, …).
-The vocabulary is additive-only: skip lines whose `type` you don't recognize. In
-particular, `text_delta` lines stream the answer token by token as a best-effort live
+The vocabulary is additive-only: skip lines whose `type` you don't recognize, and a
+client that does so keeps working across Stella upgrades without changes. Note the
+converse — a `type` you *do* recognize carrying a body that doesn't fit is a real error,
+not something to skip. See
+[Event stream compatibility](/docs/event-stream-compatibility) for the full contract and
+a conformance fixture to test your client against.
+
+In particular, `text_delta` lines stream the answer token by token as a best-effort live
 preview — the `text` event that follows carries the full step text and is authoritative
 (replace any accumulated deltas with it; a retried model call re-streams its deltas).
 


### PR DESCRIPTION
## What

Makes `AgentEvent` survive event types it has never seen, so stella's event vocabulary can grow without breaking existing readers.

An unrecognized `"type"` used to be a hard deserialization error. That froze the wire contract in practice: adding any variant broke every existing reader, and no external client — in any language — could be written against the stream safely. This is the prerequisite for treating the event stream as a public, multi-language contract.

## The rule

`AgentEvent` gains `Unknown { event_type, payload }`. An unrecognized tag deserializes into it with the original object preserved, and re-serializes with every key and value intact — so an older binary **skips** a future event instead of failing the stream, and a proxy or recorder can forward what it cannot interpret.

The tolerance is scoped to the **tag alone**, and this is the load-bearing decision:

| Input | Behaviour | Why |
| --- | --- | --- |
| `"type"` this build has never seen | Preserved as `Unknown` | Version skew — normal, must not break |
| `"type"` this build knows, body doesn't fit | **Hard error, as before** | Corruption or an encoder bug — must stay loud |

Absorbing the second case into `Unknown` would convert a loud failure into silent data loss. `KNOWN_TYPE_TAGS` is the exact boundary.

## How

- **`agent_event_tags!`** generates `type_tag` and `KNOWN_TYPE_TAGS` from one variant→tag list, so they cannot drift. This matters: a real tag missing from the list would silently demote all of its events to `Unknown`. Generating both from one list makes that class of bug unrepresentable. The `E0004` tripwire survives — the generated match is still exhaustive, so adding a variant still fails the build at the invocation.
- **`remote = "Self"`** keeps the derived codec as inherent functions so the hand-written `Serialize`/`Deserialize` can route `Unknown` around it, rather than hand-writing a visitor for all 34 variants.
- **`type_tag` widens to `&str`** and returns the *preserved* tag for `Unknown`, so an undecodable event still reports truthfully. It had no callers outside `event.rs`.
- **`Unknown` joins the `structural_diff` volatile keep-set.** An event this build cannot decode is present in exactly one of any two compared streams by construction, so counting it would report drift that says nothing about behaviour — and would break every golden trajectory the moment the vocabulary grew.

## Two caveats worth reviewing

1. **Round-trip preserves content, not bytes.** `serde_json::Value` holds keys in a `BTreeMap`, so they come back sorted. JSON key order is not meaningful (RFC 8259 §4), and forcing `preserve_order` would change every serialized output in the workspace. Documented in the module doc and the website page.
2. **`Deserialize` is now specific to self-describing formats** — it buffers through `serde_json::Value` to read the tag before dispatching. That is the only format this type has ever been defined against (`stream-json` *is* `serde_json`), so it costs nothing in practice, but it is a real narrowing.

## Tests that changed meaning

Two tests asserted the old rejecting behaviour. Both got sharper rather than weaker:

- **`stella-store`** — the journal test now distinguishes a row from a newer stella (kept, as `Unknown`) from a genuinely corrupt row (skipped). That is the distinction `skipped` was always meant to count; previously the two were conflated.
- **`reference_conformance`** — now shows both branches of the rule. `tool` and `result` are foreign tags and are preserved; `stage` collides with a tag this protocol defines and is *still rejected on its body*. The finding the file exists to pin is unchanged, and the file now demonstrates the tag-only rule with a real-world example.

## Conformance fixture

`stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl` — a well-formed turn carrying two event types that do not exist. Any client in any language that claims to consume this stream should parse it end to end; one that throws is not forward compatible however well it handles today's vocabulary.

Its baseline pair proves the real point: a vocabulary addition does not read as behavioural drift.

## Docs

- New: `website/content/docs/event-stream-compatibility.mdx` — the contract stated for someone writing a client in a language other than Rust, with the "don't wrap every line in try/catch" warning and the conformance fixture.
- Updated the in-tree docs whose rationale cited the old rejecting behaviour: `stella-protocol` lib/README/`context_event`, `replay::parse_jsonl`, and the phase-0 baseline characterization (marked resolved rather than rewritten).

## Verification

- `cargo test --workspace` — **3315 passed, 0 failed**
- `cargo clippy --workspace --all-targets` — clean, no warnings
- `cargo fmt --all` — clean
- `pnpm build` in `website/` — compiles; new page prerenders and the cross-link from `scripting` resolves

## Not addressed

#644 (adding `schema_version` to the separate `--output-format json` summary envelope) is adjacent but distinct — that is the summary envelope, this is the event vocabulary. Left open.

Other wire enums still lack a forward-compat fallback and each needs its own decision — most notably `ProviderErrorWire` in `stella-serve`, where a host sending a new error class currently hard-errors the POST. Worth a follow-up issue; deliberately out of scope here.
