### PR TITLE
fix(receipts): attribute manifest entries per occurrence, not per block (#364)

### DIFF
--- a/docs/design/session-telemetry-receipts-spec.md
+++ b/docs/design/session-telemetry-receipts-spec.md
@@ -215,6 +215,17 @@ content-addressed, a tool output that reappears verbatim (supersession) resolves
 to the same block, so "this exact content was carried for N steps" is directly
 countable.
 
+**`BlockOrigin.call_id` is birth provenance, not a call set.** Content-addressing
+cuts both ways: a block is registered exactly once, so when two *distinct* calls
+produce byte-identical output (two `git status` runs), `origin.call_id` names only
+the first. Reading eviction identities through it would silently under-report —
+the second call's contribution to context would be invisible, and an eviction
+would be attributed wholly to the first. Per-occurrence attribution therefore
+lives on [`ManifestEntry.call_id`](#5-per-step-request-manifest--the-receipt-364-item-2),
+which is recorded per manifest row rather than per block. #364 item 1 asks "which
+`call_id`s each pass evicted"; that question is answered by joining the compaction
+event's block ids against the manifests that carried them, *not* by the registry.
+
 ---
 
 ## 5. Per-step request manifest — the receipt (#364 item 2)
@@ -250,6 +261,11 @@ struct ManifestEntry {
     token_cost: u32,               // estimated tokens of this block on this step
     /// Steps this block has been resident so far (drives cost-of-carry, §8).
     resident_since_step: usize,
+    /// The tool call THIS occurrence belongs to. Per entry, not per block:
+    /// `BlockOrigin.call_id` (§4) records only the first call to mint a
+    /// content-addressed id, so duplicates would otherwise be unattributable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    call_id: Option<String>,
 }
 
 enum CacheZone {
@@ -745,6 +761,7 @@ CREATE TABLE IF NOT EXISTS step_manifest (
   block_id      TEXT    NOT NULL,
   cache_zone    TEXT    NOT NULL,      -- StablePrefix | Cacheable | Volatile
   resident_since_step INTEGER NOT NULL,
+  call_id       TEXT,                  -- per-occurrence tool attribution (§4)
   PRIMARY KEY (execution_id, turn_instance, step, ordinal)
 );
 CREATE INDEX IF NOT EXISTS step_manifest_by_block ON step_manifest(execution_id, block_id);

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -379,6 +379,7 @@ pub(crate) fn persist_event(
                         token_cost: b.token_cost,
                         resident_since_step: b.resident_since_step as u64,
                         message_index: b.message_index as u64,
+                        call_id: b.call_id.clone(),
                     })
                     .collect(),
             },
@@ -608,6 +609,7 @@ mod stream_tests {
                 token_cost: 40,
                 resident_since_step: 0,
                 message_index: 0,
+                call_id: Some("call_tool1".into()),
             }],
             effective_budget_tokens: 136_363,
             calibration_factor: 1.1,

--- a/stella-cli/src/arena.rs
+++ b/stella-cli/src/arena.rs
@@ -574,6 +574,7 @@ mod tests {
                 token_cost: 120,
                 resident_since_step: 0,
                 message_index: 0,
+                call_id: None,
             }],
             effective_budget_tokens: 4096,
             calibration_factor: 1.0,

