### PR TITLE
ci(docker): build and smoke Dockerfile.serve on every packaging change

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,12 @@
 # Patterns are matched against the path relative to the context root, so a bare
 # `.stella/` excludes only the top-level one — the tracked
 # bench/readiness/.../app/.stella/ fixture is untouched, which is what we want.
+# That cuts the other way too: a rule meant to catch a directory *wherever* it
+# appears needs a `**/` prefix, or it silently only ever matches at the root.
+# `node_modules/` was written as the recursive rule it looks like and was not
+# (verified by building a probe context: with `node_modules/`, a nested
+# `website/node_modules` still landed in the image; with `**/node_modules` it
+# did not).
 #
 # DO NOT exclude a workspace member (root Cargo.toml `members`, including
 # bench/loop-bench): cargo needs every member manifest present to load the
@@ -37,10 +43,14 @@ target/
 sandbox/
 verifications/
 
-# Docs site and its node_modules — not part of the cargo build
+# Docs site and its node_modules — not part of the cargo build. `website/` is
+# the tracked site (docs.yml builds it); `stella-docs/` is the standalone copy
+# the manual deploy uses. Neither is a workspace member, and nothing in the
+# cargo build include_str!s out of either.
 stella-docs/
+website/
 docs/
-node_modules/
+**/node_modules
 
 # Editor and OS noise
 .DS_Store

--- a/.github/workflows/docker-serve.yml
+++ b/.github/workflows/docker-serve.yml
@@ -1,0 +1,122 @@
+name: docker-serve
+
+# Builds packaging/docker/Dockerfile.serve and runs the container far enough to
+# prove it serves. Until this workflow existed the image had never been built
+# by anything — not here, not in release.yml — so the first person to build it
+# would have been the first person to find out whether it worked (#635).
+#
+# It is deliberately its own workflow rather than a job in ci.yml:
+#
+#   - ci.yml's `check` job is a required context. A multi-minute image build
+#     hanging off it would slow every Rust PR to prove something only the
+#     packaging files can break.
+#   - ci.yml uses `paths-ignore` (run unless it's prose); this needs `paths`
+#     (run only when the packaging surface moves). The two cannot be mixed in
+#     one workflow, and combining them by hand is how a filter goes wrong.
+#
+# No `merge_group` trigger for the same reason: `paths` filters are ignored on
+# that event, so queuing any PR at all would build the image.
+#
+# The two path lists below are duplicated rather than shared through a YAML
+# anchor because the Actions workflow parser does not resolve anchors. Keep
+# them in step.
+
+on:
+  pull_request:
+    paths:
+      - "packaging/docker/**"
+      - ".dockerignore"
+      # The served binary itself. Its dependency graph (stella-core,
+      # stella-protocol) is deliberately not listed: ci.yml already compiles
+      # the whole workspace in release, so a source break reaches a red gate
+      # without this job. What is unique here is the *packaging* — the base
+      # image, the unprivileged uid, the port, the healthcheck — and those
+      # move with the files below.
+      - "stella-serve/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      # The builder base tag has to track this pin; the first step asserts it.
+      - "rust-toolchain.toml"
+      - "scripts/smoke-serve-image.sh"
+      - ".github/workflows/docker-serve.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packaging/docker/**"
+      - ".dockerignore"
+      - "stella-serve/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "scripts/smoke-serve-image.sh"
+      - ".github/workflows/docker-serve.yml"
+  workflow_dispatch:
+
+concurrency:
+  # Same shape as ci.yml: cancel superseded runs on a PR, but give every push
+  # to main its own group so a queued run is never silently dropped.
+  group: docker-serve-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Builds and runs an image; publishes nothing, writes nothing to the repo.
+permissions:
+  contents: read
+
+jobs:
+  image:
+    name: build image + smoke the container
+    runs-on: ubuntu-latest
+    # A cold build compiles the stella-serve dependency graph from scratch;
+    # the cache below makes the warm case minutes shorter, not the cold one.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Toolchain-free and instant, so it runs before the build. The builder
+      # base and rust-toolchain.toml must name the same compiler, and they can
+      # drift without anything going red: cargo reads the toolchain file and
+      # rustup just downloads the pinned toolchain inside the build, so a stale
+      # base tag still produces a working image — one that ships two compilers'
+      # worth of download in the critical path. `rust:1.97-bookworm` had
+      # already drifted this way to 1.97.1 against a 1.97.0 pin.
+      - name: builder base tracks rust-toolchain.toml
+        run: |
+          set -euo pipefail
+          dockerfile=packaging/docker/Dockerfile.serve
+          pinned="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' rust-toolchain.toml)"
+          base="$(sed -n 's/^FROM rust:\([^[:space:]]*\)-bookworm .*/\1/p' "$dockerfile")"
+          if [ -z "$pinned" ] || [ -z "$base" ]; then
+            echo "could not read the toolchain pin ('$pinned') or the builder base ('$base')" >&2
+            exit 1
+          fi
+          if [ "$pinned" != "$base" ]; then
+            echo "$dockerfile builds on rust:$base-bookworm but rust-toolchain.toml pins $pinned." >&2
+            echo "Bump the FROM line to rust:$pinned-bookworm in this same change." >&2
+            exit 1
+          fi
+          echo "OK — builder base and toolchain pin both say $pinned."
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: build stella-serve image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: packaging/docker/Dockerfile.serve
+          tags: stella-serve:ci
+          # Into the runner's local image store, not a registry: this job
+          # proves the image runs, it does not publish it.
+          load: true
+          # The docker exporter cannot carry attestations, and `load: true`
+          # with the default provenance is the classic way to fail there.
+          provenance: false
+          # A cold cargo build of the dependency graph is the whole cost of
+          # this job; the layer cache is what keeps it affordable to run on
+          # every packaging change. `ignore-error` because a pull request from
+          # a fork gets a read-only cache — an export it cannot write must not
+          # be the reason the build fails.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+
+      - name: smoke the container
+        run: ./scripts/smoke-serve-image.sh stella-serve:ci

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer)
 no-scratch: ## Assert no tracked file is gitignored (agent scratch guard, #448)
 	@./scripts/check-no-scratch.sh
 
