### PR TITLE
feat(stella-pipeline): buy the witness after execution, only when the diff warrants one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ record of *changes*, curated by the person who made them.
   their independent reviewer, because deleting the wrong thing is a mistake a
   reader catches and no test would have. Design:
   `docs/design/witness-protocol.md` §7.
+- Verification cost is now fully demand-driven: a change with nothing to prove
+  no longer pays for a **witness test** either. Authoring runs after execution
+  and only when the diff warrants it, so a docs or comment edit dispatches no
+  author call at all — previously it bought one before any work existed, then
+  discovered the change was prose. The author still never sees the
+  implementation (it works in a pristine pre-execution snapshot), so a witness
+  proves the same thing it always did. A witness that cannot be produced now
+  leaves the completed work alone instead of discarding the candidate and
+  re-running the task. Design: `docs/design/witness-protocol.md` §7.3.
 
 - The pipeline no longer replays raw test-runner output into a worker's
   revision prompt. A deterministic verification failure is now disclosed

--- a/docs/design/witness-protocol.md
+++ b/docs/design/witness-protocol.md
@@ -261,11 +261,53 @@ scores `Unverified`, never `DeterministicPass`: it is honestly complete, and a
 change with nothing to prove must not outrank a flip-verified sibling in
 best-of-N.
 
-### 7.3 What this does not do yet
+### 7.3 Authoring is demand-driven
 
-Witness *authoring* still runs before execute, because a witness must fail on
-the old code. So the warrant can spare a judge call but not the authoring call
-that preceded it. Moving authoring after execution is possible —
-`stella-tools`' `verify_done` already validates a test against `HEAD` in a
-detached shadow worktree — and that reorder is what would make verification
-cost fully demand-driven. It is not in this change.
+The warrant reads a diff, so it can only answer after execution. While
+authoring ran *before* execute, that left the saving half-collected: the
+warrant spared the judge call but not the author call that had already been
+paid. A docs edit still bought a test for prose.
+
+Authoring now runs after execution, gated on the warrant. A change with
+nothing to prove dispatches no author turn at all, and `NotRequired` is
+answered from the diff rather than from the prompt.
+
+**The hazard this creates.** After execution an implementation exists, and an
+author allowed to read it writes a test that restates it. Such a test fails on
+the old code and passes on the new, so the flip oracle confirms it — while
+proving only that the code equals itself. Reordering naively would have kept
+the ceremony and hollowed out the evidence.
+
+**Two trees, not one.** The author works in a *second*
+`CandidateWorkspacePort::create` snapshot, taken when the warrant asks for a
+witness. Because a candidate's edits never leave its own workspace until
+adoption, that snapshot sees the pre-execution tree — so the author's input is
+byte-identical to what it was when this stage ran first: the goal, the recalled
+frames, and the unmodified code. The reorder buys cost, never leverage.
+
+That snapshot is also where the artifact must FAIL. The accepted file is then
+grafted into the candidate that executed — create-only, following no link on
+either side, one file — and re-fingerprinted there, so tamper exclusion pins
+the bytes that will actually run. The pass is observed in the candidate. Fail
+in the pre-execution tree, pass in the post-execution one: a flip across two
+code states rather than one tree observed twice.
+
+**What the reorder costs.** A witnessed candidate now takes two snapshots
+instead of one. A snapshot is a `git worktree add` and a patch apply; an author
+turn is a model call. So the trade is a cheap local operation *only when a
+witness is warranted*, against a model call *whenever it is not* — and prose,
+comments, config, and no-op turns are common enough on real work to make that
+lopsided in the right direction.
+
+**What it changes about failure.** Because the work already exists when the
+author is asked, a witness that cannot be *produced* no longer discards it. A
+useless witness, an unavailable author, or an artifact that cannot be grafted
+leaves the candidate on the unauthored ladder — where previously the whole
+candidate was thrown away and the task re-executed from scratch. Fail-closed is
+unchanged for artifacts that cannot be *trusted*: a tracked-file mutation, a
+symlink artifact, or a runner mismatch still aborts, now after the worker's
+turn rather than before it.
+
+`resolve_witness` still runs before execution and still guesses from wording.
+It is the deterministic ceiling on whether authoring is *permitted*; the
+warrant is the evidence-based gate on whether it is *bought*.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,9 +8,9 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 1881 stella-cli/src/agent_tests.rs
-2255 stella-cli/src/agent.rs
-1623 stella-cli/src/candidate_ws.rs
-4604 stella-cli/src/command_deck.rs
+2243 stella-cli/src/agent.rs
+1627 stella-cli/src/candidate_ws.rs
+4600 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
 2098 stella-core/src/driver.rs
 2819 stella-core/src/driver/tests.rs
@@ -19,10 +19,10 @@
 1638 stella-model/src/bedrock.rs
 1919 stella-model/src/openai.rs
 1623 stella-model/src/zai/tests.rs
-2535 stella-pipeline/src/pipeline.rs
-2044 stella-pipeline/src/pipeline/tests.rs
+2522 stella-pipeline/src/pipeline.rs
+2018 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
-2283 stella-store/src/lib.rs
+2280 stella-store/src/lib.rs
 2170 stella-store/src/tests.rs
 1884 stella-store/src/usage.rs
 1556 stella-tools/src/media.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1881 stella-cli/src/agent_tests.rs
-2243 stella-cli/src/agent.rs
+1710 stella-cli/src/agent_tests.rs
+2250 stella-cli/src/agent.rs
 1627 stella-cli/src/candidate_ws.rs
 4600 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -94,7 +94,7 @@ use crate::agent::{
 };
 
 mod witness_tools;
-use witness_tools::{WitnessToolExecutor, normalized_candidate_path};
+use witness_tools::WitnessToolExecutor;
 
 /// The commit identity for snapshot plumbing commits (which exist only
 /// inside the shadow and are discarded with it) — the user's repo may have

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -94,7 +94,7 @@ use crate::agent::{
 };
 
 mod witness_tools;
-use witness_tools::WitnessToolExecutor;
+use witness_tools::{WitnessToolExecutor, normalized_candidate_path};
 
 /// The commit identity for snapshot plumbing commits (which exist only
 /// inside the shadow and are discarded with it) — the user's repo may have
@@ -798,6 +798,10 @@ impl CandidateWorkspace for GitCandidateWorkspace {
 
     async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
         self.adopt_inner(withhold).await
+    }
+
+    async fn graft_witness(&self, source_root: &str, path: &str) -> Result<(), WorkspaceError> {
+        witness_tools::graft(&self.root, &self.dir, source_root, path).await
     }
 
     async fn remove(&self) {

--- a/stella-cli/src/candidate_ws/witness_tools.rs
+++ b/stella-cli/src/candidate_ws/witness_tools.rs
@@ -1,11 +1,12 @@
 //! Capability-minimal tool surface for candidate-local witness authoring.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use stella_core::ToolExecutor;
+use stella_pipeline::ports::WorkspaceError;
 use stella_protocol::{ToolOutput, ToolSchema};
 
 /// Candidate-root executor built specifically for witness authoring. Reads
@@ -166,7 +167,7 @@ impl ToolExecutor for WitnessToolExecutor {
     }
 }
 
-fn normalized_candidate_path(raw: &str) -> Option<String> {
+pub(super) fn normalized_candidate_path(raw: &str) -> Option<String> {
     let slash = raw.replace('\\', "/");
     if slash.is_empty() || slash.as_bytes().get(1) == Some(&b':') || Path::new(&slash).is_absolute()
     {
@@ -407,4 +408,106 @@ mod tests {
             .count();
         assert_eq!(created, 1);
     }
+}
+
+/// Copy one accepted witness artifact from the authoring snapshot into
+/// this workspace, create-only and following no link on either side.
+///
+/// The source is read with `O_NOFOLLOW` and the destination opened
+/// `create_new` + `O_NOFOLLOW`, so neither end can be redirected by a
+/// symlink planted between acceptance and this copy. Bytes are moved
+/// rather than the file being hard-linked or reflinked: the pipeline
+/// re-fingerprints the destination immediately afterwards and pins tamper
+/// exclusion to it, and a shared inode would let the authoring snapshot's
+/// teardown change what the candidate is about to run.
+///
+/// Only the file is created. A missing parent directory is an error rather
+/// than an implicit `create_dir_all`: the artifact path was validated as a
+/// recognized test path inside a *tree that already had that directory*,
+/// so a parent that is absent here means the two trees disagree about
+/// layout, and inventing directories in the candidate would paper over it.
+pub(super) async fn graft(
+    candidate_root: &str,
+    workspace_dir: &Path,
+    source_root: &str,
+    path: &str,
+) -> Result<(), WorkspaceError> {
+    let fail = |reason: String| WorkspaceError::Graft {
+        reason,
+        path: path.to_string(),
+        workspace: workspace_dir.display().to_string(),
+    };
+    let Some(rel) = normalized_candidate_path(path) else {
+        return Err(fail("the path must stay within the candidate root".into()));
+    };
+    let source = Path::new(source_root).join(&rel);
+    let bytes = read_nofollow(&source)
+        .await
+        .map_err(|e| fail(format!("could not read the authored artifact: {e}")))?;
+
+    let root = Path::new(candidate_root)
+        .canonicalize()
+        .map_err(|e| fail(format!("the candidate root is unavailable: {e}")))?;
+    let joined = root.join(&rel);
+    let parent = joined
+        .parent()
+        .ok_or_else(|| fail("the artifact has no parent directory".into()))?
+        .canonicalize()
+        .map_err(|e| fail(format!("the parent directory must already exist: {e}")))?;
+    if !parent.starts_with(&root) {
+        return Err(fail(
+            "the canonical parent escapes the candidate root".into(),
+        ));
+    }
+    let name = joined
+        .file_name()
+        .ok_or_else(|| fail("the artifact has no file name".into()))?;
+    let target = parent.join(name);
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options.open(&target).map_err(|e| {
+        // `AlreadyExists` is the interesting one: the worker wrote its own
+        // file at the artifact's path. Overwriting would delete real work
+        // to make room for scaffolding, so the graft fails and the run
+        // finishes on the unauthored ladder.
+        fail(format!("exclusive file creation failed: {e}"))
+    })?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|e| {
+            drop(file);
+            let _ = std::fs::remove_file(&target);
+            fail(format!("writing the grafted artifact failed: {e}"))
+        })
+}
+
+/// Read a file's bytes without following a final-component symlink.
+///
+/// Used for the one file that crosses between candidate workspaces. The
+/// pipeline has already accepted this path as a regular, singly-linked file in
+/// the tree that authored it; opening `O_NOFOLLOW` here keeps that acceptance
+/// meaningful by refusing to resolve a link swapped in afterwards.
+async fn read_nofollow(src: &Path) -> std::io::Result<Vec<u8>> {
+    let src = src.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        }
+        let mut file = options.open(&src)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }

--- a/stella-cli/src/candidate_ws/witness_tools.rs
+++ b/stella-cli/src/candidate_ws/witness_tools.rs
@@ -213,6 +213,108 @@ fn is_credential_path(path: &str) -> bool {
         })
 }
 
