### PR TITLE
feat(stella-pipeline): route verification failures through a feedback airlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ record of *changes*, curated by the person who made them.
 
 ## [Unreleased]
 
+- The pipeline no longer replays raw test-runner output into a worker's
+  revision prompt. A deterministic verification failure is now disclosed
+  through a **feedback airlock** at one of four grains (`L0`–`L3`), tightening
+  automatically when the same failure repeats, and model-authored text coming
+  back inbound (distress guidance, judge reasoning) is scrubbed against the
+  sealed material before it can reach the worker. Operator-facing output is
+  unchanged — `stella` still shows you the real failure; only the model's
+  prompt is redacted. Design: `docs/design/witness-protocol.md`.
+
 ## [0.5.57] — 2026-07-27
 
 ## [0.5.56] — 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ record of *changes*, curated by the person who made them.
 
 ## [Unreleased]
 
+- Short work costs less. A greeting no longer pays for a triage model call: the
+  conversational route was always resolved deterministically, but the paid
+  classification went out first and could not change the answer. `hi` now costs
+  one model call instead of two, and can no longer stall behind a wedged triage
+  provider.
+- A change with nothing to prove no longer buys a review call to be told so.
+  Verification now reads the **diff** — docs-only, tests-only, config-only,
+  comments-only, or a pure removal completes with a **stated reason** recorded
+  on the verdict, rather than escalating because no test flipped. Anything
+  mixed or unreadable still buys the test. Removals and test-only changes keep
+  their independent reviewer, because deleting the wrong thing is a mistake a
+  reader catches and no test would have. Design:
+  `docs/design/witness-protocol.md` §7.
+
 - The pipeline no longer replays raw test-runner output into a worker's
   revision prompt. A deterministic verification failure is now disclosed
   through a **feedback airlock** at one of four grains (`L0`–`L3`), tightening

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,6 +3296,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "stella-core",
  "stella-protocol",
  "tempfile",

--- a/docs/design/witness-protocol.md
+++ b/docs/design/witness-protocol.md
@@ -1,0 +1,201 @@
+# The Witness Protocol, adapted
+
+Status: approved for implementation — §4 lands in `stella-pipeline`; §5 records what is deliberately declined
+
+## Purpose
+
+The Witness Protocol v0.1 draft specifies a pipeline in which autonomous agents
+ship production software with "done" certified by machinery rather than by
+anyone's confidence. It names Stella directly in its adoption path.
+
+This document is not that specification. It is the *adoption decision*: which
+of its ideas Stella takes, which it declines, and why. It exists so the
+declined half is not re-litigated every time someone reads the draft, and so
+the adopted half is anchored to defects that are real in this codebase rather
+than to vocabulary borrowed from a different kind of system.
+
+The short version: Stella already has the draft's hardest-won mechanism — a
+deterministic oracle that cannot be talked out of a failure. What it lacks is a
+**disciplined feedback channel**, and that is what this document adds.
+
+## 1. What Stella already has, and keeps
+
+The L-E11 ladder is not replaced. Three of its properties are the reason the
+draft's machinery has something to attach to at all:
+
+- **The flip oracle.** Only a fail→pass flip of the same normalized command
+  counts, and `Flipped` is reachable only through `Failing` of that same
+  command. The draft's "family" concept is a generator plus *an oracle*; this
+  is the oracle. Replacing it would be discarding the strongest asset in the
+  crate to install new vocabulary.
+- **Tamper exclusion.** The witness artifact's full filesystem identity is
+  pinned and re-checked at verify time, and a mismatch aborts the candidate
+  before any model judge can weigh in. The draft calls this an authority
+  boundary; Stella already treats it as one.
+- **Deterministic-first laddering.** A red test never costs a judge call, and
+  the judge never overrides a deterministic failure.
+
+Anything below that would weaken these is out of scope by construction.
+
+## 2. The defects this document fixes
+
+Each is present in the shipping code, and each is already named in
+[`ROADMAP.md`](../../ROADMAP.md).
+
+**D1 and D3 are fixed by §4 of this document.** D2, D4, and D5 are recorded
+here because they are real and because the airlock's machinery makes two of
+them cheap to reach later — but they are separate changes and do not land
+together. One logical change per PR.
+
+**D1 — The failure channel leaks the detector.** On a deterministic failure the
+worker receives `"touched tests failed after execution: {tail}"` — the raw
+test-runner output. That tail carries the assertion, the literal expected and
+actual values, and the test's name. The worker is entitled to know *what is
+wrong with its code*; it is not entitled to the detector's fingerprint, because
+the fingerprint is what makes special-casing cheaper than fixing. With a
+revision budget and a single visible witness, that is a reconstruction path.
+
+**D2 — A flip is credited on command identity alone.** The oracle matches the
+normalized *command*, not the *failure*. A test that fails for reason A,
+then fails for unrelated reason B, then passes, credits a flip that no single
+defect ever explains. ROADMAP §2 names this.
+
+**D3 — Verdict evidence is unstructured and unreferenced.**
+`JudgeEvidence::evidence_refs` exists on the wire and is populated at zero
+construction sites. A verdict therefore asserts a summary no reader can go
+check. ROADMAP §4 names this.
+
+**D4 — A verdict is not replayable.** `Verdict` carries `passed`,
+`deterministic`, and a prose `summary`. The `LadderInputs` that produced it —
+the flip state, the touched-test result, the diff size against its budget — are
+discarded. Nobody can later ask *why* a run passed. ROADMAP §6 names this.
+
+**D5 — The judge reads worker-authored text as prose.** `judge_prompt`
+interpolates the diff directly into the prompt body. Diff content is authored
+by the party being judged, so a comment addressed to the reviewer arrives as
+undelimited instruction text.
+
+## 3. Principles adopted
+
+From the draft, three principles carry over intact:
+
+- **P3 — Metered disclosure.** Every bit crossing from the verification side to
+  the worker is deliberate, graded, and logged. The feedback channel is a
+  security boundary, not plumbing. (Fixes D1.)
+- **P6 — Replayable evidence.** A verdict that cannot be reproduced from what
+  it carries is an anecdote. (Fixes D3, D4.)
+- **P1 — Separation of authorship.** Whatever writes the code does not author
+  what grades it. Stella already routes the witness author and judge through
+  `Role::Judge`'s cross-family preference; this document does not weaken that.
+
+## 4. The Feedback Airlock
+
+The one new mechanism. The principle: **leak the defect, never the detector.**
+
+### 4.1 The disclosure ladder
+
+A failure brief is emitted at a grain, and the grain is a control surface:
+
+| Grain | Brief contains |
+|-------|----------------|
+| `L0` | That verification failed, and nothing else |
+| `L1` | + which criterion or command failed |
+| `L2` | + a symptom class, phrased against observable behavior |
+| `L3` | + a regenerated reproduction the worker can run itself |
+
+Default grain is `L3`, because convergence comes from iterating against a real
+failure and velocity matters. The grain drops when the same failure fingerprint
+(§4.2) repeats, on the reasoning that a worker which has seen the same brief
+twice and still fails is not being helped by a third copy of it — it is being
+given more surface to fit.
+
+### 4.2 Failure fingerprints
+
+A fingerprint is a stable hash of the *normalized* failure: runner output with
+timings, temporary paths, memory addresses, and line-number noise removed. Two
+runs that failed the same way share a fingerprint; two runs that failed
+differently do not.
+
+What it is used for today: the disclosure grain. Repetition of the *same*
+fingerprint is what tightens the ladder, so a worker thrashing against one
+failure stops being handed more surface to fit, while a worker making genuine
+progress — new failure each round — keeps full disclosure.
+
+What it is deliberately **not** used for yet: tightening the flip oracle to
+require that the failure it credits is the failure it first saw (ROADMAP §2,
+listed under D2 above). The mechanism now exists, but wiring it would reject a
+legitimate sequence that ordinary iteration produces constantly — a test fails
+on an assertion, the worker's next edit fails to compile, the edit after that
+passes. Under strict fingerprint matching that flip goes uncredited. The
+oracle's existing command-identity rule stays until there is evidence that
+false flips from *changed* failure modes are a real source of bad verdicts,
+rather than a hypothesis with a cheap-looking fix.
+
+### 4.3 The scrubber is the load-bearing part
+
+A symptom class is prose, and prose describing a failure will happily quote the
+assertion that produced it. So the redactor does not trust the description: a
+brief is scrubbed against the sealed material it was derived from, and a brief
+that still contains the test's identifier, its literal expected/actual values,
+or the witness path **degrades one grain rather than being emitted with a hole
+in it**. Failing closed is the whole point; a redactor that emits on a
+best-effort basis is a leak with a ceremony attached.
+
+Every brief is recorded alongside the material it was redacted from, so
+disclosure is auditable after the fact rather than merely asserted.
+
+## 5. What is declined, and why
+
+Recorded so it is not re-proposed.
+
+**Two trust domains on separate credentials and infrastructure.** Stella is a
+single local BYOK process. Workspace separation and type separation are
+achievable and worth having; separate infrastructure, separate credentials, and
+non-shared provider caches are not, in-process. Claiming them would be exactly
+the ceremony the draft says it exists to replace.
+
+**The shadow sandbox, synthetic twin data, contract doubles, shadow traffic,
+canary ramps, and expand/contract migration law.** These assume the pipeline
+deploys a running service. Stella verifies a change to a repository. It has no
+production to mirror and no rollout to gate.
+
+**The attestation as an underwritten warranty.** The draft's economics section
+prices a warranty off an escape rate and a fidelity score. Stella accumulates
+neither. What is adopted is the *replayable* half — verdict provenance (§2 D4)
+— without the signing, the actuarial claim, or the product tier.
+
+**Dual independent Examiners with divergence-stops-build.** Two full exam
+derivations per run multiplies model spend on a tool whose pitch is a hard
+per-run budget. The existing cross-family judge routing is the affordable
+version of the same idea, and it already ships.
+
+**Replacing the single witness with generated exam families.** The draft's P5
+targets multi-attempt overfitting. Stella's revision budget is small and its
+witness dies with the candidate workspace, so the exposure is bounded — and the
+mechanism that actually detects overfitting here is the fingerprint (§4.2), at
+a fraction of the cost. If escape data later shows workers fitting the witness,
+this is the first thing to revisit.
+
+**Criteria ratification with a frozen `AC_HASH`.** Not declined on merit —
+declined as *already spoken for*. `stella-core::context_record::contract`
+already carries a typed acceptance model (`ArtifactContract`, `Requirement`,
+`RequirementKind::{COMMAND, SEMANTIC_JUDGE}`, `ContractValidation`,
+`contract_hash`) implementing the Context Graph Protocol's lifecycle §8.12–8.14.
+It is unwired today, and its own module docs say an executor interprets it in a
+later phase. Introducing a second, parallel criteria model beside it would
+leave the workspace with two acceptance vocabularies that disagree. When
+criteria land, they land there.
+
+## 6. What would change this decision
+
+The declined half is declined against today's evidence, not forever. The
+signals that should reopen it:
+
+- A worker observed passing a witness it special-cased — reopens exam families.
+- Escapes concentrated in "the criteria never asked for it" — reopens
+  ratification, via the CGP contract model.
+- Stella growing a deployment surface — reopens everything in §5's second
+  paragraph.
+
+Until one of those is observed, building for them is speculation with a
+maintenance cost.

--- a/docs/design/witness-protocol.md
+++ b/docs/design/witness-protocol.md
@@ -1,6 +1,6 @@
 # The Witness Protocol, adapted
 
-Status: approved for implementation — §4 lands in `stella-pipeline`; §5 records what is deliberately declined
+Status: approved for implementation — §4 and §7 land in `stella-pipeline`; §5 records what is deliberately declined
 
 ## Purpose
 
@@ -199,3 +199,73 @@ signals that should reopen it:
 
 Until one of those is observed, building for them is speculation with a
 maintenance cost.
