### PR TITLE
test(stella-tools): pin the media test expiry so a clock tick can't red the suite

### DIFF
--- a/stella-tools/src/media.rs
+++ b/stella-tools/src/media.rs
@@ -577,11 +577,27 @@ mod tests {
 
     struct FixedOperationIds(&'static str);
 
+    /// One expiry for the whole test binary, minted on first use.
+    ///
+    /// The journal treats the expiry as part of a claim's identity, so a
+    /// replay under the same operation key must present a byte-identical
+    /// expiry to be recognized as the same request. Recomputing `unix_now()`
+    /// per call raced the next second boundary: two `execute` calls that
+    /// straddled one landed a claim of `now + 3600` and then `now + 3601`,
+    /// and the second was rejected as a conflicting identity instead of
+    /// replaying. Pinning it keeps `FixedOperationIds` as fixed as its name
+    /// promises. A host does the same thing — see the `SameHostOperation`
+    /// source in `tests/media_replay.rs`, which carries its expiry as a field.
+    fn fixed_expiry() -> u64 {
+        static EXPIRY: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+        *EXPIRY.get_or_init(|| unix_now() + 3600)
+    }
+
     impl MediaOperationIdSource for FixedOperationIds {
         fn operation_id(&self) -> HostMediaOperation {
             HostMediaOperation {
                 opaque_id: self.0.to_string(),
-                expires_at: unix_now() + 3600,
+                expires_at: fixed_expiry(),
             }
         }
     }
@@ -740,6 +756,58 @@ mod tests {
                 ]
             );
         }
