### PR TITLE
fix(context): an id-less memory frame keeps its content and drops its claim to citability

### DIFF
--- a/stella-cli/src/memory/recall.rs
+++ b/stella-cli/src/memory/recall.rs
@@ -313,13 +313,27 @@ pub(super) fn render_context_section(frames: &[RecalledFrame]) -> Option<String>
     let mut citable = false;
     for f in frames {
         let label = &f.citation_label;
-        if f.kind == "memory" {
-            citable = true;
-            if let Some(id) = &f.id {
+        match (f.kind.as_str(), &f.id) {
+            // A memory with an id: citable, and the id is what the model
+            // hands back to `cite_memory`.
+            ("memory", Some(id)) => {
+                citable = true;
                 lines.push(format!("- [{id}] {label} — {}", f.content.trim()));
             }
-        } else {
-            lines.push(format!("- {} — {}", label, f.content.trim()));
+            // A memory WITHOUT an id still has content worth recalling, and
+            // the recall budget has already been spent fetching it.
+            //
+            // This arm used to be missing: an id-less memory flipped `citable`
+            // and then pushed no line at all, so its content vanished from the
+            // block while the model was still told to cite `[nod_…]` lines
+            // that might not exist anywhere in it. `RecalledFrame` documents
+            // `id: None` as a legitimate state for a not-yet-materialized
+            // frame (`stella-pipeline/src/ports.rs`), so this was reachable by
+            // contract even though the only production projection happens to
+            // always set `Some`. Render it as grounding — it cannot be cited,
+            // so it must not claim to be.
+            ("memory", None) => lines.push(format!("- {label} — {}", f.content.trim())),
+            _ => lines.push(format!("- {label} — {}", f.content.trim())),
         }
     }
     if lines.is_empty() {

--- a/stella-cli/src/memory/tests.rs
+++ b/stella-cli/src/memory/tests.rs
@@ -1169,3 +1169,43 @@ fn a_lesson_logged_before_kind_existed_still_parses() {
     assert_eq!(parsed.kind, crate::memory::LessonKind::Process);
     assert!(parsed.task_id.is_empty());
 }
+
+/// An id-less memory frame keeps its content and does not claim citability.
+///
+/// The render arm for `("memory", None)` was missing: such a frame set the
+/// citable flag and then pushed no line, so the recall budget was spent
+/// fetching content that never reached the model, while the block still
+/// instructed it to cite `[nod_…]` ids that might appear nowhere in it.
+/// `RecalledFrame` documents `id: None` as a legitimate state, so this was
+/// reachable by contract.
+#[test]
+fn an_id_less_memory_frame_still_renders_and_does_not_promise_citability() {
+    let mut anonymous = frame(
+        "ignored",
+        contextgraph_types::FrameKind::Memory,
+        "house convention",
+        "amounts are integer minor units",
+    );
+    anonymous.id = None;
+
+    let section = render_context_section(&[anonymous]).expect("a frame with content renders");
+    assert!(
+        section.contains("amounts are integer minor units"),
+        "content the recall budget already paid for must reach the model: {section}"
+    );
+    assert!(
+        !section.contains("cite_memory"),
+        "nothing here is citable, so the block must not ask for a citation: {section}"
+    );
+
+    // The control: the same frame WITH an id is citable and says so.
+    let identified = frame(
+        "nod_6428c2bb9b9b7aa1adc457fa",
+        contextgraph_types::FrameKind::Memory,
+        "house convention",
+        "amounts are integer minor units",
+    );
+    let section = render_context_section(&[identified]).expect("renders");
+    assert!(section.contains("[nod_6428c2bb9b9b7aa1adc457fa]"), "{section}");
+    assert!(section.contains("cite_memory"), "{section}");
+}


### PR DESCRIPTION
End-to-end audit of the citation workflow, prompted by this repo reporting `cited_frames = 0` across two benchmark series — a figure that turned out to be **my own measurement bug** (the harness counted a `memory_citation` agent event, which does not exist; citations are rows in `store.db.memory_citations`). Corrected count: **1 citation across two series**. So I audited the real path rather than the one I had imagined.

## Hypotheses tested and refuted

Recording these because each *looked* like a serious bug and none were:

| hypothesis | verdict |
|---|---|
| Id-space mismatch — `memory.public_id` is `mem_…` but `is_memory_id` requires `nod_…`, so every citation is rejected | **Refuted.** Recalled frames carry `nod_…` (`node_public_id`); the `mem_…` ids never reach the model. The one real citation used `nod_6428c2bb9b9b7aa1adc457fa`. |
| The citation loop never fires | **Refuted.** It fired, correctly, with `useful_score=5, truthful=1` and a coherent remark. |
| Aborted turns lose their citations | **Refuted.** `record_execution_end` is called with an explicit `"aborted"` label. |

## What the funnel actually looks like

From a live arm store (10 executions):

| stage | count |
|---|---|
| memories in store | 12 |
| distinct memories ever recalled | **4** |
| memory exposures to the model | 12 |
| citations | 1 |

Recall works — every execution after the store had content recalled memories. The narrow point is **recall breadth** (4 of 12 memories ever surfaced), then model discretion (~8% of exposures cited). Neither is a plumbing defect, so neither is "fixed" here.

## The one real defect, fixed

`render_context_section` matched `kind == "memory"`, set `citable = true`, and then rendered a line only `if let Some(id)`. A memory frame arriving **without** an id contributed *no line at all*:

- the recall budget was spent fetching content that never reached the model, and
- the block still appended *"call cite_memory with that `[nod_…]` id"* for ids that might appear nowhere in it.

`RecalledFrame` documents `id: None` as a legitimate state for a not-yet-materialized frame (`stella-pipeline/src/ports.rs:48`), so this is reachable **by contract**. It is not reachable through today's single production projection, which always sets `Some` — this closes a latent defect before a second provider makes it live.

An id-less memory now renders as grounding: content preserved, no citation promise.

## Noted, not changed

`record_execution_end` drains with `take_memory_citations` *before* the write is known to succeed. If `record_memory_citations` fails the rows are gone, with no retry — it only downgrades `audit_complete`. Same shape for `take_mcp_usage`. That is consistent with the documented best-effort contract, and changing drain semantics is a wider decision than this PR should make, so it is flagged rather than altered.

## Tests

`an_id_less_memory_frame_still_renders_and_does_not_promise_citability`, with the id-carrying control asserting the citation instruction still appears.

739 `stella-cli` tests pass.

## Summary by Sourcery

Fix rendering of id-less memory frames in context sections so their content appears without promising citability, and add coverage to lock in the behavior.

Bug Fixes:
- Ensure memory frames without an id are rendered as non-citable grounding instead of being omitted while still marking the block as citable.

Tests:
- Add a regression test verifying that id-less memory frames render their content without citation instructions, while id-carrying frames remain citable.
