### PR TITLE
fix(stella-model): degrade caps-excluded attachment parts instead of panicking

### DIFF
--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -334,27 +334,32 @@ const ANTHROPIC_CAPS: crate::attachment::DialectCaps = crate::attachment::Dialec
 fn attachment_blocks(message: &CompletionMessage) -> Vec<AnthropicContentBlock> {
     crate::attachment::wire_parts(&message.attachments, ANTHROPIC_CAPS)
         .into_iter()
-        .map(|part| match part {
-            crate::attachment::WirePart::Image { media_type, base64 } => {
-                AnthropicContentBlock::Image {
-                    source: AnthropicMediaSource::base64(media_type, base64),
-                }
-            }
-            crate::attachment::WirePart::Pdf { base64, .. } => AnthropicContentBlock::Document {
-                source: AnthropicMediaSource::base64("application/pdf", base64),
-            },
-            crate::attachment::WirePart::Text { text } => AnthropicContentBlock::Text {
-                text,
-                cache_control: None,
-            },
-            // Audio/video are switched off in ANTHROPIC_CAPS, so wire_parts
-            // has already degraded them to Text notes.
-            crate::attachment::WirePart::Audio { .. }
-            | crate::attachment::WirePart::Video { .. } => {
-                unreachable!("caps exclude audio/video")
-            }
-        })
+        .map(attachment_block)
         .collect()
+}
+
+/// One resolved part as a Messages content block.
+fn attachment_block(part: crate::attachment::WirePart) -> AnthropicContentBlock {
+    match part {
+        crate::attachment::WirePart::Image { media_type, base64 } => AnthropicContentBlock::Image {
+            source: AnthropicMediaSource::base64(media_type, base64),
+        },
+        crate::attachment::WirePart::Pdf { base64, .. } => AnthropicContentBlock::Document {
+            source: AnthropicMediaSource::base64("application/pdf", base64),
+        },
+        crate::attachment::WirePart::Text { text } => AnthropicContentBlock::Text {
+            text,
+            cache_control: None,
+        },
+        // Audio/video are switched off in ANTHROPIC_CAPS, so wire_parts has
+        // already degraded them to Text notes. Turning either cap on without
+        // adding a block arm lands here — degrade, never abort the turn.
+        part @ (crate::attachment::WirePart::Audio { .. }
+        | crate::attachment::WirePart::Video { .. }) => AnthropicContentBlock::Text {
+            text: crate::attachment::unsupported_part_note(&part, "Anthropic Messages API"),
+            cache_control: None,
+        },
+    }
 }
 
 /// Streamed SSE payloads from the Messages API's `content_block_delta`

--- a/stella-model/src/anthropic/tests.rs
+++ b/stella-model/src/anthropic/tests.rs
@@ -1560,3 +1560,40 @@ async fn reasoning_false_sends_no_thinking_block_and_keeps_temperature() {
     assert!(body.contains("\"temperature\":0.3"), "{body}");
     assert!(body.contains("\"max_tokens\":4096"), "default cap: {body}");
 }
+
+/// The audio/video arm of [`attachment_block`] is out of reach only because
+/// `ANTHROPIC_CAPS` switches those kinds off. Flipping one of those bools is
+/// a routine one-line edit, so the arm it lands in has to degrade like every
+/// other unsupported attachment instead of aborting the process mid-turn.
+#[test]
+fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
+    use crate::attachment::{DialectCaps, wire_parts};
+    use stella_protocol::{Attachment, AttachmentSource};
+    let flipped = DialectCaps {
+        images: true,
+        pdfs: true,
+        audio: true,
+        video: true,
+    };
+    for (name, mime) in [("song.mp3", "audio/mpeg"), ("clip.mp4", "video/mp4")] {
+        let attachment = Attachment {
+            name: name.into(),
+            media_type: mime.into(),
+            byte_len: 3,
+            source: AttachmentSource::Data {
+                base64: "YWJj".into(),
+            },
+        };
+        let blocks: Vec<_> = wire_parts(&[attachment], flipped)
+            .into_iter()
+            .map(attachment_block)
+            .collect();
+        let [AnthropicContentBlock::Text { text, .. }] = blocks.as_slice() else {
+            panic!("expected a degrade note for {mime}, got {blocks:?}");
+        };
+        assert!(
+            text.contains(mime),
+            "the note names what was attached: {text}"
+        );
+    }
+}