+.PHONY: action-pins
+action-pins: ## Assert every workflow `uses:` is pinned to a commit SHA (#648)
+	@./scripts/check-action-pins.sh
+
 .PHONY: doc-citations
 doc-citations: ## Assert every docs/*.md cited from Rust source resolves (#652)
 	@./scripts/check-doc-citations.sh
@@ -93,6 +97,13 @@ file-size-update: ## Retighten the 1500-line ratchet baseline (run after splitti
 .PHONY: doc-warnings
 doc-warnings: ## Assert rustdoc is clean workspace-wide (#634)
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+# Deliberately not part of `gate`: it needs a Docker daemon, which the gate
+# must not. CI runs the same two commands (.github/workflows/docker-serve.yml).
+.PHONY: serve-image
+serve-image: ## Build the stella-serve image and smoke the container (needs Docker, #635)
+	docker build -f packaging/docker/Dockerfile.serve -t stella-serve:ci .
+	@./scripts/smoke-serve-image.sh stella-serve:ci
 
 .PHONY: gate
 gate: no-scratch doc-citations file-size doc-warnings format-check lint test ## Full CI gate: no-scratch + doc-citations + file-size + rustdoc + fmt-check + clippy + test

--- a/packaging/docker/Dockerfile.serve
+++ b/packaging/docker/Dockerfile.serve
@@ -7,9 +7,19 @@
 #
 #   docker build -f packaging/docker/Dockerfile.serve -t stella-serve .
 #   docker run -e STELLA_SERVE_TOKEN=$(openssl rand -hex 32) -p 8080:8080 stella-serve
+#
+# CI builds this image and runs the container on every change to it
+# (.github/workflows/docker-serve.yml, #635). `./scripts/smoke-serve-image.sh
+# <tag>` runs the same assertions locally against a tag you just built.
 
-# rust-toolchain.toml pins the exact compiler; this base tag must track it.
-FROM rust:1.97-bookworm AS builder
+# rust-toolchain.toml pins the exact compiler; this base tag must track it —
+# to the patch level, which `rust:1.97-bookworm` did not. That tag floats to
+# the newest 1.97.x (1.97.1 today), so cargo read the toolchain file and had
+# rustup download a whole second toolchain — five components — inside every
+# build before compiling a line. Naming the patch version leaves rustup only
+# the one component the official image omits (clippy). Bump this in the same
+# commit that bumps rust-toolchain.toml; docker-serve.yml fails if they drift.
+FROM rust:1.97.0-bookworm AS builder
 WORKDIR /src
 COPY . .
 # Build only the server binary and its dependency graph, in release.
