### PR TITLE
feat(tui): redesign the session transcript for reading

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -12,7 +12,7 @@
 1599 stella-cli/src/candidate_ws.rs
 4465 stella-cli/src/command_deck.rs
 1503 stella-cli/src/contextgraph.rs
-1789 stella-cli/src/main.rs
+1776 stella-cli/src/main.rs
 1641 stella-cli/src/memory.rs
 2224 stella-context/src/store.rs
 2095 stella-core/src/bus.rs
@@ -28,7 +28,7 @@
 2504 stella-pipeline/src/pipeline.rs
 2019 stella-pipeline/src/pipeline/tests.rs
 2636 stella-protocol/src/event.rs
-2270 stella-store/src/lib.rs
+2268 stella-store/src/lib.rs
 2168 stella-store/src/tests.rs
 1884 stella-store/src/usage.rs
 1558 stella-tools/src/media.rs
@@ -36,6 +36,5 @@
 1797 stella-tools/src/scripts.rs
 1670 stella-tui/src/deck_render.rs
 3940 stella-tui/src/deck_ui.rs
-1616 stella-tui/src/model.rs
-1513 stella-tui/src/render.rs
+1609 stella-tui/src/model.rs
 1650 stella-tui/src/views/engine.rs

--- a/stella-tui/src/diff.rs
+++ b/stella-tui/src/diff.rs
@@ -1,11 +1,22 @@
 //! GitHub-PR-style diff presentation, shared by every diff surface (the
-//! session REPL's right pane and the deck's Files tab) so there is exactly one
-//! implementation of "how a diff looks". The layout is the design-doc
-//! contract: the full file path inline in a horizontal rule **above** the
-//! body, a line-number gutter on the body itself, and a closing rule **below**
-//! that counts the added/removed lines. Colors come from [`crate::theme`]
-//! only — the add/remove/hunk semantics stay consistent with the rest of the
-//! deck (and with any future light variant of the theme) by construction.
+//! session REPL's right pane, the deck's Files tab, and the transcript's
+//! inline diffs) so there is exactly one implementation of "how a diff looks".
+//!
+//! A *viewer* gets the full design-doc layout: the file path inline in a
+//! horizontal rule above the body, a line-number gutter on the body, and a
+//! closing rule below counting the added/removed lines. The transcript's
+//! inline form ([`body_lines_inline`]) drops that surrounding chrome, because
+//! there the call row already names the file and the result row already states
+//! `+n −m` — the rules would be the same facts a second time, wrapped around
+//! what is often a two-row change.
+//!
+//! Two things the body does everywhere: context lines keep their syntax
+//! colours (context exists to be read), and a `-`/`+` pair close enough to
+//! align gets its differing middle picked out on a brighter ground, so a
+//! one-token edit names itself instead of leaving the reader to compare two
+//! near-identical lines by eye. Colors come from [`crate::theme`] only — the
+//! add/remove/hunk semantics stay consistent with the rest of the deck (and
+//! with any future light variant of the theme) by construction.
 
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -110,33 +121,245 @@ pub fn body_lines(diff: &str, path: Option<&str>) -> Vec<Line<'static>> {
     body_lines_capped(diff, path, usize::MAX).0
 }
 
-/// Like [`body_lines`], but styles at most `cap` lines, returning the styled
-/// prefix plus the total line count the full render would produce — so a
-/// caller that collapses long diffs (the inline transcript view) never pays
-/// tokenizing cost for lines it drops.
+/// Like [`body_lines`], but shows at most `cap` lines, returning the styled
+/// selection plus the number of lines it withheld.
+///
+/// The cap is **hunk-aware**: it emits whole hunks while they fit and drops
+/// the rest, rather than slicing the body at line `cap`. A flat cut lands
+/// wherever it lands — routinely between a `-` line and the `+` line that
+/// replaces it — leaving a change that reads as a pure deletion. Whole hunks
+/// are the smallest unit that is honest on its own. Only when the *first*
+/// hunk alone overruns the budget does this fall back to a window, and even
+/// then the window is centred on the changed lines rather than anchored at
+/// the hunk's leading context.
 pub fn body_lines_capped(
     diff: &str,
     path: Option<&str>,
     cap: usize,
 ) -> (Vec<Line<'static>>, usize) {
+    render_body(diff, path, cap, true)
+}
+
+/// [`body_lines_capped`] for the transcript's inline diffs, which drop a lone
+/// `@@ -a,b +c,d @@` header.
+///
+/// In a diff *viewer* the hunk header is orientation. Inline under a tool call
+/// it is a row of chrome restating what the line-number gutter beside it
+/// already says, and a two-line change should not cost three rows. With more
+/// than one hunk the headers stay: there they earn their space as the boundary
+/// between two disjoint regions of the file.
+pub fn body_lines_inline(
+    diff: &str,
+    path: Option<&str>,
+    cap: usize,
+) -> (Vec<Line<'static>>, usize) {
+    let multi = diff.lines().filter(|l| l.starts_with("@@")).count() > 1;
+    render_body(diff, path, cap, multi)
+}
+
+fn render_body(
+    diff: &str,
+    path: Option<&str>,
+    cap: usize,
+    hunk_headers: bool,
+) -> (Vec<Line<'static>>, usize) {
     let lang = match path {
         Some(p) => lang_from_path(p),
         None => lang_from_diff_header(diff),
     };
+    // `.lines()`, not `.split('\n')`: a diff ending in a trailing newline
+    // must not render (and count against hunk state) a spurious empty row.
+    let raw: Vec<&str> = diff.lines().collect();
+    let keep = select_lines(&raw, cap);
+    let emphasis = word_emphasis(&raw);
     let mut old_no: Option<u32> = None;
     let mut new_no: Option<u32> = None;
     let mut in_hunk = false;
     let mut lines = Vec::new();
-    let mut total = 0usize;
-    // `.lines()`, not `.split('\n')`: a diff ending in a trailing newline
-    // must not render (and count against hunk state) a spurious empty row.
-    for raw in diff.lines() {
-        total += 1;
-        if lines.len() < cap {
-            lines.push(body_line(raw, lang, &mut old_no, &mut new_no, &mut in_hunk));
+    let mut hidden = 0usize;
+    for (i, text) in raw.iter().enumerate() {
+        // Every line advances the gutter counters, shown or not — skipping a
+        // line must not renumber the ones after it.
+        let line = body_line(
+            text,
+            lang,
+            &mut old_no,
+            &mut new_no,
+            &mut in_hunk,
+            emphasis.get(&i).copied(),
+        );
+        if !keep[i] {
+            hidden += 1;
+        } else if hunk_headers || !text.starts_with("@@") {
+            lines.push(line);
         }
     }
-    (lines, total)
+    (lines, hidden)
+}
+
+/// Choose which diff lines a `cap`-limited render shows. See
+/// [`body_lines_capped`] for the policy; this is the mechanism.
+fn select_lines(raw: &[&str], cap: usize) -> Vec<bool> {
+    let n = raw.len();
+    if n <= cap {
+        return vec![true; n];
+    }
+    let mut keep = vec![false; n];
+    // Hunk boundaries. Anything before the first `@@` is file metadata that
+    // belongs with the hunk it introduces, so the first boundary is pulled
+    // back to 0; a headerless pseudo-diff (stella's event path emits these)
+    // is simply one unbounded hunk.
+    let mut bounds: Vec<usize> = (0..n).filter(|&i| raw[i].starts_with("@@")).collect();
+    if bounds.first().copied().unwrap_or(1) != 0 {
+        bounds.insert(0, 0);
+    }
+    bounds.push(n);
+
+    let mut used = 0usize;
+    for w in bounds.windows(2) {
+        let (start, end) = (w[0], w[1]);
+        if used + (end - start) > cap {
+            break;
+        }
+        keep[start..end].fill(true);
+        used += end - start;
+    }
+    if used > 0 {
+        return keep;
+    }
+
+    // The first hunk alone overruns the budget. Keep its `@@` header (it is
+    // the line that says *where* in the file this is) and a window of the
+    // body starting two lines of context above the first real change.
+    let end = bounds[1];
+    let first_change = (0..end)
+        .find(|&i| matches!(raw[i].as_bytes().first(), Some(b'+') | Some(b'-')) && !is_meta(raw[i]))
+        .unwrap_or(0);
+    let header = (0..end).find(|&i| raw[i].starts_with("@@"));
+    let mut budget = cap;
+    if let Some(h) = header {
+        keep[h] = true;
+        budget = budget.saturating_sub(1);
+    }
+    let start = first_change
+        .saturating_sub(2)
+        .max(header.map_or(0, |h| h + 1));
+    for slot in &mut keep[start..end] {
+        if budget == 0 {
+            break;
+        }
+        if !*slot {
+            *slot = true;
+            budget -= 1;
+        }
+    }
+    keep
+}
+
+/// Whether a line is diff metadata rather than source content.
+fn is_meta(line: &str) -> bool {
+    line.starts_with("+++ ")
+        || line.starts_with("--- ")
+        || line.starts_with("diff ")
+        || line.starts_with("index ")
+}
+
+/// The byte range within each changed line that actually differs from its
+/// counterpart, keyed by line index.
+///
+/// A one-token edit — `tool_policy::` becoming `crate::tool_policy::` — renders
+/// as two nearly identical lines, and finding the difference is left to the
+/// reader diffing them by eye, character by character. That is the single
+/// most common edit an agent makes and the one the transcript reads worst.
+/// Trimming the shared prefix and suffix off a `-`/`+` pair isolates the part
+/// that changed, which the body then paints brighter than the rest of the line.
+///
+/// Pairing is deliberately conservative: only a run of removals immediately
+/// followed by an equally long run of additions pairs up, index for index.
+/// Unequal runs mean lines were added or dropped, so no positional pairing is
+/// trustworthy and the whole-line colouring is left to speak for itself.
+fn word_emphasis(raw: &[&str]) -> std::collections::HashMap<usize, (usize, usize)> {
+    let mut out = std::collections::HashMap::new();
+    // A headerless pseudo-diff — bare `+`/`-` lines with no `@@`, which the
+    // event path can emit — is one implicit hunk. Starting `false` there would
+    // skip every line and silently disable emphasis for that whole shape.
+    let mut in_hunk = !raw.iter().any(|l| l.starts_with("@@"));
+    let mut i = 0;
+    while i < raw.len() {
+        if raw[i].starts_with("@@") {
+            in_hunk = true;
+            i += 1;
+            continue;
+        }
+        if !in_hunk || is_meta(raw[i]) {
+            i += 1;
+            continue;
+        }
+        let del_start = i;
+        while i < raw.len() && raw[i].starts_with('-') && !is_meta(raw[i]) {
+            i += 1;
+        }
+        let del_end = i;
+        let add_start = i;
+        while i < raw.len() && raw[i].starts_with('+') && !is_meta(raw[i]) {
+            i += 1;
+        }
+        let add_end = i;
+        let (dn, an) = (del_end - del_start, add_end - add_start);
+        if dn > 0 && dn == an {
+            for k in 0..dn {
+                let (o, n) = (raw[del_start + k], raw[add_start + k]);
+                if let Some((os, oe, ns, ne)) = changed_span(&o[1..], &n[1..]) {
+                    // +1 on every offset: the `+`/`-` marker is one ASCII byte
+                    // that the caller's slice keeps in front of the code.
+                    out.insert(del_start + k, (os + 1, oe + 1));
+                    out.insert(add_start + k, (ns + 1, ne + 1));
+                }
+            }
+        }
+        if del_end == del_start && add_end == add_start {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Trim the shared prefix and suffix off two versions of a line, returning
+/// `(old_start, old_end, new_start, new_end)` byte ranges of the differing
+/// middles — or `None` when the pair is too dissimilar for the answer to mean
+/// anything.
+fn changed_span(old: &str, new: &str) -> Option<(usize, usize, usize, usize)> {
+    if old == new {
+        return None;
+    }
+    let prefix = old
+        .char_indices()
+        .zip(new.char_indices())
+        .take_while(|((_, a), (_, b))| a == b)
+        .last()
+        .map_or(0, |((i, c), _)| i + c.len_utf8());
+    // Suffix scan stops at the prefix boundary on both sides, so the two
+    // ranges can never cross and produce a negative-width middle.
+    let mut suffix = 0usize;
+    {
+        let mut o = old[prefix..].chars().rev();
+        let mut n = new[prefix..].chars().rev();
+        loop {
+            match (o.next(), n.next()) {
+                (Some(a), Some(b)) if a == b => suffix += a.len_utf8(),
+                _ => break,
+            }
+        }
+    }
+    let (o_end, n_end) = (old.len() - suffix, new.len() - suffix);
+    // Below this much shared text the lines are different statements rather
+    // than one statement edited, and an "emphasis" covering nearly the whole
+    // row would say less than the row's own add/remove colour already does.
+    let shared = prefix + suffix;
+    if shared * 10 < old.len().max(new.len()) * 3 {
+        return None;
+    }
+    Some((prefix, o_end, prefix, n_end))
 }
 
 fn body_line(
@@ -145,6 +368,7 @@ fn body_line(
     old_no: &mut Option<u32>,
     new_no: &mut Option<u32>,
     in_hunk: &mut bool,
+    emph: Option<(usize, usize)>,
 ) -> Line<'static> {
     if raw.starts_with("diff ") {
         // A new file section: the next `+++ `/`--- ` pair are headers again.
@@ -203,6 +427,7 @@ fn body_line(
                 theme::OK,
                 Some(theme::DIFF_ADD_BG),
                 lang,
+                emph.map(|(s, e)| (s - 1, e - 1, theme::DIFF_ADD_BG_EMPH)),
             ));
             Line::from(spans)
         }
@@ -216,6 +441,7 @@ fn body_line(
                 theme::BAD,
                 Some(theme::DIFF_DEL_BG),
                 lang,
+                emph.map(|(s, e)| (s - 1, e - 1, theme::DIFF_DEL_BG_EMPH)),
             ));
             Line::from(spans)
         }
@@ -231,11 +457,13 @@ fn body_line(
                 None => ("", raw),
             };
             let mut spans = vec![gutter(n)];
-            // Context lines stay fully muted (no syntax colors — `lang` is
-            // deliberately not passed): de-emphasis is what separates the
-            // unchanged surroundings from the change itself, and a keyword
-            // glowing brand-amber on both would erase that distinction.
-            spans.extend(code_spans(marker, code, theme::MUTED, None, None));
+            // Context lines keep their syntax colours. Context exists to be
+            // *read* — it is how a reader places the change inside the
+            // function around it — and flattening it to one grey erases the
+            // structure that makes it readable at a glance. The add/remove
+            // tint already separates changed from unchanged; a second,
+            // redundant signal is not worth an unreadable surround.
+            spans.extend(code_spans(marker, code, theme::MUTED, None, lang, None));
             Line::from(spans)
         }
     }
@@ -253,21 +481,68 @@ fn code_spans(
     base: Color,
     bg: Option<Color>,
     lang: Option<Lang>,
+    emph: Option<(usize, usize, Color)>,
 ) -> Vec<Span<'static>> {
     let base_style = with_bg(Style::default().fg(base), bg);
     let Some(lang) = lang else {
-        return vec![Span::styled(format!("{marker}{code}"), base_style)];
+        let plain = vec![(code.to_string(), None)];
+        return marker_then(marker, base_style, plain, base_style, bg, emph);
     };
+    marker_then(
+        marker,
+        base_style,
+        tokenize(code, lang),
+        base_style,
+        bg,
+        emph,
+    )
+}
+
+/// Assemble a code line's spans: the uncoloured marker, then each syntax run,
+/// with any run overlapping the emphasis range split out and repainted onto
+/// the brighter background.
+fn marker_then(
+    marker: &str,
+    marker_style: Style,
+    runs: Vec<(String, Option<crate::syntax::Tok>)>,
+    base_style: Style,
+    bg: Option<Color>,
+    emph: Option<(usize, usize, Color)>,
+) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     if !marker.is_empty() {
-        spans.push(Span::styled(marker.to_string(), base_style));
+        spans.push(Span::styled(marker.to_string(), marker_style));
     }
