### PR TITLE
cli: lead every JSON summary envelope with its schema_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ record of *changes*, curated by the person who made them.
 
 ## [Unreleased]
 
+### Changed
+
+- Every `--output-format json|stream-json` summary now leads with
+  `schema_version` instead of burying it mid-object. Two of the three envelopes
+  were built with `serde_json::json!`, which emits a sorted map; they are now
+  structs, so the version is the first key a reader sees. Key order remains
+  outside the contract — consumers must keep reading by key, not position.
+
 ## [0.5.32] — 2026-07-26
 
 ### Added

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -159,6 +159,29 @@ struct PipelineRunSummary {
     reflection: serde_json::Value,
 }
 
+/// The `--output-format json` summary of a raw (`--no-pipeline`) step-loop run.
+/// A different key set from [`PipelineRunSummary`] — no verification ladder ran,
+/// and this path is the one that carries `files_touched` — but the same
+/// contract, so it declares the same [`crate::SUMMARY_SCHEMA_VERSION`]. The two
+/// can never drift: both read the one constant.
+///
+/// A struct rather than `serde_json::json!` so the version leads the object:
+/// `json!` builds a sorted map and would bury it mid-envelope. Key order is not
+/// contractual either way; this is for whoever reads the output by eye.
+#[derive(serde::Serialize)]
+struct RawRunSummary {
+    schema_version: u32,
+    status: &'static str,
+    text: Option<String>,
+    cost_usd: Option<f64>,
+    reason: Option<String>,
+    model: String,
+    events: Vec<AgentEvent>,
+    /// The session file-touch telemetry payload (one record per normalized
+    /// path: crud_events, line-delta totals, audit log).
+    files_touched: serde_json::Value,
+}
+
 impl PipelineRunSummary {
     /// Print the summary to stdout and record that the machine-readable
     /// contract has been satisfied, so `main`'s catch-all does not follow a
@@ -2070,24 +2093,16 @@ async fn run_turn(
                 ("aborted", None, Some(*cost_usd), Some(reason.clone()))
             }
         };