@@ -27,7 +37,13 @@ COPY --from=builder /src/target/release/stella-serve /usr/local/bin/stella-serve
 # executes no local tools (STELLA_SERVE_TOOLS=remote) and writes nothing to the
 # filesystem — so it must not run as root. Numeric USER so the constraint holds
 # even under a runtime that ignores /etc/passwd.
-RUN useradd --system --uid 10001 --user-group stella
+#
+# Not `--system`: that flag asks for an id below SYS_UID_MAX (999), so with an
+# explicit --uid 10001 useradd warned on every build and put the *group* at
+# gid 999 while the user sat at 10001 — a service account split across two id
+# ranges. A no-home, no-shell account is what this uid should be anyway; it
+# never logs in and writes nothing.
+RUN useradd --uid 10001 --user-group --no-create-home --shell /usr/sbin/nologin stella
 USER 10001
 
 # Bind all interfaces inside the container; the bearer token is the auth gate and

--- a/scripts/smoke-serve-image.sh
+++ b/scripts/smoke-serve-image.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Smoke: run the packaged stella-serve image far enough to prove it actually
+# serves. See #635.
+#
+# packaging/docker/Dockerfile.serve shipped on main having never been built.
+# It asserts four runtime preconditions and nothing checked any of them:
+#
+#   1. the binary starts under an unprivileged uid (USER 10001),
+#   2. it binds 8080 inside the container,
+#   3. the bearer-token gate admits a good token and refuses everything else,
+#   4. `stella-serve healthcheck` — the image's HEALTHCHECK, which carries no
+#      curl or wget — can reach the server it is probing.
+#
+# Each is plausible; "plausible" is how an image reaches a user broken. This
+# script exercises all four against a tag you have already built, so the same
+# assertions run in CI (.github/workflows/docker-serve.yml) and on a laptop:
+#
+#   docker build -f packaging/docker/Dockerfile.serve -t stella-serve:ci .
+#   ./scripts/smoke-serve-image.sh stella-serve:ci
+#
+# The token is generated per run and passed by environment, never baked into
+# the image. Container logs are dumped on every exit path — a failure here is
+# usually a startup error the container printed and took to its grave.
+set -euo pipefail
+
+image="${1:-stella-serve:ci}"
+# Host-side port only; the container side is fixed at 8080 on purpose, because
+# "does it serve on 8080" is one of the things under test.
+host_port="${STELLA_SERVE_SMOKE_PORT:-18080}"
+base="http://127.0.0.1:${host_port}"
+token="$(openssl rand -hex 32)"
+
+cid=""
+cleanup() {
+  status=$?
+  if [ -n "$cid" ]; then
+    echo "--- container logs ---"
+    docker logs "$cid" 2>&1 || true
+    docker rm --force "$cid" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "smoke-serve-image: $*" >&2
+  exit 1
+}
+
+echo "smoke-serve-image: running $image on 127.0.0.1:${host_port}"
+cid="$(docker run --detach \
+  --env STELLA_SERVE_TOKEN="$token" \
+  --publish "127.0.0.1:${host_port}:8080" \
+  "$image")"
+
+# Readiness, bounded. The loop exits early if the container is gone: a config
+# error (missing token, unparseable bind) exits non-zero in milliseconds, and
+# waiting the full timeout for a corpse only buries the log that explains it.
+ready=""
+for _ in $(seq 1 60); do
+  if [ "$(docker inspect --format '{{.State.Running}}' "$cid")" != "true" ]; then
+    fail "the container exited before it served anything"
+  fi
+  if [ "$(curl --silent --output /dev/null --write-out '%{http_code}' "${base}/healthz" || true)" = "200" ]; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+[ -n "$ready" ] || fail "no 200 from ${base}/healthz within 60s"
+
+# 1. It serves on 8080 — the request above crossed a host:8080 port mapping, so
+#    the listener is on 8080 inside the container, not merely "somewhere".
+health="$(curl --silent --show-error "${base}/healthz")"
+case "$health" in
+*'"status":"ok"'*) echo "ok: /healthz on 8080 -> $health" ;;
+*) fail "/healthz answered 200 with an unexpected body: $health" ;;
+esac
+
+# 2. An unauthenticated write is refused. Sent to a real endpoint, not a
+#    made-up path, so a 401 proves the token gate and not a 404 in disguise.
+status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  --request POST "${base}/v1/turns" \
+  --header 'content-type: application/json' \
+  --data '{}')"
+[ "$status" = "401" ] || fail "unauthenticated POST /v1/turns returned $status, want 401"
+echo "ok: unauthenticated POST /v1/turns -> 401"
+
+# 3. An authenticated write succeeds. A turn is the smallest real unit of work
+#    the wire protocol has; it parks waiting for the host to answer its first
+#    reverse request, which is exactly what a host-driven sidecar should do.
+turn="$(curl --silent --show-error --write-out '\n%{http_code}' \
+  --request POST "${base}/v1/turns" \
+  --header "authorization: Bearer ${token}" \
+  --header 'content-type: application/json' \
+  --data '{"provider_id":"smoke","messages":[{"role":"user","content":"ping"}],"max_steps":1,"reverse_request_timeout_ms":1000}')"
+status="$(printf '%s' "$turn" | tail -n 1)"
+body="$(printf '%s' "$turn" | sed '$d')"
+[ "$status" = "200" ] || fail "authenticated POST /v1/turns returned $status: $body"
+case "$body" in
+*'"turn_id"'*) echo "ok: authenticated POST /v1/turns -> 200 $body" ;;
+*) fail "authenticated POST /v1/turns returned 200 without a turn_id: $body" ;;
+esac
+
+# Hand the turn back rather than leaving it to time out on its own deadline —
+# and take a second authenticated round trip while we are here.
+turn_id="$(printf '%s' "$body" | sed -n 's/.*"turn_id":"\([^"]*\)".*/\1/p')"
+[ -n "$turn_id" ] || fail "could not read turn_id out of: $body"
+status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  --request POST "${base}/v1/turns/${turn_id}/cancel" \
+  --header "authorization: Bearer ${token}")"
+[ "$status" = "200" ] || fail "cancelling ${turn_id} returned $status, want 200"
+echo "ok: authenticated POST /v1/turns/${turn_id}/cancel -> 200"
+
+# 4. It runs unprivileged. Two questions, two answers: `id -u` reports the uid
+#    a command lands on, while /proc/1/status reports the uid the *server* is
+#    actually running under — the one that matters, and the one an image whose
+#    USER was overridden or ignored would fail.
+uid="$(docker exec "$cid" id -u | tr -d '\r')"
+[ "$uid" = "10001" ] || fail "docker exec id -u printed '$uid', want 10001"
+server_uid="$(docker exec "$cid" awk '/^Uid:/ { print $2 }' /proc/1/status | tr -d '\r')"
+[ "$server_uid" = "10001" ] || fail "the server process runs as uid '$server_uid', want 10001"
+echo "ok: uid 10001 (exec and pid 1)"
+
+# 5. The image's own HEALTHCHECK works: first the probe binary directly, then
+#    the verdict Docker forms from it. Docker's status is the end-to-end proof
+#    — it runs the declared CMD, in the image, with the image's environment.
+docker exec "$cid" /usr/local/bin/stella-serve healthcheck \
+  || fail "stella-serve healthcheck exited non-zero inside the container"
+healthy=""
+for _ in $(seq 1 30); do
+  case "$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$cid")" in
+  healthy)
+    healthy=1
+    break
+    ;;
+  unhealthy) fail "the container's HEALTHCHECK reported unhealthy" ;;
+  esac
+  sleep 2
+done
+[ -n "$healthy" ] || fail "the container never reported healthy within 60s"
+echo "ok: HEALTHCHECK -> healthy"
+
+# Nothing above should have knocked it over.
+[ "$(docker inspect --format '{{.State.Running}}' "$cid")" = "true" ] \
+  || fail "the container is no longer running at the end of the smoke"
+
+echo "smoke-serve-image: OK — $image serves on 8080 as uid 10001."

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -30,7 +30,13 @@ The binary is meant to run containerized —
 [`../packaging/docker/Dockerfile.serve`](../packaging/docker/Dockerfile.serve)
 builds it with `--bin stella-serve`, runs it under a non-root numeric UID, binds
 `0.0.0.0:8080`, and uses the binary's own `stella-serve healthcheck` subcommand as
