### PR TITLE
fix(ci): a release marker survives the merge that never ran ci

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,10 +8,16 @@ name: auto-tag
 #   'release.minor: …'   minor bump    0.1.3 -> 0.2.0   (patch reset to 0)
 #   'release:major …'    major bump    0.1.3 -> 1.0.0   (minor + patch reset)
 #
-# Put the prefix at the start of the PR title — a squash-merge uses the PR
-# title as the commit subject. `release.minor`/`release:minor` and
-# `release:major`/`release.major` are both accepted. Add `[skip release]` to
-# the title to land a change without cutting a release (docs/chore merges).
+# Put the prefix at the START of the PR title — a squash-merge uses the PR
+# title as the commit subject, and the marker is only recognized there (see
+# "Read the bump marker from EVERY commit" below for why it is anchored).
+# `release.minor`/`release:minor` and `release:major`/`release.major` are both
+# accepted. Add `[skip release]` to the title to land a change without cutting
+# a release (docs/chore merges).
+#
+# The marker is read from every commit since the last tag, not just the one
+# being tagged, so a release whose own merge never triggered this job is
+# picked up by the next one instead of being silently downgraded to a patch.
 #
 # The tag is cut on the exact commit CI validated — nothing is force-pushed to
 # main. release.yml injects the tag's version into the build so
@@ -44,6 +50,9 @@ name: auto-tag
 # exactly how a non-compiling commit shipped as a tag before this gate).
 # Because `ci` is path-ignored for docs-only changes, those merges never run
 # `ci` and so never trigger a release either — previously they tagged blindly.
+# A docs-only merge therefore does not release *at the moment it lands*; if it
+# carried a bump marker, the range scan above hands that marker to the next
+# release instead. The bump is deferred, never dropped.
 
 on:
   workflow_run:
@@ -104,15 +113,40 @@ jobs:
           if [ -z "$last" ]; then
             base="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)"
             base="${base:-0.0.0}"
+            range="HEAD"
           else
             base="${last#v}"
+            range="${last}..HEAD"
           fi
           IFS=. read -r major minor patch <<< "$base"
           major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
 
-          if printf '%s' "$msg" | grep -qiE '(^|[^[:alnum:]])release[.:]major'; then
+          # Read the bump marker from EVERY commit this tag is about to
+          # release, not just HEAD. A marker rides on one commit's subject,
+          # but that commit's own `ci` run may never happen: `ci` is
+          # path-ignored for `docs/**`, `website/**` and `*.md`, so a
+          # release-marker PR that only edits release notes produces no
+          # `workflow_run` completion and never reaches this job at all. When
+          # the next code merge finally does, reading only `git log -1` sees
+          # that unrelated subject, cuts a patch bump, and the intended minor
+          # release is gone for good — exactly how `release.minor: v0.6.0`
+          # (#758, #761) was swallowed twice while tags marched 0.5.55→0.5.59.
+          #
+          # Scanning `${last}..HEAD` makes the intent durable rather than
+          # instantaneous: a marker that misses its own release is honored by
+          # the next one. It cannot re-fire, because cutting the tag moves
+          # `last` past the marker and out of the range.
+          #
+          # Subjects only, anchored: squash-merge subjects are PR titles, and
+          # the convention documented above is that the prefix leads the
+          # title. Matching mid-message across a whole range would let a
+          # commit that merely *mentions* release.major cut a major release.
+          subjects="$(git log --format=%s "$range")"
+          printf 'Commit subjects since %s:\n%s\n\n' "${last:-<no tag>}" "$subjects"
+
+          if printf '%s\n' "$subjects" | grep -qiE '^release[.:]major'; then
             major=$((major + 1)); minor=0; patch=0; kind="major"
-          elif printf '%s' "$msg" | grep -qiE '(^|[^[:alnum:]])release[.:]minor'; then
+          elif printf '%s\n' "$subjects" | grep -qiE '^release[.:]minor'; then
             minor=$((minor + 1)); patch=0; kind="minor"
           else
             patch=$((patch + 1)); kind="patch"


### PR DESCRIPTION
## What happened