--- a/stella-cli/tests/inspect_cli.rs
+++ b/stella-cli/tests/inspect_cli.rs
@@ -37,6 +37,7 @@ fn entry(block_id: &str, message_index: u64) -> ManifestBlockRow {
         token_cost: 10,
         resident_since_step: 0,
         message_index,
+        call_id: None,
     }
 }
 

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -339,6 +339,10 @@ impl ReceiptLedger {
                 token_cost: draft.token_cost,
                 resident_since_step,
                 message_index: draft.message_index,
+                // Per occurrence, not per block: `BlockRegistered` fires once
+                // for a content-addressed id, so a repeat of byte-identical
+                // tool output would otherwise keep only the first call's id.
+                call_id: draft.call_id.clone(),
             });
         }
         let _ = events.send(AgentEvent::StepManifest {
@@ -434,6 +438,82 @@ mod tests {
             .filter(|e| matches!(e, AgentEvent::BlockRegistered { .. }))
             .count();
         assert_eq!(registered, 4);
+    }
+
+    /// Two distinct calls whose output is byte-identical collapse onto one
+    /// content-addressed `block_id`, so `BlockRegistered` fires once and its
+    /// `BlockOrigin` can only name the first call. If the manifest inherited
+    /// that provenance, "which calls left context" would silently drop the
+    /// duplicate — an eviction of this block would be attributed to `c1` alone.
+    /// The manifest records the call per occurrence, so both survive.
+    #[test]
+    fn identical_output_from_two_calls_keeps_both_call_ids_on_the_manifest() {
+        let (tx, mut rx) = unbounded_channel();
+        let events = EventSender::new(tx);
+        let mut ledger = ReceiptLedger::new(0);
+        // Same bytes, different calls — e.g. the agent runs `git status` twice.
+        let identical = |call_id: &str| CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: call_id.into(),
+                output: ToolOutput::Ok {
+                    content: "nothing to commit".into(),
+                },
+            }],
+            attachments: vec![],
+        };
+        let messages = vec![
+            CompletionMessage::system("s"),
+            identical("c1"),
+            identical("c2"),
+        ];
+        ledger.emit_step_receipt(&messages, 0, ModelCallRole::Worker, "p", "m", &events);
+        let evts = drain(&mut rx);
+
+        // The content-addressed contract still holds: one registration, one id.
+        let registered: Vec<_> = evts
+            .iter()
+            .filter_map(|e| match e {
+                AgentEvent::BlockRegistered {
+                    block_id, origin, ..
+                } => Some((block_id.clone(), origin.call_id.clone())),
+                _ => None,
+            })
+            .collect();
+        let dupes: Vec<_> = registered
+            .iter()
+            .filter(|(_, call_id)| call_id.is_some())
+            .collect();
+        assert_eq!(dupes.len(), 1, "byte-identical results register once");
+        assert_eq!(
+            dupes[0].1.as_deref(),
+            Some("c1"),
+            "birth provenance is the first call to mint the block"
+        );
+
+        let manifest = evts
+            .iter()
+            .find_map(|e| match e {
+                AgentEvent::StepManifest { blocks, .. } => Some(blocks.clone()),
+                _ => None,
+            })
+            .expect("manifest");
+        let tool_entries: Vec<_> = manifest.iter().filter(|b| b.call_id.is_some()).collect();
+        assert_eq!(tool_entries.len(), 2, "both occurrences are on the manifest");
+        assert_eq!(
+            tool_entries[0].block_id, tool_entries[1].block_id,
+            "and they do share the one content-addressed id"
+        );
+        assert_eq!(
+            tool_entries
+                .iter()
+                .map(|b| b.call_id.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["c1", "c2"],
+            "each occurrence keeps its own call — the join is not lossy"
+        );
     }
 
     #[test]

--- a/stella-protocol/src/event.rs
+++ b/stella-protocol/src/event.rs
@@ -959,7 +959,13 @@ pub struct BlockOrigin {
     pub turn_instance: u32,
     /// The step within that turn.
     pub step: usize,
-    /// Tool-call correlation id, for `ToolCall`/`ToolResult` blocks.
+    /// Tool-call correlation id, for `ToolCall`/`ToolResult` blocks — the
+    /// call that *first* minted this block. Block ids are content-addressed,
+    /// so two distinct calls with byte-identical output share one id and only
+    /// the first is registered: this is birth provenance, **not** the complete
+    /// set of calls that carried the block. For "which calls did this block
+    /// serve at step N", read [`ManifestEntry::call_id`], which is recorded
+    /// per occurrence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
     /// The `nod_…` memory node id, for a `RecalledFrame` that is a memory.
@@ -987,6 +993,17 @@ pub struct ManifestEntry {
     /// recorded before reconstruction existed.
     #[serde(default)]
     pub message_index: usize,
+    /// The tool call this *occurrence* belongs to, for `ToolCall`/`ToolResult`
+    /// blocks. Content-addressing collapses byte-identical blocks onto one
+    /// `block_id`, so [`BlockOrigin::call_id`] only ever names the first call
+    /// to mint it — two `git status` runs with identical output register once.
+    /// Recording the id per manifest entry keeps the attribution complete:
+    /// joining a compaction event's evicted/deduped/aged `block_id`s against
+    /// the manifests that carried them answers "which *calls* left context"
+    /// without under-reporting the duplicates. `None` for non-tool blocks, and
+    /// on manifests recorded before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
 }
 
 /// One provider's share of a recall's frame mix.
@@ -2092,6 +2109,7 @@ mod tests {
                     token_cost: 1200,
                     resident_since_step: 0,
                     message_index: 0,
+                    call_id: None,
                 },
                 ManifestEntry {
                     block_id: "blk_tail".into(),
@@ -2099,6 +2117,7 @@ mod tests {
                     token_cost: 90,
                     resident_since_step: 3,
                     message_index: 3,
+                    call_id: Some("call_7".into()),
                 },
             ],
             effective_budget_tokens: 136_363,

--- a/stella-store/src/ddl.rs
+++ b/stella-store/src/ddl.rs
@@ -440,8 +440,11 @@ pub(crate) const CONTEXT_BLOCKS_DDL: &str = "CREATE TABLE IF NOT EXISTS context_
 /// model saw. PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal)
 /// is the wire position; `call_seq` separates the several model calls that can
 /// share one step (worker 0, overflow summarizer 1, allocated management roles
-/// 2+ — v13). The second index is the reverse lookup (every step a given block
-/// was resident) that cost-of-carry and eviction analysis read.
+/// 2+ — v13). `call_id` is the per-occurrence tool-call attribution (v15):
+/// block ids are content-addressed, so `context_blocks.call_id` names only the
+/// call that first minted a block, and duplicates would otherwise be
+/// unattributable. The second index is the reverse lookup (every step a given
+/// block was resident) that cost-of-carry and eviction analysis read.
 pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_manifest (
        execution_id INTEGER NOT NULL,
        turn_instance INTEGER NOT NULL,
@@ -452,6 +455,7 @@ pub(crate) const STEP_MANIFEST_DDL: &str = "CREATE TABLE IF NOT EXISTS step_mani
        cache_zone TEXT NOT NULL,
        resident_since_step INTEGER NOT NULL,
        message_index INTEGER NOT NULL DEFAULT 0,
+       call_id TEXT,
        PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal)
      );
      CREATE INDEX IF NOT EXISTS step_manifest_by_block

