### PR TITLE
fix(deck,model): make deck scope review interactive; stop leaking reasoning as the answer

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,7 +8,7 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 1881 stella-cli/src/agent_tests.rs
-2254 stella-cli/src/agent.rs
+2255 stella-cli/src/agent.rs
 1623 stella-cli/src/candidate_ws.rs
 4604 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
@@ -18,9 +18,9 @@
 1599 stella-model/src/anthropic/tests.rs
 1638 stella-model/src/bedrock.rs
 1919 stella-model/src/openai.rs
-1622 stella-model/src/zai/tests.rs
+1623 stella-model/src/zai/tests.rs
 2476 stella-pipeline/src/pipeline.rs
-2021 stella-pipeline/src/pipeline/tests.rs
+2022 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2268 stella-store/src/lib.rs
 2170 stella-store/src/tests.rs

--- a/stella-cli/src/agent.rs
+++ b/stella-cli/src/agent.rs
@@ -69,7 +69,8 @@ use outcome::{
 pub(crate) use outcome::{pipeline_execution_closeout, settled_cost_since};
 use output::*;
 pub(crate) use persistence::{
-    persist_event, record_execution_end, spawn_renderer, warn_store_write_failed,
+    persist_event, persist_event_detailed, record_execution_end, spawn_renderer,
+    warn_store_write_failed,
 };
 pub(crate) use prompt::*;
 // `tool_policy` is a top-level module (`main.rs`); the re-export keeps every

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -253,6 +253,49 @@ pub(crate) fn warn_store_write_failed(what: &str) {
     );
 }
 
