### PR TITLE
fleet: wire the supervisor verbs to the live dashboard

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -19,11 +19,11 @@
 //! its live event lane, an inbox notification, and (for task workers) the
 //! board task auto-completing. Prompts queue only past the worker cap, on a
 //! dispatch hold, or when they are slash commands (the lead's dispatcher owns
-//! those). The fleet layer now carries its own per-task control verbs
-//! (`Fleet::pause_task` / `resume_task` / `stop_task`, riding
-//! `stella_fleet::WorkerControls` through the `FleetWorker` port);
-//! surfacing `stella fleet` tasks as controllable deck lanes and
-//! fleet-worktree isolation for deck workers remain follow-ups on that seam.
+//! those). The fleet layer's per-task control verbs (`Fleet::pause_task` /
+//! `resume_task` / `stop_task`, riding `stella_fleet::WorkerControls` through
+//! the `FleetWorker` port) are driven by the `stella fleet` dashboard's
+//! `[p]`/`[r]`/`[x]` keys (#645); controllable *deck* lanes and fleet-worktree
+//! isolation for deck workers remain follow-ups on that seam.
 //!
 //! ## The three engine seams handled here
 //!

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -19,10 +19,12 @@
 //! Every worker also honors its `stella_fleet::WorkerControls`: the stop
 //! line races the turn (the clean drop-at-await cancel the deck's
 //! sub-sessions use) and the pause line gates the raw step-loop at the
-//! engine's step boundary via a `TurnGate`. `stella fleet` itself drives
-//! workers to completion — the control verbs (`Fleet::pause_task` /
-//! `resume_task` / `stop_task`) exist for a supervisor; surfacing fleet
-//! tasks as controllable deck lanes is the named follow-up.
+//! engine's step boundary via a `TurnGate`. The control verbs
+//! (`Fleet::pause_task` / `resume_task` / `stop_task`) are driven from the
+//! live dashboard: its `[p]`/`[r]`/`[x]` keys send a
+//! `stella_tui::FleetControl` down a channel that this module's control pump
+//! applies to the `Fleet` (#645). Surfacing fleet tasks as
+//! controllable deck lanes is still the named follow-up.
 //!
 //! Worktrees are deliberately left in place after the run — the branches
 //! (`fleet/<task>`) carry the work product for the user to review and merge.
@@ -218,9 +220,30 @@ pub async fn run_fleet(
             let _ = done_tx.send(());
             r
         };