-    for (text, tok) in tokenize(code, lang) {
+    let mut at = 0usize;
+    for (text, tok) in runs {
         let style = match tok {
             Some(t) => with_bg(tok_style(t), bg),
             None => base_style,
         };
-        spans.push(Span::styled(text, style));
+        let end = at + text.len();
+        match emph {
+            // The run overlaps the changed span: split it so only the changed
+            // bytes take the brighter ground.
+            Some((s, e, colour)) if s < end && e > at && s < e => {
+                let (lo, hi) = (s.max(at), e.min(end));
+                for (range, hot) in [(at..lo, false), (lo..hi, true), (hi..end, false)] {
+                    if range.is_empty() {
+                        continue;
+                    }
+                    let slice = &text[range.start - at..range.end - at];
+                    let st = if hot {
+                        style
+                            .bg(colour)
+                            .add_modifier(ratatui::style::Modifier::BOLD)
+                    } else {
+                        style
+                    };
+                    spans.push(Span::styled(slice.to_string(), st));
+                }
+            }
+            _ => spans.push(Span::styled(text, style)),
+        }
+        at = end;
     }
     spans
 }
@@ -609,18 +884,24 @@ mod tests {
 
     #[test]
     fn unknown_language_falls_back_to_a_single_plain_code_span() {
-        // No path and no inferable header → one code span per line, exactly
-        // like the pre-highlighting rendering (gutter + one styled span).
+        // No path and no inferable header → the code is one unsplit span.
+        // The `+`/`-` marker is always its own span, language or not: it is
+        // diff structure rather than source text, and splitting it uniformly
+        // means the word-diff emphasis offsets mean the same thing on every
+        // line instead of shifting by one on the un-highlighted ones.
         let line = body_lines("@@ -1 +1 @@\n+fn x", None).pop().unwrap();
         assert_eq!(
             line.spans.len(),
-            2,
-            "gutter + one plain span: {:?}",
+            3,
+            "gutter + marker + one plain code span: {:?}",
             line.spans
         );
-        assert_eq!(line.spans[1].content, "+fn x");
-        assert_eq!(line.spans[1].style.fg, Some(theme::OK));
-        assert_eq!(line.spans[1].style.bg, Some(theme::DIFF_ADD_BG));
+        assert_eq!(line.spans[1].content, "+");
+        assert_eq!(line.spans[2].content, "fn x");
+        for span in &line.spans[1..] {
+            assert_eq!(span.style.fg, Some(theme::OK));
+            assert_eq!(span.style.bg, Some(theme::DIFF_ADD_BG));
+        }
     }
 
     #[test]
@@ -663,26 +944,51 @@ mod tests {
         let line = body_lines(diff, Some("q.sql")).pop().unwrap();
         assert_eq!(
             line.spans.len(),
-            2,
-            "gutter + one plain span, no Python keywords: {:?}",
+            3,
+            "gutter + marker + one plain code span, no Python keywords: {:?}",
+            line.spans
+        );
+        assert_eq!(line.spans[2].content, "import x");
+        assert_eq!(
+            line.spans[2].style.fg,
+            Some(theme::OK),
+            "the whole code run keeps the add colour — no token was recognized: {:?}",
             line.spans
         );
     }
 
     #[test]
-    fn context_lines_stay_fully_muted_without_syntax_colors() {
-        // De-emphasis is the whole point of a context line: even with a
-        // recognized language its keywords keep the muted foreground.
+    fn context_lines_keep_their_syntax_colors() {
+        // Context exists to be *read* — it is how a reader places the change
+        // inside the function around it — so it highlights exactly like the
+        // changed lines do. Flattening it to one grey erased the structure
+        // that makes it readable, and bought nothing: the add/remove
+        // background tint already says which lines changed, so a second,
+        // redundant de-emphasis signal only costs legibility.
         let diff = "@@ -1,2 +1,2 @@\n fn unchanged() {}\n+fn added() {}";
         let lines = body_lines(diff, Some("m.rs"));
         let context = &lines[1];
+        let kw = span_with(context, "fn").expect("`fn` is its own span on a context line");
         assert_eq!(
-            context.spans.len(),
-            2,
-            "gutter + one muted span: {:?}",
+            kw.style.fg,
+            Some(theme::SYNTAX_KEYWORD),
+            "context keywords are coloured: {:?}",
             context.spans
         );
-        assert_eq!(context.spans[1].style.fg, Some(theme::MUTED));
+        assert_eq!(
+            kw.style.bg, None,
+            "…but carry no add/remove tint — that is what still separates \
+             changed from unchanged: {:?}",
+            context.spans
+        );
+        // The un-tokenized remainder falls back to the muted body colour, so
+        // context still reads a shade quieter than a changed line overall.
+        assert_eq!(
+            span_with(context, " unchanged() {}").map(|s| s.style.fg),
+            Some(Some(theme::MUTED)),
+            "plain runs stay muted: {:?}",
+            context.spans
+        );
         let added = &lines[2];
         assert_eq!(
             span_with(added, "fn").map(|s| s.style.fg),
@@ -690,18 +996,54 @@ mod tests {
             "added lines still highlight: {:?}",
             added.spans
         );
+        assert_eq!(
+            span_with(added, "fn").map(|s| s.style.bg),
+            Some(Some(theme::DIFF_ADD_BG)),
+            "and keep the add tint the context line lacks: {:?}",
+            added.spans
+        );
     }
 
     #[test]
-    fn capped_rendering_styles_only_the_cap_but_counts_every_line() {
+    fn capped_rendering_styles_only_the_cap_and_reports_what_it_withheld() {
+        // The second return value is the *hidden* count, not the total: the
+        // only caller is the "⋯ N lines · ctrl+o" fold hint, and a total
+        // makes it do subtraction the renderer already knows the answer to.
         let diff = "+one\n+two\n+three\n+four\n+five";
-        let (lines, total) = body_lines_capped(diff, Some("x.rs"), 2);
+        let (lines, hidden) = body_lines_capped(diff, Some("x.rs"), 2);
         assert_eq!(lines.len(), 2, "styles stop at the cap");
-        assert_eq!(total, 5, "the footer math sees the full length");
-        // An uncapped call is byte-identical to `body_lines`.
+        assert_eq!(hidden, 3, "and the other three are reported as withheld");
+        // An uncapped call withholds nothing and is byte-identical to
+        // `body_lines`.
         let (all, n) = body_lines_capped(diff, Some("x.rs"), usize::MAX);
-        assert_eq!(n, 5);
+        assert_eq!(n, 0);
         assert_eq!(all, body_lines(diff, Some("x.rs")));
+    }
+
+    #[test]
+    fn the_cap_emits_whole_hunks_rather_than_slicing_mid_change() {
+        // A flat cut lands wherever it lands — routinely between a `-` line
+        // and the `+` line that replaces it — leaving a change that reads as
+        // a pure deletion. Whole hunks are the smallest unit that is honest
+        // on its own, so a budget that cannot fit the second hunk drops all
+        // of it instead of showing its opening half.
+        let diff = "@@ -1,2 +1,2 @@\n-a\n+A\n@@ -9,2 +9,2 @@\n-b\n+B";
+        let (lines, hidden) = body_lines_capped(diff, Some("x.rs"), 4);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert_eq!(
+            lines.len(),
+            3,
+            "the whole first hunk, header included: {texts:?}"
+        );
+        assert_eq!(hidden, 3, "the entire second hunk is withheld");
+        assert!(
+            texts.iter().any(|t| t.contains("-a")) && texts.iter().any(|t| t.contains("+A")),
+            "the pair that replaces one line stays together: {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("-b")),
+            "no half of the second hunk leaks in under the remaining budget: {texts:?}"
+        );
     }
 
     #[test]

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -22,6 +22,13 @@ use stella_protocol::{
     ScopeProposal, StageKind, TaskItem, TaskStatus, ToolOutput,
 };
 
+use std::collections::VecDeque;
+
+pub mod file_state;
+#[cfg(test)]
+pub use file_state::DIFF_HISTORY;
+pub use file_state::FileState;
+
 /// How many characters of a tool input / output summary we retain on a
 /// transcript line before eliding — the full payload is never needed on the
 /// one-line card (the diff panel and detail views carry the rest).
@@ -275,23 +282,6 @@ pub struct InlineDiffRef {
     pub path: String,
     /// [`FileState::changes`] at fold time — stale (hidden) once it differs.
     pub seq: u32,
-}
-
-/// The state of one file in the files-touched panel. `latest_diff` is
-/// literally the diff carried by the most recent *mutating* `FileChange` for
-/// this path — the single event-borne data path (L-T5). Reads never touch
-/// `kind`/`latest_diff`/`changes` (the latter doubles as the inline-diff
-/// freshness tag, so a read bumping it would hide a still-current diff);
-/// they only grow `reads`.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FileState {
-    pub path: String,
-    pub kind: FileChangeKind,
-    pub latest_diff: Option<String>,
-    /// How many mutating `FileChange` events have touched this path.
-    pub changes: u32,
-    /// How many times this path has been read.
-    pub reads: u32,
 }
 
 /// Live HUD numbers, all folded from the event stream.
@@ -779,18 +769,24 @@ impl SessionModel {
                 existing.kind = kind;
                 existing.latest_diff = diff.clone();
                 existing.changes += 1;
+                existing.remember_diff(diff);
             } else {
                 existing.reads += 1;
             }
         } else {
             let mutation = kind.is_mutation();
-            self.files.push(FileState {
+            let mut state = FileState {
                 path: path.to_string(),
                 kind,
                 latest_diff: diff.clone(),
+                recent_diffs: VecDeque::new(),
                 changes: mutation as u32,
                 reads: !mutation as u32,
-            });
+            };
+            if mutation {
+                state.remember_diff(diff);
+            }
+            self.files.push(state);
         }
     }
 }
