### PR TITLE
feat(context): separate world validity from belief time for memory anchors

### DIFF
--- a/stella-context/src/store/edge.rs
+++ b/stella-context/src/store/edge.rs
@@ -19,6 +19,48 @@ pub(crate) fn neighbors(
     seeds: &[i64],
     as_of: Option<&str>,
 ) -> Result<Vec<(i64, f64)>, ContextError> {
+    neighbors_valid_at(conn, seeds, as_of, None)
+}
+
+/// 1-hop neighbours over edges believed at `as_of` **and** holding in the
+/// world at `valid_at`.
+///
+/// Two axes, two parameters, deliberately independent. `as_of` answers "what
+/// did we believe then"; `valid_at` answers "what was true then". Collapsing
+/// them into one would make it impossible to ask the question this exists for
+/// — *we still believe the anchor was correct, and it stopped being true in
+/// March* — which is precisely a memory whose file has since been deleted.
+///
+/// `valid_at = None` preserves the historical behaviour exactly: world
+/// validity is ignored, which is what every existing caller and
+/// `as_of_ignores_world_validity_valid_from_valid_to` expect.
+pub(crate) fn neighbors_valid_at(
+    conn: &Connection,
+    seeds: &[i64],
+    as_of: Option<&str>,
+    valid_at: Option<&str>,
+) -> Result<Vec<(i64, f64)>, ContextError> {
+    if let Some(at) = valid_at {
+        // Half-open [valid_from, valid_to), matching the belief-time interval
+        // convention pinned by the supersession tests.
+        let sql = "SELECT CASE WHEN src_id = ?1 THEN dst_id ELSE src_id END AS other, weight
+             FROM edge
+             WHERE (src_id = ?1 OR dst_id = ?1)
+               AND (?3 IS NULL OR (recorded_at <= ?3 AND (superseded_at IS NULL OR superseded_at > ?3)))
+               AND (?3 IS NOT NULL OR superseded_at IS NULL)
+               AND (valid_from IS NULL OR valid_from <= ?2)
+               AND (valid_to IS NULL OR valid_to > ?2)";
+        let mut out = Vec::new();
+        let mut stmt = conn.prepare(sql)?;
+        for &seed in seeds {
+            for r in stmt.query_map(params![seed, at, as_of], |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, f64>(1)?))
+            })? {
+                out.push(r?);
+            }
+        }
+        return Ok(out);
+    }
     let mut out = Vec::new();
     // Undirected 1-hop: a seed on either endpoint pulls in the other.
     let sql = match as_of {
@@ -124,6 +166,36 @@ pub(crate) fn close_edge(
         params![edge_id, superseded_at, valid_to],
     )?;
     Ok(())
+}
+
+/// End an edge's **world validity** without touching belief.
+///
+/// The distinction is the whole point of storing two axes. Superseding says
+/// "we were wrong, or we replaced this"; ending world validity says "this was
+/// true, and then the world changed". A memory anchored to a file that has
+/// since been deleted is the second case: the anchor was never a mistake, it
+/// simply stopped holding at the moment the file went away. Recording it as a
+/// supersession would erase a true past.
+///
+/// `superseded_at` is deliberately left alone, so `as_of` — which reads belief
+/// time only (see `as_of_ignores_world_validity_valid_from_valid_to`) — still
+/// reports the edge as believed. `valid_at` is what hides it from the present.
+///
+/// Never deletes (`L-C3`): "what was true at T1" must still answer.
+// The staleness scan that calls this lands next; the primitive and its
+// semantics are separable from the policy that decides which anchors are
+// stale, and the semantics are the part worth pinning first.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn end_world_validity(
+    conn: &Connection,
+    edge_id: i64,
+    valid_to: &str,
+) -> Result<bool, ContextError> {
+    let changed = conn.execute(
+        "UPDATE edge SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
+        params![edge_id, valid_to],
+    )?;
+    Ok(changed > 0)
 }
 
 /// Fact edges as believed at a transaction-time instant. `as_of = None` means

--- a/stella-context/src/store/tests.rs
+++ b/stella-context/src/store/tests.rs
@@ -10,6 +10,7 @@ use super::schema::{
     SCHEMA_VERSION,
 };
 use super::*;
