### PR TITLE
fix(security): scrub ambient authority, close the SVG data: gap, confine workspace members

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -33,7 +33,7 @@
 1828 stella-store/src/usage.rs
 1558 stella-tools/src/media.rs
 2966 stella-tools/src/registry.rs
-1688 stella-tools/src/scripts.rs
+1797 stella-tools/src/scripts.rs
 1662 stella-tui/src/deck_render.rs
 6884 stella-tui/src/deck_ui.rs
 1615 stella-tui/src/model.rs

--- a/stella-fleet/src/git.rs
+++ b/stella-fleet/src/git.rs
@@ -77,7 +77,10 @@ pub enum GitError {
 /// The production [`GitCli`]: spawns the real `git` binary via
 /// `tokio::process`. Never inherits an interactive prompt
 /// (`GIT_TERMINAL_PROMPT=0`) so a credential-needing command fails fast
-/// instead of hanging a fleet worker.
+/// instead of hanging a fleet worker. Environment policy — credentials,
+/// git's config/command-injection family, and the ssh-agent socket — is
+/// `stella_tools::subprocess_env`'s single shared list, not a second one
+/// maintained here.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SystemGitCli;
 
@@ -94,12 +97,22 @@ impl GitCli for SystemGitCli {
         // init, config, commit, worktree add — at the OUTER repo. That is
         // not hypothetical: it once rewrote the host repo's user identity
         // and committed test fixtures onto a real branch.
+        //
+        // This list is *repo targeting* only. The git config- and
+        // command-injection family (`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/
+        // `GIT_CONFIG_VALUE_n`, `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`,
+        // `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND`,
+        // `GIT_ALTERNATE_OBJECT_DIRECTORIES`) is deliberately NOT duplicated
+        // here: it lives in the shared scrub below so `stella-tools`' and
+        // `stella-cli`'s own git invocations get identical treatment from one
+        // list, with one documented re-admission hatch
+        // (`STELLA_SUBPROCESS_ENV_ALLOW`) for a deploy-key setup that
+        // legitimately drives git through `GIT_SSH_COMMAND`.
         for var in [
             "GIT_DIR",
             "GIT_WORK_TREE",
             "GIT_INDEX_FILE",
             "GIT_OBJECT_DIRECTORY",
-            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
             "GIT_COMMON_DIR",
             "GIT_NAMESPACE",
             "GIT_PREFIX",

--- a/stella-media/src/svg.rs
+++ b/stella-media/src/svg.rs
@@ -47,10 +47,12 @@
 //!
 //!    The rule is applied **only** to attributes that can actually reference
 //!    a resource — `href`, `xlink:href`, `src`, `fill`, `stroke`, `filter`,
-//!    `mask`, `clip-path`, `marker-*`, `style` — and the scheme test is
-//!    anchored at the start of the trimmed value. Both halves are required to
-//!    avoid a false positive: a legitimate value that merely *contains* a
-//!    colon (`font-family="Foo: Bar"`) is neither a resource reference nor
+//!    `mask`, `clip-path`, `cursor`, `marker`, `color-profile`, `style`, and
+//!    the `marker-*` / `mask-*` / `*-image` / `*-source` families (see
+//!    `is_resource_reference_attribute`) — and the scheme test is anchored at
+//!    the start of the trimmed value. Both halves are required to avoid a
+//!    false positive: a legitimate value that merely *contains* a colon
+//!    (`font-family="Foo: Bar"`) is neither a resource reference nor
 //!    scheme-prefixed, and must survive sanitization untouched.
 //! 7. **Drop the `style` attribute** — the `<style>` *element* is dropped by
 //!    rule 2, but the attribute carries the same CSS and so the same
@@ -76,6 +78,13 @@
 //! sanitizer aware of it. Presentation CSS is lost rather than filtered
 //! (rule 7): an artifact that relied on `style="fill:red"` renders unstyled
 //! instead of insecurely.
+//!
+//! Rule 6 allows a *relative* reference (`fill="url(sprite.svg#g)"`), which
+//! `xml:base="https://host/"` could re-base off-host. `xml:base` is removed
+//! in SVG 2 and browsers dropped it years ago for this class of reason, so
+//! nothing here acts on it today; closing it means either dropping `xml:base`
+//! outright or refusing relative references, and that is a separate ruling
+//! about how much a same-directory reference is worth (tracked on #615).
 
 use async_trait::async_trait;
 use roxmltree::{Document, Node};
@@ -367,6 +376,25 @@ fn keep_attribute(name_low: &str, value: &str) -> bool {
 /// merely contains a colon (`font-family="Foo: Bar"`, a `transform`, a path
 /// `d`) from being mistaken for a URL scheme. `style` is listed for
 /// completeness even though rule 7 drops it before rule 6 is reached.
+///
+/// Every entry has a keyword-or-URL value grammar, never free text, so
+/// widening this list carries no false-positive risk — which is why the
+/// shape rules at the end are preferred over enumerating a moving target:
+///
+/// * `marker-` — `marker-start` / `marker-mid` / `marker-end` (`<funciri>`).
+/// * `mask-` — CSS Masking's `mask-image`, `mask-border-source`; the
+///   non-referencing siblings (`mask-type`, `mask-mode`, `mask-repeat`) hold
+///   keywords and are unaffected by being scanned.
+/// * `-image` / `-source` — the CSS `<image>`-valued properties SVG 2 exposes
+///   as presentation attributes (`background-image`, `border-image-source`,
+///   `list-style-image`).
+///
+/// `cursor` is the one that got away in the first cut of this rule:
+/// `cursor="url(evil.svg), auto"` is valid SVG 1.1 and is fetched, exactly
+/// like `fill="url(…)"`. `marker` and `color-profile` are here defensively —
+/// SVG 1.1 makes `marker` a property but *not* a presentation attribute, and
+/// `color-profile` is gone in SVG 2, so a conformant renderer ignores both as
+/// XML attributes; a lenient one does not, and neither costs anything.
 fn is_resource_reference_attribute(name_low: &str) -> bool {
     matches!(
         name_low,
@@ -378,8 +406,14 @@ fn is_resource_reference_attribute(name_low: &str) -> bool {
             | "filter"
             | "mask"
             | "clip-path"
+            | "cursor"
+            | "marker"
+            | "color-profile"
             | "style"
     ) || name_low.starts_with("marker-")
+        || name_low.starts_with("mask-")
+        || name_low.ends_with("-image")
+        || name_low.ends_with("-source")
 }
 
 /// Whether a resource-referencing value names an external target: the value
@@ -732,6 +766,14 @@ mod tests {
                 r##"<rect clip-path="url(data:text/html,x)" stroke="#000"/>"##,
                 "clip-path",
             ),
+            (
+                r##"<rect cursor="url(data:image/svg+xml;base64,AAAA), auto" stroke="#000"/>"##,
+                "cursor",
+            ),
+            (
+                r##"<rect mask-image="url(data:image/svg+xml,x)" stroke="#000"/>"##,
+                "mask-image",
+            ),
         ];
         for (fragment, attribute) in hostile {
             let out = process(&format!(
@@ -744,6 +786,103 @@ mod tests {
                 out.removed
             );
             assert!(out.svg.contains("stroke=\"#000\""), "{}", out.svg);
+        }
+    }
+
+    #[test]
+    fn cursor_url_references_are_stripped_but_keyword_cursors_survive() {
+        // `cursor="url(…), auto"` is valid SVG 1.1 and IS fetched, so it is
+        // the same off-host class as `fill="url(…)"` — it was missed in the
+        // first cut of rule 6.
+        for (fragment, marker) in [
+            (
+                r##"<rect cursor="url(data:image/svg+xml;base64,AAAA), auto" fill="#111"/>"##,
+                "data:",
+            ),
+            (
+                r##"<rect cursor="url(https://evil.example/c.svg), auto" fill="#111"/>"##,
+                "evil.example",
+            ),
+        ] {
+            let out = process(&format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg">{fragment}</svg>"#
+            ));
+            assert!(!out.svg.contains(marker), "{}", out.svg);
+            assert!(!out.svg.contains("cursor"), "{}", out.svg);
+            assert!(
+                out.removed.iter().any(|r| r.contains("cursor")),
+                "the dropped cursor must be reported: {:?}",
+                out.removed
+            );
+            assert!(out.svg.contains("fill=\"#111\""), "{}", out.svg);
+        }
+
+        // A keyword cursor carries no scheme, so it must survive untouched —
+        // the common case, and the one a false-positive-prone rule breaks.
+        let out = process(
+            r##"<svg xmlns="http://www.w3.org/2000/svg"><rect cursor="pointer" fill="#111"/><rect cursor="url(#hand), auto"/><rect mask-type="alpha"/></svg>"##,
+        );
+        assert!(
+            out.removed.is_empty(),
+            "legitimate cursors must survive: {:?}",
+            out.removed
+        );
+        assert!(out.svg.contains(r#"cursor="pointer""#), "{}", out.svg);
+        assert!(out.svg.contains("url(#hand)"), "{}", out.svg);
+        assert!(out.svg.contains(r#"mask-type="alpha""#), "{}", out.svg);
+    }
+
+    #[test]
+    fn resource_reference_attribute_list_is_pinned() {
+        // Rule 6's whole false-positive guard is this list, so what is in it
+        // and what is deliberately out are both part of the contract.
+        for referencing in [
+            "href",
+            "xlink:href",
+            "src",
+            "fill",
+            "stroke",
+            "filter",
+            "mask",
+            "clip-path",
+            "cursor",
+            "marker",
+            "marker-start",
+            "marker-mid",
+            "marker-end",
+            "mask-image",
+            "mask-border-source",
+            "color-profile",
+            "background-image",
+            "border-image-source",
+            "list-style-image",
+            "style",
+        ] {
+            assert!(
+                is_resource_reference_attribute(referencing),
+                "{referencing} can be dereferenced and must be scanned by rule 6"
+            );
+        }
+        // Deliberately out: none of these is fetched, and every one of them
+        // can legitimately hold a colon or a `//`.
+        for inert in [
+            "d",
+            "transform",
+            "font-family",
+            "points",
+            "viewbox",
+            "stop-color",
+            "id",
+            "class",
+            "systemlanguage",
+            "requiredextensions",
+            "xlink:role",
+            "xlink:arcrole",
+        ] {
+            assert!(
+                !is_resource_reference_attribute(inert),
+                "{inert} is not dereferenced; scanning it only risks false positives"
+            );
         }
     }
 

--- a/stella-media/src/svg.rs
+++ b/stella-media/src/svg.rs
@@ -37,10 +37,27 @@
 //!    references (`#id`) survive; `http(s):`, `data:`, `javascript:`,
 //!    protocol-relative, and every other target is stripped. This neutralizes
 //!    remote `<image>` exfil pixels and `javascript:` navigation.
-//! 6. **Drop attribute values that reference external resources** via a URL
-//!    scheme (`…://…`), a protocol-relative prefix (`//host/…`, including inside
-//!    `url(//…)`), or `javascript:` anywhere in the value — covers
-//!    `fill="url(http://…)"`, external paint servers, filters, and masks.
+//! 6. **Drop resource-referencing attributes whose value names an external
+//!    target** — the value (or any `url(…)` argument inside it) is external
+//!    when it begins with a URL scheme (`<ascii-alpha>[a-z0-9+.-]*:`, so
+//!    `http:`, `https:`, `data:`, `blob:`, `file:` and every future scheme
+//!    are covered), begins with the protocol-relative `//host/…`, or contains
+//!    `javascript:`. A bare `#fragment` and a relative path are same-document
+//!    or same-directory and survive, so `fill="url(#grad)"` still paints.
+//!
+//!    The rule is applied **only** to attributes that can actually reference
+//!    a resource — `href`, `xlink:href`, `src`, `fill`, `stroke`, `filter`,
+//!    `mask`, `clip-path`, `marker-*`, `style` — and the scheme test is
+//!    anchored at the start of the trimmed value. Both halves are required to
+//!    avoid a false positive: a legitimate value that merely *contains* a
+//!    colon (`font-family="Foo: Bar"`) is neither a resource reference nor
+//!    scheme-prefixed, and must survive sanitization untouched.
+//! 7. **Drop the `style` attribute** — the `<style>` *element* is dropped by
+//!    rule 2, but the attribute carries the same CSS and so the same
+//!    `url(…)`/`@import` off-host fetch. It is dropped outright rather than
+//!    URL-filtered: parsing CSS to decide is a second parser's worth of
+//!    attack surface, and an inline presentation style is never load-bearing
+//!    for an artifact whose presentation attributes survive.
 //!
 //! # Optimization (light, step 4)
 //! Comments and processing instructions are dropped; `<metadata>` elements
@@ -49,13 +66,16 @@
 //! a viewBox"), which keeps the artifact safely scalable when inlined.
 //!
 //! # Known limits (recorded, not fixed)
-//! Rule 6 keys on `//` and `javascript:`, so a `data:` URI in a non-`href`
-//! attribute value survives — including in a `style="…"` *attribute*, which
-//! (unlike the `<style>` element of rule 2) has no rule of its own. Neither
-//! is exploitable in the terminal preview ladder, which never renders SVG;
-//! both matter the moment a sanitized artifact is inlined into an HTML
-//! context, so tightening rule 6 to a scheme allow-list and adding `style` to
-//! the attribute deny-list is the recorded follow-up.
+//! Rule 6's reach is the resource-attribute list above. An attribute outside
+//! it keeps a value that happens to look like a URL — deliberate, because the
+//! attributes outside the list (`d`, `transform`, `font-family`, `points`, …)
+//! are not fetched by any renderer, and testing them all is what produced the
+//! false positives this rule was rewritten to avoid. A *new* SVG attribute
+//! that dereferences its value therefore has to be added to
+//! `is_resource_reference_attribute` in the same change that makes the
+//! sanitizer aware of it. Presentation CSS is lost rather than filtered
+//! (rule 7): an artifact that relied on `style="fill:red"` renders unstyled
+//! instead of insecurely.
 
 use async_trait::async_trait;
 use roxmltree::{Document, Node};
@@ -329,21 +349,95 @@ fn keep_attribute(name_low: &str, value: &str) -> bool {
     if name_low == "href" || name_low == "xlink:href" {
         return value.trim_start().starts_with('#');
     }
-    // Rule 6: any external/script URL reference in a value.
-    if references_external(value) {
+    // Rule 7: the `style` attribute carries the same CSS as the `<style>`
+    // element rule 2 drops, so it is dropped for the same reason.
+    if name_low == "style" {
+        return false;
+    }
+    // Rule 6: an external/script URL reference, but only where the attribute
+    // can actually dereference its value.
+    if is_resource_reference_attribute(name_low) && references_external(value) {
         return false;
     }
     true
 }
 
-/// Whether a value references an external resource: any absolute URL scheme
-/// (`…://…`), a protocol-relative URL (`//host/…`, including inside `url(//…)`),
-/// or a `javascript:` pseudo-scheme — case-insensitive. `://` is a subset of
-/// `//`, so the single `//` check covers both absolute and protocol-relative
-/// forms.
+/// Attributes whose value a renderer can dereference — the only ones rule 6
+/// inspects. Restricting the scan is what keeps a legitimate value that
+/// merely contains a colon (`font-family="Foo: Bar"`, a `transform`, a path
+/// `d`) from being mistaken for a URL scheme. `style` is listed for
+/// completeness even though rule 7 drops it before rule 6 is reached.
+fn is_resource_reference_attribute(name_low: &str) -> bool {
+    matches!(
+        name_low,
+        "href"
+            | "xlink:href"
+            | "src"
+            | "fill"
+            | "stroke"
+            | "filter"
+            | "mask"
+            | "clip-path"
+            | "style"
+    ) || name_low.starts_with("marker-")
+}
+
+/// Whether a resource-referencing value names an external target: the value
+/// itself, or any `url(…)` argument inside it, is scheme-prefixed or
+/// protocol-relative — or the value contains the `javascript:` pseudo-scheme
+/// anywhere. Case-insensitive.
 fn references_external(value: &str) -> bool {
-    let low = value.to_ascii_lowercase();
-    low.contains("//") || low.contains("javascript:")
+    let trimmed = value.trim();
+    if is_external_target(trimmed) {
+        return true;
+    }
+    let low = trimmed.to_ascii_lowercase();
+    if low.contains("javascript:") {
+        return true;
+    }
+    // `url(<target>)` is CSS functional notation: how paint servers, filters,
+    // masks and markers name what they reference. ASCII-lowercasing is
+    // byte-length preserving, so offsets found in `low` index `trimmed`.
+    let mut cursor = 0usize;
+    while let Some(offset) = low[cursor..].find("url(") {
+        let start = cursor + offset + "url(".len();
+        let end = trimmed[start..]
+            .find(')')
+            .map_or(trimmed.len(), |i| start + i);
+        if is_external_target(&trimmed[start..end]) {
+            return true;
+        }
+        cursor = start;
+    }
+    false
+}
+
+/// Whether one reference target points off-document: it carries a URL scheme
+/// or is protocol-relative. A bare `#fragment` (same document) and a relative
+/// path (same directory) are neither.
+fn is_external_target(raw: &str) -> bool {
+    let target = raw.trim().trim_matches(['"', '\'']).trim();
+    target.starts_with("//") || starts_with_url_scheme(target)
+}
+
+/// Whether `text` begins with an RFC 3986 scheme: an ASCII letter followed by
+/// any number of `[A-Za-z0-9+.-]`, then `:`. Anchored at the start on purpose
+/// — a colon later in a value (`font-family="Foo: Bar"`) is punctuation, not
+/// a scheme, and treating it as one is the false positive that blocked this
+/// rule from landing.
+fn starts_with_url_scheme(text: &str) -> bool {
+    let mut bytes = text.bytes();
+    if !bytes.next().is_some_and(|b| b.is_ascii_alphabetic()) {
+        return false;
+    }
+    for byte in bytes {
+        match byte {
+            b':' => return true,
+            b if b.is_ascii_alphanumeric() || matches!(b, b'+' | b'.' | b'-') => {}
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// Does the subtree use any XLink-namespaced attribute? Governs whether the
@@ -596,6 +690,118 @@ mod tests {
         );
         assert!(!out.svg.contains("attacker.example"), "{}", out.svg);
         assert!(out.svg.contains("stroke=\"#000\""));
+    }
+
+    #[test]
+    fn style_attribute_is_dropped_with_its_data_uri_payload() {
+        // The `<style>` element was already dropped (rule 2); the attribute
+        // carries the same CSS and so the same off-host fetch (rule 7).
+        let out = process(
+            r##"<svg xmlns="http://www.w3.org/2000/svg"><rect style="background-image:url(data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIi8+)" fill="#111"/></svg>"##,
+        );
+        assert!(!out.svg.contains("style"), "{}", out.svg);
+        assert!(!out.svg.contains("data:"), "{}", out.svg);
+        assert!(!out.svg.contains("base64"), "{}", out.svg);
+        assert!(out.svg.contains("fill=\"#111\""), "{}", out.svg);
+        assert!(out.removed.iter().any(|r| r.contains("style")));
+    }
+
+    #[test]
+    fn data_uri_targets_are_stripped_everywhere_they_can_be_dereferenced() {
+        // Each of these survived the old `//`-substring test: a `data:` URI
+        // has no `//` at all, so an inlined artifact re-opened the
+        // active-content vector the sanitizer exists to close.
+        let hostile = [
+            (
+                r##"<rect fill="url(data:image/svg+xml;base64,PHN2Zy8+)" stroke="#000"/>"##,
+                "fill",
+            ),
+            (
+                r##"<rect filter="url(data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)" stroke="#000"/>"##,
+                "filter",
+            ),
+            (
+                r##"<path marker-end="url(data:image/svg+xml,%3Csvg/%3E)" stroke="#000"/>"##,
+                "marker-end",
+            ),
+            (
+                r##"<rect mask="url(data:text/html,x)" stroke="#000"/>"##,
+                "mask",
+            ),
+            (
+                r##"<rect clip-path="url(data:text/html,x)" stroke="#000"/>"##,
+                "clip-path",
+            ),
+        ];
+        for (fragment, attribute) in hostile {
+            let out = process(&format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg">{fragment}</svg>"#
+            ));
+            assert!(!out.svg.contains("data:"), "{attribute}: {}", out.svg);
+            assert!(
+                out.removed.iter().any(|r| r.contains(attribute)),
+                "{attribute} was not reported as removed: {:?}",
+                out.removed
+            );
+            assert!(out.svg.contains("stroke=\"#000\""), "{}", out.svg);
+        }
+    }
+
+    #[test]
+    fn hostile_href_schemes_and_protocol_relative_targets_are_stripped() {
+        let out = process(
+            r##"<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><rect/></a><image href="//evil.example/x.svg"/><image href="data:text/html;base64,PHNjcmlwdD4="/></svg>"##,
+        );
+        assert!(!out.svg.contains("javascript"), "{}", out.svg);
+        assert!(!out.svg.contains("evil.example"), "{}", out.svg);
+        assert!(!out.svg.contains("data:"), "{}", out.svg);
+        assert_eq!(
+            out.removed.iter().filter(|r| r.contains("href")).count(),
+            3,
+            "every hostile href must be reported: {:?}",
+            out.removed
+        );
+    }
+
+    #[test]
+    fn legitimate_svg_survives_the_tightened_reference_rules() {
+        // The false positive the scheme test had to avoid: a value that
+        // merely *contains* a colon is not a URL, and an attribute that no
+        // renderer dereferences is not a reference at all.
+        let out = process(
+            r##"<svg xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="grad"/></defs><use href="#gradient"/><path d="M0 0L1 1" fill="url(#grad)" stroke="url(#grad)"/><text font-family="Foo: Bar" transform="translate(1,2)">hi</text></svg>"##,
+        );
+        assert!(
+            out.removed.is_empty(),
+            "legitimate SVG must survive intact: {:?}",
+            out.removed
+        );
+        assert!(out.svg.contains(r##"href="#gradient""##), "{}", out.svg);
+        assert!(out.svg.contains(r##"fill="url(#grad)""##), "{}", out.svg);
+        assert!(out.svg.contains(r#"d="M0 0L1 1""#), "{}", out.svg);
+        assert!(out.svg.contains(r#"font-family="Foo: Bar""#), "{}", out.svg);
+        assert!(
+            out.svg.contains(r#"transform="translate(1,2)""#),
+            "{}",
+            out.svg
+        );
+    }
+
+    #[test]
+    fn scheme_test_is_anchored_and_accepts_relative_references() {
+        assert!(starts_with_url_scheme("data:text/html,x"));
+        assert!(starts_with_url_scheme("HTTPS://example.test"));
+        assert!(starts_with_url_scheme("x-custom+v1.0-beta:payload"));
+        // Anchored: a colon after the first non-scheme byte is punctuation.
+        assert!(!starts_with_url_scheme("Foo Bar: baz"));
+        assert!(!starts_with_url_scheme("#fragment"));
+        assert!(!starts_with_url_scheme("1nvalid:x"));
+        assert!(!starts_with_url_scheme("./icons/star.svg"));
+        assert!(!starts_with_url_scheme(""));
+        // …but a colon straight after a legal scheme body still counts, which
+        // is why the resource-attribute restriction is the second half of the
+        // guard rather than an optimization.
+        assert!(starts_with_url_scheme("Foo: Bar"));
     }
 
     #[test]

--- a/stella-pipeline/README.md
+++ b/stella-pipeline/README.md
@@ -176,7 +176,11 @@ touches three functions in [`src/witness.rs`](src/witness.rs) that must agree:
    single exact test. A form that can run a whole suite would credit a flip the witness did
    not earn.
 3. `is_witness_test_path` — teach it the language's test-file shape so the artifact is
-   recognized at all.
+   recognized at all. Accept a filename-only form (`test_*.py`, `*_test.go`) **only** if
+   that runner really collects the file wherever it sits. Rust does not: cargo runs an
+   integration test only from `tests/`, so the `rs` arm requires a recognized test
+   directory. Accepting `src/backdoor_test.rs` would let a production file ride in as a
+   witness whose required `cargo test --test <stem>` can then never pass.
 
 **Adding a port**: define the trait in [`src/ports.rs`](src/ports.rs), add the field to
 `PipelinePorts`, and choose deliberately between a no-op default and an `Option` — a port

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -498,6 +498,17 @@ fn changed_paths(before: &HashMap<String, String>, after: &HashMap<String, Strin
 }
 
 /// Whether a candidate-relative path has a supported witness-test shape.
+///
+/// Rust is the one language here with no filename-only form: cargo can only
+/// run an integration test from a `tests/` directory, so the `"rs"` arm
+/// requires `recognized_dir` outright. A bare `_test.` fallback accepted
+/// `src/backdoor_test.rs` as a witness artifact — after which
+/// [`validate_witness_invocation`]'s required `cargo test --test <stem>` can
+/// never pass, the flip never happens, the run burns its full revision
+/// budget, and a judge scoring the diff may still PASS, adopting the stray
+/// production file into the user's real tree. The other arms keep their
+/// filename forms because their runners genuinely collect by filename
+/// wherever the file sits (`pytest test_*.py`, `go test ./... _test.go`).
 pub fn is_witness_test_path(path: &str) -> bool {
     let normalized = path.replace('\\', "/").to_ascii_lowercase();
     let name = normalized.rsplit('/').next().unwrap_or(&normalized);
@@ -506,7 +517,7 @@ pub fn is_witness_test_path(path: &str) -> bool {
         .any(|part| matches!(part, "test" | "tests" | "__tests__" | "spec" | "specs"));
     let extension = name.rsplit_once('.').map(|(_, ext)| ext).unwrap_or("");
     match extension {
-        "rs" => recognized_dir || name.contains("_test."),
+        "rs" => recognized_dir,
         "py" => recognized_dir || name.starts_with("test_") || name.contains("_test."),
         "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => {
             recognized_dir || name.contains(".test.") || name.contains(".spec.")
@@ -554,6 +565,9 @@ pub fn witness_prompt(goal: &str, recall: &[RecalledFrame], repo_structure: &str
          Hard requirements:\n\
          - Create ONE NEW test file. Never modify existing files, and never touch \
          production code — the implementation is someone else's job.\n\
+         - Put it where the language's runner collects it. Rust integration tests MUST \
+         live in `tests/` (cargo cannot run a test file under `src/`); Python, Vitest, Go \
+         and .NET may use their filename conventions.\n\
          - The test must fail NOW for the RIGHT reason (it exercises the missing/broken \
          behavior), not because of a typo, a missing import, or a harness error.\n\
          - Use `create_witness_test`; no general write, edit, process, network, or external \
@@ -978,6 +992,52 @@ mod tests {
             rust_prefix_backdoor.is_err(),
             "Rust test prefixes outside a recognized test directory are not integration tests"
         );
+        let rust_suffix_backdoor = validate_witness_artifact(
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &fps(&[("src/backdoor_test.rs", "payload")]),
+        );
+        assert!(
+            rust_suffix_backdoor.is_err(),
+            "cargo runs integration tests only from tests/, so a `_test.rs` under src/ \
+             is a production file the run would adopt, never a witness"
+        );
+    }
+
+    #[test]
+    fn witness_test_path_shapes_per_language() {
+        for accepted in [
+            "tests/authority_witness.rs",
+            "crates/api/tests/witness.rs",
+            "tests/test_authority.py",
+            "test_authority.py",
+            "authority_test.py",
+            "src/__tests__/authority.ts",
+            "src/authority.test.ts",
+            "src/authority.spec.tsx",
+            "internal/authority_test.go",
+            "tests/Authority.Tests/AuthorityWitnessTests.cs",
+        ] {
+            assert!(
+                is_witness_test_path(accepted),
+                "{accepted} is a legitimate witness artifact"
+            );
+        }
+        for rejected in [
+            // Rust: cargo cannot run an integration test outside tests/, so a
+            // filename-only form is a production file, not a witness.
+            "src/backdoor_test.rs",
+            "src/test_backdoor.rs",
+            "src/lib.rs",
+            "README.md",
+            "tests/fixture.json",
+        ] {
+            assert!(
+                !is_witness_test_path(rejected),
+                "{rejected} must not be accepted as a witness artifact"
+            );
+        }
     }
 
     // tampered_paths

--- a/stella-tools/src/scripts.rs
+++ b/stella-tools/src/scripts.rs
@@ -73,6 +73,12 @@ pub struct ScriptIndex {
     pub verbs: BTreeMap<&'static str, String>,
     /// Workspace members beyond `MAX_WORKSPACE_MEMBERS` that were skipped.
     pub truncated_members: usize,
+    /// Declared workspace members that resolved outside the workspace root
+    /// (a `../` member pattern, or a member symlinked out of the tree) and
+    /// were therefore not indexed. Counted rather than dropped silently: some
+    /// monorepos legitimately declare `../` members, and a maintainer who
+    /// sees fewer scripts than they declared needs to be told why.
+    pub out_of_root_members: usize,
 }
 
 /// Marker-order rank of a runner's ecosystem — the precedence used both for
@@ -125,7 +131,7 @@ impl ScriptIndex {
         let mut entries: Vec<ScriptEntry> = Vec::new();
         let root_pm = node_pm(root, None);
         detect_package(root, ".", true, root_pm, &mut entries);
-        let (members, truncated_members) = workspace_members(root);
+        let (members, truncated_members, out_of_root_members) = workspace_members(root);
         for dir in &members {
             detect_package(root, dir, false, root_pm, &mut entries);
         }
@@ -140,6 +146,7 @@ impl ScriptIndex {
             scripts: entries,
             verbs,
             truncated_members,
+            out_of_root_members,
         }
     }
 
@@ -347,6 +354,12 @@ impl ScriptIndex {
             s.push_str(&format!(
                 "\n({} workspace members beyond the {MAX_WORKSPACE_MEMBERS}-member cap were not indexed)\n",
                 self.truncated_members
+            ));
+        }
+        if self.out_of_root_members > 0 {
+            s.push_str(&format!(
+                "\n({} declared workspace member(s) resolve outside the workspace root and were not indexed)\n",
+                self.out_of_root_members
             ));
         }
         s.trim_end().to_string()
@@ -1047,9 +1060,12 @@ fn strip_jsonc_comments(src: &str) -> String {
 
 /// Member dirs declared by the root manifests: `package.json` `workspaces`,
 /// `pnpm-workspace.yaml` `packages`, `[workspace] members` in `Cargo.toml`.
-/// Sorted, deduplicated, capped — the overflow count is reported, never
+/// Sorted, deduplicated, capped, and confined to the workspace root — both
+/// the cap overflow and the out-of-root skips are counted and reported, never
 /// silently dropped.
-fn workspace_members(root: &Path) -> (Vec<String>, usize) {
+///
+/// Returns `(members, truncated_by_cap, skipped_out_of_root)`.
+fn workspace_members(root: &Path) -> (Vec<String>, usize, usize) {
     let mut patterns: Vec<String> = Vec::new();
     if let Ok(text) = std::fs::read_to_string(root.join("package.json"))
         && let Ok(pkg) = serde_json::from_str::<Value>(&text)
@@ -1076,14 +1092,16 @@ fn workspace_members(root: &Path) -> (Vec<String>, usize) {
     }
 
     let mut dirs: BTreeSet<String> = BTreeSet::new();
+    let mut out_of_root = 0usize;
     for pattern in &patterns {
-        expand_member_pattern(root, pattern, &mut dirs);
+        out_of_root += expand_member_pattern(root, pattern, &mut dirs);
     }
     dirs.remove(".");
     let truncated = dirs.len().saturating_sub(MAX_WORKSPACE_MEMBERS);
     (
         dirs.into_iter().take(MAX_WORKSPACE_MEMBERS).collect(),
         truncated,
+        out_of_root,
     )
 }
 
@@ -1117,29 +1135,64 @@ fn pnpm_workspace_globs(text: &str) -> Vec<String> {
 /// Expand one member pattern: a literal dir, or a `base/*` / `base/**`
 /// one-level glob. Anything fancier is skipped — deterministically, not
 /// approximately.
-fn expand_member_pattern(root: &Path, pattern: &str, dirs: &mut BTreeSet<String>) {
+///
+/// Every produced dir is confined with [`crate::resolve_within_root`], so a
+/// pattern read out of `Cargo.toml` / `package.json` / `pnpm-workspace.yaml`
+/// cannot make the index walk, or `run_script` execute in, a directory
+/// outside the workspace root. The manifests are repository-controlled input:
+/// a `../` member (or a member symlinked out of the tree) would otherwise
+/// index whatever the checkout sits next to.
+///
+/// Some monorepos legitimately declare `../` members, so the skip is a
+/// reported outcome rather than a silent one — the count returned here rides
+/// [`ScriptIndex::out_of_root_members`] into `render_list`.
+fn expand_member_pattern(root: &Path, pattern: &str, dirs: &mut BTreeSet<String>) -> usize {
     let pattern = pattern.trim().trim_end_matches('/');
     if pattern.is_empty() {
-        return;
+        return 0;
     }
     let base = pattern
         .strip_suffix("/*")
         .or_else(|| pattern.strip_suffix("/**"));
     if let Some(base) = base {
-        let Ok(read) = std::fs::read_dir(root.join(base)) else {
-            return;
+        let Some(base_dir) = crate::resolve_within_root(root, base) else {
+            return 1;
         };
+        let Ok(read) = std::fs::read_dir(base_dir) else {
+            return 0;
+        };
+        let mut out_of_root = 0usize;
         for child in read.filter_map(|e| e.ok()) {
             let name = child.file_name().to_string_lossy().into_owned();
             if name.starts_with('.') || name == "node_modules" || name == "target" {
                 continue;
             }
-            if child.path().is_dir() {
-                dirs.insert(format!("{base}/{name}"));
+            if !child.path().is_dir() {
+                continue;
+            }
+            // A member directory can itself be a symlink out of the tree, so
+            // each expansion is confined, not just the glob's base.
+            let dir = format!("{base}/{name}");
+            match crate::resolve_within_root(root, &dir) {
+                Some(_) => {
+                    dirs.insert(dir);
+                }
+                None => out_of_root += 1,
             }
         }
-    } else if !pattern.contains('*') && root.join(pattern).is_dir() {
-        dirs.insert(pattern.to_string());
+        out_of_root
+    } else if !pattern.contains('*') {
+        match crate::resolve_within_root(root, pattern) {
+            Some(full) => {
+                if full.is_dir() {
+                    dirs.insert(pattern.to_string());
+                }
+                0
+            }
+            None => 1,
+        }
+    } else {
+        0
     }
 }
 
@@ -1495,6 +1548,62 @@ mod tests {
         // Verbs bind at the root only.
         assert_eq!(index.verbs.get("start"), None);
         assert_eq!(index.verbs.get("build").unwrap(), "pnpm:build");
+    }
+
+    #[test]
+    fn a_dotdot_member_pattern_is_not_walked_and_the_skip_is_reported() {
+        // The manifests are repository-controlled input: a `../` member would
+        // otherwise index — and let `run_script` execute in — whatever the
+        // checkout happens to sit next to.
+        let outer = tempfile::tempdir().unwrap();
+        write(
+            outer.path(),
+            "sibling/package.json",
+            r#"{"scripts": {"exfil": "cat ~/.ssh/id_rsa"}}"#,
+        );
+        let root = outer.path().join("repo");
+        std::fs::create_dir_all(&root).unwrap();
+        write(
+            &root,
+            "package.json",
+            r#"{"workspaces": ["../sibling", "../*", "packages/*"], "scripts": {"build": "true"}}"#,
+        );
+        write(&root, "pnpm-lock.yaml", "");
+        write(
+            &root,
+            "packages/app/package.json",
+            r#"{"scripts": {"dev": "vite"}}"#,
+        );
+
+        let index = ScriptIndex::detect_blocking(&root);
+        assert!(
+            index.scripts.iter().all(|e| e.name != "exfil"),
+            "an out-of-root member was walked: {:?}",
+            index.scripts.iter().map(|e| &e.id).collect::<Vec<_>>()
+        );
+        assert!(
+            index.scripts.iter().all(|e| !e.dir.contains("..")),
+            "a member dir escaped the root: {:?}",
+            index.scripts.iter().map(|e| &e.dir).collect::<Vec<_>>()
+        );
+        // In-root members still index normally.
+        assert!(
+            index
+                .scripts
+                .iter()
+                .any(|e| e.dir == "packages/app" && e.name == "dev"),
+            "confinement dropped a legitimate member"
+        );
+        // The skip is observable, not silent: `../sibling` and the `../*`
+        // base both resolve outside the root.
+        assert_eq!(index.out_of_root_members, 2);
+        assert!(
+            index
+                .render_list(None)
+                .contains("resolve outside the workspace root"),
+            "{}",
+            index.render_list(None)
+        );
     }
 
     #[test]

--- a/stella-tools/src/subprocess_env.rs
+++ b/stella-tools/src/subprocess_env.rs
@@ -6,6 +6,48 @@
 //! or long-running server lets ordinary repository code print or exfiltrate
 //! the credential that pays for the agent. Apply [`crate::subprocess_env::scrub_sensitive_env`] as
 //! the final environment mutation before every such spawn.
+//!
+//! Two families are removed, and they are removed for different reasons:
+//!
+//! * **Credentials** ([`crate::subprocess_env::is_sensitive_env_name`]) — the variable's *value* is
+//!   or names a secret. Matched by exact name, by a credential suffix, and by
+//!   the names trusted settings register at startup.
+//! * **Ambient authority** ([`crate::subprocess_env::is_ambient_authority_env_name`]) — the value is
+//!   not a secret, but possessing the variable hands the child authority it
+//!   should not inherit, or redirects what a program it runs will execute.
+//!   `SSH_AUTH_SOCK` (a live agent socket signs for the user's keys) and the
+//!   git config/command-injection family (`GIT_CONFIG_COUNT` +
+//!   `GIT_CONFIG_KEY_0` + `GIT_CONFIG_VALUE_0` sets *any* git config key for
+//!   every `git` the subprocess runs; `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`
+//!   and `GIT_PROXY_COMMAND` each name a program git execs) live here. This
+//!   is the same family `stella-cli`'s `.env`-file loader refuses to import,
+//!   applied at the other end of the pipe. It lives here rather than in
+//!   `stella-fleet`'s `SystemGitCli` so `stella-tools`' and `stella-cli`'s
+//!   own git invocations get identical treatment from one list.
+//!
+//! # Re-admitting one variable: `STELLA_SUBPROCESS_ENV_ALLOW`
+//!
+//! Widening a scrub breaks real workflows — a Django dev server started via
+//! `start_process` needs `DJANGO_SECRET_KEY`, and a deploy-key setup drives
+//! git through `GIT_SSH_COMMAND`. The operator re-admits a variable by naming
+//! it in the `STELLA_SUBPROCESS_ENV_ALLOW` environment variable, a
+//! comma-separated list of **exact** names:
+//!
+//! ```sh
+//! STELLA_SUBPROCESS_ENV_ALLOW=DJANGO_SECRET_KEY,SSH_AUTH_SOCK stella
+//! ```
+//!
+//! Matching is exact (ASCII case-insensitive) by design: there are no globs
+//! and no suffix forms, so the hatch can re-admit a named variable but can
+//! never be used to switch the scrub off wholesale. Two further limits:
+//!
+//! * It is read from **Stella's own process environment** only, never from a
+//!   command's `[env]` overrides — a repository tool manifest cannot widen
+//!   the policy that is about to be applied to it.
+//! * A name that trusted settings registered as a model credential
+//!   ([`crate::subprocess_env::register_sensitive_env_names`]) is never re-admitted. The registry is
+//!   monotonic for the process lifetime, so the credential paying for the
+//!   agent cannot be handed back by editing one environment variable.
 
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
@@ -35,6 +77,56 @@ const CREDENTIAL_SOURCE_ENV_VARS: &[&str] = &[
     "GOOGLE_APPLICATION_CREDENTIALS",
     "AZURE_FEDERATED_TOKEN_FILE",
 ];
+
+/// Credential suffixes. Deliberately *specific*: bare `_KEY` and `_AUTH` are
+/// absent because they overmatch ordinary configuration — `PUBLIC_KEY`,
+/// `LICENSE_KEY`, `SSH_KEY_PATH`, `AUTH_URL` — and silently stripping those
+/// from every model-launched subprocess breaks builds with no diagnostic.
+/// Each entry here names something that is a secret in essentially every
+/// spelling it appears in.
+const CREDENTIAL_ENV_SUFFIXES: &[&str] = &[
+    "_API_KEY",
+    "_APIKEY",
+    "_TOKEN",
+    "_PASSWORD",
+    "_SECRET",
+    "_SECRET_KEY",
+    "_PRIVATE_KEY",
+    "_ACCESS_KEY",
+    "_CREDENTIALS",
+    "_CREDENTIAL",
+    "_PAT",
+];
+
+/// Ambient-authority variables: not secret *values*, but channels that let a
+/// child act as the user or redirect what a program it runs will execute.
+///
+/// `SSH_AUTH_SOCK` is a live agent socket — a child holding it can sign with
+/// the user's keys without ever seeing them. The `GIT_*` entries are git's
+/// documented command- and config-injection surface: `GIT_CONFIG_GLOBAL` /
+/// `GIT_CONFIG_SYSTEM` repoint git at an attacker-written config file, and
+/// `GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF` / `GIT_PROXY_COMMAND` name a
+/// program git will exec.
+const AMBIENT_AUTHORITY_ENV_VARS: &[&str] = &[
+    "SSH_AUTH_SOCK",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_SSH_COMMAND",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_PROXY_COMMAND",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
+/// The numbered halves of git's `GIT_CONFIG_COUNT` protocol
+/// (`GIT_CONFIG_KEY_0`, `GIT_CONFIG_VALUE_12`, …). The index is unbounded, so
+/// these are matched by prefix rather than enumerated; no legitimate variable
+/// starts with either string.
+const GIT_CONFIG_NUMBERED_PREFIXES: &[&str] = &["GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"];
+
+/// Environment variable naming exact names the operator re-admits to every
+/// scrubbed subprocess. See this module's docs for the contract.
+pub const SUBPROCESS_ENV_ALLOW_VAR: &str = "STELLA_SUBPROCESS_ENV_ALLOW";
 
 /// Exact environment authentication channels documented by GitHub CLI.
 /// Trusted `gh` call sites may preserve these while still removing every
@@ -80,7 +172,7 @@ where
 pub fn is_sensitive_env_name(name: &OsStr) -> bool {
     let upper = name.to_string_lossy().to_ascii_uppercase();
     matches!(upper.as_str(), "API_KEY" | "TOKEN" | "PASSWORD" | "SECRET")
-        || ["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"]
+        || CREDENTIAL_ENV_SUFFIXES
             .iter()
             .any(|suffix| upper.ends_with(suffix))
         || AWS_CREDENTIAL_ENV_VARS.contains(&upper.as_str())
@@ -93,6 +185,39 @@ pub fn is_sensitive_env_name(name: &OsStr) -> bool {
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .contains(&upper)
             })
+}
+
+/// Whether an environment variable name carries ambient authority rather than
+/// a secret value — an agent socket, or one of git's config/command-injection
+/// channels. Separate from [`is_sensitive_env_name`] on purpose: callers that
+/// ask "did this credential get registered for scrubbing?" must keep getting
+/// an answer about credentials.
+pub fn is_ambient_authority_env_name(name: &OsStr) -> bool {
+    let upper = name.to_string_lossy().to_ascii_uppercase();
+    AMBIENT_AUTHORITY_ENV_VARS.contains(&upper.as_str())
+        || GIT_CONFIG_NUMBERED_PREFIXES
+            .iter()
+            .any(|prefix| upper.starts_with(prefix))
+}
+
+/// The full scrub predicate: everything [`scrub_sensitive_env`] removes.
+pub fn is_scrubbed_env_name(name: &OsStr) -> bool {
+    is_sensitive_env_name(name) || is_ambient_authority_env_name(name)
+}
+
+/// Exact names the operator re-admitted through [`SUBPROCESS_ENV_ALLOW_VAR`],
+/// uppercased. Read from Stella's own environment on every scrub so a test —
+/// or a `stella` invoked with a different value — is never answered from a
+/// cached first reading.
+fn operator_allowlist() -> Vec<String> {
+    let Some(raw) = std::env::var_os(SUBPROCESS_ENV_ALLOW_VAR) else {
+        return Vec::new();
+    };
+    raw.to_string_lossy()
+        .split(',')
+        .map(|entry| entry.trim().to_ascii_uppercase())
+        .filter(|entry| !entry.is_empty())
+        .collect()
 }
 
 fn allowlisted_sensitive_env_is_safe_to_preserve(
@@ -155,17 +280,18 @@ pub fn scrub_sensitive_std_env_except(
     // A provider credential name learned from trusted settings always wins
     // over an integration allowlist collision. For example, if a custom
     // provider is configured to use `GH_TOKEN`, `gh` authentication must fail
-    // closed rather than inheriting the model-spend credential.
+    // closed rather than inheriting the model-spend credential. The same rule
+    // governs the operator's `STELLA_SUBPROCESS_ENV_ALLOW` hatch.
+    let operator_allowed = operator_allowlist();
+    let operator_allowed: Vec<&str> = operator_allowed.iter().map(String::as_str).collect();
     let is_preserved = |name: &OsStr| {
-        allowlisted_sensitive_env_is_safe_to_preserve(
-            name,
-            preserved_names,
-            is_registered_model_credential_name(name),
-        )
+        let registered = is_registered_model_credential_name(name);
+        allowlisted_sensitive_env_is_safe_to_preserve(name, preserved_names, registered)
+            || allowlisted_sensitive_env_is_safe_to_preserve(name, &operator_allowed, registered)
     };
     let mut names: Vec<OsString> = std::env::vars_os()
         .filter_map(|(name, _)| {
-            (is_sensitive_env_name(&name) && !is_preserved(&name)).then_some(name)
+            (is_scrubbed_env_name(&name) && !is_preserved(&name)).then_some(name)
         })
         .collect();
 
@@ -176,29 +302,21 @@ pub fn scrub_sensitive_std_env_except(
         command
             .get_envs()
             .filter(|(name, value)| {
-                value.is_some() && is_sensitive_env_name(name) && !is_preserved(name)
+                value.is_some() && is_scrubbed_env_name(name) && !is_preserved(name)
             })
             .map(|(name, _)| name.to_os_string())
             .collect::<Vec<_>>(),
     );
+    // Belt and braces for the exactly-known names: remove them whether or not
+    // this process or this command carries them, so the child's environment
+    // states their absence rather than inheriting one that appeared between
+    // the snapshot above and the spawn.
     names.extend(
         AWS_CREDENTIAL_ENV_VARS
             .iter()
-            .filter(|name| {
-                !preserved_names
-                    .iter()
-                    .any(|allowed| name.eq_ignore_ascii_case(allowed))
-            })
-            .map(OsString::from),
-    );
-    names.extend(
-        CREDENTIAL_SOURCE_ENV_VARS
-            .iter()
-            .filter(|name| {
-                !preserved_names
-                    .iter()
-                    .any(|allowed| name.eq_ignore_ascii_case(allowed))
-            })
+            .chain(CREDENTIAL_SOURCE_ENV_VARS)
+            .chain(AMBIENT_AUTHORITY_ENV_VARS)
+            .filter(|name| !is_preserved(OsStr::new(*name)))
             .map(OsString::from),
     );
 
@@ -268,6 +386,42 @@ pub(crate) mod test_support {
         }
     }
 
+    /// Sets one process environment variable for the guard's lifetime,
+    /// serialized against every other environment-mutating test through the
+    /// same `ENV_LOCK` [`InheritedCredentialFixture`] takes.
+    pub struct ScopedEnvVar {
+        name: &'static str,
+        previous: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl ScopedEnvVar {
+        pub fn set(name: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+            let previous = std::env::var_os(name);
+            // SAFETY: the guard owns ENV_LOCK for its whole lifetime and no
+            // production thread runs in this test process.
+            unsafe { std::env::set_var(name, value) };
+            Self {
+                name,
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: the guard still owns ENV_LOCK during restoration.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.name, value),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
     pub fn assert_scrubbed(output: &str) {
         assert_eq!(
             output, "|||visible|present",
@@ -326,6 +480,138 @@ mod tests {
                 "{benign} must remain available to task subprocesses"
             );
         }
+    }
+
+    #[test]
+    fn widened_credential_suffixes_catch_real_spellings_without_eating_configuration() {
+        for secret in [
+            "STRIPE_SECRET_KEY",
+            "DJANGO_SECRET_KEY",
+            "DEPLOY_PRIVATE_KEY",
+            "MINIO_ACCESS_KEY",
+            "SENTRY_APIKEY",
+            "REGISTRY_CREDENTIALS",
+            "VAULT_CREDENTIAL",
+            "GITHUB_PAT",
+        ] {
+            assert!(
+                is_sensitive_env_name(OsStr::new(secret)),
+                "{secret} must be classified as sensitive"
+            );
+        }
+        // `_KEY` and `_AUTH` are deliberately NOT suffixes: they overmatch
+        // ordinary configuration, and stripping these would break builds
+        // with no diagnostic anywhere.
+        for benign in [
+            "PUBLIC_KEY",
+            "LICENSE_KEY",
+            "SSH_KEY_PATH",
+            "AUTH_URL",
+            "PARTITION_KEY",
+            "SORT_KEY",
+        ] {
+            assert!(
+                !is_sensitive_env_name(OsStr::new(benign)),
+                "{benign} must remain available to task subprocesses"
+            );
+        }
+    }
+
+    #[test]
+    fn git_injection_family_and_agent_socket_are_ambient_authority_not_credentials() {
+        for name in [
+            "GIT_CONFIG_COUNT",
+            "GIT_CONFIG_KEY_0",
+            "GIT_CONFIG_VALUE_12",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_SYSTEM",
+            "GIT_SSH_COMMAND",
+            "GIT_EXTERNAL_DIFF",
+            "GIT_PROXY_COMMAND",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "SSH_AUTH_SOCK",
+        ] {
+            assert!(
+                is_ambient_authority_env_name(OsStr::new(name)),
+                "{name} hands a child authority it must not inherit"
+            );
+            assert!(
+                is_scrubbed_env_name(OsStr::new(name)),
+                "{name} not scrubbed"
+            );
+            assert!(
+                !is_sensitive_env_name(OsStr::new(name)),
+                "{name} is ambient authority, not a credential string"
+            );
+        }
+        // The numbered prefixes end in `_`, so a name that merely starts with
+        // the same letters is untouched — and git's own ordinary variables
+        // stay available to a subprocess.
+        for benign in [
+            "GIT_CONFIG_KEYRING",
+            "GIT_AUTHOR_NAME",
+            "GIT_TERMINAL_PROMPT",
+            "GIT_PAGER",
+        ] {
+            assert!(
+                !is_scrubbed_env_name(OsStr::new(benign)),
+                "{benign} must remain available to task subprocesses"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn operator_allowlist_readmits_an_exact_name_and_only_an_exact_name() {
+        let _allow = test_support::ScopedEnvVar::set(
+            SUBPROCESS_ENV_ALLOW_VAR,
+            " DJANGO_SECRET_KEY , GIT_SSH_COMMAND ",
+        );
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args([
+                "-c",
+                "printf '%s|%s|%s|%s|%s' \
+                 \"${DJANGO_SECRET_KEY-unset}\" \
+                 \"${GIT_SSH_COMMAND-unset}\" \
+                 \"${MY_DJANGO_SECRET_KEY-unset}\" \
+                 \"${GIT_CONFIG_KEY_0-unset}\" \
+                 \"${OPENROUTER_API_KEY-unset}\"",
+            ])
+            .env("DJANGO_SECRET_KEY", "dev-server-key")
+            .env("GIT_SSH_COMMAND", "ssh -i deploy_key")
+            // A suffix-shaped near-miss of an allowlisted name, so an
+            // allowlist that matched by suffix would re-admit it.
+            .env("MY_DJANGO_SECRET_KEY", "must-not-leak")
+            .env("GIT_CONFIG_KEY_0", "core.pager")
+            .env("OPENROUTER_API_KEY", "must-not-leak");
+        scrub_sensitive_env(&mut command);
+
+        let output = command.output().await.expect("spawn shell");
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "dev-server-key|ssh -i deploy_key|unset|unset|unset"
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_allowlist_cannot_re_admit_a_registered_model_credential() {
+        register_sensitive_env_names(["STELLA_TEST_ALLOWLIST_MODEL_CRED"]);
+        let _allow = test_support::ScopedEnvVar::set(
+            SUBPROCESS_ENV_ALLOW_VAR,
+            "STELLA_TEST_ALLOWLIST_MODEL_CRED",
+        );
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args([
+                "-c",
+                "printf '%s' \"${STELLA_TEST_ALLOWLIST_MODEL_CRED-unset}\"",
+            ])
+            .env("STELLA_TEST_ALLOWLIST_MODEL_CRED", "model-spend-secret");
+        scrub_sensitive_env(&mut command);
+
+        let output = command.output().await.expect("spawn shell");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "unset");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Implements five of the trust-boundary rulings on #615. Each item there was a decision, not an engineering gap: something untrusted — a model-supplied string, a repo-supplied config value, an inherited environment variable — is about to cross into a subprocess environment, a DOM, a filesystem walk, or an acceptance gate, and the strict answer breaks a real workflow while the permissive one leaves the hole open. These five are ruled and landed; the rest stay open on #615 (list at the bottom).

## What landed

### 1. Environment scrub policy — widen, with an escape hatch
`stella-tools/src/subprocess_env.rs`

The two proposals in #615 contradicted each other about whether to widen at all. Resolution:

- **Added** credential suffixes: `_SECRET_KEY`, `_PRIVATE_KEY`, `_ACCESS_KEY`, `_APIKEY`, `_CREDENTIALS`, `_CREDENTIAL`, `_PAT`. `STRIPE_SECRET_KEY` no longer passes through to every model-controlled subprocess.
- **Not added**: bare `_KEY` and `_AUTH`. They demonstrably overmatch (`PUBLIC_KEY`, `LICENSE_KEY`, `SSH_KEY_PATH`, `AUTH_URL`) and would silently strip legitimate env from every model-launched subprocess, with no diagnostic anywhere. A test pins that they are *not* scrubbed, so a future widening has to argue with a red test rather than slip in.
- `SSH_AUTH_SOCK` added as an exact entry — ambient authority (a live agent socket signs for the user's keys), not a credential string.

> [!IMPORTANT]
> **Blast radius — `SSH_AUTH_SOCK` is the one behavior change here most likely to be overturned.**
>
> Scrubbing it **breaks `git push` / `git fetch` over SSH when the model runs git through the `bash` tool, `run_script`, a hook, or `start_process`** — anywhere ssh-agent was doing the authenticating. The failure is a normal SSH auth failure, not a Stella error, so it will not obviously point back at this change.
>
> `stella-fleet`'s `SystemGitCli` is **not** affected: it only runs local plumbing (`worktree add/remove`, `add`, `commit`, `rev-parse`, `branch`) and never reaches the network.
>
> Workaround is one variable: `STELLA_SUBPROCESS_ENV_ALLOW=SSH_AUTH_SOCK`. It is documented in the module doc as the primary example.
>
> If a maintainer decides agent-mediated SSH push is a workflow worth keeping by default, this is a one-line revert (drop `SSH_AUTH_SOCK` from `AMBIENT_AUTHORITY_ENV_VARS`) that leaves the rest of the ruling intact — the git config/command-injection family does not depend on it.

**The escape hatch is what makes widening safe.** `STELLA_SUBPROCESS_ENV_ALLOW` is a comma-separated list of **exact** names:

```sh
STELLA_SUBPROCESS_ENV_ALLOW=DJANGO_SECRET_KEY,SSH_AUTH_SOCK stella
```

No globs, no suffix forms — it can re-admit `DJANGO_SECRET_KEY` for a Django dev server, but cannot be used to disable the scrub wholesale. Two further limits, both tested:

- It is read from **Stella's own process environment** only, never from a command's `[env]` overrides — a repository tool manifest cannot widen the policy about to be applied to it.
- A name trusted settings registered as a model credential (`register_sensitive_env_names`) is **never** re-admitted. The registry is monotonic for the process lifetime, so the credential paying for the agent cannot be handed back by editing one environment variable.

I chose the env var over the settings surface deliberately: `scrub_sensitive_env` is called from ~25 sites (`glob.rs`, `grep.rs`, `staleness.rs`, `hook_runner.rs`, `SystemGitCli::run`, …) that have no settings context, and threading one through all of them is a much larger change than this ruling asks for. The variable is documented in the module doc with the contract and both limits.

### 2. Git env scrub — the decision moved into `subprocess_env`
`stella-fleet/src/git.rs`, `stella-tools/src/subprocess_env.rs`

**Dependency direction checked first**: `stella-fleet` already depends on `stella-tools` (and already called `subprocess_env::scrub_sensitive_env`), so there is no cycle and no need for a shared-`const` workaround. The family moved into the shared scrub outright, which is the option #615 called "or better":

`GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` (prefix-matched — the index is unbounded), `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`.

`stella-tools`' and `stella-cli`'s own git invocations now get identical treatment from one list, behind the same exact-name hatch — so a deploy-key setup re-admits `GIT_SSH_COMMAND` by name.

These are ambient authority, not credential strings, so they classify under a separate predicate (`is_ambient_authority_env_name`), with `is_scrubbed_env_name` as the union the scrub uses. `is_sensitive_env_name` keeps its contract intact — `enterprise_telemetry` asks it "did this credential get registered for scrubbing?" and must keep getting an answer about credentials.

`git.rs` keeps only its *repo-targeting* list (`GIT_DIR` and friends), which exists for a different reason (a `-C` override inside a git hook). `GIT_ALTERNATE_OBJECT_DIRECTORIES` moved out of it so there is exactly one list per concern, and a comment points at the shared scrub.

The numbered forms are unit-tested (`GIT_CONFIG_KEY_0`, `GIT_CONFIG_VALUE_12`), including the negative case that the trailing underscore matters — `GIT_CONFIG_KEYRING` is untouched.

### 3. SVG sanitizer — closed fully
`stella-media/src/svg.rs`

- `style` added to the denied-attribute branch. Dropped outright rather than URL-filtered: parsing CSS to decide is a second parser's worth of attack surface.
- The `//`-substring test replaced with a real scheme test: `<ascii-alpha>[a-z0-9+.-]*:` anchored at the start of the trimmed value, and applied to `url(…)` arguments too. **A `data:` URI contains no `//` at all**, which is exactly why `fill="url(data:…)"` survived the old rule. A bare `#fragment` and relative paths still pass.
- **The false-positive risk the deferral names is guarded on both axes.** The scheme test is anchored *and* only applied to attributes that can actually dereference their value: `href`, `xlink:href`, `src`, `fill`, `stroke`, `filter`, `mask`, `clip-path`, `cursor`, `marker`, `color-profile`, `style`, plus the `marker-*` / `mask-*` / `*-image` / `*-source` families. Both halves are load-bearing — `font-family="Foo: Bar"` reads as a scheme under an anchored test, and is safe only because `font-family` is not a resource attribute. There is a unit test asserting exactly that (`starts_with_url_scheme("Foo: Bar")` is `true`, and the attribute survives anyway).
- Hostile corpus: `style="background-image:url(data:image/svg+xml;base64,…)"`, `fill="url(data:…)"`, `filter`/`mask`/`clip-path`/`marker-end` variants, a `data:text/html` payload, `href="javascript:alert(1)"`, `href="//evil.example/x.svg"`.
- Negative corpus proving legitimate SVG survives with **zero** removals: `href="#gradient"`, `fill="url(#grad)"`, `d="M0 0L1 1"`, `transform="translate(1,2)"`, `font-family="Foo: Bar"`.
- Rule list rewritten (rule 6 restated, rule 7 added) and the "Known limits" block replaced with what is now true: the rule's reach is the resource-attribute list, so a new dereferencing attribute has to join `is_resource_reference_attribute` in the same change.

**Second pass on the attribute list** (review caught `cursor`, commit 2). `cursor="url(evil.svg), auto"` and `cursor="url(data:…), auto"` are valid SVG 1.1 and are fetched — the same class as `fill="url(data:…)"`. Rather than patch the single miss, the whole list was re-audited. Every entry has a keyword-or-URL value grammar (never free text), so widening carries no false-positive risk:

| Attribute | In? | Why |
|---|---|---|
| `cursor` | **added** | `<funciri> [, keyword]`, genuinely fetched — the miss |
| `marker` | **added** | SVG 1.1 makes it a property but *not* a presentation attribute; conformant renderers ignore the XML attribute, lenient ones may not. Free. |
| `color-profile` | **added** | SVG 1.1 presentation attribute whose grammar includes a bare `<iri>`; removed in SVG 2. Free. |
| `mask-*` prefix | **added** | `mask-image`, `mask-border-source`. Siblings (`mask-type`, `mask-mode`) are keywords — unaffected by being scanned. |
| `*-image` / `*-source` suffix | **added** | CSS `<image>`-valued properties SVG 2 exposes as presentation attributes: `background-image`, `border-image-source`, `list-style-image` |
| `filter`, `mask`, `clip-path`, `marker-start/mid/end`, `fill`, `stroke`, `href`, `xlink:href`, `src` | already in | `<funciri>` / IRI valued |
| `stop-color`, `flood-color`, `lighting-color` | **out** | `<color>`; `icc-color` names a color profile, not a URL — no fetch |
| `xlink:role`, `xlink:arcrole`, `requiredExtensions` | **out** | IRIs that *identify*; no renderer dereferences them |
| `d`, `transform`, `font-family`, `points`, `viewBox`, `patternTransform` | **out** | Not fetched, and exactly the free-text values that can legitimately hold a colon or `//` |

Shape rules were preferred over further enumeration precisely because the `cursor` miss is evidence that enumerating a moving target does not hold. What is in and what is deliberately out is now pinned by `resource_reference_attribute_list_is_pinned`.

**One residual limit, newly recorded in the module doc**: rule 6 permits a *relative* reference (`fill="url(sprite.svg#g)"`), which `xml:base="https://host/"` could re-base off-host. `xml:base` is removed in SVG 2 and browsers dropped it years ago for this class of reason, so nothing acts on it today. Closing it means either dropping `xml:base` outright or refusing relative references — a separate ruling about what a same-directory reference is worth, left on #615.

### 4. `expand_member_pattern` confinement — confine, visibly
`stella-tools/src/scripts.rs`

Confined with `resolve_within_root`, so a member pattern from `Cargo.toml` / `package.json` / `pnpm-workspace.yaml` cannot index a directory outside the root. Each glob *expansion* is confined too, not just the glob base — a member dir can itself be a symlink out of the tree.

The deferral's objection was that silently dropping legitimate `../` members is a behavior change. **It is not silent**: skips ride a new `ScriptIndex::out_of_root_members` counter into `render_list`, next to the existing cap-overflow line. (`ScriptIndex` is only ever constructed inside `stella-tools` and the workspace is `publish = false`, so the field is not an API break in practice.)

Test: a repo whose `package.json` declares `["../sibling", "../*", "packages/*"]` next to a sibling holding an `exfil` script — the sibling is not walked, no member dir contains `..`, `packages/app` still indexes, `out_of_root_members == 2`, and the skip appears in `render_list`.

### 5. Witness path tightening
`stella-pipeline/src/witness.rs`

The `"rs"` arm now requires `recognized_dir`; the bare `name.contains("_test.")` fallback is gone. Cargo can only run an integration test from `tests/`, so `src/backdoor_test.rs` was accepted as a witness artifact whose required `cargo test --test <stem>` could then never pass — the flip never happens, the run burns its full revision budget, and a judge scoring the diff may still PASS, adopting the stray production file into the user's real tree.

Other languages keep their filename forms because their runners genuinely collect by filename wherever the file sits (`pytest test_*.py`, `go test ./... _test.go`). Added a full per-language shape table alongside the existing case, so every currently-legitimate path is pinned as still passing. Also added one line to `witness_prompt` telling the author role where Rust tests must live (otherwise the tightening only shows up as a denial), and updated the README's "adding a test-runner form" recipe with the rule for when a filename-only form is acceptable.

## Witness

Each of the six new security tests was confirmed the artisanal way — source logic reverted to its pre-change form with the new tests kept, then restored:

| Test | Reverted |
|---|---|
| `subprocess_env::widened_credential_suffixes_…` | FAILED |
| `scripts::a_dotdot_member_pattern_is_not_walked_…` | FAILED |
| `svg::style_attribute_is_dropped_with_its_data_uri_payload` | FAILED |
| `svg::data_uri_targets_are_stripped_everywhere_…` | FAILED |
| `witness::witness_test_path_shapes_per_language` | FAILED |
| `witness::witness_artifact_rejects_non_test_…` (new `src/backdoor_test.rs` case) | FAILED |
| `svg::cursor_url_references_are_stripped_…` (commit 2) | FAILED |
| `svg::resource_reference_attribute_list_is_pinned` (commit 2) | FAILED |

All pass with the change. The remaining new tests (`hostile_href_schemes_…`, `legitimate_svg_survives_…`, `git_injection_family_…`, the allowlist tests) are regression guards or cover code that does not exist on `main`.

## Gates

| Gate | Result |
|---|---|
| `./scripts/check-no-scratch.sh` | PASS |
| `./scripts/check-action-pins.sh` | PASS |
| `./scripts/check-file-size.sh` | PASS (see below) |
| `cargo fmt --check` | PASS |
| `cargo clippy --workspace --all-targets -- -D warnings` | PASS |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | PASS |
| `cargo test --workspace` | PASS — 0 failures |
| `cargo build --workspace --release` | PASS |

`stella-tools/src/scripts.rs` (grandfathered at 1688) grew to 1797 with the confinement and its test, so `make file-size-update` was run and the one-line baseline diff is in the commit.

**No new dependencies.**

## Still open on #615

Ruled out of this PR, deliberately:

- `start_process` gating/sandboxing — needs the operator-facing security-posture doc rewrite (`bash.rs:5-9`, `settings.rs:557-560`); separate PR.
- Extending the `command.started` fence to `run_lint` / `format_code` / `diagnostics` / `screenshot` / `ci_status` / `repo_*`.
- `command.started` byte-exactness for `run_tests` with `scope: "impacted"`.
- All four `stella-cli/src/export.rs` dashboard rows (DOM-building rewrite, CSP meta tag, `{watermark}` interpolation) and the `stella-observatory` `innerHTML` audit.
- The serve/observatory HTTP posture rows: unguessable turn ids, keep-alive for result POSTs, case-insensitive `Bearer`, the 500 error response text.
- `StorageManifest::load` error surfacing, `headless_scope_bypass` in the settings overlay, and inverting `prove_process_free_surface`'s deny-list.
- **New, found during this work**: whether the SVG sanitizer should keep permitting relative references at all, given `xml:base` re-basing. Recorded in the module's "Known limits"; needs its own ruling.

Trailer is `Refs #615` rather than `Closes` — several rows above are genuinely still undecided, and the issue should close on whichever PR lands the last of them.

Refs #615
