### PR TITLE
context: stop recency from filling recall with unrelated frames

### DIFF
--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -48,7 +48,7 @@ mod quarantine_tests;
 #[path = "memory/skills.rs"]
 mod skill_files;
 use private_state::resolve_context_db_path;
-use projection::{is_quarantined_local_memory, project_recalled_frame};
+use projection::{is_suppressed_local_frame, project_recalled_frame};
 #[cfg(test)]
 pub(crate) use skill_files::load_workspace_skills;
 pub(crate) use skill_files::{load_workspace_skills_with_authority, workspace_skills_dir};
@@ -757,7 +757,7 @@ impl SessionMemory {
                 .frames
                 .into_iter()
                 .filter_map(project_recalled_frame)
-                .filter(|frame| !is_quarantined_local_memory(frame, &quarantined))
+                .filter(|frame| !is_suppressed_local_frame(frame, &quarantined))
                 .collect(),
             usage: Some(recalled.usage),
         }
@@ -1225,19 +1225,54 @@ mod tests {
             "local",
             "local memory",
         );
-        assert!(is_quarantined_local_memory(&local, &quarantined));
+        assert!(is_suppressed_local_frame(&local, &quarantined));
 
         local.provider = "external-graph".into();
         assert!(
-            !is_quarantined_local_memory(&local, &quarantined),
+            !is_suppressed_local_frame(&local, &quarantined),
             "an external provider may reuse a local id"
         );
         local.provider = "workspace-memory".into();
         local.kind = "symbol".into();
         assert!(
-            !is_quarantined_local_memory(&local, &quarantined),
+            !is_suppressed_local_frame(&local, &quarantined),
             "only actual local memory frames participate in memory quarantine"
         );
+    }
+
+    /// An episode is a verbatim copy of a past user prompt, recalled and
+    /// injected exactly like a memory. It used to be unsuppressable: the
+    /// predicate required `kind == "memory"`, so `stella memory forget` on an
+    /// episode id silently did nothing and a stale instruction kept surfacing
+    /// in unrelated runs. This is the regression guard for that.
+    #[test]
+    fn a_forgotten_episode_is_suppressed_like_a_forgotten_memory() {
+        let forgotten = std::collections::HashSet::from(["ep-1".to_string()]);
+        let episode = frame(
+            "ep-1",
+            contextgraph_types::FrameKind::Episode,
+            "local",
+            "can you remove the witness tests please",
+        );
+        assert_eq!(
+            episode.kind, "episode",
+            "the fixture must actually be an episode-kind frame, or this \
+             proves nothing"
+        );
+        assert!(
+            is_suppressed_local_frame(&episode, &forgotten),
+            "forgetting an episode must stop it being recalled"
+        );
+
+        // Still scoped: a different id is untouched, so the predicate cannot
+        // be passing merely because it now accepts every episode.
+        let other = frame(
+            "ep-2",
+            contextgraph_types::FrameKind::Episode,
+            "local",
+            "unrelated prompt",
+        );
+        assert!(!is_suppressed_local_frame(&other, &forgotten));
     }
 
     #[tokio::test]

--- a/stella-cli/src/memory/projection.rs
+++ b/stella-cli/src/memory/projection.rs
@@ -42,11 +42,21 @@ pub(super) fn project_recalled_frame(
     })
 }
 