+
+## 7. Proportionate verification: escalate on evidence
+
+Everything above is about the *heavy* path. This section is about not taking it
+when it isn't warranted.
+
+Stella's contributor rule has always been nuanced — ship a witness test, **or a
+stated reason there isn't one**; pure refactors, docs, and CI changes don't need
+one. The pipeline held itself to a stricter rule than it held people to.
+
+### 7.1 Predict-then-commit is the bug
+
+The pipeline decided how much ceremony to buy by **predicting** difficulty once,
+up front, from the prompt — the single worst moment to judge, because no work
+has happened yet. Two consequences:
+
+- **Triage was a paid model call on every prompt, including `hi`.** The
+  deterministic greeting table existed and was exact-match safe, but it was
+  consulted *after* the call had already gone out. A greeting cost a
+  classification round-trip that could not change its own answer, plus up to
+  `triage_latency_ceiling` of dead air on a wedged provider.
+- **The one escape hatch guessed from wording.** `triage::resolve_witness`
+  keyword-matches removal verbs to skip witness authoring. Its reasoning is
+  right — a removal's proof is its diff — but it has to be extremely narrow,
+  because a false positive ships a real behavior change unproven and the only
+  evidence available at that moment is the phrasing of a request.
+
+### 7.2 Escalate on evidence instead
+
+The same principle the evidence ladder already applies to *verification* —
+spend only when the evidence is genuinely inconclusive — applied to the
+pipeline itself.
+
+**Deterministic answers come before paid ones.** Anything resolvable without a
+model is resolved without a model, and *then* the call is made. A route the
+code already describes as never depending on a model answer must not pay for
+one.
+
+**The change is the evidence, not the prompt.** After execution there is a
+diff, and `witness::warrant` reads it. A docs-only edit is docs-only whether
+the prompt said "document the parser" or "make the README less confusing"; no
+phrasing changes what the diff is. The recognized reasons are `NothingChanged`,
+`DocsOnly`, `TestsOnly`, `ConfigOnly`, `CommentsOnly`, and `PureRemoval`.
+
+**Fail closed.** Anything mixed, unrecognized, or invisible to the diff
+machinery falls through to "witness required". An unnecessary witness costs one
+model call; a missing one ships unverified behavior. Where the warrant is
+unsure, it buys the test.
+
+**No test needed is not the same as no review needed.** A removal's proof is
+its diff, but deleting the *wrong* thing is a real mistake a reader catches and
+no test would have covered — so `TestsOnly` and `PureRemoval` keep the
+independent reviewer even though they skip the witness. Prose, comments, and
+manifests carry no behavior for a reviewer to reason about, so a review call
+there is spend with no question to answer.
+
+**Say why.** When no test is warranted, the reason is recorded on the verdict —
+the pipeline's half of the contract contributors are already held to. The run
+scores `Unverified`, never `DeterministicPass`: it is honestly complete, and a
+change with nothing to prove must not outrank a flip-verified sibling in
+best-of-N.
+
+### 7.3 What this does not do yet
+
+Witness *authoring* still runs before execute, because a witness must fail on
+the old code. So the warrant can spare a judge call but not the authoring call
+that preceded it. Moving authoring after execution is possible —
+`stella-tools`' `verify_done` already validates a test against `HEAD` in a
+detached shadow worktree — and that reorder is what would make verification
+cost fully demand-driven. It is not in this change.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,8 +19,8 @@
 1638 stella-model/src/bedrock.rs
 1919 stella-model/src/openai.rs
 1623 stella-model/src/zai/tests.rs
-2476 stella-pipeline/src/pipeline.rs
-2022 stella-pipeline/src/pipeline/tests.rs
+2505 stella-pipeline/src/pipeline.rs
+2034 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2270 stella-store/src/lib.rs
 2170 stella-store/src/tests.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,8 +19,8 @@
 1638 stella-model/src/bedrock.rs
 1919 stella-model/src/openai.rs
 1623 stella-model/src/zai/tests.rs
-2505 stella-pipeline/src/pipeline.rs
-2034 stella-pipeline/src/pipeline/tests.rs
+2535 stella-pipeline/src/pipeline.rs
+2044 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2270 stella-store/src/lib.rs
 2170 stella-store/src/tests.rs

--- a/stella-pipeline/Cargo.toml
+++ b/stella-pipeline/Cargo.toml
@@ -19,6 +19,9 @@ thiserror.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 futures-util.workspace = true
+# Failure fingerprints (witness::airlock): the same SHA-256 the workspace already
+# uses for record_hash, so one hashing primitive covers the tree.
+sha2.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/stella-pipeline/README.md
+++ b/stella-pipeline/README.md
@@ -33,6 +33,7 @@ which owns the port implementations and the `Router` itself. It builds no binary
 | [`src/plan.rs`](src/plan.rs) | The planner's split context (`build_planner_prompt`) and the JSON-then-numbered-list `parse_plan`. |
 | [`src/scope.rs`](src/scope.rs) | `ScopeThresholds` and the pure `needs_scope_review` / `apply_trim` / `build_proposal`. |
 | [`src/witness.rs`](src/witness.rs) | Witness prompts, the closed test-command vocabulary, and the artifact/invocation/identity validators. |
+| [`src/witness/airlock.rs`](src/witness/airlock.rs) | The feedback airlock: `DisclosureGrain`, `SymptomClass`, `FailureFingerprint`, and the `scrub`/`redact` pair that decide what a failure may tell the worker. |
 | [`src/verify.rs`](src/verify.rs) | `FlipOracle`, `ladder_decision`, judge prompting/parsing, `heuristic_fallback`, `guidance_prompt`. |
 | [`src/candidate.rs`](src/candidate.rs) | `CandidateScore` and `select_best_candidate` — best-of-N selection, pure. |
 | [`src/mcp_prefetch.rs`](src/mcp_prefetch.rs) | `fold`: shared MCP context gathered once at the top of a fan-out instead of N times. |
@@ -94,6 +95,21 @@ observed-green tests, so an outage never degrades to a blanket pass. On the seco
 consecutive deterministic failure, `distress_guidance` buys one judge call for
 course-correction that rides with the next revision prompt — event-triggered, never a fixed
 mid-run checkpoint.
+
+**The feedback airlock decides what a failure may say.** Before it, a deterministic
+failure went back to the worker as the raw `stderr` tail — the assertion, the runtime
+values it compared, and the test's name, replayed on every revision. Now
+[`src/witness/airlock.rs`](src/witness/airlock.rs) builds a `FailureBrief` at a
+`DisclosureGrain`: `L3` (a reproduction) by default, stepping down to `L2` (a
+closed-vocabulary `SymptomClass` sentence), `L1` (the command), and `L0` (that it failed)
+as the same `FailureFingerprint` repeats — a worker that has seen the same brief twice
+is not helped by a third copy, only given more surface to fit. The symptom sentences are
+compile-time literals, so that grain cannot quote the assertion by construction; `scrub`
+covers the rest and **fails closed**, degrading a brief rather than emitting it with a
+hole. Model prose arriving inbound (distress guidance, judge reasoning) goes through the
+same scrub, and a rejection emits `PolicyDecision { kind: Blocked }` carrying a token,
+never content. Two audiences, two texts: the operator's `JudgeVerdict` event keeps the
+real output, because the human is not the adversary.
 
 **Degrade, never do nothing.** `WitnessAbort` splits reasons into `degradable` (no witness
 could be authored) and `rejected` (a budget limit, or an artifact-integrity violation), and

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -43,6 +43,15 @@
 //!   against the sealed material first. The operator still sees the real
 //!   output; only the worker's prompt is redacted.
 //!   [`witness::airlock`]. Design: `docs/design/witness-protocol.md` §4.
+//! - **Proportionate verification** — escalate on evidence, never on a
+//!   prediction made before any work exists. Deterministic routes resolve
+//!   before the paid triage call rather than after it (a greeting no longer
+//!   buys a classification that cannot change its own answer), and
+//!   [`witness::warrant`] reads the *diff* to decide whether a change needed a
+//!   test at all — recording a stated reason when it did not, the pipeline's
+//!   half of the contract contributors are held to. Fails closed: anything
+//!   mixed or unreadable buys the test. Design:
+//!   `docs/design/witness-protocol.md` §7.
 //! - **L-M4** — triage runs with `max_retries = 0` under a latency ceiling.
 //!   [`pipeline::Pipeline::run`].
 //! - **Distress guidance** — on the second consecutive deterministic
@@ -112,6 +121,7 @@ pub use witness::airlock::{
     DisclosureGrain, FailureBrief, FailureFingerprint, LeakKind, SealedFailure, SymptomClass,
     grain_for_repeats, redact, scrub,
 };
+pub use witness::warrant::{NoWitnessReason, WitnessWarrant, warrant};
 pub use witness::{
     TestInvocationError, Witness, WitnessArtifactError, parse_test_invocation,
     parse_witness_command, validate_witness_artifact, validate_witness_identity,

--- a/stella-pipeline/src/lib.rs
+++ b/stella-pipeline/src/lib.rs
@@ -35,6 +35,14 @@
 //!   judge's resolution) writes the failing witness test that the flip oracle
 //!   tracks — visible to the worker, integrity-checked by tamper exclusion,
 //!   never hidden. [`witness`].
+//! - **The feedback airlock** — the one channel from verification back to the
+//!   worker. A deterministic failure no longer replays the raw test-runner
+//!   output into the revision prompt: it is disclosed at a grain (`L0`–`L3`)
+//!   that tightens when the same failure repeats, and every model-authored
+//!   text crossing inbound (distress guidance, judge reasoning) is scrubbed
+//!   against the sealed material first. The operator still sees the real
+//!   output; only the worker's prompt is redacted.
+//!   [`witness::airlock`]. Design: `docs/design/witness-protocol.md` §4.
 //! - **L-M4** — triage runs with `max_retries = 0` under a latency ceiling.
 //!   [`pipeline::Pipeline::run`].
 //! - **Distress guidance** — on the second consecutive deterministic
@@ -100,6 +108,10 @@ pub use ports::{
 };
 pub use triage::TaskClass;
 pub use verify::{FlipOracle, FlipState, LadderDecision, LadderInputs};
+pub use witness::airlock::{
+    DisclosureGrain, FailureBrief, FailureFingerprint, LeakKind, SealedFailure, SymptomClass,
+    grain_for_repeats, redact, scrub,
+};
 pub use witness::{
     TestInvocationError, Witness, WitnessArtifactError, parse_test_invocation,
     parse_witness_command, validate_witness_artifact, validate_witness_identity,

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -863,6 +863,22 @@ impl<'a> Pipeline<'a> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Triage,
         });