-the container HEALTHCHECK so the runtime image needs no `curl` or `wget`.
+the container HEALTHCHECK so the runtime image needs no `curl` or `wget`. Those
+are claims a Dockerfile makes and cannot check, so
+[`../.github/workflows/docker-serve.yml`](../.github/workflows/docker-serve.yml)
+builds the image on every change to it and
+[`../scripts/smoke-serve-image.sh`](../scripts/smoke-serve-image.sh) runs the
+container until each one is answered — serving on 8080, the token gate refusing
+and admitting, uid 10001 on PID 1, and Docker's own health verdict (#635).
 
 ```
 host  ──POST /v1/turns──►  stella-serve  ──►  Session (dedicated OS thread)


### PR DESCRIPTION
## What & why

`packaging/docker/Dockerfile.serve` has been on `main` without ever being built —
nothing in `.github/workflows/` referenced it, and `release.yml` does not package
it. Its four runtime claims (non-root `USER 10001`, a listener on 8080, the
bearer-token gate, and a `HEALTHCHECK` that reaches the server with no `curl` in
the runtime image) were reviewed by reading, never by running.

This adds `.github/workflows/docker-serve.yml`, which builds the image with
buildx (GitHub Actions layer cache) and runs
[`scripts/smoke-serve-image.sh`](scripts/smoke-serve-image.sh) against the
container. The smoke asserts, in order:

| Assertion | How |
|---|---|
| serves on 8080 | `GET /healthz` → `200 {"status":"ok"}` across a `127.0.0.1:18080 -> 8080` port mapping |
| unauthenticated is refused | `POST /v1/turns` with no token → `401` (a real endpoint, so a 401 can't be a 404 in disguise) |
| authenticated succeeds | `POST /v1/turns` with the token → `200` + `turn_id`, then `POST .../cancel` → `200` |
| runs unprivileged | `docker exec <c> id -u` → `10001`, **and** `Uid:` of PID 1 in `/proc/1/status` → `10001` (the server process itself, not just where an exec lands) |
| the HEALTHCHECK works | `stella-serve healthcheck` exits 0 inside the container, and Docker's own `State.Health.Status` reaches `healthy` |

Closes #635

## Real bugs the first build found

Two of the unverified claims were wrong in ways only a build shows.

**1. The builder base did not track the toolchain pin.** The Dockerfile's own
comment says "rust-toolchain.toml pins the exact compiler; this base tag must
track it" — but `rust:1.97-bookworm` floats to the newest 1.97.x, which is
`1.97.1` today, against a `1.97.0` pin. Cargo honoured the toolchain file by
having rustup download a *whole second toolchain* inside every build, before
compiling a line:

```
$ docker run --rm -v $PWD/rust-toolchain.toml:/w/rust-toolchain.toml -w /w rust:1.97-bookworm rustc --version
info: syncing channel updates for 1.97.0-...
info: downloading 5 components
rustc 1.97.0
```

Pinned to `rust:1.97.0-bookworm`, which leaves rustup only the one component the
official image omits (`clippy`). The workflow's first step now fails if the base
tag and `rust-toolchain.toml` ever drift apart again — it has to be a check,
because drift here is invisible: the image still builds, just fatter and slower.

**2. `useradd --system --uid 10001` was self-contradictory.** `--system` asks for
an id below `SYS_UID_MAX` (999), so every build printed
`useradd warning: stella's uid 10001 is greater than SYS_UID_MAX 999` and the
account landed split across two id ranges — uid 10001, **gid 999**. Dropped
`--system` and added `--no-create-home` + a nologin shell. uid and gid are both
10001 now, and the build is warning-free.

