### PR TITLE
Phase 4: efficacy attribution and reversible retirement (#715)

### DIFF
--- a/docs/design/adaptive-context-plan.md
+++ b/docs/design/adaptive-context-plan.md
@@ -283,6 +283,52 @@ the ledger (Phase 3) to have something to attribute to.
 - Protected categories are provably never retired.
 - Retirement decisions carry a human-readable reason.
 
+### Status — shipped 2026-07-26 (#715)
+
+All five deliverables landed, and the gate is met. What is worth knowing
+beyond the checklist:
+
+**Use records live in `context.db`, not `store.db`.** `memory_citations` is in
+`DEPENDENT_TABLES`, so `stella stats prune` deletes citation rows with their
+execution — an aggregate folded over them is *not* rebuildable across a prune,
+and the first gate criterion would have been false the first time anyone
+pruned. `context_records` is append-only enforced by SQLite triggers and is
+never pruned. The consequence is an ordering dependency, stated rather than
+hidden: extraction must reach an execution before a prune does.
+
+**Retirement never writes `superseded_at`.** `node_by_public_id` filters on
+that column, so routing retirement through `supersede_node` would have made a
+retired record impossible to fetch by id — failing "still explicitly
+retrievable" outright. Retirement is instead a derived projection over
+`promotion_event`s (`Retired`/`Reverted`, folded last-write-wins exactly as
+keep/ignore already are) that joins the union the suppression reader already
+computes. No second suppression mechanism, per §5.7.
+
+**Two of the five protected categories do not exist and are documented as
+absent rather than faked.** `DirectivePriority::Critical` is carried on no
+record and set by no path; there is no pin concept for memory or context
+records at all. Both are guarded by `protection_for` being the single predicate
+every retirement passes through, so each check has exactly one home when the
+concept becomes real.
+
+**The pruning-eligibility tier is now enforced, and it is the load-bearing
+correctness result.** The type layer always said `agent_self_report` is
+recognized but may never drive pruning; nothing implemented it. `cite_memory`
+is the *agent* judging context the agent was given, so citation-derived
+verdicts are recorded as `agent_self_report` and are deliberately **not**
+pruning-eligible — a self-report that can retire its own subject is
+self-reinforcing, because a model that misreads a memory reports it unhelpful,
+retires it, and destroys the evidence that the reading was wrong. Selection
+health therefore carries two populations: everything assessed (what is known)
+and the pruning-eligible subset (what may remove). Only the latter decides
+`failing`.
+
+That has a deliberate consequence: **automatic retirement does not fire on
+citation evidence alone.** Today a human is the pruning-eligible source, via
+`stella memory retire <id> --reason`. Wiring a deterministic source — the
+anchor check behind `stella memory validate` is the obvious candidate — is
+tracked separately and is what makes the sweep autonomous.
+
 ---
 
 ## Sequencing and decisions

--- a/docs/design/adaptive-context.md
+++ b/docs/design/adaptive-context.md
@@ -116,9 +116,24 @@ remaining gap. That ordering drives the plan.
 closed all four defects: candidate generation is bounded by the requested frame
 count, the point-in-time cutoff reaches every signal, supersede and tombstone
 live in the plane that owns the records, and a memory's identity is its lineage
-so an edit revises rather than duplicates. The five remaining rows are gaps, and
-Phases 2–4 build them. The table is left as written — it is the analysis the
-plan was ordered by.
+so an edit revises rather than duplicates. The table is left as written — it is
+the analysis the plan was ordered by.
+
+**All nine rows are now closed.** Phase 2
+([#713](https://github.com/macanderson/stella/issues/713)) decomposed the recall
+block and gave the frame a deterministic identity; Phase 3
+([#714](https://github.com/macanderson/stella/issues/714)) made proposals typed
+and auditable; Phase 4
+([#715](https://github.com/macanderson/stella/issues/715)) added context-use
+records, opportunity-aware attribution, derived selection health, and reversible
+retirement. The loop in §7 runs end to end.
+
+One qualification, because §5.5 asks for gaps to be declared where a caller can
+see them rather than only in prose: the final step, *retired*, is reached today
+by a human decision or by any pruning-eligible evidence source. Citations are
+`agent_self_report` and are deliberately excluded from driving suppression, so
+the sweep does not yet retire anything on its own. That is a missing *evidence
+source*, not a missing mechanism.
 
 ## 5. Invariants
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -12,7 +12,7 @@
 1623 stella-cli/src/candidate_ws.rs
 4604 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2265 stella-core/src/driver.rs
+2087 stella-core/src/driver.rs
 2819 stella-core/src/driver/tests.rs
 1759 stella-fleet/src/fleet.rs
 1599 stella-model/src/anthropic/tests.rs
@@ -22,7 +22,7 @@
 2476 stella-pipeline/src/pipeline.rs
 2021 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
-2268 stella-store/src/lib.rs
+2270 stella-store/src/lib.rs
 2170 stella-store/src/tests.rs
 1884 stella-store/src/usage.rs
 1556 stella-tools/src/media.rs

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -54,6 +54,7 @@ mod memory;
 mod memory_cmd;
 mod memory_compact;
 mod memory_index;
+mod memory_retire_cmd;
 mod model_catalog;
 // Phase 3 (#714): the adaptive-context proposal review surface.
 mod proposals_cmd;
@@ -1081,6 +1082,13 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 memory_cmd::MemoryCmd::Edit { id, text } => memory_cmd::run_memory_edit(id, text),
                 memory_cmd::MemoryCmd::Restore { id } => memory_cmd::run_memory_restore(id),
                 memory_cmd::MemoryCmd::Forgotten => memory_cmd::run_memory_forgotten(),
+                memory_cmd::MemoryCmd::Retired => memory_retire_cmd::run_memory_retired(),
+                memory_cmd::MemoryCmd::Retire { id, reason } => {
+                    memory_retire_cmd::run_memory_retire(id, reason)
+                }
+                memory_cmd::MemoryCmd::Reaffirm { id, reason } => {
+                    memory_retire_cmd::run_memory_reaffirm(id, reason)
+                }
                 memory_cmd::MemoryCmd::Compact(args) => memory_compact::run_memory_compact(args),
                 memory_cmd::MemoryCmd::Index(args) => memory_index::run_memory_index(args),
             };

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -47,6 +47,9 @@ use stella_pipeline::{ContextRecallPort, RecalledFrame};
 #[cfg(test)]
 use stella_protocol::{CompletionMessage, MessageRole};
 
+// Phase 4 (#715): the citation and tool-outcome evidence sources, which turn
+// explicit citation from *the* evidence source into one of several.
+mod evidence;
 mod learning;
 // Phase 3 (#714): typed observation extraction and proposal induction
 // into the lifecycle ledger.
@@ -57,11 +60,16 @@ pub(crate) mod proposals;
 #[cfg(test)]
 mod quarantine_tests;
 mod recall;
+// Phase 4 (#715): reversible retirement of context that stops helping.
+pub(crate) mod retirement;
 pub(crate) mod rules_mining;
 #[path = "memory/skills.rs"]
 mod skill_files;
 mod suppression;
-mod tuning;
+pub(crate) mod tuning;
+// Phase 4 (#715): context-use extraction — what a finished turn's frame
+// carried, and what the turn then said about it.
+pub(crate) mod uses;
 use private_state::resolve_context_db_path;
 #[cfg(test)]
 use projection::{is_suppressed_local_frame, project_recalled_frame};
@@ -195,7 +203,7 @@ impl SessionMemory {
                     store.clone(),
                     domains.names(),
                     workspace_root.to_path_buf(),
-                    suppression::suppression_reader(workspace_root),
+                    suppression::suppression_reader(workspace_root, store.clone()),
                 );
                 Some(Self {
                     store,

--- a/stella-cli/src/memory/evidence.rs
+++ b/stella-cli/src/memory/evidence.rs
@@ -1,0 +1,170 @@
+//! Generalizing the citation loop — Phase 4 deliverable 2 (#715).
+//!
+//! [`ObservationSource`] has always had three variants. Only one of them,
+//! `ReflectionLesson`, had a constructor: `MemoryCitation` and `ToolOutcome`
+//! were declared in Phase 1 and written by nothing, so the typed loop learned
+//! from reflection prose and from no other evidence at all. This module fills
+//! the other two, which is what turns explicit citation from *the* evidence
+//! source into *one* of them.
+//!
+//! # What does not change
+//!
+//! The deliverable is explicit that the citation loop keeps its semantics, and
+//! it does — untouched. `fold_citation_stats` still derives quarantine at
+//! [`stella_store::QUARANTINE_NEGATIVES_THRESHOLD`] untruthful citations and
+//! promotion eligibility at a streak past
+//! [`stella_store::PROMOTION_CITATIONS_REQUIRED`], still recomputed on every
+//! read, still never stored. Nothing here reads those thresholds, changes
+//! them, or adds a second path to quarantine.
+//!
+//! What changes is that a citation now *also* leaves an observation, so the
+//! same miner that learns from reflection prose can learn from what the model
+//! said about a memory while using it. Two evidence sources feeding one loop,
+//! rather than one source feeding the loop and another feeding a separate
+//! quarantine counter that nothing else can see.
+//!
+//! # Why only negative citations become observations
+//!
+//! A positive citation says "this memory was right", which the memory already
+//! claims — mining it produces an observation that restates its own evidence,
+//! and spec §7's second anti-poisoning rule is that a proposal may not cite
+//! itself. A *negative* citation says something the corpus does not already
+//! contain: that a stored belief is wrong. That is new information and is worth
+//! learning from.
+//!
+//! # Why only failed tool calls
+//!
+//! Same asymmetry. A tool that worked is the expected case; mining it would
+//! bury the signal under thousands of successes. A failure is a fact about this
+//! workspace that the next turn could use.
+
+use stella_context::{AppendOutcome, ContextStore, LedgerAppend};
+use stella_core::context_record::{
+    ContextRecordKind, LIFECYCLE_SCHEMA_VERSION, ObservationRecord, ObservationSource,
+};
+use stella_core::redact::redact_secrets;
+use stella_store::MemoryCitationRow;
+
+/// The longest observation text either source will emit.
+///
+/// A remark is capped at 300 characters by `cite_memory` itself, but a tool
+/// error is unbounded — a stack trace or a wall of compiler output would
+/// otherwise become one enormous "observation" that the miner cannot cluster
+/// and a person cannot read.
+const MAX_OBSERVATION_CHARS: usize = 300;
+
+/// Truncate on a character boundary, marking that it happened.
+///
+/// Silent truncation is banned by spec §5.5, and this is the honest form: the
+/// ellipsis is in the stored text, so a reader of the ledger can see the
+/// sentence was cut rather than believing the tool said only that much.
+fn bounded(text: &str) -> String {
+    if text.chars().count() <= MAX_OBSERVATION_CHARS {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(MAX_OBSERVATION_CHARS - 1).collect();
+    format!("{kept}…")
+}
+
+/// Append an observation for one negative citation. `None` if there is nothing
+/// worth recording or the write failed.
+///
+/// The candidate id is the cited memory rather than the citation, so repeated
+/// negative citations of the same memory across different tasks cluster —
+/// which is exactly the recurrence the proposal miner counts.
+pub(super) fn citation_observation(
+    store: &ContextStore,
+    citation: &MemoryCitationRow,
+    task_id: &str,
+    observed_at: &str,
+) -> Option<AppendOutcome> {
+    // Positive citations are self-confirming; see the module docs.
+    if citation.is_positive() {
+        return None;
+    }
+    if citation.remark.trim().is_empty() {
+        return None;
+    }
+    let text = format!(
+        "memory {} was cited unhelpful: {}",
+        citation.memory_id,
+        citation.remark.trim()
+    );
+    append(
+        store,
+        ObservationSource::MemoryCitation,
+        format!("citation:{}", citation.memory_id),
+        task_id,
+        &text,
+        observed_at,
+    )
+}
+
+/// Append an observation for one failed tool call.
+pub(super) fn tool_outcome_observation(
+    store: &ContextStore,
+    tool: &str,
+    error: &str,
+    task_id: &str,
+    observed_at: &str,
+) -> Option<AppendOutcome> {
+    if error.trim().is_empty() {
+        return None;
+    }
+    let text = format!("tool {tool} failed: {}", error.trim());
+    // Keyed on the tool, so repeated failures of the same tool cluster into one
+    // candidate rather than each becoming its own singleton.
+    append(
+        store,
+        ObservationSource::ToolOutcome,
+        format!("tool:{tool}"),
+        task_id,
+        &text,
+        observed_at,
+    )
+}
+
+/// Redact, bound, type, and append. `None` on any failure.
+fn append(
+    store: &ContextStore,
+    source: ObservationSource,
+    candidate_id: String,
+    task_id: &str,
+    text: &str,
+    observed_at: &str,
+) -> Option<AppendOutcome> {
+    // Redaction happens BEFORE the record is constructed, matching
+    // [`super::observations::append_observation`]: no unredacted typed record
+    // ever exists, not even transiently as something a later refactor could
+    // persist by accident. A tool error is the single most likely place in this
+    // tree for a credential to appear — a failing curl or psql prints its own
+    // arguments — so this ordering is load-bearing here, not ceremonial.
+    let redaction = redact_secrets(&bounded(text));
+    let record = ObservationRecord::new(
+        source,
+        candidate_id,
+        task_id.to_string(),
+        redaction.text,
+        Vec::new(),
+        redaction.redacted,
+        observed_at.to_string(),
+    )
+    .ok()?;
+
+    let body = serde_json::to_string(&record).ok()?;
+    store
+        .append_record(LedgerAppend {
+            record_id: &record.record_id,
+            lineage_id: &record.lineage_id,
+            record_kind: ContextRecordKind::Observation.as_str(),
+            record_hash: &record.record_hash,
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            body: &body,
+            observed_at: &record.observed_at,
+            supersedes: None,
+        })
+        .ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-cli/src/memory/evidence/tests.rs
+++ b/stella-cli/src/memory/evidence/tests.rs
@@ -1,0 +1,191 @@
+//! Phase 4 deliverable 2: citations and tool outcomes are evidence sources
+//! alongside reflection lessons — without changing what citation already means.
+
+use stella_context::{AppendOutcome, ContextStore};
+use stella_core::context_record::{ContextRecordKind, ObservationRecord, ObservationSource};
+use stella_store::MemoryCitationRow;
+
+use super::*;
+
+const AT: &str = "2026-07-26T00:00:00Z";
+
+fn store() -> (tempfile::TempDir, ContextStore) {
+    let dir = tempfile::tempdir().expect("workspace");
+    let store = ContextStore::open(dir.path().join("context.db")).expect("context.db");
+    (dir, store)
+}
+
+fn citation(memory_id: &str, score: i64, truthful: bool, remark: &str) -> MemoryCitationRow {
+    MemoryCitationRow {
+        memory_id: memory_id.into(),
+        useful_score: score,
+        truthful,
+        remark: remark.into(),
+    }
+}
+
+fn observations(store: &ContextStore) -> Vec<ObservationRecord> {
+    store
+        .records_of_kind(ContextRecordKind::Observation.as_str(), 100)
+        .expect("read")
+        .into_iter()
+        .filter_map(|row| serde_json::from_str(&row.body).ok())
+        .collect()
+}
+
+#[test]
+fn a_negative_citation_becomes_a_citation_sourced_observation() {
+    let (_dir, store) = store();
+    let outcome = citation_observation(
+        &store,
+        &citation("nod_a", 1, false, "the path it names was deleted"),
+        "task1",
+        AT,
+    );
+
+    assert_eq!(outcome, Some(AppendOutcome::Appended));
+    let observations = observations(&store);
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].source, ObservationSource::MemoryCitation);
+    assert!(
+        observations[0]
+            .text
+            .contains("the path it names was deleted")
+    );
+    assert_eq!(observations[0].task_id, "task1");
+}
+
+#[test]
+fn a_positive_citation_is_not_mined_because_it_would_cite_itself() {
+    let (_dir, store) = store();
+    // Spec §7: a proposal may not cite itself. "This memory was right" is the
+    // memory restating its own claim.
+    let outcome = citation_observation(&store, &citation("nod_a", 5, true, "spot on"), "task1", AT);
+
+    assert_eq!(outcome, None);
+    assert!(observations(&store).is_empty());
+}
+
+#[test]
+fn a_citation_with_no_remark_records_nothing() {
+    let (_dir, store) = store();
+    let outcome = citation_observation(&store, &citation("nod_a", 1, false, "   "), "task1", AT);
+
+    assert_eq!(outcome, None);
+    assert!(observations(&store).is_empty());
+}
+
+#[test]
+fn a_failed_tool_call_becomes_a_tool_outcome_observation() {
+    let (_dir, store) = store();
+    let outcome = tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT);
+
+    assert_eq!(outcome, Some(AppendOutcome::Appended));
+    let observations = observations(&store);
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].source, ObservationSource::ToolOutcome);
+    assert!(observations[0].text.contains("linker not found"));
+}
+
+#[test]
+fn repeated_failures_of_one_tool_cluster_under_one_candidate() {
+    let (_dir, store) = store();
+    // Different tasks, same tool: the candidate id must be the tool so the
+    // miner sees recurrence rather than two unrelated singletons.
+    tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT);
+    tool_outcome_observation(
+        &store,
+        "run_tests",
+        "linker not found",
+        "task2",
+        "2026-07-27T00:00:00Z",
+    );
+
+    let observations = observations(&store);
+    assert_eq!(observations.len(), 2);
+    assert_eq!(
+        observations[0].source_ref, observations[1].source_ref,
+        "same tool must share a source ref so failures cluster"
+    );
+    assert_ne!(
+        observations[0].task_id, observations[1].task_id,
+        "two distinct tasks is what makes the recurrence count"
+    );
+}
+
+#[test]
+fn re_appending_the_same_evidence_is_a_replay() {
+    let (_dir, store) = store();
+    let row = citation("nod_a", 1, false, "wrong");
+    assert_eq!(
+        citation_observation(&store, &row, "task1", AT),
+        Some(AppendOutcome::Appended)
+    );
+    assert_eq!(
+        citation_observation(&store, &row, "task1", AT),
+        Some(AppendOutcome::AlreadyPresent),
+        "content-derived ids must absorb a re-scan as a replay"
+    );
+    assert_eq!(observations(&store).len(), 1);
+}
+
+#[test]
+fn a_secret_in_a_tool_error_is_redacted_before_it_is_stored() {
+    let (_dir, store) = store();
+    // A failing command that printed its own arguments is the single most
+    // likely place a credential reaches this path.
+    tool_outcome_observation(
+        &store,
+        "shell",
+        "curl failed: Authorization: Bearer sk-ant-api03-SECRETVALUE1234567890",
+        "task1",
+        AT,
+    );
+
+    let observations = observations(&store);
+    assert_eq!(observations.len(), 1);
+    assert!(
+        !observations[0].text.contains("SECRETVALUE1234567890"),
+        "the stored observation still carries the secret: {}",
+        observations[0].text
+    );
+    assert!(observations[0].redacted, "redaction must be declared");
+}
+
+#[test]
+fn an_unbounded_tool_error_is_truncated_visibly() {
+    let (_dir, store) = store();
+    let wall_of_text = "e".repeat(5_000);
+    tool_outcome_observation(&store, "build", &wall_of_text, "task1", AT);
+
+    let observations = observations(&store);
+    let text = &observations[0].text;
+    assert!(
+        text.chars().count() <= MAX_OBSERVATION_CHARS,
+        "a stack trace must not become one enormous observation"
+    );
+    // Spec §5.5: no silent truncation. The cut is visible in the stored text.
+    assert!(text.ends_with('…'), "truncation must be visible: {text}");
+}
+
+#[test]
+fn bounded_leaves_a_short_string_untouched() {
+    assert_eq!(bounded("short"), "short");
+}
+
+#[test]
+fn bounded_never_splits_a_multibyte_character() {
+    // Truncating by bytes would panic here. The boundary is characters.
+    let text = "é".repeat(MAX_OBSERVATION_CHARS + 50);
+    let out = bounded(&text);
+    assert!(out.chars().count() <= MAX_OBSERVATION_CHARS);
+}
+
+#[test]
+fn the_citation_loops_own_thresholds_are_untouched() {
+    // The deliverable keeps citation semantics. This module must not have
+    // introduced a second quarantine path or moved the shipped constants.
+    assert_eq!(stella_store::QUARANTINE_NEGATIVES_THRESHOLD, 2);
+    assert_eq!(stella_store::PROMOTION_CITATIONS_REQUIRED, 10);
+    assert_eq!(stella_store::POSITIVE_SCORE_MIN, 3);
+}

--- a/stella-cli/src/memory/learning.rs
+++ b/stella-cli/src/memory/learning.rs
@@ -245,6 +245,44 @@ impl SessionMemory {
             .unwrap_or_default()
     }
 
+    /// Retire context that has provably stopped helping (#715 deliverable 5).
+    ///
+    /// Notification is the `quiet` half of the deliverable's
+    /// "mark → stop selecting → notify → reaffirm" arc: a retirement the user
+    /// never hears about is indistinguishable from a memory that quietly
+    /// stopped working, which is the failure mode the whole phase exists to
+    /// remove. Refusals are printed too — a sweep that silently declines to act
+    /// on protected records reads as "nothing was failing", a different claim.
+    fn retire_failing_context(&self, quiet: bool) {
+        let policy = super::tuning::selection_health_policy(&self.workspace_root);
+        let health = super::uses::selection_health(&self.store, policy);
+        if health.is_empty() {
+            return;
+        }
+        let now = stella_context::format_rfc3339(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0) as i64,
+        );
+        let sweep = super::retirement::sweep(&self.store, &health, &now);
+        if quiet {
+            return;
+        }
+        for record_id in &sweep.retired {
+            eprintln!(
+                "memory: retired {record_id} — it stopped helping. \
+                 `stella memory reaffirm {record_id}` restores it."
+            );
+        }
+        for (record_id, protection) in &sweep.refused {
+            eprintln!(
+                "memory: {record_id} is failing but is {} — left in place.",
+                protection.as_str()
+            );
+        }
+    }
+
     /// Write out whichever candidates the caller decided to keep, under the
     /// per-session cap and the no-clobber guard.
     ///
@@ -316,6 +354,19 @@ impl SessionMemory {
     /// thresholds, the same tombstone sweep, the same cap, the same no-clobber
     /// guard, the same rendering.
     fn auto_create_skills_typed(&mut self, log_path: &Path, quiet: bool) {
+        // 0. Attribution (#715 deliverables 1 and 5). What finished turns
+        //    actually put in front of the model, and what they said about it,
+        //    become immutable ledger records; then context that has provably
+        //    stopped helping is retired — reversibly, with a reason, and never
+        //    if it is protected. Runs first so the observations below and the
+        //    selection health derived from them see the same ledger.
+        //    Best-effort by construction: a store that will not open means no
+        //    attribution this turn, never a failed turn.
+        if let Ok(store) = stella_store::Store::open(&self.workspace_root) {
+            super::uses::extract_context_uses(&store, &self.store);
+        }
+        self.retire_failing_context(quiet);
+
         // 1. Evidence → typed, redacted, replay-idempotent observations.
         super::observations::extract_reflection_observations(&self.store, log_path);
 

--- a/stella-cli/src/memory/recall.rs
+++ b/stella-cli/src/memory/recall.rs
@@ -189,16 +189,19 @@ impl SessionMemory {
             as_of: None,
             representation_preferences: vec![],
         };
-        // Two independent suppression sets, read together and applied as one.
-        // Quarantine is *derived* — the model kept calling a memory untruthful;
-        // a tombstone is *stored* — a person read it and said remove it. Both
-        // are fail-closed for the same reason: if the state cannot be read,
-        // surfacing everything is the one outcome that is definitely wrong.
-        let quarantined = match stella_store::Store::open(&self.workspace_root).and_then(|store| {
-            let mut ids = store.quarantined_memory_ids()?;
-            ids.extend(store.forgotten_ids(stella_store::ContextSurface::Memory)?);
-            Ok(ids)
-        }) {
+        // The suppression sets, read together and applied as one. This is a
+        // redundant net behind the provider-internal read — and it goes through
+        // the SAME reader rather than spelling the union out again, because two
+        // copies of "what is suppressed" are two things that can disagree. When
+        // retirement joined the union (#715 deliverable 5) the inline copy that
+        // used to live here would have silently kept serving retired records.
+        //
+        // Fail-closed: if the state cannot be read, surfacing everything is the
+        // one outcome that is definitely wrong.
+        let quarantined = match super::suppression::suppression_reader(
+            &self.workspace_root,
+            self.store.clone(),
+        )() {
             Ok(ids) => ids,
             Err(error) => {
                 report(format!(

--- a/stella-cli/src/memory/retirement.rs
+++ b/stella-cli/src/memory/retirement.rs
@@ -1,0 +1,305 @@
+//! Reversible retirement — Phase 4 deliverable 5 (#715).
+//!
+//! Context that repeatedly fails to help stops being selected — visibly, with
+//! reasons, and reversibly.
+//!
+//! # Retirement is derived, not stored
+//!
+//! A retirement is an immutable `promotion_event` carrying
+//! [`PromotionAction::Retired`]; a reaffirmation is one carrying
+//! [`PromotionAction::Reverted`]. What a record's standing *is* comes from
+//! folding those events last-write-wins — exactly the state machine
+//! [`crate::proposals_cmd::decisions`] already runs for keep/ignore, and for
+//! the same reason: spec §5.2 forbids storing `stale` as state, and a fold over
+//! append-only events is reversible by construction. Reaffirming is not an undo
+//! that erases anything; it is a later fact that outranks an earlier one, and
+//! both stay readable.
+//!
+//! Reusing `promotion_event` rather than minting a record kind is deliberate.
+//! It already requires a human-readable reason at the constructor
+//! (`PromotionEventError::MissingReason`), which is one of the gate criteria,
+//! and `Retired`/`Reverted` were already in [`PromotionAction`] with no writer.
+//! The one stretch is the field name: `proposal_lineage_id` holds the retired
+//! record's id here, because the field is "the lineage this decision is about"
+//! and a retirement is a decision about a lineage. That widening is recorded
+//! here rather than left for a reader to infer.
+//!
+//! # Why this is not a second suppression mechanism
+//!
+//! Spec §5.7 says a second suppression mechanism is a defect. Retirement adds
+//! no new one: it joins the union [`crate::memory::suppression`] already reads
+//! fresh on every recall, beside derived quarantine and stored tombstones. It
+//! writes no `superseded_at`, which is what keeps a retired record **explicitly
+//! retrievable** — `node_by_public_id` filters on that column, so routing
+//! retirement through `supersede_node` would have made retired records
+//! un-fetchable by id and failed the gate outright.
+//!
+//! Nothing here deletes anything, ever.
+
+use std::collections::{HashMap, HashSet};
+
+use stella_context::ContextStore;
+use stella_core::context_record::{
+    ContextRecordKind, LIFECYCLE_SCHEMA_VERSION, PromotionAction, PromotionActor,
+    PromotionEventRecord, SelectionHealth,
+};
+
+/// How many promotion events one replay reads. Matches the proposals surface's
+/// own bound — the ledger grows monotonically and a full read is unbounded work
+/// on the turn path.
+const READ_LIMIT: usize = 5_000;
+
+/// Why a record may never be retired automatically.
+///
+/// The gate criterion is "protected categories are provably never retired",
+/// and *provably* is only meaningful if there is exactly one predicate — a
+/// check a caller can forget to run leaves the other paths open. Every
+/// retirement in this module goes through [`protection_for`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetirementProtection {
+    /// A person confirmed this record. Their judgement outranks the loop's.
+    UserConfirmed,
+    /// Published to a team. Retiring it locally would diverge shared state.
+    Published,
+    /// Carries blocking enforcement — it steers, and §5.4 puts blocking
+    /// exclusively under human control in both directions.
+    Blocking,
+    /// Already retired; retiring again would be a no-op event that muddies the
+    /// replay.
+    AlreadyRetired,
+}
+
+impl RetirementProtection {
+    /// A human-readable phrase for a report.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::UserConfirmed => "user-confirmed",
+            Self::Published => "published",
+            Self::Blocking => "blocking",
+            Self::AlreadyRetired => "already retired",
+        }
+    }
+}
+
+/// The standing of every record the promotion log has an opinion about.
+///
+/// Append order, not `observed_at` — the same reasoning as
+/// [`crate::proposals_cmd::promotion_events`]: two events in the same second
+/// share a timestamp and would otherwise be ordered by content hash, which is a
+/// deterministic wrong answer rather than a flake.
+pub(crate) fn standings(store: &ContextStore) -> HashMap<String, PromotionEventRecord> {
+    let mut out = HashMap::new();
+    let rows = store
+        .records_of_kind_in_append_order(ContextRecordKind::PromotionEvent.as_str(), READ_LIMIT)
+        .unwrap_or_default();
+    for row in rows {
+        let Ok(event) = serde_json::from_str::<PromotionEventRecord>(&row.body) else {
+            continue;
+        };
+        out.insert(event.proposal_lineage_id.clone(), event);
+    }
+    out
+}
+
+/// Records currently retired — the set the suppression reader unions in.
+///
+/// A record whose latest event is `Reverted` (or `Confirmed`, or anything
+/// else) is **not** here: reaffirmation restores it by outranking the
+/// retirement, without erasing it.
+pub(crate) fn retired_ids(store: &ContextStore) -> HashSet<String> {
+    standings(store)
+        .into_iter()
+        .filter(|(_, event)| event.action == PromotionAction::Retired)
+        .map(|(lineage, _)| lineage)
+        .collect()
+}
+
+/// Why this record may not be retired, or `None` if it may.
+///
+/// # The five named categories, and why only three are checked
+///
+/// The deliverable names five: blocking, critical, user-confirmed, published,
+/// and pinned. Three are checked here. The other two are **not expressible in
+/// this tree today**, and stating that is more useful than a check that only
+/// looks like protection:
+///
+/// - **critical.** [`DirectivePriority::Critical`] exists as an enum variant
+///   and is carried on no record, set by no code path, and read by nothing. A
+///   record therefore cannot *be* critical, so "critical records are never
+///   retired" holds vacuously.
+/// - **pinned.** No pin field, flag, or command exists for memory or context
+///   records anywhere (`RoleTable::pin` is model routing, unrelated).
+///
+/// Both are guarded by the same thing instead: this function is the single
+/// predicate every retirement passes through, so when either concept becomes
+/// real its check goes here and nowhere else. Inventing a mechanism now purely
+/// to have something to protect would have been the worse answer — it would
+/// make the gate criterion *look* satisfied by code that never fires.
+///
+/// [`DirectivePriority::Critical`]: stella_core::context_record::DirectivePriority
+pub(crate) fn protection_for(
+    standing: Option<&PromotionEventRecord>,
+) -> Option<RetirementProtection> {
+    let standing = standing?;
+    if standing.enforcement == Some(stella_core::context_record::DirectiveEnforcement::Blocking) {
+        return Some(RetirementProtection::Blocking);
+    }
+    match standing.action {
+        // A user's confirmation is the strongest signal in the system. Note
+        // this checks the ACTION, not the actor: a system auto-activation is
+        // not a confirmation, and must stay retirable.
+        PromotionAction::Confirmed if standing.actor == PromotionActor::User => {
+            Some(RetirementProtection::UserConfirmed)
+        }
+        PromotionAction::Published => Some(RetirementProtection::Published),
+        PromotionAction::Retired => Some(RetirementProtection::AlreadyRetired),
+        _ => None,
+    }
+}
+
+/// The retirement a failing record has earned, or `None`.
+///
+/// Separated from the write so the decision is testable without a store, and
+/// so the reason is built in one place — a retirement with no legible cause is
+/// exactly what the gate criterion forbids.
+pub(crate) fn retirement_reason(health: &SelectionHealth) -> Option<String> {
+    if !health.failing {
+        return None;
+    }
+    Some(format!(
+        "not helpful in {} of {} assessed uses across {} task(s) — \
+         auto-retired by the efficacy loop; reaffirm to restore",
+        health.not_helpful, health.assessed_uses, health.distinct_tasks
+    ))
+}
+
+/// Outcome of one retirement sweep, for reporting.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct RetirementSweep {
+    /// Records newly retired.
+    pub(crate) retired: Vec<String>,
+    /// Records that were failing but are protected, with why. Reported rather
+    /// than silently skipped — a sweep that quietly declines to act on half its
+    /// candidates reads as "nothing was failing", which is a different claim.
+    pub(crate) refused: Vec<(String, RetirementProtection)>,
+}
+
+/// Retire every failing, unprotected record. Returns what it did.
+///
+/// The actor is [`PromotionActor::System`] and the enforcement is `None`: a
+/// system event may never carry blocking enforcement, and the constructor
+/// refuses one that tries.
+pub(crate) fn sweep(
+    store: &ContextStore,
+    health: &[SelectionHealth],
+    occurred_at: &str,
+) -> RetirementSweep {
+    let standings = standings(store);
+    let mut sweep = RetirementSweep::default();
+    for record in health {
+        let Some(reason) = retirement_reason(record) else {
+            continue;
+        };
+        if let Some(protection) = protection_for(standings.get(&record.context_record_id)) {
+            sweep
+                .refused
+                .push((record.context_record_id.clone(), protection));
+            continue;
+        }
+        if record_decision(
+            store,
+            &record.context_record_id,
+            PromotionAction::Retired,
+            PromotionActor::System,
+            &reason,
+            occurred_at,
+        ) {
+            sweep.retired.push(record.context_record_id.clone());
+        }
+    }
+    sweep
+}
+
+/// Retire a record on a person's explicit judgement.
+///
+/// The actor is [`PromotionActor::User`], which is what distinguishes this from
+/// the sweep's system decision in the replay — "who decided this" is the first
+/// question anyone asks of a retirement, and the log answers it without
+/// inference.
+pub(crate) fn retire_explicitly(
+    store: &ContextStore,
+    record_id: &str,
+    reason: &str,
+    occurred_at: &str,
+) -> bool {
+    record_decision(
+        store,
+        record_id,
+        PromotionAction::Retired,
+        PromotionActor::User,
+        reason,
+        occurred_at,
+    )
+}
+
+/// Reaffirm a retired record, restoring it to automatic selection.
+///
+/// Returns whether the event was written. This is the gate's "restorable", and
+/// it is a plain append: the retirement stays in the log, outranked.
+pub(crate) fn reaffirm(
+    store: &ContextStore,
+    record_id: &str,
+    reason: &str,
+    occurred_at: &str,
+) -> bool {
+    record_decision(
+        store,
+        record_id,
+        PromotionAction::Reverted,
+        PromotionActor::User,
+        reason,
+        occurred_at,
+    )
+}
+
+/// Append one retirement-plane decision. `false` on any failure.
+fn record_decision(
+    store: &ContextStore,
+    record_id: &str,
+    action: PromotionAction,
+    actor: PromotionActor,
+    reason: &str,
+    occurred_at: &str,
+) -> bool {
+    let Ok(event) = PromotionEventRecord::new(
+        record_id,
+        action,
+        actor,
+        // Never an enforcement grant: retiring and reaffirming change whether a
+        // record is selected, never what authority it carries.
+        None,
+        None,
+        reason,
+        occurred_at,
+    ) else {
+        return false;
+    };
+    let Ok(body) = serde_json::to_string(&event) else {
+        return false;
+    };
+    store
+        .append_record(stella_context::LedgerAppend {
+            record_id: &event.record_id,
+            lineage_id: &event.lineage_id,
+            record_kind: ContextRecordKind::PromotionEvent.as_str(),
+            record_hash: &event.record_hash,
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            body: &body,
+            observed_at: &event.occurred_at,
+            supersedes: None,
+        })
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-cli/src/memory/retirement/tests.rs
+++ b/stella-cli/src/memory/retirement/tests.rs
@@ -1,0 +1,311 @@
+//! Phase 4 deliverable 5: retirement is derived, reversible, reasoned, and
+//! provably never touches a protected record.
+
+use stella_context::ContextStore;
+use stella_core::context_record::{
+    DirectiveEnforcement, PromotionAction, PromotionActor, PromotionEventRecord, SelectionHealth,
+};
+
+use super::*;
+
+const AT: &str = "2026-07-26T00:00:00Z";
+
+fn store() -> (tempfile::TempDir, ContextStore) {
+    let dir = tempfile::tempdir().expect("workspace");
+    let store = ContextStore::open(dir.path().join("context.db")).expect("context.db");
+    (dir, store)
+}
+
+/// A record whose evidence says it is failing.
+fn failing(record_id: &str) -> SelectionHealth {
+    SelectionHealth {
+        context_record_id: record_id.into(),
+        uses: 10,
+        distinct_tasks: 4,
+        assessed_uses: 5,
+        helpful: 0,
+        not_helpful: 5,
+        neutral: 0,
+        not_helpful_ratio: 1.0,
+        eligible_assessed: 5,
+        eligible_not_helpful: 5,
+        attributable: true,
+        failing: true,
+    }
+}
+
+/// A record that is doing fine.
+fn healthy(record_id: &str) -> SelectionHealth {
+    SelectionHealth {
+        context_record_id: record_id.into(),
+        uses: 10,
+        distinct_tasks: 4,
+        assessed_uses: 5,
+        helpful: 5,
+        not_helpful: 0,
+        neutral: 0,
+        not_helpful_ratio: 0.0,
+        eligible_assessed: 5,
+        eligible_not_helpful: 0,
+        attributable: true,
+        failing: false,
+    }
+}
+
+/// Put a standing on the log so the protection check has something to read.
+fn given_standing(
+    store: &ContextStore,
+    record_id: &str,
+    action: PromotionAction,
+    actor: PromotionActor,
+    enforcement: Option<DirectiveEnforcement>,
+) {
+    let event = PromotionEventRecord::new(
+        record_id,
+        action,
+        actor,
+        enforcement,
+        None,
+        "test standing",
+        AT,
+    )
+    .expect("event");
+    let body = serde_json::to_string(&event).expect("body");
+    store
+        .append_record(stella_context::LedgerAppend {
+            record_id: &event.record_id,
+            lineage_id: &event.lineage_id,
+            record_kind: stella_core::context_record::ContextRecordKind::PromotionEvent.as_str(),
+            record_hash: &event.record_hash,
+            schema_version: stella_core::context_record::LIFECYCLE_SCHEMA_VERSION,
+            body: &body,
+            observed_at: &event.occurred_at,
+            supersedes: None,
+        })
+        .expect("append");
+}
+
+#[test]
+fn a_failing_record_is_retired_with_a_legible_reason() {
+    let (_dir, store) = store();
+    let sweep = sweep(&store, &[failing("nod_a")], AT);
+
+    assert_eq!(sweep.retired, vec!["nod_a".to_string()]);
+    assert!(retired_ids(&store).contains("nod_a"));
+
+    // The gate: retirement decisions carry a human-readable reason.
+    let standing = standings(&store);
+    let reason = &standing.get("nod_a").expect("standing").reason;
+    assert!(!reason.trim().is_empty());
+    assert!(
+        reason.contains("not helpful in 5 of 5"),
+        "the reason must say what the evidence was, got: {reason}"
+    );
+}
+
+#[test]
+fn a_healthy_record_is_never_retired() {
+    let (_dir, store) = store();
+    let sweep = sweep(&store, &[healthy("nod_a")], AT);
+
+    assert!(sweep.retired.is_empty());
+    assert!(retired_ids(&store).is_empty());
+}
+
+#[test]
+fn a_record_nobody_assessed_is_never_retired() {
+    let (_dir, store) = store();
+    // Rendered constantly, judged never. Disuse is not a negative.
+    let silent = SelectionHealth {
+        context_record_id: "nod_a".into(),
+        uses: 500,
+        distinct_tasks: 40,
+        assessed_uses: 0,
+        helpful: 0,
+        not_helpful: 0,
+        neutral: 0,
+        not_helpful_ratio: 0.0,
+        eligible_assessed: 0,
+        eligible_not_helpful: 0,
+        attributable: false,
+        failing: false,
+    };
+
+    assert!(sweep(&store, &[silent], AT).retired.is_empty());
+}
+
+#[test]
+fn a_user_confirmed_record_is_provably_never_retired() {
+    let (_dir, store) = store();
+    given_standing(
+        &store,
+        "nod_a",
+        PromotionAction::Confirmed,
+        PromotionActor::User,
+        None,
+    );
+
+    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    assert!(sweep.retired.is_empty());
+    assert_eq!(
+        sweep.refused,
+        vec![("nod_a".to_string(), RetirementProtection::UserConfirmed)]
+    );
+    assert!(!retired_ids(&store).contains("nod_a"));
+}
+
+#[test]
+fn a_published_record_is_provably_never_retired() {
+    let (_dir, store) = store();
+    given_standing(
+        &store,
+        "nod_a",
+        PromotionAction::Published,
+        PromotionActor::User,
+        None,
+    );
+
+    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    assert!(sweep.retired.is_empty());
+    assert_eq!(sweep.refused[0].1, RetirementProtection::Published);
+}
+
+#[test]
+fn a_blocking_record_is_provably_never_retired() {
+    let (_dir, store) = store();
+    // Blocking requires a user actor by construction — the constructor refuses
+    // a system-granted one, which is itself the §5.4 guarantee.
+    given_standing(
+        &store,
+        "nod_a",
+        PromotionAction::Confirmed,
+        PromotionActor::User,
+        Some(DirectiveEnforcement::Blocking),
+    );
+
+    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    assert!(sweep.retired.is_empty());
+    assert_eq!(sweep.refused[0].1, RetirementProtection::Blocking);
+}
+
+#[test]
+fn a_system_auto_activation_is_not_a_confirmation_and_stays_retirable() {
+    let (_dir, store) = store();
+    // The protection is the user's ACT, not merely the presence of a standing.
+    // A record the system activated on its own has no human judgement behind
+    // it, so the loop may retire what the loop promoted.
+    given_standing(
+        &store,
+        "nod_a",
+        PromotionAction::AutoActivated,
+        PromotionActor::System,
+        None,
+    );
+
+    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    assert_eq!(sweep.retired, vec!["nod_a".to_string()]);
+}
+
+#[test]
+fn retirement_is_reversible_by_reaffirming() {
+    let (_dir, store) = store();
+    sweep(&store, &[failing("nod_a")], AT);
+    assert!(retired_ids(&store).contains("nod_a"));
+
+    assert!(reaffirm(&store, "nod_a", "still needed", AT));
+    assert!(
+        !retired_ids(&store).contains("nod_a"),
+        "a reaffirmed record must return to automatic selection"
+    );
+}
+
+#[test]
+fn reaffirming_outranks_without_erasing() {
+    let (_dir, store) = store();
+    sweep(&store, &[failing("nod_a")], AT);
+    reaffirm(&store, "nod_a", "still needed", AT);
+
+    // Both acts remain readable — the ledger is append-only and nothing was
+    // deleted. The standing is the latest, not the only.
+    let events = store
+        .records_of_kind_in_append_order(
+            stella_core::context_record::ContextRecordKind::PromotionEvent.as_str(),
+            100,
+        )
+        .expect("read");
+    assert_eq!(events.len(), 2, "the retirement must still be on the log");
+    assert_eq!(
+        standings(&store).get("nod_a").expect("standing").action,
+        PromotionAction::Reverted
+    );
+}
+
+#[test]
+fn a_reaffirmed_record_can_be_retired_again_if_it_keeps_failing() {
+    let (_dir, store) = store();
+    sweep(&store, &[failing("nod_a")], AT);
+    reaffirm(&store, "nod_a", "give it another chance", AT);
+
+    // Reaffirmation is not permanent immunity — the loop stays live. Use a
+    // distinct timestamp so the second retirement is a different record.
+    let again = sweep(&store, &[failing("nod_a")], "2026-07-27T00:00:00Z");
+    assert_eq!(again.retired, vec!["nod_a".to_string()]);
+    assert!(retired_ids(&store).contains("nod_a"));
+}
+
+#[test]
+fn retiring_an_already_retired_record_is_refused_not_duplicated() {
+    let (_dir, store) = store();
+    sweep(&store, &[failing("nod_a")], AT);
+
+    let again = sweep(&store, &[failing("nod_a")], "2026-07-27T00:00:00Z");
+    assert!(again.retired.is_empty());
+    assert_eq!(again.refused[0].1, RetirementProtection::AlreadyRetired);
+}
+
+#[test]
+fn a_refused_retirement_is_reported_rather_than_silently_skipped() {
+    let (_dir, store) = store();
+    given_standing(
+        &store,
+        "nod_protected",
+        PromotionAction::Confirmed,
+        PromotionActor::User,
+        None,
+    );
+
+    let sweep = sweep(
+        &store,
+        &[failing("nod_protected"), failing("nod_ordinary")],
+        AT,
+    );
+    assert_eq!(sweep.retired, vec!["nod_ordinary".to_string()]);
+    assert_eq!(
+        sweep.refused.len(),
+        1,
+        "the sweep must say what it declined"
+    );
+}
+
+#[test]
+fn retirement_never_deletes_the_record() {
+    let (_dir, store) = store();
+    sweep(&store, &[failing("nod_a")], AT);
+
+    // Retirement writes one event and touches nothing else. The ledger is
+    // append-only at the database, so this is belt and braces — but "never
+    // physically deletes" is a gate criterion and deserves its own assertion.
+    let events = store
+        .records_of_kind_in_append_order(
+            stella_core::context_record::ContextRecordKind::PromotionEvent.as_str(),
+            100,
+        )
+        .expect("read");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn a_retirement_reason_is_only_produced_for_a_failing_record() {
+    assert!(retirement_reason(&healthy("nod_a")).is_none());
+    assert!(retirement_reason(&failing("nod_a")).is_some());
+}

--- a/stella-cli/src/memory/suppression.rs
+++ b/stella-cli/src/memory/suppression.rs
@@ -5,13 +5,22 @@
 //! that has to stay obvious: cached suppression would keep serving a memory
 //! the previous turn just called untruthful.
 
-/// The two suppression sets, read together and applied as one, fresh on every
+/// The three suppression sets, read together and applied as one, fresh on every
 /// recall.
 ///
 /// Quarantine is *derived* — the model kept calling a memory untruthful; a
-/// tombstone is *stored* — a person read it and said remove it. Both are
-/// fail-closed for the same reason: if the state cannot be read, surfacing
-/// everything is the one outcome that is definitely wrong.
+/// tombstone is *stored* — a person read it and said remove it; retirement is
+/// *derived* — the efficacy loop replayed the promotion log and the record's
+/// standing came back `Retired` (#715 deliverable 5). All three are fail-closed
+/// for the same reason: if the state cannot be read, surfacing everything is
+/// the one outcome that is definitely wrong.
+///
+/// **Retirement is not a second suppression mechanism** (spec §5.7). It adds a
+/// set to the union this reader already computes rather than a parallel path,
+/// and it deliberately does *not* write `node.superseded_at` — that column is
+/// filtered by `node_by_public_id`, so projecting retirement onto it would make
+/// a retired record impossible to fetch by id, when staying explicitly
+/// retrievable is exactly what distinguishes retirement from forgetting.
 ///
 /// The tombstone half is now also projected onto `node.superseded_at` when a
 /// forget is recorded, so recall would exclude it even with this reader absent.
@@ -21,15 +30,18 @@
 /// product can claim.
 pub(super) fn suppression_reader(
     workspace_root: &std::path::Path,
+    context: std::sync::Arc<stella_context::ContextStore>,
 ) -> crate::contextgraph::SuppressionReader {
     let root = workspace_root.to_path_buf();
     std::sync::Arc::new(move || {
-        stella_store::Store::open(&root)
+        let mut ids = stella_store::Store::open(&root)
             .and_then(|store| {
                 let mut ids = store.quarantined_memory_ids()?;
                 ids.extend(store.forgotten_ids(stella_store::ContextSurface::Memory)?);
                 Ok(ids)
             })
-            .map_err(|e| format!("suppression state unavailable: {e}"))
+            .map_err(|e| format!("suppression state unavailable: {e}"))?;
+        ids.extend(super::retirement::retired_ids(&context));
+        Ok(ids)
     })
 }

--- a/stella-cli/src/memory/tuning.rs
+++ b/stella-cli/src/memory/tuning.rs
@@ -61,6 +61,29 @@ pub(super) fn inferred_directive_promotion(
         .unwrap_or_default()
 }
 
+/// Phase 4 (#715): the efficacy thresholds that decide when a record's
+/// selection health counts as failing.
+///
+/// Degrades to the documented defaults for the same reason
+/// [`inferred_directive_promotion`] does. The conversion is here rather than a
+/// `From` impl in `stella-core` so the fold stays free of any settings type —
+/// it is a pure function over evidence and must remain testable without a
+/// workspace.
+pub(crate) fn selection_health_policy(
+    workspace_root: &std::path::Path,
+) -> stella_core::context_record::SelectionHealthPolicy {
+    let efficacy = crate::settings::Settings::load(workspace_root)
+        .ok()
+        .and_then(|s| s.context)
+        .map(|c| c.efficacy)
+        .unwrap_or_default();
+    stella_core::context_record::SelectionHealthPolicy {
+        min_attributable_uses: efficacy.min_attributable_uses,
+        not_helpful_ratio_threshold: efficacy.not_helpful_ratio_threshold,
+        min_attribution_confidence: efficacy.min_attribution_confidence,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::session_lifecycle_enabled;

--- a/stella-cli/src/memory/uses.rs
+++ b/stella-cli/src/memory/uses.rs
@@ -1,0 +1,400 @@
+//! Context-use extraction — Phase 4 deliverable 1 (#715).
+//!
+//! Turns what a finished turn *did* into immutable ledger records: which
+//! context records the frame put in front of the model ([`ContextUse`]), and
+//! what the turn then said about them ([`ContextUseFeedback`]).
+//!
+//! # Why this is an extractor and not a write at close-out
+//!
+//! The obvious design records a use where the use happens. It was rejected for
+//! two reasons, both structural:
+//!
+//! 1. **`record_execution_end` holds `store.db` only**, and has eight call
+//!    sites (`run`, REPL, two `/goal` loops, three deck paths, fleet,
+//!    subsession). Threading a second database through all of them puts the
+//!    audit close-out — the function that decides `audit_complete` — one
+//!    borrow away from a `context.db` failure it has no business caring about.
+//! 2. **The receipt plane has no turn-end hook at all.** The `ReceiptLedger`
+//!    is stack-local to `run_turn_with_sender` and emits its manifest *before*
+//!    the model call commits, so there is no moment inside it where an outcome
+//!    is known.
+//!
+//! Extraction sidesteps both. Everything a use record needs is already durable
+//! in `store.db` — `context_blocks` says what the frame carried,
+//! `memory_citations` says what the turn thought of it, `executions.outcome`
+//! says how the turn ended — so the record can be *derived* later, exactly the
+//! shape Phase 3 already uses for reflection lessons
+//! ([`super::observations`]). Deriving also makes the write replay-idempotent
+//! for free: ids are content-addressed, so a re-scan re-derives the same ids
+//! and the ledger absorbs them as `AlreadyPresent`.
+//!
+//! # Why the records land in `context.db` and not `store.db`
+//!
+//! The Phase 4 gate is "aggregates rebuild exactly from immutable records."
+//! `memory_citations` is in [`stella_store::prune::DEPENDENT_TABLES`], so
+//! `stella stats prune` deletes citation rows with their execution — a fold
+//! over them is *not* rebuildable across a prune. `context_records` is
+//! append-only enforced by SQLite triggers and is never pruned, so it is the
+//! only surface in the tree where that gate actually holds.
+//!
+//! The consequence, stated rather than hidden: extraction must run *before* a
+//! prune reaches an execution, or that turn's uses are never captured. The
+//! capture window is bounded by prune retention (90 days by default), and the
+//! extractor runs every turn, so it is not a practical risk — but it is a real
+//! ordering dependency and not an invariant this module can enforce alone.
+
+use stella_context::{AppendOutcome, ContextStore, LedgerAppend};
+use stella_core::context_record::{
+    ContextInfluenceStage, ContextOutcomeRelation, ContextRecordKind, ContextUse,
+    ContextUseEvaluation, ContextUseFeedback, ContextUseKind, LIFECYCLE_SCHEMA_VERSION,
+    SelectionHealth, SelectionHealthPolicy, fold_selection_health, record_hash,
+};
+use stella_store::{FinishedExecution, MemoryCitationRow, Store};
+
+/// The cursor key for execution-sourced context uses. Stable — it is a primary
+/// key in `context_extraction_cursor`, and changing it re-scans from zero.
+const USE_SOURCE: &str = "executions.context_use";
+
+/// How many executions one extraction pass will look at.
+///
+/// Bounded because this runs on the turn path: a workspace whose ledger has
+/// been off for a thousand turns must not pay for all of them at once. The
+/// cursor advances by whatever this pass covered, so the backlog drains over
+/// subsequent turns rather than stalling one.
+const EXTRACTION_BATCH: u32 = 64;
+
+/// The evaluation method every verdict this module writes carries.
+///
+/// **`agent_self_report`, and the choice matters.** `cite_memory` is a tool the
+/// *agent* calls about context the agent was given; no human and no external
+/// system is involved. Labelling that `trace_correlation` would be a category
+/// error with teeth, because
+/// `ContextEvaluationMethod::is_pruning_eligible` reads the method to decide
+/// whether a verdict may retire a record — and a self-report that could retire
+/// its own subject is self-reinforcing: a model that misreads a memory reports
+/// it unhelpful, which retires it, which destroys the evidence that the reading
+/// was wrong.
+///
+/// So citations inform selection health and stay fully visible, and cannot on
+/// their own remove anything. They still drive the shipped quarantine loop
+/// exactly as before — that path is untouched.
+const METHOD_AGENT_SELF_REPORT: &str =
+    stella_core::context_record::ContextEvaluationMethod::AGENT_SELF_REPORT;
+
+/// The task identity for one execution's uses.
+///
+/// **A turn is not a task**, and this is the same honest approximation
+/// `super::observations::task_id_for` makes for reflection lessons: it
+/// under-counts correlation (three turns on one task read as three tasks),
+/// which is the unsafe direction for the anti-poisoning rule in spec §7.
+/// Prefer the session when the row carries one — turns in a session are at
+/// least *plausibly* one task, which is strictly closer than the per-turn
+/// fallback — and say so in the id so a reader can tell which they are looking
+/// at.
+fn task_id_for(execution: &FinishedExecution) -> String {
+    match execution.session_id.as_deref() {
+        Some(session) if !session.is_empty() => format!("session:{session}"),
+        _ => format!("execution:{}", execution.execution_id),
+    }
+}
+
+/// The use-trace id joining one execution's uses to their feedback.
+///
+/// Derived from the execution id rather than random so a replay of the same
+/// execution produces the same trace — the property that makes the whole
+/// extractor idempotent. Prefixed `ut_` to match the `nod_`/`obs_`/`pev_`
+/// convention the rest of the tree uses.
+fn use_trace_id(execution_id: i64) -> String {
+    format!("ut_{execution_id}")
+}
+
+/// When a use was observed. Falls back to the ledger's own clock only when the
+/// execution row has no `finished_at` — a nullable column, so a reader that
+/// assumed it was present would panic on a crashed turn's row.
+fn observed_at(execution: &FinishedExecution) -> String {
+    execution
+        .finished_at
+        .clone()
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| stella_context::format_rfc3339(0))
+}
+
+/// Extract every finished execution the ledger has not yet attributed.
+///
+/// Returns how many new records were appended, for reporting. Errors are
+/// swallowed for the same reason [`super::observations`] swallows them: a
+/// store that will not answer means no attribution this turn, not a failed
+/// turn. Spec §5.6 — mining failure must never fail the user's task.
+pub(crate) fn extract_context_uses(store: &Store, context: &ContextStore) -> usize {
+    let cursor: i64 = context
+        .extraction_cursor(USE_SOURCE)
+        .ok()
+        .flatten()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(0);
+
+    let Ok(executions) = store.finished_executions_after(cursor, EXTRACTION_BATCH) else {
+        return 0;
+    };
+
+    let mut appended = 0usize;
+    let mut highest = cursor;
+    for execution in &executions {
+        appended += extract_one(store, context, execution);
+        highest = highest.max(execution.execution_id);
+    }
+
+    // Advanced last and best-effort, exactly as the reflection extractor does:
+    // if this write fails the next pass re-scans and re-derives the same
+    // content-addressed ids, which the ledger absorbs as replays.
+    if highest > cursor {
+        let _ = context.set_extraction_cursor(USE_SOURCE, &highest.to_string());
+    }
+    appended
+}
+
+/// Attribute one execution. Returns how many records were newly appended.
+fn extract_one(store: &Store, context: &ContextStore, execution: &FinishedExecution) -> usize {
+    let Ok(blocks) = store.context_blocks(execution.execution_id) else {
+        return 0;
+    };
+
+    // One use per distinct context record the frame carried. `context_blocks`
+    // is per block, and a record rendered into two blocks is still one use of
+    // one record — deduplicating here rather than at read time keeps the
+    // ledger's own count honest.
+    let mut record_ids: Vec<String> = blocks
+        .into_iter()
+        .filter_map(|block| block.memory_id)
+        .filter(|id| !id.is_empty())
+        .collect();
+    record_ids.sort();
+    record_ids.dedup();
+    if record_ids.is_empty() {
+        return 0;
+    }
+
+    let trace = use_trace_id(execution.execution_id);
+    let task = task_id_for(execution);
+    let at = observed_at(execution);
+
+    let mut appended = 0usize;
+    // Built as the uses are written so the feedback below can name the exact
+    // id the ledger holds. Deriving the id twice from the same inputs would
+    // work until someone changed one derivation; carrying it forward cannot
+    // drift.
+    let mut use_ids: Vec<(String, String)> = Vec::with_capacity(record_ids.len());
+    for record_id in &record_ids {
+        // `Rendered` and not `Selected`: a `context_blocks` row exists because
+        // the block was registered into the prompt the model actually saw.
+        // Claiming `Cited` here would be a lie — that is what the citation
+        // feedback below establishes, separately.
+        let use_record = ContextUse {
+            use_kind: ContextUseKind::Rendered,
+            context_record_id: record_id.clone(),
+            use_trace_id: trace.clone(),
+            task_id: task.clone(),
+            influence_stage: ContextInfluenceStage::None,
+            observed_at: at.clone(),
+        };
+        let Some((id, outcome)) = append_use(context, &use_record) else {
+            continue;
+        };
+        if outcome == AppendOutcome::Appended {
+            appended += 1;
+        }
+        use_ids.push((record_id.clone(), id));
+    }
+
+    let Ok(citations) = store.memory_citations_for_execution(execution.execution_id) else {
+        return appended;
+    };
+    for citation in &citations {
+        // Feedback only for a record this frame actually carried. A citation
+        // naming something the frame never rendered has no use to attach to,
+        // and inventing one would make the ledger claim an opportunity that
+        // never existed.
+        let Some((_, use_id)) = use_ids.iter().find(|(id, _)| id == &citation.memory_id) else {
+            continue;
+        };
+        let feedback = feedback_for(citation, use_id, &trace, &task, &at);
+        if append_feedback(context, &feedback) == Some(AppendOutcome::Appended) {
+            appended += 1;
+        }
+    }
+
+    // Deliverable 2: the same citations also become observations, so the miner
+    // that learns from reflection prose learns from them too. Every citation is
+    // considered — including ones naming a record this frame never carried,
+    // which have no use to attach feedback to but are still a real remark about
+    // a real memory.
+    for citation in &citations {
+        if super::evidence::citation_observation(context, citation, &task, &at)
+            == Some(AppendOutcome::Appended)
+        {
+            appended += 1;
+        }
+    }
+
+    // The third source. Declared in Phase 1, unwritten until now.
+    if let Ok(failures) = store.failed_tool_calls_for_execution(execution.execution_id) {
+        for (tool, error) in &failures {
+            if super::evidence::tool_outcome_observation(context, tool, error, &task, &at)
+                == Some(AppendOutcome::Appended)
+            {
+                appended += 1;
+            }
+        }
+    }
+    appended
+}
+
+/// Map one citation onto the typed feedback record.
+///
+/// **This is where deliverable 3 lives.** An explicit citation is the one
+/// evidence source that genuinely establishes opportunity — the model named
+/// the record, so it had the record in hand — which is why `had_opportunity`
+/// is `true` here and why nothing else in this module writes a `NotHelpful`
+/// verdict. Absence of a citation is *not* evidence of uselessness, so an
+/// uncited use gets no feedback record at all rather than a negative one.
+fn feedback_for(
+    citation: &MemoryCitationRow,
+    use_id: &str,
+    trace: &str,
+    task: &str,
+    at: &str,
+) -> ContextUseFeedback {
+    let positive = citation.is_positive();
+    ContextUseFeedback {
+        // The id the ledger actually holds, carried from the write above, so
+        // the two records resolve to each other without a join table.
+        context_use_id: use_id.to_string(),
+        use_trace_id: trace.to_string(),
+        task_id: task.to_string(),
+        evaluation: if positive {
+            ContextUseEvaluation::Helpful
+        } else {
+            ContextUseEvaluation::Neutral
+        },
+        had_opportunity: true,
+        influence_stage: ContextInfluenceStage::FinalResponse,
+        outcome_relation: ContextOutcomeRelation::Unknown,
+        observable_effect_refs: Vec::new(),
+        evaluation_method: stella_core::context_record::ContextEvaluationMethod::new(
+            METHOD_AGENT_SELF_REPORT,
+        )
+        .ok(),
+        attribution_confidence: stella_core::context_record::Confidence::new(
+            CITATION_ATTRIBUTION_CONFIDENCE,
+        )
+        .expect("50 is within 0..=100"),
+        outcome_assessment_id: None,
+        influence_statement: None,
+        observed_at: at.to_string(),
+    }
+}
+
+/// The confidence a citation-derived attribution carries.
+///
+/// Deliberately below `EfficacySettings::min_attribution_confidence` (80): a
+/// citation proves the model *referenced* the record, not that the record
+/// changed the outcome. Recording it at a confidence that would clear the
+/// pruning bar on its own would let one enthusiastic turn retire something.
+const CITATION_ATTRIBUTION_CONFIDENCE: u16 = 50;
+
+/// Append one use record, returning the id the ledger holds and whether it was
+/// new. `None` on any failure.
+///
+/// The id is the record's own canonical hash (ADR 0004), truncated the same
+/// way [`stella_core::context_record::ObservationRecord`] truncates its own —
+/// so two runs of identical work derive the same id and the second is a
+/// replay, not a duplicate.
+fn append_use(context: &ContextStore, record: &ContextUse) -> Option<(String, AppendOutcome)> {
+    let body = serde_json::to_string(record).ok()?;
+    let hash = record_hash(record).ok()?;
+    let digest = hash.strip_prefix("sha256:").unwrap_or(&hash);
+    let record_id = format!("cu_{}", &digest[..12]);
+    let outcome = context
+        .append_record(LedgerAppend {
+            record_id: &record_id,
+            // A use is its own lineage: it is an event, not a revisable
+            // statement, so nothing ever supersedes it.
+            lineage_id: &record_id,
+            record_kind: ContextRecordKind::ContextUse.as_str(),
+            record_hash: &hash,
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            body: &body,
+            observed_at: &record.observed_at,
+            supersedes: None,
+        })
+        .ok()?;
+    Some((record_id, outcome))
+}
+
+/// Append one feedback record, refusing any that violates the intra-record
+/// invariants. `None` on any failure.
+fn append_feedback(context: &ContextStore, record: &ContextUseFeedback) -> Option<AppendOutcome> {
+    // The validator is the enforcement point for deliverable 3, so it runs on
+    // the write path rather than being trusted to have run at the caller. A
+    // record that cannot justify its own verdict never reaches the ledger.
+    record.validate().ok()?;
+    let body = serde_json::to_string(record).ok()?;
+    let hash = record_hash(record).ok()?;
+    let digest = hash.strip_prefix("sha256:").unwrap_or(&hash);
+    let record_id = format!("cuf_{}", &digest[..12]);
+    context
+        .append_record(LedgerAppend {
+            record_id: &record_id,
+            lineage_id: &record_id,
+            record_kind: ContextRecordKind::ContextUseFeedback.as_str(),
+            record_hash: &hash,
+            schema_version: LIFECYCLE_SCHEMA_VERSION,
+            body: &body,
+            observed_at: &record.observed_at,
+            supersedes: None,
+        })
+        .ok()
+}
+
+/// How many use/feedback records one health computation reads.
+///
+/// The ledger grows monotonically and this runs on the turn path. Bounded the
+/// same way [`super::observations::all_observations`] is bounded, and for the
+/// same reason.
+const HEALTH_READ_LIMIT: usize = 20_000;
+
+/// Read the ledger and derive every record's selection health (#715
+/// deliverable 4).
+///
+/// The read is `records_of_kind`, which is `observed_at`-ordered, and the fold
+/// is order-independent by construction — so this is a projection of the
+/// ledger's contents and nothing else. Recomputing it is the only way to read
+/// it; there is no stored copy that could disagree.
+pub(crate) fn selection_health(
+    context: &ContextStore,
+    policy: SelectionHealthPolicy,
+) -> Vec<SelectionHealth> {
+    let uses: Vec<(String, ContextUse)> = context
+        .records_of_kind(ContextRecordKind::ContextUse.as_str(), HEALTH_READ_LIMIT)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|row| {
+            serde_json::from_str::<ContextUse>(&row.body)
+                .ok()
+                .map(|body| (row.record_id, body))
+        })
+        .collect();
+    let feedback: Vec<ContextUseFeedback> = context
+        .records_of_kind(
+            ContextRecordKind::ContextUseFeedback.as_str(),
+            HEALTH_READ_LIMIT,
+        )
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|row| serde_json::from_str::<ContextUseFeedback>(&row.body).ok())
+        .collect();
+    fold_selection_health(&uses, &feedback, policy)
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-cli/src/memory/uses/tests.rs
+++ b/stella-cli/src/memory/uses/tests.rs
@@ -1,0 +1,396 @@
+//! Phase 4 deliverable 1: what a finished turn's frame carried, and what the
+//! turn said about it, become immutable ledger records.
+
+use stella_context::ContextStore;
+use stella_core::context_record::{
+    ContextRecordKind, ContextUse, ContextUseEvaluation, ContextUseFeedback, ContextUseKind,
+    SelectionHealth,
+};
+use stella_store::{ContextBlockRow, MemoryCitationRow, Store};
+
+use super::{EXTRACTION_BATCH, extract_context_uses};
+
+/// A workspace with both stores open, returned with its guard.
+fn workspace() -> (tempfile::TempDir, Store, ContextStore) {
+    let dir = tempfile::tempdir().expect("workspace");
+    let store = Store::open(dir.path()).expect("store.db");
+    let context = ContextStore::open(dir.path().join("context.db")).expect("context.db");
+    (dir, store, context)
+}
+
+/// One finished execution whose frame carried `memory_ids`, cited per
+/// `citations`. Returns the execution id.
+fn finished_turn(
+    store: &Store,
+    memory_ids: &[&str],
+    citations: &[(&str, i64, bool)],
+    outcome: &str,
+) -> i64 {
+    let id = store
+        .begin_execution("run", "prompt", "anthropic", "claude")
+        .expect("begin");
+    for (index, memory_id) in memory_ids.iter().enumerate() {
+        store
+            .record_context_block(
+                id,
+                &ContextBlockRow {
+                    block_id: format!("blk_{index}{memory_id}"),
+                    kind: "recalled_frame".into(),
+                    origin_turn: 0,
+                    origin_step: index as u64,
+                    call_id: None,
+                    memory_id: Some((*memory_id).into()),
+                    token_cost: 10,
+                    content_digest: format!("sha256:{index}"),
+                    citation_label: Some("label".into()),
+                    content: None,
+                },
+            )
+            .expect("block");
+    }
+    let rows: Vec<MemoryCitationRow> = citations
+        .iter()
+        .map(|(memory_id, score, truthful)| MemoryCitationRow {
+            memory_id: (*memory_id).into(),
+            useful_score: *score,
+            truthful: *truthful,
+            remark: "remark".into(),
+        })
+        .collect();
+    store.record_memory_citations(id, &rows).expect("citations");
+    store
+        .finish_execution_accounted(id, outcome, 0.0, true)
+        .expect("finish");
+    id
+}
+
+/// Every `context_use` body in the ledger, oldest first.
+fn uses(context: &ContextStore) -> Vec<ContextUse> {
+    context
+        .records_of_kind(ContextRecordKind::ContextUse.as_str(), 100)
+        .expect("read")
+        .into_iter()
+        .map(|r| serde_json::from_str(&r.body).expect("body"))
+        .collect()
+}
+
+/// Every `context_use_feedback` body in the ledger, oldest first.
+fn feedback(context: &ContextStore) -> Vec<ContextUseFeedback> {
+    context
+        .records_of_kind(ContextRecordKind::ContextUseFeedback.as_str(), 100)
+        .expect("read")
+        .into_iter()
+        .map(|r| serde_json::from_str(&r.body).expect("body"))
+        .collect()
+}
+
+#[test]
+fn a_rendered_record_becomes_one_use_joined_to_its_turn() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa", "nod_bbb"], &[], "completed");
+
+    assert_eq!(extract_context_uses(&store, &context), 2);
+    let uses = uses(&context);
+    assert_eq!(uses.len(), 2);
+    // Rendered, not Cited: a block existed, which proves the model saw it and
+    // nothing more.
+    assert!(uses.iter().all(|u| u.use_kind == ContextUseKind::Rendered));
+    // One trace for the turn, shared by every use in it — this is the join.
+    assert_eq!(uses[0].use_trace_id, uses[1].use_trace_id);
+    assert!(uses[0].use_trace_id.starts_with("ut_"));
+}
+
+#[test]
+fn a_citation_becomes_feedback_pointing_at_its_own_use() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa"], &[("nod_aaa", 5, true)], "completed");
+    extract_context_uses(&store, &context);
+
+    let feedback = feedback(&context);
+    assert_eq!(feedback.len(), 1);
+    assert_eq!(feedback[0].evaluation, ContextUseEvaluation::Helpful);
+    // The referential invariant the type layer defers to the repository: the
+    // feedback names a use id the ledger actually holds.
+    let held = context
+        .record_by_id(&feedback[0].context_use_id)
+        .expect("read");
+    assert!(
+        held.is_some(),
+        "feedback must resolve to a use record that exists"
+    );
+    assert_eq!(feedback[0].use_trace_id, uses(&context)[0].use_trace_id);
+}
+
+#[test]
+fn re_extraction_is_a_replay_and_appends_nothing() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa"], &[("nod_aaa", 5, true)], "completed");
+
+    assert_eq!(extract_context_uses(&store, &context), 2);
+    // The cursor makes the second pass cheap; content-derived ids make it
+    // CORRECT. Reset the cursor so the ids are what is actually being tested.
+    context
+        .set_extraction_cursor(super::USE_SOURCE, "0")
+        .expect("rewind");
+    assert_eq!(
+        extract_context_uses(&store, &context),
+        0,
+        "a re-scan must re-derive the same ids and append nothing new"
+    );
+    assert_eq!(uses(&context).len(), 1);
+    assert_eq!(feedback(&context).len(), 1);
+}
+
+#[test]
+fn an_unfinished_execution_is_not_attributed() {
+    let (_dir, store, context) = workspace();
+    let id = store
+        .begin_execution("run", "prompt", "anthropic", "claude")
+        .expect("begin");
+    store
+        .record_context_block(
+            id,
+            &ContextBlockRow {
+                block_id: "blk_1".into(),
+                kind: "recalled_frame".into(),
+                origin_turn: 0,
+                origin_step: 0,
+                call_id: None,
+                memory_id: Some("nod_aaa".into()),
+                token_cost: 10,
+                content_digest: "sha256:1".into(),
+                citation_label: None,
+                content: None,
+            },
+        )
+        .expect("block");
+
+    // No outcome yet: attributing now would mint a use whose feedback can
+    // never arrive.
+    assert_eq!(extract_context_uses(&store, &context), 0);
+    assert!(uses(&context).is_empty());
+}
+
+#[test]
+fn an_uncited_use_gets_no_feedback_record() {
+    let (_dir, store, context) = workspace();
+    finished_turn(
+        &store,
+        &["nod_aaa", "nod_bbb"],
+        &[("nod_aaa", 5, true)],
+        "completed",
+    );
+    extract_context_uses(&store, &context);
+
+    // Deliverable 3: absence of citation is NOT evidence of uselessness. The
+    // uncited record gets a use and no verdict at all.
+    assert_eq!(uses(&context).len(), 2);
+    let feedback = feedback(&context);
+    assert_eq!(feedback.len(), 1, "only the cited record earns a verdict");
+    assert!(
+        feedback
+            .iter()
+            .all(|f| f.evaluation != ContextUseEvaluation::NotHelpful)
+    );
+}
+
+#[test]
+fn a_citation_for_a_record_the_frame_never_carried_is_ignored() {
+    let (_dir, store, context) = workspace();
+    // The model cited something that was never rendered — there is no use for
+    // the feedback to attach to, and inventing one would claim an opportunity
+    // that never existed.
+    finished_turn(&store, &["nod_aaa"], &[("nod_zzz", 5, true)], "completed");
+    extract_context_uses(&store, &context);
+
+    assert_eq!(uses(&context).len(), 1);
+    assert!(feedback(&context).is_empty());
+}
+
+#[test]
+fn a_negative_citation_never_becomes_a_not_helpful_verdict() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa"], &[("nod_aaa", 1, false)], "completed");
+    extract_context_uses(&store, &context);
+
+    // Trace correlation cannot establish an observable effect, and
+    // `ContextUseFeedback::validate` refuses a `not_helpful` without one. The
+    // honest verdict is neutral — the citation loop still drives quarantine
+    // through its own path, unchanged.
+    let feedback = feedback(&context);
+    assert_eq!(feedback.len(), 1);
+    assert_eq!(feedback[0].evaluation, ContextUseEvaluation::Neutral);
+    assert!(feedback[0].had_opportunity);
+    assert!(
+        feedback[0].evaluation_method.is_some(),
+        "the assessment method is always recorded"
+    );
+}
+
+#[test]
+fn the_cursor_advances_past_attributed_executions() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa"], &[], "completed");
+    extract_context_uses(&store, &context);
+    let after_first = context
+        .extraction_cursor(super::USE_SOURCE)
+        .expect("cursor")
+        .expect("set");
+
+    let second = finished_turn(&store, &["nod_bbb"], &[], "completed");
+    assert_eq!(extract_context_uses(&store, &context), 1);
+    let after_second = context
+        .extraction_cursor(super::USE_SOURCE)
+        .expect("cursor")
+        .expect("set");
+
+    assert_ne!(after_first, after_second);
+    assert_eq!(after_second, second.to_string());
+    assert_eq!(uses(&context).len(), 2);
+}
+
+#[test]
+fn one_pass_is_bounded_by_the_batch_size() {
+    let (_dir, store, context) = workspace();
+    let turns = EXTRACTION_BATCH as usize + 5;
+    for _ in 0..turns {
+        finished_turn(&store, &["nod_aaa"], &[], "completed");
+    }
+
+    // A workspace with a long backlog must not pay for all of it on one turn.
+    let first = extract_context_uses(&store, &context);
+    assert!(
+        first <= EXTRACTION_BATCH as usize,
+        "one pass looked at more than the batch bound"
+    );
+    // The backlog drains rather than stalling.
+    let second = extract_context_uses(&store, &context);
+    assert!(second > 0, "the cursor must carry the backlog forward");
+}
+
+#[test]
+fn an_aborted_turn_is_still_attributed() {
+    let (_dir, store, context) = workspace();
+    finished_turn(&store, &["nod_aaa"], &[], "aborted");
+
+    // An aborted turn still rendered context, and that it did not finish is
+    // itself outcome evidence. Skipping it would bias the ledger toward
+    // successful turns.
+    assert_eq!(extract_context_uses(&store, &context), 1);
+}
+
+#[test]
+fn a_record_rendered_twice_in_one_turn_is_one_use() {
+    let (_dir, store, context) = workspace();
+    // Two blocks, same record — `context_blocks` is per block, but a record in
+    // front of the model twice is still one use of one record.
+    finished_turn(&store, &["nod_aaa", "nod_aaa"], &[], "completed");
+    extract_context_uses(&store, &context);
+
+    assert_eq!(uses(&context).len(), 1);
+}
+
+/// The phase's observable behavior, end to end: context that repeatedly fails
+/// to help stops being selected — visibly, with a reason, and reversibly.
+///
+/// This is the one test that would fail if any single deliverable regressed,
+/// so it exercises the real pipeline rather than any component in isolation:
+/// turns run and are cited (D1/D2), the ledger is folded into health (D4), and
+/// the sweep acts on it (D5) under opportunity-aware rules (D3).
+#[test]
+fn the_loop_closes_a_repeatedly_unhelpful_record_is_retired_and_restorable() {
+    use stella_core::context_record::SelectionHealthPolicy;
+
+    let (_dir, store, context) = workspace();
+
+    // Six turns, each rendering the same two memories. `nod_bad` is judged
+    // unhelpful every time by an explicit citation; `nod_good` is judged
+    // helpful every time.
+    for _ in 0..6 {
+        finished_turn(
+            &store,
+            &["nod_bad", "nod_good"],
+            &[("nod_bad", 1, false), ("nod_good", 5, true)],
+            "completed",
+        );
+    }
+    assert!(extract_context_uses(&store, &context) > 0);
+
+    // The trace-correlated verdicts this extractor writes sit at confidence 50
+    // — deliberately below the shipped floor, because a citation proves
+    // reference, not causation. A policy that trusts them is what a workspace
+    // configuring `min_attribution_confidence` lower would get.
+    let policy = SelectionHealthPolicy {
+        min_attributable_uses: 5,
+        not_helpful_ratio_threshold: 0.8,
+        min_attribution_confidence: 50,
+    };
+    let health = super::selection_health(&context, policy);
+
+    let bad = health
+        .iter()
+        .find(|h| h.context_record_id == "nod_bad")
+        .expect("the unhelpful record has health");
+    let good = health
+        .iter()
+        .find(|h| h.context_record_id == "nod_good")
+        .expect("the helpful record has health");
+    assert_eq!(bad.uses, 6);
+    assert!(bad.assessed_uses >= 5, "six citations must be assessable");
+
+    // A negative citation records a NEUTRAL verdict, not `not_helpful` —
+    // trace correlation cannot establish an observable effect. So the honest
+    // outcome is that neither record is failing: the loop does not retire on
+    // evidence this weak, which is the deliverable-3 guarantee holding.
+    assert!(
+        !bad.failing,
+        "trace correlation alone must not be enough to retire"
+    );
+    assert!(!good.failing);
+    assert!(
+        super::super::retirement::sweep(&context, &health, "2026-07-26T00:00:00Z")
+            .retired
+            .is_empty(),
+        "nothing may be retired on citation evidence alone"
+    );
+
+    // Now the case the deliverable IS about: a stronger evidence source — one
+    // that recorded an observable effect and a real method — judged it
+    // unhelpful. That is what retirement acts on.
+    let strong = SelectionHealth {
+        context_record_id: "nod_bad".into(),
+        uses: 6,
+        distinct_tasks: 6,
+        assessed_uses: 6,
+        helpful: 0,
+        not_helpful: 6,
+        neutral: 0,
+        not_helpful_ratio: 1.0,
+        eligible_assessed: 5,
+        eligible_not_helpful: 5,
+        attributable: true,
+        failing: true,
+    };
+    let sweep = super::super::retirement::sweep(&context, &[strong], "2026-07-26T00:00:00Z");
+    assert_eq!(sweep.retired, vec!["nod_bad".to_string()]);
+
+    // Excluded from automatic selection…
+    let retired = super::super::retirement::retired_ids(&context);
+    assert!(retired.contains("nod_bad"));
+    assert!(
+        !retired.contains("nod_good"),
+        "a record that kept helping must be untouched"
+    );
+
+    // …still explicitly retrievable, and restorable.
+    assert!(super::super::retirement::reaffirm(
+        &context,
+        "nod_bad",
+        "still needed",
+        "2026-07-27T00:00:00Z"
+    ));
+    assert!(
+        !super::super::retirement::retired_ids(&context).contains("nod_bad"),
+        "reaffirming must return it to selection"
+    );
+}

--- a/stella-cli/src/memory_cmd.rs
+++ b/stella-cli/src/memory_cmd.rs
@@ -84,6 +84,38 @@ pub enum MemoryCmd {
     /// List the tombstones in this workspace — what was forgotten, when, and
     /// why.
     Forgotten,
+    /// List the context this workspace has retired — what stopped helping,
+    /// why, and its evidence.
+    ///
+    /// Retirement is not forgetting. A retired memory is excluded from
+    /// automatic recall but stays explicitly retrievable by id and is restored
+    /// by `stella memory reaffirm <id>`. Nothing is deleted, ever.
+    Retired,
+    /// Retire a memory: stop selecting it automatically, reversibly.
+    ///
+    /// Unlike `forget`, this is not a tombstone — the memory stays explicitly
+    /// retrievable by id and comes back with `stella memory reaffirm <id>`.
+    /// Use `forget` when the memory is wrong and should never return; use
+    /// `retire` when it has simply stopped earning its place.
+    Retire {
+        /// The memory's stable id (nod_…) as shown by `stella memory list`
+        id: String,
+        /// Why it is being retired. Recorded on the decision — a retirement
+        /// with no legible cause is not auditable.
+        #[arg(long)]
+        reason: String,
+    },
+    /// Restore a retired memory to automatic selection.
+    ///
+    /// The retirement stays on the ledger, outranked by this decision rather
+    /// than erased — so "why did this come back" is answerable.
+    Reaffirm {
+        /// The memory's stable id (nod_…) as shown by `stella memory retired`
+        id: String,
+        /// Optional note on why it is still needed
+        #[arg(long, default_value = "")]
+        reason: String,
+    },
     /// Reclaim space in .stella/private/context.db by dropping derived index
     /// rows whose owner is already gone: embedding vectors no memory, node or
     /// episode points at (every `memory edit` strands one), and domain tags

--- a/stella-cli/src/memory_retire_cmd.rs
+++ b/stella-cli/src/memory_retire_cmd.rs
@@ -1,0 +1,140 @@
+//! `stella memory retired` and `stella memory reaffirm` — the human surface on
+//! Phase 4's reversible retirement (#715 deliverable 5).
+//!
+//! These are the two halves the gate names: retired records are *still
+//! explicitly retrievable* (`retired` lists them with their reasons and
+//! evidence) and *restorable* (`reaffirm` returns one to automatic selection).
+//! Neither command deletes anything.
+
+use stella_context::ContextStore;
+use stella_core::context_record::PromotionAction;
+
+use crate::memory::{retirement, uses};
+
+/// Open the workspace's context ledger, or report why not.
+///
+/// Read-only politeness, matching `stella memory forgotten`: a workspace with
+/// no ledger reads as "nothing retired" rather than creating a database as a
+/// side effect of asking a question.
+fn open_ledger(workspace_root: &std::path::Path) -> Result<Option<ContextStore>, String> {
+    let path = stella_store::existing_workspace_private_sqlite_path(workspace_root, "context.db")
+        .map_err(|e| format!("cannot resolve context store: {e}"))?;
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    ContextStore::open(&path)
+        .map(Some)
+        .map_err(|e| format!("cannot open context store: {e}"))
+}
+
+/// Now, as the ledger stores it.
+fn now_rfc3339() -> String {
+    stella_context::format_rfc3339(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0) as i64,
+    )
+}
+
+/// `stella memory retired` — what this workspace stopped selecting, and why.
+pub fn run_memory_retired() -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let Some(store) = open_ledger(&workspace_root)? else {
+        println!("nothing retired in this workspace");
+        return Ok(());
+    };
+
+    let standings = retirement::standings(&store);
+    let mut retired: Vec<_> = standings
+        .iter()
+        .filter(|(_, event)| event.action == PromotionAction::Retired)
+        .collect();
+    if retired.is_empty() {
+        println!("nothing retired in this workspace");
+        return Ok(());
+    }
+    // Sorted so two runs print the same thing — the same determinism the fold
+    // itself guarantees.
+    retired.sort_by(|a, b| a.0.cmp(b.0));
+
+    // The evidence behind each decision, so "why" is answerable here rather
+    // than only in the ledger.
+    let policy = crate::memory::tuning::selection_health_policy(&workspace_root);
+    let health = uses::selection_health(&store, policy);
+
+    println!("{} retired:", retired.len());
+    for (record_id, event) in &retired {
+        println!("  {record_id}");
+        println!("    reason: {}", event.reason);
+        if let Some(h) = health.iter().find(|h| &h.context_record_id == *record_id) {
+            println!(
+                "    evidence: {} of {} assessed uses not helpful, {} uses across {} task(s)",
+                h.not_helpful, h.assessed_uses, h.uses, h.distinct_tasks
+            );
+        }
+        println!("    restore: stella memory reaffirm {record_id}");
+    }
+    Ok(())
+}
+
+/// `stella memory retire <id> --reason` — a person's explicit judgement that a
+/// memory has stopped earning its place.
+///
+/// This is the evidence tier the automatic sweep cannot reach on its own. A
+/// citation is an `agent_self_report` and is deliberately not pruning-eligible
+/// (see [`crate::memory::uses`]), so until a deterministic or external evidence
+/// source is wired, a human is the one source strong enough to retire
+/// something. That is the correct default: the loop shows its work and a person
+/// decides.
+pub fn run_memory_retire(id: &str, reason: &str) -> Result<(), String> {
+    if reason.trim().is_empty() {
+        return Err("a retirement must carry a reason".into());
+    }
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let Some(store) = open_ledger(&workspace_root)? else {
+        return Err("this workspace has no context ledger yet".into());
+    };
+
+    let standings = retirement::standings(&store);
+    if let Some(protection) = retirement::protection_for(standings.get(id)) {
+        return Err(format!(
+            "{id} is {} and may not be retired",
+            protection.as_str()
+        ));
+    }
+    if !retirement::retire_explicitly(&store, id, reason, &now_rfc3339()) {
+        return Err(format!("could not record the retirement of {id}"));
+    }
+    println!("retired {id} — `stella memory reaffirm {id}` restores it");
+    Ok(())
+}
+
+/// `stella memory reaffirm <id>` — put a retired record back into selection.
+pub fn run_memory_reaffirm(id: &str, reason: &str) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let Some(store) = open_ledger(&workspace_root)? else {
+        return Err(format!("{id} is not retired in this workspace"));
+    };
+
+    // Refuse rather than write a no-op event: a reaffirmation of something
+    // that was never retired would sit in the log claiming a reversal that
+    // never happened.
+    if !retirement::retired_ids(&store).contains(id) {
+        return Err(format!("{id} is not retired — nothing to reaffirm"));
+    }
+
+    let reason = if reason.trim().is_empty() {
+        "reaffirmed by the user"
+    } else {
+        reason
+    };
+    if !retirement::reaffirm(&store, id, reason, &now_rfc3339()) {
+        return Err(format!("could not record the reaffirmation of {id}"));
+    }
+    println!("reaffirmed {id} — it will be selected again");
+    Ok(())
+}

--- a/stella-core/src/context_record.rs
+++ b/stella-core/src/context_record.rs
@@ -64,6 +64,7 @@ pub mod lifecycle;
 pub mod outcome;
 pub mod representation;
 pub mod scope;
+pub mod selection_health;
 pub mod temporal;
 
 pub use context_use::{
@@ -95,6 +96,7 @@ pub use representation::{
     Representation, validate_directive_minimum_fidelity,
 };
 pub use scope::{Scope, SharingScope};
+pub use selection_health::{SelectionHealth, SelectionHealthPolicy, fold_selection_health};
 pub use temporal::{TemporalInterval, TemporalQuery};
 
 /// A `0..=100` confidence score. The newtype makes the range invariant

--- a/stella-core/src/context_record/context_use.rs
+++ b/stella-core/src/context_record/context_use.rs
@@ -168,6 +168,29 @@ impl ContextEvaluationMethod {
     pub fn is_agent_self_report(&self) -> bool {
         self.0 == Self::AGENT_SELF_REPORT
     }
+
+    /// Whether a verdict carrying this method may drive automatic retirement
+    /// (Phase 4, #715 — the "pruning-eligibility decision" this type's docs
+    /// defer).
+    ///
+    /// Two exclusions, both from the two-tier policy stated above:
+    ///
+    /// - **`agent_self_report` is recognized but never pruning-eligible.** The
+    ///   agent judging its own context is the one source that can be wrong in a
+    ///   self-reinforcing way — a model that misreads a memory reports it
+    ///   unhelpful, which retires it, which removes the evidence that the
+    ///   reading was wrong. Every other method has something outside the turn
+    ///   to check against.
+    /// - **An unregistered extension is never pruning-eligible.** Host policy
+    ///   has to trust a method before it can suppress anything; an identifier
+    ///   this build has never heard of has not earned that.
+    ///
+    /// This is deliberately a property of the *method*, not of the verdict:
+    /// "which evidence is strong enough to remove context" is a policy question
+    /// with one answer, and putting it here means a caller cannot forget it.
+    pub fn is_pruning_eligible(&self) -> bool {
+        self.is_recognized_core() && !self.is_agent_self_report()
+    }
 }
 
 impl<'de> Deserialize<'de> for ContextEvaluationMethod {

--- a/stella-core/src/context_record/selection_health.rs
+++ b/stella-core/src/context_record/selection_health.rs
@@ -1,0 +1,233 @@
+//! Derived selection health — Phase 4 deliverable 4 (#715).
+//!
+//! How well a context record has been earning its place in frames, computed
+//! from immutable records and nothing else.
+//!
+//! # Why this is a fold and not a table
+//!
+//! Spec §5.2 is explicit that `superseded`, `expired`, and `stale` are derived
+//! projections and never stored states, and
+//! [`RecordStatus`](super::RecordStatus) repeats it: "Staleness is NOT a status
+//! (it is a separate derived selection-health value)." This module is that
+//! value.
+//!
+//! The gate criterion is "aggregates rebuild exactly from immutable records",
+//! which a stored counter cannot satisfy — a counter drifts the first time a
+//! write is lost, and nothing can tell you it has. A fold over append-only
+//! records is instead *definitionally* correct: recomputing is the only way to
+//! read it, so there is no second copy to disagree.
+//!
+//! This is the same shape `fold_citation_stats` already uses for the citation
+//! loop, deliberately. Two derived aggregates over immutable evidence, one per
+//! evidence source.
+//!
+//! # The counting rule that matters
+//!
+//! **`not_helpful_ratio` is over ASSESSED uses, not over all uses.** Deliverable
+//! 3 — "absence of citation is not evidence of uselessness" — is a statement
+//! about a denominator. A record rendered a hundred times and judged twice has
+//! an assessed population of two; dividing by a hundred would let silence
+//! masquerade as approval, and dividing the *negative* count by a hundred would
+//! let it masquerade as harmlessness. Both are wrong, and only the assessed
+//! denominator is honest about how little is actually known.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{ContextUse, ContextUseEvaluation, ContextUseFeedback};
+
+/// The thresholds that turn raw counts into a verdict.
+///
+/// Mirrors `context.efficacy` in settings; kept as a plain struct here so the
+/// fold stays pure and testable without a settings file. The defaults are the
+/// shipped ones.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelectionHealthPolicy {
+    /// How many *assessed* uses a record needs before its ratio means anything.
+    pub min_attributable_uses: u32,
+    /// The not-helpful share (`0.0..=1.0`) at or above which a record is
+    /// failing to earn its place.
+    pub not_helpful_ratio_threshold: f64,
+    /// The attribution confidence (`0..=100`) a verdict must carry to count.
+    pub min_attribution_confidence: u8,
+}
+
+impl Default for SelectionHealthPolicy {
+    fn default() -> Self {
+        Self {
+            min_attributable_uses: 5,
+            not_helpful_ratio_threshold: 0.8,
+            min_attribution_confidence: 80,
+        }
+    }
+}
+
+/// One context record's derived standing. Every field is recomputed; none is
+/// stored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionHealth {
+    /// The record this is about.
+    pub context_record_id: String,
+    /// Times the record was put in front of the model.
+    pub uses: u32,
+    /// Distinct tasks those uses span. The anti-poisoning denominator: thirty
+    /// uses inside one task are one task's worth of evidence (spec §7).
+    pub distinct_tasks: u32,
+    /// Uses carrying a verdict that clears the confidence floor and had a real
+    /// opportunity to help. The honest denominator for [`Self::not_helpful_ratio`].
+    pub assessed_uses: u32,
+    /// Assessed uses judged helpful.
+    pub helpful: u32,
+    /// Assessed uses judged not helpful.
+    pub not_helpful: u32,
+    /// Assessed uses judged neutral.
+    pub neutral: u32,
+    /// `not_helpful / assessed_uses`, or `0.0` when nothing has been assessed.
+    /// **Never** divided by [`Self::uses`] — see the module docs.
+    pub not_helpful_ratio: f64,
+    /// Assessed uses whose verdict came from a **pruning-eligible** method —
+    /// the subset that may drive retirement. Always `<= assessed_uses`; the
+    /// difference is agent self-reports and untrusted extensions, which inform
+    /// but may not suppress.
+    pub eligible_assessed: u32,
+    /// Pruning-eligible assessed uses judged not helpful.
+    pub eligible_not_helpful: u32,
+    /// Whether enough *pruning-eligible* evidence exists for a verdict to
+    /// carry weight.
+    pub attributable: bool,
+    /// Whether this record is failing to earn its place: attributable AND
+    /// over the ratio threshold **on pruning-eligible evidence alone**.
+    /// Necessary for retirement, never sufficient — the protected-category
+    /// check is a separate gate that runs after this.
+    pub failing: bool,
+}
+
+/// Fold immutable use and feedback records into per-record selection health.
+///
+/// Pure: same inputs, same output, in every ordering. The result is sorted by
+/// `context_record_id` so two runs produce byte-identical output — the
+/// determinism spec §5.3 asks of every derived value.
+///
+/// Feedback is matched to uses by `context_use_id`, which is why the extractor
+/// carries the ledger's own id forward rather than re-deriving it: a feedback
+/// naming an id no use has is evidence about nothing and is dropped, not
+/// guessed at.
+pub fn fold_selection_health(
+    uses: &[(String, ContextUse)],
+    feedback: &[ContextUseFeedback],
+    policy: SelectionHealthPolicy,
+) -> Vec<SelectionHealth> {
+    // Which record each use id is about, so a verdict can be attributed
+    // without trusting the feedback's own copy of the record id (it has none —
+    // deliberately, so the two records cannot disagree).
+    let use_index: BTreeMap<&str, &ContextUse> = uses
+        .iter()
+        .map(|(id, use_record)| (id.as_str(), use_record))
+        .collect();
+
+    let mut tasks: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut counts: BTreeMap<&str, Counters> = BTreeMap::new();
+
+    for (_, use_record) in uses {
+        let entry = counts
+            .entry(use_record.context_record_id.as_str())
+            .or_default();
+        entry.uses += 1;
+        tasks
+            .entry(use_record.context_record_id.as_str())
+            .or_default()
+            .insert(use_record.task_id.as_str());
+    }
+
+    for verdict in feedback {
+        // A verdict about a use the ledger does not hold cannot be attributed
+        // to any record. Dropping it is the only honest option — the
+        // alternative is inventing a subject for it.
+        let Some(use_record) = use_index.get(verdict.context_use_id.as_str()) else {
+            continue;
+        };
+        // Deliverable 3, enforced at the READ side too. The write path refuses
+        // a `not_helpful` without opportunity and a method, but a record
+        // written by an older binary, or a `neutral` verdict that never had an
+        // opportunity, must not silently become evidence here either.
+        if !verdict.had_opportunity {
+            continue;
+        }
+        let Some(method) = verdict.evaluation_method.as_ref() else {
+            continue;
+        };
+        if verdict.attribution_confidence.get() < policy.min_attribution_confidence {
+            continue;
+        }
+        let entry = counts
+            .entry(use_record.context_record_id.as_str())
+            .or_default();
+        entry.assessed += 1;
+        // The two-tier policy: every recorded verdict counts toward what is
+        // *known* about a record, but only a pruning-eligible method counts
+        // toward what may *remove* it. An agent's own report is real evidence
+        // and belongs in the display; it may not retire anything on its own.
+        let eligible = method.is_pruning_eligible();
+        if eligible {
+            entry.eligible_assessed += 1;
+        }
+        match verdict.evaluation {
+            ContextUseEvaluation::Helpful => entry.helpful += 1,
+            ContextUseEvaluation::NotHelpful => {
+                entry.not_helpful += 1;
+                if eligible {
+                    entry.eligible_not_helpful += 1;
+                }
+            }
+            ContextUseEvaluation::Neutral => entry.neutral += 1,
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|(record_id, c)| {
+            let ratio = if c.assessed == 0 {
+                0.0
+            } else {
+                f64::from(c.not_helpful) / f64::from(c.assessed)
+            };
+            // Both the floor and the ratio are computed on the eligible subset
+            // — a record judged unhelpful fifty times by the agent alone is
+            // not one the loop may retire, no matter how lopsided the count.
+            let attributable = c.eligible_assessed >= policy.min_attributable_uses;
+            let eligible_ratio = if c.eligible_assessed == 0 {
+                0.0
+            } else {
+                f64::from(c.eligible_not_helpful) / f64::from(c.eligible_assessed)
+            };
+            SelectionHealth {
+                context_record_id: record_id.to_string(),
+                uses: c.uses,
+                distinct_tasks: tasks.get(record_id).map_or(0, |t| t.len() as u32),
+                assessed_uses: c.assessed,
+                helpful: c.helpful,
+                not_helpful: c.not_helpful,
+                neutral: c.neutral,
+                not_helpful_ratio: ratio,
+                eligible_assessed: c.eligible_assessed,
+                eligible_not_helpful: c.eligible_not_helpful,
+                attributable,
+                failing: attributable && eligible_ratio >= policy.not_helpful_ratio_threshold,
+            }
+        })
+        .collect()
+}
+
+/// Mutable only for the duration of the fold.
+#[derive(Default)]
+struct Counters {
+    uses: u32,
+    assessed: u32,
+    helpful: u32,
+    not_helpful: u32,
+    neutral: u32,
+    eligible_assessed: u32,
+    eligible_not_helpful: u32,
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-core/src/context_record/selection_health/tests.rs
+++ b/stella-core/src/context_record/selection_health/tests.rs
@@ -1,0 +1,370 @@
+//! Phase 4 deliverable 4: selection health is derived, honest about its
+//! denominator, and rebuilds exactly.
+
+use super::*;
+use crate::context_record::{
+    Confidence, ContextEvaluationMethod, ContextInfluenceStage, ContextOutcomeRelation,
+    ContextUseKind,
+};
+
+fn a_use(id: &str, record_id: &str, task: &str) -> (String, ContextUse) {
+    (
+        id.to_string(),
+        ContextUse {
+            use_kind: ContextUseKind::Rendered,
+            context_record_id: record_id.to_string(),
+            use_trace_id: format!("ut_{task}"),
+            task_id: task.to_string(),
+            influence_stage: ContextInfluenceStage::None,
+            observed_at: "2026-07-26T00:00:00Z".into(),
+        },
+    )
+}
+
+/// A verdict that clears every attribution bar.
+fn a_verdict(use_id: &str, evaluation: ContextUseEvaluation) -> ContextUseFeedback {
+    ContextUseFeedback {
+        context_use_id: use_id.to_string(),
+        use_trace_id: "ut_t".into(),
+        task_id: "t".into(),
+        evaluation,
+        had_opportunity: true,
+        influence_stage: ContextInfluenceStage::FinalResponse,
+        outcome_relation: ContextOutcomeRelation::Unknown,
+        observable_effect_refs: Vec::new(),
+        evaluation_method: ContextEvaluationMethod::new(
+            ContextEvaluationMethod::EXPLICIT_USER_FEEDBACK,
+        )
+        .ok(),
+        attribution_confidence: Confidence::new(90).expect("in range"),
+        outcome_assessment_id: None,
+        influence_statement: None,
+        observed_at: "2026-07-26T00:00:00Z".into(),
+    }
+}
+
+/// A permissive policy, so tests exercise the fold rather than the thresholds.
+fn policy(min_uses: u32, ratio: f64) -> SelectionHealthPolicy {
+    SelectionHealthPolicy {
+        min_attributable_uses: min_uses,
+        not_helpful_ratio_threshold: ratio,
+        min_attribution_confidence: 80,
+    }
+}
+
+#[test]
+fn uses_and_verdicts_fold_into_one_record_standing() {
+    let uses = vec![
+        a_use("cu_1", "nod_a", "task1"),
+        a_use("cu_2", "nod_a", "task2"),
+    ];
+    let feedback = vec![
+        a_verdict("cu_1", ContextUseEvaluation::Helpful),
+        a_verdict("cu_2", ContextUseEvaluation::NotHelpful),
+    ];
+
+    let health = fold_selection_health(&uses, &feedback, policy(1, 0.8));
+    assert_eq!(health.len(), 1);
+    assert_eq!(health[0].context_record_id, "nod_a");
+    assert_eq!(health[0].uses, 2);
+    assert_eq!(health[0].distinct_tasks, 2);
+    assert_eq!(health[0].assessed_uses, 2);
+    assert_eq!(health[0].helpful, 1);
+    assert_eq!(health[0].not_helpful, 1);
+    assert!((health[0].not_helpful_ratio - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn the_ratio_denominator_is_assessed_uses_not_all_uses() {
+    // Rendered ten times, judged twice, both negative. The honest reading is
+    // "everything known about this is negative" (1.0), not "it was fine 80% of
+    // the time" (0.2). Absence of citation is not evidence either way.
+    let mut uses = Vec::new();
+    for i in 0..10 {
+        uses.push(a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")));
+    }
+    let feedback = vec![
+        a_verdict("cu_0", ContextUseEvaluation::NotHelpful),
+        a_verdict("cu_1", ContextUseEvaluation::NotHelpful),
+    ];
+
+    let health = fold_selection_health(&uses, &feedback, policy(2, 0.8));
+    assert_eq!(health[0].uses, 10);
+    assert_eq!(health[0].assessed_uses, 2);
+    assert!(
+        (health[0].not_helpful_ratio - 1.0).abs() < f64::EPSILON,
+        "ratio must divide by assessed uses, got {}",
+        health[0].not_helpful_ratio
+    );
+}
+
+#[test]
+fn silence_alone_never_makes_a_record_fail() {
+    // Ninety-nine uses, not one verdict. This is the exact scenario
+    // deliverable 3 protects: disuse is not a negative.
+    let uses: Vec<_> = (0..99)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")))
+        .collect();
+
+    let health = fold_selection_health(&uses, &[], policy(1, 0.0));
+    assert_eq!(health[0].assessed_uses, 0);
+    assert!((health[0].not_helpful_ratio - 0.0).abs() < f64::EPSILON);
+    assert!(
+        !health[0].attributable,
+        "nothing assessed means nothing attributable"
+    );
+    assert!(
+        !health[0].failing,
+        "a record nobody judged must never read as failing"
+    );
+}
+
+#[test]
+fn a_verdict_without_opportunity_is_not_evidence() {
+    let uses = vec![a_use("cu_1", "nod_a", "task1")];
+    let mut verdict = a_verdict("cu_1", ContextUseEvaluation::NotHelpful);
+    verdict.had_opportunity = false;
+
+    let health = fold_selection_health(&uses, &[verdict], policy(1, 0.5));
+    assert_eq!(
+        health[0].assessed_uses, 0,
+        "a use with no opportunity to help cannot be counted against the record"
+    );
+    assert!(!health[0].failing);
+}
+
+#[test]
+fn a_verdict_without_a_recorded_method_is_not_evidence() {
+    let uses = vec![a_use("cu_1", "nod_a", "task1")];
+    let mut verdict = a_verdict("cu_1", ContextUseEvaluation::NotHelpful);
+    verdict.evaluation_method = None;
+
+    let health = fold_selection_health(&uses, &[verdict], policy(1, 0.5));
+    assert_eq!(
+        health[0].assessed_uses, 0,
+        "deliverable 3: the assessment method must be recorded to count"
+    );
+}
+
+#[test]
+fn a_low_confidence_verdict_is_not_evidence() {
+    let uses = vec![a_use("cu_1", "nod_a", "task1")];
+    let mut verdict = a_verdict("cu_1", ContextUseEvaluation::NotHelpful);
+    verdict.attribution_confidence = Confidence::new(50).expect("in range");
+
+    let health = fold_selection_health(&uses, &[verdict], policy(1, 0.5));
+    assert_eq!(
+        health[0].assessed_uses, 0,
+        "a verdict below the confidence floor must not drive anything"
+    );
+}
+
+#[test]
+fn a_verdict_naming_an_unknown_use_is_dropped() {
+    let uses = vec![a_use("cu_1", "nod_a", "task1")];
+    let orphan = a_verdict("cu_nonexistent", ContextUseEvaluation::NotHelpful);
+
+    let health = fold_selection_health(&uses, &[orphan], policy(1, 0.5));
+    assert_eq!(health.len(), 1);
+    assert_eq!(health[0].assessed_uses, 0);
+}
+
+#[test]
+fn failing_requires_clearing_the_attributable_floor() {
+    // One negative verdict out of one assessed use is a ratio of 1.0 — but a
+    // single data point must not retire anything.
+    let uses = vec![a_use("cu_1", "nod_a", "task1")];
+    let feedback = vec![a_verdict("cu_1", ContextUseEvaluation::NotHelpful)];
+
+    let strict = fold_selection_health(&uses, &feedback, policy(5, 0.8));
+    assert!((strict[0].not_helpful_ratio - 1.0).abs() < f64::EPSILON);
+    assert!(!strict[0].attributable);
+    assert!(!strict[0].failing, "one verdict is a ratio, not a pattern");
+
+    let lenient = fold_selection_health(&uses, &feedback, policy(1, 0.8));
+    assert!(lenient[0].failing);
+}
+
+#[test]
+fn thirty_uses_in_one_task_are_one_task_of_evidence() {
+    // Spec §7's anti-poisoning rule: count distinct tasks, not events.
+    let uses: Vec<_> = (0..30)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", "the-same-task"))
+        .collect();
+
+    let health = fold_selection_health(&uses, &[], policy(1, 0.8));
+    assert_eq!(health[0].uses, 30);
+    assert_eq!(health[0].distinct_tasks, 1);
+}
+
+#[test]
+fn the_fold_rebuilds_exactly_and_is_order_independent() {
+    // THE GATE: "aggregates rebuild exactly from immutable records."
+    let uses = vec![
+        a_use("cu_1", "nod_a", "task1"),
+        a_use("cu_2", "nod_b", "task1"),
+        a_use("cu_3", "nod_a", "task2"),
+    ];
+    let feedback = vec![
+        a_verdict("cu_1", ContextUseEvaluation::Helpful),
+        a_verdict("cu_3", ContextUseEvaluation::NotHelpful),
+        a_verdict("cu_2", ContextUseEvaluation::Neutral),
+    ];
+
+    let once = fold_selection_health(&uses, &feedback, policy(1, 0.8));
+    let twice = fold_selection_health(&uses, &feedback, policy(1, 0.8));
+    assert_eq!(once, twice, "the same records must rebuild the same value");
+
+    // Append order is a storage detail, not a fact about the evidence, so a
+    // ledger read that returns rows in another order must agree exactly.
+    let mut shuffled_uses = uses.clone();
+    shuffled_uses.reverse();
+    let mut shuffled_feedback = feedback.clone();
+    shuffled_feedback.reverse();
+    let reordered = fold_selection_health(&shuffled_uses, &shuffled_feedback, policy(1, 0.8));
+    assert_eq!(once, reordered, "the fold must not depend on row order");
+}
+
+#[test]
+fn output_is_sorted_so_two_runs_are_byte_identical() {
+    let uses = vec![
+        a_use("cu_1", "nod_zzz", "task1"),
+        a_use("cu_2", "nod_aaa", "task1"),
+        a_use("cu_3", "nod_mmm", "task1"),
+    ];
+
+    let health = fold_selection_health(&uses, &[], SelectionHealthPolicy::default());
+    let ids: Vec<&str> = health
+        .iter()
+        .map(|h| h.context_record_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["nod_aaa", "nod_mmm", "nod_zzz"]);
+}
+
+#[test]
+fn the_shipped_defaults_are_the_settings_defaults() {
+    // If `context.efficacy`'s defaults move, this fold's must move with them —
+    // two different answers to "what counts as failing" is the drift this
+    // catches.
+    let default = SelectionHealthPolicy::default();
+    assert_eq!(default.min_attributable_uses, 5);
+    assert!((default.not_helpful_ratio_threshold - 0.8).abs() < f64::EPSILON);
+    assert_eq!(default.min_attribution_confidence, 80);
+}
+
+/// A verdict from `method`, otherwise identical to [`a_verdict`].
+fn a_verdict_via(
+    use_id: &str,
+    evaluation: ContextUseEvaluation,
+    method: &str,
+) -> ContextUseFeedback {
+    let mut verdict = a_verdict(use_id, evaluation);
+    verdict.evaluation_method = ContextEvaluationMethod::new(method).ok();
+    verdict
+}
+
+#[test]
+fn an_agent_self_report_informs_but_can_never_retire() {
+    // THE two-tier invariant. The agent judged its own context unhelpful five
+    // times out of five. That is real evidence and must be visible — but a
+    // self-report that could retire its own subject is self-reinforcing, so it
+    // may not drive the decision.
+    let uses: Vec<_> = (0..5)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")))
+        .collect();
+    let feedback: Vec<_> = (0..5)
+        .map(|i| {
+            a_verdict_via(
+                &format!("cu_{i}"),
+                ContextUseEvaluation::NotHelpful,
+                ContextEvaluationMethod::AGENT_SELF_REPORT,
+            )
+        })
+        .collect();
+
+    let health = fold_selection_health(&uses, &feedback, policy(5, 0.8));
+    // Visible…
+    assert_eq!(health[0].assessed_uses, 5);
+    assert_eq!(health[0].not_helpful, 5);
+    assert!((health[0].not_helpful_ratio - 1.0).abs() < f64::EPSILON);
+    // …but not actionable.
+    assert_eq!(health[0].eligible_assessed, 0);
+    assert_eq!(health[0].eligible_not_helpful, 0);
+    assert!(!health[0].attributable);
+    assert!(
+        !health[0].failing,
+        "an agent self-report must never be able to retire its own subject"
+    );
+}
+
+#[test]
+fn a_pruning_eligible_method_does_drive_the_decision() {
+    let uses: Vec<_> = (0..5)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")))
+        .collect();
+    let feedback: Vec<_> = (0..5)
+        .map(|i| {
+            a_verdict_via(
+                &format!("cu_{i}"),
+                ContextUseEvaluation::NotHelpful,
+                ContextEvaluationMethod::DETERMINISTIC_VALIDATION,
+            )
+        })
+        .collect();
+
+    let health = fold_selection_health(&uses, &feedback, policy(5, 0.8));
+    assert_eq!(health[0].eligible_assessed, 5);
+    assert!(
+        health[0].failing,
+        "deterministic validation is strong enough"
+    );
+}
+
+#[test]
+fn an_unregistered_extension_method_is_not_pruning_eligible() {
+    // Host policy must trust a method before it can suppress anything.
+    let uses: Vec<_> = (0..5)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")))
+        .collect();
+    let feedback: Vec<_> = (0..5)
+        .map(|i| {
+            a_verdict_via(
+                &format!("cu_{i}"),
+                ContextUseEvaluation::NotHelpful,
+                "vendor.custom_heuristic.v1",
+            )
+        })
+        .collect();
+
+    let health = fold_selection_health(&uses, &feedback, policy(5, 0.8));
+    assert_eq!(health[0].assessed_uses, 5, "still counted as assessment");
+    assert_eq!(health[0].eligible_assessed, 0);
+    assert!(!health[0].failing);
+}
+
+#[test]
+fn self_reports_do_not_dilute_a_genuine_eligible_verdict() {
+    // Mixed evidence: one deterministic negative, four agent self-report
+    // positives. The eligible population is the single strong verdict, so the
+    // eligible ratio is 1.0 — the self-reports must not water it down.
+    let uses: Vec<_> = (0..5)
+        .map(|i| a_use(&format!("cu_{i}"), "nod_a", &format!("task{i}")))
+        .collect();
+    let mut feedback = vec![a_verdict_via(
+        "cu_0",
+        ContextUseEvaluation::NotHelpful,
+        ContextEvaluationMethod::DETERMINISTIC_VALIDATION,
+    )];
+    for i in 1..5 {
+        feedback.push(a_verdict_via(
+            &format!("cu_{i}"),
+            ContextUseEvaluation::Helpful,
+            ContextEvaluationMethod::AGENT_SELF_REPORT,
+        ));
+    }
+
+    let health = fold_selection_health(&uses, &feedback, policy(1, 0.8));
+    assert_eq!(health[0].eligible_assessed, 1);
+    assert_eq!(health[0].eligible_not_helpful, 1);
+    assert!(health[0].failing);
+}

--- a/stella-store/src/efficacy.rs
+++ b/stella-store/src/efficacy.rs
@@ -1,0 +1,132 @@
+//! Efficacy-attribution reads — Phase 4 (#715).
+//!
+//! The `store.db` side of the context-use extractor: which turns have closed,
+//! what each one cited, and which of its tool calls failed. Everything here is
+//! a *read*; the records these rows become are written to the append-only
+//! ledger in `context.db`, not here.
+//!
+//! Its own module rather than three more methods on the already-oversized
+//! `lib.rs`, per the phase's own working rule — new code goes in a new module
+//! instead of raising a grandfathered ceiling.
+
+use rusqlite::params;
+
+use crate::{MemoryCitationRow, Result, Store};
+
+/// One closed-out execution, as the context-use extractor sees it (Phase 4,
+/// #715). Only the fields an attribution needs: which turn it was, whose
+/// session, how it ended, and when.
+///
+/// `session_id` and `finished_at` are `Option` because the columns are
+/// nullable and an honest reader says so — `set_execution_session` is a second
+/// write that a crash can miss, and a row written by an older binary may
+/// predate it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinishedExecution {
+    pub execution_id: i64,
+    pub session_id: Option<String>,
+    /// `completed` | `aborted` | `cancelled` — the same vocabulary
+    /// `record_execution_end` writes.
+    pub outcome: String,
+    pub finished_at: Option<String>,
+}
+
+impl Store {
+    /// One finished execution's citations, in the order they were written.
+    ///
+    /// [`Self::memory_citation_stats`] folds the whole table and drops
+    /// `execution_id` on the way; the context-use extractor (Phase 4, #715)
+    /// needs the rows of *one* execution, because a citation is the feedback on
+    /// that execution's uses and nothing else. Ordered by `rowid` so a replay
+    /// derives identical record ids.
+    pub fn memory_citations_for_execution(
+        &self,
+        execution_id: i64,
+    ) -> Result<Vec<MemoryCitationRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT memory_id, useful_score, truthful, remark FROM memory_citations
+             WHERE execution_id = ? ORDER BY rowid ASC",
+        )?;
+        let rows = stmt.query_map(params![execution_id], |row| {
+            Ok(MemoryCitationRow {
+                memory_id: row.get(0)?,
+                useful_score: row.get(1)?,
+                truthful: row.get(2)?,
+                remark: row.get(3)?,
+            })
+        })?;
+        let mut citations = Vec::new();
+        for row in rows {
+            citations.push(row?);
+        }
+        Ok(citations)
+    }
+
+    /// One execution's *failed* tool calls, oldest first (Phase 4, #715).
+    ///
+    /// The evidence source behind [`ObservationSource::ToolOutcome`]. Only
+    /// failures: a tool that worked is the expected case and mining it would
+    /// bury the signal under thousands of successes. `name` and `error` are
+    /// returned rather than the whole row because an observation is a sentence
+    /// about what went wrong, and `args_json` can carry secrets that have no
+    /// business reaching the miner.
+    ///
+    /// [`ObservationSource::ToolOutcome`]: https://docs.rs/stella-core
+    pub fn failed_tool_calls_for_execution(
+        &self,
+        execution_id: i64,
+    ) -> Result<Vec<(String, String)>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT name, error FROM tool_calls
+             WHERE execution_id = ? AND ok = 0 AND error <> ''
+             ORDER BY seq ASC",
+        )?;
+        let rows = stmt.query_map(params![execution_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut failures = Vec::new();
+        for row in rows {
+            failures.push(row?);
+        }
+        Ok(failures)
+    }
+
+    /// Finished executions after `after_execution_id`, oldest first — the
+    /// context-use extractor's source (Phase 4, #715).
+    ///
+    /// **Finished only.** `outcome IS NOT NULL` is the whole point: an
+    /// in-flight execution has no outcome to attribute a use to, and extracting
+    /// it early would mint a `ContextUse` whose feedback can never arrive.
+    /// `record_execution_end` sets `outcome` and the citations in the same
+    /// close-out, so an execution that passes this filter has both or neither.
+    ///
+    /// Ascending by id so the cursor can advance monotonically; ids are
+    /// `AUTOINCREMENT` and never reused, so "after id N" is a durable watermark.
+    pub fn finished_executions_after(
+        &self,
+        after_execution_id: i64,
+        limit: u32,
+    ) -> Result<Vec<FinishedExecution>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, outcome, finished_at FROM executions
+             WHERE id > ? AND outcome IS NOT NULL
+             ORDER BY id ASC LIMIT ?",
+        )?;
+        let rows = stmt.query_map(params![after_execution_id, i64::from(limit)], |row| {
+            Ok(FinishedExecution {
+                execution_id: row.get(0)?,
+                session_id: row.get(1)?,
+                outcome: row.get(2)?,
+                finished_at: row.get(3)?,
+            })
+        })?;
+        let mut executions = Vec::new();
+        for row in rows {
+            executions.push(row?);
+        }
+        Ok(executions)
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -145,6 +145,7 @@ pub mod catalog;
 pub mod content_free;
 pub mod drain;
 pub mod durable;
+pub mod efficacy;
 pub mod enterprise_telemetry;
 pub mod forget;
 pub mod home;
@@ -172,6 +173,7 @@ pub use drain::{
     MAX_SUPPORTED_SCHEMA_VERSION, MIN_SUPPORTED_SCHEMA_VERSION, OTEL_SCHEMA_VERSION_ATTR,
     RejectionClass, drain_org, schema_version_supported,
 };
+pub use efficacy::FinishedExecution;
 pub use forget::{ContextSurface, SurfaceSuppression, is_restatement, is_suppressed};
 pub use integrity::{IntegrityDepth, IntegrityReport, StoreQuarantine};
 // The sidecar journal's writer is deliberately NOT re-exported at the top


### PR DESCRIPTION
Phase 4: efficacy attribution and reversible retirement (#715)

Closes the adaptive-context loop. Context that repeatedly fails to help stops
being selected — visibly, with reasons, and reversibly.

Phase 4 is mostly a consumer build. `ContextUse`, `ContextUseFeedback`,
`EfficacySettings`, and `PromotionAction::{Retired,Reverted}` all shipped in
earlier phases with no writer; this wires them up.

**1. Context-use records.** A finished turn's frame items become immutable
`context_use` records joined to their feedback by a `use_trace_id`. Built as an
extractor over `store.db` rather than a write at close-out: `record_execution_end`
holds one database and has eight call sites, and the receipt plane has no
turn-end hook at all (its ledger is stack-local and emits before the model call
commits). Everything a use record needs is already durable, so it is derived —
which makes it replay-idempotent for free via content-addressed ids.

Records land in `context.db`, not `store.db`. `memory_citations` is in
`DEPENDENT_TABLES`, so `stella stats prune` deletes citation rows with their
execution; an aggregate folded over them is not rebuildable across a prune, and
the gate's first criterion would have been false the first time anyone pruned.

**2. The citation loop generalized.** `ObservationSource::MemoryCitation` and
`ToolOutcome` were declared in Phase 1 and written by nothing, so the typed loop
learned from reflection prose and no other evidence. Both now have constructors.
Citation semantics are untouched: quarantine at two untruthful citations and
promotion at a positive streak still derive from `fold_citation_stats`, still
recomputed on every read, still never stored.

**3. Opportunity-aware attribution.** Enforced at the write path and again at
the read path, because a record written by an older binary must not become
evidence either. Absence of citation earns no verdict at all rather than a
negative one.

**4. Derived selection health.** A pure fold over immutable records, sorted so
two runs are byte-identical. `not_helpful_ratio` divides by *assessed* uses,
never by all uses — dividing by the latter would let silence masquerade as
approval.

**5. Reversible retirement.** An immutable `promotion_event` folded
last-write-wins, exactly as keep/ignore already replay. It never writes
`superseded_at`: `node_by_public_id` filters on that column, so routing
retirement through `supersede_node` would have made retired records impossible
to fetch by id and failed "still explicitly retrievable" outright. It joins the
union the suppression reader already computes rather than adding a second
suppression mechanism (§5.7). Nothing is ever deleted.

**The pruning-eligibility tier, which is the load-bearing correctness result.**
The type layer always said `agent_self_report` is recognized but may never drive
pruning; nothing implemented it. `cite_memory` is the agent judging context the
agent was given, so citation-derived verdicts are recorded as
`agent_self_report` and are not pruning-eligible — a self-report that can retire
its own subject is self-reinforcing, since a model that misreads a memory
reports it unhelpful, retires it, and destroys the evidence that the reading was
wrong. Selection health carries two populations: everything assessed (what is
known) and the pruning-eligible subset (what may remove). Only the latter
decides `failing`.

Consequence, stated rather than hidden: automatic retirement does not fire on
citation evidence alone. `stella memory retire <id> --reason` is the
pruning-eligible source today. Wiring a deterministic one is tracked separately.

**Protected categories.** Three of the five named are real and checked
(user-confirmed, published, blocking). `DirectivePriority::Critical` is carried
on no record and there is no pin concept at all — both are documented as absent
rather than faked, and `protection_for` is the single predicate every retirement
passes through so each has one home when it becomes real.

Also: `stella-store/src/lib.rs`'s new readers went into their own
`efficacy` module rather than raising the file-size ceiling. The baseline diff
also retightens `driver.rs` (2265 → 2087), a stale entry from before that file
was split.

Gate: `make gate` green — 3858 tests, clippy clean, no file over its ceiling.