+        // Deterministic short-circuit, BEFORE the paid call.
+        //
+        // `resolve_conversational` is a disjunction whose first term ignores
+        // the model entirely, so a `true` here with `model_says_chat = false`
+        // means the greeting arm fired — and no triage answer could change the
+        // outcome. Classifying `hi` used to cost a full round-trip plus, on a
+        // wedged provider, up to `triage_latency_ceiling` of dead air, for a
+        // route the module docs already describe as never depending on a model
+        // answer. This is the same assessment the resolution-failure arm below
+        // builds; it just stops paying for it first.
+        if resolve_conversational(false, goal) {
+            return Ok(TaskAssessment {
+                conversational: true,
+                ..TaskAssessment::from_class(resolve_task_class(None, goal))
+            });
+        }
         let resolved = match self.resolve_provider(Role::Triage) {
             Ok(r) => r,
             // Triage resolution failure is soft: fall through to the full path
@@ -1915,6 +1931,20 @@ impl<'a> Pipeline<'a> {
                     );
                 }
                 LadderDecision::ModelJudge => {
+                    // Escalate on evidence, not on prediction. "Inconclusive"
+                    // here can mean two very different things: a real change
+                    // nothing proved, or a change with nothing to prove. The
+                    // diff tells them apart, and the prompt never could — so
+                    // ask it before buying a judge call to confirm the absence
+                    // of a test that was never warranted
+                    // (docs/design/witness-protocol.md §7).
+                    if let Some(evidence) = self.warranted_completion(&state) {
+                        return state.into_verified(
+                            true,
+                            &evidence,
+                            score_from_verification(false, None),
+                        );
+                    }
                     // Inconclusive — escalate to the model judge (judge ≠
                     // worker; a judge-call failure falls back to a heuristic).
                     let evidence_summary = format!(

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -78,11 +78,15 @@ use crate::verify::{
     deterministic_fail_evidence, deterministic_pass_evidence, guidance_prompt, heuristic_fallback,
     judge_prompt, ladder_decision, model_verdict_evidence, parse_judge_response,
 };
+use crate::witness::airlock::{
+    DisclosureGrain, FailureFingerprint, SealedFailure, grain_for_repeats, redact, scrub,
+};
 use crate::witness::{
     Witness, parse_test_invocation, parse_witness_command, validate_witness_artifact,
     validate_witness_identity, validate_witness_invocation, witness_identity_matches,
     witness_prompt, witness_repair_prompt,
 };
+mod disclosure;
 mod raw_usage;
 mod run_error;
 mod stage_budget;
@@ -433,6 +437,11 @@ struct CandidateState {
     diff_lines: u32,
     diff_text: String,
     revisions: u32,
+    /// Every deterministic failure this candidate has produced, in order.
+    /// The airlock reads it to tell "stuck on the same thing" from "made
+    /// progress and hit something new" — the signal that decides how much the
+    /// next revision is told (`witness::airlock`).
+    failures: Vec<FailureFingerprint>,
 }
 
 impl CandidateState {
@@ -1620,6 +1629,7 @@ impl<'a> Pipeline<'a> {
             diff_lines: 0,
             diff_text: String::new(),
             revisions: 0,
+            failures: Vec::new(),
         };
 
         if let Err(reason) = self
@@ -1731,6 +1741,7 @@ impl<'a> Pipeline<'a> {
             name: StageKind::Verify,
         });
         let effective_cmd = self.effective_test_command(witness);
+        let witness_paths = Self::witness_paths(witness);
         loop {
             if let Some(workspace) = surface.workspace
                 && let Err(error) = workspace.seal().await
@@ -1789,6 +1800,17 @@ impl<'a> Pipeline<'a> {
                 diff_budget: self.config.diff_budget_lines,
             };
 
+            // Everything the verification side knows about this round's
+            // failure. Both failing arms disclose from it, and nothing reaches
+            // the worker except through `Pipeline::airlock_forward` or a
+            // `redact` of this value.
+            let sealed = SealedFailure {
+                command: effective_cmd.map_or("", |cmd| cmd.command),
+                invocation: effective_cmd.map(|cmd| cmd.invocation),
+                output: &test_tail,
+                witness_paths: &witness_paths,
+            };
+
             match ladder_decision(&inputs) {
                 LadderDecision::SubmitFast => {
                     // Deterministic pass — judge SKIPPED (L-E11).
@@ -1808,7 +1830,9 @@ impl<'a> Pipeline<'a> {
                 }
                 LadderDecision::Revise => {
                     // Deterministic failure (touched tests red) — no judge.
-                    let evidence = deterministic_fail_evidence(&test_tail);
+                    //
+                    let (evidence, brief) =
+                        Self::deterministic_disclosure(&mut state, &sealed, &test_tail);
                     self.emit(AgentEvent::JudgeVerdict {
                         passed: false,
                         evidence: evidence.clone(),
@@ -1821,10 +1845,10 @@ impl<'a> Pipeline<'a> {
                         );
                     }
                     // Distress trigger: a SECOND consecutive deterministic
-                    // failure means the raw evidence alone didn't steer the
+                    // failure means the evidence alone didn't steer the
                     // worker — spend one judge call on course-correction
                     // (event-triggered, never a fixed midpoint checkpoint).
-                    let mut reason = evidence.summary.clone();
+                    let mut reason = brief.message();
                     if self.config.distress_guidance && state.revisions >= 1 {
                         match self
                             .judge_guidance(
@@ -1837,8 +1861,13 @@ impl<'a> Pipeline<'a> {
                             .await
                         {
                             Ok(Some(guidance)) => {
-                                reason.push_str("\n\nIndependent reviewer course-correction:\n");
-                                reason.push_str(&guidance);
+                                if let Some(text) =
+                                    self.airlock_forward(&guidance, "distress_guidance", &sealed)
+                                {
+                                    reason
+                                        .push_str("\n\nIndependent reviewer course-correction:\n");
+                                    reason.push_str(&text);
+                                }
                             }
                             Ok(None) => {}
                             Err(abort) => {
@@ -1932,15 +1961,15 @@ impl<'a> Pipeline<'a> {
                             score_from_verification(false, Some(false)),
                         );
                     }
+                    // The judge read the deterministic evidence summary, so
+                    // its prose can carry the tail back. A reasoning that
+                    // quotes sealed material degrades to the symptom rather
+                    // than being forwarded (§4.3).
+                    let feedback = self
+                        .airlock_forward(&verdict.reasoning, "judge_reasoning", &sealed)
+                        .unwrap_or_else(|| redact(&sealed, DisclosureGrain::Symptom).message());
                     if let Err(reason) = self
-                        .revise_candidate(
-                            engine,
-                            surface,
-                            budget,
-                            &verdict.reasoning,
-                            total,
-                            &mut state,
-                        )
+                        .revise_candidate(engine, surface, budget, &feedback, total, &mut state)
                         .await
                     {
                         return CandidateResult::aborted(state.messages, reason);

--- a/stella-pipeline/src/pipeline/disclosure.rs
+++ b/stella-pipeline/src/pipeline/disclosure.rs
@@ -15,6 +15,7 @@ use stella_protocol::PolicyKind;
 
 use super::*;
 use crate::witness::airlock::FailureBrief;
+use crate::witness::warrant::warrant;
 
 impl CandidateState {
     /// Record one deterministic failure and return how many times *this same*
@@ -91,5 +92,32 @@ impl Pipeline<'_> {
             ..deterministic_fail_evidence(tail)
         };
         (evidence, brief)
+    }
+
+    /// A clean, reasoned completion when the change itself warranted no test.
+    ///
+    /// Reached only from the ladder's inconclusive arm, where "inconclusive"
+    /// covers two very different things: a real change nothing proved, and a
+    /// change with nothing to prove. The diff separates them; the prompt never
+    /// could. `None` means buy the judge call after all.
+    ///
+    /// The verdict records *why* no test was written rather than leaving an
+    /// unexplained absence — the pipeline's half of the contract contributors
+    /// are already held to.
+    pub(super) fn warranted_completion(&self, state: &CandidateState) -> Option<JudgeEvidence> {
+        let reason = warrant(&state.diff_text, state.file_changes).reason()?;
+        if reason.warrants_independent_review() {
+            return None;
+        }
+        let evidence = JudgeEvidence {
+            summary: format!("no witness test warranted: {}", reason.sentence()),
+            deterministic: true,
+            evidence_refs: vec![format!("warrant:{reason:?}")],
+        };
+        self.emit(AgentEvent::JudgeVerdict {
+            passed: true,
+            evidence: evidence.clone(),
+        });
+        Some(evidence)
     }
 }

--- a/stella-pipeline/src/pipeline/disclosure.rs
+++ b/stella-pipeline/src/pipeline/disclosure.rs
@@ -1,0 +1,95 @@
+//! The orchestration seam of the feedback airlock: the few `Pipeline` and
+//! `CandidateState` methods that decide what a verification failure is allowed
+//! to tell the worker.
+//!
+//! The airlock's rules are pure and live in [`crate::witness::airlock`]. What
+//! lives here is only the wiring that needs `&self` — emitting a policy event
+//! when a disclosure is refused, and threading failure identity through the
+//! candidate's revise loop. Split out of `pipeline.rs` for the same reason
+//! `witness_stage.rs` was: it is one nameable concern, and `pipeline.rs` is
+//! already the crate's largest file.
+//!
+//! Design: [`docs/design/witness-protocol.md`](../../../../docs/design/witness-protocol.md) §4.
+
+use stella_protocol::PolicyKind;
+
+use super::*;
+use crate::witness::airlock::FailureBrief;
+
+impl CandidateState {
+    /// Record one deterministic failure and return how many times *this same*
+    /// failure has now occurred, counting this one. `1` is a first sighting.
+    ///
+    /// Repetition — not the raw revision count — is what tightens disclosure:
+    /// a worker producing a *new* failure each round is making progress and
+    /// keeps full grain, while one stuck on the same failure is not helped by
+    /// a third copy of the same brief.
+    pub(super) fn record_failure(&mut self, fingerprint: FailureFingerprint) -> u32 {
+        let repeats = self
+            .failures
+            .iter()
+            .filter(|seen| **seen == fingerprint)
+            .count()
+            .saturating_add(1);
+        self.failures.push(fingerprint);
+        u32::try_from(repeats).unwrap_or(u32::MAX)
+    }
+}
+
+impl Pipeline<'_> {
+    /// The witness artifacts backing this run, withheld from every disclosure
+    /// grain — naming one hands the worker the detector itself.
+    pub(super) fn witness_paths(witness: Option<&Witness>) -> Vec<String> {
+        let mut paths: Vec<String> = witness
+            .map(|witness| witness.files.keys().cloned().collect())
+            .unwrap_or_default();
+        paths.sort();
+        paths
+    }
+
+    /// Let one model-authored text cross inbound to the worker, or drop it.
+    ///
+    /// Distress guidance and judge reasoning are both written by a model that
+    /// was shown the raw deterministic evidence, so either can quote the
+    /// detector back at the worker. `None` means the scrubber rejected it; the
+    /// emitted policy event carries a leak *token*, never the offending text.
+    pub(super) fn airlock_forward(
+        &self,
+        text: &str,
+        subject: &str,
+        sealed: &SealedFailure<'_>,
+    ) -> Option<String> {
+        match scrub(text, sealed) {
+            Ok(()) => Some(text.to_string()),
+            Err(leak) => {
+                self.emit(AgentEvent::PolicyDecision {
+                    kind: PolicyKind::Blocked,
+                    subject: subject.to_string(),
+                    outcome: leak.token().to_string(),
+                });
+                None
+            }
+        }
+    }
+
+    /// Turn one deterministic failure into the pair the revise loop needs: the
+    /// operator-facing evidence, and the worker-facing brief.
+    ///
+    /// Two audiences, two texts. The operator sees the runner's real output —
+    /// they are not the adversary, and hiding the failure from the human would
+    /// make the tool unusable. The worker sees only what the grain allows.
+    pub(super) fn deterministic_disclosure(
+        state: &mut CandidateState,
+        sealed: &SealedFailure<'_>,
+        tail: &str,
+    ) -> (JudgeEvidence, FailureBrief) {
+        let fingerprint = sealed.fingerprint();
+        let repeats = state.record_failure(fingerprint.clone());
+        let brief = redact(sealed, grain_for_repeats(repeats));
+        let evidence = JudgeEvidence {
+            evidence_refs: brief.evidence_refs(&fingerprint),
+            ..deterministic_fail_evidence(tail)
+        };
+        (evidence, brief)
+    }
+}

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -214,6 +214,9 @@ struct ScriptedRunner {
     diff: String,
     /// Untracked files this workspace reports, as `(path, added_lines)`.
     untracked: Vec<(String, u32)>,
+    /// What a failing run prints. Configurable so a test can plant a
+    /// distinctive token and assert on where it does — and does not — travel.
+    failure_tail: String,
 }
 impl ScriptedRunner {
     fn new(test_results: Vec<bool>, diff: &str) -> Self {
@@ -221,7 +224,12 @@ impl ScriptedRunner {
             test_results: std::sync::Mutex::new(test_results.into_iter().collect()),
             diff: diff.to_string(),
             untracked: Vec::new(),
+            failure_tail: "test failed".to_string(),
         }
+    }
+    fn with_failure_tail(mut self, tail: &str) -> Self {
+        self.failure_tail = tail.to_string();
+        self
     }
     fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
         self.untracked = untracked
@@ -277,7 +285,7 @@ impl TestRunner for ScriptedRunner {
             stderr_tail: if passed {
                 String::new()
             } else {
-                "test failed".into()
+                self.failure_tail.clone()
             },
         }
     }
@@ -1841,6 +1849,10 @@ mod verification_honesty {
     }
 }
 
+/// The feedback airlock (`witness::airlock`) observed end to end: what a
+/// verification failure tells the operator versus what it tells the worker.
+/// A child module, so it reaches the scripted ports above via `super::*`.
+mod airlock;
 mod best_of_n;
 mod chaos;
 /// Golden-trajectory recordings of this pipeline's real event stream — a

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -908,18 +908,18 @@ async fn clean_lookup_skips_plan_verify_and_judge() {
     assert!(!s.contains(&StageKind::Judge));
 }
 
-/// A greeting (triage → `chat`) takes the conversational fast path: one plain
-/// completion, no plan / witness / execute / verify / judge. This is the fix
-/// for "typing `hi` authored a witness test". The scripted provider serves
-/// exactly two calls — triage and the conversational reply — so if any work
-/// stage tried to run, the provider would be exhausted and the run would error.
+/// A greeting takes the conversational fast path: **one** plain completion, no
+/// triage call, no plan / witness / execute / verify / judge. This is the fix
+/// for "typing `hi` authored a witness test", and now also for "typing `hi`
+/// paid for a classification that could not change the answer".
+///
+/// The scripted provider serves exactly ONE call. If triage still called the
+/// model — or any work stage ran — the queue would be exhausted and the run
+/// would error, so the fixture size is itself the assertion.
 #[tokio::test]
 async fn a_greeting_takes_the_conversational_path_and_skips_all_work() {
-    // triage → "chat"; then the single conversational reply. No third call.
-    let provider = ScriptedProvider::new(vec![
-        text_result("chat"),
-        text_result("Hi! How can I help with your codebase?"),
-    ]);
+    let provider =
+        ScriptedProvider::new(vec![text_result("Hi! How can I help with your codebase?")]);
     let resolver = OneProvider(&provider);
     let runner = ScriptedRunner::new(vec![], "");
     let tools = EmptyTools;
@@ -963,6 +963,12 @@ async fn a_greeting_takes_the_conversational_path_and_skips_all_work() {
     assert_eq!(outcome.final_text, "Hi! How can I help with your codebase?");
     assert!(outcome.verdict.is_none(), "no verification for a greeting");
     assert_eq!(outcome.revisions, 0);
+    // Exactly one model call: the reply. A greeting resolves deterministically,
+    // so paying a triage round-trip to be told so is pure latency.
+    assert!(
+        provider.script.lock().await.is_empty(),
+        "the greeting spent exactly the one scripted call"
+    );
 
     // The assistant turn is adopted into the trajectory for follow-up context.
     assert!(matches!(
@@ -1866,6 +1872,10 @@ mod mcp_prefetch;
 mod scope_gate_interactive;
 mod terminal_outcomes;
 mod usage;
+/// Proportionate verification: changes with nothing to prove complete with a
+/// stated reason rather than escalating. A child module, so it reaches the
+/// scripted ports above via `super::*`.
+mod warrant;
 mod witness_isolation;
 
 /// The headless approval port is `AlwaysAbortGate`, so "bypass scope review"

--- a/stella-pipeline/src/pipeline/tests/airlock.rs
+++ b/stella-pipeline/src/pipeline/tests/airlock.rs
@@ -1,0 +1,111 @@
+//! The feedback airlock at the pipeline seam: the operator sees the runner's
+//! real failure, the worker sees only what the disclosure grain allows.
+//!
+//! Design: [`docs/design/witness-protocol.md`](../../../../../docs/design/witness-protocol.md) §4.
+
+use super::*;
+
+/// The witness for the feedback airlock: a distinctive token printed by the
+/// failing test runner must reach the OPERATOR's verdict and must never reach
+/// the WORKER's revision prompt.
+///
+/// Before the airlock, `verify_candidate` fed `deterministic_fail_evidence`'s
+/// summary — the raw stderr tail — straight into `revision_prompt`, so this
+/// test fails on the old code for the right reason: the token is present in
+/// the worker's messages.
+#[tokio::test]
+async fn the_runner_tail_reaches_the_operator_but_never_the_worker() {
+    // A tail shaped like a real assertion failure: it names the test, and it
+    // carries the runtime values the assertion compared.
+    const SEALED_TAIL: &str = "\
+thread 'witness_totals_reconcile' panicked at tests/witness_zz9.rs:14:5:
+assertion `left == right` failed
+  left: 8675309
+ right: 0";
+
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),       // worker
+        text_result("first fix"),  // revision 1
+        text_result("second fix"), // revision 2
+    ]);
+    let resolver = OneProvider(&provider);
+    // baseline (fail), post-execute (fail) → revise; post-revision-1 (fail) →
+    // revise; post-revision-2 (fail) → revisions exhausted.
+    let runner = ScriptedRunner::new(vec![false, false, false, false], "@@ -1 +1 @@\n-a\n+b")
+        .with_failure_tail(SEALED_TAIL);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: Some("cargo test -p x".into()),
+        max_revisions: 2,
+        // Isolate the airlock: guidance is a separate model call with its own
+        // scrub, and this witness is about the deterministic path.
+        distress_guidance: false,
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the failing test", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    // The operator is not the adversary: their verdict keeps the real output.
+    let verdict = outcome.verdict.expect("verified");
+    assert!(!verdict.passed);
+    assert!(
+        verdict.summary.contains("8675309"),
+        "the operator's verdict must carry the real failure: {}",
+        verdict.summary
+    );
+
+    // The worker never sees the detector's fingerprint.
+    let worker_prompts: String = messages.iter().map(|m| m.content.as_str()).collect();
+    for sealed in [
+        "8675309",
+        "assertion `left == right`",
+        "witness_totals_reconcile",
+        "witness_zz9.rs",
+    ] {
+        assert!(
+            !worker_prompts.contains(sealed),
+            "the revision prompt leaked sealed material {sealed:?}:\n{worker_prompts}"
+        );
+    }
+
+    // ...but it is still told enough to converge.
+    assert!(
+        worker_prompts.contains("Verification did not pass"),
+        "the worker must still learn that verification failed"
+    );
+    assert_eq!(outcome.revisions, 2, "the revise loop still ran");
+}

--- a/stella-pipeline/src/pipeline/tests/warrant.rs
+++ b/stella-pipeline/src/pipeline/tests/warrant.rs
@@ -1,0 +1,89 @@
+//! Proportionate verification: a change with nothing to prove completes with a
+//! stated reason instead of buying a judge call to confirm the absence of a
+//! test that was never warranted.
+//!
+//! Design: [`docs/design/witness-protocol.md`](../../../../../docs/design/witness-protocol.md) §7.
+
+use super::*;
+
+const DOCS_DIFF: &str = "\
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # stella
++A clearer opening paragraph.
+";
+
+/// The witness: a docs-only change reaches the ladder with no flip and no test
+/// command — the shape that used to mean `ModelJudge` — and completes anyway.
+///
+/// The scripted provider serves exactly TWO calls (triage, worker). A judge
+/// call would exhaust it and error the run, so the fixture size is the
+/// assertion. Before the warrant, this run paid for a third call to be told
+/// that prose has no runtime behavior.
+#[tokio::test]
+async fn a_docs_only_change_completes_without_buying_a_judge_call() {
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], DOCS_DIFF);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            // No test command and no witness writer: the ladder has nothing
+            // deterministic to stand on, which is exactly the case that used
+            // to escalate.
+            witness_writer: false,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Rewrite the README opening", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert!(
+        provider.script.lock().await.is_empty(),
+        "the run spent exactly triage + worker; a judge call would be a third"
+    );
+    assert!(
+        !stages(&drain(&mut rx)).contains(&StageKind::Judge),
+        "no judge stage for a change with nothing to prove"
+    );
+
+    let verdict = outcome.verdict.expect("a reasoned verdict, not silence");
+    assert!(verdict.passed);
+    assert!(
+        verdict.summary.contains("documentation only"),
+        "the verdict must STATE why no test was written: {}",
+        verdict.summary
+    );
+}

--- a/stella-pipeline/src/triage.rs
+++ b/stella-pipeline/src/triage.rs
@@ -319,6 +319,12 @@ pub fn resolve_witness(model_opinion: Option<bool>, class: TaskClass, goal: &str
 ///
 /// Note this only turns off the *authored witness*. The verification ladder and
 /// the judge still run — deleting the wrong file stays a reviewable mistake.
+///
+/// This is the **pre-execution** half of the question, and it has to guess from
+/// wording because no diff exists yet. [`crate::witness::warrant`] answers the
+/// same question **after** execution, from the change itself, where the answer
+/// is evidence rather than a guess. The two are complementary: this one can
+/// spare the authoring call, that one can spare the review call.
 fn is_pure_deletion(goal: &str) -> bool {
     let lower = goal.to_ascii_lowercase();
 

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -27,6 +27,8 @@
 //! the tamper check. Running the witness engine turn, executing the authored
 //! command, and the one bounded repair retry live in [`crate::pipeline`].
 
+pub mod airlock;
+
 use std::collections::HashMap;
 
 use crate::ports::{ArtifactIdentity, RecalledFrame, TestInvocation};

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -28,6 +28,7 @@
 //! command, and the one bounded repair retry live in [`crate::pipeline`].
 
 pub mod airlock;
+pub mod warrant;
 
 use std::collections::HashMap;
 

--- a/stella-pipeline/src/witness/airlock.rs
+++ b/stella-pipeline/src/witness/airlock.rs
@@ -1,0 +1,560 @@
+//! The feedback airlock: the one channel from verification back to the worker.
+//!
+//! Design: [`docs/design/witness-protocol.md`](../../../../docs/design/witness-protocol.md) §4.
+//!
+//! # Leak the defect, never the detector
+//!
+//! Before this module, a deterministic failure went back to the worker as
+//! `"touched tests failed after execution: {stderr_tail}"` — the raw
+//! test-runner output, verbatim, on every revision. That tail carries the
+//! runtime values an assertion compared, the inputs that reached it, and the
+//! test's identifier. The worker is entitled to know *what is wrong with its
+//! code*; handing it the detector's fingerprint for free is what makes
+//! special-casing cheaper than fixing.
+//!
+//! What this module is honest about: with a visible witness the worker can run
+//! the test itself and read the same bytes. The airlock does not seal what a
+//! shell could reach. What it does buy is that the *revision loop* no longer
+//! trains on detector output for free, that disclosure is a graded control
+//! surface which tightens when a worker thrashes, and that every disclosure is
+//! recorded rather than incidental.
+//!
+//! # Closed vocabulary, not model prose
+//!
+//! The source draft has a model author the symptom description. Stella derives
+//! it mechanically from a closed [`SymptomClass`] vocabulary instead: it is
+//! free, it is deterministic (so a verdict stays replayable), and a fixed
+//! sentence drawn from an enum cannot quote the assertion that produced it. The
+//! scrubber ([`scrub`]) is still applied, because the reproduction hint at
+//! [`DisclosureGrain::Reproduction`] is derived from sealed material.
+//!
+//! # The pure/orchestration split
+//!
+//! Like its siblings, everything here is a synchronous function over owned
+//! data. Nothing in this module runs a process, calls a model, or touches the
+//! filesystem.
+
+use std::fmt;
+
+use sha2::{Digest, Sha256};
+
+use crate::ports::TestInvocation;
+
+/// How much the worker is told about a verification failure.
+///
+/// Ordered weakest-to-strongest so a grain can be compared and stepped down
+/// (`Outcome < Command < Symptom < Reproduction`). Each grain is a superset of
+/// the one below it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum DisclosureGrain {
+    /// `L0` — that verification failed, and nothing else.
+    Outcome,
+    /// `L1` — which command failed.
+    Command,
+    /// `L2` — a symptom class phrased against observable behavior.
+    Symptom,
+    /// `L3` — a reproduction the worker can run itself. The default, because
+    /// convergence comes from iterating against a real failure.
+    #[default]
+    Reproduction,
+}
+
+impl DisclosureGrain {
+    /// The `L0`–`L3` label used in logs and evidence refs, so a reader can see
+    /// at which grain a run was disclosing without decoding the variant name.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Outcome => "L0",
+            Self::Command => "L1",
+            Self::Symptom => "L2",
+            Self::Reproduction => "L3",
+        }
+    }
+
+    /// One rung down the ladder, saturating at [`DisclosureGrain::Outcome`].
+    pub fn tightened(self) -> Self {
+        match self {
+            Self::Reproduction => Self::Symptom,
+            Self::Symptom => Self::Command,
+            Self::Command | Self::Outcome => Self::Outcome,
+        }
+    }
+}
+
+/// A coarse, closed classification of *how* a test run failed.
+///
+/// Deliberately small and deliberately not model-authored: every variant maps
+/// to one fixed sentence, so the symptom text can never quote the runtime
+/// values that produced it. Classification reads the runner's output but the
+/// output itself never crosses into a brief.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymptomClass {
+    /// The code under test did not build.
+    BuildFailure,
+    /// An assertion or expectation compared two values and rejected them.
+    Assertion,
+    /// The process crashed — a panic, an abort, or a signal.
+    Crash,
+    /// The run exceeded its time budget.
+    Timeout,
+    /// A non-zero exit with nothing more specific recoverable from the output.
+    ExitFailure,
+}
+
+impl SymptomClass {
+    /// The fixed, behavior-facing sentence disclosed at
+    /// [`DisclosureGrain::Symptom`].
+    ///
+    /// Every string here is a compile-time literal. That is the property that
+    /// makes this grain safe by construction rather than by scrubbing.
+    pub fn sentence(self) -> &'static str {
+        match self {
+            Self::BuildFailure => "the change does not compile",
+            Self::Assertion => "an expected behavior did not hold at runtime",
+            Self::Crash => "the code panicked or aborted while under test",
+            Self::Timeout => "the run did not finish within its time budget",
+            Self::ExitFailure => "verification exited non-zero without a recoverable diagnosis",
+        }
+    }
+
+    /// Classify a runner's output. Ordered most-specific first: a build
+    /// failure that also prints the word `assertion` is a build failure, since
+    /// nothing ran.
+    pub fn classify(output: &str) -> Self {
+        let lower = output.to_ascii_lowercase();
+        if lower.contains("error[e")
+            || lower.contains("could not compile")
+            || lower.contains("syntaxerror")
+            || lower.contains("cannot find")
+            || lower.contains("compilation failed")
+        {
+            return Self::BuildFailure;
+        }
+        if lower.contains("timed out") || lower.contains("timeout") {
+            return Self::Timeout;
+        }
+        if lower.contains("panicked at")
+            || lower.contains("segmentation fault")
+            || lower.contains("fatal error")
+            || lower.contains("core dumped")
+        {
+            return Self::Crash;
+        }
+        if lower.contains("assertion")
+            || lower.contains("assert_eq")
+            || lower.contains("assertionerror")
+            || lower.contains("expected")
+        {
+            return Self::Assertion;
+        }
+        Self::ExitFailure
+    }
+}
+
+/// A stable identity for *how* a run failed, as opposed to *that* it failed.
+///
+/// Two runs that failed the same way share a fingerprint; two runs that failed
+/// differently do not. Computed over normalized output ([`normalize_failure`])
+/// so that timings, temporary paths, addresses, and line-number churn do not
+/// split one recurring failure into many.
+///
+/// A fingerprint is verification-side only. It is never disclosed to the
+/// worker, which is why it may be derived from sealed material.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FailureFingerprint(String);
+
+impl FailureFingerprint {
+    /// Fingerprint one failing run's output.
+    pub fn of(output: &str) -> Self {
+        let normalized = normalize_failure(output);
+        let digest = Sha256::digest(normalized.as_bytes());
+        // 16 hex chars is ample to separate the handful of distinct failures a
+        // single task produces, and short enough to read in a log line.
+        Self(
+            digest
+                .iter()
+                .take(8)
+                .map(|byte| format!("{byte:02x}"))
+                .collect(),
+        )
+    }
+
+    /// The hex digest.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for FailureFingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Strip the parts of runner output that change between two runs of the *same*
+/// failure, so a fingerprint identifies the failure rather than the run.
+///
+/// Removed: ANSI escapes, durations, hex addresses, process and thread ids,
+/// absolute paths, and the `:line:col` suffix on source locations. Kept: the
+/// failing test's identity and the shape of the diagnosis, which is what makes
+/// two occurrences the *same* failure.
+pub fn normalize_failure(output: &str) -> String {
+    let mut normalized = String::with_capacity(output.len());
+    for raw_line in strip_ansi(output).lines() {
+        if raw_line.trim().is_empty() {
+            continue;
+        }
+        let rebuilt: Vec<String> = raw_line.split_whitespace().map(normalize_token).collect();
+        normalized.push_str(&rebuilt.join(" "));
+        normalized.push('\n');
+    }
+    normalized
+}
+
+/// Replace one whitespace-delimited token with a stable placeholder when it is
+/// run-specific. Path handling keeps the final component so two failures in
+/// different files stay distinct while a temp-directory prefix does not split
+/// one failure across runs.
+fn normalize_token(token: &str) -> String {
+    if token.starts_with("0x")
+        && token.len() > 2
+        && token[2..].chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return "<addr>".to_string();
+    }
+    // A duration: `1.23s`, `0.05ms`, `12s`.
+    let numeric_prefix: String = token
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    if !numeric_prefix.is_empty() {
+        let suffix = &token[numeric_prefix.len()..];
+        if matches!(suffix, "s" | "ms" | "us" | "ns" | "s," | "ms," | "secs") {
+            return "<dur>".to_string();
+        }
+        if suffix.is_empty() {
+            return "<num>".to_string();
+        }
+    }
+    let trimmed = token.trim_matches(|c: char| matches!(c, '(' | ')' | ',' | '\'' | '"' | '`'));
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        let separator = if trimmed.contains('/') { '/' } else { '\\' };
+        let last = trimmed.rsplit(separator).next().unwrap_or(trimmed);
+        // Drop a `:line:col` suffix so inserting a line above a failure does
+        // not look like a different failure.
+        let base = last.split(':').next().unwrap_or(last);
+        if base.is_empty() {
+            return "<path>".to_string();
+        }
+        return format!("<path>/{base}");
+    }
+    trimmed.to_string()
+}
+
+/// Remove ANSI CSI/OSC escape sequences. Runners colorize by default and the
+/// same failure rendered with and without color must fingerprint identically.
+fn strip_ansi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next() {
+            // CSI: consume through the final byte in `@`..=`~`.
+            Some('[') => {
+                for next in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            // OSC: consume through BEL or ST.
+            Some(']') => {
+                while let Some(next) = chars.next() {
+                    if next == '\u{7}' {
+                        break;
+                    }
+                    if next == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            Some(other) => out.push(other),
+            None => {}
+        }
+    }
+    out
+}
+
+/// Everything the verification side knows about one failure. Never crosses to
+/// the worker — [`redact`] converts it into a [`FailureBrief`], and only the
+/// brief is disclosable.
+#[derive(Debug, Clone)]
+pub struct SealedFailure<'a> {
+    /// The user-facing command whose run failed.
+    pub command: &'a str,
+    /// The parsed invocation. Its argument vector names the exact test, which
+    /// is the single most reconstruction-useful string in this struct.
+    pub invocation: Option<&'a TestInvocation>,
+    /// The raw runner output. The detector's fingerprint lives here.
+    pub output: &'a str,
+    /// Paths of the witness artifacts backing this run, withheld from every
+    /// grain.
+    pub witness_paths: &'a [String],
+}
+
+impl SealedFailure<'_> {
+    /// The failure's identity, for the oracle and the grain policy.
+    pub fn fingerprint(&self) -> FailureFingerprint {
+        FailureFingerprint::of(self.output)
+    }
+
+    /// The closed-vocabulary classification disclosed at
+    /// [`DisclosureGrain::Symptom`].
+    pub fn symptom(&self) -> SymptomClass {
+        SymptomClass::classify(self.output)
+    }
+}
+
+/// What actually crosses to the worker. Constructed only by [`redact`], so
+/// there is exactly one code path from sealed material to worker-visible text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailureBrief {
+    /// The grain this brief was emitted at — after any scrub-driven
+    /// tightening, so it reports what was actually disclosed.
+    pub grain: DisclosureGrain,
+    /// The failing command, from [`DisclosureGrain::Command`] up.
+    pub command: Option<String>,
+    /// The closed-vocabulary symptom, from [`DisclosureGrain::Symptom`] up.
+    pub symptom: Option<SymptomClass>,
+    /// How to reproduce it, at [`DisclosureGrain::Reproduction`].
+    pub reproduction: Option<String>,
+}
+
+impl FailureBrief {
+    /// The evidence body handed to the worker's revision turn.
+    ///
+    /// Deliberately headerless: the caller wraps this in `revision_prompt`,
+    /// which already states that verification failed. At
+    /// [`DisclosureGrain::Outcome`] this is a single line and that is the
+    /// whole disclosure.
+    pub fn message(&self) -> String {
+        let mut lines = Vec::new();
+        if let Some(symptom) = self.symptom {
+            lines.push(format!("Symptom: {}.", symptom.sentence()));
+        }
+        if let Some(command) = &self.command {
+            lines.push(format!("Failing check: `{command}`."));
+        }
+        if let Some(reproduction) = &self.reproduction {
+            lines.push(format!("Reproduce it yourself with: {reproduction}"));
+        }
+        lines.push(
+            "Diagnose the underlying cause and fix it. Do not special-case the check.".to_string(),
+        );
+        lines.join("\n")
+    }
+
+    /// Whether this brief disclosed anything beyond the bare fact of failure.
+    pub fn is_bare(&self) -> bool {
+        self.command.is_none() && self.symptom.is_none() && self.reproduction.is_none()
+    }
+
+    /// Pointers a reader can follow to check this verdict rather than take it
+    /// on faith — the `evidence_refs` that were empty at every construction
+    /// site before the airlock existed.
+    pub fn evidence_refs(&self, fingerprint: &FailureFingerprint) -> Vec<String> {
+        let mut refs = vec![
+            format!("disclosure:{}", self.grain.label()),
+            format!("failure:{fingerprint}"),
+        ];
+        if let Some(symptom) = self.symptom {
+            refs.push(format!("symptom:{symptom:?}"));
+        }
+        refs
+    }
+}
+
+/// Why a candidate brief was rejected by the scrubber.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LeakKind {
+    /// The text named a witness artifact.
+    #[error("brief names witness artifact `{0}`")]
+    WitnessPath(String),
+    /// The text named the exact test the detector runs.
+    #[error("brief names the sealed test selector `{0}`")]
+    TestSelector(String),
+    /// The text quoted a long literal span of the runner's output.
+    #[error("brief quotes {0} characters of sealed runner output")]
+    QuotedOutput(usize),
+}
+
+impl LeakKind {
+    /// A short, fixed token naming *which* rule rejected the text — safe for
+    /// the `outcome` field of a policy event, which carries tokens and never
+    /// content.
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::WitnessPath(_) => "witness_path",
+            Self::TestSelector(_) => "test_selector",
+            Self::QuotedOutput(_) => "quoted_output",
+        }
+    }
+}
+
+/// The shortest run of sealed output that counts as a quote.
+///
+/// Short spans collide constantly on ordinary English and on the command name,
+/// which the brief is *supposed* to carry; 24 characters is long enough that a
+/// match is a copied diagnostic rather than a coincidence.
+const QUOTE_SPAN: usize = 24;
+
+/// Reject `text` if it carries sealed material.
+///
+/// Fails closed: [`redact`] degrades a brief that does not pass rather than
+/// emitting it with a hole in it. A best-effort redactor is a leak with a
+/// ceremony attached.
+pub fn scrub(text: &str, sealed: &SealedFailure<'_>) -> Result<(), LeakKind> {
+    for path in sealed.witness_paths {
+        if text.contains(path.as_str()) {
+            return Err(LeakKind::WitnessPath(path.clone()));
+        }
+        if let Some(stem) = path.rsplit('/').next()
+            && !stem.is_empty()
+            && text.contains(stem)
+        {
+            return Err(LeakKind::WitnessPath(stem.to_string()));
+        }
+    }
+    if let Some(invocation) = sealed.invocation {
+        for selector in test_selectors(invocation) {
+            if text.contains(selector.as_str()) {
+                return Err(LeakKind::TestSelector(selector));
+            }
+        }
+    }
+    if let Some(span) = quoted_span(text, sealed.output, QUOTE_SPAN) {
+        return Err(LeakKind::QuotedOutput(span));
+    }
+    Ok(())
+}
+
+/// The arguments that name *which* test runs, as opposed to which crate or
+/// runner. These are the strings that make a brief reconstruction-useful.
+fn test_selectors(invocation: &TestInvocation) -> Vec<String> {
+    invocation
+        .args
+        .iter()
+        .filter(|arg| {
+            // Flags and package selectors describe the suite; a bare token
+            // (or a pytest node id) names the test itself.
+            !arg.starts_with('-') && arg.len() >= 3
+        })
+        .filter(|arg| !matches!(arg.as_str(), "test" | "run" | "nextest" | "exec"))
+        .cloned()
+        .collect()
+}
+
+/// The length of a run of sealed output that `text` reproduces verbatim, if
+/// one reaches `minimum`. Compared on collapsed whitespace and folded case so
+/// reflowing or recasing a quote does not evade the check.
+fn quoted_span(text: &str, sealed_output: &str, minimum: usize) -> Option<usize> {
+    let haystack = collapse_whitespace(text);
+    let sealed = collapse_whitespace(sealed_output);
+    if haystack.is_empty() || sealed.len() < minimum {
+        return None;
+    }
+    // Every window of exactly `minimum` is enough to decide: any longer shared
+    // run necessarily contains one, so finding none rules all of them out.
+    (0..=sealed.len() - minimum)
+        .filter_map(|start| {
+            let end = start + minimum;
+            (sealed.is_char_boundary(start) && sealed.is_char_boundary(end))
+                .then(|| &sealed[start..end])
+        })
+        .find(|window| haystack.contains(window))
+        .map(str::len)
+}
+
+/// Collapse every run of whitespace to one space and lowercase, so quoting
+/// survives reformatting and case changes.
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+/// Build the brief the worker sees, at no more than `requested` grain.
+///
+/// The scrubber runs on every field that could carry sealed material. A field
+/// that fails is dropped *and the grain steps down with it*, so the returned
+/// brief's `grain` always reports what was really disclosed rather than what
+/// was asked for.
+pub fn redact(sealed: &SealedFailure<'_>, requested: DisclosureGrain) -> FailureBrief {
+    let mut grain = requested;
+
+    let reproduction = if grain >= DisclosureGrain::Reproduction {
+        let candidate = format!("`{}`", sealed.command);
+        match scrub(&candidate, sealed) {
+            Ok(()) => Some(candidate),
+            Err(_) => {
+                grain = DisclosureGrain::Symptom;
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let symptom = (grain >= DisclosureGrain::Symptom).then(|| sealed.symptom());
+
+    let command = if grain >= DisclosureGrain::Command {
+        let candidate = sealed.command.to_string();
+        match scrub(&candidate, sealed) {
+            Ok(()) => Some(candidate),
+            Err(_) => {
+                grain = DisclosureGrain::Outcome;
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    FailureBrief {
+        grain,
+        // A grain that fell to `Outcome` withholds the command it could not
+        // scrub; one that merely lost its reproduction keeps it.
+        command: (grain >= DisclosureGrain::Command)
+            .then_some(command)
+            .flatten(),
+        symptom: (grain >= DisclosureGrain::Symptom)
+            .then_some(symptom)
+            .flatten(),
+        reproduction,
+    }
+}
+
+/// The disclosure grain a run has earned, given how many times it has now
+/// produced the *same* failure.
+///
+/// A worker that has seen the same brief twice and still fails is not being
+/// helped by a third copy of it — it is being given more surface to fit. The
+/// ladder therefore tightens on repetition rather than on a raw revision
+/// count, which is what makes it a response to thrashing rather than a tax on
+/// ordinary iteration.
+pub fn grain_for_repeats(repeats: u32) -> DisclosureGrain {
+    match repeats {
+        0 | 1 => DisclosureGrain::Reproduction,
+        2 => DisclosureGrain::Symptom,
+        3 => DisclosureGrain::Command,
+        _ => DisclosureGrain::Outcome,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-pipeline/src/witness/airlock/tests.rs
+++ b/stella-pipeline/src/witness/airlock/tests.rs
@@ -1,0 +1,266 @@
+//! Tests for the feedback airlock. The properties that matter are negative:
+//! what must *not* reach a brief, and that a scrub failure tightens the grain
+//! rather than emitting a hole.
+
+use super::*;
+use crate::ports::TestInvocation;
+
+fn invocation(args: &[&str]) -> TestInvocation {
+    TestInvocation {
+        program: "cargo".to_string(),
+        args: args.iter().map(|a| (*a).to_string()).collect(),
+    }
+}
+
+fn sealed<'a>(
+    command: &'a str,
+    output: &'a str,
+    invocation: Option<&'a TestInvocation>,
+    witness_paths: &'a [String],
+) -> SealedFailure<'a> {
+    SealedFailure {
+        command,
+        invocation,
+        output,
+        witness_paths,
+    }
+}
+
+const ASSERTION_TAIL: &str = "\
+running 1 test
+test witness_balance_stays_consistent ... FAILED
+
+failures:
+
+---- witness_balance_stays_consistent stdout ----
+thread 'witness_balance_stays_consistent' panicked at tests/witness_ab12.rs:14:5:
+assertion `left == right` failed
+  left: 4200
+ right: 0
+";
+
+#[test]
+fn a_brief_never_carries_the_runner_output() {
+    let paths = vec!["tests/witness_ab12.rs".to_string()];
+    let inv = invocation(&["test", "--test", "witness_ab12", "--exact"]);
+    let failure = sealed(
+        "cargo test --test witness_ab12 --exact",
+        ASSERTION_TAIL,
+        Some(&inv),
+        &paths,
+    );
+
+    let brief = redact(&failure, DisclosureGrain::Reproduction);
+    let message = brief.message();
+
+    for leaked in [
+        "4200",
+        "assertion `left == right`",
+        "witness_balance_stays_consistent",
+        "tests/witness_ab12.rs",
+    ] {
+        assert!(
+            !message.contains(leaked),
+            "brief leaked sealed material {leaked:?}: {message}"
+        );
+    }
+}
+
+#[test]
+fn the_witness_path_is_withheld_at_every_grain() {
+    // The realistic authored-witness shape: the command names the witness
+    // file, so disclosing the command verbatim would hand over the artifact.
+    let paths = vec!["tests/witness_ab12.rs".to_string()];
+    let inv = invocation(&["test", "--test", "witness_ab12"]);
+    let failure = sealed(
+        "cargo test --test witness_ab12",
+        ASSERTION_TAIL,
+        Some(&inv),
+        &paths,
+    );
+    for grain in [
+        DisclosureGrain::Outcome,
+        DisclosureGrain::Command,
+        DisclosureGrain::Symptom,
+        DisclosureGrain::Reproduction,
+    ] {
+        let message = redact(&failure, grain).message();
+        assert!(
+            !message.contains("witness_ab12"),
+            "grain {grain:?} disclosed the witness artifact: {message}"
+        );
+    }
+}
+
+#[test]
+fn a_command_naming_the_sealed_test_tightens_the_grain() {
+    // The command itself names the exact test, so it cannot be disclosed —
+    // the brief must step down rather than emit it.
+    let paths: Vec<String> = Vec::new();
+    let inv = invocation(&["test", "--exact", "witness_balance_stays_consistent"]);
+    let failure = sealed(
+        "cargo test --exact witness_balance_stays_consistent",
+        ASSERTION_TAIL,
+        Some(&inv),
+        &paths,
+    );
+
+    let brief = redact(&failure, DisclosureGrain::Reproduction);
+    assert!(brief.grain < DisclosureGrain::Reproduction);
+    assert_eq!(brief.reproduction, None);
+    assert!(!brief.message().contains("witness_balance_stays_consistent"));
+}
+
+#[test]
+fn grain_is_monotone_in_what_it_discloses() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed("pnpm test", ASSERTION_TAIL, None, &paths);
+
+    let outcome = redact(&failure, DisclosureGrain::Outcome);
+    assert_eq!(outcome.command, None);
+    assert_eq!(outcome.symptom, None);
+    assert_eq!(outcome.reproduction, None);
+
+    let command = redact(&failure, DisclosureGrain::Command);
+    assert!(command.command.is_some());
+    assert_eq!(command.symptom, None);
+
+    let symptom = redact(&failure, DisclosureGrain::Symptom);
+    assert!(symptom.symptom.is_some());
+    assert_eq!(symptom.reproduction, None);
+
+    let full = redact(&failure, DisclosureGrain::Reproduction);
+    assert!(full.reproduction.is_some());
+}
+
+#[test]
+fn the_same_failure_fingerprints_identically_across_runs() {
+    let first = "\
+test foo ... FAILED
+thread 'foo' panicked at /var/folders/9x/T/candidate-1/src/lib.rs:14:5:
+assertion failed
+test result: FAILED. 0 passed; 1 failed; finished in 0.31s
+";
+    let second = "\
+test foo ... FAILED
+thread 'foo' panicked at /tmp/candidate-2/src/lib.rs:14:5:
+assertion failed
+test result: FAILED. 0 passed; 1 failed; finished in 1.07s
+";
+    assert_eq!(
+        FailureFingerprint::of(first),
+        FailureFingerprint::of(second),
+        "a temp-dir prefix and a timing must not split one failure"
+    );
+}
+
+#[test]
+fn a_different_failure_fingerprints_differently() {
+    let assertion = "thread 'foo' panicked at src/lib.rs:14:5: assertion failed";
+    let compile = "error[E0308]: mismatched types";
+    assert_ne!(
+        FailureFingerprint::of(assertion),
+        FailureFingerprint::of(compile)
+    );
+}
+
+#[test]
+fn color_does_not_change_a_fingerprint() {
+    let plain = "test foo ... FAILED\nassertion failed\n";
+    let colored = "test foo ... \u{1b}[31mFAILED\u{1b}[0m\n\u{1b}[1massertion failed\u{1b}[0m\n";
+    assert_eq!(
+        FailureFingerprint::of(plain),
+        FailureFingerprint::of(colored)
+    );
+}
+
+#[test]
+fn symptom_classification_prefers_the_most_specific_cause() {
+    // A build failure that also prints "expected" is a build failure: nothing
+    // ran, so there is no assertion to report.
+    assert_eq!(
+        SymptomClass::classify("error[E0308]: mismatched types, expected `u32`"),
+        SymptomClass::BuildFailure
+    );
+    assert_eq!(
+        SymptomClass::classify("thread 'x' panicked at src/a.rs:1:1: boom"),
+        SymptomClass::Crash
+    );
+    assert_eq!(
+        SymptomClass::classify("assertion `left == right` failed"),
+        SymptomClass::Assertion
+    );
+    assert_eq!(
+        SymptomClass::classify("error: test timed out after 60s"),
+        SymptomClass::Timeout
+    );
+    assert_eq!(
+        SymptomClass::classify("exit status 1"),
+        SymptomClass::ExitFailure
+    );
+}
+
+#[test]
+fn every_symptom_sentence_is_behavioral_not_internal() {
+    for class in [
+        SymptomClass::BuildFailure,
+        SymptomClass::Assertion,
+        SymptomClass::Crash,
+        SymptomClass::Timeout,
+        SymptomClass::ExitFailure,
+    ] {
+        let sentence = class.sentence();
+        for internal in ["assert_eq", "left", "right", "test ", ".rs"] {
+            assert!(
+                !sentence.contains(internal),
+                "{class:?} sentence names a test internal: {sentence}"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_scrubber_catches_a_reflowed_quote() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed("cargo test", ASSERTION_TAIL, None, &paths);
+    // Same words as the sealed output, rewrapped and recased.
+    let reflowed = "ASSERTION `LEFT == RIGHT` FAILED   LEFT: 4200";
+    assert!(matches!(
+        scrub(reflowed, &failure),
+        Err(LeakKind::QuotedOutput(_))
+    ));
+}
+
+#[test]
+fn the_scrubber_admits_ordinary_guidance() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed("cargo test", ASSERTION_TAIL, None, &paths);
+    assert_eq!(scrub("Verification did not pass.", &failure), Ok(()));
+}
+
+#[test]
+fn repeated_failures_tighten_the_ladder() {
+    assert_eq!(grain_for_repeats(0), DisclosureGrain::Reproduction);
+    assert_eq!(grain_for_repeats(1), DisclosureGrain::Reproduction);
+    assert_eq!(grain_for_repeats(2), DisclosureGrain::Symptom);
+    assert_eq!(grain_for_repeats(3), DisclosureGrain::Command);
+    assert_eq!(grain_for_repeats(9), DisclosureGrain::Outcome);
+
+    // Monotone: more repeats never discloses more.
+    let mut previous = grain_for_repeats(0);
+    for repeats in 1..12 {
+        let current = grain_for_repeats(repeats);
+        assert!(current <= previous, "grain widened at {repeats} repeats");
+        previous = current;
+    }
+}
+
+#[test]
+fn evidence_refs_name_the_grain_and_the_failure() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed("cargo test", ASSERTION_TAIL, None, &paths);
+    let brief = redact(&failure, DisclosureGrain::Reproduction);
+    let refs = brief.evidence_refs(&failure.fingerprint());
+    assert!(refs.iter().any(|r| r.starts_with("disclosure:L")));
+    assert!(refs.iter().any(|r| r.starts_with("failure:")));
+}

--- a/stella-pipeline/src/witness/warrant.rs
+++ b/stella-pipeline/src/witness/warrant.rs
@@ -1,0 +1,292 @@
+//! Does *this change* warrant a witness test, and if not, why not.
+//!
+//! Design: [`docs/design/witness-protocol.md`](../../../../docs/design/witness-protocol.md) §7.
+//!
+//! # Escalate on evidence, do not predict up front
+//!
+//! Stella's contributor rule has always been nuanced: ship a witness test, *or*
+//! a stated reason there isn't one. Pure refactors, docs, and CI changes don't
+//! need one. The pipeline held itself to a stricter rule than it held people
+//! to, and the one escape hatch it had ([`crate::triage::resolve_witness`])
+//! guessed from the *prompt* — before any work existed — by keyword-matching
+//! removal verbs. That mechanism has to be narrow, because a false positive
+//! ships a real behavior change unproven, and the only evidence available at
+//! that moment is the wording of a request.
+//!
+//! This module answers the same question from the **change itself**. After
+//! execution there is a diff, and a diff is evidence rather than a guess. A
+//! docs-only edit is docs-only whether the prompt said "document the parser" or
+//! "make the README less confusing"; no phrasing changes what the diff is.
+//!
+//! # Fail closed
+//!
+//! Every rule here must be *certain* to return [`WitnessWarrant::NotRequired`].
+//! Anything mixed, anything unrecognized, and anything the diff machinery could
+//! not see falls through to [`WitnessWarrant::Required`]. The asymmetry is
+//! deliberate: an unnecessary witness costs one model call, while a missing one
+//! ships unverified behavior. When this module is unsure, it buys the test.
+
+/// Why a change legitimately needs no witness test. Each variant is a *stated
+/// reason*, recorded in the verdict — the pipeline's half of the same contract
+/// contributors are held to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoWitnessReason {
+    /// The turn changed no files at all — a question, a lookup, an
+    /// explanation. There is no behavior to prove.
+    NothingChanged,
+    /// Only documentation changed. Prose has no runtime behavior to flip.
+    DocsOnly,
+    /// Only test files changed. The change *is* the test; authoring a second
+    /// test to prove the first one exists is circular.
+    TestsOnly,
+    /// Only build, CI, or dependency manifests changed. These are verified by
+    /// the build and the gate, not by a unit test.
+    ConfigOnly,
+    /// Every changed line is a comment or blank. Nothing executable moved.
+    CommentsOnly,
+    /// The change only removes code. A witness must fail on the old code and
+    /// pass on the new, and there is nothing to write that against when the
+    /// subject stops existing — a removal's proof is its diff.
+    PureRemoval,
+}
+
+impl NoWitnessReason {
+    /// The sentence recorded in the verdict, so a reader sees *why* no test was
+    /// written rather than an unexplained absence.
+    pub fn sentence(self) -> &'static str {
+        match self {
+            Self::NothingChanged => "no files changed; there is no behavior to prove",
+            Self::DocsOnly => "documentation only; prose has no runtime behavior to flip",
+            Self::TestsOnly => "test files only; the change is itself the test",
+            Self::ConfigOnly => {
+                "build, CI, or dependency manifests only; the build and gate verify these"
+            }
+            Self::CommentsOnly => "comments and blank lines only; nothing executable changed",
+            Self::PureRemoval => "removal only; a removal's proof is its diff",
+        }
+    }
+}
+
+impl NoWitnessReason {
+    /// Whether an independent reviewer still adds something, even though no
+    /// witness test is warranted.
+    ///
+    /// The split is about what a reviewer can *catch* that a test cannot. A
+    /// removal's proof is its diff — but deleting the *wrong* thing is a real
+    /// mistake a reader spots and no test would have covered, which is why
+    /// [`crate::triage::resolve_witness`] has always kept the judge for
+    /// deletions. Test-only changes are the same shape: nothing to prove, but
+    /// plenty to get wrong. Prose, comments, and manifests carry no behavior
+    /// for a reviewer to reason about, so a review call there is spend without
+    /// a question to answer.
+    pub fn warrants_independent_review(self) -> bool {
+        match self {
+            Self::TestsOnly | Self::PureRemoval => true,
+            Self::NothingChanged | Self::DocsOnly | Self::ConfigOnly | Self::CommentsOnly => false,
+        }
+    }
+}
+
+/// Whether this change needs an authored witness test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WitnessWarrant {
+    /// Behavior may have changed. Prove it.
+    Required,
+    /// No test is warranted, with the reason to record.
+    NotRequired(NoWitnessReason),
+}
+
+impl WitnessWarrant {
+    /// Whether a witness test is warranted.
+    pub fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
+
+    /// The stated reason, when no test is warranted.
+    pub fn reason(self) -> Option<NoWitnessReason> {
+        match self {
+            Self::Required => None,
+            Self::NotRequired(reason) => Some(reason),
+        }
+    }
+}
+
+/// One changed line's role, for the comments-only rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineRole {
+    Blank,
+    Comment,
+    Code,
+}
+
+/// Decide from the change what the prompt could never tell us.
+///
+/// `file_changes` is the count of `FileChange` events the turn emitted. It is
+/// consulted only to distinguish "genuinely changed nothing" from "changed
+/// something the diff machinery could not see" — the same honesty guard
+/// `verification_honest_diff` exists for. A turn that touched files but
+/// produced no readable diff is [`WitnessWarrant::Required`], never
+/// [`NoWitnessReason::NothingChanged`].
+pub fn warrant(diff: &str, file_changes: u32) -> WitnessWarrant {
+    let paths = changed_paths(diff);
+
+    if paths.is_empty() {
+        // A blind diff over a turn that demonstrably touched files is the one
+        // case that must not read as "nothing happened".
+        return if file_changes == 0 && diff.trim().is_empty() {
+            WitnessWarrant::NotRequired(NoWitnessReason::NothingChanged)
+        } else {
+            WitnessWarrant::Required
+        };
+    }
+
+    // Every path must agree. A change that touches docs *and* source is a
+    // source change that also updated its docs.
+    if paths.iter().all(|path| is_docs(path)) {
+        return WitnessWarrant::NotRequired(NoWitnessReason::DocsOnly);
+    }
+    if paths.iter().all(|path| is_test(path)) {
+        return WitnessWarrant::NotRequired(NoWitnessReason::TestsOnly);
+    }
+    if paths.iter().all(|path| is_config(path)) {
+        return WitnessWarrant::NotRequired(NoWitnessReason::ConfigOnly);
+    }
+
+    let (added, removed) = changed_lines(diff);
+    if added
+        .iter()
+        .chain(removed.iter())
+        .all(|line| !matches!(classify_line(line), LineRole::Code))
+    {
+        return WitnessWarrant::NotRequired(NoWitnessReason::CommentsOnly);
+    }
+    // Nothing executable was *introduced*: the change only takes code away.
+    // Blank and comment additions are allowed, so removing a function and
+    // leaving a note behind still reads as a removal.
+    if !removed.is_empty()
+        && added
+            .iter()
+            .all(|line| !matches!(classify_line(line), LineRole::Code))
+    {
+        return WitnessWarrant::NotRequired(NoWitnessReason::PureRemoval);
+    }
+
+    WitnessWarrant::Required
+}
+
+/// Post-image paths from a unified diff (`+++ b/path`), with `/dev/null`
+/// dropped and the `b/` prefix stripped. Falls back to the pre-image path so a
+/// deletion still reports what it removed.
+fn changed_paths(diff: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in diff.lines() {
+        let raw = if let Some(rest) = line.strip_prefix("+++ ") {
+            rest
+        } else if let Some(rest) = line.strip_prefix("--- ") {
+            rest
+        } else {
+            continue;
+        };
+        let raw = raw.split('\t').next().unwrap_or(raw).trim();
+        if raw == "/dev/null" || raw.is_empty() {
+            continue;
+        }
+        let path = raw
+            .strip_prefix("a/")
+            .or_else(|| raw.strip_prefix("b/"))
+            .unwrap_or(raw);
+        if !paths.iter().any(|seen| seen == path) {
+            paths.push(path.to_string());
+        }
+    }
+    paths
+}
+
+/// Added and removed content lines, excluding the `+++`/`---` file headers.
+fn changed_lines(diff: &str) -> (Vec<String>, Vec<String>) {
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    for line in diff.lines() {
+        if line.starts_with("+++") || line.starts_with("---") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('+') {
+            added.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('-') {
+            removed.push(rest.to_string());
+        }
+    }
+    (added, removed)
+}
+
+/// Classify one changed line. Language-agnostic on purpose: the comment
+/// markers below cover every language Stella's test-runner vocabulary spans,
+/// and anything unrecognized is [`LineRole::Code`] so the rule fails closed.
+fn classify_line(line: &str) -> LineRole {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return LineRole::Blank;
+    }
+    const COMMENT_MARKERS: &[&str] = &["//", "#", "/*", "*/", "*", "<!--", "-->", "--", ";"];
+    if COMMENT_MARKERS
+        .iter()
+        .any(|marker| trimmed.starts_with(marker))
+    {
+        return LineRole::Comment;
+    }
+    LineRole::Code
+}
+
+/// Documentation: prose, not behavior.
+fn is_docs(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.ends_with(".md")
+        || lower.ends_with(".mdx")
+        || lower.ends_with(".txt")
+        || lower.ends_with(".rst")
+        || lower.ends_with(".adoc")
+        || lower.starts_with("docs/")
+        || lower.contains("/docs/")
+}
+
+/// A test file — matched on the conventions the test-command vocabulary
+/// already understands (`crate::witness::is_witness_test_path` covers the
+/// authored-witness case; this is the broader "is this a test" question).
+fn is_test(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    let name = lower.rsplit('/').next().unwrap_or(&lower);
+    // `foo/tests.rs` is this workspace's dominant idiom, and `tests.rs` alone
+    // matches none of the suffix rules below.
+    name == "tests.rs"
+        || name == "test.rs"
+        || lower.starts_with("tests/")
+        || lower.contains("/tests/")
+        || lower.contains("/__tests__/")
+        || lower.contains("/test/")
+        || name.starts_with("test_")
+        || name.ends_with("_test.rs")
+        || name.ends_with("_test.go")
+        || name.ends_with("_test.py")
+        || name.ends_with("_tests.rs")
+        || name.contains(".test.")
+        || name.contains(".spec.")
+}
+
+/// Build, CI, and dependency manifests: verified by the build and the gate.
+fn is_config(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    let name = lower.rsplit('/').next().unwrap_or(&lower);
+    lower.starts_with(".github/")
+        || name == "cargo.lock"
+        || name == "cargo.toml"
+        || name == "package-lock.json"
+        || name == "pnpm-lock.yaml"
+        || name == "makefile"
+        || name == ".gitignore"
+        || lower.ends_with(".yml")
+        || lower.ends_with(".yaml")
+        || lower.ends_with(".lock")
+}
+
+#[cfg(test)]
+mod tests;

--- a/stella-pipeline/src/witness/warrant.rs
+++ b/stella-pipeline/src/witness/warrant.rs
@@ -222,17 +222,39 @@ fn changed_lines(diff: &str) -> (Vec<String>, Vec<String>) {
 /// Classify one changed line. Language-agnostic on purpose: the comment
 /// markers below cover every language Stella's test-runner vocabulary spans,
 /// and anything unrecognized is [`LineRole::Code`] so the rule fails closed.
+///
+/// The markers split in two. Some *only* ever open a comment — nothing
+/// executable in any language Stella supports begins with `//`, `/*`, or
+/// `<!--`, so those match on prefix alone. The rest are ambiguous: they open a
+/// comment in one language and real code in another. `*` continues a
+/// block-comment line but also writes through a Rust/C pointer (`*p = 1;`);
+/// `#` opens a shell/Python comment but also a Rust attribute (`#[derive]`), a
+/// C preprocessor directive (`#define X`), or a JS private field
+/// (`#balance = 0`); `--`/`;` open SQL/Lisp comments but also spell a decrement
+/// or a statement. For those, a marker fused to a token is code; only a bare
+/// marker or one trailed by whitespace is prose. Fusing the check to a
+/// delimiter keeps the rule failing closed — an ambiguous line reads as
+/// [`LineRole::Code`] and buys the test rather than silently waiving it.
 fn classify_line(line: &str) -> LineRole {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return LineRole::Blank;
     }
-    const COMMENT_MARKERS: &[&str] = &["//", "#", "/*", "*/", "*", "<!--", "-->", "--", ";"];
-    if COMMENT_MARKERS
+    const UNAMBIGUOUS_MARKERS: &[&str] = &["//", "/*", "<!--"];
+    if UNAMBIGUOUS_MARKERS
         .iter()
         .any(|marker| trimmed.starts_with(marker))
     {
         return LineRole::Comment;
+    }
+    // `*/` before `*` so a block-comment close is not first stripped to `/…`.
+    const DELIMITED_MARKERS: &[&str] = &["#", "*/", "*", "-->", "--", ";"];
+    for marker in DELIMITED_MARKERS {
+        if let Some(rest) = trimmed.strip_prefix(marker) {
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                return LineRole::Comment;
+            }
+        }
     }
     LineRole::Code
 }

--- a/stella-pipeline/src/witness/warrant/tests.rs
+++ b/stella-pipeline/src/witness/warrant/tests.rs
@@ -1,0 +1,161 @@
+//! Tests for the witness warrant. The load-bearing property is the *closed*
+//! direction: anything mixed, unrecognized, or invisible must fall through to
+//! `Required`, because a false "no test needed" ships unverified behavior.
+
+use super::*;
+
+fn diff(paths: &[&str], body: &str) -> String {
+    let mut out = String::new();
+    for path in paths {
+        out.push_str(&format!("--- a/{path}\n+++ b/{path}\n"));
+    }
+    out.push_str(body);
+    out
+}
+
+#[test]
+fn a_question_that_touched_nothing_needs_no_test() {
+    assert_eq!(
+        warrant("", 0),
+        WitnessWarrant::NotRequired(NoWitnessReason::NothingChanged)
+    );
+}
+
+#[test]
+fn a_turn_that_touched_files_invisibly_still_needs_one() {
+    // The honesty guard: FileChange events fired but the diff is blind. This
+    // must never read as "nothing happened".
+    assert_eq!(warrant("", 3), WitnessWarrant::Required);
+}
+
+#[test]
+fn docs_only_needs_no_test() {
+    let d = diff(&["README.md", "docs/design/x.md"], "+Some new prose.\n");
+    assert_eq!(
+        warrant(&d, 2),
+        WitnessWarrant::NotRequired(NoWitnessReason::DocsOnly)
+    );
+}
+
+#[test]
+fn tests_only_needs_no_test() {
+    let d = diff(&["stella-core/src/foo/tests.rs"], "+assert_eq!(1, 1);\n");
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::TestsOnly)
+    );
+}
+
+#[test]
+fn config_only_needs_no_test() {
+    let d = diff(&[".github/workflows/ci.yml"], "+  timeout-minutes: 30\n");
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::ConfigOnly)
+    );
+}
+
+#[test]
+fn comments_only_needs_no_test() {
+    let d = diff(
+        &["stella-core/src/driver.rs"],
+        "-// old note\n+// a clearer note\n+\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::CommentsOnly)
+    );
+}
+
+#[test]
+fn a_pure_removal_needs_no_test() {
+    let d = diff(
+        &["stella-core/src/dead.rs"],
+        "-pub fn unused() -> u32 {\n-    7\n-}\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::PureRemoval)
+    );
+}
+
+#[test]
+fn a_removal_that_leaves_a_note_is_still_a_removal() {
+    let d = diff(
+        &["stella-core/src/dead.rs"],
+        "-pub fn unused() -> u32 {\n-    7\n-}\n+// removed: superseded by `live()`\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::PureRemoval)
+    );
+}
+
+// ---- the closed direction: these must all buy the test ----
+
+#[test]
+fn docs_plus_source_is_a_source_change() {
+    let d = diff(
+        &["README.md", "stella-core/src/driver.rs"],
+        "+let x = compute();\n",
+    );
+    assert_eq!(
+        warrant(&d, 2),
+        WitnessWarrant::Required,
+        "a source change that also updated its docs is still a source change"
+    );
+}
+
+#[test]
+fn tests_plus_source_is_a_source_change() {
+    let d = diff(
+        &["tests/a.rs", "stella-core/src/driver.rs"],
+        "+let x = compute();\n",
+    );
+    assert_eq!(warrant(&d, 2), WitnessWarrant::Required);
+}
+
+#[test]
+fn a_removal_that_adds_real_code_is_a_rewrite() {
+    let d = diff(
+        &["stella-core/src/driver.rs"],
+        "-pub fn old() -> u32 { 7 }\n+pub fn new() -> u32 { 8 }\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::Required,
+        "replacing code is a behavior change, not a removal"
+    );
+}
+
+#[test]
+fn an_unrecognized_path_buys_the_test() {
+    let d = diff(&["some/unknown/thing.zz"], "+data\n");
+    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+}
+
+#[test]
+fn a_source_file_under_a_docs_named_crate_is_not_docs() {
+    // `stella-docs/src/lib.rs` is Rust, not prose.
+    let d = diff(&["stella-docs/src/lib.rs"], "+pub fn render() {}\n");
+    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+}
+
+#[test]
+fn every_reason_states_why_rather_than_merely_asserting() {
+    for reason in [
+        NoWitnessReason::NothingChanged,
+        NoWitnessReason::DocsOnly,
+        NoWitnessReason::TestsOnly,
+        NoWitnessReason::ConfigOnly,
+        NoWitnessReason::CommentsOnly,
+        NoWitnessReason::PureRemoval,
+    ] {
+        let sentence = reason.sentence();
+        assert!(sentence.len() > 20, "{reason:?} has no stated reason");
+        assert!(
+            sentence.contains(';') || sentence.contains(','),
+            "{reason:?} states what but not why: {sentence}"
+        );
+    }
+}

