### PR TITLE
feat(model,tui): stream chain-of-thought to the transcript's thinking channel

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,7 +15,7 @@
 2087 stella-core/src/driver.rs
 2819 stella-core/src/driver/tests.rs
 1759 stella-fleet/src/fleet.rs
-1599 stella-model/src/anthropic/tests.rs
+1601 stella-model/src/anthropic/tests.rs
 1638 stella-model/src/bedrock.rs
 1919 stella-model/src/openai.rs
 1623 stella-model/src/zai/tests.rs

--- a/stella-core/src/speculation.rs
+++ b/stella-core/src/speculation.rs
@@ -140,6 +140,18 @@ impl ToolCallObserver for SpeculationGate {
         });
     }
 
+    fn reasoning_delta(&self, delta: &str) {
+        if delta.is_empty() {
+            return;
+        }
+        // `Reasoning`, never `TextDelta`: the transcript folds this into its
+        // own collapsible entry, keeping thinking visible but plainly
+        // distinct from the answer.
+        let _ = self.events.send(AgentEvent::Reasoning {
+            delta: delta.to_string(),
+        });
+    }
+
     fn tool_call_streamed(&self, call: &ToolCall) {
         if self.fenced.load(Ordering::Relaxed) {
             return;
@@ -223,6 +235,25 @@ mod tests {
             })
             .collect();
         assert_eq!(forwarded, vec!["Hel".to_string(), "lo".to_string()]);
+    }
+
+    /// Thinking rides `Reasoning`, not `TextDelta` — the transcript renders
+    /// the two differently (collapsed and dimmed vs. the reply), and merging
+    /// them is what once published chain-of-thought as the answer.
+    #[test]
+    fn reasoning_deltas_forward_as_reasoning_never_as_text() {
+        let (gate, _rx, mut events_rx) = gate_with(&[]);
+        gate.reasoning_delta("weigh");
+        gate.reasoning_delta("");
+        gate.reasoning_delta("ing");
+
+        let forwarded: Vec<String> = std::iter::from_fn(|| events_rx.try_recv().ok())
+            .map(|e| match e {
+                AgentEvent::Reasoning { delta } => delta,
+                other => panic!("thinking must never ride another event: {other:?}"),
+            })
+            .collect();
+        assert_eq!(forwarded, vec!["weigh".to_string(), "ing".to_string()]);
     }
 
     #[test]

--- a/stella-model/src/anthropic.rs
+++ b/stella-model/src/anthropic.rs
@@ -492,6 +492,12 @@ enum AnthropicDelta {
     InputJsonDelta {
         partial_json: String,
     },
+    /// Extended-thinking content. Announced to the observer on the reasoning
+    /// channel so the transcript can show it live, collapsed and dimmed —
+    /// never folded into the answer text.
+    ThinkingDelta {
+        thinking: String,
+    },
     #[serde(other)]
     Other,
 }