-        let summary = serde_json::json!({
-            // Governed by the same bump rule as the pipeline summary
-            // (`crate::SUMMARY_SCHEMA_VERSION`) — the two paths are one
-            // contract surface with different key sets, so they must never
-            // carry different version numbers. Written first here for the
-            // reader's benefit only: `json!` emits its keys sorted, so this
-            // lands mid-object on the wire. Consumers read it by key.
-            "schema_version": crate::SUMMARY_SCHEMA_VERSION,
-            "status": status,
-            "text": text,
-            "cost_usd": cost_usd,
-            "reason": reason,
-            "model": format!("{}/{}", cfg.provider.id, cfg.model_id),
-            "events": collected,
-            // The session file-touch telemetry payload (one record per
-            // normalized path: crud_events, line-delta totals, audit log).
-            "files_touched": registry.file_touch_telemetry().to_json(),
-        });
+        let summary = RawRunSummary {
+            schema_version: crate::SUMMARY_SCHEMA_VERSION,
+            status,
+            text,
+            cost_usd,
+            reason,
+            model: format!("{}/{}", cfg.provider.id, cfg.model_id),
+            events: collected,
+            files_touched: registry.file_touch_telemetry().to_json(),
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&summary).unwrap_or_else(|e| format!(

--- a/stella-cli/src/agent_tests.rs
+++ b/stella-cli/src/agent_tests.rs
@@ -1666,3 +1666,49 @@ fn the_json_summary_envelope_declares_its_schema_version_on_both_arms() {
     );
     assert!(keys(&ok).contains("schema_version"));
 }
+
+/// Both machine-readable summaries lead with `schema_version`. Key order is
+/// deliberately *not* part of the consumer contract — this pins a build
+/// convention, not a promise: every envelope is assembled from a struct with the
+/// version declared first, so a derived `Serialize` emits it at the head of the
+/// object where a human eyeballing output sees it immediately. Rebuilding any of
+/// them with `serde_json::json!` would silently undo that (a `json!` object is a
+/// sorted map, which sorts `schema_version` into the middle), and nothing else
+/// in the suite would notice.
+#[test]
+fn every_summary_envelope_leads_with_its_version() {
+    let pipeline = PipelineRunSummary {
+        schema_version: crate::SUMMARY_SCHEMA_VERSION,
+        status: "completed",
+        text: None,
+        cost_usd: 0.0,
+        reason: None,
+        task_class: None,
+        verdict: None,
+        revisions: None,
+        candidates_run: None,
+        model: "anthropic/claude-opus".to_string(),
+        events: Vec::new(),
+        reflection: serde_json::Value::Null,
+    };
+    let raw = RawRunSummary {
+        schema_version: crate::SUMMARY_SCHEMA_VERSION,
+        status: "completed",
+        text: None,
+        cost_usd: None,
+        reason: None,
+        model: "anthropic/claude-opus".to_string(),
+        events: Vec::new(),
+        files_touched: serde_json::Value::Null,
+    };
+
+    for (label, encoded) in [
+        ("pipeline", serde_json::to_string(&pipeline).unwrap()),
+        ("raw step-loop", serde_json::to_string(&raw).unwrap()),
+    ] {
+        assert!(
+            encoded.starts_with(r#"{"schema_version":"#),
+            "the {label} summary must lead with its version, got: {encoded}"
+        );
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -117,10 +117,14 @@ pub(crate) fn note_json_summary_emitted() {
 /// step-loop summary, and the pre-flight error envelope — so a consumer can
 /// branch on the shape it was handed instead of sniffing for keys. A version
 /// stamped on only some summaries would be worse than none: a script could not
-/// rely on reading it. Consumers read it by key: key order is outside the
-/// contract, and in fact varies by construction site — the derived `Serialize`
-/// on `PipelineRunSummary` emits declaration order, while the `json!`-built
-/// envelopes here and in the raw step loop emit their keys sorted.
+/// rely on reading it.
+///
+/// All three envelopes are built from structs with the version declared first,
+/// so a derived `Serialize` puts it at the head of the object. That is a
+/// courtesy to whoever reads the output by eye, not a promise: key order stays
+/// outside the contract and consumers must read by key. Building any of them
+/// with `serde_json::json!` would quietly undo it — a `json!` object is a
+/// sorted map, which buries `schema_version` mid-envelope.
 ///
 /// # Why version at all
 ///
@@ -165,19 +169,38 @@ pub(crate) const SUMMARY_SCHEMA_VERSION: u32 = 1;
 /// means the single most likely headless failure is no longer answered with
 /// empty stdout. `stream-json` gets it compact, so the line-delimited contract
 /// holds.
+///
+/// Built from a struct rather than `serde_json::json!` for the key order: a
+/// `json!` object is a sorted map, which would bury `schema_version` in the
+/// middle of the envelope, while a derived `Serialize` emits fields in
+/// declaration order. Order is not part of the contract — consumers read by key
+/// — but a version a human can see at a glance is worth the struct.
+#[derive(serde::Serialize)]
+struct PreflightErrorSummary<'a> {
+    schema_version: u32,
+    status: &'static str,
+    text: Option<&'a str>,
+    reason: &'a str,
+}
+
 pub(crate) fn error_summary_json(format: OutputFormat, msg: &str) -> Option<String> {
-    let value = serde_json::json!({
-        "schema_version": SUMMARY_SCHEMA_VERSION,
-        "status": "error",
-        "text": null,
-        "reason": msg,
-    });
+    let value = PreflightErrorSummary {
+        schema_version: SUMMARY_SCHEMA_VERSION,
+        status: "error",
+        text: None,
+        reason: msg,
+    };
+    // A struct of two integers and two strings cannot fail to serialize; the
+    // fallback keeps the contract rather than proving the point.
+    let fallback = || format!(r#"{{"schema_version":{SUMMARY_SCHEMA_VERSION},"status":"error"}}"#);
     match format {
         OutputFormat::Text => None,
         OutputFormat::Json => {
-            Some(serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()))
+            Some(serde_json::to_string_pretty(&value).unwrap_or_else(|_| fallback()))
         }
-        OutputFormat::StreamJson => Some(value.to_string()),
+        OutputFormat::StreamJson => {
+            Some(serde_json::to_string(&value).unwrap_or_else(|_| fallback()))
+        }
     }
 }
 

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -364,9 +364,21 @@ fn pre_flight_failures_emit_a_machine_readable_error_envelope() {
         serde_json::json!(crate::SUMMARY_SCHEMA_VERSION)
     );
 
+    // Leads with the version, in both encodings — a build convention (every
+    // envelope is a struct with `schema_version` declared first), not a promise
+    // to consumers, who read by key. See `every_summary_envelope_leads_with_its_version`.
+    assert!(
+        pretty.starts_with("{\n  \"schema_version\":"),
+        "pre-flight envelope must lead with its version, got: {pretty}"
+    );
+
     // stream-json is line-delimited: the envelope must be exactly one line.
     let line =
         error_summary_json(OutputFormat::StreamJson, msg).expect("stream-json must emit one");
+    assert!(
+        line.starts_with(r#"{"schema_version":"#),
+        "compact envelope must lead with its version, got: {line}"
+    );
     assert!(
         !line.contains('\n'),
         "stream-json envelope must be one line"


### PR DESCRIPTION
## What & why

Follow-up to #679, which landed `schema_version` on the machine-readable summary envelopes.

That PR claimed in its own code comments that the version was written first. Running the real
binary showed it was not: `serde_json::json!` builds a **sorted** map, so two of the three
envelopes emitted

```json
{ "reason": "unknown provider `bogusprovider` — …", "schema_version": 1, "status": "error", "text": null }
```

with the version buried in the middle. Only `PipelineRunSummary` — a derived `Serialize`, whose
declaration order *is* wire order — actually led with it.

This PR makes the behavior match the intent: the two `json!` literals become structs with
`schema_version` declared first.

| Envelope | Before | After |
| --- | --- | --- |
| Pipeline summary | struct — already led with it | unchanged |
| `--no-pipeline` raw summary | `json!` → sorted, version mid-object | `RawRunSummary` struct |
| Pre-flight error envelope | `json!` → sorted, version mid-object | `PreflightErrorSummary` struct |

Refs #644

## Why not just enable `preserve_order`

`serde_json`'s `preserve_order` feature would fix the key order in one line, but it is a
**workspace-global** behavior change: every `json!`-built object everywhere in Stella would switch
from sorted to insertion order, including replay manifests, golden trajectory fixtures, and the
canonicalizer. That is a large blast radius to buy a cosmetic win. Two local structs are contained,
type-safe, and self-documenting.

## To be clear about what this does and does not change

Key order is **not** part of the envelope contract, and this PR does not make it one. The docs
still say — and still mean — read by key, never by position. What changes is that the first thing a
human sees when they eyeball `stella --output-format json … | head` is the version of the shape
they are looking at.

## The witness

- [x] This PR includes a witness test

`every_summary_envelope_leads_with_its_version` (`stella-cli/src/agent_tests.rs`) serializes both
summary structs and asserts each encoding starts with `{"schema_version":`. It fails on the
pre-#679-follow-up code for the raw summary. `pre_flight_failures_emit_a_machine_readable_error_envelope`
gained the same assertion for both the pretty and compact encodings.

The test comment is explicit that it pins a *build convention*, not a consumer promise — otherwise
a future reader could mistake it for an order guarantee we deliberately do not make.

Verified against the built binary (forced pre-flight failure, isolated `HOME`, bogus model — no
credentials load, no paid call possible):

```
$ stella --output-format json --model bogusprovider/bogusmodel run "hi"
{
  "schema_version": 1,
  "status": "error",
  "text": null,
...
$ stella --output-format stream-json ... | cut -c1-40
{"schema_version":1,"status":"error","te
```

stream-json still emits exactly one line, `--output-format text` still keeps stdout clean, and the
`jq` guard shipped in the docs still accepts `1` and exits 5 on `2`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated (CHANGELOG; the `scripting.mdx` example already showed this order and now matches
      real output byte-for-byte)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The `SUMMARY_SCHEMA_VERSION` doc comment previously described the sorted-key behavior as a known
  quirk. That paragraph is now wrong in the other direction, so it is rewritten to say all three
  envelopes lead with the version and to warn that rebuilding any of them with `json!` would
  silently undo it.
- Purely a construction change — no key added, removed, renamed, or retyped — so
  `SUMMARY_SCHEMA_VERSION` stays at `1` under its own bump rule.
