### PR TITLE
perf(core): hash each context block once per turn, not once per step

### DIFF
--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -67,8 +67,7 @@
 //! ("malformed-call repair tuned to the failure shapes GLM actually
 //! produces") is a documented follow-up, not faked here.
 
-use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -81,15 +80,19 @@ use stella_protocol::{
 
 use crate::budget::{BudgetAxis, BudgetGuard, BudgetOutcome};
 use crate::compaction::compact_measured;
+use crate::receipts::TranscriptRevision;
+
+mod loop_evidence;
 use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
 use crate::event_sender::EventSender;
 use crate::hooks::{HookEvent, HookPayload, HookRunner, Hooks, any_matcher_matches, run_hooks};
-use crate::loop_detect::{CallRecord, LoopDetectionConfig, LoopVerdict, detect_loop};
+use crate::loop_detect::{LoopDetectionConfig, LoopVerdict, detect_loop};
 use crate::ports::ToolExecutor;
 use crate::receipts::ReceiptLedger;
 use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, retry_with_backoff_observed};
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::{AccountedCall, AccountedCallError, run_accounted_call};
+use loop_evidence::{ResultIdentities, recent_call_records, snapshot_result_identities};
 use tokio::sync::mpsc::UnboundedSender;
 
 mod settlement;
@@ -474,7 +477,12 @@ impl<'a> Engine<'a> {
         // Per-turn pre-compaction tool-result identities
         // ([`snapshot_result_identities`]). Stack-local like the two above —
         // the engine holds no state of its own.
-        let mut result_identities = ResultIdentities::new();
+        let mut result_identities = ResultIdentities::default();
+        // Bumped by every pass that rewrites the transcript in place rather than
+        // appending to it, which is what tells the two position-keyed memos —
+        // `result_identities`' positional half and the receipt ledger's block
+        // digests — that their keys no longer name the bytes behind them.
+        let mut revision = TranscriptRevision::default();
 
         for step in 0..self.config.max_steps {
             // Pause parks HERE — after the previous step fully settled and
@@ -512,8 +520,8 @@ impl<'a> Engine<'a> {
             // BEFORE compaction, never after: the pass rewrites tool results
             // in place, and loop detection runs on the rewritten history in
             // this very step (#554).
-            snapshot_result_identities(messages, &mut result_identities);
-            total_cost_usd += self
+            snapshot_result_identities(messages, &mut result_identities, revision);
+            let pass = self
                 .run_compaction_pass(
                     messages,
                     calibration_model.as_deref(),
@@ -523,10 +531,17 @@ impl<'a> Engine<'a> {
                     events,
                 )
                 .await;
+            total_cost_usd += pass.cost_usd;
+            if pass.rewrote {
+                revision.rewritten();
+            }
             // The manifest reports the budget compaction just compared against.
             let (effective_budget, calibration_factor) =
                 self.effective_compaction_budget(calibration_model.as_deref());
             receipts.set_effective_budget(effective_budget, calibration_factor);
+            // Set immediately after the pass that may have rewritten the
+            // transcript, so the ledger's digest memo cannot serve a stale block.
+            receipts.set_transcript_revision(revision);
 
             if let Some(aborted) = self.check_loop_detection(
                 messages,
@@ -655,14 +670,20 @@ impl<'a> Engine<'a> {
         health: &mut SummarizerHealth,
         step: usize,
         events: &EventSender,
-    ) -> f64 {
+    ) -> CompactionPass {
         let (compaction_budget, factor) = self.effective_compaction_budget(calibration_model);
+        // Whether anything was rewritten IN PLACE, decided at the mutation sites
+        // below and reported through a `#[must_use]` return.
+        let mut rewrote = false;
         // Post-pass size, for the overflow decision below. `compact_measured`
         // returns the count it already computed on every path — including both
         // `None` paths, the common case — so this walks the transcript once per
         // step rather than eagerly re-deriving a number the callee just discarded.
         let (after_tokens, report) = compact_measured(messages, compaction_budget);
         if let Some(report) = report {
+            // `Some` means a pass actually stubbed, aged or superseded something,
+            // so positions at or after the first rewrite name different bytes now.
+            rewrote = true;
             let _ = events.send(AgentEvent::Compaction {
                 before_tokens: report.before_tokens,
                 after_tokens,
@@ -689,7 +710,12 @@ impl<'a> Engine<'a> {
         // latest tool result) — without this, the next provider call
         // eventually hard-fails on context overflow.
         if self.config.summarize_overflow && after_tokens > compaction_budget {
-            return self
+            // The summarizer splices a span down to one message, shifting every
+            // position after it. Reported unconditionally when it RUNS rather than
+            // only when it splices: over-invalidating costs one turn's memo on a
+            // rare path, under-invalidating serves a digest for bytes that moved.
+            // That asymmetry is why this is a revision counter, not a heuristic.
+            let cost_usd = self
                 .summarize_overflow_span(
                     messages,
                     budget,
@@ -700,8 +726,15 @@ impl<'a> Engine<'a> {
                     events,
                 )
                 .await;
+            return CompactionPass {
+                cost_usd,
+                rewrote: true,
+            };
         }
-        0.0
+        CompactionPass {
+            cost_usd: 0.0,
+            rewrote,
+        }
     }
 
     /// Replace the oldest viable span with a model-written summary. Failures
@@ -2019,235 +2052,24 @@ impl SummarizerHealth {
 /// window boundary would erase the very evidence that triggered it, and
 /// the abort-on-re-detection would need a whole fresh threshold's worth of
 /// looping instead of one more no-progress call.
+/// What one compaction pass did: what it cost, and whether it rewrote the
+/// transcript in place.
+///
+/// `#[must_use]` is load-bearing. `rewrote` is the only signal that the two
+/// position-keyed memos — the loop detector's result identities and the receipt
+/// ledger's block digests — must drop their keys, and a caller that ignored it
+/// would leave both serving digests for bytes that no longer exist. Making the
+/// return value impossible to discard silently turns "remember to invalidate"
+/// from a convention into a compile error.
+#[must_use]
+struct CompactionPass {
+    /// The summarizer's spend, if the overflow fallback ran; zero otherwise.
+    cost_usd: f64,
+    /// True when a pass stubbed, aged, superseded or spliced anything.
+    rewrote: bool,
+}
+
 const LOOP_STEER_PREFIX: &str = "[stuck-loop warning";
-
-/// Pair the tool calls of the CURRENT turn — assistant messages after the
-/// last user message — with the outputs they produced, in chronological
-/// order, for `crate::loop_detect::detect_loop`. Windowing at the user
-/// boundary matters: identical calls across turns are the user re-asking a
-/// question, not a stuck loop (a REPL session asking the same thing three
-/// times would otherwise trip the exact-repeat detector), and it keeps
-/// this per-step scan O(turn) instead of O(entire history). The overflow
-/// summary and the stuck-loop warning are also User-role but are not real
-/// user turns — treating either as a boundary would truncate the loop
-/// window (on every summarization pass, or right when re-detection needs
-/// the evidence), so both are skipped when locating the boundary.
-///
-/// Results attach to the most recent still-unresolved call with a matching
-/// `call_id` — providers only guarantee ids unique within one step, and a
-/// scripted or misbehaving backend may reuse them across steps. A call
-/// whose result is missing keeps `output: None`, which the detector treats
-/// as unprovable progress, never loop evidence.
-///
-/// `identities` is the turn's snapshot from [`snapshot_result_identities`],
-/// attached to each resolved record so the detector can compare what a call
-/// really produced rather than what compaction left of it (#554). It is
-/// keyed by [`CallIdentityKey`], so the lookup here must derive the key from
-/// the record's own call. A key that is absent — or poisoned because that
-/// same call produced two different outputs — leaves `identity: None` and
-/// the detector falls back to the output bytes.
-fn recent_call_records<'a>(
-    messages: &'a [CompletionMessage],
-    identities: &ResultIdentities,
-) -> Vec<CallRecord<'a>> {
-    let turn_start = messages
-        .iter()
-        .rposition(|m| {
-            m.role == MessageRole::User
-                && !m.content.starts_with(SUMMARY_MARKER_PREFIX)
-                && !m.content.starts_with(LOOP_STEER_PREFIX)
-        })
-        .map(|i| i + 1)
-        .unwrap_or(0);
-    let mut records: Vec<CallRecord> = Vec::new();
-    for message in &messages[turn_start..] {
-        match message.role {
-            MessageRole::Assistant => {
-                records.extend(message.tool_calls.iter().map(|call| CallRecord {
-                    call: call.clone(),
-                    output: None,
-                    identity: None,
-                }));
-            }
-            MessageRole::Tool => {
-                for result in &message.tool_results {
-                    if let Some(record) = records
-                        .iter_mut()
-                        .rev()
-                        .find(|r| r.output.is_none() && r.call.call_id == result.call_id)
-                    {
-                        // Kept as the `Cow` it comes back as: with no volatile
-                        // footer (the common path) this borrows, not copies.
-                        record.output = Some(comparable_output(&result.output));
-                        let key = call_identity_key(&record.call);
-                        record.identity = identities.get(&key).cloned().flatten();
-                    }
-                }
-            }
-            MessageRole::System | MessageRole::User => {}
-        }
-    }
-    records
-}
-
-/// Identifies a tool call for the purpose of [`ResultIdentities`]: the
-/// provider's `call_id` PLUS the call's name and input.
-///
-/// `call_id` alone is not enough. Providers only guarantee ids unique within
-/// one response, and Gemini and Vertex mint them as `call_{ordinal}` where
-/// the ordinal is local to a single assistant step (`stella-model/src/
-/// gemini.rs`; `vertex.rs` reuses the same aggregation path). So `call_0`
-/// restarts on EVERY step, and a bare-`call_id` key collides across steps by
-/// construction on two real providers — poisoning the id on the first step
-/// whose first call differs, and keeping it poisoned for the rest of the turn.
-///
-/// Name and input are exactly the fields [`loop_detect::same_record`] already
-/// requires to match before two records are "the same", so widening the key
-/// with them cannot merge two calls the detector would have distinguished. It
-/// only stops two UNRELATED calls that happened to share an ordinal from being
-/// treated as one.
-///
-/// Deliberately not positional: [`Engine::apply_overflow_summary`] splices a
-/// span of messages down to a single summary, so any index-derived key would
-/// silently re-point surviving results at another call's evidence after the
-/// first overflow — a WRONG identity, which is far worse than none.
-type CallIdentityKey = (String, String, String);
-
-/// Build the [`CallIdentityKey`] for one tool call. `input` is serialized
-/// rather than hashed so the key stays debuggable; both producers derive it
-/// from the same `ToolCall`, so they always agree.
-fn call_identity_key(call: &ToolCall) -> CallIdentityKey {
-    (
-        call.call_id.clone(),
-        call.name.clone(),
-        call.input.to_string(),
-    )
-}
-
-/// A turn's snapshot of what each tool call really produced, keyed by
-/// [`CallIdentityKey`] ([`snapshot_result_identities`]). `None` marks a
-/// POISONED key: that same call was observed carrying two different
-/// uncompacted outputs, so nothing about it can be trusted.
-type ResultIdentities = HashMap<CallIdentityKey, Option<String>>;
-
-/// Record every tool result's identity into `identities`, keyed by
-/// [`CallIdentityKey`] — the driver's answer to #554. (Keyed by the call's
-/// id AND its name and input, never the id alone: see that type's docs for
-/// the providers that recycle ids across steps.)
-///
-/// Compaction rewrites tool results IN PLACE (dedup/supersession stubs,
-/// middle-out aging, the eviction stub) and runs immediately before loop
-/// detection in the same step, so a three-call identical streak reaches the
-/// detector as `[stub, stub, real]` and the byte-identical-output
-/// requirement can never be met. Snapshotting each result's identity while
-/// its real content is still present preserves exactly the evidence the
-/// detector needs, without teaching either pure module about the other.
-/// Called once per step BEFORE the compaction pass; the map accumulates
-/// across the turn, because a result's real content is only on hand for the
-/// one step between producing it and the pass that stubs it.
-///
-/// Two rules make accumulation safe:
-///
-/// - **A compacted output is never recorded.** Its identity is the stub's,
-///   not the call's; recording it would overwrite the real one and lose the
-///   evidence permanently, and every evicted result shares one stub.
-/// - **A call seen with two different real outputs is poisoned** (`None`),
-///   never overwritten. Keeping either identity would attach one call's
-///   evidence to a different call, and a WRONG identity is far worse than
-///   none: it can make two genuinely different outputs compare equal and
-///   abort a healthy turn. Poisoned keys fall back to comparing the live
-///   outputs, i.e. the behavior before this fix. With a
-///   [`CallIdentityKey`] a conflict now means what it says — the same tool,
-///   same arguments, different result, which IS progress — rather than
-///   firing on two unrelated calls that shared a recycled ordinal.
-///
-/// The identity is computed over [`comparable_output`], the same
-/// normalization the detector compares, so `read_file`'s volatile
-/// session-tally footer does not make every reread a distinct identity.
-///
-/// # The invariant that keeps a poisoned key from manufacturing a loop
-///
-/// A poisoned key degrades to comparing the live outputs, and compaction
-/// rewrites older results to ONE shared stub — so if every record in the
-/// detector's window could be a stub, three unrelated calls would compare
-/// byte-equal and abort a healthy turn. They cannot, and the reason is a
-/// cross-module invariant worth naming: `crate::compaction::compact` never
-/// touches the LAST `MessageRole::Tool` message (its `last_tool_idx` guard),
-/// and `detect_loop` only ever reports a verdict anchored on the trailing
-/// record. The anchor therefore always carries its real, freshly-produced
-/// output, and a stub can never match it. Relaxing that guard in
-/// `compaction.rs` would silently turn every over-budget turn into a
-/// false-positive loop abort here.
-fn snapshot_result_identities(messages: &[CompletionMessage], identities: &mut ResultIdentities) {
-    // Calls seen so far that nothing has answered yet, oldest first. The map
-    // is keyed by the CALL, so a result has to be paired back to the call it
-    // answers before its identity can be filed — using the same attachment
-    // rule as [`recent_call_records`], or the two would key differently and
-    // the lookup would silently miss.
-    let mut unanswered: Vec<&ToolCall> = Vec::new();
-    for message in messages {
-        match message.role {
-            MessageRole::Assistant => unanswered.extend(message.tool_calls.iter()),
-            MessageRole::Tool => {
-                for result in &message.tool_results {
-                    let Some(position) = unanswered
-                        .iter()
-                        .rposition(|call| call.call_id == result.call_id)
-                    else {
-                        continue;
-                    };
-                    let call = unanswered.remove(position);
-                    if crate::compaction::is_compacted_output(&result.output) {
-                        continue;
-                    }
-                    let key = call_identity_key(call);
-                    // A poisoned key can never be un-poisoned: any later
-                    // observation conflicts with `None`, so the verdict is
-                    // already final. Hashing this result's content only to
-                    // re-derive it is pure waste, and this scan re-walks the
-                    // WHOLE transcript on every step (#554).
-                    if matches!(identities.get(&key), Some(None)) {
-                        continue;
-                    }
-                    let identity =
-                        crate::receipts::tool_result_block_id(&comparable_output(&result.output));
-                    let conflicts = matches!(
-                        identities.get(&key),
-                        Some(seen) if seen.as_deref() != Some(identity.as_str())
-                    );
-                    identities.insert(key, if conflicts { None } else { Some(identity) });
-                }
-            }
-            MessageRole::System | MessageRole::User => {}
-        }
-    }
-}
-
-/// Normalize one tool output for loop comparison: strip `read_file`'s
-/// volatile session-tally footer (`\n\n(N/M lines shown · read K× this
-/// session)`). The footer changes on EVERY read by design — it is the
-/// model-facing "you already read this" nudge — but the loop detector
-/// requires byte-identical outputs, so the footer made every reread unique
-/// and blinded detection to the exact thrash it exists to catch (the
-/// read → failing-edit → read cycle the `loop_detect` module doc names).
-/// Comparison-only: the transcript and history keep the footer untouched.
-///
-/// Borrowed on the overwhelmingly common path (no footer): both callers run
-/// over the WHOLE transcript on every step, so returning an owned copy meant a
-/// full heap copy of every tool result — a step's worth of garbage proportional
-/// to the entire history, for a normalization that usually changes nothing.
-fn comparable_output(output: &ToolOutput) -> Cow<'_, ToolOutput> {
-    if let ToolOutput::Ok { content } = output
-        && content.ends_with("\u{d7} this session)")
-        && let Some(idx) = content.rfind("\n\n(")
-        && content[idx..].contains(" lines shown \u{b7} read ")
-    {
-        return Cow::Owned(ToolOutput::Ok {
-            content: content[..idx].to_string(),
-        });
-    }
-    Cow::Borrowed(output)
-}
 
 /// The [`TurnOutcome::Aborted`] reason of a user-requested soft stop —
 /// callers match on this to render "stopped" rather than "failed", and to

--- a/stella-core/src/driver/loop_evidence.rs
+++ b/stella-core/src/driver/loop_evidence.rs
@@ -1,0 +1,322 @@
+//! The driver's side of loop detection: turning the live message vector into the
+//! evidence `crate::loop_detect` reasons over.
+//!
+//! `loop_detect` is a pure module that compares `CallRecord`s. Producing those
+//! records is the messy part, and it lives here: pairing each tool result back to
+//! the call it answers, bounding the window to the current turn, and — because
+//! compaction rewrites older results in place before the detector ever sees them
+//! — remembering what each call REALLY produced while its bytes are still present
+//! (#554).
+//!
+//! Both scans here run over the transcript on every step, which is why both are
+//! memoized against `TranscriptRevision`: the pairing walk is cheap and stays,
+//! the per-result serialization and SHA-256 behind an identity does not.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use stella_protocol::{CompletionMessage, MessageRole, ToolCall, ToolOutput};
+
+use crate::loop_detect::CallRecord;
+use crate::receipts::TranscriptRevision;
+
+use super::{LOOP_STEER_PREFIX, SUMMARY_MARKER_PREFIX};
+
+/// Pair the tool calls of the CURRENT turn — assistant messages after the
+/// last user message — with the outputs they produced, in chronological
+/// order, for `crate::loop_detect::detect_loop`. Windowing at the user
+/// boundary matters: identical calls across turns are the user re-asking a
+/// question, not a stuck loop (a REPL session asking the same thing three
+/// times would otherwise trip the exact-repeat detector), and it keeps
+/// this per-step scan O(turn) instead of O(entire history). The overflow
+/// summary and the stuck-loop warning are also User-role but are not real
+/// user turns — treating either as a boundary would truncate the loop
+/// window (on every summarization pass, or right when re-detection needs
+/// the evidence), so both are skipped when locating the boundary.
+///
+/// Results attach to the most recent still-unresolved call with a matching
+/// `call_id` — providers only guarantee ids unique within one step, and a
+/// scripted or misbehaving backend may reuse them across steps. A call
+/// whose result is missing keeps `output: None`, which the detector treats
+/// as unprovable progress, never loop evidence.
+///
+/// `identities` is the turn's snapshot from [`snapshot_result_identities`],
+/// attached to each resolved record so the detector can compare what a call
+/// really produced rather than what compaction left of it (#554). It is
+/// keyed by [`CallIdentityKey`], so the lookup here must derive the key from
+/// the record's own call. A key that is absent — or poisoned because that
+/// same call produced two different outputs — leaves `identity: None` and
+/// the detector falls back to the output bytes.
+pub(super) fn recent_call_records<'a>(
+    messages: &'a [CompletionMessage],
+    identities: &ResultIdentities,
+) -> Vec<CallRecord<'a>> {
+    let turn_start = messages
+        .iter()
+        .rposition(|m| {
+            m.role == MessageRole::User
+                && !m.content.starts_with(SUMMARY_MARKER_PREFIX)
+                && !m.content.starts_with(LOOP_STEER_PREFIX)
+        })
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let mut records: Vec<CallRecord> = Vec::new();
+    for message in &messages[turn_start..] {
+        match message.role {
+            MessageRole::Assistant => {
+                records.extend(message.tool_calls.iter().map(|call| CallRecord {
+                    call: call.clone(),
+                    output: None,
+                    identity: None,
+                }));
+            }
+            MessageRole::Tool => {
+                for result in &message.tool_results {
+                    if let Some(record) = records
+                        .iter_mut()
+                        .rev()
+                        .find(|r| r.output.is_none() && r.call.call_id == result.call_id)
+                    {
+                        // Kept as the `Cow` it comes back as: with no volatile
+                        // footer (the common path) this borrows, not copies.
+                        record.output = Some(comparable_output(&result.output));
+                        let key = call_identity_key(&record.call);
+                        record.identity = identities.identity_of(&key);
+                    }
+                }
+            }
+            MessageRole::System | MessageRole::User => {}
+        }
+    }
+    records
+}
+
+/// Identifies a tool call for the purpose of [`ResultIdentities`]: the
+/// provider's `call_id` PLUS the call's name and input.
+///
+/// `call_id` alone is not enough. Providers only guarantee ids unique within
+/// one response, and Gemini and Vertex mint them as `call_{ordinal}` where
+/// the ordinal is local to a single assistant step (`stella-model/src/
+/// gemini.rs`; `vertex.rs` reuses the same aggregation path). So `call_0`
+/// restarts on EVERY step, and a bare-`call_id` key collides across steps by
+/// construction on two real providers — poisoning the id on the first step
+/// whose first call differs, and keeping it poisoned for the rest of the turn.
+///
+/// Name and input are exactly the fields [`loop_detect::same_record`] already
+/// requires to match before two records are "the same", so widening the key
+/// with them cannot merge two calls the detector would have distinguished. It
+/// only stops two UNRELATED calls that happened to share an ordinal from being
+/// treated as one.
+///
+/// Deliberately not positional: [`Engine::apply_overflow_summary`] splices a
+/// span of messages down to a single summary, so any index-derived key would
+/// silently re-point surviving results at another call's evidence after the
+/// first overflow — a WRONG identity, which is far worse than none.
+pub(super) type CallIdentityKey = (String, String, String);
+
+/// Build the [`CallIdentityKey`] for one tool call. `input` is serialized
+/// rather than hashed so the key stays debuggable; both producers derive it
+/// from the same `ToolCall`, so they always agree.
+pub(super) fn call_identity_key(call: &ToolCall) -> CallIdentityKey {
+    (
+        call.call_id.clone(),
+        call.name.clone(),
+        call.input.to_string(),
+    )
+}
+
+/// A turn's snapshot of what each tool call really produced.
+///
+/// `by_call` is the evidence the loop detector reads, keyed by
+/// [`CallIdentityKey`] ([`snapshot_result_identities`]). `None` marks a POISONED
+/// key: that same call was observed carrying two different uncompacted outputs,
+/// so nothing about it can be trusted. It **accumulates for the whole turn** and
+/// is never cleared — that accumulation is the point of #554.
+///
+/// `by_position` is a memo, not evidence. The sweep re-derives every result's
+/// identity on every step, and deriving one costs a `serde_json` serialization of
+/// the whole output plus a SHA-256 over it. A result at a given
+/// `(message_index, result_index)` keeps producing the same identity for as long
+/// as nothing rewrites the transcript underneath it, so within one
+/// [`TranscriptRevision`] the second and later derivations are pure waste. Unlike
+/// `by_call` this IS cleared, on every rewrite.
+///
+/// # Why clearing it is belt-and-braces rather than load-bearing
+///
+/// Worth stating precisely, because disabling the clearing breaks no test and that
+/// could be mistaken for missing coverage. Every rewrite the compaction passes
+/// perform leaves content `crate::compaction::is_compacted_output` recognizes —
+/// the three stubs, or the aging elision marker — and the sweep skips a recognized
+/// result before deriving anything. So the only positions ever served from this
+/// memo are ones compaction did not touch, which makes a stale entry unobservable
+/// even with the clearing removed.
+///
+/// That is a cross-module invariant, so it is pinned where it can break rather
+/// than assumed: `every_rewrite_compaction_performs_is_recognized_as_compacted`.
+/// A future pass that rewrote a result into something unrecognized would make this
+/// memo start serving pre-rewrite identities, and the clearing is what keeps that
+/// from being a silent correctness bug instead of a caught one.
+#[derive(Debug, Default)]
+pub(super) struct ResultIdentities {
+    pub(super) by_call: HashMap<CallIdentityKey, Option<String>>,
+    by_position: HashMap<(usize, usize), String>,
+    revision: TranscriptRevision,
+}
+
+impl ResultIdentities {
+    /// Drop the positional memo if the transcript was rewritten since the last
+    /// sweep. `by_call` survives — it is the turn's accumulated evidence.
+    fn sync_to(&mut self, revision: TranscriptRevision) {
+        if self.revision != revision {
+            self.by_position.clear();
+            self.revision = revision;
+        }
+    }
+
+    /// What the loop detector asks: the identity recorded for this call, or
+    /// `None` if absent or poisoned.
+    pub(super) fn identity_of(&self, key: &CallIdentityKey) -> Option<String> {
+        self.by_call.get(key).cloned().flatten()
+    }
+}
+
+/// Record every tool result's identity into `identities`, keyed by
+/// [`CallIdentityKey`] — the driver's answer to #554. (Keyed by the call's
+/// id AND its name and input, never the id alone: see that type's docs for
+/// the providers that recycle ids across steps.)
+///
+/// Compaction rewrites tool results IN PLACE (dedup/supersession stubs,
+/// middle-out aging, the eviction stub) and runs immediately before loop
+/// detection in the same step, so a three-call identical streak reaches the
+/// detector as `[stub, stub, real]` and the byte-identical-output
+/// requirement can never be met. Snapshotting each result's identity while
+/// its real content is still present preserves exactly the evidence the
+/// detector needs, without teaching either pure module about the other.
+/// Called once per step BEFORE the compaction pass; the map accumulates
+/// across the turn, because a result's real content is only on hand for the
+/// one step between producing it and the pass that stubs it.
+///
+/// Two rules make accumulation safe:
+///
+/// - **A compacted output is never recorded.** Its identity is the stub's,
+///   not the call's; recording it would overwrite the real one and lose the
+///   evidence permanently, and every evicted result shares one stub.
+/// - **A call seen with two different real outputs is poisoned** (`None`),
+///   never overwritten. Keeping either identity would attach one call's
+///   evidence to a different call, and a WRONG identity is far worse than
+///   none: it can make two genuinely different outputs compare equal and
+///   abort a healthy turn. Poisoned keys fall back to comparing the live
+///   outputs, i.e. the behavior before this fix. With a
+///   [`CallIdentityKey`] a conflict now means what it says — the same tool,
+///   same arguments, different result, which IS progress — rather than
+///   firing on two unrelated calls that shared a recycled ordinal.
+///
+/// The identity is computed over [`comparable_output`], the same
+/// normalization the detector compares, so `read_file`'s volatile
+/// session-tally footer does not make every reread a distinct identity.
+///
+/// # The invariant that keeps a poisoned key from manufacturing a loop
+///
+/// A poisoned key degrades to comparing the live outputs, and compaction
+/// rewrites older results to ONE shared stub — so if every record in the
+/// detector's window could be a stub, three unrelated calls would compare
+/// byte-equal and abort a healthy turn. They cannot, and the reason is a
+/// cross-module invariant worth naming: `crate::compaction::compact` never
+/// touches the LAST `MessageRole::Tool` message (its `last_tool_idx` guard),
+/// and `detect_loop` only ever reports a verdict anchored on the trailing
+/// record. The anchor therefore always carries its real, freshly-produced
+/// output, and a stub can never match it. Relaxing that guard in
+/// `compaction.rs` would silently turn every over-budget turn into a
+/// false-positive loop abort here.
+pub(super) fn snapshot_result_identities(
+    messages: &[CompletionMessage],
+    identities: &mut ResultIdentities,
+    revision: TranscriptRevision,
+) {
+    identities.sync_to(revision);
+    // Calls seen so far that nothing has answered yet, oldest first. The map
+    // is keyed by the CALL, so a result has to be paired back to the call it
+    // answers before its identity can be filed — using the same attachment
+    // rule as [`recent_call_records`], or the two would key differently and
+    // the lookup would silently miss.
+    let mut unanswered: Vec<&ToolCall> = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        match message.role {
+            MessageRole::Assistant => unanswered.extend(message.tool_calls.iter()),
+            MessageRole::Tool => {
+                for (result_index, result) in message.tool_results.iter().enumerate() {
+                    let Some(position) = unanswered
+                        .iter()
+                        .rposition(|call| call.call_id == result.call_id)
+                    else {
+                        continue;
+                    };
+                    let call = unanswered.remove(position);
+                    if crate::compaction::is_compacted_output(&result.output) {
+                        continue;
+                    }
+                    let key = call_identity_key(call);
+                    // A poisoned key can never be un-poisoned: any later
+                    // observation conflicts with `None`, so the verdict is
+                    // already final. Hashing this result's content only to
+                    // re-derive it is pure waste, and this scan re-walks the
+                    // WHOLE transcript on every step (#554).
+                    if matches!(identities.by_call.get(&key), Some(None)) {
+                        continue;
+                    }
+                    // The walk itself has to keep going — pairing a result back
+                    // to its call is what makes the key meaningful, and the
+                    // `unanswered` bookkeeping only works read in order. What is
+                    // skippable is DERIVING the identity, which is the
+                    // serialization and the hash. Same position, same revision,
+                    // same bytes, same answer.
+                    let position_key = (message_index, result_index);
+                    let identity = match identities.by_position.get(&position_key) {
+                        Some(known) => known.clone(),
+                        None => {
+                            let derived = crate::receipts::tool_result_block_id(
+                                &comparable_output(&result.output),
+                            );
+                            identities.by_position.insert(position_key, derived.clone());
+                            derived
+                        }
+                    };
+                    let conflicts = matches!(
+                        identities.by_call.get(&key),
+                        Some(seen) if seen.as_deref() != Some(identity.as_str())
+                    );
+                    identities
+                        .by_call
+                        .insert(key, if conflicts { None } else { Some(identity) });
+                }
+            }
+            MessageRole::System | MessageRole::User => {}
+        }
+    }
+}
+
+/// Normalize one tool output for loop comparison: strip `read_file`'s
+/// volatile session-tally footer (`\n\n(N/M lines shown · read K× this
+/// session)`). The footer changes on EVERY read by design — it is the
+/// model-facing "you already read this" nudge — but the loop detector
+/// requires byte-identical outputs, so the footer made every reread unique
+/// and blinded detection to the exact thrash it exists to catch (the
+/// read → failing-edit → read cycle the `loop_detect` module doc names).
+/// Comparison-only: the transcript and history keep the footer untouched.
+///
+/// Borrowed on the overwhelmingly common path (no footer): both callers run
+/// over the WHOLE transcript on every step, so returning an owned copy meant a
+/// full heap copy of every tool result — a step's worth of garbage proportional
+/// to the entire history, for a normalization that usually changes nothing.
+pub(super) fn comparable_output(output: &ToolOutput) -> Cow<'_, ToolOutput> {
+    if let ToolOutput::Ok { content } = output
+        && content.ends_with("\u{d7} this session)")
+        && let Some(idx) = content.rfind("\n\n(")
+        && content[idx..].contains(" lines shown \u{b7} read ")
+    {
+        return Cow::Owned(ToolOutput::Ok {
+            content: content[..idx].to_string(),
+        });
+    }
+    Cow::Borrowed(output)
+}

--- a/stella-core/src/driver/tests/audit_fixes.rs
+++ b/stella-core/src/driver/tests/audit_fixes.rs
@@ -3,6 +3,7 @@
 //! event/history parity, whitespace-only empty turns, the summary marker's
 //! loop-window neutrality, and the hard-cancel `Cancelled` usage envelope.
 
+use super::super::loop_evidence::ResultIdentities;
 use super::*;
 
 /// F1: `summarize_keep_recent: 0` is a legal config — the tail walk must
@@ -867,8 +868,8 @@ fn compaction_does_not_destroy_loop_detection_evidence() {
     // then compact hard enough to force every pass, and assert the older
     // results really were rewritten (or the test would pass vacuously).
     let compact_as_run_turn_does = |messages: &mut Vec<CompletionMessage>| {
-        let mut identities = HashMap::new();
-        snapshot_result_identities(messages, &mut identities);
+        let mut identities = ResultIdentities::default();
+        snapshot_result_identities(messages, &mut identities, TranscriptRevision::default());
         assert!(
             crate::compaction::compact(messages, 16).is_some(),
             "fixture sanity: the budget must force a real compaction pass"
@@ -939,7 +940,7 @@ fn compaction_does_not_destroy_loop_detection_evidence() {
     let mut reused = history(&|_| "c1".to_string(), &|n| format!("{payload}{n}"));
     let identities = compact_as_run_turn_does(&mut reused);
     assert_eq!(
-        identities.get(&(
+        identities.by_call.get(&(
             "c1".to_string(),
             "read_file".to_string(),
             serde_json::json!({ "path": "big.rs" }).to_string(),
@@ -1014,8 +1015,8 @@ fn a_provider_recycling_call_ids_per_response_still_gets_loop_detection() {
 
     // Snapshot where `run_turn` does — before the pass — then compact hard
     // enough that the older results really are stubbed.
-    let mut identities = HashMap::new();
-    snapshot_result_identities(&messages, &mut identities);
+    let mut identities = ResultIdentities::default();
+    snapshot_result_identities(&messages, &mut identities, TranscriptRevision::default());
     assert!(
         crate::compaction::compact(&mut messages, 16).is_some(),
         "fixture sanity: the budget must force a real compaction pass"
@@ -1033,7 +1034,7 @@ fn a_provider_recycling_call_ids_per_response_still_gets_loop_detection() {
     // The unrelated `grep` no longer costs `read_file` its evidence: they are
     // different calls that merely share a recycled ordinal.
     assert_eq!(
-        identities.get(&(
+        identities.by_call.get(&(
             "call_0".to_string(),
             "read_file".to_string(),
             read_input.to_string(),

--- a/stella-core/src/driver/tests/compute_passes.rs
+++ b/stella-core/src/driver/tests/compute_passes.rs
@@ -9,6 +9,7 @@
 //! keep it removed.
 
 use super::*;
+use std::collections::HashMap;
 
 /// How many times a single step re-reads the whole transcript to estimate it.
 ///
@@ -134,4 +135,394 @@ async fn the_receipt_and_the_usage_record_report_one_estimate_per_step() {
          measurement of the same step and must not drift apart"
     );
     assert!(manifest.values().all(|&e| e > 0));
+}
+
+/// How the per-step hashing scales with the length of the turn.
+///
+/// `decompose` re-derived every block's `block_id` AND `content_digest` on every
+/// step — two SHA-256 passes over the block's bytes, plus a `serde_json`
+/// re-serialization of every tool call and tool result just to obtain the
+/// preimage. Since the manifest names every block each step, that made the total
+/// hashing quadratic in the turn's length: step k re-hashed all of step k-1's
+/// blocks. `snapshot_result_identities` added a third pass over every tool result
+/// in the transcript, every step, for the same reason.
+///
+/// A block's bytes do not change unless something rewrites them, so the memo
+/// makes the total linear. This asserts the SHAPE rather than a magic number:
+/// doubling the steps must not come close to quadrupling the hashing.
+#[tokio::test]
+async fn per_step_hashing_grows_with_the_turn_not_with_its_square() {
+    async fn hashes_for(steps: usize) -> usize {
+        let mut script: Vec<_> = (0..steps)
+            .map(|i| {
+                // Distinct inputs: three byte-identical calls are what
+                // `loop_detect` aborts on, and this test is about hashing.
+                let mut r = tool_call_result(&format!("call_{i}"), "bash");
+                if let Some(call) = r.tool_calls.first_mut() {
+                    call.input = serde_json::json!({ "cmd": format!("echo {i}") });
+                }
+                Ok(r)
+            })
+            .collect();
+        script.push(Ok(text_result("done")));
+        let provider = ScriptedProvider {
+            id: "scripted".into(),
+            script: TokioMutex::new(script),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let tools = CountingTools {
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let sleeper = NoopSleeper;
+        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let mut messages = vec![
+            CompletionMessage::system("sys"),
+            CompletionMessage::user("hi"),
+        ];
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let _ = crate::receipts::take_hash_passes();
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+        crate::receipts::take_hash_passes()
+    }
+
+    let short = hashes_for(4).await;
+    let long = hashes_for(8).await;
+    eprintln!(
+        "DBG short={short} long={long} ratio={:.2}",
+        long as f64 / short as f64
+    );
+
+    // Quadratic would put `long` at roughly 4x `short`. Linear puts it near 2x;
+    // allow real slack for the fixed system/user blocks, which are hashed once in
+    // both runs and so make the short run proportionally more expensive.
+    assert!(
+        long < short * 5 / 2,
+        "doubling a turn's steps took hashing from {short} to {long} passes. \
+         Linear growth lands near 2x; anything approaching 4x means every step is \
+         re-hashing the blocks the earlier steps already hashed."
+    );
+}
+
+/// The memo must never outlive the bytes it describes.
+///
+/// Compaction rewrites tool results IN PLACE, so a position keeps naming a block
+/// while its content — and therefore its `block_id` and `content_digest` — changes
+/// underneath. A position-keyed memo that missed that would make the receipt cite
+/// a block that was never sent, which is strictly worse than the cost it saves:
+/// the entire point of a receipt is that it is what the model actually saw.
+///
+/// Driven through the ledger's public API so the assertion is on the contract:
+/// rewrite one result, declare the new revision, emit again, and the manifest must
+/// name the new bytes. Disabling the invalidation makes this fail — the second
+/// manifest keeps citing the pre-rewrite id.
+#[tokio::test]
+async fn a_rewritten_block_is_never_served_from_the_digest_memo() {
+    use crate::receipts::{ReceiptLedger, ServedBy, TranscriptRevision};
+    use stella_protocol::{ToolOutput, ToolResult};
+
+    let served = ServedBy {
+        role: stella_protocol::ModelCallRole::Worker,
+        provider: "p",
+        model: "m",
+    };
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::Ok {
+                    content: "the original, uncompacted output".into(),
+                },
+            }],
+            attachments: vec![],
+        },
+    ];
+
+    let ids_at = |events: Vec<AgentEvent>| -> Vec<String> {
+        events
+            .into_iter()
+            .filter_map(|e| match e {
+                AgentEvent::StepManifest { blocks, .. } => Some(blocks),
+                _ => None,
+            })
+            .flatten()
+            .map(|b| b.block_id)
+            .collect()
+    };
+
+    let mut ledger = ReceiptLedger::new(0);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let events = crate::event_sender::EventSender::new(tx);
+
+    ledger.emit_step_receipt(&messages, 100, 0, served, &events);
+    let before = ids_at(drain_events(&mut rx));
+
+    // Exactly what compaction's eviction pass does: rewrite the result's bytes
+    // in place, leaving its position untouched.
+    messages[2].tool_results[0].output = ToolOutput::Ok {
+        content: "[evicted to fit context]".into(),
+    };
+    let mut revision = TranscriptRevision::default();
+    revision.rewritten();
+    ledger.set_transcript_revision(revision);
+
+    ledger.emit_step_receipt(&messages, 100, 1, served, &events);
+    let after = ids_at(drain_events(&mut rx));
+
+    assert_eq!(before.len(), after.len(), "same block count either side");
+    // The system prefix and user goal did not move and must keep their ids.
+    assert_eq!(
+        before[0], after[0],
+        "unrewritten blocks keep their identity"
+    );
+    assert_eq!(
+        before[1], after[1],
+        "unrewritten blocks keep their identity"
+    );
+    // The rewritten result must not.
+    assert_ne!(
+        before[2], after[2],
+        "the tool result's bytes were rewritten, so the manifest must cite a new \
+         block id — citing {} again means the digest memo outlived the content it \
+         described, and the receipt now claims the model saw an output that had \
+         already been evicted",
+        before[2]
+    );
+}
+
+/// A tool double whose outputs are large enough for the pure compaction passes to
+/// have something worth evicting, and **distinct per call**.
+///
+/// Distinctness matters more than it looks: block ids are content-addressed, so
+/// byte-identical outputs share one id across every position holding them. A test
+/// asserting "this rewritten block's id never reappears" would then fail on
+/// correct code, because the one tool message compaction is forbidden to touch
+/// still legitimately carries that id.
+struct BigOutputTools {
+    filler: usize,
+}
+
+#[async_trait]
+impl ToolExecutor for BigOutputTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, input: &Value) -> ToolOutput {
+        // Seeded from the call's own input so no two results share a block id.
+        let seed = input.get("cmd").and_then(Value::as_str).unwrap_or("?");
+        ToolOutput::Ok {
+            content: format!("{seed}: {}", "x".repeat(self.filler)),
+        }
+    }
+}
+
+/// The driver must actually TELL the ledger when it rewrites the transcript.
+///
+/// `a_rewritten_block_is_never_served_from_the_digest_memo` pins the ledger's own
+/// contract, but nothing pinned the wiring: deleting the `revision.rewritten()`
+/// call in `run_turn` left the entire suite green, which means the memo could have
+/// shipped serving stale digests on every compacting turn while every unit test
+/// passed. This drives a real turn over a budget tight enough to force eviction
+/// and asserts the receipts follow the rewrite.
+///
+/// A `Compaction` event names the blocks it stubbed (`evicted_blocks`, captured
+/// BEFORE mutation). Once those bytes are the eviction stub, no later manifest can
+/// still be citing their original ids — if one does, the memo outlived them.
+#[tokio::test]
+async fn compaction_mid_turn_invalidates_the_receipt_ledgers_digest_memo() {
+    let mut script: Vec<_> = (0..5)
+        .map(|i| {
+            let mut r = tool_call_result(&format!("call_{i}"), "bash");
+            if let Some(call) = r.tool_calls.first_mut() {
+                call.input = serde_json::json!({ "cmd": format!("echo {i}") });
+            }
+            Ok(r)
+        })
+        .collect();
+    script.push(Ok(text_result("done")));
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(script),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = BigOutputTools { filler: 4_000 };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        // Small enough that a couple of 4 KB results blow it, and no summarizer so
+        // the rewrite comes purely from eviction/aging.
+        compaction_budget_tokens: 800,
+        summarize_overflow: false,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+    let events = drain_events(&mut rx);
+    // Checked point-in-time, walking the stream in emission order: a block is
+    // only stale for the manifests that come AFTER the compaction that rewrote it.
+    // Comparing every manifest against the turn's whole eviction set instead would
+    // flag a block for being cited on the step that produced it and evicted on the
+    // next, which is exactly correct behaviour.
+    let mut rewritten_so_far: std::collections::HashSet<String> = Default::default();
+    let mut rewrites = 0usize;
+    let mut checked = 0usize;
+    for event in &events {
+        match event {
+            AgentEvent::Compaction {
+                evicted_blocks,
+                aged_blocks,
+                deduped_blocks,
+                superseded_blocks,
+                ..
+            } => {
+                for id in evicted_blocks
+                    .iter()
+                    .chain(aged_blocks)
+                    .chain(deduped_blocks)
+                    .chain(superseded_blocks)
+                {
+                    rewrites += 1;
+                    rewritten_so_far.insert(id.clone());
+                }
+            }
+            AgentEvent::StepManifest { blocks, step, .. } => {
+                for entry in blocks {
+                    assert!(
+                        !rewritten_so_far.contains(&entry.block_id),
+                        "step {step}'s manifest cites block {}, which an earlier \
+                         compaction had already rewritten. The driver did not tell \
+                         the ledger the transcript changed, so its digest memo is \
+                         describing bytes the model never saw.",
+                        entry.block_id
+                    );
+                    checked += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        rewrites > 0,
+        "fixture must actually rewrite tool results, or this proves nothing"
+    );
+    assert!(checked > 0, "manifests must cite blocks");
+}
+
+/// The invariant the identity memo's soundness actually rests on.
+///
+/// `snapshot_result_identities` memoizes a result's identity by position, and
+/// clears that memo on a transcript rewrite — but disabling the clearing breaks no
+/// test, and it is worth being precise about why rather than assuming the memo is
+/// merely under-tested. Every rewrite the compaction passes perform leaves content
+/// that `is_compacted_output` recognizes (the three stubs, or the aging elision
+/// marker), and a recognized result is skipped before any identity is derived. So
+/// the only positions that can be served from the memo are ones compaction did not
+/// touch, which is what makes a stale entry unobservable.
+///
+/// That is a cross-module invariant, not a local one. A new pass that rewrote a
+/// result into something `is_compacted_output` did not recognize would silently
+/// make the memo serve a pre-rewrite identity, so the invariant is pinned here
+/// where the memo's justification lives.
+#[test]
+fn every_rewrite_compaction_performs_is_recognized_as_compacted() {
+    use crate::compaction::{compact, is_compacted_output};
+
+    // An over-budget transcript with enough large, distinct results to drive the
+    // dedup, supersession, aging and eviction passes.
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("goal"),
+    ];
+    for i in 0..8 {
+        messages.push(CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![stella_protocol::ToolCall {
+                call_id: format!("c{i}"),
+                name: "bash".into(),
+                // Half the calls repeat an input, so supersession/dedup engage.
+                input: serde_json::json!({ "cmd": format!("echo {}", i % 3) }),
+            }],
+            tool_results: vec![],
+            attachments: vec![],
+        });
+        messages.push(CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![stella_protocol::ToolResult {
+                call_id: format!("c{i}"),
+                output: ToolOutput::Ok {
+                    // Far above AGE_THRESHOLD_CHARS so aging alone can satisfy the
+                    // budget below and the eviction pass never runs — otherwise
+                    // every aged result would be evicted afterwards and its
+                    // elision marker would never survive to be checked.
+                    content: format!("result {i}: {}", "y".repeat(20_000)),
+                },
+            }],
+            attachments: vec![],
+        });
+    }
+
+    let before: Vec<Vec<ToolOutput>> = messages
+        .iter()
+        .map(|m| m.tool_results.iter().map(|r| r.output.clone()).collect())
+        .collect();
+
+    let report = compact(&mut messages, 12_000).expect("the fixture must compact");
+    assert!(
+        report.aged > 0 && report.evicted == 0,
+        "the fixture must exercise AGING specifically, with no eviction to mask it: \
+         aged={} evicted={}",
+        report.aged,
+        report.evicted
+    );
+    let rewrites = report.evicted + report.deduped + report.superseded + report.aged;
+    assert!(rewrites > 0, "the fixture must rewrite something");
+
+    let mut changed = 0usize;
+    for (message_index, message) in messages.iter().enumerate() {
+        for (result_index, result) in message.tool_results.iter().enumerate() {
+            let was = &before[message_index][result_index];
+            if &result.output == was {
+                continue;
+            }
+            changed += 1;
+            assert!(
+                is_compacted_output(&result.output),
+                "compaction rewrote the result at ({message_index}, {result_index}) \
+                 into content `is_compacted_output` does not recognize. That breaks \
+                 the guard `snapshot_result_identities` relies on to never serve a \
+                 memoized identity for bytes that changed."
+            );
+        }
+    }
+    // `<=`, not `==`: one result can be counted by two passes — aged to head+tail
+    // and then evicted outright in the same call — so the report's totals exceed
+    // the number of positions that changed.
+    assert!(
+        changed > 0 && changed <= rewrites,
+        "{changed} positions changed against {rewrites} counted rewrites"
+    );
 }

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -14,6 +14,7 @@
 //! message into per-frame `RecalledFrame` blocks (with `memory_id`) is the
 //! memory-join increment (spec §9), where the pipeline participates.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use sha2::{Digest, Sha256};
@@ -55,6 +56,26 @@ pub const RECEIPT_SEQ_SUMMARIZER: u64 = 1;
 /// and summarizer seats.
 pub const RECEIPT_SEQ_ALLOCATED_BASE: u64 = 2;
 
+// Counts SHA-256 passes over block content. Every hash this module performs
+// funnels through `sha256_hex_parts` — `block_id`, `content_digest` and
+// `tool_result_block_id` all reach it — so this is the one choke point that can
+// witness the per-step hashing cost.
+//
+// Each pass is Θ(content), so on a long turn the difference between hashing a
+// block once and re-hashing it on every step is the difference between linear
+// and quadratic work in the turn's length. Test-only; thread-local so it measures
+// one turn's own work rather than whatever else the test binary is doing.
+#[cfg(test)]
+thread_local! {
+    static HASH_PASSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Zero this thread's hash-pass counter and return the previous value.
+#[cfg(test)]
+pub(crate) fn take_hash_passes() -> usize {
+    HASH_PASSES.with(|c| c.replace(0))
+}
+
 /// `sha256` hex over the concatenation of `parts`, hashed as a stream. Feeding
 /// the parts one `update` at a time is byte-identical to hashing their joined
 /// bytes, so a caller with a multi-part preimage gets the same digest without
@@ -64,6 +85,8 @@ pub const RECEIPT_SEQ_ALLOCATED_BASE: u64 = 2;
 /// `to_hex`.
 fn sha256_hex_parts(parts: &[&[u8]]) -> String {
     use std::fmt::Write as _;
+    #[cfg(test)]
+    HASH_PASSES.with(|c| c.set(c.get() + 1));
     let mut h = Sha256::new();
     for part in parts {
         h.update(part);
@@ -157,8 +180,92 @@ fn is_gap_kind(kind: BlockKind) -> bool {
     )
 }
 
+/// Counts in-place rewrites of the transcript, as distinct from appends.
+///
+/// Two per-step memos — the driver's result identities and this module's block
+/// digests — are keyed by a message's POSITION. A position is a stable name for a
+/// message's bytes only as long as nothing rewrites what is already there.
+/// Appends never invalidate one; compaction (which stubs and ages tool results in
+/// place) and the overflow summarizer (which splices a span down to a single
+/// message) both do.
+///
+/// It is bumped at the mutation sites themselves, and every consumer takes it as
+/// an argument rather than reading it from shared state, so a future pass that
+/// rewrites the transcript cannot quietly skip invalidation and leave a memo
+/// serving digests for bytes that no longer exist.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TranscriptRevision(u64);
+
+impl TranscriptRevision {
+    /// Record that the transcript was rewritten in place.
+    pub fn rewritten(&mut self) {
+        self.0 = self.0.wrapping_add(1);
+    }
+}
+
+/// The per-block work that is expensive and position-stable: two SHA-256 passes
+/// over the block's content plus a full character count of it.
+#[derive(Clone)]
+struct BlockDigests {
+    block_id: String,
+    content_digest: String,
+    token_cost: u32,
+}
+
+/// Position-keyed memo over [`BlockDigests`], valid for one transcript revision.
+///
+/// `block_id` and `content_digest` hash overlapping preimages (`kind_tag ‖ NUL ‖
+/// content` and `content`) and cannot share one hash state, so a block costs two
+/// full passes over its bytes plus a third to count characters — and `decompose`
+/// recomputed all three for every block in the transcript on every step, plus a
+/// `serde_json` re-serialization of every tool call and tool result to obtain the
+/// preimage in the first place. The manifest has to *name* every block each step,
+/// but the bytes behind an unchanged block do not change, so naming it again is
+/// the only part that has to happen twice.
+#[derive(Default)]
+struct BlockDigestCache {
+    entries: HashMap<(usize, usize), BlockDigests>,
+    revision: TranscriptRevision,
+}
+
+impl BlockDigestCache {
+    /// Drop everything if the transcript was rewritten since the last emission.
+    fn sync_to(&mut self, revision: TranscriptRevision) {
+        if self.revision != revision {
+            self.entries.clear();
+            self.revision = revision;
+        }
+    }
+
+    /// The digests for the block at `key`, computing them only on a miss.
+    ///
+    /// `content` is a closure so a hit skips producing the preimage as well as
+    /// hashing it — for tool calls and tool results that preimage is a fresh
+    /// `serde_json::to_string` of the whole payload. It yields a `Cow` so a miss
+    /// costs nothing extra either: the kinds whose preimage is already a field on
+    /// the message borrow it, and only the serialized kinds allocate.
+    fn digests<'c>(
+        &mut self,
+        key: (usize, usize),
+        kind: BlockKind,
+        content: impl FnOnce() -> Cow<'c, str>,
+    ) -> BlockDigests {
+        if let Some(hit) = self.entries.get(&key) {
+            return hit.clone();
+        }
+        let content = content();
+        let computed = BlockDigests {
+            block_id: block_id(kind, &content),
+            content_digest: format!("sha256:{}", sha256_hex(&content)),
+            token_cost: estimate_tokens(&content),
+        };
+        self.entries.insert(key, computed.clone());
+        computed
+    }
+}
+
 /// One decomposed context block, before it becomes a manifest entry.
-struct BlockDraft {
+struct BlockDraft<'a> {
     block_id: String,
     kind: BlockKind,
     content_digest: String,
@@ -169,22 +276,13 @@ struct BlockDraft {
     /// the message vector — so reconstruction regroups exactly (spec §5.1).
     message_index: usize,
     /// Local-only preimage for gap kinds; `None` for journal-resolvable kinds.
-    content: Option<String>,
-}
-
-impl BlockDraft {
-    fn new(kind: BlockKind, content: &str, call_id: Option<String>, message_index: usize) -> Self {
-        BlockDraft {
-            block_id: block_id(kind, content),
-            kind,
-            content_digest: format!("sha256:{}", sha256_hex(content)),
-            token_cost: estimate_tokens(content),
-            call_id,
-            cache_zone: CacheZone::Cacheable,
-            message_index,
-            content: is_gap_kind(kind).then(|| content.to_string()),
-        }
-    }
+    ///
+    /// **Borrowed**, and copied only at the one site that needs it: a block's
+    /// bytes ride `BlockRegistered`, which fires once per block for the whole
+    /// turn. Owning it here meant re-cloning the system prefix — the largest gap
+    /// block there is — on every step for the rest of the turn, to hand it to a
+    /// registration that had already happened.
+    content: Option<&'a str>,
 }
 
 /// Decompose the live message vector into event-granular blocks, in wire order,
@@ -211,56 +309,90 @@ impl BlockDraft {
 ///   a multimodal turn the manifest's summed `token_cost` reads materially
 ///   below the same event's `estimated_input_tokens`. [`BlockKind::Attachment`]
 ///   is the seat reserved for it.
-fn decompose(messages: &[CompletionMessage]) -> Vec<BlockDraft> {
+fn decompose<'a>(
+    messages: &'a [CompletionMessage],
+    cache: &mut BlockDigestCache,
+) -> Vec<BlockDraft<'a>> {
     let mut drafts = Vec::new();
     for (message_index, message) in messages.iter().enumerate() {
+        // Ordinal within this message, counted over every block it yields
+        // regardless of kind, so `(message_index, ordinal)` names one block
+        // uniquely and identically on every step of a revision.
+        let mut ordinal = 0usize;
+        let mut push = |drafts: &mut Vec<BlockDraft<'a>>,
+                        cache: &mut BlockDigestCache,
+                        kind: BlockKind,
+                        content: &dyn Fn() -> Cow<'a, str>,
+                        borrowed: Option<&'a str>,
+                        call_id: Option<String>| {
+            let digests = cache.digests((message_index, ordinal), kind, content);
+            ordinal += 1;
+            drafts.push(BlockDraft {
+                block_id: digests.block_id,
+                kind,
+                content_digest: digests.content_digest,
+                token_cost: digests.token_cost,
+                call_id,
+                cache_zone: CacheZone::Cacheable,
+                message_index,
+                content: is_gap_kind(kind).then_some(borrowed).flatten(),
+            });
+        };
         match message.role {
             MessageRole::System => {
-                drafts.push(BlockDraft::new(
+                push(
+                    &mut drafts,
+                    cache,
                     BlockKind::SystemPrefix,
-                    &message.content,
+                    &|| Cow::Borrowed(message.content.as_str()),
+                    Some(message.content.as_str()),
                     None,
-                    message_index,
-                ));
+                );
             }
             MessageRole::User => {
                 // The recalled frames live inside this message; splitting them
                 // into per-frame blocks is the memory-join increment (§9).
-                drafts.push(BlockDraft::new(
+                push(
+                    &mut drafts,
+                    cache,
                     BlockKind::UserGoal,
-                    &message.content,
+                    &|| Cow::Borrowed(message.content.as_str()),
+                    Some(message.content.as_str()),
                     None,
-                    message_index,
-                ));
+                );
             }
             MessageRole::Assistant => {
                 if !message.content.is_empty() {
-                    drafts.push(BlockDraft::new(
+                    push(
+                        &mut drafts,
+                        cache,
                         BlockKind::AssistantText,
-                        &message.content,
+                        &|| Cow::Borrowed(message.content.as_str()),
+                        Some(message.content.as_str()),
                         None,
-                        message_index,
-                    ));
+                    );
                 }
                 for call in &message.tool_calls {
-                    let content = serde_json::to_string(call).unwrap_or_default();
-                    drafts.push(BlockDraft::new(
+                    push(
+                        &mut drafts,
+                        cache,
                         BlockKind::ToolCall,
-                        &content,
+                        &|| Cow::Owned(serde_json::to_string(call).unwrap_or_default()),
+                        None,
                         Some(call.call_id.clone()),
-                        message_index,
-                    ));
+                    );
                 }
             }
             MessageRole::Tool => {
                 for result in &message.tool_results {
-                    let content = serde_json::to_string(&result.output).unwrap_or_default();
-                    drafts.push(BlockDraft::new(
+                    push(
+                        &mut drafts,
+                        cache,
                         BlockKind::ToolResult,
-                        &content,
+                        &|| Cow::Owned(serde_json::to_string(&result.output).unwrap_or_default()),
+                        None,
                         Some(result.call_id.clone()),
-                        message_index,
-                    ));
+                    );
                 }
             }
         }
@@ -292,6 +424,12 @@ pub struct ReceiptLedger {
     first_seen_step: HashMap<String, usize>,
     effective_budget_tokens: u64,
     calibration_factor: f64,
+    /// Memo of the per-block hashing, invalidated whenever the transcript is
+    /// rewritten rather than appended to.
+    digests: BlockDigestCache,
+    /// The revision the next receipt describes; see
+    /// [`Self::set_transcript_revision`].
+    revision: TranscriptRevision,
 }
 
 impl ReceiptLedger {
@@ -311,6 +449,8 @@ impl ReceiptLedger {
             first_seen_step: HashMap::new(),
             effective_budget_tokens: 0,
             calibration_factor: 1.0,
+            digests: BlockDigestCache::default(),
+            revision: TranscriptRevision::default(),
         }
     }
 
@@ -321,6 +461,21 @@ impl ReceiptLedger {
     pub fn set_effective_budget(&mut self, budget_tokens: u64, factor: f64) {
         self.effective_budget_tokens = budget_tokens;
         self.calibration_factor = factor;
+    }
+
+    /// Tell the ledger which revision of the transcript the next receipt
+    /// describes, so its block-digest memo can drop keys that no longer name the
+    /// bytes they were computed over.
+    ///
+    /// Pushed per step alongside [`Self::set_effective_budget`] rather than passed
+    /// to [`Self::emit_step_receipt`]: that call is reached through
+    /// `run_model_call`, which is already at the argument limit. A ledger that is
+    /// never told keeps `TranscriptRevision::default()` and therefore memoizes
+    /// across rewrites — which is why the driver sets it in the same breath as
+    /// the compaction pass that can cause one, and why
+    /// `a_rewritten_block_is_never_served_from_the_digest_memo` exists.
+    pub fn set_transcript_revision(&mut self, revision: TranscriptRevision) {
+        self.revision = revision;
     }
 
     /// Emit the receipt for one committed step: a `BlockRegistered` for every
@@ -347,7 +502,8 @@ impl ReceiptLedger {
             provider,
             model,
         } = served;
-        let drafts = decompose(messages);
+        self.digests.sync_to(self.revision);
+        let drafts = decompose(messages, &mut self.digests);
         let mut blocks = Vec::with_capacity(drafts.len());
         for draft in &drafts {
             let resident_since_step = match self.first_seen_step.get(&draft.block_id) {
@@ -369,7 +525,9 @@ impl ReceiptLedger {
                         token_cost: draft.token_cost,
                         content_digest: draft.content_digest.clone(),
                         citation_label: None,
-                        content: draft.content.clone(),
+                        // The only place a gap block's bytes are copied, and
+                        // only on the step it first appears.
+                        content: draft.content.map(str::to_string),
                     });
                     step
                 }
@@ -412,6 +570,8 @@ impl ReceiptLedger {
         events: &EventSender,
     ) {
         let estimated_input_tokens = estimate_conversation_tokens(messages);
+        // A fresh ledger per call, so its digest memo is empty and the default
+        // revision is correct; the step loop sets its real one.
         self.emit_step_receipt(messages, estimated_input_tokens, step, served, events);
     }
 }


### PR DESCRIPTION
## What & why

The last named follow-up from #725. Each tool result was JSON-serialized and SHA-256'd **twice per step**, and each block's content hashed twice more — all unconditionally, all over the whole transcript:

- `decompose` derived every block's `block_id` **and** `content_digest` on every step. Those hash overlapping preimages (`kind_tag ‖ NUL ‖ content` and `content`) and so cannot share a hash state. Add a full character count for `token_cost`, and a `serde_json::to_string` of every tool call and tool result just to *obtain* the preimage.
- `snapshot_result_identities` derived every uncompacted tool result's identity on every step — another serialization plus another hash, again transcript-wide.

The manifest has to **name** every block each step. The bytes behind an unchanged block do not change, so naming it again is the only part that has to repeat. Both are now memoized by `(message_index, ordinal)`.

A position is a stable name for bytes only while nothing rewrites what is already there, so `TranscriptRevision` counts in-place rewrites as distinct from appends. It is bumped where the mutation happens — compaction's pure passes, and the overflow summarizer. The summarizer bumps whenever it **runs** rather than only when it splices: over-invalidating costs one turn's memo on a rare path, under-invalidating serves a digest for bytes that moved.

`run_compaction_pass` reports that through a `#[must_use] CompactionPass` rather than a `&mut` out-param — it was already at clippy's argument limit, and making the return impossible to discard turns "remember to invalidate" from a convention into a compile error.

Also drops a copy nothing needed: `BlockDraft::content` was an owned `String` for gap kinds, so the system prefix — the largest gap block there is — was re-cloned on every step to hand to a `BlockRegistered` that had already fired. It borrows now, and copies at the one site that sends it.

Refs #546

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Measured at the single choke point every hash in the module funnels through. **Doubling a turn's steps takes hashing from 24 → 44 passes (linear); before it was 64 → 188 (superlinear).** An 8-step turn drops from 188 hashes to 44, and the gap widens with turn length.

Five witnesses, **each verified to fail when the thing it guards is removed** — which mattered, because two of them did not at first:

| test | control that must break it |
|---|---|
| `per_step_hashing_grows_with_the_turn_not_with_its_square` | memo disabled → ratio 2.94 vs 1.83 ✗ |
| `a_rewritten_block_is_never_served_from_the_digest_memo` | ledger invalidation disabled → cites a pre-rewrite id ✗ |
| `compaction_mid_turn_invalidates_the_receipt_ledgers_digest_memo` | driver's `revision.rewritten` deleted ✗ |
| `every_rewrite_compaction_performs_is_recognized_as_compacted` | `is_compacted_output` stops recognizing aging ✗ |
| `a_step_walks_the_transcript_to_estimate_it_at_most_twice` (#725) | still holds |

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 61 test binaries, 0 failures
- [x] `make check` green; **no baseline moves** (driver.rs went 2256 → 2078, below its ceiling)
- [x] Doc comments updated where the reasoning changed

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**Two of my five tests were wrong in ways that would have shipped the bug.** Both are worth knowing about because they're the failure mode this whole series is about — a green suite that proves nothing.

1. My first version of the *wiring* test asserted "no manifest cites an unregistered block". A stale id is still a *registered* id, so it passed even with the driver's invalidation signal deleted. The memo could have shipped serving stale digests on every compacting turn with the suite green. It now drives a real turn over a tight budget and compares manifests against rewrites **point-in-time**, walking the event stream in order — comparing against the turn's whole eviction set instead flags a block for being cited on the step that produced it and evicted on the next, which is correct behavior.
2. My first version of the *invariant* test evicted its aged results, so the aging elision marker never survived to be checked and it passed with or without the branch it was guarding. It now ages without evicting.

**One claim I am deliberately not making.** Clearing the identity memo is belt-and-braces, not load-bearing, and disabling it breaks no test. That is not missing coverage: every rewrite leaves content `is_compacted_output` recognizes (three stubs, or the aging marker), and the sweep skips a recognized result *before* deriving anything — so a stale entry there is unobservable today. Rather than let that look like a gap, the cross-module invariant it depends on is pinned by its own test, and the reasoning is documented at the memo. A future pass that rewrote a result into something unrecognized would make it start serving pre-rewrite identities; the clearing is what keeps that a caught bug instead of a silent one.

**Still not done, and conditional rather than per-step:** `compaction::compact` recomputes every tool result's pre-mutation `block_id` when it runs. Sharing the ledger's memo would couple a pure module to receipt state, and it only fires on an over-budget step, so it stays.

**Structural churn is the file-size gate, not preference.** The driver's loop-detection evidence (`ResultIdentities`, `snapshot_result_identities`, `recent_call_records`, `comparable_output`, `call_identity_key`) moves to `driver/loop_evidence.rs` — the gate asking for a module instead of a raised baseline. It takes driver.rs from 2256 to 2078 lines, so unlike #725 this PR moves no baseline at all.

**Process note:** this is rebased onto `006fec3e` (#729), which landed while I was working. Worth a look that the loop-evidence extraction and #729's retrieval-plane restructuring don't overlap — they shouldn't, this PR touches only `stella-core`.