+/// Why an event's accounting came out incomplete — the distinction the old
+/// bare `bool` collapsed.
+///
+/// `persist_event` folds two unrelated conditions together: whether our own
+/// rows hit disk, and whether the *provider* reported a terminal usage frame.
+/// A stream that dies mid-turn (a gateway 5xx, a cancelled call) leaves usage
+/// unreported even though every INSERT succeeded — and the deck then told the
+/// user "store write failed", sending them to look at a database that was
+/// perfectly fine. Splitting them lets each surface say what actually
+/// happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PersistOutcome {
+    /// Rows written and usage fully reported.
+    Complete,
+    /// An INSERT failed — a real persistence problem.
+    StoreWriteFailed,
+    /// Everything was written, but the provider never delivered final usage,
+    /// so token/cost accounting for this turn is short.
+    UsageIncomplete,
+}
+
+impl PersistOutcome {
+    pub(crate) fn is_complete(self) -> bool {
+        matches!(self, PersistOutcome::Complete)
+    }
+
+    /// The user-facing sentence for this outcome, or `None` when complete.
+    pub(crate) fn message(self, what: &str) -> Option<String> {
+        match self {
+            PersistOutcome::Complete => None,
+            PersistOutcome::StoreWriteFailed => {
+                Some(format!("store write failed — {what} could not be written"))
+            }
+            PersistOutcome::UsageIncomplete => Some(format!(
+                "provider reported no final usage — token and cost accounting for {what} is \
+                 incomplete (the work itself is unaffected)"
+            )),
+        }
+    }
+}
+
+/// Thin `bool` face of [`persist_event_detailed`], kept for call sites that
+/// only care whether accounting was complete.
 pub(crate) fn persist_event(
     store: &Store,
     execution_id: i64,
@@ -260,6 +303,16 @@ pub(crate) fn persist_event(
     event: &AgentEvent,
     legacy_provider_id: &str,
 ) -> bool {
+    persist_event_detailed(store, execution_id, seq, event, legacy_provider_id).is_complete()
+}
+
+pub(crate) fn persist_event_detailed(
+    store: &Store,
+    execution_id: i64,
+    seq: u64,
+    event: &AgentEvent,
+    legacy_provider_id: &str,
+) -> PersistOutcome {
     let recorded = store.record_event(execution_id, seq, event).is_ok();
     let mut telemetry_ok = true;
     let mut usage_complete = true;
@@ -394,7 +447,15 @@ pub(crate) fn persist_event(
     if !complete {
         let _ = store.mark_execution_usage_incomplete(execution_id);
     }
-    complete
+    // A failed write outranks unreported usage: it is the more serious of the
+    // two and the only one that points at the store.
+    if !recorded || !telemetry_ok {
+        PersistOutcome::StoreWriteFailed
+    } else if !usage_complete {
+        PersistOutcome::UsageIncomplete
+    } else {
+        PersistOutcome::Complete
+    }
 }
 
 #[cfg(test)]

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -92,8 +92,8 @@ use stella_tools::issue_ops::{CreateParams, IssueFilters, IssueSummary, LabelInf
 use stella_tools::issues::IssueBackend;
 use stella_tui::{
     AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityField, EntityHit, Inbound, IssueAction,
-    IssueRow, SkillOp, SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput,
-    WorkspaceInput, run_deck,
+    IssueRow, ScopeDecision as DeckScopeDecision, SkillOp, SkillScope, SkillSearchHit, SkillsView,
+    SlashCommand, SplashCue, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -104,11 +104,13 @@ use crate::interactive::{AskUserIo, FREE_TEXT_LABEL, InteractiveToolSet, SkillRe
 
 mod authoring;
 mod forwarder;
+mod scope_gate;
 use crate::memory::{SessionMemory, inject_recall_block};
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::handle_agent_create;
 pub(crate) use forwarder::spawn_forwarder;
+use scope_gate::DeckApprovalGate;
 
 /// The lead agent's id — the one conversation this driver runs.
 const LEAD: &str = "lead";
@@ -394,6 +396,8 @@ pub async fn run_deck_session(
     let (deck_tx, deck_rx) = mpsc::unbounded_channel::<Inbound>();
     let (sub_tx, mut sub_rx) = mpsc::unbounded_channel::<WorkspaceInput>();
     let (ask_tx, ask_rx) = mpsc::unbounded_channel::<String>();
+    // Scope review's answer path — same shape as `ask_tx`/`ask_rx` above.
+    let (scope_tx, scope_rx) = mpsc::unbounded_channel::<DeckScopeDecision>();
     // The supervisor channel: `task_assign` spawn requests (tap → driver)
     // and sub-session endings (worker → driver). See `crate::subsession`.
     let (sup_tx, mut sup_rx) = mpsc::unbounded_channel::<SupervisorMsg>();
@@ -543,6 +547,7 @@ pub async fn run_deck_session(
         inbound: in_tx.clone(),
         answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
     };
+    let scope_gate = DeckApprovalGate::new(LEAD.to_string(), in_tx.clone(), scope_rx);
 
     // The deck drives turns through the staged pipeline by default (triage →
     // recall → plan → scope → witness → execute → verify → judge); `/pipeline`
@@ -1314,6 +1319,7 @@ pub async fn run_deck_session(
                         files_before,
                         &in_tx,
                         &ask_io,
+                        &scope_gate,
                         &sup_tx,
                         &lead_holder,
                         &discovery_activation,
@@ -1631,16 +1637,20 @@ pub async fn run_deck_session(
                         ) => {
                             handle_issues_input(&input, cfg, &issue_backend_cache, &in_tx);
                         }
-                        // Scope review is not engine-driven yet, and
-                        // lead-lane pause/resume/restart still need a
+                        // Scope review IS engine-driven now: the pipeline's
+                        // `DeckApprovalGate` parks on this channel, so the
+                        // card's a/t/x keypress becomes its `ScopeDecision`.
+                        Some(WorkspaceInput::ToAgent {
+                            input: UserInput::ScopeDecision(decision), ..
+                        }) => {
+                            let _ = scope_tx.send(decision);
+                        }
+                        // Lead-lane pause/resume/restart still need a
                         // staged-pipeline boundary gate (the PipelinePorts
                         // follow-up; the fleet layer's own per-task verbs
                         // exist now, but fleet tasks are not deck lanes
-                        // yet) — named seams, no-ops here.
-                        Some(WorkspaceInput::ToAgent {
-                            input: UserInput::ScopeDecision(_), ..
-                        })
-                        | Some(WorkspaceInput::Control { .. }) => {}
+                        // yet) — a named seam, no-op here.
+                        Some(WorkspaceInput::Control { .. }) => {}
                     },
                 }
             }
@@ -3893,10 +3903,11 @@ async fn run_deck_command(
             let _ = in_tx.send(Inbound::Pipeline(*pipeline_on));
             say(if *pipeline_on {
                 "staged pipeline ON — turns now run triage → recall → (plan → scope review) → \
-                 witness → execute → verify → judge, with bounded revision. The witness stage \
-                 authors a failing test that must flip to green before work counts as done; \
-                 large plans stop with a named scope-review error until a deck-native host \
-                 approval gate is available. \
+                 witness → execute → verify → judge, with bounded revision. Triage already \
+                 right-sizes each turn: chat answers in one completion, and only genuinely \
+                 multi-step goals plan at all. The witness stage authors a failing test that \
+                 must flip to green before work counts as done; a large plan raises the scope \
+                 card and waits for you (a approve · t trim · x abort). \
                  `/pipeline` again to return to the raw engine loop."
                     .to_string()
             } else {
@@ -4150,15 +4161,7 @@ async fn run_lead_turn(
             cost,
             persistence_complete,
         ) {
-            let _ = in_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Error {
-                    message: "store write failed — the audit record (files touched / \
-                              memory citations / outcome) for this execution is incomplete"
-                        .to_string(),
-                    retryable: true,
-                },
-            });
+            forwarder::warn_audit_record_incomplete(in_tx, LEAD, persistence_complete);
             // That warning lands AFTER the turn's Complete event, and the
             // deck's status fold maps a retryable Error back to Running — so
             // without this re-assert a finished turn would show as running
@@ -4186,10 +4189,10 @@ async fn run_lead_turn(
 /// place of the raw `Engine::run_turn`.
 ///
 /// Deck-mode seams, all named:
-/// - **Scope review fails closed.** The deck cannot block a turn on a stdio
-///   gate (the alternate screen owns the terminal), so a large plan returns
-///   `ScopeReviewRequiredHeadless`. Deck-native host approval remains the
-///   follow-up; output/event rendering is never treated as authority.
+/// - **Scope review is interactive** ([`DeckApprovalGate`]). A plan over the
+///   thresholds raises the deck's approval card and the turn parks until the
+///   user answers (a/t/x) — the deck runs `headless: false` because it *can*
+///   ask. It fails closed only if the deck itself goes away mid-gate.
 /// - **The session's system prompt stays.** It was assembled once at deck
 ///   startup (byte-stable for the cache prefix, L-E8); toggling `/pipeline`
 ///   must not rewrite history. The pipeline's stage prompts (witness, judge,
@@ -4213,6 +4216,7 @@ async fn run_lead_pipeline_turn(
     files_before: usize,
     in_tx: &UnboundedSender<Inbound>,
     ask_io: &DeckAskUserIo,
+    scope_gate: &DeckApprovalGate,
     sup_tx: &UnboundedSender<SupervisorMsg>,
     claim_holder: &str,
     activated: &crate::discovery::ActivatedTools,
@@ -4299,7 +4303,7 @@ async fn run_lead_pipeline_turn(
             repo_status: &ws_ports.repo_status,
             diagnostics: &ws_ports.diagnostic_runner,
             tests: &ws_ports.test_runner,
-            approvals: &agent::HEADLESS_APPROVAL_GATE,
+            approvals: scope_gate,
             sleeper: &TokioSleeper,
             hooks: cfg
                 .hooks
@@ -4317,8 +4321,12 @@ async fn run_lead_pipeline_turn(
         let config = PipelineConfig {
             engine: agent::pipeline_engine_config_for(cfg, &wiring.worker_model),
             role_overrides: wiring.role_overrides.clone(),
-            headless: true,
-            headless_bypass_scope_review: agent::HEADLESS_SCOPE_REVIEW_BYPASS,
+            // Not headless: the deck has a real approval surface, so scope
+            // review asks instead of returning `ScopeReviewRequiredHeadless`.
+            // The bypass flag is deliberately left off — it only exists to let
+            // a run with *nobody to ask* proceed, and this run has someone.
+            headless: false,
+            headless_bypass_scope_review: false,
             ..PipelineConfig::default()
         };
         let pipeline = Pipeline::new(ports, tx.clone(), config);
@@ -4339,15 +4347,7 @@ async fn run_lead_pipeline_turn(
             cost,
             persistence_complete,
         ) {
-            let _ = in_tx.send(Inbound::Event {
-                agent: LEAD.to_string(),
-                event: AgentEvent::Error {
-                    message: "store write failed — the audit record (files touched / \
-                              memory citations / outcome) for this execution is incomplete"
-                        .to_string(),
-                    retryable: true,
-                },
-            });
+            forwarder::warn_audit_record_incomplete(in_tx, LEAD, persistence_complete);
             // Same re-assert as run_lead_turn: the retryable warning above
             // folds the lead back to Running, so restate the terminal state.
             let _ = in_tx.send(Inbound::Status {

--- a/stella-cli/src/command_deck/forwarder.rs
+++ b/stella-cli/src/command_deck/forwarder.rs
@@ -12,6 +12,34 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use crate::agent;
 use crate::cache_insight::cache_insight_for;
 
+/// Warn that execution closeout could not write its audit record (files
+/// touched / memory citations / outcome).
+///
+/// `record_execution_end` folds `persistence_complete` into its own answer, so
+/// a turn the forwarder already warned about arrives here guaranteed-false.
+/// Emitting again restated one condition as two independent failures — the
+/// pair of near-identical "store write failed" rows users read as compounding
+/// damage. Only speak when the audit writes are the *new* thing that went
+/// wrong; the caller re-asserts terminal status either way.
+pub(crate) fn warn_audit_record_incomplete(
+    inbound: &UnboundedSender<Inbound>,
+    lane: &str,
+    persistence_complete: bool,
+) {
+    if !persistence_complete {
+        return;
+    }
+    let _ = inbound.send(Inbound::Event {
+        agent: lane.to_string(),
+        event: AgentEvent::Error {
+            message: "store write failed — the audit record (files touched / memory \
+                      citations / outcome) for this execution is incomplete"
+                .to_string(),
+            retryable: true,
+        },
+    });
+}
+
 /// Persist each event (via the shared [`agent::persist_event`] write path)
 /// and forward it to the deck as `agent`'s `Inbound::Event`, plus a derived
 /// `Inbound::CacheInsight` when the event carries pricing-relevant usage
@@ -32,16 +60,20 @@ pub(crate) fn spawn_forwarder(
         let mut persistence_complete = true;
         while let Some(event) = rx.recv().await {
             if let Some((store, id)) = &execution {
-                if !agent::persist_event(store, *id, seq, &event, &provider_id) {
+                let outcome = agent::persist_event_detailed(store, *id, seq, &event, &provider_id);
+                if !outcome.is_complete() {
                     persistence_complete = false;
-                    if !store_warned {
+                    // One warning per turn, and it names the condition that
+                    // actually occurred: a failed INSERT points at the store,
+                    // while unreported provider usage does not — conflating
+                    // them sent users hunting for a database fault that was
+                    // really a truncated model stream.
+                    if !store_warned && let Some(message) = outcome.message("this session") {
                         store_warned = true;
                         let _ = inbound.send(Inbound::Event {
                             agent: lane.clone(),
                             event: AgentEvent::Error {
-                                message: "store write failed — the persisted event/telemetry \
-                                          record for this session is incomplete"
-                                    .to_string(),
+                                message,
                                 retryable: true,
                             },
                         });

--- a/stella-cli/src/command_deck/scope_gate.rs
+++ b/stella-cli/src/command_deck/scope_gate.rs
@@ -1,0 +1,180 @@
+//! Scope review through the deck — the interactive [`ApprovalGate`] the
+//! staged pipeline blocks on when a plan exceeds the scope thresholds.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use stella_pipeline::{ApprovalGate, ScopeDecision};
+use stella_protocol::{AgentEvent, ScopeProposal};
+use stella_tui::{Inbound, ScopeDecision as DeckScopeDecision};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// The deck-native approval gate — the "deck-native host approval" the
+/// pipeline turn's doc comment used to name as a follow-up.
+///
+/// The deck could never use `StdioApprovalGate` (the alternate screen owns the
+/// terminal), so it previously ran the pipeline with `headless: true` and an
+/// `AlwaysAbortGate`. That made every plan past the scope thresholds — more
+/// than 5 steps, 8 files, or $1.00 — a dead end: the turn aborted with advice
+/// to set `headless_scope_bypass`, a setting only `stella run` reads, so
+/// following the advice changed nothing. Meanwhile the TUI's approval card
+/// and its a/t/x keys were fully built and wired to nothing.
+///
+/// This closes that loop the same way `DeckAskUserIo` closes `ask_user`: emit
+/// the card, park on a channel, let the input pump deliver the keypress. The
+/// pipeline emits its own `ScopeReview` event on the non-headless branch, which
+/// is what raises the card, so this gate only awaits the answer.
+pub(crate) struct DeckApprovalGate {
+    pub(crate) agent: String,
+    pub(crate) inbound: UnboundedSender<Inbound>,
+    pub(crate) decisions: Arc<tokio::sync::Mutex<UnboundedReceiver<DeckScopeDecision>>>,
+    /// The step ceiling `Trim` trims to — the deck's card has no per-step
+    /// picker, so "trim" means "keep the largest prefix that would not have
+    /// tripped review in the first place".
+    pub(crate) max_steps: usize,
+}
+
+impl DeckApprovalGate {
+    /// Build the gate for a deck session. `max_steps` comes from the same
+    /// [`ScopeThresholds`] defaults the pipeline gates on, so the trim target
+    /// can never drift from the threshold that raised the card.
+    ///
+    /// [`ScopeThresholds`]: stella_pipeline::scope::ScopeThresholds
+    pub(crate) fn new(
+        agent: String,
+        inbound: UnboundedSender<Inbound>,
+        decisions: UnboundedReceiver<DeckScopeDecision>,
+    ) -> Self {
+        Self {
+            agent,
+            inbound,
+            decisions: Arc::new(tokio::sync::Mutex::new(decisions)),
+            max_steps: stella_pipeline::scope::ScopeThresholds::default()
+                .max_steps
+                .unwrap_or(5),
+        }
+    }
+
+    /// The pure half of [`ApprovalGate::review`]: map a deck keypress onto the
+    /// pipeline's decision, given how many steps the proposal carries. Split
+    /// out so the mapping — especially `Trim`'s arithmetic — is testable
+    /// without a live channel or a running deck.
+    pub(crate) fn decide(&self, decision: DeckScopeDecision, step_count: usize) -> ScopeDecision {
+        match decision {
+            DeckScopeDecision::Approve => ScopeDecision::Approve,
+            DeckScopeDecision::Abort => ScopeDecision::Abort,
+            DeckScopeDecision::Trim => ScopeDecision::Trim {
+                keep_steps: (0..self.max_steps.min(step_count)).collect(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl ApprovalGate for DeckApprovalGate {
+    async fn review(&self, proposal: &ScopeProposal) -> ScopeDecision {
+        let mut decisions = self.decisions.lock().await;
+        // Drop decisions stranded by a cancelled turn — they belong to a card
+        // that no longer exists (same hygiene as `DeckAskUserIo::prompt`).
+        while decisions.try_recv().is_ok() {}
+
+        let Some(decision) = decisions.recv().await else {
+            // The deck closed with the gate still open. Fail closed — the same
+            // posture as every other gate in the system.
+            return ScopeDecision::Abort;
+        };
+
+        let resolved = self.decide(decision, proposal.steps.len());
+        if let ScopeDecision::Trim { keep_steps } = &resolved {
+            // Announce exactly what survives. A trim that silently dropped
+            // steps would be the failure mode `StdioApprovalGate` avoids by
+            // refusing to offer Trim at all; naming the count is what makes
+            // offering it honest here.
+            let keep = keep_steps.len();
+            let dropped = proposal.steps.len().saturating_sub(keep);
+            let _ = self.inbound.send(Inbound::Event {
+                agent: self.agent.clone(),
+                event: AgentEvent::Text {
+                    delta: format!(
+                        "\n[scope trimmed to the first {keep} step{} — {dropped} dropped]\n",
+                        if keep == 1 { "" } else { "s" },
+                    ),
+                },
+            });
+        }
+        resolved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn gate(max_steps: usize) -> DeckApprovalGate {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (_dtx, drx) = mpsc::unbounded_channel();
+        DeckApprovalGate {
+            agent: "lead".to_string(),
+            inbound: tx,
+            decisions: Arc::new(tokio::sync::Mutex::new(drx)),
+            max_steps,
+        }
+    }
+
+    #[test]
+    fn approve_and_abort_pass_straight_through() {
+        let g = gate(5);
+        assert_eq!(
+            g.decide(DeckScopeDecision::Approve, 9),
+            ScopeDecision::Approve
+        );
+        assert_eq!(g.decide(DeckScopeDecision::Abort, 9), ScopeDecision::Abort);
+    }
+
+    /// The reported case: a 9-step scaffold plan against the default ceiling
+    /// of 5. Trim keeps the first five, in order.
+    #[test]
+    fn trim_keeps_the_leading_steps_up_to_the_threshold() {
+        assert_eq!(
+            gate(5).decide(DeckScopeDecision::Trim, 9),
+            ScopeDecision::Trim {
+                keep_steps: vec![0, 1, 2, 3, 4]
+            }
+        );
+    }
+
+    /// A plan shorter than the ceiling must never mint out-of-range indices —
+    /// the pipeline ignores those, but a Trim that claims steps the plan does
+    /// not have would misreport what ran.
+    #[test]
+    fn trim_never_exceeds_the_plan_length() {
+        assert_eq!(
+            gate(5).decide(DeckScopeDecision::Trim, 2),
+            ScopeDecision::Trim {
+                keep_steps: vec![0, 1]
+            }
+        );
+    }
+
+    /// A closed decision channel (the deck went away mid-gate) fails closed.
+    #[tokio::test]
+    async fn a_closed_deck_aborts_rather_than_approving() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (dtx, drx) = mpsc::unbounded_channel();
+        drop(dtx);
+        let g = DeckApprovalGate {
+            agent: "lead".to_string(),
+            inbound: tx,
+            decisions: Arc::new(tokio::sync::Mutex::new(drx)),
+            max_steps: 5,
+        };
+        let proposal = ScopeProposal {
+            summary: "big".into(),
+            steps: vec!["a".into(), "b".into()],
+            estimated_files: 9,
+            estimated_cost_usd: None,
+        };
+        assert_eq!(g.review(&proposal).await, ScopeDecision::Abort);
+    }
+}

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -560,15 +560,40 @@ struct ZaiStreamChunk {
     error: Option<ZaiStreamError>,
 }
 
-/// An OpenAI-compatible in-band error object. We classify only on
-/// `type`/`message` text — the gateways don't share a stable machine
-/// code, so matching on human-readable text is the only reliable signal.
+/// An OpenAI-compatible in-band error object. Classification reads
+/// `type`/`message` text plus `code` — the gateways don't share a stable
+/// machine code *vocabulary*, so human-readable text is still the primary
+/// signal, but when a numeric status is present it is the most reliable part
+/// of the frame and must not be dropped.
 #[derive(Deserialize, Debug, Default)]
 struct ZaiStreamError {
     #[serde(default)]
     message: String,
     #[serde(default, rename = "type")]
     kind: String,
+    /// OpenRouter puts the upstream HTTP status here and nowhere else:
+    /// `{"error":{"message":"Provider returned an empty response","code":502}}`.
+    /// Without this field the status never reaches the haystack below, so the
+    /// `contains("502")` arm could not fire and a transient upstream 5xx fell
+    /// through to non-retryable `Terminal` — burning the turn on attempt 1
+    /// with all three configured retries unused. Untyped (`Value`) because
+    /// the gateways disagree on whether it is a number or a string.
+    #[serde(default)]
+    code: Option<serde_json::Value>,
+}
+
+impl ZaiStreamError {
+    /// The lowercased text classification matches against: `type`, `message`,
+    /// and the stringified `code`. A JSON string code is unquoted first so
+    /// `"502"` and `502` produce the same haystack.
+    fn haystack(&self) -> String {
+        let code = match &self.code {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => String::new(),
+        };
+        format!("{} {} {}", self.kind, self.message, code).to_lowercase()
+    }
 }
 
 /// Classify an in-band OpenAI-compatible error frame into a typed
@@ -581,7 +606,7 @@ struct ZaiStreamError {
 /// the concrete provider (Z.ai / xAI / DeepSeek / …) so the surfaced message
 /// points at the right credential and endpoint.
 fn classify_zai_stream_error(err: &ZaiStreamError, label: &str) -> ProviderError {
-    let haystack = format!("{} {}", err.kind, err.message).to_lowercase();
+    let haystack = err.haystack();
     let detail = if err.message.is_empty() {
         format!("{label} stream error ({})", err.kind)
     } else {
@@ -597,7 +622,11 @@ fn classify_zai_stream_error(err: &ZaiStreamError, label: &str) -> ProviderError
         || haystack.contains("529")
     {
         ProviderError::Transport(detail)
-    } else if haystack.contains("rate") && haystack.contains("limit") {
+    } else if haystack.contains("429") || (haystack.contains("rate") && haystack.contains("limit"))
+    {
+        // A `code: 429` frame carries no "rate limit" prose on some gateways,
+        // so the numeric status is the only signal that this is throttling
+        // rather than a permanent rejection.
         ProviderError::RateLimited {
             message: detail,
             retry_after_ms: None,
@@ -1275,7 +1304,17 @@ async fn aggregate_zai_stream(
     // Reasoning-only fallback: if the model emitted no answer `content` but did
     // stream chain-of-thought, surface the reasoning as the text so the turn is
     // never blank. Normal turns keep `content` as the answer and ignore it.
-    if text.trim().is_empty() && !reasoning.trim().is_empty() {
+    //
+    // `calls.is_empty()` is load-bearing, not defensive. A tool-calling turn
+    // legitimately has empty `content` — that is the *normal* shape for every
+    // Anthropic model routed through OpenRouter, which streams `content: ""`
+    // alongside `reasoning` and the tool call. Without this guard the fallback
+    // fired on essentially every reasoning-model tool turn and published the
+    // model's private chain-of-thought as its user-visible answer (users saw
+    // "The user is asking… I should clarify…" third-person deliberation in
+    // place of a reply). A turn that called a tool is not blank, so it never
+    // needs the fallback.
+    if text.trim().is_empty() && calls.is_empty() && !reasoning.trim().is_empty() {
         text = reasoning;
     }
 

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -1502,6 +1502,7 @@ async fn zai_identity_never_sends_reasoning_effort_even_when_pinned() {
 }
 
 mod error_classify_tests;
+mod openrouter_stream_tests;
 
 #[test]
 fn rejects_disabled_reasoning_matches_the_upstream_wording_only() {

--- a/stella-model/src/zai/tests/openrouter_stream_tests.rs
+++ b/stella-model/src/zai/tests/openrouter_stream_tests.rs
@@ -1,0 +1,168 @@
+//! OpenRouter streaming regressions: the gateway's own frame shapes —
+//! `content: ""` beside `reasoning` on a tool turn, and in-band error frames
+//! whose only status lives in `code`. Split out of the parent `tests.rs`
+//! (file-size gate) since they share a distinct fixture shape: a mock SSE
+//! stream driven through the `openrouter` identity.
+
+use super::*;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The regression behind the "stella is talking to itself" reports: an
+/// Anthropic model routed through OpenRouter streams `content: ""` alongside
+/// `reasoning` and the tool call on EVERY tool-calling turn. The
+/// reasoning-only fallback existed for turns that would otherwise render
+/// blank, but without a `calls.is_empty()` guard it fired here too and
+/// published the model's private deliberation as its user-visible answer.
+/// A turn that called a tool is not blank and must keep `text` empty.
+#[tokio::test]
+async fn openrouter_tool_call_turn_never_leaks_reasoning_as_the_answer() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning\":\"The user is asking \"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning\":\"something I should check first.\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"project_overview\",\"arguments\":\"{}\"}}]}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("scaffold a nextjs app")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let result = provider.complete(req).await.expect("should succeed");
+    assert_eq!(
+        result.text, "",
+        "chain-of-thought must never become the answer on a tool turn"
+    );
+    assert_eq!(result.tool_calls.len(), 1, "the tool call still lands");
+    assert_eq!(result.tool_calls[0].name, "project_overview");
+}
+
+/// OpenRouter reports the upstream HTTP status ONLY in the in-band frame's
+/// `code` field. Dropping it meant the classifier's own `contains("502")`
+/// arm could never fire, so a transient gateway failure fell through to
+/// non-retryable `Terminal` and burned the turn with every configured retry
+/// unused.
+#[tokio::test]
+async fn openrouter_in_band_error_code_502_is_retryable() {
+    let server = MockServer::start().await;
+    // The exact frame a live OpenRouter stream emits when its upstream
+    // provider returns nothing — note the status lives in `code`, and the
+    // message text contains no digits at all.
+    let sse_body = concat!(
+        "data: {\"error\":{\"message\":\"Provider returned an empty response\",\"code\":502}}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let err = provider.complete(req).await.expect_err("must be an error");
+    assert!(
+        err.is_retryable(),
+        "a transient upstream 502 must be retried, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Provider returned an empty response"),
+        "surfaces the gateway's own text: {msg}"
+    );
+}
+
+/// A `code: 429` frame whose prose never says "rate limit" must still
+/// classify as throttling rather than a permanent rejection.
+#[tokio::test]
+async fn openrouter_in_band_error_code_429_is_rate_limited() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"error\":{\"message\":\"Too many requests upstream\",\"code\":429}}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let err = provider.complete(req).await.expect_err("must be an error");
+    assert!(
+        matches!(err, ProviderError::RateLimited { .. }),
+        "got {err:?}"
+    );
+    assert!(err.is_retryable());
+}
+
+/// The negative control for the two tests above: a genuinely blank turn —
+/// reasoning streamed, no content, and NO tool call — must still fall back
+/// to the reasoning so the turn is never silently empty. This is the
+/// behavior the `calls.is_empty()` guard has to preserve.
+#[tokio::test]
+async fn openrouter_reasoning_only_turn_still_falls_back() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning\":\"only thinking\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let result = provider.complete(req).await.expect("should succeed");
+    assert_eq!(result.text, "only thinking");
+    assert!(result.tool_calls.is_empty());
+}

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -1851,6 +1851,7 @@ mod golden;
 /// `pipeline.rs`; a child module, so it reaches the fakes above via
 /// `super::*`.
 mod mcp_prefetch;
+mod scope_gate_interactive;
 mod terminal_outcomes;
 mod usage;
 mod witness_isolation;

--- a/stella-pipeline/src/pipeline/tests/scope_gate_interactive.rs
+++ b/stella-pipeline/src/pipeline/tests/scope_gate_interactive.rs
@@ -1,0 +1,86 @@
+//! The interactive scope-review seam: a run that is NOT headless and carries a
+//! real approval gate must raise the card and, on approve, execute — the
+//! posture the command deck adopted once it grew a native approval surface.
+//! Its headless twin (`ScopeReviewRequiredHeadless`) lives in the parent
+//! module; this is the branch that had no coverage.
+
+use super::*;
+
+/// The deck's configuration: NOT headless, with a real approval gate. The
+/// same 6-step plan that returns `ScopeReviewRequiredHeadless` for a headless
+/// run must instead raise a `ScopeReview` card and, on approve, carry on into
+/// execution. This is the seam the command deck relies on — before it was
+/// wired, an interactive session dead-ended on any plan over five steps and
+/// pointed the user at `headless_scope_bypass`, which that path never reads.
+#[tokio::test]
+async fn interactive_scope_review_approve_proceeds_past_the_gate() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("multi"),
+        text_result(r#"["s1","s2","s3","s4","s5","s6"]"#),
+        text_result("working"),
+        text_result("done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = FixedGate(ScopeDecision::Approve);
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        // `headless: false` is the default — the deck's exact posture.
+        PipelineConfig::default(),
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let result = pipeline
+        .run(
+            "Refactor across the codebase and then update all callers",
+            &mut messages,
+            &mut budget,
+        )
+        .await;
+
+    // Whatever else the scripted run does downstream, the scope gate must not
+    // be what stopped it.
+    if let Err(err) = &result {
+        assert_ne!(
+            err.cause,
+            PipelineError::ScopeReviewRequiredHeadless,
+            "an interactive run has someone to ask: {err:?}"
+        );
+    }
+    let events = drain(&mut rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ScopeReview { .. })),
+        "the approval card must be raised so the deck can render it"
+    );
+    assert!(
+        stages(&events).contains(&StageKind::Execute),
+        "an approved plan proceeds into execution"
+    );
+}


### PR DESCRIPTION
Diagnosed from a real deck session that scaffolded nothing and emitted a wall of misleading errors. Four independent defects; none of the error messages named what actually went wrong.

## 1. The deck dead-ended on any plan over five steps

`run_lead_pipeline_turn` hardcoded `headless: true` with an `AlwaysAbortGate`, so scope review failed closed on every plan past the thresholds (>5 steps / >8 files / >$1.00) and advised setting `headless_scope_bypass` — a key only `stella run` reads (`agent/engine.rs:153`). The deck, goal loop, and fleet all pass the bare `false` const, so **following the advice changed nothing**. Meanwhile the TUI's approval card and its a/t/x keys were fully built and wired to nothing: the decision was explicitly discarded in the input pump.

Adds `DeckApprovalGate` — the "deck-native host approval" the old doc comment named as a follow-up — using the same channel shape `DeckAskUserIo` already uses for `ask_user`. The deck now runs `headless: false`, so a large plan raises the card and the turn parks until you answer. `Trim` keeps the largest prefix that would not have tripped review and announces how many steps it dropped. It still fails closed if the deck goes away mid-gate.

`config.headless` is read in exactly two places, both inside `scope_review`, so flipping it changes nothing else.

## 2. Chain-of-thought was published as the assistant's answer

The reasoning-only fallback in `zai.rs` had no `calls.is_empty` guard. Anthropic models routed via OpenRouter stream `content: ""` beside `reasoning` on **every** tool-calling turn, so the fallback fired constantly and the user saw the model's private deliberation — third-person prose like *"The user is asking... I should clarify..."* — in place of a reply. Verified against the live gateway: same prompt and model returns content 0 chars, reasoning 206 chars, 3 tool-call deltas. A turn that called a tool is not blank.

## 3. Transient gateway 5xx were classified non-retryable

`ZaiStreamError` deserialized only `message`/`type`. OpenRouter reports the upstream status **only** in `code`, so `{"error":{"message":"Provider returned an empty response","code":502}}` produced a haystack with no digits — the classifier's own `contains("502")` arm could never fire, and a retryable `Transport` failure fell through to the conservative `Terminal` default. `is_retryable` false meant zero of the three configured retries ran; the turn died on attempt 1. Also lets a `code: 429` frame classify as throttling when the prose does not happen to say "rate limit".

## 4. "store write failed" was reported when no write failed

`persist_event` ANDed provider usage-reporting into the same bit as its two INSERT results, so a stream that died before its terminal usage frame reported as a store failure — sending users to inspect a database that was fine. Split into `PersistOutcome`. The closeout's "audit record" message was a mechanical re-report of the forwarder's, so one condition rendered as two independent failures; it now only speaks when the audit writes are the new problem.

## Verification

`make gate` green — fmt, clippy `-D warnings`, file-size, doc-citations, rustdoc, **3814 tests**.

Every new test was negative-controlled (reverted the fix, confirmed the test fails):
- `interactive_scope_review_approve_proceeds_past_the_gate` reproduces the user's exact `ScopeReviewRequiredHeadless` when flipped back to `headless: true`, and asserts the run reaches `Execute` when not.
- `openrouter_tool_call_turn_never_leaks_reasoning_as_the_answer` — with a control, `openrouter_reasoning_only_turn_still_falls_back`, proving a genuinely blank turn still surfaces its reasoning.
- `openrouter_in_band_error_code_502_is_retryable` / `_429_is_rate_limited`.
- Four `scope_gate` unit tests covering the decision mapping, trim arithmetic, and fail-closed-on-closed-deck.

New code went into new modules (`command_deck/scope_gate.rs`, two test submodules) rather than growing the grandfathered files. The three `+1` baseline entries are module declarations / a re-export — the case the gate names as irreducible.

## Not fixed here

`prompt prefix is unstable between turns` is a fall-through `else` in `cache_panel.rs:57` that never hashes any prefix — it infers instability from a <20% hit rate, which failed calls drive to 0%, and it aggregates across different models whose prefixes can never share a cache. Advisory-only and cosmetic; a correct fix needs per-model cache accounting in the TUI, which is a larger change than belongs in this PR.
