### PR TITLE
cli: version the machine-readable JSON summary envelope (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ record of *changes*, curated by the person who made them.
 
 ## [Unreleased]
 
+### Added
+
+- `--output-format json|stream-json` summaries now declare `schema_version`
+  (currently `1`). Every envelope carries it — the pipeline summary, the
+  `--no-pipeline` summary, and the pre-flight error envelope — and all three
+  always declare the same value. The bump rule is documented in
+  [Scripting & automation](https://stella.oxagen.sh/docs/scripting#the-envelope-contract):
+  it increments only when a key is removed, renamed, retyped, or changes
+  meaning, never when a key is added, so consumers must keep ignoring
+  unrecognized keys.
+
 ## [0.5.30] — 2026-07-26
 
 ## [0.5.29] — 2026-07-26

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -136,8 +136,16 @@ pub async fn run_one_shot(
 /// deserializers (serde non-`Option` fields, `jq -e`, Pydantic) written
 /// against the success shape. `Option` fields are serialized as `null`, never
 /// skipped — the key set is the contract.
+///
+/// That contract is versioned: [`schema_version`](Self::schema_version) is
+/// declared first and governed by the bump rule on
+/// [`crate::SUMMARY_SCHEMA_VERSION`]. Declaration order is wire order for a
+/// derived `Serialize`, so keeping the version at the top is a convention worth
+/// holding — though consumers read it by key, not position.
 #[derive(serde::Serialize)]
 struct PipelineRunSummary {
+    /// The envelope contract version — always [`crate::SUMMARY_SCHEMA_VERSION`].
+    schema_version: u32,
     status: &'static str,
     text: Option<String>,
     cost_usd: f64,
@@ -515,6 +523,7 @@ async fn run_pipeline_one_shot(
         Ok(outcome) => {
             if format == OutputFormat::Json {
                 let summary = PipelineRunSummary {
+                    schema_version: crate::SUMMARY_SCHEMA_VERSION,
                     status: pipeline_status_label(&outcome.status),
                     text: Some(outcome.final_text.clone()),
                     cost_usd: outcome.total_cost_usd + reflection_report.cost_usd,
@@ -562,6 +571,7 @@ async fn run_pipeline_one_shot(
             // failing).
             if format == OutputFormat::Json {
                 let summary = PipelineRunSummary {
+                    schema_version: crate::SUMMARY_SCHEMA_VERSION,
                     status: "error",
                     text: None,
                     cost_usd: budget.session_spent_usd(),
@@ -2061,6 +2071,13 @@ async fn run_turn(
             }
         };
         let summary = serde_json::json!({
+            // Governed by the same bump rule as the pipeline summary
+            // (`crate::SUMMARY_SCHEMA_VERSION`) — the two paths are one
+            // contract surface with different key sets, so they must never
+            // carry different version numbers. Written first here for the
+            // reader's benefit only: `json!` emits its keys sorted, so this
+            // lands mid-object on the wire. Consumers read it by key.
+            "schema_version": crate::SUMMARY_SCHEMA_VERSION,
             "status": status,
             "text": text,
             "cost_usd": cost_usd,

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -1534,3 +1534,54 @@ fn index_workspace_graph_blocking_reports_generated_skips_end_to_end() {
     let line = format_graph_stats(&summary);
     assert!(line.contains("skipped 1 generated file"), "{line}");
 }
+
+/// Issue #644: the machine-readable envelope declares its contract version, and
+/// declares the *same* one on both arms. A version present on the success shape
+/// but missing from the error shape is worse than no version at all — a script
+/// could not rely on reading it, and the error arm is the one a headless
+/// consumer hits most.
+#[test]
+fn the_json_summary_envelope_declares_its_schema_version_on_both_arms() {
+    let sample = |status, text: Option<&str>, reason: Option<&str>| PipelineRunSummary {
+        schema_version: crate::SUMMARY_SCHEMA_VERSION,
+        status,
+        text: text.map(str::to_string),
+        cost_usd: 0.25,
+        reason: reason.map(str::to_string),
+        task_class: text.map(|_| "Edit".to_string()),
+        verdict: text.map(|_| serde_json::json!({ "passed": true })),
+        revisions: text.map(|_| 1),
+        candidates_run: text.map(|_| 2),
+        model: "anthropic/claude-opus".to_string(),
+        events: Vec::new(),
+        reflection: serde_json::Value::Null,
+    };
+
+    let ok = serde_json::to_value(sample("completed", Some("done"), None)).expect("serializes");
+    let err = serde_json::to_value(sample("error", None, Some("boom"))).expect("serializes");
+
+    assert_eq!(
+        ok["schema_version"],
+        serde_json::json!(crate::SUMMARY_SCHEMA_VERSION)
+    );
+    assert_eq!(
+        err["schema_version"], ok["schema_version"],
+        "one run, one envelope contract: the arms cannot declare different versions"
+    );
+
+    // The key set is the contract (#373), and the version stamp is now part of
+    // it — on both arms, as an explicit key rather than an inferred default.
+    let keys = |v: &serde_json::Value| {
+        v.as_object()
+            .expect("the summary serializes as an object")
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>()
+    };
+    assert_eq!(
+        keys(&ok),
+        keys(&err),
+        "the success and error arms share one key set"
+    );
+    assert!(keys(&ok).contains("schema_version"));
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -112,6 +112,48 @@ pub(crate) fn note_json_summary_emitted() {
     JSON_SUMMARY_EMITTED.store(true, std::sync::atomic::Ordering::SeqCst);
 }
 
+/// The version of the `--output-format json|stream-json` summary envelope this
+/// build emits. Every summary object carries it — the pipeline summary, the raw
+/// step-loop summary, and the pre-flight error envelope — so a consumer can
+/// branch on the shape it was handed instead of sniffing for keys. A version
+/// stamped on only some summaries would be worse than none: a script could not
+/// rely on reading it. Consumers read it by key: key order is outside the
+/// contract, and in fact varies by construction site — the derived `Serialize`
+/// on `PipelineRunSummary` emits declaration order, while the `json!`-built
+/// envelopes here and in the raw step loop emit their keys sorted.
+///
+/// # Why version at all
+///
+/// The envelope's key set is a contract with every script that parses it, and
+/// the cost of adding the stamp rises with the number of consumers. Today it is
+/// additive and harmless; after the first external script pins the current
+/// shape, it is a compatibility negotiation (#644). This is the same reasoning
+/// that versioned the drain wire format ahead of its transport — see
+/// `DRAIN_SCHEMA_VERSION` in `stella-store`.
+///
+/// # When to bump
+///
+/// Increment when a consumer written against the previous version could break:
+///
+/// - a key is removed or renamed,
+/// - a key's value type changes (`string` → `object`, scalar → array),
+/// - a key's *meaning* changes while its name and type stay the same.
+///
+/// Do **not** increment for purely additive change — a new key appended to the
+/// envelope. Consumers are required to ignore keys they do not recognize (the
+/// same discipline rule 1 of the event-stream contract imposes), so an addition
+/// cannot break a correct client, and bumping for one would burn the signal.
+///
+/// The `events` array is deliberately **out of scope**: the event vocabulary
+/// carries its own forward-compatibility contract
+/// (`website/content/docs/event-stream-compatibility.mdx`), and a new event type
+/// never bumps this number. Everything else the envelope owns — including the
+/// nested `verdict`, `reflection`, and `files_touched` payloads — is covered.
+///
+/// The consumer-facing statement of this rule lives in
+/// `website/content/docs/scripting.mdx`; keep the two in step.
+pub(crate) const SUMMARY_SCHEMA_VERSION: u32 = 1;
+
 /// The stdout envelope for a failure under `--output-format json|stream-json`,
 /// or `None` when the caller asked for human output (a text run must keep
 /// stdout clean; its diagnostic is the stderr line).
@@ -119,11 +161,17 @@ pub(crate) fn note_json_summary_emitted() {
 /// Pre-configuration failures — no API key, unknown provider, unknown model, a
 /// malformed settings file — are returned by `run()` before an agent exists,
 /// so they never reach `agent.rs`'s summary. Emitting the same
-/// `{"status":"error","text":null,"reason":…}` shape here means the single
-/// most likely headless failure is no longer answered with empty stdout.
-/// `stream-json` gets it compact, so the line-delimited contract holds.
+/// `{"schema_version":…,"status":"error","text":null,"reason":…}` shape here
+/// means the single most likely headless failure is no longer answered with
+/// empty stdout. `stream-json` gets it compact, so the line-delimited contract
+/// holds.
 pub(crate) fn error_summary_json(format: OutputFormat, msg: &str) -> Option<String> {
-    let value = serde_json::json!({ "status": "error", "text": null, "reason": msg });
+    let value = serde_json::json!({
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "status": "error",
+        "text": null,
+        "reason": msg,
+    });
     match format {
         OutputFormat::Text => None,
         OutputFormat::Json => {

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -356,6 +356,13 @@ fn pre_flight_failures_emit_a_machine_readable_error_envelope() {
     assert_eq!(parsed["status"], "error");
     assert!(parsed["text"].is_null());
     assert_eq!(parsed["reason"], msg);
+    // #644: the pre-flight envelope is a summary like any other, so it declares
+    // the same contract version. A consumer that branches on `schema_version`
+    // must not have to special-case the earliest failure it can hit.
+    assert_eq!(
+        parsed["schema_version"],
+        serde_json::json!(crate::SUMMARY_SCHEMA_VERSION)
+    );
 
     // stream-json is line-delimited: the envelope must be exactly one line.
     let line =

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -42,9 +42,10 @@ done
 ```
 
 `json` embeds those same event objects under an `events` key in its single summary
-object — exactly what `stream-json` would have emitted line by line. The summary's other
-keys depend on the execution path: a default run goes through the staged pipeline and
-summarizes as `status`, `text`, `cost_usd`, `reason`, `task_class`, `verdict`,
+object — exactly what `stream-json` would have emitted line by line. Every summary object
+declares `schema_version` (see [The envelope contract](#the-envelope-contract) below). The
+summary's other keys depend on the execution path: a default run goes through the staged
+pipeline and summarizes as `status`, `text`, `cost_usd`, `reason`, `task_class`, `verdict`,
 `revisions`, `candidates_run`, `model`, `events`, and `reflection`; a `--no-pipeline` (raw step-loop)
 run summarizes as `status`, `text`, `cost_usd`, `reason`, `model`, and `events`, plus the
 top-level [`files_touched`](/docs/telemetry/files-touched) telemetry payload — which the
@@ -59,11 +60,52 @@ model or an event log, so it emits the minimal envelope on stdout alongside the 
 line on stderr:
 
 ```json
-{ "status": "error", "text": null, "reason": "no API key found. …" }
+{ "schema_version": 1, "status": "error", "text": null, "reason": "no API key found. …" }
 ```
 
 Under `--output-format text` stdout stays clean in both cases; the diagnostic is the stderr
 line.
+
+## The envelope contract
+
+Every summary object above — the pipeline summary, the `--no-pipeline` summary, and the
+pre-flight error envelope — carries a `schema_version` integer. It is **1** today. The
+three shapes always declare the same value: it versions the envelope contract, not the
+execution path, so you never have to special-case which run you got.
+
+`schema_version` increments only when a change could break a script written against the
+previous version:
+
+- a key is **removed** or **renamed**,
+- a key's value **type** changes (`string` → `object`, scalar → array),
+- a key's **meaning** changes while its name and type stay the same.
+
+It does **not** increment when a key is added. New keys may appear in any release, so your
+parser must ignore keys it does not recognize — the same rule the
+[event stream](/docs/event-stream-compatibility) asks of clients. If additions bumped the
+version, the number would change so often it would tell you nothing.
+
+The `events` array is outside this contract: the event vocabulary has its
+[own forward-compatibility guarantee](/docs/event-stream-compatibility), and a new event
+type never bumps `schema_version`. Everything else the envelope owns — including the nested
+`verdict`, `reflection`, and `files_touched` payloads — is covered by it.
+
+Two practical consequences for a consumer:
+
+- **Pin what you require, not what you receive.** Assert on the keys you actually read;
+  do not assert the full key set, and do not reject an object because it carries keys you
+  have never seen.
+- **Treat an unexpected `schema_version` as the branch point.** A number higher than the
+  one you were written against means the shape may have changed under you; fail loudly
+  there rather than silently misreading a renamed key.
+
+```bash
+# Refuse to parse a shape this script was not written for
+stella --output-format json run "…" | jq -e '
+  if .schema_version == 1 then .status else error("unsupported schema_version") end'
+```
+
+Key order is not part of the contract — read by key, never by position.
 
 ## Configure via environment
 


### PR DESCRIPTION
## What & why

The `--output-format json|stream-json` summary envelope carried no version. Versioning it is
additive and harmless today; once the first external script pins the current shape it becomes a
compatibility negotiation. This is the same reasoning that versioned the drain wire format ahead
of its transport (`DRAIN_SCHEMA_VERSION`).

Every summary envelope a consumer can receive now declares `schema_version` (`1`):

| Envelope | Where |
| --- | --- |
| Pipeline summary (success **and** error arm) | `stella-cli/src/agent.rs` — `PipelineRunSummary` |
| `--no-pipeline` raw step-loop summary | `stella-cli/src/agent.rs` — `run_turn` |
| Pre-flight error envelope (no API key, unknown provider/model, bad settings) | `stella-cli/src/main.rs` — `error_summary_json` |

The issue named only the pipeline summary. I versioned all three deliberately: a field present on
some summaries but not others is *worse* than no field, because a script cannot rely on reading
it — and the pre-flight error is the envelope a headless consumer hits most often. All three
declare one shared constant, so they can never drift apart.

Closes #644

## The bump rule

Written down in two places that point at each other — `SUMMARY_SCHEMA_VERSION`'s doc comment for
contributors, and [Scripting & automation](website/content/docs/scripting.mdx) for consumers.

Bump when a consumer written against the previous version could break: a key **removed**,
**renamed**, **retyped**, or whose **meaning** changes. Do **not** bump when a key is added —
consumers are required to ignore unrecognized keys, and bumping for additions would burn the
signal until it meant nothing.

`events` is explicitly outside the contract: the event vocabulary has its own
forward-compatibility guarantee, so a new event type never bumps this number. Everything else the
envelope owns — `verdict`, `reflection`, `files_touched` — is covered.

## The witness

- [x] This PR includes a witness test

`the_json_summary_envelope_declares_its_schema_version_on_both_arms` (`stella-cli/src/agent_tests.rs`)
asserts the version is present, that the success and error arms declare the *same* value, and that
the two arms still share one key set. `pre_flight_failures_emit_a_machine_readable_error_envelope`
(`stella-cli/src/main_tests.rs`) gained the same assertion for the pre-flight envelope.

Being precise about the "fails on main" half: both assertions reference the constant this PR
introduces, so against `main` they fail to *compile* rather than fail at runtime. The behavioral
delta they pin is real and observable — before, `.schema_version` is `null` on every envelope;
after, it is `1`.

Verified end-to-end against the built binary, not only through tests (forced pre-flight failure,
isolated `HOME`, bogus model — so no credentials load and no paid call is possible):

- `--output-format json` → carries `"schema_version": 1`
- `--output-format stream-json` → carries it and stays exactly one line
- `--output-format text` → stdout still completely clean
- the `jq` guard shipped in the docs accepts `1` and refuses `2` (exit 5)

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated (`website/content/docs/scripting.mdx`, `CHANGELOG.md`, doc comments)
- [x] `Closes #644` appears both here and as a commit trailer

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- **Key order is not what the code comments first claimed.** `serde_json`'s `json!` emits keys
  sorted, so on the wire `schema_version` lands mid-object for the two `json!`-built envelopes,
  while the derived `Serialize` on `PipelineRunSummary` emits it first. I caught this by running
  the real binary and corrected the comments; the docs state plainly that key order is outside the
  contract and consumers must read by key.
- **`u32`, not a semver string.** The envelope needs one monotonically increasing integer a `jq`
  guard can compare, matching `DRAIN_SCHEMA_VERSION` and `stella scripts list --json` house style.
- **No in-repo consumer breaks on the added key.** I swept `bench/`, `scripts/`, the harbor
  adapter and loop-bench: all read keys by name; nothing uses `deny_unknown_fields`, Pydantic
  `extra="forbid"`, or whole-object equality against real CLI output.
- **The second commit is empty on purpose.** It exists only to carry the `Closes #644` trailer
  into the squash body; the first commit holds the entire change. I did not amend and force-push.
- **Patch-level release.** Purely additive, so no `release:minor` prefix.