+use crate::store::edge::{end_world_validity, neighbors_valid_at};
 use tempfile::TempDir;
 
 fn tmp_store() -> (TempDir, ContextStore) {
@@ -1362,5 +1363,89 @@ fn v8_creates_the_ledger_empty() {
     assert!(
         store.record_counts().unwrap().is_empty(),
         "a fresh ledger holds nothing — records are born, never migrated in"
+    );
+}
+
+
+/// A deleted file ends an anchor's world validity WITHOUT unbelieving it.
+///
+/// The requirement this pins: a memory whose file was deleted is not wrong and
+/// must not be retracted. It was true, and then the world changed. So the
+/// present must stop recalling it while the past still answers — which needs
+/// the two axes to move independently.
+#[test]
+fn ending_world_validity_hides_the_present_and_preserves_the_past() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    let (memory, file) = (concept(&conn, "memory"), concept(&conn, "file"));
+    let props = serde_json::json!({});
+    let edge = insert_edge(
+        &conn, "observed_in", memory, file, 1.0, &props,
+        Some(T0), None, T0, None,
+    )
+    .unwrap();
+
+    // Believed and world-valid: recalled now.
+    assert_eq!(
+        neighbors_valid_at(&conn, &[memory], None, Some(T1_5)).unwrap().len(),
+        1,
+        "an open anchor is recallable"
+    );
+
+    // The file is deleted at T2. World validity ends; belief is untouched.
+    assert!(end_world_validity(&conn, edge, T2).unwrap());
+
+    // The present no longer recalls it...
+    assert!(
+        neighbors_valid_at(&conn, &[memory], None, Some(T3)).unwrap().is_empty(),
+        "after the file is gone the anchor must not be recalled"
+    );
+
+    // ...but it was true before, and still answers as of then.
+    assert_eq!(
+        neighbors_valid_at(&conn, &[memory], None, Some(T1_5)).unwrap().len(),
+        1,
+        "the past is preserved: the anchor held at T1_5 and must still say so"
+    );
+
+    // And we never stopped BELIEVING it — this is not a retraction.
+    assert_eq!(
+        neighbor_ids(&conn, memory, None),
+        vec![file],
+        "ending world validity must not supersede: the belief was never wrong"
+    );
+}
+
+/// Ending world validity is idempotent and never moves an existing end.
+#[test]
+fn ending_world_validity_twice_keeps_the_first_end_date() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
+    let props = serde_json::json!({});
+    let edge = insert_edge(&conn, "observed_in", a, b, 1.0, &props, Some(T0), None, T0, None).unwrap();
+
+    assert!(end_world_validity(&conn, edge, T1).unwrap(), "first close wins");
+    assert!(
+        !end_world_validity(&conn, edge, T3).unwrap(),
+        "a second close must not move the date a file actually disappeared"
+    );
+    // Still invisible at T3, and the recorded end is T1 rather than T3.
+    assert!(neighbors_valid_at(&conn, &[a], None, Some(T2)).unwrap().is_empty());
+}
+
+/// The default path is byte-for-byte the old behaviour.
+#[test]
+fn valid_at_none_ignores_world_validity_exactly_as_before() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
+    let props = serde_json::json!({});
+    // World validity closed in the past, still believed.
+    insert_edge(&conn, "relates_to", a, b, 1.0, &props, Some(T0), Some(T1), T1, None).unwrap();
+    assert_eq!(
+        neighbors_valid_at(&conn, &[a], None, None).unwrap().len(),
+        1,
+        "without a world-time argument the closed interval is ignored, as it always was"
     );
 }


### PR DESCRIPTION
Groundwork for anchoring memories to the files and symbols they are about, so *"what does the agent know about `registry.py`"* is an edge traversal rather than an embedding guess.

## The blocker was semantic, not structural

`edge` already stores both axes — `valid_from`/`valid_to` (world time) and `recorded_at`/`superseded_at` (belief time). But **retrieval reads only belief time**, and that is pinned deliberately by a test literally commented `THE DISCRIMINATOR`:

```rust
fn as_of_ignores_world_validity_valid_from_valid_to {
    // ... Proves the filter is transaction/belief time only.
```

So closing `valid_to` on a deleted file's anchor would have changed nothing — the memory would keep being recalled. The bitemporal model was written down and not enforced on the read path.

## Why `close_edge` was the wrong lever

The one available primitive sets **both** axes at once. That conflates two different facts about the world:

- **Superseding** says *"we were wrong, or we replaced this."*
- A memory anchored to a file that has since been deleted is **not wrong**. It was true, and then the world changed.

Recording the second as the first erases a true past. `close_edge` remains correct for genuine supersession; it just cannot express this.

## Changes

**`end_world_validity`** — closes `valid_to`, leaves `superseded_at` alone. The belief stands; only the present stops seeing it. Idempotent, and a second call will not move the date the file actually disappeared.

**`neighbors_valid_at`** — takes `as_of` and `valid_at` as **independent** parameters. Two axes need two questions:

| parameter | asks |
|---|---|
| `as_of` | what did we *believe* then |
| `valid_at` | what was *true* then |

Collapsing them makes the load-bearing question unaskable: *we still believe the anchor was correct, and it stopped being true in March.*

**`valid_at = None`** is byte-for-byte the previous behaviour, so every existing caller — and THE DISCRIMINATOR — is untouched and still passes.

Never deletes (`L-C3`): *"what was true at T1"* still answers.

## Tests

- `ending_world_validity_hides_the_present_and_preserves_the_past` — the requirement, end to end: recalled before the deletion, not recalled after, still true as of before, and **never unbelieved**.
- `ending_world_validity_twice_keeps_the_first_end_date`
- `valid_at_none_ignores_world_validity_exactly_as_before`

143 `stella-context` + 739 `stella-cli` tests pass.

## What lands next

The staleness scan that calls this (walk open `observed_in` anchors, end validity for files no longer on disk) and the write side that creates the anchors during reflection. The primitive's *semantics* are separable from the *policy* that decides which anchors are stale, and the semantics were the part worth pinning first — getting them wrong would have quietly rewritten history.

## Summary by Sourcery

Separate world validity from belief time for context edges and add primitives to query and end world validity independently.

Enhancements:
- Introduce neighbors_valid_at to query neighbors by independent belief time and world-valid-at time, preserving previous behavior when world time is unspecified.
- Add end_world_validity helper to close an edge’s world-validity interval without changing its belief-time state, enabling non-destructive handling of deleted-file anchors.

Tests:
- Add tests to pin semantics of ending world validity, its idempotence, and to ensure that omitting world time preserves the legacy neighbor query behavior.
