### PR TITLE
feat(context): ship the adaptive-context lifecycle on by default

### DIFF
--- a/docs/design/adaptive-context-plan.md
+++ b/docs/design/adaptive-context-plan.md
@@ -24,9 +24,14 @@ the layer that is supposed to make them accountable.
 ### Working rules
 
 - One phase, one branch, one PR. Never cross phases on a branch.
-- Behavior-changing work ships behind `context.lifecycle.enabled` (default off)
-  **except Phase 1**, which is defect repair and ships on — a bug fix behind a
-  flag is a bug that is still shipping.
+- Behavior-changing work ships behind `context.lifecycle.enabled`. Phase 1 was
+  defect repair and shipped on unconditionally — a bug fix behind a flag is a
+  bug that is still shipping. **The flag itself now defaults to on** (changed
+  after Phases 2 and 3 landed): a lifecycle nobody runs cannot be evaluated,
+  and the behavior-compatibility suite asserts every spec §8 guarantee on both
+  the typed and the opted-out path, so "on" is a claim with tests behind it
+  rather than a hope. Setting it `false` restores the previous behavior
+  wholesale.
 - `make gate` green before a phase is claimed done. Do not claim a gate passed
   without running it and reading the output.
 - No coordinates in any document this plan produces (spec §1).

--- a/stella-cli/src/memory/learning/guarantees.rs
+++ b/stella-cli/src/memory/learning/guarantees.rs
@@ -89,12 +89,12 @@ fn each_path(case: impl Fn(Loop)) {
 /// session reads at open. Writing real settings rather than reaching into the
 /// struct is deliberate: the flag's whole job is to be readable from a user's
 /// settings file, and a test that bypassed that would not prove it works.
-fn enable_lifecycle(root: &Path) {
+fn set_lifecycle(root: &Path, enabled: bool) {
     let dir = root.join(".stella");
     std::fs::create_dir_all(&dir).expect("stella dir");
     std::fs::write(
         dir.join("settings.json"),
-        r#"{"context":{"lifecycle":{"enabled":true}}}"#,
+        format!(r#"{{"context":{{"lifecycle":{{"enabled":{enabled}}}}}}}"#),
     )
     .expect("write settings");
 }
@@ -109,9 +109,10 @@ fn session_with_workspace_skills(
     path: Loop,
     include_workspace_skills: bool,
 ) -> SessionMemory {
-    if path == Loop::Typed {
-        enable_lifecycle(root);
-    }
+    // Both arms write settings explicitly. The lifecycle now ships ON, so
+    // "write nothing and get the lexical loop" is no longer true — a lexical
+    // case has to opt out in the same way a user would.
+    set_lifecycle(root, path == Loop::Typed);
     SessionMemory::open_with_workspace_skills(root, false, include_workspace_skills)
         .expect("session memory")
 }
@@ -570,7 +571,8 @@ fn the_typed_path_records_why_it_promoted() {
 }
 
 /// …and the lexical path records nothing, so turning the flag off really does
-/// mean "no ledger writes", not "quieter ledger writes".
+/// mean "no ledger writes", not "quieter ledger writes". Since the lifecycle
+/// now ships on, this is the opt-out path rather than the default one.
 #[test]
 fn the_lexical_path_writes_nothing_to_the_ledger() {
     let dir = workspace_with_log(&three_occurrences_of(RECURRING));
@@ -580,7 +582,7 @@ fn the_lexical_path_writes_nothing_to_the_ledger() {
     assert_eq!(
         memory.store.record_counts().expect("counts"),
         Vec::new(),
-        "the default path touched the lifecycle ledger"
+        "the opted-out path touched the lifecycle ledger"
     );
     assert!(
         !skill_files(dir.path()).is_empty(),
@@ -740,7 +742,7 @@ fn a_well_evidenced_rule_activates_and_reaches_the_loader() {
 }
 
 /// The rules miner is off with the flag off, exactly like the rest of the
-/// typed path. Nothing appears in `.stella/rules` on the default path.
+/// typed path. Nothing appears in `.stella/rules` when a user opts out.
 #[test]
 fn the_lexical_path_mines_no_rules() {
     let strong = "Always run the database migration before the integration suite starts.";
@@ -750,6 +752,6 @@ fn the_lexical_path_mines_no_rules() {
     memory.auto_create_skills(&log_path(dir.path()), true);
     assert!(
         !dir.path().join(".stella/rules").exists(),
-        "the default path wrote a rule"
+        "the opted-out path wrote a rule"
     );
 }

--- a/stella-cli/src/memory/tuning.rs
+++ b/stella-cli/src/memory/tuning.rs
@@ -31,10 +31,17 @@ pub(super) fn session_retrieval_settings(workspace_root: &std::path::Path) -> Re
 /// the file into silently enabling a lifecycle nobody asked for, and the safe
 /// answer to "I could not tell" is "keep doing what already works".
 pub fn session_lifecycle_enabled(workspace_root: &std::path::Path) -> bool {
-    crate::settings::Settings::load(workspace_root)
-        .ok()
-        .and_then(|s| s.context)
-        .is_some_and(|c| c.lifecycle.enabled)
+    let Ok(settings) = crate::settings::Settings::load(workspace_root) else {
+        // Unreadable or malformed. This is the one case that does NOT take the
+        // default: a file we could not parse may be the file in which someone
+        // turned the lifecycle off, and silently overriding an opt-out we
+        // failed to read is worse than leaving a default unapplied.
+        return false;
+    };
+    // An absent `context` block means "the defaults", not "off" — a workspace
+    // with no settings.json at all is the common case, and it must land on the
+    // shipped default like every other one.
+    settings.context.unwrap_or_default().lifecycle.enabled
 }
 
 /// Phase 3 (#714): the promotion thresholds gating when observations may become
@@ -52,4 +59,60 @@ pub(super) fn inferred_directive_promotion(
         .and_then(|s| s.context)
         .map(|c| c.promotion.inferred_directive)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::session_lifecycle_enabled;
+
+    /// The case that decides whether the flip actually shipped: a workspace
+    /// with no `settings.json` at all. The reader used to ask
+    /// `is_some_and(..)` on an `Option<ContextSettings>`, so an absent block
+    /// answered `false` no matter what the struct's default was — flipping
+    /// `LifecycleSettings::default()` alone would have left every real user off.
+    #[test]
+    fn a_workspace_with_no_settings_file_gets_the_lifecycle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            session_lifecycle_enabled(dir.path()),
+            "a fresh workspace must land on the shipped default"
+        );
+    }
+
+    /// An empty `context` block means "the defaults", not "off".
+    #[test]
+    fn an_empty_context_block_gets_the_lifecycle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stella = dir.path().join(".stella");
+        std::fs::create_dir_all(&stella).expect("stella dir");
+        std::fs::write(stella.join("settings.json"), r#"{"context":{}}"#).expect("write");
+        assert!(session_lifecycle_enabled(dir.path()));
+    }
+
+    /// An explicit opt-out is honored — the whole point of keeping the switch.
+    #[test]
+    fn an_explicit_false_turns_the_lifecycle_off() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stella = dir.path().join(".stella");
+        std::fs::create_dir_all(&stella).expect("stella dir");
+        std::fs::write(
+            stella.join("settings.json"),
+            r#"{"context":{"lifecycle":{"enabled":false}}}"#,
+        )
+        .expect("write");
+        assert!(!session_lifecycle_enabled(dir.path()));
+    }
+
+    /// A file we cannot parse is the one case that does not take the default:
+    /// it may be the file in which someone turned the lifecycle off, and
+    /// overriding an opt-out we failed to read is worse than leaving a default
+    /// unapplied.
+    #[test]
+    fn an_unparseable_settings_file_stays_off() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stella = dir.path().join(".stella");
+        std::fs::create_dir_all(&stella).expect("stella dir");
+        std::fs::write(stella.join("settings.json"), "{ not json").expect("write");
+        assert!(!session_lifecycle_enabled(dir.path()));
+    }
 }

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -138,10 +138,11 @@ pub struct Settings {
     /// changed, beside the file and cost panels. No model call. Default off.
     #[serde(default)]
     pub enable_recap: Option<Toggle>,
-    /// Adaptive-context lifecycle configuration (the `context` block). INERT
-    /// in Phase 0: deserialized, round-tripped, and merged, but read by no
-    /// code yet — `context.lifecycle.enabled` defaults `false`, which is what
-    /// preserves current behavior. `None` = the block was absent. Whole-block
+    /// Adaptive-context lifecycle configuration (the `context` block).
+    /// `context.lifecycle.enabled` defaults **`true`** — the lifecycle ships
+    /// on, and setting it `false` restores every pre-adaptive behavior.
+    /// `None` = the block was absent, which means the defaults apply, not that
+    /// the lifecycle is off. Whole-block
     /// last-wins across scopes (see [`Settings::overlay_scope`]). See
     /// [`ContextSettings`].
     #[serde(default)]

--- a/stella-cli/src/settings/context.rs
+++ b/stella-cli/src/settings/context.rs
@@ -23,8 +23,8 @@
 use serde::{Deserialize, Serialize};
 
 /// The `context` block of `settings.json`. All fields default, so `"context":
-/// {}` — or an absent block — yields the behavior-preserving defaults
-/// (lifecycle disabled, learning off, governance solo).
+/// {}` — or an absent block — yields the shipped defaults: the lifecycle **on**,
+/// learning off, governance solo.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct ContextSettings {
@@ -38,12 +38,21 @@ pub struct ContextSettings {
 }
 
 /// Master switch for the whole adaptive-context lifecycle.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LifecycleSettings {
-    /// `false` (default) preserves all pre-adaptive-context behavior: every
-    /// other field in the `context` block is ignored while this is off.
+    /// `true` (default) — the lifecycle ships on. Setting it `false` restores
+    /// every pre-adaptive-context behavior: the recall block is not
+    /// decomposed, no frame identity is recorded, and the learning loop runs
+    /// its lexical path. Every other field in the `context` block is ignored
+    /// while this is off.
     pub enabled: bool,
+}
+
+impl Default for LifecycleSettings {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 /// How much of the learning loop runs. Orthogonal to [`GovernanceMode`].
@@ -313,11 +322,12 @@ mod tests {
     }
 
     #[test]
-    fn empty_context_block_yields_behavior_preserving_defaults() {
+    fn empty_context_block_yields_the_shipped_defaults() {
         let s: Settings = serde_json::from_str(r#"{"context":{}}"#).expect("empty context parse");
         let ctx = s.context.expect("context present");
-        // The one field that gates behavior: disabled by default.
-        assert!(!ctx.lifecycle.enabled, "lifecycle must default disabled");
+        // The one field that gates behavior. It ships ON: an empty block is a
+        // request for the defaults, and the default is now the lifecycle.
+        assert!(ctx.lifecycle.enabled, "lifecycle must default enabled");
         assert_eq!(ctx.learning.mode, LearningMode::Off);
         assert_eq!(ctx.governance.mode, GovernanceMode::Solo);
         assert_eq!(ctx, ContextSettings::default());
@@ -327,8 +337,8 @@ mod tests {
     fn canonical_fixture_deserializes_to_the_documented_defaults() {
         let s: Settings = serde_json::from_str(FIXTURE).expect("fixture parse");
         let ctx = s.context.expect("fixture has a context block");
-        // Disabled-by-default lifecycle is what keeps behavior unchanged.
-        assert!(!ctx.lifecycle.enabled);
+        // The lifecycle ships on; the fixture documents that.
+        assert!(ctx.lifecycle.enabled);
         assert_eq!(ctx.learning.mode, LearningMode::Off);
         assert_eq!(ctx.governance.mode, GovernanceMode::Solo);
         assert_eq!(ctx.promotion.inferred_directive.min_observations, 3);

--- a/stella-cli/tests/fixtures/context_settings.json
+++ b/stella-cli/tests/fixtures/context_settings.json
@@ -1,7 +1,7 @@
 {
   "context": {
     "lifecycle": {
-      "enabled": false
+      "enabled": true
     },
     "learning": {
       "mode": "off"

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -195,9 +195,10 @@ pub struct EngineConfig {
     /// (the receipt is still valid — `(execution_id, step)` disambiguates
     /// within an execution).
     pub turn_instance: u32,
-    /// `context.lifecycle.enabled` — Phase 2 (#713). `false` (its own default)
-    /// preserves every pre-adaptive behavior; it gates only the compiled-frame
-    /// identity on this turn's step manifests.
+    /// `context.lifecycle.enabled` — Phase 2 (#713). Gates the compiled-frame
+    /// identity on this turn's step manifests. The setting ships on; this
+    /// field still defaults `false` so a programmatically-built config opts in
+    /// deliberately rather than inheriting a product default it never read.
     pub lifecycle_enabled: bool,
 }
 

--- a/stella-core/src/receipts.rs
+++ b/stella-core/src/receipts.rs
@@ -20,7 +20,7 @@
 //! content-addressed id and a byte-stable hash over what entered the prompt,
 //! excluding the accounting around it. ADR 0006 as amended: the compiled frame
 //! is this manifest extended, not a parallel aggregate. Gated on
-//! `context.lifecycle.enabled`, off by default.
+//! `context.lifecycle.enabled`, which ships on.
 
 use std::borrow::Cow;
 use std::collections::HashMap;


### PR DESCRIPTION
`context.lifecycle.enabled` now defaults to **`true`**. The whole lifecycle — decomposed recall, frame identity, recall telemetry, selection reasons, the typed learning loop, the ledger and its review surface — is what a workspace gets without configuring anything.

> Stacked on #745, which repairs a `main` that does not currently compile. Review that first.

## Why this is safe to default on

The behavior-compatibility suite asserts **every spec §8 guarantee on both the typed path and the opted-out one**, from the same assertions: tombstone suppression across re-learning on every surface, the per-session creation cap, never clobbering a hand-edited file, deterministic candidate identity, and failure isolation.

Phase 3 deliberately kept the lexical loop reachable rather than deleting it, so "behavior-compatible" stays a checkable claim rather than a promise. Defaulting on is the point of having built that evidence — a lifecycle nobody runs cannot be evaluated.

## The flip is two changes, not one

This is the part worth reviewing closely. **Flipping `LifecycleSettings::default` alone would have shipped nothing.**

The reader asked:

```rust
.and_then(|s| s.context).is_some_and(|c| c.lifecycle.enabled)
```

A workspace with no `settings.json` — the common case, and every new user — answered `false` regardless of the struct's default, because the `context` block was **absent** rather than present-and-false. An absent block now means "the defaults", which is what it always should have meant.

There are tests for the no-settings-file case and the empty-block case specifically, because that is exactly the gap that would have shipped this as a silent no-op.

## What still fails closed

An **unreadable or malformed** settings file stays OFF. That file may be the one in which someone turned the lifecycle off, and silently overriding an opt-out we failed to parse is worse than leaving a default unapplied. An explicit `"enabled": false` is honored and restores the previous behavior wholesale.

## Notes for the reviewer

- The test fixtures that used to get the lexical loop *by writing nothing* now opt out explicitly, since "write nothing and get the old path" is no longer true. That is a change to what the fixtures **say**, not to what they **assert** — no assertion was relaxed.
- `DriverConfig::lifecycle_enabled` still defaults `false` on purpose: a programmatically built config should opt in deliberately rather than inherit a product default it never read. The CLI passes the real setting.
- `learning.mode` and `governance.mode` remain inert — they have no consumers outside settings tests. `lifecycle.enabled` is the only real switch.

## Gate

`make gate` green: **exit 0, 3805 tests**, `check-file-size: OK — 475 Rust files, none over 1500 lines except 25 grandfathered (none grew).`
