### PR TITLE
fix(core): reap the resources a dropped future leaves behind (#613)

### DIFF
--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -489,10 +489,25 @@ async fn run_command(mut cmd: tokio::process::Command) -> CmdOutcome {
     };
     #[cfg(unix)]
     let pid = child.id().unwrap_or(0) as i32;
+    // Cancellation backstop, the same guard every other `pre_exec(setsid)`
+    // spawn site in the workspace uses (`stella_tools::exec::GroupKillGuard`)
+    // rather than a second copy of the shape. The child is in its OWN session,
+    // so Ctrl-C's SIGINT never reaches it: without this, dropping the pipeline
+    // future mid-test (Esc, a signal, a `select!` losing the race) left a
+    // whole `cargo test`/`git diff` tree running against the workspace after
+    // the user believed the run had stopped.
+    #[cfg(unix)]
+    let mut guard = stella_tools::exec::GroupKillGuard::arm(pid);
 
     let timeout = Duration::from_secs(300);
     let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
-        Ok(Ok(output)) => output,
+        Ok(Ok(output)) => {
+            #[cfg(unix)]
+            guard.disarm();
+            output
+        }
+        // Wait failure leaves the child's state unknown — the still-armed
+        // guard kills the group on return rather than leak it.
         Ok(Err(e)) => {
             return CmdOutcome {
                 exit_code: -1,
@@ -502,11 +517,7 @@ async fn run_command(mut cmd: tokio::process::Command) -> CmdOutcome {
         }
         Err(_) => {
             #[cfg(unix)]
-            unsafe {
-                if pid > 0 {
-                    libc::kill(-pid, libc::SIGKILL);
-                }
-            }
+            guard.kill_now();
             return CmdOutcome {
                 exit_code: -1,
                 stdout_tail: String::new(),
@@ -1156,5 +1167,49 @@ mod diff_baseline_tests {
         let dir = tempfile::tempdir().unwrap();
         let runner = GitDiagnosticRunner::new(dir.path().to_path_buf());
         assert!(runner.baseline_commit().is_none());
+    }
+
+    /// #613: this crate's `pre_exec(setsid)` spawn site had no
+    /// `GroupKillGuard`, so dropping the future mid-run orphaned the whole
+    /// process group — the exact leak #582 fixed in stella-tools and skipped
+    /// here. The grandchild's pid is recorded because an orphaned direct
+    /// child is reaped by init anyway; a surviving grandchild is the leak.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_dropped_run_command_kills_the_whole_process_group() {
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("pid");
+        let script = format!("sleep 30 & echo $! > {} && wait", pidfile.display());
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.arg("-c").arg(script);
+
+        let handle = tokio::spawn(async move { run_command(cmd).await });
+        let mut pid = None;
+        for _ in 0..250 {
+            if let Some(p) = std::fs::read_to_string(&pidfile)
+                .ok()
+                .and_then(|s| s.trim().parse::<i32>().ok())
+            {
+                pid = Some(p);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let pid = pid.expect("the child never started");
+
+        handle.abort();
+        let _ = handle.await;
+
+        let mut dead = false;
+        for _ in 0..250 {
+            if unsafe { libc::kill(pid, 0) } == -1 {
+                dead = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(dead, "cancelled run_command left subprocess {pid} running");
     }
 }

--- a/stella-cli/src/signals.rs
+++ b/stella-cli/src/signals.rs
@@ -26,6 +26,37 @@
 //! So the signal races the work future, and losing that race drops the work
 //! — on the thread that owns the `block_on`, inside a live runtime. That
 //! drop *is* the teardown.
+//!
+//! # The contract (#613)
+//!
+//! What a SIGINT or SIGTERM now **guarantees**:
+//!
+//! - every RAII guard on the interrupted work future's stack runs, inside a
+//!   live runtime — that is what reaps `setsid` child process groups
+//!   (`GroupKillGuard`), releases fleet claim locks (`ClaimGuard`), removes a
+//!   `verify_done` shadow worktree (`ShadowDirGuard`), and stops a detached
+//!   context warm;
+//! - the process exits `128 + signum` (130 for SIGINT, 143 for SIGTERM), so a
+//!   script wrapping `stella run` can tell "the user stopped this" from "this
+//!   failed";
+//! - shutdown is *bounded*: the runtime gets two seconds to retire blocking
+//!   tasks and then goes anyway, so one wedged `spawn_blocking` cannot make
+//!   Ctrl-C look ignored;
+//! - a **second** signal is a hard kill. The default disposition is restored
+//!   the moment the first one is caught, so a guard that wedges can never trap
+//!   the user in an uninterruptible process.
+//!
+//! What it does **not** guarantee:
+//!
+//! - nothing awaits during teardown. A cleanup that genuinely needs an `await`
+//!   — `verify_done`'s `git worktree` unregistration, `run_best_of_n`'s
+//!   candidate-workspace removal — does not run, by construction; those
+//!   resources are reclaimed by a prune on the next start instead;
+//! - it only covers work driven through [`block_on_interruptible`]. Short
+//!   local commands that build their own runtime (`stella models refresh`)
+//!   create no reapable resources and are deliberately not wrapped;
+//! - it is not a `kill -9` substitute for the child of a child that
+//!   `setsid`s itself out of the group Stella knows about.
 
 use std::future::Future;
 
@@ -86,13 +117,26 @@ async fn first_signal() -> Interrupt {
 /// on its stack. Nothing waits on those guards: none of them await, and one
 /// that needed to could not have run from `Drop` at all.
 pub(crate) async fn until_interrupted<F: Future>(work: F) -> Result<F::Output, Interrupt> {
+    race(work, first_signal()).await
+}
+
+/// The coordinator itself, over an arbitrary `signal` future.
+///
+/// Split out of [`until_interrupted`] purely so the state transition is
+/// testable: [`first_signal`] can only be driven by raising a real signal at
+/// the *process*, which in a test harness would take down every other test in
+/// the binary. Production has exactly one caller and it passes `first_signal`.
+async fn race<F: Future>(
+    work: F,
+    signal: impl Future<Output = Interrupt>,
+) -> Result<F::Output, Interrupt> {
     let mut work = Box::pin(work);
     tokio::select! {
         // A work future that has already completed wins the race — a signal
         // arriving in the same tick must not discard a finished turn.
         biased;
         output = &mut work => Ok(output),
-        signal = first_signal() => {
+        signal = signal => {
             // Restore the default disposition before running teardown, so a
             // second Ctrl-C is a hard kill. A guard that wedges must never
             // be able to trap the user in an uninterruptible process.
@@ -153,20 +197,23 @@ mod tests {
         assert_eq!(out, Ok(7));
     }
 
+    /// A guard that records its own drop — the synchronous shape every RAII
+    /// guard in this workspace has (`GroupKillGuard` is one `libc::kill`,
+    /// `ClaimGuard` one DELETE, `ShadowDirGuard` one `remove_dir_all`).
+    struct Guard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     /// The property the whole module exists for: when the work future is
-    /// dropped, its guards run. `GroupKillGuard` is synchronous, so a plain
-    /// `Drop` witness models it exactly.
+    /// dropped, its guards run.
     #[tokio::test]
     async fn dropping_the_work_future_runs_its_guards() {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicBool, Ordering};
-
-        struct Guard(Arc<AtomicBool>);
-        impl Drop for Guard {
-            fn drop(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
 
         let fired = Arc::new(AtomicBool::new(false));
         let flag = fired.clone();
@@ -190,6 +237,42 @@ mod tests {
             fired.load(Ordering::SeqCst),
             "dropping the work future must run the guards on its stack"
         );
+    }
+
+    /// The coordinator transition, end to end over a stand-in signal source
+    /// (#613): a signal must abandon the in-flight work, run its guards, and
+    /// report *which* signal it was so `main` can pick the exit code. The
+    /// signal itself is never raised at the process level — that would kill
+    /// the whole test binary — so `race` is driven with an explicit future.
+    #[tokio::test]
+    async fn a_signal_abandons_the_work_and_names_itself() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        for signal in [Interrupt::Int, Interrupt::Term] {
+            let fired = Arc::new(AtomicBool::new(false));
+            let flag = fired.clone();
+            let work = async move {
+                let _guard = Guard(flag);
+                std::future::pending::<u32>().await
+            };
+
+            let outcome = race(work, async move { signal }).await;
+
+            assert_eq!(outcome, Err(signal), "the signal must be reported as-is");
+            assert!(
+                fired.load(Ordering::SeqCst),
+                "{signal:?} must run the guards on the abandoned work's stack"
+            );
+        }
+    }
+
+    /// The `biased` arm ordering, which is not cosmetic: a signal landing in
+    /// the same tick as a completed turn must not discard the turn's result.
+    #[tokio::test]
+    async fn work_that_already_finished_beats_a_simultaneous_signal() {
+        let outcome = race(async { 7u32 }, async { Interrupt::Int }).await;
+        assert_eq!(outcome, Ok(7));
     }
 
     #[test]

--- a/stella-context/src/lib.rs
+++ b/stella-context/src/lib.rs
@@ -57,6 +57,7 @@ mod error;
 mod provider;
 mod retrieval;
 mod store;
+mod warm;
 mod writeback;
 
 pub use clock::{Clock, FixedClock, SystemClock, format_rfc3339};

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -382,6 +382,17 @@ pub struct NodeRow {
 /// and a recall's latency grow monotonically with the workspace's lifetime.
 /// That is fine at CLI-local scale and is the plane's first scaling wall; a
 /// forget/compaction path is the tracked follow-up, not an oversight.
+///
+/// # Drop
+///
+/// Dropping the store **stops its background warm task** (#613): `Drop` raises
+/// the cancel flag the batch loop checks and aborts the join handle. Warming is
+/// no longer detached-until-done — if you need it finished, call
+/// [`Self::await_warm`] first. Committed batches are unaffected (each is its own
+/// transaction) and the remainder is caught up at the next mount, so the only
+/// difference is that work for a store nobody holds stops. A caller that already
+/// joined sees nothing: `await_warm` took the handle, so `Drop` finds none. See
+/// [`crate::warm`] for why this is a flag plus an abort, never a spawn.
 pub struct ContextStore {
     /// The DB path, kept so warming can open its own WAL connection.
     path: PathBuf,
@@ -394,6 +405,24 @@ pub struct ContextStore {
     clock: Arc<dyn Clock>,
     /// The background warm task, joinable via `await_warm`.
     warm: Mutex<Option<tokio::task::JoinHandle<Result<usize, ContextError>>>>,
+    /// Raised by `Drop`, checked between warm batches.
+    warm_cancel: crate::warm::WarmCancel,
+}
+
+impl Drop for ContextStore {
+    fn drop(&mut self) {
+        self.warm_cancel.cancel();
+        // `get_mut` rather than `lock`: `&mut self` already proves exclusive
+        // access, so there is no lock to contend or poison here.
+        if let Some(handle) = self
+            .warm
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            handle.abort();
+        }
+    }
 }
 
 impl ContextStore {
@@ -427,6 +456,7 @@ impl ContextStore {
             fingerprint,
             clock,
             warm: Mutex::new(None),
+            warm_cancel: crate::warm::WarmCancel::default(),
         })
     }
 
@@ -446,8 +476,10 @@ impl ContextStore {
             let embedder = store.embedder.clone();
             let fingerprint = store.fingerprint.id();
             let clock = store.clock.clone();
-            let task =
-                handle.spawn(async move { warm_index(path, embedder, fingerprint, clock).await });
+            let cancel = store.warm_cancel.clone();
+            let task = handle.spawn(async move {
+                crate::warm::warm_index(path, embedder, fingerprint, clock, cancel).await
+            });
             *lock(&store.warm) = Some(task);
         }
         Ok(store)
@@ -469,6 +501,11 @@ impl ContextStore {
     /// — the same answer as "warming never started" (no runtime at
     /// [`Self::open_and_warm`], or an in-memory store). Read `Ok(0)` as "there
     /// is no warm left to wait for", never as "the index was already complete".
+    ///
+    /// Unchanged by the `Drop` added in #613 — taking the handle is exactly
+    /// what makes `Drop` a no-op for a caller who already joined. But a caller
+    /// who never joins no longer gets a detached warm that finishes on its
+    /// own: see the type's `# Drop` section.
     pub async fn await_warm(&self) -> Result<usize, ContextError> {
         let handle = lock(&self.warm).take();
         match handle {
@@ -482,12 +519,16 @@ impl ContextStore {
     /// Drive embedding catch-up to completion synchronously (awaitable).
     /// Reused by the background warm task; exposed for callers/tests that want
     /// a deterministic, joined warm without a spawn.
+    ///
+    /// It shares the store's cancel flag, which is inert here: only `Drop`
+    /// raises it, and `&self` keeps the store alive for the whole call.
     pub async fn warm_now(&self) -> Result<usize, ContextError> {
-        warm_index(
+        crate::warm::warm_index(
             self.path.clone(),
             self.embedder.clone(),
             self.fingerprint.id(),
             self.clock.clone(),
+            self.warm_cancel.clone(),
         )
         .await
     }
@@ -610,7 +651,7 @@ fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
 /// reader/writer, `NORMAL` sync (durable enough with WAL, far cheaper than
 /// `FULL`), foreign keys on, and a busy timeout so a warm-task write never
 /// races the main connection into `SQLITE_BUSY`.
-fn open_connection(path: &Path) -> Result<Connection, ContextError> {
+pub(crate) fn open_connection(path: &Path) -> Result<Connection, ContextError> {
     let conn = Connection::open(path)?;
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;\
@@ -683,48 +724,6 @@ fn register_fingerprint(
         ],
     )?;
     Ok(())
-}
-
-/// Background embedding catch-up: embed every live node whose content lacks a
-/// vector under the active fingerprint. Opens its own WAL connection (so it
-/// never contends with the store's lock) and writes each batch as one
-/// transaction (`L-L1` crash consistency). Returns the count embedded.
-async fn warm_index(
-    path: PathBuf,
-    embedder: Arc<dyn Embedder>,
-    fingerprint: String,
-    clock: Arc<dyn Clock>,
-) -> Result<usize, ContextError> {
-    // An in-memory store's second connection would be a different empty DB;
-    // warming only makes sense for a file-backed store.
-    if path.as_os_str() == ":memory:" {
-        return Ok(0);
-    }
-    let conn = open_connection(&path)?;
-    let pending = nodes_missing_embedding(&conn, &fingerprint)?;
-    if pending.is_empty() {
-        return Ok(0);
-    }
-
-    let mut embedded = 0usize;
-    // Batch the *embedder* calls and the transactions, so a kill mid-index
-    // loses at most one chunk (`L-L1`) and a backend with a request-size limit
-    // is never handed the whole corpus at once. Note this does NOT bound peak
-    // memory: `pending` above already materialized every un-embedded node's
-    // content. Streaming that query is the fix for very large first indexes.
-    const BATCH: usize = 64;
-    for chunk in pending.chunks(BATCH) {
-        let texts: Vec<String> = chunk.iter().map(|(_, c)| c.clone()).collect();
-        let vectors = embedder.embed(&texts).await?;
-        let now = clock.now_rfc3339();
-        let tx = conn.unchecked_transaction()?;
-        for ((content_hash, _), emb) in chunk.iter().zip(vectors.iter()) {
-            store_embedding(&tx, content_hash, &fingerprint, &emb.vector, &now)?;
-            embedded += 1;
-        }
-        tx.commit()?;
-    }
-    Ok(embedded)
 }
 
 // Low-level accessors (pub(crate)) shared by retrieval.rs and writeback.rs.
@@ -1335,7 +1334,7 @@ pub(crate) fn list_domains(
 
 /// Live nodes lacking a vector under `fingerprint`, as `(content_hash, content)`.
 /// Deduplicated by content hash so identical content is embedded once.
-fn nodes_missing_embedding(
+pub(crate) fn nodes_missing_embedding(
     conn: &Connection,
     fingerprint: &str,
 ) -> Result<Vec<(String, String)>, ContextError> {

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -392,7 +392,8 @@ pub struct NodeRow {
 /// transaction) and the remainder is caught up at the next mount, so the only
 /// difference is that work for a store nobody holds stops. A caller that already
 /// joined sees nothing: `await_warm` took the handle, so `Drop` finds none. See
-/// [`crate::warm`] for why this is a flag plus an abort, never a spawn.
+/// the crate-private `warm` module for why this is a flag plus an abort, never
+/// a spawn.
 pub struct ContextStore {
     /// The DB path, kept so warming can open its own WAL connection.
     path: PathBuf,

--- a/stella-context/src/warm.rs
+++ b/stella-context/src/warm.rs
@@ -1,0 +1,293 @@
+//! Embedding catch-up ("warming") and its cancellation contract.
+//!
+//! [`ContextStore::open_and_warm`](crate::ContextStore::open_and_warm) spawns
+//! [`warm_index`] as a detached tokio task at mount (`L-C1`: pay indexing at
+//! mount, not on the first prompt). This module owns that task's body and the
+//! one flag that can stop it early.
+//!
+//! # Why there is a cancel flag at all
+//!
+//! The task used to be genuinely detached: nothing aborted it and its batch
+//! loop had no deadline, budget, or abort check, so a store dropped mid-warm
+//! left a task embedding — and writing to a SQLite file — for a workspace no
+//! one was using any more. On a large first index that is real CPU and real
+//! WAL traffic after the session it belonged to has gone (#613).
+//!
+//! `ContextStore`'s `Drop` now sets [`WarmCancel`] and aborts the join handle.
+//! Both are needed, and neither is redundant:
+//!
+//! - `abort()` only takes effect at an `.await` point. The task spends most of
+//!   its time inside `Embedder::embed`, which is an await for a hosted
+//!   backend but resolves immediately for the pure-Rust default — a large
+//!   `HashEmbedder` warm can therefore run whole batches without yielding.
+//! - The flag is checked between batches, so it stops a task that abort
+//!   cannot reach, at a boundary where the store is already consistent: each
+//!   batch is its own transaction (`L-L1`), so stopping early leaves committed
+//!   batches durable and the remainder simply un-embedded — which is exactly
+//!   the state warming exists to catch up on, and the next mount will.
+//!
+//! What is deliberately NOT here is a `tokio::spawn` from `Drop`. During
+//! runtime shutdown — the case a Ctrl-C'd session is in — that spawn silently
+//! does nothing, so it would look like teardown in review while leaking in
+//! production. Setting an `AtomicBool` and calling `JoinHandle::abort` are
+//! both synchronous and need no runtime.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::clock::Clock;
+use crate::embed::Embedder;
+use crate::error::ContextError;
+use crate::store::{nodes_missing_embedding, open_connection, store_embedding};
+
+/// How many nodes are embedded and committed per transaction. Batching bounds
+/// what a kill mid-index loses (`L-L1`) and keeps a backend with a
+/// request-size limit from being handed the whole corpus at once.
+const BATCH: usize = 64;
+
+/// The stop flag shared by a [`crate::ContextStore`] and its background warm
+/// task. Cloneable and cheap; the store holds one, the task the other.
+///
+/// Only `ContextStore::drop` ever raises it, so a live store's warm always
+/// runs to completion.
+#[derive(Clone, Default)]
+pub(crate) struct WarmCancel(Arc<AtomicBool>);
+
+impl WarmCancel {
+    /// Stop the warm at its next batch boundary. Idempotent.
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether the warm has been asked to stop.
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// Background embedding catch-up: embed every live node whose content lacks a
+/// vector under the active fingerprint. Opens its own WAL connection (so it
+/// never contends with the store's lock) and writes each batch as one
+/// transaction (`L-L1` crash consistency). Returns the count embedded.
+///
+/// Returns `Ok(n)` — not an error — when `cancel` cuts it short: the batches
+/// it did commit are durable and correct, and "how many vectors exist now" is
+/// the honest answer to give a caller. There is no partial-write state to
+/// report.
+pub(crate) async fn warm_index(
+    path: PathBuf,
+    embedder: Arc<dyn Embedder>,
+    fingerprint: String,
+    clock: Arc<dyn Clock>,
+    cancel: WarmCancel,
+) -> Result<usize, ContextError> {
+    // An in-memory store's second connection would be a different empty DB;
+    // warming only makes sense for a file-backed store.
+    if path.as_os_str() == ":memory:" {
+        return Ok(0);
+    }
+    let conn = open_connection(&path)?;
+    let pending = nodes_missing_embedding(&conn, &fingerprint)?;
+    if pending.is_empty() {
+        return Ok(0);
+    }
+
+    let mut embedded = 0usize;
+    // Note the batching does NOT bound peak memory: `pending` above already
+    // materialized every un-embedded node's content. Streaming that query is
+    // the fix for very large first indexes.
+    for chunk in pending.chunks(BATCH) {
+        // The abort check the loop lacked. Between batches, so the store is
+        // at a transaction boundary and nothing is half-written.
+        if cancel.is_cancelled() {
+            break;
+        }
+        let texts: Vec<String> = chunk.iter().map(|(_, c)| c.clone()).collect();
+        let vectors = embedder.embed(&texts).await?;
+        let now = clock.now_rfc3339();
+        let tx = conn.unchecked_transaction()?;
+        for ((content_hash, _), emb) in chunk.iter().zip(vectors.iter()) {
+            store_embedding(&tx, content_hash, &fingerprint, &emb.vector, &now)?;
+            embedded += 1;
+        }
+        tx.commit()?;
+    }
+    Ok(embedded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::SystemClock;
+    use crate::embed::{EmbedError, EmbedderFingerprint, Embedding, HashEmbedder};
+    use crate::store::{ContextStore, NodeInput, NodeKind};
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+
+    /// An embedder that parks inside the first batch until the test lets go,
+    /// so a drop can be delivered while the warm is provably in flight.
+    ///
+    /// The gate receiver is *taken out* of the shared struct and awaited on
+    /// the embed future's own stack. That is what makes the witness
+    /// deterministic instead of timing-based: when the task is dropped, the
+    /// receiver goes with it, and the test's `Sender::closed()` resolves.
+    struct GatedEmbedder {
+        inner: HashEmbedder,
+        calls: AtomicUsize,
+        started: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        gate: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for GatedEmbedder {
+        fn fingerprint(&self) -> EmbedderFingerprint {
+            self.inner.fingerprint()
+        }
+
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(tx) = self
+                .started
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .take()
+            {
+                let _ = tx.send(());
+            }
+            let gate = self.gate.lock().unwrap_or_else(|p| p.into_inner()).take();
+            if let Some(rx) = gate {
+                let _ = rx.await;
+            }
+            self.inner.embed(texts).await
+        }
+    }
+
+    /// Seed `count` nodes whose vectors exist only under a *stale* embedder
+    /// revision, which is what leaves work for a later warm to do: `upsert`
+    /// embeds inline under its own store's fingerprint, so seeding with the
+    /// same embedder would leave nothing pending.
+    async fn seed(path: &std::path::Path, count: usize) {
+        let store = ContextStore::open_with(
+            path,
+            Arc::new(HashEmbedder::with_revision("stale")),
+            Arc::new(SystemClock),
+        )
+        .unwrap();
+        let mut delta = crate::writeback::ContextDelta::new();
+        for i in 0..count {
+            delta = delta.with_node(
+                NodeInput::new(NodeKind::Concept, format!("node-{i}"))
+                    .with_content(format!("distinct content {i}")),
+            );
+        }
+        store.upsert(delta).await.unwrap();
+    }
+
+    /// #613: dropping the store must stop its detached warm task. Before this,
+    /// nothing aborted the handle and the batch loop had no abort check, so
+    /// the task kept embedding for a store nobody held.
+    ///
+    /// The assertion is on the task's future being *dropped* (the gate sender
+    /// observing its receiver disappear), which is exact — no sleep, no
+    /// "wait and hope it didn't advance".
+    #[tokio::test]
+    async fn dropping_the_store_stops_the_background_warm() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("context.db");
+        seed(&path, BATCH * 3).await;
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (mut gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+        let embedder = Arc::new(GatedEmbedder {
+            inner: HashEmbedder::default(),
+            calls: AtomicUsize::new(0),
+            started: Mutex::new(Some(started_tx)),
+            gate: Mutex::new(Some(gate_rx)),
+        });
+
+        let store =
+            ContextStore::open_and_warm(&path, embedder.clone(), Arc::new(SystemClock)).unwrap();
+        started_rx.await.expect("the warm task never began a batch");
+        assert_eq!(embedder.calls.load(Ordering::SeqCst), 1);
+
+        drop(store);
+
+        // Resolves only when the receiver — which lives on the aborted task's
+        // stack — is dropped. On the old code it never resolves, so the
+        // timeout is the failure report rather than a hang.
+        tokio::time::timeout(std::time::Duration::from_secs(10), gate_tx.closed())
+            .await
+            .expect("dropping the store must abort the in-flight warm task");
+        assert_eq!(
+            embedder.calls.load(Ordering::SeqCst),
+            1,
+            "no further batch may start after the store is dropped"
+        );
+    }
+
+    /// The flag half, independent of `abort`: a warm already asked to stop
+    /// does no work at all, and stops at a batch boundary rather than
+    /// mid-transaction.
+    #[tokio::test]
+    async fn a_cancelled_warm_stops_at_a_batch_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("context.db");
+        seed(&path, BATCH * 2).await;
+
+        let cancel = WarmCancel::default();
+        cancel.cancel();
+        assert!(cancel.is_cancelled());
+
+        let embedder = Arc::new(HashEmbedder::default());
+        let fingerprint = embedder.fingerprint().id();
+        let embedded = warm_index(
+            path.clone(),
+            embedder.clone(),
+            fingerprint.clone(),
+            Arc::new(SystemClock),
+            cancel,
+        )
+        .await
+        .unwrap();
+        assert_eq!(embedded, 0, "a cancelled warm must not embed a batch");
+
+        // Un-cancelled, the same call embeds everything — so the zero above is
+        // the flag, not an empty work list.
+        let embedded = warm_index(
+            path,
+            embedder,
+            fingerprint,
+            Arc::new(SystemClock),
+            WarmCancel::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(embedded, BATCH * 2);
+    }
+
+    /// `await_warm`'s documented join-once semantics are unchanged by the new
+    /// `Drop`: a caller that already joined sees the same answer it always
+    /// did, and dropping afterwards aborts nothing (the handle is gone).
+    #[tokio::test]
+    async fn joining_before_the_drop_keeps_await_warm_s_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("context.db");
+        seed(&path, 3).await;
+
+        let store = ContextStore::open_and_warm(
+            &path,
+            Arc::new(HashEmbedder::default()),
+            Arc::new(SystemClock),
+        )
+        .unwrap();
+        assert_eq!(store.await_warm().await.unwrap(), 3);
+        // Join-once: the handle was taken, so a second call is `Ok(0)`.
+        assert_eq!(store.await_warm().await.unwrap(), 0);
+        drop(store);
+
+        // The work survived the drop, because it had already completed.
+        let reopened = ContextStore::open(&path).unwrap();
+        assert_eq!(reopened.warm_now().await.unwrap(), 0);
+    }
+}

--- a/stella-mcp/src/stdio.rs
+++ b/stella-mcp/src/stdio.rs
@@ -17,9 +17,14 @@
 //!    requests can be outstanding at once — though today
 //!    [`crate::client::McpClient`] holds its connection mutex for the whole
 //!    call, so calls to one server are serialized a layer above this one.
-//!    Dropping a `request` future (a caller-side timeout) leaves its slot in
-//!    the map until the matching response arrives or the connection is drained
-//!    by EOF/`close`; the sender is then discarded harmlessly.
+//!    Dropping a `request` future (a caller-side timeout, Ctrl-C, a `select!`
+//!    losing the race) reclaims its slot immediately: the slot is owned by a
+//!    [`PendingSlot`] RAII guard on the request future's own stack, which is
+//!    why the map is behind a `std::sync::Mutex` and not tokio's — `Drop`
+//!    cannot await. Before #613 the entry and its `oneshot` sender leaked
+//!    until the matching response arrived or the connection was drained by
+//!    EOF/`close`, so a server that timed out N times held N dead slots for
+//!    the life of the session.
 //!
 //! Server stderr is kept on its **own pipe**, never merged into stdout, so a
 //! server that logs to stderr cannot corrupt the JSON-RPC framing — but it is
@@ -105,7 +110,56 @@ const STDERR_SETTLE: Duration = Duration::from_millis(150);
 /// unterminated event.
 const MAX_LINE_BYTES: u64 = 8 * 1024 * 1024;
 
-type Pending = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value, McpError>>>>>;
+/// The in-flight request table: response id → the waiter's `oneshot` sender.
+///
+/// The lock is a **`std::sync::Mutex`**, not tokio's, and that is load-bearing
+/// (#613). A dropped `request` future — a caller-side timeout, Ctrl-C, a
+/// `select!` losing the race — must reclaim its slot, and reclamation can only
+/// happen in `Drop`, which cannot `await`. The two shapes that a tokio mutex
+/// leaves are both wrong: leak the entry (what this file did until #613 — one
+/// map entry plus its sender per timed-out call, held until EOF or `close()`),
+/// or `tokio::spawn` the removal from `Drop`, which silently does nothing
+/// during runtime shutdown, precisely the case being fixed.
+///
+/// The one hazard of a sync mutex in async code is holding the guard across an
+/// `.await`, which would block the executor thread. It never happens here:
+/// every critical section is a single `insert`/`remove`/`take` on a `HashMap`
+/// and the guard is dropped before the statement ends — see [`lock_pending`],
+/// [`PendingSlot`], and the `std::mem::take` drains in [`read_loop`] and
+/// `close`. Keep it that way.
+type Pending = Arc<std::sync::Mutex<HashMap<u64, oneshot::Sender<Result<Value, McpError>>>>>;
+
+/// Lock the pending map, recovering from a poisoned mutex — a panicking
+/// waiter must not wedge every later request on this connection.
+///
+/// **Never hold the returned guard across an `.await`.**
+fn lock_pending(
+    pending: &Pending,
+) -> std::sync::MutexGuard<'_, HashMap<u64, oneshot::Sender<Result<Value, McpError>>>> {
+    pending
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Owns one row of the pending map for the lifetime of a `request` call, and
+/// removes it on drop (#613).
+///
+/// Always armed: on the happy path the reader task has already taken the entry
+/// by the time this drops, so the removal is a no-op — ids are monotonic and
+/// never reused, so it can never reclaim someone else's slot. That makes the
+/// cancelled path (the future dropped mid-`await`) and the success path the
+/// same code, with no flag to forget to set.
+struct PendingSlot {
+    pending: Pending,
+    id: u64,
+}
+
+impl Drop for PendingSlot {
+    fn drop(&mut self) {
+        // Synchronous by construction — see the note on [`Pending`].
+        lock_pending(&self.pending).remove(&self.id);
+    }
+}
 
 /// The last few lines a child wrote to stderr, kept so a dead server can say
 /// *why* it died (#638).
@@ -226,7 +280,7 @@ impl StdioTransport {
             .take()
             .ok_or_else(|| McpError::Transport("child process has no stderr".into()))?;
 
-        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending: Pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let closed = Arc::new(AtomicBool::new(false));
         // Drain stderr continuously into the ring: an unread pipe would
         // eventually block a chatty child mid-write, so this task keeps
@@ -254,6 +308,13 @@ impl StdioTransport {
         })
     }
 
+    /// How many requests are currently outstanding. The observable that makes
+    /// the #613 slot leak testable at all.
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        lock_pending(&self.pending).len()
+    }
+
     /// The "not connected" error, carrying whatever the child last wrote to
     /// stderr — for a server that died on startup that tail is the only
     /// explanation the operator will ever get.
@@ -274,17 +335,20 @@ impl Transport for StdioTransport {
 
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let (tx, rx) = oneshot::channel();
-        self.pending.lock().await.insert(id, tx);
+        lock_pending(&self.pending).insert(id, tx);
+        // From here the slot belongs to this future's stack: every exit —
+        // the write failing, the response arriving, or the CALLER DROPPING
+        // this future mid-`await` — reclaims it. No `.await` is held under
+        // the lock above; the guard dies with the statement.
+        let _slot = PendingSlot {
+            pending: self.pending.clone(),
+            id,
+        };
 
         let request = JsonRpcRequest::new(id, method, params);
         let line = encode_line(&request)?;
 
-        // Write under the stdin lock; on any write failure, reclaim the
-        // pending slot so it never leaks.
-        if let Err(e) = self.write_line(&line).await {
-            self.pending.lock().await.remove(&id);
-            return Err(e);
-        }
+        self.write_line(&line).await?;
 
         // The reader task fulfills this via the oneshot. A dropped sender
         // (reader exited on EOF) surfaces as a closed connection.
@@ -335,8 +399,13 @@ impl Transport for StdioTransport {
         // so without this drain a concurrent `request` awaiting its response
         // would hang until its own caller-side timeout (forever, for a caller
         // that has none). Same shape as the reader's EOF drain.
-        let mut pending = self.pending.lock().await;
-        for (_id, tx) in pending.drain() {
+        //
+        // The whole map is moved out under the lock and the sends happen
+        // outside it: `oneshot::Sender::send` never awaits, but taking first
+        // keeps the critical section a single statement, which is the
+        // invariant [`Pending`] depends on.
+        let orphaned = std::mem::take(&mut *lock_pending(&self.pending));
+        for (_id, tx) in orphaned {
             let _ = tx.send(Err(McpError::Closed(self.stderr_tail.annotate(format!(
                 "server `{}` connection was closed before the response arrived",
                 self.server_name
@@ -446,9 +515,13 @@ async fn read_loop<R: AsyncRead + Unpin>(
         // server->client surface.
         if message.is_response()
             && let Some(id) = message.correlated_id()
-            && let Some(tx) = pending.lock().await.remove(&id)
         {
-            let _ = tx.send(message.into_result());
+            // Take the waiter out under the lock, then release it before the
+            // send — no `.await` under the sync mutex ([`Pending`]).
+            let waiter = lock_pending(&pending).remove(&id);
+            if let Some(tx) = waiter {
+                let _ = tx.send(message.into_result());
+            }
         }
     }
 
@@ -460,8 +533,8 @@ async fn read_loop<R: AsyncRead + Unpin>(
     if let Some(drain) = stderr_drain {
         let _ = tokio::time::timeout(STDERR_SETTLE, drain).await;
     }
-    let mut map = pending.lock().await;
-    for (_id, tx) in map.drain() {
+    let orphaned = std::mem::take(&mut *lock_pending(&pending));
+    for (_id, tx) in orphaned {
         let _ = tx.send(Err(McpError::Closed(stderr.annotate(format!(
             "server `{server_name}` closed the connection before responding"
         )))));
@@ -552,14 +625,74 @@ mod tests {
         let _ = transport.close().await;
     }
 
+    /// #613: a caller-side timeout drops the `request` future, and the slot it
+    /// registered in the pending map must go with it. `cat` is a server that
+    /// never answers — it echoes the request line back, and an echoed
+    /// *request* (it carries a `method`) is never routed to a waiter — so the
+    /// call can only end by being dropped.
+    ///
+    /// Before the [`PendingSlot`] guard every such call left one map entry
+    /// plus its `oneshot` sender behind until EOF or `close()`; a session that
+    /// timed out repeatedly against one server grew the map monotonically.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_dropped_request_reclaims_its_pending_slot() {
+        let env = BTreeMap::new();
+        let transport = StdioTransport::spawn("cat-server", "cat", &[], &env)
+            .await
+            .expect("cat must spawn");
+
+        for expected_id in 1..=3u64 {
+            let call = transport.request("tools/list", serde_json::json!({}));
+            let timed_out = tokio::time::timeout(Duration::from_millis(150), call).await;
+            assert!(timed_out.is_err(), "cat must never answer a request");
+            assert_eq!(
+                transport.pending_len(),
+                0,
+                "request {expected_id} leaked its pending slot"
+            );
+        }
+
+        let _ = transport.close().await;
+    }
+
+    /// The guard in isolation: the row is gone the moment it drops, with no
+    /// runtime, no `await`, and no spawn — the property that makes it correct
+    /// during runtime shutdown.
+    #[test]
+    fn the_pending_slot_guard_reclaims_synchronously_on_drop() {
+        let pending: Pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let (tx, _rx) = oneshot::channel();
+        lock_pending(&pending).insert(7, tx);
+
+        let slot = PendingSlot {
+            pending: pending.clone(),
+            id: 7,
+        };
+        assert_eq!(lock_pending(&pending).len(), 1);
+        drop(slot);
+        assert!(lock_pending(&pending).is_empty());
+
+        // Reclaiming a row the reader already took is a harmless no-op — ids
+        // are monotonic, so it can never evict a later request's slot.
+        let slot = PendingSlot {
+            pending: pending.clone(),
+            id: 7,
+        };
+        let (other, _other_rx) = oneshot::channel();
+        lock_pending(&pending).insert(8, other);
+        drop(slot);
+        assert_eq!(lock_pending(&pending).len(), 1);
+    }
+
     /// Drive `read_loop` over an in-memory pipe with one pending waiter, feed
     /// it `lines`, and return what (if anything) the waiter for `id` received.
     async fn route_lines(id: u64, lines: Vec<Vec<u8>>) -> Option<Result<Value, McpError>> {
         let (reader_side, mut writer_side) = tokio::io::duplex(64 * 1024);
-        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending: Pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let closed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = oneshot::channel();
-        pending.lock().await.insert(id, tx);
+        lock_pending(&pending).insert(id, tx);
 
         let reader = tokio::spawn(read_loop(
             reader_side,
@@ -697,10 +830,10 @@ mod tests {
             .expect("write stderr");
         drop(stderr_writer); // the child's stderr pipe closes with it
 
-        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending: Pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let closed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = oneshot::channel();
-        pending.lock().await.insert(1, tx);
+        lock_pending(&pending).insert(1, tx);
 
         drop(stdout_writer); // …and so does its stdout: EOF, connection dead
         let reader = tokio::spawn(read_loop(

--- a/stella-mcp/src/stdio.rs
+++ b/stella-mcp/src/stdio.rs
@@ -19,7 +19,7 @@
 //!    call, so calls to one server are serialized a layer above this one.
 //!    Dropping a `request` future (a caller-side timeout, Ctrl-C, a `select!`
 //!    losing the race) reclaims its slot immediately: the slot is owned by a
-//!    [`PendingSlot`] RAII guard on the request future's own stack, which is
+//!    `PendingSlot` RAII guard on the request future's own stack, which is
 //!    why the map is behind a `std::sync::Mutex` and not tokio's — `Drop`
 //!    cannot await. Before #613 the entry and its `oneshot` sender leaked
 //!    until the matching response arrived or the connection was drained by

--- a/stella-tools/src/bash.rs
+++ b/stella-tools/src/bash.rs
@@ -274,15 +274,13 @@ impl Tool for Bash {
         // Cancellation backstop: a dropped future (Esc, the engine's tool
         // timeout, a fleet stop) must not leave the setsid'd group running.
         #[cfg(unix)]
-        let mut guard = crate::exec::GroupKillGuard { pid, armed: true };
+        let mut guard = crate::exec::GroupKillGuard::arm(pid);
 
         let timeout = Duration::from_secs(timeout_secs);
         let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
             Ok(Ok(output)) => {
                 #[cfg(unix)]
-                {
-                    guard.armed = false;
-                }
+                guard.disarm();
                 output
             }
             // Wait failure leaves the child's state unknown — the still-armed
@@ -295,16 +293,7 @@ impl Tool for Bash {
             Err(_) => {
                 // Timeout — kill the process group.
                 #[cfg(unix)]
-                {
-                    guard.armed = false;
-                    unsafe {
-                        // Guard on a real pid: kill(-0, …) would SIGKILL
-                        // Stella's OWN process group.
-                        if pid > 0 {
-                            libc::kill(-pid, libc::SIGKILL);
-                        }
-                    }
-                }
+                guard.kill_now();
                 return ToolOutput::Error {
                     message: format!("command timed out after {timeout_secs}s"),
                 };

--- a/stella-tools/src/custom.rs
+++ b/stella-tools/src/custom.rs
@@ -462,7 +462,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
     // Cancellation backstop: a dropped future (Esc, the engine's tool
     // timeout, a fleet stop) must not leave the setsid'd group running.
     #[cfg(unix)]
-    let mut guard = crate::exec::GroupKillGuard { pid, armed: true };
+    let mut guard = crate::exec::GroupKillGuard::arm(pid);
 
     // Deliver the input as one JSON document on stdin, concurrently with
     // draining stdout/stderr, so a chatty child cannot deadlock the write.
@@ -479,9 +479,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
     let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
         Ok(Ok(output)) => {
             #[cfg(unix)]
-            {
-                guard.armed = false;
-            }
+            guard.disarm();
             output
         }
         // Wait failure leaves the child's state unknown — the still-armed
@@ -493,16 +491,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
         }
         Err(_) => {
             #[cfg(unix)]
-            {
-                guard.armed = false;
-                unsafe {
-                    // Guard on a real pid: kill(-0, …) would SIGKILL Stella's
-                    // OWN process group.
-                    if pid > 0 {
-                        libc::kill(-pid, libc::SIGKILL);
-                    }
-                }
-            }
+            guard.kill_now();
             return ToolOutput::Error {
                 message: format!(
                     "custom tool `{}` timed out after {}ms",

--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -166,10 +166,51 @@ pub(crate) async fn run_argv_untruncated(
 /// mid-wait (Esc cancels the turn), the detached process group must not keep
 /// running — and mutating the tree — after the user believes the turn
 /// stopped. Normal exit and the timeout path disarm it.
+///
+/// It is deliberately `pub`: every `pre_exec(setsid)` spawn site in the
+/// workspace must use *this* guard rather than grow a second one. A `setsid`
+/// child is in its own session, so Ctrl-C's SIGINT — delivered only to the
+/// tty's foreground process group — never reaches it; this guard is the only
+/// thing that reaps the tree, and it fires because the CLI drops the work
+/// future on a signal instead of calling `exit` (`stella-cli/src/signals.rs`).
+///
+/// Never `tokio::spawn` teardown from a `Drop` instead: during runtime
+/// shutdown the spawn silently does nothing, which is precisely the case
+/// being handled. `kill(2)` is synchronous, so this guard needs no runtime.
 #[cfg(unix)]
-pub(crate) struct GroupKillGuard {
-    pub(crate) pid: i32,
-    pub(crate) armed: bool,
+pub struct GroupKillGuard {
+    pid: i32,
+    armed: bool,
+}
+
+#[cfg(unix)]
+impl GroupKillGuard {
+    /// Arm a guard over the process group led by `pid` (a child spawned with
+    /// `pre_exec(setsid)`, so its pid *is* its process-group id). A pid of 0
+    /// — `Child::id` after the child was already reaped — is inert.
+    pub fn arm(pid: i32) -> Self {
+        Self { pid, armed: true }
+    }
+
+    /// Stop the guard from killing on drop. Call it once the group is known
+    /// to be gone: the child exited normally, or the caller already killed
+    /// the group itself on its timeout path.
+    pub fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    /// SIGKILL the group now, and disarm. The timeout path: the child is
+    /// still running and must die *before* the caller returns an error,
+    /// rather than at some later scope exit.
+    pub fn kill_now(&mut self) {
+        self.armed = false;
+        // Same real-pid guard as `Drop`.
+        if self.pid > 0 {
+            unsafe {
+                libc::kill(-self.pid, libc::SIGKILL);
+            }
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -224,7 +265,7 @@ async fn drive(
     #[cfg(unix)]
     let pid = child.id().unwrap_or(0) as i32;
     #[cfg(unix)]
-    let mut guard = GroupKillGuard { pid, armed: true };
+    let mut guard = GroupKillGuard::arm(pid);
 
     let output =
         match tokio::time::timeout(Duration::from_secs(timeout_secs), child.wait_with_output())
@@ -232,9 +273,7 @@ async fn drive(
         {
             Ok(Ok(output)) => {
                 #[cfg(unix)]
-                {
-                    guard.armed = false;
-                }
+                guard.disarm();
                 output
             }
             // Wait failure leaves the child's state unknown — the still-armed
@@ -242,15 +281,7 @@ async fn drive(
             Ok(Err(e)) => return Err(format!("command failed: {e}")),
             Err(_) => {
                 #[cfg(unix)]
-                {
-                    guard.armed = false;
-                    unsafe {
-                        // Same real-pid guard as `GroupKillGuard`.
-                        if pid > 0 {
-                            libc::kill(-pid, libc::SIGKILL);
-                        }
-                    }
-                }
+                guard.kill_now();
                 return Err(format!("`{command}` timed out after {timeout_secs}s"));
             }
         };

--- a/stella-tools/src/exec.rs
+++ b/stella-tools/src/exec.rs
@@ -160,8 +160,8 @@ pub(crate) async fn run_argv_untruncated(
 }
 
 /// SIGKILLs `pid`'s process group on drop unless disarmed — the
-/// cancellation backstop for [`drive`] and for the tools that spawn their
-/// own child instead of coming through it ([`crate::bash`],
+/// cancellation backstop for this module's shared runner and for the tools
+/// that spawn their own child instead of coming through it ([`crate::bash`],
 /// [`crate::custom`]): when the future driving a tool call is dropped
 /// mid-wait (Esc cancels the turn), the detached process group must not keep
 /// running — and mutating the tree — after the user believes the turn

--- a/stella-tools/src/verify.rs
+++ b/stella-tools/src/verify.rs
@@ -27,7 +27,7 @@
 //! teardown is now split along the one line that matters — whether the
 //! syscall is synchronous:
 //!
-//! - the `/tmp` directory is removed by [`ShadowDirGuard`], a synchronous
+//! - the `/tmp` directory is removed by `ShadowDirGuard`, a synchronous
 //!   `Drop` guard, which is the only kind that still runs during runtime
 //!   shutdown;
 //! - the git registration is reclaimed by a `git worktree prune` at the start

--- a/stella-tools/src/verify.rs
+++ b/stella-tools/src/verify.rs
@@ -18,6 +18,22 @@
 //! the witness. The shadow worktree is removed afterward, success or
 //! failure.
 //!
+//! # Cancellation
+//!
+//! "Success or failure" used to exclude a third outcome: the future being
+//! dropped (Ctrl-C, Esc, a session timeout, a caller `select!`). That skipped
+//! `cleanup_shadow` entirely and stranded both a `/tmp` directory and a
+//! `.git/worktrees` registration that no later run removed (#613). The
+//! teardown is now split along the one line that matters — whether the
+//! syscall is synchronous:
+//!
+//! - the `/tmp` directory is removed by [`ShadowDirGuard`], a synchronous
+//!   `Drop` guard, which is the only kind that still runs during runtime
+//!   shutdown;
+//! - the git registration is reclaimed by a `git worktree prune` at the start
+//!   of the *next* `verify_done`, because removing it requires an awaited
+//!   subprocess.
+//!
 //! # Reading the verdict
 //!
 //! The shadow run's output tail is always included: a shadow failure that
@@ -86,6 +102,38 @@ async fn cleanup_shadow(root: &std::path::Path, shadow: &std::path::Path) {
         .await;
     let _ = tokio::fs::remove_dir_all(shadow).await;
     let _ = git_in(root).args(["worktree", "prune"]).output().await;
+}
+
+/// Drop half of the cancellation fix (#613): removes the shadow worktree's
+/// `/tmp` **directory** synchronously.
+///
+/// [`cleanup_shadow`] cannot be an RAII guard — it awaits three git
+/// subprocesses and `tokio::fs::remove_dir_all`, and `Drop` cannot await.
+/// Spawning it from `Drop` is worse than useless: during runtime shutdown, the
+/// exact case a cancelled `verify_done` is in, the spawn silently does nothing.
+/// So the teardown is split by what each half needs:
+///
+/// - the directory goes here, because `std::fs::remove_dir_all` is one
+///   synchronous syscall that needs no runtime;
+/// - the `.git/worktrees/<name>` **registration** cannot, so it is reclaimed
+///   by the `git worktree prune` that every `verify_done` now runs at start
+///   (cheap, idempotent, and it also clears registrations stranded by earlier
+///   releases).
+///
+/// Idempotent with `cleanup_shadow`: on every non-cancelled path the directory
+/// is already gone by the time this drops and `remove_dir_all` is a no-op on a
+/// missing path, so the guard stays armed rather than carrying a flag that a
+/// future early-return could forget to set.
+struct ShadowDirGuard {
+    shadow: std::path::PathBuf,
+}
+
+impl Drop for ShadowDirGuard {
+    fn drop(&mut self) {
+        // Blocking, but bounded: a shadow worktree is a checkout of HEAD in
+        // `std::env::temp_dir()`, and this only runs on the cancellation path.
+        let _ = std::fs::remove_dir_all(&self.shadow);
+    }
 }
 
 #[async_trait]
@@ -211,6 +259,18 @@ impl Tool for VerifyDone {
             }
         };
 
+        // Prune-on-start (#613): reclaim `.git/worktrees` registrations left
+        // by a PREVIOUS run whose future was dropped. Such a run could only
+        // remove its `/tmp` directory synchronously ([`ShadowDirGuard`]);
+        // unregistering needs an awaited git call, which a `Drop` cannot make.
+        // It runs here — before either half, as soon as the repo is known to
+        // exist — so a NOT DONE or VACUOUS verdict, which never reaches
+        // `cleanup_shadow`, still collects the debris. `prune` drops only
+        // registrations whose directory is already gone, so it is cheap,
+        // idempotent, and can never disturb a live worktree (this run's or a
+        // concurrent one's).
+        let _ = git_in(root).args(["worktree", "prune"]).output().await;
+
         // Half 1: the new code must pass.
         let (new_exit, new_output) = match run(test_cmd, root, timeout_secs).await {
             Ok(pair) => pair,
@@ -258,6 +318,13 @@ impl Tool for VerifyDone {
                 };
             }
         }
+        // Armed the instant the directory exists. Everything below awaits —
+        // the file copies, and above all the shadow test run, which is where
+        // a cancelled turn actually lands — and none of it is reached when
+        // this future is dropped.
+        let _shadow_dir = ShadowDirGuard {
+            shadow: shadow.clone(),
+        };
 
         // Layer ONLY the test files onto the previous version.
         for (rel, src, relpath) in &resolved {
@@ -466,6 +533,191 @@ mod tests {
             }
             other => panic!("{other:?}"),
         }
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Count the live `.git/worktrees/*` registrations in a repo.
+    fn registrations(root: &std::path::Path) -> usize {
+        std::fs::read_dir(root.join(".git").join("worktrees"))
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0)
+    }
+
+    /// #613, drop half: the synchronous `Drop` guard removes the shadow's
+    /// `/tmp` directory with no runtime, no `await`, and no spawn — the only
+    /// shape that still works while the runtime is shutting down.
+    #[test]
+    fn the_shadow_dir_guard_removes_the_directory_synchronously_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let shadow = dir.path().join("shadow");
+        std::fs::create_dir_all(shadow.join("nested")).unwrap();
+        std::fs::write(shadow.join("nested").join("f"), b"x").unwrap();
+
+        let guard = ShadowDirGuard {
+            shadow: shadow.clone(),
+        };
+        assert!(shadow.exists());
+        drop(guard);
+        assert!(!shadow.exists(), "the guard must remove the shadow tree");
+
+        // Idempotent with `cleanup_shadow` having already run: a second drop
+        // over a missing path is a no-op, not an error.
+        drop(ShadowDirGuard { shadow });
+    }
+
+    /// #613, prune half: the `/tmp` directory the drop guard removes leaves a
+    /// `.git/worktrees/<name>` registration behind, because unregistering it
+    /// needs an awaited git call. The next `verify_done` collects it.
+    ///
+    /// The stranded state is produced directly — add a worktree, then delete
+    /// its directory the way the sync guard does — because racing a real
+    /// cancellation into the window between `worktree add` and cleanup is
+    /// racy by construction.
+    ///
+    /// The verdict is deliberately **NOT DONE**: that path returns before any
+    /// worktree is created and therefore never reaches `cleanup_shadow`,
+    /// whose trailing `prune` would otherwise make this pass vacuously. The
+    /// reclamation has to come from the prune at *start*.
+    #[tokio::test]
+    async fn a_stranded_worktree_registration_is_pruned_on_the_next_start() {
+        let root = scaffold("prune").await;
+        let stranded = std::env::temp_dir().join(format!(
+            "stella_verify_stranded_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let out = git_in(&root)
+            .args(["worktree", "add", "--detach"])
+            .arg(&stranded)
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success(), "fixture worktree add failed");
+        // What the synchronous drop guard can do, and all it can do.
+        std::fs::remove_dir_all(&stranded).unwrap();
+        assert_eq!(
+            registrations(&root),
+            1,
+            "the fixture must leave exactly the stranded registration"
+        );
+
+        std::fs::write(root.join("witness.sh"), "grep -q 'nonexistent' impl.txt\n").unwrap();
+        let input = serde_json::json!({
+            "test_cmd": "bash witness.sh",
+            "test_files": ["witness.sh"],
+            "timeout_secs": 60
+        });
+        match VerifyDone.execute(&input, &root).await {
+            ToolOutput::Error { message } => assert!(message.contains("NOT DONE"), "{message}"),
+            other => panic!("expected NOT DONE, got {other:?}"),
+        }
+        assert_eq!(
+            registrations(&root),
+            0,
+            "verify_done must prune the stranded registration on start"
+        );
+
+        // Idempotent: a second run over an already-clean repo prunes nothing
+        // and reaches the same verdict.
+        assert!(VerifyDone.execute(&input, &root).await.is_error());
+        assert_eq!(registrations(&root), 0);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// #613, end to end: dropping the `verify_done` future while the shadow
+    /// run is in flight must not leave the shadow directory behind. The
+    /// witness script branches on whether `.git` is a directory — true in the
+    /// real workspace, false in a linked worktree, where it is a file — so
+    /// only the *shadow* half hangs, after announcing itself through a marker
+    /// file in the real root. Waiting on that marker (rather than on the
+    /// worktree appearing) is what makes the cancellation land inside the
+    /// shadow run every time instead of racing `git worktree add`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_cancelled_verify_done_removes_its_shadow_directory() {
+        use std::time::Duration;
+
+        let root = scaffold("cancelled").await;
+        let started = root.join("shadow-started");
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+        std::fs::write(
+            root.join("witness.sh"),
+            format!(
+                "if [ -d .git ]; then grep -q 'new behavior' impl.txt; else touch '{}'; sleep \
+                 300; fi\n",
+                started.display()
+            ),
+        )
+        .unwrap();
+
+        let run_root = root.clone();
+        let handle = tokio::spawn(async move {
+            VerifyDone
+                .execute(
+                    &serde_json::json!({
+                        "test_cmd": "bash witness.sh",
+                        "test_files": ["witness.sh"],
+                        "timeout_secs": 600
+                    }),
+                    &run_root,
+                )
+                .await
+        });
+
+        for _ in 0..500 {
+            if started.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(started.exists(), "the shadow run never started");
+
+        // The shadow's path, read out of THIS repo's registration — sibling
+        // tests share the `/tmp` `stella_verify_<pid>_` prefix, so scanning
+        // the temp dir would pick up their worktrees too.
+        let shadow = std::fs::read_dir(root.join(".git").join("worktrees"))
+            .ok()
+            .and_then(|entries| {
+                entries.flatten().find_map(|entry| {
+                    let gitdir = std::fs::read_to_string(entry.path().join("gitdir")).ok()?;
+                    // `<shadow>/.git` → `<shadow>`.
+                    Some(
+                        std::path::PathBuf::from(gitdir.trim())
+                            .parent()?
+                            .to_path_buf(),
+                    )
+                })
+            })
+            .expect("a running shadow test implies a registered worktree");
+
+        handle.abort();
+        let _ = handle.await;
+
+        let mut gone = false;
+        for _ in 0..250 {
+            if !shadow.exists() {
+                gone = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            gone,
+            "a cancelled verify_done left the shadow worktree at {}",
+            shadow.display()
+        );
+
+        // And the registration the synchronous guard could not remove is
+        // collected by a prune — the other half of the fix, which every later
+        // `verify_done` runs at start.
+        assert_eq!(registrations(&root), 1);
+        let _ = git_in(&root).args(["worktree", "prune"]).output().await;
+        assert_eq!(registrations(&root), 0);
+
         std::fs::remove_dir_all(&root).ok();
     }
 


### PR DESCRIPTION
## What & why

#613 is a decision issue: eleven resource leaks, all blocked on one unanswered question — who reaps a resource created mid-flight when a future is dropped (Ctrl-C, a caller `select!`, a session timeout, Esc in the deck).

**The rule this PR applies, at every site:** a synchronous `Drop` guard wherever the teardown syscall is synchronous, plus prune-on-next-start (or an explicit runner) wherever it is not. Never `tokio::spawn` from `Drop` — that spawn silently does nothing during runtime shutdown, which is exactly the case being fixed, so it is the shape that looks correct in review while leaking in production.

Refs #613

Four of the eleven rows land here. The remaining rows are deliberately out of scope and listed below so a future audit stops re-reporting them.

### 1. Signal handling — the gating item (verified, already shipped)

`stella-cli/src/signals.rs` + `main.rs`. **This landed on `main` in #658**, after #613 was filed. It was verified rather than rebuilt:

- `tokio::signal::ctrl_c` plus `SignalKind::terminate` under `#[cfg(unix)]`, with `#[cfg(not(unix))]` degrading to `ctrl_c` only;
- the signal races the work future and *drops* it inside a live runtime — no `std::process::exit` from the handler, which is precisely what would skip every `Drop`;
- bounded grace: `rt.shutdown_timeout(2s)` after the guards have run;
- `128 + signum` exit codes (130 SIGINT / 143 SIGTERM), threaded through a static so `main`'s `ExitCode` reads them;
- a **second** signal is a hard kill — the default disposition is restored the instant the first is caught.

What this PR adds: `until_interrupted` is split over a `race(work, signal)` seam so the coordinator transition is testable without raising a real signal at the process (which would take down the test binary), plus a **`# The contract` section in the module doc** stating what a signal now guarantees *and what it does not* — nothing awaits during teardown, only `block_on_interruptible` work is covered, and it is not a substitute for `kill -9` on a grandchild that `setsid`s itself away.

### 2. `ContextStore`'s detached warm task

`stella-context/src/store.rs` + new `stella-context/src/warm.rs`.

`impl Drop for ContextStore` raises a cancel flag and aborts the background warm `JoinHandle`, and the batch loop — which had no deadline, budget, or abort check — polls that flag between batches. Both halves are needed: `abort` only lands at an `.await`, and the pure-Rust `HashEmbedder` resolves immediately, so a large warm can run whole batches without yielding.

The deferral's objection is answered rather than waved past: **`await_warm`'s join-once contract is unchanged.** It *takes* the handle, so a caller who already joined leaves `Drop` nothing to abort — that is now a regression test. The behavior change (a caller relying on detached completion no longer gets it) is documented in a `# Drop` section on the type: call `await_warm` before dropping, committed batches are durable, and the remainder is caught up at the next mount.

`warm_index` moved into `warm.rs` with its rationale and tests. That is also what keeps `store.rs` off its 2142-line grandfathered ceiling — see "size ratchet" below.

### 3. MCP pending-map slot leak

`stella-mcp/src/stdio.rs`. Every timed-out call leaked one map entry plus its `oneshot` sender until EOF or `close`.

Chosen fix as ruled: the pending map swaps from `tokio::sync::Mutex` to **`std::sync::Mutex`**, so a synchronous `PendingSlot` RAII guard on the request future's own stack reclaims the row on *any* exit, including the caller dropping the future mid-`await`. No spawn from `Drop`.

The one hazard of a sync mutex in async code — holding the guard across an `.await` — is addressed explicitly: every critical section is a single `insert`/`remove`/`take` that dies with its statement. `read_loop` and `close` now `std::mem::take` the whole map under the lock and send outside it. The `Pending` type doc and `lock_pending` both say so, in those words, so the invariant is enforceable in review.

The guard is always armed rather than arm/disarm: ids are monotonic and never reused, so removing a row the reader already took is a no-op that can never evict someone else's slot.

### 4. `verify_done` leaks a registered git worktree

`stella-tools/src/verify.rs`. **Both halves**, as ruled:

- **(i)** `ShadowDirGuard` — a synchronous `Drop` guard that removes the `/tmp` directory with `std::fs::remove_dir_all`. `cleanup_shadow` cannot be an RAII guard: it awaits three git subprocesses and `tokio::fs::remove_dir_all`.
- **(ii)** `git worktree prune` at the start of every `verify_done`, reclaiming the `.git/worktrees` registration the sync guard cannot.

One refinement worth reviewer attention: the prune runs **before both verdict halves**, not just before `worktree add`. Placed at the `add`, it would be witness-vacuous — `cleanup_shadow` already prunes on the success path — and, worse, it would never run on the NOT DONE or VACUOUS paths, which return before `cleanup_shadow` and are the most common non-success outcomes. Prune-on-start is cheap and idempotent: `prune` drops only registrations whose directory is already gone, so it can never disturb a live or concurrent worktree.

### 5. The other unguarded `pre_exec(setsid)` spawn site

`stella-cli/src/agent/tools.rs::run_command` — same orphaned-process-group shape #582 fixed in stella-tools, with no guard. It now uses **the same** `GroupKillGuard`, not a second copy: the guard is `pub` with `arm` / `disarm` / `kill_now`, its doc says why every `setsid` site must reuse it, and `bash.rs` / `custom.rs` / `exec.rs` were moved onto the same constructor (they were assembling the struct literal and open-coding the timeout kill).

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Each was checked the artisanal way — the fix reverted in place, the test re-run, the fix restored:

| Test | Reverting… | Result on old code |
|---|---|---|
| `warm::tests::dropping_the_store_stops_the_background_warm` | `impl Drop for ContextStore` | FAILED (10s timeout: the task future is never dropped) |
| `warm::tests::a_cancelled_warm_stops_at_a_batch_boundary` | the between-batch abort check | FAILED (`a cancelled warm must not embed a batch`) |
| `stdio::tests::a_dropped_request_reclaims_its_pending_slot` | the `PendingSlot` guard | FAILED (`request 1 leaked its pending slot`) |
| `verify::tests::a_cancelled_verify_done_removes_its_shadow_directory` | `ShadowDirGuard` | FAILED (shadow worktree left behind) |
| `verify::tests::a_stranded_worktree_registration_is_pruned_on_the_next_start` | the prune-on-start | FAILED (`must prune the stranded registration on start`) |
| `agent::tools::…::a_dropped_run_command_kills_the_whole_process_group` | the `GroupKillGuard` | FAILED (`left subprocess N running`) |

Non-witness supporting tests: `the_pending_slot_guard_reclaims_synchronously_on_drop` and `the_shadow_dir_guard_removes_the_directory_synchronously_on_drop` (the guards in isolation — no runtime, no `await`, no spawn, which is the property that makes them correct during shutdown), `joining_before_the_drop_keeps_await_warm_s_contract` (a regression test on the contract this PR must *not* change), and `signals::tests::a_signal_abandons_the_work_and_names_itself` / `work_that_already_finished_beats_a_simultaneous_signal`.

**On flakiness.** The three cancellation tests drop a real future mid-flight, so they were written to have a deterministic observable rather than a sleep-and-hope:

- the warm test asserts on `oneshot::Sender::closed`, which resolves exactly when the aborted task's stack (holding the receiver) is dropped;
- the `verify_done` test waits on a **marker file the shadow run itself writes** before hanging. An earlier draft waited for the worktree to appear and was genuinely flaky — it could abort during `git worktree add` instead of during the shadow run. The marker removes that race; the current version was run repeatedly, green each time.
- the process-group test follows the existing `exec.rs` `dropped_run_kills_the_process_group` shape, recording the *grandchild*'s pid (an orphaned direct child is reaped by init anyway, so only a surviving grandchild is a real leak).

**What could NOT be tested, and why:**

1. **Actual signal delivery.** Raising SIGINT/SIGTERM at the process would take down the whole test binary and every other test in it. The coordinator transition is tested instead, over an explicit signal future through the new `race` seam — which covers everything except `tokio::signal`'s own registration, i.e. the part that is tokio's tested code, not ours. A vacuous "we called `ctrl_c`" test would be worse than none.
2. **The tty side of a `setsid` child never receiving Ctrl-C.** That is a terminal/session-group property, not observable from `cargo test`.
3. **The `verify_done` prune reclaiming state stranded by a *real* prior cancellation.** The test produces the stranded state directly (add a worktree, delete its directory the way the sync guard does) because racing a real cancellation into the window between `worktree add` and cleanup is racy by construction — the issue says as much. The end-to-end cancellation test covers the other half.

## The gate

Every one run locally, in this order, all green:

- [x] `./scripts/check-no-scratch.sh` — OK
- [x] `./scripts/check-action-pins.sh` — OK, all 35 pinned
- [x] `./scripts/check-file-size.sh` — OK, none grew
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- [x] `cargo test --workspace` — exit 0, no failures
- [x] `cargo build --workspace --release` — exit 0
- [x] Docs updated: module docs on `signals.rs`, `stdio.rs`, `verify.rs`, the new `warm.rs`, and the `# Drop` section on `ContextStore`

**Size ratchet:** `make file-size-update` was NOT run and `scripts/file-size-baseline.txt` is unchanged. `stella-context/src/store.rs` is at its 2142-line ceiling, so `warm_index` was extracted to a new 293-line `warm.rs` (well under the 1500 limit) — which pays for the `Drop` impl and the doc, and leaves store.rs one line *below* its ceiling. `stella-cli/src/main.rs` is untouched; the signal work is entirely inside the existing `signals.rs`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**Ruled OUT of #613 and deliberately not touched** — recorded here so a future audit stops re-reporting them:

- **`MediaError::Cancelled` (`stella-media/src/error.rs`)** — cancellation is out of scope for stella-media. The variant and its module-doc claim stay for now, tracked on #613.
- **`run_best_of_n` candidate-workspace leak (`stella-pipeline/src/pipeline.rs`)** — needs a cross-crate `CandidateWorkspace` trait reshape (a sync `remove`), which is its own change.
- **Fleet worktree reclamation / `stella fleet clean` (`stella-fleet/src/git.rs`)** and **the `file_locks` claim-TTL escape hatch (`stella-fleet/src/fleet.rs`)** — both add new user-facing CLI verbs plus a retention/expiry policy; an owner decision, not a mechanical port.
- **The deck's `!`-escape process group (`stella-tui/src/deck_shell.rs`)** and **grep/glob's `rg` spawn (`stella-tools/src/grep.rs`)** — both depend on the shared-runner decision, which is not this PR.

`Refs #613`, not `Closes` — five of eleven rows remain, four of them deliberately.

**Behavior changes a reviewer should weigh:**

1. `ContextStore` warming is no longer detached-until-done. Documented on the type; `await_warm` callers are unaffected. Every in-tree caller either joins or holds the store for the session's life.
2. `verify_done` runs one extra `git worktree prune` per invocation. It is a no-op when there is nothing stale.
3. `GroupKillGuard`'s fields are now private behind `arm`/`disarm`/`kill_now`. That is what makes reuse across crates possible and stops the next spawn site open-coding a fourth `libc::kill(-pid, SIGKILL)`.
