### PR TITLE
audit remediation: factory down, store.db retention, threat model, god-function ratchet

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,16 @@ Out of scope: vulnerabilities in the model providers themselves, and the
 inherent risk of running an agent with `bash` access on code you don't trust —
 that's the user's judgment call, not a boundary Stella claims to enforce.
 
+## Threat model
+
+`docs/design/threat-model.md` enumerates the assets, the adversaries, the
+trust boundaries, and the attack paths that cross them — including the risks
+Stella knowingly does not defend against, and why. Read it before deciding
+whether a behavior you found is a vulnerability or a documented choice: several
+of the sharper edges (no SSRF guard on `web` tools, the sandbox covering
+`bash` only, materially weaker guarantees off Unix) are deliberate and recorded
+there.
+
 ## Supported versions
 
 Pre-1.0, only the latest release (and `main`) receive security fixes.

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -1,0 +1,328 @@
+# Stella Threat Model
+
+Status: descriptive — this documents the posture as shipped, not a plan
+
+## Purpose, and why this document did not exist
+
+Stella's security reasoning has always been written down. It was just never
+written down *together*: the project trust boundary is argued in
+`stella-cli/src/settings/merge.rs`, the authority ceiling in
+`settings/authority.rs`, the subprocess scrub in
+`stella-tools/src/subprocess_env.rs`, the sandbox's scope in
+`stella-tools/src/sandbox.rs`, the deliberate absence of an SSRF guard in
+`stella-tools/src/web.rs`, the filesystem identity checks in
+`stella-store/src/private.rs`, and the dotenv refusals in
+`stella-cli/src/env_files.rs`. Each is careful. None of them can tell you
+whether the set is *complete*, because none of them enumerates the assets or
+the adversary.
+
+`SECURITY.md` is a disclosure policy plus an in-scope/out-of-scope list.
+`docs/design/enterprise-authority-telemetry.md` is an invariants list scoped to
+the managed plane. `AGENTS.md` invariant 3 covers telemetry egress. This
+document is the missing middle: assets, adversaries, boundaries, and the
+attack paths that cross them — including the ones Stella deliberately does not
+defend against.
+
+The most useful section is probably [Residual risk](#residual-risk). A threat
+model that only lists wins is marketing.
+
+## Method and scope
+
+Scope is the Stella CLI, its crates, and the state it writes on a developer
+workstation. Out of scope: vulnerabilities in model providers themselves, the
+security of code the user chooses to run, and the Oxagen Enterprise control
+plane (covered by its own design doc).
+
+The framing throughout is a single question: **what can a repository do?**
+Stella's defining exposure is that `git clone && stella` runs an agent inside
+attacker-authored content. Almost every boundary below exists to answer that.
+
+## Assets
+
+| Asset | Where it lives | Why an attacker wants it |
+|---|---|---|
+| Model provider credentials | env, `~/.stella/credentials.toml`, `settings.json` | Directly monetizable; also the pivot for exfiltrating everything the agent reads |
+| Web/session auth | `~/.stella/web_auth.toml` | Authenticated access to the user's internal services |
+| MCP OAuth tokens | `.stella/private/mcp_oauth.json` | Third-party account access |
+| Source under the workspace | the checkout | Confidentiality; also the integrity target for a supply-chain edit |
+| Execution history | `.stella/private/store.db` | Full prompt text (`executions.prompt`) and full event payloads (`events.payload`) — the richest single record of the user's work |
+| Cross-project telemetry | `~/.stella/usage.db` | Content-free by construction, but reveals project names and spend |
+| Ambient authority on the host | env, ssh agent, git config | Escalation beyond the workspace |
+| The user's compute and spend | provider accounts | Cryptomining, spend exhaustion |
+
+## Adversaries
+
+**A1 — Hostile repository.** The primary adversary. Supplies
+`.stella/settings.json`, `.stella/mcp.toml`, `.stella/tools/*.toml`,
+`.stella/{commands,agents,skills}`, `package.json` scripts, `Cargo.toml`
+members, `.env` files, and every byte the agent reads. Cannot execute code
+until Stella gives it a way to.
+
+**A2 — Prompt injection via retrieved content.** Text the agent reads — a
+file, a fetched page, a tool result, an issue body — that attempts to steer it
+into taking an action on the attacker's behalf. Distinct from A1 in that it
+attacks the *model*, not the config loader.
+
+**A3 — Local unprivileged co-tenant.** Another uid on the same machine, or a
+process running as the user, racing Stella's state files or planting files at
+paths Stella will write.
+
+**A4 — Network position.** Can observe or redirect outbound traffic. Largely
+delegated to TLS.
+
+**A5 — Malicious dependency.** In Stella's own supply chain, or in the
+workspace's. Out of scope for Stella's own defenses beyond `deny.toml` and
+release integrity.
+
+Explicitly **not** modeled: an adversary with root, or with the user's own
+shell. Stella's private-state hardening is about *identity* (this file is
+mine, not something planted here), not about defending against someone who
+already is the user.
+
+## Trust boundaries
+
+### B1 — Repository content → configuration authority
+
+The load-bearing boundary. `Settings::load`
+(`stella-cli/src/settings/merge.rs:205`) merges user, managed, and project
+scopes per provider id and per field, and the project scope is treated as
+untrusted input.
+
+Dropped from an untrusted project scope: `hooks`, `context_providers`,
+per-provider `base_url` / `api_key` / `api_key_env`, `mcp.registry_url`,
+`tools.bash`/`tools.web` set to `"on"`, and agent `prompt` overrides. Never
+read from the project scope at any trust level: the `authority` block
+(`#[serde(skip)]`) and `enterprise_telemetry`.
+
+Honored from an untrusted project: model, effort, sampling, `allowed_models`
+— they carry no credential routing — and `tools.*` set to `"off"`, because
+lower authority may always narrow.
+
+The asymmetry in that last pair is the whole design: **lower-precedence input
+may narrow authority but never widen it.**
+
+Trust is granted by `STELLA_TRUST_PROJECT=1` (`settings.rs:718`). See
+[R1](#r1--trust-is-an-env-var-not-a-decision-the-user-is-asked-to-make).
+
+### B2 — Managed ceiling → everything below it
+
+`AuthorityPolicy` (`settings/authority.rs:37`) is an org-managed ceiling read
+only from the managed scope, which itself is loaded through a hardened path
+(`O_NOFOLLOW`, single-link regular file, root-or-euid owner, no group/other
+write). Its semantics are deliberately one-directional: `off` denies; `on`
+*permits a later explicit grant but never grants by itself*.
+
+`apply_tool_ceiling` forces `tools.bash`/`tools.web` to `Off` after the merge,
+so managed denial survives explicit repository trust — the witness is
+`managed_tool_denial_survives_explicit_project_trust` (`settings.rs:1382`).
+
+### B3 — Model output → code execution
+
+The agent's tool surface is the blast radius of a successful A2. Two
+sub-boundaries matter and they are frequently conflated:
+
+- **`bash` is opt-in** (`tools.bash: "on"`), and its module doc is explicit
+  that the default surface has no shell at all.
+- **The default surface is nonetheless not execution-free.** `run_script`,
+  `start_process`, `repo_commit`/`repo_push`, and workspace custom tools all
+  execute code without `bash` ever being enabled. `start_process` spawns argv
+  directly — "no shell" is a quoting guarantee, not a power bound, which is
+  why the registry routes its joined argv through the same `command.started`
+  policy chain as `bash`.
+
+See [R2](#r2--the-default-tool-surface-executes-code).
+
+### B4 — Process → subprocess (ambient authority)
+
+`stella-tools/src/subprocess_env.rs` scrubs two families before every spawn
+(16 sites): credential-shaped names, and ambient-authority names that would
+turn a subprocess into arbitrary code execution — `GIT_CONFIG_*` (including
+the unbounded `GIT_CONFIG_KEY_n`/`VALUE_n` pairs), `GIT_SSH_COMMAND`,
+`GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND`, `SSH_AUTH_SOCK`, and others.
+
+The escape hatch `STELLA_SUBPROCESS_ENV_ALLOW` takes exact names only, no
+globs, and is read from Stella's own environment — so a repository tool
+manifest cannot widen the policy about to be applied to it. A registered
+model-credential name is never re-admitted.
+
+`stella-cli/src/env_files.rs` applies the same logic to dotenv loading: it
+refuses to ever apply `LD_*`, `DYLD_*`, `PATH`, `NODE_OPTIONS`, `BASH_ENV`,
+`GIT_SSH_COMMAND`, `LESSOPEN`, and friends, because applying them would make
+`git clone && stella` arbitrary code execution on the first subprocess.
+
+### B5 — Workspace root → filesystem
+
+`stella_tools::resolve_within_root` canonicalizes and rejects escapes, using
+`symlink_metadata` rather than `exists()` so a dangling symlink is caught.
+#695 extended this to workspace-member patterns read from `Cargo.toml`,
+`package.json`, and `pnpm-workspace.yaml`, and made out-of-root skips counted
+and surfaced rather than silent.
+
+### B6 — Stella's private state → other local processes
+
+`stella-store/src/private.rs` asserts *identity* on every private read and
+write: `O_NOFOLLOW|O_CLOEXEC`, regular file, `uid == geteuid()`, `nlink == 1`,
+mode `0600`, inside a `0700` directory whose parent is owner-controlled with
+no group/other write. `.stella/.gitignore` is generated so private state
+cannot be committed by accident.
+
+This is the boundary most weakened off Unix — see
+[R5](#r5--non-unix-platforms-are-materially-weaker).
+
+### B7 — Local execution data → network
+
+Zero telemetry egress by default is an `AGENTS.md` invariant with a real
+enforcement mechanism: `stella-store/src/content_free.rs` holds a reviewed
+allowlist of hub columns plus a sentinel harness every egress encoder
+registers with, and adding a column or an encoder key fails `make gate` until
+the allowlist is edited in the same PR.
+
+Automatic outbound calls are narrow. The models.dev catalog refresh never
+fires on a fresh install — it requires a sync row to already exist, i.e. the
+user ran `stella models refresh` at least once. Provider-native `/models`
+listings do auto-sync, but only to providers the user already supplied a key
+for. Enterprise export requires a signed managed enrollment with an exact
+HTTPS endpoint allowlist.
+
+## Attack paths
+
+| # | Path | Boundary | Status |
+|---|---|---|---|
+| P1 | Repo sets `providers.anthropic.base_url` to attacker host → key exfiltrated on first call | B1 | Mitigated (dropped untrusted) |
+| P2 | Repo sets `api_key_env` to repoint at another env var | B1 | Mitigated (dropped untrusted) |
+| P3 | Repo declares a stdio MCP server → RCE at session start | B1/B3 | Mitigated (gated on `project_code_execution_trusted`) |
+| P4 | Repo declares an `enabled` stdio `context_provider` → spawn at admission | B1 | Mitigated (dropped wholesale) |
+| P5 | Repo ships `.env` with `GIT_SSH_COMMAND` → RCE on first git subprocess | B4 | Mitigated (refused, never applied) |
+| P6 | Repo sets `GIT_CONFIG_KEY_n` in the environment a tool inherits | B4 | Mitigated (prefix-scrubbed) |
+| P7 | Workspace member pattern escapes root via `../` or glob | B5 | Mitigated (#695) |
+| P8 | Injected instruction in a read file drives `bash` to exfiltrate | B3 | Partial — sandbox is opt-in |
+| P9 | Injected instruction drives `run_script` / `start_process` | B3 | **Not mitigated by the sandbox** — see R2, R3 |
+| P10 | Injected instruction drives `web_fetch` at cloud metadata / localhost | B3 | **Deliberately not mitigated** — see R4 |
+| P11 | Co-tenant plants a symlink at a private-state path | B6 | Mitigated on Unix; not off it |
+| P12 | SVG `data:` URI smuggled past the sanitizer | — | Mitigated (#695 replaced the `//` substring test with a real scheme test) |
+| P13 | Partial-read defeats the MCP OAuth `state` CSRF check | — | Mitigated (#696 read-until-CRLFCRLF) |
+| P14 | Credential reaches a log line, trace record, or panic message | — | Mitigated (`ApiKey` has no `Display`, redacted `Debug`) |
+| P15 | Credential recovered from process memory after use | — | Partial — see R6 |
+| P16 | Credential read from `ps` | — | **Not mitigated** — see R7 |
+
+## Residual risk
+
+These are known, and in several cases deliberate. They are listed here so the
+choice is legible rather than discovered.
+
+### R1 — Trust is an env var, not a decision the user is asked to make
+
+`STELLA_TRUST_PROJECT=1` is process-wide and set before launch. There is no
+trust prompt and no persisted trust store. This differs from the
+"do you trust the authors of the files in this folder?" model users may expect
+from editors.
+
+Consequence: trust is all-or-nothing per invocation, and a user who exports it
+in their shell profile silently trusts every repository thereafter. The
+mitigation today is that the *default* is untrusted and the drops are loud
+(warnings to stderr, with the repo-controlled provider id `escape_debug`'d).
+
+### R2 — The default tool surface executes code
+
+"`bash` is off by default" is true and is not the same claim as "the agent
+cannot run code by default." `run_script` executes commands sourced from repo
+manifests (`package.json` scripts, `Makefile` targets, `Cargo.toml` aliases);
+`start_process` spawns argv; `repo_commit`/`repo_push` mutate and publish;
+workspace custom tools under `.stella/tools/` are auto-discovered.
+
+Custom tools are gated on `authority.project_custom_tools_allowed`, which
+defaults false. `run_script` and `start_process` are not gated that way — they
+route through the `command.started` policy chain, which is a policy-handler
+seam rather than an interactive confirmation.
+
+### R3 — The sandbox wraps `bash` only
+
+`STELLA_BASH_SANDBOX` (`workspace-write` / `restricted`, Seatbelt on macOS,
+`bwrap` on Linux) is off by default and, when on, confines only the `bash`
+tool. `start_process`, `run_script`, custom tools, and hooks run unconfined.
+The sandbox's own doc names prompt injection as the threat it mitigates — that
+mitigation therefore has a shape the threat does not.
+
+### R4 — No SSRF guard on web tools, by design
+
+An opted-in session can fetch any http(s) URL the host can reach, including
+`localhost` and cloud metadata endpoints. This is a documented decision: it
+matches the `bash` opt-in and is required for the "fetch my internal dev
+server" use case. The gate is the settings opt-in, not a network allowlist.
+
+One sharp edge is recorded in `web.rs`: reqwest strips `Cookie` and
+`Authorization` across a cross-host redirect, but a secret placed in a custom
+`[domains.x.headers]` entry is not in reqwest's sensitive set and **will**
+follow the redirect.
+
+### R5 — Non-Unix platforms are materially weaker
+
+Off Unix there are no managed settings at all (the loader returns
+`PermissionDenied` unconditionally), no owner/mode validation, no
+`O_NOFOLLOW`, no `0600` enforcement, no credentials-file permission advisory,
+and no legacy-state migration. `validate_owner_controlled_parent` degrades to
+"is a real directory, not a symlink."
+
+This is a considered position — refusing to store state is not a stronger
+posture than storing it under the OS's own permissions, it just moves the
+secret somewhere Stella cannot protect at all — but it means B6 and B2 should
+be read as Unix-only guarantees.
+
+### R6 — `zeroize` cannot reach copies already made
+
+`ApiKey`, `CredentialsFileData`, `Secret`, and the masked prompt buffer wipe on
+drop. The module doc is honest about the limit: it cannot reach a `String`
+that grew and reallocated, a page the OS swapped out, or a `HeaderValue`
+reqwest built from `reveal()`.
+
+### R7 — `--api-key` is visible in `ps`
+
+The credential chain accepts a CLI flag as its highest-precedence step. Flag
+values are argv and therefore readable by other processes. The flag's own help
+text steers users to an env var or the credentials file for anything
+long-lived; nothing enforces that.
+
+### R8 — The credentials file warns rather than enforces
+
+A `credentials.toml` with group/other bits set produces a `LoosePermissions`
+advisory and is read anyway. Both alternatives were considered and rejected:
+refusing locks a user out over a condition they may not be able to fix, and
+silently `chmod`-ing changes the mode of a file Stella did not create.
+
+### R9 — No secret detector exists
+
+#696 deliberately did *not* ship `AgentEvent::redacted()` or
+`AttachmentKind::is_inlined_verbatim()`, on the grounds that both would
+advertise a guarantee nothing enforces. Consequence: a secret the *user* pastes
+into a prompt, or that appears in a tool result, is stored in
+`store.db` (`executions.prompt`, `events.payload`) in the clear. The mitigation
+available today is retention — `stella storage prune` — not redaction.
+
+## Platform and posture summary
+
+| Guarantee | Unix | Windows/other |
+|---|---|---|
+| Managed authority ceiling | Yes | **No** (loader denies) |
+| Private-state owner/mode validation | Yes | No |
+| `O_NOFOLLOW` on private reads | Yes | No |
+| `0600` / `0700` enforcement | Yes | No |
+| Credentials-file permission advisory | Yes | No |
+| Subprocess env scrub | Yes | Yes |
+| Workspace-root confinement | Yes | Yes |
+| Settings trust boundary | Yes | Yes |
+
+## What would change this model
+
+- An interactive or persisted trust decision would retire R1.
+- Extending the sandbox to `start_process` / `run_script` / hooks would close
+  the gap between R3 and the threat it names.
+- Gating `run_script` behind an authority flag would narrow R2.
+- A secret detector — if one could be made accurate enough to not be
+  false assurance — would narrow R9.
+
+## Maintenance
+
+This document describes shipped behavior. When a boundary moves, it moves
+here in the same PR. The distributed doc comments cited throughout remain the
+normative source for *why* each individual check exists; this file exists to
+make the set reviewable as a set.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -12,9 +12,9 @@
 1589 stella-cli/src/candidate_ws.rs
 4489 stella-cli/src/command_deck.rs
 1503 stella-cli/src/contextgraph.rs
-1728 stella-cli/src/main.rs
+1741 stella-cli/src/main.rs
 1635 stella-cli/src/memory.rs
-2221 stella-context/src/store.rs
+2201 stella-context/src/store.rs
 2046 stella-core/src/bus.rs
 2147 stella-core/src/driver.rs
 2750 stella-core/src/driver/tests.rs
@@ -25,10 +25,10 @@
 1618 stella-model/src/bedrock.rs
 1909 stella-model/src/openai.rs
 1622 stella-model/src/zai/tests.rs
-2455 stella-pipeline/src/pipeline.rs
+2447 stella-pipeline/src/pipeline.rs
 2019 stella-pipeline/src/pipeline/tests.rs
 2424 stella-protocol/src/event.rs
-2231 stella-store/src/lib.rs
+2234 stella-store/src/lib.rs
 2168 stella-store/src/tests.rs
 1828 stella-store/src/usage.rs
 1558 stella-tools/src/media.rs

--- a/stella-cli/src/agent/engine.rs
+++ b/stella-cli/src/agent/engine.rs
@@ -550,103 +550,28 @@ fn build_provider_parts(
     effective_base_url: String,
     base_url_override: Option<&str>,
 ) -> Result<Box<dyn Provider>, String> {
-    use crate::config::Dialect;
-
-    let provider_id = provider_config.id;
-    let display_name = provider_config.display_name;
-    // The anti-invalid-slug gate, for EVERY provider (not just seeded
-    // ones): the seed floor always passes; a provider whose master-list
-    // rows are synced (`stella models refresh`) gets hard validation with
+    // The full anti-invalid-slug ladder, for EVERY provider (not just seeded
+    // ones): the seed floor always passes; a provider whose master-list rows
+    // are synced (`stella models refresh`) gets hard validation with
     // suggestions; `local` and never-synced custom endpoints keep their
     // endpoint-is-the-authority posture. See
     // `crate::model_catalog::validate_model_slug` for the full ladder.
+    //
+    // The seed-floor half of this also runs inside
+    // `stella_model::factory::build_provider`, so a caller that reaches the
+    // factory without going through here — a second host, or stella-model's
+    // own live smoke tests — still cannot construct a phantom-slug provider.
+    // Running it here first is what buys the synced-catalog escalation and its
+    // suggestions, which need the on-disk catalog this crate owns.
     crate::model_catalog::validate_model_slug(provider_config, model_id)?;
 
-    match provider_config.dialect {
-        Dialect::OpenaiResponses => {
-            let provider = stella_model::openai::OpenAiProvider::new(api_key, model_id.to_string())
-                .with_base_url(effective_base_url);
-            Ok(Box::new(provider))
-        }
-        Dialect::Anthropic => {
-            let provider =
-                stella_model::anthropic::AnthropicProvider::new(api_key, model_id.to_string())
-                    .with_base_url(effective_base_url);
-            Ok(Box::new(provider))
-        }
-        Dialect::Gemini => {
-            let provider = stella_model::gemini::GeminiProvider::new(api_key, model_id.to_string())
-                .with_base_url(effective_base_url);
-            Ok(Box::new(provider))
-        }
-        Dialect::Vertex => {
-            // The access token is `api_key` (VERTEX_ACCESS_TOKEN via the
-            // credential chain); project and location are Vertex-specific
-            // addressing, owned by `stella_model::credential` so a second
-            // host of the engine gets the same variable names, the same
-            // fallback order, and the same named errors without copying them.
-            let addressing =
-                stella_model::credential::VertexAddressing::resolve().map_err(|e| e.to_string())?;
-            let mut provider = stella_model::vertex::VertexProvider::new(
-                api_key,
-                model_id.to_string(),
-                addressing.project,
-                addressing.location,
-            );
-            if let Some(override_url) = base_url_override {
-                provider = provider.with_base_url(override_url.to_string());
-            }
-            Ok(Box::new(provider))
-        }
-        Dialect::Bedrock => {
-            // `api_key` is AWS_ACCESS_KEY_ID via the credential chain; the
-            // rest of the standard AWS env set is resolved by
-            // `stella_model::credential`, alongside the adapter that needs
-            // it. A missing secret is a named error pointing at the exact
-            // var, not a doomed unsigned request.
-            let aws = stella_model::credential::BedrockCredentials::resolve()
-                .map_err(|e| e.to_string())?;
-            let mut provider = stella_model::bedrock::BedrockProvider::new(
-                api_key,
-                aws.secret_access_key,
-                aws.session_token,
-                aws.region,
-                model_id.to_string(),
-            );
-            if let Some(override_url) = base_url_override {
-                provider = provider.with_base_url(override_url.to_string());
-            }
-            Ok(Box::new(provider))
-        }
-        // Z.ai, xAI, DeepSeek, OpenRouter, local, and config-defined
-        // providers (settings.json) — the shared Chat Completions adapter,
-        // re-identified per provider so its `Provider::id()` and error
-        // messages name the surface actually being called.
-        Dialect::OpenaiCompatible => {
-            let label = match provider_id {
-                "zai" => "Z.ai",
-                "xai" => "xAI",
-                "deepseek" => "DeepSeek",
-                "openrouter" => "OpenRouter",
-                "local" => "the local endpoint",
-                _ => display_name,
-            };
-            let mut provider = stella_model::zai::ZaiProvider::new(api_key, model_id.to_string())
-                .with_base_url(effective_base_url)
-                .with_identity(provider_id, label);
-            if provider_id == "openrouter" {
-                // First-class OpenRouter: app attribution on every request,
-                // and the gateway's own usage accounting so
-                // `CompletionResult::cost_usd` is the routed call's real
-                // price (its slugs are unseeded — see config.rs — so there
-                // is no catalog list price to fall back on).
-                provider = provider
-                    .with_attribution("https://stella.oxagen.sh", "Stella")
-                    .with_usage_accounting();
-            }
-            Ok(Box::new(provider))
-        }
-    }
+    stella_model::factory::build_provider(
+        &provider_config.factory_spec(),
+        model_id,
+        api_key,
+        effective_base_url,
+        base_url_override,
+    )
 }
 
 /// Cross-family grouping key for judge selection. Same-vendor providers must

--- a/stella-cli/src/config.rs
+++ b/stella-cli/src/config.rs
@@ -142,42 +142,31 @@ pub struct ProviderConfig {
     pub seeded: bool,
 }
 
-/// The wire dialect a provider speaks — which `stella_model` adapter is
-/// constructed for it. Serialized form is the settings.json `dialect` field
-/// (kebab-case, e.g. `"openai-compatible"`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum Dialect {
-    /// OpenAI Chat Completions shape (`stella_model::zai::ZaiProvider`,
-    /// re-identified per provider) — Z.ai, xAI, DeepSeek, OpenRouter,
-    /// local endpoints, and the default for config-defined providers.
-    OpenaiCompatible,
-    /// OpenAI Responses API (`stella_model::openai::OpenAiProvider`).
-    OpenaiResponses,
-    /// Anthropic Messages API (`stella_model::anthropic::AnthropicProvider`).
-    Anthropic,
-    /// Gemini generateContent (`stella_model::gemini::GeminiProvider`).
-    Gemini,
-    /// Vertex generateContent with project/location addressing. Built-in
-    /// only: it needs `VERTEX_PROJECT_ID`/`VERTEX_LOCATION` resolution that
-    /// a settings.json entry has no way to express.
-    Vertex,
-    /// Bedrock Converse with SigV4. Built-in only, same reasoning.
-    Bedrock,
-}
-
-impl Dialect {
-    /// Human-readable label for `stella config` / `stella models`.
-    pub fn label(self) -> &'static str {
-        match self {
-            Dialect::OpenaiCompatible => "OpenAI-compatible",
-            Dialect::OpenaiResponses => "OpenAI Responses",
-            Dialect::Anthropic => "Anthropic Messages",
-            Dialect::Gemini | Dialect::Vertex => "Gemini generateContent",
-            Dialect::Bedrock => "Bedrock Converse",
+impl ProviderConfig {
+    /// Narrow this to the parts [`stella_model::factory::build_provider`] needs.
+    ///
+    /// The factory deliberately does not take a whole `ProviderConfig`: env var
+    /// names, aliases, and the default model are credential-resolution and
+    /// config-UI concerns that belong up here, not in the model layer.
+    pub fn factory_spec(&self) -> stella_model::factory::ProviderSpec<'_> {
+        stella_model::factory::ProviderSpec {
+            id: self.id,
+            display_name: self.display_name,
+            dialect: self.dialect,
+            seeded: self.seeded,
         }
     }
 }
+
+/// The wire dialect a provider speaks — which `stella_model` adapter is
+/// constructed for it. Serialized form is the settings.json `dialect` field
+/// (kebab-case, e.g. `"openai-compatible"`).
+///
+/// Defined in [`stella_model::factory`], alongside the adapters its variants
+/// name and the factory that dispatches on it, so callers below `stella-cli`
+/// in the dependency graph can construct providers too. Re-exported here
+/// because settings.json parsing and the provider table are this module's job.
+pub use stella_model::factory::Dialect;
 
 /// All supported providers, in preference order. Order matters twice over:
 /// auto-detection picks the first row with a resolvable credential, which is

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -61,6 +61,7 @@ mod settings_check;
 mod signals;
 mod skill_manager;
 mod stats;
+mod storage_prune;
 mod subsession;
 mod tui;
 mod usage_cmd;
@@ -951,6 +952,10 @@ enum StorageCmd {
     /// Drift report: near-duplicate relations, orphaned manifest meanings,
     /// and intent coverage. Report-only — nothing is changed.
     Drift,
+    /// Bound `store.db`'s growth: drop whole executions (and every row that
+    /// hangs off them) by age and/or a ceiling. In-flight turns and
+    /// `forgotten` tombstones are never removed. Start with `--dry-run`.
+    Prune(crate::storage_prune::PruneArgs),
 }
 
 /// `stella observe` — serve the Observatory dashboard for this workspace on
@@ -1106,6 +1111,12 @@ fn load_storage_snapshot_checked(
 
 fn run_storage(cmd: &StorageCmd) -> Result<(), String> {
     use stella_graph::storage::{dedup_key, display_address, embed_card, normalize_name};
+    // Retention operates on store.db itself, not on the storage *map*, so it
+    // runs ahead of the snapshot load below — a workspace with no
+    // stella.storage.toml still has a store.db worth bounding.
+    if let StorageCmd::Prune(args) = cmd {
+        return crate::storage_prune::run(args);
+    }
     let root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let snapshot = load_storage_snapshot_checked(&root)?;
@@ -1275,6 +1286,8 @@ fn run_storage(cmd: &StorageCmd) -> Result<(), String> {
                 println!("{}", "no drift signals".dimmed());
             }
         }
+        // Handled above, before the storage-map snapshot is loaded.
+        StorageCmd::Prune(_) => unreachable!("`storage prune` returns before the map loads"),
     }
     Ok(())
 }

--- a/stella-cli/src/storage_prune.rs
+++ b/stella-cli/src/storage_prune.rs
@@ -1,0 +1,149 @@
+//! `stella storage prune` — bound `store.db`'s growth.
+//!
+//! The counterpart to `stella usage prune`. That verb bounds the *derived*
+//! cross-project hub; this one bounds the workspace's source of truth, which
+//! is the tier that actually holds prompt text and event payloads and grows a
+//! row per event forever.
+//!
+//! Deliberately conservative, because the thing being pruned is not
+//! reconstructible from anywhere else: it refuses to run without an explicit
+//! knob, `--dry-run` shows the exact report a real run would produce, and the
+//! guards that protect in-flight turns and `forgotten` tombstones are
+//! structural rather than flags (see [`stella_store::retention`]).
+
+use clap::Args;
+use colored::Colorize as _;
+
+use stella_store::Store;
+use stella_store::retention::{RetentionPolicy, RetentionReport};
+
+/// Flags for `stella storage prune`.
+///
+/// Defined here rather than inline in `main.rs`'s `StorageCmd` so the knobs sit
+/// next to the code that interprets them — and so adding a verb costs the
+/// already-oversized `main.rs` one line instead of forty.
+#[derive(Args, Debug, Clone)]
+pub(crate) struct PruneArgs {
+    /// Drop executions that finished longer ago than this window: N followed
+    /// by d, w, h, mo, or y (e.g. `90d`)
+    #[arg(long, value_name = "AGE")]
+    pub older_than: Option<String>,
+    /// Hard ceiling on retained executions; evict the oldest first
+    #[arg(long, value_name = "N")]
+    pub max_executions: Option<i64>,
+    /// Also prune executions whose enterprise export is still pending (breaks
+    /// that drain). Does not reach in-flight turns or tombstones.
+    #[arg(long)]
+    pub force: bool,
+    /// `VACUUM` afterwards to return file bytes to the filesystem
+    #[arg(long)]
+    pub vacuum: bool,
+    /// Report what would be removed without removing anything
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Run the prune and print its report.
+pub(crate) fn run(args: &PruneArgs) -> Result<(), String> {
+    let PruneArgs {
+        older_than,
+        max_executions,
+        force,
+        vacuum,
+        dry_run,
+    } = args.clone();
+    if older_than.is_none() && max_executions.is_none() {
+        return Err(
+            "nothing to prune — pass at least one of --older-than or --max-executions".to_string(),
+        );
+    }
+    let older_than = older_than
+        .as_deref()
+        .map(crate::usage_cmd::parse_age_window)
+        .transpose()?;
+
+    let root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let store = Store::open(&root).map_err(|e| format!("cannot open store.db: {e}"))?;
+
+    let policy = RetentionPolicy {
+        older_than,
+        max_executions,
+        force,
+        vacuum,
+        dry_run,
+    };
+    let report = store.prune(&policy).map_err(|e| e.0)?;
+    print_report(&report, dry_run);
+    Ok(())
+}
+
+fn print_report(report: &RetentionReport, dry_run: bool) {
+    let lead = if dry_run { "would remove" } else { "removed" };
+
+    if report.is_empty() {
+        println!(
+            "{}",
+            "nothing to prune — no execution matched the policy".dimmed()
+        );
+    } else {
+        println!(
+            "{} {} execution(s) and {} related row(s)",
+            if dry_run { "◇" } else { "◆" }.bright_magenta(),
+            report.executions_removed().to_string().bold(),
+            report.child_rows_removed.to_string().bold(),
+        );
+        if report.aged_out > 0 {
+            println!(
+                "  {} {} past the age cutoff",
+                lead.dimmed(),
+                report.aged_out
+            );
+        }
+        if report.ceiling_evicted > 0 {
+            println!(
+                "  {} {} to satisfy the ceiling",
+                lead.dimmed(),
+                report.ceiling_evicted
+            );
+        }
+    }
+
+    // Always explain what was held back — a smaller-than-expected prune with
+    // no explanation is the thing that makes people reach for `--force`.
+    if report.protected_unfinished > 0 {
+        println!(
+            "  {} {} unfinished execution(s) kept (in flight; never pruned)",
+            "•".dimmed(),
+            report.protected_unfinished
+        );
+    }
+    if report.protected_pending_export > 0 {
+        println!(
+            "  {} {} execution(s) kept for a pending enterprise export — drain first, or \
+             re-run with {}",
+            "•".dimmed(),
+            report.protected_pending_export,
+            "--force".bold()
+        );
+    }
+    if report.still_over_ceiling > 0 {
+        println!(
+            "  {} still {} over the ceiling: the rest are protected",
+            "•".dimmed(),
+            report.still_over_ceiling
+        );
+    }
+    if report.vacuumed {
+        println!(
+            "  {} VACUUMed — file bytes returned to the filesystem",
+            "•".dimmed()
+        );
+    }
+    if dry_run {
+        println!(
+            "{}",
+            "dry run — nothing was deleted; re-run without --dry-run to apply".dimmed()
+        );
+    }
+}

--- a/stella-cli/src/usage_cmd.rs
+++ b/stella-cli/src/usage_cmd.rs
@@ -260,7 +260,13 @@ fn sync_one(hub: &UsageStore, root: &Path) -> Result<u64, String> {
 /// Parse a retention window (`90d`, `12w`, `720h`, `3mo`, `1y`; a bare number is
 /// days) into a SQLite datetime modifier like `"-90 days"`. SQLite has no
 /// `weeks` modifier, so weeks fold into days.
-fn parse_age_window(s: &str) -> Result<String, String> {
+/// Parse an `N<unit>` retention window into a SQLite datetime modifier.
+///
+/// Shared with `stella storage prune` (see `crate::storage_prune`) so both
+/// retention verbs accept exactly the same grammar — a user who learns
+/// `--older-than 90d` for the hub should not discover a different spelling for
+/// the store.
+pub(crate) fn parse_age_window(s: &str) -> Result<String, String> {
     let s = s.trim();
     let split = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
     let (num, unit) = s.split_at(split);

--- a/stella-model/src/factory.rs
+++ b/stella-model/src/factory.rs
@@ -1,0 +1,335 @@
+//! The per-dialect provider factory — one place that turns "which wire shape
+//! does this provider speak" into a constructed [`Provider`].
+//!
+//! ## Why this lives in `stella-model` and not in the CLI
+//!
+//! Every arm of this factory constructs a `stella_model` adapter, and every
+//! variant of [`Dialect`] names one. Hosting the match one crate up meant the
+//! only callable copy sat behind `stella-cli`'s binary-only target, so two
+//! things that should have shared it could not:
+//!
+//! - **a second host of the engine** — anything embedding Stella's model layer
+//!   without the CLI had to re-derive the dialect→adapter mapping, including
+//!   the OpenRouter attribution/usage-accounting special case;
+//! - **`stella-model`'s own live smoke tests** — which sit *below* `stella-cli`
+//!   in the dependency graph and so could never call the factory at all. They
+//!   hand-rolled nine construction sites instead, and because the factory is
+//!   also where the anti-phantom-slug check runs, those nine sites silently
+//!   skipped it.
+//!
+//! Moving the factory down fixes both: the dispatch and the slug floor now
+//! live where the adapters live, reachable by every caller above them.
+//!
+//! ## The slug gate is layered, on purpose
+//!
+//! [`build_provider`] enforces the **seed floor** unconditionally: a slug that
+//! is not in [`Catalog::seed`] for a `seeded` provider is a hard, named error
+//! before any wire call. That is the half that needs no on-disk state, so it
+//! can live here and apply to every caller including tests.
+//!
+//! The *escalation* — vetoing a slug against the user's synced master list,
+//! with suggestions — needs `stella-store`'s catalog database, which sits above
+//! this crate. It stays in `stella_cli::model_catalog::validate_model_slug`,
+//! which runs before delegating here. So the CLI gets the full ladder and a
+//! bare `stella-model` embedder still cannot construct a phantom-slug provider.
+
+use stella_protocol::provider::Provider;
+
+use crate::catalog::Catalog;
+use crate::credential::ApiKey;
+
+/// The wire dialect a provider speaks — which adapter is constructed for it.
+/// Serialized form is the settings.json `dialect` field (kebab-case, e.g.
+/// `"openai-compatible"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Dialect {
+    /// OpenAI Chat Completions shape ([`crate::zai::ZaiProvider`],
+    /// re-identified per provider) — Z.ai, xAI, DeepSeek, OpenRouter,
+    /// local endpoints, and the default for config-defined providers.
+    OpenaiCompatible,
+    /// OpenAI Responses API ([`crate::openai::OpenAiProvider`]).
+    OpenaiResponses,
+    /// Anthropic Messages API ([`crate::anthropic::AnthropicProvider`]).
+    Anthropic,
+    /// Gemini generateContent ([`crate::gemini::GeminiProvider`]).
+    Gemini,
+    /// Vertex generateContent with project/location addressing. Built-in
+    /// only: it needs `VERTEX_PROJECT_ID`/`VERTEX_LOCATION` resolution that
+    /// a settings.json entry has no way to express.
+    Vertex,
+    /// Bedrock Converse with SigV4. Built-in only, same reasoning.
+    Bedrock,
+}
+
+impl Dialect {
+    /// Human-readable label for `stella config` / `stella models`.
+    pub fn label(self) -> &'static str {
+        match self {
+            Dialect::OpenaiCompatible => "OpenAI-compatible",
+            Dialect::OpenaiResponses => "OpenAI Responses",
+            Dialect::Anthropic => "Anthropic Messages",
+            Dialect::Gemini | Dialect::Vertex => "Gemini generateContent",
+            Dialect::Bedrock => "Bedrock Converse",
+        }
+    }
+}
+
+/// The parts of a provider's configuration the factory actually needs, so the
+/// signature does not drag the CLI's whole `ProviderConfig` (env var names,
+/// aliases, default model) down into this crate. `stella_cli::config::
+/// ProviderConfig` converts into one of these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderSpec<'a> {
+    /// Stable provider id — `"anthropic"`, `"openrouter"`, `"local"`, or a
+    /// settings.json-defined one. Becomes the adapter's `Provider::id()`.
+    pub id: &'a str,
+    /// Human label used in the OpenAI-compatible arm's error messages when the
+    /// id is not one of the known gateways.
+    pub display_name: &'a str,
+    /// Which adapter to construct.
+    pub dialect: Dialect,
+    /// Whether this provider's models are curated in the catalog seed. `true`
+    /// for the built-in rows — an unknown slug is a hard, named error. `false`
+    /// for `local` and settings.json-defined providers, whose models are
+    /// whatever the user's endpoint actually serves.
+    pub seeded: bool,
+}
+
+/// The provider id whose models are whatever the user pulled into their local
+/// server — exempt from the slug floor.
+const LOCAL_PROVIDER_ID: &str = "local";
+
+/// Enforce the seed floor: reject a slug that a `seeded` provider's catalog
+/// seed does not know, before any wire call.
+///
+/// Exemptions mirror the CLI's fuller ladder: `local` is always exempt, and an
+/// unseeded provider (custom endpoint) keeps its endpoint-is-the-authority
+/// posture. See the module docs for why the synced-catalog escalation is not
+/// here.
+pub fn check_seed_floor(spec: &ProviderSpec<'_>, model_id: &str) -> Result<(), String> {
+    if spec.id == LOCAL_PROVIDER_ID || !spec.seeded {
+        return Ok(());
+    }
+    Catalog::seed()
+        .resolve_for(spec.id, model_id)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Construct the adapter for `spec`'s dialect, over already-resolved parts.
+///
+/// `effective_base_url` is the base URL requests go to (override-or-default);
+/// `base_url_override` is the raw `--base-url`, which only the Vertex/Bedrock
+/// arms consume (they build region/project-scoped URLs themselves).
+///
+/// Runs [`check_seed_floor`] first — no caller can skip the anti-phantom-slug
+/// floor by going through this function.
+pub fn build_provider(
+    spec: &ProviderSpec<'_>,
+    model_id: &str,
+    api_key: ApiKey,
+    effective_base_url: String,
+    base_url_override: Option<&str>,
+) -> Result<Box<dyn Provider>, String> {
+    check_seed_floor(spec, model_id)?;
+
+    match spec.dialect {
+        Dialect::OpenaiResponses => {
+            let provider = crate::openai::OpenAiProvider::new(api_key, model_id.to_string())
+                .with_base_url(effective_base_url);
+            Ok(Box::new(provider))
+        }
+        Dialect::Anthropic => {
+            let provider = crate::anthropic::AnthropicProvider::new(api_key, model_id.to_string())
+                .with_base_url(effective_base_url);
+            Ok(Box::new(provider))
+        }
+        Dialect::Gemini => {
+            let provider = crate::gemini::GeminiProvider::new(api_key, model_id.to_string())
+                .with_base_url(effective_base_url);
+            Ok(Box::new(provider))
+        }
+        Dialect::Vertex => {
+            // The access token is `api_key` (VERTEX_ACCESS_TOKEN via the
+            // credential chain); project and location are Vertex-specific
+            // addressing, owned by `crate::credential` so a second host of the
+            // engine gets the same variable names, the same fallback order,
+            // and the same named errors without copying them.
+            let addressing =
+                crate::credential::VertexAddressing::resolve().map_err(|e| e.to_string())?;
+            let mut provider = crate::vertex::VertexProvider::new(
+                api_key,
+                model_id.to_string(),
+                addressing.project,
+                addressing.location,
+            );
+            if let Some(override_url) = base_url_override {
+                provider = provider.with_base_url(override_url.to_string());
+            }
+            Ok(Box::new(provider))
+        }
+        Dialect::Bedrock => {
+            // `api_key` is AWS_ACCESS_KEY_ID via the credential chain; the rest
+            // of the standard AWS env set is resolved by `crate::credential`,
+            // alongside the adapter that needs it. A missing secret is a named
+            // error pointing at the exact var, not a doomed unsigned request.
+            let aws =
+                crate::credential::BedrockCredentials::resolve().map_err(|e| e.to_string())?;
+            let mut provider = crate::bedrock::BedrockProvider::new(
+                api_key,
+                aws.secret_access_key,
+                aws.session_token,
+                aws.region,
+                model_id.to_string(),
+            );
+            if let Some(override_url) = base_url_override {
+                provider = provider.with_base_url(override_url.to_string());
+            }
+            Ok(Box::new(provider))
+        }
+        // Z.ai, xAI, DeepSeek, OpenRouter, local, and config-defined providers
+        // (settings.json) — the shared Chat Completions adapter, re-identified
+        // per provider so its `Provider::id()` and error messages name the
+        // surface actually being called.
+        Dialect::OpenaiCompatible => {
+            let label = match spec.id {
+                "zai" => "Z.ai",
+                "xai" => "xAI",
+                "deepseek" => "DeepSeek",
+                "openrouter" => "OpenRouter",
+                "local" => "the local endpoint",
+                _ => spec.display_name,
+            };
+            let mut provider = crate::zai::ZaiProvider::new(api_key, model_id.to_string())
+                .with_base_url(effective_base_url)
+                .with_identity(spec.id, label);
+            if spec.id == "openrouter" {
+                // First-class OpenRouter: app attribution on every request, and
+                // the gateway's own usage accounting so
+                // `CompletionResult::cost_usd` is the routed call's real price
+                // (its slugs are unseeded, so there is no catalog list price to
+                // fall back on).
+                provider = provider
+                    .with_attribution("https://stella.oxagen.sh", "Stella")
+                    .with_usage_accounting();
+            }
+            Ok(Box::new(provider))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(id: &'static str, dialect: Dialect, seeded: bool) -> ProviderSpec<'static> {
+        ProviderSpec {
+            id,
+            display_name: id,
+            dialect,
+            seeded,
+        }
+    }
+
+    fn key() -> ApiKey {
+        ApiKey::new("test-key".to_string())
+    }
+
+    #[test]
+    fn each_dialect_constructs_the_adapter_that_names_it() {
+        // The seeded arms need a real slug to clear the floor; the id each
+        // adapter reports is the contract callers dispatch on downstream.
+        let cases: &[(&'static str, Dialect, &str, &str)] = &[
+            (
+                "anthropic",
+                Dialect::Anthropic,
+                "claude-fable-5",
+                "anthropic",
+            ),
+            ("openai", Dialect::OpenaiResponses, "gpt-5.5", "openai"),
+            ("gemini", Dialect::Gemini, "gemini-3-pro", "gemini"),
+        ];
+        for (id, dialect, slug, want_id) in cases {
+            let provider = build_provider(
+                &spec(id, *dialect, true),
+                slug,
+                key(),
+                "https://example.invalid".to_string(),
+                None,
+            )
+            .unwrap_or_else(|e| panic!("{id}/{slug} should construct: {e}"));
+            assert_eq!(&provider.id(), want_id, "{id} adapter reports a wrong id");
+        }
+    }
+
+    #[test]
+    fn openai_compatible_relabels_known_gateways_and_falls_back_otherwise() {
+        // Unseeded, so the floor is skipped and any slug constructs.
+        for (id, _label) in [("zai", "Z.ai"), ("xai", "xAI"), ("deepseek", "DeepSeek")] {
+            let provider = build_provider(
+                &spec(id, Dialect::OpenaiCompatible, false),
+                "whatever-the-endpoint-serves",
+                key(),
+                "https://example.invalid".to_string(),
+                None,
+            )
+            .expect("openai-compatible arm constructs for any slug when unseeded");
+            assert_eq!(provider.id(), id);
+        }
+    }
+
+    #[test]
+    fn the_seed_floor_rejects_a_phantom_slug_for_a_seeded_provider() {
+        // `expect_err` would need `Box<dyn Provider>: Debug`, which a trait
+        // object cannot supply — destructure instead.
+        let Err(err) = build_provider(
+            &spec("anthropic", Dialect::Anthropic, true),
+            "claude-does-not-exist-9",
+            key(),
+            "https://example.invalid".to_string(),
+            None,
+        ) else {
+            panic!("a phantom slug must not construct a provider");
+        };
+        assert!(
+            err.contains("claude-does-not-exist-9"),
+            "the error must name the rejected slug, got: {err}"
+        );
+    }
+
+    #[test]
+    fn local_and_unseeded_providers_stay_permissive() {
+        // The endpoint is the authority for these — a slug the seed has never
+        // heard of is not an error.
+        for (id, seeded) in [("local", false), ("my-custom-gateway", false)] {
+            check_seed_floor(
+                &spec(id, Dialect::OpenaiCompatible, seeded),
+                "some-locally-pulled-model",
+            )
+            .unwrap_or_else(|e| panic!("{id} must stay permissive, got: {e}"));
+        }
+    }
+
+    #[test]
+    fn label_covers_every_dialect() {
+        for dialect in [
+            Dialect::OpenaiCompatible,
+            Dialect::OpenaiResponses,
+            Dialect::Anthropic,
+            Dialect::Gemini,
+            Dialect::Vertex,
+            Dialect::Bedrock,
+        ] {
+            assert!(!dialect.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn dialect_deserializes_from_the_settings_json_kebab_case_form() {
+        let parsed: Dialect = serde_json::from_str("\"openai-compatible\"").unwrap();
+        assert_eq!(parsed, Dialect::OpenaiCompatible);
+        let parsed: Dialect = serde_json::from_str("\"openai-responses\"").unwrap();
+        assert_eq!(parsed, Dialect::OpenaiResponses);
+    }
+}

--- a/stella-model/src/factory.rs
+++ b/stella-model/src/factory.rs
@@ -22,10 +22,14 @@
 //!
 //! ## The slug gate is layered, on purpose
 //!
-//! [`build_provider`] enforces the **seed floor** unconditionally: a slug that
-//! is not in [`Catalog::seed`] for a `seeded` provider is a hard, named error
-//! before any wire call. That is the half that needs no on-disk state, so it
-//! can live here and apply to every caller including tests.
+//! [`build_provider`] enforces the **catalog floor** unconditionally: a slug
+//! that is not in [`Catalog::current`] for a `seeded` provider is a hard, named
+//! error before any wire call. With no runtime catalog installed, `current()`
+//! is the compiled [`Catalog::seed`], so a bare `stella-model` embedder or a
+//! live smoke test gets exactly the seed floor with no on-disk state; when the
+//! CLI has installed a runtime catalog (seed + synced model cards), a
+//! newly-released synced model passes here too, matching the CLI ladder's
+//! store-hit allow rather than silently narrowing it.
 //!
 //! The *escalation* — vetoing a slug against the user's synced master list,
 //! with suggestions — needs `stella-store`'s catalog database, which sits above
@@ -100,18 +104,29 @@ pub struct ProviderSpec<'a> {
 /// server — exempt from the slug floor.
 const LOCAL_PROVIDER_ID: &str = "local";
 
-/// Enforce the seed floor: reject a slug that a `seeded` provider's catalog
-/// seed does not know, before any wire call.
+/// Enforce the catalog floor: reject a slug that a `seeded` provider's catalog
+/// does not know, before any wire call.
+///
+/// Resolves against [`Catalog::current`], not [`Catalog::seed`]: when
+/// `stella-cli` has installed a runtime catalog (the seed merged with the
+/// on-disk model cards synced from each provider's live `/models` listing), a
+/// newly-released model that is present in that runtime catalog but not yet in
+/// the compiled seed must pass — otherwise this floor would silently veto slugs
+/// the CLI's fuller ladder (`validate_model_slug`) already allowed via its
+/// store-hit path, blocking every seeded provider's auto-synced models. A bare
+/// `stella-model` embedder or a live smoke test never installs a runtime
+/// catalog, so `current()` falls back to the seed and the anti-phantom-slug
+/// floor is exactly the seed there.
 ///
 /// Exemptions mirror the CLI's fuller ladder: `local` is always exempt, and an
 /// unseeded provider (custom endpoint) keeps its endpoint-is-the-authority
-/// posture. See the module docs for why the synced-catalog escalation is not
-/// here.
+/// posture. See the module docs for why the synced-catalog escalation with
+/// suggestions is not here.
 pub fn check_seed_floor(spec: &ProviderSpec<'_>, model_id: &str) -> Result<(), String> {
     if spec.id == LOCAL_PROVIDER_ID || !spec.seeded {
         return Ok(());
     }
-    Catalog::seed()
+    Catalog::current()
         .resolve_for(spec.id, model_id)
         .map(|_| ())
         .map_err(|e| e.to_string())

--- a/stella-model/src/lib.rs
+++ b/stella-model/src/lib.rs
@@ -40,6 +40,7 @@ pub mod bedrock;
 pub mod cache_economics;
 pub mod catalog;
 pub mod credential;
+pub mod factory;
 pub mod gemini;
 pub(crate) mod http;
 pub mod modelsdev;

--- a/stella-model/tests/live_smoke.rs
+++ b/stella-model/tests/live_smoke.rs
@@ -16,6 +16,25 @@
 //! `STELLA_LIVE_SMOKE=1 ANTHROPIC_API_KEY=sk-… cargo test -p stella-model \
 //! --test live_smoke -- --nocapture`.
 //!
+//! **What is NOT gated**: the drift guards over [`LIVE_PROVIDERS`] — the
+//! table this suite drives — run on every `cargo test`, with no credential
+//! and no network call. The gate above is right for spending money; it was
+//! wrong for the things a catalog can check offline for free, and applying
+//! it to everything is what let a phantom slug produce a green default run
+//! and surface (at most weekly, from the scheduled workflow) as an ambiguous
+//! wire-shape-or-billing panic. See
+//! [`every_live_smoke_slug_resolves_against_the_catalog_seed`] and
+//! [`every_row_constructs_through_the_real_factory`].
+//!
+//! **How providers are constructed**: through
+//! [`stella_model::factory::build_provider`] — the same factory
+//! `stella_cli::agent::engine::build_provider_parts` delegates to. Each test
+//! used to hand-build its adapter, which meant nine construction sites could
+//! drift from production's one (and did: the OpenRouter attribution literals
+//! were copied verbatim), and meant every one of them silently bypassed the
+//! factory's anti-phantom-slug check. Adding a provider is now a row in
+//! [`LIVE_PROVIDERS`] plus a four-line test.
+//!
 //! **What each test asserts**: wire-shape ACCEPTANCE — the live endpoint
 //! returns 200 and stella's own parser reassembles a `CompletionResult` from
 //! it — never model quality (no assertion on what the model actually says).
@@ -36,14 +55,10 @@
 //! a real cache write is exercised, not just accepted-but-inert) and asserting
 //! the call succeeds.
 
-use stella_model::anthropic::AnthropicProvider;
-use stella_model::bedrock::BedrockProvider;
+use stella_model::catalog::Catalog;
 use stella_model::credential::{ApiKey, CredentialsFile};
-use stella_model::gemini::GeminiProvider;
-use stella_model::openai::OpenAiProvider;
+use stella_model::factory::{Dialect, ProviderSpec, build_provider};
 use stella_model::provider::Provider;
-use stella_model::vertex::VertexProvider;
-use stella_model::zai::ZaiProvider;
 use stella_protocol::{CompletionMessage, CompletionRequest};
 
 /// Serializes the tests in this file that mutate `STELLA_LIVE_SMOKE` (the
@@ -239,8 +254,333 @@ fn armed_key_skips_cleanly_when_the_gate_is_on_but_no_key_resolves() {
         std::env::remove_var("STELLA_LIVE_SMOKE");
     }
 }
+// ---- the provider matrix -------------------------------------------------
+
+/// One row of the live matrix — the parts needed to construct a provider and
+/// name the credential that unlocks it.
+///
+/// This mirrors `stella_cli::config::PROVIDERS`. It has to be a mirror rather
+/// than a reference: `stella-cli` depends on `stella-model`, so this crate
+/// cannot import it without a dependency cycle. The same constraint (and the
+/// same mirroring convention) is documented on
+/// `stella_model::catalog`'s `seed_covers_every_provider_stella_cli_can_select`.
+///
+/// The drift guards below are what make the mirror safe:
+/// [`every_live_smoke_slug_resolves_against_the_catalog_seed`] fails the
+/// moment a slug here stops being real, and
+/// [`every_row_constructs_through_the_real_factory`] fails the moment a row
+/// stops being constructible — both unconditionally, with no network call.
+struct LiveProvider {
+    /// Stable provider id — must match the `stella_cli::config::PROVIDERS` row.
+    id: &'static str,
+    env_var: &'static str,
+    aliases: &'static [&'static str],
+    dialect: Dialect,
+    /// The slug to smoke. Matches the production row's `default_model`, so a
+    /// live run exercises what an auto-detected `stella` run would actually
+    /// send.
+    model: &'static str,
+    base_url: &'static str,
+    seeded: bool,
+}
+
+impl LiveProvider {
+    fn spec(&self) -> ProviderSpec<'_> {
+        ProviderSpec {
+            id: self.id,
+            display_name: self.id,
+            dialect: self.dialect,
+            seeded: self.seeded,
+        }
+    }
+}
+
+/// Every adapter with a live smoke test, in `stella_cli::config::PROVIDERS`
+/// order. Adding an adapter here is all it takes to smoke it — the drift
+/// guards and the per-provider tests below both read this table.
+const LIVE_PROVIDERS: &[LiveProvider] = &[
+    LiveProvider {
+        id: "zai",
+        env_var: "ZAI_API_KEY",
+        aliases: &[],
+        dialect: Dialect::OpenaiCompatible,
+        model: "glm-5.2",
+        base_url: "https://api.z.ai/api/paas/v4",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "anthropic",
+        env_var: "ANTHROPIC_API_KEY",
+        aliases: &[],
+        dialect: Dialect::Anthropic,
+        model: "claude-fable-5",
+        base_url: "https://api.anthropic.com",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "openai",
+        env_var: "OPENAI_API_KEY",
+        aliases: &[],
+        dialect: Dialect::OpenaiResponses,
+        model: "gpt-5.5",
+        base_url: "https://api.openai.com/v1",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "xai",
+        env_var: "XAI_API_KEY",
+        aliases: &[],
+        dialect: Dialect::OpenaiCompatible,
+        model: "grok-4",
+        base_url: "https://api.x.ai/v1",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "deepseek",
+        env_var: "DEEPSEEK_API_KEY",
+        aliases: &[],
+        dialect: Dialect::OpenaiCompatible,
+        model: "deepseek-chat",
+        base_url: "https://api.deepseek.com/v1",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "gemini",
+        env_var: "GEMINI_API_KEY",
+        aliases: &["GOOGLE_API_KEY"],
+        dialect: Dialect::Gemini,
+        model: "gemini-3-pro",
+        base_url: "https://generativelanguage.googleapis.com/v1beta",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "openrouter",
+        env_var: "OPENROUTER_API_KEY",
+        aliases: &[],
+        dialect: Dialect::OpenaiCompatible,
+        model: "openrouter/auto",
+        base_url: "https://openrouter.ai/api/v1",
+        // Deliberately unseeded, matching production: OpenRouter's catalog is
+        // vendor-namespaced and routed, so there is no curated seed row (and
+        // no list price) for its slugs.
+        seeded: false,
+    },
+    LiveProvider {
+        id: "vertex",
+        env_var: "VERTEX_ACCESS_TOKEN",
+        aliases: &[],
+        dialect: Dialect::Vertex,
+        model: "gemini-3-pro",
+        base_url: "https://aiplatform.googleapis.com",
+        seeded: true,
+    },
+    LiveProvider {
+        id: "bedrock",
+        env_var: "AWS_ACCESS_KEY_ID",
+        aliases: &[],
+        dialect: Dialect::Bedrock,
+        model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        base_url: "https://bedrock-runtime.<AWS_REGION>.amazonaws.com",
+        seeded: true,
+    },
+];
+
+fn row(id: &str) -> &'static LiveProvider {
+    LIVE_PROVIDERS
+        .iter()
+        .find(|p| p.id == id)
+        .unwrap_or_else(|| panic!("no LIVE_PROVIDERS row for `{id}`"))
+}
+
+// ---- drift guards (always run; never touch the network) ------------------
+
+/// **The anti-phantom-slug gate for this suite.**
+///
+/// Unconditional on purpose. Every live test below is gated behind
+/// `STELLA_LIVE_SMOKE=1` *and* a resolvable credential, which is right for
+/// something that spends money — but it meant a slug that quietly stopped
+/// existing produced a green run on every default `cargo test --workspace`,
+/// and surfaced at most weekly, as an ambiguous "wire-shape regression OR
+/// account/auth/quota/billing problem" panic from the scheduled workflow.
+///
+/// That is the wrong failure mode for the one thing a *catalog* can check
+/// offline for free. This test runs on every `cargo test`, makes no network
+/// call, needs no credential, and fails by name.
+///
+/// It mirrors `stella_cli::config::tests::
+/// every_provider_default_model_resolves_against_the_catalog_seed`, which
+/// asserts the same property for the production table.
+#[test]
+fn every_live_smoke_slug_resolves_against_the_catalog_seed() {
+    let catalog = Catalog::seed();
+    for provider in LIVE_PROVIDERS {
+        if !provider.seeded {
+            // Unseeded providers (OpenRouter) have no curated rows by design —
+            // asserting a seed hit here would be asserting a falsehood.
+            continue;
+        }
+        catalog
+            .resolve_for(provider.id, provider.model)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "live smoke provider `{}` smokes slug `{}`, which is not in the catalog \
+                     seed: {e}. A live run would spend a real call to discover this; fix the \
+                     slug here (and in stella_cli::config::PROVIDERS, which this table \
+                     mirrors) or add the catalog row.",
+                    provider.id, provider.model
+                )
+            });
+    }
+}
+
+/// Every row constructs through the **real** factory
+/// ([`stella_model::factory::build_provider`]) — the same function
+/// `stella_cli::agent::engine::build_provider_parts` delegates to.
+///
+/// This is the structural half of the fix: before, each test below built its
+/// adapter by hand, so nine construction sites could drift from production's
+/// one (and did — the OpenRouter attribution literals were copied verbatim).
+/// Now the tests call the factory, and this guard proves every row reaches a
+/// constructible adapter with the right identity, offline and for free.
+#[test]
+fn every_row_constructs_through_the_real_factory() {
+    for provider in LIVE_PROVIDERS {
+        // Vertex and Bedrock resolve extra addressing/credentials from the
+        // environment inside the factory; skip those two here rather than
+        // depend on an AWS/GCP environment being present. Their construction
+        // is still exercised live by the tests below when armed.
+        if matches!(provider.dialect, Dialect::Vertex | Dialect::Bedrock) {
+            continue;
+        }
+        let built = build_provider(
+            &provider.spec(),
+            provider.model,
+            ApiKey::new("smoke-test-not-a-real-key".to_string()),
+            provider.base_url.to_string(),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("`{}` must construct through the factory: {e}", provider.id));
+        assert_eq!(
+            &built.id(),
+            &provider.id,
+            "`{}`'s adapter must report its own identity — that id is what error messages, \
+             telemetry, and cost attribution key on",
+            provider.id
+        );
+    }
+}
+
+/// The table stays a faithful mirror: no duplicate ids, and every row names a
+/// credential env var. Cheap, but it is the kind of thing a copy-paste row
+/// gets wrong silently.
+#[test]
+fn the_provider_table_is_well_formed() {
+    let mut seen = std::collections::BTreeSet::new();
+    for provider in LIVE_PROVIDERS {
+        assert!(
+            seen.insert(provider.id),
+            "duplicate LIVE_PROVIDERS row for `{}`",
+            provider.id
+        );
+        assert!(
+            !provider.env_var.is_empty(),
+            "`{}` must name the env var that unlocks it",
+            provider.id
+        );
+        assert!(
+            !provider.model.is_empty(),
+            "`{}` must name a slug to smoke",
+            provider.id
+        );
+    }
+}
 
 // ---- live smoke: one minimal real call per adapter -----------------------
+
+/// Construct `provider`'s adapter through the production factory, or `None`
+/// to skip cleanly.
+///
+/// Returns `None` — never a failure — when the suite is unarmed, the
+/// credential does not resolve, or (Vertex/Bedrock) the extra addressing the
+/// factory needs is absent. A factory error for any *other* reason is a real
+/// failure: that is the anti-phantom-slug gate and the dialect dispatch
+/// talking, and a live run must not paper over them.
+fn armed_provider(provider: &LiveProvider) -> Option<Box<dyn Provider>> {
+    let key = armed_key(provider.id, provider.env_var, provider.aliases)?;
+
+    // Vertex/Bedrock need more than the one credential `armed_key` resolves.
+    // The factory resolves that itself (via `stella_model::credential`), so
+    // pre-flighting here keeps "not configured" a clean skip while leaving the
+    // real resolution to production code.
+    match provider.dialect {
+        Dialect::Vertex => {
+            if let Err(e) = stella_model::credential::VertexAddressing::resolve() {
+                eprintln!(
+                    "[live_smoke] {}: skipped — {} is set but Vertex addressing does not \
+                     resolve: {e}",
+                    provider.id, provider.env_var
+                );
+                return None;
+            }
+        }
+        Dialect::Bedrock => {
+            if let Err(e) = stella_model::credential::BedrockCredentials::resolve() {
+                eprintln!(
+                    "[live_smoke] {}: skipped — {} is set but the AWS credential chain does \
+                     not resolve: {e}",
+                    provider.id, provider.env_var
+                );
+                return None;
+            }
+        }
+        _ => {}
+    }
+
+    match build_provider(
+        &provider.spec(),
+        provider.model,
+        key,
+        provider.base_url.to_string(),
+        None,
+    ) {
+        Ok(built) => Some(built),
+        Err(e) => panic!(
+            "`{}` failed to construct through the factory — this is a config/catalog fault, \
+             not a network one, and would fail an ordinary `stella --model {}/{}` run the \
+             same way: {e}",
+            provider.id, provider.id, provider.model
+        ),
+    }
+}
+
+/// Send `request` and report. Shared by every provider so the success log and
+/// the failure wording stay identical across adapters.
+async fn smoke(provider: &LiveProvider, built: Box<dyn Provider>, request: CompletionRequest) {
+    match built.complete(request).await {
+        Ok(r) => eprintln!(
+            "[live_smoke] {}: OK — model={} finish={:?} usage={:?} cost_usd={} text={:?}",
+            provider.id, r.model, r.finish_reason, r.usage, r.cost_usd, r.text
+        ),
+        // Deliberately does NOT say "rejected the request shape": a failure
+        // here can be an account-billing 400 that never reached shape
+        // validation, so pre-judging the cause would print something false on
+        // the exact failure this suite exists to distinguish from a real
+        // regression. `e` already carries the provider's own status + body
+        // (never a raw credential), so a human reading it tells wire-shape
+        // apart from auth/quota/billing.
+        //
+        // What it can no longer be is an unknown slug: the factory's seed
+        // floor rejects those before any wire call, and
+        // `every_live_smoke_slug_resolves_against_the_catalog_seed` catches
+        // them offline before that.
+        Err(e) => panic!(
+            "{} live smoke did not return a parseable 200 — could be a genuine wire-shape \
+             regression OR an unrelated account/auth/quota/billing problem; read the status \
+             and body below to tell which: {e}",
+            provider.id
+        ),
+    }
+}
 
 /// Anthropic Messages API. Also the `cache_control` settlement: every
 /// Anthropic request `stella` builds carries `cache_control` on the system
@@ -259,17 +599,16 @@ fn armed_key_skips_cleanly_when_the_gate_is_on_but_no_key_resolves() {
 /// A billing/quota 400 (`"credit balance is too low"`) is NOT a wire-shape
 /// verdict: Anthropic names the offending field in `invalid_request_error`
 /// when a request is actually malformed, so a balance rejection never
-/// exercises the request shape at all. Re-run with
-/// `STELLA_LIVE_SMOKE=1 cargo test -p stella-model --test live_smoke \
-/// anthropic_smoke -- --nocapture`.
+/// exercises the request shape at all.
 #[tokio::test]
 async fn anthropic_smoke() {
-    let Some(key) = armed_key("anthropic", "ANTHROPIC_API_KEY", &[]) else {
+    let provider = row("anthropic");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = AnthropicProvider::new(key, "claude-fable-5");
-    let req = tiny_request(anthropic_cache_probe_system_prompt());
-    match provider.complete(req).await {
+    // The one provider whose system prompt is not tiny — see the probe's doc.
+    let request = tiny_request(anthropic_cache_probe_system_prompt());
+    match built.complete(request).await {
         Ok(r) => eprintln!(
             "[live_smoke] anthropic: OK — model={} finish={:?} usage={:?} \
              cache_write_tokens={} cached_input_tokens={} text={:?}",
@@ -280,13 +619,6 @@ async fn anthropic_smoke() {
             r.usage.cached_input_tokens,
             r.text
         ),
-        // Deliberately does NOT say "rejected the request shape": a failure
-        // here can be an account-billing 400 that never reached shape
-        // validation, so pre-judging the cause would print something false on
-        // the exact failure this suite exists to distinguish from a real
-        // regression. `e` already carries the provider's own status + body
-        // (never a raw credential), so a human reading it tells wire-shape
-        // apart from auth/quota/billing.
         Err(e) => panic!(
             "anthropic live smoke did not return a parseable 200 — could be a genuine \
              wire-shape regression OR an unrelated account/auth/quota/billing problem; \
@@ -298,206 +630,97 @@ async fn anthropic_smoke() {
 /// OpenAI Responses API.
 #[tokio::test]
 async fn openai_smoke() {
-    let Some(key) = armed_key("openai", "OPENAI_API_KEY", &[]) else {
+    let provider = row("openai");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = OpenAiProvider::new(key, "gpt-5.5");
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] openai: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("openai live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
-/// Gemini direct `generateContent`. `GEMINI_API_KEY` (spec-documented
-/// alias `GOOGLE_API_KEY`, same as `stella-cli`'s `config::PROVIDERS` row).
+/// Gemini direct `generateContent`. `GEMINI_API_KEY` (spec-documented alias
+/// `GOOGLE_API_KEY`, same as `stella-cli`'s `config::PROVIDERS` row).
 #[tokio::test]
 async fn gemini_smoke() {
-    let Some(key) = armed_key("gemini", "GEMINI_API_KEY", &["GOOGLE_API_KEY"]) else {
+    let provider = row("gemini");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = GeminiProvider::new(key, "gemini-3-pro");
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] gemini: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("gemini live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
 /// Vertex AI `generateContent`. Needs the OAuth2 bearer
 /// (`VERTEX_ACCESS_TOKEN`, e.g. `$(gcloud auth print-access-token)`) AND a
-/// project id (`VERTEX_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT`) — mirrors
-/// `stella-cli::agent::engine::build_provider_parts`'s Vertex arm exactly,
-/// so this test skips the same way a real `stella --model vertex/…` run
-/// would fail with a named error, rather than sending a doomed request.
+/// project id (`VERTEX_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT`).
+///
+/// Both the addressing resolution and the adapter construction are now the
+/// factory's (`stella_model::credential::VertexAddressing` +
+/// `Dialect::Vertex`), so this test cannot drift from what a real
+/// `stella --model vertex/…` run does — it calls the same code.
 #[tokio::test]
 async fn vertex_smoke() {
-    let Some(access_token) = armed_key("vertex", "VERTEX_ACCESS_TOKEN", &[]) else {
+    let provider = row("vertex");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let Some(project) = std::env::var("VERTEX_PROJECT_ID")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .or_else(|| {
-            std::env::var("GOOGLE_CLOUD_PROJECT")
-                .ok()
-                .filter(|v| !v.is_empty())
-        })
-    else {
-        eprintln!(
-            "[live_smoke] vertex: skipped — VERTEX_ACCESS_TOKEN is set but no \
-             VERTEX_PROJECT_ID/GOOGLE_CLOUD_PROJECT"
-        );
-        return;
-    };
-    let location = std::env::var("VERTEX_LOCATION")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| "global".to_string());
-    let provider = VertexProvider::new(access_token, "gemini-3-pro", project, location);
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] vertex: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("vertex live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
 /// Amazon Bedrock Converse. Needs the standard AWS chain
 /// (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, optional
-/// `AWS_SESSION_TOKEN`/`AWS_REGION`) — mirrors
-/// `build_provider_parts`'s Bedrock arm exactly.
+/// `AWS_SESSION_TOKEN`/`AWS_REGION`), resolved inside the factory by
+/// `stella_model::credential::BedrockCredentials` — the same resolution a
+/// real run uses.
 #[tokio::test]
 async fn bedrock_smoke() {
-    let Some(access_key) = armed_key("bedrock", "AWS_ACCESS_KEY_ID", &[]) else {
+    let provider = row("bedrock");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let Some(secret) = std::env::var("AWS_SECRET_ACCESS_KEY")
-        .ok()
-        .filter(|v| !v.is_empty())
-    else {
-        eprintln!(
-            "[live_smoke] bedrock: skipped — AWS_ACCESS_KEY_ID is set but no \
-             AWS_SECRET_ACCESS_KEY"
-        );
-        return;
-    };
-    let session_token = std::env::var("AWS_SESSION_TOKEN")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(ApiKey::new);
-    let region = std::env::var("AWS_REGION")
-        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
-        .ok()
-        .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| "us-east-1".to_string());
-    let provider = BedrockProvider::new(
-        access_key,
-        ApiKey::new(secret),
-        session_token,
-        region,
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    );
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] bedrock: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("bedrock live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
-/// OpenRouter, via the shared OpenAI-compatible `ZaiProvider` re-identified
-/// (`with_identity`) exactly like `build_provider_parts`'s
-/// `Dialect::OpenaiCompatible` arm — including app attribution and
-/// `usage: {"include": true}` accounting, so this test also exercises
-/// OpenRouter's own per-call cost-reporting frame. `openrouter/auto` is the
-/// real vendor-namespaced slug for OpenRouter's own auto-router model (its
-/// catalog is namespaced `vendor/model`; this is genuinely how
-/// `stella-cli`'s auto-detected default reaches it — see
-/// `config::PROVIDERS`'s `openrouter` row).
+/// OpenRouter, via the shared OpenAI-compatible adapter. The app attribution
+/// and `usage: {"include": true}` accounting are applied by the factory's
+/// `Dialect::OpenaiCompatible` arm, not by this test — which is the point:
+/// the attribution literals used to be copy-pasted here and could drift from
+/// production silently. `openrouter/auto` is the real vendor-namespaced slug
+/// for OpenRouter's own auto-router model, and genuinely how `stella-cli`'s
+/// auto-detected default reaches it.
 #[tokio::test]
 async fn openrouter_smoke() {
-    let Some(key) = armed_key("openrouter", "OPENROUTER_API_KEY", &[]) else {
+    let provider = row("openrouter");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = ZaiProvider::new(key, "openrouter/auto")
-        .with_base_url("https://openrouter.ai/api/v1")
-        .with_identity("openrouter", "OpenRouter")
-        .with_attribution("https://stella.oxagen.sh", "Stella")
-        .with_usage_accounting();
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] openrouter: OK — model={} finish={:?} usage={:?} cost_usd={} text={:?}",
-            r.model, r.finish_reason, r.usage, r.cost_usd, r.text
-        ),
-        Err(e) => panic!("openrouter live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
 /// Z.ai (GLM), via the OpenAI-compatible adapter under its own identity.
 #[tokio::test]
 async fn zai_smoke() {
-    let Some(key) = armed_key("zai", "ZAI_API_KEY", &[]) else {
+    let provider = row("zai");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = ZaiProvider::new(key, "glm-5.2")
-        .with_base_url("https://api.z.ai/api/paas/v4")
-        .with_identity("zai", "Z.ai");
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] zai: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("zai live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
 /// DeepSeek, via the OpenAI-compatible adapter under its own identity.
 #[tokio::test]
 async fn deepseek_smoke() {
-    let Some(key) = armed_key("deepseek", "DEEPSEEK_API_KEY", &[]) else {
+    let provider = row("deepseek");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = ZaiProvider::new(key, "deepseek-chat")
-        .with_base_url("https://api.deepseek.com/v1")
-        .with_identity("deepseek", "DeepSeek");
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] deepseek: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("deepseek live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
 /// xAI (Grok), via the OpenAI-compatible adapter under its own identity.
 #[tokio::test]
 async fn xai_smoke() {
-    let Some(key) = armed_key("xai", "XAI_API_KEY", &[]) else {
+    let provider = row("xai");
+    let Some(built) = armed_provider(provider) else {
         return;
     };
-    let provider = ZaiProvider::new(key, "grok-4")
-        .with_base_url("https://api.x.ai/v1")
-        .with_identity("xai", "xAI");
-    let req = tiny_request(TINY_SYSTEM_PROMPT);
-    match provider.complete(req).await {
-        Ok(r) => eprintln!(
-            "[live_smoke] xai: OK — model={} finish={:?} usage={:?} text={:?}",
-            r.model, r.finish_reason, r.usage, r.text
-        ),
-        Err(e) => panic!("xai live smoke failed: {e}"),
-    }
+    smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }

--- a/stella-store/src/identity.rs
+++ b/stella-store/src/identity.rs
@@ -74,7 +74,7 @@ fn cloud_json_path() -> PathBuf {
 
 /// Load the registration, `Default` (all `None`) when absent or unreadable.
 ///
-/// On Unix the read goes through [`crate::read_sensitive_file_to_string`]
+/// The read goes through [`crate::read_sensitive_file_to_string`]
 /// (O_NOFOLLOW, uid + single-link checks, an owner-controlled parent), which
 /// also means an unreadable-*because-untrustworthy* file degrades to the
 /// unregistered state rather than being believed. That is the correct
@@ -87,8 +87,9 @@ pub fn cloud_registration() -> CloudRegistration {
 }
 
 fn cloud_registration_at(path: &Path) -> CloudRegistration {
-    read_cloud_json(path)
-        .and_then(|raw| serde_json::from_str(&raw).ok())
+    crate::read_sensitive_file_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<CloudRegistration>(&raw).ok())
         .unwrap_or_default()
 }
 
@@ -114,7 +115,7 @@ fn save_cloud_registration_at(path: &Path, reg: &CloudRegistration) -> Result<()
     let body = serde_json::to_string_pretty(reg)
         .map_err(|e| StoreError(format!("cannot render cloud registration: {e}")))?
         + "\n";
-    crate::write_sensitive_file_atomic(&path, body.as_bytes())
+    crate::write_sensitive_file_atomic(path, body.as_bytes())
 }
 
 /// The org this installation reports into, `None` until registered.

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -114,6 +114,8 @@ mod private_state_tests;
 mod quarantine_tests;
 mod receipts;
 mod reconstruct;
+#[cfg(test)]
+mod retention_tests;
 mod telemetry;
 #[cfg(test)]
 mod tests;
@@ -133,6 +135,7 @@ pub mod identity;
 pub mod integrity;
 pub mod journal;
 pub mod notify;
+pub mod retention;
 pub mod sessions;
 pub mod usage;
 

--- a/stella-store/src/retention.rs
+++ b/stella-store/src/retention.rs
@@ -1,0 +1,304 @@
+//! Bounding `store.db`'s growth — the engine behind `stella storage prune`.
+//!
+//! ## Why this exists
+//!
+//! `store.db` grows one row per event, per model call, per tool call, per
+//! context block, forever. `executions.prompt` holds the full prompt text and
+//! `events.payload` the full event payload, so it is also the tier that holds
+//! the actual content — not a rollup of it.
+//!
+//! Its sibling [`crate::usage`] — a *derived, content-free* hub — has had an
+//! age cutoff, a row ceiling, project GC, `VACUUM`, dry-run, and a CLI verb
+//! since #520. `store.db` had none of it. That asymmetry pointed the wrong
+//! way: the derived copy could be bounded and the source of truth holding the
+//! prompts could not, so the only way a user could reclaim that space (or
+//! shed that content) was to delete the file and lose everything.
+//!
+//! ## The unit of retention is the execution
+//!
+//! `executions` is the spine every other table keys off. Pruning means
+//! choosing a set of execution ids and deleting them together with every row
+//! that hangs off them, in one transaction. A partial cascade would leave
+//! orphaned events pointing at a missing turn, which reads back as corruption.
+//!
+//! ## What this will never delete
+//!
+//! Retention on a source of truth has to be conservative, so three classes of
+//! row are excluded by construction rather than by policy:
+//!
+//! - **`forgotten`** — the tombstones. A tombstone is the *record that
+//!   something was forgotten*; dropping one un-forgets that content on the
+//!   next re-mine. It is append-only by design (see [`crate::forget`]) and
+//!   retention does not touch it, at any age, even under `--force`.
+//! - **Unfinished executions** (`finished_at IS NULL`) — an in-flight turn.
+//!   Age says nothing useful about a row that is still being written.
+//! - **Executions with a pending enterprise export** — the exact analogue of
+//!   the hub's cloud-drain guard. An execution the sink has not spooled yet
+//!   is dropped only under `force`.
+//!
+//! Not execution-scoped and so out of scope entirely: `rules`, `graph_nodes`,
+//! `graph_edges`, `file_locks`, `pull_requests`. The `enterprise_export_*`
+//! bookkeeping tables are left alone too — they have their own compaction
+//! ([`crate::Store::compact_enterprise_export_ledger`]), and a ledger row
+//! outliving its execution is inert.
+//!
+//! ## Never automatic
+//!
+//! There is no sweep on open and no background daemon. Retention runs when a
+//! user asks for it, needs at least one explicit knob, and supports
+//! `dry_run` so the report can be read before anything is deleted.
+
+use rusqlite::params;
+
+use crate::{Result, Store, StoreError};
+
+/// Every table keyed on a NOT NULL `execution_id`, deleted as part of an
+/// execution's cascade.
+///
+/// `reflections` is deliberately absent: its `execution_id` is nullable
+/// (cross-turn reflections carry NULL) so it needs an `IS NOT NULL` guard and
+/// is handled separately. `tasks` is present — a task board belongs to the
+/// turn that produced it.
+const CASCADE_TABLES: &[&str] = &[
+    "events",
+    "files_touched",
+    "telemetry",
+    "memory_citations",
+    "agent_uses",
+    "skill_usage",
+    "mcp_usage",
+    "tool_calls",
+    "execution_reflection",
+    "context_blocks",
+    "step_manifest",
+    "step_receipt",
+    "tasks",
+];
+
+/// Row count past which a non-empty prune runs `VACUUM` on its own, so a big
+/// reclamation actually returns bytes to the filesystem instead of leaving a
+/// sparse file. Mirrors the hub's `LARGE_PRUNE_ROWS`.
+const LARGE_PRUNE_EXECUTIONS: u64 = 5_000;
+
+/// Retention knobs for [`Store::prune`]. Every field is opt-in; a policy with
+/// neither `older_than` nor `max_executions` is rejected rather than silently
+/// doing nothing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// A SQLite datetime modifier (e.g. `"-90 days"`); executions that
+    /// *finished* before `now + modifier` are dropped. `None` disables the age
+    /// cutoff. The CLI builds this from `--older-than 90d`.
+    pub older_than: Option<String>,
+    /// Hard ceiling on retained executions; the oldest prunable ones are
+    /// evicted until at/under it. `None` disables the ceiling.
+    pub max_executions: Option<i64>,
+    /// Prune executions with a pending enterprise export too, breaking that
+    /// drain. Off by default. Never overrides the `forgotten`-table or
+    /// unfinished-execution exclusions — those are structural, not policy.
+    pub force: bool,
+    /// `VACUUM` after pruning to return bytes to the filesystem (also happens
+    /// automatically past [`LARGE_PRUNE_EXECUTIONS`]).
+    pub vacuum: bool,
+    /// Compute the report without deleting anything: the transaction is rolled
+    /// back and `VACUUM` is skipped.
+    pub dry_run: bool,
+}
+
+impl RetentionPolicy {
+    /// Whether this policy asks for anything at all.
+    pub fn is_noop(&self) -> bool {
+        self.older_than.is_none() && self.max_executions.is_none()
+    }
+}
+
+/// What [`Store::prune`] did (or, under `dry_run`, would have done).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetentionReport {
+    /// Executions removed by the age cutoff.
+    pub aged_out: u64,
+    /// Executions removed to satisfy the row ceiling.
+    pub ceiling_evicted: u64,
+    /// Rows removed from the cascade tables across every pruned execution.
+    pub child_rows_removed: u64,
+    /// Executions that matched the age cutoff or ceiling but were kept because
+    /// an enterprise export is still pending and `force` was not set.
+    pub protected_pending_export: u64,
+    /// Executions kept because they had not finished yet.
+    pub protected_unfinished: u64,
+    /// Executions still above the ceiling after eviction, because the rest are
+    /// protected. Non-zero means "drain first, or re-run with `--force`".
+    pub still_over_ceiling: u64,
+    /// Whether `VACUUM` ran.
+    pub vacuumed: bool,
+}
+
+impl RetentionReport {
+    /// Total executions removed.
+    pub fn executions_removed(&self) -> u64 {
+        self.aged_out + self.ceiling_evicted
+    }
+
+    /// Whether anything was (or would be) removed.
+    pub fn is_empty(&self) -> bool {
+        self.executions_removed() == 0 && self.child_rows_removed == 0
+    }
+}
+
+/// The `executions`-row predicate for "safe to drop", correlated to the outer
+/// `executions` row.
+///
+/// An unfinished execution is never prunable — that exclusion is structural
+/// and `force` does not lift it. `force` only lifts the pending-export guard.
+fn prunable_predicate(force: bool) -> &'static str {
+    if force {
+        "executions.finished_at IS NOT NULL"
+    } else {
+        "executions.finished_at IS NOT NULL \
+         AND NOT EXISTS ( \
+           SELECT 1 FROM enterprise_export_ledger l \
+           WHERE l.execution_id = executions.id AND l.status = 'pending')"
+    }
+}
+
+impl Store {
+    /// Bound `store.db`'s growth per a [`RetentionPolicy`] — the engine behind
+    /// `stella storage prune`.
+    ///
+    /// Runs, in order: age cutoff → row ceiling, both cascading to every
+    /// execution-scoped table, all in one transaction, then (optionally)
+    /// `VACUUM`. See the [module docs](self) for what is excluded by
+    /// construction and why.
+    ///
+    /// `dry_run` computes the same report but rolls the transaction back and
+    /// skips `VACUUM`, so nothing is deleted.
+    pub fn prune(&self, policy: &RetentionPolicy) -> Result<RetentionReport> {
+        if policy.is_noop() {
+            return Err(StoreError(
+                "nothing to prune — pass at least one of --older-than or --max-executions"
+                    .to_string(),
+            ));
+        }
+
+        let mut conn = self.lock();
+        let mut report = RetentionReport::default();
+        let prunable = prunable_predicate(policy.force);
+
+        {
+            let tx = conn.transaction()?;
+
+            // 1) Age cutoff. `finished_at` rather than `started_at`: a turn's
+            //    age is when it ended, and the NOT NULL check in `prunable`
+            //    already excludes in-flight rows.
+            if let Some(modifier) = &policy.older_than {
+                let doomed: Vec<i64> = {
+                    let sql = format!(
+                        "SELECT id FROM executions \
+                         WHERE finished_at < datetime('now', ?1) AND {prunable}"
+                    );
+                    let mut stmt = tx.prepare(&sql)?;
+                    let rows = stmt.query_map(params![modifier], |r| r.get::<_, i64>(0))?;
+                    rows.collect::<std::result::Result<_, _>>()?
+                };
+                report.child_rows_removed += cascade_delete(&tx, &doomed)?;
+                report.aged_out = doomed.len() as u64;
+
+                // Count what the guards held back, so the report explains a
+                // smaller-than-expected prune instead of leaving the user to
+                // guess.
+                report.protected_pending_export += tx.query_row(
+                    "SELECT COUNT(*) FROM executions \
+                     WHERE finished_at < datetime('now', ?1) \
+                       AND finished_at IS NOT NULL \
+                       AND EXISTS (SELECT 1 FROM enterprise_export_ledger l \
+                                   WHERE l.execution_id = executions.id \
+                                     AND l.status = 'pending')",
+                    params![modifier],
+                    |r| r.get::<_, i64>(0),
+                )? as u64;
+                report.protected_unfinished += tx.query_row(
+                    "SELECT COUNT(*) FROM executions \
+                     WHERE started_at < datetime('now', ?1) AND finished_at IS NULL",
+                    params![modifier],
+                    |r| r.get::<_, i64>(0),
+                )? as u64;
+            }
+
+            // 2) Row ceiling: evict oldest-first until at/under it.
+            if let Some(ceiling) = policy.max_executions {
+                let ceiling = ceiling.max(0);
+                let total: i64 =
+                    tx.query_row("SELECT COUNT(*) FROM executions", [], |r| r.get(0))?;
+                let excess = total - ceiling;
+                if excess > 0 {
+                    let doomed: Vec<i64> = {
+                        let sql = format!(
+                            "SELECT id FROM executions WHERE {prunable} \
+                             ORDER BY id ASC LIMIT ?1"
+                        );
+                        let mut stmt = tx.prepare(&sql)?;
+                        let rows = stmt.query_map(params![excess], |r| r.get::<_, i64>(0))?;
+                        rows.collect::<std::result::Result<_, _>>()?
+                    };
+                    report.child_rows_removed += cascade_delete(&tx, &doomed)?;
+                    report.ceiling_evicted = doomed.len() as u64;
+                    // Whatever we could not evict is protected; say so.
+                    report.still_over_ceiling = (excess - doomed.len() as i64).max(0) as u64;
+                }
+            }
+
+            if policy.dry_run {
+                tx.rollback()?;
+            } else {
+                tx.commit()?;
+            }
+        }
+
+        let removed = report.executions_removed();
+        let should_vacuum =
+            !policy.dry_run && removed > 0 && (policy.vacuum || removed >= LARGE_PRUNE_EXECUTIONS);
+        if should_vacuum {
+            // store.db has no rowid-anchored external cursor (the enterprise
+            // ledger keys on `execution_id`, which VACUUM preserves), so unlike
+            // the hub there is nothing to re-anchor afterwards.
+            conn.execute_batch("VACUUM")?;
+            report.vacuumed = true;
+        }
+
+        Ok(report)
+    }
+}
+
+/// Delete `ids` from `executions` and every table keyed on them, returning the
+/// number of child rows removed.
+///
+/// Chunked so a large prune cannot blow SQLite's variable limit
+/// (`SQLITE_MAX_VARIABLE_NUMBER`, 999 on older builds).
+fn cascade_delete(tx: &rusqlite::Transaction<'_>, ids: &[i64]) -> Result<u64> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let mut child_rows = 0u64;
+    for chunk in ids.chunks(500) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let bound: Vec<&dyn rusqlite::ToSql> =
+            chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+
+        for table in CASCADE_TABLES {
+            let sql = format!("DELETE FROM {table} WHERE execution_id IN ({placeholders})");
+            child_rows += tx.execute(&sql, bound.as_slice())? as u64;
+        }
+        // `reflections.execution_id` is nullable — cross-turn reflections carry
+        // NULL and belong to no execution, so they must survive.
+        let sql = format!(
+            "DELETE FROM reflections \
+             WHERE execution_id IS NOT NULL AND execution_id IN ({placeholders})"
+        );
+        child_rows += tx.execute(&sql, bound.as_slice())? as u64;
+
+        let sql = format!("DELETE FROM executions WHERE id IN ({placeholders})");
+        tx.execute(&sql, bound.as_slice())?;
+    }
+    Ok(child_rows)
+}

--- a/stella-store/src/retention_tests.rs
+++ b/stella-store/src/retention_tests.rs
@@ -1,0 +1,397 @@
+//! Tests for [`crate::retention`].
+//!
+//! Retention on a source of truth is the one feature where "it deleted
+//! slightly too much" is unrecoverable, so most of these assert what
+//! **survives** rather than what goes.
+
+use crate::retention::{RetentionPolicy, RetentionReport};
+use crate::{AgentEvent, Store, ToolCallRow};
+use rusqlite::params;
+
+/// An execution that finished `age_days` ago, with one event and one tool call
+/// hanging off it so the cascade has something to remove.
+fn aged_execution(store: &Store, prompt: &str, age_days: i64) -> i64 {
+    let id = store
+        .begin_execution("goal", prompt, "zai", "glm-5.2")
+        .unwrap();
+    store
+        .record_event(
+            id,
+            0,
+            &AgentEvent::Text {
+                delta: format!("{prompt} output"),
+            },
+        )
+        .unwrap();
+    store
+        .record_tool_calls(
+            id,
+            &[ToolCallRow {
+                call_id: format!("call-{prompt}"),
+                name: "read_file".into(),
+                surface: "native".into(),
+                args_json: "{}".into(),
+                args_digest: "d0".into(),
+                reason: String::new(),
+                ok: true,
+                error: String::new(),
+                bytes_out: 128,
+                duration_ms: 3,
+            }],
+        )
+        .unwrap();
+    store.finish_execution(id, "success", 0.01).unwrap();
+    backdate(store, id, age_days);
+    id
+}
+
+/// Move an execution's timestamps `age_days` into the past. Direct SQL: the
+/// public API always stamps `CURRENT_TIMESTAMP`, and these tests need a
+/// deterministic age.
+fn backdate(store: &Store, id: i64, age_days: i64) {
+    store
+        .lock()
+        .execute(
+            "UPDATE executions \
+             SET finished_at = datetime('now', ?1), started_at = datetime('now', ?1) \
+             WHERE id = ?2",
+            params![format!("-{age_days} days"), id],
+        )
+        .unwrap();
+}
+
+/// An execution left in flight — begun and backdated, never finished.
+fn unfinished_execution(store: &Store, prompt: &str, age_days: i64) -> i64 {
+    let id = store
+        .begin_execution("goal", prompt, "zai", "glm-5.2")
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE executions SET started_at = datetime('now', ?1) WHERE id = ?2",
+            params![format!("-{age_days} days"), id],
+        )
+        .unwrap();
+    id
+}
+
+fn mark_export_pending(store: &Store, execution_id: i64) {
+    store
+        .lock()
+        .execute(
+            "INSERT INTO enterprise_export_ledger \
+             (sink_fingerprint, execution_id, export_nonce, status) \
+             VALUES ('sink-a', ?1, 'nonce', 'pending')",
+            params![execution_id],
+        )
+        .unwrap();
+}
+
+fn ninety_days() -> RetentionPolicy {
+    RetentionPolicy {
+        older_than: Some("-90 days".to_string()),
+        ..Default::default()
+    }
+}
+
+// ---- the happy path -----------------------------------------------------
+
+#[test]
+fn the_age_cutoff_removes_old_executions_and_cascades_their_rows() {
+    let store = Store::in_memory().unwrap();
+    aged_execution(&store, "ancient", 200);
+    let recent = aged_execution(&store, "recent", 3);
+
+    let report = store.prune(&ninety_days()).unwrap();
+
+    assert_eq!(report.aged_out, 1, "only the 200-day-old turn is past 90d");
+    assert!(
+        report.child_rows_removed >= 2,
+        "its event and tool call must go with it, got {}",
+        report.child_rows_removed
+    );
+    assert_eq!(store.count("executions").unwrap(), 1);
+    assert_eq!(
+        store.count("events").unwrap(),
+        1,
+        "the recent turn's event must survive"
+    );
+    // And the survivor is the right one.
+    let surviving: i64 = store
+        .lock()
+        .query_row("SELECT id FROM executions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(surviving, recent);
+}
+
+#[test]
+fn a_cascade_leaves_no_orphans_behind() {
+    let store = Store::in_memory().unwrap();
+    let doomed = aged_execution(&store, "ancient", 200);
+    aged_execution(&store, "recent", 1);
+
+    store.prune(&ninety_days()).unwrap();
+
+    // Every execution-scoped table must be free of the pruned id — an orphan
+    // pointing at a missing turn reads back as corruption.
+    for table in ["events", "tool_calls", "telemetry", "files_touched"] {
+        let orphans: i64 = store
+            .lock()
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE execution_id = ?1"),
+                params![doomed],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0, "`{table}` still holds rows for a pruned turn");
+    }
+}
+
+// ---- what must never be deleted -----------------------------------------
+
+#[test]
+fn an_unfinished_execution_is_never_pruned_even_when_ancient() {
+    let store = Store::in_memory().unwrap();
+    let in_flight = unfinished_execution(&store, "still running", 500);
+
+    let report = store.prune(&ninety_days()).unwrap();
+
+    assert_eq!(report.aged_out, 0, "an in-flight turn must not be pruned");
+    assert_eq!(
+        report.protected_unfinished, 1,
+        "and must be reported as held"
+    );
+    assert_eq!(store.count("executions").unwrap(), 1);
+
+    // `force` does not lift this one — it is structural, not policy.
+    let forced = RetentionPolicy {
+        force: true,
+        ..ninety_days()
+    };
+    store.prune(&forced).unwrap();
+    assert_eq!(
+        store.count("executions").unwrap(),
+        1,
+        "--force must not reach an unfinished execution"
+    );
+    let still_there: i64 = store
+        .lock()
+        .query_row("SELECT id FROM executions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(still_there, in_flight);
+}
+
+#[test]
+fn forgotten_tombstones_survive_every_policy() {
+    let store = Store::in_memory().unwrap();
+    aged_execution(&store, "ancient", 900);
+    store
+        .lock()
+        .execute(
+            "INSERT INTO forgotten (surface, item_id, content, reason, forgotten_at) \
+             VALUES ('memory', 'm-1', 'the forgotten text', 'user asked', \
+                     datetime('now', '-900 days'))",
+            [],
+        )
+        .unwrap();
+
+    let scorched = RetentionPolicy {
+        older_than: Some("-1 days".to_string()),
+        max_executions: Some(0),
+        force: true,
+        vacuum: true,
+        ..Default::default()
+    };
+    store.prune(&scorched).unwrap();
+
+    assert_eq!(
+        store.count("forgotten").unwrap(),
+        1,
+        "a tombstone is the record that something was forgotten — dropping it \
+         un-forgets that content on the next re-mine"
+    );
+}
+
+#[test]
+fn a_pending_export_holds_an_execution_back_until_forced() {
+    let store = Store::in_memory().unwrap();
+    let pending = aged_execution(&store, "not yet drained", 200);
+    aged_execution(&store, "drained", 200);
+    mark_export_pending(&store, pending);
+
+    let report = store.prune(&ninety_days()).unwrap();
+    assert_eq!(report.aged_out, 1, "only the drained turn may go");
+    assert_eq!(report.protected_pending_export, 1);
+    assert_eq!(store.count("executions").unwrap(), 1);
+
+    // `force` is exactly what lifts this guard.
+    let report = store
+        .prune(&RetentionPolicy {
+            force: true,
+            ..ninety_days()
+        })
+        .unwrap();
+    assert_eq!(report.aged_out, 1);
+    assert_eq!(store.count("executions").unwrap(), 0);
+}
+
+#[test]
+fn cross_turn_reflections_are_not_owned_by_any_execution_and_survive() {
+    let store = Store::in_memory().unwrap();
+    let doomed = aged_execution(&store, "ancient", 200);
+    store
+        .lock()
+        .execute(
+            "INSERT INTO reflections (execution_id, kind, content, occurred_at) \
+             VALUES (NULL, 'insight', 'a cross-turn lesson', 0)",
+            [],
+        )
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "INSERT INTO reflections (execution_id, kind, content, occurred_at) \
+             VALUES (?1, 'insight', 'tied to one turn', 0)",
+            params![doomed],
+        )
+        .unwrap();
+
+    store.prune(&ninety_days()).unwrap();
+
+    let remaining: i64 = store
+        .lock()
+        .query_row("SELECT COUNT(*) FROM reflections", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        remaining, 1,
+        "the NULL-execution reflection belongs to no turn and must survive"
+    );
+    let is_null: i64 = store
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM reflections WHERE execution_id IS NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(is_null, 1);
+}
+
+// ---- dry run, ceiling, and the no-op guard ------------------------------
+
+#[test]
+fn a_dry_run_reports_exactly_what_a_real_run_would_do_and_deletes_nothing() {
+    let store = Store::in_memory().unwrap();
+    for i in 0..4 {
+        aged_execution(&store, &format!("ancient-{i}"), 200);
+    }
+    aged_execution(&store, "recent", 2);
+    let before = store.count("executions").unwrap();
+    let events_before = store.count("events").unwrap();
+
+    let dry = store
+        .prune(&RetentionPolicy {
+            dry_run: true,
+            ..ninety_days()
+        })
+        .unwrap();
+
+    assert_eq!(
+        store.count("executions").unwrap(),
+        before,
+        "dry run deleted"
+    );
+    assert_eq!(store.count("events").unwrap(), events_before);
+    assert!(!dry.vacuumed, "a dry run must not VACUUM");
+
+    let wet = store.prune(&ninety_days()).unwrap();
+    assert_eq!(
+        dry.aged_out, wet.aged_out,
+        "the dry run's headline number must be the truth"
+    );
+    assert_eq!(dry.child_rows_removed, wet.child_rows_removed);
+    assert_eq!(store.count("executions").unwrap(), 1);
+}
+
+#[test]
+fn the_row_ceiling_evicts_oldest_first() {
+    let store = Store::in_memory().unwrap();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        // Ages descend, so the lowest id is the oldest.
+        ids.push(aged_execution(&store, &format!("turn-{i}"), 50 - i));
+    }
+
+    let report = store
+        .prune(&RetentionPolicy {
+            max_executions: Some(2),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(report.ceiling_evicted, 3);
+    assert_eq!(store.count("executions").unwrap(), 2);
+    let survivors: Vec<i64> = {
+        let conn = store.lock();
+        let mut stmt = conn
+            .prepare("SELECT id FROM executions ORDER BY id ASC")
+            .unwrap();
+        let rows = stmt.query_map([], |r| r.get::<_, i64>(0)).unwrap();
+        rows.collect::<std::result::Result<_, _>>().unwrap()
+    };
+    assert_eq!(
+        survivors,
+        vec![ids[3], ids[4]],
+        "the two newest turns must be the ones kept"
+    );
+}
+
+#[test]
+fn the_ceiling_reports_what_protection_kept_it_from_reaching() {
+    let store = Store::in_memory().unwrap();
+    for i in 0..3 {
+        let id = aged_execution(&store, &format!("turn-{i}"), 10);
+        mark_export_pending(&store, id);
+    }
+
+    let report = store
+        .prune(&RetentionPolicy {
+            max_executions: Some(0),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(report.ceiling_evicted, 0);
+    assert_eq!(
+        report.still_over_ceiling, 3,
+        "a ceiling that could not be reached must say so, not silently under-deliver"
+    );
+    assert_eq!(store.count("executions").unwrap(), 3);
+}
+
+#[test]
+fn a_policy_that_asks_for_nothing_is_an_error_not_a_silent_noop() {
+    let store = Store::in_memory().unwrap();
+    let err = store.prune(&RetentionPolicy::default()).unwrap_err();
+    assert!(
+        err.0.contains("--older-than") && err.0.contains("--max-executions"),
+        "the error must name the knobs that would make it do something, got: {}",
+        err.0
+    );
+    assert!(RetentionPolicy::default().is_noop());
+}
+
+#[test]
+fn an_empty_report_is_empty() {
+    let report = RetentionReport::default();
+    assert!(report.is_empty());
+    assert_eq!(report.executions_removed(), 0);
+}
+
+#[test]
+fn pruning_an_empty_store_is_harmless() {
+    let store = Store::in_memory().unwrap();
+    let report = store.prune(&ninety_days()).unwrap();
+    assert!(report.is_empty());
+    assert_eq!(store.count("executions").unwrap(), 0);
+}


### PR DESCRIPTION
Remediation for **three of the five untouched structural findings**, a durable gate for a fourth, and the fix that unbroke `main`. Five independent commits, each separately reviewable.

| # | commit | finding |
|---|---|---|
| 1 | `fix(store)` | main hasn't compiled since #699 |
| 2 | `model` | live_smoke's nine arms + missing slug gate — **closed** |
| 3 | `store` | store.db has no retention path — **closed** |
| 4 | `docs(security)` | no threat model document — **closed** |
| 5 | `lint` | 1,580-line `async fn` — **gated**, not decomposed |

---

## 1. `fix(store)`: main has not compiled since #699

`a69dfd95` deleted `read_cloud_json` but left `cloud_registration_at` calling it. The deletion was *correct* — the helper only worked around `validate_owner_controlled_parent` being hard-wired to `Err` off Unix, and #699 gave the non-Unix branch a real implementation — so this inlines it unconditionally, matching the write path. Plus an adjacent `needless_borrow`.

## 2. The provider factory moves down

> *"…live_smoke.rs still hand-reimplements nine construction arms with the anti-phantom-slug gate silently missing."*

The finding is right; the implied fix would not have worked. **`stella-cli` depends on `stella-model`**, so `live_smoke.rs` sits *below* the factory and could never call it, `lib.rs` or not. The nine hand-rolled arms were what the dependency direction allowed.

So the factory moves **down**: `Dialect` + the 6-arm dispatch → `stella_model::factory`. **The slug gate is now layered** — the seed floor runs inside the factory for every caller; the synced-catalog escalation (needs `catalog.db`) stays in the CLI ahead of the delegation.

**Why the gate was missing:** every live test is gated behind `STELLA_LIVE_SMOKE=1` *and* a credential — right for spending money, wrong for the one property a catalog checks offline for free. A dead slug produced a green `cargo test --workspace`. Three guards now run unconditionally. **Mutation-verified**: `claude-fable-5-PHANTOM` fails two by name.

## 3. store.db gets the retention path its derived sibling already had

The asymmetry points the wrong way: `usage.db` is a *derived, content-free* rollup with a full prune engine since #520; `store.db` is the **source of truth** (`executions.prompt`, `events.payload`) and could only be bounded by deleting the file. *(#699 did not widen this — the gap opened with #520.)*

Prunes **by execution**, cascading to thirteen tables in one transaction. Three classes excluded **by construction, not by flag** — `forgotten` tombstones (dropping one un-forgets that content on the next re-mine), unfinished executions, pending enterprise exports. `--force` lifts **only the third**.

**Verified end-to-end**: seeded a real workspace, `--dry-run` reported 2 executions + 2 rows and changed nothing; the real run removed exactly those, kept the recent turn, the in-flight turn and the tombstone, and left **zero orphans**. Twelve unit tests, most asserting what *survives*.

## 4. The threat model that was missing

The reasoning always existed — it was just never written down *together*, scattered across doc comments in `merge.rs`, `authority.rs`, `subprocess_env.rs`, `sandbox.rs`, `web.rs`, `private.rs`, `env_files.rs`. None of them can tell you whether the set is complete.

`docs/design/threat-model.md`: 8 assets, 5 adversaries (A1 hostile repository is primary — the framing question is *"what can a repository do?"*), 7 trust boundaries, 16 attack paths.

The section worth reading is **Residual risk** — a threat model that only lists wins is marketing. Nine recorded, several deliberate:

- **R2** — *"bash is off by default"* is true and is **not** the same claim as "the agent cannot run code": `run_script`, `start_process`, `repo_commit`/`push` and workspace custom tools all execute without bash enabled.
- **R3** — the sandbox wraps `bash` **only**. Its own doc names prompt injection as the threat it mitigates; that mitigation has a shape the threat does not.
- **R1** — trust is an env var; there is no prompt and no persisted trust store.
- **R9** — no secret detector, so a pasted secret lands in `store.db` in the clear. The mitigation available today is retention (#3 above), not redaction.

Claims spot-checked against code, not asserted. SECURITY.md now points here.

## 5. A god-function ratchet

Does **not** decompose anything — stops the next one. The 1,500-line *file* ratchet from #685 has no counterpart for functions, which is how a single `fn` grew past the file limit that same script enforces.

`clippy::too_many_lines` at **300** (its default 100 would flood and get deleted). Exactly five functions violate it; each gets an `#[allow]` naming what its decomposition would be. Enabled via `[workspace.lints.clippy]` in all 15 members rather than a CI flag, so the verdict shows up locally and in IDEs — *a gate only CI can see is one people discover by having their PR rejected.*

**Mutation-verified**: a synthetic 320-line fn fails with `this function has too many lines (320/300)`.

---

## On the file-size ratchet

It caught this PR twice, which is the gate working. Moving the prune flags into `storage_prune.rs` cut `main.rs`'s growth **+44 → +13**; comments were tightened before the second bump. Baselines bumped visibly per the script's own workflow — and the same `--update` **tightened two ceilings that had drifted down on main** (−20, −8).

## Verification

| gate | result |
|---|---|
| `cargo test --workspace` | exit 0, 59 suites, 0 failures |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --all --check` | exit 0 |
| `./scripts/check-file-size.sh` | exit 0 |

## Still outstanding

- **`stella-cli` has no `lib.rs`** — the settings trust gate stays unreachable to a second host. 73 files, 44 modules; a dedicated change.
- **`run_deck_session`** — the prologue extracts into a `DeckSession`, but the loop owns ~30 mutable bindings and channel handles that must move together. Now annotated at the site and gated against growth.
- **`deck_ui.rs`** — the test split landed as #697 (6,884 → 3,926); the production-side handler decomposition did not.

## One correction to the audit

> *"the 1500-line violator population went from 21 files to 32 with nothing arresting it"*

The count is right (32). But a ratchet **does** arrest it — `scripts/check-file-size.sh`, wired into `ci.yml:92` and the Makefile, landed with #685. It is what caught this PR, twice.