### PR TITLE
fix(stella-observatory): name the undated day bucket, give /api/explorations a consumer (#640)

### DIFF
--- a/docs/design/exploration-sharing.md
+++ b/docs/design/exploration-sharing.md
@@ -556,7 +556,7 @@ re-implemented.
 | Compaction & dedup (`stella-core/src/compaction.rs`) | Already dedups byte-identical repeated tool outputs, so re-reading a map inside one session is near-free; unchanged | **Untouched** |
 | Speculative read-only execution (`stella-core/src/driver.rs:517-543`) | `explorations` is `read_only: true`, so map reads already parallelize with streaming; unchanged | **Untouched** |
 | Schema gate + `SchemaIndex` (`stella-tools/src/schema_gate.rs`) | Precedent: the coverage index (§6a) is its read-side analogue in the same struct; gate itself unchanged | **Untouched** — pattern reused |
-| Observatory (`stella-observatory`) | Gains `/api/explorations` (§4e) | **Extended** |
+| Observatory (`stella-observatory`) | Gains `/api/explorations` (§4e), rendered in the dashboard's **memory & rules** tab: every map with its freshness verdict, drift counts, and in-flight claims | **Extended** |
 | Skills frontloading, `usage.db` cross-project rollup, hooks | Out of this spec's scope: skills are behavioral, not cartographic; cross-checkout map sharing needs a remote-keyed store (§7); SessionStart hooks remain available for user-side injection | **Bounded** — reasons stated |
 
 The audit rule this table enforces going forward: any future context-caching

--- a/stella-observatory/README.md
+++ b/stella-observatory/README.md
@@ -62,7 +62,7 @@ instead. The no-`Host` allowance itself is deliberate — a browser `fetch`
 always sends one, so its absence means raw curl or a test, not the attack.
 
 **Read-only** is `OpenFlags::SQLITE_OPEN_READ_ONLY` at all three open sites —
-`db::open_read_only` (`src/db.rs:716`), `global::open_usage`
+`db::open_read_only` (`src/db.rs:736`), `global::open_usage`
 (`src/global.rs:59`), `codegraph::snapshot` (`src/codegraph.rs:38`) — each with
 a 5 s `busy_timeout`, so a checkpoint or a migration's exclusive lock makes a
 poll wait rather than 500. `Observatory::new` opens nothing, and each open
@@ -99,7 +99,7 @@ keep the original root.
 — one row in `executions`, the foreign key `telemetry`, `tool_calls`,
 `files_touched` and `execution_reflection` hang off; every join in
 `Observatory::executions`, `execution`, `models` and `activity` is on it.
-`run_id` appears only in `Observatory::fleet` (`src/db.rs:658`), against a
+`run_id` appears only in `Observatory::fleet` (`src/db.rs:678`), against a
 different file (`fleet.db`) and a different hierarchy: a fleet run fans out to
 tasks, then attempts, then commits. It is not an execution and not a session,
 and no query may join the two. AGENTS.md's glossary is the authority.
@@ -108,7 +108,7 @@ and no query may join the two. AGENTS.md's glossary is the authority.
 
 A workspace that has never run `stella` renders an empty dashboard, not a 500.
 An absent file yields `None` and an empty payload at the call site; an absent
-*table* is caught by `is_missing_table` (`src/db.rs:779`), degrading
+*table* is caught by `is_missing_table` (`src/db.rs:799`), degrading
 `collect_rows`/`or_empty` to `[]`/`{}`. `global.rs` goes further — `query_rows`
 treats any `prepare` failure as empty, because a `usage.db` predating the hub
 replica has no `telemetry` table at all.

--- a/stella-observatory/src/assets/index.html
+++ b/stella-observatory/src/assets/index.html
@@ -339,6 +339,7 @@ footer b{color:var(--text-2)}
 
   <!-- ══ ACTIVITY ══════════════════════════════════════════════════════ -->
   <section data-tab="activity">
+    <div id="act-undated"></div>
     <div class="grid cols-2e">
       <div class="card">
         <div class="kick">Spend</div>
@@ -434,6 +435,11 @@ footer b{color:var(--text-2)}
         <div class="kick" style="margin-top:18px">Promoted rules</div>
         <div id="rules-list"></div>
       </div>
+    </div>
+    <div class="card" style="margin-top:14px">
+      <div class="kick">.stella/explorations · shared across every session on this workspace</div>
+      <h2>Exploration maps · freshness re-hashed against the working tree</h2>
+      <div class="scroll-x" id="mem-explorations"></div>
     </div>
   </section>
 
@@ -551,7 +557,12 @@ const inTf = (startedAt) => {
   const d = utc(startedAt);
   return d && (Date.now() - d.getTime()) <= TF_MS[state.tf];
 };
+// `/api/activity` buckets runs whose timestamp didn't parse under the day
+// `undated` (db.rs `UNDATED`). It has no position on a date axis, so it is
+// out of every window — renderActivity reports it beside the charts instead.
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
 const inTfDay = (day) => {
+  if (!ISO_DAY.test(day)) return false;
   if (state.tf === "all") return true;
   const d = new Date(day + "T00:00:00Z");
   return d && (Date.now() - d.getTime()) <= (TF_MS[state.tf] + 864e5);
@@ -692,8 +703,28 @@ function renderDaily(elId, days, series, fmt, stacked) {
     r.addEventListener("mouseleave", hideTip);
   });
 }