-        let (run_result, dash_result) = tokio::join!(
+        // The supervisor seam (#645): the dashboard sends verbs, this pump
+        // applies them to the real `Fleet`. It lives in the same `join!` as the
+        // run because `Fleet`'s three control verbs take `&self` and are
+        // synchronous — no clone, no `Arc`, no second task. The pump ends when
+        // the dashboard drops its sender, which is exactly when the dashboard
+        // returns, so the `join!` always completes.
+        let (ctl_tx, mut ctl_rx) = mpsc::unbounded_channel::<stella_tui::FleetControl>();
+        let control_pump = async {
+            while let Some(verb) = ctl_rx.recv().await {
+                // Every verb answers `false` for a task with no live worker
+                // (already finished, or never dispatched). That is the
+                // documented stale-verb no-op, not an error worth surfacing
+                // over the alternate screen.
+                let _ = match &verb {
+                    stella_tui::FleetControl::Pause(id) => fleet.pause_task(id),
+                    stella_tui::FleetControl::Resume(id) => fleet.resume_task(id),
+                    stella_tui::FleetControl::Stop(id) => fleet.stop_task(id),
+                };
+            }
+        };
+        let (run_result, dash_result, ()) = tokio::join!(
             run_and_signal,
-            stella_tui::run_fleet_dashboard(label, seed, dash_rx, done_rx)
+            stella_tui::run_fleet_dashboard(label, seed, dash_rx, done_rx, ctl_tx),
+            control_pump
         );
         let report = run_result.map_err(|e| format!("fleet run failed: {e}"))?;
         if let Ok(res) = dash_result {

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -20,12 +20,12 @@
 //! receives [`WorkerControls`] (a pause watch + a stop oneshot — the exact
 //! channel shapes the deck's sub-sessions use), and the fleet exposes the
 //! matching verbs, [`Fleet::pause_task`] / [`Fleet::resume_task`] /
-//! [`Fleet::stop_task`]. That makes the "fleet supervisor seam"
-//! `command_deck.rs` named as the follow-up *available*: per-worker
-//! pause/stop exists and is tested at the fleet layer, not just for deck
-//! sub-session lanes. It is not yet *closed* — nothing in the product drives
-//! these verbs today, so wiring the deck's key handling to them is still the
-//! open follow-up. Restart is deliberately not a fleet verb —
+//! [`Fleet::stop_task`]. That closes the "fleet supervisor seam"
+//! `command_deck.rs` named as the follow-up: the verbs are reachable by a
+//! user, driven by the `stella fleet` live dashboard's `[p]`/`[r]`/`[x]`
+//! keys through `stella_tui::FleetControl` and the control pump in
+//! `stella-cli/src/fleet_cmd.rs` (#645). Surfacing fleet tasks as deck lanes
+//! remains a separate follow-up. Restart is deliberately not a fleet verb —
 //! [`Fleet::dispatch`] is re-runnable, so a restart is the caller
 //! re-dispatching the same [`Task`]; the fleet keeps no respawn state.
 //!

--- a/stella-fleet/src/lib.rs
+++ b/stella-fleet/src/lib.rs
@@ -29,7 +29,9 @@
 //! the parent [`stella_core::BudgetGuard`], and handing every worker its
 //! per-task control lines ([`WorkerControls`] through the [`FleetWorker`]
 //! port, driven by [`Fleet::pause_task`] / [`Fleet::resume_task`] /
-//! [`Fleet::stop_task`]; restart = re-dispatch).
+//! [`Fleet::stop_task`] — which the `stella fleet` dashboard's
+//! `[p]`/`[r]`/`[x]` keys reach through `stella-cli`'s control pump;
+//! restart = re-dispatch).
 //!
 //! Design constraints: we shell out
 //! to the `git`/`gh` binaries via `tokio::process` behind port traits rather

--- a/stella-tui/src/fleet_dashboard.rs
+++ b/stella-tui/src/fleet_dashboard.rs
@@ -170,6 +170,16 @@ impl FleetStatus {
         )
     }
 
+    /// True while a dispatched worker backs this task, i.e. `Fleet` has live
+    /// control lines registered for it. Only `Running` and `Blocked` qualify:
+    /// `Blocked` is reached from an `AskUser`/`ScopeReview` event, which fires
+    /// inside the worker's run span, whereas `Queued` (not yet dispatched) and
+    /// the terminal states have no controls — a verb there is a guaranteed
+    /// no-op.
+    pub fn has_live_worker(self) -> bool {
+        matches!(self, FleetStatus::Running | FleetStatus::Blocked)
+    }
+
     /// Sort bucket for the default ordering: blocked first (can't hide), then
     /// running, then queued, then finished.
     fn group_rank(self) -> u8 {
@@ -576,13 +586,15 @@ enum KeyAction {
 }
 
 /// The focused task, but only when a supervisor verb could still reach a live
-/// worker. A terminal task has no control lines registered — `Fleet` would
-/// answer `false` — so the dashboard declines instead of sending a verb that is
-/// guaranteed to be a no-op.
+/// worker. Control lines exist only for the span a worker runs, so a task
+/// without a live worker — a terminal task *or* a still-`Queued` one that has
+/// not been dispatched — would have `Fleet` answer `false`. The dashboard
+/// declines rather than record local intent (`paused`/`stopped`) and render a
+/// marker for a verb that is guaranteed to be a no-op.
 fn controllable_focus(board: &FleetBoard, view: &FleetView) -> Option<String> {
     let id = view.focused_id.as_deref()?;
     let row = board.rows.iter().find(|r| r.id == id)?;
-    (!row.status.is_terminal()).then(|| row.id.clone())
+    row.status.has_live_worker().then(|| row.id.clone())
 }
 
 /// Fold one keystroke into the view, returning what the caller should do.

--- a/stella-tui/src/fleet_dashboard.rs
+++ b/stella-tui/src/fleet_dashboard.rs
@@ -28,13 +28,13 @@
 //! - **TOOL-AGO** (per task) — time since *that* task last started a tool call.
 //!   Yellow past 60s, red past 180s; `----` once the task is finished.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::buffer::Buffer;
@@ -71,6 +71,40 @@ pub enum FleetMsg {
     /// which distinguishes done/failed more reliably than inferring from the
     /// event stream).
     Status { id: String, status: FleetStatus },
+}
+
+// ── Wire type: dashboard → fleet driver ─────────────────────────────────────
+
+/// One supervisor verb the dashboard asks its driver to perform on one task.
+///
+/// The dashboard deliberately does **not** hold a `Fleet`: `stella-tui` does
+/// not depend on `stella-fleet`, and keeping the view a pure fold of its
+/// inbound stream is what makes it testable without a terminal. So the three
+/// control verbs travel the other way down this channel, and the driver
+/// (`stella-cli/src/fleet_cmd.rs`) applies them to the real `Fleet`.
+///
+/// The verbs map one-to-one onto `Fleet::pause_task` / `Fleet::resume_task` /
+/// `Fleet::stop_task`. Each is a no-op against a task with no live worker, so
+/// a stale verb is never an error — but the dashboard still declines to send
+/// one for a task it can already see is terminal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FleetControl {
+    /// Park the task's worker at its next safe step boundary.
+    Pause(String),
+    /// Un-park a paused worker.
+    Resume(String),
+    /// Fire the task's stop line; the worker drops its turn future at the
+    /// next await point.
+    Stop(String),
+}
+
+impl FleetControl {
+    /// The task id this verb addresses.
+    pub fn task_id(&self) -> &str {
+        match self {
+            FleetControl::Pause(id) | FleetControl::Resume(id) | FleetControl::Stop(id) => id,
+        }
+    }
 }
 
 // ── Status ──────────────────────────────────────────────────────────────────
@@ -479,9 +513,26 @@ impl SortKey {
 
 /// Ephemeral interaction state — focus is pinned to a task **id** so it survives
 /// re-sorts, exactly as the spec requires.
+///
+/// The three supervisor sets below record what *this supervisor asked for*, not
+/// what the fleet reports: a pause has no wire representation coming back (the
+/// worker parks silently at a step boundary), so without local intent the grid
+/// could not distinguish a parked worker from a slow one. Fleet truth still
+/// wins wherever the two can disagree — a task that reaches a terminal status
+/// is rendered from its status, never from these sets.
 struct FleetView {
     focused_id: Option<String>,
     sort: SortKey,
+    /// Tasks this supervisor has paused and not yet resumed.
+    paused: HashSet<String>,
+    /// Tasks whose stop line this supervisor has already fired. Kept so the
+    /// grid can show the stop as in-flight during the window between the verb
+    /// and the worker's terminal `Status`.
+    stopped: HashSet<String>,
+    /// The task a first `[x]` armed. Stop is the one irreversible verb here —
+    /// it drops a worker's turn and loses whatever it had not committed — so it
+    /// takes two keystrokes. Any other keystroke disarms it.
+    pending_stop: Option<String>,
 }
 
 impl FleetView {
@@ -489,7 +540,106 @@ impl FleetView {
         Self {
             focused_id: rows.first().map(|r| r.id.clone()),
             sort: SortKey::Default,
+            paused: HashSet::new(),
+            stopped: HashSet::new(),
+            pending_stop: None,
         }
+    }
+
+    /// The supervisor marker for one row, if any. Terminal status wins: a task
+    /// that finished while paused is done, not paused.
+    fn marker(&self, entry: &TaskRow) -> Option<&'static str> {
+        if entry.status.is_terminal() {
+            return None;
+        }
+        if self.stopped.contains(&entry.id) {
+            Some("stopping")
+        } else if self.paused.contains(&entry.id) {
+            Some("paused")
+        } else {
+            None
+        }
+    }
+}
+
+/// What one keystroke decided. Returned rather than acted on so the whole key
+/// surface is unit-testable without a terminal — the gap that kept these verbs
+/// unwired (#645).
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum KeyAction {
+    /// Handled internally (focus, sort, arming a stop) or ignored.
+    None,
+    /// Leave the dashboard; the run continues in the background.
+    Detach,
+    /// Send this verb to the driver.
+    Control(FleetControl),
+}
+
+/// The focused task, but only when a supervisor verb could still reach a live
+/// worker. A terminal task has no control lines registered — `Fleet` would
+/// answer `false` — so the dashboard declines instead of sending a verb that is
+/// guaranteed to be a no-op.
+fn controllable_focus(board: &FleetBoard, view: &FleetView) -> Option<String> {
+    let id = view.focused_id.as_deref()?;
+    let row = board.rows.iter().find(|r| r.id == id)?;
+    (!row.status.is_terminal()).then(|| row.id.clone())
+}
+
+/// Fold one keystroke into the view, returning what the caller should do.
+///
+/// Pure apart from the `view` mutation: it never touches the terminal and never
+/// sends anything, which is what lets the tests drive the entire supervisor
+/// surface as a sequence of `KeyEvent`s.
+fn on_key(key: KeyEvent, board: &FleetBoard, view: &mut FleetView, now: Instant) -> KeyAction {
+    // Taken unconditionally: an armed stop must not survive an unrelated
+    // keystroke, so every branch below starts from a disarmed view and only
+    // the confirming `[x]` reads what was armed.
+    let armed = view.pending_stop.take();
+
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => KeyAction::Detach,
+        KeyCode::Char('q') | KeyCode::Esc => KeyAction::Detach,
+        KeyCode::Up | KeyCode::Char('k') => {
+            move_focus(board, view, now, -1);
+            KeyAction::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            move_focus(board, view, now, 1);
+            KeyAction::None
+        }
+        KeyCode::Char('s') => {
+            view.sort = view.sort.next();
+            KeyAction::None
+        }
+        KeyCode::Char('p') => match controllable_focus(board, view) {
+            Some(id) => {
+                view.paused.insert(id.clone());
+                KeyAction::Control(FleetControl::Pause(id))
+            }
+            None => KeyAction::None,
+        },
+        KeyCode::Char('r') => match controllable_focus(board, view) {
+            Some(id) => {
+                view.paused.remove(&id);
+                KeyAction::Control(FleetControl::Resume(id))
+            }
+            None => KeyAction::None,
+        },
+        KeyCode::Char('x') => match controllable_focus(board, view) {
+            // Second `[x]` on the same task confirms.
+            Some(id) if armed.as_deref() == Some(id.as_str()) => {
+                view.paused.remove(&id);
+                view.stopped.insert(id.clone());
+                KeyAction::Control(FleetControl::Stop(id))
+            }
+            // First `[x]` arms; the footer says so until something disarms it.
+            Some(id) => {
+                view.pending_stop = Some(id);
+                KeyAction::None
+            }
+            None => KeyAction::None,
+        },
+        _ => KeyAction::None,
     }
 }
 
