### PR TITLE
fix: repair main — Phases 2 and 3 each shipped their own lifecycle reader

### DIFF
--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -208,7 +208,7 @@ impl SessionMemory {
                     ab_suppressed: false,
                     ab_turn: 0,
                     // Phase 3 (#714)
-                    lifecycle_enabled: tuning::lifecycle_enabled(workspace_root),
+                    lifecycle_enabled: tuning::session_lifecycle_enabled(workspace_root),
                 })
             }
             Err(e) => {

--- a/stella-cli/src/memory/tuning.rs
+++ b/stella-cli/src/memory/tuning.rs
@@ -22,15 +22,15 @@ pub(super) fn session_retrieval_settings(workspace_root: &std::path::Path) -> Re
         .unwrap_or_default()
 }
 
-/// Phase 3 (#714): whether the adaptive-context lifecycle is on for this
-/// session.
+/// Whether `context.lifecycle.enabled` is on for this session (#713, #714).
 ///
-/// Defaults to `false` — the shipped default — and degrades to `false` on an
-/// unreadable settings file. That posture is the opposite of the retrieval read
-/// above and deliberately so: this flag switches the learning loop from the
-/// path users are running today onto a new one, and the safe answer to "I could
-/// not tell" is "keep doing what already works".
-pub(super) fn lifecycle_enabled(workspace_root: &std::path::Path) -> bool {
+/// Degrades to `false` on an unreadable settings file. That is the setting's
+/// own default, and it is the opposite posture to the retrieval read above,
+/// deliberately: this flag moves both the recall plane and the learning loop
+/// off the paths users run today. Failing *open* would turn a typo elsewhere in
+/// the file into silently enabling a lifecycle nobody asked for, and the safe
+/// answer to "I could not tell" is "keep doing what already works".
+pub fn session_lifecycle_enabled(workspace_root: &std::path::Path) -> bool {
     crate::settings::Settings::load(workspace_root)
         .ok()
         .and_then(|s| s.context)


### PR DESCRIPTION
**`main` does not compile.**

```
error[E0432]: unresolved import `tuning::session_lifecycle_enabled`
  --> stella-cli/src/memory.rs:78:9
```

## Cause

Phase 2 (#738) and Phase 3 (#736) were built in parallel, and each independently needed to read `context.lifecycle.enabled`. Neither could see the other, so both wrote the reader — with a **byte-identical body** and the same fail-closed reasoning, differing only in name and visibility:

| | |
|---|---|
| Phase 3 | `pub(super) fn lifecycle_enabled(..)` |
| Phase 2 | `pub fn session_lifecycle_enabled(..)` |

Phase 3 merged first. Phase 2 merged second **from a rebase that predated it**, so `tuning.rs` kept Phase 3's function while `memory.rs` kept Phase 2's re-export of a name that no longer exists.

Neither PR was wrong, and neither conflicted textually with the `main` that existed when it merged.

## Fix

The resolution both branches were converging on anyway: one reader, `pub` because Phase 2's engine-config builder calls it from outside the module, documented with both phases' reasoning, and one call site updated.

## The pattern, since this is the third repair this week

- #739 — #733 moved `MemoryCmd`; #735 was cut from an older main and re-added it. Zero textual conflict, nine type errors.
- This one — same shape, one level down.

**Parallel branches that merge cleanly are not thereby compatible.** A branch that lands second is verified against the main it was *rebased onto*, not the main it *lands on*, and nothing in the tooling notices the difference. Re-verifying the second branch against the actual post-merge tree is the step that catches this, and it is far cheaper than a red main.

## Gate

`make gate` green: **exit 0, 3801 tests**, `check-file-size: OK — 475 Rust files, none over 1500 lines except 25 grandfathered (none grew).`