+/* Runs stella recorded with a timestamp it can't parse: real work with no
+   day to sit on, so it is named rather than hidden or faked onto the axis. */
+function renderUndated(d) {
+  const el = $("act-undated");
+  if (!d || !((d.runs ?? 0) || (d.tool_calls ?? 0))) {
+    el.innerHTML = "";
+    return;
+  }
+  const runs = d.runs ?? 0;
+  el.innerHTML = `<div class="card" style="margin-bottom:14px">
+    <div class="kick">Off the day axis</div>
+    <h2>${runs} undated ${runs === 1 ? "run" : "runs"}
+      <span class="badge warn">unparseable timestamp</span></h2>
+    <div style="color:var(--text-2)">${fmtUsd(d.cost_usd ?? 0)} ·
+      ${fmtTok(d.input_tokens ?? 0)} in · ${fmtTok(d.output_tokens ?? 0)} out ·
+      ${d.tool_calls ?? 0} tool calls (${d.tool_errors ?? 0} failed) — left out of the
+      charts below because <code>started_at</code> didn't parse as a date.</div></div>`;
+}
 function renderActivity() {
-  const days = (D.activity ?? []).filter(d => inTfDay(d.day));
+  const rows = D.activity ?? [];
+  renderUndated(rows.find(d => !ISO_DAY.test(d.day)));
+  const days = rows.filter(d => inTfDay(d.day));
   const withOther = days.map(d => ({ ...d, other: (d.runs ?? 0) - (d.resolved ?? 0) }));
   renderDaily("ch-cost", days,
     [{ key: "cost_usd", label: "spend", color: "var(--c1)" }], fmtUsd, false);
@@ -983,7 +1014,45 @@ function renderMcpTab(cfg) {
 }
 
 /* ── memory & rules tab ──────────────────────────────────────────────── */
-function renderMemoryTab(files, rules) {
+/* The human-facing twin of the startup index every session reads: which
+   maps exist, and whether the tree still matches the manifest they pinned. */
+const FRESHNESS = {
+  fresh: ["ok", "✓ fresh"],
+  drifted: ["warn", "◌ drifted"],
+  unknown: ["dim", "· unknown"],
+};
+function renderExplorations(rows) {
+  rows = rows ?? [];
+  if (!rows.length) {
+    $("mem-explorations").innerHTML = `<div class="empty">no exploration maps yet —
+      stella writes one to <code>.stella/explorations/</code> when a session maps a slice
+      of this codebase, and every other session reads it instead of re-reading the tree</div>`;
+    return;
+  }
+  $("mem-explorations").innerHTML = `<table><thead><tr>
+    <th>map</th><th>freshness</th><th class="num">files</th>
+    <th>drift</th><th class="num">recorded</th></tr></thead><tbody>` +
+    rows.map(r => {
+      const [cls, label] = FRESHNESS[r.freshness] ?? ["dim", r.freshness];
+      const changed = r.changed ?? [], missing = r.missing ?? [];
+      const drift = [
+        changed.length ? `${changed.length} changed` : "",
+        missing.length ? `${missing.length} missing` : "",
+      ].filter(Boolean).join(" · ") || "—";
+      return `<tr>
+        <td class="main" title="${esc(r.slice ?? "")}">${esc(r.title || r.slice || "—")}
+          ${r.status === "draft"
+            ? `<span class="badge dim" title="a session is exploring this slice right now">◐ in flight · pid ${esc(r.pid)}</span>`
+            : ""}</td>
+        <td><span class="badge ${cls}">${esc(label)}</span></td>
+        <td class="num">${r.manifest_files ?? 0}</td>
+        <td class="wrap-txt" style="max-width:420px;color:var(--text-2)"
+            title="${esc(changed.concat(missing).join("\n"))}">${esc(drift)}</td>
+        <td class="num">${r.created_at_ms ? agoMs(r.created_at_ms) : "—"}</td></tr>`;
+    }).join("") + `</tbody></table>`;
+}
+function renderMemoryTab(files, rules, explorations) {
+  renderExplorations(explorations);
   $("mem-files").innerHTML = (files ?? []).length
     ? files.map(f => `<div class="mem-card">
         <span class="name">${esc(f.name)}</span>
@@ -1596,9 +1665,11 @@ async function loadTab(tab, force) {
       lazyCache[key] = data;
       renderMcpTab(data);
     } else if (tab === "memory") {
-      const data = cached ?? await Promise.all([api("/api/memories"), api("/api/rules")]);
+      const data = cached ?? await Promise.all([
+        api("/api/memories"), api("/api/rules"), api("/api/explorations"),
+      ]);
       lazyCache[key] = data;
-      renderMemoryTab(data[0], data[1]);
+      renderMemoryTab(data[0], data[1], data[2]);
     } else if (tab === "improve") {
       const data = cached ?? await api("/api/skills");
       lazyCache[`skills:${state.project}`] = data;

--- a/stella-observatory/src/db.rs
+++ b/stella-observatory/src/db.rs
@@ -15,6 +15,11 @@ use std::path::{Path, PathBuf};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::{Value, json};
 
+/// Day bucket for rows SQLite's `date()` can't parse — see
+/// [`Observatory::activity`]. The dashboard matches on this exact string to
+/// keep the bucket off its date axis, so the two must not drift apart.
+pub const UNDATED: &str = "undated";
+
 /// Everything that can go wrong serving observatory data.
 #[derive(Debug, thiserror::Error)]
 pub enum DbError {
@@ -519,6 +524,12 @@ impl Observatory {
     /// per UTC day — the timeframe charts' raw material. Days are merged
     /// across the three tables in Rust (a day may have tool calls but no
     /// finished executions, or vice versa).
+    ///
+    /// Rows whose timestamp SQLite cannot parse land in the [`UNDATED`]
+    /// bucket: `date()` returns NULL for those, and reading NULL as `String`
+    /// used to fail the whole query and blank the dashboard. They are real
+    /// runs, so they keep a named bucket instead of being dropped — the UI
+    /// keeps them off the date axis and reports the total separately.
     pub fn activity(&self) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {
             return Ok(json!([]));
@@ -533,10 +544,19 @@ impl Observatory {
                 })
             })
         }
+        // The `coalesce(date(…), '')` in each query below turns an unparseable
+        // timestamp into the empty string; name it here so it never reaches
+        // the UI blank. `UNDATED` sorts after every ISO day, so it lands last.
+        fn day_key(row: &Value) -> String {
+            match row["day"].as_str().unwrap_or_default() {
+                "" => UNDATED.to_string(),
+                day => day.to_string(),
+            }
+        }
         let mut days: BTreeMap<String, Value> = BTreeMap::new();
         for row in collect_rows(
             &conn,
-            "SELECT date(started_at), count(*),
+            "SELECT coalesce(date(started_at), ''), count(*),
                     count(*) FILTER (WHERE outcome = 'completed'),
                     coalesce(sum(cost_usd), 0)
              FROM executions GROUP BY 1",
@@ -549,7 +569,7 @@ impl Observatory {
                 }))
             },
         )? {
-            let day = row["day"].as_str().unwrap_or_default().to_string();
+            let day = day_key(&row);
             let entry = day_slot(&mut days, &day);
             entry["runs"] = row["runs"].clone();
             entry["resolved"] = row["resolved"].clone();
@@ -557,7 +577,7 @@ impl Observatory {
         }
         for row in collect_rows(
             &conn,
-            "SELECT date(e.started_at),
+            "SELECT coalesce(date(e.started_at), ''),
                     coalesce(sum(t.input_tokens), 0),
                     coalesce(sum(t.output_tokens), 0),
                     coalesce(sum(t.duration_ms), 0)
@@ -572,7 +592,7 @@ impl Observatory {
                 }))
             },
         )? {
-            let day = row["day"].as_str().unwrap_or_default().to_string();
+            let day = day_key(&row);
             let entry = day_slot(&mut days, &day);
             entry["input_tokens"] = row["input_tokens"].clone();
             entry["output_tokens"] = row["output_tokens"].clone();
@@ -580,7 +600,7 @@ impl Observatory {
         }
         for row in collect_rows(
             &conn,
-            "SELECT date(ts), count(*), count(*) FILTER (WHERE ok = 0)
+            "SELECT coalesce(date(ts), ''), count(*), count(*) FILTER (WHERE ok = 0)
              FROM tool_calls GROUP BY 1",
             |r| {
                 Ok(json!({
@@ -590,7 +610,7 @@ impl Observatory {
                 }))
             },
         )? {
-            let day = row["day"].as_str().unwrap_or_default().to_string();
+            let day = day_key(&row);
             let entry = day_slot(&mut days, &day);
             entry["tool_calls"] = row["tool_calls"].clone();
             entry["tool_errors"] = row["tool_errors"].clone();

--- a/stella-observatory/src/lib.rs
+++ b/stella-observatory/src/lib.rs
@@ -656,6 +656,34 @@ mod tests {
         }
     }
 
+    /// The route table and the embedded page must not drift apart. A route
+    /// nothing fetches is dead weight that still drags in its dependencies —
+    /// `/api/explorations` sat unconsumed for exactly that long (#640).
+    #[test]
+    fn every_served_route_is_fetched_by_the_embedded_page() {
+        // Route-table arms are `"/api/<name>" => …`; the same literal
+        // appearing as a call argument (tests, 404 fixtures) has no `=>`.
+        let routes: Vec<&str> = include_str!("lib.rs")
+            .lines()
+            .filter_map(|line| {
+                let rest = line.trim().strip_prefix("\"/api/")?;
+                let (route, tail) = rest.split_once('"')?;
+                tail.trim_start().starts_with("=>").then_some(route)
+            })
+            .collect();
+        assert!(
+            routes.len() >= 19,
+            "route table not recognised, only found {routes:?}"
+        );
+        for route in routes {
+            assert!(
+                INDEX_HTML.contains(&format!("/api/{route}")),
+                "/api/{route} is served but nothing in the dashboard fetches it: \
+                 give it a consumer or delete the route"
+            );
+        }
+    }
+
     #[test]
     fn activity_rolls_up_runs_tokens_and_tool_calls_by_day() {
         let ws = seeded_workspace();
@@ -669,6 +697,38 @@ mod tests {
         assert_eq!(d["input_tokens"], 3000);
         assert_eq!(d["tool_calls"], 3);
         assert_eq!(d["tool_errors"], 1);
+    }
+
+    /// A timestamp `date()` can't parse used to NULL out the group key and
+    /// fail the whole rollup — one bad row blanked the dashboard. The work
+    /// is real, so it lands in a named bucket that sorts last.
+    #[test]
+    fn activity_buckets_unparseable_timestamps_instead_of_failing() {
+        let ws = seeded_workspace();
+        let conn = Connection::open(ws.path().join(".stella/private/store.db")).unwrap();
+        conn.execute_batch(
+            "INSERT INTO executions
+               (kind, prompt, provider, model, started_at, outcome, cost_usd)
+             VALUES ('run', 'clock skew', 'zai', 'glm-5.2', 'sometime', 'completed', 0.5);
+             INSERT INTO telemetry VALUES
+               (3, 1, 'sometime', 'zai', 'glm-5.2', 7, 0, 9, 0, 0, 0, 0.5, 11, 0, 1);
+             INSERT INTO tool_calls
+               (execution_id, seq, name, ok, error, bytes_out, duration_ms, ts)
+             VALUES (3, 1, 'bash', 0, 'boom', 0, 4, 'sometime');",
+        )
+        .unwrap();
+        let response = respond(ws.path(), "/api/activity");
+        assert_eq!(response.status, "200 OK");
+        let v: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        let days = v.as_array().unwrap();
+        assert_eq!(days.len(), 2, "today plus the undated bucket");
+        let undated = days.last().unwrap();
+        assert_eq!(undated["day"], crate::db::UNDATED);
+        assert_eq!(undated["runs"], 1);
+        assert_eq!(undated["resolved"], 1);
+        assert_eq!(undated["input_tokens"], 7);
+        assert_eq!(undated["tool_calls"], 1);
+        assert_eq!(undated["tool_errors"], 1);
     }
 
     #[test]

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -42,7 +42,7 @@ panels labeled *all-time* ignore it.
 | **Code graph** | The tree-sitter code-graph index of the workspace — a searchable force-directed canvas of files (with per-file symbol counts) and their resolved import edges, plus a selection detail panel |
 | **Skills** | Installed and learned skills, with per-skill usage |
 | **MCP** | Configured servers (`.stella/mcp.toml`) and observed per-server / per-tool traffic |
-| **Memory & rules** | The memory plane: memories on disk (`.stella/memories`), citation receipts (were they useful and truthful?), and promoted rules |
+| **Memory & rules** | The memory plane: memories on disk (`.stella/memories`), citation receipts (were they useful and truthful?), promoted rules, and the exploration maps sessions share (`.stella/explorations`) — each re-hashed against the working tree so you can see which are still fresh, which have drifted, and which a session is claiming right now |
 | **Self-improve** | The self-improvement loop, receipted from `.stella`: self-rating per reflection, owned shortcomings, distilled lessons, and auto-extracted learned skills |
 | **Config** | The merged engine config (user → org → project), where every store and database lives, and the per-scope config files |
 


### PR DESCRIPTION
## What & why

Two observatory items from #640 — one live crash, one dead route.

**1. The crash on an unattributable day bucket.** `Observatory::activity` grouped by `date(started_at)` and read column 0 as `String`. A timestamp SQLite can't parse makes `date` return NULL, and `r.get::<_, String>(0)?` then fails the *whole* rollup — one bad row 500s `/api/activity` and blanks the activity tab. The two sibling queries over `telemetry` and `tool_calls` had the identical shape, so all three now `coalesce(date(…), '')`.

**The naming call the issue flagged as the real blocker:** the empty key becomes **`undated`**, not hidden. Those are real runs with real spend, and dropping them would quietly under-report. But `undated` has no position on a date axis — sorted into a `BTreeMap` it would sit at the far left, impersonating the earliest day. So the payload keeps it, `inTfDay` refuses any non-ISO day (in every window, including *all*), and the tab reports it in a card above the charts:

> **Off the day axis** — 1 undated run · `unparseable timestamp`
> $0.4200 · 31.0k in · 4.2k out · 2 tool calls (1 failed) — left out of the charts below because `started_at` didn't parse as a date.

**2. `/api/explorations`.** The issue called deleting the cheaper default, and it would have dropped the `sha2` dep — but the exploration-sharing spec lists the observatory as **Extended** with exactly this route (`docs/design/exploration-sharing.md` §11, §4e), and `fsview::explorations`' own doc comment calls it "the human-facing twin of the agents' startup index." The route was the half that shipped; the UI was the half that didn't. Deleting it would have silently reversed a design decision, so this wires the consumer instead — a table in **memory & rules** showing each map's freshness (re-hashed against the working tree), drift counts, and in-flight claims:

| map | freshness | files | drift | recorded |
|---|---|---|---|---|
| Dashboard routes ◐ in flight · pid 93455 | · unknown | 0 | — | 4m ago |
| How the driver turns a prompt into tool calls | ✓ fresh | 1 | — | 62m ago |
| Tool surface and MCP fan-out | ◌ drifted | 2 | 1 changed · 1 missing | 24h ago |

Closes #640

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, both verified to fail without their fix:

- `activity_buckets_unparseable_timestamps_instead_of_failing` — seeds a run with `started_at = 'sometime'`. Reverting only the `coalesce` (keeping everything else) fails it at the `200 OK` assertion, which is the reported crash.
- `every_served_route_is_fetched_by_the_embedded_page` — parses the route table out of `lib.rs` and asserts each route appears in the embedded page. Renaming the new `api("/api/explorations")` call reproduces the issue's own diagnosis: *"/api/explorations is served but nothing in the dashboard fetches it: give it a consumer or delete the route."* This is what keeps either half from rotting back into dead weight.

**Also verified end-to-end, not just in tests.** The Chrome extension wasn't connected, so I drove the real dashboard with headless Chrome against a fixture workspace (`examples/serve`) holding a poisoned timestamp and three exploration maps (fresh / drifted / draft):

- `/api/activity` returns 200 with `undated` sorted last; `/api/explorations` returns all three freshness verdicts.
- `--dump-dom` on `#activity` shows the undated card rendered and the four charts carrying only `07-25`/`07-26` — the bucket is genuinely off the axis, not just filtered from one chart.
- `--dump-dom` on `#memory` renders all three rows with correct drift counts.
- No JS console errors on either tab.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed
- [x] `Closes #640` appears both here and as a commit trailer

`make gate` green on the final tree — 3340 tests passed, 0 failures. (Captured the real exit code rather than piping to `tail`, which returns *tail's* status and would have reported a red gate as green.)

## Ground-rule check

- [x] No new deps — `sha2` is *kept* rather than dropped, now with a live consumer
- [x] No new outbound network calls

## Anything reviewers should know?

- **The one judgement call worth pushing back on:** I chose *name it* over *hide it* for the undated bucket. Hiding is a one-line diff (`filter` it out in `activity`) and produces a tidier tab, at the cost of spend that exists in the DB but appears nowhere in the UI. If you'd rather it be hidden, the change is small and local.
- **`undated` is a magic string shared across the Rust/JS boundary.** It's `db::UNDATED` on one side and the `ISO_DAY` regex on the other, with a comment on each pointing at the other. There's no compile-time link between them; the guard is that the UI matches "not ISO" rather than the literal, so a rename can't silently put the bucket back on the axis.
- **Docs touched:** the §11 inventory row (extended in place, per that section's own audit rule — not a parallel surface), the dashboard tab tour, and three `src/db.rs:NNN` line citations in the observatory README that my edit shifted by +20.
- **Pre-existing drift I did *not* touch:** the README cites `../stella-cli/src/main.rs:847` for `run_observe`, which now lives at `:879`. Out of scope for this PR — happy to fix here if you'd prefer.