@@ -900,14 +896,11 @@ fn format_tool_input(name: &str, input: &serde_json::Value) -> String {
     // Primary field per tool — the one the user cares about at a glance.
     if let Some(p) = str_field("path").or_else(|| str_field("file_path")) {
         return match name {
-            "edit_file" => {
-                let old = str_field("old_string").map(|s| truncate_field(&s, 40));
-                let new = str_field("new_string").map(|s| truncate_field(&s, 40));
-                match (old, new) {
-                    (Some(o), Some(n)) => format!("{p}  {o} → {n}"),
-                    _ => p,
-                }
-            }
+            // Just the path. The old/new strings used to ride along here,
+            // truncated to 40 characters each — long enough to fill the row,
+            // never long enough to read, and describing exactly the change the
+            // inline diff below renders properly.
+            "edit_file" => p,
             "write_file" => {
                 let lines = str_field("content").map(|c| c.lines().count()).unwrap_or(0);
                 format!("{p}  ({lines} lines)")

--- a/stella-tui/src/model/file_state.rs
+++ b/stella-tui/src/model/file_state.rs
@@ -1,0 +1,72 @@
+//! One file's state in the files-touched panel, and the short diff history
+//! that lets an older tool result still render the change *it* made.
+//!
+//! The history is the point. Keeping only the newest diff per path made the
+//! transcript erase itself: a result resolved its diff by checking the path's
+//! mutation counter still matched the value recorded when the result folded,
+//! so the second edit to a file silently stripped the first edit's diff off
+//! its row. Attribution was always the goal — this reaches it by keeping the
+//! right diff rather than by dropping every diff that might be the wrong one.
+
+use std::collections::VecDeque;
+
+use stella_protocol::FileChangeKind;
+
+/// The state of one file in the files-touched panel. `latest_diff` is
+/// literally the diff carried by the most recent *mutating* `FileChange` for
+/// this path — the single event-borne data path (L-T5). Reads never touch
+/// `kind`/`latest_diff`/`changes` (the latter doubles as the inline-diff
+/// freshness tag, so a read bumping it would hide a still-current diff);
+/// they only grow `reads`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileState {
+    pub path: String,
+    pub kind: FileChangeKind,
+    pub latest_diff: Option<String>,
+    /// The last [`DIFF_HISTORY`] diffs for this path, each tagged with the
+    /// `changes` value it was recorded at, newest last.
+    ///
+    /// Keeping only `latest_diff` made the transcript *erase* its own history:
+    /// the second edit to a file bumped `changes` past the seq the first
+    /// edit's result recorded, so that result's diff stopped resolving and its
+    /// row silently lost the change it had made. Scrolling back through a
+    /// session that touched one file five times showed four edits with no
+    /// diff and one with. The bytes still live on the single event-borne path
+    /// (L-T5) — this is the same store, given a shallow memory instead of a
+    /// depth of one.
+    pub recent_diffs: VecDeque<(u32, String)>,
+    /// How many mutating `FileChange` events have touched this path.
+    pub changes: u32,
+    /// How many times this path has been read.
+    pub reads: u32,
+}
+
+/// How many past diffs a path keeps so older tool results can still render
+/// the change they made. Deep enough to cover the common "edit the same file
+/// a few times in one turn" shape; bounded so a file edited in a loop cannot
+/// grow the model without limit. Beyond it, a result's row degrades to naming
+/// the change rather than showing it — the pre-existing behaviour, now the
+/// exception instead of the rule.
+pub const DIFF_HISTORY: usize = 8;
+
+impl FileState {
+    /// Record a mutation's diff against the `changes` value it produced.
+    /// Called only for mutations, and only after `changes` has been bumped, so
+    /// the tag matches the seq a tool result folds at the same moment.
+    pub(crate) fn remember_diff(&mut self, diff: &Option<String>) {
+        let Some(text) = diff else { return };
+        self.recent_diffs.push_back((self.changes, text.clone()));
+        while self.recent_diffs.len() > DIFF_HISTORY {
+            self.recent_diffs.pop_front();
+        }
+    }
+
+    /// The diff this path produced at mutation `seq`, if still remembered.
+    #[must_use]
+    pub fn diff_at(&self, seq: u32) -> Option<&str> {
+        self.recent_diffs
+            .iter()
+            .find(|(s, _)| *s == seq)
+            .map(|(_, d)| d.as_str())
+    }
+}

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -27,7 +27,6 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use stella_protocol::{CiStatus, FileChangeKind, PrStatus};
 
@@ -38,7 +37,10 @@ use crate::textline::{
     stage_label,
 };
 use crate::ui::{PanelFocus, UiState, ViewportMetrics};
+
+mod row;
 use crate::{diff, theme};
+pub(crate) use row::*;
 
 /// Draw the whole TUI for one frame. Records the panels' viewport sizes back
 /// into `ui.metrics` so the pure key handler can clamp scrolling on the next
@@ -207,30 +209,6 @@ pub(crate) fn inner_width(area: Rect) -> usize {
 }
 
 // Word-aware line wrapping (pre-wrap so scroll math stays line-exact, L-T4)
-
-/// Coalesce adjacent same-styled characters into spans for compact output.
-fn styled_chars_to_spans(chars: Vec<(char, Style)>) -> Vec<Span<'static>> {
-    if chars.is_empty() {
-        return Vec::new();
-    }
-    let mut spans = Vec::new();
-    let mut buf = String::new();
-    let mut style = chars[0].1;
-    for (ch, st) in chars {
-        if st != style && !buf.is_empty() {
-            spans.push(Span::styled(std::mem::take(&mut buf), style));
-            style = st;
-        }
-        if buf.is_empty() {
-            style = st;
-        }
-        buf.push(ch);
-    }
-    if !buf.is_empty() {
-        spans.push(Span::styled(buf, style));
-    }
-    spans
-}
 
 // Panel panic boundary (L-T7)
 
@@ -711,142 +689,22 @@ fn render_composer(
         .render(area, buf);
 }
 
-// Two-column transcript layout
-
-/// Width of the right-aligned label column: 20 chars for `[name]` (right-aligned),
-/// then `:` and one space. Content always begins at column 22.
-pub(crate) const LABEL_COL: usize = 22;
-
-/// Format a label as `[name]` right-aligned so content starts at
-/// [`LABEL_COL`]. Padding is display-width aware — a wide glyph or emoji in
-/// the label must not shift the content column.
-fn label_tag(name: &str) -> String {
-    let bracketed = format!("[{name}]");
-    let pad = (LABEL_COL - 2).saturating_sub(UnicodeWidthStr::width(bracketed.as_str()));
-    format!("{}{bracketed}: ", " ".repeat(pad))
-}
-
-/// Indent string for wrapped continuation lines — exactly `LABEL_COL` spaces.
-fn cont_indent() -> String {
-    " ".repeat(LABEL_COL)
-}
-
-/// Wrap a single styled line into multiple lines of at most `max_width`,
-/// with continuation lines indented by `indent` spaces. The first line
-/// passes through unchanged (it already has its label prefix).
-fn wrap_one_indent(
-    line: Line<'static>,
-    max_width: usize,
-    indent: usize,
-    out: &mut Vec<Line<'static>>,
-) {
-    let line_width = line.width();
-    // The last clause is the narrow-terminal guard: with `indent >= max_width`
-    // the content column has zero width, and the loop below would then flush a
-    // row per character — a 60-character reply exploding into 60 rows on a
-    // ≤40-column terminal (the transcript pane is 60% of the frame, so its
-    // inner width drops under LABEL_COL there). Clip at the pane edge instead,
-    // exactly as the un-wrapped diff rows already do.
-    if line_width <= max_width || max_width == 0 || max_width <= indent {
-        out.push(line);
-        return;
-    }
-    let styled: Vec<(char, Style)> = line
-        .spans
-        .iter()
-        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
-        .collect();
-
-    let content_width = max_width.saturating_sub(indent);
-    let mut current: Vec<(char, Style)> = Vec::new();
-    let mut current_w = 0usize;
-
-    let flush = |cur: &mut Vec<(char, Style)>, first: bool, out: &mut Vec<Line<'static>>| {
-        if !cur.is_empty() {
-            let pairs = std::mem::take(cur);
-            if first {
-                out.push(Line::from(styled_chars_to_spans(pairs)));
-            } else {
-                let mut spans = vec![Span::raw(" ".repeat(indent))];
-                spans.extend(styled_chars_to_spans(pairs));
-                out.push(Line::from(spans));
-            }
-        }
-    };
-
-    let mut is_first = true;
-    for (ch, style) in styled {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if current_w + cw > content_width && !current.is_empty() {
-            if let Some(space_idx) = current.iter().rposition(|(c, _)| *c == ' ') {
-                let mut remainder: Vec<(char, Style)> = current.split_off(space_idx);
-                // Consume the wrap-boundary whitespace so the continuation line
-                // starts flush at the indent column. Left in place, the leading
-                // space stacks on top of `indent` and pushes every wrapped row
-                // one column right of the clean left edge — the "extra blank
-                // space after the colon" bug.
-                let lead = remainder.iter().take_while(|(c, _)| *c == ' ').count();
-                remainder.drain(..lead);
-                flush(&mut current, is_first, out);
-                is_first = false;
-                current = remainder;
-                current_w = current
-                    .iter()
-                    .map(|(c, _)| UnicodeWidthChar::width(*c).unwrap_or(0))
-                    .sum();
-            } else {
-                flush(&mut current, is_first, out);
-                is_first = false;
-                current_w = 0;
-            }
-        }
-        current.push((ch, style));
-        current_w += cw;
-    }
-    flush(&mut current, is_first, out);
-}
-
-/// Emit one transcript row in the canonical two-column layout: a
-/// right-aligned `[label]: ` tag in the gutter, content starting at
-/// [`LABEL_COL`], wrap continuations indented to the content column.
-///
-/// Every `entry_lines` arm MUST route its rows through this (or
-/// [`push_labeled_block`] for multi-line content) — no transcript row
-/// renders at the left margin. The
-/// `every_transcript_entry_renders_in_the_label_gutter` test enforces it,
-/// with exactly one deliberate exception: [`TranscriptEntry::Evicted`] is a
-/// system note *about* the transcript rather than an entry in it, so it is
-/// rendered untagged and full-bleed.
-fn push_labeled(
-    label: &str,
-    label_style: Style,
-    content: Vec<Span<'static>>,
-    width: usize,
-    out: &mut Vec<Line<'static>>,
-) {
-    push_labeled_block(label, label_style, vec![Line::from(content)], width, out);
-}
-
-/// Emit one expanded-detail row (a ctrl+o body line) at the content column.
-/// Detail rows sit directly under their parent row's content — aligned to
-/// [`LABEL_COL`] exactly like wrap continuations — never at the left margin,
-/// so an expanded body reads as part of the same two-column layout.
-fn push_detail_line(text: &str, width: usize, out: &mut Vec<Line<'static>>) {
-    wrap_one_indent(
-        Line::from(vec![
-            Span::raw(cont_indent()),
-            Span::styled(text.to_owned(), Style::new().fg(theme::MUTED)),
-        ]),
-        width,
-        LABEL_COL,
-        out,
-    );
-}
+// Transcript rail layout
+//
+// A transcript is a list, and lists are scanned down their left edge. Every
+// row therefore opens with a fixed-width *rail* — a glyph in column 0 (or 2
+// for subordinate rows) that names the row's kind — so the eye can run
+// straight down the margin and land on "what happened" without reading a
+// word. The predecessor layout right-aligned a `[name]:` tag into column 22,
+// which put the tag's *left* edge at a different column on every row (`[cmd]`
+// at 15, `[✓ read_file]` at 7): the index column jittered, so there was
+// nothing to scan. It also spent 22 columns — 19% of a 118-column pane — on
+// chrome, which the diff bodies then paid for again in clipped code.
 
 /// Most styled diff lines a collapsed tool result shows inline before folding
 /// the rest behind ctrl+o — a mutation stays glanceable in the transcript
 /// without a large diff flooding it uninvited.
-pub(crate) const INLINE_DIFF_CAP: usize = 10;
+pub(crate) const INLINE_DIFF_CAP: usize = 20;
 
 /// Resolve a tool result's [`InlineDiffRef`] to the diff text it may render,
 /// or `None` when the reference went stale: the diff shown must be the one
@@ -857,38 +715,7 @@ fn resolve_inline_diff<'a>(dref: &InlineDiffRef, files: &'a [FileState]) -> Opti
     files
         .iter()
         .find(|f| f.path == dref.path)
-        .filter(|f| f.changes == dref.seq)
-        .and_then(|f| f.latest_diff.as_deref())
-}
-
-/// Emit one inline-diff row at the content column. Diff lines are pushed
-/// un-wrapped — the transcript renders without wrap (one logical line per row
-/// keeps the scroll math line-exact), so overflow clips at the pane edge like
-/// the diff viewer, and the line-number gutter never mis-aligns mid-diff.
-fn push_diff_line(line: Line<'static>, out: &mut Vec<Line<'static>>) {
-    let mut spans = vec![Span::raw(cont_indent())];
-    spans.extend(line.spans);
-    out.push(Line::from(spans));
-}
-
-/// Multi-line form of [`push_labeled`]: the tag labels the first line and
-/// every following line indents to the content column.
-fn push_labeled_block(
-    label: &str,
-    label_style: Style,
-    lines: Vec<Line<'static>>,
-    width: usize,
-    out: &mut Vec<Line<'static>>,
-) {
-    for (i, line) in lines.into_iter().enumerate() {
-        let mut spans = if i == 0 {
-            vec![Span::styled(label_tag(label), label_style)]
-        } else {
-            vec![Span::raw(cont_indent())]
-        };
-        spans.extend(line.spans);
-        wrap_one_indent(Line::from(spans), width, LABEL_COL, out);
-    }
+        .and_then(|f| f.diff_at(dref.seq))
 }
 
 // Pure content builders (unit-tested directly)
@@ -928,7 +755,38 @@ pub(crate) fn transcript_lines(
     out
 }
 