+    }
+
+    /// A host that recomputes its expiry from a clock on every call, which is
+    /// what [`FixedOperationIds`] used to do — the drift is one second, the
+    /// same step a real clock takes across a boundary.
+    struct DriftingOperationIds {
+        opaque_id: &'static str,
+        calls: AtomicUsize,
+    }
+
+    impl MediaOperationIdSource for DriftingOperationIds {
+        fn operation_id(&self) -> HostMediaOperation {
+            HostMediaOperation {
+                opaque_id: self.opaque_id.to_string(),
+                expires_at: fixed_expiry() + self.calls.fetch_add(1, Ordering::SeqCst) as u64,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_drifting_host_expiry_is_refused_instead_of_replayed() {
+        let dir = tempfile::tempdir().unwrap();
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tool: Arc<dyn Tool> = Arc::new(GenerateImage::with_host_context(
+            Arc::new(OrderedProvider {
+                events: events.clone(),
+                image_price: Some(0.01),
+                video_price: None,
+            }),
+            Arc::new(OrderedGate(events.clone())),
+            Arc::new(DriftingOperationIds {
+                opaque_id: "host-drifting-image",
+                calls: AtomicUsize::new(0),
+            }),
+            operation_journal(),
+        ));
+        let args = serde_json::json!({"prompt": "same"});
+
+        let first = tool.execute(&args, dir.path()).await;
+        assert!(matches!(first, ToolOutput::Ok { .. }), "{first:?}");
+        let second = tool.execute(&args, dir.path()).await;
+
+        let ToolOutput::Error { message } = second else {
+            panic!("a moved expiry is a different request, not a replay: {second:?}");
+        };
+        assert!(
+            message.contains("conflicting media identity or expiry"),
+            "{message}"
+        );
+        // Refused at the claim, so the second attempt never reaches the gate
+        // or the provider: the two events are the first attempt's.
+        assert_eq!(events.lock().unwrap().len(), 2);
     }
 
     fn tool() -> GenerateImage {

--- a/stella-tools/src/media/authority.rs
+++ b/stella-tools/src/media/authority.rs
@@ -28,6 +28,13 @@ pub struct HostMediaOperation {
 }
 
 pub trait MediaOperationIdSource: Send + Sync {
+    /// Both fields are part of one operation's identity, so a host retrying
+    /// the same call must return the same `expires_at` as well as the same
+    /// `opaque_id`. Deriving the expiry from a clock read *per call* looks
+    /// stable and is not: two calls that straddle a second boundary present
+    /// `now + ttl` and then `now + ttl + 1`, and the journal refuses the
+    /// second as a different request wearing the same key. Mint the expiry
+    /// once, when the operation is created, and hand back the same value.
     fn operation_id(&self) -> HostMediaOperation;
 }
 


### PR DESCRIPTION
## What & why

`stella-tools`' `media::tests::priced_and_unpriced_media_share_gate_then_provider_order` is time-flaky, and it reddened CI on [#676](https://github.com/macanderson/stella/pull/676) — a PR whose diff touches only `stella-model`:

```
thread 'media::tests::priced_and_unpriced_media_share_gate_then_provider_order' panicked at stella-tools/src/media.rs:727:17:
Error { message: "media_operation_journal_unavailable: artifact store error: operation key is already claimed with a conflicting media identity or expiry" }
```

The test helper `FixedOperationIds` is fixed in name only — it recomputed `unix_now + 3600` on every `operation_id` call:

```rust
struct FixedOperationIds(&'static str);

impl MediaOperationIdSource for FixedOperationIds {
    fn operation_id(&self) -> HostMediaOperation {
        HostMediaOperation {
            opaque_id: self.0.to_string,
            expires_at: unix_now + 3600,   // <- moves
        }
    }
}
```

The journal treats the expiry as part of a claim's identity, *deliberately* — `claim_at` says so in as many words: "a retry that moves it forward is a different request wearing the same key." The test drives one tool twice with the same prompt and expects the second call to replay off the first claim. When those two calls straddle a second boundary, they claim `now + 3600` and then `now + 3601`, and the replay is refused instead.

The window is the gap between the two claims, so it fires rarely and lands on whichever PR happens to be running — which is why `main` is green and #676 was not.

The expiry is now minted once per test binary, matching what a real host does: the `SameHostOperation` source in `tests/media_replay.rs` already carries its expiry as a field rather than reading a clock per call.

**No product code changes.** `DeniedOperationIds` — the fallback used when a host supplies no id source — mints a unique `opaque_id` per call, so it never replays and never hits this. The bug was confined to the test helper.

## The witness

- [x] No witness needed (test-only flake fix) — because: the defect *is* a race in a test helper. A test asserting "two `operation_id` calls agree" would only fail when the clock happens to tick, i.e. it would be as flaky as the bug. Adding a flaky test to guard a flaky test is worse than the disease.

Verified instead by making the race deterministic. With an id source whose expiry advances one second per call — exactly the step a real clock takes across a boundary — the current code reproduces the CI failure verbatim on the second call:

```
attempt 0: Ok { content: "generated \"same\" → med_d44feb756d82ccdd.png (1024x1024, model ordered-image, $0.0100)" }
attempt 1: Error { message: "media_operation_journal_unavailable: artifact store error: operation key is already claimed with a conflicting media identity or expiry" }
```

That reproduction is not what shipped here, since it pins a behavior rather than a fix. What shipped is the same idea kept for its own sake: `a_drifting_host_expiry_is_refused_instead_of_replayed` covers the tool layer, which had none — refusing a moved expiry is deliberate behavior, so **it holds before and after this change** and is coverage, not a witness.

`MediaOperationIdSource` also gained the contract it was missing. The trait had no doc at all; `HostMediaOperation`'s said identity "remains stable when the host retries one call" without settling whether that included `expires_at`. It does, and a per-call clock read only looks like it complies — that ambiguity is what the helper walked into, and a host implementor could walk into it the same way.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed (trait contract + helper rationale)
- [x] No `Closes` trailer — no issue was filed for this flake

`make gate` passes end to end, including `no-scratch` and `doc-citations`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`fixed_expiry` is a process-wide `OnceLock` rather than a per-instance field, purely to keep the 14 `FixedOperationIds(...)` call sites untouched. Tests each build their own in-memory journal, so a shared expiry can't leak between them; it stays 90 days inside the default retention and comfortably ahead of `now` for a suite that runs in seconds.

#676 is green as of its re-run, so this is not blocking it — it's the reason it was red.