--- a/stella-store/src/migrations.rs
+++ b/stella-store/src/migrations.rs
@@ -28,7 +28,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 14] = [
+pub(crate) const MIGRATIONS: [Migration; 15] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -77,6 +77,11 @@ pub(crate) const MIGRATIONS: [Migration; 14] = [
     // v13 → v14: `forgotten` — explicit, reversible human tombstones over any
     // context surface. Purely additive; no existing table changes shape.
     migrate_v13_to_v14,
+    // v14 → v15: `step_manifest` grows a nullable `call_id` — per-occurrence
+    // tool-call attribution, which content-addressed block ids cannot carry
+    // (byte-identical blocks share an id, so only the first minting call was
+    // ever recorded). Additive ADD COLUMN, column-guarded.
+    migrate_v14_to_v15,
 ];
 
 /// The schema version this build writes — the `PRAGMA user_version` of
@@ -423,6 +428,22 @@ fn migrate_v9_to_v10(tx: &rusqlite::Transaction<'_>) -> Result<()> {
 /// in the shared DDL also tolerates a partial file that already grew it.
 fn migrate_v13_to_v14(tx: &rusqlite::Transaction<'_>) -> Result<()> {
     tx.execute_batch(FORGOTTEN_DDL)?;
+    Ok(())
+}
+
+/// v14 → v15: per-occurrence tool-call attribution on the manifest (#364 gap 1).
+/// `block_id` is content-addressed, so two distinct calls with byte-identical
+/// output share one id and `BlockRegistered`/`context_blocks.call_id` keeps only
+/// the first — which silently under-reports "which calls left context" when a
+/// compaction pass evicts such a block. `step_manifest` grows a nullable
+/// `call_id` recorded per entry instead. Plain additive ADD COLUMN, nullable
+/// because pre-v15 rows genuinely do not know theirs (and non-tool blocks never
+/// have one); column-guarded for stores whose tables were created at the v15
+/// shape by this build's [`STEP_MANIFEST_DDL`].
+fn migrate_v14_to_v15(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !column_exists(tx, "step_manifest", "call_id")? {
+        tx.execute_batch("ALTER TABLE step_manifest ADD COLUMN call_id TEXT;")?;
+    }
     Ok(())
 }
 
@@ -802,5 +823,70 @@ mod tests {
 
         // Idempotent on a file already at the v13 shape.
         apply_migration(&mut conn, migrate_v12_to_v13, 13).expect("idempotent");
+    }
+
+    #[test]
+    fn v15_migration_adds_manifest_call_id_leaving_older_rows_honestly_null() {
+        // A v14-shaped file with one recorded manifest row. The pre-v15 row
+        // genuinely does not know its call, so it must migrate to NULL rather
+        // than borrow the block's birth provenance — an inferred attribution
+        // would be exactly the under-reporting this column exists to fix.
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE step_manifest (
+               execution_id INTEGER NOT NULL, turn_instance INTEGER NOT NULL, step INTEGER NOT NULL,
+               call_seq INTEGER NOT NULL DEFAULT 0, ordinal INTEGER NOT NULL,
+               block_id TEXT NOT NULL, cache_zone TEXT NOT NULL,
+               resident_since_step INTEGER NOT NULL, message_index INTEGER NOT NULL DEFAULT 0,
+               PRIMARY KEY (execution_id, turn_instance, step, call_seq, ordinal));
+             INSERT INTO step_manifest
+               (execution_id, turn_instance, step, call_seq, ordinal, block_id, cache_zone,
+                resident_since_step, message_index)
+               VALUES (1, 0, 2, 0, 0, 'blk_tool', 'volatile', 0, 1);",
+        )
+        .expect("v14 receipts shape");
+        assert!(!column_exists(&conn, "step_manifest", "call_id").unwrap());
+
+        apply_migration(&mut conn, migrate_v14_to_v15, 15).expect("migrate");
+
+        assert!(column_exists(&conn, "step_manifest", "call_id").unwrap());
+        let (block, call_id): (String, Option<String>) = conn
+            .query_row(
+                "SELECT block_id, call_id FROM step_manifest WHERE execution_id = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("manifest row preserved");
+        assert_eq!(block, "blk_tool", "the existing row survives verbatim");
+        assert_eq!(call_id, None, "pre-v15 rows admit they do not know");
+
+        // Two occurrences of one content-addressed block, each with its own
+        // call — the shape the old schema could not express at all.
+        conn.execute_batch(
+            "INSERT INTO step_manifest
+               (execution_id, turn_instance, step, call_seq, ordinal, block_id, cache_zone,
+                resident_since_step, message_index, call_id)
+               VALUES (1, 0, 3, 0, 0, 'blk_dup', 'volatile', 0, 1, 'c1'),
+                      (1, 0, 3, 0, 1, 'blk_dup', 'volatile', 0, 2, 'c2');",
+        )
+        .expect("duplicate block, distinct calls");
+        // Scoped so the statement's borrow of `conn` ends before the
+        // idempotency re-run below needs it mutably.
+        let calls: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT call_id FROM step_manifest
+                     WHERE block_id = 'blk_dup' ORDER BY ordinal",
+                )
+                .expect("prepare");
+            stmt.query_map([], |r| r.get::<_, String>(0))
+                .expect("query")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("rows")
+        };
+        assert_eq!(calls, vec!["c1", "c2"], "both calls are attributable");
+
+        // Idempotent on a file already at the v15 shape.
+        apply_migration(&mut conn, migrate_v14_to_v15, 15).expect("idempotent");
     }
 }

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -40,6 +40,11 @@ pub struct ManifestBlockRow {
     /// The sent-message this block belonged to; reconstruction regroups blocks
     /// sharing a `message_index` back into one `CompletionMessage` (spec §5.1).
     pub message_index: u64,
+    /// The tool call this occurrence belongs to. Distinct from
+    /// `ContextBlockRow::call_id`, which is birth provenance only: a
+    /// content-addressed block minted by one call and repeated by another is
+    /// registered once, so per-occurrence attribution has to live here.
+    pub call_id: Option<String>,
 }
 
 /// A full per-step manifest: the header (`step_receipt`) plus its ordered
