### PR TITLE
api: delete the dead public surface, wire the two checks worth keeping

### DIFF
--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -880,7 +880,7 @@ mod tests {
         );
         assert_eq!(usage.budget_requested, 1_000, "the query's max_tokens");
         assert_eq!(usage.total_frames_served(), 3);
-        assert!(!usage.as_of.is_empty(), "an accounting snapshot is stamped");
+        assert!(usage.as_of_is_wellformed(), "as_of must be RFC 3339");
 
         let mem = usage
             .providers

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -628,13 +628,13 @@ impl SessionMemory {
         let Ok(log) = std::fs::read_to_string(log_path) else {
             return;
         };
-        // Tombstones from BOTH surfaces: forgetting the memory should stop the
-        // lesson being promoted to a skill, and forgetting the skill should
-        // stop it being re-created from the same log lines it came from.
+        // Every surface a background loop can regenerate; `ContextSurface` owns which.
         let forgotten: Vec<String> = stella_store::Store::open(&self.workspace_root)
             .and_then(|store| {
-                let mut texts = store.forgotten_texts(stella_store::ContextSurface::Memory)?;
-                texts.extend(store.forgotten_texts(stella_store::ContextSurface::Skill)?);
+                let mut texts = Vec::new();
+                for surface in stella_store::ContextSurface::restatement_suppressing() {
+                    texts.extend(store.forgotten_texts(surface)?);
+                }
                 Ok(texts)
             })
             .unwrap_or_default();

--- a/stella-fleet/src/fleet.rs
+++ b/stella-fleet/src/fleet.rs
@@ -805,7 +805,7 @@ where
         }
     }
 
-    // Read-through accessors (tests + real callers)
+    // Read-through accessors. Every caller today is a test (no production one).
 
     /// The parent budget guard's current state (a `Copy` snapshot).
     pub fn budget_snapshot(&self) -> BudgetGuard {

--- a/stella-graph/src/manifest.rs
+++ b/stella-graph/src/manifest.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::storage::{
-    DEFAULT_NAMESPACE, DEFAULT_SQL_LAYER, LayerEntry, RedirectEntry, RelationEntry,
-    StorageSnapshot, normalize_name, relation_address,
+    DEFAULT_NAMESPACE, LayerEntry, RedirectEntry, RelationEntry, StorageSnapshot, normalize_name,
+    relation_address,
 };
 
 /// File name at the workspace root.
@@ -118,12 +118,6 @@ impl StorageManifest {
             .map(|(key, _)| key.clone())
     }
 
-    /// [`Self::layer_claim`], falling back to the implicit SQL layer.
-    pub fn layer_for(&self, rel_path: &str) -> String {
-        self.layer_claim(rel_path)
-            .unwrap_or_else(|| DEFAULT_SQL_LAYER.to_string())
-    }
-
     fn meaning_for<'a>(
         table: &'a BTreeMap<String, MeaningDecl>,
         address: &str,
@@ -140,20 +134,6 @@ impl StorageManifest {
 
     pub fn field_meaning(&self, address: &str) -> Option<&MeaningDecl> {
         Self::meaning_for(&self.fields, address)
-    }
-
-    pub fn namespace_meaning(&self, layer: &str, namespace: &str) -> Option<&MeaningDecl> {
-        let layer_key = normalize_name(layer);
-        let ns_key = normalize_name(namespace);
-        self.namespaces
-            .iter()
-            .find(|(key, _)| normalize_name(key) == layer_key)
-            .and_then(|(_, table)| {
-                table
-                    .iter()
-                    .find(|(ns, _)| normalize_name(ns) == ns_key)
-                    .map(|(_, decl)| decl)
-            })
     }
 
     /// Declared layers as snapshot entries (engine/class default to
@@ -238,7 +218,7 @@ pub fn merge_snapshot(
                     .collect();
             }
             for field in &mut rel.fields {
-                let address = format!("{}/{}", rel.address, normalize_name(&field.name));
+                let address = crate::storage::field_address(&rel.address, &field.name);
                 if let Some(meaning) = manifest.field_meaning(&address)
                     && meaning.intent.is_some()
                 {
@@ -511,14 +491,18 @@ intent = "Gross amount charged."
             m.field_meaning("primary_pg/billing/payments/amount")
                 .is_some()
         );
-        assert!(m.namespace_meaning("primary-pg", "billing").is_some());
     }
 
     #[test]
     fn layer_matching_uses_paths_globs() {
         let m = manifest();
-        assert_eq!(m.layer_for("migrations/001_init.sql"), "primary-pg");
-        assert_eq!(m.layer_for("src/schema.sql"), DEFAULT_SQL_LAYER);
+        assert_eq!(
+            m.layer_claim("migrations/001_init.sql").as_deref(),
+            Some("primary-pg")
+        );
+        // No layer claims a bare `src/*.sql`; callers fall back to the
+        // implicit SQL layer themselves.
+        assert_eq!(m.layer_claim("src/schema.sql"), None);
     }
 
     #[test]

--- a/stella-graph/src/storage/mod.rs
+++ b/stella-graph/src/storage/mod.rs
@@ -55,15 +55,6 @@ impl RelationKind {
         }
     }
 
-    pub fn from_tag(tag: &str) -> RelationKind {
-        match tag {
-            "view" => RelationKind::View,
-            "enum" => RelationKind::EnumType,
-            "collection" => RelationKind::Collection,
-            _ => RelationKind::Table,
-        }
-    }
-
     pub fn label(self) -> &'static str {
         match self {
             RelationKind::Table => "Table",
@@ -309,13 +300,14 @@ pub fn relation_address(layer: &str, namespace: &str, relation: &str) -> String 
     )
 }
 