+/// Copy one accepted witness artifact from the authoring snapshot into
+/// this workspace, create-only and following no link on either side.
+///
+/// The source is read with `O_NOFOLLOW` and the destination opened
+/// `create_new` + `O_NOFOLLOW`, so neither end can be redirected by a
+/// symlink planted between acceptance and this copy. Bytes are moved
+/// rather than the file being hard-linked or reflinked: the pipeline
+/// re-fingerprints the destination immediately afterwards and pins tamper
+/// exclusion to it, and a shared inode would let the authoring snapshot's
+/// teardown change what the candidate is about to run.
+///
+/// Only the file is created. A missing parent directory is an error rather
+/// than an implicit `create_dir_all`: the artifact path was validated as a
+/// recognized test path inside a *tree that already had that directory*,
+/// so a parent that is absent here means the two trees disagree about
+/// layout, and inventing directories in the candidate would paper over it.
+pub(super) async fn graft(
+    candidate_root: &str,
+    workspace_dir: &Path,
+    source_root: &str,
+    path: &str,
+) -> Result<(), WorkspaceError> {
+    let fail = |reason: String| WorkspaceError::Graft {
+        reason,
+        path: path.to_string(),
+        workspace: workspace_dir.display().to_string(),
+    };
+    let Some(rel) = normalized_candidate_path(path) else {
+        return Err(fail("the path must stay within the candidate root".into()));
+    };
+    let source = Path::new(source_root).join(&rel);
+    let bytes = read_nofollow(&source)
+        .await
+        .map_err(|e| fail(format!("could not read the authored artifact: {e}")))?;
+
+    let root = Path::new(candidate_root)
+        .canonicalize()
+        .map_err(|e| fail(format!("the candidate root is unavailable: {e}")))?;
+    let joined = root.join(&rel);
+    let parent = joined
+        .parent()
+        .ok_or_else(|| fail("the artifact has no parent directory".into()))?
+        .canonicalize()
+        .map_err(|e| fail(format!("the parent directory must already exist: {e}")))?;
+    if !parent.starts_with(&root) {
+        return Err(fail(
+            "the canonical parent escapes the candidate root".into(),
+        ));
+    }
+    let name = joined
+        .file_name()
+        .ok_or_else(|| fail("the artifact has no file name".into()))?;
+    let target = parent.join(name);
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options.open(&target).map_err(|e| {
+        // `AlreadyExists` is the interesting one: the worker wrote its own
+        // file at the artifact's path. Overwriting would delete real work
+        // to make room for scaffolding, so the graft fails and the run
+        // finishes on the unauthored ladder.
+        fail(format!("exclusive file creation failed: {e}"))
+    })?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|e| {
+            drop(file);
+            let _ = std::fs::remove_file(&target);
+            fail(format!("writing the grafted artifact failed: {e}"))
+        })
+}
+
+/// Read a file's bytes without following a final-component symlink.
+///
+/// Used for the one file that crosses between candidate workspaces. The
+/// pipeline has already accepted this path as a regular, singly-linked file in
+/// the tree that authored it; opening `O_NOFOLLOW` here keeps that acceptance
+/// meaningful by refusing to resolve a link swapped in afterwards.
+async fn read_nofollow(src: &Path) -> std::io::Result<Vec<u8>> {
+    let src = src.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        }
+        let mut file = options.open(&src)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,106 +510,4 @@ mod tests {
             .count();
         assert_eq!(created, 1);
     }
-}
-
-/// Copy one accepted witness artifact from the authoring snapshot into
-/// this workspace, create-only and following no link on either side.
-///
-/// The source is read with `O_NOFOLLOW` and the destination opened
-/// `create_new` + `O_NOFOLLOW`, so neither end can be redirected by a
-/// symlink planted between acceptance and this copy. Bytes are moved
-/// rather than the file being hard-linked or reflinked: the pipeline
-/// re-fingerprints the destination immediately afterwards and pins tamper
-/// exclusion to it, and a shared inode would let the authoring snapshot's
-/// teardown change what the candidate is about to run.
-///
-/// Only the file is created. A missing parent directory is an error rather
-/// than an implicit `create_dir_all`: the artifact path was validated as a
-/// recognized test path inside a *tree that already had that directory*,
-/// so a parent that is absent here means the two trees disagree about
-/// layout, and inventing directories in the candidate would paper over it.
-pub(super) async fn graft(
-    candidate_root: &str,
-    workspace_dir: &Path,
-    source_root: &str,
-    path: &str,
-) -> Result<(), WorkspaceError> {
-    let fail = |reason: String| WorkspaceError::Graft {
-        reason,
-        path: path.to_string(),
-        workspace: workspace_dir.display().to_string(),
-    };
-    let Some(rel) = normalized_candidate_path(path) else {
-        return Err(fail("the path must stay within the candidate root".into()));
-    };
-    let source = Path::new(source_root).join(&rel);
-    let bytes = read_nofollow(&source)
-        .await
-        .map_err(|e| fail(format!("could not read the authored artifact: {e}")))?;
-
-    let root = Path::new(candidate_root)
-        .canonicalize()
-        .map_err(|e| fail(format!("the candidate root is unavailable: {e}")))?;
-    let joined = root.join(&rel);
-    let parent = joined
-        .parent()
-        .ok_or_else(|| fail("the artifact has no parent directory".into()))?
-        .canonicalize()
-        .map_err(|e| fail(format!("the parent directory must already exist: {e}")))?;
-    if !parent.starts_with(&root) {
-        return Err(fail(
-            "the canonical parent escapes the candidate root".into(),
-        ));
-    }
-    let name = joined
-        .file_name()
-        .ok_or_else(|| fail("the artifact has no file name".into()))?;
-    let target = parent.join(name);
-
-    let mut options = std::fs::OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
-    }
-    let mut file = options.open(&target).map_err(|e| {
-        // `AlreadyExists` is the interesting one: the worker wrote its own
-        // file at the artifact's path. Overwriting would delete real work
-        // to make room for scaffolding, so the graft fails and the run
-        // finishes on the unauthored ladder.
-        fail(format!("exclusive file creation failed: {e}"))
-    })?;
-    file.write_all(&bytes)
-        .and_then(|()| file.sync_all())
-        .map_err(|e| {
-            drop(file);
-            let _ = std::fs::remove_file(&target);
-            fail(format!("writing the grafted artifact failed: {e}"))
-        })
-}
-
-/// Read a file's bytes without following a final-component symlink.
-///
-/// Used for the one file that crosses between candidate workspaces. The
-/// pipeline has already accepted this path as a regular, singly-linked file in
-/// the tree that authored it; opening `O_NOFOLLOW` here keeps that acceptance
-/// meaningful by refusing to resolve a link swapped in afterwards.
-async fn read_nofollow(src: &Path) -> std::io::Result<Vec<u8>> {
-    let src = src.to_path_buf();
-    tokio::task::spawn_blocking(move || {
-        let mut options = std::fs::OpenOptions::new();
-        options.read(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
-        }
-        let mut file = options.open(&src)?;
-        let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes)?;
-        Ok(bytes)
-    })
-    .await
-    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -81,6 +81,7 @@ use crate::verify::{
 use crate::witness::airlock::{
     DisclosureGrain, FailureFingerprint, SealedFailure, grain_for_repeats, redact, scrub,
 };
+use crate::witness::warrant::warrant;
 use crate::witness::{
     Witness, parse_test_invocation, parse_witness_command, validate_witness_artifact,
     validate_witness_identity, validate_witness_invocation, witness_identity_matches,
@@ -95,7 +96,7 @@ use raw_usage::{RawCall, RawCallError};
 use run_error::RoleResolveError;
 pub use run_error::{PipelineError, PipelineRunError};
 use stage_budget::{PipelineBudgetAbort, budget_abort};
-use witness_stage::BoundHookRunner;
+use witness_stage::{BoundHookRunner, WitnessAuthoring};
 /// Make a diff that verification hands downstream *incapable of lying*.
 ///
 /// An empty diff is ambiguous: it can mean the agent genuinely changed
@@ -378,6 +379,16 @@ struct CandidateResult {
     score: CandidateScore,
     diff_lines: u32,
     revisions: u32,
+    /// Workspace-relative paths of the witness artifact this candidate had
+    /// grafted into it, withheld from adoption unless
+    /// [`PipelineConfig::keep_witness`]. Empty when no witness was warranted,
+    /// which under demand-driven authoring is the common case.
+    ///
+    /// These ride on the result rather than beside the workspace because
+    /// authoring now happens *inside* the candidate, after execution: the
+    /// paths are an output of the run, and the caller indexes them by the same
+    /// index it already uses to find the workspace.
+    witness_paths: Vec<String>,
 }
 
 impl CandidateResult {
@@ -405,6 +416,7 @@ impl CandidateResult {
             score: CandidateScore::Failed,
             diff_lines: 0,
             revisions: 0,
+            witness_paths: Vec::new(),
         }
     }
 
@@ -437,6 +449,10 @@ struct CandidateState {
     diff_lines: u32,
     diff_text: String,
     revisions: u32,
+    /// Paths of the witness artifact grafted into this candidate, if the
+    /// warrant bought one after execution. Empty until then, and empty forever
+    /// when the change had nothing to prove.
+    witness_paths: Vec<String>,
     /// Every deterministic failure this candidate has produced, in order.
     /// The airlock reads it to tell "stuck on the same thing" from "made
     /// progress and hit something new" — the signal that decides how much the
@@ -462,6 +478,7 @@ impl CandidateState {
             score,
             diff_lines: self.diff_lines,
             revisions: self.revisions,
+            witness_paths: self.witness_paths,
         }
     }
 
@@ -476,6 +493,7 @@ impl CandidateState {
             score: CandidateScore::Unverified,
             diff_lines: self.diff_lines,
             revisions: self.revisions,
+            witness_paths: self.witness_paths,
         }
     }
 }
@@ -492,21 +510,6 @@ struct CandidateSurface<'c> {
     cwd: Option<&'c str>,
     hook_runner: Option<&'c dyn HookRunner>,
     workspace: Option<&'c dyn CandidateWorkspace>,
-}
-
-/// One candidate's live workspace plus the witness paths authored inside it.
-///
-/// They travel together because adoption needs both and indexes by candidate:
-/// a parallel `Vec<Vec<String>>` would have to be kept aligned by hand at
-/// every early `continue` in the candidate loop, and a single missed push
-/// would silently shift every later candidate's witness onto the wrong
-/// workspace. Pairing them makes that misalignment unrepresentable.
-struct CandidateSlot {
-    workspace: Box<dyn CandidateWorkspace>,
-    /// Workspace-relative paths of the accepted witness artifact(s). Withheld
-    /// from adoption unless [`PipelineConfig::keep_witness`]; empty when the
-    /// candidate authored no witness.
-    witness_paths: Vec<String>,
 }
 
 /// The staged orchestrator. Holds only borrowed ports + an owned event sender