@@ -563,11 +713,16 @@ pub struct FleetDashResult {
 /// fires, or the user detaches with `q`. Owns the alternate screen for its
 /// lifetime and restores the terminal on every exit path (including panic, via
 /// `PanicHookGuard`).
+///
+/// `control` carries the supervisor verbs back to the driver. It is dropped
+/// when this function returns, which is how the driver's control pump learns
+/// the dashboard is gone and stops.
 pub async fn run(
     label: impl Into<String>,
     tasks: Vec<(String, String)>,
     mut inbound: UnboundedReceiver<FleetMsg>,
     mut done: oneshot::Receiver<()>,
+    control: tokio::sync::mpsc::UnboundedSender<FleetControl>,
 ) -> io::Result<FleetDashResult> {
     let guard = TerminalGuard::enter(false)?;
     let _hook = PanicHookGuard::install(None, &guard);
@@ -631,18 +786,12 @@ pub async fn run(
             maybe_key = key_rx.recv(), if keys_open => {
                 match maybe_key {
                     Some(Event::Key(key)) if key.kind != KeyEventKind::Release => {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => { detached = true; break 'run; }
-                            KeyCode::Char('c')
-                                if key.modifiers.contains(KeyModifiers::CONTROL) =>
-                            {
-                                detached = true;
-                                break 'run;
-                            }
-                            KeyCode::Up | KeyCode::Char('k') => move_focus(&board, &mut view, now, -1),
-                            KeyCode::Down | KeyCode::Char('j') => move_focus(&board, &mut view, now, 1),
-                            KeyCode::Char('s') => view.sort = view.sort.next(),
-                            _ => {}
+                        match on_key(key, &board, &mut view, now) {
+                            KeyAction::Detach => { detached = true; break 'run; }
+                            // A closed control channel means the driver already
+                            // settled the run; the verb is moot, not an error.
+                            KeyAction::Control(verb) => { let _ = control.send(verb); }
+                            KeyAction::None => {}
                         }
                     }
                     Some(_) => {}
@@ -735,7 +884,7 @@ fn render(board: &FleetBoard, view: &FleetView, now: Instant, area: Rect, buf: &
     render_grid(board, view, &order, now, bands[3], buf);
     rule(bands[4], buf);
     render_detail(board, view, &order, now, bands[5], buf);
-    render_footer(bands[6], buf);
+    render_footer(view, bands[6], buf);
 }
 
 fn render_header(board: &FleetBoard, now: Instant, area: Rect, buf: &mut Buffer) {
@@ -835,13 +984,15 @@ fn render_grid(
         .map(|(pos, &i)| {
             let entry = &board.rows[i];
             let focused = view.focused_id.as_deref() == Some(entry.id.as_str());
-            grid_row(pos + 1, entry, now, focused)
+            grid_row(pos + 1, entry, now, focused, view.marker(entry))
         })
         .collect();
     let widths = [
         Constraint::Length(3),  // #
         Constraint::Length(22), // TASK
-        Constraint::Length(8),  // STATUS
+        // 10, not 8: wide enough for the longest supervisor marker
+        // ("⏸ stopping") as well as every `FleetStatus::label`.
+        Constraint::Length(10), // STATUS
         Constraint::Fill(1),    // LAST ACTION
         Constraint::Length(9),  // TOOL-AGO
         Constraint::Length(8),  // ELAPSED
@@ -852,13 +1003,28 @@ fn render_grid(
         .render(area, buf);
 }
 
-fn grid_row(pos: usize, entry: &TaskRow, now: Instant, focused: bool) -> Row<'static> {
+fn grid_row(
+    pos: usize,
+    entry: &TaskRow,
+    now: Instant,
+    focused: bool,
+    marker: Option<&'static str>,
+) -> Row<'static> {
     let status_color = entry.status.color();
     let caret = if focused { "▸" } else { " " };
     let num = Cell::from(format!("{caret}{pos}")).style(theme::muted());
     let task = Cell::from(truncate(&entry.title_or_id(), 22)).style(theme::body());
-    let status = Cell::from(format!("{} {}", entry.status.glyph(), entry.status.label()))
-        .style(Style::default().fg(status_color));
+    // A supervised task reads as its supervisor verb rather than its fleet
+    // status: "running" on a worker the operator just paused would be a lie the
+    // grid tells for as long as the park lasts.
+    let (status_text, status_color) = match marker {
+        Some(m) => (format!("⏸ {m}"), theme::WARNING_BRIGHT),
+        None => (
+            format!("{} {}", entry.status.glyph(), entry.status.label()),
+            status_color,
+        ),
+    };
+    let status = Cell::from(status_text).style(Style::default().fg(status_color));
     let action = Cell::from(entry.action_text()).style(theme::body());
 
     let (tool_ago_text, tool_ago_color) = match entry.tool_ago(now) {
@@ -967,10 +1133,30 @@ fn render_detail(
     Paragraph::new(lines).render(area, buf);
 }
 
-fn render_footer(area: Rect, buf: &mut Buffer) {
+fn render_footer(view: &FleetView, area: Rect, buf: &mut Buffer) {
+    // An armed stop replaces the whole help line: it is the only state in this
+    // view where the next keystroke is destructive, so it must not have to
+    // compete for attention with the key legend.
+    if let Some(id) = &view.pending_stop {
+        let line = Line::from(vec![
+            Span::styled(
+                format!("  stop {id}? "),
+                Style::default()
+                    .fg(theme::DANGER_BRIGHT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("[x] again to confirm   ", theme::muted()),
+            Span::styled("any other key cancels", theme::muted()),
+        ]);
+        Paragraph::new(line).render(area, buf);
+        return;
+    }
     let line = Line::from(vec![
         Span::styled("  [↑/↓] focus   ", theme::muted()),
         Span::styled("[s] sort   ", theme::muted()),
+        Span::styled("[p] pause   ", theme::muted()),
+        Span::styled("[r] resume   ", theme::muted()),
+        Span::styled("[x] stop   ", theme::muted()),
         Span::styled("[q] detach   ", theme::muted()),
         Span::styled("·   deeper telemetry: ", theme::muted()),
         Span::styled("stella observe", Style::default().fg(theme::ACCENT)),

--- a/stella-tui/src/fleet_dashboard/tests.rs
+++ b/stella-tui/src/fleet_dashboard/tests.rs
@@ -281,3 +281,186 @@ fn terminal_status_freezes_elapsed_and_wins_over_late_events() {
     // Terminal → tool-ago dashes.
     assert!(row.tool_ago(start + Duration::from_secs(30)).is_none());
 }
+
+// ── Supervisor verbs (#645) ─────────────────────────────────────────────────
+//
+// These drive the whole `[p]`/`[r]`/`[x]` surface as `KeyEvent`s against
+// `on_key`, which is why the verbs could be wired without an interactive
+// rendering harness: the key handling is a pure fold over the view.
+
+fn key(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+}
+
+/// A board whose `t1` is dispatched and running, focus pinned to it.
+fn running_board() -> (FleetBoard, FleetView) {
+    let now = Instant::now();
+    let board = {
+        let mut b = FleetBoard::new("stella", &seed(), now);
+        b.apply(
+            FleetMsg::Status {
+                id: "t1".into(),
+                status: FleetStatus::Running,
+            },
+            now,
+        );
+        b
+    };
+    let view = FleetView::new(&board.rows);
+    (board, view)
+}
+
+#[test]
+fn pause_and_resume_emit_verbs_for_the_focused_task() {
+    let (board, mut view) = running_board();
+    let now = Instant::now();
+    assert_eq!(view.focused_id.as_deref(), Some("t1"));
+
+    assert_eq!(
+        on_key(key('p'), &board, &mut view, now),
+        KeyAction::Control(FleetControl::Pause("t1".into()))
+    );
+    assert!(view.paused.contains("t1"), "pause is recorded locally");
+    assert_eq!(view.marker(&board.rows[0]), Some("paused"));
+
+    assert_eq!(
+        on_key(key('r'), &board, &mut view, now),
+        KeyAction::Control(FleetControl::Resume("t1".into()))
+    );
+    assert!(!view.paused.contains("t1"), "resume clears the pause");
+    assert_eq!(view.marker(&board.rows[0]), None);
+}
+
+#[test]
+fn stop_takes_two_keystrokes_and_any_other_key_disarms() {
+    let (board, mut view) = running_board();
+    let now = Instant::now();
+
+    // First `x` only arms — no verb leaves the dashboard.
+    assert_eq!(on_key(key('x'), &board, &mut view, now), KeyAction::None);
+    assert_eq!(view.pending_stop.as_deref(), Some("t1"));
+
+    // An unrelated keystroke disarms it.
+    assert_eq!(on_key(key('s'), &board, &mut view, now), KeyAction::None);
+    assert_eq!(view.pending_stop, None, "sort disarmed the pending stop");
+
+    // Re-arm, then confirm.
+    assert_eq!(on_key(key('x'), &board, &mut view, now), KeyAction::None);
+    assert_eq!(
+        on_key(key('x'), &board, &mut view, now),
+        KeyAction::Control(FleetControl::Stop("t1".into()))
+    );
+    assert_eq!(view.pending_stop, None, "confirming consumes the arm");
+    assert_eq!(view.marker(&board.rows[0]), Some("stopping"));
+}
+
+#[test]
+fn moving_focus_between_the_two_stop_keystrokes_does_not_stop_the_new_task() {
+    let (board, mut view) = running_board();
+    let now = Instant::now();
+
+    on_key(key('x'), &board, &mut view, now);
+    assert_eq!(view.pending_stop.as_deref(), Some("t1"));
+    // Focus moves to t2 — the arm must not travel with it.
+    on_key(key('j'), &board, &mut view, now);
+    assert_eq!(view.focused_id.as_deref(), Some("t2"));
+    assert_eq!(view.pending_stop, None);
+    // So this `x` arms t2 rather than stopping it.
+    assert_eq!(on_key(key('x'), &board, &mut view, now), KeyAction::None);
+    assert!(view.stopped.is_empty(), "nothing was stopped");
+}
+
+#[test]
+fn a_terminal_task_accepts_no_supervisor_verb() {
+    let now = Instant::now();
+    let mut board = FleetBoard::new("stella", &seed(), now);
+    board.apply(
+        FleetMsg::Status {
+            id: "t1".into(),
+            status: FleetStatus::Done,
+        },
+        now,
+    );
+    let mut view = FleetView::new(&board.rows);
+    assert_eq!(view.focused_id.as_deref(), Some("t1"));
+
+    for c in ['p', 'r', 'x'] {
+        assert_eq!(
+            on_key(key(c), &board, &mut view, now),
+            KeyAction::None,
+            "`{c}` on a finished task is declined"
+        );
+    }
+    assert!(view.paused.is_empty() && view.stopped.is_empty());
+    assert_eq!(view.pending_stop, None);
+}
+
+#[test]
+fn a_task_that_finishes_while_paused_renders_as_finished() {
+    let (mut board, mut view) = running_board();
+    let now = Instant::now();
+    on_key(key('p'), &board, &mut view, now);
+    assert_eq!(view.marker(&board.rows[0]), Some("paused"));
+
+    board.apply(
+        FleetMsg::Status {
+            id: "t1".into(),
+            status: FleetStatus::Done,
+        },
+        now,
+    );
+    // Fleet truth wins over local supervisor intent.
+    assert_eq!(view.marker(&board.rows[0]), None);
+    let text = draw(&board, &view, 110, 24);
+    assert!(text.contains("done"), "terminal status rendered:\n{text}");
+}
+
+#[test]
+fn the_grid_and_footer_advertise_the_supervisor_keys() {
+    let (board, mut view) = running_board();
+    let now = Instant::now();
+
+    let text = draw(&board, &view, 110, 24);
+    for hint in ["[p] pause", "[r] resume", "[x] stop"] {
+        assert!(text.contains(hint), "footer advertises {hint}:\n{text}");
+    }
+
+    // A paused task says so in the grid.
+    on_key(key('p'), &board, &mut view, now);
+    let text = draw(&board, &view, 110, 24);
+    assert!(text.contains("paused"), "grid marks the pause:\n{text}");
+
+    // An armed stop replaces the legend with the confirmation prompt.
+    on_key(key('x'), &board, &mut view, now);
+    let text = draw(&board, &view, 110, 24);
+    assert!(text.contains("stop t1?"), "confirm prompt:\n{text}");
+    assert!(
+        text.contains("[x] again to confirm"),
+        "confirm hint:\n{text}"
+    );
+}
+
+#[test]
+fn detach_keys_are_unchanged_by_the_supervisor_surface() {
+    let (board, mut view) = running_board();
+    let now = Instant::now();
+    assert_eq!(on_key(key('q'), &board, &mut view, now), KeyAction::Detach);
+    assert_eq!(
+        on_key(
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &board,
+            &mut view,
+            now
+        ),
+        KeyAction::Detach
+    );
+    assert_eq!(
+        on_key(
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            &board,
+            &mut view,
+            now
+        ),
+        KeyAction::Detach
+    );
+}

--- a/stella-tui/src/fleet_dashboard/tests.rs
+++ b/stella-tui/src/fleet_dashboard/tests.rs
@@ -396,6 +396,31 @@ fn a_terminal_task_accepts_no_supervisor_verb() {
 }
 
 #[test]
+fn a_queued_task_accepts_no_supervisor_verb() {
+    // A not-yet-dispatched task has no control lines registered, so `Fleet`
+    // would no-op the verb. The dashboard must decline rather than record
+    // local intent and paint a `paused`/`stopping` marker that outlives the
+    // no-op once the wave dispatches and the worker runs at full speed.
+    let now = Instant::now();
+    let board = FleetBoard::new("stella", &seed(), now);
+    let mut view = FleetView::new(&board.rows);
+    assert_eq!(view.focused_id.as_deref(), Some("t1"));
+    assert_eq!(board.rows[0].status, FleetStatus::Queued);
+
+    // Two `x` keystrokes: even a fully "confirmed" stop is declined.
+    for c in ['p', 'r', 'x', 'x'] {
+        assert_eq!(
+            on_key(key(c), &board, &mut view, now),
+            KeyAction::None,
+            "`{c}` on a queued task is declined"
+        );
+    }
+    assert!(view.paused.is_empty() && view.stopped.is_empty());
+    assert_eq!(view.pending_stop, None);
+    assert_eq!(view.marker(&board.rows[0]), None);
+}
+
+#[test]
 fn a_task_that_finishes_while_paused_renders_as_finished() {
     let (mut board, mut view) = running_board();
     let now = Instant::now();

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -98,7 +98,7 @@ pub use envelope::{
     SkillScope, SkillSearchHit, SkillsView, SplashCue, WorkspaceInput,
 };
 pub use fleet_dashboard::{
-    FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,
+    FleetControl, FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,
 };
 pub use graph::{GraphEdge, GraphNode, GraphSnapshot};
 pub use resource::ResourceMonitor;


### PR DESCRIPTION
Closes #645

## The zombie

`Fleet::pause_task` / `resume_task` / `stop_task` existed, were tested in `stella-fleet`, and **nothing called them**. Every hit outside the crate was a doc comment *describing* the verbs. Tested-and-unreachable is the worst of both states: maintenance cost, no delivery, and docs that promise a capability a user cannot reach.

The issue offered two ways out — wire them or delete them. The fleet dashboard already owns a live grid keyed by task id, which is exactly the surface these verbs were built for, so this wires them.

## What a supervisor can now do

From the `stella fleet` live dashboard:

| key | verb |
|-----|------|
| `[p]` | pause the focused task at its next safe step boundary |
| `[r]` | resume it |
| `[x]` `[x]` | stop it (two keystrokes) |

- **Stop is armed, not immediate.** It is the one irreversible verb — it drops a worker's turn and loses whatever it had not committed — so the first `[x]` arms and the footer swaps the key legend for a confirmation prompt. *Any* other key disarms, **including moving focus**, so an arm can never travel to a task the operator did not aim at.
- **Terminal tasks decline.** `Fleet` answers `false` for a task with no live worker; the dashboard declines rather than sending a verb that is guaranteed to be a no-op.
- **The grid shows supervisor intent** (`⏸ paused` / `⏸ stopping`). A pause has no wire representation coming back — the worker just parks — so without local intent the grid could not distinguish a parked worker from a slow one, and "running" on a paused worker would be a lie. Fleet truth still wins where the two can disagree: a task that finishes while paused renders as finished.

## Shape

`stella-tui` does not depend on `stella-fleet` and deliberately still doesn't. The verbs travel back down a new `FleetControl` channel, and `stella-cli/src/fleet_cmd.rs` applies them to the real `Fleet` in a control pump added as a third arm of the existing `join!`. The three verbs take `&self` and are synchronous, so this needs no clone, no `Arc`, and no second task. The pump ends when the dashboard drops its sender — which is when the dashboard returns — so the `join!` always completes.

## Why this could land now

Wiring was deferred as "a new user-facing feature with no witness test for interactive rendering". This PR removes that blocker rather than working around it: the key handling moved out of the `select!` arm into a pure `on_key(key, board, view, now) -> KeyAction` fold. The entire supervisor surface is now drivable as a sequence of `KeyEvent`s with no terminal.

Seven new tests: both verbs emit for the focused task, the two-keystroke stop, disarm-on-unrelated-key, disarm-on-focus-move, the terminal-task refusal, terminal status beating a local pause marker, and the rendered grid/footer strings. Detach keys are pinned unchanged.

## Docs

The comments in `stella-fleet/src/{lib,fleet}.rs`, `stella-cli/src/fleet_cmd.rs` and `command_deck.rs` that named this as an open follow-up now describe what shipped. Surfacing fleet tasks as controllable *deck* lanes remains a separate follow-up and is still labelled as one.

## Gates run locally

`check-no-scratch` · `check-action-pins` · `check-file-size` · `cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` · `cargo test --workspace` — all green.

Note the file-size ratchet: the `command_deck.rs` doc edit was kept line-neutral rather than raising the ceiling on the tree's second-worst file.