### PR TITLE
style(stella-core): restore rustfmt cleanliness on main

### DIFF
--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -501,7 +501,11 @@ mod tests {
             })
             .expect("manifest");
         let tool_entries: Vec<_> = manifest.iter().filter(|b| b.call_id.is_some()).collect();
-        assert_eq!(tool_entries.len(), 2, "both occurrences are on the manifest");
+        assert_eq!(
+            tool_entries.len(),
+            2,
+            "both occurrences are on the manifest"
+        );
         assert_eq!(
             tool_entries[0].block_id, tool_entries[1].block_id,
             "and they do share the one content-addressed id"


### PR DESCRIPTION
## What & why

`main` is red. `cargo fmt --check` has been failing since #684, which merged with its `fmt + clippy + test` required check **failing** — see [run 30188106847](https://github.com/macanderson/stella/actions/runs/30188106847).

The whole failure is one `assert_eq!` in `stella-core/src/receipts.rs:501` that rustfmt wants split across lines. This is that split, nothing else.

Found while triaging the issue backlog, not as part of it — filing separately so it can land ahead of anything else.

## The gate

- [x] `cargo fmt --all -- --check` — clean (was exit 1)
- [x] `cargo check -p stella-core --all-targets` — exit 0
-  Full `make gate` — not run locally; CI should cover it

No behavior change: this is whitespace inside a test assertion.

## Note for reviewers

Branch protection lists `fmt + clippy + test` as required, yet #684 landed with it red — `enforce_admins` is `false`. Related: #306 wires `merge_group:` into `ci.yml` but the merge queue was never enabled in repo settings, so two individually-green PRs can still land a red main. Both are worth settling together.