-/// Canonical address of a field: `layer/namespace/relation/field`.
-pub fn field_address(layer: &str, namespace: &str, relation: &str, field: &str) -> String {
-    format!(
-        "{}/{}",
-        relation_address(layer, namespace, relation),
-        normalize_name(field)
-    )
+/// Canonical address of a field: `<relation address>/field`.
+///
+/// Takes the already-composed relation address rather than its three parts:
+/// every caller reaches this point holding a `RelationEntry::address` that
+/// [`relation_address`] produced, and splitting it back apart to recompose it
+/// would be the only reason for a four-argument form.
+pub fn field_address(relation_address: &str, field: &str) -> String {
+    format!("{}/{}", relation_address, normalize_name(field))
 }
 
 /// Human rendering of an address (`store://…`, spec §3a).
@@ -489,7 +481,7 @@ mod tests {
             "primary_pg/public/payments"
         );
         assert_eq!(
-            field_address("sql", "default", "payments", "userId"),
+            field_address(&relation_address("sql", "default", "payments"), "userId"),
             "sql/default/payments/user_id"
         );
         assert_eq!(display_address("a/b/c"), "store://a/b/c");

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -102,6 +102,6 @@ pub use triage::TaskClass;
 pub use verify::{FlipOracle, FlipState, LadderDecision, LadderInputs};
 pub use witness::{
     TestInvocationError, Witness, WitnessArtifactError, parse_test_invocation,
-    parse_witness_command, tampered_paths, validate_witness_artifact, validate_witness_identity,
-    validate_witness_invocation, witness_identity_matches, witness_watchlist,
+    parse_witness_command, validate_witness_artifact, validate_witness_identity,
+    validate_witness_invocation, witness_identity_matches,
 };

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -538,14 +538,6 @@ impl<'a> Pipeline<'a> {
         }
     }
 
-    /// Replace the ordinary channel wrapper with a caller-supplied ordered
-    /// sender. Benchmark mode uses this to journal+flush every event before
-    /// the same event enters the renderer queue.
-    pub fn with_event_sender(mut self, events: EventSender) -> Self {
-        self.events = events;
-        self
-    }
-
     /// Drive one prompt through the full staged flow. `messages` is the
     /// caller-owned history: seed it with the stable system prefix (the cached
     /// prompt prefix, L-E8); the pipeline appends the volatile recall+goal

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -621,54 +621,10 @@ pub fn parse_witness_command(text: &str) -> Option<String> {
     found
 }
 