**3. `.dockerignore`'s `node_modules/` was not the recursive rule it looks like.**
`.dockerignore` patterns match the whole path relative to the context root, so
`node_modules/` only ever matched a top-level one; a contributor's
`website/node_modules` went straight into the build context. Verified against a
probe context, both ways:

```
.dockerignore: node_modules/     -> /c/website/node_modules/nested.bin  present
.dockerignore: **/node_modules   -> (absent)
```

Now `**/node_modules`, with `website/` named alongside the other docs
directories the comment already claimed to cover. Cross-checked against the root
`Cargo.toml` `members` list: no ignore pattern matches a workspace member
(including `bench/loop-bench`), which is the file's stated invariant — cargo
needs every member manifest to load the workspace.

**Drive-by:** `make check` — documented in AGENTS.md as the fast pre-push check —
has always listed `action-pins` as a prerequisite with no rule to build it, so it
died on ``No rule to make target `action-pins'``. Added the one-line target.

## Verification — the image was actually built and run

Not "should work": built and smoked locally on Docker 29.5.2 (colima,
aarch64/Linux), with the fixed Dockerfile, via the new `make serve-image`:

```
smoke-serve-image: running stella-serve:ci on 127.0.0.1:18080
ok: /healthz on 8080 -> {"status":"ok"}
ok: unauthenticated POST /v1/turns -> 401
ok: authenticated POST /v1/turns -> 200 {"turn_id":"turn-0"}
ok: authenticated POST /v1/turns/turn-0/cancel -> 200
ok: uid 10001 (exec and pid 1)
ok: HEALTHCHECK -> healthy
smoke-serve-image: OK — stella-serve:ci serves on 8080 as uid 10001.
```

`cargo build --release --locked --bin stella-serve` completes inside the
container in ~19s: the git dependency on `context-graph-protocol` is not in this
binary's dependency graph (`stella-serve` → `stella-core`, `stella-protocol`
only), and `--locked` is satisfied by the committed `Cargo.lock`.

The failure path was exercised too — `./scripts/smoke-serve-image.sh busybox`
exits 1 on "the container exited before it served anything" rather than hanging
for the readiness timeout.

Local Docker is arm64, so what was smoked on this machine is an arm64 image.
The amd64 half — plus the parts that only exist on a runner: the `type=gha`
layer cache and `load: true` against the runner's image store — is covered by
[this PR's own first run of the job](https://github.com/macanderson/stella/actions/runs/30192451274),
which went green in ~4 minutes with the same six `ok:` lines and a successful
cache export.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is CI plus
      the packaging files it exercises. The workflow *is* the witness for #635:
      it fails on the old Dockerfile's shape (the base-tracks-pin step) and the
      smoke fails on any regression in the uid, the port, the token gate, or the
      healthcheck.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `./scripts/check-no-scratch.sh`, `./scripts/check-action-pins.sh` (38 refs,
      all pinned — the two new `docker/*` actions are pinned to full SHAs with
      `# vX` comments), `./scripts/check-file-size.sh`,
      `./scripts/check-doc-citations.sh`
- [x] Docs updated: `stella-serve/README.md` no longer says `cargo test
      --workspace` is the only thing that exercises this crate.
- [x] `Closes #635` appears above **and** as a commit trailer

## Ground-rule check

- [x] No Rust changed at all — no I/O in `stella-core`, no new deps
- [x] No new outbound network calls from Stella (the workflow pulls base images
      and crates at build time, as any container build does)

## Anything reviewers should know?

- **Trigger scope.** `paths` covers `packaging/docker/**`, `.dockerignore`,
  `stella-serve/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, the smoke
  script and the workflow itself. `stella-core/**` and `stella-protocol/**` are
  deliberately *not* listed: `ci.yml` already compiles the whole workspace in
  release, so a source break is caught without paying an image build on every
  Rust PR. What is unique here is the packaging.
- **Not a job in `ci.yml`**, on purpose: `check` is a required context and
  shouldn't grow a multi-minute image build, and `ci.yml` uses `paths-ignore`
  where this needs `paths` — the two can't be mixed in one workflow.
- **No `merge_group` trigger**: `paths` filters are ignored on that event, so
  queuing any PR at all would build the image. This is not proposed as a required
  check.
- `cache-to` carries `ignore-error=true` because a fork PR gets a read-only
  Actions cache, and a cache export it cannot write must not be the reason a
  build fails. `provenance: false` because the docker exporter (`load: true`)
  cannot carry attestations.
- The Dockerfile still does `COPY . .` then one `cargo build`, so any source
  change busts the whole compile layer. A cargo-chef-style dependency stage would
  cache better; left out as scope creep — happy to follow up if wanted.