-pub(super) fn is_quarantined_local_memory(
+/// Whether a recalled frame has been suppressed — quarantined by repeated
+/// untruthful citations, or explicitly forgotten by the user.
+///
+/// Covers both recallable kinds. `episode` used to be excluded, which made an
+/// entire class of frame unsuppressable: an episode is a verbatim copy of a
+/// past user prompt, it is recalled and injected exactly like a memory, and
+/// `stella memory forget` silently had no effect on one. A prior instruction
+/// could therefore keep surfacing in unrelated runs with no way to stop it —
+/// the shape that let "can you remove the witness tests please" reach the
+/// witness author on a task about a TUI keybinding.
+pub(super) fn is_suppressed_local_frame(
     frame: &RecalledFrame,
-    quarantined: &HashSet<String>,
+    suppressed: &HashSet<String>,
 ) -> bool {
     frame.provider == "workspace-memory"
-        && frame.kind == "memory"
-        && frame.id.as_ref().is_some_and(|id| quarantined.contains(id))
+        && matches!(frame.kind.as_str(), "memory" | "episode")
+        && frame.id.as_ref().is_some_and(|id| suppressed.contains(id))
 }

--- a/stella-cli/src/memory_cmd.rs
+++ b/stella-cli/src/memory_cmd.rs
@@ -36,6 +36,11 @@ pub enum MemoryFormat {
 #[derive(Debug, Clone, Serialize)]
 struct MemoryListRow {
     id: String,
+    /// `memory` (a mined reflection) or `episode` (a verbatim past prompt).
+    /// Episodes are listed because they are recalled and injected exactly like
+    /// memories — omitting them hid a whole class of steering input from the
+    /// only command that can name it for `stella memory forget`.
+    kind: String,
     citations: i64,
     avg_score: f64,
     truthful_rate: f64,
@@ -113,8 +118,10 @@ fn list_rows(workspace_root: &std::path::Path) -> Result<Vec<MemoryListRow>, Str
     };
     let context =
         ContextStore::open(&context_db).map_err(|e| format!("cannot open context store: {e}"))?;
+    // Episodes as well as memories: both are recalled and injected, so both
+    // must be nameable for `stella memory forget`.
     let memories = context
-        .memory_nodes()
+        .recallable_nodes()
         .map_err(|e| format!("cannot read memories: {e}"))?;
     let stats = citation_stats(workspace_root)?;
     Ok(join_rows(memories, &stats))
@@ -226,6 +233,7 @@ fn join_rows(memories: Vec<NodeRow>, stats: &[MemoryCitationStats]) -> Vec<Memor
         match stats.iter().find(|s| s.memory_id == node.public_id) {
             Some(s) => cited.push(MemoryListRow {
                 id: node.public_id.clone(),
+                kind: node.kind.as_str().to_string(),
                 citations: s.citations,
                 avg_score: s.avg_score,
                 truthful_rate: s.truthful_rate,
@@ -236,6 +244,7 @@ fn join_rows(memories: Vec<NodeRow>, stats: &[MemoryCitationStats]) -> Vec<Memor
             }),
             None => uncited.push(MemoryListRow {
                 id: node.public_id.clone(),
+                kind: node.kind.as_str().to_string(),
                 citations: 0,
                 avg_score: 0.0,
                 truthful_rate: 0.0,
@@ -543,8 +552,10 @@ fn validate_memories(workspace_root: &std::path::Path) -> Result<Vec<MemoryValid
     };
     let context =
         ContextStore::open(&context_db).map_err(|e| format!("cannot open context store: {e}"))?;
+    // Episodes as well as memories: both are recalled and injected, so both
+    // must be nameable for `stella memory forget`.
     let memories = context
-        .memory_nodes()
+        .recallable_nodes()
         .map_err(|e| format!("cannot read memories: {e}"))?;
 
     // Built lazily: a workspace whose memories name no bare filenames never
@@ -638,11 +649,11 @@ fn slugify(label: &str) -> String {
 
 /// Column headers, in `MemoryListRow` field order (`memory` last, so the
 /// one unbounded column never breaks alignment).
-const TABLE_HEADERS: [&str; 7] = [
-    "ID", "CITES", "AVG", "TRUTHFUL", "STREAK", "STATUS", "MEMORY",
+const TABLE_HEADERS: [&str; 8] = [
+    "ID", "KIND", "CITES", "AVG", "TRUTHFUL", "STREAK", "STATUS", "MEMORY",
 ];
 
-fn table_cells(row: &MemoryListRow) -> [String; 7] {
+fn table_cells(row: &MemoryListRow) -> [String; 8] {
     let mut memory: String = row.memory.chars().take(60).collect();
     if row.memory.chars().count() > 60 {
         memory.push('…');
@@ -658,6 +669,7 @@ fn table_cells(row: &MemoryListRow) -> [String; 7] {
     };
     [
         row.id.clone(),
+        row.kind.clone(),
         row.citations.to_string(),
         if row.citations > 0 {
             format!("{:.1}", row.avg_score)
@@ -678,7 +690,7 @@ fn table_cells(row: &MemoryListRow) -> [String; 7] {
 /// Aligned table, `stella stats` style: left-aligned strings, right-aligned
 /// numbers, two-space gutter, no trailing whitespace.
 fn render_table(rows: &[MemoryListRow]) -> String {
-    let body: Vec<[String; 7]> = rows.iter().map(table_cells).collect();
+    let body: Vec<[String; 8]> = rows.iter().map(table_cells).collect();
     let mut widths: Vec<usize> = TABLE_HEADERS.iter().map(|h| h.len()).collect();
     for cells in &body {
         for (w, cell) in widths.iter_mut().zip(cells.iter()) {
@@ -690,8 +702,9 @@ fn render_table(rows: &[MemoryListRow]) -> String {
             .iter()
             .enumerate()
             .map(|(i, cell)| {
-                // Numeric middle columns right-align; ID and MEMORY stay left.
-                if (1..=4).contains(&i) {
+                // Numeric middle columns right-align; ID, KIND and MEMORY
+                // stay left.
+                if (2..=5).contains(&i) {
                     format!("{cell:>width$}", width = widths[i])
                 } else {
                     format!("{cell:<width$}", width = widths[i])

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -41,6 +41,33 @@ pub(crate) const LEXICAL_FALLBACK_METHOD: &str = "stella-context/lexical-fallbac
 
 /// Reciprocal-rank-fusion constant (the standard 60).
 const RRF_K: f64 = 60.0;
+/// How much the recency list counts for, relative to vector similarity.
+///
+/// Recency used to be fused at full weight, as a peer of similarity. Because
+/// RRF is flat (see [`rrf_fuse`]), that made the N most recently written nodes
+/// structurally guaranteed a top-N slot no matter what the query asked: the
+/// newest node banked `1/61` from recency alone — the exact contribution of the
+/// single best semantic match — so with `max_frames: 5` the five newest rows
+/// could occupy every slot.
+///
+/// That is not hypothetical. A run asking to remove some test files wrote four
+/// reflections plus an episode; the very next run, on a completely unrelated
+/// TUI keybinding, recalled all five and handed them to the witness author,
+/// which then went looking for test files to delete.
+///
+/// A relevance floor was measured and rejected as the fix: under the default
+/// [`crate::embed::HashEmbedder`] (character-trigram hashing, not semantics)
+/// those five contaminants scored 0.38–0.50 against that prompt while
+/// genuinely relevant frames scored 0.45–0.63. The sets overlap, so no
+/// threshold separates them. Recency was the thing doing the damage, so
+/// recency is what changed.
+///
+/// At 0.15 the newest node banks `0.15/61 ≈ 0.0025`, which cannot outweigh
+/// even a mid-ranked semantic hit (`1/150 ≈ 0.0067`). Every embedded node is
+/// already in the vector list, so recency keeps its real job — ordering among
+/// comparably-relevant frames — and loses only its ability to inject a frame
+/// the query never asked for.
+const RECENCY_WEIGHT: f64 = 0.15;
 /// MMR relevance/diversity trade-off; 0.7 favors relevance while still
 /// breaking up near-duplicate clusters.
 const MMR_LAMBDA: f32 = 0.7;
@@ -299,8 +326,17 @@ impl ContextStore {
             let graph_ranked: Vec<i64> = graph_scored.iter().map(|(id, _)| *id).collect();
 
             // 4c. Fuse (RRF) → dedup by content hash → MMR diversity pass.
+            // Vector, graph, and domain are all grounded signals — they answer
+            // "does this relate to what was asked". Recency answers "was this
+            // written lately", which is a tiebreaker, not evidence, so it
+            // enters damped ([`RECENCY_WEIGHT`]).
             let fused = rrf_fuse(
-                &[vector_ranked, recency_ranked, graph_ranked, domain_ranked],
+                &[
+                    (vector_ranked, 1.0),
+                    (recency_ranked, RECENCY_WEIGHT),
+                    (graph_ranked, 1.0),
+                    (domain_ranked, 1.0),
+                ],
                 RRF_K,
             );
             let ordered = dedup_by_content_hash(&fused, &node_by_id);
@@ -472,12 +508,19 @@ fn coverage_score(cos_sorted: &[(i64, f32)]) -> f32 {
     sum / k as f32
 }
 
-/// Reciprocal-rank fusion over several ranked id lists.
-fn rrf_fuse(lists: &[Vec<i64>], k: f64) -> HashMap<i64, f64> {
+/// Reciprocal-rank fusion over several ranked id lists, each contributing
+/// `weight / (k + rank + 1)`.
+///
+/// The weights exist because RRF is deliberately *flat*: with `k = 60`, rank 1
+/// scores 1/61 and rank 100 scores 1/161 — barely a 2.6× spread across the
+/// whole corpus. A list added at weight 1.0 is therefore not a hint, it is a
+/// peer that can single-handedly decide the top of the result. See
+/// [`RECENCY_WEIGHT`].
+fn rrf_fuse(lists: &[(Vec<i64>, f64)], k: f64) -> HashMap<i64, f64> {
     let mut scores: HashMap<i64, f64> = HashMap::new();
-    for list in lists {
+    for (list, weight) in lists {
         for (rank, &id) in list.iter().enumerate() {
-            *scores.entry(id).or_insert(0.0) += 1.0 / (k + rank as f64 + 1.0);
+            *scores.entry(id).or_insert(0.0) += weight / (k + rank as f64 + 1.0);
         }
     }
     scores
@@ -738,10 +781,86 @@ mod tests {
 
     #[test]
     fn rrf_rewards_appearing_high_in_multiple_lists() {
-        let fused = rrf_fuse(&[vec![1, 2, 3], vec![1, 3, 2]], 60.0);
+        let fused = rrf_fuse(&[(vec![1, 2, 3], 1.0), (vec![1, 3, 2], 1.0)], 60.0);
         // id 1 is rank-0 in both lists → strictly highest.
         assert!(fused[&1] > fused[&2]);
         assert!(fused[&1] > fused[&3]);
+    }
+
+    /// Build a ranked list of `len` ids, placing specific ids at specific
+    /// ranks. Filler ids start at 1000 so they never collide with the ids
+    /// under test.
+    fn ranked_with(placements: &[(i64, usize)], len: usize) -> Vec<i64> {
+        let mut list: Vec<i64> = (0..len).map(|i| 1000 + i as i64).collect();
+        for &(id, rank) in placements {
+            list[rank] = id;
+        }
+        list
+    }
+
+    /// The contamination regression, reduced to its arithmetic.
+    ///
+    /// Faithful to the real failure rather than a symmetric reversal (which
+    /// scores identically and proves nothing): `STALE` is the best semantic
+    /// match but was written long ago, while `FRESH` is the newest row in the
+    /// store with only middling similarity — exactly the shape of a previous
+    /// run's leftover reflections meeting an unrelated new prompt. At equal
+    /// weight recency hands `FRESH` the win; damped, similarity decides.
+    #[test]
+    fn recency_cannot_outrank_similarity_on_its_own() {
+        const STALE: i64 = 1;
+        const FRESH: i64 = 2;
+        let vector_ranked = ranked_with(&[(STALE, 0), (FRESH, 50)], 200);
+        let recency_ranked = ranked_with(&[(FRESH, 0), (STALE, 150)], 200);
+
+        let equal_weight = rrf_fuse(
+            &[(vector_ranked.clone(), 1.0), (recency_ranked.clone(), 1.0)],
+            RRF_K,
+        );
+        assert!(
+            equal_weight[&FRESH] > equal_weight[&STALE],
+            "the pre-fix behavior this test exists to prevent: the newest row \
+             beats the best semantic match purely on recency"
+        );
+
+        let damped = rrf_fuse(
+            &[(vector_ranked, 1.0), (recency_ranked, RECENCY_WEIGHT)],
+            RRF_K,
+        );
+        assert!(
+            damped[&STALE] > damped[&FRESH],
+            "the best semantic match must outrank the newest unrelated node"
+        );
+    }
+
+    /// Damping must not *silence* recency — ordering comparably-relevant
+    /// frames is its legitimate job, and a weight of 0 would be a different
+    /// (also wrong) change. Adjacent similarity ranks, big recency gap: the
+    /// newer one still wins.
+    #[test]
+    fn recency_still_reorders_comparably_relevant_frames() {
+        const OLDER: i64 = 1;
+        const NEWER: i64 = 2;
+        // Effectively tied on similarity (ranks 10 and 11)...
+        let vector_ranked = ranked_with(&[(OLDER, 10), (NEWER, 11)], 200);
+        // ...and far apart in age.
+        let recency_ranked = ranked_with(&[(NEWER, 0), (OLDER, 100)], 200);
+
+        let damped = rrf_fuse(
+            &[
+                (vector_ranked.clone(), 1.0),
+                (recency_ranked, RECENCY_WEIGHT),
+            ],
+            RRF_K,
+        );
+        assert!(
+            damped[&NEWER] > damped[&OLDER],
+            "recency must still decide between frames similarity ranks alike"
+        );
+        // Without any recency signal the similarity order stands, which is
+        // what makes the assertion above attributable to recency.
+        let no_recency = rrf_fuse(&[(vector_ranked, 1.0)], RRF_K);
+        assert!(no_recency[&OLDER] > no_recency[&NEWER]);
     }
 
     #[test]

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -549,13 +549,33 @@ impl ContextStore {
     /// behind `stella memory` (its citation stats join on `public_id`, the
     /// same stable id recalled frames carry).
     pub fn memory_nodes(&self) -> Result<Vec<NodeRow>, ContextError> {
+        self.nodes_of_kinds(&["memory"])
+    }
+
+    /// Every live node a recall can actually inject into a prompt: memories
+    /// *and* episodes, newest first.
+    ///
+    /// [`Self::memory_nodes`] shows only `memory`, which left a blind spot.
+    /// An episode is a verbatim copy of a past user prompt; it is recalled and
+    /// injected exactly like a memory, yet no command could display one — so a
+    /// stale instruction that kept surfacing in unrelated runs could not even
+    /// be named, let alone forgotten (`stella memory forget` resolves ids
+    /// through [`Self::node_by_public_id`], which was never the limitation).
+    pub fn recallable_nodes(&self) -> Result<Vec<NodeRow>, ContextError> {
+        self.nodes_of_kinds(&["memory", "episode"])
+    }
+
+    fn nodes_of_kinds(&self, kinds: &[&str]) -> Result<Vec<NodeRow>, ContextError> {
         let conn = lock(&self.conn);
-        let mut stmt = conn.prepare(
+        // Kinds are crate-internal literals, never user input, but the query
+        // is parameterized rather than formatted all the same.
+        let placeholders = vec!["?"; kinds.len()].join(", ");
+        let mut stmt = conn.prepare(&format!(
             "SELECT id, public_id, kind, display_name, content, content_hash, uri, valid_from, recorded_at
-             FROM node WHERE kind = 'memory' AND superseded_at IS NULL
+             FROM node WHERE kind IN ({placeholders}) AND superseded_at IS NULL
              ORDER BY recorded_at DESC, id DESC",
-        )?;
-        let rows = stmt.query_map([], map_node_row)?;
+        ))?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(kinds), map_node_row)?;
         let mut out = Vec::new();
         for r in rows {
             out.push(r?);


### PR DESCRIPTION
Third in the series (after #668, #670). This one explains the Ctrl+O transcript: a request to add a keybinding to the issues dialog was routed into witness authoring, and the author spent the run grepping for witness test files.

## What actually happened

The prompt was clear. The system appended 272 tokens of a *previous* task's leftovers to it, and the witness author obeyed those.

The earlier "remove the witness tests" run wrote 4 reflections + 1 episode. On the next, unrelated run, all five were recalled and interpolated into `witness_prompt` — which takes every frame unconditionally.

## Cause: recency was a peer of similarity

`recall_scoped` fuses four ranked lists via RRF, one of which is **pure recency over every node in the store**, at full weight.

RRF is deliberately flat — with `k = 60`, rank 1 scores `1/61` and rank 100 scores `1/161`, a 2.6× spread across the entire corpus. A list added at weight 1.0 is therefore not a hint; it decides the top of the result. The newest node banked `1/61` from recency alone — **exactly the contribution of the single best semantic match** — so with `max_frames: 5` the five newest rows could occupy every slot no matter what was asked.

`rrf_fuse` now takes per-list weights; recency enters at `0.15`. Vector, graph, and domain stay at 1.0 — they answer *"does this relate to what was asked"*; recency answers *"was this written lately"*, which is a tiebreaker, not evidence. Every embedded node is already in the vector list, so recency keeps its real job (ordering comparably-relevant frames) and loses only its ability to inject a frame the query never asked for.

## The relevance floor was measured and rejected

This was the fix I set out to build. I measured it first, against the real frames:

| frame | cosine to the Ctrl+O prompt |
|---|---|
| "Ensure tests are non-vacuous…" | **0.5029** (contaminant) |
| "interactive.rs binds Ctrl+O to open a preview dialog" | 0.4954 (relevant) |
| "connect_cmd.rs runs browser OAuth for linear" | 0.4512 (relevant) |
| "can you remove the witness tests please" | 0.3843 (contaminant) |

The contaminants **outscore genuinely relevant frames**. The default `HashEmbedder` is character-trigram hashing, not semantics, so no threshold separates these sets. A floor would have looked principled and changed nothing — so it isn't here. Recency was doing the damage; recency is what changed.

## Episodes were unsuppressable and invisible

An episode is a verbatim copy of a past user prompt, recalled and injected exactly like a memory. But:

- `is_quarantined_local_memory` required `kind == "memory"` → **`stella memory forget` on an episode silently did nothing**
- `memory_nodes` queried `kind = 'memory'` → **the id could never be discovered**

So a stale instruction could keep surfacing forever with no way to stop it. Both now cover episodes (`stella memory list` gains a `KIND` column). `forget` resolves ids via `node_by_public_id`, which was never the limitation.

**No second forget mechanism was added** — tombstones in `store.db` already exist and already gate recall. This widens the surface they cover.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` — all confirmed **by exit code**, not by reading filtered output (a `rg`-filtered view hid a real failure for me earlier today)
- `recency_cannot_outrank_similarity_on_its_own` asserts the **old** behavior at equal weight before asserting the new one, so it cannot pass vacuously. My first draft of it was a symmetric reversal that scored identically and proved nothing; it now models the real asymmetry (best-match-but-old vs newest-but-middling)
- `recency_still_reorders_comparably_relevant_frames` pins that damping ≠ silencing — a weight of 0 would be a different, also-wrong change
- `a_forgotten_episode_is_suppressed_like_a_forgotten_memory` asserts the fixture really is episode-kind, then that a *different* id is still untouched

## Still open

The witness author receives recalled frames with no filter at all (`witness.rs:572-581`). Better ranking makes that less dangerous but not safe — an authored test should probably be grounded in the goal and the tree, not in prose recalled from other tasks.