--- a/stella-model/src/attachment.rs
+++ b/stella-model/src/attachment.rs
@@ -15,6 +15,13 @@
 //! the conversation replays every turn, so a hard error here would brick the
 //! session permanently.
 //!
+//! [`DialectCaps`] is what normally keeps a part an adapter has no wire shape
+//! for from ever reaching that adapter. The two are edited independently
+//! though — switching a cap on is a one-line change — so adapters back the
+//! caps up with [`unsupported_part_note`] on the arms their caps exclude
+//! today. A half-finished caps edit then degrades like any other unsupported
+//! attachment instead of aborting the process mid-turn.
+//!
 //! ## Size
 //!
 //! Stella imposes no size cap of its own. Payloads are hydrated from disk at
@@ -61,6 +68,37 @@ pub(crate) enum WirePart {
     Text {
         text: String,
     },
+}
+
+impl WirePart {
+    /// A phrase naming what this part carries, for a degrade note the model
+    /// reads aloud. Media types and file names come along because they are
+    /// what lets the model suggest a workable format.
+    fn describe(&self) -> String {
+        match self {
+            WirePart::Image { media_type, .. } => format!("an image ({media_type})"),
+            WirePart::Pdf { name, .. } => format!("a PDF document ({name})"),
+            WirePart::Audio { media_type, .. } => format!("an audio file ({media_type})"),
+            WirePart::Video { media_type, .. } => format!("a video ({media_type})"),
+            WirePart::Text { .. } => "a text note".to_string(),
+        }
+    }
+}
+
+/// The note an adapter emits for a part its dialect has no wire shape for —
+/// the belt to [`DialectCaps`]'s braces.
+///
+/// Reaching this means a caps const advertises a kind the adapter's mapping
+/// never learned to encode, which is a wiring mistake rather than anything
+/// the user did. It still degrades: the module's promise is that an
+/// attachment never fails the request, and a panic here would abort the
+/// process mid-turn over a config flag.
+pub(crate) fn unsupported_part_note(part: &WirePart, dialect: &str) -> String {
+    format!(
+        "[the user attached {}, but the {dialect} cannot carry it on the wire; acknowledge \
+         the attachment and suggest a provider or format that can be read]",
+        part.describe()
+    )
 }
 
 /// Resolve a message's attachments into wire parts for a dialect. Infallible