-/// The witness watchlist: every untracked file the witness turn created or
-/// modified, as `path -> fingerprint` — present in `after` with no `before`
-/// entry or a different fingerprint. This *observed* delta is the tamper
-/// baseline; the author's own claims about which files it wrote are never
-/// trusted (a wrong claim would corrupt tamper detection, an observed delta
-/// cannot).
-///
-/// Superseded inside this crate by [`validate_witness_artifact`], which admits
-/// exactly one newly created test file rather than a whole delta; kept as
-/// public API for callers building their own witness acceptance.
-pub fn witness_watchlist(
-    before: &HashMap<String, String>,
-    after: &HashMap<String, String>,
-) -> HashMap<String, String> {
-    after
-        .iter()
-        .filter(|(path, fp)| before.get(*path) != Some(*fp))
-        .map(|(path, fp)| (path.clone(), fp.clone()))
-        .collect()
-}
-
-/// Tamper check: which watchlisted witness files are no longer byte-identical
-/// (fingerprint changed) or gone (deleted / moved out of the untracked set)
-/// at verify time. Non-empty means the deterministic flip must NOT be
-/// credited — the candidate hard-fails before judge evaluation. Sorted for
-/// deterministic error text.
-///
-/// The pipeline itself enforces the strictly stronger
-/// [`witness_identity_matches`] check (bytes *plus* type, mode, and link
-/// count, read without following symlinks), which a fingerprint comparison
-/// alone cannot express; this remains public for callers whose repo status
-/// carries fingerprints only.
-pub fn tampered_paths(
-    watchlist: &HashMap<String, String>,
-    current: &HashMap<String, String>,
-) -> Vec<String> {
-    let mut tampered: Vec<String> = watchlist
-        .iter()
-        .filter(|(path, fp)| current.get(*path) != Some(*fp))
-        .map(|(path, _)| path.clone())
-        .collect();
-    tampered.sort();
-    tampered
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::ArtifactKind;
 
     fn fps(entries: &[(&str, &str)]) -> HashMap<String, String> {
         entries
@@ -779,23 +735,6 @@ mod tests {
                 "candidate escape must be rejected: {command}"
             );
         }
-    }
-
-    // witness_watchlist
-
-    #[test]
-    fn watchlist_is_created_and_modified_files_only() {
-        let before = fps(&[("stale.txt", "a"), ("edited_test.rs", "old")]);
-        let after = fps(&[
-            ("stale.txt", "a"),         // untouched pre-existing dirt
-            ("edited_test.rs", "new"),  // modified by the witness turn
-            ("tests/witness.rs", "w1"), // created by the witness turn
-        ]);
-        let list = witness_watchlist(&before, &after);
-        assert_eq!(list.len(), 2);
-        assert_eq!(list.get("tests/witness.rs"), Some(&"w1".to_string()));
-        assert_eq!(list.get("edited_test.rs"), Some(&"new".to_string()));
-        assert!(!list.contains_key("stale.txt"));
     }
 
     #[test]
@@ -980,34 +919,87 @@ mod tests {
         );
     }
 
-    // tampered_paths
+    // witness_identity_matches — the tamper check the pipeline actually runs.
+    //
+    // These cases were inherited from the deleted `tampered_paths`, which
+    // compared fingerprints only and had no caller. The live check is strictly
+    // stronger (bytes *plus* type, mode and link count, read without following
+    // symlinks), so the last three cases below are ones a fingerprint
+    // comparison could not express at all.
 