@@ -723,7 +726,6 @@ impl<'a> Pipeline<'a> {
                     &base_messages,
                     plan.as_deref(),
                     assessment,
-                    None,
                     &worker,
                     1,
                     budget,
@@ -1240,7 +1242,6 @@ impl<'a> Pipeline<'a> {
             base_messages,
             plan,
             assessment,
-            None,
             &worker,
             1,
             budget,
@@ -1260,7 +1261,6 @@ impl<'a> Pipeline<'a> {
         base_messages: &[CompletionMessage],
         plan: Option<&[PlanStep]>,
         assessment: TaskAssessment,
-        witness: Option<&Witness>,
         worker: &ResolvedRole<'a>,
         n: u32,
         budget: &mut BudgetGuard,
@@ -1294,7 +1294,10 @@ impl<'a> Pipeline<'a> {
                     base_messages,
                     plan,
                     assessment,
-                    witness,
+                    // A shared-tree run has no workspace to graft into and no
+                    // pristine snapshot to author blind in, so it never buys a
+                    // witness — exactly as before, when it was passed `None`.
+                    None,
                     &engine,
                     surface,
                     budget,
@@ -1366,7 +1369,6 @@ impl<'a> Pipeline<'a> {
                     base_messages,
                     plan,
                     assessment,
-                    None,
                     &worker,
                     n,
                     budget,
@@ -1423,11 +1425,12 @@ impl<'a> Pipeline<'a> {
         };
 
         let mut candidates: Vec<CandidateResult> = Vec::with_capacity(n as usize);
-        // The witness paths ride WITH their workspace rather than in a parallel
-        // vector: adoption indexes by candidate, and every early `continue`
-        // below would otherwise have to remember to keep a second vector
-        // aligned. Carrying them together makes drift unrepresentable.
-        let mut workspaces: Vec<Option<CandidateSlot>> = Vec::with_capacity(n as usize);
+        // Index-aligned with `candidates` — every path below pushes to both, so
+        // adoption can pair a workspace with the result that produced it (and
+        // with the witness paths that result carries). `None` marks a candidate
+        // that never got a workspace.
+        let mut workspaces: Vec<Option<Box<dyn CandidateWorkspace>>> =
+            Vec::with_capacity(n as usize);
         for i in 0..n {
             let ws = match port.create().await {
                 Ok(ws) => ws,
@@ -1444,7 +1447,7 @@ impl<'a> Pipeline<'a> {
                     continue;
                 }
             };
-            let (result, witness_paths) = {
+            let result = {
                 let bound_hook_runner = self.hooks.map(|(_, runner)| BoundHookRunner {
                     inner: runner,
                     cwd: ws.root(),
@@ -1459,48 +1462,16 @@ impl<'a> Pipeline<'a> {
                         .map(|runner| runner as &dyn HookRunner),
                     workspace: Some(ws.as_ref()),
                 };
-                let witness = if author_witness {
-                    let author = witness_author
+                // Handed to the candidate rather than spent here: whether this
+                // run buys a witness is not knowable until the candidate has
+                // executed and its diff can be read.
+                let authoring = author_witness.then(|| WitnessAuthoring {
+                    port,
+                    author: witness_author
                         .as_ref()
-                        .expect("authored witness identity is resolved before dispatch");
-                    match self
-                        .witness_stage(goal, frames, author, surface, budget, total)
-                        .await
-                    {
-                        Ok(witness) => witness,
-                        Err(abort) => {
-                            // A witness that couldn't be AUTHORED degrades to a
-                            // bare run (the task needs no witness). An
-                            // artifact-INTEGRITY violation stays fail-closed,
-                            // so a poisoned witness is surfaced, never silently
-                            // traded for an unverified run.
-                            let candidate = if abort.degradable {
-                                CandidateResult::setup_aborted(base_messages.to_vec(), abort.reason)
-                            } else {
-                                CandidateResult::aborted(base_messages.to_vec(), abort.reason)
-                            };
-                            candidates.push(candidate);
-                            // No accepted witness, so nothing to withhold. This
-                            // candidate cannot be adopted anyway (adoption
-                            // requires a passing verdict, and this one aborted),
-                            // but the slot must still be pushed to keep indices
-                            // aligned with `candidates`.
-                            workspaces.push(Some(CandidateSlot {
-                                workspace: ws,
-                                witness_paths: Vec::new(),
-                            }));
-                            continue;
-                        }
-                    }
-                } else {
-                    None
-                };
-                // Captured before `witness` is handed to the candidate: these
-                // are the paths withheld from adoption unless `keep_witness`.
-                let witness_paths: Vec<String> = witness
-                    .as_ref()
-                    .map(|w| w.files.keys().cloned().collect())
-                    .unwrap_or_default();
+                        .expect("authored witness identity is resolved before dispatch"),
+                    frames,
+                });
                 let mut engine = Engine::with_sleeper(
                     worker.provider,
                     ws.tools(),
@@ -1513,26 +1484,24 @@ impl<'a> Pipeline<'a> {
                 if let Some(steering) = self.steering {
                     engine = engine.with_steering(steering);
                 }
-                let result = self
-                    .run_candidate(
-                        goal,
-                        base_messages,
-                        plan,
-                        assessment,
-                        witness.as_ref(),
-                        &engine,
-                        surface,
-                        budget,
-                        total,
-                    )
-                    .await;
-                (result, witness_paths)
+                self.run_candidate(
+                    goal,
+                    base_messages,
+                    plan,
+                    assessment,
+                    authoring,
+                    &engine,
+                    surface,
+                    budget,
+                    total,
+                )
+                .await
             };
+            // Pushed together, always: adoption pairs `candidates[i]` with
+            // `workspaces[i]`, and the witness paths now ride on the result,
+            // so a candidate can never be matched to another one's artifact.
             candidates.push(result);
-            workspaces.push(Some(CandidateSlot {
-                workspace: ws,
-                witness_paths,
-            }));
+            workspaces.push(Some(ws));
         }
 
         let best_idx = best_index(&candidates);
@@ -1543,11 +1512,7 @@ impl<'a> Pipeline<'a> {
         // aborted best-of-N run leaves the real tree untouched.
         let mut adopt_failure: Option<WorkspaceError> = None;
         for (i, slot) in workspaces.into_iter().enumerate() {
-            let Some(CandidateSlot {
-                workspace: ws,
-                witness_paths,
-            }) = slot
-            else {
+            let Some(ws) = slot else {
                 continue;
             };
             if i == best_idx
@@ -1562,7 +1527,7 @@ impl<'a> Pipeline<'a> {
                 let withhold: &[String] = if self.config.keep_witness {
                     &[]
                 } else {
-                    &witness_paths
+                    &candidates[best_idx].witness_paths
                 };
                 match ws.adopt(withhold).await {
                     Ok(adopted) => {
@@ -1605,7 +1570,7 @@ impl<'a> Pipeline<'a> {
         base_messages: &[CompletionMessage],
         plan: Option<&[PlanStep]>,
         assessment: TaskAssessment,
-        witness: Option<&Witness>,
+        authoring: Option<WitnessAuthoring<'_>>,
         engine: &Engine<'_>,
         surface: CandidateSurface<'_>,
         budget: &mut BudgetGuard,
@@ -1616,14 +1581,17 @@ impl<'a> Pipeline<'a> {
         // fail→pass flip (L-E11). Simple lookups skip the baseline — they are
         // only verified at all if the zero-diff guard trips, and then the
         // absence of a baseline correctly leaves the oracle unflipped.
-        // The baseline runs per candidate even though the witness stage
-        // already saw its command fail once: the observation must come from
-        // this candidate's own surface (its isolated snapshot under
-        // best-of-N, or a shared tree an earlier candidate may have
-        // modified), and a seeded observation would be a fabricated one.
+        //
+        // This is the *configured* command only. A user who names a test
+        // command names one that exists now, so its baseline is a real
+        // observation of this candidate's own surface, taken here. An authored
+        // witness has no command at this point — it is not written until after
+        // execution, once the warrant has established there is something to
+        // prove — and its baseline is observed where it is written, in a
+        // pristine snapshot of this same pre-execution tree.
         let mut oracle = FlipOracle::new();
         if assessment.class.verifies_unconditionally()
-            && let Some(cmd) = self.effective_test_command(witness)
+            && let Some(cmd) = self.effective_test_command(None)
         {
             let pre = surface.tests.run_test(cmd.invocation).await;
             oracle.observe(cmd.command, pre.passed());
@@ -1645,6 +1613,7 @@ impl<'a> Pipeline<'a> {
             diff_lines: 0,
             diff_text: String::new(),
             revisions: 0,
+            witness_paths: Vec::new(),
             failures: Vec::new(),
         };
 
@@ -1671,8 +1640,26 @@ impl<'a> Pipeline<'a> {
             return state.into_unverified();
         }
 
+        // Buy the witness now, or not at all. Everything above this line has
+        // already happened, so the diff is evidence rather than a prediction —
+        // which is the whole reason authoring waits until here.
+        let witness = match self
+            .witness_on_demand(goal, authoring, surface, &mut state, budget, total)
+            .await
+        {
+            Ok(witness) => witness,
+            Err(reason) => return CandidateResult::aborted(state.messages, reason),
+        };
+
         self.verify_candidate(
-            goal, assessment, witness, engine, surface, budget, total, state,
+            goal,
+            assessment,
+            witness.as_ref(),
+            engine,
+            surface,
+            budget,
+            total,
+            state,
         )
         .await
     }

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -340,6 +340,10 @@ struct FakeWorkspace {
     repo_status: SeqRepoStatus,
     adopt_result: Result<Vec<AdoptedChange>, WorkspaceError>,
     sealed_unchanged: bool,
+    /// Canned outcome for the one artifact copy between workspaces. `Err`
+    /// stands in for the real failures: the worker already wrote a file at
+    /// that path, or the parent directory is absent.
+    graft_result: Result<(), WorkspaceError>,
     log: Arc<std::sync::Mutex<Vec<String>>>,
 }
 
@@ -358,12 +362,38 @@ impl FakeWorkspace {
             repo_status: SeqRepoStatus::new(vec![]),
             adopt_result,
             sealed_unchanged: true,
+            graft_result: Ok(()),
             log,
         }
     }
 
     fn with_repo_status(mut self, repo_status: SeqRepoStatus) -> Self {
         self.repo_status = repo_status;
+        self
+    }
+
+    /// Untracked files this workspace reports, as `(path, added_lines)` —
+    /// what a diff gather bills to the turn unless the path was already known.
+    fn with_untracked(mut self, untracked: Vec<(&str, u32)>) -> Self {
+        self.diagnostics =
+            std::mem::replace(&mut self.diagnostics, ScriptedRunner::new(vec![], ""))
+                .with_untracked(untracked);
+        self
+    }
+
+    /// The diff this workspace reports after execution — what the warrant
+    /// reads to decide whether a witness is worth buying.
+    fn with_diff(mut self, diff: &str) -> Self {
+        self.diagnostics.diff = diff.to_string();
+        self
+    }
+
+    fn with_graft_failure(mut self, reason: &str) -> Self {
+        self.graft_result = Err(WorkspaceError::Graft {
+            reason: reason.into(),
+            path: "tests/witness.rs".into(),
+            workspace: "/candidate/workspace".into(),
+        });
         self
     }
 
@@ -416,6 +446,16 @@ impl CandidateWorkspace for FakeWorkspace {
             format!("adopt:{}:withhold={}", self.id, withhold.join(","))
         });
         self.adopt_result.clone()
+    }
+    async fn graft_witness(&self, source_root: &str, path: &str) -> Result<(), WorkspaceError> {
+        // Logged with the source so a test can prove the artifact came from a
+        // *different* workspace than the one it lands in — the whole point of
+        // authoring blind in a pristine snapshot.
+        self.log
+            .lock()
+            .unwrap()
+            .push(format!("graft:{}:{source_root}:{path}", self.id));
+        self.graft_result.clone()
     }
     async fn remove(&self) {
         self.log.lock().unwrap().push(format!("remove:{}", self.id));
@@ -1244,20 +1284,25 @@ fn assemble_user_message_is_just_the_goal_when_no_recall() {
 /// the run submits fast on deterministic evidence — judge skipped.
 #[tokio::test]
 async fn witness_authored_command_arms_the_flip_oracle_and_submits_fast() {
-    // triage → "single"; witness author turn → marker line; worker → done.
+    // triage → "single"; worker → done; THEN the witness author, because the
+    // warrant only has a diff to read once the worker has produced one.
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
-        text_result("wrote the test.\nTEST_COMMAND: cargo test --test witness witness -- --exact"),
         text_result("done"),
+        text_result("wrote the test.\nTEST_COMMAND: cargo test --test witness witness -- --exact"),
     ]);
-    // Test-command pops: witness fail-check (fail), per-candidate baseline
-    // (fail), post-execute observation (pass) → a genuine flip.
+    // The two halves of the flip now come from two trees. Candidate (id 0):
+    // the post-execute observation passes. Baseline (id 1): the same command
+    // fails on the pre-execution code, which is what makes it a flip rather
+    // than one tree observed twice.
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace =
-        FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone()).with_repo_status(
-            SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
-        );
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
+    );
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
+    );
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
     let (outcome, events, _) = run_isolated(
         &provider,
         &port,
@@ -1371,30 +1416,41 @@ async fn single_model_config_degrades_to_unauthored_witness_instead_of_aborting(
     assert!(warned, "the degradation is announced once: {events:?}");
 }
 
-/// A witness whose test passes on the unmodified code proves nothing: one
-/// bounded repair retry, and if it still passes the contaminated candidate is
-/// discarded rather than letting author-written files reach adoption.
+/// A witness whose test passes on the pre-execution code proves nothing: one
+/// bounded repair retry, and if it still passes the run finishes without one.
+///
+/// What changed with demand-driven authoring is the *cost* of that outcome.
+/// While authoring ran first, a useless witness discarded the whole candidate
+/// and `run` degraded to a fresh bare worker turn — the task was executed
+/// twice because scaffolding failed. Now the work already exists when the
+/// author is asked, so a useless witness costs only the authoring calls and
+/// the candidate finishes on the unauthored ladder. The artifact never leaves
+/// the authoring snapshot, so nothing the author wrote can reach adoption
+/// either way.
 #[tokio::test]
-async fn a_witness_that_never_fails_aborts_and_removes_the_candidate() {
+async fn a_witness_that_never_fails_finishes_the_run_without_re_executing_it() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("done"), // worker
         text_result("TEST_COMMAND: cargo test --test witness always_green -- --exact"),
         // The repair attempt also yields a command that passes -> useless.
         text_result("TEST_COMMAND: cargo test --test witness still_green -- --exact"),
-        // Then the run degrades to a bare worker turn (+ its verification),
-        // so give the fallback generous responses.
-        text_result("done"),
+        // The candidate then finishes on the unauthored ladder, so give the
+        // fallback generous responses.
         text_result("PASS looks right"),
         text_result("done"),
         text_result("PASS looks right"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace =
-        FakeWorkspace::new(0, vec![true, true], Ok(vec![]), log.clone()).with_repo_status(
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    // Both the author's command and its repair PASS on the pre-execution
+    // code, so neither proves anything.
+    let baseline =
+        FakeWorkspace::new(1, vec![true, true], Ok(vec![]), log.clone()).with_repo_status(
             SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
         );
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
-    let (outcome, events) = run_degrade_over_working_session(
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
+    let (outcome, events, _) = run_isolated(
         &provider,
         &port,
         PipelineConfig::default(),
@@ -1412,64 +1468,29 @@ async fn a_witness_that_never_fails_aborts_and_removes_the_candidate() {
         events.iter().any(|e| matches!(
             e,
             AgentEvent::Error { message, retryable: true }
-                if message.contains("running a bare worker turn")
+                if message.contains("continuing without an authored witness")
         )),
         "the degradation announces itself: {events:?}"
     );
-}
-
-/// Tamper exclusion: the worker modified the witness test file after it
-/// was authored, so the candidate hard-fails without judge override.
-#[tokio::test]
-async fn a_tampered_witness_file_hard_fails_before_judge_evaluation() {
-    let provider = ScriptedProvider::new(vec![
-        text_result("single"),
-        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
-        text_result("done"),                     // worker
-        text_result("FAIL the test was edited"), // must remain unused
-    ]);
-    // witness check (fail), baseline (fail), post-execute (pass) → the
-    // oracle flips — but the tamper check below must hard-fail the candidate.
-    // untracked_fingerprints call order: witness-before (empty),
-    // witness-after (test authored at w1 → watchlist), candidate
-    // untracked_before, gather_diff after execute, tamper check — where
-    // the file now reads w2: TAMPERED.
-    let repo_status = SeqRepoStatus::new(vec![
-        vec![],
-        vec![("tests/witness.rs", "w1")],
-        vec![("tests/witness.rs", "w1")],
-        vec![("tests/witness.rs", "w1")],
-        vec![("tests/witness.rs", "w2")],
-    ])
-    .with_artifact_identities(vec![
-        Some(ArtifactIdentity {
-            fingerprint: "w1".into(),
-            kind: ArtifactKind::Regular,
-            mode: 0o100644,
-            link_count: 1,
-        }),
-        Some(ArtifactIdentity {
-            fingerprint: "w2".into(),
-            kind: ArtifactKind::Regular,
-            mode: 0o100644,
-            link_count: 1,
-        }),
-    ]);
-    let config = PipelineConfig {
-        max_revisions: 0, // judge FAIL ends the run — keeps the script short
-        ..PipelineConfig::default()
-    };
-    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(repo_status);
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
-    let (outcome, events, _) = run_isolated(&provider, &port, config, "Fix the retry bug").await;
-    let outcome = outcome.expect("run succeeds");
-
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
+    // The verdict is not deterministic: with no witness there was no flip, so
+    // the ladder had to buy the judge. Nothing is scored as proven.
+    let verdict = outcome.verdict.expect("verified");
     assert!(
-        !stages(&events).contains(&StageKind::Judge),
-        "tamper is not eligible for judge override"
+        !verdict.deterministic,
+        "an unauthored run has no deterministic evidence: {}",
+        verdict.summary
+    );
+    // One candidate workspace and one authoring snapshot — NOT a second
+    // execution. The old behavior re-ran the whole task here.
+    let log = log.lock().unwrap().clone();
+    assert_eq!(
+        log.iter().filter(|entry| *entry == "create").count(),
+        2,
+        "one candidate + one authoring snapshot: {log:?}"
+    );
+    assert!(
+        !log.iter().any(|entry| entry.starts_with("graft:")),
+        "a rejected witness is never grafted into the candidate: {log:?}"
     );
 }
 
@@ -1660,53 +1681,6 @@ async fn a_setup_failure_degrades_to_a_bare_execution_instead_of_aborting() {
         "the degradation announces itself once: {events:?}"
     );
 }
-
-/// Like [`run_unisolated_with_router`] but WITH a candidate workspace port,
-/// for exercising the setup-failure -> bare-execution degrade: the candidate
-/// path fails, and the bare fallback must run over these WORKING session
-/// ports (unlike `run_isolated`, whose session ports panic on touch).
-async fn run_degrade_over_working_session(
-    provider: &ScriptedProvider,
-    port: &FakeWorkspacePort,
-    config: PipelineConfig,
-    goal: &str,
-) -> (Result<PipelineOutcome, PipelineRunError>, Vec<AgentEvent>) {
-    let resolver = OneProvider(provider);
-    let runner = ScriptedRunner::new(vec![], "@@ -1 +1 @@\n-a\n+b");
-    let repo_status = SeqRepoStatus::new(vec![vec![]]);
-    let tools = EmptyTools;
-    let recall = NoContextRecall;
-    let repo = NoRepoStructure;
-    let approvals = AutoApproveGate;
-    let sleeper = NoopSleeper;
-    let router = router();
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let pipeline = Pipeline::new(
-        PipelinePorts {
-            router: &router,
-            providers: &resolver,
-            tools: &tools,
-            recall: &recall,
-            repo: &repo,
-            repo_status: &repo_status,
-            diagnostics: &runner,
-            tests: &runner,
-            approvals: &approvals,
-            sleeper: &sleeper,
-            hooks: None,
-            candidate_workspaces: Some(port),
-            mcp_prefetch: None,
-            steering: None,
-        },
-        tx,
-        config,
-    );
-    let mut messages = vec![CompletionMessage::system("sys")];
-    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
-    let outcome = pipeline.run(goal, &mut messages, &mut budget).await;
-    (outcome, drain(&mut rx))
-}
-
 async fn run_unisolated_with_router(
     provider: &ScriptedProvider,
     config: PipelineConfig,

--- a/stella-pipeline/src/pipeline/tests/usage.rs
+++ b/stella-pipeline/src/pipeline/tests/usage.rs
@@ -15,7 +15,7 @@ fn usage_events(events: &[AgentEvent]) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn usage_roles(events: &[AgentEvent]) -> Vec<String> {
+pub(super) fn usage_roles(events: &[AgentEvent]) -> Vec<String> {
     usage_events(events)
         .into_iter()
         .filter_map(|event| event.get("role")?.as_str().map(str::to_owned))
@@ -233,21 +233,20 @@ async fn plan_and_plan_repair_each_emit_one_paid_call_envelope() {
 async fn witness_author_and_repair_are_individually_metered_before_degrade() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("done"), // worker executes before the author is asked
         text_result("TEST_COMMAND: cargo test --test witness always_green -- --exact"),
         text_result("TEST_COMMAND: cargo test --test witness still_green -- --exact"),
-        // The useless witness degrades to a bare worker turn (+ verification).
-        text_result("done"),
-        text_result("PASS looks right"),
-        text_result("done"),
+        // The useless witness leaves the candidate on the unauthored ladder.
         text_result("PASS looks right"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace =
-        FakeWorkspace::new(0, vec![true, true], Ok(vec![]), log.clone()).with_repo_status(
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    let baseline =
+        FakeWorkspace::new(1, vec![true, true], Ok(vec![]), log.clone()).with_repo_status(
             SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
         );
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
-    let (outcome, events) = run_degrade_over_working_session(
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
+    let (outcome, events, _) = run_isolated(
         &provider,
         &port,
         PipelineConfig::default(),
@@ -255,11 +254,13 @@ async fn witness_author_and_repair_are_individually_metered_before_degrade() {
     )
     .await;
     // The witness author and its repair are each metered individually, even
-    // though the useless witness then degrades rather than aborts.
+    // though the useless witness then degrades rather than aborts. The worker
+    // now sits between triage and the author, because authoring is demand-
+    // driven: it is only bought once there is a diff worth proving.
     let roles = usage_roles(&events);
     assert_eq!(
-        &roles[..3],
-        ["triage", "witness_author", "witness_repair"],
+        &roles[..4],
+        ["triage", "worker", "witness_author", "witness_repair"],
         "author and repair are individually metered: {roles:?}"
     );
     assert!(

--- a/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -76,25 +76,35 @@ impl HookRunner for RecordingHookRunner {
 async fn witness_worker_and_revision_hooks_are_bound_to_the_candidate_root() {
     let candidate_root = tempfile::tempdir().unwrap();
     let session_root = tempfile::tempdir().unwrap();
+    let baseline_root = tempfile::tempdir().unwrap();
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        tool_result("write_file"),
+        text_result("worker done"),
+        // Authoring runs after the worker, and its tool call must NOT fire a
+        // hook: the authoring snapshot is not the user's tree.
         tool_result("write_file"),
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
         tool_result("write_file"),
-        text_result("worker done"),
-        tool_result("write_file"),
         text_result("revision done"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![false, false, false, true], Ok(vec![]), log.clone())
+    // Candidate: post-execute observation fails, then the revision's passes.
+    let candidate = FakeWorkspace::new(0, vec![false, true], Ok(vec![]), log.clone())
         .with_root(candidate_root.path().display().to_string())
         .with_repo_status(SeqRepoStatus::new(vec![
             vec![],
             vec![("tests/authority_witness.rs", "sha256:test")],
         ]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_root(baseline_root.path().display().to_string())
+        .with_repo_status(SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/authority_witness.rs", "sha256:test")],
+        ]));
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
     let resolver = OneProvider(&provider);
     let session_runner = NeverRunner;
     let session_status = NeverRepoStatus;
@@ -247,27 +257,43 @@ async fn authored_witness_degrades_when_judge_is_worker() {
     assert!(!stages(&events).contains(&StageKind::Witness));
 }
 
-/// `keep_witness` is the explicit promotion step: the same run, opted in,
-/// adopts the witness alongside the work. Paired with the default-path
-/// assertion in `authored_witness_with_one_candidate_uses_one_disposable_snapshot`,
-/// this pins BOTH directions of the flag — a default-only test would still
-/// pass if the flag were ignored entirely.
-#[tokio::test]
-async fn keep_witness_promotes_the_authored_witness_into_the_real_tree() {
+/// The candidate that executes (id 0) and the pristine snapshot the witness is
+/// authored in (id 1), with distinct roots so a graft's source is provable.
+fn witness_pair(
+    log: &Arc<std::sync::Mutex<Vec<String>>>,
+) -> (FakeWorkspace, FakeWorkspace, ScriptedProvider) {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("done"), // worker executes FIRST
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
-        text_result("done"),
     ]);
-    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![
+            vec![],
+            vec![("tests/authority_witness.rs", "sha256:test")],
+        ]),
+    );
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_root("/authoring/snapshot")
         .with_repo_status(SeqRepoStatus::new(vec![
             vec![],
             vec![("tests/authority_witness.rs", "sha256:test")],
         ]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    (candidate, baseline, provider)
+}
+
+/// `keep_witness` is the explicit promotion step: the same run, opted in,
+/// adopts the witness alongside the work. Paired with the default-path
+/// assertion in `authored_witness_uses_a_disposable_snapshot_and_grafts_one_file`,
+/// this pins BOTH directions of the flag — a default-only test would still
+/// pass if the flag were ignored entirely.
+#[tokio::test]
+async fn keep_witness_promotes_the_authored_witness_into_the_real_tree() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (candidate, baseline, provider) = witness_pair(&log);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -284,27 +310,30 @@ async fn keep_witness_promotes_the_authored_witness_into_the_real_tree() {
     assert_eq!(outcome.status, PipelineStatus::Completed);
     assert_eq!(
         *log.lock().unwrap(),
-        vec!["create", "seal:0", "adopt:0", "remove:0"],
+        vec![
+            "create",
+            "create",
+            "graft:0:/authoring/snapshot:tests/authority_witness.rs",
+            "remove:1",
+            "seal:0",
+            "adopt:0",
+            "remove:0"
+        ],
         "keep_witness withholds nothing — the witness is adopted with the work"
     );
 }
 
+/// One candidate workspace to execute in, one throwaway snapshot to author
+/// blind in, and exactly one file crossing between them.
+///
+/// The authoring snapshot is created only because the warrant asked for a
+/// witness, and it is removed the moment the artifact has been copied across —
+/// it never seals, never adopts, and never outlives the stage.
 #[tokio::test]
-async fn authored_witness_with_one_candidate_uses_one_disposable_snapshot() {
-    let provider = ScriptedProvider::new(vec![
-        text_result("single"),
-        text_result(
-            "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
-        ),
-        text_result("done"),
-    ]);
+async fn authored_witness_uses_a_disposable_snapshot_and_grafts_one_file() {
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(SeqRepoStatus::new(vec![
-            vec![],
-            vec![("tests/authority_witness.rs", "sha256:test")],
-        ]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    let (candidate, baseline, provider) = witness_pair(&log);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -322,12 +351,17 @@ async fn authored_witness_with_one_candidate_uses_one_disposable_snapshot() {
         *log.lock().unwrap(),
         vec![
             "create",
+            "create",
+            // Grafted INTO candidate 0, FROM the authoring snapshot's root:
+            // the author worked in a tree that never saw the worker's edits.
+            "graft:0:/authoring/snapshot:tests/authority_witness.rs",
+            "remove:1",
             "seal:0",
             "adopt:0:withhold=tests/authority_witness.rs",
             "remove:0"
         ],
-        "authoring, worker verification, and adoption share one workspace, \
-         and the witness is withheld from the real tree by default"
+        "the witness is authored elsewhere, grafted in to be run, and withheld \
+         from the real tree by default"
     );
 }
 
@@ -335,10 +369,10 @@ async fn authored_witness_with_one_candidate_uses_one_disposable_snapshot() {
 async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_files() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("done"), // worker
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
-        text_result("done"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let identity = ArtifactIdentity {
@@ -347,19 +381,25 @@ async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_
         mode: 0o100644,
         link_count: 1,
     };
-    let status = SeqRepoStatus::new(vec![
+    let candidate_status = SeqRepoStatus::new(vec![
         vec![],
         vec![("tests/authority_witness.rs", "sha256:test")],
-        vec![("tests/authority_witness.rs", "sha256:test")],
-        vec![("tests/authority_witness.rs", "sha256:test")],
-        // `git add -A && git commit` in `seal()` makes the accepted witness
+        // `git add -A && git commit` in `seal()` makes the grafted witness
         // tracked. Classification changes; filesystem identity does not.
         vec![],
     ])
+    .with_artifact_identity(identity.clone());
+    let baseline_status = SeqRepoStatus::new(vec![
+        vec![],
+        vec![("tests/authority_witness.rs", "sha256:test")],
+    ])
     .with_artifact_identity(identity);
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(status);
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_repo_status(candidate_status);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_root("/authoring/snapshot")
+        .with_repo_status(baseline_status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -378,6 +418,9 @@ async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_
         *log.lock().unwrap(),
         vec![
             "create",
+            "create",
+            "graft:0:/authoring/snapshot:tests/authority_witness.rs",
+            "remove:1",
             "seal:0",
             "adopt:0:withhold=tests/authority_witness.rs",
             "remove:0"
@@ -458,10 +501,28 @@ async fn authored_witness_isolation_failure_degrades_to_a_bare_run() {
     );
 }
 
+/// Assert an aborted run stopped for the stated reason.
+///
+/// Every abort test below scripts a provider, and an exhausted `ScriptedProvider`
+/// *also* aborts the run — with a passing `matches!(.., Aborted { .. })`. So
+/// matching on the variant alone cannot tell "the integrity gate fired" from
+/// "the fixture ran out of responses one turn earlier", and a reordering of the
+/// pipeline silently converts these guards into tests of the fixture.
+fn assert_aborted_because(status: &PipelineStatus, expected: &str) {
+    let PipelineStatus::Aborted { reason } = status else {
+        panic!("expected an aborted run, got {status:?}");
+    };
+    assert!(
+        reason.contains(expected),
+        "aborted for the wrong reason\n  expected to contain: {expected}\n  actual: {reason}"
+    );
+}
+
 #[tokio::test]
 async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("worker done"),
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
@@ -472,12 +533,13 @@ async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
         vec![("tests/authority_witness.rs", "sha256:test")],
     ])
     .with_tracked(vec![vec![], vec![("src/lib.rs", "sha256:mutated")]]);
-    // The witness test FAILS on unmodified code (vec![false]) so the flow
-    // reaches the tracked-file mutation check — a fail-closed SECURITY
-    // rejection — rather than the (now degradable) repair path.
-    let workspace =
-        FakeWorkspace::new(0, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    // The witness test FAILS on the pre-execution code (vec![false]) so the
+    // flow reaches the tracked-file mutation check — a fail-closed SECURITY
+    // rejection — rather than the (degradable) repair path.
+    let baseline =
+        FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -487,28 +549,41 @@ async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
     )
     .await;
     let outcome = outcome.expect("author mutation is an aborted candidate");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
+    assert_aborted_because(
+        &outcome.status,
+        "witness author modified tracked file(s): src/lib.rs",
+    );
     let log = log.lock().unwrap().clone();
     assert!(!log.iter().any(|entry| entry.starts_with("adopt:")));
     assert!(log.contains(&"remove:0".to_string()));
+    assert!(
+        log.contains(&"remove:1".to_string()),
+        "the authoring snapshot is torn down even when it is what failed: {log:?}"
+    );
 }
 
+/// An artifact whose language does not match its runner is rejected — and now
+/// rejected *after* the worker has run, because that is when authoring happens.
+/// The fail-closed decision is unchanged; what it costs changed, and this pins
+/// both halves so the trade is visible rather than assumed.
 #[tokio::test]
-async fn witness_language_mismatch_aborts_before_worker_execution() {
+async fn witness_language_mismatch_aborts_after_worker_execution() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("worker done"),
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
-        text_result("worker done"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(SeqRepoStatus::new(vec![
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![
             vec![],
             vec![("tests/test_authority.py", "sha256:test")],
-        ]));
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+        ]),
+    );
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -518,18 +593,26 @@ async fn witness_language_mismatch_aborts_before_worker_execution() {
     )
     .await;
     let outcome = outcome.expect("mismatch is a truthful candidate abort");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
-    assert_eq!(*log.lock().unwrap(), vec!["create", "remove:0"]);
+    assert_aborted_because(
+        &outcome.status,
+        "witness artifact `tests/test_authority.py` does not match test runner `cargo`",
+    );
+    // Two snapshots, both torn down, nothing adopted: a rejected witness never
+    // reaches the real tree and never leaks a workspace.
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["create", "create", "remove:1", "remove:0"]
+    );
 }
 
 #[tokio::test]
-async fn symlink_witness_artifact_aborts_before_worker_execution() {
+async fn symlink_witness_artifact_aborts_after_worker_execution() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
+        text_result("worker done"),
         text_result(
             "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
         ),
-        text_result("worker done"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let status = SeqRepoStatus::new(vec![
@@ -542,9 +625,10 @@ async fn symlink_witness_artifact_aborts_before_worker_execution() {
         mode: 0o120777,
         link_count: 1,
     });
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(status);
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone());
+    let baseline =
+        FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, _, _) = run_isolated(
         &provider,
@@ -554,23 +638,32 @@ async fn symlink_witness_artifact_aborts_before_worker_execution() {
     )
     .await;
     let outcome = outcome.expect("symlink is a truthful candidate abort");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
-    assert_eq!(*log.lock().unwrap(), vec!["create", "remove:0"]);
+    // Rejected in the tree that authored it, before any copy — a symlink must
+    // never be resolved by the graft into the candidate.
+    assert_aborted_because(
+        &outcome.status,
+        "witness artifact `tests/authority_witness.rs` has an unsafe or unstable filesystem identity",
+    );
+    let log = log.lock().unwrap().clone();
+    assert!(
+        !log.iter().any(|entry| entry.starts_with("graft:")),
+        "a symlink artifact is rejected before it can be grafted: {log:?}"
+    );
 }
 
 #[tokio::test]
 async fn post_baseline_witness_tamper_is_hard_failure_even_if_judge_would_pass() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
-        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
         text_result("worker done"),
+        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
         text_result("PASS override attempt"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let status = SeqRepoStatus::new(vec![
+    // Candidate: pinned at w1 straight after the graft, then found at w2 by
+    // the tamper check — the worker rewrote the test it was being judged by.
+    let candidate_status = SeqRepoStatus::new(vec![
         vec![],
-        vec![("tests/witness.rs", "w1")],
-        vec![("tests/witness.rs", "w1")],
         vec![("tests/witness.rs", "w1")],
         vec![("tests/witness.rs", "w2")],
     ])
@@ -588,9 +681,18 @@ async fn post_baseline_witness_tamper_is_hard_failure_even_if_judge_would_pass()
             link_count: 1,
         }),
     ]);
-    let workspace = FakeWorkspace::new(0, vec![false, false, true], Ok(vec![]), log.clone())
-        .with_repo_status(status);
-    let port = FakeWorkspacePort::new(vec![Ok(workspace)], log.clone());
+    let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
+        .with_artifact_identity(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        });
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_repo_status(candidate_status);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_repo_status(baseline_status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
     let (outcome, events, _) = run_isolated(
         &provider,
@@ -603,7 +705,10 @@ async fn post_baseline_witness_tamper_is_hard_failure_even_if_judge_would_pass()
     )
     .await;
     let outcome = outcome.expect("tamper is a truthful candidate failure");
-    assert!(matches!(outcome.status, PipelineStatus::Aborted { .. }));
+    assert_aborted_because(
+        &outcome.status,
+        "witness artifact changed after its accepted baseline: tests/witness.rs",
+    );
     assert!(!stages(&events).contains(&StageKind::Judge));
     let log = log.lock().unwrap().clone();
     assert!(
@@ -682,4 +787,279 @@ async fn post_verification_candidate_drift_is_rejected_before_adoption() {
         "{log:?}"
     );
     assert!(log.contains(&"remove:0".to_string()));
+}
+
+/// The saving this change exists for: a change with nothing to prove buys no
+/// witness at all.
+///
+/// The worker edits documentation only. Because authoring now runs *after*
+/// execution, `witness::warrant` reads that diff before anything is bought and
+/// answers `DocsOnly` — so no authoring snapshot is created and no author model
+/// call is dispatched. Under the previous ordering this exact run paid for a
+/// witness author turn against a tree that had not been touched yet, and only
+/// discovered afterwards that the change was prose.
+///
+/// Scripting exactly THREE provider responses is what makes this a real test: a
+/// surviving witness-author call would exhaust the queue and abort the run.
+#[tokio::test]
+async fn a_docs_only_change_authors_no_witness_and_creates_no_second_snapshot() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("updated the docs"), // worker
+        text_result("PASS reads well"),  // judge: TestsOnly/PureRemoval keep it
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let candidate = FakeWorkspace::new(0, vec![], Ok(vec![]), log.clone())
+        .with_diff("--- a/docs/retry.md\n+++ b/docs/retry.md\n@@ -1 +1 @@\n-old prose\n+new prose");
+    // ONE workspace queued. A second `create` would fail the snapshot and warn,
+    // so the `create` count assertion below cannot be satisfied by accident.
+    let port = FakeWorkspacePort::new(vec![Ok(candidate)], log.clone());
+    let (outcome, events, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig::default(),
+        "Document the retry helper",
+    )
+    .await;
+    let outcome = outcome.expect("run succeeds");
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    let verdict = outcome.verdict.expect("verified");
+    assert!(verdict.passed);
+    assert!(
+        verdict.summary.contains("documentation only"),
+        "the run states why no test was written: {}",
+        verdict.summary
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Witness),
+        "no witness stage runs when nothing warrants one: {:?}",
+        stages(&events)
+    );
+    assert!(
+        !usage::usage_roles(&events)
+            .iter()
+            .any(|role| role == "witness_author"),
+        "a docs-only change dispatches no author call: {:?}",
+        usage::usage_roles(&events)
+    );
+    let log = log.lock().unwrap().clone();
+    assert_eq!(
+        log.iter().filter(|entry| *entry == "create").count(),
+        1,
+        "no authoring snapshot is taken for a change with nothing to prove: {log:?}"
+    );
+}
+
+/// A graft that cannot land degrades; it does not discard the work.
+///
+/// The realistic collision: the worker wrote its own test at the path the
+/// author chose. Overwriting would destroy real work to make room for
+/// scaffolding, so the graft fails — and because execution already happened,
+/// the candidate finishes on the unauthored ladder instead of being thrown
+/// away. Fail-closed still applies to artifacts that cannot be *trusted*; this
+/// is one that cannot be *placed*.
+#[tokio::test]
+async fn a_graft_collision_keeps_the_work_and_drops_only_the_witness() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"), // worker
+        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
+        text_result("PASS looks right"), // judge, since there is no flip
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_graft_failure("exclusive file creation failed: File exists (os error 17)");
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(
+        SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]]),
+    );
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
+    let (outcome, events, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig::default(),
+        "Fix the retry bug",
+    )
+    .await;
+    let outcome = outcome.expect("a failed graft is not a failed run");
+
+    assert!(
+        !matches!(outcome.status, PipelineStatus::Aborted { .. }),
+        "the worker's change survives a failed graft: {outcome:?}"
+    );
+    let verdict = outcome.verdict.expect("verified");
+    assert!(
+        !verdict.deterministic,
+        "with no witness in the tree there is no flip to be deterministic about: {}",
+        verdict.summary
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("continuing without an authored witness")
+        )),
+        "the degradation announces itself: {events:?}"
+    );
+    // Nothing is withheld, because nothing was grafted — the withhold list and
+    // what is actually in the tree can never disagree.
+    let log = log.lock().unwrap().clone();
+    assert!(
+        log.contains(&"adopt:0".to_string()),
+        "the work is adopted with no witness to withhold: {log:?}"
+    );
+}
+
+/// Tamper exclusion: the worker modified the witness test file after it
+/// was authored, so the candidate hard-fails without judge override.
+#[tokio::test]
+async fn a_tampered_witness_file_hard_fails_before_judge_evaluation() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"), // worker
+        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
+        text_result("FAIL the test was edited"), // must remain unused
+    ]);
+    // The candidate's own repo status. `artifact_identity` is asked twice: once
+    // right after the graft, to pin the baseline against the bytes that will
+    // actually run (w1), and once at the tamper check, where the worker has
+    // since rewritten the file (w2) — TAMPERED.
+    let candidate_status = SeqRepoStatus::new(vec![
+        vec![],
+        vec![("tests/witness.rs", "w1")],
+        vec![("tests/witness.rs", "w2")],
+    ])
+    .with_artifact_identities(vec![
+        Some(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        }),
+        Some(ArtifactIdentity {
+            fingerprint: "w2".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        }),
+    ]);
+    // The authoring snapshot: the artifact appears (w1) and is accepted there.
+    let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
+        .with_artifact_identity(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        });
+    let config = PipelineConfig {
+        max_revisions: 0, // judge FAIL ends the run — keeps the script short
+        ..PipelineConfig::default()
+    };
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Candidate: the post-execute observation PASSES, so the oracle flips and
+    // the ladder would otherwise submit fast. Tamper must override that.
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_repo_status(candidate_status);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_repo_status(baseline_status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log);
+    let (outcome, events, _) = run_isolated(&provider, &port, config, "Fix the retry bug").await;
+    let outcome = outcome.expect("run succeeds");
+
+    let PipelineStatus::Aborted { reason } = &outcome.status else {
+        panic!("tamper must abort the candidate, got {:?}", outcome.status);
+    };
+    assert!(
+        reason.contains("witness artifact changed after its accepted baseline: tests/witness.rs"),
+        "aborted for the wrong reason: {reason}"
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Judge),
+        "tamper is not eligible for judge override"
+    );
+}
+
+/// The grafted witness is scaffolding, not the worker's work, so it must never
+/// be attributed to the turn's diff.
+///
+/// Authoring-before-execute got this exclusion for free: the artifact existed
+/// before `untracked_before` was snapshotted, so every later gather saw it as
+/// pre-existing dirty state. Grafting after execution writes the file *after*
+/// that snapshot, so the next gather — the one a revision performs — would read
+/// a new untracked file and bill it to the worker, inflating `diff_lines`
+/// against the SubmitFast budget and showing a judge a change nobody made.
+/// `witness_on_demand` enrolls the grafted path at its pinned fingerprint to
+/// restore the exclusion.
+#[tokio::test]
+async fn a_grafted_witness_is_not_billed_to_the_workers_diff() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"), // worker
+        text_result(
+            "TEST_COMMAND: cargo test --test authority_witness authority_witness -- --exact",
+        ),
+        text_result("revision done"),
+        // No judge response. An escalation past SubmitFast aborts the run
+        // rather than quietly passing on a heuristic.
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let identity = ArtifactIdentity {
+        fingerprint: "sha256:test".into(),
+        kind: ArtifactKind::Regular,
+        mode: 0o100644,
+        link_count: 1,
+    };
+    // The witness only appears in the candidate's untracked set once it has
+    // been grafted — i.e. from the revision's diff gather onward, which is
+    // exactly the gather that would misattribute it.
+    let candidate = FakeWorkspace::new(0, vec![false, true], Ok(vec![]), log.clone())
+        .with_untracked(vec![("tests/authority_witness.rs", 40)])
+        .with_repo_status(
+            SeqRepoStatus::new(vec![
+                vec![],
+                vec![],
+                vec![("tests/authority_witness.rs", "sha256:test")],
+            ])
+            .with_artifact_identity(identity.clone()),
+        );
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_root("/authoring/snapshot")
+        .with_repo_status(
+            SeqRepoStatus::new(vec![
+                vec![],
+                vec![("tests/authority_witness.rs", "sha256:test")],
+            ])
+            .with_artifact_identity(identity),
+        );
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
+
+    let (outcome, events, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig {
+            candidates: Some(1),
+            max_revisions: 1,
+            // Deliberately tiny. The worker's own diff fits; the witness's 40
+            // added lines would not, so SubmitFast survives only if the
+            // grafted artifact is excluded from the count.
+            diff_budget_lines: 5,
+            ..PipelineConfig::default()
+        },
+        "Fix the failing test",
+    )
+    .await;
+    let outcome = outcome.expect("run succeeds");
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+
+    let verdict = outcome.verdict.expect("verified");
+    assert!(
+        verdict.deterministic,
+        "the flip submits fast; the witness never entered the diff budget: {}",
+        verdict.summary
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Judge),
+        "no judge is bought: {:?}",
+        stages(&events)
+    );
 }

--- a/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/stella-pipeline/src/pipeline/witness_stage.rs
@@ -57,6 +57,23 @@ impl WitnessAbort {
     }
 }
 
+/// Everything one candidate needs to buy itself a witness *after* it has
+/// executed and the warrant has read the resulting diff.
+///
+/// Carried as one optional value rather than three loose parameters so the
+/// invariant is structural: a candidate either can author (isolation port,
+/// resolved independent author, and the frames to prompt with — all present)
+/// or cannot (`None`). There is no state where it holds a port but no author.
+#[derive(Clone, Copy)]
+pub(super) struct WitnessAuthoring<'c> {
+    /// Snapshots the *pre-execution* tree for the author to work blind in.
+    /// The same port that made the executing candidate, called a second time.
+    pub(super) port: &'c dyn CandidateWorkspacePort,
+    /// The independent author — resolved as a different model from the worker.
+    pub(super) author: &'c ResolvedRole<'c>,
+    pub(super) frames: &'c [RecalledFrame],
+}
+
 impl<'a> Pipeline<'a> {
     pub(super) fn engine_config_for(&self, surface: CandidateSurface<'_>) -> EngineConfig {
         let mut config = self.config.engine.clone();
@@ -66,14 +83,38 @@ impl<'a> Pipeline<'a> {
         config
     }
 
-    /// Author one failing witness inside the same disposable candidate that
-    /// will execute, revise, verify, and (only on pass) adopt it.
+    /// Author one failing witness in `baseline` — a pristine snapshot of the
+    /// tree as it stood *before* execution — and graft the artifact it accepts
+    /// into `candidate`, the tree that actually did the work.
+    ///
+    /// # Why two trees
+    ///
+    /// This stage runs *after* execution, so that the warrant
+    /// ([`crate::witness::warrant`]) can read the diff and skip authoring
+    /// entirely when the change has nothing to prove. That ordering creates a
+    /// hazard the pre-execution version did not have: by now an implementation
+    /// exists, and an author allowed to read it will write a test that restates
+    /// it. Such a test still fails on the old code and passes on the new, so the
+    /// flip oracle would confirm it — while proving only that the code equals
+    /// itself.
+    ///
+    /// The fix is to keep the author's *input* byte-identical to what it was
+    /// when this stage ran first: the goal, the recalled frames, and the
+    /// unmodified tree. `baseline` is a second [`CandidateWorkspacePort::create`]
+    /// snapshot, which sees the pre-execution tree because a candidate's edits
+    /// never leave its own workspace until adoption. So the author is blind to
+    /// the implementation, and moving this call later buys cost, never leverage.
+    ///
+    /// `baseline` is also where the artifact must FAIL, which is what makes the
+    /// later pass in `candidate` a genuine fail→pass flip across two code
+    /// states rather than one tree observed twice.
     pub(super) async fn witness_stage(
         &self,
         goal: &str,
         frames: &[RecalledFrame],
         author: &ResolvedRole<'a>,
-        surface: CandidateSurface<'_>,
+        baseline: CandidateSurface<'_>,
+        candidate: CandidateSurface<'_>,
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> Result<Option<Witness>, WitnessAbort> {
@@ -81,17 +122,17 @@ impl<'a> Pipeline<'a> {
             name: StageKind::Witness,
         });
 
-        let tracked_before = surface.repo_status.tracked_fingerprints().await;
-        let untracked_before = surface.repo_status.untracked_fingerprints().await;
+        let tracked_before = baseline.repo_status.tracked_fingerprints().await;
+        let untracked_before = baseline.repo_status.untracked_fingerprints().await;
         let structure = self.repo.structure_summary().await;
-        let witness_tools = surface
+        let baseline_workspace = baseline
             .workspace
-            .expect("witness authoring requires a candidate workspace")
-            .witness_tools();
+            .expect("witness authoring requires a pristine baseline workspace");
+        let witness_tools = baseline_workspace.witness_tools();
         let engine = Engine::with_sleeper(
             author.provider,
             witness_tools,
-            self.engine_config_for(surface),
+            self.engine_config_for(baseline),
             self.sleeper,
         )
         .with_call_role(stella_protocol::ModelCallRole::WitnessAuthor);
@@ -130,12 +171,12 @@ impl<'a> Pipeline<'a> {
                 "witness author produced an unsafe or unsupported test command `{command}`"
             )));
         };
-        if surface.tests.run_test(&invocation).await.passed() {
+        if baseline.tests.run_test(&invocation).await.passed() {
             messages.push(CompletionMessage::user(witness_repair_prompt(&command)));
             let repair_engine = Engine::with_sleeper(
                 author.provider,
                 witness_tools,
-                self.engine_config_for(surface),
+                self.engine_config_for(baseline),
                 self.sleeper,
             )
             .with_call_role(stella_protocol::ModelCallRole::WitnessRepair);
@@ -164,15 +205,15 @@ impl<'a> Pipeline<'a> {
                 )));
             };
             invocation = repaired_invocation;
-            if surface.tests.run_test(&invocation).await.passed() {
+            if baseline.tests.run_test(&invocation).await.passed() {
                 return Err(WitnessAbort::degradable(
                     "witness test still passes on the unmodified code after one repair".to_string(),
                 ));
             }
         }
 
-        let tracked_after = surface.repo_status.tracked_fingerprints().await;
-        let untracked_after = surface.repo_status.untracked_fingerprints().await;
+        let tracked_after = baseline.repo_status.tracked_fingerprints().await;
+        let untracked_after = baseline.repo_status.untracked_fingerprints().await;
         let fingerprints = validate_witness_artifact(
             &tracked_before,
             &tracked_after,
@@ -186,7 +227,30 @@ impl<'a> Pipeline<'a> {
             .expect("validated witness artifact contains exactly one path");
         validate_witness_invocation(path, &invocation)
             .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
-        let identity = surface.repo_status.artifact_identity(path).await;
+        // Accept the artifact where it was written before copying it anywhere:
+        // a symlink or multiply-linked file must be rejected in the snapshot
+        // that produced it, never resolved by a copy.
+        let authored = baseline.repo_status.artifact_identity(path).await;
+        validate_witness_identity(path, &fingerprints[path], authored.as_ref())
+            .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
+
+        // Cross into the tree that executed. A failure here is degradable: the
+        // candidate's work is untouched and already done, so it falls through
+        // to the unauthored ladder rather than being discarded for want of
+        // scaffolding.
+        candidate
+            .workspace
+            .expect("witness grafting requires the candidate workspace")
+            .graft_witness(baseline_workspace.root(), path)
+            .await
+            .map_err(|error| WitnessAbort::degradable(error.to_string()))?;
+
+        // Re-pin against the *grafted* copy. Tamper exclusion runs against the
+        // candidate's repo status for the rest of the run, so the baseline it
+        // compares to has to be the identity of the bytes that will actually
+        // execute — not the identity of the original in a snapshot that is
+        // about to be deleted.
+        let identity = candidate.repo_status.artifact_identity(path).await;
         validate_witness_identity(path, &fingerprints[path], identity.as_ref())
             .map_err(|error| WitnessAbort::rejected(error.to_string()))?;
         let files = HashMap::from([(
@@ -198,5 +262,107 @@ impl<'a> Pipeline<'a> {
             invocation,
             files,
         }))
+    }
+
+    /// Author a witness for this candidate only if its diff warrants one.
+    ///
+    /// The saving this exists for: [`crate::witness::warrant`] answers from the
+    /// change itself, so a docs edit, a comment fix, or a turn that touched
+    /// nothing returns here having spent zero model calls. Before authoring
+    /// moved after execution, that same run paid for an author turn (and
+    /// sometimes a repair turn) to produce a test for a change with nothing to
+    /// prove, and only afterwards discovered the warrant.
+    ///
+    /// `Err` is reserved for fail-closed integrity rejections. Everything else
+    /// — no isolation port for the baseline, an author that got stuck, an
+    /// artifact that could not be grafted — returns `Ok(None)` and lets the
+    /// candidate finish on the unauthored ladder. That asymmetry is new and
+    /// deliberate: the work is already done by the time this runs, so a witness
+    /// that cannot be *produced* must not throw away a real change, while a
+    /// witness that cannot be *trusted* must still stop the run.
+    pub(super) async fn witness_on_demand(
+        &self,
+        goal: &str,
+        authoring: Option<WitnessAuthoring<'_>>,
+        surface: CandidateSurface<'_>,
+        state: &mut CandidateState,
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Result<Option<Witness>, String> {
+        let Some(authoring) = authoring else {
+            return Ok(None);
+        };
+        if !warrant(&state.diff_text, state.file_changes).is_required() {
+            // No Witness stage is emitted, because none runs. The reason is
+            // not lost: `warranted_completion` reads the same warrant during
+            // verification and records the sentence on the verdict, which is
+            // the run's half of "a witness test, or a stated reason there
+            // isn't one".
+            return Ok(None);
+        }
+
+        // A second snapshot of the same untouched tree. The candidate's edits
+        // live only in the candidate's own workspace until adoption, so this
+        // sees exactly the pre-execution state the author used to be given.
+        let baseline = match authoring.port.create().await {
+            Ok(baseline) => baseline,
+            Err(e) => {
+                self.warn(format!("witness authoring skipped: {e}"));
+                return Ok(None);
+            }
+        };
+        let baseline_surface = CandidateSurface {
+            diagnostics: baseline.diagnostics(),
+            tests: baseline.tests(),
+            repo_status: baseline.repo_status(),
+            cwd: Some(baseline.root()),
+            // No hooks in the baseline: nothing there is the user's work, and
+            // an authoring snapshot must not fire the project's lifecycle.
+            hook_runner: None,
+            workspace: Some(baseline.as_ref()),
+        };
+        let authored = self
+            .witness_stage(
+                goal,
+                authoring.frames,
+                authoring.author,
+                baseline_surface,
+                surface,
+                budget,
+                total,
+            )
+            .await;
+        baseline.remove().await;
+
+        let witness = match authored {
+            Ok(Some(witness)) => witness,
+            Ok(None) => return Ok(None),
+            Err(abort) if abort.degradable => {
+                self.warn(format!(
+                    "continuing without an authored witness: {}",
+                    abort.reason
+                ));
+                return Ok(None);
+            }
+            Err(abort) => return Err(abort.reason),
+        };
+
+        // The artifact failed in the baseline — `witness_stage` cannot return
+        // it otherwise — and that snapshot was created for this candidate from
+        // this candidate's own pre-execution tree. So this records an
+        // observation that was made, not one that is assumed.
+        state.oracle.observe(&witness.command, false);
+        // The graft added an untracked file after the pre-execution snapshot
+        // was taken. Enrolling it as pre-existing keeps every later diff
+        // gather (each revision re-gathers) from reading the scaffolding as
+        // the worker's work — the same exclusion authoring-before-execute got
+        // for free by writing the file before this map was built.
+        for (path, identity) in &witness.files {
+            state
+                .untracked_before
+                .insert(path.clone(), identity.fingerprint.clone());
+        }
+        state.witness_paths = witness.files.keys().cloned().collect();
+        Ok(Some(witness))
     }
 }

--- a/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/stella-pipeline/src/pipeline/witness_stage.rs
@@ -111,13 +111,16 @@ impl<'a> Pipeline<'a> {
     pub(super) async fn witness_stage(
         &self,
         goal: &str,
-        frames: &[RecalledFrame],
-        author: &ResolvedRole<'a>,
+        authoring: WitnessAuthoring<'_>,
         baseline: CandidateSurface<'_>,
         candidate: CandidateSurface<'_>,
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> Result<Option<Witness>, WitnessAbort> {
+        // `port` is deliberately not used here: the caller has already spent it
+        // to make `baseline`, and a second snapshot from inside this stage would
+        // be a tree nothing is proved against.
+        let WitnessAuthoring { author, frames, .. } = authoring;
         self.emit(AgentEvent::Stage {
             name: StageKind::Witness,
         });
@@ -322,15 +325,7 @@ impl<'a> Pipeline<'a> {
             workspace: Some(baseline.as_ref()),
         };
         let authored = self
-            .witness_stage(
-                goal,
-                authoring.frames,
-                authoring.author,
-                baseline_surface,
-                surface,
-                budget,
-                total,
-            )
+            .witness_stage(goal, authoring, baseline_surface, surface, budget, total)
             .await;
         baseline.remove().await;
 

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -366,6 +366,17 @@ pub enum WorkspaceError {
         paths: Vec<String>,
         workspace: String,
     },
+    /// An accepted witness artifact could not be copied out of the pristine
+    /// authoring snapshot into the candidate that executed. The candidate is
+    /// left exactly as the worker made it and the run degrades to the
+    /// unauthored ladder: a witness that cannot be placed proves nothing, but
+    /// the work it would have pinned is real and already done.
+    #[error("could not graft witness artifact `{path}` into `{workspace}`: {reason}")]
+    Graft {
+        reason: String,
+        path: String,
+        workspace: String,
+    },
 }
 
 /// One isolated best-of-N candidate workspace: a snapshot of the working
@@ -415,6 +426,25 @@ pub trait CandidateWorkspace: Send + Sync {
     /// user asked for, so by default it dies with the workspace instead of
     /// being copied into the real tree. Empty means adopt everything.
     async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError>;
+    /// Copy one accepted witness artifact from another workspace's root into
+    /// this one at the same relative `path`, and fail if anything is already
+    /// there.
+    ///
+    /// Witness authoring runs in a *pristine* sibling snapshot so the author
+    /// never reads the implementation it is meant to pin (see
+    /// [`crate::witness`]). The artifact it produces has to end up in the
+    /// candidate that executed, because that is the tree the flip oracle
+    /// observes the pass in. This is the one byte-for-byte crossing between
+    /// the two, and it carries exactly one already-validated file.
+    ///
+    /// Create-only, and no link is followed on either side. A destination that
+    /// already exists is [`WorkspaceError::Graft`], never an overwrite: the
+    /// worker may legitimately have written a test at that path, and silently
+    /// replacing it would destroy the candidate's own work to make room for
+    /// scaffolding. The caller re-validates the identity of the *written* copy
+    /// against the candidate's own repo status, so the bytes tamper exclusion
+    /// pins are the bytes that will actually run.
+    async fn graft_witness(&self, source_root: &str, path: &str) -> Result<(), WorkspaceError>;
     /// Remove the workspace. Best-effort and infallible — the cleanup
     /// discipline is the pipeline's (every workspace is removed on every
     /// path, except a winner whose adoption failed, which is preserved for

--- a/stella-pipeline/src/witness/warrant/tests.rs
+++ b/stella-pipeline/src/witness/warrant/tests.rs
@@ -145,15 +145,24 @@ fn a_rust_deref_assignment_is_code_not_a_comment() {
 
 #[test]
 fn a_js_private_field_and_c_preprocessor_are_code_not_comments() {
-    let js = diff(&["ui/src/wallet.ts"], "-    #balance = 0;\n+    #balance = 100;\n");
+    let js = diff(
+        &["ui/src/wallet.ts"],
+        "-    #balance = 0;\n+    #balance = 100;\n",
+    );
     assert_eq!(warrant(&js, 1), WitnessWarrant::Required);
-    let c = diff(&["native/buffer.c"], "-#define BUFFER 256\n+#define BUFFER 512\n");
+    let c = diff(
+        &["native/buffer.c"],
+        "-#define BUFFER 256\n+#define BUFFER 512\n",
+    );
     assert_eq!(warrant(&c, 1), WitnessWarrant::Required);
 }
 
 #[test]
 fn a_decrement_is_code_not_a_sql_comment() {
-    let d = diff(&["stella-core/src/driver.rs"], "-    --count;\n+    --count;\n+    step();\n");
+    let d = diff(
+        &["stella-core/src/driver.rs"],
+        "-    --count;\n+    --count;\n+    step();\n",
+    );
     assert_eq!(warrant(&d, 1), WitnessWarrant::Required);
 }
 


### PR DESCRIPTION
## What & why

Finishes the work `#765` explicitly deferred:

> **Not in this change:** witness authoring still runs before execute, so the
> warrant spares the judge call but not the authoring that preceded it. Moving
> authoring after execution is possible and is what would make verification cost
> fully demand-driven.

The warrant reads a diff, so it can only answer after execution. Authoring ran
before it, which left the saving half-collected: a docs edit was told "no test
warranted" by the warrant, having already paid an author turn to write one
against a tree nobody had touched yet.

Authoring now runs after execute, gated on the warrant. A change with nothing to
prove dispatches no author turn at all.

### Reordering naively would have hollowed out the evidence

After execution an implementation exists, and an author allowed to read it writes
a test that restates it. That test fails on the old code and passes on the new, so
the flip oracle confirms it — while proving only that the code equals itself.

So the author gets a **second tree**, not the candidate's. `CandidateWorkspacePort`
is called again when the warrant asks for a witness, and because a candidate's edits
never leave its own workspace until adoption, that snapshot *is* the pre-execution
tree. The author's input is byte-identical to what it was when this stage ran first.
The reorder buys cost, never leverage.

That snapshot is also where the artifact must fail. The accepted file is grafted
into the candidate that executed (`CandidateWorkspace::graft_witness` — create-only,
`O_NOFOLLOW` both ends, one already-validated file) and re-fingerprinted there, so
tamper exclusion pins the bytes that will actually run. Fail in the pre-execution
tree, pass in the post-execution one: a flip across two code states, not one tree
observed twice.

### The trade

A witnessed candidate takes two snapshots instead of one. A snapshot is a
`git worktree add` and a patch apply; an author turn is a model call. The extra
snapshot is paid only when a witness **is** warranted; the model call is saved
whenever it is not.

### A witness that cannot be produced no longer discards the work

It is already done by the time the author is asked, so a useless witness, an
unavailable author, or a failed graft leaves the candidate on the unauthored
ladder — where it used to throw the candidate away and re-execute the whole task.
Fail-closed is unchanged for artifacts that cannot be **trusted**: a tracked-file
mutation, a symlink artifact, or a runner mismatch still aborts, now after the
worker's turn rather than before it.

### Three existing guards were passing vacuously

An exhausted `ScriptedProvider` also aborts a run, and `matches!(.., Aborted { .. })`
cannot tell that from an integrity rejection — so the reorder silently converted
them into tests of the fixture. `tracked_production_edit_by_witness_author_aborts_without_adoption`
was aborting on `"scripted provider exhausted"` and testing nothing. New
`assert_aborted_because` pins the cause on all three.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
-  No witness needed (pure refactor / docs / CI) — because:

Three, each verified red on the previous code:

- `a_docs_only_change_authors_no_witness_and_creates_no_second_snapshot` — the
  headline saving. Scripts exactly three provider responses and queues **one**
  workspace, so a surviving author call exhausts the queue and a baseline snapshot
  fails the `create` count.
- `a_grafted_witness_is_not_billed_to_the_workers_diff` — sets `diff_budget_lines`
  to 5 against a 40-line artifact and scripts no judge, so a misattributed witness
  escalates and aborts. Confirmed red by removing the enrollment loop and re-running.
- `a_graft_collision_keeps_the_work_and_drops_only_the_witness` — the worker owns
  the artifact path; the work survives, only the witness is dropped.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 3,920 tests, 0 failures
- [x] Docs updated where behavior/flags changed — `docs/design/witness-protocol.md` §7.3
      rewritten from "what this does not do yet" into the delivered design; CHANGELOG entry added
- [x] CLA signed
- [x] `scripts/check-{file-size,invariants,doc-citations,no-scratch,normative-home}.sh`

## Notes for review

- **`scripts/file-size-baseline.txt`** — `candidate_ws.rs` **+4** (the required
  `graft_witness` trait delegate; the implementation lives in
  `candidate_ws/witness_tools.rs` next to the other create-only/no-follow code).
  `pipeline.rs` **−13** and `pipeline/tests.rs` **−26** ratchet *down*:
  `witness_on_demand` moved to `pipeline/witness_stage.rs` and the witness tests
  to `pipeline/tests/witness_isolation.rs`. The other three entries are
  pre-existing shrinkages the updater picked up.
- **`witness/warrant/tests.rs`** — 15 lines of pure `cargo fmt` output. That file
  landed unformatted with #765 and currently fails the fmt gate on `main`.

## Summary by Sourcery

Make witness authoring demand-driven by moving it after execution, gating it on the warrant, and grafting authored tests from a pristine pre-execution snapshot into the executed candidate while preserving tamper and integrity guarantees.

New Features:
- Introduce demand-driven witness authoring that runs only when the diff-based warrant requires it, avoiding witness tests for docs-only and other non-proof changes.

Enhancements:
- Refine the witness pipeline to author tests in a separate pre-execution snapshot and graft the accepted artifact into the executing candidate, ensuring fail→pass flips across two code states.
- Extend candidate workspaces with a graft operation and track witness artifact paths on candidate results so adoption can withhold or keep witnesses correctly.
- Adjust failure handling so witnesses that cannot be produced degrade to unauthored runs while integrity violations (tamper, runner mismatch, unsafe identities) remain fail-closed.
- Expose additional helper APIs for fake workspaces and witness tools to support grafting, diff/untracked reporting, and more precise abort reason assertions in tests.

Documentation:
- Update witness protocol design docs to describe demand-driven authoring, two-tree witness workflow, and the new trade-offs and failure modes.
- Add changelog entry documenting that verification cost is now fully demand-driven and that failed witness production no longer discards completed work.

Tests:
- Rework and extend pipeline witness tests to cover post-execution authoring, graft behavior, docs-only runs, tamper exclusion, language/symlink rejection, and correct metering and degradation semantics.
- Tighten abort tests with explicit reason matching and adjust usage tests to reflect the new authoring order and roles.