@@ -157,7 +195,9 @@ fn degrade_note(attachment: &Attachment, kind: AttachmentKind) -> String {
         AttachmentKind::Video => "video",
         AttachmentKind::Pdf => "PDF documents",
         AttachmentKind::Binary => "this file format",
-        AttachmentKind::Text => unreachable!("text always inlines"),
+        // Text inlines before this is called, so this arm is dead today. It
+        // stays total anyway — a note is a fine answer, an abort is not.
+        AttachmentKind::Text => "text files",
     };
     format!(
         "[the user attached {}, but the current provider cannot ingest {noun} natively; \

--- a/stella-model/src/bedrock.rs
+++ b/stella-model/src/bedrock.rs
@@ -265,48 +265,59 @@ fn sanitize_document_name(name: &str) -> String {
 fn attachment_blocks(message: &CompletionMessage) -> Vec<BedrockContentBlock> {
     crate::attachment::wire_parts(&message.attachments, BEDROCK_CAPS)
         .into_iter()
-        .map(|part| match part {
-            crate::attachment::WirePart::Text { text } => BedrockContentBlock {
-                text: Some(text),
-                ..Default::default()
-            },
-            crate::attachment::WirePart::Image { media_type, base64 } => {
-                match bedrock_image_format(&media_type) {
-                    Some(format) => BedrockContentBlock {
-                        image: Some(BedrockMediaBlock {
-                            format,
-                            source: BedrockMediaSource { bytes: base64 },
-                        }),
-                        ..Default::default()
-                    },
-                    None => unsupported_format_note("image", &media_type),
-                }
-            }
-            crate::attachment::WirePart::Video { media_type, base64 } => {
-                match bedrock_video_format(&media_type) {
-                    Some(format) => BedrockContentBlock {
-                        video: Some(BedrockMediaBlock {
-                            format,
-                            source: BedrockMediaSource { bytes: base64 },
-                        }),
-                        ..Default::default()
-                    },
-                    None => unsupported_format_note("video", &media_type),
-                }
-            }
-            crate::attachment::WirePart::Pdf { name, base64 } => BedrockContentBlock {
-                document: Some(BedrockDocumentBlock {
-                    format: "pdf",
-                    name: sanitize_document_name(&name),
-                    source: BedrockMediaSource { bytes: base64 },
-                }),
-                ..Default::default()
-            },
-            crate::attachment::WirePart::Audio { .. } => {
-                unreachable!("caps exclude audio")
-            }
-        })
+        .map(attachment_block)
         .collect()
+}
+
+/// One resolved part as a Converse content block.
+fn attachment_block(part: crate::attachment::WirePart) -> BedrockContentBlock {
+    match part {
+        crate::attachment::WirePart::Text { text } => BedrockContentBlock {
+            text: Some(text),
+            ..Default::default()
+        },
+        crate::attachment::WirePart::Image { media_type, base64 } => {
+            match bedrock_image_format(&media_type) {
+                Some(format) => BedrockContentBlock {
+                    image: Some(BedrockMediaBlock {
+                        format,
+                        source: BedrockMediaSource { bytes: base64 },
+                    }),
+                    ..Default::default()
+                },
+                None => unsupported_format_note("image", &media_type),
+            }
+        }
+        crate::attachment::WirePart::Video { media_type, base64 } => {
+            match bedrock_video_format(&media_type) {
+                Some(format) => BedrockContentBlock {
+                    video: Some(BedrockMediaBlock {
+                        format,
+                        source: BedrockMediaSource { bytes: base64 },
+                    }),
+                    ..Default::default()
+                },
+                None => unsupported_format_note("video", &media_type),
+            }
+        }
+        crate::attachment::WirePart::Pdf { name, base64 } => BedrockContentBlock {
+            document: Some(BedrockDocumentBlock {
+                format: "pdf",
+                name: sanitize_document_name(&name),
+                source: BedrockMediaSource { bytes: base64 },
+            }),
+            ..Default::default()
+        },
+        // Excluded by BEDROCK_CAPS today; turning audio on without adding a
+        // block arm lands here — degrade, never abort the turn.
+        part @ crate::attachment::WirePart::Audio { .. } => BedrockContentBlock {
+            text: Some(crate::attachment::unsupported_part_note(
+                &part,
+                "Bedrock Converse API",
+            )),
+            ..Default::default()
+        },
+    }
 }
 
 fn unsupported_format_note(kind: &str, media_type: &str) -> BedrockContentBlock {
@@ -1101,6 +1112,45 @@ mod tests {
     use stella_protocol::{ToolOutput, ToolResult};
     use wiremock::matchers::{body_string_contains, header_regex, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The audio arm of [`attachment_block`] is out of reach only because
+    /// `BEDROCK_CAPS` switches audio off. Flipping that bool is a routine
+    /// one-line edit, so the arm it lands in has to degrade like every other
+    /// unsupported attachment instead of aborting the process mid-turn.
+    #[test]
+    fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
+        use crate::attachment::{DialectCaps, wire_parts};
+        use stella_protocol::{Attachment, AttachmentSource};
+        let flipped = DialectCaps {
+            images: true,
+            pdfs: true,
+            audio: true,
+            video: true,
+        };
+        let attachment = Attachment {
+            name: "song.mp3".into(),
+            media_type: "audio/mpeg".into(),
+            byte_len: 3,
+            source: AttachmentSource::Data {
+                base64: "YWJj".into(),
+            },
+        };
+        let blocks: Vec<_> = wire_parts(&[attachment], flipped)
+            .into_iter()
+            .map(attachment_block)
+            .collect();
+        let [block] = blocks.as_slice() else {
+            panic!("expected one degrade block, got {blocks:?}");
+        };
+        let note = block
+            .text
+            .as_deref()
+            .unwrap_or_else(|| panic!("expected a text degrade note, got {block:?}"));
+        assert!(
+            note.contains("audio/mpeg"),
+            "the note names what was attached: {note}"
+        );
+    }
 
     #[test]
     fn user_attachments_map_to_converse_blocks_with_format_allowlists() {

--- a/stella-model/src/openai.rs
+++ b/stella-model/src/openai.rs
@@ -254,23 +254,30 @@ const OPENAI_CAPS: crate::attachment::DialectCaps = crate::attachment::DialectCa
 fn attachment_parts(message: &CompletionMessage) -> Vec<OpenAiContentPart> {
     crate::attachment::wire_parts(&message.attachments, OPENAI_CAPS)
         .into_iter()
-        .map(|part| match part {
-            crate::attachment::WirePart::Image { media_type, base64 } => {
-                OpenAiContentPart::InputImage {
-                    image_url: format!("data:{media_type};base64,{base64}"),
-                }
-            }
-            crate::attachment::WirePart::Pdf { name, base64 } => OpenAiContentPart::InputFile {
-                filename: name,
-                file_data: format!("data:application/pdf;base64,{base64}"),
-            },
-            crate::attachment::WirePart::Text { text } => OpenAiContentPart::InputText { text },
-            crate::attachment::WirePart::Audio { .. }
-            | crate::attachment::WirePart::Video { .. } => {
-                unreachable!("caps exclude audio/video")
-            }
-        })
+        .map(attachment_part)
         .collect()
+}
+
+/// One resolved part as a Responses input part.
+fn attachment_part(part: crate::attachment::WirePart) -> OpenAiContentPart {
+    match part {
+        crate::attachment::WirePart::Image { media_type, base64 } => {
+            OpenAiContentPart::InputImage {
+                image_url: format!("data:{media_type};base64,{base64}"),
+            }
+        }
+        crate::attachment::WirePart::Pdf { name, base64 } => OpenAiContentPart::InputFile {
+            filename: name,
+            file_data: format!("data:application/pdf;base64,{base64}"),
+        },
+        crate::attachment::WirePart::Text { text } => OpenAiContentPart::InputText { text },
+        // Excluded by OPENAI_CAPS today; turning either cap on without adding
+        // a part arm lands here — degrade, never abort the turn.
+        part @ (crate::attachment::WirePart::Audio { .. }
+        | crate::attachment::WirePart::Video { .. }) => OpenAiContentPart::InputText {
+            text: crate::attachment::unsupported_part_note(&part, "OpenAI Responses API"),
+        },
+    }
 }
 
 /// Streamed SSE payloads from the Responses API. Unlike Chat Completions'
@@ -813,6 +820,44 @@ mod tests {
     use stella_protocol::tool::ToolSchema;
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The audio/video arm of [`attachment_part`] is out of reach only
+    /// because `OPENAI_CAPS` switches those kinds off. Flipping one of those
+    /// bools is a routine one-line edit, so the arm it lands in has to
+    /// degrade like every other unsupported attachment instead of aborting
+    /// the process mid-turn.
+    #[test]
+    fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
+        use crate::attachment::{DialectCaps, wire_parts};
+        use stella_protocol::{Attachment, AttachmentSource};
+        let flipped = DialectCaps {
+            images: true,
+            pdfs: true,
+            audio: true,
+            video: true,
+        };
+        for (name, mime) in [("song.mp3", "audio/mpeg"), ("clip.mp4", "video/mp4")] {
+            let attachment = Attachment {
+                name: name.into(),
+                media_type: mime.into(),
+                byte_len: 3,
+                source: AttachmentSource::Data {
+                    base64: "YWJj".into(),
+                },
+            };
+            let parts: Vec<_> = wire_parts(&[attachment], flipped)
+                .into_iter()
+                .map(attachment_part)
+                .collect();
+            let [OpenAiContentPart::InputText { text }] = parts.as_slice() else {
+                panic!("expected a degrade note for {mime}, got {parts:?}");
+            };
+            assert!(
+                text.contains(mime),
+                "the note names what was attached: {text}"
+            );
+        }
+    }
 
     #[test]
     fn user_attachments_map_to_input_image_and_input_file_parts() {

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -485,21 +485,7 @@ fn user_content(message: &CompletionMessage) -> ZaiContent {
     let mut parts: Vec<ZaiContentPart> =
         crate::attachment::wire_parts(&message.attachments, ZAI_CAPS)
             .into_iter()
-            .map(|part| match part {
-                crate::attachment::WirePart::Image { media_type, base64 } => {
-                    ZaiContentPart::ImageUrl {
-                        image_url: ZaiImageUrl {
-                            url: format!("data:{media_type};base64,{base64}"),
-                        },
-                    }
-                }
-                crate::attachment::WirePart::Text { text } => ZaiContentPart::Text { text },
-                crate::attachment::WirePart::Pdf { .. }
-                | crate::attachment::WirePart::Audio { .. }
-                | crate::attachment::WirePart::Video { .. } => {
-                    unreachable!("caps exclude pdf/audio/video")
-                }
-            })
+            .map(attachment_part)
             .collect();
     if !message.content.is_empty() {
         parts.push(ZaiContentPart::Text {
@@ -507,6 +493,25 @@ fn user_content(message: &CompletionMessage) -> ZaiContent {
         });
     }
     ZaiContent::Parts(parts)
+}
+
+/// One resolved part as a GLM content part.
+fn attachment_part(part: crate::attachment::WirePart) -> ZaiContentPart {
+    match part {
+        crate::attachment::WirePart::Image { media_type, base64 } => ZaiContentPart::ImageUrl {
+            image_url: ZaiImageUrl {
+                url: format!("data:{media_type};base64,{base64}"),
+            },
+        },
+        crate::attachment::WirePart::Text { text } => ZaiContentPart::Text { text },
+        // Excluded by ZAI_CAPS today; turning one of those caps on without
+        // adding a part arm lands here — degrade, never abort the turn.
+        part @ (crate::attachment::WirePart::Pdf { .. }
+        | crate::attachment::WirePart::Audio { .. }
+        | crate::attachment::WirePart::Video { .. }) => ZaiContentPart::Text {
+            text: crate::attachment::unsupported_part_note(&part, "Z.ai chat API"),
+        },
+    }
 }
 
 /// An assistant-authored tool call echoed back in conversation history

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -1577,3 +1577,46 @@ async fn openrouter_resends_without_reasoning_when_the_endpoint_mandates_it() {
         "the resend drops the field so the endpoint applies its own default: {second}"
     );
 }
+
+/// The pdf/audio/video arm of [`attachment_part`] is out of reach only
+/// because `ZAI_CAPS` switches those kinds off. Flipping one of those bools
+/// is a routine one-line edit, so the arm it lands in has to degrade like
+/// every other unsupported attachment instead of aborting the process
+/// mid-turn.
+#[test]
+fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
+    use crate::attachment::{DialectCaps, wire_parts};
+    use stella_protocol::{Attachment, AttachmentSource};
+    let flipped = DialectCaps {
+        images: true,
+        pdfs: true,
+        audio: true,
+        video: true,
+    };
+    let cases = [
+        ("spec.pdf", "application/pdf", "spec.pdf"),
+        ("song.mp3", "audio/mpeg", "audio/mpeg"),
+        ("clip.mp4", "video/mp4", "video/mp4"),
+    ];
+    for (name, mime, needle) in cases {
+        let attachment = Attachment {
+            name: name.into(),
+            media_type: mime.into(),
+            byte_len: 3,
+            source: AttachmentSource::Data {
+                base64: "YWJj".into(),
+            },
+        };
+        let parts: Vec<_> = wire_parts(&[attachment], flipped)
+            .into_iter()
+            .map(attachment_part)
+            .collect();
+        let [ZaiContentPart::Text { text }] = parts.as_slice() else {
+            panic!("expected a degrade note for {mime}, got {parts:?}");
+        };
+        assert!(
+            text.contains(needle),
+            "the note names what was attached: {text}"
+        );
+    }
+}

--- a/stella-tools/src/media.rs
+++ b/stella-tools/src/media.rs
@@ -579,11 +579,36 @@ mod tests {
 
     impl MediaOperationIdSource for FixedOperationIds {
         fn operation_id(&self) -> HostMediaOperation {
+            // The journal folds `expires_at` into a claim's identity, so
+            // recomputing it per call would hand the same operation a different
+            // deadline as soon as the clock ticked between two `execute`s —
+            // the retry then reads as a different request wearing the same key
+            // and the claim is rejected. Snapshot the deadline once, process
+            // wide, so a "fixed" id source is fixed in both of its fields.
+            static EXPIRES_AT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
             HostMediaOperation {
                 opaque_id: self.0.to_string(),
-                expires_at: unix_now() + 3600,
+                expires_at: *EXPIRES_AT.get_or_init(|| unix_now() + 3600),
             }
         }
+    }
+
+    /// Guards the helper above, not production code: every retry-safety test
+    /// here calls `execute` twice against one id source and would pass by luck
+    /// on a machine fast enough to stay inside a single second. Crossing a
+    /// second boundary on purpose is the only way to make that luck visible.
+    #[test]
+    fn a_fixed_operation_id_source_holds_one_expiry_across_a_clock_tick() {
+        let ids = FixedOperationIds("host-stable-expiry");
+        let first = ids.operation_id();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let second = ids.operation_id();
+        assert_eq!(
+            first.expires_at, second.expires_at,
+            "a retry must re-present the same expiry or the journal reads it as \
+             a different request wearing the same key",
+        );
+        assert_eq!(first.opaque_id, second.opaque_id);
     }
 
     #[async_trait]


### PR DESCRIPTION
## What & why

`stella-model`'s zai, anthropic, openai, and bedrock adapters each had `unreachable!` arms for the `WirePart` variants their `*_CAPS` const currently excludes. Those arms are unreachable *only because of the current caps values*. Flipping one caps bool — enabling PDFs in `ZAI_CAPS`, say — turns a user attaching a PDF into a panic that aborts the process mid-turn, contradicting the attachment module's documented promise that an attachment *"NEVER fails the request"*.

Each arm now emits a degrade note through a shared `attachment::unsupported_part_note`, wrapped in the adapter's own text-block shape and naming its dialect. `degrade_note`'s dead `AttachmentKind::Text` arm is made total for the same reason, so **no `unreachable!` remains anywhere on an attachment path** in the crate.

Two things deliberately preserved:

- Variants stay **listed explicitly** rather than collapsing into a `_ =>` catch-all. A catch-all would silence the exhaustiveness check that makes adding a new `WirePart` a compile error in every adapter — the caps footgun and the new-variant footgun are different problems and only one of them wanted fixing here.
- Gemini already switches every cap on and handles every variant, so it needed no change.

Closes #636

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The triage noted no test could reach these arms without editing the caps. The fix is to make that editable: each adapter's per-part mapping becomes a named function, and `a_caps_flip_degrades_instead_of_aborting_the_turn` drives `wire_parts` with every cap switched on — exactly the flip a future editor would make — then asserts a text note naming the attachment comes back.

Verified in both directions. With the `unreachable!` arms temporarily restored, all four fail with the exact panic the issue describes:

```
test zai::tests::a_caps_flip_degrades_instead_of_aborting_the_turn ... FAILED
test openai::tests::a_caps_flip_degrades_instead_of_aborting_the_turn ... FAILED
test anthropic::tests::a_caps_flip_degrades_instead_of_aborting_the_turn ... FAILED
test bedrock::tests::a_caps_flip_degrades_instead_of_aborting_the_turn ... FAILED

panicked at stella-model/src/zai.rs:511:56:
internal error: entered unreachable code: caps exclude pdf/audio/video
```

On this branch all four pass, with the rest of `stella-model` green (268 tests).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed (attachment module docs gained a paragraph on the caps/adapter split; each new arm carries a comment explaining what reaching it means)
- [x] `Closes #636` appears both above and as a commit trailer

`make gate` passes end to end (exit 0), including `no-scratch` and `doc-citations`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The bedrock/openai diffs look larger than they are — most of it is reindentation from lifting the `.map(|part| match part { … })` closure into a named function so the mapping is reachable from tests. `git diff -w` shows the real change is the arm replacement alone; no working path changed.

The degrade wording is one shared sentence parameterised by dialect and part rather than four hand-written strings, matching the module's stated design that graceful degradation lives in one place. The note carries the media type (or file name, for PDFs) so the model can suggest a workable format rather than just apologizing.

One judgment call worth flagging: reaching these arms means a caps const advertises a kind the adapter never learned to encode — a wiring mistake, not user error. There's no `tracing` dependency in `stella-model`, so it degrades silently rather than logging a warning. If you'd rather that mistake be loud, a log line is the natural follow-up, but it shouldn't be a panic.
