### PR TITLE
docs: card-based mobile layout, and fix the stale content it exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,17 @@ Stella is BYOK and auto-detects the provider from whichever keys you have set.
 | **Z.ai** (GLM) | `ZAI_API_KEY` | `glm-5.2` |
 | **Anthropic** (Claude) | `ANTHROPIC_API_KEY` | `claude-fable-5` |
 | **OpenAI** (GPT) | `OPENAI_API_KEY` | `gpt-5.5` |
-| **xAI** (Grok) | `XAI_API_KEY` | `grok-4` |
+| **xAI** (Grok) | `XAI_API_KEY` | `grok-4` — [retires 2026-08-15](https://stella.oxagen.sh/docs/api-providers/xai) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` | `deepseek-chat` |
 | **Google Gemini** | `GEMINI_API_KEY` (alias `GOOGLE_API_KEY`) | `gemini-3-pro` |
-| **OpenRouter** | `OPENROUTER_API_KEY` | `auto` |
+| **OpenRouter** | `OPENROUTER_API_KEY` | `openrouter/auto` |
 | **Google Vertex AI** | `VERTEX_ACCESS_TOKEN` + `VERTEX_PROJECT_ID` | `gemini-3-pro` |
-| **Amazon Bedrock** | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | Claude via Converse |
+| **Amazon Bedrock** | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
 | **Local** | *none* — pass `--base-url` | whatever your server hosts |
+
+OpenRouter's slug keeps its vendor namespace on the wire, so pinning it on the CLI needs
+both halves: `--model openrouter/openrouter/auto`. `--model` splits on the first `/`, and
+the singly-qualified form sends the wire slug `auto`, which OpenRouter does not serve.
 
 ```bash
 export ANTHROPIC_API_KEY=your_key_here     # or OPENAI_API_KEY, GEMINI_API_KEY, …

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -728,3 +728,180 @@ fn every_common_key_env_var_belongs_to_a_real_provider() {
         );
     }
 }
+
+/// The docs' provider cards must not drift from [`PROVIDERS`].
+///
+/// `website/src/components/provider-cards.tsx` holds one typed record per
+/// provider, rendered as the card grid on both the API Providers index and the
+/// getting-started walkthrough. Before it existed the same facts were typed
+/// into a markdown table on each page, and they had already drifted: Bedrock's
+/// "default model" cell read `Claude via Converse` — a wire dialect, not a
+/// slug. Consolidating the two copies into one record removed the drift
+/// *between the pages*; it did nothing about drift from this file, which is
+/// the copy that actually decides what the binary does.
+///
+/// So: `id`, `env`, and `defaultModel` are pinned here. A renamed env var or a
+/// bumped default model now fails a test instead of silently sending readers
+/// to a variable Stella stopped reading.
+///
+/// `dialect` and `blurb` are deliberately NOT pinned — those are prose written
+/// for a human ("Anthropic Messages", "OpenAI-compatible"), not the
+/// kebab-case `Dialect` wire value, and asserting on them would force the
+/// docs to speak the enum's language rather than the reader's.
+#[test]
+fn provider_cards_match_the_registry() {
+    let Some(source) = read_provider_cards() else {
+        return;
+    };
+    let cards = parse_provider_cards(&source);
+    assert!(
+        cards.len() >= PROVIDERS.len(),
+        "parsed only {} cards from provider-cards.tsx — the parser has \
+         probably gone stale against the file's shape",
+        cards.len()
+    );
+
+    for provider in PROVIDERS {
+        let card = cards
+            .iter()
+            .find(|c| c.id == provider.id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "provider `{}` has no card in provider-cards.tsx — every \
+                     supported provider must appear in the docs grid",
+                    provider.id
+                )
+            });
+
+        assert_eq!(
+            card.default_model, provider.default_model,
+            "the docs card for `{}` says its default model is `{}`, but \
+             PROVIDERS says `{}`",
+            provider.id, card.default_model, provider.default_model
+        );
+
+        let (primary, aliases) = split_env(&card.env);
+        assert_eq!(
+            primary, provider.env_var,
+            "the docs card for `{}` names `{primary}` as the primary \
+             credential variable, but PROVIDERS reads `{}`",
+            provider.id, provider.env_var
+        );
+        assert_eq!(
+            aliases, provider.env_var_aliases,
+            "the docs card for `{}` lists aliases {aliases:?}, but PROVIDERS \
+             has {:?}",
+            provider.id, provider.env_var_aliases
+        );
+
+        assert_eq!(
+            card.href,
+            format!("/docs/api-providers/{}", provider.id),
+            "the docs card for `{}` links to `{}`, which is not that \
+             provider's page",
+            provider.id,
+            card.href
+        );
+    }
+
+    // The reverse direction: a card for a provider that no longer exists sends
+    // readers to a page for something they cannot select. `local` is the one
+    // legitimate extra — a pseudo-provider that is deliberately absent from
+    // PROVIDERS so auto-detection can never pick it.
+    for card in &cards {
+        assert!(
+            PROVIDERS.iter().any(|p| p.id == card.id) || card.id == LOCAL_PROVIDER.id,
+            "provider-cards.tsx documents `{}`, which is not a provider \
+             Stella supports",
+            card.id
+        );
+    }
+}
+
+/// A card's pinned fields, as written in the TSX record.
+struct ProviderCard {
+    id: String,
+    href: String,
+    env: String,
+    default_model: String,
+}
+
+/// The docs tree, or `None` when it isn't checked out — same posture as
+/// `stella-tools/tests/docs_in_sync.rs`: a repo-hygiene gate, not a runtime
+/// invariant. Note the granularity — a missing *tree* skips, but a missing
+/// file inside a present tree panics, so renaming the component cannot
+/// silently disable this test.
+fn read_provider_cards() -> Option<String> {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).parent()?;
+    let website = root.join("website");
+    if !website.is_dir() {
+        return None;
+    }
+    let path = website.join("src/components/provider-cards.tsx");
+    Some(
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} is missing or unreadable: {e}", path.display())),
+    )
+}
+
+/// Every `{ id: "…", …, env: "…", defaultModel: "…" }` record inside the
+/// `PROVIDER_CATALOG` array.
+fn parse_provider_cards(source: &str) -> Vec<ProviderCard> {
+    let start = source
+        .find("PROVIDER_CATALOG")
+        .expect("provider-cards.tsx no longer declares PROVIDER_CATALOG");
+    let body = &source[start..];
+
+    let mut out = vec![];
+    for (offset, _) in body.match_indices("id: \"") {
+        // Each record runs to the start of the next one; the last runs to the
+        // end. Bounding the field search this way keeps a missing field in one
+        // record from silently picking up the next record's value.
+        let rest = &body[offset..];
+        let end = rest[1..]
+            .find("id: \"")
+            .map_or(rest.len(), |next| next + 1);
+        let record = &rest[..end];
+
+        let Some(id) = tsx_field(record, "id") else {
+            continue;
+        };
+        out.push(ProviderCard {
+            href: tsx_field(record, "href")
+                .unwrap_or_else(|| panic!("the `{id}` card has no href")),
+            env: tsx_field(record, "env").unwrap_or_else(|| panic!("the `{id}` card has no env")),
+            default_model: tsx_field(record, "defaultModel")
+                .unwrap_or_else(|| panic!("the `{id}` card has no defaultModel")),
+            id,
+        });
+    }
+    out
+}
+
+/// The value of a `key: "value"` field in a TSX object literal.
+fn tsx_field(record: &str, key: &str) -> Option<String> {
+    let needle = format!("{key}: \"");
+    let start = record.find(&needle)? + needle.len();
+    let rest = &record[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Split a card's `env` string into its primary variable and its aliases.
+///
+/// The docs render aliases in parentheses — `GEMINI_API_KEY (GOOGLE_API_KEY)`
+/// — because that is how a reader wants to see "this one, or that one".
+fn split_env(env: &str) -> (&str, Vec<&str>) {
+    match env.split_once('(') {
+        Some((primary, aliases)) => (
+            primary.trim(),
+            aliases
+                .trim_end_matches(')')
+                .split(',')
+                .map(str::trim)
+                .filter(|a| !a.is_empty())
+                .collect(),
+        ),
+        None => (env.trim(), vec![]),
+    }
+}

--- a/stella-cli/src/config/tests.rs
+++ b/stella-cli/src/config/tests.rs
@@ -858,9 +858,7 @@ fn parse_provider_cards(source: &str) -> Vec<ProviderCard> {
         // end. Bounding the field search this way keeps a missing field in one
         // record from silently picking up the next record's value.
         let rest = &body[offset..];
-        let end = rest[1..]
-            .find("id: \"")
-            .map_or(rest.len(), |next| next + 1);
+        let end = rest[1..].find("id: \"").map_or(rest.len(), |next| next + 1);
         let record = &rest[..end];
 
         let Some(id) = tsx_field(record, "id") else {

--- a/stella-cli/src/settings/merge.rs
+++ b/stella-cli/src/settings/merge.rs
@@ -106,6 +106,18 @@ impl Settings {
         if let Some(authority) = scope.managed_authority {
             self.managed_authority = Some(authority);
         }
+        // Last-wins, and only when the scope actually declares it — an absent
+        // key must not reset a lower scope's `"on"` back to the default.
+        //
+        // This was missing entirely, which made `enable_recap` inert: every
+        // scope parsed it, `overlay_scope` dropped it, and `recap_enabled()`
+        // read `None` off the merged value no matter what any file said. The
+        // accessor's own tests passed throughout because they call it on a
+        // directly-deserialized `Settings`, never on a merged one — the merge
+        // is the only place the field was lost.
+        if let Some(recap) = scope.enable_recap {
+            self.enable_recap = Some(recap);
+        }
         // Adaptive-context config: whole-block last-wins (a higher-precedence
         // scope that declares `context` replaces a lower one's). Inert in
         // Phase 0 — nothing reads it — so no trust restoration is needed (it

--- a/stella-cli/src/settings/tests.rs
+++ b/stella-cli/src/settings/tests.rs
@@ -872,3 +872,43 @@ fn managed_authority_settings_round_trip() {
     let round_trip: ManagedAuthoritySettings = serde_json::from_str(&json).unwrap();
     assert_eq!(round_trip, policy);
 }
+
+/// `enable_recap` must survive the scope merge.
+///
+/// It did not: `overlay_scope` copied every other top-level key and silently
+/// dropped this one, so `"enable_recap": "on"` in any settings.json parsed
+/// fine, merged to `None`, and never reached the runtime. The existing
+/// coverage missed it because it exercised `recap_enabled()` on a
+/// directly-deserialized `Settings` — which is exactly the one path where the
+/// field was never lost. This test goes through `Settings::load`, the way the
+/// binary does.
+#[test]
+fn enable_recap_survives_the_scope_merge() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace = dir.path();
+    std::fs::create_dir_all(workspace.join(".stella")).expect("mkdir .stella");
+    std::fs::write(
+        workspace.join(".stella/settings.json"),
+        r#"{"enable_recap": "on"}"#,
+    )
+    .expect("write settings");
+
+    let merged = Settings::load(workspace).expect("settings load");
+    assert!(
+        merged.recap_enabled(),
+        "a scope that sets `enable_recap: on` must reach the merged settings"
+    );
+}
+
+/// The complement: an absent key must not reset a lower scope's value, and the
+/// default stays off.
+#[test]
+fn enable_recap_defaults_off_when_no_scope_sets_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace = dir.path();
+    std::fs::create_dir_all(workspace.join(".stella")).expect("mkdir .stella");
+    std::fs::write(workspace.join(".stella/settings.json"), r#"{}"#).expect("write settings");
+
+    let merged = Settings::load(workspace).expect("settings load");
+    assert!(!merged.recap_enabled(), "recap defaults off");
+}

--- a/stella-cli/src/usage_cmd.rs
+++ b/stella-cli/src/usage_cmd.rs
@@ -57,8 +57,8 @@ pub enum UsageCmd {
         max_rows: Option<i64>,
 
         /// GC rollup for projects whose checkout is gone and were never
-        /// org-registered. A project on an unmounted volume reads as "gone"
-        /// (its rollup re-replicates on next sync, so this is recoverable)
+        /// org-registered. A project on an unmounted volume is NOT treated as
+        /// gone — an absent parent reads as a missing volume, not a deletion
         #[arg(long)]
         gc_deleted: bool,
 

--- a/stella-tools/tests/docs_in_sync.rs
+++ b/stella-tools/tests/docs_in_sync.rs
@@ -87,36 +87,64 @@ fn count_between(text: &str, before: &str, after: &str) -> usize {
     panic!("the docs no longer contain the phrase {before:?}<number>{after:?}")
 }
 
-/// Every markdown table row whose first cell is a single backticked name,
-/// paired with that row's access marker. Splitting on `|` is safe because the
-/// helper demands the access cell be *exactly* `Read-only` or `Mutating`, so a
-/// pipe inside a description can only ever cause a loud miss, never a false
-/// pass.
+/// The opening tag starting at the front of `text`, i.e. everything before the
+/// first `>` that is not inside a double-quoted attribute value.
+///
+/// The quote tracking is not pedantry: a card's `when=` prose is free text and
+/// may legitimately contain a `>`. Stopping at the first raw `>` would truncate
+/// the tag mid-attribute and lose the marker that follows it.
+fn opening_tag(text: &str) -> &str {
+    let mut in_quotes = false;
+    for (i, ch) in text.char_indices() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            '>' if !in_quotes => return &text[..i],
+            _ => {}
+        }
+    }
+    panic!("a <ToolCard element is never closed with `>`: {text:.80}")
+}
+
+/// The value of a double-quoted JSX attribute in an opening tag.
+fn attr(tag: &str, key: &str) -> Option<String> {
+    let needle = format!("{key}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Every `<ToolCard name="…" access="…">` in `text`, paired with whether its
+/// access marker says read-only.
+///
+/// The catalog used to be a stack of markdown tables and this parser split on
+/// `|`. A five-column table is a desktop-only artifact — on a phone it either
+/// overflows the viewport or crushes every cell to two words — so the catalog
+/// is now a grid of `<ToolCard>` elements. The gate is unchanged in substance:
+/// the tool *name* and its *access marker* still come out of the doc and still
+/// get compared against `catalog.rs`. Only the syntax being read moved.
+///
+/// Every failure mode here is a panic rather than a skip. A silently-ignored
+/// card would drop a tool out of the set-equality checks below, turning real
+/// drift into a vacuous pass — which is the exact class of bug this file
+/// exists to prevent.
 fn documented_tools(text: &str) -> Vec<(String, bool)> {
     let mut out = vec![];
-    for line in text.lines() {
-        let line = line.trim();
-        if !line.starts_with('|') {
-            continue;
-        }
-        let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
-        let Some(first) = cells.first() else { continue };
-        // The name cell is exactly one backticked identifier.
-        let names = backticked(first);
-        if names.len() != 1 || first.trim_matches('`') != names[0] {
-            continue;
-        }
-        let reads = cells.iter().filter(|c| **c == "Read-only").count();
-        let mutates = cells.iter().filter(|c| **c == "Mutating").count();
-        let read_only = match reads + mutates {
-            1 => reads == 1,
-            n => panic!(
-                "row for `{}` has {n} access cells — expected exactly one \
-                 `Read-only` or `Mutating`",
-                names[0]
+    for (offset, _) in text.match_indices("<ToolCard") {
+        let tag = opening_tag(&text[offset..]);
+        let name = attr(tag, "name")
+            .unwrap_or_else(|| panic!("a <ToolCard is missing its `name` attribute: {tag}"));
+        let access = attr(tag, "access")
+            .unwrap_or_else(|| panic!("<ToolCard name=\"{name}\"> is missing `access`"));
+        let read_only = match access.as_str() {
+            "read" => true,
+            "mutating" => false,
+            other => panic!(
+                "<ToolCard name=\"{name}\"> has access=\"{other}\" — expected \
+                 exactly `read` or `mutating`"
             ),
         };
-        out.push((names[0].clone(), read_only));
+        out.push((name, read_only));
     }
     out
 }
@@ -274,19 +302,29 @@ fn session_tool_count_prose_matches_the_catalog() {
 /// The parser is what makes the rest of this file meaningful: if it silently
 /// matched nothing, every set-equality above would pass vacuously.
 #[test]
-fn the_table_parser_actually_finds_rows() {
+fn the_card_parser_actually_finds_tools() {
     let sample = "\
-| Tool | Description | Access |
-| --- | --- | --- |
-| `read_file` | Read a file. | Read-only |
-| `write_file` | Write a file. | Mutating |
-| not a tool | filler | Read-only |
+Some prose about `read_file` that must not be mistaken for a card.
+
+<CardGrid size=\"md\">
+  <ToolCard name=\"read_file\" access=\"read\">
+    Read a file, with 1-based line numbers.
+  </ToolCard>
+  <ToolCard name=\"write_file\" access=\"mutating\">
+    Create a file or overwrite an existing one.
+  </ToolCard>
+  <ToolCard name=\"web_search\" access=\"read\" when=\"a search key is set (limit > 0)\">
+    Search the web.
+  </ToolCard>
+</CardGrid>
 ";
     assert_eq!(
         documented_tools(sample),
         vec![
             ("read_file".to_string(), true),
             ("write_file".to_string(), false),
+            // The `>` inside `when=` must not truncate the tag before `access`.
+            ("web_search".to_string(), true),
         ]
     );
     assert_eq!(backticked("a `b` c `d`"), vec!["b", "d"]);
@@ -294,4 +332,12 @@ fn the_table_parser_actually_finds_rows() {
     let prose = "up to 9 native things. All told: 42 always-on tools, up to 58 native tools.";
     assert_eq!(count_between(prose, "up to ", " native tools"), 58);
     assert_eq!(count_between(prose, "All told: ", " always-on tools"), 42);
+}
+
+/// An access marker the component itself would reject must fail loudly here
+/// rather than silently dropping the tool from the set-equality checks.
+#[test]
+#[should_panic(expected = "expected exactly `read` or `mutating`")]
+fn an_unknown_access_marker_is_a_hard_failure() {
+    documented_tools("<ToolCard name=\"read_file\" access=\"Read-only\">x</ToolCard>");
 }

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -50,16 +50,135 @@ came through:
 
 ## The map
 
-| Path | Command | Turn shape | Verification | Execution kind | Headless? |
-| --- | --- | --- | --- | --- | --- |
-| One-shot, pipeline | `stella run "…"` | One staged pipeline run | Pipeline stages + judge; `--test-command` arms the deterministic fail→pass oracle | `pipeline` | Yes (`--output-format json\|stream-json`) |
-| One-shot, raw | `stella run --no-pipeline "…"` | One step-loop turn | The model stops when done | `run` | Yes |
-| Plain REPL | `stella --plain` (or non-TTY) | One raw turn per prompt, shared conversation | You, live | `chat` | Interactive only |
-| Command Deck lead | `stella` | One turn per prompt; `/pipeline` toggles staged (default) vs raw | Pipeline stages, or you | `deck-pipeline` / `deck` | Interactive only |
-| Deck sub-agents | `task_assign` (agent-initiated) | One raw turn per delegated task, own context | The lead reviews results | `deck-sub` | Follows the deck |
-| Goal mode | `stella goal "…"` | Judged **rounds** until the goal is met; pipeline rounds by default, `--no-pipeline` for raw | An independent judge, from evidence, over read-only tools | `goal` | Yes |
-| CI monitor | `stella monitor [target]` | Goal mode with a fixed objective | The judge reads `ci_status`; ends only on a fully green latest run | `goal` | Yes |
-| Fleet workers | `stella fleet …` | One worker per task, wave-scheduled by dependency | Per task (pipeline when available, else raw); attempts recorded in `.stella/private/fleet.db` | fleet ledger | Yes |
+<CardGrid size="lg">
+  <SpecCard
+    title="One-shot, pipeline"
+    meta={[
+      { label: "Command", value: "stella run \"…\"" },
+      { label: "Turn shape", value: "One staged pipeline run", mono: false },
+      { label: "Execution kind", value: "pipeline" },
+      { label: "Headless", value: "Yes — json / stream-json", mono: false },
+    ]}
+  >
+    Verified by the pipeline stages plus the judge. `--test-command` arms the
+    deterministic fail→pass oracle, and a clean flip can submit without a judge
+    call at all.
+  </SpecCard>
+  <SpecCard
+    title="One-shot, raw"
+    meta={[
+      { label: "Command", value: "stella run --no-pipeline \"…\"" },
+      { label: "Turn shape", value: "One step-loop turn", mono: false },
+      { label: "Execution kind", value: "run" },
+      { label: "Headless", value: "Yes", mono: false },
+    ]}
+  >
+    No stages, no judge — the model works until it decides it is done. You are
+    the verification.
+  </SpecCard>
+  <SpecCard
+    title="Plain REPL"
+    meta={[
+      { label: "Command", value: "stella --plain" },
+      { label: "Turn shape", value: "One raw turn per prompt, shared conversation", mono: false },
+      { label: "Execution kind", value: "chat" },
+      { label: "Headless", value: "Interactive only", mono: false },
+    ]}
+  >
+    Also what you get on a non-TTY stdin/stdout, or with `STELLA_PLAIN=1`. You
+    verify, live, between prompts.
+  </SpecCard>
+  <SpecCard
+    title="Command Deck lead"
+    meta={[
+      { label: "Command", value: "stella" },
+      { label: "Turn shape", value: "One turn per prompt; /pipeline toggles staged (default) vs raw", mono: false },
+      { label: "Execution kind", value: "deck-pipeline / deck" },
+      { label: "Headless", value: "Interactive only", mono: false },
+    ]}
+  >
+    Pipeline stages when `/pipeline` is on — which it is by default — otherwise
+    you, watching the FILES and DIFF tabs fill in.
+  </SpecCard>
+  <SpecCard
+    title="Deck sub-agents"
+    meta={[
+      { label: "Command", value: "task_assign (agent-initiated)" },
+      { label: "Turn shape", value: "One raw turn per delegated task, own context", mono: false },
+      { label: "Execution kind", value: "deck-sub" },
+      { label: "Headless", value: "Follows the deck", mono: false },
+    ]}
+  >
+    The lead reviews each result. You never invoke this path directly — you ask
+    for work that warrants it.
+  </SpecCard>
+  <SpecCard
+    title="Goal mode"
+    meta={[
+      { label: "Command", value: "stella goal \"…\"" },
+      { label: "Turn shape", value: "Judged rounds until the goal is met — pipeline rounds by default", mono: false },
+      { label: "Execution kind", value: "goal" },
+      { label: "Headless", value: "Yes", mono: false },
+    ]}
+  >
+    An independent judge assesses the goal from evidence, over a **read-only**
+    view of the tool stack. `--no-pipeline` makes each round a raw step-loop
+    turn.
+  </SpecCard>
+  <SpecCard
+    title="CI monitor"
+    meta={[
+      { label: "Command", value: "stella monitor [target]" },
+      { label: "Turn shape", value: "Goal mode with a fixed objective", mono: false },
+      { label: "Execution kind", value: "goal" },
+      { label: "Headless", value: "Yes", mono: false },
+    ]}
+  >
+    The judge reads `ci_status` itself; only a fully green *latest* run for the
+    target ends the loop. `target` defaults to `main`.
+  </SpecCard>
+  <SpecCard
+    title="Fleet workers"
+    meta={[
+      { label: "Command", value: "stella fleet …" },
+      { label: "Turn shape", value: "One worker per task, wave-scheduled by dependency", mono: false },
+      { label: "Execution kind", value: "fleet ledger" },
+      { label: "Headless", value: "Yes", mono: false },
+    ]}
+  >
+    Verified per task — the staged pipeline when available, the raw step loop
+    otherwise. Every attempt is recorded in `.stella/private/fleet.db`.
+  </SpecCard>
+</CardGrid>
+
+One command per door, to paste and compare:
+
+```bash
+# One-shot, pipeline — the strongest verification a single command can buy.
+stella run --test-command "cargo test -p stella-pipeline" \
+  "make the witness tamper check reject a renamed test file"
+
+# One-shot, raw — a question, not a change.
+stella run --no-pipeline "what does resolve_engine_wiring do with an uncredentialed judge?"
+
+# Interactive, tabbed.
+stella
+
+# Interactive, line-based — SSH, a minimal terminal, a recording.
+stella --plain
+
+# A defined outcome, unknown steps.
+stella goal "cargo clippy --all-targets -- -D warnings is clean and the suite passes"
+
+# CI must be green — target defaults to main.
+stella monitor fix/pager-off-by-one
+
+# A backlog, not a task.
+stella fleet "Add unit tests for the parser module" "Fix the clippy warnings in the store crate"
+
+# Continue yesterday's session.
+stella resume
+```
 
 ## One-shot: `stella run`
 
@@ -184,12 +303,23 @@ modules, a list of independent fixes, wide refactors.
 The [tool catalog](/docs/agent-tools) is shared, but each path decorates it
 differently:
 
-| Path | On top of the shared stack |
-| --- | --- |
-| One-shot / REPL / goal worker | Nothing extra — the shared stack as-is |
-| Command Deck lead | File-change tap + task tap (live tabs, sub-agent spawning), claim-on-first-write |
-| Goal / pipeline judge | A **read-only** view — only `read_only: true` tools are visible or executable |
-| Fleet workers | Claim coordination in the shared tree; a private worktree when isolated |
+<CardGrid size="md">
+  <OptionCard name="One-shot / REPL / goal worker">
+    Nothing extra — the shared stack as-is.
+  </OptionCard>
+  <OptionCard name="Command Deck lead">
+    A file-change tap and a task tap on top: live FILES/DIFF tabs, the task
+    board, sub-agent spawning — plus claim-on-first-write.
+  </OptionCard>
+  <OptionCard name="Goal / pipeline judge">
+    A **read-only** view. Only tools marked `read_only: true` are visible or
+    executable, so a judge structurally cannot edit its way to a verdict.
+  </OptionCard>
+  <OptionCard name="Fleet workers">
+    Claim coordination in the shared tree; a private worktree when the task is
+    marked `isolation = "isolated"`.
+  </OptionCard>
+</CardGrid>
 
 Every path can also opt into the lean toolset — `STELLA_LEAN_TOOLS`
 advertises only a lean core plus the discovery tools; see
@@ -217,22 +347,81 @@ discovery tools are read-only, even the judge can run `tool_search`,
 Every path is a thin `stella-cli` entry point over `stella_core::Engine`.
 If you're changing engine behavior, these are the seams:
 
-| Path | Entry (stella-cli) | Engine call |
-| --- | --- | --- |
-| One-shot pipeline | `agent::run_one_shot` → `run_pipeline_one_shot` | staged pipeline over the engine |
-| One-shot raw | `agent::run_one_shot` → `run_raw_one_shot` → `run_turn` | `Engine::run_turn` |
-| Plain REPL | `agent::run_interactive` → `run_turn` per prompt | `Engine::run_turn` |
-| Deck lead | `command_deck::run_lead_turn` / `run_lead_pipeline_turn` | `Engine::run_turn` / pipeline |
-| Deck sub-agent | `subsession::run_worker` | `Engine::run_turn` |
-| Goal (raw rounds) | `agent::run_goal_cmd` → `run_goal_turn` | `Engine::run_goal` with a judge |
-| Goal (pipeline rounds) | `agent::run_goal_cmd` → `run_goal_pipeline_turn` | pipeline rounds + a judge engine over `ReadOnlyTools` |
-| Fleet worker | `fleet_cmd` per-task worker | pipeline when available, else `Engine::run_turn` |
+<CardGrid size="md">
+  <SpecCard
+    title="One-shot pipeline"
+    meta={[
+      { label: "Entry", value: "agent::run_one_shot → run_pipeline_one_shot" },
+      { label: "Engine call", value: "staged pipeline over the engine", mono: false },
+    ]}
+  />
+  <SpecCard
+    title="One-shot raw"
+    meta={[
+      { label: "Entry", value: "agent::run_one_shot → agent::goal::run_raw_one_shot" },
+      { label: "Engine call", value: "Engine::run_turn" },
+    ]}
+  />
+  <SpecCard
+    title="Plain REPL"
+    meta={[
+      { label: "Entry", value: "agent::run_interactive" },
+      { label: "Engine call", value: "Engine::run_turn per prompt", mono: false },
+    ]}
+  />
+  <SpecCard
+    title="Deck lead"
+    meta={[
+      { label: "Entry", value: "command_deck::run_lead_turn / run_lead_pipeline_turn" },
+      { label: "Engine call", value: "Engine::run_turn, or the pipeline", mono: false },
+    ]}
+  />
+  <SpecCard
+    title="Deck sub-agent"
+    meta={[
+      { label: "Entry", value: "subsession::run_worker" },
+      { label: "Engine call", value: "Engine::run_turn" },
+    ]}
+  />
+  <SpecCard
+    title="Goal — raw rounds"
+    meta={[
+      { label: "Entry", value: "agent::goal::run_goal_cmd → run_goal_turn" },
+      { label: "Engine call", value: "Engine::run_goal with a judge", mono: false },
+    ]}
+  />
+  <SpecCard
+    title="Goal — pipeline rounds"
+    meta={[
+      { label: "Entry", value: "agent::goal::run_goal_cmd → run_goal_pipeline_turn" },
+      { label: "Engine call", value: "pipeline rounds + a judge engine over ReadOnlyTools", mono: false },
+    ]}
+  />
+  <SpecCard
+    title="Fleet worker"
+    meta={[
+      { label: "Entry", value: "fleet_cmd::run_fleet, per task" },
+      { label: "Engine call", value: "pipeline when available, else Engine::run_turn", mono: false },
+    ]}
+  />
+</CardGrid>
 
 The execution-kind strings in [the map](#the-map) are what these paths stamp
 on their execution records — the same strings you'll see in
 `stella stats`, the exported [dashboard](/docs/telemetry/dashboard), and the
 deck's AGENTS tab, so a telemetry row always traces back to the door
 the work came through.
+
+The store is ordinary SQLite, so you can ask that question directly — which
+doors your spend actually went through:
+
+```bash
+sqlite3 .stella/private/store.db \
+  "SELECT kind, COUNT(*) AS runs, ROUND(SUM(cost_usd), 4) AS usd
+     FROM executions
+    GROUP BY kind
+    ORDER BY usd DESC;"
+```
 
 ## Where to go next
 

--- a/website/content/docs/agent-fleets.mdx
+++ b/website/content/docs/agent-fleets.mdx
@@ -51,9 +51,20 @@ stella fleet \
    instead of the staged pipeline.
 5. **Record.** Every attempt, commit, and dollar lands in the fleet ledger
    at `.stella/private/fleet.db` — local SQLite, like all
-   [Stella telemetry](/docs/telemetry). Past runs (tasks, attempts,
-   successes, commits) also surface on the **Fleet runs** card of the
+   [Stella telemetry](/docs/telemetry), with `runs`, `tasks`, `attempts`,
+   and `commits` tables you can query directly. Past runs also surface on
+   the **Fleet runs** card of the
    [Observatory dashboard](/docs/telemetry/dashboard).
+
+   ```bash
+   # Which tasks failed in the most recent run, and what the worker said.
+   sqlite3 .stella/private/fleet.db \
+     "SELECT a.task_id, a.branch, a.summary
+        FROM attempts a
+       WHERE a.run_id = (SELECT id FROM runs ORDER BY created_at_ms DESC LIMIT 1)
+         AND a.success = 0;"
+   ```
+
 6. **Review.** Shared-tree work lands directly on your current branch as
    interleaved commits. Isolated tasks' worktrees and `fleet/*` branches are
    deliberately **left in place** — those branches *are* the work product.
@@ -79,18 +90,83 @@ prompt = "Update the release notes for 1.4.0 from the merged PRs"
 depends_on = ["t1"]
 ```
 
-Each task carries an `id`, `title`, and `prompt`, plus optionally:
+Every task field, in the shape the plan parser accepts:
 
-- `depends_on` — ids that must succeed before this task dispatches (orders
-  the waves).
-- `isolation` — `shared_tree` (the default: run directly in the repo root
-  under the cooperative claim discipline) or `isolated` (own worktree, own
-  branch — the explicit opt-in for genuinely *divergent* work: best-of-N
-  attempts producing competing versions of the same files, or tasks that
-  mutate checkout state. Claims can't help there — the conflict is the
-  point — and the costs are real: a cold build cache per tree, and
-  conflicts deferred to integration time).
-- `claims` — workspace-relative paths held as cooperative file locks.
+<CardGrid size="md">
+  <OptionCard name="id" required>
+    Stable, plan-unique identifier. It is what `depends_on` edges reference, the
+    dispatch tie-break, and the seed for this task's worktree directory and
+    branch name.
+  </OptionCard>
+  <OptionCard name="title" required>
+    One-line human label, shown in the run report and stored on the ledger's
+    `tasks` row. Never interpreted.
+  </OptionCard>
+  <OptionCard name="prompt" required>
+    What the worker is asked to do — a full Stella prompt.
+  </OptionCard>
+  <OptionCard name="depends_on" defaultValue="[]">
+    Ids that must succeed before this task dispatches; this is what orders the
+    waves. Every id must name a task in the same plan.
+  </OptionCard>
+  <OptionCard name="isolation" defaultValue="shared_tree">
+    `shared_tree` runs directly in the repo root under the cooperative claim
+    discipline. `isolated` gets its own worktree on its own branch — the
+    explicit opt-in for genuinely *divergent* work: best-of-N attempts producing
+    competing versions of the same files, or tasks that mutate checkout state.
+    Claims can't help there — the conflict is the point — and the costs are
+    real: a cold build cache per tree, and conflicts deferred to integration
+    time.
+  </OptionCard>
+  <OptionCard name="claims" defaultValue="[]">
+    Workspace-relative paths held as cooperative file locks for the attempt's
+    duration. Matched as exact strings, so spell each path one way throughout
+    the plan.
+  </OptionCard>
+</CardGrid>
+
+A plan exercising all of it — three waves, one isolated task, and claims that
+keep the parallel writers apart. Claims are matched as **exact strings**, so
+name files, not directories:
+
+```toml title="feature-buildout.toml"
+[[tasks]]
+id = "schema"
+title = "Add the migration"
+prompt = "Add a migration creating the `receipts` table with an execution_id foreign key"
+claims = ["src/store/schema.rs", "src/store/migrations.rs"]
+
+[[tasks]]
+id = "reader"
+title = "Read path"
+prompt = "Add Store::receipts_for_execution reading the new receipts table"
+depends_on = ["schema"]
+claims = ["src/store/read.rs"]
+
+[[tasks]]
+id = "writer"
+title = "Write path"
+prompt = "Record one receipt row per model call from the pipeline's emit path"
+depends_on = ["schema"]
+claims = ["src/store/write.rs"]
+
+[[tasks]]
+id = "docs"
+title = "Rewrite the receipts page"
+prompt = "Rewrite docs/receipts.md against the new table; try two structures and keep the better one"
+depends_on = ["reader", "writer"]
+isolation = "isolated"
+```
+
+```bash
+stella --budget 6 fleet --plan feature-buildout.toml
+```
+
+`schema` runs alone in wave one; `reader` and `writer` run together in wave two
+with disjoint claims; `docs` runs last in wave three, in its own worktree on its
+own `fleet/docs-<hash>` branch — divergent work, so isolation rather than
+claims. Had `reader` and `writer` both claimed `src/store/schema.rs`, the second
+dispatch would have failed by name instead of racing.
 
 ### File claims — cooperative locks
 
@@ -139,14 +215,38 @@ stella fleet --plan release-prep.toml --max-concurrency 2 --watch
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `<task>...` | One or more task prompts. Required unless `--plan` is given. |
-| `--plan <FILE>` | A `.json`/`.toml` plan with `[[tasks]]` entries. |
-| `--max-concurrency <N>` | Max tasks running at once per wave. Default `4`. |
-| `--base-ref <ref>` | Git ref the worktrees branch from. Default: current `HEAD`, pinned to a SHA at start so mid-run commits can't drift the base. |
-| `--watch` | Watch each successful branch's CI to completion after the fan-out. |
-| `--no-pipeline` | Workers run the raw step loop instead of the staged pipeline. |
+<CardGrid size="md">
+  <OptionCard name="<task>..." required>
+    One or more task prompts, each becoming an independent shared-tree task.
+    Required unless `--plan` is given — the two are mutually exclusive.
+  </OptionCard>
+  <OptionCard name="--plan <FILE>">
+    A `.json` or `.toml` plan with `[[tasks]]` entries instead of inline
+    prompts — the only way to declare `depends_on`, `claims`, or `isolation`.
+  </OptionCard>
+  <OptionCard name="--max-concurrency <N>" defaultValue="4">
+    Max tasks dispatched at once within one wave.
+  </OptionCard>
+  <OptionCard name="--base-ref <ref>" defaultValue="current HEAD">
+    Git ref the `isolation = "isolated"` worktrees branch from, resolved to a
+    SHA at start so mid-run commits can't drift the base. Shared-tree tasks
+    ignore it.
+  </OptionCard>
+  <OptionCard name="--watch">
+    After the fan-out, watch each fleet branch's CI to completion and reconcile
+    its PR status via `gh`. Exits non-zero if any watched branch ends red.
+  </OptionCard>
+  <OptionCard name="--no-pipeline">
+    Workers run the raw step loop instead of the staged pipeline.
+  </OptionCard>
+</CardGrid>
+
+The budget flag is **global**, so it goes before the subcommand — the one
+ordering mistake worth memorizing:
+
+```bash
+stella --budget 8 fleet --plan release-prep.toml --max-concurrency 3 --watch
+```
 
 ## Cleaning up
 
@@ -154,8 +254,22 @@ When you've merged (or rejected) the branches your isolated tasks left —
 the branch names carry a hash suffix, so list them rather than guessing:
 
 ```bash
-git worktree list                 # what the fleet left in .stella/worktrees/
-git worktree remove <path>        # per worktree
-git branch --list 'fleet/*'      # the fleet branches
-git branch -D fleet/<slug>-<hash> # per branch, exactly as listed
+git worktree list                  # what the fleet left in .stella/worktrees/
+git worktree remove <path>         # per worktree
+git branch --list 'fleet/*'        # the fleet branches
+git branch -D fleet/<slug>-<hash>  # per branch, exactly as listed
 ```
+
+Once every branch is merged or rejected, the whole sweep in two lines:
+
+```bash
+git worktree list --porcelain | awk '/^worktree .*\.stella\/worktrees\//{print $2}' \
+  | xargs -r -n1 git worktree remove
+git branch --list 'fleet/*' --format='%(refname:short)' | xargs -r git branch -D
+```
+
+<Callout type="warn">
+  That second pair deletes every `fleet/*` branch, merged or not — the branches
+  *are* the work product for isolated tasks. Run `git branch --list 'fleet/*'`
+  on its own first and confirm the list is one you are finished with.
+</Callout>

--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -8,14 +8,66 @@ autonomy you're delegating and how the work should be checked. (For the
 under-the-hood view — what each mode actually does differently inside the
 engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
 
-| Mode | Command | Best for | Verification |
-| --- | --- | --- | --- |
-| Interactive chat | `stella` / `stella chat` | Exploring, iterating, supervising | You, live |
-| One-shot run | `stella run "…"` | Scripts, CI, a single well-defined task | The [staged pipeline](/docs/inference-pipeline) |
-| Raw step loop | `stella run --no-pipeline "…"` | Quick questions, cheap tasks | The model stops when done |
-| Goal mode | `stella goal "…"` | An outcome, not a task list | An independent [judge](/docs/agent-modes#outcome-driven-goal-mode) over staged-pipeline rounds (`--no-pipeline` for raw) |
-| CI monitor | `stella monitor` | "Make CI green and keep it green" | The latest CI run, all-green |
-| Fleet | `stella fleet …` | Many tasks in parallel | Per task, in one shared tree with cooperative [claims](/docs/agent-fleets) (worktrees on opt-in) |
+<CardGrid size="md">
+  <SpecCard
+    title="Interactive chat"
+    meta={[
+      { label: "Command", value: "stella" },
+      { label: "Verified by", value: "you, live", mono: false },
+    ]}
+  >
+    Exploring, iterating, supervising.
+  </SpecCard>
+  <SpecCard
+    title="One-shot run"
+    href="/docs/commands/run"
+    meta={[
+      { label: "Command", value: "stella run \"…\"" },
+      { label: "Verified by", value: "the staged pipeline", mono: false },
+    ]}
+  >
+    Scripts, CI, a single well-defined task.
+  </SpecCard>
+  <SpecCard
+    title="Raw step loop"
+    meta={[
+      { label: "Command", value: "stella run --no-pipeline \"…\"" },
+      { label: "Verified by", value: "nothing — the model stops when it decides it is done", mono: false },
+    ]}
+  >
+    Quick questions and cheap tasks, where a full pipeline costs more than the answer is worth.
+  </SpecCard>
+  <SpecCard
+    title="Goal mode"
+    href="/docs/agent-modes#outcome-driven-goal-mode"
+    meta={[
+      { label: "Command", value: "stella goal \"…\"" },
+      { label: "Verified by", value: "an independent judge, over staged-pipeline rounds", mono: false },
+    ]}
+  >
+    An outcome, not a task list. `--no-pipeline` makes each round a raw loop.
+  </SpecCard>
+  <SpecCard
+    title="CI monitor"
+    href="/docs/commands/monitor"
+    meta={[
+      { label: "Command", value: "stella monitor" },
+      { label: "Verified by", value: "the latest CI run, all green", mono: false },
+    ]}
+  >
+    "Make CI green and keep it green."
+  </SpecCard>
+  <SpecCard
+    title="Fleet"
+    href="/docs/agent-fleets"
+    meta={[
+      { label: "Command", value: "stella fleet …" },
+      { label: "Verified by", value: "per task, independently", mono: false },
+    ]}
+  >
+    Many tasks in parallel — one shared tree with cooperative claims, or a worktree each on opt-in.
+  </SpecCard>
+</CardGrid>
 
 ## Interactive: the Command Deck
 
@@ -23,18 +75,29 @@ Running `stella` with no subcommand opens the **Command Deck** — a tabbed
 terminal UI over the same engine. Type to send a prompt; slash commands open
 tabs and overlays:
 
-| Command | Does |
-| --- | --- |
-| `/help` | Show help |
-| `/models` | List providers and models |
-| `/files` · `/diff` | What this session changed, and the working diff |
-| `/graph` | The code-graph tab |
-| `/agents` · `/skills` · `/mcp` | The AGENTS tab (executions & installed agents), skills, MCP servers |
-| `/settings` | The SETTINGS tab — home of all config, incl. the [engine-config panel](/docs/configuration/agent-engine-config) |
-| `/pipeline` | Toggle staged-pipeline turns (ON by default) |
-| `/sessions` · `/inbox` | Every session on this machine; notifications |
-| `/export` | Export session telemetry to a ZIP + [HTML dashboard](/docs/telemetry/dashboard) |
-| `/clear` | Reset the conversation |
+<CardGrid size="sm">
+  <OptionCard name="/help">Show help.</OptionCard>
+  <OptionCard name="/models">List providers and models.</OptionCard>
+  <OptionCard name="/files · /diff">What this session changed, and the working diff.</OptionCard>
+  <OptionCard name="/graph">The code-graph tab.</OptionCard>
+  <OptionCard name="/agents · /skills · /mcp">
+    The AGENTS tab (executions and installed agents), skills, and MCP servers.
+  </OptionCard>
+  <OptionCard name="/settings">
+    The SETTINGS tab — home of all config, including the
+    [engine-config panel](/docs/configuration/agent-engine-config).
+  </OptionCard>
+  <OptionCard name="/pipeline">Toggle staged-pipeline turns. On by default.</OptionCard>
+  <OptionCard name="/sessions · /inbox">Every session on this machine; notifications.</OptionCard>
+  <OptionCard name="/export">
+    Export session telemetry to a ZIP plus an
+    [HTML dashboard](/docs/telemetry/dashboard).
+  </OptionCard>
+  <OptionCard name="/clear">Reset the conversation.</OptionCard>
+</CardGrid>
+
+The full deck command set — including `/inspect` and `/context` — is on
+[`stella chat`](/docs/commands/chat).
 
 **⏎** inserts a line break; **⌘⏎ / ⌃⏎** submits. Prompts queue while a turn
 runs — you never wait for the agent to finish before typing the next thing

--- a/website/content/docs/agent-tools/commands.mdx
+++ b/website/content/docs/agent-tools/commands.mdx
@@ -46,10 +46,26 @@ the prompt:
 
 ## Where commands live
 
-| Scope | Path | Travels with |
-| --- | --- | --- |
-| Project | `<workspace>/.stella/commands/` | The repo — commit it, the team shares it |
-| User | `~/.stella/commands/` | You, across every workspace |
+<CardGrid size="md">
+  <SpecCard
+    title="Project"
+    meta={[
+      { label: "Path", value: "<workspace>/.stella/commands/" },
+      { label: "Travels with", value: "the repo", mono: false },
+    ]}
+  >
+    Commit it — everyone who clones gets the command in their slash menu.
+  </SpecCard>
+  <SpecCard
+    title="User"
+    meta={[
+      { label: "Path", value: "~/.stella/commands/" },
+      { label: "Travels with", value: "you, across every workspace", mono: false },
+    ]}
+  >
+    Your own templates, in every repo you open.
+  </SpecCard>
+</CardGrid>
 
 Definitions load user-global first, then workspace — **workspace wins** on
 a name collision. In the slash menu, built-ins can never be shadowed, and

--- a/website/content/docs/agent-tools/custom-agents.mdx
+++ b/website/content/docs/agent-tools/custom-agents.mdx
@@ -27,12 +27,26 @@ You are a technical writer. Prefer working examples over abstractions.
 Never document a flag you haven't verified against --help output.
 ```
 
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `name` | No | The agent's slug. Falls back to the filename stem (flat layout) or the directory name (nested layout). |
-| `description` | No | One-line summary for the `/agents` listing. Falls back to the body's first non-empty line, truncated to 72 characters. |
-| `tools` | No | The agent's toolbelt — the tool names granted to this persona. Omitted means **all** tools. |
-| *body* | **Yes** | The persona's instructions — everything after the frontmatter. A file with an empty body is skipped with a diagnostic, never a fatal error. |
+Every field, in the shape the loader accepts:
+
+<CardGrid size="md">
+  <OptionCard name="name" defaultValue="the filename stem, or the directory name">
+    The agent's slug — what `/name` invokes. Falls back to the filename stem
+    (flat layout) or the directory name (nested layout).
+  </OptionCard>
+  <OptionCard name="description" defaultValue="the body's first non-empty line">
+    One-line summary for the `/agents` listing. The fallback strips leading
+    markdown heading markers and truncates to 72 characters with an ellipsis.
+  </OptionCard>
+  <OptionCard name="tools" defaultValue="all tools">
+    The agent's toolbelt — the tool names granted to this persona. Omitted
+    means **all** tools.
+  </OptionCard>
+  <OptionCard name="body" required>
+    The persona's instructions — everything after the frontmatter. A file with
+    an empty body is skipped with a diagnostic, never a fatal error.
+  </OptionCard>
+</CardGrid>
 
 The `tools:` field is parsed tolerantly, accepting every shape the
 ecosystem has taught authors: a bare comma list (`Read, Grep`), a JSON/YAML
@@ -43,10 +57,26 @@ duplicates collapsed. An empty list or the explicit wildcard forms (`*`,
 
 ## Where agents live
 
-| Scope | Path | Travels with |
-| --- | --- | --- |
-| Project | `<workspace>/.stella/agents/` | The repo — commit it, the team shares it |
-| User | `~/.stella/agents/` | You, across every workspace |
+<CardGrid size="md">
+  <SpecCard
+    title="Project"
+    meta={[
+      { label: "Path", value: "<workspace>/.stella/agents/" },
+      { label: "Travels with", value: "the repo", mono: false },
+    ]}
+  >
+    Commit it and the whole team gets the persona on their next session.
+  </SpecCard>
+  <SpecCard
+    title="User"
+    meta={[
+      { label: "Path", value: "~/.stella/agents/" },
+      { label: "Travels with", value: "you, across every workspace", mono: false },
+    ]}
+  >
+    Your own personas, available in every repo you open.
+  </SpecCard>
+</CardGrid>
 
 Definitions load user-global first, then workspace — **workspace wins** on
 a name collision.
@@ -84,10 +114,26 @@ definitions found there are **symlinked** into the matching Stella
 directory — adopted, not copied, so edits stay in one place and your
 existing setup carries over instead of being rewritten:
 
-| Source | Destination |
-| --- | --- |
-| `<workspace>/.claude/agents/` · `<workspace>/.agents/agents/` | `<workspace>/.stella/agents/` |
-| `~/.claude/agents/` · `~/.agents/agents/` | `~/.stella/agents/` |
+<CardGrid size="md">
+  <SpecCard
+    title="Workspace scope"
+    meta={[
+      { label: "Sources", value: "<workspace>/.claude/agents/ · <workspace>/.agents/agents/" },
+      { label: "Destination", value: "<workspace>/.stella/agents/" },
+    ]}
+  >
+    Adopted when you run `stella init` inside the repo.
+  </SpecCard>
+  <SpecCard
+    title="User scope"
+    meta={[
+      { label: "Sources", value: "~/.claude/agents/ · ~/.agents/agents/" },
+      { label: "Destination", value: "~/.stella/agents/" },
+    ]}
+  >
+    Adopted by the same run — your global personas carry over once.
+  </SpecCard>
+</CardGrid>
 
 (The same sync adopts `commands/` and `skills/` into their matching
 directories.) Three rules keep the adoption sane:

--- a/website/content/docs/agent-tools/custom-tools.mdx
+++ b/website/content/docs/agent-tools/custom-tools.mdx
@@ -16,13 +16,26 @@ If the same tool name is defined in both locations, the **workspace** manifest w
 
 Run `stella tools` at any time to see which custom tools were discovered, alongside the built-ins.
 
+<Callout type="warn">
+  Workspace manifests are behind the
+  [project trust boundary](/docs/configuration/settings#the-project-trust-boundary). A
+  manifest is a command a cloned repo gets to run on your machine, so `.stella/tools/`
+  is **not scanned at all** until you trust the repo — its manifests are neither loaded
+  nor reported as diagnostics. The user-global directory always loads. Opt in per repo:
+
+  ```bash
+  export STELLA_TRUST_PROJECT=1
+  ```
+
+  An org-managed `authority.project_custom_tools: "off"` keeps workspace manifests off
+  even for a trusted repo — that ceiling is not overridable from below.
+</Callout>
+
 ## Manifest shape
 
 A manifest declares the tool's `name`, `description`, the `command` to run, and an `input_schema`:
 
-```toml
-# .stella/tools/wordcount.toml
-
+```toml title=".stella/tools/wordcount.toml"
 name = "wordcount"
 description = "Count the words in a file and print the total."
 
@@ -50,6 +63,40 @@ type = "string"
 description = "Path to the file whose words should be counted."
 ```
 
+Every field, in the shape the manifest parser accepts:
+
+<CardGrid size="md">
+  <OptionCard name="name" required>
+    The name the model sees. Must match `^[a-z][a-z0-9_]{1,63}$` — a lowercase
+    letter followed by 1–63 more of `[a-z0-9_]`. A name that collides with a
+    built-in (or `ask_user`) is skipped with a diagnostic rather than shadowing
+    it.
+  </OptionCard>
+  <OptionCard name="description" required>
+    What the tool does, advertised to the model. An empty description is an
+    error, not a warning — it is the only thing the model has to decide with.
+  </OptionCard>
+  <OptionCard name="command" required>
+    An **argv array**, spawned directly with no shell. `command[0]` resolves
+    against the workspace root, which is also the child's working directory.
+  </OptionCard>
+  <OptionCard name="timeout_ms" defaultValue="30000">
+    Wall-clock budget for one call. Hard-capped at `600000` (10 minutes) — a
+    manifest asking for more is clamped with a warning. Past the timeout the
+    script's whole process group is killed and the tool returns a named error.
+  </OptionCard>
+  <OptionCard name="[env]">
+    Extra environment variables for the child, applied on top of the inherited
+    environment. Credential variables are stripped from the result either way —
+    see below.
+  </OptionCard>
+  <OptionCard name="[input_schema]">
+    The tool's inputs as a JSON Schema written in TOML, converted verbatim. A
+    non-table value is an error; an absent one leaves the tool with an empty
+    schema.
+  </OptionCard>
+</CardGrid>
+
 <Callout type="warn">
 `command` must be an **argv array** (`["scripts/wordcount.sh"]`), not a bare string — a string fails to parse and the tool never loads. Inputs go under `[input_schema]` (a JSON Schema), not `[parameters]`; an unknown table like `[parameters]` is silently ignored, leaving the tool with an empty schema.
 </Callout>
@@ -66,6 +113,10 @@ When the agent calls a custom tool, Stella spawns `command` **directly** from th
 2. Each top-level **scalar** property (string, number, bool) is exported as `STELLA_INPUT_<UPPER_SNAKE_KEY>` — `path` becomes `STELLA_INPUT_PATH`, `dry_run` becomes `STELLA_INPUT_DRY_RUN`. Nested objects and arrays are delivered on stdin only.
 
 The manifest's `[env]` table is applied on top of the inherited environment, before the `STELLA_INPUT_*` exports. Input keys come from the model but are namespaced under `STELLA_INPUT_`, so they can never clobber `PATH` or your `[env]` values.
+
+<Callout type="warn">
+The child's environment is **credential-scrubbed last**, after both the inherited environment and the manifest's `[env]`. A custom tool never sees Stella's provider keys (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …) or repository/AWS tokens, and a manifest cannot reintroduce one by naming it in `[env]` — that entry is removed too. Ordinary task configuration in `[env]` survives untouched. If your script genuinely needs a credential, pass it as a tool *input* or have the script fetch it from your own secret store.
+</Callout>
 
 A script consuming both channels:
 
@@ -94,7 +145,27 @@ stella tools --validate            # scans .stella/tools/ and ~/.stella/tools/
 stella tools --validate ./mytools  # or an explicit directory
 ```
 
-It parses each `<name>.toml` and reports **errors** (bad TOML, missing/invalid/reserved name, empty description or command, a non-table `input_schema`), **warnings** (e.g. a `timeout_ms` over the 10-minute cap is clamped, a name that shadows a built-in or another manifest), and info. It exits non-zero if any manifest has errors — handy in CI.
+Discovery is deliberately lenient — a broken manifest becomes a diagnostic and the session runs on — so this is the pre-flight that tells you before a run has already spent budget. It parses each `<name>.toml` and reports three severities:
+
+<CardGrid size="md">
+  <OptionCard name="Error">
+    The manifest will not load: unreadable file, invalid TOML, a missing field,
+    an invalid or **reserved** name (one a built-in already claims), an empty
+    description, an empty `command`, or a non-table `input_schema`.
+  </OptionCard>
+  <OptionCard name="Warning">
+    It loads but will not behave as written: a `timeout_ms` over the 10-minute
+    cap (clamped at runtime), a name already claimed by an earlier manifest
+    (that one wins, this one is ignored), and a `command[0]` that does not
+    exist or is not executable — a warning, not an error, because the script
+    may legitimately be built or checked out later.
+  </OptionCard>
+  <OptionCard name="Info">
+    `timeout_ms` omitted or `0`, which silently becomes the 30-second default.
+  </OptionCard>
+</CardGrid>
+
+It exits non-zero if any manifest has errors — handy in CI.
 
 ## How custom tools appear
 

--- a/website/content/docs/agent-tools/hooks.mdx
+++ b/website/content/docs/agent-tools/hooks.mdx
@@ -18,11 +18,20 @@ Each hook receives the event payload as **JSON on stdin**, so your command can r
 
 Stella fires hooks on three lifecycle events. Each behaves differently, and each has its own rules for matching and blocking.
 
-| Event | When it runs | Blocking? | Matcher |
-| --- | --- | --- | --- |
-| `SessionStart` | Once before the turn. | No — output is used as context. | Ignored. |
-| `PreToolUse` | Before a tool executes. | Yes — a non-zero exit blocks the tool. | Glob over the tool name. |
-| `PostToolUse` | After a tool executes. | No — side effects only, never blocks. | Glob over the tool name. |
+<CardGrid size="md">
+  <OptionCard name="SessionStart">
+    Runs once before the turn. **Never blocks** — its stdout is used as context instead.
+    The matcher is ignored.
+  </OptionCard>
+  <OptionCard name="PreToolUse">
+    Runs before a tool executes. **Blocking**: a non-zero exit stops the tool. The matcher
+    is a glob over the tool name.
+  </OptionCard>
+  <OptionCard name="PostToolUse">
+    Runs after a tool executes. **Never blocks** — side effects only. The matcher is a glob
+    over the tool name.
+  </OptionCard>
+</CardGrid>
 
 ### `SessionStart`
 
@@ -40,7 +49,7 @@ Runs after a tool executes. It is for **side effects only and never blocks** —
 
 Every hook receives one JSON document on stdin. Its shape:
 
-```json
+```json title="stdin of a PostToolUse hook"
 {
   "event": "PostToolUse",
   "cwd": "/path/to/workspace",
@@ -52,27 +61,52 @@ Every hook receives one JSON document on stdin. Its shape:
 }
 ```
 
-| Field | Type | Present for | Meaning |
-| --- | --- | --- | --- |
-| `event` | string | Always | `"SessionStart"`, `"PreToolUse"`, or `"PostToolUse"` — the same PascalCase names as the config keys. |
-| `cwd` | string | Always | The workspace root — also the hook's working directory. |
-| `tool` | object | `PreToolUse`, `PostToolUse` | `{ "name": …, "input": … }` — the tool's exact name and the model-produced JSON input it was (or will be) called with. |
-| `toolResult` | string | `PostToolUse` only | The (clipped) result string the tool returned. |
+<CardGrid size="md">
+  <OptionCard name="event">
+    String, always present. `"SessionStart"`, `"PreToolUse"`, or `"PostToolUse"` — the same
+    PascalCase names as the config keys.
+  </OptionCard>
+  <OptionCard name="cwd">
+    String, always present. The workspace root — also the hook's working directory.
+  </OptionCard>
+  <OptionCard name="tool">
+    Object, on `PreToolUse` and `PostToolUse`. `{ "name": …, "input": … }` — the tool's
+    exact name and the model-produced JSON input it was (or will be) called with.
+  </OptionCard>
+  <OptionCard name="toolResult">
+    String, on `PostToolUse` only. The result string the tool returned — either the
+    success content or the error message. **Nothing clips it.** A hook matched against a
+    tool that returns a large body receives that whole body on stdin, so if you only want a
+    summary, truncate on your own side.
+  </OptionCard>
+</CardGrid>
 
 Absent fields are **omitted entirely**, not set to `null` — a `SessionStart` payload is just `{ "event": "SessionStart", "cwd": "…" }`, and `toolResult` never appears on a `PreToolUse` payload.
+
+<Callout type="warn">
+  Because `toolResult` is unbounded, a `PostToolUse` hook matched on `"*"` will be handed
+  the full output of every tool call in the session — including a `read_file` of a large
+  file. Match narrowly, and read stdin in a streaming or size-capped way if the hook logs
+  it anywhere.
+</Callout>
 
 ## Timeouts
 
 Each hook may set a `timeoutMs`, the maximum time the command is allowed to run:
 
-- **Default:** `60000` (60 seconds).
-- **Hard maximum:** `600000` (600 seconds / 10 minutes).
+<CardGrid size="sm">
+  <OptionCard name="timeoutMs" defaultValue="60000">
+    Milliseconds a hook command may run before it is killed — 60 seconds by default. The
+    hard maximum is `600000` (600 seconds, or 10 minutes); a larger value buys no more
+    time.
+  </OptionCard>
+</CardGrid>
 
 ## Example
 
 The following `settings.json` runs `./scripts/guard.sh` before every `bash` tool call, with a 5-second timeout. Because it is a `PreToolUse` hook, a non-zero exit from the script blocks the `bash` call. Each hook runs as `bash -c <command>` with its working directory set to the workspace root, so a relative path like `./scripts/guard.sh` resolves from the repository root.
 
-```json
+```json title="<workspace>/.stella/settings.json"
 {
   "hooks": {
     "PreToolUse": [
@@ -115,8 +149,43 @@ exit 0
 
 Blocking is **fail-closed** on `PreToolUse`: a hook that times out or fails to start at all also blocks the tool, with the failure message as the reason — a missing or broken guard script never silently waves a call through. (`PostToolUse` and `SessionStart` never block on either failure mode.)
 
+### A `PostToolUse` logger that respects the unbounded result
+
+`toolResult` arrives whole, so a hook that appends it somewhere has to bound it itself. This one keeps a one-line-per-call audit trail with the result capped at 200 characters:
+
+```bash title="scripts/audit.sh"
+#!/usr/bin/env bash
+# PostToolUse audit trail. Never blocks — its exit status is ignored.
+set -euo pipefail
+
+payload="$(cat)"
+tool="$(jq -r '.tool.name // "?"' <<<"$payload")"
+# `toolResult` is NOT clipped by Stella: cap it here, not downstream.
+result="$(jq -r '(.toolResult // "") | .[0:200]' <<<"$payload" | tr '\n' ' ')"
+
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$tool" "$result" \
+  >> "${TMPDIR:-/tmp}/stella-tool-audit.tsv"
+```
+
+Wire it to every tool with a `"*"` matcher:
+
+```json title="~/.stella/settings.json"
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "./scripts/audit.sh", "timeoutMs": 2000 }
+        ]
+      }
+    ]
+  }
+}
+```
+
 <Callout type="warn">
-**Project-scope hooks are a trust boundary.** Hooks declared in a repository's project-scope file (`<workspace>/.stella/settings.json`) do **not** load unless you set `STELLA_PROJECT_HOOKS=1` — otherwise the merged hook set is rebuilt from the user and org-managed scopes alone, and a stderr notice names what was skipped. This stops a cloned repo from running arbitrary commands on your machine. Hooks in the user scope (`~/.stella/settings.json`) always load.
+**Project-scope hooks are a trust boundary.** Hooks declared in a repository's project-scope file (`<workspace>/.stella/settings.json`) do **not** load unless the repo is trusted — set `STELLA_TRUST_PROJECT=1`, or the legacy hooks-scoped `STELLA_PROJECT_HOOKS=1`. Either flag unlocks them; without one, the merged hook set is rebuilt from the user and org-managed scopes alone and a stderr notice names what was skipped. This stops a cloned repo from running arbitrary commands on your machine. Hooks in the user scope (`~/.stella/settings.json`) always load. See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
 </Callout>
 
 <Callout type="info">

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -23,107 +23,203 @@ Read-only also means **speculative-eligible**: the engine executes an all-read-o
 
 Tool names are their exact identifiers — the agent dispatches by name, and these are the names `stella tools` prints.
 
+<Callout type="info">
+This page is not maintained by hand. `stella-tools/tests/docs_in_sync.rs` asserts that every card below matches `catalog.rs` — the name, the access marker, and the counts. Adding a tool without documenting it fails the test suite by name.
+</Callout>
+
 ### Always available
 
 These 46 tools register in every session — no configuration, no prerequisites. Grouped by what they touch:
 
 #### Files
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `read_file` | Read a file, returned with 1-based line numbers; `offset`/`limit` read a range. | Read-only |
-| `read_symbol` | Read a named symbol's exact source span, resolved through the code graph — no line-offset guessing. Multiple definitions are listed (pick one with `path`), never silently chosen. | Read-only |
-| `write_file` | Create a file or overwrite an existing one — parent directories are created as needed. | Mutating |
-| `edit_file` | Replace an exact substring in a file — exactly-once by default, every occurrence with `replace_all`. | Mutating |
-| `apply_edits` | Apply a batch of exact-substring edits — across multiple files — in one transactional call: every edit validates first, and if any fails nothing is written. `dry_run` validates without writing. | Mutating |
-| `delete_file` | Delete a file — preferred over shelling out to `rm`, so the deletion lands in the file-touch audit log. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="read_file" access="read">
+    Read a file, returned with 1-based line numbers; `offset`/`limit` read a range.
+  </ToolCard>
+  <ToolCard name="read_symbol" access="read">
+    Read a named symbol's exact source span, resolved through the code graph — no line-offset guessing. Multiple definitions are listed (pick one with `path`), never silently chosen.
+  </ToolCard>
+  <ToolCard name="write_file" access="mutating">
+    Create a file or overwrite an existing one — parent directories are created as needed.
+  </ToolCard>
+  <ToolCard name="edit_file" access="mutating">
+    Replace an exact substring in a file — exactly-once by default, every occurrence with `replace_all`.
+  </ToolCard>
+  <ToolCard name="apply_edits" access="mutating">
+    Apply a batch of exact-substring edits — across multiple files — in one transactional call: every edit validates first, and if any fails nothing is written. `dry_run` validates without writing.
+  </ToolCard>
+  <ToolCard name="delete_file" access="mutating">
+    Delete a file — preferred over shelling out to `rm`, so the deletion lands in the file-touch audit log.
+  </ToolCard>
+</CardGrid>
 
 #### Search
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `grep` | Search file contents with a regex (ripgrep-backed when available); once the code-graph index exists, matches carry a code-map footer. | Read-only |
-| `glob` | Find files by glob pattern, returned as workspace-relative paths. | Read-only |
-| `graph_query` | Query the indexed code graph instead of grepping: definitions, references, imports, importers, or a file's full graph neighborhood. Registers every session and builds its own code-graph index on first use. | Read-only |
+<CardGrid size="md">
+  <ToolCard name="grep" access="read">
+    Search file contents with a regex (ripgrep-backed when available); once the code-graph index exists, matches carry a code-map footer.
+  </ToolCard>
+  <ToolCard name="glob" access="read">
+    Find files by glob pattern, returned as workspace-relative paths.
+  </ToolCard>
+  <ToolCard name="graph_query" access="read">
+    Query the indexed code graph instead of grepping: definitions, references, imports, importers, or a file's full graph neighborhood. Registers every session and builds its own code-graph index on first use.
+  </ToolCard>
+</CardGrid>
 
 #### Context &amp; memory
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `project_overview` | Orient in the workspace: languages, entry points, and layout, in one read-only pass. | Read-only |
-| `gather_context` | Run one deterministic context sweep — grep patterns + file globs + code-graph symbol lookups + bounded excerpts — in a single call, saved as a reusable context pack. | Read-only |
-| `explorations` | List saved codebase explorations, or read one back by slice. | Read-only |
-| `save_exploration` | Persist an end-to-end map of a codebase slice for other agents to reuse. | Mutating |
-| `save_memory` | Save a durable workspace lesson (gotcha, convention, failed approach) to `.stella/memories/` — loaded into every future session's prompt. | Mutating |
-| `cite_memory` | Cite a recalled memory that informed the turn (feeds the citation loop). | Mutating |
+<CardGrid size="md">
+  <ToolCard name="project_overview" access="read">
+    Orient in the workspace: languages, entry points, and layout, in one read-only pass.
+  </ToolCard>
+  <ToolCard name="gather_context" access="read">
+    Run one deterministic context sweep — grep patterns + file globs + code-graph symbol lookups + bounded excerpts — in a single call, saved as a reusable context pack.
+  </ToolCard>
+  <ToolCard name="explorations" access="read">
+    List saved codebase explorations, or read one back by slice.
+  </ToolCard>
+  <ToolCard name="save_exploration" access="mutating">
+    Persist an end-to-end map of a codebase slice for other agents to reuse.
+  </ToolCard>
+  <ToolCard name="save_memory" access="mutating">
+    Save a durable workspace lesson (gotcha, convention, failed approach) to `.stella/memories/` — loaded into every future session's prompt.
+  </ToolCard>
+  <ToolCard name="cite_memory" access="mutating">
+    Cite a recalled memory that informed the turn (feeds the citation loop).
+  </ToolCard>
+</CardGrid>
 
 #### Verify &amp; build
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `verify_done` | Prove a change is done: the test command must pass on the new code and fail on `git HEAD`. Runs in a shadow worktree and never edits your working tree. | Mutating |
-| `build_project` | Build the workspace with its own toolchain (cargo/npm/go/make), or a custom command. | Mutating |
-| `run_tests` | Run the project's tests with its own runner — `kind` picks unit/e2e/all, `filter` is runner-native, and `scope: "impacted"` runs only the tests reaching the working-tree change through the code graph's importer edges (TS/JS/Python today; falls back loudly to the full suite when selection is unavailable). | Mutating |
-| `diagnostics` | Fast typecheck: run the toolchain's native machine-readable check (`cargo check` / `tsc` / `eslint` / `ruff`) and return structured file:line:col diagnostics with severity and rule code, grouped by file. | Read-only |
-| `run_lint` | Run the project's own linter (cargo clippy, or the `lint` script); `fix` applies automatic fixes. | Mutating |
-| `format_code` | Run the project's own formatter (cargo fmt, or the `format` script); `check` verifies without rewriting. | Mutating |
-| `list_scripts` | List the verbs the project declares (Makefile targets, package.json scripts, cargo aliases) — the index `run_script` draws from. | Read-only |
-| `run_script` | Run a verb the project itself declares — a Makefile target, a package.json script, or a cargo alias — argv-style, never through a shell. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="verify_done" access="mutating">
+    Prove a change is done: the test command must pass on the new code and fail on `git HEAD`. Runs in a shadow worktree and never edits your working tree.
+  </ToolCard>
+  <ToolCard name="build_project" access="mutating">
+    Build the workspace with its own toolchain (cargo/npm/go/make), or a custom command.
+  </ToolCard>
+  <ToolCard name="run_tests" access="mutating">
+    Run the project's tests with its own runner — `kind` picks unit/e2e/all, `filter` is runner-native, and `scope: "impacted"` runs only the tests reaching the working-tree change through the code graph's importer edges (TS/JS/Python today; falls back loudly to the full suite when selection is unavailable).
+  </ToolCard>
+  <ToolCard name="diagnostics" access="read">
+    Fast typecheck: run the toolchain's native machine-readable check (`cargo check` / `tsc` / `eslint` / `ruff`) and return structured file:line:col diagnostics with severity and rule code, grouped by file.
+  </ToolCard>
+  <ToolCard name="run_lint" access="mutating">
+    Run the project's own linter (cargo clippy, or the `lint` script); `fix` applies automatic fixes.
+  </ToolCard>
+  <ToolCard name="format_code" access="mutating">
+    Run the project's own formatter (cargo fmt, or the `format` script); `check` verifies without rewriting.
+  </ToolCard>
+  <ToolCard name="list_scripts" access="read">
+    List the verbs the project declares (Makefile targets, package.json scripts, cargo aliases) — the index `run_script` draws from.
+  </ToolCard>
+  <ToolCard name="run_script" access="mutating">
+    Run a verb the project itself declares — a Makefile target, a package.json script, or a cargo alias — argv-style, never through a shell.
+  </ToolCard>
+</CardGrid>
 
 #### Process control
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `start_process` | Start a long-running process (dev server, REPL, watcher) from an argv vector — no shell — and get a handle for the other three. | Mutating |
-| `read_output` | Read a started process's buffered stdout+stderr since the last read, plus its running/exited state. | Mutating |
-| `send_stdin` | Write text to a started process's stdin (e.g. a REPL command). | Mutating |
-| `stop_process` | Stop a started process: SIGTERM to its process group, then SIGKILL; remaining output stays readable. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="start_process" access="mutating">
+    Start a long-running process (dev server, REPL, watcher) from an argv vector — no shell — and get a handle for the other three.
+  </ToolCard>
+  <ToolCard name="read_output" access="mutating">
+    Read a started process's buffered stdout+stderr since the last read, plus its running/exited state.
+  </ToolCard>
+  <ToolCard name="send_stdin" access="mutating">
+    Write text to a started process's stdin (e.g. a REPL command).
+  </ToolCard>
+  <ToolCard name="stop_process" access="mutating">
+    Stop a started process: SIGTERM to its process group, then SIGKILL; remaining output stays readable.
+  </ToolCard>
+</CardGrid>
 
 #### Shell
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `bash` | Run a shell command in the workspace root, with a timeout backstop. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="bash" access="mutating">
+    Run a shell command in the workspace root, with a timeout backstop.
+  </ToolCard>
+</CardGrid>
 
 #### Web
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `web_fetch` | Fetch a URL and read it as markdown, plain text, or raw HTML — links absolutized so the agent can follow them. | Read-only |
-| `web_extract_assets` | Fetch a page and mine its design assets — stylesheets, scripts, images, fonts, plus design tokens (colors, font families, custom properties, `@font-face`) distilled from the CSS. | Read-only |
-| `web_download` | Download a URL to a file inside the workspace (images, fonts, stylesheets, archives). | Mutating |
+<CardGrid size="md">
+  <ToolCard name="web_fetch" access="read">
+    Fetch a URL and read it as markdown, plain text, or raw HTML — links absolutized so the agent can follow them.
+  </ToolCard>
+  <ToolCard name="web_extract_assets" access="read">
+    Fetch a page and mine its design assets — stylesheets, scripts, images, fonts, plus design tokens (colors, font families, custom properties, `@font-face`) distilled from the CSS.
+  </ToolCard>
+  <ToolCard name="web_download" access="mutating">
+    Download a URL to a file inside the workspace (images, fonts, stylesheets, archives).
+  </ToolCard>
+</CardGrid>
 
 `web_search` is the one web tool with a prerequisite — a BYOK search key — so it sits in the next section.
 
 #### Git
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `repo_status` | Current branch, commits ahead/behind upstream, and the changed files as structured rows. | Read-only |
-| `repo_diff` | The pending changes as patch hunks plus a per-file +added/-removed summary — self-review before committing. Unstaged by default, `staged: true` for staged changes, optionally scoped to `paths`; the patch is capped with a loud elision marker. | Read-only |
-| `repo_commit` | Commit exactly the named paths — there is no stage-everything mode. | Mutating |
-| `repo_push` | Push the current (or named) branch; structurally refuses the default branch, and force-push does not exist here. | Mutating |
-| `repo_pull` | Update the current branch from upstream, fast-forward only — never merges or rewrites. | Mutating |
-| `repo_rollback` | Restore exactly the named paths to their last committed state; history itself is never rewritten. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="repo_status" access="read">
+    Current branch, commits ahead/behind upstream, and the changed files as structured rows.
+  </ToolCard>
+  <ToolCard name="repo_diff" access="read">
+    The pending changes as patch hunks plus a per-file +added/-removed summary — self-review before committing. Unstaged by default, `staged: true` for staged changes, optionally scoped to `paths`; the patch is capped with a loud elision marker.
+  </ToolCard>
+  <ToolCard name="repo_commit" access="mutating">
+    Commit exactly the named paths — there is no stage-everything mode.
+  </ToolCard>
+  <ToolCard name="repo_push" access="mutating">
+    Push the current (or named) branch; structurally refuses the default branch, and force-push does not exist here.
+  </ToolCard>
+  <ToolCard name="repo_pull" access="mutating">
+    Update the current branch from upstream, fast-forward only — never merges or rewrites.
+  </ToolCard>
+  <ToolCard name="repo_rollback" access="mutating">
+    Restore exactly the named paths to their last committed state; history itself is never rewritten.
+  </ToolCard>
+</CardGrid>
 
 #### CI &amp; media
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `ci_status` | Inspect CI runs and failure-log tails for a branch, PR, or commit via `gh`; `wait` blocks until the latest run finishes. | Read-only |
-| `screenshot` | Capture the screen to a PNG in `.stella/screenshots/` as verification evidence. | Mutating |
-| `generate_svg` | Validate, sanitize, and save an SVG the agent authored into `.stella/artifacts/` — scripts, event handlers, and external references are stripped. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="ci_status" access="read">
+    Inspect CI runs and failure-log tails for a branch, PR, or commit via `gh`; `wait` blocks until the latest run finishes.
+  </ToolCard>
+  <ToolCard name="screenshot" access="mutating">
+    Capture the screen to a PNG in `.stella/screenshots/` as verification evidence.
+  </ToolCard>
+  <ToolCard name="generate_svg" access="mutating">
+    Validate, sanitize, and save an SVG the agent authored into `.stella/artifacts/` — scripts, event handlers, and external references are stripped.
+  </ToolCard>
+</CardGrid>
 
 #### Task board
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `task_create` | Add a task to the session task board — one per concrete deliverable, created before multi-step work starts. | Mutating |
-| `task_list` | Show the board: every task as `[status] #id subject (owner)`. | Read-only |
-| `task_start` | Mark a board task in-progress — exactly one at a time. | Mutating |
-| `task_complete` | Mark a board task completed the moment its work is done and verified. | Mutating |
-| `task_cancel` | Cancel a task that is no longer worth doing, with a reason; the row stays as an audit trail. | Mutating |
-| `task_assign` | Delegate a board task to a parallel sub-agent — the briefing is passed verbatim, so write it self-contained. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="task_create" access="mutating">
+    Add a task to the session task board — one per concrete deliverable, created before multi-step work starts.
+  </ToolCard>
+  <ToolCard name="task_list" access="read">
+    Show the board: every task as `[status] #id subject (owner)`.
+  </ToolCard>
+  <ToolCard name="task_start" access="mutating">
+    Mark a board task in-progress — exactly one at a time.
+  </ToolCard>
+  <ToolCard name="task_complete" access="mutating">
+    Mark a board task completed the moment its work is done and verified.
+  </ToolCard>
+  <ToolCard name="task_cancel" access="mutating">
+    Cancel a task that is no longer worth doing, with a reason; the row stays as an audit trail.
+  </ToolCard>
+  <ToolCard name="task_assign" access="mutating">
+    Delegate a board task to a parallel sub-agent — the briefing is passed verbatim, so write it self-contained.
+  </ToolCard>
+</CardGrid>
 
 <Callout type="info">
 `verify_done` and `screenshot` are **mutating** in the permission model (`read_only: false`) even though `verify_done` never edits your working tree and `screenshot` only writes into `.stella/`. `web_download` is mutating for the same reason — it writes a file.
@@ -135,20 +231,44 @@ The read-only partition is exactly: `read_file`, `read_symbol`, `grep`, `glob`, 
 
 These appear only when their prerequisite is met. A prerequisite is something the **environment** supplies — a key, a backend — never a default someone has to discover. Turning an available tool *off* is a separate thing, covered under [Switching tools off](#switching-tools-off).
 
-| Tool | Description | Access | Appears when |
-| --- | --- | --- | --- |
-| `web_search` | Search the web and get ranked results (title, URL, snippet). | Read-only | A BYOK search key is present (`BRAVE_API_KEY` or `TAVILY_API_KEY`) — the other three web tools need no key. |
-| `generate_image` | Generate an image from a text prompt into `.stella/artifacts/`. | Mutating | An image-capable BYOK provider key is configured. |
-| `generate_video` | Submit an asynchronous text-to-video job. Video costs real money: any job with a positive estimated cost is denied unless `confirm_spend` is true. | Mutating | The configured media provider has a **video** adapter — an image-only key registers `generate_image` without the video pair. |
-| `poll_video` | Poll a video job, reconciling its state live against the provider. | Mutating | Same video-adapter condition as `generate_video`. |
-| `create_issue` | Create an issue (title, body, labels, assignee, Linear team). Labels and assignees must exist — search them first. | Mutating | An issue backend is configured (see below). |
-| `update_issue` | Update title/body, comment, change status, add labels, set the assignee — any combination. | Mutating | An issue backend is configured. |
-| `close_issue` | Close an issue, optionally with a closing comment. | Mutating | An issue backend is configured. |
-| `search_issues` | Search or list issues, with state/assignee/label filters. | Read-only | An issue backend is configured. |
-| `get_issue` | Read one issue in full, including its comment thread. | Read-only | An issue backend is configured. |
-| `list_labels` | Search labels by substring — no guessing exact names. | Read-only | An issue backend is configured. |
-| `list_members` | Search assignable people by login, name, or email substring. | Read-only | An issue backend is configured. |
-| `start_work_on_issue` | Move an issue to in-progress and create or check out its branch. | Mutating | An issue backend is configured. |
+<CardGrid size="md">
+  <ToolCard name="web_search" access="read" when="a BYOK search key is present — BRAVE_API_KEY or TAVILY_API_KEY. The other three web tools need no key.">
+    Search the web and get ranked results (title, URL, snippet).
+  </ToolCard>
+  <ToolCard name="generate_image" access="mutating" when="an image-capable BYOK provider key is configured.">
+    Generate an image from a text prompt into `.stella/artifacts/`.
+  </ToolCard>
+  <ToolCard name="generate_video" access="mutating" when="the configured media provider has a video adapter — an image-only key registers generate_image without the video pair.">
+    Submit an asynchronous text-to-video job. Video costs real money: any job with a positive estimated cost is denied unless `confirm_spend` is true.
+  </ToolCard>
+  <ToolCard name="poll_video" access="mutating" when="the same video-adapter condition as generate_video.">
+    Poll a video job, reconciling its state live against the provider.
+  </ToolCard>
+  <ToolCard name="create_issue" access="mutating" when="an issue backend is configured.">
+    Create an issue (title, body, labels, assignee, Linear team). Labels and assignees must exist — search them first.
+  </ToolCard>
+  <ToolCard name="update_issue" access="mutating" when="an issue backend is configured.">
+    Update title/body, comment, change status, add labels, set the assignee — any combination.
+  </ToolCard>
+  <ToolCard name="close_issue" access="mutating" when="an issue backend is configured.">
+    Close an issue, optionally with a closing comment.
+  </ToolCard>
+  <ToolCard name="search_issues" access="read" when="an issue backend is configured.">
+    Search or list issues, with state/assignee/label filters.
+  </ToolCard>
+  <ToolCard name="get_issue" access="read" when="an issue backend is configured.">
+    Read one issue in full, including its comment thread.
+  </ToolCard>
+  <ToolCard name="list_labels" access="read" when="an issue backend is configured.">
+    Search labels by substring — no guessing exact names.
+  </ToolCard>
+  <ToolCard name="list_members" access="read" when="an issue backend is configured.">
+    Search assignable people by login, name, or email substring.
+  </ToolCard>
+  <ToolCard name="start_work_on_issue" access="mutating" when="an issue backend is configured.">
+    Move an issue to in-progress and create or check out its branch.
+  </ToolCard>
+</CardGrid>
 
 <Callout type="info">
 The issue backend resolves in precedence order: `LINEAR_API_KEY` env → a stored **Linear** connection (`stella connect linear`) → a stored **GitHub** connection (`stella connect github`, runs over REST with no `gh` CLI needed) → ambient `gh` CLI auth. If none is available, no issue tools are registered at all. See [stella connect](/docs/commands/connect).
@@ -168,7 +288,27 @@ Every tool ships **on**, `bash` and the web family included. The one way to turn
 }
 ```
 
-A key is a **tool name**, a **group name** (the family headings above — `file`, `search`, `process`, `repo`, `web`, `bash`, `task`, …, plus `mcp` and `custom` for tools the built-in catalog has never heard of), or `"*"` for everything. Most specific wins: name beats group beats `"*"`, and anything unmentioned is on. So `{"*": "off", "read_file": "on"}` is a read-only agent in two lines, and `{"process": "off", "read_output": "on"}` keeps exactly one of the four process tools.
+A key is a **tool name**, a **group name** (the family headings above — `file`, `search`, `process`, `repo`, `web`, `bash`, `task`, …, plus `mcp` and `custom` for tools the built-in catalog has never heard of), or `"*"` for everything. Most specific wins: name beats group beats `"*"`, and anything unmentioned is on.
+
+Two recipes that fall out of that rule:
+
+```json title="A read-only agent, in two lines"
+{
+  "tools": {
+    "*": "off",
+    "read_file": "on"
+  }
+}
+```
+
+```json title="Keep exactly one of the four process tools"
+{
+  "tools": {
+    "process": "off",
+    "read_output": "on"
+  }
+}
+```
 
 A switched-off tool is **withheld from the schema list and refused if called anyway** — the refusal reads like the unknown-tool error, so a disabled tool is indistinguishable from one that was never built. Enforcement is at the tool boundary, not by prompt discipline.
 
@@ -178,13 +318,11 @@ Scopes merge per key (project beats user), with one asymmetry: an **org-managed*
 
 The web family gives the agent the open internet: search, fetch-and-read, asset extraction, and download. It powers things like *"build me a design system based on this site"* or *"read this article and summarize it."*
 
-Three tools register with **no key required**:
+Three of the four register with **no key required** — `web_fetch`, `web_extract_assets`, and `web_download`, all listed above. Worth knowing beyond their one-line summaries:
 
-| Tool | What it does | Access |
-| --- | --- | --- |
-| `web_fetch` | Fetch a URL and read it. HTML renders as markdown (default), plain `text`, or raw `html`; links and images come back absolute so the agent can follow them. Binary responses are reported, not dumped — use `web_download` for those. | Read-only |
-| `web_extract_assets` | Fetch a page and mine its design assets: external + inline stylesheets, scripts, images, preloaded fonts, and **design tokens distilled from the CSS** — colors and font families ranked by frequency, CSS custom properties, and `@font-face` families with their source files. The starting point for reconstructing a site's design system. | Read-only |
-| `web_download` | Download a URL to a workspace-relative path (confined to the workspace root, audited in the file-touch ledger like `write_file`). Assets belong under `.stella/artifacts/web/`. | Mutating |
+- **`web_fetch`** renders HTML as markdown by default, or returns plain `text` or raw `html`. Links and images come back absolute so the agent can follow them. A binary response is reported, not dumped — use `web_download` for those.
+- **`web_extract_assets`** distills **design tokens from the CSS**: colors and font families ranked by frequency, CSS custom properties, and `@font-face` families with their source files. It is the starting point for reconstructing a site's design system.
+- **`web_download`** is confined to the workspace root and audited in the file-touch ledger exactly like `write_file`. Assets belong under `.stella/artifacts/web/`.
 
 `web_search` registers additionally when a **BYOK search key** is present — `BRAVE_API_KEY` (a dedicated web-search API) or `TAVILY_API_KEY`. Without a key the other three still work; you just fetch URLs you already know.
 
@@ -208,6 +346,11 @@ authorization = "Bearer …"
 X-Tenant = "acme"
 ```
 
+```bash
+# Lock it down — it holds live session secrets.
+chmod 600 ~/.stella/web_auth.toml
+```
+
 <Callout type="warn">
 `web_auth.toml` holds live session secrets — treat it like `credentials.toml`. Stella redacts the values from its own logs and never echoes them into a tool result, but the file itself is plaintext: restrict it to owner-only (`chmod 600`). Unknown keys are a hard parse error, and a broken file makes every web tool fail loudly rather than silently fetching unauthenticated. `cookie` and `authorization` are dropped on a cross-host redirect; a secret in a custom `headers` entry is **not** — it would follow the redirect, so only put secrets in custom headers for hosts you trust to redirect.
 </Callout>
@@ -220,25 +363,49 @@ X-Tenant = "acme"
 
 The CLI layers **six** more tools on top of the native registry. Three belong to interactive sessions:
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `ask_user` | Ask the user a multiple-choice question when a decision is genuinely theirs to make — 2–6 short options, and the UI always adds a free-text option. In a headless run it returns a named error instead of hanging on stdin. | Mutating |
-| `search_skills` | Search the public skills registry for reusable agent [skills](/docs/agent-tools/skills) matching a topic. | Read-only |
-| `install_skill` | Install a skill from the registry into the project's `.stella/skills/` — always asks for confirmation first. | Mutating |
+<CardGrid size="md">
+  <ToolCard name="ask_user" access="mutating">
+    Ask the user a multiple-choice question when a decision is genuinely theirs to make — 2–6 short options, and the UI always adds a free-text option. In a headless run it returns a named error instead of hanging on stdin.
+  </ToolCard>
+  <ToolCard name="search_skills" access="read">
+    Search the public skills registry for reusable agent [skills](/docs/agent-tools/skills) matching a topic.
+  </ToolCard>
+  <ToolCard name="install_skill" access="mutating">
+    Install a skill from the registry into the project's `.stella/skills/` — always asks for confirmation first.
+  </ToolCard>
+</CardGrid>
 
 ### Discovery tools
 
 The other three session tools are read-only **discovery** tools layered over the whole catalog. They exist so the agent never needs the entire tool, skill, and MCP surface frontloaded: a workspace can carry hundreds of tools and thousands of installed skills, and the agent finds the best fit on demand instead of carrying all of it in every prompt.
 
-| Tool | Description | Access |
-| --- | --- | --- |
-| `tool_search` | Search every tool available this session — built-ins, `mcp__<server>__<tool>` MCP tools, custom tools — ranked by fit. Queries are keywords (`issue tracking`), `+required` terms (`+github pr`), or `select:name1,name2` for exact lookup. | Read-only |
-| `skill_search` | Search the skills **installed** in this workspace (`.stella/skills/` plus the user-global directory), ranked by fit. `include_body: true` also returns the best match's full instructions. Complements `search_skills`, which queries the public registry for skills you'd still have to install. | Read-only |
-| `mcp_search` | Find MCP servers and their tools: the workspace's configured servers (default scope), or the public MCP registry (`scope: "registry"`) for servers worth installing with `stella mcp install <name>`. | Read-only |
+<CardGrid size="md">
+  <ToolCard name="tool_search" access="read">
+    Search every tool available this session — built-ins, `mcp__<server>__<tool>` MCP tools, custom tools — ranked by fit. Queries are keywords (`issue tracking`), `+required` terms (`+github pr`), or `select:name1,name2` for exact lookup.
+  </ToolCard>
+  <ToolCard name="skill_search" access="read">
+    Search the skills **installed** in this workspace (`.stella/skills/` plus the user-global directory), ranked by fit. `include_body: true` also returns the best match's full instructions. Complements `search_skills`, which queries the public registry for skills you'd still have to install.
+  </ToolCard>
+  <ToolCard name="mcp_search" access="read">
+    Find MCP servers and their tools: the workspace's configured servers (default scope), or the public MCP registry (`scope: "registry"`) for servers worth installing with `stella mcp install <name>`.
+  </ToolCard>
+</CardGrid>
 
 #### Lean frontloading (experimental)
 
-Set `STELLA_LEAN_TOOLS=1` to advertise only a lean core toolset (file CRUD, search, build/test/verify, `ask_user`, and `bash`) plus the discovery tools; everything else stays out of the prompt until a `tool_search` surfaces it. Matched tools are *activated* — advertised for the rest of the session. Set the variable to a comma-separated list of tool names to choose your own core. A hidden tool called by name still executes, so lean mode trims prompt weight without ever gating a capability.
+Set `STELLA_LEAN_TOOLS=1` to advertise only a lean core toolset plus the discovery tools; everything else stays out of the prompt until a `tool_search` surfaces it.
+
+```bash
+# Trim the prompt to the core eleven plus the discovery tools.
+STELLA_LEAN_TOOLS=1 stella run "wire up the new webhook handler"
+
+# Or choose your own core — a comma-separated list replaces the default.
+STELLA_LEAN_TOOLS=read_file,grep,glob,bash stella run "audit the config loader"
+```
+
+The default core is exactly eleven tools: `read_file`, `write_file`, `edit_file`, `grep`, `glob`, `gather_context`, `build_project`, `run_tests`, `verify_done`, `bash`, and `ask_user`. Note what is *not* in it — `delete_file` and `apply_edits` are absent, so lean mode is read/write/edit rather than full file CRUD.
+
+Matched tools are *activated* — advertised for the rest of the session. A hidden tool called by name still executes, so lean mode trims prompt weight without ever gating a capability.
 
 All told: 46 always-on tools, up to 58 native tools with the code graph, media keys, a search key, and an issue backend, plus the six session tools — before any custom script tools or MCP servers merge in.
 

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -9,23 +9,50 @@ Stella can connect to [Model Context Protocol](https://modelcontextprotocol.io) 
 
 MCP servers are configured in `.stella/mcp.toml` in your workspace. Stella connects to each configured server at **session start** and merges the tools it exposes into the agent, alongside the [built-in tools](/docs/agent-tools) and any custom tools.
 
-The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) command family — `stella mcp search <query>` to find one in the registry, then `stella mcp install <name>` to write the `.stella/mcp.toml` entry for you (no hand-editing). `stella mcp list` shows what's configured, and `stella mcp remove <name>` drops one.
+The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) command family — no hand-editing:
 
-Because the tools are added at session start, connecting a new server takes effect on your next session.
+```bash
+stella mcp search github          # find one in the registry
+stella mcp install github         # write the .stella/mcp.toml entry
+stella mcp list                   # what's configured, and which have credentials
+stella mcp usage                  # per-server, per-tool call counts from local telemetry
+stella mcp remove github          # drop one
+```
+
+Enabling and disabling a server is deliberately *not* a CLI verb: it is session-scoped (it changes a running conversation's tool set), so it lives in the deck's MCP tab (`/mcp`).
+
+Because the tools are added at session start, connecting a new server takes effect on your next session. Each server gets a **10-second** connect budget, and connects are isolated per server — one that hangs or fails is recorded and skipped, it does not take the session down.
 
 <Callout type="warn">
 `stella tools` does **not** enumerate MCP tools — it prints a note that MCP servers merge more tools at session start. Confirm a server is wired up with `stella mcp list`, or verify its tools from inside a session (the deck's MCP tab, `/mcp`).
 </Callout>
 
+## `.stella/mcp.toml` is behind the project trust boundary
+
+<Callout type="warn">
+  A repo's `.stella/mcp.toml` is **not loaded** until you trust the repo. An entry can
+  name an arbitrary `cmd` that runs at session start — the `git clone && stella`
+  remote-execution hole — or an attacker-controlled `url` that workspace content gets
+  sent to, which is the same risk class as [project hooks](/docs/agent-tools/hooks).
+  Untrusted, Stella connects nothing and prints the reason once. Opt in per repo:
+
+  ```bash
+  export STELLA_TRUST_PROJECT=1
+  ```
+
+  Scope it with direnv or a shell-profile guard rather than exporting it globally, and
+  see the [trust boundary](/docs/configuration/settings#the-project-trust-boundary) for
+  what else the flag governs.
+</Callout>
+
 ## Example configuration
 
-```toml
-# .stella/mcp.toml
-
+```toml title=".stella/mcp.toml"
 [servers.filesystem]
 transport = "stdio"
 cmd = "npx"
 args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+env = { LOG_LEVEL = "info" }
 
 [servers.github]
 transport = "http"
@@ -33,16 +60,45 @@ url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer …" }
 ```
 
-A server entry needs a `transport` discriminant — `stdio` or `http`:
+A server entry needs a `transport` discriminant — `stdio` or `http` — and the remaining fields follow from it:
 
-- **`stdio`** — `cmd` is the executable and `args` its arguments; Stella launches the child process and speaks JSON-RPC over its stdio.
-- **`http`** — `url` is a streamable-HTTP endpoint Stella POSTs JSON-RPC to; the optional `headers` table holds static headers replayed on every request (an `Authorization` bearer, an API key). Header values are written to `mcp.toml` verbatim but redacted from logs and debug output.
+<CardGrid size="md">
+  <OptionCard name="transport" required>
+    `stdio` or `http`. The discriminant; everything else in the entry depends
+    on it.
+  </OptionCard>
+  <OptionCard name="cmd">
+    stdio only, required there. The executable Stella launches, speaking
+    JSON-RPC over the child's stdio.
+  </OptionCard>
+  <OptionCard name="args" defaultValue="[]">
+    stdio only. Arguments passed to `cmd`.
+  </OptionCard>
+  <OptionCard name="env" defaultValue="{}">
+    stdio only. The variables the child receives — see the scrub note below.
+  </OptionCard>
+  <OptionCard name="url">
+    http only, required there. A streamable-HTTP endpoint Stella POSTs JSON-RPC
+    to.
+  </OptionCard>
+  <OptionCard name="headers" defaultValue="{}">
+    http only. Static headers replayed on every request (an `Authorization`
+    bearer, an API key). Values are written to `mcp.toml` verbatim but redacted
+    from logs and debug output.
+  </OptionCard>
+  <OptionCard name="candidate_safe" defaultValue="false">
+    Opt this server into Best-of-N candidate runs — see
+    [below](#mcp-in-best-of-n-candidates). Never inferred, always human-set.
+  </OptionCard>
+</CardGrid>
 
-Either way, Stella merges the tools the server reports for the session.
+Either way, Stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide, and the entry's name in `mcp.toml` is what shows up in the middle segment.
 
 <Callout type="warn">
-A stdio MCP subprocess runs with a **scrubbed environment** — ambient shell variables (including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`) are **not** inherited. Any variable the server needs must be listed explicitly in the entry's `env` table, e.g. `env = { GITHUB_TOKEN = "…" }`.
+A stdio MCP subprocess runs with a **scrubbed environment** — ambient shell variables (including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`) are **not** inherited. Any variable the server needs must be listed explicitly in the entry's `env` table, e.g. `env = { GITHUB_TOKEN = "…" }`. The single exception is `PATH`, which is inherited so a bare runner (`npx`, `uvx`, `docker`) can resolve at all; an `env` entry named `PATH` overrides it.
 </Callout>
+
+For an HTTP server that speaks OAuth rather than a static bearer, `stella mcp login <name>` runs the browser flow and stores the tokens in a workspace-owned, owner-only token store instead of in `mcp.toml`; `stella mcp logout <name>` forgets them.
 
 <Callout type="info">
 MCP tools are treated like any other tool once merged in: they follow the [per-tool permission model](/docs/agent-tools/permissions) and their calls can be gated or blocked with a [`PreToolUse` hook](/docs/agent-tools/hooks).
@@ -62,9 +118,7 @@ The servers worth sharing — read-only, external context that doesn't depend
 on which tree it's called from (docs/web search, a code graph, GitHub/Linear
 reads) — opt in explicitly per server:
 
-```toml
-# .stella/mcp.toml
-
+```toml title=".stella/mcp.toml"
 [servers.docs]
 transport = "http"
 url = "https://docs.example.com/mcp"

--- a/website/content/docs/agent-tools/permissions.mdx
+++ b/website/content/docs/agent-tools/permissions.mdx
@@ -5,6 +5,10 @@ description: How Stella's per-tool permission model separates read-only tools fr
 
 Every tool the agent can call — built-in, [custom](/docs/agent-tools/custom-tools), or provided by an [MCP server](/docs/agent-tools/mcp) — has a per-tool permission model. This is what lets Stella treat a harmless file read differently from a shell command that can change your system.
 
+<PermissionGateDiagram />
+
+Both exits are real outcomes: an allowed call executes and then fires `PostToolUse`, and a refused one is returned to the model as a refusal it can read and react to. The decision happens at the tool boundary — never by asking the model nicely in a prompt.
+
 ## Read-only vs. mutating tools
 
 Tools fall into two categories:
@@ -28,7 +32,7 @@ This gives you a programmable gate in front of any tool. A `PreToolUse` hook's m
 For blocking by pattern without a hook script, Stella also has native workspace-rule guards enforced at the tool boundary: `guard-tool` (deny a tool), `guard-deny-command` (a glob over the `bash` command), and `guard-deny-path` (a glob over a file tool's path). A rule such as `guard-deny-command: "git push --force*"` is hard-enforced per invocation.
 </Callout>
 
-```json
+```json title="~/.stella/settings.json"
 {
   "hooks": {
     "PreToolUse": [
@@ -53,11 +57,18 @@ For the full hook model — events, matchers, timeouts, and the JSON payload del
 
 Hooks and guard rules decide *whether* a command runs. An OS sandbox bounds what it can reach once it does — the difference that matters when instructions hidden in a file the agent read steer the model into running something you never asked for. `STELLA_BASH_SANDBOX` turns it on for the [`bash`](/docs/agent-tools#shell) tool:
 
-| Setting | Effect |
-| --- | --- |
-| `STELLA_BASH_SANDBOX=off` (the default) | No sandbox. `bash` runs with your own privileges. |
-| `STELLA_BASH_SANDBOX=workspace-write` | File writes confined to the workspace root plus the standard tmp directories. Reads and network are unrestricted. |
-| `STELLA_BASH_SANDBOX=restricted` | Everything `workspace-write` does, plus a blanket network denial. |
+<CardGrid size="md">
+  <OptionCard name="STELLA_BASH_SANDBOX=off">
+    No sandbox. `bash` runs with your own privileges. This is the shipped default.
+  </OptionCard>
+  <OptionCard name="STELLA_BASH_SANDBOX=workspace-write">
+    File writes confined to the workspace root plus the standard tmp directories. Reads and
+    network are unrestricted.
+  </OptionCard>
+  <OptionCard name="STELLA_BASH_SANDBOX=restricted">
+    Everything `workspace-write` does, plus a blanket network denial.
+  </OptionCard>
+</CardGrid>
 
 ```bash
 STELLA_BASH_SANDBOX=workspace-write stella run "run the migration and fix what breaks"

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -24,14 +24,49 @@ domains: [build, ci]
 ```
 
 Both layouts are accepted: nested `<slug>/SKILL.md` (the ecosystem layout)
-or a flat `<slug>.md`.
+or a flat `<slug>.md`. The frontmatter fields:
+
+<CardGrid size="md">
+  <OptionCard name="name" defaultValue="the filename stem, or the directory name">
+    The skill's slug — also the ⚡ slash command it registers.
+  </OptionCard>
+  <OptionCard name="description" required>
+    One line on what the skill is for. Unlike a command or an agent, a skill
+    has **no fallback** here: a `SKILL.md` without a description is skipped
+    with a diagnostic, because the description is what selection matches
+    against.
+  </OptionCard>
+  <OptionCard name="domains" defaultValue="[]">
+    Domain tags from `.stella/domains.toml`, used by selection alongside the
+    lexical match.
+  </OptionCard>
+  <OptionCard name="body" required>
+    The know-how itself. An empty body is skipped with a diagnostic.
+  </OptionCard>
+</CardGrid>
 
 ## Scopes and precedence
 
-| Scope | Path | Travels with |
-| --- | --- | --- |
-| Project | `<workspace>/.stella/skills/` | The repo — commit it, the team shares it |
-| User | `~/.stella/skills/` | You, across every workspace |
+<CardGrid size="md">
+  <SpecCard
+    title="Project"
+    meta={[
+      { label: "Path", value: "<workspace>/.stella/skills/" },
+      { label: "Travels with", value: "the repo", mono: false },
+    ]}
+  >
+    Commit it and the team shares the playbook.
+  </SpecCard>
+  <SpecCard
+    title="User"
+    meta={[
+      { label: "Path", value: "~/.stella/skills/" },
+      { label: "Travels with", value: "you, across every workspace", mono: false },
+    ]}
+  >
+    Your own conventions, in every repo you open.
+  </SpecCard>
+</CardGrid>
 
 When both scopes define the same name, **project wins** for recall; the
 SKILLS tab lists both.
@@ -51,10 +86,19 @@ SKILLS tab lists both.
 ## Versions and pinning
 
 Every edit bumps a version: history lives under `<slug>/versions/vN/SKILL.md`,
-and a state sidecar (`.stella-skills.json`) tracks which version is
-**pinned** (active) and which skills are **disabled** (kept on disk,
-excluded from recall). Pin an older version to roll back without losing the
-newer one.
+and a per-scope state sidecar tracks which version is **pinned** (active) and
+which skills are **disabled** (kept on disk, excluded from recall). Pin an
+older version to roll back without losing the newer one.
+
+```text
+<skills-dir>/<slug>/SKILL.md              ← the loaded definition
+<skills-dir>/<slug>/versions/v1/SKILL.md  ← immutable version snapshots
+<skills-dir>/<slug>/versions/v2/SKILL.md
+<skills-dir>/.stella-skills.json          ← { "disabled": [...], "pins": { "<slug>": 2 } }
+```
+
+No pin entry means the latest version. The sidecar is dot-prefixed so the
+recall walk — which reads only `*.md` and `<slug>/SKILL.md` — never sees it.
 
 ## Searching installed skills
 
@@ -82,14 +126,33 @@ The underlying commands are overridable (`STELLA_SKILLS_SEARCH_CMD`,
 
 `/skills` opens the SKILLS tab:
 
-| Key | Does |
-| --- | --- |
-| `space` | Enable / disable the selected skill |
-| `e` | Edit (saves as a new version and pins it) |
-| `p` | Pin a specific version |
-| `n` | Create a new skill (LLM-drafted from a description) |
-| `ctrl+x` ×2 | Uninstall |
-| `←` / `→` | Switch panes (installed ↔ search) |
+<CardGrid size="sm">
+  <OptionCard name="space">
+    Enable / disable the selected skill. A disabled skill stays on disk and
+    drops out of recall.
+  </OptionCard>
+  <OptionCard name="ctrl+o">
+    Preview the highlighted skill's body in a modal overlay — installed pane
+    and registry pane both.
+  </OptionCard>
+  <OptionCard name="e">
+    Edit. Saving always writes a new version and pins it; no prior version is
+    modified or deleted.
+  </OptionCard>
+  <OptionCard name="p">
+    Pin a specific version — the rollback control. Pinning never creates a
+    version.
+  </OptionCard>
+  <OptionCard name="n">
+    Create a new skill, LLM-drafted from a description.
+  </OptionCard>
+  <OptionCard name="ctrl+x ×2">
+    Uninstall — delete from disk. The first press arms it, the second commits.
+  </OptionCard>
+  <OptionCard name="← / →">
+    Switch panes: installed ↔ registry search.
+  </OptionCard>
+</CardGrid>
 
 `/context` shows which skills (and MCP servers) are active in the current
 session.

--- a/website/content/docs/api-providers/anthropic.mdx
+++ b/website/content/docs/api-providers/anthropic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-description: Claude over the native Anthropic Messages API — extended thinking mapped from Stella's effort tiers, first-class prompt caching, and claude-fable-5 as the default model.
+description: Claude over the native Anthropic Messages API — adaptive thinking, effort as a first-class control, no sampling parameters, first-class prompt caching, and claude-fable-5 as the default model.
 icon: anthropic
 ---
 
@@ -30,6 +30,8 @@ env var Stella reads with `providers.anthropic.api_key_env` — see
 The provider id is `anthropic`; the default model is `claude-fable-5`.
 
 ```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+
 stella --model anthropic/claude-fable-5 run "refactor the session store"
 export STELLA_MODEL=anthropic/claude-fable-5   # pin for the whole shell
 ```
@@ -56,12 +58,60 @@ the settings value. User scope shown deliberately: in a project's
 
 ## Reasoning and sampling
 
-Stella's reasoning setting maps to Anthropic **extended thinking**, with a thinking-token
-budget tiered by [effort](/docs/configuration/agent-engine-config) — a higher effort buys
-a larger budget. One API rule to know: while thinking is enabled, `temperature` is
-**omitted** from the request — the Messages API does not accept both, and Stella complies
-rather than erroring. Set `reasoning: "off"` for an agent if you need temperature control
-back.
+`claude-fable-5` speaks Anthropic's **adaptive** thinking shape, and Stella sends it that
+way. There is no budget to tier and no budget to tune:
+
+<CardGrid size="md">
+  <OptionCard name="reasoning">
+    `on` sends `thinking: {"type": "adaptive"}` — the model decides its own depth per
+    turn, with no budget field. `off` omits the `thinking` block entirely.
+  </OptionCard>
+  <OptionCard name="effort" defaultValue="the API's own default (high)">
+    Sent as `output_config.effort`, one of `low`, `medium`, `high`, `xhigh`, `max` —
+    all five map 1:1, no collapsing. Effort is an independent control: it is forwarded
+    whenever you pin one, whether or not thinking is on.
+  </OptionCard>
+  <OptionCard name="params.max_tokens" defaultValue="32000 with thinking on, 4096 with it off">
+    Adaptive thinking spends from the **same** output allowance as the answer, so the
+    ceiling rises when thinking is on — a max-effort judge would otherwise truncate
+    mid-verdict and return empty text. A value you set is honored as-is.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="warn">
+  `temperature`, `top_p`, and `top_k` are **never** sent to this model family —
+  regardless of your reasoning setting. Claude 4.6 and the 5-line answer any sampling
+  parameter with an HTTP 400, so Stella omits them unconditionally rather than letting a
+  run die on the wire. Turning `reasoning` off does not buy temperature control back;
+  there is no setting on this provider that does.
+</Callout>
+
+Older generations — Claude 4.5 and below — still use the legacy
+`thinking: {"type": "enabled", "budget_tokens": N}` shape and do accept sampling
+parameters. Stella classifies by model id and sends whichever shape that generation
+requires, so pinning an older snapshot needs no configuration change.
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Maximum depth for a judging pass over a large diff.
+stella --model anthropic/claude-fable-5 run "review the auth refactor as a strict judge"
+```
+
+```json title="~/.stella/settings.json"
+{
+  "agent_engine_config": {
+    "agents": {
+      "judge": {
+        "provider": "anthropic",
+        "model": "claude-fable-5",
+        "reasoning": "on",
+        "effort": "max"
+      }
+    }
+  }
+}
+```
 
 ## Prompt caching
 

--- a/website/content/docs/api-providers/bedrock.mdx
+++ b/website/content/docs/api-providers/bedrock.mdx
@@ -20,19 +20,46 @@ export AWS_SESSION_TOKEN="..."          # optional — for STS / SSO sessions
 export AWS_REGION="us-east-1"           # or AWS_DEFAULT_REGION; us-east-1 is the default
 ```
 
-`AWS_REGION` wins over `AWS_DEFAULT_REGION` when both are set; with neither, Stella uses
-`us-east-1`. Short-lived STS or SSO credentials work as long as `AWS_SESSION_TOKEN`
-accompanies them. Your IAM principal needs Bedrock invoke permissions for the models you
-call, and the models must be enabled in your account's Bedrock console.
+Short-lived STS or SSO credentials work as long as `AWS_SESSION_TOKEN` accompanies them.
+Your IAM principal needs Bedrock invoke permissions for the models you call, and the
+models must be enabled in your account's Bedrock console.
 
 <Callout type="warn">
-  Stella reads **only these explicit env vars** — it does not consult the AWS credential
-  chain. `AWS_PROFILE`, `~/.aws/credentials`, the SSO token cache, and IMDS/instance
-  roles are never read. If your setup is profile- or SSO-based, materialize static keys
-  into the environment first — e.g. `eval "$(aws configure export-credentials --format
-  env)"` after `aws sso login` — or a run fails with missing credentials even though
-  `aws` CLI calls succeed in the same shell.
+  Stella does not consult the **AWS** credential chain. `AWS_PROFILE`, `~/.aws/credentials`,
+  the SSO token cache, and IMDS/instance roles are never read. If your setup is profile- or
+  SSO-based, materialize static keys into the environment first — e.g.
+  `eval "$(aws configure export-credentials --format env)"` after `aws sso login` — or a
+  run fails with missing credentials even though `aws` CLI calls succeed in the same shell.
 </Callout>
+
+The two halves of the AWS credential are resolved by different machinery, and the
+difference matters when you want the keys out of your shell:
+
+<CardGrid size="md">
+  <OptionCard name="AWS_ACCESS_KEY_ID" required>
+    Bedrock's **primary credential**, so it rides Stella's own
+    [credential chain](/docs/api-providers#the-credential-chain) in full — `--api-key`,
+    the env var, `settings.json` `providers.bedrock.api_key`,
+    `~/.stella/credentials.toml`, and the interactive prompt all work, exactly as they
+    do for an ordinary API key.
+  </OptionCard>
+  <OptionCard name="AWS_SECRET_ACCESS_KEY" required>
+    **Environment only.** Read straight from the process environment — no
+    `credentials.toml` entry, no `settings.json` field, no prompt. Missing, it is a named
+    error rather than a doomed unsigned request.
+  </OptionCard>
+  <OptionCard name="AWS_SESSION_TOKEN">
+    **Environment only.** Optional; supply it for short-lived STS or SSO credentials.
+  </OptionCard>
+  <OptionCard name="AWS_REGION" defaultValue="us-east-1">
+    **Environment only.** `AWS_REGION` wins over `AWS_DEFAULT_REGION` when both are set;
+    with neither, Stella uses `us-east-1`.
+  </OptionCard>
+</CardGrid>
+
+So storing `AWS_ACCESS_KEY_ID` in `credentials.toml` and leaving the rest in the
+environment is a supported — if lopsided — arrangement. Putting the secret there is not:
+it will not be read.
 
 ## Selecting models
 
@@ -40,6 +67,10 @@ The provider id is `bedrock`; the default model is the **cross-region inference 
 `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
 
 ```bash
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_REGION="us-east-1"
+
 stella --model bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 run "harden the S3 policy module"
 ```
 
@@ -71,6 +102,28 @@ cloud credential must never hijack provider selection — if you want Bedrock, p
 The pin sits between the `--model` flag and auto-detection — an explicit flag still
 wins, but with the pin in place Bedrock no longer loses to whichever direct-vendor key
 happens to be in the shell.
+
+## Reasoning is dropped on this provider
+
+<Callout type="warn">
+  Bedrock's reasoning posture is **unsupported**. Claude-on-Bedrock does expose extended
+  thinking through `additionalModelRequestFields.reasoning_config`, but Stella's Converse
+  adapter has no passthrough for it — so a pinned `effort` is **discarded**, surfaced as a
+  boot notice rather than sent. The model reasons at its own default depth. If per-agent
+  effort control is what you are after, the direct
+  [Anthropic provider](/docs/api-providers/anthropic) is where it lives.
+</Callout>
+
+## `base_url` in settings.json does not reach the wire
+
+<Callout type="warn">
+  This provider builds its own region-scoped endpoint from `AWS_REGION`, and it consumes
+  only the raw `--base-url` flag. A `providers.bedrock.base_url` in `settings.json` is
+  **silently inert on the wire**: it changes the endpoint `stella models` displays for
+  Bedrock and nothing else — requests still go to the region-derived host. To route
+  Bedrock through a proxy for a run, pass `--base-url` (or export `STELLA_BASE_URL`)
+  explicitly.
+</Callout>
 
 ## In the pipeline
 

--- a/website/content/docs/api-providers/deepseek.mdx
+++ b/website/content/docs/api-providers/deepseek.mdx
@@ -29,9 +29,34 @@ The provider id is `deepseek`; the default model is `deepseek-chat` (the V3 line
 through 2025).
 
 ```bash
+export DEEPSEEK_API_KEY="sk-..."
+
 stella --model deepseek/deepseek-chat run "fix the flaky date test"
 export STELLA_MODEL=deepseek/deepseek-chat
 ```
+
+## Reasoning is dropped on this provider
+
+<Callout type="warn">
+  DeepSeek's reasoning posture is **unsupported**. Its chat-completions API exposes no
+  request-level effort control, so a pinned `effort` is **discarded** — surfaced as a boot
+  notice rather than sent — and the model reasons at its own fixed depth.
+</Callout>
+
+There is a second layer on the default model specifically. `deepseek-chat` is the seed
+catalog's one entry that declares `supports_reasoning: false` — it is the non-thinking
+chat model — and a confirmed "no" makes the effort picker offer **no levels at all** for
+it, rather than showing a dial that does nothing. That is the intended behavior, not a
+missing capability: an unknown capability keeps a provider's full vocabulary, and only a
+confirmed "no" is allowed to empty it.
+
+DeepSeek does publish a reasoning model, `deepseek-reasoner`, which reasons
+unconditionally. It is **not** in Stella's seed catalog — the seed carries `deepseek-chat`
+only — so it arrives with the catalog sync that pulls DeepSeek's own `/models` listing
+(that listing syncs from the first run with a key present; see
+[the live model catalog](/docs/api-providers/models#the-live-model-catalog-stella-models-refresh)).
+Effort stays unsent either way: the posture above is a property of the provider's API, not
+of the model you pick.
 
 ## The triage model
 

--- a/website/content/docs/api-providers/gemini.mdx
+++ b/website/content/docs/api-providers/gemini.mdx
@@ -28,8 +28,18 @@ rename the env var Stella reads with `providers.gemini.api_key_env` — see
 The provider id is `gemini`; the default model is `gemini-3-pro`.
 
 ```bash
+export GEMINI_API_KEY="..."
+
 stella --model gemini/gemini-3-pro run "summarize why the nightly build broke"
 export STELLA_MODEL=gemini/gemini-3-pro
+```
+
+The 1M window is the reason to reach for this provider, so give it something that needs
+one — a whole subsystem rather than a file:
+
+```bash
+stella --model gemini/gemini-3-pro run \
+  "read every module under src/ingest and write a design note on where retries are handled inconsistently"
 ```
 
 The same models are also reachable through

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -9,24 +9,22 @@ dialect directly — Anthropic Messages, OpenAI Responses, Gemini generateConten
 Converse, and the OpenAI-compatible dialect the rest of the field converged on. Switching
 vendors is a `--model` flag, not a migration.
 
-## The provider matrix
+## Every provider Stella speaks
 
-| Provider | id | Primary env var | Default model | Dialect |
-| --- | --- | --- | --- | --- |
-| <ProviderMark id="anthropic" /> [Anthropic](/docs/api-providers/anthropic) | `anthropic` | `ANTHROPIC_API_KEY` | `claude-fable-5` | Anthropic Messages |
-| <ProviderMark id="openai" /> [OpenAI](/docs/api-providers/openai) | `openai` | `OPENAI_API_KEY` | `gpt-5.5` | OpenAI Responses |
-| <ProviderMark id="gemini" /> [Google Gemini](/docs/api-providers/gemini) | `gemini` | `GEMINI_API_KEY` (alias `GOOGLE_API_KEY`) | `gemini-3-pro` | Gemini generateContent |
-| <ProviderMark id="vertex" /> [Google Vertex AI](/docs/api-providers/vertex) | `vertex` | `VERTEX_ACCESS_TOKEN` | `gemini-3-pro` | Gemini via Vertex |
-| <ProviderMark id="bedrock" /> [Amazon Bedrock](/docs/api-providers/bedrock) | `bedrock` | `AWS_ACCESS_KEY_ID` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Bedrock Converse |
-| <ProviderMark id="xai" /> [xAI](/docs/api-providers/xai) | `xai` | `XAI_API_KEY` | `grok-4` | OpenAI-compatible |
-| <ProviderMark id="deepseek" /> [DeepSeek](/docs/api-providers/deepseek) | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible |
-| <ProviderMark id="zai" /> [Z.ai](/docs/api-providers/zai) | `zai` | `ZAI_API_KEY` | `glm-5.2` | OpenAI-compatible |
-| <ProviderMark id="openrouter" /> [OpenRouter](/docs/api-providers/openrouter) | `openrouter` | `OPENROUTER_API_KEY` | `openrouter/auto` | OpenAI-compatible |
-| <ProviderMark id="local" /> [Local](/docs/api-providers/local) | `local` | none (optional `LOCAL_API_KEY`) | you choose | OpenAI-compatible |
+<ProviderGrid />
 
-Each provider name links to its dedicated page — setup, model selection,
-provider-specific configuration, and catalog pricing. For a quick first-run walkthrough,
-see [Providers &amp; models](/docs/getting-started/providers).
+Each card links to that provider's page — setup, model selection, provider-specific
+configuration, and catalog pricing. For a first-run walkthrough instead, see
+[Providers &amp; models](/docs/getting-started/providers).
+
+Switching between any two of them is one flag:
+
+```bash
+# The same task, three vendors — no config change, no restart.
+stella --model anthropic/claude-fable-5 run "add a retry to the upload path"
+stella --model openai/gpt-5.5        run "add a retry to the upload path"
+stella --model deepseek/deepseek-chat run "add a retry to the upload path"
+```
 
 ## Auto-detection
 
@@ -67,12 +65,24 @@ but a settings-configured default beats "first provider with a key":
 
 For the selected provider, Stella resolves the API key in this order — **first hit wins**:
 
+<CredentialChainDiagram />
+
 1. The `--api-key` flag (requires an explicit `--model provider/...`)
 2. The provider's env var, plus aliases — e.g. `GOOGLE_API_KEY` for Gemini
 3. [`settings.json`](/docs/configuration/settings) `providers.<id>.api_key`
 4. `~/.stella/credentials.toml`
 5. An interactive prompt (on a TTY) — the entered key is saved to `credentials.toml`, so
    you are only prompted once
+
+To see which link in the chain actually answered for each provider, ask:
+
+```bash
+stella models
+```
+
+Every configured row carries its credential source in parentheses — `env:ANTHROPIC_API_KEY`,
+a dotenv filename, `credentials.toml`, or `settings.json` — so a key you thought was coming
+from one place and is really coming from another shows up immediately.
 
 See [Credentials](/docs/configuration/credentials) for the file format and the fine print.
 

--- a/website/content/docs/api-providers/local.mdx
+++ b/website/content/docs/api-providers/local.mdx
@@ -56,6 +56,14 @@ your own provider under a non-reserved id with a `base_url`; the `dialect` defau
 stella --model ollama/llama3.3 chat
 ```
 
+A complete first run, endpoint baked in:
+
+```bash
+ollama pull qwen2.5-coder:32b
+
+stella --model ollama/qwen2.5-coder:32b run "add a --dry-run flag to the sync command"
+```
+
 See [settings.json](/docs/configuration/settings) for the full `providers` schema —
 custom providers get the same treatment as built-ins, including a `default_model`. Two
 more knobs worth knowing:
@@ -69,6 +77,20 @@ more knobs worth knowing:
   Gemini-shaped gateway too. `vertex` and `bedrock` are **rejected** for custom ids:
   those dialects need credential resolution (project/region addressing, SigV4 signing)
   that a settings entry cannot express.
+
+## Reasoning is dropped on this provider
+
+<Callout type="warn">
+  The `local` posture is **unsupported**, and deliberately so: OpenAI-compatible servers
+  have no portable reasoning field, so a pinned `effort` is **discarded** — surfaced as a
+  boot notice rather than guessed at. Sending a key the server has never heard of risks a
+  400 on an endpoint you never opted into experimenting with. A local model that reasons
+  does so at whatever depth it was built or served with; control it at the server, not
+  from Stella.
+</Callout>
+
+This applies to `settings.json`-defined custom providers too — they inherit the same
+shared OpenAI-compatible adapter, which sends no reasoning field.
 
 ## In the pipeline
 

--- a/website/content/docs/api-providers/models.mdx
+++ b/website/content/docs/api-providers/models.mdx
@@ -84,9 +84,9 @@ stella models list --provider anthropic    # browse valid slugs + live pricing
   overlay resolves through each provider's configured credential (only the models.dev
   master list is keyless).
 - **Incremental.** The HTTP `ETag` is persisted and replayed; an unchanged list is one
-  conditional request, zero writes. After your first explicit refresh, Stella re-syncs a
-  stale list (>24h) automatically at startup — never before your first refresh (the
-  no-phone-home rule), and `STELLA_CATALOG_AUTO_REFRESH=0` turns the re-sync off.
+  conditional request, zero writes. A stale list (>24h) re-syncs automatically at startup,
+  and `STELLA_CATALOG_AUTO_REFRESH=0` turns the re-sync off — though *when* automatic
+  syncing may first fire differs by source (see below).
 - **Strict slug validation, everywhere.** Once a provider's master-list rows are synced,
   an invalid `--model` slug is a hard, immediate, named error with did-you-mean
   suggestions — before any wire call, for **every** provider including OpenRouter and
@@ -98,6 +98,33 @@ stella models list --provider anthropic    # browse valid slugs + live pricing
   telemetry) — to `(api provider, model provider, model version, model card)`, so
   per-model cost analytics never split one model across its spellings.
 
+### When each source may sync on its own
+
+<Callout type="info">
+  **A fresh install never contacts models.dev on its own.** The two sources are gated
+  differently, and deliberately:
+
+  - **Each configured provider's own `/models` listing** auto-syncs whenever it is stale,
+    **including the very first time** — this is what surfaces new releases as they ship.
+    That traffic is BYOK-clean: it goes to a provider you already gave Stella a key for,
+    the same host your next turn calls anyway. No credential for a provider means nothing
+    is fetched for it.
+  - **The models.dev master list** is a third party, so the no-phone-home rule forbids
+    contacting it implicitly. It may only auto-refresh once a sync record already exists —
+    that is, **after your first explicit `stella models refresh`**. Until you run that
+    command once, the seed table above is your whole catalog and models.dev is never
+    touched.
+</Callout>
+
+Because the native overlay resolves through each provider's configured credential, the
+slugs and prices you get back are exactly what that key can see. It is the same
+[credential chain](/docs/api-providers#the-credential-chain) that authorizes inference —
+resolved once, used for both:
+
+<CredentialChainDiagram />
+
+Only the models.dev master list is keyless.
+
 ## Prompt caching changes the math
 
 The **cached-input** column is what most worker input actually costs mid-run. Stella keeps
@@ -107,6 +134,36 @@ cache hit billed at the cached-input rate: a 10x–20x discount depending on pro
 is why real per-run cost lands far below naive input-tokens-times-list-price math, and why
 a model's cached-input price matters more than its headline input price for long agentic
 runs.
+
+### The cache-write rate
+
+Reads are only half the ledger. Writing a prefix into the cache is itself billed, at a
+**premium over the input rate**, and the seed catalog carries that figure per model
+alongside the other three. It appears in no column above because it is not a price you
+shop on — it is the cost of entry you amortize:
+
+| Model | Provider | In $/Mtok | Cache-write $/Mtok | Premium |
+| --- | --- | --- | --- | --- |
+| `claude-fable-5` | `anthropic` | 3.00 | 3.75 | 1.25x |
+| `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 3.00 | 3.75 | 1.25x |
+| `gpt-5.5` | `openai` | 1.25 | 1.25 | 1x |
+| `gemini-3-pro` | `gemini`, `vertex` | 1.25 | 1.25 | 1x |
+| `grok-4` | `xai` | 3.00 | 3.00 | 1x |
+| `glm-5.2` | `zai` | 0.60 | 0.60 | 1x |
+| `deepseek-chat` | `deepseek` | 0.27 | 0.27 | 1x |
+| `openrouter/auto` | `openrouter` | gateway-priced | gateway-priced | — |
+
+The Claude family is the only one in the seed catalog carrying a write premium — and, not
+coincidentally, the only one where caching is **opt-in** rather than implicit: Anthropic,
+Bedrock, and Claude routed through OpenRouter each take an explicit cache marker, while
+the rest of the field caches for you. With reads at roughly a tenth of the input rate and
+writes at 1.25x, a written prefix breaks even after **two** requests — and an agent loop
+replays its prefix every turn, so the premium is paid once and repaid immediately.
+
+The failure case is worth naming: a prefix that goes cold before it is read back is a
+write you paid for and never used. `stella stats` reports this directly — a negative
+`SAVED ($)` means the write premium outran the reads it bought, and `TTL REWRITES` counts
+the prefixes that expired between turns. See [`stella stats`](/docs/commands/stats).
 
 <Callout type="info">
   `stella models` lists the full catalog with live key status per provider. And the

--- a/website/content/docs/api-providers/openai.mdx
+++ b/website/content/docs/api-providers/openai.mdx
@@ -63,15 +63,51 @@ gpt-5 and o-series families, `temperature` and `top_p` are **omitted** from the 
 the API rejects them outright, and Stella drops them rather than letting your run die on a
 400. What you control instead:
 
-| Stella setting | Wire field |
-| --- | --- |
-| `effort` (low → max) | `reasoning.effort` |
-| `verbosity` (low / medium / high) | `text.verbosity` |
-| `service_tier` | `service_tier` — `auto`, `default`, `flex`, or `priority` |
+<CardGrid size="md">
+  <OptionCard name="effort" defaultValue="medium when reasoning is on and no effort is pinned">
+    Sent as `reasoning.effort`. Stella's five tiers do **not** map 1:1 here: `low`,
+    `medium`, and `high` go through as themselves, and `xhigh` and `max` both **collapse
+    down to `high`**. The Responses API's finer tiers are model-dependent, and sending one
+    the routed model does not accept is a 400 — so the adapter stops at the value every
+    current gpt-5 and o-series model takes. Pinning `max` on this provider gets you
+    `high`.
+  </OptionCard>
+  <OptionCard name="verbosity">
+    Sent as `text.verbosity` — `low`, `medium`, or `high`.
+  </OptionCard>
+  <OptionCard name="service_tier">
+    Sent as `service_tier` — `auto`, `default`, `flex`, or `priority`. `flex` trades
+    latency for a cheaper rate on tolerant workloads; `priority` does the reverse.
+  </OptionCard>
+</CardGrid>
 
-`service_tier: "flex"` trades latency for a cheaper rate on tolerant workloads;
-`"priority"` does the reverse. Set any of these per agent in
-[`agent_engine_config`](/docs/configuration/agent-engine-config).
+Set any of these per agent in
+[`agent_engine_config`](/docs/configuration/agent-engine-config):
+
+```json title="~/.stella/settings.json"
+{
+  "agent_engine_config": {
+    "agents": {
+      "judge": {
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "reasoning": "on",
+        "effort": "high",
+        "params": {
+          "verbosity": "low",
+          "service_tier": "priority"
+        }
+      }
+    }
+  }
+}
+```
+
+```bash
+export OPENAI_API_KEY="sk-..."
+
+stella --model openai/gpt-5.5 run "judge the caching rewrite against the original spec"
+```
 
 ## In the pipeline
 

--- a/website/content/docs/api-providers/openrouter.mdx
+++ b/website/content/docs/api-providers/openrouter.mdx
@@ -32,9 +32,32 @@ or not Stella's catalog has ever heard of it. A typo fails with OpenRouter's own
 not a Stella error.
 
 ```bash
-stella --model openrouter/auto run "tidy the changelog"
+export OPENROUTER_API_KEY="sk-or-..."
+
+stella --model openrouter/openrouter/auto run "tidy the changelog"
 stella --model openrouter/openai/gpt-5.5 run "review this diff as a strict judge"
 stella --model openrouter/anthropic/claude-fable-5 run "refactor the scheduler"
+```
+
+<Callout type="warn">
+  The doubled prefix on the first line is correct, not a typo. `--model` splits on the
+  **first** `/` — everything before it is the provider id, everything after it is the wire
+  slug sent verbatim as the request's `model`. Every OpenRouter model id is `vendor/model`,
+  and the meta-router's own id is `openrouter/auto`, so the full spec is
+  `openrouter` + `/` + `openrouter/auto`. Write `--model openrouter/auto` and the wire
+  slug becomes the bare `auto`, which OpenRouter does not serve. Stella checks the
+  resolved wire slug at launch and warns on stderr that it is *missing the vendor
+  namespace* — advisory, not a gate, so the run still reaches the gateway and fails there.
+</Callout>
+
+The rule generalizes: whatever slug OpenRouter's own model list shows you, paste it whole
+after `openrouter/`. The doubling only looks odd for `openrouter/auto`, because that is
+the one model whose vendor half happens to be OpenRouter itself. Pin one for the shell
+the same way:
+
+```bash
+export STELLA_MODEL=openrouter/anthropic/claude-fable-5
+stella run "refactor the scheduler"
 ```
 
 ## Real prices, not catalog prices

--- a/website/content/docs/api-providers/vertex.mdx
+++ b/website/content/docs/api-providers/vertex.mdx
@@ -60,6 +60,18 @@ stella --model vertex/gemini-3-pro run "audit the IAM bindings module"
 
 Pinning with `--model vertex/…` matters here, because of detection order.
 
+## `base_url` in settings.json does not reach the wire
+
+<Callout type="warn">
+  This provider builds its own project- and location-scoped endpoint from
+  `VERTEX_PROJECT_ID` and `VERTEX_LOCATION`, and it consumes only the raw `--base-url`
+  flag. A `providers.vertex.base_url` in `settings.json` is **silently inert on the
+  wire**: it changes the endpoint `stella models` displays for Vertex and nothing else —
+  requests still go to the address derived from your project and location. To route
+  Vertex through a proxy for a run, pass `--base-url` (or export `STELLA_BASE_URL`)
+  explicitly.
+</Callout>
+
 ## Last in auto-detection — on purpose
 
 Vertex sits **last** in [auto-detection](/docs/api-providers#auto-detection) (alongside

--- a/website/content/docs/api-providers/xai.mdx
+++ b/website/content/docs/api-providers/xai.mdx
@@ -28,28 +28,58 @@ env var Stella reads with `providers.xai.api_key_env` — see
 The provider id is `xai`; the default model is `grok-4`.
 
 ```bash
+export XAI_API_KEY="xai-..."
+
 stella --model xai/grok-4 run "review the retry logic for races"
 export STELLA_MODEL=xai/grok-4
 ```
 
-## Configuration
+<Callout type="warn">
+  **`grok-4` retires 2026-08-15.** It is still the seeded default for this provider, so a
+  bare `--model xai/…` or an unpinned auto-detected run lands on it. Pin a successor —
+  a `grok-4.x` point release or a `grok-4-fast` variant — before that date, in
+  `settings.json` under `providers.xai.default_model` or per agent in
+  [`agent_engine_config`](/docs/configuration/agent-engine-config). Any slug xAI serves
+  works; the seed catalog only decides what you get when you name nothing.
+</Callout>
+
+## Reasoning and sampling
 
 Being OpenAI-compatible, xAI takes the standard sampling parameters — `temperature`,
 `top_p`, `max_tokens`, and friends — configured per agent under
-[`agent_engine_config`](/docs/configuration/agent-engine-config). The
-[settings.json `providers` map](/docs/configuration/settings) can override the base URL
-or default model like any other provider:
+[`agent_engine_config`](/docs/configuration/agent-engine-config).
+
+Effort is the exception, and only on the default model:
+
+<Callout type="info">
+  **`effort` is a no-op on the original `grok-4`.** That model reasons, but it rejects
+  the `reasoning_effort` parameter with a hard 400 ("does not support parameter
+  reasoning_effort"), so Stella gates the parameter out for `grok-4` and its dated
+  snapshots (`grok-4-0709` and friends) rather than 400-ing every reasoning turn. The
+  model reasons at its own fixed depth and your pinned effort is simply not sent. Every
+  other xAI model — the `grok-4.1`/`.3`/`.5` point releases, the `grok-4-fast` variants,
+  `grok-3-mini` — accepts `reasoning_effort`, where Stella maps `low`/`medium`/`high`
+  directly and collapses `xhigh`/`max` down to `high`.
+</Callout>
+
+## Configuration
+
+The [settings.json `providers` map](/docs/configuration/settings) can override the base
+URL or default model like any other provider:
 
 ```json title="~/.stella/settings.json"
 {
   "providers": {
     "xai": {
       "base_url": "https://llm-gateway.internal.example.com/v1",
-      "default_model": "grok-4"
+      "default_model": "grok-4-fast-reasoning"
     }
   }
 }
 ```
+
+`default_model` is also how you move off the retiring `grok-4` in one place, for every
+unpinned run — and, unlike `grok-4`, a successor honors your `effort` setting.
 
 `--base-url` (env form `STELLA_BASE_URL`) overrides the settings value for one run. In a
 project's `.stella/settings.json`, `base_url` is ignored unless `STELLA_TRUST_PROJECT=1`

--- a/website/content/docs/api-providers/zai.mdx
+++ b/website/content/docs/api-providers/zai.mdx
@@ -28,8 +28,20 @@ env var Stella reads with `providers.zai.api_key_env` — see
 The provider id is `zai`; the default model is `glm-5.2`.
 
 ```bash
+export ZAI_API_KEY="..."
+
 stella --model zai/glm-5.2 run "implement the pagination endpoint"
 export STELLA_MODEL=zai/glm-5.2
+```
+
+On a coding plan, the same run costs the same whatever it consumes — which is the setup
+worth copying:
+
+```bash
+export ZAI_API_KEY="..."
+export ZAI_GLM_CODING_PLAN=1
+
+stella --model zai/glm-5.2 run "migrate the remaining callers off the deprecated client"
 ```
 
 ## The coding-plan endpoint

--- a/website/content/docs/commands/auth.mdx
+++ b/website/content/docs/commands/auth.mdx
@@ -23,10 +23,15 @@ A key stored here persists across sessions and shells, so you don't re-export an
 
 Store (or replace) a provider's key. With no flag, Stella shows an interactive masked prompt — the recommended path, since nothing lands in your shell history.
 
-| Flag | Meaning |
-| --- | --- |
-| `--key <key>` | Pass the key inline. **Visible in shell history and `ps` output** — prefer `--stdin` or the interactive prompt. Conflicts with `--stdin`. |
-| `--stdin` | Read the key from stdin (one trimmed line) — for scripts and secret managers. |
+<CardGrid size="md">
+  <OptionCard name="--key <key>">
+    Pass the key inline. **Visible in shell history and in `ps` output** — prefer
+    `--stdin` or the interactive prompt. Conflicts with `--stdin`.
+  </OptionCard>
+  <OptionCard name="--stdin">
+    Read the key from stdin, one trimmed line — for scripts and secret managers.
+  </OptionCard>
+</CardGrid>
 
 ```bash
 # Interactive, masked (recommended)

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -30,20 +30,32 @@ The default **Command Deck** presents the session as a set of tabs — **SESSION
 Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and Stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment.
 
 <Callout type="info">
-All [global flags](/docs/commands) apply. Because they are top-level flags, put them before the subcommand — e.g. `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session.
+All [global flags](/docs/commands) apply, in either position — `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session, and `stella chat --model openai/gpt-5.5` does the same thing.
 </Callout>
 
 ## Flags
 
 `stella chat` takes only the [global flags](/docs/commands). The ones that shape the chat surface:
 
-| Flag | Why it matters here |
-| --- | --- |
-| `--plain` | Use the plain line-based REPL instead of the Command Deck (env `STELLA_PLAIN=1`; also auto-selected on a non-TTY). |
-| `--no-anim` | Freeze deck animation (progress shimmer, caret blink) to a static frame — for recordings and CI (env `STELLA_NO_ANIM` / `NO_COLOR`). |
-| `--model <provider/model_id>` | Pin the worker model for the session. |
-| `--budget <usd>` | Apply a hard spend cap across the entire session. |
-| `--base-url <url>` | Required with `--model local/<model>`; an optional proxy override otherwise. |
+<CardGrid size="md">
+  <OptionCard name="--plain">
+    Use the plain line-based REPL instead of the Command Deck. Env `STELLA_PLAIN=1`; also
+    auto-selected on a non-TTY.
+  </OptionCard>
+  <OptionCard name="--no-anim">
+    Freeze deck animation (progress shimmer, caret blink) to a static frame — for
+    recordings and CI. Env `STELLA_NO_ANIM` / `NO_COLOR`.
+  </OptionCard>
+  <OptionCard name="--model <provider/model_id>">
+    Pin the worker model for the session.
+  </OptionCard>
+  <OptionCard name="--budget <usd>">
+    Apply a hard spend cap across the entire session.
+  </OptionCard>
+  <OptionCard name="--base-url <url>">
+    Required with `--model local/<model>`; an optional proxy override otherwise.
+  </OptionCard>
+</CardGrid>
 
 ## Slash commands
 
@@ -53,46 +65,124 @@ The available commands depend on the surface.
 
 Open a tab or run an action:
 
-| Command | Description |
-| --- | --- |
-| `/help` | Show help. |
-| `/clear` | Clear the session / blank the transcript. |
-| `/models` | List providers and models (same output as `stella models`). |
-| `/init` | Run workspace initialization. |
-| `/pipeline` | Toggle the staged pipeline on or off for subsequent turns. |
-| `/agents` | Open the AGENTS tab — executions & installed agents. |
-| `/settings` | Open the SETTINGS tab — the home of all config, incl. the engine-config panel. |
-| `/files` | Open the FILES (files-touched) tab. |
-| `/diff` | Show the working diff. |
-| `/graph` | Open the GRAPH (code-graph) tab. |
-| `/skills` | Open the SKILLS tab. |
-| `/mcp` | Open the MCP tab (enable/disable servers, enter credentials). |
-| `/mcp-search` | Search the MCP registry without leaving the deck. |
-| `/sessions` | Browse and resume past sessions. |
-| `/context` | Open the context overlay — what's in the model's window right now. |
-| `/inbox` | Open the persistent inbox. |
-| `/export` | Export session telemetry as a self-contained ZIP. |
-| `/donate` | Support Stella's development. |
+<CardGrid size="sm">
+  <OptionCard name="/help">
+    Show the deck's command list.
+  </OptionCard>
+  <OptionCard name="/clear">
+    Reset the conversation — blank the transcript and drop the history.
+  </OptionCard>
+  <OptionCard name="/models">
+    List providers and models (the same output as `stella models`). Also accepts
+    `refresh [--force]` and `list` — see below.
+  </OptionCard>
+  <OptionCard name="/init">
+    Index the workspace: domain taxonomy plus the code graph.
+  </OptionCard>
+  <OptionCard name="/pipeline">
+    Toggle the staged pipeline on or off for subsequent turns.
+  </OptionCard>
+  <OptionCard name="/agents">
+    Open the AGENTS tab — executions and installed agents.
+  </OptionCard>
+  <OptionCard name="/settings">
+    Open the SETTINGS tab — the home of all config, models included. There are no
+    per-agent slash commands; the engine-config editor lives here.
+  </OptionCard>
+  <OptionCard name="/files">
+    Open the FILES (files-touched) tab.
+  </OptionCard>
+  <OptionCard name="/diff">
+    Open the diff viewer on the working tree.
+  </OptionCard>
+  <OptionCard name="/graph">
+    Open the GRAPH (code-graph) tab.
+  </OptionCard>
+  <OptionCard name="/skills">
+    Open the SKILLS tab — manage, search, create.
+  </OptionCard>
+  <OptionCard name="/mcp">
+    Open the MCP servers tab (enable/disable servers, enter credentials).
+  </OptionCard>
+  <OptionCard name="/mcp-search">
+    Search the MCP registry and install servers without leaving the deck.
+  </OptionCard>
+  <OptionCard name="/sessions">
+    Every Stella session on this machine, grouped by status. Also reachable with `←` on an
+    empty prompt.
+  </OptionCard>
+  <OptionCard name="/context">
+    This session's active skills and MCP servers. Also reachable with `→` on an empty
+    prompt.
+  </OptionCard>
+  <OptionCard name="/inspect">
+    The context sent to the model on any recorded call — the deck's view of
+    [`stella inspect`](/docs/commands/inspect). Also **Ctrl-G**.
+  </OptionCard>
+  <OptionCard name="/inbox">
+    Notifications — messages persist until read.
+  </OptionCard>
+  <OptionCard name="/export">
+    Export session telemetry to a ZIP plus an HTML dashboard.
+  </OptionCard>
+  <OptionCard name="/donate">
+    Support Stella — become a GitHub Sponsor.
+  </OptionCard>
+</CardGrid>
 
 Press **Ctrl-C** to quit the deck.
+
+#### `/models` with an argument
+
+`/models` also takes two arguments, and both are handled inside the deck without a model call — when the configured model is itself broken, `/models refresh` is how you dig out, and routing it through a turn would fail on the very error you are fixing:
+
+```text
+/models refresh           re-sync the catalog
+/models refresh --force   re-download everything, ignoring ETags
+/models list              the same listing the bare /models prints
+```
+
+Parsing is deliberately conservative: one recognized token (plus `refresh --force`). A single unrecognized token gets usage back rather than a wasted model call, and anything sentence-like after `/models` stays an ordinary prompt.
 
 ### Plain REPL (`--plain`)
 
 The line REPL has a smaller, different set:
 
-| Command | Description |
-| --- | --- |
-| `/help` | Show help. |
-| `/models` | List providers and models. |
-| `/config` | Show the current configuration. |
-| `/clear` | Clear the conversation history. |
-| `/goal <goal>` | Run a goal-driven turn toward the stated goal. |
-| `/files` | Show files touched this session. |
-| `/agents` | List custom agents (from `.stella/agents` or `~/.stella/agents`). |
-| `/init` | Index the workspace: domain taxonomy + code graph. |
-| `/rename <name>` | Rename this terminal tab. |
-| `/color <name>` | Change the accent color (for multi-window setups). |
-| `exit` / `/exit` / `/quit` (or **Ctrl-D**) | Leave Stella. |
+<CardGrid size="sm">
+  <OptionCard name="/help">
+    Show help.
+  </OptionCard>
+  <OptionCard name="/models">
+    List providers and models.
+  </OptionCard>
+  <OptionCard name="/config">
+    Show the current configuration — the deck has no `/config`; this is the REPL's own.
+  </OptionCard>
+  <OptionCard name="/clear">
+    Clear the conversation history.
+  </OptionCard>
+  <OptionCard name="/goal <goal>">
+    Run a goal-driven turn toward the stated goal.
+  </OptionCard>
+  <OptionCard name="/files">
+    Show files touched this session.
+  </OptionCard>
+  <OptionCard name="/agents">
+    List custom agents, from `.stella/agents` or `~/.stella/agents`.
+  </OptionCard>
+  <OptionCard name="/init">
+    Index the workspace: domain taxonomy plus the code graph.
+  </OptionCard>
+  <OptionCard name="/rename <name>">
+    Rename this terminal tab.
+  </OptionCard>
+  <OptionCard name="/color <name>">
+    Change the accent color, for multi-window setups.
+  </OptionCard>
+  <OptionCard name="exit  /exit  /quit">
+    Leave Stella. **Ctrl-D** does the same.
+  </OptionCard>
+</CardGrid>
 
 ## Examples
 
@@ -108,7 +198,7 @@ Start a session by simply running the binary (chat is the default):
 stella
 ```
 
-Pin a model and cap session spend (global flags before the subcommand):
+Pin a model and cap session spend:
 
 ```bash
 stella --model zai/glm-5.2 --budget 5.00 chat

--- a/website/content/docs/commands/cloud.mdx
+++ b/website/content/docs/commands/cloud.mdx
@@ -1,0 +1,165 @@
+---
+title: stella cloud
+description: Show or set the org and workspace identity that scopes replicated telemetry — a deliberate stub today, with the OAuth login landing on the same file later.
+---
+
+Every row [`stella usage`](/docs/commands/usage) replicates into the hub carries an identity: which organization it reports into, which workspace it came from, and which repository that workspace maps to. `stella cloud` is where you read that identity and set it.
+
+It is a deliberate **stub**. `register` persists ids locally and mints a durable workspace id; the OAuth login that will attach a token lands later, on the same file. Nothing is uploaded today, and registering does not change what telemetry is collected — only which ids it is stamped with.
+
+## Synopsis
+
+```bash
+stella cloud status
+stella cloud register --org <ORG_ID> [--workspace-id <ID>]
+```
+
+A subcommand is required. Neither one needs a provider or an API key.
+
+## What it does
+
+Four ids describe an installation, and they answer different questions:
+
+<CardGrid size="md">
+  <OptionCard name="org_id">
+    The organization this installation reports into. `NULL` until you register.
+    `STELLA_ORG_ID` wins if set; otherwise it comes from the `org_id` in
+    `~/.stella/cloud.json`, written by `stella cloud register`.
+  </OptionCard>
+  <OptionCard name="workspace_id">
+    A durable UUID at `<root>/.stella/workspace.json`, written **only** by registration
+    and never minted implicitly — an unregistered workspace reports `NULL`. It lives
+    outside `.stella/private/` on purpose, so committing it gives every clone and every
+    machine one shared workspace identity.
+  </OptionCard>
+  <OptionCard name="repo_id">
+    A workspace is only *usually* a repository. `repo_id` hashes the normalized `origin`
+    remote URL — the SSH and HTTPS forms of the same repo agree — and falls back to the
+    path hash when there is no git remote. Rows carry it separately so a multi-repo
+    workspace still reports per repository.
+  </OptionCard>
+  <OptionCard name="project_id">
+    A hash of the canonical workspace path. Always present, registration or not, and it
+    is the key replication runs on. This is what makes `stella usage` work on a machine
+    that has never heard of a cloud org.
+  </OptionCard>
+</CardGrid>
+
+Resolution is infallible by design: telemetry scoping must never fail a turn, so unregistered ids resolve to `NULL` and a missing git remote degrades `repo_id` rather than erroring.
+
+### `stella cloud status`
+
+Print this installation's identity for the current workspace, and — once an org is set — any rows the cloud intake permanently rejected.
+
+```bash
+stella cloud status
+```
+
+Unregistered:
+
+```text
+org_id:   (not registered)
+workspace:   (not registered)
+repo_id:   9f2c1ad4e7b03518
+project:   4b81c0e2f39a77de
+
+register with `stella cloud register --org <org-id>` — telemetry replicates locally either way; org scoping gates what a future cloud sync would ship
+```
+
+Registered:
+
+```text
+org_id:   acme
+workspace:   6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa
+repo_id:   9f2c1ad4e7b03518
+project:   4b81c0e2f39a77de
+```
+
+#### Quarantined rows
+
+When an org is registered, `status` also reports rows the cloud intake rejected *permanently*. This is the only place they surface, and that is the point: the drain dead-letters such a row and steps its cursor over it so newer rows keep flowing — after which everything downstream looks healthy while a silent casualty sits in the hub.
+
+```text
+quarantined:   3 row(s) the cloud intake permanently rejected
+              2 x HTTP 422: model slug not in the intake catalog
+              1 x HTTP 413: payload too large
+              retained in the hub for inspection; the cursor advanced past them
+```
+
+At most three reason groups are listed before the tail folds into a `+N more reason(s)` line. The rows themselves are retained, not deleted. The check is best-effort — `status` answers about identity first, so an unopenable hub degrades to a one-line note instead of failing the command.
+
+### `stella cloud register`
+
+Persist an org id and register this workspace.
+
+<CardGrid size="md">
+  <OptionCard name="--org <ORG_ID>" required>
+    The cloud organization id telemetry rolls up under. Written to `~/.stella/cloud.json`
+    — the same file the future OAuth login will keep its token in, so registration and
+    auth stay one file. Must not be empty.
+  </OptionCard>
+  <OptionCard name="--workspace-id <ID>">
+    Adopt a cloud-assigned workspace id instead of minting a UUID. Ignored if this
+    workspace is already registered — registration is idempotent and an existing id always
+    wins, because one workspace must never fork into two identities.
+  </OptionCard>
+</CardGrid>
+
+```bash
+stella cloud register --org acme
+```
+
+```text
+registered to org acme (stub — OAuth login lands later)
+workspace id 6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa written to .stella/workspace.json
+commit .stella/workspace.json so every clone reports as this workspace
+```
+
+<Callout type="info">
+Commit `.stella/workspace.json`. It sits outside `.stella/private/` for exactly that
+reason. Without it, a clone has no workspace id at all until someone registers there —
+and if they do, the same project ends up reporting under two identities.
+</Callout>
+
+The written file is small and readable:
+
+```json title=".stella/workspace.json"
+{"workspace_id": "6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa"}
+```
+
+## What registration does not do
+
+- **It does not upload anything.** There is no cloud sync today; `register` writes two local files. Telemetry replicates into `~/.stella/usage.db` whether you register or not.
+- **It does not change what is collected.** Only the ids stamped onto each row change — from `NULL` org and workspace to yours.
+- **It does not re-stamp history.** Rows written before registration keep their `NULL` org, which is why `stella usage report --org <id>` excludes them.
+
+It does change one thing worth knowing about: once rows carry an org, [`stella usage prune`](/docs/commands/usage#stella-usage-prune) will not drop the ones a cloud drain has not acknowledged unless you pass `--force`.
+
+## Examples
+
+Check what identity this workspace reports under before wiring up CI:
+
+```bash
+stella cloud status
+```
+
+Register a machine to an org and adopt a workspace id issued elsewhere:
+
+```bash
+stella cloud register --org acme --workspace-id 6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa
+```
+
+Scope an org to one shell session without touching `cloud.json` — the environment variable
+outranks the file:
+
+```bash
+STELLA_ORG_ID=acme-staging stella cloud status
+```
+
+Register, then confirm the hub is stamping rows the way you expect:
+
+```bash
+stella cloud register --org acme
+stella usage sync
+stella usage report --org acme
+```

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -18,10 +18,16 @@ Today it runs exactly one check — **`store integrity`**, the soundness of this
 
 A verdict is deliberately binary. There is no "warn": a check that cannot say *this is fine* has failed, and a third maybe-state would only be an invitation to ignore it.
 
-| Verdict | When |
-| --- | --- |
-| ✓ pass | The store passed, **or** there is no store yet — `store.db` is created by your first session, and its absence is not a fault. |
-| ✗ fail | SQLite reported damage, **or** the check could not be performed at all (a locked file, a permissions problem). |
+<CardGrid size="md">
+  <OptionCard name="✓ pass">
+    The store passed, **or** there is no store yet — `store.db` is created by your first
+    session, and its absence is not a fault.
+  </OptionCard>
+  <OptionCard name="✗ fail">
+    SQLite reported damage, **or** the check could not be performed at all — a locked
+    file, a permissions problem.
+  </OptionCard>
+</CardGrid>
 
 Diagnosis never writes. The check opens the database immutably — no locks, no `-shm`, zero bytes written — and escalates to a read-write open only when a first verdict already looks bad and a `-wal` sibling exists. Being asked a question is not a reason to create a `.stella/` that wasn't there.
 
@@ -29,9 +35,13 @@ Diagnosis never writes. The check opens the database immutably — no locks, no 
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--repair` | Act on a store SQLite judged corrupt: move it aside to a timestamped name (renamed, **never** deleted) and copy out whatever is still readable. A healthy store and an inconclusive check are both left untouched. |
+<CardGrid size="md">
+  <OptionCard name="--repair">
+    Act on a store SQLite judged corrupt: move it aside to a timestamped name — renamed,
+    **never** deleted — and copy out whatever is still readable. A healthy store and an
+    inconclusive check are both left untouched.
+  </OptionCard>
+</CardGrid>
 
 ## Exit codes
 

--- a/website/content/docs/commands/fleet.mdx
+++ b/website/content/docs/commands/fleet.mdx
@@ -23,18 +23,35 @@ For anything beyond a handful of independent prompts, use a plan file (`--plan`)
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `<task>...` | One or more task prompts, each an independent shared-tree task. Required unless `--plan` is given. |
-| `--plan <FILE>` | A `.json` or `.toml` plan file with `[[tasks]]` entries (`id`, `title`, `prompt`, optional `depends_on`, `isolation`, and `claims`) instead of inline prompts. |
-| `--max-concurrency <N>` | Maximum tasks dispatched concurrently within one wave. Default `4`. |
-| `--base-ref <ref>` | Git ref the isolated worktrees branch from. Default: the current `HEAD`, pinned to a SHA at start so mid-run commits can't drift the base. |
-| `--watch` | After the fan-out, watch each successful branch's CI to completion and reconcile its PR status via `gh` (30s polls, 10m startup grace, 20m stall limit, 2h wall cap). Exits non-zero if any watched branch ends red. |
-| `--no-pipeline` | Workers run the raw step loop instead of the staged pipeline. |
+<CardGrid size="md">
+  <OptionCard name="<task>...">
+    One or more task prompts, each an independent shared-tree task. Required unless
+    `--plan` is given.
+  </OptionCard>
+  <OptionCard name="--plan <FILE>">
+    A `.json` or `.toml` plan file with `[[tasks]]` entries — `id`, `title`, `prompt`, and
+    optional `depends_on`, `isolation`, and `claims` — instead of inline prompts.
+  </OptionCard>
+  <OptionCard name="--max-concurrency <N>" defaultValue="4">
+    Maximum tasks dispatched concurrently within one wave.
+  </OptionCard>
+  <OptionCard name="--base-ref <ref>" defaultValue="current HEAD">
+    Git ref the isolated worktrees branch from. The default is pinned to a SHA at start,
+    so mid-run commits cannot drift the base.
+  </OptionCard>
+  <OptionCard name="--watch">
+    After the fan-out, watch each successful branch's CI to completion and reconcile its
+    PR status via `gh` — 30s polls, 10m startup grace, 20m stall limit, 2h wall cap. Exits
+    non-zero if any watched branch ends red.
+  </OptionCard>
+  <OptionCard name="--no-pipeline">
+    Workers run the raw step loop instead of the staged pipeline.
+  </OptionCard>
+</CardGrid>
 
 ## Budget
 
-The budget cap is the **global** `--budget` flag (or `STELLA_BUDGET`), so it goes before the subcommand. Each child is guarded by the aggregate cap divided across the concurrency width (`budget ÷ max-concurrency`), and the fleet stops launching new waves once total metered spend crosses the cap.
+The budget cap is the **global** `--budget` flag (or `STELLA_BUDGET`) rather than one of `fleet`'s own; it reads most clearly before the subcommand, though [either position parses](/docs/commands#global-flags). Each child is guarded by the aggregate cap divided across the concurrency width (`budget ÷ max-concurrency`), and the fleet stops launching new waves once total metered spend crosses the cap.
 
 ```bash
 stella --budget 5 fleet --plan release-prep.toml

--- a/website/content/docs/commands/goal.mdx
+++ b/website/content/docs/commands/goal.mdx
@@ -25,11 +25,19 @@ For the full explanation of judged rounds, the cross-family judge, and the defin
 
 `stella goal` takes the [global flags](/docs/commands), plus one of its own:
 
-| Flag | Why it matters here |
-| --- | --- |
-| `--no-pipeline` | Each working round runs the raw step loop instead of the staged pipeline (triage, plan, witness, execute, verify). The pipeline is the default. |
-| `--model <provider/model_id>` | Pin the worker model. The judge is routed to a different family automatically when one is available. |
-| `--budget <usd>` | Cap total spend across all rounds; work aborts cleanly once the cap is exceeded. |
+<CardGrid size="md">
+  <OptionCard name="--no-pipeline">
+    Each working round runs the raw step loop instead of the staged pipeline (triage,
+    plan, witness, execute, verify). The pipeline is the default.
+  </OptionCard>
+  <OptionCard name="--model <provider/model_id>">
+    Pin the worker model. The judge is routed to a different family automatically when one
+    is available.
+  </OptionCard>
+  <OptionCard name="--budget <usd>">
+    Cap total spend across all rounds; work aborts cleanly once the cap is exceeded.
+  </OptionCard>
+</CardGrid>
 
 <Callout type="info">
 `stella goal` is an interactive mode: it always renders human-readable text and does **not** honor `--output-format`. Use [`stella run`](/docs/commands/run) for headless `json` / `stream-json` output.
@@ -47,7 +55,7 @@ Work toward a goal until the judge confirms it is met:
 stella goal "Migrate the config loader to use serde and add tests"
 ```
 
-Pin the worker model and cap spend across all rounds (global flags go before the subcommand):
+Pin the worker model and cap spend across all rounds:
 
 ```bash
 stella --model anthropic/claude-fable-5 --budget 10.00 \

--- a/website/content/docs/commands/graph.mdx
+++ b/website/content/docs/commands/graph.mdx
@@ -17,13 +17,24 @@ stella graph <op> <target>
 
 `<op>` is one of five operations, and `<target>` is interpreted according to the operation:
 
-| `<op>` | `<target>` is | Answers |
-| --- | --- | --- |
-| `definitions` | a symbol name | Where is this symbol defined? |
-| `references` | a symbol name | Where is this symbol used? |
-| `imports` | a workspace-relative file path | What does this file import? |
-| `importers` | a workspace-relative file path | Which files import this file? |
-| `neighbors` | a workspace-relative file path | What is this file's immediate graph neighborhood? |
+<CardGrid size="md">
+  <OptionCard name="definitions <symbol>">
+    Where is this symbol defined? `<target>` is a symbol name.
+  </OptionCard>
+  <OptionCard name="references <symbol>">
+    Where is this symbol used? `<target>` is a symbol name.
+  </OptionCard>
+  <OptionCard name="imports <path>">
+    What does this file import? `<target>` is a workspace-relative file path.
+  </OptionCard>
+  <OptionCard name="importers <path>">
+    Which files import this file? `<target>` is a workspace-relative file path.
+  </OptionCard>
+  <OptionCard name="neighbors <path>">
+    What is this file's immediate graph neighborhood? `<target>` is a workspace-relative
+    file path.
+  </OptionCard>
+</CardGrid>
 
 <Callout type="info">
 Run [`stella init`](/docs/commands/init) first. The graph is only as current as the last `init` — if you have moved or renamed a lot of code since, re-run `init` to rebuild `.stella/private/codegraph.db`.
@@ -44,4 +55,16 @@ Inspect a file's imports, its importers, and its neighborhood:
 stella graph imports    stella-cli/src/config.rs
 stella graph importers  stella-cli/src/config.rs
 stella graph neighbors  stella-cli/src/config.rs
+```
+
+Check the blast radius of a file before you change it — who would you break:
+
+```bash
+stella graph importers src/db/schema.ts
+```
+
+Confirm a symbol you are about to rename is defined exactly once:
+
+```bash
+stella graph definitions parse_age_window
 ```

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -15,36 +15,99 @@ stella chat
 
 ## Subcommands
 
-| Command | Purpose |
-| --- | --- |
-| `stella run <prompt>` | Send a one-shot prompt, non-interactive (staged pipeline by default). |
-| `stella chat` | Interactive session — the Command Deck TUI (the default when no subcommand is given). |
-| `stella resume [id]` | Reopen a previous Command Deck session exactly where it stood; `--list` shows every session on this machine. |
-| `stella goal <goal>` | Work in judged rounds until a judge model confirms the goal is met. |
-| `stella monitor [target]` | Watch CI for a branch/PR and fix failures until fully green. |
-| `stella init` | Analyze the workspace, infer its domain taxonomy, and build the code-graph index. |
-| `stella fleet <tasks...>` | Fan tasks out to a fleet of worker agents in one shared tree, coordinated by cooperative file claims. |
-| `stella graph <op> <target>` | Query the code graph built by `stella init` (offline, no API key). |
-| `stella storage <tree\|show\|grep\|drift>` | Inspect the [storage map](/docs/commands/storage) — layers, relations, and fields with intent (offline, no API key). |
-| `stella scripts <list\|run>` | List and run the project's [package-manager scripts](/docs/commands/scripts) via canonical verbs (offline, no API key). |
-| `stella models` | List configured providers and available models. |
-| `stella stats [prune]` | Summarize cost, tokens, and resolve rate per provider/model from local telemetry — this workspace only. `prune` bounds that store's growth: it drops executions past `--older-than`/`--max-rows` along with every row keyed to them, and never destroys telemetry that has not reached the hub yet unless `--force`. |
-| `stella usage <report\|sync\|prune>` | The same numbers across *every* project on this machine, via the local hub at `~/.stella/usage.db`. `sync` replicates from a cursor (safe to re-run), `prune` bounds the hub's growth. Local-only; nothing is uploaded. |
-| `stella cloud <status\|register>` | Show or set the org/workspace identity that scopes hub rows. A stub today: it persists ids locally, and the OAuth login lands later. |
-| `stella inspect` | Show the exact context a past model call was sent — the [reconstructed message array](/docs/commands/inspect), verified against the digests recorded at emission. |
-| `stella observe` | Serve the [Observatory dashboard](/docs/telemetry/dashboard) — your local telemetry in the browser, loopback-only. |
-| `stella memory` | Inspect memories through the citation loop, and promote one to a project rule. |
-| `stella mcp` | Manage MCP servers — search a registry, install, list, OAuth login, and show usage telemetry. |
-| `stella connect` | Connect GitHub or Linear via OAuth so the agent gains the [issue toolset](/docs/agent-tools). |
-| `stella auth <set\|remove\|list>` | Manage BYOK provider keys in [`credentials.toml`](/docs/commands/auth) (never prints a secret). |
-| `stella tools` | List every tool available to the agent this session. |
-| `stella config` | Show the fully resolved configuration. |
-| `stella doctor` | Check the local state stella owns — today the integrity of this workspace's [session store](/docs/commands/doctor) — and exit non-zero if any check fails. `--repair` moves a corrupt `store.db` aside (renamed, never deleted). |
-| `stella version` | Print the version and exit. |
+<CardGrid size="sm">
+  <SpecCard title="stella run" href="/docs/commands/run">
+    `<prompt>` — send a one-shot prompt, non-interactive. The staged pipeline by default.
+  </SpecCard>
+  <SpecCard title="stella chat" href="/docs/commands/chat">
+    Interactive session in the Command Deck TUI. The default when no subcommand is given.
+  </SpecCard>
+  <SpecCard title="stella resume" href="/docs/commands/resume">
+    `[id]` — reopen a previous deck session exactly where it stood; `--list` shows every
+    session on this machine.
+  </SpecCard>
+  <SpecCard title="stella goal" href="/docs/commands/goal">
+    `<goal>` — work in judged rounds until a judge model confirms the goal is met.
+  </SpecCard>
+  <SpecCard title="stella monitor" href="/docs/commands/monitor">
+    `[target]` — watch CI for a branch or PR and fix failures until it is fully green.
+  </SpecCard>
+  <SpecCard title="stella init" href="/docs/commands/init">
+    Analyze the workspace, infer its domain taxonomy, and build the code-graph index.
+  </SpecCard>
+  <SpecCard title="stella fleet" href="/docs/commands/fleet">
+    `<tasks...>` — fan tasks out to worker agents in one shared tree, coordinated by
+    cooperative file claims.
+  </SpecCard>
+  <SpecCard title="stella graph" href="/docs/commands/graph">
+    `<op> <target>` — query the code graph built by `stella init`. Offline, no API key.
+  </SpecCard>
+  <SpecCard title="stella storage" href="/docs/commands/storage">
+    `<tree|show|grep|drift|prune>` — inspect the storage map (layers, relations, and
+    fields with intent), and bound the session store's growth. Offline, no API key.
+  </SpecCard>
+  <SpecCard title="stella scripts" href="/docs/commands/scripts">
+    `<list|run>` — list and run the project's package-manager scripts via canonical verbs.
+    Offline, no API key.
+  </SpecCard>
+  <SpecCard title="stella models" href="/docs/commands/models">
+    `[refresh|list]` — list configured providers and available models, and manage the live
+    model catalog.
+  </SpecCard>
+  <SpecCard title="stella stats" href="/docs/commands/stats">
+    `[prune]` — cost, tokens, and resolve rate per provider and model from this
+    workspace's telemetry. `prune` bounds that store's growth, and never destroys
+    telemetry that has not reached the hub unless `--force`.
+  </SpecCard>
+  <SpecCard title="stella usage" href="/docs/commands/usage">
+    `<report|sync|prune>` — the same numbers across *every* project on this machine, via
+    the local hub at `~/.stella/usage.db`. Local-only; nothing is uploaded.
+  </SpecCard>
+  <SpecCard title="stella cloud" href="/docs/commands/cloud">
+    `<status|register>` — show or set the org and workspace identity that scopes hub rows.
+    A stub today: it persists ids locally, and the OAuth login lands later.
+  </SpecCard>
+  <SpecCard title="stella inspect" href="/docs/commands/inspect">
+    Show the exact context a past model call was sent, verified against the digests
+    recorded at emission.
+  </SpecCard>
+  <SpecCard title="stella observe" href="/docs/commands/observe">
+    Serve the Observatory dashboard — your local telemetry in the browser, loopback-only.
+  </SpecCard>
+  <SpecCard title="stella memory" href="/docs/commands/memory">
+    `<list|promote|validate|forget|restore|forgotten>` — inspect memories through the
+    citation loop, and promote a proven one to a project rule.
+  </SpecCard>
+  <SpecCard title="stella mcp" href="/docs/commands/mcp">
+    `<list|search|install|remove|login|logout|usage>` — manage MCP servers, including
+    OAuth login and tool-usage telemetry.
+  </SpecCard>
+  <SpecCard title="stella connect" href="/docs/commands/connect">
+    `<github|linear|status|remove>` — connect a tracker via OAuth so the agent gains the
+    issue toolset.
+  </SpecCard>
+  <SpecCard title="stella auth" href="/docs/commands/auth">
+    `<set|remove|list>` — manage BYOK provider keys in `credentials.toml`. Never prints a
+    secret.
+  </SpecCard>
+  <SpecCard title="stella tools" href="/docs/commands/tools">
+    List every tool available to the agent this session.
+  </SpecCard>
+  <SpecCard title="stella config" href="/docs/commands/config">
+    Show the fully resolved configuration for the current session.
+  </SpecCard>
+  <SpecCard title="stella doctor" href="/docs/commands/doctor">
+    Check the local state stella owns and exit non-zero if any check fails. `--repair`
+    moves a corrupt `store.db` aside — renamed, never deleted.
+  </SpecCard>
+  <SpecCard title="stella version" href="/docs/commands/version">
+    Print the version and exit.
+  </SpecCard>
+</CardGrid>
 
 Each command page in this section documents its usage synopsis, behavior, relevant flags, and realistic examples.
 
-Two subcommands are deliberately absent from the table because they are not part of the day-to-day surface:
+Two subcommands are deliberately absent from the list above because they are not part of the day-to-day surface:
 
 - `stella telemetry` (`status` / `flush` / `rollover-discard`) manages the managed enterprise operational spool. It is disabled by default and requires a signed org-managed enrollment — see the [Enterprise telemetry boundary](/docs/telemetry#oxagen-enterprise-managed-export).
 - `stella arena` is the [arena-bench](https://github.com/macanderson/arena-bench) harness adapter. It runs a benchmark task from a `--task-dir` and records the trace journal the arena runner scores; it is for benchmarking Stella, not for using it.
@@ -55,15 +118,36 @@ The following flags apply to **every** command. Most have a corresponding enviro
 
 Every one of them is registered with every subcommand, so **either position parses** — `stella --output-format json run "…"` and `stella run "…" --output-format json` are equivalent. (That is not clap's default: a plain root-level flag is only accepted before the subcommand token, which is why `main.rs` marks each of these `global = true` and a test asserts no new one is added without it.) Because the flag names are reserved CLI-wide, no subcommand reuses them — `stella connect linear` pastes a key with `--paste-key`, not `--api-key`.
 
-| Flag | Env var | Default | Meaning |
-| --- | --- | --- | --- |
-| `--model <provider/model_id>` | `STELLA_MODEL` | auto-detected | Pin the worker model, e.g. `zai/glm-5.2`, `anthropic/claude-fable-5`, `openai/gpt-5.5`, `local/llama3.3`. |
-| `--api-key <key>` | — | none | Highest-precedence step of the credential chain. Requires an explicit `--model provider/...` (a bare key is ambiguous). |
-| `--base-url <url>` | `STELLA_BASE_URL` | provider default | Required with `--model local/<model>` to point at a local OpenAI-compatible server; an optional proxy override for any other provider. |
-| `--output-format <text\|json\|stream-json>` | `STELLA_OUTPUT_FORMAT` | `text` | Response rendering mode, honored by `stella run` (the interactive `chat`/`goal`/`monitor` modes always render text). See the table below. |
-| `--budget <usd>` | `STELLA_BUDGET` | none (observed) | Hard USD spend cap for the whole run/session. Must be positive and finite. |
-| `--plain` | `STELLA_PLAIN=1` | off | Use the plain line-based REPL for chat instead of the Command Deck (also auto-selected on a non-TTY). |
-| `--no-anim` | `STELLA_NO_ANIM` / `NO_COLOR` | off | Freeze all deck animation to a static frame (for CI and asciinema-style recordings). |
+<CardGrid size="md">
+  <OptionCard name="--model <provider/model_id>" defaultValue="auto-detected">
+    Pin the worker model — `zai/glm-5.2`, `anthropic/claude-fable-5`, `openai/gpt-5.5`,
+    `local/llama3.3`. Env `STELLA_MODEL`.
+  </OptionCard>
+  <OptionCard name="--api-key <key>">
+    Highest-precedence step of the credential chain. Requires an explicit
+    `--model provider/…` — a bare key is ambiguous. No env var, deliberately.
+  </OptionCard>
+  <OptionCard name="--base-url <url>" defaultValue="provider default">
+    Required with `--model local/<model>` to point at a local OpenAI-compatible server; an
+    optional proxy override for any other provider. Env `STELLA_BASE_URL`.
+  </OptionCard>
+  <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
+    Response rendering mode, honored by `stella run` — the interactive `chat`, `goal`, and
+    `monitor` modes always render text. Env `STELLA_OUTPUT_FORMAT`.
+  </OptionCard>
+  <OptionCard name="--budget <usd>" defaultValue="none (observed)">
+    Hard USD spend cap for the whole run or session. Must be positive and finite. Env
+    `STELLA_BUDGET`.
+  </OptionCard>
+  <OptionCard name="--plain" defaultValue="off">
+    Use the plain line-based REPL for chat instead of the Command Deck — also
+    auto-selected on a non-TTY. Env `STELLA_PLAIN=1`.
+  </OptionCard>
+  <OptionCard name="--no-anim" defaultValue="off">
+    Freeze all deck animation to a static frame, for CI and asciinema-style recordings.
+    Env `STELLA_NO_ANIM` / `NO_COLOR`.
+  </OptionCard>
+</CardGrid>
 
 <Callout type="warn">
 Prefer an environment variable or `credentials.toml` for anything long-lived. A key passed with `--api-key` is visible in your shell history and in `ps` output.
@@ -71,18 +155,29 @@ Prefer an environment variable or `credentials.toml` for anything long-lived. A 
 
 ### `--output-format` values
 
-| Value | Behavior |
-| --- | --- |
-| `text` | Interactive, human-readable render (the default). |
-| `json` | One final JSON object emitted at the end of the run (headless). |
-| `stream-json` | One JSON line per `AgentEvent` as it happens (headless streaming). |
+<CardGrid size="sm">
+  <OptionCard name="text">
+    Interactive, human-readable render. The default.
+  </OptionCard>
+  <OptionCard name="json">
+    One final JSON object emitted at the end of the run. Headless.
+  </OptionCard>
+  <OptionCard name="stream-json">
+    One JSON line per `AgentEvent` as it happens. Headless streaming.
+  </OptionCard>
+</CardGrid>
 
 ### `--budget` modes
 
-| Mode | How to trigger | Behavior |
-| --- | --- | --- |
-| Observed | Omit `--budget` | Spend is metered for the cost summary but never blocks. |
-| Enforced | Pass `--budget <usd>` | A hard cap. Work aborts cleanly (never mid-tool) once spend exceeds the cap. |
+<CardGrid size="md">
+  <SpecCard title="Observed">
+    Omit `--budget`. Spend is metered for the cost summary but never blocks.
+  </SpecCard>
+  <SpecCard title="Enforced">
+    Pass `--budget <usd>`. A hard cap: work aborts cleanly — never mid-tool — once spend
+    exceeds it.
+  </SpecCard>
+</CardGrid>
 
 Token usage, cost, and per-step metering are recorded in a local SQLite store on your disk (`<workspace>/.stella/private/store.db`) — nothing is sent anywhere. See [`stella stats`](/docs/commands/stats).
 
@@ -100,9 +195,30 @@ zai, anthropic, openai, xai, deepseek, gemini, openrouter, then vertex, and bedr
 
 Every command follows standard shell conventions:
 
-| Exit code | Meaning |
-| --- | --- |
-| `0` | Success. |
-| non-zero | An error occurred (for example, a missing credential, an aborted budget-capped run, or a failed goal). |
+<CardGrid size="md">
+  <OptionCard name="0">
+    Success.
+  </OptionCard>
+  <OptionCard name="1">
+    An error occurred — a missing credential, an aborted budget-capped run, a failed goal,
+    a doctor check that did not pass.
+  </OptionCard>
+  <OptionCard name="128 + signal">
+    The run was interrupted by a signal rather than failing on its own. `SIGINT`
+    (Ctrl-C) exits `130`, `SIGTERM` exits `143`.
+  </OptionCard>
+</CardGrid>
+
+The signal range exists so a script wrapping `stella run` can tell *the user stopped this*
+from *this failed*, which are different outcomes and usually want different handling:
+
+```bash
+stella run "Fix the failing tests"
+case $? in
+  0)   echo "done" ;;
+  130) echo "interrupted — nothing to report" ;;
+  *)   echo "run failed" ;;
+esac
+```
 
 This makes Stella safe to compose in scripts and CI pipelines — check `$?` (or rely on `set -e`) to react to failures.

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -29,19 +29,29 @@ Run `stella init` once per workspace to prime Stella's understanding of your cod
 
 `stella init` takes the [global flags](/docs/commands). Because it can run offline, model selection is optional:
 
-| Flag | Why it matters here |
-| --- | --- |
-| `--model <provider/model_id>` | Pin the model used for taxonomy inference. Omit it to rely on auto-detection or the offline heuristic fallback. |
+<CardGrid size="md">
+  <OptionCard name="--model <provider/model_id>" defaultValue="auto-detected">
+    Pin the model used for taxonomy inference. Omit it to rely on auto-detection, or on
+    the offline heuristic fallback when nothing resolves.
+  </OptionCard>
+</CardGrid>
 
 The global `--budget` flag is accepted but not honored by `init` — the analysis makes at most a couple of token-capped inference calls and does not track a budget.
 
 ## Generated files
 
-| Path | Contents |
-| --- | --- |
-| `<workspace>/.stella/domains.toml` | The inferred domain taxonomy (tagging vocabulary). |
-| `<workspace>/.stella/private/codegraph.db` | The code-graph index (queried by `stella graph`). |
-| `<workspace>/.stella/private/context.db` | The context plane — the domain taxonomy and context facts. |
+<CardGrid size="md">
+  <OptionCard name="<workspace>/.stella/domains.toml">
+    The inferred domain taxonomy — the tagging vocabulary.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/private/codegraph.db">
+    The code-graph index, queried by [`stella graph`](/docs/commands/graph) and
+    [`stella storage`](/docs/commands/storage).
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/private/context.db">
+    The context plane — the domain taxonomy and context facts.
+  </OptionCard>
+</CardGrid>
 
 ## Examples
 
@@ -55,4 +65,18 @@ Initialize using a specific model for taxonomy inference:
 
 ```bash
 stella --model openai/gpt-5.5 init
+```
+
+Re-index after a large refactor, then confirm the graph followed the move:
+
+```bash
+stella init
+stella graph definitions resolve_provider_key
+```
+
+Initialize with no credential configured at all — the heuristic fallback still produces a
+usable taxonomy and graph:
+
+```bash
+env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY stella init
 ```

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -21,13 +21,24 @@ It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it re
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--turn <T>` | Turn instance within the execution. Default `0`. |
-| `--step <N>` | Step to reconstruct. Omit to list the execution's calls instead. |
-| `--call-seq <S>` | Which model call at that step. Default `0`. |
-| `--format <text\|json>` | `text` (default) prints a role-delimited transcript; `json` gives the messages plus the verification verdict. |
-| `--full` | Print message bodies in full instead of eliding long ones. |
+<CardGrid size="md">
+  <OptionCard name="--turn <T>" defaultValue="0">
+    Turn instance within the execution.
+  </OptionCard>
+  <OptionCard name="--step <N>">
+    Step to reconstruct. Omit it to list the execution's calls instead.
+  </OptionCard>
+  <OptionCard name="--call-seq <S>" defaultValue="0">
+    Which model call at that step — see below for why a step can have several.
+  </OptionCard>
+  <OptionCard name="--format <text|json>" defaultValue="text">
+    `text` prints a role-delimited transcript; `json` gives the messages plus the
+    verification verdict.
+  </OptionCard>
+  <OptionCard name="--full">
+    Print message bodies in full instead of eliding long ones.
+  </OptionCard>
+</CardGrid>
 
 ## Why `--call-seq` exists
 
@@ -37,7 +48,7 @@ These auxiliary calls assemble their own prompts — a role task prompt, an opti
 
 ## Reading the verification banner
 
-```
+```text
 execution 42 · turn 0 · step 3 · call-seq 0
 7 message(s)
 verified: every journal-resolved block re-hashed to its recorded digest
@@ -45,12 +56,51 @@ verified: every journal-resolved block re-hashed to its recorded digest
 
 Two failure modes are reported separately, because they mean very different things:
 
-| Line | Meaning |
-| --- | --- |
-| `! N block(s) could not be resolved` | A documented coverage gap — budget-abort synthetic tool results, discarded speculation, or attachments. The rest of the transcript is still faithful. |
-| `!! N block(s) did NOT re-hash to their recorded digest` | The journal is torn or was altered. Treat the reconstruction as untrustworthy. |
+<CardGrid size="md">
+  <OptionCard name="! N block(s) could not be resolved">
+    A documented coverage gap — budget-abort synthetic tool results, discarded
+    speculation, or attachments. The rest of the transcript is still faithful.
+  </OptionCard>
+  <OptionCard name="!! N block(s) did NOT re-hash">
+    The journal is torn or was altered. Treat the reconstruction as untrustworthy.
+  </OptionCard>
+</CardGrid>
 
 The system prefix and the assembled user message are stored as local bytes rather than resolved from the journal, so their digest check is tautological and is deliberately **not** counted as evidence. The proof lives in the journal-resolved kinds.
+
+## Examples
+
+Start from the index — which executions have receipts at all:
+
+```bash
+stella inspect
+```
+
+Then list one execution's recorded calls, with their roles and sequence numbers:
+
+```bash
+stella inspect 42
+```
+
+Reconstruct the worker call at step 3 and read it as a transcript:
+
+```bash
+stella inspect 42 --step 3
+```
+
+Read the judge's prompt instead of the worker's — the auxiliary calls at that step:
+
+```bash
+stella inspect 42 --step 3 --call-seq 2 --full
+```
+
+Check the verdict from a script without reading the transcript — `verified`, plus the two
+failure lists behind it:
+
+```bash
+stella inspect 42 --step 3 --format json |
+  jq '{verified, unresolved, digest_mismatches}'
+```
 
 ## What it can't show you
 

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -1,16 +1,16 @@
 ---
 title: stella memory
-description: Inspect memories through the citation feedback loop, validate them against the code, and promote one to a project rule.
+description: Inspect memories through the citation feedback loop, validate them against the code, promote a proven one to a project rule, and forget the ones that turned out wrong.
 ---
 
-Inspect the project's memories through the citation feedback loop — most-cited first, with usefulness and truthfulness — and promote a proven memory to a project rule. It reads local state only and needs no API key.
+Inspect the project's memories through the citation feedback loop — most-cited first, with usefulness and truthfulness — promote a proven memory to a project rule, and tombstone the ones that turned out wrong. It reads local state only and needs no API key.
 
 For the concepts behind memories, reflections, and the code graph, see [Memory](/docs/context-engine). This page is the command reference.
 
 ## Synopsis
 
 ```bash
-stella memory <list|promote|validate> [args]
+stella memory <list|promote|validate|forget|restore|forgotten> [args]
 ```
 
 ## What it does
@@ -49,3 +49,45 @@ Re-validate old memories against the current codebase. It scans each memory for 
 ```bash
 stella memory validate
 ```
+
+### `stella memory forget <id>`
+
+Stop a memory steering the agent — and stop the reflection loop re-learning it.
+
+```bash
+stella memory forget nod_9f2c1a
+stella memory forget nod_9f2c1a --reason "superseded by the new store API"
+```
+
+This writes a **tombstone**, not a delete, and the distinction is the whole point.
+The reflection loop mines the session log for lessons and re-records paraphrases of
+what it has already learned, so deleting the row alone does not hold — the memory
+grows back under a new id within a few sessions. The tombstone also suppresses
+restatements at the two points new lessons enter: when a lesson is recorded, and when
+the log is mined into skills.
+
+`--reason` is optional and shown later by `stella memory forgotten`. Write one — the
+future reader deciding whether to `restore` is usually you, months on.
+
+### `stella memory restore <id>`
+
+Lift a tombstone: the memory can be recalled again, and becomes re-learnable.
+
+```bash
+stella memory restore nod_9f2c1a
+```
+
+### `stella memory forgotten`
+
+List this workspace's tombstones — what was forgotten, when, and why.
+
+```bash
+stella memory forgotten
+```
+
+<Callout type="info">
+`forget` is reversible and `validate` is advisory: neither destroys anything. Between
+them they are the maintenance pass for a memory store that has drifted — `validate` to
+find memories pointing at code that no longer exists, `forget` to retire the ones that
+turned out to be wrong rather than merely stale.
+</Callout>

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Commands",
-  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "models", "stats", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "version"]
+  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "models", "stats", "usage", "cloud", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "version"]
 }

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -17,7 +17,7 @@ stella models list [--provider <id>] [--all]
 
 `stella models` enumerates the built-in providers and reports, for each one, its display name, key status, default model, and base URL, followed by a status line for the local model catalog. Any custom providers you define in `settings.json` are listed too, under a separate **Config-defined providers** heading with their wire dialect. It is the quickest way to confirm which providers are ready to use before you pin one with `--model`.
 
-The **key status** reflects only whether the provider's environment variable (primary or an alias) is set, or a non-empty `api_key` is present in `settings.json`. A key stored only in `~/.stella/credentials.toml` (or supplied at the interactive prompt) resolves fine at run time but does not light up this column.
+The **key status** is resolved through the same chain `stella run` uses — the shared resolver, run non-interactively so a listing command never blocks on a prompt. Every source counts: an environment variable (primary or alias), a project `.env` file, a `settings.json` literal, and `~/.stella/credentials.toml` alike. Each configured row names the source that actually won, so `stella models`, [`stella config`](/docs/commands/config), and [`stella auth list`](/docs/commands/auth) can never disagree with each other or with a real run.
 
 The same listing is available from inside an interactive session via the [`/models`](/docs/commands/chat) slash command.
 
@@ -27,16 +27,35 @@ The catalog behind model validation and pricing syncs from [models.dev](https://
 
 ### `stella models refresh [--force]`
 
-Sync the catalog now. Incremental by default (ETag-aware); `--force` re-downloads everything. Without an explicit refresh, the catalog auto-resyncs when it is older than 24 hours (disable with `STELLA_CATALOG_AUTO_REFRESH=0`).
+Sync the catalog now. Incremental by default (ETag-aware); `--force` re-downloads everything.
 
 ```bash
 stella models refresh
 stella models refresh --force
 ```
 
+#### What auto-syncs, and what does not
+
+There are two catalog sources, and they follow deliberately different rules. Both use the same 24-hour staleness window, and `STELLA_CATALOG_AUTO_REFRESH=0` disables all implicit fetching.
+
+<CardGrid size="md">
+  <OptionCard name="Native provider listings">
+    Each configured provider's own `/models` endpoint. Auto-syncs whenever it is stale,
+    **including the very first time** — this is what surfaces new releases as they ship.
+    BYOK-clean: the request goes to a provider you already gave Stella a key for, the same
+    host your next turn calls anyway. No credential, nothing fetched.
+  </OptionCard>
+  <OptionCard name="The models.dev master list">
+    A third party, so it is never contacted implicitly. It may auto-*re*fresh only once a
+    sync row already exists — that is, after your own first explicit `stella models
+    refresh`. A fresh install never touches models.dev on its own, and the catalog line
+    reads `seed only` until you run that first refresh.
+  </OptionCard>
+</CardGrid>
+
 ### `stella models list [--provider <id>] [--all]`
 
-List the models in the local catalog — slug, display name, context window, and current pricing — optionally filtered to one provider. By default the listing is scoped to providers whose credential resolves; add `--all` to include providers with no configured credential too.
+List the models in the local catalog, optionally filtered to one provider. Each row is `provider/slug`, then in / out / cached-in price per Mtok, then the context window, then the model's **maker**, a `thinks` marker when the model supports reasoning, and the pricing card's version.
 
 ```bash
 stella models list
@@ -44,10 +63,30 @@ stella models list --provider anthropic
 stella models list --all
 ```
 
-| Flag | Effect |
-| --- | --- |
-| `--provider <id>` | Filter to a single provider. |
-| `--all` | Include providers with no configured credential (the listing is otherwise scoped to providers whose credential resolves). |
+```text
+Stella — Model Catalog
+
+  provider/slug  ·  $in / $out / $cached-in per Mtok  ·  context  ·  maker  [pricing v]
+  anthropic/claude-fable-5  $3.00 / $15.00 / $0.30  ctx 200k  anthropic  thinks  [v3]
+  zai/glm-5.2  $0.60 / $2.20 / $0.11  ctx 200k  z-ai  thinks  [v1]
+
+  2 models. Pricing shown is each card's latest version.
+  master list last refreshed 2026-07-18 09:14:03 UTC — `stella models refresh` to update
+```
+
+With no `--provider`, the listing is scoped to providers whose credential currently resolves — the same set the deck's model picker offers, because "what can I actually select right now" is the question a bare `list` answers. A footer line reports how many models were hidden that way.
+
+<CardGrid size="md">
+  <OptionCard name="--provider <id>">
+    Filter to a single provider. Credential scoping does not apply on this path: you get
+    every model the catalog holds for that provider whether or not its key resolves.
+  </OptionCard>
+  <OptionCard name="--all">
+    Lift the credential scope and list the whole catalog. Only meaningful **without**
+    `--provider` — passing both leaves `--all` with nothing to do, since a `--provider`
+    listing is already unscoped.
+  </OptionCard>
+</CardGrid>
 
 <Callout type="info">
 Provider credentials are resolved through the credential chain: `--api-key` flag, then the provider env var (and aliases), then `settings.json`, then `~/.stella/credentials.toml`, and finally an interactive prompt on a TTY.
@@ -55,9 +94,11 @@ Provider credentials are resolved through the credential chain: `--api-key` flag
 
 ## Flags
 
-`stella models` takes the [global flags](/docs/commands), but the listing itself depends only on your `settings.json` and environment variables — `--model`, `--base-url`, and `--api-key` do not change its output.
+`stella models` takes the [global flags](/docs/commands), but the listing itself depends only on what the credential chain resolves from disk and environment — `settings.json`, your environment variables and dotenv files, and `credentials.toml`. `--model`, `--base-url`, and `--api-key` do not change its output.
 
-## Example
+## Examples
+
+Confirm which providers are ready before pinning one:
 
 ```bash
 stella models
@@ -68,8 +109,8 @@ Representative output (illustrative — one line per provider, in auto-detect pr
 ```text
 Stella — Available Providers & Models
 
-  ✓ configured zai/glm-5.2  Z.ai (GLM 5.2)  [https://api.z.ai/api/paas/v4]
-  ✓ configured anthropic/claude-fable-5  Anthropic (Claude)  [https://api.anthropic.com]
+  ✓ configured zai/glm-5.2  Z.ai (GLM 5.2)  [https://api.z.ai/api/paas/v4] (env:ZAI_API_KEY)
+  ✓ configured anthropic/claude-fable-5  Anthropic (Claude)  [https://api.anthropic.com] (credentials.toml)
   ✗ no key openai/gpt-5.5  OpenAI (GPT)  [https://api.openai.com/v1]
   ✗ no key xai/grok-4  xAI (Grok)  [https://api.x.ai/v1]
   ✗ no key deepseek/deepseek-chat  DeepSeek  [https://api.deepseek.com/v1]
@@ -79,16 +120,18 @@ Stella — Available Providers & Models
   ✗ no key bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0  Amazon Bedrock  [https://bedrock-runtime.<AWS_REGION>.amazonaws.com]
 
   Config-defined providers (settings.json):
-  ✓ configured myproxy/<model>  My proxy  [https://llm.internal.example/v1] (OpenAI-compatible)
+  ✓ configured myproxy/<model>  My proxy  [https://llm.internal.example/v1] (OpenAI-compatible) (.env.local)
 
   Use --model provider/model_id to pin a specific model.
   Example: stella --model zai/glm-5.2 run 'fix the failing test'
   Local endpoints (Ollama, vLLM, LM Studio): stella --model local/<model> --base-url http://localhost:11434/v1
 
-  Model catalog: 1204 models / 118 aliases — master list refreshed 2026-07-18 09:14 UTC (`stella models list` to browse, `stella models refresh` to update).
+  Model catalog: 1204 models / 118 aliases — master list refreshed 2026-07-18 09:14:03 UTC (`stella models list` to browse, `stella models refresh` to update).
 ```
 
-Each row is `{key status} {id}/{default model}  {display name}  [{base url}]`. The `vertex` and `bedrock` base URLs are display anchors — the real endpoint is built per request from your project/location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or `AWS_REGION`. Config-defined providers from `settings.json` follow under their own heading with the wire dialect appended. The **Config-defined providers** section only appears when `settings.json` defines one, and the catalog line reads `seed only` until your first `stella models refresh`.
+Each row is `{key status} {id}/{default model}  {display name}  [{base url}] ({source})`, where the trailing source appears only on a configured row and names where the winning key came from — `env:VAR_NAME`, the project dotenv file it was loaded from (`.env.local`), `credentials.toml`, or `settings.json`. That suffix is why the second row above reads `✓ configured` with no environment variable set: a key living only in `~/.stella/credentials.toml` counts, and the listing says so.
+
+The `vertex` and `bedrock` base URLs are display anchors — the real endpoint is built per request from your project/location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or `AWS_REGION`. Config-defined providers from `settings.json` follow under their own heading with the wire dialect appended before the source suffix, and that section only appears when `settings.json` actually defines one. Until your first `stella models refresh`, the closing catalog line reads `seed only` instead.
 
 `local` is not a provider row — it is surfaced only as the footer hint that reminds you to
 point at a local endpoint yourself, e.g. `stella --model local/<model> --base-url http://localhost:11434/v1`.
@@ -96,3 +139,22 @@ point at a local endpoint yourself, e.g. `stella --model local/<model> --base-ur
 <Callout type="warn">
 The values above are for illustration. Your actual key status depends on which credentials resolve in your environment, and default models and base URLs can be overridden per provider via `settings.json`.
 </Callout>
+
+Browse the catalog for a provider you have not configured yet — `--provider` lists it regardless of whether its key resolves:
+
+```bash
+stella models list --provider openai
+```
+
+See everything the catalog holds, credentialed or not:
+
+```bash
+stella models list --all
+```
+
+Pull the models.dev master list for the first time, then read the catalog status line back:
+
+```bash
+stella models refresh
+stella models
+```

--- a/website/content/docs/commands/monitor.mdx
+++ b/website/content/docs/commands/monitor.mdx
@@ -31,10 +31,14 @@ Under the hood, `monitor` is [goal mode](/docs/agent-modes#outcome-driven-goal-m
 
 `stella monitor` takes the [global flags](/docs/commands). The most relevant ones:
 
-| Flag | Why it matters here |
-| --- | --- |
-| `--model <provider/model_id>` | Pin the worker model used to diagnose and fix failures. |
-| `--budget <usd>` | Cap total spend while it works across CI runs. |
+<CardGrid size="md">
+  <OptionCard name="--model <provider/model_id>">
+    Pin the worker model used to diagnose and fix failures.
+  </OptionCard>
+  <OptionCard name="--budget <usd>">
+    Cap total spend while it works across CI runs.
+  </OptionCard>
+</CardGrid>
 
 <Callout type="info">
 `monitor` is an interactive mode and always renders human-readable text; it does **not** honor `--output-format`.

--- a/website/content/docs/commands/observe.mdx
+++ b/website/content/docs/commands/observe.mdx
@@ -25,10 +25,14 @@ The dashboard's tabs cover the overview, executions (with per-run drill-down), t
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--port <N>` | Port to bind on `127.0.0.1`. Default `7787`; `0` picks a free port. |
-| `--open` | Open the dashboard in your default browser once the server is up. |
+<CardGrid size="md">
+  <OptionCard name="--port <N>" defaultValue="7787">
+    Port to bind on `127.0.0.1`. `0` picks a free port.
+  </OptionCard>
+  <OptionCard name="--open">
+    Open the dashboard in your default browser once the server is up.
+  </OptionCard>
+</CardGrid>
 
 ## Examples
 
@@ -42,4 +46,16 @@ Bind an ephemeral port (useful when 7787 is taken):
 
 ```bash
 stella observe --port 0
+```
+
+Pin a port so a bookmark keeps working, and leave it running in the background:
+
+```bash
+stella observe --port 8080 &
+```
+
+Serve a different workspace's telemetry by starting from its root:
+
+```bash
+(cd ~/projects/acme && stella observe --open)
 ```

--- a/website/content/docs/commands/resume.mdx
+++ b/website/content/docs/commands/resume.mdx
@@ -43,10 +43,15 @@ The deck's **SESSIONS** overlay (`←` on an empty prompt, or `/sessions`) is th
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `[id]` | Registry id (`ses-…`) of the session to reopen. Omitted: the most recently active resumable session of this workspace. |
-| `--list` | List this machine's sessions (resumable ones marked) and exit. |
+<CardGrid size="md">
+  <OptionCard name="[id]">
+    Registry id (`ses-…`) of the session to reopen. Omitted, the most recently active
+    resumable session of this workspace.
+  </OptionCard>
+  <OptionCard name="--list">
+    List this machine's sessions, resumable ones marked, and exit.
+  </OptionCard>
+</CardGrid>
 
 The [global flags](/docs/commands) apply — `--budget` is re-seeded with the session's prior spend, and `--no-anim` freezes deck animation as usual.
 

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -8,7 +8,7 @@ Send a one-shot prompt and let the agent work to completion without any interact
 ## Synopsis
 
 ```bash
-stella run <prompt> [--no-pipeline] [--test-command <CMD>] [global flags]
+stella run <prompt> [--no-pipeline] [--test-command <CMD>] [--keep-witness] [global flags]
 ```
 
 ## What it does
@@ -25,20 +25,43 @@ Because it is non-interactive, `stella run` is the natural place to combine `--o
 
 ## Flags
 
-`stella run` adds two command-specific flags on top of the [global flags](/docs/commands):
+`stella run` adds three command-specific flags on top of the [global flags](/docs/commands):
 
-| Flag | Meaning |
-| --- | --- |
-| `--no-pipeline` | Use the raw step loop instead of the staged pipeline (triage, plan, execute, verify, judge). |
-| `--test-command <CMD>` | The test command the pipeline's verify stage runs (e.g. `"cargo test -p my-crate"`). Arms the fail→pass flip oracle: a change that flips a failing test to passing can submit without a model-judge call. Omitted, verification always escalates to the judge. |
+<CardGrid size="md">
+  <OptionCard name="--no-pipeline">
+    Use the raw step loop instead of the staged pipeline (triage, plan, execute, verify,
+    judge).
+  </OptionCard>
+  <OptionCard name="--test-command <CMD>">
+    The test command the pipeline's verify stage runs deterministically — e.g.
+    `"cargo test -p my-crate"`. Arms the fail→pass flip oracle: a change that flips a
+    failing test to passing can submit without a model-judge call. Omitted, verification
+    always escalates to the judge.
+  </OptionCard>
+  <OptionCard name="--keep-witness">
+    Keep the authored witness test as a file in your working tree. By default the witness
+    is scaffolding — it proves this run's goal inside the candidate workspace and is
+    discarded with it, so an already-satisfied test is never left behind in your test
+    tree. Pass this to promote it to a real test you can commit.
+  </OptionCard>
+</CardGrid>
 
 The most relevant global flags here:
 
-| Flag | Why it matters here |
-| --- | --- |
-| `--model <provider/model_id>` | Pin the worker model instead of relying on auto-detection. |
-| `--output-format <text\|json\|stream-json>` | Use `json` or `stream-json` for machine-readable, headless output. Place it before the subcommand: `stella --output-format json run "…"`. |
-| `--budget <usd>` | Cap total spend for the run; work aborts cleanly once the cap is exceeded. |
+<CardGrid size="md">
+  <OptionCard name="--model <provider/model_id>">
+    Pin the worker model instead of relying on auto-detection.
+  </OptionCard>
+  <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
+    Use `json` or `stream-json` for machine-readable, headless output. Like every global
+    flag it is registered with the subcommand too, so either position parses —
+    `stella --output-format json run "…"` and `stella run "…" --output-format json` are
+    the same command.
+  </OptionCard>
+  <OptionCard name="--budget <usd>">
+    Cap total spend for the run; work aborts cleanly once the cap is exceeded.
+  </OptionCard>
+</CardGrid>
 
 ## Examples
 
@@ -48,7 +71,7 @@ Run a simple one-shot task with the default (auto-detected) model:
 stella run "Add a docstring to every public function in src/utils.py"
 ```
 
-Pin a specific model and emit a single JSON object for a script to parse. Global flags go **before** the `run` subcommand:
+Pin a specific model and emit a single JSON object for a script to parse. Global flags read most clearly before the subcommand, though [either position parses](/docs/commands#global-flags):
 
 ```bash
 stella --model anthropic/claude-fable-5 --output-format json \
@@ -67,4 +90,25 @@ Point at a local OpenAI-compatible server:
 ```bash
 stella --model local/llama3.3 --base-url http://localhost:11434/v1 \
   run "Explain what main.rs does"
+```
+
+Hand the verify stage a deterministic oracle, so a fixed test can submit without a
+model-judge call:
+
+```bash
+stella run --test-command "cargo test -p stella-store" \
+  "Fix the failing WAL checkpoint test"
+```
+
+Keep the witness the pipeline authored, so you can review and commit it alongside the fix:
+
+```bash
+stella run --keep-witness \
+  "Add retry-with-backoff to the HTTP client and prove it with a test"
+```
+
+Skip the pipeline entirely for a small mechanical edit:
+
+```bash
+stella run --no-pipeline "Bump the serde dependency to 1.0.220 in every crate"
 ```

--- a/website/content/docs/commands/scripts.mdx
+++ b/website/content/docs/commands/scripts.mdx
@@ -20,10 +20,16 @@ Instead of guessing that a repo uses `pnpm test` versus `cargo test` versus `mak
 
 List detected scripts and their canonical verb bindings.
 
-| Flag | Meaning |
-| --- | --- |
-| `--json` | Emit the index as JSON (`schema_version` 1) for tooling. |
-| `--dir <path>` | Narrow to one workspace package directory. |
+<CardGrid size="md">
+  <OptionCard name="--json">
+    Emit the index as JSON for tooling — `schema_version`, the canonical `verbs` map, and
+    a `scripts` array of entries (`id`, `runner`, `name`, `command`, `dir`, `source`, and
+    `verb` on the entry each canonical verb binds to).
+  </OptionCard>
+  <OptionCard name="--dir <path>">
+    Narrow to one workspace package directory.
+  </OptionCard>
+</CardGrid>
 
 ```bash
 stella scripts list
@@ -34,12 +40,21 @@ stella scripts list --json --dir apps/web
 
 Run a script by canonical verb or by qualified id (e.g. `test`, `pnpm:build`).
 
-| Flag / arg | Default | Meaning |
-| --- | --- | --- |
-| `<script>` | — | `install` \| `build` \| `check` \| `start` \| `test` \| `lint` \| `format`, or a qualified id like `pnpm:build`. |
-| `--dir <path>` | — | Package dir when the id exists in several packages. |
-| `--timeout-secs <n>` | `600` | Abort the subprocess after this many seconds. |
-| `-- <args...>` | — | Extra args appended runner-natively (after `--` for npm-family runners). |
+<CardGrid size="md">
+  <OptionCard name="<script>" required>
+    One of `install`, `build`, `check`, `start`, `test`, `lint`, `format`, or a qualified
+    id like `pnpm:build`.
+  </OptionCard>
+  <OptionCard name="--dir <path>">
+    Package dir, for when the id exists in several packages.
+  </OptionCard>
+  <OptionCard name="--timeout-secs <n>" defaultValue="600">
+    Abort the subprocess after this many seconds.
+  </OptionCard>
+  <OptionCard name="-- <args...>">
+    Extra args, appended runner-natively — after a `--` for npm-family runners.
+  </OptionCard>
+</CardGrid>
 
 ```bash
 # Canonical verb
@@ -47,6 +62,12 @@ stella scripts run test
 
 # Qualified id in a specific package, with extra args
 stella scripts run pnpm:build --dir apps/web -- --no-lint
+
+# A long build, given room to finish
+stella scripts run build --timeout-secs 1800
+
+# Feed the index to another tool
+stella scripts list --json | jq '.scripts[] | select(.verb == "test")'
 ```
 
 <Callout type="info">

--- a/website/content/docs/commands/stats.mdx
+++ b/website/content/docs/commands/stats.mdx
@@ -9,6 +9,7 @@ Read back what your runs actually cost. `stella stats` summarizes cost, tokens, 
 
 ```bash
 stella stats [--format <table|json|csv>] [--provider <id>]
+stella stats prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] [--dry-run]
 ```
 
 ## What it does
@@ -17,20 +18,40 @@ stella stats [--format <table|json|csv>] [--provider <id>]
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--format <table\|json\|csv>` | Output format. `table` (default) prints an aligned table with a `TOTAL` row; `json` and `csv` are for piping into other tools. |
-| `--provider <id>` | Only include executions for this provider id (e.g. `zai`, `anthropic`, `local`). |
+<CardGrid size="md">
+  <OptionCard name="--format <table|json|csv>" defaultValue="table">
+    Output format. `table` prints aligned columns with a `TOTAL` row; `json` and `csv`
+    are for piping into other tools.
+  </OptionCard>
+  <OptionCard name="--provider <id>">
+    Only include executions for this provider id — `zai`, `anthropic`, `local`, and so on.
+  </OptionCard>
+</CardGrid>
 
 ## Reading the cache columns
 
 Every row also carries three cache-economics columns, derived at display time from your local telemetry (they aren't stored — `stella stats` computes them fresh from the raw token counts each run):
 
-| Column | Meaning |
-| --- | --- |
-| `HIT%` | Cache-read tokens over total input tokens for that row — the same figure the deck's `CACHE` statline cell shows for the live session. |
-| `SAVED ($)` | Estimated USD saved by prompt caching, priced at **today's** catalog rates (not the price in effect when each call actually ran). Signed: negative means the provider's cache-write premium outran the reads it bought — the "cache never actually helped" incident worth investigating. `-` when the model isn't in the running catalog. |
-| `TTL REWRITES` | Calls whose cache prefix went cold — the gap since that session's previous call exceeded the provider's cache TTL — and got rewritten instead of read back. `0` for a provider with no documented TTL. This is the tax cache-TTL-aware fleet scheduling exists to cut: a session parked too long between turns pays the write premium again for no reason. |
+<CardGrid size="md">
+  <OptionCard name="HIT%">
+    Cache-read tokens over total input tokens for that row — the same figure the deck's
+    `CACHE` statline cell shows for the live session.
+  </OptionCard>
+  <OptionCard name="SAVED ($)">
+    Estimated USD saved by prompt caching, priced at **today's** catalog rates — not the
+    price in effect when each call actually ran. Signed: a negative value means the
+    provider's cache-write premium outran the reads it bought, which is the "the cache
+    never actually helped" incident worth investigating. Shows `-` when the model isn't
+    in the running catalog.
+  </OptionCard>
+  <OptionCard name="TTL REWRITES">
+    Calls whose cache prefix went cold — the gap since that session's previous call
+    exceeded the provider's cache TTL — and got rewritten instead of read back. `0` for
+    a provider with no documented TTL. This is the tax cache-TTL-aware fleet scheduling
+    exists to cut: a session parked too long between turns pays the write premium again
+    for nothing.
+  </OptionCard>
+</CardGrid>
 
 A `0%` `HIT%` across several turns on an opt-in provider (Anthropic, Bedrock, or Claude-via-OpenRouter) with `CACHE WR` also at `0` usually means the opt-in cache marker never reached the wire — check your adapter config before assuming the model just isn't cacheable. If `CACHE WR` is nonzero but `HIT%` stays low, the prompt prefix is likely being rewritten between turns instead of reused.
 
@@ -67,3 +88,54 @@ stella stats --format json | jq '.[] | select(.cache_hit_rate < 0.2) | {provider
 <Callout type="info">
 The store is a real SQLite file. Beyond `stella stats` you can query it directly with any SQLite client — see [Telemetry &amp; budget](/docs/telemetry).
 </Callout>
+
+## Bounding the store — `stella stats prune`
+
+`store.db` grows monotonically: every run appends executions and everything keyed to
+them — events, telemetry, tool calls, context blocks, receipts. `prune` is the retention
+control.
+
+```bash
+# What would go, without touching anything.
+stella stats prune --older-than 90d --dry-run
+
+# Keep a quarter of history, and hand the freed pages back to the filesystem.
+stella stats prune --older-than 90d --vacuum
+
+# Or bound it by row count instead of age.
+stella stats prune --max-rows 5000
+```
+
+<CardGrid size="md">
+  <OptionCard name="--older-than <AGE>">
+    Drop executions older than this window. `N` followed by `d`, `w`, `h`, `mo`, or `y` —
+    `90d`, `12w`, `720h`, `3mo`. A bare number means days.
+  </OptionCard>
+  <OptionCard name="--max-rows <N>">
+    Hard ceiling on retained executions; the oldest prunable ones are evicted until the
+    store is at or under it.
+  </OptionCard>
+  <OptionCard name="--dry-run">
+    Report what would be pruned and delete nothing. Worth running first — the deletion
+    cascades to every table keyed to an execution.
+  </OptionCard>
+  <OptionCard name="--vacuum">
+    `VACUUM` afterwards, handing freed pages back to the filesystem. Deleting rows alone
+    shrinks the *contents* but not the file. Also runs automatically after a large prune.
+  </OptionCard>
+  <OptionCard name="--force">
+    Also drop executions whose telemetry has not replicated into the usage hub. This
+    permanently loses that cost data — off by default.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="warn">
+Prune is **replication-safe by default**: an execution whose telemetry has not yet
+reached the usage hub is never dropped, so a prune run before a sync cannot silently
+destroy cost data you are still billing against. `--force` is the deliberate override,
+and it is irreversible.
+</Callout>
+
+The same flags are also mounted as [`stella storage prune`](/docs/commands/storage#stella-storage-prune) —
+one implementation with two entry points, so store retention is discoverable both from
+where you notice the store is too big and from where the rest of the store verbs live.

--- a/website/content/docs/commands/storage.mdx
+++ b/website/content/docs/commands/storage.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella storage
-description: Inspect the storage map — every storage layer, namespace, relation, and field, with intent and boundaries from stella.storage.toml.
+description: Inspect the storage map — every storage layer, namespace, relation, and field, with intent and boundaries from stella.storage.toml — and bound the session store's growth.
 ---
 
-`stella storage` inspects the **storage map**: every storage layer, namespace, relation, and field in your workspace, annotated with intent and boundaries from `stella.storage.toml`. It reads the local index built by [`stella init`](/docs/commands/init) (`.stella/private/codegraph.db`) plus the manifest, so it is fully offline and needs no API key.
+`stella storage` inspects the **storage map**: every storage layer, namespace, relation, and field in your workspace, annotated with intent and boundaries from `stella.storage.toml`. It reads the local index built by [`stella init`](/docs/commands/init) (`.stella/private/codegraph.db`) plus the manifest, so it is fully offline and needs no API key. One verb — `prune` — also does the store's retention housekeeping.
 
 ## Synopsis
 
@@ -12,18 +12,33 @@ stella storage tree
 stella storage show <address>
 stella storage grep <name>
 stella storage drift
+stella storage prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] [--dry-run]
 ```
 
 ## What it does
 
 The storage map is Stella's vendor-agnostic index of where your data lives — SQL tables, key-value namespaces, document collections, and their fields — so the agent (and you) can reason about persistence without re-deriving the schema every time. It is the zero-drift companion to the [code graph](/docs/commands/graph): the code graph answers "who calls what," the storage map answers "what is stored where, and what does it mean."
 
-| Subcommand | Answers |
-| --- | --- |
-| `tree` | The full map — `layer → namespace → relation` tree, each with its declared intent. |
-| `show <address>` | One relation's card: fields, constraints, meaning, and provenance. Accepts a `store://` address, a bare address, or a relation name. |
-| `grep <name>` | Every relation and field whose normalized name contains the query. |
-| `drift` | A report-only drift check: near-duplicate relations, orphaned manifest meanings, and intent coverage. Changes nothing. |
+<CardGrid size="md">
+  <OptionCard name="tree">
+    The full map — `layer → namespace → relation` tree, each with its declared intent.
+  </OptionCard>
+  <OptionCard name="show <address>">
+    One relation's card: fields, constraints, meaning, and provenance. Accepts a
+    `store://` address, a bare address, or a relation name.
+  </OptionCard>
+  <OptionCard name="grep <name>">
+    Every relation and field whose normalized name contains the query.
+  </OptionCard>
+  <OptionCard name="drift">
+    A report-only drift check: near-duplicate relations, orphaned manifest meanings, and
+    intent coverage. Changes nothing.
+  </OptionCard>
+  <OptionCard name="prune">
+    The one verb here that writes. Bounds `store.db`'s growth by dropping whole
+    executions and every row keyed to them — see [below](#stella-storage-prune).
+  </OptionCard>
+</CardGrid>
 
 ```bash
 stella storage tree
@@ -34,4 +49,52 @@ stella storage drift
 
 <Callout type="info">
 The map is only as current as the last [`stella init`](/docs/commands/init). Intent and boundaries come from `stella.storage.toml`; `stella storage drift` tells you where that manifest has fallen behind the code.
+</Callout>
+
+### stella storage prune
+
+Bound the growth of this workspace's session store, `<workspace>/.stella/private/store.db`
+— dropping whole executions past `--older-than` and `--max-rows`, along with every row
+keyed to them. It is the same implementation as
+[`stella stats prune`](/docs/commands/stats#bounding-the-store--stella-stats-prune) mounted
+at a second entry point: one `PruneArgs`, the same five flags, the same engine, so store
+retention is reachable both from where you notice the store is too big and from where the
+rest of the store verbs live.
+
+```bash
+# What would go, without touching anything.
+stella storage prune --older-than 90d --dry-run
+
+# Keep a quarter of history, and hand the freed pages back to the filesystem.
+stella storage prune --older-than 90d --vacuum
+
+# Or bound it by row count instead of age.
+stella storage prune --max-rows 5000
+```
+
+<CardGrid size="sm">
+  <OptionCard name="--older-than <AGE>">
+    Drop executions older than this window — `90d`, `12w`, `720h`, `3mo`.
+  </OptionCard>
+  <OptionCard name="--max-rows <N>">
+    Hard ceiling on retained executions.
+  </OptionCard>
+  <OptionCard name="--dry-run">
+    Report what would be pruned and delete nothing.
+  </OptionCard>
+  <OptionCard name="--vacuum">
+    `VACUUM` afterwards, handing freed pages back to the filesystem.
+  </OptionCard>
+  <OptionCard name="--force">
+    Also drop executions whose telemetry has not reached the usage hub. Irreversible.
+  </OptionCard>
+</CardGrid>
+
+Each flag is documented in full — units, the replication-safety guarantee, and what
+`--force` actually costs you — on
+[`stella stats prune`](/docs/commands/stats#bounding-the-store--stella-stats-prune).
+
+<Callout type="warn">
+Unlike the other `stella storage` verbs, `prune` is not a read. It deletes rows from
+`store.db`, and only `--dry-run` makes it safe to run without thinking first.
 </Callout>

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -26,9 +26,14 @@ Custom tools come from a `<name>.toml` manifest dropped in `<workspace>/.stella/
 
 ## Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--validate [DIR]` | Strict pre-flight check of custom-tool manifests instead of listing. Parses every `<name>.toml` in `.stella/tools/` and `~/.stella/tools/` (or the given `DIR`), reports errors, warnings, and info per manifest, and exits non-zero if any manifest has errors. |
+<CardGrid size="md">
+  <OptionCard name="--validate [DIR]">
+    Strict pre-flight check of custom-tool manifests instead of listing. Parses every
+    `<name>.toml` in `.stella/tools/` and `~/.stella/tools/` — or in the given `DIR` —
+    reports errors, warnings, and info per manifest, and exits non-zero if any manifest
+    has errors.
+  </OptionCard>
+</CardGrid>
 
 `stella tools` otherwise takes the [global flags](/docs/commands); model selection rarely matters for this diagnostic command.
 
@@ -44,4 +49,10 @@ Validate custom-tool manifests in CI (non-zero exit on any error):
 
 ```bash
 stella tools --validate
+```
+
+Validate one directory of manifests before installing them:
+
+```bash
+stella tools --validate ./contrib/stella-tools
 ```

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -1,0 +1,217 @@
+---
+title: stella usage
+description: Report, replicate, and prune the cross-project telemetry hub at ~/.stella/usage.db — the same cost numbers as stella stats, across every project on this machine.
+---
+
+`stella stats` answers "what did *this* workspace cost." `stella usage` answers the same question across every project on this machine, by reading the **usage hub** — one SQLite database per developer at `~/.stella/usage.db`. It needs no provider and no API key, and nothing it does sends anything anywhere.
+
+## Synopsis
+
+```bash
+stella usage
+stella usage report [--format <table|json|csv>] [--org <id>]
+stella usage sync [--all]
+stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
+```
+
+A bare `stella usage` is `stella usage report` with the defaults. The flags belong to the subcommand, so name `report` explicitly when you pass one.
+
+## What it does
+
+Every project keeps its own source of truth at `<workspace>/.stella/private/store.db` — that is the store [`stella stats`](/docs/commands/stats) and [`stella inspect`](/docs/commands/inspect) read. The hub is **derived** from those stores: each finished turn rolls its telemetry up into `~/.stella/usage.db` so a cross-project question can be answered without opening every project database in turn.
+
+Two properties fall out of that design, and they are the reason the command exists:
+
+- **It reads even when the project stores are busy.** A report from the hub does not contend with a live session holding `store.db`.
+- **It outlives the checkout.** A project you deleted six months ago still contributes to the totals, because its rows were replicated before the directory went away.
+
+Flow is strictly one way — `store.db` → `usage.db`. Nothing here writes back into a project store, and a hub that is missing or briefly unopenable never fails a turn; replication is best-effort by design.
+
+<Callout type="info">
+The hub stores **metadata and rollups**, never source code or tool output. Prompts are reduced to a digest plus a short preview. Registration with [`stella cloud`](/docs/commands/cloud) changes which ids the rows carry, not what is in them, and does not upload anything today.
+</Callout>
+
+## Subcommands
+
+<CardGrid size="md">
+  <OptionCard name="report">
+    Per (org, provider, model) totals across every replicated project: calls, tokens,
+    cache reads, cost, and how many distinct projects contributed. The default.
+  </OptionCard>
+  <OptionCard name="sync">
+    Replicate this workspace's telemetry into the hub from a cursor. Safe to re-run;
+    `--all` heals every project the hub has ever seen.
+  </OptionCard>
+  <OptionCard name="prune">
+    Bound the hub's growth — by age, by a row ceiling, and by GC of projects whose
+    checkout is gone.
+  </OptionCard>
+</CardGrid>
+
+### `stella usage report`
+
+Group every hub row by org, provider, and model, and total it. Rows are ordered by cost, descending.
+
+<CardGrid size="md">
+  <OptionCard name="--format <table|json|csv>" defaultValue="table">
+    `table` prints aligned columns with a `TOTAL` row; `json` and `csv` are for piping
+    into other tools. The three text columns in CSV are RFC-4180 escaped, so an org id or
+    a model slug containing a comma cannot shift the following columns.
+  </OptionCard>
+  <OptionCard name="--org <id>">
+    Only rows replicated under this org id. Rows written before you registered carry no
+    org and are excluded by any `--org` filter.
+  </OptionCard>
+</CardGrid>
+
+```bash
+stella usage
+stella usage report --format json
+stella usage report --org acme --format csv > acme-spend.csv
+```
+
+Representative table output (illustrative):
+
+```text
+ORG            PROVIDER   MODEL                           CALLS        INPUT       OUTPUT   CACHE-READ       COST  PROJECTS
+(local)        anthropic  claude-fable-5                    412      8214003       411220      6120884    31.4188         7
+(local)        zai        glm-5.2                           268      3901556       288104      1902330     4.9071         4
+TOTAL                                                       680     12115559       699324      8023214    36.3259
+```
+
+An unregistered installation reports its rows under `(local)` — the display for a `NULL` org id. An empty hub says so and points you at `stella usage sync`.
+
+### `stella usage sync`
+
+Replication normally happens on its own: each finished turn ships its telemetry into the hub best-effort. `sync` is the explicit and the repair path — it walks the hub's per-project cursor forward, so re-running it is safe and only ever ships rows the hub does not already have.
+
+<CardGrid size="md">
+  <OptionCard name="--all">
+    Walk every project in the hub's registry instead of just the current directory. This
+    is the repair path: a project whose best-effort sync failed mid-turn has a cursor that
+    fell behind, and `--all` heals all of them in one pass. A registered project with no
+    local `store.db` is reported as skipped rather than treated as an error.
+  </OptionCard>
+</CardGrid>
+
+```bash
+# This workspace only.
+stella usage sync
+
+# Every project the hub knows about — the repair pass.
+stella usage sync --all
+```
+
+The single-workspace form reports one number; `--all` reports per project first:
+
+```text
+acme-api                 128 row(s)
+acme-web                 0 row(s)
+old-prototype            skipped (no local store)
+replicated 128 telemetry row(s) across 3 project(s)
+```
+
+### `stella usage prune`
+
+The hub keeps one telemetry row per model call, across every project, forever — including rows from checkouts that no longer exist. `prune` is the retention control. It refuses to run with none of `--older-than`, `--max-rows`, or `--gc-deleted` set, so a bare `stella usage prune` can never mean "delete something."
+
+<CardGrid size="md">
+  <OptionCard name="--older-than <AGE>">
+    Drop rows older than this window. `N` followed by `d`, `w`, `h`, `mo`, or `y` — `90d`,
+    `12w`, `720h`, `3mo`, `1y`. A bare number means days. The window must be positive: `0`
+    would prune everything older than now, which is almost always a typo.
+  </OptionCard>
+  <OptionCard name="--max-rows <N>">
+    Hard ceiling on retained telemetry rows; the oldest prunable ones are evicted until
+    the hub is at or under it.
+  </OptionCard>
+  <OptionCard name="--gc-deleted">
+    Also drop everything the hub holds for a project whose checkout is gone *and* that was
+    never org-registered — its telemetry, its rollups, its sync cursor, and its registry
+    row. "Gone" means the project root is missing while its parent directory still exists,
+    which is a deletion. A whole volume being absent — an unplugged drive, a down network
+    share — is deliberately **not** a deletion, so an unmounted disk never GCs your local
+    history. A project that does come back re-replicates on its next sync.
+  </OptionCard>
+  <OptionCard name="--dry-run">
+    Compute the report and delete nothing. Worth running first.
+  </OptionCard>
+  <OptionCard name="--vacuum">
+    `VACUUM` afterwards, handing freed pages back to the filesystem, and re-anchor the
+    cloud cursors across it. Also runs automatically after a large prune.
+  </OptionCard>
+  <OptionCard name="--force">
+    Also drop un-acked cloud rows, breaking a pending drain. Off by default.
+  </OptionCard>
+</CardGrid>
+
+```bash
+# What would go, without touching anything.
+stella usage prune --older-than 1y --dry-run
+
+# A year of history, plus everything held for repos you have since deleted.
+stella usage prune --older-than 1y --gc-deleted --vacuum
+
+# Or bound it by row count instead of age.
+stella usage prune --max-rows 100000
+```
+
+<Callout type="warn">
+Prune is **cloud-safe by default**: a row belonging to a registered org that the cloud
+drain has not yet acknowledged is never dropped, even when it falls inside the age window.
+Those rows are reported back to you as kept — `--force` is the deliberate override, and it
+breaks the pending drain permanently. Rollup rows never drain, so they age out
+unconditionally.
+</Callout>
+
+If the ceiling could not be met because the excess rows were un-acked, `prune` says so rather than silently leaving the hub over budget: drain them, or re-run with `--force`.
+
+## Relationship to `stella stats`
+
+<CardGrid size="md">
+  <OptionCard name="stella stats">
+    One workspace. Reads `<workspace>/.stella/private/store.db`, the source of truth, with
+    the per-run cache-economics columns. Its `prune` bounds *that* store.
+  </OptionCard>
+  <OptionCard name="stella usage">
+    Every workspace. Reads `~/.stella/usage.db`, derived from the above. Its `prune` bounds
+    *the hub*, and the two retention commands are independent — pruning one never touches
+    the other.
+  </OptionCard>
+</CardGrid>
+
+The two `--older-than` vocabularies are shared code precisely so `--older-than 3mo` cannot work on one command and fail on the other.
+
+## Examples
+
+Your five most expensive models across every project — the rows already arrive sorted by
+cost:
+
+```bash
+stella usage report --format json | jq '.[0:5] | .[] | {provider, model, cost_usd}'
+```
+
+Find the models you use across the most projects:
+
+```bash
+stella usage report --format json | jq '.[] | select(.projects > 2) | {provider, model, projects, cost_usd}'
+```
+
+Heal every stale cursor after a stretch of interrupted sessions, then report:
+
+```bash
+stella usage sync --all
+stella usage report
+```
+
+Keep the hub bounded on a schedule, safely:
+
+```bash
+stella usage prune --older-than 6mo --gc-deleted --vacuum
+```
+
+<Callout type="info">
+The hub is a real SQLite file at `~/.stella/usage.db` (`STELLA_DATA_DIR` overrides the
+directory). Beyond this command you can query it with any SQLite client — see
+[Telemetry &amp; budget](/docs/telemetry).
+</Callout>

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -22,19 +22,40 @@ stella --version
 The `version` subcommand prints a `v`-prefixed line:
 
 ```text
-stella v0.5.0
+stella v0.5.44
 ```
 
 `stella --version` prints clap's default form instead — the binary name, a space, then the
 bare version:
 
 ```text
-stella 0.5.0
+stella 0.5.44
 ```
 
 The exact number tracks the release you installed. Binaries built in dev mode
-(`scripts/dev.sh`) append a git-sha stamp, e.g. `stella v0.5.0-dev.abc1234`; released
+(`scripts/dev.sh`) append a git-sha stamp, e.g. `stella v0.5.44-dev.abc1234`; released
 binaries print the bare semver.
 
 Use it to confirm an install or upgrade, or to capture the version in a CI log. This
 command needs no provider or API key configured.
+
+## Examples
+
+Confirm what you just installed:
+
+```bash
+stella version
+```
+
+Capture the bare semver for a CI log or a build label — strip the `v` from the
+subcommand's form, or use the flag, which never emits one:
+
+```bash
+stella --version | cut -d' ' -f2
+```
+
+Check that a binary is on `PATH` at all before a script depends on it:
+
+```bash
+stella version >/dev/null 2>&1 || { echo "stella is not installed"; exit 1; }
+```

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -6,12 +6,30 @@ description: Give each engine agent — default, worker, judge, triage — its o
 The `agent_engine_config` object in [`settings.json`](/docs/configuration/settings)
 configures the four engine agents individually:
 
-| Agent | Runs |
-| --- | --- |
-| `default` | The interactive / step-loop agent (`stella chat`, the Command Deck, `--no-pipeline`) — and the **model source for the pipeline's execute turns** (see [Model precedence](#model-precedence)) |
-| `worker` | The [pipeline](/docs/inference-pipeline)'s execute-turn **tuning** — prompt, effort, reasoning, params (plan rides it too) |
-| `judge` | The pipeline's verify judge and [goal mode](/docs/agent-modes#outcome-driven-goal-mode)'s round judge — the witness author also rides the judge's model, falling back to the worker when no judge resolves |
-| `triage` | The pipeline's fast task classifier |
+<CardGrid size="md">
+  <OptionCard name="default">
+    The interactive / step-loop agent — `stella chat`, the Command Deck,
+    `stella run --no-pipeline`. Its model is also the **session default** every
+    other role falls back to.
+  </OptionCard>
+  <OptionCard name="worker">
+    The [pipeline](/docs/inference-pipeline)'s execute turns — both the model
+    they route to and their tuning (prompt, effort, reasoning, params). Plan
+    and witness turns share the worker's tier, so they follow it.
+  </OptionCard>
+  <OptionCard name="judge">
+    The pipeline's verify judge and
+    [goal mode](/docs/agent-modes#outcome-driven-goal-mode)'s round judge. The
+    witness author rides the judge's resolution too — the test that defines
+    "done" is written by the same independent role that enforces it — falling
+    back to the worker when no judge resolves.
+  </OptionCard>
+  <OptionCard name="triage">
+    The pipeline's fast task classifier. One call, roughly one token out, under
+    a hard 10-second latency ceiling — route it to the cheapest, fastest model
+    you have.
+  </OptionCard>
+</CardGrid>
 
 Every field is optional, and it merges across the same user → org-managed →
 project scope chain as the rest of `settings.json`, per field — a project can
@@ -19,13 +37,14 @@ pin just the judge model while your user scope keeps everything else.
 
 ## The full schema
 
-```jsonc title="settings.json"
+```jsonc title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     // Flat per-role models ("provider/slug", or a bare catalog slug).
-    // default_model doubles as the WORKER route — the pipeline's execute
-    // turns run the worker/default chain (see Model precedence below).
+    // default_model is the session default AND the fallback every other
+    // role lands on when it sets nothing (see Model precedence below).
     "default_model": "zai/glm-5.2",
+    "pipeline_worker_model": "zai/glm-5.2",
     "pipeline_judge_model": "openrouter/openai/gpt-5.5",
     "pipeline_triage_model": "deepseek/deepseek-chat",
 
@@ -71,37 +90,66 @@ pin just the judge model while your user scope keeps everything else.
 
 ## Model precedence
 
-The chain differs by role — `--model` governs the **worker**, while an explicitly
-configured judge or triage keeps its own model even under a `--model` flag.
+Every role resolves on its own chain. `--model` sets the **session default** —
+the model the interactive agent runs on and the one every unconfigured role
+falls back to — while an explicitly configured role keeps its own model even
+under a `--model` flag.
 
-**Worker &amp; default agent** (one model, shared by the interactive agent and the
-pipeline's execute turns) — first hit wins:
+**Default agent** (interactive / step-loop) — first hit wins:
 
 1. The `--model` CLI flag
 2. `agents.default.model`
 3. `default_model`
 4. Auto-detection / the provider's own default
 
+**Worker** (the pipeline's execute turns, and the plan and witness turns that
+share its tier) — first hit wins:
+
+1. `agents.worker.model`, sent verbatim to `agents.worker.provider` when that is set
+2. `pipeline_worker_model`
+3. `default_model`
+4. No configuration — the role rides the session default resolved above
+
 **Judge and triage** — first hit wins:
 
 1. `agents.judge.model` / `agents.triage.model`
 2. `pipeline_judge_model` / `pipeline_triage_model`
 3. `default_model`
-4. No configuration — the role rides the worker's model
+4. No configuration — the role rides the session default
 
 `auto_mode: "on"` replaces the judge spec with the cross-family pick from
-`allowed_models` (below). A `--model` flag does **not** override an explicitly
-configured judge or triage — `stella --model anthropic/claude-fable-5 goal "…"` with
-`pipeline_judge_model: openrouter/openai/gpt-5.5` runs a Fable worker under a GPT judge,
-which is usually exactly what you want from a cross-family setup.
+`allowed_models` (below), compared against the model the worker **actually**
+resolves to, not the session default. A `--model` flag does **not** override an
+explicitly configured judge or triage — `stella --model anthropic/claude-fable-5 goal "…"`
+with `pipeline_judge_model: openrouter/openai/gpt-5.5` runs a Fable worker under
+a GPT judge, which is usually exactly what you want from a cross-family setup.
 
-<Callout type="warn">
-  `pipeline_worker_model` and `agents.worker.model` are accepted, saved, and shown in the
-  deck's engine panel, but the **executing** worker model follows the worker/default chain
-  above — route the worker with `default_model` (or `--model`), not the worker-specific
-  model fields. The `worker` agent's tuning fields (`prompt`, `effort`, `reasoning`,
-  `params`) do apply to execute turns.
+<Callout type="info">
+  Because the worker's chain falls through to `default_model`, a configured
+  `default_model` pins the execute turns even when you pass `--model` for the
+  session. If you want a one-off `--model` to change what the pipeline executes
+  on, either leave `default_model` unset or set `pipeline_worker_model`
+  deliberately.
 </Callout>
+
+Every override here is **soft**. A worker, judge, or triage model whose provider
+has no resolvable credential — or whose adapter fails to build — is skipped with
+a notice on stderr, and that role rides the session default exactly as it would
+with no config at all:
+
+```text
+  ! engine config: judge model `openrouter/openai/gpt-5.5` skipped — no resolvable
+    credential for provider `openrouter`; judge rides the session default (`zai/glm-5.2`)
+```
+
+`stella config` prints the resolved provider, session-default model, credential
+source, base URL, and dialect — the inputs those chains start from — and
+`stella models --all` shows which slugs each provider will accept:
+
+```bash
+stella config
+stella models --all
+```
 
 ## One gateway per agent (BYOK per agent)
 
@@ -109,7 +157,7 @@ An agent's `provider` field routes its model slug through **that** provider
 verbatim — no prefix splitting. That is how you mix billing relationships in
 one pipeline:
 
-```jsonc
+```jsonc title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "default_model": "anthropic/claude-fable-5",             // worker — your Anthropic key
@@ -121,6 +169,15 @@ one pipeline:
 }
 ```
 
+Three keys, three bills, one pipeline:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENROUTER_API_KEY=sk-or-...
+export ZAI_API_KEY=...
+stella run --test-command "cargo test -p stella-router" "add a per-provider breaker cooldown"
+```
+
 Without a `provider` field, model strings use `--model` semantics:
 `provider/slug` splits on the first `/` when the prefix names a known
 provider (so `openrouter/openai/gpt-5.5` routes `openai/gpt-5.5` through
@@ -130,18 +187,59 @@ OpenRouter), and a bare slug resolves through the model catalog.
 
 Set any of the three autos to `"on"` and stop thinking about it:
 
-- **`auto_mode`** — the judge model is picked automatically from
-  `allowed_models`: prefer a candidate from a **different model family** than
-  the worker (an independent second opinion), then the highest catalog price
-  tier as a capability proxy, then list order. Candidates whose provider has
-  no resolvable credential are skipped.
-- **`effort_auto`** — reasoning effort per agent: judge `high`, worker and
-  default `medium`, triage `low`.
-- **`reasoning_auto`** — thinking mode on for judge/worker/default, off for
-  triage (a latency-bound, one-token classification).
+<CardGrid size="md">
+  <OptionCard name="auto_mode" defaultValue="off">
+    The judge model is picked automatically from `allowed_models`: prefer a
+    candidate from a **different model family** than the worker (an independent
+    second opinion), then the highest catalog price tier as a capability proxy,
+    then list order. Candidates whose provider has no resolvable credential are
+    skipped. The family comparison uses the model the worker *actually*
+    resolves to.
+  </OptionCard>
+  <OptionCard name="effort_auto" defaultValue="off">
+    Reasoning effort per agent: judge `high`, worker and default `medium`,
+    triage `low`.
+  </OptionCard>
+  <OptionCard name="reasoning_auto" defaultValue="off">
+    Thinking mode on for judge, worker, and default; off for triage — a
+    latency-bound, one-token classification that gains nothing from it.
+  </OptionCard>
+  <OptionCard name="headless_scope_bypass" defaultValue="off">
+    A headless run may proceed past [scope review](/docs/inference-pipeline)
+    instead of stopping at the gate that has nobody to ask. Off deliberately:
+    turn it on only where the working tree is disposable and the budget cap is
+    the real guard — a benchmark container, CI on a scratch checkout.
+  </OptionCard>
+</CardGrid>
 
 When an auto is `"on"` it overrides the corresponding per-agent setting —
 that is its contract.
+
+The smallest useful config is three lines: a cheap worker, a flagship judge
+from a different family, and the autos left alone.
+
+```json title=".stella/settings.json"
+{
+  "agent_engine_config": {
+    "default_model": "zai/glm-5.2",
+    "pipeline_judge_model": "anthropic/claude-fable-5",
+    "pipeline_triage_model": "deepseek/deepseek-chat"
+  }
+}
+```
+
+Or hand the judge choice over entirely, and let `auto_mode` keep it
+cross-family as your lineup changes:
+
+```json title=".stella/settings.json"
+{
+  "agent_engine_config": {
+    "default_model": "zai/glm-5.2",
+    "auto_mode": "on",
+    "allowed_models": ["zai/glm-5.2", "anthropic/claude-fable-5", "openrouter/openai/gpt-5.5"]
+  }
+}
+```
 
 ## Generation parameters
 
@@ -153,13 +251,66 @@ intact), and a set field goes on the wire.
 Each provider adapter forwards only the parameters its wire supports, and
 maps reasoning to the provider's native mechanism:
 
-| Provider | Reasoning maps to | Notes |
-| --- | --- | --- |
-| Z.ai (GLM) | `thinking: {"type": "enabled"\|"disabled"}` | |
-| OpenRouter | `reasoning` object (`effort` / `enabled`) | also accepts `top_k` and `repetition_penalty` |
-| Anthropic | extended thinking with an effort-tiered token budget | temperature is omitted while thinking is on (API rule) |
-| OpenAI | `reasoning.effort`, plus `text.verbosity` and `service_tier` | `temperature`/`top_p` are omitted for reasoning models (API rule) |
-| Gemini / Vertex | `thinkingLevel` | Gemini 3 cannot fully disable thinking; `"off"` maps to the lowest level |
+<CardGrid size="md">
+  <SpecCard
+    title="Z.ai (GLM)"
+    meta={[{ label: "Reasoning", value: "thinking: {\"type\": \"enabled\"|\"disabled\"}" }]}
+  >
+    GLM's own request-level thinking object. Also forwards `top_p`, `top_k`,
+    `frequency_penalty`, `presence_penalty`, `repetition_penalty`, and `seed`.
+  </SpecCard>
+  <SpecCard
+    title="OpenRouter"
+    meta={[{ label: "Reasoning", value: "reasoning object (effort / enabled)" }]}
+  >
+    The normalized reasoning object. Some upstreams OpenRouter fronts make
+    reasoning mandatory and answer `reasoning: {enabled: false}` with a hard
+    400 — Stella resends once without the object rather than losing the call,
+    since "off" is an economy preference, not a correctness requirement.
+  </SpecCard>
+  <SpecCard
+    title="xAI (Grok)"
+    meta={[{ label: "Reasoning", value: "top-level reasoning_effort" }]}
+  >
+    Sent only for Grok models that accept the parameter — the original `grok-4`
+    400s on it, so it is gated by model, not just by provider.
+  </SpecCard>
+  <SpecCard
+    title="Anthropic"
+    meta={[{ label: "Reasoning", value: "extended thinking, two dialects" }]}
+  >
+    Current models (Claude 4.6+ and the 5-family) take
+    `thinking: {"type": "adaptive"}` plus `output_config.effort`, and **reject**
+    `budget_tokens` and the sampling parameters. Legacy models (≤ 4.5) keep
+    `{"type": "enabled", "budget_tokens": N}` with an effort-tiered budget, and
+    do accept sampling — though `temperature` is omitted whenever thinking is
+    on, because the Messages API rejects any value but 1 alongside it.
+  </SpecCard>
+  <SpecCard
+    title="OpenAI"
+    meta={[{ label: "Reasoning", value: "reasoning.effort" }]}
+  >
+    Plus `text.verbosity` and `service_tier` from `params`. `temperature` and
+    `top_p` are omitted for reasoning models — an API rule, not a Stella
+    choice.
+  </SpecCard>
+  <SpecCard
+    title="Gemini / Vertex"
+    meta={[{ label: "Reasoning", value: "thinkingConfig.thinkingLevel" }]}
+  >
+    Gemini 3 cannot fully disable thinking, so `"off"` maps to the lowest level
+    the model documents — the closest honest expression of "suppress thinking".
+    `verbosity`, `service_tier`, and `repetition_penalty` are dropped.
+  </SpecCard>
+  <SpecCard
+    title="DeepSeek, local, and settings-defined providers"
+    meta={[{ label: "Reasoning", value: "not sent" }]}
+  >
+    There is no portable Chat Completions reasoning field, and an unknown key
+    risks a hard 400 on a server you never opted into experimenting with — so
+    these identities send neither shape. Sampling parameters still go through.
+  </SpecCard>
+</CardGrid>
 
 Parameters a provider cannot express are silently dropped — an unsupported
 knob never fails a request.

--- a/website/content/docs/configuration/credentials.mdx
+++ b/website/content/docs/configuration/credentials.mdx
@@ -8,7 +8,10 @@ persist keys in a permission-restricted file so you're only prompted once.
 
 ## The credential chain
 
-For the selected provider, the key is resolved in this order — **first hit wins**:
+<CredentialChainDiagram />
+
+For the selected provider, the key is resolved in this order — **first hit wins**,
+and nothing below the first hit is ever read:
 
 1. **`--api-key` flag** — highest precedence. Requires an explicit `--model provider/...`
    (a bare key is ambiguous about which provider it belongs to).
@@ -17,7 +20,10 @@ For the selected provider, the key is resolved in this order — **first hit win
    [settings.json](/docs/configuration/settings) **renames the primary variable**: the
    named variable becomes the one checked first and the provider's original env var
    demotes to an alias — handy for team key rotation (`MY_TEAM_ZAI_KEY`) without
-   touching anyone's shell profile.
+   touching anyone's shell profile. Project
+   [dotenv files](/docs/getting-started/providers) are loaded into the environment before
+   this step runs, so a repo's `.env.local` reaches it — but an exported shell value
+   always wins.
 3. **`settings.json`** — `providers.<id>.api_key` (an empty string is treated as unset; see
    [settings.json](/docs/configuration/settings)).
 4. **`~/.stella/credentials.toml`** — the stored-keys file below.
@@ -26,6 +32,20 @@ For the selected provider, the key is resolved in this order — **first hit win
    the key and saves it to `credentials.toml`, so you are only asked once. A bare invocation
    with no `--model` uses auto-detection, which does **not** prompt — it errors with guidance
    to name a provider instead.
+
+Each rung, as you would actually reach for it:
+
+```bash
+# 1. The flag — needs an explicit provider, and lands in your shell history.
+stella --model anthropic/claude-fable-5 --api-key sk-ant-... run "…"
+
+# 2. The env var — the CI-friendly one.
+export ANTHROPIC_API_KEY=sk-ant-...
+stella run "…"
+
+# 5. The prompt — name a provider on a TTY and Stella asks once, then stores it.
+stella --model anthropic/claude-fable-5 run "…"
+```
 
 <Callout type="warn">
   Prefer an env var, `settings.json`, or `credentials.toml` over `--api-key` for anything
@@ -37,7 +57,7 @@ For the selected provider, the key is resolved in this order — **first hit win
 Keys can be stored in `~/.stella/credentials.toml`. It is a flat table keyed by
 provider id:
 
-```toml
+```toml title="~/.stella/credentials.toml"
 [credentials]
 zai = "sk-..."
 anthropic = "sk-ant-..."
@@ -65,6 +85,55 @@ together = "..."
   and does not silently `chmod` a file it did not create. Run the suggested `chmod`
   and the warning goes away.
 
+## Managing stored keys — `stella auth`
+
+You do not have to hand-edit the file. `stella auth` is the write surface for
+`credentials.toml`:
+
+<CardGrid size="md">
+  <OptionCard name="stella auth set <provider>">
+    Store or replace a provider's key. With neither `--key` nor `--stdin` it
+    prompts with the input masked, which is the form to prefer.
+  </OptionCard>
+  <OptionCard name="stella auth set <provider> --stdin">
+    Read the key from stdin — one line, trimmed. The scriptable form, and the
+    one that keeps the secret out of your shell history and `ps`.
+  </OptionCard>
+  <OptionCard name="stella auth set <provider> --key <KEY>">
+    Pass the key directly on the command line. Visible in shell history and
+    `ps` output — use `--stdin` instead unless you know you want this.
+  </OptionCard>
+  <OptionCard name="stella auth remove <provider>">
+    Drop a provider's stored key from `credentials.toml`.
+  </OptionCard>
+  <OptionCard name="stella auth list">
+    List every provider with a stored key — redacted preview plus the
+    resolution source, so you can see which rung of the chain is actually
+    answering.
+  </OptionCard>
+</CardGrid>
+
+```bash
+# Masked prompt — nothing lands in history.
+stella auth set anthropic
+
+# From a secret manager, without the value ever becoming an argument.
+op read "op://Private/Anthropic/api-key" | stella auth set anthropic --stdin
+
+# Rotate: overwrite in place, then confirm which source now answers.
+printf '%s' "$NEW_ZAI_KEY" | stella auth set zai --stdin
+stella auth list
+
+# Revoke locally.
+stella auth remove openai
+```
+
+<Callout type="info">
+  `stella auth set` writes to a **settings-defined** provider id just as happily
+  as a built-in one — the key simply has to match the id you gave the entry in
+  `settings.json`.
+</Callout>
+
 ## Which key is active?
 
 ```bash
@@ -73,16 +142,47 @@ stella config
 
 This prints the provider, model, and a **redacted preview** of the active key (a few
 leading and trailing characters, middle elided) so you can confirm *which* key is in use
-without printing the secret.
+without printing the secret — alongside the base URL, the wire dialect, the workspace
+root, and which `.env*` files were loaded.
 
 ## Cloud provider credentials
 
-Some providers need more than a single key:
+Some providers need more than a single key, and read the extras from the
+environment:
 
-- **Vertex AI** — `VERTEX_ACCESS_TOKEN` plus `VERTEX_PROJECT_ID` (or
-  `GOOGLE_CLOUD_PROJECT`), and optionally `VERTEX_LOCATION`.
-- **Amazon Bedrock** — `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, plus optional
-  `AWS_SESSION_TOKEN` and `AWS_REGION`.
+<CardGrid size="md">
+  <SpecCard
+    title="Vertex AI"
+    meta={[
+      { label: "Key", value: "VERTEX_ACCESS_TOKEN" },
+      { label: "Project", value: "VERTEX_PROJECT_ID → GOOGLE_CLOUD_PROJECT" },
+      { label: "Location", value: "VERTEX_LOCATION (default: global)" },
+    ]}
+  >
+    The access token rides the normal credential chain; the project id and
+    location are read straight from the environment. A missing project id is a
+    named error, not a silent default.
+  </SpecCard>
+  <SpecCard
+    title="Amazon Bedrock"
+    meta={[
+      { label: "Key", value: "AWS_ACCESS_KEY_ID" },
+      { label: "Secret", value: "AWS_SECRET_ACCESS_KEY" },
+      { label: "Session", value: "AWS_SESSION_TOKEN (temporary creds only)" },
+      { label: "Region", value: "AWS_REGION → AWS_DEFAULT_REGION → us-east-1" },
+    ]}
+  >
+    SigV4 cannot sign without the secret, so `AWS_ACCESS_KEY_ID` alone is a
+    named error rather than a failed request later.
+  </SpecCard>
+</CardGrid>
 
-These are read from the environment. See [Providers &amp; models](/docs/getting-started/providers) for the
-full matrix.
+```bash
+# Vertex — a short-lived token from gcloud, minted per session.
+export VERTEX_ACCESS_TOKEN="$(gcloud auth print-access-token)"
+export VERTEX_PROJECT_ID=my-gcp-project
+export VERTEX_LOCATION=us-central1
+stella --model vertex/gemini-3-pro run "summarize the changes since the last tag"
+```
+
+See [Providers &amp; models](/docs/getting-started/providers) for the full matrix.

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -8,17 +8,41 @@ key; teams and power users reach for `settings.json`.
 
 ## What lives where
 
-| Path | Purpose |
-| --- | --- |
-| `~/.stella/settings.json` | User-scope [settings](/docs/configuration/settings): provider overrides, hooks |
-| `<workspace>/.stella/settings.json` | Project-scope settings (highest precedence) |
-| org-managed `settings.json` | Organization defaults ([see below](#the-settings-hierarchy)) |
-| `~/.stella/credentials.toml` | Stored [API keys](/docs/configuration/credentials) |
-| `<workspace>/.stella/mcp.toml` | [MCP servers](/docs/agent-tools/mcp) to connect at session start |
-| `<workspace>/.stella/tools/*.toml` | [Custom script tools](/docs/agent-tools/custom-tools) |
-| `<workspace>/.stella/domains.toml` | Domain taxonomy (from `stella init`) |
-| `<workspace>/.stella/memories/*.md` | Saved [workspace memories](/docs/context-engine) |
-| `<workspace>/.stella/private/store.db` | Local [telemetry &amp; store](/docs/telemetry) — embedded SQLite |
+<CardGrid size="md">
+  <OptionCard name="~/.stella/settings.json">
+    User-scope [settings](/docs/configuration/settings): provider overrides, hooks, tools,
+    the `context` block.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/settings.json">
+    Project-scope settings — highest precedence, and a
+    [trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+  </OptionCard>
+  <OptionCard name="org-managed settings.json">
+    Organization defaults ([see below](#the-settings-hierarchy)). The only scope that may
+    carry `authority` or `enterprise_telemetry`.
+  </OptionCard>
+  <OptionCard name="~/.stella/credentials.toml">
+    Stored [API keys](/docs/configuration/credentials), written with owner-only permissions.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/mcp.toml">
+    [MCP servers](/docs/agent-tools/mcp) to connect at session start.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/tools/*.toml">
+    [Custom script tools](/docs/agent-tools/custom-tools).
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/domains.toml">
+    Domain taxonomy, inferred by `stella init`.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/memories/*.md">
+    Saved [workspace memories](/docs/context-engine).
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/rules/*.md">
+    Promoted rules and guard rules. Also read from `.claude/rules/` and `~/.stella/rules/`.
+  </OptionCard>
+  <OptionCard name="<workspace>/.stella/private/store.db">
+    Local [telemetry &amp; store](/docs/telemetry) — embedded SQLite.
+  </OptionCard>
+</CardGrid>
 
 ## The settings hierarchy
 
@@ -33,8 +57,10 @@ A project entry overrides an org-managed one, which overrides a user one — per
 project can change just a base URL while inheriting an API key from a higher scope. This is
 the same layering the rest of Stella's settings use.
 
-See **[settings.json](/docs/configuration/settings)** for the full schema, the org-managed
-path, and worked examples.
+<SettingsCascadeDiagram />
+
+See **[settings.json](/docs/configuration/settings)** for the full schema — all ten
+top-level sections — the org-managed path, and worked examples.
 
 ## Configuration vs. credentials
 
@@ -51,30 +77,216 @@ Both feed the [credential chain](/docs/getting-started/providers#the-credential-
 ## Everything you can configure
 
 Stella is configured through three kinds of surface — **files**, **environment variables**,
-and **command-line flags** — with flags winning over env vars winning over files. This table
-is the complete map; each row links to its detail page.
+and **command-line flags** — with flags winning over env vars winning over files. What
+follows is the complete map; each card links to its detail page.
 
-| What you want to set | Surface | Example |
-| --- | --- | --- |
-| Which provider/model runs | `--model` flag · `STELLA_MODEL` · `providers.<id>.default_model` | `stella --model anthropic/claude-fable-5 run "…"` |
-| A provider's API key | `--api-key` flag · provider env var · `settings.json` `api_key` · `credentials.toml` | `export ANTHROPIC_API_KEY=…` |
-| A provider's base URL | `--base-url` flag · `STELLA_BASE_URL` · `providers.<id>.base_url` | `providers.zai.base_url` → coding endpoint |
-| A provider's display name | `settings.json` `providers.<id>.name` | see [settings.json](/docs/configuration/settings) |
-| Output format (text/json/stream-json) | `--output-format` flag · `STELLA_OUTPUT_FORMAT` | `stella --output-format json run "…"` |
-| A hard USD spend cap | `--budget` flag · `STELLA_BUDGET` | `stella --budget 2.00 goal "…"` |
-| Shell commands on lifecycle events | `settings.json` `hooks` key | [Hooks](/docs/agent-tools/hooks) |
-| Per-agent engine models (worker/judge/triage) | `settings.json` `agent_engine_config` | [Agent engine config](/docs/configuration/agent-engine-config) |
-| Switch off the raw `bash` tool (on by default) | `settings.json` `tools.bash: "off"` | [settings.json](/docs/configuration/settings#the-tools-section) |
-| Switch off a whole family — e.g. the `web` tools, or the `process` group | `settings.json` `tools.web: "off"` | [settings.json](/docs/configuration/settings#the-tools-section) |
-| Org-managed defaults for a fleet | `STELLA_MANAGED_SETTINGS` → a `settings.json` | [settings hierarchy](#the-settings-hierarchy) |
-| Trust a repo's project-scope hooks &amp; routing | `STELLA_TRUST_PROJECT=1` | [trust boundary](/docs/configuration/settings#the-project-trust-boundary) |
-| MCP servers to connect | `<workspace>/.stella/mcp.toml` | [MCP](/docs/agent-tools/mcp) |
-| Custom script tools | `<workspace>/.stella/tools/*.toml` | [Custom tools](/docs/agent-tools/custom-tools) |
-| Per-tool permission gates | `hooks` `PreToolUse` matchers + the `tools` switches | [Permissions](/docs/agent-tools/permissions) |
-| Force the plain REPL (no TUI) | `--plain` flag · `STELLA_PLAIN=1` | `stella --plain chat` |
-| Freeze TUI animation (CI/recordings) | `--no-anim` flag · `STELLA_NO_ANIM` · `NO_COLOR` | `stella --no-anim chat` |
-| Write the Command Deck's structured debug log | `STELLA_DEBUG=1` → `~/.local/state/stella/logs/deck-&lt;pid&gt;.jsonl` (owner-only) | `STELLA_DEBUG=1 stella chat` |
-| Arm the paid media live smokes (contributors) | `STELLA_MEDIA_LIVE=1` + the provider key | `STELLA_MEDIA_LIVE=1 cargo test -p stella-media` |
+### Providers, models, and keys
+
+<CardGrid size="md">
+  <SpecCard
+    title="Which provider/model runs"
+    href="/docs/api-providers"
+    meta={[
+      { label: "Surface", value: "--model · STELLA_MODEL · providers.<id>.default_model" },
+      { label: "Example", value: "stella --model anthropic/claude-fable-5 run …" },
+    ]}
+  >
+    Flags beat the environment, which beats the file.
+  </SpecCard>
+  <SpecCard
+    title="A provider's API key"
+    href="/docs/getting-started/providers#the-credential-chain"
+    meta={[
+      { label: "Surface", value: "--api-key · provider env var · api_key · credentials.toml" },
+      { label: "Example", value: "export ANTHROPIC_API_KEY=…" },
+    ]}
+  >
+    The first hit in the credential chain wins; nothing below it is read.
+  </SpecCard>
+  <SpecCard
+    title="A provider's base URL"
+    href="/docs/configuration/settings#the-providers-map"
+    meta={[
+      { label: "Surface", value: "--base-url · STELLA_BASE_URL · providers.<id>.base_url" },
+      { label: "Example", value: "providers.zai.base_url" },
+    ]}
+  >
+    A coding-plan endpoint, a proxy, or a gateway.
+  </SpecCard>
+  <SpecCard
+    title="A provider's display name"
+    href="/docs/configuration/settings#the-providers-map"
+    meta={[{ label: "Surface", value: "providers.<id>.name" }]}
+  >
+    What `stella config` and `stella models` print.
+  </SpecCard>
+</CardGrid>
+
+### Output, budget, and the run itself
+
+<CardGrid size="md">
+  <SpecCard
+    title="Output format"
+    href="/docs/scripting"
+    meta={[
+      { label: "Surface", value: "--output-format · STELLA_OUTPUT_FORMAT" },
+      { label: "Example", value: "stella --output-format json run …" },
+    ]}
+  >
+    `text`, `json`, or `stream-json`.
+  </SpecCard>
+  <SpecCard
+    title="A hard USD spend cap"
+    href="/docs/telemetry#budget-observed-vs-enforced"
+    meta={[
+      { label: "Surface", value: "--budget · STELLA_BUDGET" },
+      { label: "Example", value: 'stella --budget 2.00 goal "…"' },
+    ]}
+  >
+    Enforced, not advisory: work aborts cleanly once spend passes the cap.
+  </SpecCard>
+  <SpecCard
+    title="An end-of-run recap"
+    href="/docs/configuration/settings#the-end-of-run-recap"
+    meta={[
+      { label: "Surface", value: "settings.json enable_recap" },
+      { label: "Example", value: '{ "enable_recap": "on" }' },
+    ]}
+  >
+    A deterministic outcome-and-changes panel in text mode. No model call.
+  </SpecCard>
+  <SpecCard
+    title="Force the plain REPL (no TUI)"
+    href="/docs/agent-modes"
+    meta={[
+      { label: "Surface", value: "--plain · STELLA_PLAIN=1" },
+      { label: "Example", value: "stella --plain chat" },
+    ]}
+  >
+    For pipes, dumb terminals, and recordings.
+  </SpecCard>
+  <SpecCard
+    title="Freeze TUI animation"
+    href="/docs/agent-modes"
+    meta={[
+      { label: "Surface", value: "--no-anim · STELLA_NO_ANIM · NO_COLOR" },
+      { label: "Example", value: "stella --no-anim chat" },
+    ]}
+  >
+    For CI logs and screen recordings.
+  </SpecCard>
+</CardGrid>
+
+### Tools, hooks, and context
+
+<CardGrid size="md">
+  <SpecCard
+    title="Shell commands on lifecycle events"
+    href="/docs/agent-tools/hooks"
+    meta={[{ label: "Surface", value: "settings.json hooks" }]}
+  >
+    `SessionStart`, `PreToolUse`, `PostToolUse`.
+  </SpecCard>
+  <SpecCard
+    title="Per-agent engine models"
+    href="/docs/configuration/agent-engine-config"
+    meta={[{ label: "Surface", value: "settings.json agent_engine_config" }]}
+  >
+    Worker, judge, and triage roles, each with its own model and sampling params.
+  </SpecCard>
+  <SpecCard
+    title="Switch off the raw bash tool"
+    href="/docs/configuration/settings#the-tools-section"
+    meta={[{ label: "Surface", value: 'settings.json tools.bash: "off"' }]}
+  >
+    It ships on. The `tools` section is the one way to turn it off.
+  </SpecCard>
+  <SpecCard
+    title="Switch off a whole family"
+    href="/docs/configuration/settings#the-tools-section"
+    meta={[{ label: "Surface", value: 'settings.json tools.web: "off"' }]}
+  >
+    Groups such as `web`, `process`, or `repo` — or `"*"` for everything.
+  </SpecCard>
+  <SpecCard
+    title="Per-tool permission gates"
+    href="/docs/agent-tools/permissions"
+    meta={[{ label: "Surface", value: "hooks PreToolUse matchers + tools switches" }]}
+  >
+    A programmable veto in front of any tool call.
+  </SpecCard>
+  <SpecCard
+    title="The adaptive-context lifecycle"
+    href="/docs/configuration/settings#the-context-block"
+    meta={[{ label: "Surface", value: "settings.json context" }]}
+  >
+    Learning, governance, promotion, efficacy, and retention knobs. Disabled by default.
+  </SpecCard>
+  <SpecCard
+    title="Third-party context sources"
+    href="/docs/configuration/settings#external-context-providers"
+    meta={[{ label: "Surface", value: "settings.json context_providers" }]}
+  >
+    CGP providers over stdio or HTTP, admitted only after conformance and consent.
+  </SpecCard>
+  <SpecCard
+    title="MCP servers to connect"
+    href="/docs/agent-tools/mcp"
+    meta={[{ label: "Surface", value: "<workspace>/.stella/mcp.toml" }]}
+  >
+    Connected at session start.
+  </SpecCard>
+  <SpecCard
+    title="Custom script tools"
+    href="/docs/agent-tools/custom-tools"
+    meta={[{ label: "Surface", value: "<workspace>/.stella/tools/*.toml" }]}
+  >
+    Your own executables, described as tool manifests.
+  </SpecCard>
+</CardGrid>
+
+### Fleet defaults, trust, and diagnostics
+
+<CardGrid size="md">
+  <SpecCard
+    title="Org-managed defaults for a fleet"
+    href="#the-settings-hierarchy"
+    meta={[
+      { label: "Surface", value: "STELLA_MANAGED_SETTINGS" },
+      { label: "Example", value: "/etc/stella/settings.json" },
+    ]}
+  >
+    One file every project on the machine inherits.
+  </SpecCard>
+  <SpecCard
+    title="Trust a repo's project-scope file"
+    href="/docs/configuration/settings#the-project-trust-boundary"
+    meta={[{ label: "Surface", value: "STELLA_TRUST_PROJECT=1" }]}
+  >
+    Unlocks project hooks, credential routing, context providers, tool grants, replacement
+    prompts, and workspace custom tools.
+  </SpecCard>
+  <SpecCard
+    title="The Command Deck's debug log"
+    href="/docs/agent-modes"
+    meta={[
+      { label: "Surface", value: "STELLA_DEBUG=1" },
+      { label: "Writes", value: "~/.local/state/stella/logs/deck-<pid>.jsonl" },
+    ]}
+  >
+    Structured, owner-only, and off unless asked for.
+  </SpecCard>
+  <SpecCard
+    title="Arm the paid media live smokes"
+    href="/docs/agent-tools"
+    meta={[
+      { label: "Surface", value: "STELLA_MEDIA_LIVE=1 + the provider key" },
+      { label: "Example", value: "STELLA_MEDIA_LIVE=1 cargo test -p stella-media" },
+    ]}
+  >
+    For contributors — these tests spend real money.
+  </SpecCard>
+</CardGrid>
 
 <Callout type="warn">
   `STELLA_DEBUG` and `STELLA_MEDIA_LIVE` were previously spelled `OXAGEN_DEBUG` and
@@ -121,7 +333,7 @@ stella --model local/llama3.1 --base-url http://localhost:11434/v1 run "…"
 
 **Gate every `bash` call through a guard script** (`settings.json`):
 
-```json
+```json title="~/.stella/settings.json"
 { "hooks": { "PreToolUse": [ { "matcher": "bash",
   "hooks": [ { "command": "./scripts/guard.sh", "timeoutMs": 5000 } ] } ] } }
 ```

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -1,19 +1,91 @@
 ---
 title: settings.json
-description: Configure providers, agents, tools, and managed authority across project, org-managed, and user scopes.
+description: Configure providers, agents, tools, context, and managed authority across project, org-managed, and user scopes.
 ---
 
-`settings.json` is Stella's configuration file. It has six top-level sections, each with
+`settings.json` is Stella's configuration file. It has ten top-level sections, each with
 its own merge rule across the [scope hierarchy](#the-scope-hierarchy):
 
-| Section | Configures | Merge across scopes |
-| --- | --- | --- |
-| [`providers`](#the-providers-map) | Override any built-in provider — or define new ones | per field |
-| [`agent_engine_config`](/docs/configuration/agent-engine-config) | Per-agent models, gateways, prompts, effort, params | per field, per agent |
-| [`hooks`](#lifecycle-hooks) | Shell commands on lifecycle events | concatenate |
-| [`tools`](#the-tools-section) | Per-tool switches — any tool name, group, or `"*"` | last scope wins per key |
-| [`mcp`](#the-mcp-section) | MCP registry override | last scope wins |
-| [`authority`](#managed-authority-ceilings) | Managed ceilings for project prompts, custom tools, bash, web, and media approval | org-managed only; denial cannot be overridden |
+<CardGrid size="md">
+  <SpecCard
+    title={<code>providers</code>}
+    href="#the-providers-map"
+    meta={[{ label: "Merges", value: "per field", mono: false }]}
+  >
+    Override any built-in provider — or define a new one.
+  </SpecCard>
+  <SpecCard
+    title={<code>agent_engine_config</code>}
+    href="/docs/configuration/agent-engine-config"
+    meta={[{ label: "Merges", value: "per field, per agent", mono: false }]}
+  >
+    Per-agent models, gateways, prompts, effort, and sampling params.
+  </SpecCard>
+  <SpecCard
+    title={<code>hooks</code>}
+    href="#lifecycle-hooks"
+    meta={[{ label: "Merges", value: "concatenate", mono: false }]}
+  >
+    Shell commands on lifecycle events. Every scope may add matchers; none replaces
+    another's.
+  </SpecCard>
+  <SpecCard
+    title={<code>tools</code>}
+    href="#the-tools-section"
+    meta={[{ label: "Merges", value: "last scope wins, per key", mono: false }]}
+  >
+    Per-tool switches — any tool name, group, or `"*"`.
+  </SpecCard>
+  <SpecCard
+    title={<code>mcp</code>}
+    href="#the-mcp-section"
+    meta={[{ label: "Merges", value: "last scope wins, per field", mono: false }]}
+  >
+    MCP registry override.
+  </SpecCard>
+  <SpecCard
+    title={<code>enable_recap</code>}
+    href="#the-end-of-run-recap"
+    meta={[{ label: "Values", value: '"on" | "off"' }]}
+  >
+    Print a deterministic end-of-run recap in text mode. Off unless set.
+  </SpecCard>
+  <SpecCard
+    title={<code>context</code>}
+    href="#the-context-block"
+    meta={[{ label: "Merges", value: "whole block, last scope wins", mono: false }]}
+  >
+    The adaptive-context lifecycle: learning, governance, promotion, efficacy, retention.
+  </SpecCard>
+  <SpecCard
+    title={<code>context_providers</code>}
+    href="#external-context-providers"
+    meta={[{ label: "Merges", value: "per entry, last scope wins", mono: false }]}
+  >
+    Third-party Context Graph Protocol sources reached over stdio or HTTP.
+  </SpecCard>
+  <SpecCard
+    title={<code>authority</code>}
+    href="#managed-authority-ceilings"
+    meta={[{ label: "Scope", value: "org-managed only", mono: false }]}
+  >
+    Managed ceilings for project prompts, custom tools, bash, web, and media approval. A
+    denial cannot be overridden.
+  </SpecCard>
+  <SpecCard
+    title={<code>enterprise_telemetry</code>}
+    href="#enterprise-telemetry-enrollment"
+    meta={[{ label: "Scope", value: "org-managed only", mono: false }]}
+  >
+    The signed managed-enrollment document that authorizes operational export.
+  </SpecCard>
+</CardGrid>
+
+<Callout type="info">
+  `authority_policy` is **not** a file key. It is the effective authority Stella computes
+  while loading the scope chain, and it is skipped during parsing precisely so repository
+  text cannot supply it.
+</Callout>
 
 The `providers` map lets you override the built-in defaults for any provider — **without
 reaching for a provider-specific environment variable**. In **user scope**
@@ -26,7 +98,7 @@ coding-plan subscription through its dedicated endpoint — see the
 Keyed by provider id. Every field is optional — supply only what differs from the built-in
 default:
 
-```json
+```json title="~/.stella/settings.json"
 {
   "providers": {
     "zai": {
@@ -39,15 +111,33 @@ default:
 }
 ```
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `id` | string | Optional restatement of the map key; if present it **must equal the key** — a mismatch is a hard, named load error (guards against copy-pasting the wrong provider) |
-| `name` | string | Display name shown by `stella config` / `stella models` |
-| `base_url` | string | Base URL requests go to (a coding-plan endpoint, a proxy, a gateway) |
-| `api_key` | string | API key for this provider (slots into the [credential chain](/docs/getting-started/providers#the-credential-chain)) |
-| `api_key_env` | string | Name of an environment variable to read the key from — safer than an inline `api_key` in a committed project file |
-| `default_model` | string | Model used when none is pinned with `--model` |
-| `dialect` | string | Wire adapter for a **new** provider: `openai-compatible` (default) \| `openai-responses` \| `anthropic` \| `gemini` (`vertex`/`bedrock` are reserved to built-ins) |
+<CardGrid size="md">
+  <OptionCard name="id">
+    Optional restatement of the map key; if present it **must equal the key** — a mismatch
+    is a hard, named load error, which guards against copy-pasting the wrong provider.
+  </OptionCard>
+  <OptionCard name="name">
+    Display name shown by `stella config` / `stella models`.
+  </OptionCard>
+  <OptionCard name="base_url">
+    Base URL requests go to — a coding-plan endpoint, a proxy, a gateway.
+  </OptionCard>
+  <OptionCard name="api_key">
+    API key for this provider. It slots into the
+    [credential chain](/docs/getting-started/providers#the-credential-chain).
+  </OptionCard>
+  <OptionCard name="api_key_env">
+    Name of an environment variable to read the key from — safer than an inline `api_key`
+    in a committed project file.
+  </OptionCard>
+  <OptionCard name="default_model">
+    Model used when none is pinned with `--model`.
+  </OptionCard>
+  <OptionCard name="dialect" defaultValue="openai-compatible">
+    Wire adapter for a **new** provider: `openai-compatible`, `openai-responses`,
+    `anthropic`, or `gemini`. `vertex` and `bedrock` are reserved to built-ins.
+  </OptionCard>
+</CardGrid>
 
 The map key **is** the provider id (`zai` above). Leave a field out entirely to inherit the
 built-in default — note that an **empty string** for `base_url`, `name`, or
@@ -69,11 +159,38 @@ more specific scope wins. The merge is **field by field** for `providers` and
 merging), **last-scope-wins** for `mcp` and `tools`, and `hooks` are the exception — they
 **concatenate** across scopes (see [Lifecycle hooks](#lifecycle-hooks)).
 
-| Preference | Scope | Path |
-| --- | --- | --- |
-| Highest | **project** | `<workspace>/.stella/settings.json` |
-| Middle | **org-managed** | `STELLA_MANAGED_SETTINGS`, else the platform default (below) |
-| Lowest | **user** | `~/.stella/settings.json` |
+<SettingsCascadeDiagram />
+
+<CardGrid size="sm">
+  <SpecCard
+    title="project"
+    meta={[
+      { label: "Preference", value: "highest", mono: false },
+      { label: "Path", value: <code>{"<workspace>/.stella/settings.json"}</code> },
+    ]}
+  >
+    The repository's own file — and a [trust boundary](#the-project-trust-boundary).
+  </SpecCard>
+  <SpecCard
+    title="org-managed"
+    meta={[
+      { label: "Preference", value: "middle", mono: false },
+      { label: "Path", value: <code>STELLA_MANAGED_SETTINGS</code> },
+    ]}
+  >
+    Or the platform default, resolved below. The only scope that may carry `authority` or
+    `enterprise_telemetry`.
+  </SpecCard>
+  <SpecCard
+    title="user"
+    meta={[
+      { label: "Preference", value: "lowest", mono: false },
+      { label: "Path", value: <code>~/.stella/settings.json</code> },
+    ]}
+  >
+    Your personal defaults — the right home for a subscription endpoint or a personal key.
+  </SpecCard>
+</CardGrid>
 
 The org-managed path is resolved as:
 
@@ -83,9 +200,10 @@ The org-managed path is resolved as:
 
 Ordinary fields merge project over org-managed over user. Authority-sensitive fields are
 stricter: a project may narrow a grant with `"off"`, but it may not enable tools, replace
-an agent prompt, redirect credentials, or load executable custom tools until the user sets
-`STELLA_TRUST_PROJECT=1`. An org-managed denial is a ceiling even after that explicit
-trust. The legacy `STELLA_PROJECT_HOOKS=1` flag grants hooks only.
+an agent prompt, redirect credentials, register a context provider, or load executable
+custom tools until the user sets `STELLA_TRUST_PROJECT=1`. An org-managed denial is a
+ceiling even after that explicit trust. The legacy `STELLA_PROJECT_HOOKS=1` flag grants
+hooks only.
 
 <Callout type="info">
   A missing file at any scope is fine — it is simply skipped. A file that is present but
@@ -200,7 +318,7 @@ the MCP Server Registry that `stella mcp search` and the deck's MCP tab query; w
 falls back to the official registry. Like `providers`, it merges last-scope-wins per field,
 so a project can point at a different registry than the user default.
 
-```json
+```json title="~/.stella/settings.json"
 {
   "mcp": {
     "registry_url": "https://registry.example.internal/mcp"
@@ -250,6 +368,265 @@ scope winning. A project `"off"` always narrows an earlier grant; project `"on"`
 at any level of specificity: a managed `{"process": "off"}` cannot be defeated by a
 project naming `{"start_process": "on"}`.
 
+## The end-of-run recap
+
+`enable_recap` is a single top-level toggle using the same strict `"on"`/`"off"`
+vocabulary as the `tools` switches — a bare `true` is a hard parse error, and an absent
+key means off.
+
+```json title="~/.stella/settings.json"
+{
+  "enable_recap": "on"
+}
+```
+
+With it on, a text-mode run prints a **recap panel** after the files and cost panels: a
+deterministic synthesis of the outcome (`completed`, `completed — verified`,
+`verification failed`, `aborted`) plus a created/modified/deleted tally. It reads the
+run's own facts and costs **no model call** — it is the "so what" line that the file list
+alone does not give you.
+
+## The `context` block
+
+The `context` block configures the **adaptive-context lifecycle**: mining observations
+from your sessions, inducing directive proposals from them, governing which of those get
+promoted, and measuring whether the context selected actually helped.
+
+<Callout type="info">
+  The block is currently **inert**. Every field parses, round-trips, and merges, but no
+  code reads it yet — `context.lifecycle.enabled` defaults to `false`, which is what
+  preserves today's behavior. The schema ships ahead of the loop so a later release can
+  turn it on without a settings migration, and so the vocabulary below is pinned by
+  round-trip tests rather than invented later. Read the values here as the committed
+  vocabulary and defaults, not as a description of a running mechanism.
+</Callout>
+
+Two dimensions are kept deliberately separate: **learning mode** (how much of the loop
+runs) and **governance mode** (who signs off on a promotion). Every mode enum is *loud* —
+an unrecognized value such as `"advisary"` is a hard parse error, never a silent fallback.
+Omitted fields fall back to the defaults below, so `"context": {}` and an absent block are
+equivalent in effect.
+
+Unlike `providers`, the block merges **whole**: a higher-precedence scope that declares
+`context` replaces the lower scope's block outright rather than overlaying field by field.
+
+### Lifecycle and modes
+
+<CardGrid size="md">
+  <OptionCard name="context.lifecycle.enabled" defaultValue="false">
+    The master switch for the whole lifecycle. While it is off, every other field in the
+    `context` block is ignored.
+  </OptionCard>
+  <OptionCard name="context.learning.mode" defaultValue="off">
+    How much of the learning loop runs. `off` disables mining, proposal induction, and
+    efficacy learning. `record_only` captures observations, proposals, uses, and outcomes
+    without selecting or promoting inferred records. `advisory` enables governed inferred
+    *advisory* use.
+  </OptionCard>
+  <OptionCard name="context.governance.mode" defaultValue="solo">
+    Who governs promotions: `solo`, `team`, or `regulated`. Orthogonal to the learning
+    mode — the two dimensions do not collapse into one another.
+  </OptionCard>
+</CardGrid>
+
+### Promotion
+
+Thresholds gating when a set of observations may become an inferred directive, and the
+confirmation a blocking directive requires. Confidence values are on a `0`–`100` scale.
+
+<CardGrid size="sm">
+  <OptionCard name="context.promotion.inferred_directive.min_observations" defaultValue="3">
+    The minimum observation count. A whole number.
+  </OptionCard>
+  <OptionCard name="context.promotion.inferred_directive.min_distinct_tasks" defaultValue="3">
+    The minimum number of *distinct* tasks those observations must span — the guard against
+    one repetitive task promoting itself into a rule.
+  </OptionCard>
+  <OptionCard name="context.promotion.inferred_directive.auto_activate_at_confidence" defaultValue="85">
+    The confidence, `0`–`100`, at which an inferred directive activates without being asked.
+  </OptionCard>
+  <OptionCard name="context.promotion.inferred_directive.initial_enforcement" defaultValue="advisory">
+    The enforcement a newly inferred directive carries. Only two states exist — `advisory`
+    and `blocking` — and an inferred directive may only ever *start* advisory.
+  </OptionCard>
+  <OptionCard
+    name="context.promotion.blocking_directive.requires_explicit_confirmation"
+    defaultValue="true"
+  >
+    A blocking directive always requires an explicit human confirmation. Not a field to
+    turn off lightly.
+  </OptionCard>
+</CardGrid>
+
+### Efficacy
+
+Efficacy-attribution thresholds. Confidence values are on a `0`–`100` scale;
+`not_helpful_ratio_threshold` is a `0.0`–`1.0` ratio.
+
+<CardGrid size="sm">
+  <OptionCard name="context.efficacy.min_attributable_uses" defaultValue="5">
+    The minimum number of attributable uses. A whole number.
+  </OptionCard>
+  <OptionCard name="context.efficacy.not_helpful_ratio_threshold" defaultValue="0.8">
+    The not-helpful ratio threshold, between `0.0` and `1.0`.
+  </OptionCard>
+  <OptionCard name="context.efficacy.min_attribution_confidence" defaultValue="80">
+    The minimum attribution confidence, `0`–`100`.
+  </OptionCard>
+  <OptionCard
+    name="context.efficacy.receipt_display_min_attribution_confidence"
+    defaultValue="80"
+  >
+    The minimum attribution confidence a use needs before it is *displayed* on a receipt —
+    a knob of its own, separate from the attribution threshold above.
+  </OptionCard>
+</CardGrid>
+
+### Retention
+
+How long raw observations, proposals, and inferred directives are kept before review or
+expiry, in days.
+
+<CardGrid size="sm">
+  <OptionCard name="context.retention.raw_observation_days" defaultValue="30">
+    Retention for raw observations.
+  </OptionCard>
+  <OptionCard name="context.retention.proposal_days" defaultValue="30">
+    Retention for proposals.
+  </OptionCard>
+  <OptionCard name="context.retention.inferred_directive_review_days" defaultValue="180">
+    How long an inferred directive runs before it comes back up for review.
+  </OptionCard>
+</CardGrid>
+
+### A fully written-out `context` block
+
+Every value below is the shipped default, so this file changes nothing — it is the
+copy-paste starting point you edit down to the two or three keys you actually want:
+
+```json title="~/.stella/settings.json"
+{
+  "enable_recap": "on",
+  "context": {
+    "lifecycle": { "enabled": false },
+    "learning": { "mode": "off" },
+    "governance": { "mode": "solo" },
+    "promotion": {
+      "inferred_directive": {
+        "min_observations": 3,
+        "min_distinct_tasks": 3,
+        "auto_activate_at_confidence": 85,
+        "initial_enforcement": "advisory"
+      },
+      "blocking_directive": { "requires_explicit_confirmation": true }
+    },
+    "efficacy": {
+      "min_attributable_uses": 5,
+      "not_helpful_ratio_threshold": 0.8,
+      "min_attribution_confidence": 80,
+      "receipt_display_min_attribution_confidence": 80
+    },
+    "retention": {
+      "raw_observation_days": 30,
+      "proposal_days": 30,
+      "inferred_directive_review_days": 180
+    }
+  }
+}
+```
+
+## External context providers
+
+`context_providers.<id>` registers a third-party
+[Context Graph Protocol](/docs/context-engine#the-context-graph-protocol) source — a
+company wiki, an issue tracker, a vector store — so it can feed the recall block alongside
+the built-in workspace-memory and code-graph providers. Until this section exists, every
+provider is in-process; with it, a third-party source is a config entry rather than a fork.
+
+The block is **empty by default**, which registers nothing and leaves recall exactly as it
+is today.
+
+```json title="~/.stella/settings.json"
+{
+  "context_providers": {
+    "acme-wiki": {
+      "transport": "http",
+      "url": "https://ctx.acme.example/cgp",
+      "enabled": true,
+      "egress_consent": ["org_tenant"],
+      "consent_grantor": "policy:security-review"
+    },
+    "local-notes": {
+      "transport": "stdio",
+      "command": "acme-cgp",
+      "args": ["--serve"],
+      "enabled": true
+    }
+  }
+}
+```
+
+<CardGrid size="md">
+  <OptionCard name="transport" defaultValue="stdio">
+    How the host reaches the provider: `stdio` (a child process speaking the protocol) or
+    `http` (a remote endpoint). An unrecognized transport is a hard parse error.
+  </OptionCard>
+  <OptionCard name="command">
+    The program to spawn. Required, and non-empty, when `transport` is `stdio` — a missing
+    one is reported as a configuration error naming the field, not as a process that would
+    not start.
+  </OptionCard>
+  <OptionCard name="args">
+    Arguments for `command`.
+  </OptionCard>
+  <OptionCard name="url">
+    The endpoint to connect to. Required, and non-empty, when `transport` is `http`.
+  </OptionCard>
+  <OptionCard name="enabled" defaultValue="false">
+    Whether the entry is live. Declaring a provider is not turning it on: that is a
+    separate, deliberate act, so an org-managed entry merged in from a lower scope never
+    starts serving a turn just because someone defined it.
+  </OptionCard>
+  <OptionCard name="egress_consent">
+    The off-machine egress scopes you have consented to for this provider, as CGP scope
+    strings — `org_tenant`, `third_party_index`, `third_party_model`, or a namespaced one
+    like `acme:vector-store`.
+  </OptionCard>
+  <OptionCard name="consent_grantor">
+    Who granted that consent, for the audit ledger. Free text — a user id, an email, a
+    policy name. Absent means the local operator.
+  </OptionCard>
+</CardGrid>
+
+Two properties are load-bearing and deliberately not optional:
+
+- **Conformance is an admission gate, not a badge.** A provider is run through the
+  protocol's own conformance suite *before* it is registered on the session host, so a
+  source that lies about token cost, serves frames with no citation label, or cannot shut
+  down cleanly never serves a turn. Register-first-discover-later would mean the first
+  evidence of non-conformance is a corrupted prompt.
+- **Egress is consented, never assumed.** Every built-in provider is non-egressing, so the
+  consent store has never had occasion to prompt. An external provider is the first thing
+  that can send workspace content off the machine, and it stays gated until the config
+  records consent for every off-machine scope it declares — the host refuses to transmit,
+  and the query payload, which carries workspace content, never leaves.
+
+Entries merge **per entry** across scopes, so a project can enable a provider the user
+scope declared without restating its transport. A higher scope's entry replaces the lower
+one's *wholesale*: field-level merging would let a project file inherit a user's
+`egress_consent` while swapping the `url`, silently reusing consent granted for a
+different endpoint.
+
+The map key is the routing **and** consent key, so renaming an entry creates a new
+provider whose consent must be granted afresh. That is the point, not an inconvenience.
+
+<Callout type="warn">
+  `context_providers` sits on the same code-execution boundary as `hooks` and
+  `.stella/mcp.toml`. An untrusted project scope's entries are dropped in favour of the
+  user and org-managed scopes', with a stderr notice — see
+  [the project trust boundary](#the-project-trust-boundary).
+</Callout>
+
 ## Managed authority ceilings
 
 Only the org-managed settings file may define the top-level `authority` section. User and
@@ -275,6 +652,18 @@ still requires `STELLA_TRUST_PROJECT=1`, while `project_custom_tools: "off"` kee
 workspace manifests disabled even when that trust flag is present. Media host approval
 defaults to required when the field is absent.
 
+## Enterprise telemetry enrollment
+
+`enterprise_telemetry` is the other org-managed-only section: the signed enrollment
+document that authorizes Oxagen Enterprise operational export. It is captured from the
+managed snapshot alone — a project or user file carrying the key contributes nothing —
+and is validated by its adapter, so an invalid, missing, expired, or unsupported
+enrollment simply leaves export inactive rather than failing the run.
+
+Community and default mode construct no spool and no HTTP client at all. The full
+schema, the sink-authorization rules, and the closed event envelope are documented on
+[Telemetry &amp; budget](/docs/telemetry#oxagen-enterprise-managed-export).
+
 ## The project trust boundary
 
 A repository you just cloned can carry a `<workspace>/.stella/settings.json` — and an
@@ -284,6 +673,11 @@ file until you opt in with **`STELLA_TRUST_PROJECT=1`**:
 
 - **Hooks.** Project-scope `hooks` load only when the project is trusted. (The legacy
   `STELLA_PROJECT_HOOKS=1` flag still unlocks hooks — and only hooks.)
+- **Context providers.** Project-scope `context_providers` entries are dropped in favour
+  of whatever the user and org-managed scopes declared. An enabled `stdio` entry spawns
+  its `command` at admission time — the same `git clone && stella` exposure that gates
+  `.stella/mcp.toml` — and an `http` entry is no safer, because the same untrusted file
+  would be supplying the `egress_consent` that lets workspace content leave the machine.
 - **Credential routing.** Project-scope values for `providers.<id>.base_url`,
   `providers.<id>.api_key`, `providers.<id>.api_key_env`, and `mcp.registry_url` are
   **silently dropped** (the trusted-scope values win) — otherwise a malicious repo could
@@ -299,8 +693,8 @@ file until you opt in with **`STELLA_TRUST_PROJECT=1`**:
   unless full project trust is present and managed policy permits them. User-global
   manifests under `~/.stella/tools/` remain available.
 
-A stderr notice names skipped hooks and credential-routing fields, so a
-trusted-but-forgotten flag is diagnosable. Cosmetic project fields (`name`,
+A stderr notice names skipped hooks, skipped context providers, and credential-routing
+fields, so a trusted-but-forgotten flag is diagnosable. Cosmetic project fields (`name`,
 `default_model`, `dialect`) apply regardless of trust. Managed denials from the captured
 org settings snapshot always win; changing the file takes effect on the next settings load.
 
@@ -315,6 +709,64 @@ declared in a repository's project-scope file load **only** behind the
 [project trust boundary](#the-project-trust-boundary) (`STELLA_TRUST_PROJECT=1`, or the
 legacy hooks-only `STELLA_PROJECT_HOOKS=1`); a stderr notice names any skipped project
 hooks.
+
+## A complete example file
+
+Everything above, in one user-scope file — a routed provider, a narrowed tool surface, a
+guard hook, the recap on, and a `context` block with only the keys that differ from the
+defaults. Copy it, delete what you don't want:
+
+```json title="~/.stella/settings.json"
+{
+  "providers": {
+    "zai": {
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "api_key_env": "ZAI_API_KEY",
+      "default_model": "n-5.2"
+    }
+  },
+  "tools": {
+    "process": "off",
+    "read_output": "on"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash",
+        "hooks": [
+          { "type": "command", "command": "./scripts/guard.sh", "timeoutMs": 5000 }
+        ]
+      }
+    ]
+  },
+  "mcp": {
+    "registry_url": "https://registry.example.internal/mcp"
+  },
+  "enable_recap": "on",
+  "context": {
+    "lifecycle": { "enabled": false },
+    "learning": { "mode": "record_only" },
+    "governance": { "mode": "team" },
+    "retention": { "raw_observation_days": 14 }
+  },
+  "context_providers": {
+    "acme-wiki": {
+      "transport": "http",
+      "url": "https://ctx.acme.example/cgp",
+      "enabled": true,
+      "egress_consent": ["org_tenant"],
+      "consent_grantor": "policy:security-review"
+    }
+  }
+}
+```
+
+Check what actually resolved:
+
+```bash
+stella config    # provider, model, key preview, base URL
+stella models    # every provider with its effective base URL and key status
+```
 
 ## Security
 

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -12,21 +12,66 @@ full price every call.
 
 Everything is on your disk, under `.stella/`:
 
-| Path | What it holds |
-| --- | --- |
-| `.stella/memories/*.md` | Workspace memories — one Markdown lesson per file, written by `save_memory` |
-| `.stella/private/context.db` | The **bi-temporal** context store: episodes, reflection memories, domain facts |
-| `.stella/private/reflections.jsonl` | The reflection mining log — one JSON lesson per line |
-| `.stella/private/codegraph.db` | The tree-sitter code-graph index |
-| `.stella/explorations/*` | Saved **exploration maps** — reusable codebase-slice notes with per-file staleness |
-| `.stella/rules/*.md` | Rules — promoted memories and guard rules |
-| `.stella/skills/` | Project [skills](/docs/agent-tools/skills) |
-| `.stella/domains.toml` | The domain taxonomy — the shared tagging vocabulary |
-| `.stella/private/store.db` | The citation ledger and [telemetry](/docs/telemetry) |
+<CardGrid size="md">
+  <OptionCard name=".stella/memories/*.md">
+    Workspace memories — one Markdown lesson per file, written by `save_memory`.
+  </OptionCard>
+  <OptionCard name=".stella/private/context.db">
+    The **bi-temporal** context store: episodes, reflection memories, domain facts.
+  </OptionCard>
+  <OptionCard name=".stella/private/reflections.jsonl">
+    The reflection mining log — one JSON lesson per line.
+  </OptionCard>
+  <OptionCard name=".stella/private/codegraph.db">
+    The tree-sitter code-graph index.
+  </OptionCard>
+  <OptionCard name=".stella/explorations/*">
+    Saved **exploration maps** — reusable codebase-slice notes with per-file staleness.
+  </OptionCard>
+  <OptionCard name=".stella/rules/*.md">
+    Rules — promoted memories and guard rules. Also read from `.claude/rules/` and
+    `~/.stella/rules/`.
+  </OptionCard>
+  <OptionCard name=".stella/skills/">
+    Project [skills](/docs/agent-tools/skills).
+  </OptionCard>
+  <OptionCard name=".stella/domains.toml">
+    The domain taxonomy — the shared tagging vocabulary.
+  </OptionCard>
+  <OptionCard name=".stella/private/store.db">
+    The citation ledger and [telemetry](/docs/telemetry).
+  </OptionCard>
+</CardGrid>
 
 *Bi-temporal* means the context store keeps both when a fact was true and
 when Stella believed it: re-running `stella init` **supersedes** stale facts
 rather than deleting them, so "what did we believe then?" stays answerable.
+
+### Where rules come from
+
+Rules are read from **three** directories, in precedence order — a later one overrides an
+earlier one *by rule id*, so a repository can replace a personal rule that shares its name:
+
+<CardGrid size="sm">
+  <OptionCard name="~/.stella/rules/">
+    Your own rules, applied in every workspace. Lowest precedence, and the only directory
+    that survives when project prompts are not permitted.
+  </OptionCard>
+  <OptionCard name=".claude/rules/">
+    Claude Code interop — an existing rules directory works unchanged.
+  </OptionCard>
+  <OptionCard name=".stella/rules/">
+    The workspace's own rules, and where `stella memory promote` writes. Highest
+    precedence.
+  </OptionCard>
+</CardGrid>
+
+Both project directories are skipped entirely when the effective
+[managed authority](/docs/configuration/settings#managed-authority-ceilings) does not
+permit project prompts, leaving your user rules armed. Prompt-only (Tier-1) rules follow
+that plain latest-wins precedence; user-global **hard guards** are monotonic instead — a
+project rule with the same id can never disarm one, and a distinct project guard is added
+under a provenance-qualified id so both constraints stay in force.
 
 ## Local-first today; share rules through Git
 

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -21,11 +21,36 @@ parser fail on a stream it used to handle.
 
 That holds in both directions:
 
-| Change | Older client, newer stream | Newer client, older stream |
-| --- | --- | --- |
-| A new field on an existing event | Ignored | Filled with its default |
-| A brand-new event type | Preserved, reported as unrecognized | Never appears |
-| A renamed or removed event type | **Does not happen** — the vocabulary is additive only | — |
+<CardGrid size="md">
+  <SpecCard
+    title="A new field on an existing event"
+    meta={[
+      { label: "Older client", value: "ignores it", mono: false },
+      { label: "Newer client", value: "filled with its default", mono: false },
+    ]}
+  >
+    Adding a field is always safe in both directions.
+  </SpecCard>
+  <SpecCard
+    title="A brand-new event type"
+    meta={[
+      { label: "Older client", value: "preserved, reported as unrecognized", mono: false },
+      { label: "Newer client", value: "never appears", mono: false },
+    ]}
+  >
+    An unknown event must survive the round trip, not abort the parse.
+  </SpecCard>
+  <SpecCard
+    title="A renamed or removed event type"
+    meta={[
+      { label: "Older client", value: "does not happen", mono: false },
+      { label: "Newer client", value: "does not happen", mono: false },
+    ]}
+  >
+    The vocabulary is **additive only** — this row exists to say the case is ruled out,
+    not handled.
+  </SpecCard>
+</CardGrid>
 
 Event type names and field names are never renamed or repurposed once shipped.
 Growth is by addition.
@@ -144,7 +169,7 @@ it next, which may be a newer client that would have understood them.
 The repository ships a fixture whose only purpose is to break clients that get
 rule 1 wrong:
 
-```
+```text
 stella-pipeline/tests/fixtures/from_a_newer_stella.jsonl
 ```
 

--- a/website/content/docs/examples/balanced.mdx
+++ b/website/content/docs/examples/balanced.mdx
@@ -10,7 +10,9 @@ cheap insurance. This is the sensible default for day-to-day work.
 
 ## The config
 
-```jsonc title="~/.stella/settings.json"
+Three keys, one file — paste it whole:
+
+```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "pipeline_worker_model": "zai/glm-5.2",
@@ -32,22 +34,35 @@ cheap insurance. This is the sensible default for day-to-day work.
 }
 ```
 
+The three keys it expects:
+
+```bash
+export ZAI_API_KEY="..."                # the worker
+export ANTHROPIC_API_KEY="sk-ant-..."   # the judge
+export DEEPSEEK_API_KEY="sk-..."        # triage
+
+stella models    # every provider with its key status — all three must read configured
+stella config    # the resolved provider, model, and a redacted key preview
+```
+
 Why these choices:
 
 - **GLM-5.2 as worker** — the price/performance sweet spot of the
-  [catalog](/docs/api-providers/models): excellent coding at $2.20/Mtok out
-  vs. a flagship's $15. On a Z.ai coding-plan subscription
-  ([one settings line](/docs/api-providers/zai)) the marginal cost drops
-  further still.
+  [catalog](/docs/api-providers/models): excellent coding at $0.60/$2.20 per
+  Mtok against a flagship's $3.00/$15.00, on the same 200k window. On a Z.ai
+  coding-plan subscription ([one settings line](/docs/api-providers/zai)) the
+  marginal cost drops further still.
 - **Fable 5 as judge.** A flagship verdict costs cents per verification and
   is naturally **cross-family** to the GLM worker. The judge is where you
   *don't* save. (Prefer OpenAI? `openai/gpt-5.5` judges equally well here.)
 - **`effort_auto` / `reasoning_auto` on.** The autos encode the sensible
   mapping — judge high, worker medium, triage low; thinking on everywhere
   except triage — and you stop thinking about it. That's their contract.
+  They also *override* any per-agent `effort`/`reasoning`, which is why this
+  profile carries no `agents` block at all.
 - Swap-in: worker `gemini/gemini-3-pro` when your tasks need the 1M-token
-  window (whole-repo comprehension) at the same output price class as
-  GPT-5.5.
+  window (whole-repo comprehension) — at $1.25/$10.00 per Mtok, exactly
+  GPT-5.5's list price.
 
 Feeling indecisive about the judge? Turn `auto_mode: "on"` and let stella
 pick the best cross-family judge from `allowed_models` per run.
@@ -59,15 +74,25 @@ stella run "add pagination to the /orders endpoint and update its tests" \
   --test-command "pnpm test orders"
 
 stella --budget 3.00 goal "clippy is clean and the test suite passes"
+
+stella stats     # cost, tokens, and resolve rate per provider and model
 ```
 
 ## What it costs
 
-| Task shape | Ballpark |
-| --- | --- |
-| Focused single-file fix | $0.02 – $0.10 |
-| Medium multi-file change, one revision | **$0.05 – $0.50** |
-| Hard refactor / long session | $0.30 – $1.50 |
+<CardGrid size="sm">
+  <SpecCard title="Focused single-file fix" meta={[{ label: "Ballpark", value: "$0.02 – $0.10" }]} />
+  <SpecCard
+    title="Medium multi-file change, one revision"
+    meta={[{ label: "Ballpark", value: "$0.05 – $0.50" }]}
+  >
+    The reference shape for the estimate on the [examples index](/docs/examples).
+  </SpecCard>
+  <SpecCard
+    title="Hard refactor / long session"
+    meta={[{ label: "Ballpark", value: "$0.30 – $1.50" }]}
+  />
+</CardGrid>
 
 Roughly **5–7× cheaper** than the [maximum-quality](/docs/examples/max-quality)
 profile on the same work, with the same class of judge watching the result.

--- a/website/content/docs/examples/dirt-cheap.mdx
+++ b/website/content/docs/examples/dirt-cheap.mdx
@@ -12,7 +12,9 @@ spending real money.
 
 ## The config
 
-```jsonc title="~/.stella/settings.json"
+Two keys, one file — paste it whole:
+
+```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "pipeline_worker_model": "deepseek/deepseek-chat",
@@ -39,18 +41,31 @@ spending real money.
 }
 ```
 
+The two keys it expects:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."   # the worker and triage
+export ZAI_API_KEY="..."           # the judge
+
+stella models    # both must read configured
+stella config    # the resolved provider, model, and a redacted key preview
+```
+
 Why these choices:
 
 - **DeepSeek as worker** — $0.27/$1.10 per Mtok with a $0.07 cached rate:
   the [catalog](/docs/api-providers/models)'s price floor among hosted
   models. Thinking off and `max_tokens` capped: mechanical work doesn't
-  need deliberation, and a runaway answer can't run far.
+  need deliberation, and a runaway answer can't run far. (DeepSeek drops
+  `effort` on the wire, so `low` there records intent; `reasoning: "off"`
+  and `max_tokens` are the settings actually doing the work.)
 - **GLM-5.2 as judge** — still cheap, still a *different family* than the
   worker, with thinking on: the judge is the one place this profile keeps
   its brain switched fully on. The whole judge call costs a fraction of a
   cent.
-- **No autos** — `effort_auto` would raise the worker to medium; this
-  profile wants the floor.
+- **No autos** — `effort_auto` would raise the worker to medium and
+  `reasoning_auto` would switch thinking back on for it; this profile wants
+  the floor, so both stay off.
 
 ## Run it with a hard cap
 
@@ -63,20 +78,32 @@ stella --budget 1.00 fleet \
   "fix clippy warnings in stella-store" \
   "fix clippy warnings in stella-tools" \
   "normalize log messages to sentence case"
+
+# Confirm the bill.
+stella stats --format table
 ```
 
-Always pass `--test-command` when there are tests — the deterministic
-fail→pass flip is **free verification** that skips the judge call entirely
-on the happy path.
+On a `stella run`, always pass `--test-command` when there are tests — the
+deterministic fail→pass flip is **free verification** that skips the judge
+call entirely on the happy path. (It is a `run` flag; `goal` and `fleet`
+drive verification from their own prompts.)
 
 ## What it costs
 
-| Task shape | Ballpark |
-| --- | --- |
-| Lookup / explain | well under $0.01 |
-| Focused single-file fix | $0.005 – $0.03 |
-| Medium multi-file change | **$0.01 – $0.10** |
-| A ten-task chore fleet | often under $0.50 total |
+<CardGrid size="sm">
+  <SpecCard title="Lookup / explain" meta={[{ label: "Ballpark", value: "well under $0.01", mono: false }]} />
+  <SpecCard title="Focused single-file fix" meta={[{ label: "Ballpark", value: "$0.005 – $0.03" }]} />
+  <SpecCard
+    title="Medium multi-file change"
+    meta={[{ label: "Ballpark", value: "$0.01 – $0.10" }]}
+  >
+    The reference shape for the estimate on the [examples index](/docs/examples).
+  </SpecCard>
+  <SpecCard
+    title="A ten-task chore fleet"
+    meta={[{ label: "Ballpark", value: "often under $0.50 total", mono: false }]}
+  />
+</CardGrid>
 
 ## The $0.00 tier: local models
 

--- a/website/content/docs/examples/enterprise-cloud.mdx
+++ b/website/content/docs/examples/enterprise-cloud.mdx
@@ -8,6 +8,8 @@ VPC routing, enterprise data terms — Stella speaks both native dialects. Both 
 sit **last** in auto-detection on purpose (their credentials are often present for
 unrelated reasons), so pin them explicitly.
 
+<ProviderGrid only={["vertex", "bedrock"]} />
+
 ## Vertex AI
 
 ```bash
@@ -15,18 +17,55 @@ export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)
 export VERTEX_PROJECT_ID=my-gcp-project        # or GOOGLE_CLOUD_PROJECT
 export VERTEX_LOCATION=global                  # optional; default "global"
 
+stella models    # vertex reads configured
 stella --model vertex/gemini-3-pro run "…"
 ```
 
+<CardGrid size="md">
+  <OptionCard name="VERTEX_ACCESS_TOKEN" required>
+    The credential Stella keys Vertex on — deliberately Vertex-specific rather
+    than a generic Google variable, so auto-detection is an explicit opt-in.
+  </OptionCard>
+  <OptionCard name="VERTEX_PROJECT_ID" required>
+    Your GCP project. `GOOGLE_CLOUD_PROJECT` is accepted as the alternative
+    name.
+  </OptionCard>
+  <OptionCard name="VERTEX_LOCATION" defaultValue="global">
+    The region the adapter builds its per-request endpoint from.
+  </OptionCard>
+</CardGrid>
+
 Access tokens expire hourly — wrap the export in a shell function so a fresh token is a
 keystroke away (the [Vertex page](/docs/api-providers/vertex) has the snippet). Pin it
-as your default so `--model` isn't needed every run:
+as your default so `--model` isn't needed every run — this is the whole file:
 
 ```json title="~/.stella/settings.json"
 {
-  "agent_engine_config": { "default_model": "vertex/gemini-3-pro" }
+  "agent_engine_config": {
+    "default_model": "vertex/gemini-3-pro",
+    "pipeline_worker_model": "vertex/gemini-3-pro",
+    "pipeline_judge_model": "vertex/gemini-3-pro",
+    "pipeline_triage_model": "vertex/gemini-3-pro",
+
+    "allowed_models": ["vertex/gemini-3-pro"],
+
+    "auto_mode": "off",
+    "effort_auto": "off",
+    "reasoning_auto": "on",
+
+    "agents": {
+      "judge": {
+        "effort": "high",
+        "prompt": "You are a strict, evidence-first code judge. Claimed success without deterministic evidence is a FAIL."
+      }
+    }
+  }
 }
 ```
+
+`gemini-3-pro` on Vertex is the same model — and the same list price, $1.25/$10.00 per
+Mtok on a 1M-token window — as the Gemini-direct row; only the billing relationship and
+the wire path differ.
 
 ## Amazon Bedrock
 
@@ -36,8 +75,40 @@ export AWS_SECRET_ACCESS_KEY=...
 export AWS_SESSION_TOKEN=...                   # when using STS/SSO-derived creds
 export AWS_REGION=us-east-1                    # or AWS_DEFAULT_REGION; default us-east-1
 
+stella models    # bedrock reads configured
 stella --model bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 run "…"
 ```
+
+<CardGrid size="md">
+  <OptionCard name="AWS_ACCESS_KEY_ID" required>
+    The variable Bedrock's row is keyed on. Because it is commonly exported for
+    unrelated reasons, Bedrock sits **last** in auto-detection.
+  </OptionCard>
+  <OptionCard name="AWS_SECRET_ACCESS_KEY" required>
+    Resolved alongside the key id when the adapter is built.
+  </OptionCard>
+  <OptionCard name="AWS_SESSION_TOKEN">
+    Required only for STS- or SSO-derived temporary credentials.
+  </OptionCard>
+  <OptionCard name="AWS_REGION" defaultValue="us-east-1">
+    Also read from `AWS_DEFAULT_REGION`. The real host is region-scoped —
+    `bedrock-runtime.<AWS_REGION>.amazonaws.com` — and built per request.
+  </OptionCard>
+</CardGrid>
+
+The default Bedrock model is a **cross-region inference profile**
+(`us.anthropic.claude-sonnet-4-5-20250929-v1:0`), not a bare model id: Bedrock rejects
+on-demand invocation of newer Anthropic models without one. It is priced as Claude
+Sonnet 4.5 at $3.00/$15.00 per Mtok on a 200k window.
+
+<Callout type="info">
+  Bedrock's Converse `inferenceConfig` has slots for only `max_tokens`, `temperature`,
+  and `top_p` — so `effort`, the `reasoning` switch, and every other generation param
+  are silently dropped there. Shape a Bedrock judge with its **`prompt`** (and, if you
+  want, `max_tokens`); an `effort: "xhigh"` line will not change anything. This is the
+  never-fail contract, not a bug: a param the provider cannot express must never fail
+  the request.
+</Callout>
 
 <Callout type="warn">
   Stella reads **only these environment variables** — it does not walk the AWS
@@ -65,29 +136,61 @@ inherits — users keep their own keys, projects keep their own overrides:
       "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
     ]
   },
+  "tools": {
+    "web": "off"
+  },
+  "authority": {
+    "project_prompts": "off",
+    "project_custom_tools": "off"
+  },
   "hooks": {
     "PreToolUse": [
       { "matcher": "repo_push",
-        "hooks": [ { "command": "/usr/local/bin/acme-push-policy" } ] }
+        "hooks": [ { "command": "/usr/local/bin/acme-push-policy", "timeoutMs": 10000 } ] }
     ]
   }
 }
 ```
 
-- `STELLA_MANAGED_SETTINGS=/path/to/settings.json` overrides the platform path — the CI
-  and container route.
-- `allowed_models` constrains the deck's model pickers and `auto_mode`'s choices to the
-  approved list — and it **replaces wholesale** across scopes, so the org list is the
-  list unless a more specific scope replaces it entirely.
-- Org-managed hooks always load (no trust flag needed) — they are your machine's
-  policy, unlike a cloned repo's. Projects can still add their own behind
-  [`STELLA_TRUST_PROJECT=1`](/docs/configuration/settings#the-project-trust-boundary).
+<CardGrid size="md">
+  <OptionCard name="STELLA_MANAGED_SETTINGS">
+    Overrides the platform path with an explicit file — the CI and container
+    route.
+  </OptionCard>
+  <OptionCard name="allowed_models">
+    Constrains the deck's model pickers and `auto_mode`'s choices to the
+    approved list. It **replaces wholesale** across scopes, so the org list is
+    the list unless a more specific scope replaces it entirely.
+  </OptionCard>
+  <OptionCard name="hooks">
+    Org-managed hooks always load — no trust flag needed, because they are your
+    machine's policy rather than a cloned repo's. `matcher` is a glob over the
+    tool name. Hooks concatenate across scopes, so projects can still add their
+    own behind
+    [`STELLA_TRUST_PROJECT=1`](/docs/configuration/settings#the-project-trust-boundary);
+    none of them can remove yours.
+  </OptionCard>
+  <OptionCard name="tools">
+    A managed `off` is a **ceiling**, not a preference: a lower scope cannot
+    grant back a tool the org denied, even a trusted project. Keys are tool
+    names, group names (`web`, `bash`, `repo`, …), or `"*"`.
+  </OptionCard>
+  <OptionCard name="authority.project_prompts" defaultValue="on">
+    `off` keeps a repo from replacing an agent's system prompt even when the
+    user has trusted it. Honored only from this file.
+  </OptionCard>
+  <OptionCard name="authority.project_custom_tools" defaultValue="on">
+    `off` keeps `.stella/tools/` manifests from loading even on a trusted repo;
+    only `~/.stella/tools/` is scanned.
+  </OptionCard>
+</CardGrid>
 
 ## Verify a seat
 
 ```bash
 stella models    # ✓ configured rows for vertex/bedrock, org gateway URLs visible
 stella config    # the resolved provider, model, and a redacted key preview
+stella stats     # after a first run: cost and resolve rate per provider and model
 ```
 
 ## Optional managed operational telemetry

--- a/website/content/docs/examples/index.mdx
+++ b/website/content/docs/examples/index.mdx
@@ -8,14 +8,26 @@ file** — pick the page that matches your situation, paste, verify, adjust.
 
 ## Setups by use case
 
-| Your situation | Recipe |
-| --- | --- |
-| One API key, want the best default setup | [Single provider, single key](/docs/examples/single-key) |
-| Z.ai GLM coding-plan subscriber | [Z.ai coding plan](/docs/examples/zai-coding-plan) |
-| One OpenRouter key for every model family | [One gateway key](/docs/examples/openrouter-gateway) |
-| Ollama / vLLM / LM Studio, or no network at all | [Local &amp; air-gapped](/docs/examples/local-airgapped) |
-| Models must flow through GCP / AWS | [Enterprise cloud](/docs/examples/enterprise-cloud) |
-| Sharing `.stella/` config across a team | [Team-shared settings](/docs/examples/team-settings) |
+<CardGrid size="md">
+  <SpecCard title="Single provider, single key" href="/docs/examples/single-key">
+    One API key, and you want the best setup it can buy.
+  </SpecCard>
+  <SpecCard title="Z.ai coding plan" href="/docs/examples/zai-coding-plan">
+    A GLM coding-plan subscription, where cost is flat rather than per token.
+  </SpecCard>
+  <SpecCard title="One gateway key" href="/docs/examples/openrouter-gateway">
+    A single OpenRouter key reaching every model family.
+  </SpecCard>
+  <SpecCard title="Local &amp; air-gapped" href="/docs/examples/local-airgapped">
+    Ollama, vLLM, or LM Studio — or no network at all.
+  </SpecCard>
+  <SpecCard title="Enterprise cloud" href="/docs/examples/enterprise-cloud">
+    Models must flow through your GCP or AWS account.
+  </SpecCard>
+  <SpecCard title="Team-shared settings" href="/docs/examples/team-settings">
+    Sharing `.stella/` configuration across a team.
+  </SpecCard>
+</CardGrid>
 
 ## Cost-tier profiles
 
@@ -23,11 +35,44 @@ The [inference pipeline](/docs/inference-pipeline) makes several model calls
 per run, and each one is [independently configurable](/docs/configuration/agent-engine-config).
 Three ready-to-paste tiers — and below, the cost model to reason about your own:
 
-| Profile | Worker | Judge | Triage | Typical run* |
-| --- | --- | --- | --- | --- |
-| [Maximum quality](/docs/examples/max-quality) | claude-fable-5 | gpt-5.5 | deepseek-chat | ~$0.40 – $2.50 |
-| [Balanced](/docs/examples/balanced) | glm-5.2 | claude-fable-5 | deepseek-chat | ~$0.05 – $0.50 |
-| [Dirt cheap](/docs/examples/dirt-cheap) | deepseek-chat | glm-5.2 | deepseek-chat | ~$0.01 – $0.10 |
+<CardGrid size="md">
+  <SpecCard
+    title="Maximum quality"
+    href="/docs/examples/max-quality"
+    meta={[
+      { label: "Worker", value: "claude-fable-5" },
+      { label: "Judge", value: "gpt-5.5" },
+      { label: "Triage", value: "deepseek-chat" },
+      { label: "Typical run", value: "~$0.40 – $2.50" },
+    ]}
+  >
+    The strongest worker money buys, judged by a different family.
+  </SpecCard>
+  <SpecCard
+    title="Balanced"
+    href="/docs/examples/balanced"
+    meta={[
+      { label: "Worker", value: "glm-5.2" },
+      { label: "Judge", value: "claude-fable-5" },
+      { label: "Triage", value: "deepseek-chat" },
+      { label: "Typical run", value: "~$0.05 – $0.50" },
+    ]}
+  >
+    A cheap worker under a flagship judge — most of the quality, a fraction of the bill.
+  </SpecCard>
+  <SpecCard
+    title="Dirt cheap"
+    href="/docs/examples/dirt-cheap"
+    meta={[
+      { label: "Worker", value: "deepseek-chat" },
+      { label: "Judge", value: "glm-5.2" },
+      { label: "Triage", value: "deepseek-chat" },
+      { label: "Typical run", value: "~$0.01 – $0.10" },
+    ]}
+  >
+    Pennies per run, for high-volume or exploratory work.
+  </SpecCard>
+</CardGrid>
 
 *Estimates for a *medium* task (a focused multi-file change, one revision) at
 the catalog's list prices, with prompt caching working normally. A lookup
@@ -40,15 +85,74 @@ profiles assume keys for two or three providers — with one key, start from
 
 Cost intuition starts with knowing who calls the model, and how much:
 
-| Stage | Calls | Typical size | Cost driver |
-| --- | --- | --- | --- |
-| Triage | 1 | ~1–2k in, ~1 token out | Negligible on any model — but why pay flagship rates for one token? Route it to the cheapest model you have. |
-| Plan | 1 (+1 repair, rarely) | ~5–15k in, ~1k out | Small. Rides the worker's settings. |
-| Witness | ~1 engine turn | ~10–30k in, ~1–2k out | Only when no `--test-command` was given. Test runs themselves are local and free. |
-| **Execute** | 5–40+ steps | ~100–500k in (mostly **cached**), ~5–30k out | **The dominant cost.** The worker model's price — especially its *output* price — is most of your bill. |
-| Verify | 0 | — | The deterministic ladder (flip oracle, diff budget) is free. |
-| Judge | 0–1 per verification | ~3–10k in, ~0.5–1k out | Only when deterministic evidence is inconclusive. Cents, even on a flagship. |
-| Revise | 0–2 extra execute rounds | like Execute, smaller | Each revision re-runs part of the execute cost. |
+<PipelineFlowDiagram />
+
+<CardGrid size="md">
+  <SpecCard
+    title="Triage"
+    meta={[
+      { label: "Calls", value: "1" },
+      { label: "Size", value: "~1–2k in, ~1 token out" },
+    ]}
+  >
+    Negligible on any model — but why pay flagship rates for one token? Route it to the
+    cheapest model you have.
+  </SpecCard>
+  <SpecCard
+    title="Plan"
+    meta={[
+      { label: "Calls", value: "1 (+1 repair, rarely)" },
+      { label: "Size", value: "~5–15k in, ~1k out" },
+    ]}
+  >
+    Small. Rides the worker's settings.
+  </SpecCard>
+  <SpecCard
+    title="Witness"
+    meta={[
+      { label: "Calls", value: "~1 engine turn" },
+      { label: "Size", value: "~10–30k in, ~1–2k out" },
+    ]}
+  >
+    Only when no `--test-command` was given. Test runs themselves are local and free.
+  </SpecCard>
+  <SpecCard
+    title="Execute — the dominant cost"
+    meta={[
+      { label: "Calls", value: "5–40+ steps" },
+      { label: "Size", value: "~100–500k in (mostly cached), ~5–30k out" },
+    ]}
+  >
+    The worker model's price — especially its **output** price — is most of your bill.
+  </SpecCard>
+  <SpecCard
+    title="Verify"
+    meta={[
+      { label: "Calls", value: "0" },
+      { label: "Size", value: "—" },
+    ]}
+  >
+    The deterministic ladder (flip oracle, diff budget) is free.
+  </SpecCard>
+  <SpecCard
+    title="Judge"
+    meta={[
+      { label: "Calls", value: "0–1 per verification" },
+      { label: "Size", value: "~3–10k in, ~0.5–1k out" },
+    ]}
+  >
+    Only when deterministic evidence is inconclusive. Cents, even on a flagship.
+  </SpecCard>
+  <SpecCard
+    title="Revise"
+    meta={[
+      { label: "Calls", value: "0–2 extra execute rounds" },
+      { label: "Size", value: "like Execute, smaller" },
+    ]}
+  >
+    Each revision re-runs part of the execute cost.
+  </SpecCard>
+</CardGrid>
 
 Three consequences worth internalizing:
 

--- a/website/content/docs/examples/local-airgapped.mdx
+++ b/website/content/docs/examples/local-airgapped.mdx
@@ -10,6 +10,8 @@ telemetry, memories, and code graph stay on your machine. The sole exception is 
 whose current signed policy authorizes a minimal content-free operational rollup to one
 exact HTTPS sink; do not enroll that mode on a fully air-gapped host.
 
+<ProviderGrid only={["local"]} />
+
 ## Quick: the `local` pseudo-provider
 
 ```bash
@@ -18,6 +20,10 @@ stella --model local/llama3.3 --base-url http://localhost:11434/v1 chat
 
 # vLLM / LM Studio / llama.cpp server — same shape, different port
 stella --model local/qwen2.5-coder --base-url http://localhost:8000/v1 run "…"
+
+# Stop retyping the endpoint, then confirm what resolved
+export STELLA_BASE_URL=http://localhost:11434/v1
+stella --model local/llama3.3 config
 ```
 
 `local` is never auto-detected and requires `--base-url` every time — export
@@ -45,6 +51,9 @@ default-model'd, even auto-detected:
 ```
 
 ```bash
+stella models    # ollama appears as a configured provider, after the built-ins
+stella config    # the resolved provider, base URL, and default model
+
 stella --model ollama/llama3.3 run "add unit tests for the parser"
 stella run "…"   # auto-detects ollama if no other provider key is present
 ```
@@ -85,9 +94,17 @@ like in the cloud — a big worker and a fast judge:
 }
 ```
 
+```bash
+stella config
+stella run "add cursor pagination to /orders" --test-command "pnpm test orders"
+```
+
 Local judges are same-family by definition — lean on
 [`--test-command`](/docs/inference-pipeline) for deterministic verification, exactly as
-in the [single-key setup](/docs/examples/single-key).
+in the [single-key setup](/docs/examples/single-key). Note also that `effort` is
+silently dropped on local endpoints, so the judge's `effort: "high"` above records
+intent rather than reaching the wire; its `prompt` is what actually differentiates it
+from the worker.
 
 ## Fully air-gapped
 
@@ -97,6 +114,9 @@ from `models.dev` (at most once per 24h). Turn it off for an air-gapped deployme
 
 ```bash
 export STELLA_CATALOG_AUTO_REFRESH=0
+
+stella config    # every resolved value, computed from local files alone
+stella doctor    # checks the local session store's integrity; reads local state only
 ```
 
 Community/default telemetry remains local in `.stella/private/store.db`, the

--- a/website/content/docs/examples/max-quality.mdx
+++ b/website/content/docs/examples/max-quality.mdx
@@ -11,7 +11,9 @@ pay $2 for once than $0.20 for three times.
 
 ## The config
 
-```jsonc title="~/.stella/settings.json"
+Three keys, one file — paste it whole:
+
+```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "pipeline_worker_model": "anthropic/claude-fable-5",
@@ -47,6 +49,17 @@ pay $2 for once than $0.20 for three times.
 }
 ```
 
+The three keys it expects:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # the worker
+export OPENAI_API_KEY="sk-..."          # the judge
+export DEEPSEEK_API_KEY="sk-..."        # triage
+
+stella models    # every provider with its key status — all three must read configured
+stella config    # the resolved provider, model, and a redacted key preview
+```
+
 Why these choices:
 
 - **Fable 5 as worker.** The strongest coding/agentic model in the
@@ -55,13 +68,17 @@ Why these choices:
   thinking on: let it deliberate.
 - **GPT-5.5 as judge — not another Claude.** Cross-family judging is the
   point: a different family shares fewer blind spots with the worker. High
-  effort, thinking on, and a stricter custom prompt. `service_tier:
-  "priority"` buys faster verdicts on providers that support tiers.
+  effort, thinking on, a stricter custom prompt, and a roomy 400k window.
+  `service_tier: "priority"` buys faster verdicts — OpenAI's is the one
+  dialect that puts it on the wire, so it is only worth setting on an
+  OpenAI-routed agent.
 - **DeepSeek triage.** Even a maximal setup shouldn't pay flagship rates
   for a one-token classification. This is the one dial that *never* needs
-  to be expensive.
+  to be expensive. (DeepSeek drops `effort` silently — the `low` above is
+  documentation of intent, not a wire parameter.)
 - **Autos off.** In a hand-tuned profile, explicit settings beat automatic
-  ones.
+  ones. Leaving `effort_auto` off is specifically what lets the per-agent
+  `effort` values stand; turning it on would overwrite all three.
 
 ## Run it hard
 
@@ -73,6 +90,9 @@ stella --budget 8.00 run \
 
 # Outcome-driven, judged rounds, capped.
 stella --budget 15.00 goal "the payments integration test suite passes on CI"
+
+# Then read back what it actually cost, per provider and model.
+stella stats
 ```
 
 ## What it costs
@@ -80,12 +100,22 @@ stella --budget 15.00 goal "the payments integration test suite passes on CI"
 Estimates at list prices, medium task, caching healthy (see the
 [cost anatomy](/docs/examples)):
 
-| Task shape | Ballpark |
-| --- | --- |
-| Focused single-file fix | $0.15 – $0.60 |
-| Medium multi-file change, one revision | **$0.40 – $2.50** |
-| Hard refactor / long session | $2 – $8+ |
-| Goal mode, several rounds | multiply by rounds — cap with `--budget` |
+<CardGrid size="sm">
+  <SpecCard title="Focused single-file fix" meta={[{ label: "Ballpark", value: "$0.15 – $0.60" }]} />
+  <SpecCard
+    title="Medium multi-file change, one revision"
+    meta={[{ label: "Ballpark", value: "$0.40 – $2.50" }]}
+  >
+    The reference shape for the estimate on the [examples index](/docs/examples).
+  </SpecCard>
+  <SpecCard title="Hard refactor / long session" meta={[{ label: "Ballpark", value: "$2 – $8+" }]} />
+  <SpecCard
+    title="Goal mode, several rounds"
+    meta={[{ label: "Ballpark", value: "× rounds", mono: false }]}
+  >
+    Multiply by the number of judged rounds, and cap it with `--budget`.
+  </SpecCard>
+</CardGrid>
 
 The judge adds only cents per verification; the worker's output tokens are
 ~80–90% of the bill. If this profile stings, the

--- a/website/content/docs/examples/openrouter-gateway.mdx
+++ b/website/content/docs/examples/openrouter-gateway.mdx
@@ -3,19 +3,27 @@ title: "One gateway key (OpenRouter)"
 description: Every model family through a single OpenRouter key — cross-family judging with one billing relationship, and how the family logic sees through the gateway.
 ---
 
-<ProviderMark id="openrouter" size={30} />
-
 The cross-family profiles usually cost you a keyring: an Anthropic key, an OpenAI key, a
 Z.ai key. A gateway inverts that — **one `OPENROUTER_API_KEY`, any model family**, one
 invoice. This is the setup for people who want the [balanced](/docs/examples/balanced)
 architecture without three billing relationships.
 
+<ProviderGrid only={["openrouter"]} />
+
 ## The profile
+
+One key, a complete file:
 
 ```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "default_model": "openrouter/anthropic/claude-fable-5",
+    "pipeline_worker_model": "openrouter/anthropic/claude-fable-5",
+
+    "auto_mode": "off",
+    "effort_auto": "on",
+    "reasoning_auto": "on",
+
     "agents": {
       "judge":  { "provider": "openrouter", "model": "openai/gpt-5.5" },
       "triage": { "provider": "openrouter", "model": "deepseek/deepseek-chat" }
@@ -24,19 +32,58 @@ architecture without three billing relationships.
 }
 ```
 
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+
+stella config    # provider openrouter, and the resolved slug
+stella run "add cursor pagination to /orders" --test-command "pnpm test orders"
+```
+
 Two routing forms, deliberately shown side by side:
 
-- **`default_model: "openrouter/<vendor>/<slug>"`** — `--model` grammar. The string
-  splits on the *first* slash: provider `openrouter`, slug `<vendor>/<slug>` sent to it
-  verbatim.
-- **`agents.<agent>.provider: "openrouter"`** — the per-agent gateway pin. The `model`
-  string goes to that provider **verbatim, no splitting** — which is exactly what lets
-  an OpenRouter slug itself contain `/`.
+<CardGrid size="md">
+  <SpecCard
+    title="Flat model field"
+    meta={[
+      { label: "Written as", value: "openrouter/<vendor>/<slug>" },
+      { label: "Sent on the wire", value: "<vendor>/<slug>" },
+    ]}
+  >
+    `--model` grammar. The string splits on the **first** slash: provider
+    `openrouter`, and everything after it is the slug, forwarded verbatim.
+  </SpecCard>
+  <SpecCard
+    title="Per-agent gateway pin"
+    meta={[
+      { label: "Written as", value: "provider: openrouter · model: <vendor>/<slug>" },
+      { label: "Sent on the wire", value: "<vendor>/<slug>" },
+    ]}
+  >
+    With `provider` set, `model` goes to that provider **verbatim, no
+    splitting** — which is exactly what lets an OpenRouter slug contain a `/`
+    of its own.
+  </SpecCard>
+</CardGrid>
 
 Use OpenRouter's own catalog for slugs — they are vendor-prefixed
 (`openai/gpt-5.5`, `anthropic/claude-fable-5`, …) and OpenRouter adds models without
 Stella needing a catalog update: gateway slugs are **unseeded**, passed through
 unvalidated (typos surface as OpenRouter API errors, not local ones).
+
+<Callout type="warn">
+  The gateway's own meta-router is one place the first-slash split bites. Its
+  wire slug is `openrouter/auto` — vendor-prefixed like every other OpenRouter
+  id — so on the CLI you must write it **doubly qualified**:
+
+  ```bash
+  stella --model openrouter/openrouter/auto run "…"
+  ```
+
+  `--model openrouter/auto` splits into provider `openrouter` + slug `auto`,
+  and OpenRouter does not serve a bare `auto`. The settings-file equivalent is
+  `"default_model": "openrouter/openrouter/auto"`, or the per-agent pin with
+  `"provider": "openrouter", "model": "openrouter/auto"`.
+</Callout>
 
 ## Cross-family judging still works
 
@@ -59,15 +106,34 @@ gateway exactly as it does across native keys:
 }
 ```
 
+`auto_mode` picks the **judge** — not the worker — ranking candidates by cross-family
+first, then the seed catalog's output list price, then list order. Gateway slugs are
+unpriced locally, so on an all-OpenRouter list the price tier is a tie at zero and the
+choice comes down to family plus the order you wrote them in. Put your preferred judge
+first.
+
+Confirm the family logic picked what you expected — the per-agent model each role
+resolved to is in `stella config`, and the per-model breakdown after a run is in
+`stella stats`:
+
+```bash
+stella config
+stella --budget 3.00 goal "clippy is clean and the test suite passes"
+stella stats --format json | jq '.[] | {provider, model, input_tokens, output_tokens, resolve_rate}'
+```
+
 ## What you trade
 
 <Callout type="info">
-  **Cost telemetry moves to the gateway.** Gateway slugs are unseeded, so the local
-  catalog prices them at `$0` — `stella stats` still counts tokens, steps, and
-  resolution, but the dollar column for `openrouter/*` models reads zero. Stella
-  requests OpenRouter's **usage accounting** on every call and sends app-attribution
-  headers, so your authoritative spend lives in the OpenRouter dashboard instead.
-  `--budget` (which prices from the catalog) cannot meaningfully cap gateway runs.
+  **Cost telemetry comes from the gateway, not the catalog.** Gateway slugs are
+  unseeded, so there is no local list price to meter against. Stella therefore
+  requests OpenRouter's **usage accounting** on every call — and sends
+  app-attribution headers — and takes the gateway's reported per-call cost as the
+  authoritative one, overriding catalog pricing. That is what keeps `stella stats`
+  dollars and `--budget` caps real on a gateway whose routed model (and therefore
+  price) is only known after the fact. If a call's final usage frame carries no
+  cost, that call falls back to the unseeded slug's `$0` — so treat the OpenRouter
+  dashboard as the reconciliation source of record.
 </Callout>
 
 You also add a hop: your traffic goes through OpenRouter's servers rather than to each

--- a/website/content/docs/examples/single-key.mdx
+++ b/website/content/docs/examples/single-key.mdx
@@ -8,12 +8,16 @@ means two or three API keys. If you have **one** key, everything here works with
 is the setup most people should run first; graduate to a cross-family judge later if the
 data says so.
 
+<ProviderGrid only={["anthropic", "openai", "zai", "deepseek"]} />
+
 ## The zero-config baseline
 
 One env var is a working setup — auto-detection does the rest:
 
 ```bash
-export ANTHROPIC_API_KEY="..."   # or OPENAI_API_KEY, ZAI_API_KEY, …
+export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY, ZAI_API_KEY, DEEPSEEK_API_KEY
+
+stella config                            # confirm: provider, model, redacted key preview
 stella run "fix the flaky retry test"
 ```
 
@@ -35,30 +39,95 @@ stella --budget 2.00 goal "the linter passes and the snapshot tests are green"
 ## A tuned one-key profile
 
 When every role is the same family, make the judge *behave* differently: strict prompt,
-high effort. Same shape for any provider — swap the model line:
+high effort. Paste this whole file — it is a complete `settings.json`, not a fragment:
 
-```json title="~/.stella/settings.json (Anthropic)"
+```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
     "default_model": "anthropic/claude-fable-5",
+    "pipeline_worker_model": "anthropic/claude-fable-5",
     "pipeline_judge_model": "anthropic/claude-fable-5",
+    "pipeline_triage_model": "anthropic/claude-fable-5",
+
+    "allowed_models": ["anthropic/claude-fable-5"],
+
+    "auto_mode": "off",
+    "effort_auto": "off",
+    "reasoning_auto": "on",
+
     "agents": {
+      "worker": { "effort": "high" },
       "judge": {
-        "prompt": "You are a strict, evidence-first code judge. Demand proof over plausibility.",
-        "effort": "high"
-      }
-    },
-    "reasoning_auto": "on"
+        "effort": "high",
+        "prompt": "You are a strict, evidence-first code judge. Claimed success without deterministic evidence is a FAIL."
+      },
+      "triage": { "effort": "low" }
+    }
   }
 }
 ```
 
-| One key for… | Worker &amp; judge model | Notes |
-| --- | --- | --- |
-| Anthropic | `anthropic/claude-fable-5` | Flagship quality; the priciest single-key option |
-| OpenAI | `openai/gpt-5.5` | 400k window; `service_tier: "priority"` available for the judge |
-| Z.ai | `zai/glm-5.2` | The budget pick — and on a [coding plan](/docs/examples/zai-coding-plan), flat-rate |
-| DeepSeek | `deepseek/deepseek-chat` | Cheapest metered option; see [dirt cheap](/docs/examples/dirt-cheap) |
+`reasoning_auto: "on"` puts thinking on for the worker, judge, and default agents and
+off for triage, so the per-agent `reasoning` field is left out on purpose — the auto
+would override it anyway. `effort_auto` stays off, which is what lets the per-agent
+`effort` values above apply.
+
+Then run it and read back what it cost:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+stella config                                    # verify the file resolved as you expect
+stella --budget 2.00 run "add cursor pagination to /orders" \
+  --test-command "cargo test -p api"
+stella stats                                     # tokens, cost, and resolve rate per model
+```
+
+### The same file for the other providers
+
+Swap the four model strings and the `allowed_models` entry. Only OpenAI takes the extra
+`params` block — `service_tier` is forwarded by the OpenAI dialect and silently dropped
+by every other adapter:
+
+```json title="~/.stella/settings.json"
+{
+  "agent_engine_config": {
+    "default_model": "openai/gpt-5.5",
+    "pipeline_worker_model": "openai/gpt-5.5",
+    "pipeline_judge_model": "openai/gpt-5.5",
+    "pipeline_triage_model": "openai/gpt-5.5",
+
+    "allowed_models": ["openai/gpt-5.5"],
+
+    "auto_mode": "off",
+    "effort_auto": "off",
+    "reasoning_auto": "on",
+
+    "agents": {
+      "worker": { "effort": "high" },
+      "judge": {
+        "effort": "high",
+        "prompt": "You are a strict, evidence-first code judge. Claimed success without deterministic evidence is a FAIL.",
+        "params": { "service_tier": "priority" }
+      },
+      "triage": { "effort": "low" }
+    }
+  }
+}
+```
+
+Which one to hold the key for:
+
+- **Anthropic** — `anthropic/claude-fable-5`, a 200k window at $3.00/$15.00 per Mtok.
+  Flagship quality, and the priciest single-key option.
+- **OpenAI** — `openai/gpt-5.5`, the largest window of these four at 400k, $1.25/$10.00,
+  and the only provider where `service_tier: "priority"` reaches the wire.
+- **Z.ai** — `zai/glm-5.2`, 200k at $0.60/$2.20. The budget pick, and on a
+  [coding plan](/docs/examples/zai-coding-plan) it is flat-rate rather than metered.
+- **DeepSeek** — `deepseek/deepseek-chat`, 128k at $0.27/$1.10. The cheapest metered
+  option; see [dirt cheap](/docs/examples/dirt-cheap). Note that `effort` is silently
+  dropped on DeepSeek, so the per-agent `effort` lines above are inert there — vary the
+  judge with its `prompt` instead.
 
 <Callout type="warn">
   A same-family judge shares the worker's blind spots — it is real review, not

--- a/website/content/docs/examples/team-settings.mdx
+++ b/website/content/docs/examples/team-settings.mdx
@@ -46,18 +46,25 @@ A committed project `settings.json` that works for every teammate:
 
 - **`api_key_env`** points every teammate at the same variable name
   (`ACME_ZAI_KEY`) while each supplies their own value — key rotation becomes a
-  vault/CI change, not a settings edit.
-- **`agent_engine_config`** is deliberately *outside* the trust boundary — model
-  routing suggestions from a repo are safe and apply immediately for everyone.
+  vault/CI change, not a settings edit. It is also a credential-routing field, so it
+  only takes effect once the teammate trusts the repo (see below).
+- **`agent_engine_config`** is *mostly* outside the trust boundary — model routing,
+  effort, reasoning, and sampling params from a repo are safe and apply immediately for
+  everyone. The one exception is a per-agent **`prompt`**: a replacement system prompt
+  is privileged, so an untrusted repo's is dropped and the user/org scope's value is
+  restored in its place. An org can keep it that way even for trusted repos with
+  `authority.project_prompts: "off"` in the managed scope.
 - **`tools`** and the guard hook travel with the repo that needs them: this repo
-  handles customer data, so it switches the whole `web` family off for everyone who
-  clones it. Narrowing needs no trust flag — only *granting* does.
+  handles customer data, so it switches the whole `web` group off for everyone who
+  clones it. Narrowing needs no trust flag — only *granting* does. (`web` is a group
+  name; a key here can equally be one tool's name or `"*"`.)
 
 ## The flag that makes it real
 
 <Callout type="warn">
-  A fresh clone's `hooks`, `providers.*.base_url`/`api_key`/`api_key_env`, and
-  `mcp.registry_url` are **held back** until the user opts in — otherwise any repo you
+  A fresh clone's `hooks`, `providers.*.base_url`/`api_key`/`api_key_env`,
+  `mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
+  `.stella/mcp.toml` are **held back** until the user opts in — otherwise any repo you
   clone could run commands on your machine or route your keys through its server. Each
   teammate enables their own trusted repos:
 
@@ -66,15 +73,21 @@ A committed project `settings.json` that works for every teammate:
   ```
 
   A stderr notice names anything skipped, so "why isn't the team config applying?" is
-  diagnosable in one glance. Details: the
-  [trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+  diagnosable in one glance. `STELLA_PROJECT_HOOKS=1` is the narrower, legacy form: it
+  trusts hooks, MCP, and context providers but leaves credential routing gated.
+  Details: the [trust boundary](/docs/configuration/settings#the-project-trust-boundary).
 </Callout>
+
+So a committed `.stella/mcp.toml` is real team configuration — it just does nothing on a
+teammate's machine until they set the flag, which is the intended shape: the repo
+proposes, each seat consents.
 
 ## Each user: keys and taste
 
-```json title="~/.stella/settings.json (per teammate)"
+```json title="~/.stella/settings.json"
 {
   "agent_engine_config": {
+    "effort_auto": "off",
     "agents": {
       "judge": { "effort": "high" }
     }
@@ -82,9 +95,17 @@ A committed project `settings.json` that works for every teammate:
 }
 ```
 
+`effort_auto` is spelled out because it is the setting that decides whether the
+per-agent `effort` above means anything: with the auto on, it overwrites every
+per-agent value.
+
 ```bash
 export ACME_ZAI_KEY="sk-..."          # the value behind the repo's api_key_env
 export ANTHROPIC_API_KEY="sk-ant-..." # the judge's key
+export STELLA_TRUST_PROJECT=1         # per-repo; makes the committed config actually load
+
+stella config                          # verify: provider, model, redacted key preview
+stella models                          # every provider with its key status
 ```
 
 Keys can equally live in [`credentials.toml`](/docs/configuration/credentials) (0600,
@@ -93,15 +114,40 @@ written once via the interactive prompt). Personal endpoint routing — like a
 
 ## Merge semantics you'll actually rely on
 
-- `providers` and `agent_engine_config` merge **per field** — the repo pins the judge
-  model, a user's `effort: "high"` still applies.
-- `hooks` **concatenate** — org policy hooks, repo guard hooks, and personal hooks all
-  fire; none replaces another.
-- `tools` and `mcp` are **last scope wins, per key** — the repo's `web: "off"` beats a
-  user's `"on"`. The reverse needs `STELLA_TRUST_PROJECT=1`: a repo may narrow the tool
-  surface on its own, never widen it.
-- `allowed_models` **replaces wholesale** — whichever scope sets it owns the whole
-  list.
+<CardGrid size="md">
+  <SpecCard
+    title="providers · agent_engine_config"
+    meta={[{ label: "Rule", value: "merge per field", mono: false }]}
+  >
+    The repo pins the judge model, a user's `effort: "high"` still applies. Even
+    `agents.<role>.params` composes per knob, so one scope can set `temperature`
+    without clobbering another's `max_tokens`.
+  </SpecCard>
+  <SpecCard title="hooks" meta={[{ label: "Rule", value: "concatenate", mono: false }]}>
+    Org policy hooks, repo guard hooks, and personal hooks all fire. None
+    replaces another — no scope can remove another's gate.
+  </SpecCard>
+  <SpecCard
+    title="tools · mcp"
+    meta={[{ label: "Rule", value: "last scope wins, per key", mono: false }]}
+  >
+    The repo's `web: "off"` beats a user's `"on"`. The reverse needs
+    `STELLA_TRUST_PROJECT=1`: untrusted, every key the repo turned **on** reverts
+    to the trusted scopes' value, while every key it turned **off** stands — a
+    repo may narrow the tool surface on its own, never widen it.
+  </SpecCard>
+  <SpecCard
+    title="allowed_models"
+    meta={[{ label: "Rule", value: "replaces wholesale", mono: false }]}
+  >
+    It is one vocabulary, not a set of independent knobs — whichever scope sets
+    it owns the entire list.
+  </SpecCard>
+</CardGrid>
+
+Scope precedence for everything that merges is **user → org-managed → project**, later
+winning. The exception runs the other way: an org-managed `tools` denial is a ceiling
+applied last, so no lower scope can grant back a tool the org switched off.
 
 ## Shared spend visibility
 

--- a/website/content/docs/examples/zai-coding-plan.mdx
+++ b/website/content/docs/examples/zai-coding-plan.mdx
@@ -14,11 +14,14 @@ subscription instead of a meter. This page is the complete setup.
 
 Two equivalent routes — pick one:
 
-**The env toggle** (quickest — one line in your shell profile):
+**The env toggle** (quickest — two lines in your shell profile):
 
 ```bash
 export ZAI_API_KEY="..."
 export ZAI_GLM_CODING_PLAN=1
+
+stella config    # Base URL must read https://api.z.ai/api/coding/paas/v4
+stella run "fix the flaky retry test"
 ```
 
 **The settings route** (durable, provider-agnostic mechanism). A subscription is
@@ -46,21 +49,24 @@ personal, so this belongs in **user scope**:
   unless `STELLA_TRUST_PROJECT=1` is set.
 </Callout>
 
-Verify before trusting it:
+Verify before trusting it, whichever route you took:
 
 ```bash
 stella config    # Base URL must read https://api.z.ai/api/coding/paas/v4
+stella models    # zai reads configured; the row shows the model and key status
 ```
 
 ## The full profile
 
 With the plan carrying the worker, route the whole pipeline accordingly. Two sensible
-shapes:
+shapes — both are complete files, paste one wholesale.
 
 **Plan worker, API judge** — the [balanced](/docs/examples/balanced) shape with the
 worker's marginal cost near zero. The judge stays cross-family on a metered key you
-barely touch (a verdict is a few cents, and `--test-command` runs often skip it
-entirely):
+barely touch: a verdict is a few cents, and `--test-command` runs often skip it
+entirely. Two providers, two keys:
+
+<ProviderGrid only={["zai", "anthropic"]} />
 
 ```json title="~/.stella/settings.json"
 {
@@ -69,16 +75,30 @@ entirely):
   },
   "agent_engine_config": {
     "default_model": "zai/glm-5.2",
+    "pipeline_worker_model": "zai/glm-5.2",
     "pipeline_judge_model": "anthropic/claude-fable-5",
     "pipeline_triage_model": "zai/glm-5.2",
+
+    "allowed_models": ["zai/glm-5.2", "anthropic/claude-fable-5"],
+
+    "auto_mode": "off",
     "effort_auto": "on",
     "reasoning_auto": "on"
   }
 }
 ```
 
-**All-in on the plan** — every role on GLM, nothing metered. The judge is same-family
-with the worker, so give it a strict prompt and prefer arming
+```bash
+export ZAI_API_KEY="..."                # the coding-plan subscription
+export ANTHROPIC_API_KEY="sk-ant-..."   # the metered judge
+
+stella config
+stella run "add cursor pagination to /orders" --test-command "pnpm test orders"
+stella stats     # token counts are real; see the note below on the dollar column
+```
+
+**All-in on the plan** — every role on GLM, nothing metered. One key, one bill. The
+judge is same-family with the worker, so give it a strict prompt and prefer arming
 [`--test-command`](/docs/inference-pipeline) so verification is deterministic rather
 than a same-family opinion:
 
@@ -89,12 +109,20 @@ than a same-family opinion:
   },
   "agent_engine_config": {
     "default_model": "zai/glm-5.2",
+    "pipeline_worker_model": "zai/glm-5.2",
     "pipeline_judge_model": "zai/glm-5.2",
     "pipeline_triage_model": "zai/glm-5.2",
+
+    "allowed_models": ["zai/glm-5.2"],
+
+    "auto_mode": "off",
+    "effort_auto": "off",
+    "reasoning_auto": "on",
+
     "agents": {
       "judge": {
-        "prompt": "You are a strict, evidence-first code judge. Demand proof.",
-        "effort": "high"
+        "effort": "high",
+        "prompt": "You are a strict, evidence-first code judge. Claimed success without deterministic evidence is a FAIL."
       }
     }
   }
@@ -102,7 +130,9 @@ than a same-family opinion:
 ```
 
 `default_model` is what routes the pipeline's execute turns — see
-[model precedence](/docs/configuration/agent-engine-config#model-precedence).
+[model precedence](/docs/configuration/agent-engine-config#model-precedence). Note that
+`effort_auto` is off in the second file on purpose: with it on, the judge's `effort:
+"high"` would be overwritten by the automatic mapping.
 
 ## Fleets on a flat quota
 

--- a/website/content/docs/extensions.mdx
+++ b/website/content/docs/extensions.mdx
@@ -59,12 +59,21 @@ let sub = bus.on("file.*", |event| {
 
 Matching:
 
-| Pattern | Matches |
-| --- | --- |
-| `file.read` | exactly that event |
-| `file.*` | `file.read`, `file.created`, `file.diff.computed`, … |
-| `tool.*` | `tool.call.requested`, `tool.call.completed`, … |
-| `*` | every event |
+<CardGrid size="sm">
+  <OptionCard name="file.read">
+    An exact name — exactly that event, nothing else.
+  </OptionCard>
+  <OptionCard name="file.*">
+    A namespace wildcard — `file.read`, `file.created`, `file.diff.computed`, and the rest
+    of the namespace.
+  </OptionCard>
+  <OptionCard name="tool.*">
+    Likewise: `tool.call.requested`, `tool.call.completed`, …
+  </OptionCard>
+  <OptionCard name="*">
+    Every event the host emits.
+  </OptionCard>
+</CardGrid>
 
 ### Policy hooks — gate the sensitive actions
 
@@ -146,17 +155,53 @@ sub.unsubscribe();          // or: drop(sub);  — same effect
 The host emits events across these namespaces. Extensions may also emit their own names —
 the catalog is the contract for what the *host* emits.
 
-| Namespace | Events |
-| --- | --- |
-| `session.*` | `created`, `started`, `paused`, `resumed`, `cancel_requested`, `cancelled`, `completed`, `failed` |
-| `agent.*` / `transcript.*` | `agent.turn.started/completed`, `agent.thinking.*`, `agent.message.*`, `agent.error`, `transcript.entry.created/updated` |
-| `model.*` | `request.started/completed/failed`, `response.started/delta/completed`, `rate_limited`, `context.compacted` |
-| `tool.*` | `registered`, `call.requested`, `call.validated`, `call.started`, `call.progress`, `call.completed`, `call.failed`, `call.cancelled` |
-| `policy.*` / `approval.*` | `policy.evaluated/allowed/blocked`, `approval.requested/granted/denied/expired`, `secret.detected`, `sensitive_operation.detected` |
-| `file.*` / `workspace.*` / `search.*` | `file.read/created/updated/deleted/renamed/diff.computed`, `files_touched.updated`, `workspace.opened`, `workspace.index.started/completed`, `search.started/completed/failed` |
-| `command.*` / `build.*` / `test.*` | `command.started/stdout/stderr/completed/failed`, `build.*`, `test.*`, `diagnostic.detected/resolved` |
-| `git.*` / delivery | `git.status.changed`, `git.diff.created`, `git.commit.requested/created`, `git.push.requested/completed`, `pull_request.requested/created`, `deployment.requested/completed/failed` |
-| `extension.*` / `telemetry.*` | `extension.loaded/unloaded/error`, `telemetry.event.queued/flushed/failed` |
+<CardGrid size="md">
+  <OptionCard name="session.*">
+    `created`, `started`, `paused`, `resumed`, `cancel_requested`, `cancelled`,
+    `completed`, `failed`.
+  </OptionCard>
+  <OptionCard name="agent.* / transcript.*">
+    `agent.turn.started/completed`, `agent.thinking.*`, `agent.message.*`, `agent.error`,
+    `transcript.entry.created/updated`.
+  </OptionCard>
+  <OptionCard name="model.*">
+    `request.started/completed/failed`, `response.started/delta/completed`,
+    `rate_limited`, `context.compacted`.
+  </OptionCard>
+  <OptionCard name="tool.*">
+    `registered`, `call.requested`, `call.validated`, `call.started`, `call.progress`,
+    `call.completed`, `call.failed`, `call.cancelled`.
+  </OptionCard>
+  <OptionCard name="policy.* / approval.*">
+    `policy.evaluated/allowed/blocked`, `approval.requested/granted/denied/expired`,
+    `secret.detected`, `sensitive_operation.detected`.
+  </OptionCard>
+  <OptionCard name="file.* / workspace.* / search.*">
+    `file.read/created/updated/deleted/renamed/diff.computed`, `files_touched.updated`,
+    `workspace.opened`, `workspace.index.started/completed`,
+    `search.started/completed/failed`.
+  </OptionCard>
+  <OptionCard name="command.* / build.* / test.*">
+    `command.started/stdout/stderr/completed/failed`, `build.*`, `test.*`,
+    `diagnostic.detected/resolved`.
+  </OptionCard>
+  <OptionCard name="git.* / delivery">
+    `git.status.changed`, `git.diff.created`, `git.commit.requested/created`,
+    `git.push.requested/completed`, `pull_request.requested/created`,
+    `deployment.requested/completed/failed`.
+  </OptionCard>
+  <OptionCard name="extension.* / telemetry.*">
+    `extension.loaded`, `extension.unloaded`, `extension.error`,
+    `extension.quarantined`, `telemetry.event.queued/flushed/failed`.
+  </OptionCard>
+</CardGrid>
+
+`extension.quarantined` is the one worth knowing about before you need it: an observer
+that repeatedly overruns its per-dispatch time budget is **quarantined** — skipped for the
+rest of the session — and the event is how you find out. Observers run inline on the
+emitting thread, so this is the resilience valve that stops a wedged extension from
+silently stalling the agent. If your handler is doing real work, move it off-thread rather
+than discovering it in a quarantine event.
 
 ## Relationship to file-touch telemetry
 

--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -9,6 +9,24 @@ key, **[initialize](/docs/getting-started/initialization)** the repo, and run.
 The full provider matrix (OpenRouter, local servers, Vertex, Bedrock, custom
 gateways) lives in **[Providers & models](/docs/getting-started/providers)**.
 
+<QuickstartDiagram />
+
+If you would rather paste one block and read afterwards, this is the whole path:
+
+```bash
+# 1. Install.
+curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
+
+# 2. Bring your own key — any one provider will do.
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# 3. From inside a git repository: learn the codebase.
+stella init
+
+# 4. Ship something.
+stella run "explain what this repository does, then list the riskiest files"
+```
+
 ## 1. Set an API key
 
 Stella is bring-your-own-key. Export a key for any one provider — Stella auto-detects it:
@@ -58,22 +76,23 @@ Running `stella` with no subcommand opens the **Command Deck**, a tabbed termina
 stella
 ```
 
-Inside the deck, type a message to send it, or use a slash command to open a tab:
+Inside the deck, type a message to send it, or use a slash command to open a tab. The ones
+worth knowing on day one:
 
-| Command     | Does                                     |
-| ----------- | ---------------------------------------- |
-| `/help`     | Show help                                |
-| `/models`   | List providers and models                |
-| `/files`    | Files changed this session               |
-| `/diff`     | Review the working diff                  |
-| `/pipeline` | Toggle the staged pipeline on/off        |
-| `/graph`    | The code-graph tab                       |
-| `/skills`   | The skills tab                           |
-| `/mcp`      | The MCP tab (enable/disable servers)     |
-| `/clear`    | Clear the session                        |
+<CardGrid size="sm">
+  <OptionCard name="/help">Show help.</OptionCard>
+  <OptionCard name="/models">List providers and models.</OptionCard>
+  <OptionCard name="/files">Files changed this session.</OptionCard>
+  <OptionCard name="/diff">Review the working diff.</OptionCard>
+  <OptionCard name="/pipeline">Toggle the staged pipeline on or off.</OptionCard>
+  <OptionCard name="/graph">The code-graph tab.</OptionCard>
+  <OptionCard name="/skills">The skills tab.</OptionCard>
+  <OptionCard name="/mcp">The MCP tab — enable and disable servers.</OptionCard>
+  <OptionCard name="/clear">Clear the session.</OptionCard>
+</CardGrid>
 
-Press **Ctrl-C** to quit. (The plain REPL has a different, smaller set — including `/config`
-and `/goal` — see [`stella chat`](/docs/commands/chat).)
+Press **Ctrl-C** to quit. That is a partial list — see [`stella chat`](/docs/commands/chat)
+for the full deck command set, and for the plain REPL's separate, smaller one.
 
 ## 5. Give it a goal
 

--- a/website/content/docs/getting-started/initialization.mdx
+++ b/website/content/docs/getting-started/initialization.mdx
@@ -42,24 +42,67 @@ hard-fails: you can initialize before configuring any provider key.
 Everything Stella knows about a workspace lives under `.stella/` — plain
 files and SQLite databases you can inspect, version, or delete at will:
 
-| Path | What it holds |
-| --- | --- |
-| `.stella/domains.toml` | The domain taxonomy (tagging vocabulary) |
-| `.stella/private/codegraph.db` | The tree-sitter code-graph index |
-| `.stella/private/context.db` | The context plane — memory nodes, reflections, episodes, bi-temporal facts |
-| `.stella/private/store.db` | Executions, events, token/cost telemetry, the files-touched ledger |
-| `.stella/memories/*.md` | Workspace [memories](/docs/context-engine) (plain Markdown) |
-| `.stella/rules/*.md` | Workspace rules — promoted memories and guard rules |
-| `.stella/skills/` | Project-scope [skills](/docs/agent-tools/skills) |
-| `.stella/settings.json` | Project-scope [settings](/docs/configuration/settings) |
-| `.stella/mcp.toml` | [MCP servers](/docs/agent-tools/mcp) to connect at session start |
-| `.stella/tools/*.toml` | [Custom script tools](/docs/agent-tools/custom-tools) |
-| `.stella/commands/` · `.stella/agents/` | [Custom commands](/docs/agent-tools/commands) and [custom agents](/docs/agent-tools/custom-agents) |
-| `.stella/private/fleet.db` | The [fleet](/docs/agent-fleets) ledger — runs, attempts, commits |
-| `.stella/worktrees/` | Dedicated worktrees for fleet tasks marked `isolation = "isolated"` |
-| `.stella/exports/` | Session telemetry [exports](/docs/telemetry/dashboard) (ZIP + HTML) |
-| `.stella/private/reflections.jsonl` | Post-turn reflection log (lessons the [context engine](/docs/context-engine) distills) |
-| `.stella/private/mcp_oauth.json` | **OAuth tokens** for MCP servers you've logged into — a secret, never commit it |
+### Shared — commit these
+
+<CardGrid size="md">
+  <OptionCard name=".stella/domains.toml">
+    The domain taxonomy — the tagging vocabulary `stella init` infers.
+  </OptionCard>
+  <OptionCard name=".stella/memories/*.md">
+    Workspace [memories](/docs/context-engine), as plain Markdown.
+  </OptionCard>
+  <OptionCard name=".stella/rules/*.md">
+    Workspace rules — promoted memories and guard rules.
+  </OptionCard>
+  <OptionCard name=".stella/skills/">
+    Project-scope [skills](/docs/agent-tools/skills).
+  </OptionCard>
+  <OptionCard name=".stella/settings.json">
+    Project-scope [settings](/docs/configuration/settings).
+  </OptionCard>
+  <OptionCard name=".stella/mcp.toml">
+    [MCP servers](/docs/agent-tools/mcp) to connect at session start.
+  </OptionCard>
+  <OptionCard name=".stella/tools/*.toml">
+    [Custom script tools](/docs/agent-tools/custom-tools).
+  </OptionCard>
+  <OptionCard name=".stella/commands/ · .stella/agents/">
+    [Custom commands](/docs/agent-tools/commands) and
+    [custom agents](/docs/agent-tools/custom-agents).
+  </OptionCard>
+</CardGrid>
+
+### Local state — never commit these
+
+<CardGrid size="md">
+  <OptionCard name=".stella/private/codegraph.db">
+    The tree-sitter code-graph index.
+  </OptionCard>
+  <OptionCard name=".stella/private/context.db">
+    The context plane — memory nodes, reflections, episodes, bi-temporal facts.
+  </OptionCard>
+  <OptionCard name=".stella/private/store.db">
+    Executions, events, token/cost telemetry, the files-touched ledger, and the
+    `file_locks` table fleets coordinate through.
+  </OptionCard>
+  <OptionCard name=".stella/private/fleet.db">
+    The [fleet](/docs/agent-fleets) ledger — runs, tasks, attempts, commits.
+  </OptionCard>
+  <OptionCard name=".stella/private/reflections.jsonl">
+    Post-turn reflection log — lessons the
+    [context engine](/docs/context-engine) distills.
+  </OptionCard>
+  <OptionCard name=".stella/private/mcp_oauth.json">
+    **OAuth tokens** for MCP servers you have logged into. A secret — never
+    commit it.
+  </OptionCard>
+  <OptionCard name=".stella/worktrees/">
+    Dedicated worktrees for fleet tasks marked `isolation = "isolated"`.
+  </OptionCard>
+  <OptionCard name=".stella/exports/">
+    Session telemetry [exports](/docs/telemetry/dashboard) — ZIP + HTML.
+  </OptionCard>
+</CardGrid>
 
 When upgrading from a release that wrote private files directly under
 `.stella/`, Stella migrates safe, closed legacy files into `.stella/private/`
@@ -71,14 +114,25 @@ agents, credentials).
 
 ### What to commit
 
-`.stella/domains.toml`, `.stella/memories/`, `.stella/rules/`,
-`.stella/skills/`, `.stella/settings.json`, `.stella/mcp.toml`, and
-`.stella/tools/` are team-shareable and version-control-friendly — with one caveat:
-if `.stella/settings.json` carries an inline `api_key`, keep it out of version control
-(prefer [`api_key_env` or `credentials.toml`](/docs/configuration/credentials)).
-Everything under `.stella/private/` is local state, including MCP OAuth
-tokens. `stella` generates `.stella/.gitignore` with `private/`; if the
-repository uses a root ignore file, exclude the whole private directory:
+The shared group above is team-shareable and version-control-friendly — with one
+caveat: if `.stella/settings.json` carries an inline `api_key`, keep it out of
+version control (prefer
+[`api_key_env` or `credentials.toml`](/docs/configuration/credentials)).
+
+Everything under `.stella/private/` is local state, including MCP OAuth tokens.
+Stella generates `.stella/.gitignore` for you, covering the private directory
+and any stray database or reflection log left by an older layout:
+
+```text title=".stella/.gitignore"
+*.db
+*.db-wal
+*.db-shm
+reflections.jsonl
+private/
+```
+
+If your repository uses a root ignore file instead, exclude the whole private
+directory plus the two derived directories that ride outside it:
 
 ```text title=".gitignore"
 .stella/private/
@@ -89,9 +143,26 @@ repository uses a root ignore file, exclude the whole private directory:
 ## Verify the result
 
 ```bash
-stella graph definitions <SomeSymbol>   # the index answers structural questions
-stella config                            # the resolved provider/model/workspace
+# The index answers structural questions — offline, no API key.
+stella graph definitions Config
+stella graph importers src/main.rs
+stella graph neighbors src/main.rs
+
+# The taxonomy it inferred.
+cat .stella/domains.toml
+
+# The store it will write telemetry into.
+stella doctor
 ```
+
+```bash
+# And the resolved provider, model, credential source, and workspace root.
+stella config
+```
+
+Re-run `stella init` after a large refactor to rebuild the index and re-infer
+the taxonomy. It is idempotent and works offline — the code graph is built with
+no provider at all, and only the taxonomy degrades to a directory heuristic.
 
 Next: [configure your provider keys](/docs/getting-started/providers), then
 run your first task from the [quickstart](/docs/getting-started).

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -4,7 +4,9 @@ description: Install the Stella CLI via the install script, Homebrew, cargo, or 
 ---
 
 Stella ships as a single self-contained binary named `stella`. There is no runtime to
-install alongside it.
+install alongside it. Installing is the first of four steps:
+
+<QuickstartDiagram />
 
 ## Prerequisites
 
@@ -31,9 +33,20 @@ curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh 
 stella --version
 ```
 
-The binary lands in `~/.local/bin` by default — if `stella` isn't found afterwards, add
-that directory to your `PATH`. Two env vars tune the script: `STELLA_INSTALL_DIR`
-overrides the destination, `STELLA_VERSION` pins a specific release tag:
+The binary lands in `~/.local/bin` by default — if `stella` isn't found afterwards, the
+script says so and prints the `export` line to add. Two env vars tune it:
+
+<CardGrid size="md">
+  <OptionCard name="STELLA_INSTALL_DIR" defaultValue="$HOME/.local/bin">
+    Where the binary lands. On the `cargo install` fallback path, a value
+    ending in `/bin` is honored as the cargo root's `bin` directory, so the
+    same variable works either way.
+  </OptionCard>
+  <OptionCard name="STELLA_VERSION" defaultValue="the latest release">
+    Pin a specific release tag. With or without the leading `v` — both forms
+    normalize to the same tag.
+  </OptionCard>
+</CardGrid>
 
 ```bash
 STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.5.0 \
@@ -41,8 +54,7 @@ STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.5.0 \
 ```
 
 Pick the tag from the
-[releases page](https://github.com/macanderson/stella/releases) — with or
-without the leading `v`, both forms work.
+[releases page](https://github.com/macanderson/stella/releases).
 
 ### Homebrew
 
@@ -82,14 +94,35 @@ cargo build --release
 
 ## Verify
 
-```bash
-stella version
-```
-
-Then confirm a provider is configured:
+Three commands that work before you have configured anything at all — they
+resolve no provider and need no API key:
 
 ```bash
-stella models   # every provider, its default model, key status, and base URL
+stella version                  # the build you just installed
+stella models --all             # every provider, its slugs, pricing, and key status
+stella doctor                   # the integrity of this workspace's local state
 ```
 
-Next: the [Quickstart](/docs/getting-started).
+`stella models` on its own scopes to providers whose credential resolves —
+which makes it the fastest way to answer "did my key land?". `--all` lifts that
+scope so you can read the whole catalog before configuring anything.
+
+Once a key is in place, `stella config` reports what actually resolved — and it
+is the one verification command that does require a credential:
+
+```bash
+stella config
+```
+
+Then run something. With one key exported, this is the whole install-to-first-change arc:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cd your-project
+stella init                                     # index the repo, infer the domain taxonomy
+stella --budget 1 run "explain what this repo builds and how it is laid out"
+```
+
+Next: the [Quickstart](/docs/getting-started), or
+[repo initialization](/docs/getting-started/initialization) for what `stella init`
+leaves behind.

--- a/website/content/docs/getting-started/providers.mdx
+++ b/website/content/docs/getting-started/providers.mdx
@@ -13,24 +13,23 @@ and for choosing between models (pricing, release dates, what each is best at) s
 
 ## Supported providers
 
-| Provider | id | Primary env var | Default model | Base URL | Dialect |
-| --- | --- | --- | --- | --- | --- |
-| Anthropic (Claude) | `anthropic` | `ANTHROPIC_API_KEY` | `claude-fable-5` | `https://api.anthropic.com` | Anthropic Messages |
-| OpenAI (GPT) | `openai` | `OPENAI_API_KEY` | `gpt-5.5` | `https://api.openai.com/v1` | OpenAI Responses |
-| Google Gemini | `gemini` | `GEMINI_API_KEY` (alias `GOOGLE_API_KEY`) | `gemini-3-pro` | `https://generativelanguage.googleapis.com/v1beta` | Gemini generateContent |
-| Google Vertex AI | `vertex` | `VERTEX_ACCESS_TOKEN` | `gemini-3-pro` | project/region-scoped | Gemini generateContent |
-| Amazon Bedrock | `bedrock` | `AWS_ACCESS_KEY_ID` | Claude via Converse | region-scoped | Bedrock Converse |
-| xAI (Grok) | `xai` | `XAI_API_KEY` | `grok-4` | `https://api.x.ai/v1` | OpenAI-compatible |
-| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` | `https://api.deepseek.com/v1` | OpenAI-compatible |
-| Z.ai (GLM) | `zai` | `ZAI_API_KEY` | `glm-5.2` | `https://api.z.ai/api/paas/v4` | OpenAI-compatible |
-| OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `openrouter/auto` | `https://openrouter.ai/api/v1` | OpenAI-compatible |
-| Local | `local` | *none* (optional `LOCAL_API_KEY`) | *you choose* | pass `--base-url` | OpenAI-compatible |
+Each card carries what you need to start: the provider id you put before the `/` in
+`--model`, the env var Stella reads, the model you get if you name none, and the wire
+dialect it speaks. Click through for setup and provider-specific configuration.
 
-List them at any time — with live key status and effective base URLs:
+<ProviderGrid />
+
+List them at any time — with live key status and the effective base URL each one resolves
+to:
 
 ```bash
 stella models
 ```
+
+That listing is the authority on your machine — it is the only view that knows which keys
+you actually have. The cards above are rendered from one typed record shared with the
+[API Providers](/docs/api-providers) index, so the two pages cannot disagree with each
+other.
 
 ## Selecting a model
 
@@ -87,9 +86,32 @@ details.
 and optionally `VERTEX_LOCATION` (defaults to `global`). The access token is typically
 `export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)`.
 
+```bash
+export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)
+export VERTEX_PROJECT_ID="my-gcp-project"
+
+stella --model vertex/gemini-3-pro run "audit the IAM bindings module"
+```
+
 **Amazon Bedrock** needs `AWS_SECRET_ACCESS_KEY` alongside `AWS_ACCESS_KEY_ID`, plus an
 optional `AWS_SESSION_TOKEN` and `AWS_REGION` / `AWS_DEFAULT_REGION` (defaults to
 `us-east-1`).
+
+```bash
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_REGION="us-east-1"
+
+stella --model bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 run "harden the S3 policy module"
+```
+
+<Callout type="info">
+  Only `AWS_ACCESS_KEY_ID` — Bedrock's primary credential — rides the credential chain
+  above. The secondary variables (`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`,
+  `AWS_REGION`) are read from the environment and **nowhere else**: no
+  `credentials.toml` entry, no `settings.json` field, no prompt. See
+  [Amazon Bedrock](/docs/api-providers/bedrock) for the full split.
+</Callout>
 
 ## Local / any OpenAI-compatible server
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -40,6 +40,15 @@ stella run "add a --json flag to the export command and update the tests"
   of it anywhere. Explicitly enrolled Oxagen Enterprise managed mode may export only a
   minimal content-free operational rollup from a process-free eligible path.
 
+## Bring your own provider
+
+Ten providers, one flag. Stella speaks each one's native wire dialect rather than
+funnelling everything through a single OpenAI-shaped adapter, so provider features —
+Anthropic's thinking blocks, Gemini's thinking levels, Bedrock's Converse shape — are
+native rather than emulated.
+
+<ProviderGrid />
+
 ## How it fits together
 
 <HeroFlowDiagram />

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -62,10 +62,26 @@ blocks the work.
 
 ### 3. Scope review
 
-If the plan's blast radius crosses configured thresholds (estimated files
-touched), Stella pauses for an interactive **scope review** — you approve,
-trim, or abort the plan before any file changes. Headless runs must opt in to
-bypass this gate explicitly; there is no silent auto-approve.
+If the plan's blast radius crosses any of three configured thresholds, Stella
+pauses for an interactive **scope review** — you approve, trim, or abort the
+plan before any file changes:
+
+<CardGrid size="sm">
+  <OptionCard name="max_steps" defaultValue="5">
+    Fires when the plan has strictly more than this many steps.
+  </OptionCard>
+  <OptionCard name="max_files" defaultValue="8">
+    Fires when the plan's estimated files-touched count strictly exceeds this.
+  </OptionCard>
+  <OptionCard name="max_cost_usd" defaultValue="1.00">
+    Fires when the plan's estimated cost strictly exceeds this.
+  </OptionCard>
+</CardGrid>
+
+The comparison is strict `>` on every axis, so a plan sitting exactly at a
+threshold passes without a gate. Headless runs must opt in to bypass this gate
+explicitly — `agent_engine_config.headless_scope_bypass: "on"` — and there is
+no silent auto-approve: without it, a plan over the thresholds ends the run.
 
 ### 4. Witness
 
@@ -82,6 +98,15 @@ it lives and dies inside the candidate workspace and is **not** adopted into
 your tree: you never find an already-satisfied test sitting in `tests/` that
 nobody reviewed. Pass `--keep-witness` to promote it into your working tree
 when the test is worth keeping.
+
+```bash
+# No oracle armed — an independent model authors the witness, and it is
+# discarded with the candidate workspace.
+stella run "make Plan::validate reject a self-dependency by name"
+
+# Same run, but keep the authored test as a file you can review and commit.
+stella run --keep-witness "make Plan::validate reject a self-dependency by name"
+```
 
 ### 5. Execute
 
@@ -176,6 +201,24 @@ on the diff and evidence summary. Same destination, more model calls at
 risk — the deterministic path is why `--test-command` is the strongest flag
 you can pass.
 
+You can read that distinction back out of any headless run. `verdict.deterministic`
+is `true` exactly when the ladder answered without a judge call:
+
+```bash
+stella --output-format json run --test-command "cargo test -p pager" \
+  "fix the off-by-one in the pager" \
+  | jq '{status, deterministic: .verdict.deterministic, evidence: .verdict.summary, cost_usd}'
+```
+
+```json
+{
+  "status": "completed",
+  "deterministic": true,
+  "evidence": "flip oracle: fail→pass of 'cargo test -p pager'; touched tests green; diff 6 lines within budget",
+  "cost_usd": 0.0412
+}
+```
+
 ## Per-role model routing
 
 Each stage can run on its own model, provider, and gateway — see
@@ -198,17 +241,40 @@ that resolves each role also carries reliability machinery:
 
 `--budget <usd>` caps the whole run. The pipeline checks the meter **between**
 steps and stages and aborts cleanly — never mid-tool-call — so you are never
-left with a half-applied edit. See [Telemetry &amp; budget](/docs/telemetry).
+left with a half-applied edit. It is a **global** flag, so it goes before the
+subcommand:
+
+```bash
+stella --budget 1.50 run --test-command "cargo test -p stella-core" \
+  "make the loop detector treat a repeated no-op tool call as progress-free"
+```
+
+`STELLA_BUDGET` is the same knob without touching the command line. See
+[Telemetry &amp; budget](/docs/telemetry).
 
 ## Where each mode picks it up
 
-| Mode | Uses |
-| --- | --- |
-| `stella run` | The full staged pipeline (default) |
-| `stella run --no-pipeline` | The raw step loop |
-| Command Deck (`/pipeline` ON, the default) | The staged pipeline per turn |
-| [`stella goal`](/docs/agent-modes#outcome-driven-goal-mode) | Pipeline rounds + an independent goal judge (default; `--no-pipeline` for raw rounds) |
-| [`stella fleet`](/docs/agent-fleets) | The pipeline per worker, fanned out in one shared tree (worktrees on opt-in) |
+<CardGrid size="md">
+  <OptionCard name="stella run">
+    The full staged pipeline — the default.
+  </OptionCard>
+  <OptionCard name="stella run --no-pipeline">
+    The raw step loop, with none of the stages above.
+  </OptionCard>
+  <OptionCard name="Command Deck">
+    The staged pipeline per turn while `/pipeline` is ON, which it is by
+    default.
+  </OptionCard>
+  <OptionCard name="stella goal">
+    Pipeline rounds plus an independent goal judge by default;
+    `--no-pipeline` makes the rounds raw. See
+    [goal mode](/docs/agent-modes#outcome-driven-goal-mode).
+  </OptionCard>
+  <OptionCard name="stella fleet">
+    The pipeline per worker, fanned out in one shared tree — worktrees on
+    opt-in. See [fleets](/docs/agent-fleets).
+  </OptionCard>
+</CardGrid>
 
 Pipeline goal rounds mean **double verification**: the pipeline's own judge
 checks each round's work, and the outer goal judge checks the objective.

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -54,6 +54,32 @@ independent single-thread engines over one shared tree, coordinated only by
 cooperative file claims (dedicated git worktrees per task on opt-in) — parallel
 work, no swarm coordination, no inter-agent messages to degrade.
 
+The coordination is a lock table, not a conversation. Two workers that declare
+overlapping `claims` do not negotiate; the second dispatch fails by name,
+before it starts:
+
+```toml title="parallel.toml"
+[[tasks]]
+id = "a"
+title = "Rename the error type"
+prompt = "Rename StoreError to StoreFailure across the crate"
+claims = ["src/store/error.rs"]
+
+[[tasks]]
+id = "b"
+title = "Add a variant"
+prompt = "Add a StoreError::Corrupt variant carrying the failing pragma"
+claims = ["src/store/error.rs"]   # same path — one of these two will not run
+```
+
+```bash
+stella fleet --plan parallel.toml --max-concurrency 2
+```
+
+That is the whole coordination protocol. There is no message for the two agents
+to misread, and no summary between them to lose information — the third MAST
+failure class has nowhere to occur.
+
 ## The principle generalized
 
 "Prefer determinism over intelligence" is not anti-model — Stella exists to
@@ -77,6 +103,23 @@ The payoff compounds: deterministic mechanisms cost nothing per run, never
 rate-limit, never hallucinate, and give the *same answer twice* — which is
 exactly what you want from the parts of an agent that decide whether to
 trust it.
+
+And because the distinction is structural rather than rhetorical, it is
+machine-readable. Every verified run says which kind of evidence it stood on:
+
+```bash
+stella --output-format json run --test-command "cargo test -p stella-core" \
+  "make the loop detector count identical no-op calls as progress-free" \
+  | jq '{deterministic: .verdict.deterministic, evidence: .verdict.summary}'
+```
+
+A CI gate can therefore insist on the mechanism and refuse the opinion:
+
+```bash
+stella --output-format json run --test-command "make test" "$TASK" \
+  | jq -e '.verdict.deterministic == true' >/dev/null \
+  || { echo "verified only by a model judge — holding this one for review" >&2; exit 1; }
+```
 
 <Callout type="info">
   Read the full papers in the repo:

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -26,14 +26,59 @@ has the research grounding; the shape of it:
 
 You can see the rule everywhere in the product:
 
-| Decision | The deterministic mechanism | The model, only as fallback |
-| --- | --- | --- |
-| Is the work done? | The [flip oracle](/docs/inference-pipeline): the same test fails before, passes after — plus the zero-diff guard and diff budget | The judge is consulted only when deterministic evidence is inconclusive |
-| What proves the change? | `verify_done` replays the witness test on a shadow worktree at `git HEAD` | A merely-green suite is *weak* evidence, never proof |
-| Which model serves a role? | Explicit pins and typed absence (`Option::None`) — never an `"auto"` magic string | `auto_mode` picks from *your* allowed list, by stated rules |
-| What goes in the prompt? | A byte-stable prefix + one fixed-position recall block | — |
-| When does a run stop? | The budget guard, between steps — never mid-tool | — |
-| What happened? | An append-only event stream and local SQLite ledgers | — |
+<CardGrid size="md">
+  <SpecCard title="Is the work done?">
+    **Mechanism:** the [flip oracle](/docs/inference-pipeline) — the same test
+    fails before the change and passes after — plus the zero-diff guard and a
+    400-line diff budget.
+
+    **Model, as fallback:** the judge is consulted only when the deterministic
+    evidence is unavailable or inconclusive.
+  </SpecCard>
+  <SpecCard title="What proves the change?">
+    **Mechanism:** `verify_done` replays the witness test on a shadow worktree
+    at `git HEAD` — it must fail there and pass on the change.
+
+    **Model, as fallback:** none. A merely-green suite is *weak* evidence, never
+    proof, whoever asserts it.
+  </SpecCard>
+  <SpecCard title="Which model serves a role?">
+    **Mechanism:** explicit pins and typed absence (`Option::None`) — never an
+    `"auto"` magic string.
+
+    **Model, as fallback:** `auto_mode` picks from *your* `allowed_models`, by
+    stated rules — different family first, then price tier, then list order.
+  </SpecCard>
+  <SpecCard title="What goes in the prompt?">
+    **Mechanism:** a byte-stable system prefix plus one fixed-position recall
+    block, so prompt caching survives across turns.
+
+    **Model, as fallback:** none.
+  </SpecCard>
+  <SpecCard title="When does a run stop?">
+    **Mechanism:** the budget guard, checked between steps — never mid-tool, so
+    an abort never leaves a half-applied edit.
+
+    **Model, as fallback:** none.
+  </SpecCard>
+  <SpecCard title="What happened?">
+    **Mechanism:** an append-only event stream and local SQLite ledgers you can
+    query yourself.
+
+    **Model, as fallback:** none.
+  </SpecCard>
+</CardGrid>
+
+Two of those are one command away. The mechanisms are not aspirational — they
+are the surfaces you already use:
+
+```bash
+# The flip oracle, armed: a run that cannot prove fail→pass does not submit.
+stella run --test-command "cargo test -p stella-pipeline" "fix the witness tamper check"
+
+# The ledgers, read back — no model involved, no network, no key.
+stella stats
+```
 
 ## The seven invariants, briefly
 

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -11,11 +11,21 @@ an environment-variable equivalent for CI.
 
 `--output-format` (env `STELLA_OUTPUT_FORMAT`) takes one of three values:
 
-| Value | Shape | Use |
-| --- | --- | --- |
-| `text` | Interactive human rendering (default) | Local, interactive use |
-| `json` | One final JSON object summarizing the turn | Capture a result in a script |
-| `stream-json` | One JSON line per agent event, as it happens | Live progress in a pipeline |
+<CardGrid size="md">
+  <OptionCard name="text">
+    The default. Interactive human rendering, for local use — and the only
+    format that keeps stdout clean on failure, routing the diagnostic to
+    stderr instead.
+  </OptionCard>
+  <OptionCard name="json">
+    One final JSON object summarizing the turn, pretty-printed. Capture a result
+    in a script.
+  </OptionCard>
+  <OptionCard name="stream-json">
+    One compact JSON line per agent event, as it happens. Live progress in a
+    pipeline.
+  </OptionCard>
+</CardGrid>
 
 `stream-json` is a line-per-event serialization of Stella's internal event enum — a stable
 machine interface you can parse incrementally. Each line is one event object tagged
@@ -47,9 +57,33 @@ declares `schema_version` (see [The envelope contract](#the-envelope-contract) b
 summary's other keys depend on the execution path: a default run goes through the staged
 pipeline and summarizes as `status`, `text`, `cost_usd`, `reason`, `task_class`, `verdict`,
 `revisions`, `candidates_run`, `model`, `events`, and `reflection`; a `--no-pipeline` (raw step-loop)
-run summarizes as `status`, `text`, `cost_usd`, `reason`, `model`, and `events`, plus the
-top-level [`files_touched`](/docs/telemetry/files-touched) telemetry payload — which the
-pipeline summary does **not** carry.
+run summarizes as `status`, `text`, `cost_usd`, `reason`, `model`, and `events`, plus a
+top-level `files_touched` key holding the
+[files-touched](/docs/telemetry/files-touched) telemetry payload — which the pipeline
+summary does **not** carry. That payload is the serialized telemetry object, so the array
+of records sits one level in, at `.files_touched.files_touched`.
+
+The `status` value is the first thing most scripts branch on. A pipeline run
+reports one of four; a `--no-pipeline` run reports three, since no verification
+ladder ran:
+
+<CardGrid size="sm">
+  <OptionCard name="completed">
+    The turn finished. On the pipeline path this also means verification
+    passed — check `verdict.deterministic` to see whether a judge was spent.
+  </OptionCard>
+  <OptionCard name="verification_failed">
+    Pipeline only. The work happened but did not verify; `reason` carries the
+    verdict summary. Exits non-zero.
+  </OptionCard>
+  <OptionCard name="aborted">
+    A backstop ended the run — the budget cap, a scope gate with nobody to ask,
+    a signal. `reason` says which. Exits non-zero.
+  </OptionCard>
+  <OptionCard name="error">
+    The run failed outright, including every pre-flight failure. Exits non-zero.
+  </OptionCard>
+</CardGrid>
 
 **Failures keep the same key set.** A pipeline run that errors emits every key above, with
 `text` and the pipeline-only keys (`task_class`, `verdict`, `revisions`, `candidates_run`)
@@ -109,15 +143,42 @@ Key order is not part of the contract — read by key, never by position.
 
 ## Configure via environment
 
-Every core flag has an environment variable, so a CI job can be configured without editing
-the command line:
+Every core global flag has an environment variable, so a CI job can be configured without
+editing the command line:
 
-| Flag | Environment variable |
-| --- | --- |
-| `--model` | `STELLA_MODEL` |
-| `--base-url` | `STELLA_BASE_URL` |
-| `--output-format` | `STELLA_OUTPUT_FORMAT` |
-| `--budget` | `STELLA_BUDGET` |
+<CardGrid size="md">
+  <OptionCard name="STELLA_MODEL">
+    Equivalent to `--model`. The worker model for this invocation:
+    `provider/model_id`, e.g. `anthropic/claude-fable-5`.
+  </OptionCard>
+  <OptionCard name="STELLA_BASE_URL">
+    Equivalent to `--base-url`. Required alongside `--model local/<model>` to
+    point at a local OpenAI-compatible server; optional elsewhere to route
+    through a proxy.
+  </OptionCard>
+  <OptionCard name="STELLA_OUTPUT_FORMAT" defaultValue="text">
+    Equivalent to `--output-format`: `text`, `json`, or `stream-json`.
+  </OptionCard>
+  <OptionCard name="STELLA_BUDGET">
+    Equivalent to `--budget`. Hard USD cap for the whole run. Unset means
+    spend is metered but never blocked.
+  </OptionCard>
+  <OptionCard name="STELLA_PLAIN">
+    Set to `1` for the plain line-based REPL instead of the Command Deck. Rarely
+    needed in CI — the deck already steps aside when stdout is not a terminal.
+  </OptionCard>
+  <OptionCard name="STELLA_NO_ANIM">
+    Freeze all deck animation to a static frame, for CI logs and
+    asciinema-style recordings. `NO_COLOR` forces the same.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="warn">
+  `--api-key` deliberately has **no** `STELLA_*` equivalent. Supply the key
+  through the provider's own variable (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …),
+  which is step 2 of the [credential chain](/docs/configuration/credentials)
+  and never lands in a process argument list.
+</Callout>
 
 ```bash
 export STELLA_MODEL=anthropic/claude-fable-5
@@ -125,6 +186,13 @@ export STELLA_OUTPUT_FORMAT=stream-json
 export STELLA_BUDGET=5
 stella run "update the changelog for the pending release"
 ```
+
+Stella also loads project dotenv files into the environment before any of this
+resolves — `.env.<mode>.local`, then `.env.local`, then `.env`, most-specific
+first, confined to the enclosing git repository. An exported shell value always
+beats a file value, `.env.example` and committed `.env.<mode>` files are never
+read, and `STELLA_NO_ENV_FILE=1` disables the mechanism entirely. In CI, prefer
+the runner's secret store over a checked-in file.
 
 ## Headless credentials
 
@@ -153,9 +221,147 @@ stella --budget 3 --output-format json run "port the utils module to the new cli
 ```
 
 Work aborts cleanly once the cap is reached — never mid-tool — so the workspace is left in
-a consistent state.
+a consistent state, and the summary comes back `"status": "aborted"` with the cap named in
+`reason`. A fleet divides the same cap across its concurrency width, so the number you set
+is the number you spend:
+
+```bash
+stella --budget 10 fleet --plan cleanup.toml --max-concurrency 4
+```
 
 ## Exit codes
 
-`stella` exits `0` on success and non-zero on failure (an unresolved credential, an
-invalid flag, or an aborted run), so you can gate a pipeline on its result.
+<CardGrid size="sm">
+  <OptionCard name="0">
+    Success. On the pipeline path that means verification passed, not merely
+    that the model stopped talking.
+  </OptionCard>
+  <OptionCard name="1">
+    Failure — an unresolved credential, an invalid flag, a failed verification,
+    or an aborted run.
+  </OptionCard>
+  <OptionCard name="128 + signal">
+    The run was interrupted: `130` for `SIGINT` (Ctrl-C), `143` for `SIGTERM`
+    (a CI job cancellation or timeout kill). The shell convention, so a wrapper
+    script can tell "someone stopped this" from "this failed".
+  </OptionCard>
+</CardGrid>
+
+```bash
+stella --budget 3 --output-format json run \
+  --test-command "cargo test -p stella-store" \
+  "make the store migration idempotent on an already-v2 file" > result.json
+case $? in
+  0)   echo "verified" ;;
+  130) echo "cancelled by the operator"; exit 0 ;;
+  143) echo "the runner killed us — probably a job timeout"; exit 0 ;;
+  *)   echo "failed"; exit 1 ;;
+esac
+```
+
+## A complete CI job
+
+The whole contract in one GitHub Actions step: a budget cap that cannot be
+exceeded, a deterministic oracle so most runs never spend a judge call, JSON on
+stdout, and the summary parsed for the job log.
+
+```yaml title=".github/workflows/autofix.yml"
+name: autofix
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: What Stella should do
+        required: true
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Stella
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run the task
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          STELLA_MODEL: anthropic/claude-fable-5
+          STELLA_OUTPUT_FORMAT: json
+          STELLA_BUDGET: "3"
+        run: stella run --test-command "cargo test --workspace" "${{ inputs.task }}" > result.json
+
+      - name: Summarize
+        if: always()
+        run: |
+          jq -r '
+            "status:        \(.status)",
+            "cost:          $\(.cost_usd)",
+            "task class:    \(.task_class // "n/a")",
+            "revisions:     \(.revisions // 0)",
+            "deterministic: \(.verdict.deterministic // false)",
+            "evidence:      \(.verdict.summary // .reason // "—")"
+          ' result.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open a PR with the result
+        if: success()
+        run: |
+          git switch -c "stella/${{ github.run_id }}"
+          git commit -am "${{ inputs.task }}"
+          git push -u origin HEAD
+          gh pr create --fill
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<Callout type="warn">
+  One headless-only gate to know about: a plan whose blast radius crosses the
+  [scope-review thresholds](/docs/inference-pipeline) has nobody to ask in CI,
+  so the run ends rather than auto-approving. If the checkout is disposable and
+  the budget cap is your real guard, opt in explicitly with
+  `agent_engine_config.headless_scope_bypass: "on"` — never as a default.
+</Callout>
+
+## Parsing the output with jq
+
+The summary object and the event stream answer different questions. A few
+pipelines worth keeping:
+
+```bash
+# Gate a script on deterministic evidence only — refuse a judge-only pass.
+stella --output-format json run --test-command "make test" "$TASK" \
+  | jq -e '.status == "completed" and .verdict.deterministic == true' >/dev/null \
+  || { echo "no deterministic proof — not merging" >&2; exit 1; }
+```
+
+```bash
+# Every file the raw step loop touched, with its line delta. Note the nesting:
+# the summary's `files_touched` key holds the telemetry payload object, whose
+# own `files_touched` key holds the array.
+stella --output-format json run --no-pipeline "tidy up the error types in stella-store" \
+  | jq -r '.files_touched.files_touched[] | "\(.path)\t+\(.lines_added)/-\(.lines_removed)"'
+```
+
+```bash
+# Watch the stages go by, live, without parsing anything else. Stage names are
+# snake_case: triage, context_recall, plan, scope_review, witness, execute,
+# verify, judge.
+stella --output-format stream-json run "$TASK" \
+  | jq -r --unbuffered 'select(.type == "stage") | "→ \(.name)"'
+```
+
+```bash
+# Which tools the run actually reached for, most-used first. A tool_start event
+# carries its call under `call`, so the name is `.call.name`.
+stella --output-format json run "$TASK" \
+  | jq -r '.events[] | select(.type == "tool_start") | .call.name' \
+  | sort | uniq -c | sort -rn
+```
+
+<Callout type="info">
+  Skip lines and keys you do not recognize — that is what makes these pipelines
+  survive an upgrade. See
+  [Event stream compatibility](/docs/event-stream-compatibility) for the event
+  vocabulary's own guarantee.
+</Callout>

--- a/website/content/docs/showcase.mdx
+++ b/website/content/docs/showcase.mdx
@@ -36,19 +36,122 @@ is the open configuration cookbook for Stella itself: a working example for
 Stella actually parses, each directory README saying where the file goes on
 disk. Clone it, copy a file into place, and it works.
 
-| Surface | Examples |
-| --- | --- |
-| [Settings profiles](https://github.com/macanderson/stella-examples/tree/main/settings) | [minimal](https://github.com/macanderson/stella-examples/blob/main/settings/minimal.settings.json), [balanced](https://github.com/macanderson/stella-examples/blob/main/settings/balanced.settings.json), [max-quality](https://github.com/macanderson/stella-examples/blob/main/settings/max-quality.settings.json), [dirt-cheap](https://github.com/macanderson/stella-examples/blob/main/settings/dirt-cheap.settings.json), [local-ollama](https://github.com/macanderson/stella-examples/blob/main/settings/local-ollama.settings.json), and [team](https://github.com/macanderson/stella-examples/blob/main/settings/team.settings.json) `settings.json` profiles, plus the [`credentials.toml`](https://github.com/macanderson/stella-examples/blob/main/settings/credentials.example.toml) shape — the model lineups from the [examples](/docs/examples) as ready-to-copy files |
-| [Lifecycle hooks](https://github.com/macanderson/stella-examples/tree/main/hooks) | A [`SessionStart` context injector](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/session-context.sh), a [`PreToolUse` bash guard](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/guard-bash.sh) that vetoes destructive commands, and a [`PostToolUse` JSONL audit log](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/log-tool-use.sh) — wired together in one [`hooks` block](https://github.com/macanderson/stella-examples/blob/main/hooks/settings.json) ([docs](/docs/agent-tools/hooks)) |
-| [Custom commands](https://github.com/macanderson/stella-examples/tree/main/commands) | [`/fix-issue`](https://github.com/macanderson/stella-examples/blob/main/commands/fix-issue.md) (with `$ARGUMENTS`), [`/changelog`](https://github.com/macanderson/stella-examples/blob/main/commands/changelog.md), [`/pr-description`](https://github.com/macanderson/stella-examples/blob/main/commands/pr-description.md) ([docs](/docs/agent-tools/commands)) |
-| [Custom agents](https://github.com/macanderson/stella-examples/tree/main/agents) | [`code-reviewer`](https://github.com/macanderson/stella-examples/blob/main/agents/code-reviewer.md) (read-only toolbelt), [`test-writer`](https://github.com/macanderson/stella-examples/blob/main/agents/test-writer.md) (witness tests + `verify_done`), [`docs-writer`](https://github.com/macanderson/stella-examples/blob/main/agents/docs-writer.md) (no shell) ([docs](/docs/agent-tools/custom-agents)) |
-| [Skills](https://github.com/macanderson/stella-examples/tree/main/skills) | [`conventional-commits`](https://github.com/macanderson/stella-examples/blob/main/skills/conventional-commits/SKILL.md) and [`release-checklist`](https://github.com/macanderson/stella-examples/blob/main/skills/release-checklist/SKILL.md) ([docs](/docs/agent-tools/skills)) |
-| [Rules & guards](https://github.com/macanderson/stella-examples/tree/main/rules) | Hard guards — [`no-force-push`](https://github.com/macanderson/stella-examples/blob/main/rules/no-force-push.md), [`protect-migrations`](https://github.com/macanderson/stella-examples/blob/main/rules/protect-migrations.md), [`no-shell`](https://github.com/macanderson/stella-examples/blob/main/rules/no-shell.md) — and a soft [`code-conventions`](https://github.com/macanderson/stella-examples/blob/main/rules/code-conventions.md) rule ([docs](/docs/agent-tools/permissions)) |
-| [Custom tools](https://github.com/macanderson/stella-examples/tree/main/tools) | [`todo_scan`](https://github.com/macanderson/stella-examples/blob/main/tools/todo-scan.toml) (input schema + `STELLA_INPUT_*` env) and [`loc_report`](https://github.com/macanderson/stella-examples/blob/main/tools/loc-report.toml) (minimal manifest) ([docs](/docs/agent-tools/custom-tools)) |
-| [MCP servers](https://github.com/macanderson/stella-examples/tree/main/mcp) | An [`mcp.toml`](https://github.com/macanderson/stella-examples/blob/main/mcp/mcp.toml) with both stdio and HTTP transports ([docs](/docs/agent-tools/mcp)) |
-| [Fleet plans](https://github.com/macanderson/stella-examples/tree/main/fleet) | A feature build-out DAG in [TOML](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.toml) and a parallel cleanup sweep in [JSON](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.json), with claims and worktree isolation ([docs](/docs/agent-fleets)) |
-| [Memory & domains](https://github.com/macanderson/stella-examples/tree/main/memory) | A hand-tuned [`domains.toml`](https://github.com/macanderson/stella-examples/blob/main/memory/domains.toml) and the lesson → skill → rule promotion loop ([docs](/docs/commands/memory)) |
-| [Scripting & CI](https://github.com/macanderson/stella-examples/tree/main/scripting) | [`ci-autofix.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/ci-autofix.sh) (budget-capped, oracle-armed) and [`nightly-goal.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/nightly-goal.sh) (cron-able goal runs) |
+<CardGrid size="md">
+  <SpecCard title="Settings profiles">
+    [minimal](https://github.com/macanderson/stella-examples/blob/main/settings/minimal.settings.json),
+    [balanced](https://github.com/macanderson/stella-examples/blob/main/settings/balanced.settings.json),
+    [max-quality](https://github.com/macanderson/stella-examples/blob/main/settings/max-quality.settings.json),
+    [dirt-cheap](https://github.com/macanderson/stella-examples/blob/main/settings/dirt-cheap.settings.json),
+    [local-ollama](https://github.com/macanderson/stella-examples/blob/main/settings/local-ollama.settings.json),
+    and [team](https://github.com/macanderson/stella-examples/blob/main/settings/team.settings.json)
+    `settings.json` profiles, plus the
+    [`credentials.toml`](https://github.com/macanderson/stella-examples/blob/main/settings/credentials.example.toml)
+    shape — the model lineups from the docs as ready-to-copy files.
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/settings) · [Examples docs](/docs/examples)
+  </SpecCard>
+  <SpecCard title="Lifecycle hooks">
+    A [`SessionStart` context injector](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/session-context.sh),
+    a [`PreToolUse` bash guard](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/guard-bash.sh)
+    that vetoes destructive commands, and a
+    [`PostToolUse` JSONL audit log](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/log-tool-use.sh)
+    — wired together in one
+    [`hooks` block](https://github.com/macanderson/stella-examples/blob/main/hooks/settings.json).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/hooks) · [Hooks docs](/docs/agent-tools/hooks)
+  </SpecCard>
+  <SpecCard title="Custom commands">
+    [`/fix-issue`](https://github.com/macanderson/stella-examples/blob/main/commands/fix-issue.md)
+    (with `$ARGUMENTS`),
+    [`/changelog`](https://github.com/macanderson/stella-examples/blob/main/commands/changelog.md),
+    and [`/pr-description`](https://github.com/macanderson/stella-examples/blob/main/commands/pr-description.md).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/commands) · [Commands docs](/docs/agent-tools/commands)
+  </SpecCard>
+  <SpecCard title="Custom agents">
+    [`code-reviewer`](https://github.com/macanderson/stella-examples/blob/main/agents/code-reviewer.md)
+    (read-only toolbelt),
+    [`test-writer`](https://github.com/macanderson/stella-examples/blob/main/agents/test-writer.md)
+    (witness tests + `verify_done`), and
+    [`docs-writer`](https://github.com/macanderson/stella-examples/blob/main/agents/docs-writer.md)
+    (no shell).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/agents) · [Custom agents docs](/docs/agent-tools/custom-agents)
+  </SpecCard>
+  <SpecCard title="Skills">
+    [`conventional-commits`](https://github.com/macanderson/stella-examples/blob/main/skills/conventional-commits/SKILL.md)
+    and [`release-checklist`](https://github.com/macanderson/stella-examples/blob/main/skills/release-checklist/SKILL.md).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/skills) · [Skills docs](/docs/agent-tools/skills)
+  </SpecCard>
+  <SpecCard title="Rules &amp; guards">
+    Hard guards —
+    [`no-force-push`](https://github.com/macanderson/stella-examples/blob/main/rules/no-force-push.md),
+    [`protect-migrations`](https://github.com/macanderson/stella-examples/blob/main/rules/protect-migrations.md),
+    [`no-shell`](https://github.com/macanderson/stella-examples/blob/main/rules/no-shell.md)
+    — and a soft
+    [`code-conventions`](https://github.com/macanderson/stella-examples/blob/main/rules/code-conventions.md)
+    rule.
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/rules) · [Permissions docs](/docs/agent-tools/permissions)
+  </SpecCard>
+  <SpecCard title="Custom tools">
+    [`todo_scan`](https://github.com/macanderson/stella-examples/blob/main/tools/todo-scan.toml)
+    (input schema + `STELLA_INPUT_*` env) and
+    [`loc_report`](https://github.com/macanderson/stella-examples/blob/main/tools/loc-report.toml)
+    (minimal manifest).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/tools) · [Custom tools docs](/docs/agent-tools/custom-tools)
+  </SpecCard>
+  <SpecCard title="MCP servers">
+    An [`mcp.toml`](https://github.com/macanderson/stella-examples/blob/main/mcp/mcp.toml)
+    with both stdio and HTTP transports.
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/mcp) · [MCP servers docs](/docs/agent-tools/mcp)
+  </SpecCard>
+  <SpecCard title="Fleet plans">
+    A feature build-out DAG in
+    [TOML](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.toml)
+    and a parallel cleanup sweep in
+    [JSON](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.json),
+    with claims and worktree isolation.
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/fleet) · [Agent fleets docs](/docs/agent-fleets)
+  </SpecCard>
+  <SpecCard title="Memory &amp; domains">
+    A hand-tuned
+    [`domains.toml`](https://github.com/macanderson/stella-examples/blob/main/memory/domains.toml)
+    and the lesson → skill → rule promotion loop.
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/memory) · [Memory docs](/docs/commands/memory)
+  </SpecCard>
+  <SpecCard title="Scripting &amp; CI">
+    [`ci-autofix.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/ci-autofix.sh)
+    (budget-capped, oracle-armed) and
+    [`nightly-goal.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/nightly-goal.sh)
+    (cron-able goal runs).
+
+    [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/scripting) · [Scripting docs](/docs/scripting)
+  </SpecCard>
+</CardGrid>
+
+Clone it once and the whole cookbook is a `cp` away:
+
+```bash
+git clone https://github.com/macanderson/stella-examples.git
+cd your-project
+
+# A settings profile — user scope, so every project inherits it.
+mkdir -p ~/.stella && cp ../stella-examples/settings/balanced.settings.json ~/.stella/settings.json
+
+# A guard rule and a custom tool — project scope, committed with the repo.
+mkdir -p .stella/rules .stella/tools
+cp ../stella-examples/rules/no-force-push.md .stella/rules/
+cp ../stella-examples/tools/todo-scan.toml .stella/tools/
+
+# Validate the manifest before a session ever loads it.
+stella tools --validate
+```
 
 <Callout type="info">
 Everything in stella-examples respects the trust boundary: project-scope

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Observatory dashboard
-description: stella observe opens a local, loopback-only dashboard over your workspace telemetry — runs, spend, models, tools, files, memory, MCP traffic, and the fleet ledger.
+description: stella observe opens a local, loopback-only dashboard over your workspace telemetry — runs, spend, models, tools, files, memory, MCP traffic, the fleet ledger, and cross-project spend from the hub.
 ---
 
 `stella observe` opens the **Observatory** — a local web dashboard over the
@@ -30,25 +30,103 @@ Stella — not as a policy, as a construction:
 
 ## What you can see
 
-The nav has eight tabs, plus a **window** selector — `24h` / `7d` / `30d` /
+The nav has nine tabs, plus a **window** selector — `24h` / `7d` / `30d` /
 `all` (the default). The Overview KPIs, the tokens-per-run timeline, the
 Executions table, and every Activity chart honor the window; the leaderboard
 panels labeled *all-time* ignore it.
 
-| Tab | Answers |
-| --- | --- |
-| **Overview** | KPI tiles (runs, resolve rate, total spend, tokens in/out, cache hits, model time), a tokens-per-run timeline, the **Models** breakdown (**$/resolved task** per provider/model), the tool leaderboard (calls, errors, p50/max latency, bytes returned), the most-touched files, the **fleet ledger** (per fleet run: tasks, attempts, successes, commits) with MCP traffic, a memory/reflections/skills digest — and the **Executions** table: every run's kind, prompt, model, outcome, steps, tool calls, files touched, tokens, and cost. Clicking a row opens a drill-down drawer with per-step tokens and latency, every tool call, the files touched, and the post-turn self-reflection |
-| **Activity** | Per-day time series over the window: cost, tokens (input vs output), runs (resolved vs other outcomes), and tool calls (calls vs errors) |
-| **Code graph** | The tree-sitter code-graph index of the workspace — a searchable force-directed canvas of files (with per-file symbol counts) and their resolved import edges, plus a selection detail panel |
-| **Skills** | Installed and learned skills, with per-skill usage |
-| **MCP** | Configured servers (`.stella/mcp.toml`) and observed per-server / per-tool traffic |
-| **Memory & rules** | The memory plane: memories on disk (`.stella/memories`), citation receipts (were they useful and truthful?), promoted rules, and the exploration maps sessions share (`.stella/explorations`) — each re-hashed against the working tree so you can see which are still fresh, which have drifted, and which a session is claiming right now |
-| **Self-improve** | The self-improvement loop, receipted from `.stella`: self-rating per reflection, owned shortcomings, distilled lessons, and auto-extracted learned skills |
-| **Config** | The merged engine config (user → org → project), where every store and database lives, and the per-scope config files |
+<CardGrid size="md">
+  <OptionCard name="overview">
+    KPI tiles (runs, resolve rate, total spend, tokens in/out, cache hits, model time), a
+    tokens-per-run timeline, the **Models** breakdown (**$/resolved task** per
+    provider/model), the tool leaderboard (calls, errors, p50/max latency, bytes returned),
+    the most-touched files, the **fleet ledger** (per fleet run: tasks, attempts,
+    successes, commits) with MCP traffic, and a memory/reflections/skills digest — plus the
+    **Executions** table: every run's kind, prompt, model, outcome, steps, tool calls,
+    files touched, tokens, and cost. Clicking a row opens a drill-down drawer with per-step
+    tokens and latency, every tool call, the files touched, and the post-turn
+    self-reflection.
+  </OptionCard>
+  <OptionCard name="activity">
+    Per-day time series over the window: cost, tokens (input vs output), runs (resolved vs
+    other outcomes), and tool calls (calls vs errors).
+  </OptionCard>
+  <OptionCard name="code graph">
+    The tree-sitter code-graph index of the workspace — a searchable force-directed canvas
+    of files (with per-file symbol counts) and their resolved import edges, plus a
+    selection detail panel.
+  </OptionCard>
+  <OptionCard name="skills">
+    Installed and learned skills, with per-skill usage.
+  </OptionCard>
+  <OptionCard name="mcp">
+    Configured servers (`.stella/mcp.toml`) and observed per-server / per-tool traffic.
+  </OptionCard>
+  <OptionCard name="memory & rules">
+    The memory plane: memories on disk (`.stella/memories`), citation receipts (were they
+    useful and truthful?), promoted rules, and the exploration maps sessions share
+    (`.stella/explorations`) — each re-hashed against the working tree so you can see which
+    are still fresh, which have drifted, and which a session is claiming right now.
+  </OptionCard>
+  <OptionCard name="self-improve">
+    The self-improvement loop, receipted from `.stella`: self-rating per reflection, owned
+    shortcomings, distilled lessons, and auto-extracted learned skills.
+  </OptionCard>
+  <OptionCard name="org / hub">
+    Spend across **every project on this machine**, not just this workspace — read from the
+    cross-project hub at `~/.stella/usage.db`. See below.
+  </OptionCard>
+  <OptionCard name="config">
+    The merged engine config (user → org → project), where every store and database lives,
+    and the per-scope config files.
+  </OptionCard>
+</CardGrid>
 
-Everything is served from `<workspace>/.stella/private/store.db` (and
-`.stella/private/fleet.db` for the fleet view) — the same SQLite files you can query
-directly with any SQLite client.
+Everything except **org / hub** is served from
+`<workspace>/.stella/private/store.db` (and `.stella/private/fleet.db` for the
+fleet view) — the same SQLite files you can query directly with any SQLite
+client.
+
+## The `org / hub` tab: spend beyond this workspace
+
+Every other tab answers "what did *this* repo cost". The **org / hub** tab
+answers "what did all of them cost", reading the cross-project telemetry hub at
+`~/.stella/usage.db` — which finished turns replicate into, and which
+`stella usage sync --all` repairs if a best-effort replication was missed.
+
+It opens on a KPI row (calls, cost, input/output tokens, cache-read rate,
+projects, orgs) over everything the hub has ever seen, and a breadcrumb reading
+**all orgs**. From there it is a drill-down: click a row in the breakdown panel
+to descend **org → workspace → repo → project**, with the breadcrumb popping you
+back to any level. Clicking a *project* row leaves the hub entirely and reopens
+the Overview tab scoped to that project.
+
+Three panels re-scope as you drill:
+
+<CardGrid size="sm">
+  <OptionCard name="Breakdown">
+    One level in from the current scope, with calls, cost, cache rate, tokens in/out, and
+    a contributing-projects count per row.
+  </OptionCard>
+  <OptionCard name="Models">
+    Per provider/model spend across every project in scope — the same aggregation
+    `stella usage report` prints, plus a cache-read rate.
+  </OptionCard>
+  <OptionCard name="Spend per day / By repo">
+    Daily spend bars, and a per-repository table for the current scope.
+  </OptionCard>
+</CardGrid>
+
+Rows whose org, workspace, or repo id is unset render as `(local)` — that is
+what you see before `stella cloud register` mints the durable ids. An empty hub
+says so and points you at `stella usage sync --all`, rather than rendering a
+blank panel. The tab is deliberately never cached: its payload depends on the live
+drill scope, so each entry and each drill re-queries.
+
+<Callout type="info">
+  The hub is local like everything else — `~/.stella/usage.db` is a file on your machine,
+  and nothing about the org/hub view involves a network call.
+</Callout>
 
 ## `$/resolved` — the metric that matters
 

--- a/website/content/docs/telemetry/files-touched.mdx
+++ b/website/content/docs/telemetry/files-touched.mdx
@@ -16,13 +16,33 @@ Only Stella's dedicated file tools are attributable. Shell commands are opaque �
 cannot see what a `bash` command did to the filesystem, which is one reason the file tools
 exist and the agent is steered toward them.
 
-| Tool | CRUD event | Line counts |
-| --- | --- | --- |
-| `read_file` | **R** | always `0` added, `0` removed |
-| `write_file` (new path) | **C** | `lines_added` = the full new file's line count |
-| `write_file` (existing path) | **U** | the line diff of pre- vs post-write content |
-| `edit_file` | **U** | the line diff of the replaced region |
-| `delete_file` | **D** | `lines_removed` = the full pre-deletion line count |
+<CardGrid size="md">
+  <OptionCard name="read_file">
+    **R** — always `0` added, `0` removed. A read is a first-class touch, not a
+    non-event.
+  </OptionCard>
+  <OptionCard name="write_file (new path)">
+    **C** — `lines_added` is the full new file's line count.
+  </OptionCard>
+  <OptionCard name="write_file (existing path)">
+    **U** — the line diff of pre- versus post-write content.
+  </OptionCard>
+  <OptionCard name="web_download">
+    **C** or **U**, chosen exactly as `write_file` does: it lands a file at a path, so it
+    takes the same ledger classification — and the same hook gating.
+  </OptionCard>
+  <OptionCard name="edit_file">
+    **U** — the line diff of the replaced region.
+  </OptionCard>
+  <OptionCard name="delete_file">
+    **D** — `lines_removed` is the full pre-deletion line count.
+  </OptionCard>
+  <OptionCard name="apply_edits">
+    One **U** per *distinct* file in the batch — the one tool that can produce several
+    ledger records from a single call. A `dry_run` batch records nothing, because nothing
+    was written.
+  </OptionCard>
+</CardGrid>
 
 A **failed** operation records nothing — a blocked write, a missing file, or an
 out-of-workspace path never produces a ledger entry.
@@ -106,11 +126,19 @@ Which keys the final JSON object carries depends on which execution path ran:
   `status`, `text`, `cost_usd`, `reason`, `model`, and `events` — plus the full telemetry
   payload under `files_touched`.
 
+<Callout type="info">
+  Mind the nesting: the envelope's `files_touched` key holds the whole telemetry
+  **object**, and that object's own `files_touched` key holds the record array. So the
+  records are at `.files_touched.files_touched[]`, not `.files_touched[]`. The doubled key
+  is not a typo — the payload is the same serialized shape that goes into the store, and
+  it is embedded rather than flattened.
+</Callout>
+
 So a script that asserts on exactly what a run changed must pass `--no-pipeline`:
 
 ```bash
 stella --output-format json run --no-pipeline "add a --health flag and wire the readiness probe" \
-  | jq '.files_touched[] | {path, crud_events, lines_added, lines_removed}'
+  | jq '.files_touched.files_touched[] | {path, crud_events, lines_added, lines_removed}'
 ```
 
 ```json
@@ -120,7 +148,7 @@ stella --output-format json run --no-pipeline "add a --health flag and wire the 
 
 <Callout type="warn">
   On a default (pipeline) run, `.files_touched` is absent from the JSON —
-  `jq '.files_touched[]'` errors out, and a CI gate built on it fails every run. Add
+  `jq '.files_touched.files_touched[]'` errors out, and a CI gate built on it fails every run. Add
   `--no-pipeline`, or read the ledger back from the store: it is persisted on **both**
   paths.
 </Callout>
@@ -137,7 +165,7 @@ it stays entirely on your machine.
 **Fail CI when a run edits files outside a directory.**
 
 ```bash
-touched=$(stella --output-format json run --no-pipeline "$TASK" | jq -r '.files_touched[].path')
+touched=$(stella --output-format json run --no-pipeline "$TASK" | jq -r '.files_touched.files_touched[].path')
 echo "$touched" | grep -qv '^src/' && { echo "run touched files outside src/"; exit 1; }
 ```
 
@@ -145,9 +173,21 @@ echo "$touched" | grep -qv '^src/' && { echo "run touched files outside src/"; e
 
 ```bash
 stella --output-format json run --no-pipeline "$TASK" \
-  | jq -r '.files_touched[] | "\(.crud_events|join("")) \(.path) (+\(.lines_added) -\(.lines_removed))"'
-# CU src/router.rs (+18 -4)
+  | jq -r '.files_touched.files_touched[] | "\(.crud_events|join("")) \(.path) (+\(.lines_added) -\(.lines_removed))"'
+# RU src/router.rs (+18 -4)
 # C  src/health.rs (+22 -0)
+```
+
+**Read the same ledger back out of the store**, on either execution path — no
+`--no-pipeline` needed, because it is persisted on both:
+
+```bash
+sqlite3 -json .stella/private/store.db \
+  "SELECT path, ops, lines_added, lines_removed
+     FROM files_touched
+    WHERE execution_id = (SELECT MAX(id) FROM executions)
+    ORDER BY path" \
+  | jq -r '.[] | "\(.ops)\t\(.path) (+\(.lines_added) -\(.lines_removed))"'
 ```
 
 <Callout type="info">

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -6,6 +6,8 @@ description: Local-first metering, the opt-in Oxagen Enterprise operational expo
 Stella meters every run **locally**. Token usage, cost, per-step accounting, and the
 full execution record land in SQLite on your disk.
 
+<TelemetryFlowDiagram />
+
 **Community/default mode has zero telemetry egress.** It constructs no enterprise
 spool or HTTP client. The model provider you selected remains Stella's normal BYOK
 network path; the local Observatory remains loopback-only.
@@ -28,28 +30,146 @@ can only derive the closed rollup described below.
 
 ### What's in the store
 
-Metering is only part of it. The store owns **17 tables** — a full record of what each run
+Metering is only part of it. The store owns **21 tables** — a full record of what each run
 *did*, not just what it cost — and the [Observatory](/docs/telemetry/dashboard) reads these
-same tables:
+same tables.
 
-| Table | What it records |
-| --- | --- |
-| `executions` | One row per run / goal / chat turn — kind, prompt, provider/model, outcome, cost. The spine every other table keys off |
-| `events` | The full, ordered event stream of each execution — replayable, reasoning deltas included |
-| `telemetry` | One row per model call: input/output tokens, cache read/write/miss, cost, latency, retries |
-| `files_touched` | The per-execution file-touch ledger — CRUD letters, line deltas, JSON audit log ([details](/docs/telemetry/files-touched)) |
-| `tool_calls` | One row per tool call (native, MCP, skill, or agent) — shape, timing, success, bytes returned |
-| `mcp_usage` | Per-call MCP log: server, tool, reason, call time |
-| `skill_usage` | One row per skill applied in a turn, with the skill's pinned version |
-| `agent_uses` | One row per invocation of an installed agent definition, with its pinned version |
-| `memory_citations` | Recall receipts: per memory cited in a turn, its usefulness score and truthfulness verdict |
-| `rules` | Promoted workspace rules — the full rule markdown, one row per rule |
-| `reflections` | Durable lessons and self-critiques, tagged by domain |
-| `execution_reflection` | The post-turn self-review, tied 1:1 to its execution |
-| `tasks` | The latest task-board snapshot, one row per task per session |
-| `pull_requests` | Tracked pull requests — status and CI verdict, keyed by URL |
-| `file_locks` | Cooperative file claims for multi-agent work |
-| `graph_nodes` / `graph_edges` | Reserved schema for a future context-plane seam — the code graph itself lives in `.stella/private/codegraph.db` |
+<CardGrid size="md">
+  <OptionCard name="executions">
+    One row per run / goal / chat turn — kind, prompt, provider/model, outcome, cost. The
+    spine every other table keys off.
+  </OptionCard>
+  <OptionCard name="events">
+    The full, ordered event stream of each execution — replayable, reasoning deltas
+    included.
+  </OptionCard>
+  <OptionCard name="telemetry">
+    One row per model call: input/output tokens, cache read/write/miss, cost, latency,
+    retries.
+  </OptionCard>
+  <OptionCard name="files_touched">
+    The per-execution file-touch ledger — CRUD letters, line deltas, JSON audit log
+    ([details](/docs/telemetry/files-touched)).
+  </OptionCard>
+  <OptionCard name="tool_calls">
+    One row per tool call (native, MCP, skill, or agent) — shape, timing, success, bytes
+    returned. Large outputs are never stored, only their size.
+  </OptionCard>
+  <OptionCard name="mcp_usage">
+    Per-call MCP log: server, tool, reason, call time.
+  </OptionCard>
+  <OptionCard name="skill_usage">
+    One row per skill applied in a turn, with the skill's pinned version.
+  </OptionCard>
+  <OptionCard name="agent_uses">
+    One row per invocation of an installed agent definition, with its pinned version.
+  </OptionCard>
+  <OptionCard name="memory_citations">
+    Recall receipts: per memory cited in a turn, its usefulness score and truthfulness
+    verdict.
+  </OptionCard>
+  <OptionCard name="forgotten">
+    Explicit human tombstones over anything that steers the agent — one verdict per item,
+    with the forgotten text copied in at forget time. That copy is what makes the tombstone
+    survive re-learning: the reflection recorder and the skill miner compare *candidates*
+    against it, so a re-mined paraphrase with a brand-new id is still caught. Unlike
+    quarantine, which is derived from citation counts, this is a stored judgment — a
+    person read it and said remove it. Restoring is a plain delete.
+  </OptionCard>
+  <OptionCard name="rules">
+    Promoted workspace rules — the full rule markdown, one row per rule.
+  </OptionCard>
+  <OptionCard name="reflections">
+    Durable lessons and self-critiques, tagged by domain.
+  </OptionCard>
+  <OptionCard name="execution_reflection">
+    The post-turn self-review, tied 1:1 to its execution — the model's self-rating beside
+    the objective companions (did it produce output, did it write files, was it truncated),
+    so a silent zero-output turn is visibly a failure even if the model rated itself kindly.
+  </OptionCard>
+  <OptionCard name="tasks">
+    The latest task-board snapshot, one row per task per session.
+  </OptionCard>
+  <OptionCard name="pull_requests">
+    Tracked pull requests — status and CI verdict, keyed by URL.
+  </OptionCard>
+  <OptionCard name="file_locks">
+    Cooperative file claims for multi-agent work.
+  </OptionCard>
+  <OptionCard name="graph_nodes / graph_edges">
+    Two tables: reserved schema for a future context-plane seam — the code graph itself
+    lives in `.stella/private/codegraph.db`.
+  </OptionCard>
+</CardGrid>
+
+#### The receipts plane: what made a past step
+
+Three of the twenty-one exist for one question — *what exactly did the model see on step
+N, and why was it allowed to see that much?* Together they make a past step
+reconstructable without keeping a copy of the prompt: replay the ordering and the numbers
+line up with the decision that was actually made.
+
+<CardGrid size="md">
+  <OptionCard name="context_blocks">
+    One row per durable, individually attributable unit that entered a step's prompt, born
+    once and keyed by its content-addressed `block_id`. Carries `kind`, `token_cost`,
+    `content_digest`, and `citation_label` — and is deliberately **content-free**: the
+    digest, never the payload bytes, whose preimage lives in the originating event in the
+    journal. `call_id` / `memory_id` join back to the tool call or memory node that
+    produced the block. A byte-identical block re-entering context resolves to the same id,
+    so the second registration is an idempotent no-op rather than data.
+  </OptionCard>
+  <OptionCard name="step_manifest">
+    One row per (step, block) in **wire order** — the receipt that makes a past step
+    reconstructable, because replaying the fold plus this ordering yields exactly what the
+    model saw. `call_seq` separates the several model calls that can share one step (the
+    worker, an overflow summarizer, allocated management roles), `cache_zone` and
+    `resident_since_step` record where a block sat and how long it had been carried, and
+    `call_id` gives per-occurrence attribution that content-addressed block ids cannot.
+    Its reverse index — every step a given block was resident for — is what cost-of-carry
+    and eviction analysis read.
+  </OptionCard>
+  <OptionCard name="step_receipt">
+    The manifest header: one row per **model call**, not per step. Records `provider`,
+    `model`, `call_role`, `effective_budget_tokens`, `calibration_factor`, and
+    `estimated_input_tokens` — the budget the compaction pass actually compared against,
+    so a receipt's numbers reconcile with the decision it documents rather than with a
+    figure recomputed later.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="info">
+  Those twenty-one are the tables the store *owns* — the ones versioned by the migration
+  chain. `store.db` additionally carries the optional `enterprise_export_*` tables, which
+  converge by column probing **outside** that chain and are created after the fresh-file
+  probe runs. They exist only where a managed enrollment does.
+</Callout>
+
+### Querying it yourself
+
+It is an ordinary SQLite file, so anything that speaks SQLite speaks to it. The five most
+expensive runs in this workspace:
+
+```bash
+sqlite3 -json .stella/private/store.db \
+  "SELECT id, kind, model, outcome, cost_usd
+     FROM executions
+    ORDER BY cost_usd DESC
+    LIMIT 5" \
+  | jq -r '.[] | "\(.cost_usd)\t\(.model)\t\(.outcome // "—")\t\(.kind)"'
+```
+
+And the receipts for one run — every model call, what it estimated it was sending, and the
+budget it was measured against:
+
+```bash
+sqlite3 -json .stella/private/store.db \
+  "SELECT step, call_seq, call_role, model, estimated_input_tokens, effective_budget_tokens
+     FROM step_receipt
+    WHERE execution_id = 42
+    ORDER BY step, call_seq" \
+  | jq -r '.[] | "step \(.step).\(.call_seq)\t\(.call_role)\t\(.estimated_input_tokens)/\(.effective_budget_tokens)"'
+```
 
 ## Oxagen Enterprise managed export
 

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -117,6 +117,238 @@
 }
 
 /* ───────────────────────────────────────────────────────────────────────────
+ * Docs cards — the mobile-first replacement for reference tables.
+ * Namespaced `sc-*` (stella card); see src/components/cards.tsx.
+ *
+ * A wide reference table is a desktop-only artifact: on a phone it either
+ * overflows the viewport or crushes every column to two words, and the header
+ * row scrolls out of sight exactly when you need it. A card carries its own
+ * labels, so it reads identically at 380px and 1400px.
+ *
+ * The grid is `auto-fill` over a min column width rather than a breakpoint
+ * ladder, so the column count falls out of the available width — including
+ * inside the narrower `/docs` content column — with no media queries to keep
+ * in sync.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.sc-grid {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+/* Below the min width the track collapses to one stacked column — the phone
+ * case — because `minmax()`'s floor would otherwise force a sideways scroll. */
+.sc-grid-sm {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 15rem), 1fr));
+}
+.sc-grid-md {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 19rem), 1fr));
+}
+.sc-grid-lg {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 24rem), 1fr));
+}
+
+.sc-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.75rem;
+  background: var(--color-fd-card);
+  /* Cards sit in a prose column; MDX would otherwise inherit paragraph rhythm. */
+  font-size: 0.875rem;
+  line-height: 1.55;
+}
+
+.sc-card-link {
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.15s ease;
+}
+.sc-card-link:hover {
+  border-color: color-mix(in oklch, var(--color-fd-foreground) 28%, transparent);
+  background: var(--color-fd-accent);
+}
+/* Keyboard parity with hover — the whole card is one tab stop. */
+.sc-card-link:focus-visible {
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: 2px;
+}
+
+.sc-card-logo {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  margin-bottom: 0.15rem;
+  color: var(--color-fd-foreground);
+}
+
+.sc-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sc-card-title {
+  font-weight: 600;
+  color: var(--color-fd-foreground);
+  /* Long provider names wrap rather than pushing the badge off the card. */
+  min-width: 0;
+}
+
+.sc-card-body {
+  color: var(--color-fd-muted-foreground);
+  /* MDX wraps card children in <p>; strip the block margins it brings. */
+  margin: 0;
+}
+.sc-card-body > :first-child {
+  margin-top: 0;
+}
+.sc-card-body > :last-child {
+  margin-bottom: 0;
+}
+
+/* ── label/value list ──────────────────────────────────────────────────────
+ * Two columns on anything wide enough for the labels to stay on one line,
+ * stacked below that. This is the part a table gets wrong on a phone: here the
+ * label rides *with* its value instead of living in a scrolled-away header. */
+
+.sc-meta {
+  display: grid;
+  gap: 0.3rem 0.75rem;
+  margin: 0.15rem 0 0;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--color-fd-border);
+  font-size: 0.8125rem;
+}
+
+.sc-meta-row {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) 1fr;
+  gap: 0.15rem 0.75rem;
+  align-items: baseline;
+}
+
+@container (max-width: 20rem) {
+  .sc-meta-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sc-meta-label {
+  color: var(--color-fd-muted-foreground);
+  font-weight: 500;
+}
+
+.sc-meta-value {
+  margin: 0;
+  color: var(--color-fd-foreground);
+  /* Identifiers (env vars, model ids) are long and unbreakable at spaces —
+   * let them break anywhere rather than widening the whole grid track. */
+  overflow-wrap: anywhere;
+}
+
+.sc-mono {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.9em;
+}
+
+/* ── badges ───────────────────────────────────────────────────────────────
+ * Neutral by default. `mutating`/`caution` spend the same functional amber the
+ * callouts use, because "this can change your files" is a warning rather than
+ * decoration — the one exception the neutral brand already makes. */
+
+.sc-badge {
+  flex: none;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 9999px;
+  background: var(--color-fd-muted);
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.sc-badge[data-tone="mutating"],
+.sc-badge[data-tone="caution"] {
+  border-color: color-mix(in oklch, var(--stella-warning-ink) 35%, transparent);
+  color: var(--stella-warning-ink);
+  background: color-mix(in oklch, var(--stella-warning-ink) 8%, transparent);
+}
+
+.dark .sc-badge[data-tone="mutating"],
+.dark .sc-badge[data-tone="caution"] {
+  border-color: color-mix(in oklch, var(--stella-warning) 35%, transparent);
+  color: var(--stella-warning);
+  background: color-mix(in oklch, var(--stella-warning) 10%, transparent);
+}
+
+/* ── tool cards ───────────────────────────────────────────────────────────
+ * The left rule repeats the badge as shape rather than text, so the
+ * read-only/mutating partition survives a squint. Color is never the sole
+ * cue — the badge always spells it out. */
+
+.sc-option {
+  container-type: inline-size;
+}
+
+.sc-tool {
+  border-left-width: 3px;
+  container-type: inline-size;
+}
+.sc-tool[data-access="read"] {
+  border-left-color: var(--color-fd-border);
+}
+.sc-tool[data-access="mutating"] {
+  border-left-color: color-mix(in oklch, var(--stella-warning-ink) 55%, transparent);
+}
+.dark .sc-tool[data-access="mutating"] {
+  border-left-color: color-mix(in oklch, var(--stella-warning) 55%, transparent);
+}
+
+.sc-tool-name {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-fd-foreground);
+  overflow-wrap: anywhere;
+  /* Fumadocs styles bare <code>; this is a card heading, not inline code. */
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+.sc-tool-when {
+  margin: 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.8125rem;
+}
+
+.sc-tool-when-label {
+  font-weight: 600;
+  color: var(--color-fd-foreground);
+}
+
+/* Not every table should become a card: a genuine numeric matrix (the pricing
+ * catalog) is read *down* its columns, which cards destroy. Those stay tables.
+ * Fumadocs already wraps every MDX table in an `overflow-auto` div, so the page
+ * body never scrolls sideways on its own — nothing to add here. */
+
+/* ───────────────────────────────────────────────────────────────────────────
  * Landing page (the (home) route only). Pure-CSS, namespaced `lp-*`.
  * ─────────────────────────────────────────────────────────────────────────── */
 

--- a/website/src/components/cards.tsx
+++ b/website/src/components/cards.tsx
@@ -1,0 +1,232 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/**
+ * Card primitives for the docs — the mobile-first replacement for reference
+ * tables.
+ *
+ * Why cards at all: a five-column table is a fine desktop artifact and a bad
+ * phone one. It either overflows the viewport or squeezes every column to two
+ * words, and on a narrow screen the reader loses the header row long before
+ * they reach the cell that mattered. A card carries its own labels, so it reads
+ * the same at 380px and 1400px — and it stacks instead of scrolling sideways.
+ *
+ * Three shapes, all built on the same `sc-grid`:
+ * - `ProviderCard` — logo lockup + the facts you need to start (env var,
+ *   default model, wire dialect).
+ * - `ToolCard`     — tool name in mono, a read-only/mutating badge, one line
+ *   of prose.
+ * - `SpecCard`     — the generic escape hatch: a title, optional badge, prose,
+ *   and an arbitrary label/value list.
+ *
+ * Styles live in `src/app/global.css` under the `sc-` (stella card) prefix
+ * rather than in a `<style>` tag here, so a page rendering forty cards emits
+ * one stylesheet instead of forty. Every color is a Fumadocs or brand token —
+ * no hex literals — so all three invert with the theme.
+ */
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Grid
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+type GridSize = "sm" | "md" | "lg";
+
+/**
+ * Responsive card grid. `size` sets the *minimum* column width, and the grid
+ * fits as many as the container allows — so the column count falls out of the
+ * viewport instead of being hardcoded per breakpoint. Below the minimum it is
+ * a single stacked column, which is the phone case.
+ */
+export function CardGrid({
+  children,
+  size = "md",
+}: {
+  children: ReactNode;
+  size?: GridSize;
+}) {
+  return <div className={`sc-grid sc-grid-${size}`}>{children}</div>;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Shared pieces
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * A label/value row inside a card. `mono` is the default because these values
+ * are overwhelmingly identifiers you will type or paste — env vars, model ids,
+ * file paths — and a proportional face makes `l`/`1` and `O`/`0` ambiguous in
+ * exactly the strings where that costs you a failed command.
+ */
+export interface CardMeta {
+  label: string;
+  value: ReactNode;
+  /** Set false for prose values (a wire-dialect name, a sentence). */
+  mono?: boolean;
+}
+
+function MetaList({ items }: { items: CardMeta[] }) {
+  if (items.length === 0) return null;
+  return (
+    <dl className="sc-meta">
+      {items.map((item) => (
+        <div className="sc-meta-row" key={item.label}>
+          <dt className="sc-meta-label">{item.label}</dt>
+          <dd className={item.mono === false ? "sc-meta-value" : "sc-meta-value sc-mono"}>
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/**
+ * Status badge. `tone` is semantic, not decorative: `mutating` and `caution`
+ * borrow the same functional amber the callouts use, because "this tool can
+ * change your files" is a warning, not a label. Everything else stays neutral
+ * so the amber keeps meaning something.
+ */
+export function Badge({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "read" | "mutating" | "caution";
+}) {
+  return (
+    <span className="sc-badge" data-tone={tone}>
+      {children}
+    </span>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Cards
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Generic card. When `href` is set the whole card is the link target — a
+ * 300x160px tap target instead of a 12-character one, which is the difference
+ * between usable and not on a phone.
+ */
+export function SpecCard({
+  title,
+  href,
+  badge,
+  logo,
+  children,
+  meta = [],
+}: {
+  /**
+   * Optional: a provider card's identity is its logo lockup, which already
+   * contains the wordmark. Repeating the name as text under it is noise, and
+   * the lockup carries its own `aria-label`, so nothing is lost.
+   */
+  title?: ReactNode;
+  href?: string;
+  badge?: ReactNode;
+  /** The card's visual identity — a provider lockup, an icon. */
+  logo?: ReactNode;
+  children?: ReactNode;
+  meta?: CardMeta[];
+}) {
+  const body = (
+    <>
+      {logo ? <div className="sc-card-logo">{logo}</div> : null}
+      {title || badge ? (
+        <div className="sc-card-head">
+          {title ? <span className="sc-card-title">{title}</span> : <span />}
+          {badge}
+        </div>
+      ) : null}
+      {children ? <div className="sc-card-body">{children}</div> : null}
+      <MetaList items={meta} />
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link className="sc-card sc-card-link" href={href}>
+        {body}
+      </Link>
+    );
+  }
+  return <div className="sc-card">{body}</div>;
+}
+
+/**
+ * One CLI flag, subcommand, or settings key.
+ *
+ * Almost every command page carried a two-column `| Flag | Meaning |` table.
+ * Two columns survive a phone better than five, but barely: the flag names are
+ * long and unbreakable, so the first column either wraps mid-identifier or
+ * shoves the meaning into a 12-character gutter. A card gives the name its own
+ * line and the prose the full width.
+ *
+ * `defaultValue` is a distinct slot rather than a sentence in the description
+ * because "what happens if I don't pass this" is the question a flag reference
+ * is most often opened to answer, and it should not need reading a paragraph.
+ */
+export function OptionCard({
+  name,
+  defaultValue,
+  required,
+  children,
+}: {
+  name: string;
+  defaultValue?: string;
+  required?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="sc-card sc-option">
+      <div className="sc-card-head">
+        <code className="sc-tool-name">{name}</code>
+        {required ? <Badge tone="caution">Required</Badge> : null}
+      </div>
+      <div className="sc-card-body">{children}</div>
+      {defaultValue ? (
+        <p className="sc-tool-when">
+          <span className="sc-tool-when-label">Default</span>{" "}
+          <code className="sc-mono">{defaultValue}</code>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One tool in the built-in catalog. `access` drives both the badge and the
+ * card's left rule, so the read-only/mutating split survives a squint — the
+ * partition matters (read-only tools are speculative-eligible and permission
+ * decisions hang off it), and it should not require reading a table column.
+ */
+export function ToolCard({
+  name,
+  access,
+  children,
+  when,
+}: {
+  name: string;
+  access: "read" | "mutating";
+  children: ReactNode;
+  /** For conditionally-registered tools: what has to be true for it to exist. */
+  when?: ReactNode;
+}) {
+  return (
+    <div className="sc-card sc-tool" data-access={access}>
+      <div className="sc-card-head">
+        <code className="sc-tool-name">{name}</code>
+        <Badge tone={access === "read" ? "read" : "mutating"}>
+          {access === "read" ? "Read-only" : "Mutating"}
+        </Badge>
+      </div>
+      <div className="sc-card-body">{children}</div>
+      {when ? (
+        <p className="sc-tool-when">
+          <span className="sc-tool-when-label">Appears when</span> {when}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/website/src/components/diagrams.tsx
+++ b/website/src/components/diagrams.tsx
@@ -58,6 +58,70 @@ function Defs() {
   );
 }
 
+/**
+ * A labelled box. Nearly every diagram below is boxes-and-wires, and hand-
+ * writing the rect/label/sub triple three times per diagram is where typos in
+ * `textAnchor` and off-by-one `y` offsets come from.
+ */
+function Node({
+  x,
+  y,
+  w = 150,
+  h = 52,
+  label,
+  sub,
+  accent = false,
+  pulse = false,
+}: {
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  label: string;
+  sub?: string;
+  accent?: boolean;
+  pulse?: boolean;
+}) {
+  const cx = x + w / 2;
+  // With a sub-label the pair is centered as a block; alone, the label centers
+  // on the box itself.
+  const labelY = sub ? y + h / 2 - 2 : y + h / 2 + 4;
+  return (
+    <g>
+      <rect
+        className={`${accent ? "sdg-box-accent" : "sdg-box"}${pulse ? " sdg-pulse" : ""}`}
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={10}
+      />
+      <text className="sdg-label" x={cx} y={labelY} textAnchor="middle">
+        {label}
+      </text>
+      {sub && (
+        <text className="sdg-sub" x={cx} y={y + h / 2 + 15} textAnchor="middle">
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}
+
+/** A wire with its animated flow line laid over it, arrowhead at the end. */
+function Wire({ d, slow = false, arrow = true }: { d: string; slow?: boolean; arrow?: boolean }) {
+  return (
+    <g>
+      <path className="sdg-wire" d={d} />
+      <path
+        className={`sdg-flow${slow ? " sdg-flow-slow" : ""}`}
+        d={d}
+        markerEnd={arrow ? "url(#sdg-arrow)" : undefined}
+      />
+    </g>
+  );
+}
+
 /** Landing page: you → stella → your provider, telemetry staying local. */
 export function HeroFlowDiagram() {
   return (
@@ -198,6 +262,170 @@ export function FleetFanoutDiagram() {
       <circle className="sdg-dot sdg-pulse" cx="648" cy="90" r="7" />
       <text className="sdg-label" x="648" y="66" textAnchor="middle">review</text>
       <text className="sdg-sub" x="648" y="118" textAnchor="middle">merge on your terms</text>
+    </svg>
+  );
+}
+
+/** Getting started: the four commands between an empty shell and a shipped change. */
+export function QuickstartDiagram() {
+  const steps: [string, string][] = [
+    ["install", "one curl | sh"],
+    ["authenticate", "export one key"],
+    ["init", "learn the repo"],
+    ["run", "ship a change"],
+  ];
+  return (
+    <svg className="sdg" viewBox="0 0 720 132" role="img" aria-label="Four steps: install, authenticate, init, run.">
+      <title>From empty shell to first change</title>
+      <style>{STYLE}</style>
+      <Defs />
+      {steps.map(([label, sub], i) => {
+        const x = 16 + i * 174;
+        return (
+          <g key={label}>
+            <Node x={x} y={32} w={150} h={56} label={label} sub={sub} accent={i === 3} />
+            {i < steps.length - 1 && <Wire d={`M${x + 150} 60 H${x + 172}`} />}
+          </g>
+        );
+      })}
+      <text className="sdg-sub" x="360" y="116" textAnchor="middle">
+        about two minutes, end to end — no account, no proxy
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Credentials: the five sources, tried top to bottom, first hit wins. Drawn as
+ * a ladder rather than a list because the *fall-through* is the point — the
+ * rungs are ordered, and any one of them can end the search.
+ */
+export function CredentialChainDiagram() {
+  const rungs = [
+    "--api-key flag (needs an explicit --model)",
+    "the provider's env var, plus its aliases",
+    "settings.json — providers.<id>.api_key",
+    "~/.stella/credentials.toml",
+    "interactive prompt — saved, so it asks once",
+  ];
+  return (
+    <svg className="sdg" viewBox="0 0 720 228" role="img" aria-label="Five credential sources tried in order — flag, environment variable, settings.json, credentials.toml, interactive prompt — and the first one that resolves is used.">
+      <title>The credential chain</title>
+      <style>{STYLE}</style>
+      <Defs />
+      {/* the fall-through spine: tried in order, top to bottom */}
+      <path className="sdg-wire" d="M28 24 V196" />
+      <path className="sdg-flow sdg-flow-slow" d="M28 24 V196" markerEnd="url(#sdg-arrow)" />
+      {rungs.map((text, i) => {
+        const y = 16 + i * 40;
+        return (
+          <g key={text}>
+            <circle className="sdg-dot" cx={28} cy={y + 15} r={8} />
+            <text className="sdg-sub" x={28} y={y + 19} textAnchor="middle" fill="var(--color-fd-background)" fontWeight={700}>
+              {i + 1}
+            </text>
+            <rect className="sdg-box" x={48} y={y} width={312} height={30} rx={8} />
+            <text className="sdg-sub" x={62} y={y + 19}>{text}</text>
+            {/* every rung can exit to "resolved" — that is what first-hit-wins means */}
+            <path className="sdg-wire" d={`M360 ${y + 15} C410 ${y + 15} 410 122 458 122`} />
+          </g>
+        );
+      })}
+      <path className="sdg-flow" d="M360 31 C410 31 410 122 458 122" markerEnd="url(#sdg-arrow)" />
+      <Node x={458} y={96} w={230} h={52} label="key resolved" sub="first hit wins — the rest are skipped" accent pulse />
+      <text className="sdg-sub" x={204} y={214} textAnchor="middle">
+        nothing below the first hit is ever read
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Settings scopes: three files merged per key, with the org layer acting as a
+ * ceiling rather than another peer. The asymmetry is the whole diagram — a
+ * cascade where one layer can only ever subtract.
+ */
+export function SettingsCascadeDiagram() {
+  const layers: [string, string, boolean][] = [
+    ["org-managed", "a ceiling — off stays off", true],
+    ["project — .stella/settings.json", "beats user, for keys it is trusted with", false],
+    ["user — ~/.stella/settings.json", "your defaults, always applied", false],
+  ];
+  return (
+    <svg className="sdg" viewBox="0 0 720 216" role="img" aria-label="Org-managed, project, and user settings merge per key into the effective settings; the org layer is a ceiling that lower scopes can narrow but never re-open.">
+      <title>How settings scopes merge</title>
+      <style>{STYLE}</style>
+      <Defs />
+      {layers.map(([label, sub, accent], i) => {
+        const y = 20 + i * 64;
+        return (
+          <g key={label}>
+            <Node x={24} y={y} w={330} h={52} label={label} sub={sub} accent={accent} />
+            <Wire d={`M354 ${y + 26} C420 ${y + 26} 420 110 466 110`} slow={i !== 1} />
+          </g>
+        );
+      })}
+      <Node x={466} y={84} w={224} h={52} label="effective settings" sub="merged per key" accent pulse />
+      <text className="sdg-sub" x="360" y="204" textAnchor="middle">
+        most specific wins — except that an org &ldquo;off&rdquo; can be narrowed further, never re-opened
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * The permission gate a tool call passes through. Both exits are drawn: the
+ * refusal is a real, documented outcome, not an error path to hide.
+ */
+export function PermissionGateDiagram() {
+  return (
+    <svg className="sdg" viewBox="0 0 720 200" role="img" aria-label="A tool call passes through the PreToolUse hook and the permission rules; allowed calls execute and fire PostToolUse, denied calls come back to the model as a refusal.">
+      <title>How a tool call is gated</title>
+      <style>{STYLE}</style>
+      <Defs />
+      <Node x={12} y={74} w={128} h={52} label="tool call" sub="the model asks" />
+      <Node x={168} y={74} w={150} h={52} label="PreToolUse" sub="your hook may veto" />
+      <Node x={346} y={74} w={150} h={52} label="permission" sub="rules + settings" accent />
+      <Wire d="M140 100 H166" />
+      <Wire d="M318 100 H344" />
+      {/* allow */}
+      <Wire d="M496 92 C536 92 536 46 562 46" />
+      <Node x={562} y={20} w={142} h={52} label="execute" sub="then PostToolUse" accent />
+      <text className="sdg-sub" x={528} y={62}>allow</text>
+      {/* deny */}
+      <Wire d="M496 108 C536 108 536 154 562 154" slow />
+      <Node x={562} y={128} w={142} h={52} label="refused" sub="returned to the model" />
+      <text className="sdg-sub" x={528} y={150}>deny</text>
+      <text className="sdg-sub" x="248" y="188" textAnchor="middle">
+        enforced at the tool boundary — never by prompt discipline
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Telemetry: where a run's numbers go. The point of the picture is the absent
+ * arrow — there is no edge leaving the machine, so there is nothing to opt out
+ * of.
+ */
+export function TelemetryFlowDiagram() {
+  return (
+    <svg className="sdg" viewBox="0 0 720 196" role="img" aria-label="Each session turn writes a receipt into .stella/ on your disk, which stella stats and the observatory read back. No arrow leaves the machine.">
+      <title>Where telemetry goes</title>
+      <style>{STYLE}</style>
+      <Defs />
+      <Node x={12} y={70} w={150} h={54} label="a session turn" sub="tokens · tools · files" />
+      <Node x={196} y={70} w={150} h={54} label="a receipt" sub="one row, per turn" accent pulse />
+      <Node x={380} y={70} w={158} h={54} label=".stella/" sub="on your disk, as JSON" />
+      <Wire d="M162 97 H194" />
+      <Wire d="M346 97 H378" />
+      <Wire d="M538 84 C566 84 566 48 592 48" />
+      <Wire d="M538 110 C566 110 566 146 592 146" slow />
+      <Node x={592} y={22} w={116} h={52} label="stella stats" sub="the numbers" />
+      <Node x={592} y={120} w={116} h={52} label="observatory" sub="the dashboard" />
+      <text className="sdg-sub" x="275" y="184" textAnchor="middle">
+        no arrow leaves this picture — there is no endpoint, so there is nothing to opt out of
+      </text>
     </svg>
   );
 }

--- a/website/src/components/provider-cards.tsx
+++ b/website/src/components/provider-cards.tsx
@@ -1,0 +1,158 @@
+import { CardGrid, SpecCard } from "@/components/cards";
+import { ProviderLogo } from "@/components/provider-logos";
+
+/**
+ * The provider catalog, rendered as cards.
+ *
+ * This file is the single place the per-provider facts live. They used to be
+ * repeated in a five-column table on the API Providers index *and* again in
+ * prose on `getting-started/providers`, which is how the two drifted: a table
+ * cell is invisible to every check the repo runs, so a renamed env var is only
+ * ever found by a reader who tries it and fails. One typed record, two call
+ * sites.
+ *
+ * The wire `dialect` is worth carrying per provider: it is what "vendor-
+ * agnostic" actually cashes out to. Stella speaks each vendor's own protocol
+ * rather than normalizing everything through one OpenAI-shaped adapter, so the
+ * dialect tells you which provider quirks (thinking blocks, cache-control,
+ * tool-call shapes) are native rather than emulated.
+ */
+
+export interface ProviderSpec {
+  /** Registry id — the `provider` half of `--model provider/model`. */
+  id: string;
+  name: string;
+  href: string;
+  /** One line on when you would pick this provider over the others. */
+  blurb: string;
+  /** The primary credential variable; aliases in parentheses. */
+  env: string;
+  defaultModel: string;
+  dialect: string;
+}
+
+export const PROVIDER_CATALOG: ProviderSpec[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    href: "/docs/api-providers/anthropic",
+    blurb: "The strongest coding and agentic models in the catalog, with first-class prompt caching.",
+    env: "ANTHROPIC_API_KEY",
+    defaultModel: "claude-fable-5",
+    dialect: "Anthropic Messages",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    href: "/docs/api-providers/openai",
+    blurb: "A strong worker and the usual second family for cross-family judging.",
+    env: "OPENAI_API_KEY",
+    defaultModel: "gpt-5.5",
+    dialect: "OpenAI Responses",
+  },
+  {
+    id: "gemini",
+    name: "Google Gemini",
+    href: "/docs/api-providers/gemini",
+    blurb: "Very large context windows at a low price — the long-document worker.",
+    env: "GEMINI_API_KEY (GOOGLE_API_KEY)",
+    defaultModel: "gemini-3-pro",
+    dialect: "Gemini generateContent",
+  },
+  {
+    id: "vertex",
+    name: "Google Vertex AI",
+    href: "/docs/api-providers/vertex",
+    blurb: "The same Gemini models billed through your GCP project, for enterprises that require it.",
+    env: "VERTEX_ACCESS_TOKEN",
+    defaultModel: "gemini-3-pro",
+    dialect: "Gemini via Vertex",
+  },
+  {
+    id: "bedrock",
+    name: "Amazon Bedrock",
+    href: "/docs/api-providers/bedrock",
+    blurb: "Claude and friends inside your AWS account, on your existing IAM and billing.",
+    env: "AWS_ACCESS_KEY_ID",
+    defaultModel: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    dialect: "Bedrock Converse",
+  },
+  {
+    id: "xai",
+    name: "xAI",
+    href: "/docs/api-providers/xai",
+    blurb: "Grok, over the OpenAI-compatible dialect.",
+    env: "XAI_API_KEY",
+    defaultModel: "grok-4",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    href: "/docs/api-providers/deepseek",
+    blurb: "Very cheap per token — the reference budget worker.",
+    env: "DEEPSEEK_API_KEY",
+    defaultModel: "deepseek-chat",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "zai",
+    name: "Z.ai",
+    href: "/docs/api-providers/zai",
+    blurb: "GLM models, and a flat-rate coding plan that decouples cost from token count.",
+    env: "ZAI_API_KEY",
+    defaultModel: "glm-5.2",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    href: "/docs/api-providers/openrouter",
+    blurb: "One key, hundreds of models — the gateway when you would rather not manage keys.",
+    env: "OPENROUTER_API_KEY",
+    defaultModel: "openrouter/auto",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "local",
+    name: "Local server",
+    href: "/docs/api-providers/local",
+    blurb: "Ollama, llama.cpp, vLLM, LM Studio — anything that serves the OpenAI shape. No key, no egress.",
+    env: "none (optional LOCAL_API_KEY)",
+    defaultModel: "you choose",
+    dialect: "OpenAI-compatible",
+  },
+];
+
+/**
+ * Every supported provider as a card grid.
+ *
+ * `only` narrows the set for pages that discuss a subset (the getting-started
+ * walkthrough shows the three single-key providers, not all ten), keeping those
+ * pages sourced from this same record instead of re-typing the facts.
+ */
+export function ProviderGrid({ only }: { only?: string[] }) {
+  const providers = only
+    ? (only.map((id) => PROVIDER_CATALOG.find((p) => p.id === id)).filter(Boolean) as ProviderSpec[])
+    : PROVIDER_CATALOG;
+
+  return (
+    <CardGrid size="md">
+      {providers.map((p) => (
+        <SpecCard
+          key={p.id}
+          href={p.href}
+          logo={<ProviderLogo id={p.id} size={24} />}
+          meta={[
+            { label: "id", value: p.id },
+            { label: "Env var", value: p.env },
+            { label: "Default", value: p.defaultModel },
+            { label: "Dialect", value: p.dialect, mono: false },
+          ]}
+        >
+          {p.blurb}
+        </SpecCard>
+      ))}
+    </CardGrid>
+  );
+}

--- a/website/src/mdx-components.tsx
+++ b/website/src/mdx-components.tsx
@@ -1,27 +1,51 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 
+import { Badge, CardGrid, OptionCard, SpecCard, ToolCard } from "@/components/cards";
 import {
+  CredentialChainDiagram,
   FleetFanoutDiagram,
   HeroFlowDiagram,
+  PermissionGateDiagram,
   PipelineFlowDiagram,
+  QuickstartDiagram,
   RecallLoopDiagram,
+  SettingsCascadeDiagram,
+  TelemetryFlowDiagram,
 } from "@/components/diagrams";
+import { ProviderGrid } from "@/components/provider-cards";
 import { ProviderLogo, ProviderMark } from "@/components/provider-logos";
 
 /**
- * MDX component map. The Fumadocs defaults (callouts, tabs, cards, code
- * blocks, headings) plus Stella's own bespoke pieces: the animated inline
- * SVG diagrams and the provider logomarks — registered globally so any MDX
- * page can use them without imports.
+ * MDX component map. The Fumadocs defaults (callouts, tabs, cards, code blocks
+ * with copy buttons, headings) plus Stella's own bespoke pieces — registered
+ * globally so any MDX page can use them without an import line.
+ *
+ * The card primitives are here for a specific reason: a wide reference table is
+ * the docs' worst mobile surface, and every one that becomes a `CardGrid` is a
+ * page that stops scrolling sideways on a phone.
  */
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    // Diagrams
     HeroFlowDiagram,
     PipelineFlowDiagram,
     RecallLoopDiagram,
     FleetFanoutDiagram,
+    QuickstartDiagram,
+    CredentialChainDiagram,
+    SettingsCascadeDiagram,
+    PermissionGateDiagram,
+    TelemetryFlowDiagram,
+    // Cards — the mobile-first replacement for reference tables
+    CardGrid,
+    SpecCard,
+    ToolCard,
+    OptionCard,
+    Badge,
+    ProviderGrid,
+    // Logos
     ProviderLogo,
     ProviderMark,
     ...components,


### PR DESCRIPTION
## What & why

The docs' reference tables were a desktop-only artifact. On a phone a five-column table
either overflows the viewport or crushes every column to two words, and the header row
scrolls out of sight exactly when you need the cell it labels. This replaces them with
card grids that carry their own labels, so a page reads the same at 380px and 1400px.

Auditing every page against the Rust source in order to do that turned up substantial
drift — including three real defects.

### Defects fixed

- **`stella --model openrouter/auto` was a documented command that fails.** `--model`
  splits on the first `/` (`config.rs:728`), so it sends the wire slug `auto`, which
  OpenRouter does not serve. Every OpenRouter id is `vendor/model`, so the correct form
  is `openrouter/openrouter/auto`. `settings_check.rs` already had a dedicated validator
  for this exact fingerprint — the docs were shipping the shape it warns about.
- **`enable_recap` never reached the runtime.** `overlay_scope` copied every other
  top-level settings key and silently dropped this one, so `"enable_recap": "on"` parsed,
  merged to `None`, and did nothing regardless of scope. Existing coverage missed it
  because it exercised `recap_enabled` on a directly-deserialized `Settings` — the one
  path where the field was never lost.
- **`stella usage prune --gc-deleted`'s help stated the opposite of its behavior.** It
  said an unmounted volume reads as "gone"; `checkout_is_deleted` deliberately treats a
  missing parent as an absent volume and refuses to GC.

### Presentation

- 46 tool cards, 10 provider cards with real vendor logos, the command index as a linked
  card grid, and ~48 flag/subcommand tables converted across `commands/`.
- Genuine numeric matrices (model pricing: context / $in / $out / $cached) stay tables —
  those are read *down* their columns and cards destroy the comparison.
- Five new diagrams: credential chain, settings cascade, permission gate, telemetry flow,
  quickstart.
- Card primitives in `website/src/components/cards.tsx`; styles under the `sc-` prefix in
  `global.css`. The grid is `auto-fill` over a min column width rather than a breakpoint
  ladder, so column count falls out of available width with no media queries to keep in
  sync.

### Two new guardrails

The audit's one fully-accurate surface was the tool catalog — the only one a test already
pinned. So:

- `docs_in_sync.rs` now parses `<ToolCard>` elements instead of markdown table rows. Same
  gate, new syntax. Unknown access markers panic rather than skip, so a dropped card
  cannot turn real drift into a vacuous pass.
- New `provider_cards_match_the_registry` pins the provider cards' `id`, env var (primary
  *and* aliases), default model, and href to `PROVIDERS`. The hand-written table it
  replaced had already drifted: Bedrock's "default model" cell read `Claude via Converse`,
  a wire dialect rather than a slug.

### Other corrections, all verified against source

`anthropic.mdx`'s reasoning section described a legacy wire shape (it is adaptive thinking
now, and `temperature`/`top_p`/`top_k` are dropped *unconditionally* — the old "set
`reasoning: off` to get temperature back" advice did nothing); `models.mdx` documented a
`credentials.toml` blind spot that was explicitly fixed and regression-guarded;
`toolResult` is not clipped; settings sections 6 → 10 (`enable_recap`, `context`,
`context_providers`, `enterprise_telemetry` were undocumented anywhere); store tables
17 → 21; dashboard tabs 8 → 9; `--budget` *does* cap OpenRouter runs (the gateway's
reported cost is authoritative via `with_usage_accounting`); the files-touched jq path is
`.files_touched.files_touched`, not `.files_touched`; `grok-4` retires **2026-08-15**
and ignores effort; effort is silently dropped on bedrock, deepseek, and local; fleet
claims are exact strings, so the old directory-claim example could not work.

README's provider table carried two of the same drifts (OpenRouter `auto`, Bedrock's
dialect-as-slug) and is corrected too.

Closes #N

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

Three witnesses, each of which fails on `main`:

- `enable_recap_survives_the_scope_merge` — goes through `Settings::load` the way the
  binary does, rather than the accessor path that hid the bug. I confirmed it fails before
  the `merge.rs` fix (merged value was `None`).
- `provider_cards_match_the_registry` — mutation-tested: flipping the doc's
  `claude-fable-5` to `claude-fable-4` fails with a named message rather than passing.
- `an_unknown_access_marker_is_a_hard_failure` — the parser rewrite's own guard, so a
  malformed `<ToolCard>` can never silently shrink the audited set.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 3617 passed, 0 failed
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
-  CLA signed
-  `Closes #N` appears **both** above and as a commit trailer

Also verified: 91 pages build; **0 broken links or anchors** across 80 pages (checked with
a github-slugger-compatible checker, then confirmed against the rendered HTML); no
untagged code fences remain; the only surviving tables are the intentional pricing
matrices.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

**`Closes #N` is a placeholder** — I did not have an issue number. Please set it or delete
the line; note the template's warning that it must also appear as a commit trailer to
close on squash.

**The `enable_recap` merge fix is a behavior change, not a docs change.** It is one line
plus tests, and I made it because the alternative was documenting a setting that provably
does nothing. If you would rather ship it separately, it is isolated in `merge.rs` and
easy to split out.

**Mobile verification was measured, not eyeballed.** I measured the shared `.sc-grid` rule
in a real browser at 360 / 414 / 600 / 900px: one column at all mobile widths, two at
900px, zero horizontal overflow, and the body never scrolls sideways. Every grid on the
site uses that same rule, so I verified the rule rather than each page — worth a spot-check
on a device if you want belt-and-braces.

**One thing I corrected about my own reporting:** syntax highlighting was already working
site-wide via Fumadocs/shiki. My first probe used a bad CSS selector (shiki emits
`--shiki-light`/`--shiki-dark` custom properties, not `color`) and I briefly believed it
was broken. The only real gap was a single untagged fence, now fixed.

Deferred: `stella-tools/tests/docs_in_sync.rs`'s derive-and-assert pattern would extend
cheaply to `Settings`' serde keys, `ddl::TABLES`, and the observatory's `data-tab` list —
every drifted item in this PR lived in a doc that pattern doesn't yet reach.