+/// Whether an entry closes a readable block, and so is followed by a spacer.
+///
+/// Trailing rather than leading, which is what lets the rhythm stay
+/// entry-local: a leading gap would have to know what preceded it, and the
+/// deck's incremental fold renders each entry in isolation. Two entries are
+/// deliberately *not* block-closing — a [`TranscriptEntry::ToolStart`], whose
+/// result belongs directly beneath it, and [`TranscriptEntry::Evicted`], the
+/// one-line note that opens the scrollback. A consequence worth keeping: a
+/// batch of parallel `ToolStart`s renders as a tight block, which is exactly
+/// how a fan-out should read.
+fn closes_block(entry: &TranscriptEntry) -> bool {
+    !matches!(
+        entry,
+        TranscriptEntry::ToolStart { .. } | TranscriptEntry::Evicted { .. }
+    )
+}
+
 pub(crate) fn entry_lines(
+    entry: &TranscriptEntry,
+    files: &[FileState],
+    expand_thinking: bool,
+    expanded: bool,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    entry_body(entry, files, expand_thinking, expanded, width, out);
+    if closes_block(entry) {
+        push_gap(out);
+    }
+}
+
+fn entry_body(
     entry: &TranscriptEntry,
     files: &[FileState],
     expand_thinking: bool,
@@ -955,14 +813,14 @@ pub(crate) fn entry_lines(
                 .split('\n')
                 .map(|l| Line::from(Span::styled(l.to_owned(), violet)))
                 .collect();
-            push_labeled_block("user", violet, lines, width, out);
+            push_row_block(Rail::User, lines, width, out);
         }
         TranscriptEntry::Stage(name) => {
             let style = Style::new()
                 .fg(theme::ACCENT_DEEP)
                 .add_modifier(Modifier::BOLD);
-            push_labeled(
-                "stage",
+            push_note(
+                "◇ stage",
                 style,
                 vec![Span::styled(stage_label(*name), style)],
                 width,
@@ -970,13 +828,7 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::Text(text) => {
-            push_labeled_block(
-                "agent",
-                theme::accent(),
-                crate::markdown::render(text),
-                width,
-                out,
-            );
+            push_row_block(Rail::Agent, crate::markdown::render(text), width, out);
         }
         TranscriptEntry::Reasoning(text) => {
             let total_lines = text.lines().count().max(1);
@@ -1013,7 +865,7 @@ pub(crate) fn entry_lines(
                     )));
                 }
             }
-            push_labeled_block(
+            push_note_block(
                 &format!("{chevron} thinking"),
                 header_style,
                 block,
@@ -1022,20 +874,25 @@ pub(crate) fn entry_lines(
             );
         }
         TranscriptEntry::ToolStart {
-            name, input, raw, ..
+            name,
+            input,
+            raw,
+            path,
+            ..
         } => {
-            push_labeled(
-                name,
+            // `name` then `argument`, the name soft-padded to a common column
+            // so arguments line up across a run of calls. Soft, not hard: a
+            // long MCP name (`mcp__github__create_pull_request`) overruns the
+            // column rather than being truncated, since the tool's identity
+            // outranks the alignment it would cost.
+            let mut left = vec![Span::styled(
+                pad_name(name),
                 Style::new()
                     .fg(theme::ACCENT_DEEP)
                     .add_modifier(Modifier::BOLD),
-                vec![Span::styled(
-                    input.clone(),
-                    Style::new().fg(Color::DarkGray),
-                )],
-                width,
-                out,
-            );
+            )];
+            left.extend(path_spans(input, path.is_some()));
+            push_row(Rail::Call, left, width, out);
             if expanded {
                 // ctrl+o: the full argument object, pretty-printed and dim.
                 // An over-budget argument may not parse (char-capped raw) —
@@ -1049,40 +906,55 @@ pub(crate) fn entry_lines(
             }
         }
         TranscriptEntry::ToolResult {
-            name,
             ok,
-            summary,
             full,
             duration_ms,
             speculated,
             diff,
             ..
         } => {
-            let (glyph, color) = if *ok {
-                ("✓", theme::ACCENT)
-            } else {
-                ("✗", theme::DANGER)
-            };
-            // The result labels itself with the tool it answers (resolved
-            // from the start entry) so call/result rows read as a pair.
-            let label = format!("{glyph} {name}");
-            let label_style = Style::new().fg(color).add_modifier(Modifier::BOLD);
-            let extra = full.lines().count().saturating_sub(1);
+            let rail = if *ok { Rail::Result } else { Rail::Fail };
+            let dim = Style::new().fg(theme::MUTED);
+            let total = full.lines().count();
             // ⚡ marks a speculated result: the duration overlapped the
             // model's own streaming instead of following it.
             let dur = if *speculated {
-                format!("⚡{duration_ms}ms")
+                format!("⚡{}", human_duration(*duration_ms))
             } else {
-                format!("{duration_ms}ms")
+                human_duration(*duration_ms)
             };
+            let inline = diff.as_ref().and_then(|d| resolve_inline_diff(d, files));
+
+            // The right-hand metric column. A diff states its own size in
+            // added/removed lines, which is the honest unit for an edit —
+            // "42 lines of output" would describe the tool's chatter, not the
+            // change. Everything else reports output size, and only when
+            // there is more than the one line already shown.
+            let mut metric: Vec<Span<'static>> = Vec::new();
+            if let Some(d) = inline {
+                let (added, removed) = diff::count_diff_lines(d);
+                metric.push(Span::styled(
+                    format!("+{added}"),
+                    Style::new().fg(theme::OK),
+                ));
+                metric.push(Span::styled(" ".to_string(), dim));
+                metric.push(Span::styled(
+                    format!("−{removed}"),
+                    Style::new().fg(theme::BAD),
+                ));
+                metric.push(Span::styled(" · ".to_string(), dim));
+            } else if total > 1 && !expanded {
+                // `⋯` is the one glyph this UI uses for "there is more behind
+                // this", so it carries the ctrl+o affordance the removed hint
+                // row used to spell out — at no extra row.
+                metric.push(Span::styled(format!("⋯ {} · ", plural_lines(total)), dim));
+            }
+            metric.push(Span::styled(dur, dim));
+
             if expanded {
-                push_labeled(
-                    &label,
-                    label_style,
-                    vec![Span::styled(
-                        format!("({} lines · {dur})", extra + 1),
-                        Style::new().fg(Color::DarkGray),
-                    )],
+                push_row(
+                    rail,
+                    justify(vec![], metric, width, rail.indent()),
                     width,
                     out,
                 );
@@ -1090,29 +962,53 @@ pub(crate) fn entry_lines(
                     push_detail_line(l, width, out);
                 }
             } else {
-                // Collapsed: exactly one output line; the hint names how many
-                // more ctrl+o would reveal. Multi-line output NEVER floods the
-                // transcript uninvited.
-                let first = full
-                    .lines()
-                    .find(|l| !l.trim().is_empty())
-                    .unwrap_or(summary.as_str());
-                let shown: String = first.chars().take(160).collect();
-                let hint = if extra > 0 {
-                    format!("  (+{extra} lines · {dur})")
+                // A failure never collapses to a single line. The whole point
+                // of reading a transcript at the moment something breaks is to
+                // see *why*, and a one-line preview of a stack trace is a
+                // prompt to go hunting rather than an answer.
+                // With a diff below, a prose summary ("Applied edit to
+                // src/agent.rs") would restate the call row above it and the
+                // diff under it in the same breath. The row carries only its
+                // metrics and gets out of the way.
+                let shown: Vec<&str> = if inline.is_some() {
+                    Vec::new()
                 } else {
-                    format!("  ({dur})")
+                    // A failure never collapses to a single line. The point of
+                    // reading a transcript at the moment something breaks is to
+                    // see *why*, and a one-line preview of a stack trace is a
+                    // prompt to go hunting rather than an answer.
+                    let budget = if *ok { 1 } else { FAIL_PREVIEW };
+                    full.lines().skip(salient_line(full)).take(budget).collect()
                 };
-                push_labeled(
-                    &label,
-                    label_style,
-                    vec![
-                        Span::raw(shown),
-                        Span::styled(hint, Style::new().fg(Color::DarkGray)),
-                    ],
+                let head: Vec<Span<'static>> = match shown.first() {
+                    Some(l) => vec![Span::styled(
+                        l.trim_end().to_owned(),
+                        if *ok {
+                            dim
+                        } else {
+                            Style::new().fg(theme::BAD)
+                        },
+                    )],
+                    None => Vec::new(),
+                };
+                push_row(
+                    rail,
+                    justify(head, metric, width, rail.indent()),
                     width,
                     out,
                 );
+                for l in shown.iter().skip(1) {
+                    push_detail_line(l.trim_end(), width, out);
+                }
+                // Only a failure earns the "there is more" row: a successful
+                // result already states its size in the metric column, and
+                // saying it twice is how a dense layout turns back into a
+                // sparse one. Anchoring mid-output also means the count is
+                // "everything but the window", not "everything after it".
+                let hidden = total.saturating_sub(shown.len());
+                if hidden > 0 && !*ok {
+                    push_detail_line(&format!("⋯ {} · ctrl+o", plural_lines(hidden)), width, out);
+                }
             }
             // The mutation's diff, inline under the result — GitHub-PR style
             // via `crate::diff` (the one implementation of "how a diff
@@ -1121,39 +1017,35 @@ pub(crate) fn entry_lines(
             // no longer belongs to this call, so it is hidden rather than
             // misattributed. Collapsed shows at most [`INLINE_DIFF_CAP`]
             // styled lines; ctrl+o reveals the whole diff.
-            if let Some(dref) = diff
-                && let Some(d) = resolve_inline_diff(dref, files)
-            {
-                let rule_w = width.saturating_sub(LABEL_COL);
+            if let (Some(dref), Some(d)) = (diff.as_ref(), inline) {
+                // No path header and no counts footer here, unlike the
+                // standalone viewer: the call row above already names the file
+                // and the metric column already states `+n −m`, so both rules
+                // would be the same facts a second time — four rows of chrome
+                // around what is often a two-row change.
                 let cap = if expanded {
                     usize::MAX
                 } else {
                     INLINE_DIFF_CAP
                 };
-                let (body, total) = diff::body_lines_capped(d, Some(&dref.path), cap);
-                let (added, removed) = diff::count_diff_lines(d);
-                push_diff_line(diff::header_line(&dref.path, rule_w), out);
+                let (body, hidden) = diff::body_lines_inline(d, Some(&dref.path), cap);
                 for line in body {
                     push_diff_line(line, out);
                 }
-                if !expanded && total > INLINE_DIFF_CAP {
+                if hidden > 0 {
                     push_diff_line(
                         Line::from(Span::styled(
-                            format!(
-                                "⋯ +{} more diff lines · ctrl+o opens the full diff",
-                                total - INLINE_DIFF_CAP
-                            ),
-                            Style::new().fg(Color::DarkGray),
+                            format!("⋯ {} · ctrl+o", plural_lines(hidden)),
+                            Style::new().fg(theme::MUTED),
                         )),
                         out,
                     );
                 }
-                push_diff_line(diff::footer_line(added, removed, rule_w), out);
             }
         }
         TranscriptEntry::Retry { attempt, reason } => {
             let style = Style::new().fg(theme::WARNING_BRIGHT);
-            push_labeled(
+            push_note(
                 "↻ retry",
                 style,
                 vec![Span::styled(format!("#{attempt}: {reason}"), style)],
@@ -1168,7 +1060,7 @@ pub(crate) fn entry_lines(
             deduped,
         } => {
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "⇣ compacted",
                 style,
                 vec![Span::styled(
@@ -1188,8 +1080,8 @@ pub(crate) fn entry_lines(
         } => {
             let limit = limit_usd.map(|l| format!("/${l:.2}")).unwrap_or_default();
             let style = Style::new().fg(theme::WARNING);
-            push_labeled(
-                "spend",
+            push_note(
+                "◇ spend",
                 style,
                 vec![Span::styled(
                     format!("${spent_usd:.4}{limit} ({})", budget_mode_label(*mode)),
@@ -1201,7 +1093,7 @@ pub(crate) fn entry_lines(
         }
         TranscriptEntry::ProviderFallback { from, to, reason } => {
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "⚡ fallback",
                 style,
                 vec![Span::styled(format!("{from} → {to}: {reason}"), style)],
@@ -1216,7 +1108,7 @@ pub(crate) fn entry_lines(
         } => {
             let cited = labels.join(", ");
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "◉ recalled",
                 style,
                 vec![Span::styled(
@@ -1233,7 +1125,7 @@ pub(crate) fn entry_lines(
             superseded,
         } => {
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "✎ memory",
                 style,
                 vec![Span::styled(
@@ -1250,7 +1142,7 @@ pub(crate) fn entry_lines(
             state,
         } => {
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "🎞 media",
                 style,
                 vec![Span::styled(
@@ -1269,7 +1161,7 @@ pub(crate) fn entry_lines(
             let style = Style::new()
                 .fg(theme::ACCENT_DEEP)
                 .add_modifier(Modifier::BOLD);
-            push_labeled(
+            push_note(
                 "🎨 media",
                 style,
                 vec![
@@ -1295,7 +1187,7 @@ pub(crate) fn entry_lines(
             } else {
                 "model-judge"
             };
-            push_labeled(
+            push_note(
                 &format!("{glyph} verdict"),
                 Style::new().fg(color).add_modifier(Modifier::BOLD),
                 vec![
@@ -1316,7 +1208,7 @@ pub(crate) fn entry_lines(
             } else {
                 ("○", theme::WARN)
             };
-            push_labeled(
+            push_note(
                 &format!("{glyph} goal"),
                 Style::new().fg(color).add_modifier(Modifier::BOLD),
                 vec![
@@ -1342,7 +1234,7 @@ pub(crate) fn entry_lines(
             let style = Style::new()
                 .fg(theme::WARNING_BRIGHT)
                 .add_modifier(Modifier::BOLD);
-            push_labeled(
+            push_note(
                 "⏸ scope",
                 style,
                 vec![Span::styled(
@@ -1357,7 +1249,7 @@ pub(crate) fn entry_lines(
             let style = Style::new()
                 .fg(theme::WARNING_BRIGHT)
                 .add_modifier(Modifier::BOLD);
-            push_labeled(
+            push_note(
                 "? ask",
                 style,
                 vec![Span::styled(
@@ -1371,7 +1263,7 @@ pub(crate) fn entry_lines(
         TranscriptEntry::Commit { sha, message } => {
             let short = sha.chars().take(9).collect::<String>();
             let style = Style::new().fg(theme::ACCENT_DEEP);
-            push_labeled(
+            push_note(
                 "● commit",
                 style,
                 vec![
@@ -1405,7 +1297,7 @@ pub(crate) fn entry_lines(
                 ));
             }
             spans.push(Span::styled(url.clone(), Style::new().fg(Color::DarkGray)));
-            push_labeled("⇢ pr", style, spans, width, out);
+            push_note("⇢ pr", style, spans, width, out);
         }
         TranscriptEntry::TaskUpdate {
             done,
@@ -1420,12 +1312,12 @@ pub(crate) fn entry_lines(
                     Style::new().fg(theme::TEXT_SECONDARY),
                 ));
             }
-            push_labeled("☰ tasks", style, spans, width, out);
+            push_note("☰ tasks", style, spans, width, out);
         }
         TranscriptEntry::Error { message, retryable } => {
             let tag = if *retryable { " (retryable)" } else { "" };
             let style = Style::new().fg(theme::DANGER).add_modifier(Modifier::BOLD);
-            push_labeled(
+            push_note(
                 "✗ error",
                 style,
                 vec![Span::styled(format!("{message}{tag}"), style)],
@@ -1437,8 +1329,8 @@ pub(crate) fn entry_lines(
             // A quiet footnote, not an event — warning-orange keeps the cost
             // in the warm family without borrowing the reserved brand gold.
             let style = Style::new().fg(theme::WARNING);
-            push_labeled(
-                "cost",
+            push_note(
+                "◇ cost",
                 style,
                 vec![Span::styled(format!("${cost_usd:.4} · {model}"), style)],
                 width,

--- a/stella-tui/src/render/row.rs
+++ b/stella-tui/src/render/row.rs
@@ -1,0 +1,514 @@
+//! The vocabulary of a transcript row: the rails that index the left margin,
+//! the wrapping that keeps a wrapped line aligned under its own text, and the
+//! small presentation helpers (durations, counts, paths, the right-hand metric
+//! column) that decide how a row reads.
+//!
+//! Split out from `render` because these are the *grammar* of a row, while
+//! `render::entry_lines` is the *sentence* each transcript entry composes from
+//! it. Keeping them apart means a change to how one entry kind is phrased
+//! cannot quietly change the layout every other kind depends on.
+//!
+//! The governing idea is that a transcript is a list and lists are read down
+//! their left edge. Every row therefore opens with a fixed-width rail whose
+//! glyph names the row's kind, so the margin can be scanned for shape before
+//! anything is read for content.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::theme;
+
+/// Coalesce adjacent same-styled characters into spans for compact output.
+pub(crate) fn styled_chars_to_spans(chars: Vec<(char, Style)>) -> Vec<Span<'static>> {
+    if chars.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    let mut buf = String::new();
+    let mut style = chars[0].1;
+    for (ch, st) in chars {
+        if st != style && !buf.is_empty() {
+            spans.push(Span::styled(std::mem::take(&mut buf), style));
+            style = st;
+        }
+        if buf.is_empty() {
+            style = st;
+        }
+        buf.push(ch);
+    }
+    if !buf.is_empty() {
+        spans.push(Span::styled(buf, style));
+    }
+    spans
+}
+
+/// Content column for a top-level row: the rail glyph occupies column 0 and
+/// one space separates it from the text.
+pub(crate) const LEAD: usize = 2;
+
+/// Content column for a subordinate row (a tool result and its body). Indented
+/// one rail-width past its parent call so the hierarchy is visible without a
+/// connecting line on every row.
+pub(crate) const BODY: usize = 4;
+
+/// Which rail a transcript row rides. The glyph is the row's type signature —
+/// a reader scanning the margin sees the shape of the session (calls, their
+/// outcomes, prose, prompts) before reading any content.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Rail {
+    /// A tool invocation — the thing that happened.
+    Call,
+    /// A tool result body, subordinate to the call above it.
+    Result,
+    /// A failed tool result. Distinct glyph *and* column-2 position, so a
+    /// failure is findable by margin-scan alone.
+    Fail,
+    /// A user prompt — the strongest landmark in the scrollback, since it is
+    /// where a reader re-orients when scrolling back.
+    User,
+    /// Assistant prose. Deliberately glyph-less: prose is the default voice of
+    /// the transcript, and a marker on every paragraph would be noise.
+    Agent,
+}
+
+impl Rail {
+    /// The literal prefix this rail prints before a row's first line.
+    pub(crate) fn prefix(self) -> &'static str {
+        match self {
+            Rail::Call => "● ",
+            Rail::Result => "  ⎿ ",
+            Rail::Fail => "  ✗ ",
+            Rail::User => "▌ ",
+            Rail::Agent => "  ",
+        }
+    }
+
+    /// The column continuation lines indent to — always the width of
+    /// [`Rail::prefix`], so wrapped text lines up under the first line's text
+    /// rather than under its glyph.
+    pub(crate) fn indent(self) -> usize {
+        UnicodeWidthStr::width(self.prefix())
+    }
+
+    /// The style the rail glyph itself renders in. Content styling is the
+    /// caller's; the glyph is always the rail's own semantic color so the
+    /// margin reads consistently even when content colors vary.
+    pub(crate) fn style(self) -> Style {
+        match self {
+            Rail::Call => Style::new().fg(theme::ACCENT_DEEP),
+            Rail::Result => Style::new().fg(theme::MUTED),
+            Rail::Fail => Style::new().fg(theme::DANGER),
+            Rail::User => Style::new().fg(theme::VIOLET).add_modifier(Modifier::BOLD),
+            Rail::Agent => Style::new(),
+        }
+    }
+}
+
+/// Wrap a single styled line into multiple lines of at most `max_width`,
+/// with continuation lines indented by `indent` spaces. The first line
+/// passes through unchanged (it already has its label prefix).
+pub(crate) fn wrap_one_indent(
+    line: Line<'static>,
+    max_width: usize,
+    indent: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    let line_width = line.width();
+    // The last clause is the narrow-terminal guard: with `indent >= max_width`
+    // the content column has zero width, and the loop below would then flush a
+    // row per character — a 60-character reply exploding into 60 rows on a
+    // ≤40-column terminal (the transcript pane is 60% of the frame, so its
+    // inner width drops under LABEL_COL there). Clip at the pane edge instead,
+    // exactly as the un-wrapped diff rows already do.
+    if line_width <= max_width || max_width == 0 || max_width <= indent {
+        out.push(line);
+        return;
+    }
+    let styled: Vec<(char, Style)> = line
+        .spans
+        .iter()
+        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
+        .collect();
+
+    let content_width = max_width.saturating_sub(indent);
+    let mut current: Vec<(char, Style)> = Vec::new();
+    let mut current_w = 0usize;
+
+    let flush = |cur: &mut Vec<(char, Style)>, first: bool, out: &mut Vec<Line<'static>>| {
+        if !cur.is_empty() {
+            let pairs = std::mem::take(cur);
+            if first {
+                out.push(Line::from(styled_chars_to_spans(pairs)));
+            } else {
+                let mut spans = vec![Span::raw(" ".repeat(indent))];
+                spans.extend(styled_chars_to_spans(pairs));
+                out.push(Line::from(spans));
+            }
+        }
+    };
+
+    let mut is_first = true;
+    for (ch, style) in styled {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if current_w + cw > content_width && !current.is_empty() {
+            if let Some(space_idx) = current.iter().rposition(|(c, _)| *c == ' ') {
+                let mut remainder: Vec<(char, Style)> = current.split_off(space_idx);
+                // Consume the wrap-boundary whitespace so the continuation line
+                // starts flush at the indent column. Left in place, the leading
+                // space stacks on top of `indent` and pushes every wrapped row
+                // one column right of the clean left edge — the "extra blank
+                // space after the colon" bug.
+                let lead = remainder.iter().take_while(|(c, _)| *c == ' ').count();
+                remainder.drain(..lead);
+                flush(&mut current, is_first, out);
+                is_first = false;
+                current = remainder;
+                current_w = current
+                    .iter()
+                    .map(|(c, _)| UnicodeWidthChar::width(*c).unwrap_or(0))
+                    .sum();
+            } else {
+                flush(&mut current, is_first, out);
+                is_first = false;
+                current_w = 0;
+            }
+        }
+        current.push((ch, style));
+        current_w += cw;
+    }
+    flush(&mut current, is_first, out);
+}
+
+/// Emit one transcript row on `rail`: the rail glyph, then `content`, with
+/// wrap continuations indented to the rail's content column.
+///
+/// Every `entry_lines` arm MUST route its rows through this (or
+/// [`push_row_block`] for multi-line content) — no transcript row renders at
+/// the left margin without a rail. The
+/// `every_transcript_entry_renders_on_a_rail` test enforces it, with exactly
+/// one deliberate exception: [`TranscriptEntry::Evicted`] is a system note
+/// *about* the transcript rather than an entry in it, so it renders untagged
+/// and full-bleed.
+pub(crate) fn push_row(
+    rail: Rail,
+    content: Vec<Span<'static>>,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    push_row_block(rail, vec![Line::from(content)], width, out);
+}
+
+/// Emit one expanded-detail row (a ctrl+o body line) at the subordinate body
+/// column. Detail rows sit directly under their parent result's content —
+/// aligned to [`BODY`] — so an expanded body reads as part of the same block
+/// rather than as a new top-level event.
+pub(crate) fn push_detail_line(text: &str, width: usize, out: &mut Vec<Line<'static>>) {
+    wrap_one_indent(
+        Line::from(vec![
+            Span::raw(" ".repeat(BODY)),
+            Span::styled(text.to_owned(), Style::new().fg(theme::MUTED)),
+        ]),
+        width,
+        BODY,
+        out,
+    );
+}
+
+/// Emit a system-note row: `↻ retry`, `⇣ compacted`, `✗ error` and friends.
+///
+/// These rows *are* their own rail — each label already opens with a glyph in
+/// column 0, so it indexes the margin exactly like [`Rail::Call`] does without
+/// needing a second marker in front of it. Content follows two spaces later;
+/// wrapped lines indent to [`LEAD`].
+pub(crate) fn push_note(
+    label: &str,
+    label_style: Style,
+    content: Vec<Span<'static>>,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    push_note_block(label, label_style, vec![Line::from(content)], width, out);
+}
+
+/// Multi-line form of [`push_note`].
+pub(crate) fn push_note_block(
+    label: &str,
+    label_style: Style,
+    lines: Vec<Line<'static>>,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    for (i, line) in lines.into_iter().enumerate() {
+        let mut spans = if i == 0 {
+            vec![Span::styled(format!("{label}  "), label_style)]
+        } else {
+            vec![Span::raw(" ".repeat(LEAD))]
+        };
+        spans.extend(line.spans);
+        wrap_one_indent(Line::from(spans), width, LEAD, out);
+    }
+}
+
+/// Emit a blank spacer row.
+///
+/// Rhythm is what turns a wall of rows into a readable page, but a blank line
+/// between *every* pair of rows would halve the visible history — so the gap
+/// is structural, not uniform: it precedes a block-level entry (a call, a
+/// prompt, a paragraph of prose) and never separates a result from the call
+/// it belongs to. Dense runs of one-line reads stay dense; the substantial
+/// things get air around them. This is paragraph spacing, not line spacing.
+pub(crate) fn push_gap(out: &mut Vec<Line<'static>>) {
+    out.push(Line::default());
+}
+
+/// Emit one inline-diff row at the body column. Diff lines are pushed
+/// un-wrapped — the transcript renders without wrap (one logical line per row
+/// keeps the scroll math line-exact), so overflow clips at the pane edge like
+/// the diff viewer, and the line-number gutter never mis-aligns mid-diff.
+pub(crate) fn push_diff_line(line: Line<'static>, out: &mut Vec<Line<'static>>) {
+    let mut spans = vec![Span::raw(" ".repeat(BODY))];
+    spans.extend(line.spans);
+    out.push(Line::from(spans));
+}
+
+/// Multi-line form of [`push_row`]: the rail glyph prefixes the first line and
+/// every following line indents to the rail's content column.
+pub(crate) fn push_row_block(
+    rail: Rail,
+    lines: Vec<Line<'static>>,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    let indent = rail.indent();
+    for (i, line) in lines.into_iter().enumerate() {
+        let mut spans = if i == 0 {
+            vec![Span::styled(rail.prefix().to_string(), rail.style())]
+        } else {
+            vec![Span::raw(" ".repeat(indent))]
+        };
+        spans.extend(line.spans);
+        wrap_one_indent(Line::from(spans), width, indent, out);
+    }
+}
+
+/// Widest the `content … metric` span grows before the metric stops tracking
+/// the pane edge. Chosen above any ordinary transcript width so normal panes
+/// stay flush-right and only genuinely wide ones are reined in.
+pub(crate) const METRIC_SPAN: usize = 140;
+
+/// Soft column the tool-name field pads to, so arguments align down a run of
+/// calls. A longer name overruns it rather than truncating — identity beats
+/// alignment — and the argument simply starts one space later on that row.
+pub(crate) const NAME_COL: usize = 13;
+
+/// Lines of a *failed* result shown without expanding. Enough for a compiler
+/// error with its location and caret line, or the top of a panic backtrace.
+pub(crate) const FAIL_PREVIEW: usize = 6;
+
+/// Pad a tool name to [`NAME_COL`], display-width aware.
+pub(crate) fn pad_name(name: &str) -> String {
+    let w = UnicodeWidthStr::width(name);
+    format!("{name}{} ", " ".repeat(NAME_COL.saturating_sub(w + 1)))
+}
+
+/// A duration at human scale. Raw milliseconds are the wrong unit above a
+/// second — `4210ms` forces the reader to count digits to learn "about four
+/// seconds" — so the unit follows the magnitude, always at two significant
+/// figures of useful precision.
+pub(crate) fn human_duration(ms: u64) -> String {
+    match ms {
+        0..=999 => format!("{ms}ms"),
+        1_000..=59_999 => {
+            let s = ms as f64 / 1000.0;
+            // Sub-10s keeps a decimal (4.2s reads as distinct from 4.9s);
+            // above that the tenth is noise next to the whole seconds.
+            if s < 10.0 {
+                format!("{s:.1}s")
+            } else {
+                format!("{}s", ms / 1000)
+            }
+        }
+        _ => {
+            let total = ms / 1000;
+            format!("{}m{:02}s", total / 60, total % 60)
+        }
+    }
+}
+
+/// `1 line` / `2 lines` — a count that reads as English rather than as a
+/// template with a number substituted into it.
+pub(crate) fn plural_lines(n: usize) -> String {
+    if n == 1 {
+        "1 line".to_string()
+    } else {
+        format!("{} lines", thousands(n))
+    }
+}
+
+/// A count with thousands separators — `1,584 lines` is legible at a glance
+/// where `1584 lines` needs a beat of digit-counting.
+pub(crate) fn thousands(n: usize) -> String {
+    let digits = n.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Split a path into (directory, basename) spans so the basename carries the
+/// emphasis. In a scan, the file *identity* is what the eye is hunting; the
+/// directory is context that only matters once you've found the file, so it
+/// recedes. Non-path text renders as a single unemphasised span.
+pub(crate) fn path_spans(text: &str, is_path: bool) -> Vec<Span<'static>> {
+    let dim = Style::new().fg(theme::MUTED);
+    let bright = Style::new().fg(theme::INK);
+    match text.rfind('/').filter(|_| is_path) {
+        Some(cut) => vec![
+            Span::styled(text[..=cut].to_owned(), dim),
+            Span::styled(text[cut + 1..].to_owned(), bright),
+        ],
+        None if is_path => vec![Span::styled(text.to_owned(), bright)],
+        None => vec![Span::styled(text.to_owned(), dim)],
+    }
+}
+
+/// Lay a row out as `left … right`, with `right` flush to the pane edge and
+/// `left` truncated (not wrapped) if the two would collide.
+///
+/// The right edge becomes a second scan column: durations and sizes stack into
+/// a vertical strip a reader can run down to find "what was slow" or "what was
+/// big" without reading a single tool name. Truncation falls on the left
+/// because the metric is fixed-width and the argument is the elastic part.
+pub(crate) fn justify(
+    left: Vec<Span<'static>>,
+    right: Vec<Span<'static>>,
+    width: usize,
+    indent: usize,
+) -> Vec<Span<'static>> {
+    let left_w: usize = left
+        .iter()
+        .map(|s| UnicodeWidthStr::width(&*s.content))
+        .sum();
+    let right_w: usize = right
+        .iter()
+        .map(|s| UnicodeWidthStr::width(&*s.content))
+        .sum();
+    let full = width.saturating_sub(indent);
+    if right_w == 0 {
+        return left;
+    }
+    // No room to justify: drop the right column rather than let it collide or
+    // push the row into a wrap. The metric is recoverable via ctrl+o; a mangled
+    // row is not recoverable at all.
+    if full <= right_w + 1 {
+        return left;
+    }
+    // One space minimum between the two, or the metric loses its own column.
+    if left_w + right_w + 1 > full {
+        let budget = full - right_w - 1;
+        let mut spans = truncate_spans(left, budget);
+        spans.push(Span::raw(" "));
+        spans.extend(right);
+        return spans;
+    }
+    // Right-aligned, but only within [`METRIC_SPAN`]. Flush to the pane edge is
+    // right at ordinary widths and wrong on an ultrawide terminal, where the
+    // metric ends up so far from the row it labels that the two stop reading as
+    // one line — a scan column has to stay within a saccade of its content.
+    let span = full.min(METRIC_SPAN.max(left_w + right_w + 1));
+    let mut spans = left;
+    spans.push(Span::raw(" ".repeat(span - left_w - right_w)));
+    spans.extend(right);
+    spans
+}
+
+/// Truncate a styled run to `budget` display columns, ending in `…` when it
+/// had to cut. Styling is preserved per span.
+pub(crate) fn truncate_spans(spans: Vec<Span<'static>>, budget: usize) -> Vec<Span<'static>> {
+    let total: usize = spans
+        .iter()
+        .map(|s| UnicodeWidthStr::width(&*s.content))
+        .sum();
+    if total <= budget {
+        return spans;
+    }
+    let keep = budget.saturating_sub(1);
+    let mut out = Vec::new();
+    let mut used = 0usize;
+    for span in spans {
+        let w = UnicodeWidthStr::width(&*span.content);
+        if used + w <= keep {
+            used += w;
+            out.push(span);
+            continue;
+        }
+        let room = keep - used;
+        let mut text = String::new();
+        let mut tw = 0usize;
+        for c in span.content.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if tw + cw > room {
+                break;
+            }
+            tw += cw;
+            text.push(c);
+        }
+        let style = span.style;
+        out.push(Span::styled(text, style));
+        out.push(Span::styled("…".to_string(), style));
+        return out;
+    }
+    out
+}
+
+/// Markers that make a line of tool output worth surfacing over the line that
+/// merely happens to be first. Matched case-insensitively at a word boundary.
+pub(crate) const SALIENT: [&str; 8] = [
+    "error",
+    "warning",
+    "failed",
+    "failure",
+    "panic",
+    "assert",
+    "fatal",
+    "exception",
+];
+
+/// Pick the line of `text` a collapsed result should show.
+///
+/// Showing line 1 is the obvious rule and the wrong one: a build's first line
+/// is `Checking foo v0.1.0` while the line that matters — the error — is
+/// twenty lines down, so the collapsed row reliably shows the least
+/// informative part of the most important output. Instead, find the first
+/// line that carries a failure marker and anchor there; fall back to the
+/// first non-blank line when nothing stands out. Returns the index into
+/// `text.lines()`.
+pub(crate) fn salient_line(text: &str) -> usize {
+    let mut first_nonblank = 0;
+    let mut seen_nonblank = false;
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if !seen_nonblank && !trimmed.is_empty() {
+            first_nonblank = i;
+            seen_nonblank = true;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if SALIENT.iter().any(|m| {
+            lower.starts_with(m)
+                // `error[E0432]:` / `warning:` / `error --> ` all count; a
+                // prose line that merely contains "error" does not, or every
+                // log line mentioning error handling would hijack the row.
+                || lower
+                    .split_once(&format!("{m}:"))
+                    .is_some_and(|(head, _)| head.len() <= 12)
+        }) {
+            return i;
+        }
+    }
+    first_nonblank
+}

--- a/stella-tui/src/render/tests.rs
+++ b/stella-tui/src/render/tests.rs
@@ -54,11 +54,18 @@ fn hud_and_transcript_render_the_event_content() {
     assert!(text.contains("complete"), "shows completion:\n{text}");
 }
 
-/// Every transcript entry renders through the shared label gutter: its
-/// first line starts with a right-aligned `[label]: ` tag whose display
-/// width is exactly `LABEL_COL`. Nothing prints at the left margin.
+/// Every transcript entry opens on a rail, so the left margin stays a
+/// scannable index column rather than a ragged edge: a reader running their
+/// eye down column 0 sees the *shape* of the session — calls, outcomes,
+/// prompts, system notes — before reading a single word.
+///
+/// The invariant is about the margin carrying a glyph, not about the prefix's
+/// width. A system note's prefix (`↻ retry  `, `⇣ compacted  `) is far wider
+/// than [`BODY`] and that is correct: the label *is* the note's rail, opening
+/// with its own glyph in column 0. What must never happen is a row that
+/// begins with bare unstyled text at the left margin.
 #[test]
-fn every_transcript_entry_renders_in_the_label_gutter() {
+fn every_transcript_entry_renders_on_a_rail() {
     let samples = vec![
         TranscriptEntry::User("hi".into()),
         TranscriptEntry::Stage(StageKind::Execute),
@@ -167,7 +174,8 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
     for entry in &samples {
         // Exhaustive on purpose: adding a `TranscriptEntry` variant fails
         // to compile here — add a sample above and render the new arm
-        // through `push_labeled`/`push_labeled_block`.
+        // through `push_row`/`push_row_block` (a rail) or `push_note` (a
+        // system note, whose label carries its own glyph).
         match entry {
             TranscriptEntry::User(_)
             | TranscriptEntry::Stage(_)
@@ -177,9 +185,9 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
             | TranscriptEntry::ToolResult { .. }
             | TranscriptEntry::Retry { .. }
             | TranscriptEntry::Compaction { .. }
-            // Not in `samples`: it deliberately renders as an untagged
-            // system note, not a `[label]: ` line — see
-            // `eviction_marker_renders_as_a_one_line_system_note`.
+            // Not in `samples`: it is a note *about* the transcript rather
+            // than an entry in it, so it renders untagged and full-bleed —
+            // see `eviction_marker_renders_as_a_one_line_system_note`.
             | TranscriptEntry::Evicted { .. }
             | TranscriptEntry::BudgetTick { .. }
             | TranscriptEntry::ProviderFallback { .. }
@@ -202,23 +210,43 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
         let first = lines
             .first()
             .unwrap_or_else(|| panic!("{entry:?} renders no lines"));
-        let tag = first.spans.first().expect("first span is the label tag");
+        let rail = first.spans.first().expect("first span is the rail prefix");
+        let prefix = rail.content.as_ref();
         assert!(
-            tag.content.ends_with("]: "),
-            "{entry:?} must start with a `[label]: ` tag, got {:?}",
-            tag.content
+            !prefix.is_empty(),
+            "{entry:?} renders with no rail prefix at all"
         );
-        assert_eq!(
-            UnicodeWidthStr::width(tag.content.as_ref()),
-            LABEL_COL,
-            "{entry:?} label tag must place content at LABEL_COL, got {:?}",
-            tag.content
+        let opens_in_column_zero = !prefix.starts_with(' ');
+        // A tool result and its body are subordinate to the call above them,
+        // so they indent one rail-width and carry their glyph at column 2.
+        // These two prefixes are the *only* legal indented rails.
+        let subordinate = prefix == Rail::Result.prefix() || prefix == Rail::Fail.prefix();
+        // Assistant prose is the deliberate exception: `Rail::Agent` is two
+        // bare spaces. Prose is the transcript's default voice, and a marker
+        // on every paragraph would be noise in the one place a reader is
+        // reading words rather than scanning the margin — so it indents to
+        // the content column and shows nothing.
+        let agent_prose = prefix == Rail::Agent.prefix();
+        assert!(
+            opens_in_column_zero || subordinate || agent_prose,
+            "{entry:?} must open on a rail — a glyph in column 0, the \
+             subordinate `{:?}`/`{:?}` result rails, or assistant prose — \
+             never bare text at the left margin; got {prefix:?}",
+            Rail::Result.prefix(),
+            Rail::Fail.prefix(),
         );
+        if opens_in_column_zero {
+            let glyph = prefix.chars().next().expect("non-empty prefix");
+            assert!(
+                !glyph.is_whitespace() && !glyph.is_alphanumeric(),
+                "{entry:?} must index the margin with a glyph, not a letter: {prefix:?}"
+            );
+        }
     }
 }
 
 /// A wrapped continuation line begins flush at the content column: exactly
-/// `LABEL_COL` leading spaces, never one more. Regression for the bug where
+/// the rail's indent in leading spaces, never one more. Regression for the bug where
 /// the wrap-boundary space was carried onto the next line, stacking on top
 /// of the indent and drifting every wrapped row one column right of the
 /// clean left edge (the "extra blank space after the colon on wrap" report).
@@ -226,10 +254,13 @@ fn every_transcript_entry_renders_in_the_label_gutter() {
 fn wrapped_continuation_starts_flush_at_the_content_column() {
     let content = "the quick brown fox jumps over the lazy dog and then keeps \
                    on running well past the right edge to force several wraps";
-    let spans = vec![Span::raw(label_tag("agent")), Span::raw(content)];
+    let spans = vec![
+        Span::raw(Rail::Result.prefix().to_string()),
+        Span::raw(content),
+    ];
     let mut out = Vec::new();
     // Narrow width so the content wraps several times.
-    wrap_one_indent(Line::from(spans), 60, LABEL_COL, &mut out);
+    wrap_one_indent(Line::from(spans), 60, BODY, &mut out);
 
     assert!(
         out.len() > 1,
@@ -240,9 +271,9 @@ fn wrapped_continuation_starts_flush_at_the_content_column() {
         let text: String = line.spans.iter().flat_map(|s| s.content.chars()).collect();
         let leading = text.chars().take_while(|c| *c == ' ').count();
         assert_eq!(
-            leading, LABEL_COL,
+            leading, BODY,
             "continuation row {i} must start exactly at the content column \
-             (indent {LABEL_COL}, no carried wrap space); got {leading}: {text:?}",
+             (indent {BODY}, no carried wrap space); got {leading}: {text:?}",
         );
     }
 }
@@ -291,13 +322,17 @@ fn thinking_is_collapsed_by_default_and_expands_with_the_toggle() {
     });
     let mut ui = UiState::default();
     let collapsed = draw(&model, &mut ui, 100, 24);
+    // A system note is its own rail: the `⏵ thinking` label already opens
+    // with a glyph in column 0, so it indexes the margin without a second
+    // marker (and without the old right-aligned `[…]: ` tag column).
     assert!(
-        collapsed.contains("[⏵ thinking]: 3 lines"),
+        collapsed.contains("⏵ thinking  3 lines"),
         "collapsed header:\n{collapsed}"
     );
-    // Collapsed = header + 3 preview lines (all 3 fit within preview count).
+    // Collapsed = header + 3 preview lines (all 3 fit within preview count),
+    // then the spacer every block-closing entry ends on.
     let c_lines = transcript_lines(&model, false, 0);
-    assert_eq!(c_lines.len(), 4, "header + 3 preview lines");
+    assert_eq!(c_lines.len(), 5, "header + 3 preview lines + block spacer");
     // Preview shows the reasoning content.
     let c_text: String = c_lines
         .iter()
@@ -315,8 +350,8 @@ fn thinking_is_collapsed_by_default_and_expands_with_the_toggle() {
         expanded.contains("alpha") && expanded.contains("gamma"),
         "expanded shows the full reasoning:\n{expanded}"
     );
-    // Expanded = header + 3 content lines.
-    assert_eq!(transcript_lines(&model, true, 0).len(), 4);
+    // Expanded = header + 3 content lines + the same block spacer.
+    assert_eq!(transcript_lines(&model, true, 0).len(), 5);
 }
 
 #[test]
@@ -325,8 +360,8 @@ fn collapsed_thinking_shows_preview_lines_not_the_full_wall() {
     let long = format!("{}THE-TAIL", "reasoning noise ".repeat(20));
     model.apply(&AgentEvent::Reasoning { delta: long });
     let lines = transcript_lines(&model, false, 0);
-    // 1 line of text → header + 1 preview = 2 lines.
-    assert_eq!(lines.len(), 2);
+    // 1 line of text → header + 1 preview, then the block spacer.
+    assert_eq!(lines.len(), 3);
     // The preview should be visible.
     let text: String = lines
         .iter()
@@ -347,9 +382,9 @@ fn collapsed_thinking_preview_updates_as_deltas_stream() {
         delta: " now checking tests".into(),
     });
     let after = transcript_lines(&model, false, 0);
-    // Both produce header + 1 preview = 2 lines.
-    assert_eq!(before.len(), 2);
-    assert_eq!(after.len(), 2, "still header + 1 preview line");
+    // Both produce header + 1 preview + the block spacer.
+    assert_eq!(before.len(), 3);
+    assert_eq!(after.len(), 3, "still header + 1 preview line");
     // The preview line (index 1) visibly changes with each delta.
     assert_ne!(
         before[1], after[1],
@@ -573,13 +608,20 @@ fn transcript_scrolls_line_exact_to_show_the_tail() {
 }
 
 #[test]
-fn ui_transcript_cache_invalidates_when_a_file_mutation_stales_an_inline_diff() {
+fn ui_transcript_cache_follows_file_mutations_and_keeps_each_results_own_diff() {
     use stella_protocol::FileChangeKind as FK;
     // A FileChange appends NOTHING to the transcript — every older
     // fingerprint term (entry count, tail lengths, width) holds still —
-    // yet it stales a settled tool result's inline diff. Only the
-    // file-mutation term can catch it; without it the cache would keep
-    // showing a diff the entry no longer owns.
+    // yet it can change what a *settled* tool result renders. Only the
+    // file-mutation term can catch that.
+    //
+    // What it changes moved with `FileState::recent_diffs`: a single later
+    // mutation no longer stales anything, because each result resolves the
+    // diff recorded at its own seq and the path remembers the last
+    // `DIFF_HISTORY` of them. A row therefore keeps showing the change it
+    // made instead of blanking the moment the file is touched again. Only
+    // once its diff is *evicted* from that history does the row lose it —
+    // and the cache has to notice, still with nothing appended.
     let mut model = SessionModel::new();
     model.apply(&AgentEvent::ToolStart {
         call: ToolCall {
@@ -624,8 +666,34 @@ fn ui_transcript_cache_invalidates_when_a_file_mutation_stales_an_inline_diff() 
     ui.ensure_transcript_lines(&model, false, 120);
     let after = text(ui.transcript_lines());
     assert!(
-        !after.contains("first_diff_line") && !after.contains("second_diff_line"),
-        "the stale diff is dropped, not misattributed: {after}"
+        after.contains("first_diff_line"),
+        "the settled row keeps the diff IT produced: {after}"
+    );
+    assert!(
+        !after.contains("second_diff_line"),
+        "a newer change is never misattributed to it: {after}"
+    );
+
+    // Keep mutating until the recorded seq falls off the end of the
+    // history. The render must now drop the diff — and the cache must
+    // rebuild to show that, with the transcript still untouched.
+    for i in 0..crate::model::DIFF_HISTORY {
+        model.apply(&AgentEvent::FileChange {
+            path: "src/x.rs".into(),
+            kind: FK::Modified,
+            diff: Some(format!("@@ -1,1 +1,1 @@\n+evicting_edit_{i}")),
+        });
+    }
+    assert_eq!(model.transcript.len(), len_before, "still no append");
+    ui.ensure_transcript_lines(&model, false, 120);
+    let evicted = text(ui.transcript_lines());
+    assert!(
+        !evicted.contains("first_diff_line"),
+        "a forgotten diff stops rendering: {evicted}"
+    );
+    assert!(
+        !evicted.contains("evicting_edit_"),
+        "and is not replaced by a change the call never made: {evicted}"
     );
 }
 
@@ -795,7 +863,9 @@ fn tool_cards_and_verdicts_style_content_deterministically() {
         duration_ms: 12,
         speculated: false,
     });
-    let lines = transcript_lines(&model, false, 0);
+    // A realistic width: the right-hand metric column only lays out when
+    // there is room for it, so a 0-width render would drop the duration.
+    let lines = transcript_lines(&model, false, 120);
     let joined: String = lines
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.clone()))
@@ -803,21 +873,36 @@ fn tool_cards_and_verdicts_style_content_deterministically() {
     assert!(joined.contains("read_file"));
     assert!(joined.contains("not found"));
     assert!(joined.contains("12ms"));
-    // The result row resolves its tool name from the call so the two
-    // rows read as an aligned pair.
+    // The tool is named exactly once, by its call row. The result row
+    // underneath carries only the failure text and the metric column: the
+    // rail already ties it to the call above it, so re-labelling it would
+    // spend a second row restating what the first row just said.
+    assert_eq!(
+        joined.matches("read_file").count(),
+        1,
+        "the call names the tool; the result does not repeat it: {joined}"
+    );
+    let line_text =
+        |l: &Line<'_>| -> String { l.spans.iter().map(|s| s.content.as_ref()).collect() };
+    let result = lines
+        .iter()
+        .find(|l| line_text(l).contains("not found"))
+        .expect("the failure renders");
     assert!(
-        joined.contains("[✗ read_file]"),
-        "result labels itself with its tool: {joined}"
+        line_text(result).starts_with(Rail::Fail.prefix()),
+        "a failed result rides the ✗ rail: {:?}",
+        result.spans
     );
 }
 
 /// Expanded (ctrl+o) detail rows — full tool output and pretty-printed
-/// call args — align at the content column exactly like their parent
-/// row's content, not at the left margin: the transcript's two-column
-/// layout must hold for the hidden rows too.
+/// call args — align at the subordinate body column ([`BODY`]), exactly
+/// where their parent row's content sits, not at the left margin: an
+/// expanded body must read as part of the same block rather than as a run
+/// of new top-level events.
 #[test]
 fn expanded_detail_rows_align_at_the_content_column() {
-    let indent = " ".repeat(LABEL_COL);
+    let indent = " ".repeat(BODY);
     let line_text =
         |l: &Line<'_>| -> String { l.spans.iter().map(|s| s.content.as_ref()).collect() };
 
@@ -839,12 +924,22 @@ fn expanded_detail_rows_align_at_the_content_column() {
         120,
         &mut result_rows,
     );
-    let details: Vec<String> = result_rows.iter().skip(1).map(line_text).collect();
+    // `entry_lines` closes a block with a blank spacer row; the detail rows
+    // are everything between the rail row and that trailing gap.
+    assert_eq!(
+        result_rows.last().map(line_text).as_deref(),
+        Some(""),
+        "a tool result closes its block with a spacer"
+    );
+    let details: Vec<String> = result_rows[1..result_rows.len() - 1]
+        .iter()
+        .map(line_text)
+        .collect();
     assert_eq!(details.len(), 2, "both output lines render");
     for d in &details {
         assert!(
             d.starts_with(&indent) && !d.starts_with(&format!("{indent} ")),
-            "detail row starts exactly at LABEL_COL: {d:?}"
+            "detail row starts exactly at BODY: {d:?}"
         );
     }
 
@@ -874,12 +969,20 @@ fn expanded_detail_rows_align_at_the_content_column() {
 
 // ---- Inline transcript diffs (mutating tool results) ----
 
+/// Additions in the fixture diff below. Sized off [`INLINE_DIFF_CAP`] rather
+/// than hardcoded so the collapsed render is always exercising the fold —
+/// a fixture that silently slipped under a raised cap would leave the
+/// capping contract untested while still passing.
+const FIXTURE_ADDS: usize = INLINE_DIFF_CAP + 10;
+
 /// A successful mutation's result entry, plus the file state its
-/// [`InlineDiffRef`] resolves against: a 15-line Rust diff (1 hunk header
-/// + 14 additions) whose freshness seq matches.
+/// [`InlineDiffRef`] resolves against: a one-hunk Rust diff of
+/// [`FIXTURE_ADDS`] additions whose freshness seq matches.
 fn mutation_entry_and_files() -> (TranscriptEntry, Vec<FileState>) {
-    let body: String = (1..=14).map(|i| format!("+let x{i} = {i};\n")).collect();
-    let diff_text = format!("@@ -0,0 +1,14 @@\n{body}");
+    let body: String = (1..=FIXTURE_ADDS)
+        .map(|i| format!("+let x{i} = {i};\n"))
+        .collect();
+    let diff_text = format!("@@ -0,0 +1,{FIXTURE_ADDS} @@\n{body}");
     let entry = TranscriptEntry::ToolResult {
         call_id: "c1".into(),
         name: "edit_file".into(),
@@ -896,7 +999,8 @@ fn mutation_entry_and_files() -> (TranscriptEntry, Vec<FileState>) {
     let files = vec![FileState {
         path: "src/x.rs".into(),
         kind: FileChangeKind::Modified,
-        latest_diff: Some(diff_text),
+        latest_diff: Some(diff_text.clone()),
+        recent_diffs: [(1, diff_text)].into_iter().collect(),
         changes: 1,
         reads: 0,
     }];
@@ -923,19 +1027,43 @@ fn collapsed_tool_result_shows_a_capped_syntax_highlighted_inline_diff() {
     entry_lines(&entry, &files, false, false, 120, &mut out);
     let text = flat_text(&out);
 
-    // The header rule carries the path; the footer carries the counts.
-    assert!(text.contains("── src/x.rs"), "path rule present:\n{text}");
-    assert!(text.contains("+14 additions"), "footer counts:\n{text}");
-    // Capped at INLINE_DIFF_CAP styled diff lines: the hunk header plus
-    // the first 9 additions — the 10th addition is folded away.
-    assert!(text.contains("@@ -0,0 +1,14 @@"), "hunk header:\n{text}");
-    assert!(text.contains("+let x9 = 9;"), "9th addition shown:\n{text}");
+    // No path rule and no counts footer inline, unlike the standalone diff
+    // viewer: the call row above already names the file and the metric
+    // column already states `+n −m`, so both rules would be the same facts
+    // a second time — four rows of chrome around a small change.
     assert!(
-        !text.contains("+let x10 = 10;"),
-        "the 11th diff line is folded behind ctrl+o:\n{text}"
+        !text.contains("── src/x.rs"),
+        "no path rule inline:\n{text}"
     );
     assert!(
-        text.contains("⋯ +5 more diff lines · ctrl+o opens the full diff"),
+        !text.contains("additions"),
+        "no counts footer inline:\n{text}"
+    );
+    assert!(
+        text.contains(&format!("+{FIXTURE_ADDS} −0")),
+        "the metric column states the change's size instead:\n{text}"
+    );
+    // A lone hunk header is dropped too: inline under a call it restates
+    // what the line-number gutter beside it already says.
+    assert!(
+        !text.contains("@@ -0,0"),
+        "a single hunk's header is not worth a row inline:\n{text}"
+    );
+    // The cap counts raw diff lines, hunk header included — so the last
+    // addition shown is number INLINE_DIFF_CAP - 1 and the rest fold away.
+    let last_shown = INLINE_DIFF_CAP - 1;
+    let first_hidden = last_shown + 1;
+    let hidden = FIXTURE_ADDS + 1 - INLINE_DIFF_CAP;
+    assert!(
+        text.contains(&format!("+let x{last_shown} = {last_shown};")),
+        "addition {last_shown} is the last one shown:\n{text}"
+    );
+    assert!(
+        !text.contains(&format!("+let x{first_hidden} = {first_hidden};")),
+        "addition {first_hidden} is folded behind ctrl+o:\n{text}"
+    );
+    assert!(
+        text.contains(&format!("⋯ {} · ctrl+o", plural_lines(hidden))),
         "the fold names the hidden count and the key:\n{text}"
     );
     // Line-level standard: added lines are numbered on the new side.
@@ -956,40 +1084,58 @@ fn expanded_tool_result_shows_the_full_inline_diff() {
     entry_lines(&entry, &files, false, true, 120, &mut out);
     let text = flat_text(&out);
     assert!(
-        text.contains("+let x14 = 14;"),
+        text.contains(&format!("+let x{FIXTURE_ADDS} = {FIXTURE_ADDS};")),
         "ctrl+o reveals every diff line:\n{text}"
     );
     assert!(
-        !text.contains("more diff lines"),
+        !text.contains("· ctrl+o"),
         "no fold hint once expanded:\n{text}"
     );
+    // The size still reads off the metric column, expanded or not — the
+    // inline diff never grows a footer rule of its own.
     assert!(
-        text.contains("+14 additions"),
-        "footer still closes:\n{text}"
+        text.contains(&format!("+{FIXTURE_ADDS} −0")),
+        "the metric column still states the change's size:\n{text}"
+    );
+    assert!(
+        !text.contains("additions"),
+        "and still without a counts footer:\n{text}"
     );
 }
 
 #[test]
 fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
     let (entry, mut files) = mutation_entry_and_files();
-    // A later mutation bumped the path's change counter past the seq the
-    // result recorded — showing the newer diff under this ✓ would
-    // attribute a change the call never made.
-    files[0].changes = 2;
+    // The path went on mutating until this call's diff aged out of the
+    // bounded history — exactly the state `DIFF_HISTORY` evictions leave
+    // behind. No remembered diff belongs to this result any more, and
+    // showing the newest one instead would attribute a change the call
+    // never made, so the row degrades to naming its result.
+    files[0].changes = crate::model::DIFF_HISTORY as u32 + 1;
+    files[0].recent_diffs = (2..=files[0].changes)
+        .map(|seq| (seq, format!("@@ -0,0 +1,1 @@\n+later_edit_{seq}\n")))
+        .collect();
     let mut out = Vec::new();
     entry_lines(&entry, &files, false, false, 120, &mut out);
     let text = flat_text(&out);
     assert!(
-        !text.contains("── src/x.rs"),
-        "stale ref hides the diff:\n{text}"
+        !text.contains("+let x1 = 1;"),
+        "the forgotten diff cannot render:\n{text}"
     );
-    assert!(!text.contains("@@"), "no diff body either:\n{text}");
+    assert!(
+        !text.contains("later_edit_"),
+        "and a newer one is never substituted for it:\n{text}"
+    );
+    assert!(
+        text.contains("ok"),
+        "the row falls back to naming the result:\n{text}"
+    );
 
     // A ref whose path is no longer tracked resolves to nothing at all.
     let mut out = Vec::new();
     entry_lines(&entry, &[], false, false, 120, &mut out);
     assert!(
-        !flat_text(&out).contains("@@"),
+        !flat_text(&out).contains("+let x1 = 1;"),
         "unknown path renders no diff"
     );
 }
@@ -1060,9 +1206,17 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
     );
 }
 
-/// Every other entry's `[label]:` prefix stays inside the warm brand
-/// family — failure crimson, success gold — so no raw ANSI cyan/blue/
+/// Every rail and note glyph stays inside the warm brand family — failure
+/// crimson, calls deep gold, prompts violet — so no raw ANSI cyan/blue/
 /// magenta survives from before the palette landed.
+///
+/// The margin's colour is itself the hierarchy, in three steps: the `●`
+/// call rail is brand gold because the call *is* the event; the `⎿` result
+/// rail is muted because a successful outcome is that event's consequence,
+/// subordinate chrome rather than a second thing to look at; and the `✗`
+/// fail rail is danger, the one outcome worth interrupting a scan for.
+/// Painting every ✓ as loudly as every ✗ would leave a failure with nothing
+/// to stand out against.
 #[test]
 fn transcript_prefix_colors_stay_in_the_brand_family() {
     let prefix_fg = |entry: &TranscriptEntry| -> Option<Color> {
@@ -1079,6 +1233,17 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
         "error prefix is crimson",
     );
     assert_eq!(
+        prefix_fg(&TranscriptEntry::ToolStart {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            input: "x".into(),
+            raw: "{}".into(),
+            path: None,
+        }),
+        Some(theme::ACCENT_DEEP),
+        "a tool call — the thing that happened — carries the deep-gold rail",
+    );
+    assert_eq!(
         prefix_fg(&TranscriptEntry::ToolResult {
             call_id: "c1".into(),
             name: "read_file".into(),
@@ -1089,8 +1254,9 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
             speculated: false,
             diff: None,
         }),
-        Some(theme::ACCENT),
-        "successful tool-result prefix is gold",
+        Some(theme::MUTED),
+        "a successful result's rail recedes — it is a continuation of its \
+         call, not a second event competing for the eye",
     );
     assert_eq!(
         prefix_fg(&TranscriptEntry::ToolResult {
@@ -1111,6 +1277,23 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
         prefix_fg(&TranscriptEntry::Stage(StageKind::Execute)),
         Some(theme::ACCENT_DEEP),
         "stage prefix is deep gold",
+    );
+    // A prompt is the strongest landmark in the scrollback — where a reader
+    // re-orients when scrolling back — and rides the interactive-chrome
+    // violet shared with the composer, never the reserved brand gold.
+    assert_eq!(
+        prefix_fg(&TranscriptEntry::User("hi".into())),
+        Some(theme::VIOLET),
+        "the user rail is violet",
+    );
+    // Assistant prose is the one rail with no colour, because it has no
+    // glyph to colour: `Rail::Agent` is two bare spaces. Prose is the
+    // transcript's default voice, and a marker on every paragraph would be
+    // noise exactly where a reader is reading rather than scanning.
+    assert_eq!(
+        prefix_fg(&TranscriptEntry::Text("ok".into())),
+        None,
+        "agent prose rides an unstyled, glyph-less rail",
     );
 }
 

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -134,6 +134,14 @@ pub const DIFF_ADD_BG: Color = Color::Rgb(20, 44, 26);
 /// Subtle background tint behind removed diff lines (pair with [`BAD`]).
 pub const DIFF_DEL_BG: Color = Color::Rgb(52, 24, 26);
 
+/// Background behind the bytes of an added line that actually changed, when a
+/// `-`/`+` pair is close enough to word-diff. Two steps brighter than
+/// [`DIFF_ADD_BG`]: the whole line is already "added", so this has to read as
+/// a second level of emphasis *within* it rather than a different category.
+pub const DIFF_ADD_BG_EMPH: Color = Color::Rgb(26, 82, 44);
+/// The removed-line counterpart of [`DIFF_ADD_BG_EMPH`].
+pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(102, 34, 42);
+
 // ── Syntax highlighting (diff bodies) ───────────────────────────────────────
 //
 // A four-color code palette layered *under* the add/remove diff semantics:
@@ -341,6 +349,8 @@ const FALLBACKS: &[(Color, u8, u8)] = &[
     (AGENT_ICE, 153, 12),
     (DIFF_ADD_BG, 22, 2),
     (DIFF_DEL_BG, 52, 1),
+    (DIFF_ADD_BG_EMPH, 28, 2),
+    (DIFF_DEL_BG_EMPH, 88, 1),
     (SYNTAX_STRING, 114, 10),
     (SYNTAX_COMMENT, 244, 8),
 ];
@@ -610,6 +620,8 @@ mod tests {
         AGENT_ICE,
         DIFF_ADD_BG,
         DIFF_DEL_BG,
+        DIFF_ADD_BG_EMPH,
+        DIFF_DEL_BG_EMPH,
         SYNTAX_STRING,
         SYNTAX_COMMENT,
     ];

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -581,14 +581,26 @@ mod tests {
     }
 
     #[test]
-    fn a_later_mutation_to_the_same_path_stales_the_settled_inline_diff() {
+    fn a_later_mutation_leaves_the_settled_inline_diff_showing_its_own_change() {
         use stella_protocol::{FileChangeKind, ToolCall, ToolOutput};
         // A successful edit_file: ToolStart → FileChange (the engine's tap
         // fires during execution) → ToolResult. The result's inline diff
-        // must render — and must vanish once a LATER mutation of the same
-        // path makes the recorded seq stale, even though nothing was
-        // appended to the transcript (the fold cache's only moving
-        // fingerprint is the file-mutation count).
+        // must render, and must go on rendering *the change that call made*
+        // when the same path is edited again.
+        //
+        // It used to vanish instead: `FileState` kept one `latest_diff` and
+        // the ref resolved only while `changes` still equalled the recorded
+        // seq, so the second edit to a file silently stripped the first
+        // edit's diff off its row. A session that touched one file five
+        // times showed four edits with nothing under them. The path now
+        // remembers its last `DIFF_HISTORY` diffs by seq, so each row
+        // resolves its own — attribution, which was always the point, now
+        // achieved by keeping the right diff rather than by dropping every
+        // diff that might be the wrong one.
+        //
+        // The fold cache still keys on the total mutation count, because
+        // eviction from that history *can* change how a settled entry
+        // renders while nothing is appended to the transcript.
         let mut model = SessionModel::new();
         model.apply(&AgentEvent::ToolStart {
             call: ToolCall {
@@ -633,13 +645,15 @@ mod tests {
             "the fresh inline diff renders:\n{text}"
         );
 
-        // The same path mutates again — no transcript append, but the
-        // settled result's diff no longer belongs to its call.
+        // The same path mutates again — no transcript append. The settled
+        // result keeps the diff it produced and never adopts the new one.
+        let len_before = model.transcript.len();
         model.apply(&AgentEvent::FileChange {
             path: "src/x.rs".into(),
             kind: FileChangeKind::Modified,
             diff: Some("@@ -1,1 +1,1 @@\n+second_diff_line".into()),
         });
+        assert_eq!(model.transcript.len(), len_before, "no transcript append");
         fold.refresh(
             "lead",
             &model.transcript,
@@ -657,8 +671,49 @@ mod tests {
             .flat_map(|l| l.spans.iter().map(|s| s.content.clone()))
             .collect();
         assert!(
-            !text.contains("first_diff_line") && !text.contains("second_diff_line"),
-            "a stale diff is hidden, never misattributed:\n{text}"
+            text.contains("first_diff_line"),
+            "the settled row still shows the change its own call made:\n{text}"
+        );
+        assert!(
+            !text.contains("second_diff_line"),
+            "and never adopts a later call's change:\n{text}"
+        );
+
+        // Past `DIFF_HISTORY` mutations the recorded seq falls off the end
+        // of the ring and there is no diff left that belongs to this call.
+        // The row degrades to naming its result — and the fold must refold
+        // to show that, with the transcript still untouched.
+        for i in 0..crate::model::DIFF_HISTORY {
+            model.apply(&AgentEvent::FileChange {
+                path: "src/x.rs".into(),
+                kind: FileChangeKind::Modified,
+                diff: Some(format!("@@ -1,1 +1,1 @@\n+evicting_edit_{i}")),
+            });
+        }
+        assert_eq!(model.transcript.len(), len_before, "still no append");
+        fold.refresh(
+            "lead",
+            &model.transcript,
+            &model.files,
+            "",
+            false,
+            &expanded,
+            false,
+            0,
+            120,
+        );
+        let text: String = fold
+            .window_lines(0..fold.total())
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.clone()))
+            .collect();
+        assert!(
+            !text.contains("first_diff_line"),
+            "an evicted diff stops rendering:\n{text}"
+        );
+        assert!(
+            !text.contains("evicting_edit_"),
+            "and is not replaced by a change the call never made:\n{text}"
         );
 
         // And the incrementally-invalidated fold stays line-exact.


### PR DESCRIPTION
Design doc with the full before/after and the reasoning behind each decision:
**

## Why

A transcript is a list, and lists are scanned down their left edge. The layout right-aligned a `[label]: ` tag into column 22 — which put the tag's **left** edge at a different column on every row (`[cmd]` at 15, `[✓ read_file]` at 7). The index column jittered, so there was nothing to scan. It also spent 22 columns (19% of a 118-column pane) on chrome the diff bodies then paid for again in clipped code, and inserted no vertical separation anywhere.

## What changed

**Geometry.** Rows open on a fixed-width rail — `●` call, `⎿` result, `✗` failure, `▌` prompt — glyph in column 0, content at 2 or 4. 18 columns given back.

**Rhythm.** A spacer follows an entry that *closes a block*, never separating a result from its call. Trailing rather than leading keeps it entry-local, so the deck's incremental fold needs no lookback. Parallel `ToolStart`s render as one tight block as a result.

**Salience.** Collapsed output anchors on the first line carrying a failure marker rather than line 1 — `warning: unused import` instead of `Checking stella-cli v0.5.39`. Failures never collapse to a single line.

**Diffs.** Hunk-aware cap (a flat cut at line N routinely landed between a `-` and the `+` replacing it). Header/footer rules dropped inline — the call row names the file, the metric column states `+n −m`. Context lines keep their syntax colours. Word-level intra-line emphasis picks out the differing middle of a `-`/`+` pair, so a one-token edit names itself.

**Presentation.** Human durations (`4.2s`, not `4210ms`), thousands separators, directory dimmed / basename emphasised, right-aligned metric column capped so it stays within a saccade of its row on wide terminals.

## Bug fixed

`FileState` kept only `latest_diff`, and a result resolved its diff by checking the path's mutation counter still equalled the value recorded at fold time. So the **second** edit to a file silently stripped the **first** edit's diff off its row — a session that touched one file five times showed four edits with nothing under them. The path now remembers its last `DIFF_HISTORY` (8) diffs by seq. Attribution was always the goal; this reaches it by keeping the right diff rather than dropping every diff that might be the wrong one.

## Structure

`render/row.rs` (row vocabulary) and `model/file_state.rs` (the type + its history) are new modules, per the file-size gate's rule that non-irreducible growth belongs in its own module. `render.rs` ends up small enough to graduate off the grandfathered baseline entirely; `model.rs`'s ceiling drops.

## Verification

`make gate` passes end to end — no-scratch, doc-citations, file-size, rustdoc, fmt-check, clippy `-D warnings`, and the full workspace test suite.

Test contracts were rewritten rather than relaxed. Two of them (`..._stales_the_settled_inline_diff`) encoded the defect above as intended behaviour and now assert the opposite, against distinguishing diff content plus the ring-eviction boundary. `a_stale_or_unresolvable_diff_ref_renders_no_inline_diff` had been passing vacuously — its assertions referenced chrome the inline renderer no longer emits — and is rebuilt around real eviction. New coverage for hunk-aware capping.

## Deliberately not done

- Fusing call + result into one row: the status glyph can't reach the `●` row without the model tracking resolution, which invalidates the fold cache on every tool result. The `●`/`⎿` hierarchy gets most of the benefit for none of the risk.
- Suppressing the gap between two bodyless calls: needs lookback, and predictable rhythm beats optimal density.
- A "created"/"deleted" word on the diff row: would mean reshaping `recent_diffs` to carry per-seq kind, and `+42 −0` already reads as "new file".

Navigation features — jump-to-next-failure, turn folding, transcript search — are stacked in a follow-up PR.
