### PR TITLE
style(cli): rustfmt the assertion #771 left unwrapped

### DIFF
--- a/stella-cli/src/memory/tests.rs
+++ b/stella-cli/src/memory/tests.rs
@@ -1206,6 +1206,9 @@ fn an_id_less_memory_frame_still_renders_and_does_not_promise_citability() {
         "amounts are integer minor units",
     );
     let section = render_context_section(&[identified]).expect("renders");
-    assert!(section.contains("[nod_6428c2bb9b9b7aa1adc457fa]"), "{section}");
+    assert!(
+        section.contains("[nod_6428c2bb9b9b7aa1adc457fa]"),
+        "{section}"
+    );
     assert!(section.contains("cite_memory"), "{section}");
 }


### PR DESCRIPTION
`main` is currently red on `cargo fmt --check`.

[#771](https://github.com/macanderson/stella/pull/771) added an `assert!` whose line runs past the width limit. It merged before its own CI run finished, so the failure landed on `main` instead of on the PR — the same pattern as #768 and #769 earlier today.

## The change

`cargo fmt --all`, and nothing else. The entire diff:

```diff
-    assert!(section.contains("[nod_6428c2bb9b9b7aa1adc457fa]"), "{section}");
+    assert!(
+        section.contains("[nod_6428c2bb9b9b7aa1adc457fa]"),
+        "{section}"
+    );
```

No assertion, name, or behavior change — the predicate and the panic message are byte-identical.

## Verification

The full `ci.yml` sequence, run locally on this branch:

| step | result |
|---|---|
| `check-no-scratch`, `check-action-pins`, `check-file-size` | pass |
| `check-normative-home`, `check-doc-citations`, `check-invariants` | pass |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | pass |
| `cargo test --workspace` | pass (63 test binaries) |

## Summary by Sourcery

Enhancements:
- Reformat a CLI memory test assertion to adhere to rustfmt line width constraints without changing behavior.