@@ -874,14 +880,20 @@ async fn aggregate_anthropic_stream(
                     }
                 }
                 Ok(AnthropicStreamEvent::ContentBlockDelta { index, delta }) => match delta {
-                    // Only user-visible answer text is announced — thinking
-                    // deltas (`thinking_delta`) deserialize as `Other` and
-                    // never reach the observer.
+                    // Answer text and thinking are announced on separate
+                    // observer channels and never merged: `text` remains the
+                    // reply, while thinking renders as its own collapsible
+                    // transcript entry.
                     AnthropicDelta::TextDelta { text: delta } => {
                         if let Some(observer) = observer {
                             observer.text_delta(&delta);
                         }
                         text.push_str(&delta);
+                    }
+                    AnthropicDelta::ThinkingDelta { thinking } => {
+                        if let Some(observer) = observer {
+                            observer.reasoning_delta(&thinking);
+                        }
                     }
                     AnthropicDelta::InputJsonDelta { partial_json } => {
                         if let Some(acc) = tool_uses.get_mut(&index) {

--- a/stella-model/src/anthropic/tests.rs
+++ b/stella-model/src/anthropic/tests.rs
@@ -886,9 +886,9 @@ impl ToolCallObserver for RecordingObserver {
 #[tokio::test]
 async fn complete_observed_streams_answer_deltas_in_order_never_thinking() {
     let server = MockServer::start().await;
-    // Answer fragments interleaved with a thinking delta: the observer
-    // must see exactly the user-visible fragments, in stream order —
-    // thinking deltas parse as `Other` and never reach it.
+    // Answer fragments interleaved with a thinking delta: this channel
+    // carries exactly the user-visible fragments, in stream order. Thinking
+    // rides `reasoning_delta` instead (see `tests::thinking`).
     let sse_body = concat!(
         "event: content_block_delta\n",
         "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"let me think\"}}\n\n",
@@ -1597,3 +1597,5 @@ fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
         );
     }
 }
+
+mod thinking;

--- a/stella-model/src/anthropic/tests/thinking.rs
+++ b/stella-model/src/anthropic/tests/thinking.rs
@@ -1,0 +1,76 @@
+//! Extended-thinking deltas reach the observer on the reasoning channel.
+//! Split from the parent `tests.rs` (file-size gate).
+
+use super::*;
+
+/// `thinking_delta` blocks used to deserialize as `Other` and vanish, so a
+/// thinking model's deliberation was invisible in the transcript. They now
+/// announce on the reasoning channel — separate from the answer, which is
+/// what lets the deck render them collapsed and dimmed rather than as a
+/// reply.
+#[tokio::test]
+async fn thinking_deltas_reach_the_reasoning_channel_not_the_answer() {
+    #[derive(Default)]
+    struct SplitObserver {
+        text: std::sync::Mutex<Vec<String>>,
+        thinking: std::sync::Mutex<Vec<String>>,
+    }
+    impl ToolCallObserver for SplitObserver {
+        fn tool_call_streamed(&self, _call: &stella_protocol::ToolCall) {}
+        fn text_delta(&self, delta: &str) {
+            self.text.lock().unwrap().push(delta.to_string());
+        }
+        fn reasoning_delta(&self, delta: &str) {
+            self.thinking.lock().unwrap().push(delta.to_string());
+        }
+    }
+
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"weighing \"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"the options\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"The answer.\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5")
+        .with_base_url(server.uri());
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let observer = SplitObserver::default();
+    let result = provider
+        .complete_observed(req, &observer)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(
+        *observer.thinking.lock().unwrap(),
+        vec!["weighing ", "the options"],
+        "thinking streams in order on its own channel"
+    );
+    assert_eq!(
+        *observer.text.lock().unwrap(),
+        vec!["The answer."],
+        "the answer channel never carries thinking"
+    );
+    assert_eq!(
+        result.text, "The answer.",
+        "thinking is never folded into the reply"
+    );
+}

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -1185,19 +1185,28 @@ async fn aggregate_zai_stream(
                     truncated_at_token_limit = true;
                 }
                 if let Some(content) = choice.delta.content {
-                    // Only `content` (the user-visible answer) is announced —
-                    // `reasoning_content`/`reasoning` stay observer-silent,
-                    // including when the reasoning-only fallback below ends up
-                    // supplying the final text (the deltas are best-effort).
+                    // `content` is the user-visible answer; thinking rides
+                    // `reasoning_delta` below. The two channels stay separate
+                    // all the way to the transcript.
                     if let Some(observer) = observer {
                         observer.text_delta(&content);
                     }
                     text.push_str(&content);
                 }
+                // GLM's name for chain-of-thought and OpenRouter's normalized
+                // one. Both announce as thinking, so a reasoning model's
+                // deliberation is visible live (collapsed, dimmed) instead of
+                // the turn looking idle until the answer lands.
                 if let Some(rc) = choice.delta.reasoning_content {
+                    if let Some(observer) = observer {
+                        observer.reasoning_delta(&rc);
+                    }
                     reasoning.push_str(&rc);
                 }
                 if let Some(r) = choice.delta.reasoning {
+                    if let Some(observer) = observer {
+                        observer.reasoning_delta(&r);
+                    }
                     reasoning.push_str(&r);
                 }
                 for tc_delta in choice.delta.tool_calls {

--- a/stella-model/src/zai/tests/openrouter_stream_tests.rs
+++ b/stella-model/src/zai/tests/openrouter_stream_tests.rs
@@ -166,3 +166,70 @@ async fn openrouter_reasoning_only_turn_still_falls_back() {
     assert_eq!(result.text, "only thinking");
     assert!(result.tool_calls.is_empty());
 }
+
+/// Thinking must reach the observer on its OWN channel. The transcript folds
+/// `reasoning_delta` into a collapsible, dimmed entry, so wiring it here is
+/// what makes a reasoning model's deliberation visible live without it ever
+/// being mistaken for the answer — the whole point of keeping the two
+/// channels separate rather than reviving the old text fallback.
+#[tokio::test]
+async fn reasoning_streams_to_the_observer_separately_from_the_answer() {
+    #[derive(Default)]
+    struct SplitObserver {
+        text: std::sync::Mutex<Vec<String>>,
+        thinking: std::sync::Mutex<Vec<String>>,
+    }
+    impl ToolCallObserver for SplitObserver {
+        fn tool_call_streamed(&self, _call: &ToolCall) {}
+        fn text_delta(&self, delta: &str) {
+            self.text.lock().unwrap().push(delta.to_string());
+        }
+        fn reasoning_delta(&self, delta: &str) {
+            self.thinking.lock().unwrap().push(delta.to_string());
+        }
+    }
+
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning\":\"weighing \"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning\":\"the options\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"The answer.\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let observer = SplitObserver::default();
+    let result = provider
+        .complete_observed(req, &observer)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(
+        *observer.thinking.lock().unwrap(),
+        vec!["weighing ", "the options"],
+        "thinking streams in order on its own channel"
+    );
+    assert_eq!(
+        *observer.text.lock().unwrap(),
+        vec!["", "", "The answer."],
+        "the answer channel carries only content, never thinking"
+    );
+    assert_eq!(result.text, "The answer.");
+}

--- a/stella-protocol/src/provider.rs
+++ b/stella-protocol/src/provider.rs
@@ -42,6 +42,24 @@ pub trait ToolCallObserver: Send + Sync {
     fn text_delta(&self, delta: &str) {
         let _ = delta;
     }
+
+    /// One fragment of *thinking* arrived on the stream, in order — the
+    /// counterpart to [`Self::text_delta`] for models that stream
+    /// chain-of-thought on a separate channel (OpenRouter's `reasoning`,
+    /// GLM's `reasoning_content`, Anthropic's `thinking_delta`).
+    ///
+    /// Kept a distinct method rather than folded into `text_delta` because
+    /// the two must never be confused downstream: thinking is displayed as
+    /// collapsible, visibly-secondary content, while answer text is the
+    /// reply. Conflating them is exactly the defect that made the adapter
+    /// publish private deliberation as the model's answer.
+    ///
+    /// Same best-effort contract as `text_delta`: lossy, re-streamed on a
+    /// retried attempt, and not called at all by adapters without mid-stream
+    /// visibility. Default no-op so existing observers compile unchanged.
+    fn reasoning_delta(&self, delta: &str) {
+        let _ = delta;
+    }
 }
 
 /// One model provider adapter. `stella-core` drives every call through


### PR DESCRIPTION
Follow-up to #750 (merged). That PR stopped the adapter from publishing reasoning as the assistant's *answer* — which was correct, but it removed the **only** path by which chain-of-thought was reaching the screen at all. On tool-calling turns thinking would now be dropped entirely. This gives it a proper channel.

## The surface already existed

`AgentEvent::Reasoning`, `TranscriptEntry::Reasoning`, `push_reasoning`, journal persistence, the deck's `think` trace kind, the collapsible dim-italic renderer, and the `ctrl+r` expand toggle were **all already built and emitted by nobody**. Same built-but-unwired shape as the scope-review card in #750.

## Changes

- **`ToolCallObserver::reasoning_delta`** — new, default no-op so every existing observer compiles unchanged. Deliberately a separate method from `text_delta` rather than folded into it: conflating the two channels is precisely the defect #750 fixed. The trait doc for `text_delta` already promised "never thinking/reasoning content"; this is where that content goes instead.
- **`SpeculationGate`** forwards it as `AgentEvent::Reasoning`, never `TextDelta`.
- **`zai.rs`** emits it for OpenRouter's normalized `reasoning` and GLM's `reasoning_content`.
- **`anthropic.rs`** emits it for `thinking_delta`, which previously deserialized to the `Other` catch-all and was silently discarded — so the direct-Anthropic path gets thinking too, not just the gateway.

Thinking renders collapsed by default (one-line live tail); `ctrl+r` expands.

## Verification

`make gate` green on current `main` (which has since moved — Phase 4 #715 landed), **3870 tests**.

Three new tests, one per hop in the chain:
- `zai`: `reasoning_streams_to_the_observer_separately_from_the_answer` — asserts thinking arrives in order on its own channel and the answer channel carries only content.
- `anthropic`: `thinking_deltas_reach_the_reasoning_channel_not_the_answer` — same, plus that `result.text` is never polluted.
- `stella-core`: `reasoning_deltas_forward_as_reasoning_never_as_text` — panics if thinking rides any other event.

The pre-existing `complete_observed_streams_answer_deltas_in_order_never_thinking` tests in both adapters still pass unchanged; their comments were updated where they described the old drop-it behavior.

New test code went into new modules rather than growing the grandfathered files; the single `+2` baseline entry is a blank line plus a `mod` declaration.