-    #[test]
-    fn untouched_watchlist_reports_no_tampering() {
-        let watch = fps(&[("tests/witness.rs", "w1")]);
-        let current = fps(&[("tests/witness.rs", "w1"), ("other.rs", "x")]);
-        assert!(tampered_paths(&watch, &current).is_empty());
+    fn identity(fingerprint: &str) -> ArtifactIdentity {
+        ArtifactIdentity {
+            fingerprint: fingerprint.to_string(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100_644,
+            link_count: 1,
+        }
     }
 
     #[test]
-    fn a_modified_witness_file_is_tampered() {
-        let watch = fps(&[("tests/witness.rs", "w1")]);
-        let current = fps(&[("tests/witness.rs", "w2")]);
-        assert_eq!(tampered_paths(&watch, &current), vec!["tests/witness.rs"]);
+    fn an_untouched_witness_artifact_is_not_tampered() {
+        let expected = identity("w1");
+        assert!(witness_identity_matches(&expected, Some(&expected.clone())));
     }
 
     #[test]
-    fn a_deleted_witness_file_is_tampered() {
-        let watch = fps(&[("tests/witness.rs", "w1")]);
-        let current = HashMap::new();
-        assert_eq!(tampered_paths(&watch, &current), vec!["tests/witness.rs"]);
+    fn a_modified_witness_artifact_is_tampered() {
+        let expected = identity("w1");
+        assert!(!witness_identity_matches(&expected, Some(&identity("w2"))));
     }
 
     #[test]
-    fn tampered_paths_are_sorted_for_deterministic_evidence() {
-        let watch = fps(&[("b.rs", "1"), ("a.rs", "1")]);
-        let current = HashMap::new();
-        assert_eq!(tampered_paths(&watch, &current), vec!["a.rs", "b.rs"]);
+    fn a_deleted_witness_artifact_is_tampered() {
+        let expected = identity("w1");
+        assert!(
+            !witness_identity_matches(&expected, None),
+            "an artifact that no longer exists can never match"
+        );
+    }
+
+    #[test]
+    fn identical_bytes_with_a_changed_mode_are_tampered() {
+        let expected = identity("w1");
+        let chmodded = ArtifactIdentity {
+            mode: 0o100_755,
+            ..expected.clone()
+        };
+        assert!(
+            !witness_identity_matches(&expected, Some(&chmodded)),
+            "mode is part of the identity — a fingerprint comparison misses this"
+        );
+    }
+
+    #[test]
+    fn a_witness_artifact_that_gained_a_hard_link_is_tampered() {
+        let expected = identity("w1");
+        let linked = ArtifactIdentity {
+            link_count: 2,
+            ..expected.clone()
+        };
+        assert!(!witness_identity_matches(&expected, Some(&linked)));
+    }
+
+    #[test]
+    fn a_non_regular_expected_identity_never_matches_even_itself() {
+        // The accepted-at-authoring-time guard: a symlink or multi-link file
+        // was never a valid witness artifact, so re-observing it unchanged
+        // must still fail rather than credit the flip.
+        for kind in [ArtifactKind::Symlink, ArtifactKind::Other] {
+            let odd = ArtifactIdentity {
+                kind,
+                ..identity("w1")
+            };
+            assert!(
+                !witness_identity_matches(&odd, Some(&odd.clone())),
+                "{kind:?} is not an acceptable witness artifact"
+            );
+        }
+        let multi = ArtifactIdentity {
+            link_count: 2,
+            ..identity("w1")
+        };
+        assert!(!witness_identity_matches(&multi, Some(&multi.clone())));
     }
 
     // prompts

--- a/stella-store/src/forget.rs
+++ b/stella-store/src/forget.rs
@@ -143,6 +143,19 @@ impl ContextSurface {
     pub fn suppresses_restatements(&self) -> bool {
         matches!(self, Self::Memory | Self::Skill)
     }
+
+    /// Every surface [`Self::suppresses_restatements`] answers `true` for.
+    ///
+    /// The enumeration lives next to the predicate so a tombstone sweep cannot
+    /// drift from it: callers used to name `Memory` and `Skill` inline, which
+    /// meant a newly regenerable surface would have been silently skipped by
+    /// the sweep while the predicate said it should not be.
+    pub fn restatement_suppressing() -> Vec<Self> {
+        Self::all()
+            .into_iter()
+            .filter(|s| s.suppresses_restatements())
+            .collect()
+    }
 }
 
 /// Comparison tokens: lowercased alphanumeric runs, keeping the characters


### PR DESCRIPTION
Refs #618, #620

Nine `pub` items across five crates had **no caller**. Each was exercised only by its own unit test, and each read as supported API — the worst shape for a reader, who cannot tell a load-bearing function from a decorative one without grepping the workspace.

## Why this can land now

Both issues declined to act on the same premise: *"removing public items is a public API change, which the audit rules place out of bounds."*

That premise does not hold. The workspace root sets `publish = false` — none of these crates ship to a registry, so there is no external caller to break. Two of the deleted items justified themselves in their own rustdoc:

> "…kept as public API for callers building their own witness acceptance."
> "…remains public for callers whose repo status carries fingerprints only."

Those callers cannot exist.

## Deleted — zero references anywhere, not even a test

| item | note |
|---|---|
| `Pipeline::with_event_sender` | doc claimed *"Benchmark mode uses this to journal+flush every event"* — `bench/loop-bench` never mentions `EventSender` |
| `RelationKind::from_tag` | `tag` is live (it writes the column); nothing reads it back into the enum |

## Deleted — test-only, superseded by a stronger live mechanism

- `witness_watchlist` / `tampered_paths` + their `lib.rs` re-exports — the pipeline enforces tamper exclusion via `validate_witness_artifact` + `witness_identity_matches`.
- `StorageManifest::layer_for` — a fallback wrapper over `layer_claim`, which every real caller uses directly.
- `StorageManifest::namespace_meaning`.

## The tests moved to the live path, and got stronger

`tampered_paths` had **four tests**; the live `witness_identity_matches` had **none**. The dead code was better covered than the mechanism that actually runs.

Those cases now target the live check — plus three properties a fingerprint-only comparison could not express at all:

- identical bytes with a **changed mode** are tampered,
- an artifact that **gained a hard link** is tampered,
- a **non-regular expected identity** (symlink, multi-link) fails to match *even itself*, so re-observing it unchanged cannot credit the flip.

## Wired instead of deleted

Two items deserved a caller, not a grave:

- **`ContextSurface::suppresses_restatements`** encoded which surfaces a tombstone suppresses *restatements* for. Nothing consulted it — `auto_create_skills` named `Memory` and `Skill` inline, duplicating the policy. A newly regenerable surface would have been silently skipped by the sweep while the predicate said it should not be. The enumeration now lives beside the predicate as `ContextSurface::restatement_suppressing`.
- **`storage::field_address`** took four arguments and had no caller, while `manifest.rs` hand-rolled the identical `format!` from an already-composed relation address. Reshaped to that call's real shape and used there, so canonical address formatting has one home.

## `as_of_is_wellformed` — a caller, but not a fake one

`ContextUsage::as_of_is_wellformed` (#618) now has a non-crate-local caller: the CGP host test that previously asserted only `!as_of.is_empty` asserts the RFC 3339 shape — the property that makes receipts sortable, and the regression guard on `now_rfc3339`.

I considered a runtime enforcement point in `to_context_usage` and **deliberately did not add one**: `as_of` on that path is stamped by stella's own clock (`fanout.usage_report(query, now_rfc3339)`), never by a provider, so the guard branch could never fire. Adding dead code to retire dead code is not a trade worth making. The row stays open for a host that ingests a foreign usage report.

## One comment corrected

`Fleet`'s read-through accessors were labelled `// Read-through accessors (tests + real callers)`. There are no real callers.

## Gates run locally

`check-no-scratch` · `check-file-size` · `cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` · `cargo test --workspace` (59 test binaries, 0 failures) — all green.

Net **−139 / +112** lines. Additions to already-grandfathered files were kept under their `scripts/file-size-baseline.txt` ceilings rather than raising them.