@@ -141,8 +146,8 @@ impl Store {
             tx.execute(
                 "INSERT INTO step_manifest
                    (execution_id, turn_instance, step, call_seq, ordinal, block_id,
-                    cache_zone, resident_since_step, message_index)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    cache_zone, resident_since_step, message_index, call_id)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     execution_id,
                     turn,
@@ -153,6 +158,7 @@ impl Store {
                     block.cache_zone,
                     resident,
                     message_index,
+                    block.call_id,
                 ],
             )?;
         }
@@ -201,7 +207,7 @@ impl Store {
         let conn = self.lock();
         let mut stmt = conn.prepare(
             "SELECT sm.block_id, sm.cache_zone, cb.token_cost, sm.resident_since_step,
-                    sm.message_index
+                    sm.message_index, sm.call_id
              FROM step_manifest sm
              LEFT JOIN context_blocks cb
                ON cb.execution_id = sm.execution_id AND cb.block_id = sm.block_id
@@ -222,6 +228,7 @@ impl Store {
                         token_cost: r.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
                         resident_since_step: r.get::<_, i64>(3)? as u64,
                         message_index: r.get::<_, i64>(4)? as u64,
+                        call_id: r.get(5)?,
                     })
                 },
             )?
@@ -372,6 +379,7 @@ mod tests {
                     token_cost: 100,
                     resident_since_step: 0,
                     message_index: 0,
+                    call_id: None,
                 },
                 ManifestBlockRow {
                     block_id: "blk_tail".into(),
@@ -379,6 +387,7 @@ mod tests {
                     token_cost: 103,
                     resident_since_step: 3,
                     message_index: 1,
+                    call_id: Some("call_a".into()),
                 },
             ],
         };