`release.minor: v0.6.0` was merged **twice** — #758 and #761 — and **v0.6.0 was never tagged at all.** This isn't a revert; the minor bump never fired once. Tags went 0.5.55 → 0.5.56 → 0.5.57 → 0.5.58 → 0.5.59, and `git ls-remote --tags` has no `v0.6.0`.

## Root cause

Both release-marker PRs changed only two files:

```
docs/llms.txt
website/content/docs/release-notes.mdx
```

Both live under `docs/**` and `website/**` — which are in **`ci.yml`'s `paths-ignore`**. So:

1. `ci` never ran on main for `83de483e` or `f5736990`. Confirmed: 83de483e's only push/main runs were `docs`, `normative-home`, `scorecard`. `f5736990` has no `ci` run at all.
2. `auto-tag` triggers **only** on `workflow_run: workflows: [ci]`. No ci run → no completion event → auto-tag never invoked → no `v0.6.0`.
3. The next code merge *did* run ci. auto-tag fired, read `git log -1` on **that** commit, saw an ordinary subject, and cut a patch bump.

The bump intent lived in exactly one commit message and was read exactly once, from a commit that was never guaranteed to be the one auto-tag saw. Miss that window and the release is gone permanently.

## The fix

Read the marker from **every commit since the last tag** (`${last}..HEAD`), not just `HEAD`. A marker that misses its own release is honored by the next one — deferred, never dropped. It can't re-fire, because cutting the tag moves `last` past the marker and out of the range.

Range scanning needs a tighter match than reading a single subject did, so the regex is **anchored to the start of the subject** — the convention the header comment already documented ("Put the prefix at the start of the PR title"). Unanchored across a range, a commit merely *mentioning* `release.major` would cut a major release.

## Verification

Replayed the real history through both old and new logic:

| range | old (shipped) | new |
|---|---|---|
| `v0.5.56..f4e934c4` (contains #758's marker) | `0.5.57` ✅ matches what shipped | `0.6.0` |
| `v0.5.58..8f8c48e8` (contains #761's marker) | `0.5.59` ✅ matches what shipped | `0.6.0` |

The old logic reproduces the bug exactly, so the test is load-bearing rather than tautological. Negative tests, all passing:

- plain merge with no marker → patch bump (unchanged)
- `[skip release]` on HEAD → still skips
- marker already behind the base tag → **no re-fire**, plain patch
- synthetic `docs: explain how release.major works` → **no** major bump (mutating the anchor off makes this one spuriously cut v2.0.0, proving the anchor earns its place)
- `release.major` outranks `release.minor` when both are in range

`shellcheck -s bash` clean on the extracted step; YAML parses with all 6 steps intact.

## Not fixed here — two things worth a follow-up

1. **v0.6.0 still needs cutting.** This change prevents recurrence but can't recover the lost release: `f5736990` is an ancestor of `v0.5.59`, so it's already behind the base tag and out of range. A fresh `release.minor:` PR (or a manual tag) is needed. **I did not cut a release — that's your call.**
2. **`auto-tag`'s concurrency group can evict a pending run.** `group: auto-tag` with `cancel-in-progress: false` still lets a *third* arrival cancel the queued one — GitHub keeps only one in-progress + one pending per group. Run `30281087841` died 8s after creation with `"jobs": ` (killed at the queue, before any job was allocated) and was superseded by a run that then *skipped*. Since auto-tag fires on **every** ci completion — PRs, `merge_group`, dispatched `bot/version-sync` runs — no-op runs compete with real ones for that slot. `ci.yml` documents this exact GitHub behavior and works around it with per-SHA groups; `auto-tag` never got the same treatment. Left alone because the group is genuinely needed to serialize tag computation, so the fix isn't a one-liner.

## Summary by Sourcery

Update the auto-tag workflow to derive release bump markers from all commits since the last tag instead of only the latest commit, preventing missed minor/major releases when CI is skipped for docs-only merges.

CI:
- Adjust auto-tag logic to scan commit subjects in the last-tag-to-HEAD range and anchor release markers to the start of the subject so deferred release markers are correctly honored without accidental bumps.

Documentation:
- Clarify auto-tag workflow comments to document the anchored marker convention and the behavior of deferred releases for docs-only merges.