--- a/stella-pipeline/src/witness/warrant/tests.rs
+++ b/stella-pipeline/src/witness/warrant/tests.rs
@@ -129,6 +129,49 @@ fn a_removal_that_adds_real_code_is_a_rewrite() {
 }
 
 #[test]
+fn a_rust_deref_assignment_is_code_not_a_comment() {
+    // `*counter = …` starts with `*`, the block-comment continuation marker,
+    // but writes through a pointer. It must not read as comments-only.
+    let d = diff(
+        &["stella-core/src/driver.rs"],
+        "-    *counter = 0;\n+    *counter = 1;\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::Required,
+        "a deref assignment is a behavior change, not a comment"
+    );
+}
+
+#[test]
+fn a_js_private_field_and_c_preprocessor_are_code_not_comments() {
+    let js = diff(&["ui/src/wallet.ts"], "-    #balance = 0;\n+    #balance = 100;\n");
+    assert_eq!(warrant(&js, 1), WitnessWarrant::Required);
+    let c = diff(&["native/buffer.c"], "-#define BUFFER 256\n+#define BUFFER 512\n");
+    assert_eq!(warrant(&c, 1), WitnessWarrant::Required);
+}
+
+#[test]
+fn a_decrement_is_code_not_a_sql_comment() {
+    let d = diff(&["stella-core/src/driver.rs"], "-    --count;\n+    --count;\n+    step();\n");
+    assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
+}
+
+#[test]
+fn block_and_sql_comments_still_read_as_comments() {
+    // The delimited markers must still recognize genuine comments: a
+    // block-comment continuation, a block close, and a spaced SQL comment.
+    let d = diff(
+        &["stella-core/src/driver.rs"],
+        "+ * a doc line\n+ */\n+-- a note\n+# a python note\n",
+    );
+    assert_eq!(
+        warrant(&d, 1),
+        WitnessWarrant::NotRequired(NoWitnessReason::CommentsOnly)
+    );
+}
+
+#[test]
 fn an_unrecognized_path_buys_the_test() {
     let d = diff(&["some/unknown/thing.zz"], "+data\n");
     assert_eq!(warrant(&d, 1), WitnessWarrant::Required);


### PR DESCRIPTION
## What

A deterministic verification failure used to reach the worker as the **raw test-runner tail**. `deterministic_fail_evidence(&test_tail).summary` went straight into `revision_prompt`, replayed on every revision. That tail carries the detector's fingerprint — the exact assertion, the runtime values it compared, the failing test's identity — and the fingerprint is what makes special-casing cheaper than fixing.

Failures now cross through a **feedback airlock** (`stella-pipeline/src/witness/airlock.rs`).

**Two audiences, two texts.** The operator's `JudgeVerdict` keeps the real runner output — the human is not the adversary, and hiding the failure would make the tool unusable. Only the worker's prompt is redacted.

## The disclosure ladder

| Grain | Brief contains |
|---|---|
| `L3` | a reproduction the worker can run (default) |
| `L2` | + a closed-vocabulary `SymptomClass` sentence |
| `L1` | + the failing command |
| `L0` | that verification failed, and nothing else |

The grain steps down as the same `FailureFingerprint` repeats. A worker that has seen the same brief twice is not helped by a third copy — only handed more surface to fit — so the ladder responds to *thrashing* rather than taxing ordinary iteration.

`SymptomClass` sentences are compile-time literals, so that grain cannot quote an assertion **by construction**. `scrub` covers the rest and **fails closed**: a brief carrying a witness path, the sealed test selector, or a ≥24-char verbatim span of runner output degrades one grain rather than being emitted with a hole in it.

Model prose arriving *inbound* — distress guidance and judge reasoning, both written against the raw evidence — goes through the same scrub. A rejection emits `PolicyDecision { kind: Blocked }` carrying a leak **token**, never content.

Also fills `JudgeEvidence::evidence_refs`, which existed on the wire and was populated at **zero** construction sites (ROADMAP §4).

## What is deliberately not changed

- **The flip oracle and tamper exclusion are untouched.** They are the strongest thing in the crate.
- **Fingerprints are not wired into the oracle.** ROADMAP §2 asks for "same failure, not just same command", and the mechanism now exists — but ordinary iteration changes the failure mode constantly (assertion → compile error → green), and strict matching would leave that flip uncredited. The design doc records the evidence that would justify revisiting it.

## Scope decision

This started as "replace stella's verification with the Witness Protocol draft". `docs/design/witness-protocol.md` records why it became an increment instead, and what is **declined** so it is not re-litigated: two trust domains (Stella is one local process), shadow sandbox / shadow traffic / canary ramps (Stella verifies a repo, not a deployed service), warranties, dual Examiners (cost), and a parallel criteria model — that last one because `stella-core::context_record::contract` already carries a typed acceptance model (`ArtifactContract`, `RequirementKind::{COMMAND, SEMANTIC_JUDGE}`, `contract_hash`) that is wired to nothing. When criteria land, they land there rather than beside it.

## Witness test

`pipeline::tests::airlock::the_runner_tail_reaches_the_operator_but_never_the_worker` plants a distinctive value in the runner tail and asserts it reaches the operator's verdict and **never** the worker's prompt.

Verified it fails on the previous code — reverting only the feedback line reports the leaked value inside the revision prompt:

```
the revision prompt leaked sealed material "8675309":
sysFix the failing testdoneVerification did not pass. Evidence:
touched tests failed after execution: thread 'witness_totals_reconcile' panicked at tests/witness_zz9.rs:14:5:
assertion `left == right` failed
  left: 8675309
```

The 13 unit tests were mutation-checked too: disabling `scrub` turns 3 of them red.

## New dependency

`sha2` on `stella-pipeline` — already a workspace dependency used by `stella-core`'s `record_hash`, so one hashing primitive covers the tree.

## Baseline bumps

`pipeline.rs` +29 and `pipeline/tests.rs` +12 against the file-size ratchet. 90 lines of orchestration went into a new `pipeline/disclosure.rs` and the witness test into `pipeline/tests/airlock.rs` first; the residue is call sites, one state field, and the harness change.

## Gate

`make gate` green (all seven checks, full workspace suite, zero failures).


---

# Second commit: decide ceremony from evidence, not from a prediction

The pipeline chose how much machinery to buy by **predicting** difficulty once, up front, from the prompt — the worst moment to judge, since no work has happened yet. Both costs land on exactly the short, easy work where they're least affordable.

**A greeting paid for a classification that could not change its own answer.** `resolve_conversational` is a disjunction whose first term ignores the model entirely, and `triage.rs` already documents that route as one that "never depends on a model answer" — but it was evaluated *after* `metered_raw_call` went out. `hi` cost two round-trips, plus up to `triage_latency_ceiling` of dead air on a wedged provider. The check now runs before provider resolution; the early return is byte-identical to the assessment the existing resolution-failure arm already builds.

**A change with nothing to prove bought a review call to be told so.** No flip + no test command → `ModelJudge`. Correct when a real change went unproven; wasteful when there was nothing to prove. `witness::warrant` reads the **diff** and answers from evidence — `NothingChanged`, `DocsOnly`, `TestsOnly`, `ConfigOnly`, `CommentsOnly`, `PureRemoval` — and the run completes with the reason **recorded on the verdict**. That's the pipeline's half of the contract contributors are already held to: *a witness test, or a stated reason there isn't one.*

**Fails closed.** Anything mixed, unrecognized, or invisible to the diff machinery buys the test. A turn that touched files but produced no readable diff is `Required`, never `NothingChanged` — the same honesty guard `verification_honest_diff` exists for.

**No test needed ≠ no review needed.** `TestsOnly` and `PureRemoval` keep the independent reviewer, preserving what `resolve_witness` already guaranteed for deletions: deleting the wrong thing is a mistake a reader catches and no test would have. Scored `Unverified`, never `DeterministicPass`.

`resolve_witness` stays — it's the pre-execution half of the same question and has to guess from wording; the warrant is the post-execution half and doesn't. One spares the authoring call, the other the review call. Cross-referenced both ways.

**Not in this change:** witness authoring still runs before execute, so the warrant spares the judge call but not the authoring before it. Moving authoring after execution is possible (`verify_done` already validates against `HEAD` in a detached shadow worktree) and is what makes verification cost fully demand-driven.

### Witness tests (both verified red on the previous code)
- `a_greeting_takes_the_conversational_path_and_skips_all_work` — now scripts exactly **one** provider response, so a surviving triage call exhausts the queue.
- `warrant::a_docs_only_change_completes_without_buying_a_judge_call` — scripts exactly **two**, so a judge call exhausts it.

`make gate` green on both commits.