@@ -418,6 +427,7 @@ mod tests {
                     token_cost: 1,
                     resident_since_step: 0,
                     message_index: 0,
+                    call_id: None,
                 })
                 .collect(),
         };

--- a/stella-store/src/reconstruct.rs
+++ b/stella-store/src/reconstruct.rs
@@ -314,6 +314,7 @@ mod tests {
             token_cost: 10,
             resident_since_step: 0,
             message_index: mi,
+            call_id: None,
         }
     }
 

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -976,9 +976,12 @@ fn skill_usage_records_per_execution_version_rows() {
     // reconstruction support (context_blocks.content / step_manifest.message_index),
     // v13 rekeys both receipt tables on call_seq so the auxiliary calls
     // sharing a step (overflow summarizer, pipeline management roles) each keep
-    // their own receipt, and v14 adds `forgotten` — explicit, reversible human
-    // tombstones over any context surface.
-    assert_eq!(SCHEMA_VERSION, 14);
+    // their own receipt, v14 adds `forgotten` — explicit, reversible human
+    // tombstones over any context surface — and v15 adds
+    // `step_manifest.call_id`, the per-occurrence tool-call attribution that
+    // content-addressed block ids cannot carry (byte-identical blocks share an
+    // id, so only the first minting call was ever recorded).
+    assert_eq!(SCHEMA_VERSION, 15);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
Closes the one real deviation left by #364: gap 1 asked *which `call_id`s* each compaction pass stubbed/aged/evicted, and the shipped receipts plane cannot actually answer it.

## The bug

`block_id` is `sha256(kind \0 content)`, and `BlockRegistered` fires **only on first sight** of an id (`stella-core/src/receipts.rs:311-334`). So two distinct calls with byte-identical output — two `git status` runs, two reads of the same unchanged file, two identical error results — collapse onto one block that is registered once, carrying only the **first** call's id.

When compaction evicts that block, `evicted_blocks` names one `block_id`, and joining through `BlockOrigin.call_id` yields one call. The second call's contribution to context is invisible, and the eviction is attributed wholly to the first. The join looked complete and was quietly lossy.

## The fix

Put the per-occurrence key on the per-occurrence record. `decompose` already has the right `call_id` for each draft and was discarding it at manifest construction.

- `ManifestEntry.call_id: Option<String>` — additive, `serde(default)`, so old journals keep parsing
- `step_manifest.call_id` — schema **v15**, nullable `ADD COLUMN`, following the v12 precedent
- `BlockOrigin.call_id` keeps its content-addressed contract, now documented as **birth provenance, not a call set**

Joining a compaction event's block ids against the manifests that carried them now answers "which calls left context" without under-reporting duplicates.

Pre-v15 rows migrate to `NULL` rather than borrowing the block's birth provenance — inferring it would be the same under-reporting this column exists to fix, dressed up as data.

## Verification

- The core test **fails without the fix** (verified by disabling only the manifest site: 0 of 2 occurrences attributable) while the one-registration/one-id assertions still pass — content-addressing is provably untouched, not merely asserted to be
- Migration test pins NULL-not-inferred, and the duplicate-block shape the old schema could not express at all
- `cargo test --workspace`: **exit 0, 3340 tests across 58 suites**, zero failures
- `cargo clippy --workspace --all-targets`: exit 0

One unrelated flake surfaced once under full-suite parallelism (`stella-tools media::tests::poll_does_not_report_success_when_job_cleanup_fails` — a fixed operation id colliding in the media operation journal). It did not recur here or on unmodified main, and `stella-tools` is untouched by this diff.

## Spec

`docs/design/session-telemetry-receipts-spec.md` §4/§5/§12 updated. §4 claimed a `ToolResult` block "carries the `call_id` that produced it" — exactly the too-strong claim this fixes.
