### PR TITLE
feat(context): anchor memories to files, and let a deleted file end the anchor

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10631,6 +10631,32 @@ Re-validate old memories against the current codebase. It scans each memory for 
 stella memory validate
 ```
 
+It also walks the **anchor edges** the reflection loop writes — the same question
+asked of the graph rather than of the text. When a lesson names a file, that file
+becomes an `observed_in` edge, so *"what do we know about `registry.py`"* is a
+traversal instead of an embedding guess.
+
+```bash
+stella memory validate --end-stale
+```
+
+`--end-stale` records that anchors pointing at deleted files stopped holding.
+This is the one write the command can make, and it is narrower than it looks:
+
+- The memory is **not retracted**. It was not wrong — the file simply went away.
+  `as_of` queries still return it, and `stella memory list` still shows it.
+- Only *world validity* ends, so live recall stops traversing that edge while
+  "what was true last March" keeps answering.
+- Running it twice is safe: the second pass reports no change rather than moving
+  the date the file disappeared.
+
+> **Note**
+>
+> An anchor is only written for a file that exists at the time the lesson is
+> learned, and a bare filename matching several files (`mod.rs`) is skipped rather
+> than guessed. A confidently wrong edge teaches the graph something false; a
+> missing one only costs a little recall precision.
+
 ### `stella memory forget <id>`
 
 Stop a memory steering the agent — and stop the reflection loop re-learning it.

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -1075,7 +1075,9 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             return match cmd {
                 memory_cmd::MemoryCmd::List { format } => memory_cmd::run_memory_list(*format),
                 memory_cmd::MemoryCmd::Promote { id } => memory_cmd::run_memory_promote(id),
-                memory_cmd::MemoryCmd::Validate => memory_cmd::run_memory_validate(),
+                memory_cmd::MemoryCmd::Validate { end_stale } => {
+                    memory_cmd::run_memory_validate(*end_stale)
+                }
                 memory_cmd::MemoryCmd::Forget { id, reason } => {
                     memory_cmd::run_memory_forget(id, reason)
                 }

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -47,6 +47,11 @@ use stella_pipeline::{ContextRecallPort, RecalledFrame};
 #[cfg(test)]
 use stella_protocol::{CompletionMessage, MessageRole};
 
+// Which files a memory is about — shared by the reflection write path and by
+// `stella memory validate`, which must agree on what counts as an anchor.
+pub(crate) mod anchors;
+// The policy half: which anchors have gone stale, and recording that they did.
+pub(crate) mod anchor_scan;
 // Phase 4 (#715): the citation and tool-outcome evidence sources, which turn
 // explicit citation from *the* evidence source into one of several.
 mod evidence;

--- a/stella-cli/src/memory/anchor_scan.rs
+++ b/stella-cli/src/memory/anchor_scan.rs
@@ -1,0 +1,186 @@
+//! The staleness scan: which memory anchors stopped holding, and recording it.
+//!
+//! This is the *policy* half of #775. `stella-context` owns the semantics —
+//! ending world validity is not supersession, and never deletes — while the
+//! question "does this file still exist" is about a filesystem, which the store
+//! deliberately cannot answer. Keeping the two apart is what lets the store be
+//! tested without a real tree, and lets this decide staleness without knowing
+//! any SQL.
+//!
+//! Split out of `memory_cmd` because it is the memory subsystem's logic that
+//! the command merely invokes, and because `memory_cmd` sits on the repo's
+//! 1500-line file ceiling.
+
+use colored::Colorize;
+use stella_context::{Clock, ContextStore, SystemClock};
+
+/// One anchor the scan found pointing at a file that is no longer there.
+struct StaleAnchor {
+    edge_id: i64,
+    path: String,
+    memory: String,
+}
+
+/// Walk the open `observed_in` anchors and report — or end — the ones whose
+/// file has left the tree.
+///
+/// This is the *policy* half of #775. The store owns the semantics (ending
+/// world validity is not supersession, and never deletes); deciding which
+/// anchors are stale is a question about a filesystem, which the store
+/// deliberately cannot answer.
+///
+/// Read-only unless `end_stale`. Ending an anchor is a write to history, and
+/// the default for a command named `validate` must be to tell you what it
+/// found, not to change the store because you ran an inspection.
+pub(crate) fn scan_stale_anchors(
+    workspace_root: &std::path::Path,
+    end_stale: bool,
+) -> Result<(), String> {
+    let Some(context_db) =
+        stella_store::existing_workspace_private_sqlite_path(workspace_root, "context.db")
+            .map_err(|e| format!("cannot resolve context store: {e}"))?
+    else {
+        return Ok(());
+    };
+    let context =
+        ContextStore::open(&context_db).map_err(|e| format!("cannot open context store: {e}"))?;
+    let anchors = context
+        .open_anchors()
+        .map_err(|e| format!("cannot read anchors: {e}"))?;
+    if anchors.is_empty() {
+        return Ok(());
+    }
+
+    let stale: Vec<StaleAnchor> = anchors
+        .into_iter()
+        .filter(|a| !workspace_root.join(&a.path).exists())
+        .map(|a| StaleAnchor {
+            edge_id: a.edge_id,
+            path: a.path,
+            memory: a.memory,
+        })
+        .collect();
+
+    if stale.is_empty() {
+        println!(
+            "\n  {} every memory anchor still points at a file",
+            "✓".green()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "\n  {} {} anchor(s) point at files that are gone:",
+        "⚠".yellow(),
+        stale.len()
+    );
+    for a in &stale {
+        println!(
+            "    {} — {}",
+            a.path.yellow(),
+            a.memory.chars().take(60).collect::<String>().dimmed()
+        );
+    }
+
+    if !end_stale {
+        println!(
+            "\n  run `stella memory validate --end-stale` to record that these \
+             stopped holding.\n  The memories are NOT retracted — they were true, \
+             and then the world changed."
+        );
+        return Ok(());
+    }
+
+    // One timestamp for the whole scan, so every anchor this pass ends carries
+    // the same world-time boundary. Stamping each one as it is written would
+    // scatter a single event across a range of instants for no reason.
+    // The same clock the store writes `recorded_at` with, so the two axes are
+    // rendered identically — these strings are compared lexicographically by
+    // every bi-temporal range scan, and a second format would sort wrong.
+    let now = SystemClock.now_rfc3339();
+    let mut ended = 0usize;
+    for a in &stale {
+        match context.end_anchor_validity(a.edge_id, &now) {
+            // `false` means a previous scan already ended it. Not an error, and
+            // not counted — the date the file disappeared stays the first one
+            // recorded rather than being moved forward by every later run.
+            Ok(true) => ended += 1,
+            Ok(false) => {}
+            Err(e) => return Err(format!("cannot end anchor {}: {e}", a.edge_id)),
+        }
+    }
+    println!(
+        "\n  {} ended world validity for {ended} anchor(s) at {now}.\n  \
+         Belief is untouched: `as_of` queries still report them, because they \
+         were never wrong.",
+        "✓".green()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// The anchor scan resolves stored `file://` uris back onto the workspace.
+    ///
+    /// This is the spelling risk made explicit: anchors are written
+    /// workspace-relative (matching `record_taxonomy`), while the code-graph
+    /// plane mints `file://` uris with an *absolute* path. If the scan joined
+    /// an absolute uri onto the workspace root it would resolve nothing and
+    /// report every anchor stale — deleting the whole graph on the first run.
+    #[test]
+    fn the_anchor_scan_ends_only_anchors_whose_file_is_gone() {
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/live.rs"), "pub fn x() {}").unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let context = stella_context::ContextStore::open(&context_db).unwrap();
+            use stella_context::{ContextDelta, MemoryInput};
+            let delta = ContextDelta {
+                memories: vec![
+                    MemoryInput::reflection("about a live file", Vec::<String>::new())
+                        .with_anchors(["src/live.rs"]),
+                    MemoryInput::reflection("about a file since deleted", Vec::<String>::new())
+                        .with_anchors(["src/gone.rs"]),
+                ],
+                ..Default::default()
+            };
+            context.upsert(delta).await.unwrap();
+            assert_eq!(context.open_anchors().unwrap().len(), 2);
+        });
+
+        // Report-only: the store must be untouched.
+        scan_stale_anchors(root.path(), false).unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        assert_eq!(
+            context.open_anchors().unwrap().len(),
+            2,
+            "a scan without --end-stale changes nothing"
+        );
+        drop(context);
+
+        scan_stale_anchors(root.path(), true).unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        let open = context.open_anchors().unwrap();
+        assert_eq!(open.len(), 1, "only the deleted file's anchor ends");
+        assert_eq!(open[0].path, "src/live.rs");
+
+        // The ended anchor is still believed — it was not wrong.
+        assert!(
+            context
+                .facts_as_of(None)
+                .unwrap()
+                .iter()
+                .filter(|f| f.predicate == stella_context::ANCHOR_REL)
+                .count()
+                == 2,
+            "both anchors remain believed; only one stopped holding"
+        );
+    }
+}

--- a/stella-cli/src/memory/anchors.rs
+++ b/stella-cli/src/memory/anchors.rs
@@ -1,0 +1,282 @@
+//! File anchors: which files a memory is *about*.
+//!
+//! Two callers share this, and they must agree or the feature is incoherent:
+//!
+//! * the write side ([`resolve_anchors`]), which turns a freshly mined lesson
+//!   into `observed_in` edges at reflection time, and
+//! * `stella memory validate`, which reads the same tokens out of memory text
+//!   to report which memories have rotted.
+//!
+//! The extraction lives here rather than in the command module because the
+//! write path depending on a `_cmd` module would invert the layering — the CLI
+//! surface should call the memory subsystem, not the other way round.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+/// Source extensions a token must end in to count as a file reference.
+const ANCHOR_EXTS: &[&str] = &[
+    "rs", "py", "ts", "tsx", "js", "jsx", "go", "md", "sql", "toml",
+];
+
+/// At most this many anchors per memory.
+///
+/// A lesson that recites a dozen filenames is a summary of a turn, not a fact
+/// about one file, and anchoring it to all of them would make every one of
+/// those files recall it. The cap keeps a single bad lesson from polluting a
+/// wide slice of the graph, and the truncation is deterministic (the extraction
+/// order is the order the paths appear in the text).
+const MAX_ANCHORS_PER_MEMORY: usize = 8;
+
+/// Extract file anchors from memory text. Two shapes count:
+///
+/// * **Rooted paths** — `word/word[/word…]` with a recognized source
+///   extension, e.g. `stella-cli/src/agent.rs`, `docs/context-reuse.md`.
+///   These resolve against the workspace root directly.
+/// * **Bare filenames** — a name with a recognized extension and no
+///   directory at all, e.g. `slash_models_witness.rs`, `Cargo.toml`.
+///
+/// Bare filenames matter because that is how reflections actually name
+/// files: a lesson mined from a turn says "in `slash_models_witness.rs`",
+/// not "in `stella-cli/tests/slash_models_witness.rs`". Requiring a slash
+/// meant the memories most likely to rot — the ones naming a single test
+/// file that later got deleted — were reported as `no-anchors` and never
+/// checked, which is the failure this function exists to catch.
+pub(crate) fn extract_path_anchors(text: &str) -> Vec<String> {
+    text.split(|c: char| !(c.is_alphanumeric() || c == '/' || c == '.' || c == '-' || c == '_'))
+        .filter_map(|tok| {
+            // Trim trailing dots — a sentence like "see src/lib.rs." would
+            // otherwise produce token "src/lib.rs." with extension "rs.".
+            let tok = tok.trim_end_matches('.');
+            if tok.len() > 256 || tok.starts_with('/') || tok.split('/').any(|seg| seg == "..") {
+                return None;
+            }
+            let (stem, ext) = tok.rsplit_once('.')?;
+            // A bare `.rs` has no stem and names nothing; `graph_snapshot`
+            // has no extension. Both must stay out.
+            if stem.is_empty() || !ANCHOR_EXTS.contains(&ext) {
+                return None;
+            }
+            Some(tok.to_string())
+        })
+        .collect()
+}
+
+/// Directories that never hold source a memory would meaningfully anchor to,
+/// and that dominate the walk cost when present.
+const ANCHOR_WALK_SKIP: &[&str] = &[
+    ".git",
+    ".stella",
+    "target",
+    "node_modules",
+    ".next",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "__pycache__",
+];
+
+/// Cap on the tree walk, so a pathological or symlinked tree cannot stall a
+/// turn's reflection or an inspection command.
+const MAX_FILES: usize = 200_000;
+
+/// Every file name present anywhere under the workspace, for resolving
+/// bare-filename anchors — they carry no directory to join onto the root, so
+/// existence is a "does the tree contain a file by this name" question.
+pub(crate) fn workspace_file_names(root: &Path) -> HashSet<String> {
+    workspace_file_index(root).into_keys().collect()
+}
+
+/// File name → every workspace-relative path carrying that name.
+///
+/// The write side needs the paths, not just the names: an anchor edge points at
+/// a `file://` node and a bare name is not a location. Where a name is
+/// ambiguous the list has more than one entry, and [`resolve_anchors`] declines
+/// to guess.
+pub(crate) fn workspace_file_index(root: &Path) -> HashMap<String, Vec<String>> {
+    let mut index: HashMap<String, Vec<String>> = HashMap::new();
+    let mut seen = 0usize;
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(kind) = entry.file_type() else {
+                continue;
+            };
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // `is_dir`/`is_file` on the entry type does not follow symlinks,
+            // so a self-referential link cannot re-enter the walk.
+            if kind.is_dir() {
+                if !ANCHOR_WALK_SKIP.contains(&name.as_str()) {
+                    queue.push_back(entry.path());
+                }
+            } else if kind.is_file() {
+                let path = entry.path();
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                index.entry(name).or_default().push(rel);
+                seen += 1;
+                if seen >= MAX_FILES {
+                    return index;
+                }
+            }
+        }
+    }
+    index
+}
+
+/// Workspace-relative paths a memory should anchor to, resolved against the
+/// tree as it is right now.
+///
+/// Only files that **exist** are anchored. An anchor to a path that was never
+/// there is not a fact that went stale, it is a hallucinated filename, and
+/// writing it would make the staleness scan's first pass immediately "end" an
+/// anchor that never held — recording a fiction in the world-time axis.
+///
+/// A bare filename matching **several** files is skipped rather than guessed.
+/// Anchoring `mod.rs` to whichever copy the walk happened to reach first would
+/// attach the lesson to an arbitrary file, and a confidently wrong edge is
+/// worse here than a missing one: the missing edge costs recall a little
+/// precision, the wrong one teaches the graph something false.
+pub(crate) fn resolve_anchors(root: &Path, text: &str) -> Vec<String> {
+    let tokens = extract_path_anchors(text);
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+    // Only pay for the tree walk if a bare name actually needs resolving.
+    let needs_index = tokens.iter().any(|t| !t.contains('/'));
+    let index = if needs_index {
+        workspace_file_index(root)
+    } else {
+        HashMap::new()
+    };
+
+    let mut out: Vec<String> = Vec::new();
+    for tok in tokens {
+        let resolved = if tok.contains('/') {
+            root.join(&tok).is_file().then_some(tok)
+        } else {
+            match index.get(&tok).map(Vec::as_slice) {
+                Some([only]) => Some(only.clone()),
+                _ => None,
+            }
+        };
+        if let Some(path) = resolved
+            && !out.contains(&path)
+        {
+            out.push(path);
+            if out.len() >= MAX_ANCHORS_PER_MEMORY {
+                break;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn extract_path_anchors_finds_source_paths() {
+        let text = "graph_snapshot() in stella-cli/src/agent.rs computes the \
+                    neighborhood. See also docs/hooks.md and src/lib.rs.";
+        let anchors = extract_path_anchors(text);
+        assert!(anchors.contains(&"stella-cli/src/agent.rs".to_string()));
+        assert!(anchors.contains(&"docs/hooks.md".to_string()));
+        assert!(anchors.contains(&"src/lib.rs".to_string()));
+        // No false positives from bare words.
+        assert!(!anchors.iter().any(|a| a == "graph_snapshot"));
+    }
+
+    #[test]
+    fn extract_path_anchors_finds_bare_filenames() {
+        // The shape reflections actually use: a file named with no directory.
+        let text = "In stella-cli witness tests (slash_models_witness.rs), prefer \
+                    updating assertions rather than changing the renderer.";
+        let anchors = extract_path_anchors(text);
+        assert!(
+            anchors.contains(&"slash_models_witness.rs".to_string()),
+            "bare filenames must anchor: {anchors:?}"
+        );
+    }
+
+    #[test]
+    fn extract_path_anchors_rejects_non_files() {
+        // A bare extension has no stem, version strings have no source
+        // extension, and prose words have no extension at all.
+        let anchors = extract_path_anchors("the .rs files in v0.4.47 use cargo test -- --exact");
+        assert!(anchors.is_empty(), "no false anchors: {anchors:?}");
+    }
+
+    #[test]
+    fn resolve_anchors_keeps_only_files_that_exist() {
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/real.rs"), "").unwrap();
+
+        let got = resolve_anchors(
+            root.path(),
+            "the fix is in src/real.rs, not src/imaginary.rs",
+        );
+        assert_eq!(got, vec!["src/real.rs".to_string()]);
+    }
+
+    #[test]
+    fn resolve_anchors_resolves_an_unambiguous_bare_filename_to_its_path() {
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("a/b")).unwrap();
+        std::fs::write(root.path().join("a/b/only.rs"), "").unwrap();
+
+        let got = resolve_anchors(root.path(), "see only.rs for the registry");
+        assert_eq!(got, vec!["a/b/only.rs".to_string()]);
+    }
+
+    #[test]
+    fn resolve_anchors_declines_to_guess_an_ambiguous_bare_filename() {
+        // Two files named `mod.rs`. Picking either would attach the lesson to
+        // an arbitrary one — a confidently wrong edge, which is worse than none.
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("a")).unwrap();
+        std::fs::create_dir_all(root.path().join("b")).unwrap();
+        std::fs::write(root.path().join("a/mod.rs"), "").unwrap();
+        std::fs::write(root.path().join("b/mod.rs"), "").unwrap();
+
+        assert!(resolve_anchors(root.path(), "as mod.rs shows").is_empty());
+    }
+
+    #[test]
+    fn resolve_anchors_caps_a_lesson_that_recites_the_whole_tree() {
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let mut text = String::new();
+        for i in 0..(MAX_ANCHORS_PER_MEMORY + 5) {
+            std::fs::write(root.path().join(format!("src/f{i}.rs")), "").unwrap();
+            text.push_str(&format!("src/f{i}.rs "));
+        }
+        assert_eq!(
+            resolve_anchors(root.path(), &text).len(),
+            MAX_ANCHORS_PER_MEMORY
+        );
+    }
+
+    #[test]
+    fn resolve_anchors_skips_the_tree_walk_when_no_bare_name_needs_it() {
+        // A rooted path resolves by `join`, so a workspace with no readable
+        // tree still anchors it. Guards the `needs_index` shortcut.
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/one.rs"), "").unwrap();
+        assert_eq!(
+            resolve_anchors(root.path(), "src/one.rs is the place"),
+            vec!["src/one.rs".to_string()]
+        );
+    }
+}

--- a/stella-cli/src/memory/learning.rs
+++ b/stella-cli/src/memory/learning.rs
@@ -134,12 +134,23 @@ impl SessionMemory {
         // identical reflection memories, so the taxonomy existed on disk in
         // `reflections.jsonl` and meant nothing to the ranking that actually
         // decides what reaches a prompt.
+        // Anchor each lesson to the files it names, so "what do we know about
+        // `registry.py`" becomes an edge traversal rather than an embedding
+        // guess. Resolved against the tree as it is now: only files that exist
+        // are anchored, and an ambiguous bare filename is skipped rather than
+        // guessed (see `anchors::resolve_anchors`). A lesson that names no file
+        // simply gets no anchors, which is the common case for process notes
+        // and is exactly right — they are not about a file.
         let delta = ContextDelta {
             memories: lessons
                 .iter()
                 .map(|l| {
                     MemoryInput::reflection(&l.lesson, l.domains.iter().cloned())
                         .with_recall_tier(l.kind.recall_tier())
+                        .with_anchors(crate::memory::anchors::resolve_anchors(
+                            &self.workspace_root,
+                            &l.lesson,
+                        ))
                 })
                 .collect(),
             ..Default::default()

--- a/stella-cli/src/memory_cmd.rs
+++ b/stella-cli/src/memory_cmd.rs
@@ -17,6 +17,8 @@ use clap::{Subcommand, ValueEnum};
 use colored::Colorize;
 use serde::Serialize;
 use stella_context::{ContextStore, NodeKind, NodeRow};
+
+use crate::memory::anchors::{extract_path_anchors, workspace_file_names};
 use stella_core::rules::{self, PromoteStatus, RuleCandidate};
 use stella_store::{ContextSurface, MemoryCitationStats, PROMOTION_CITATIONS_REQUIRED, Store};
 
@@ -46,7 +48,19 @@ pub enum MemoryCmd {
     /// checks whether those paths still exist, and flags stale ones. A stale
     /// memory is one whose referenced path no longer exists — a strong signal
     /// the memory is about refactored-away code and may mislead.
-    Validate,
+    ///
+    /// Also walks the stored `observed_in` anchor edges, which is the same
+    /// question asked of the graph rather than of the text.
+    Validate {
+        /// Record that anchors pointing at deleted files stopped holding.
+        ///
+        /// Ends each stale anchor's *world validity* — the memory keeps being
+        /// believed and `as_of` queries still return it, because it was not
+        /// wrong; the file simply went away. Live recall stops traversing it.
+        /// Without this flag the scan only reports.
+        #[arg(long)]
+        end_stale: bool,
+    },
     /// Forget a memory: stop it steering the agent, and stop the reflection
     /// loop re-learning it. Reversible with `stella memory restore <id>`.
     ///
@@ -390,7 +404,7 @@ struct MemoryValidationRow {
 /// `stella-cli/src/agent.rs`), checks whether those paths still exist, and
 /// reports stale memories — ones whose referenced files have been moved or
 /// deleted, a strong signal the memory is about refactored-away code.
-pub fn run_memory_validate() -> Result<(), String> {
+pub fn run_memory_validate(end_stale: bool) -> Result<(), String> {
     let workspace_root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let rows = validate_memories(&workspace_root)?;
@@ -435,6 +449,7 @@ pub fn run_memory_validate() -> Result<(), String> {
         );
     }
     report_duplicate_lineages(&workspace_root)?;
+    crate::memory::anchor_scan::scan_stale_anchors(&workspace_root, end_stale)?;
     Ok(())
 }
 
@@ -766,96 +781,6 @@ fn memory_text(workspace_root: &std::path::Path, id: &str) -> Result<Option<Stri
         .node_by_public_id(id)
         .map_err(|e| format!("cannot read memory `{id}`: {e}"))?;
     Ok(node.map(|n| n.content))
-}
-
-/// Source extensions a token must end in to count as a file reference.
-const ANCHOR_EXTS: &[&str] = &[
-    "rs", "py", "ts", "tsx", "js", "jsx", "go", "md", "sql", "toml",
-];
-
-/// Extract file anchors from memory text. Two shapes count:
-///
-/// * **Rooted paths** — `word/word[/word…]` with a recognized source
-///   extension, e.g. `stella-cli/src/agent.rs`, `docs/context-reuse.md`.
-///   These resolve against the workspace root directly.
-/// * **Bare filenames** — a name with a recognized extension and no
-///   directory at all, e.g. `slash_models_witness.rs`, `Cargo.toml`.
-///
-/// Bare filenames matter because that is how reflections actually name
-/// files: a lesson mined from a turn says "in `slash_models_witness.rs`",
-/// not "in `stella-cli/tests/slash_models_witness.rs`". Requiring a slash
-/// meant the memories most likely to rot — the ones naming a single test
-/// file that later got deleted — were reported as `no-anchors` and never
-/// checked, which is the failure this function exists to catch.
-fn extract_path_anchors(text: &str) -> Vec<String> {
-    text.split(|c: char| !(c.is_alphanumeric() || c == '/' || c == '.' || c == '-' || c == '_'))
-        .filter_map(|tok| {
-            // Trim trailing dots — a sentence like "see src/lib.rs." would
-            // otherwise produce token "src/lib.rs." with extension "rs.".
-            let tok = tok.trim_end_matches('.');
-            if tok.len() > 256 || tok.starts_with('/') || tok.split('/').any(|seg| seg == "..") {
-                return None;
-            }
-            let (stem, ext) = tok.rsplit_once('.')?;
-            // A bare `.rs` has no stem and names nothing; `graph_snapshot`
-            // has no extension. Both must stay out.
-            if stem.is_empty() || !ANCHOR_EXTS.contains(&ext) {
-                return None;
-            }
-            Some(tok.to_string())
-        })
-        .collect()
-}
-
-/// Directories that never hold source a memory would meaningfully anchor to,
-/// and that dominate the walk cost when present.
-const ANCHOR_WALK_SKIP: &[&str] = &[
-    ".git",
-    ".stella",
-    "target",
-    "node_modules",
-    ".next",
-    ".venv",
-    "venv",
-    "dist",
-    "build",
-    "__pycache__",
-];
-
-/// Every file name present anywhere under the workspace, for resolving
-/// bare-filename anchors — they carry no directory to join onto the root, so
-/// existence is a "does the tree contain a file by this name" question.
-///
-/// Built once per `validate` run and bounded: a pathological or symlinked
-/// tree must not stall an inspection command.
-fn workspace_file_names(root: &std::path::Path) -> std::collections::HashSet<String> {
-    const MAX_FILES: usize = 200_000;
-    let mut names = std::collections::HashSet::new();
-    let mut queue = std::collections::VecDeque::from([root.to_path_buf()]);
-    while let Some(dir) = queue.pop_front() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(kind) = entry.file_type() else {
-                continue;
-            };
-            let name = entry.file_name().to_string_lossy().into_owned();
-            // `is_dir`/`is_file` on the entry type does not follow symlinks,
-            // so a self-referential link cannot re-enter the walk.
-            if kind.is_dir() {
-                if !ANCHOR_WALK_SKIP.contains(&name.as_str()) {
-                    queue.push_back(entry.path());
-                }
-            } else if kind.is_file() {
-                names.insert(name);
-                if names.len() >= MAX_FILES {
-                    return names;
-                }
-            }
-        }
-    }
-    names
 }
 
 /// Validate all memories in a workspace against the current file tree.
@@ -1229,39 +1154,6 @@ mod tests {
             "uncited rows show `-`, not fake zeros: {out}"
         );
     }
-
-    #[test]
-    fn extract_path_anchors_finds_source_paths() {
-        let text = "graph_snapshot() in stella-cli/src/agent.rs computes the \
-                    neighborhood. See also docs/hooks.md and src/lib.rs.";
-        let anchors = extract_path_anchors(text);
-        assert!(anchors.contains(&"stella-cli/src/agent.rs".to_string()));
-        assert!(anchors.contains(&"docs/hooks.md".to_string()));
-        assert!(anchors.contains(&"src/lib.rs".to_string()));
-        // No false positives from bare words.
-        assert!(!anchors.iter().any(|a| a == "graph_snapshot"));
-    }
-
-    #[test]
-    fn extract_path_anchors_finds_bare_filenames() {
-        // The shape reflections actually use: a file named with no directory.
-        let text = "In stella-cli witness tests (slash_models_witness.rs), prefer \
-                    updating assertions rather than changing the renderer.";
-        let anchors = extract_path_anchors(text);
-        assert!(
-            anchors.contains(&"slash_models_witness.rs".to_string()),
-            "bare filenames must anchor: {anchors:?}"
-        );
-    }
-
-    #[test]
-    fn extract_path_anchors_rejects_non_files() {
-        // A bare extension has no stem, version strings have no source
-        // extension, and prose words have no extension at all.
-        let anchors = extract_path_anchors("the .rs files in v0.4.47 use cargo test -- --exact");
-        assert!(anchors.is_empty(), "no false anchors: {anchors:?}");
-    }
-
     #[test]
     fn validate_flags_stale_bare_filename_anchors() {
         // Regression: a memory naming a deleted test file by bare name was

--- a/stella-context/src/lib.rs
+++ b/stella-context/src/lib.rs
@@ -87,8 +87,8 @@ pub use store::{
     MemoryLineageStats, MemoryRevision, NodeInput, NodeKind, NodeRow,
 };
 pub use writeback::{
-    ContextDelta, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion, FactView, MemoryInput,
-    MemoryKind, UpsertReceipt,
+    ANCHOR_REL, AnchorView, ContextDelta, DomainInput, EpisodeInput, EpisodeOutcome, FactAssertion,
+    FactView, MemoryInput, MemoryKind, UpsertReceipt,
 };
 
 // Re-export the CGP wire types callers pass in/out, so a consumer needs only

--- a/stella-context/src/retrieval.rs
+++ b/stella-context/src/retrieval.rs
@@ -32,8 +32,8 @@ use crate::candidates::{
 };
 use crate::error::ContextError;
 use crate::store::{
-    ContextStore, NodeRow, domains_by_node, lock_conn, neighbors, node_ids_excluded_by_scope,
-    node_ids_for_uris,
+    ContextStore, NodeRow, domains_by_node, lock_conn, neighbors_valid_at,
+    node_ids_excluded_by_scope, node_ids_for_uris,
 };
 
 /// Provenance `kind` marking a frame's domain tag, so a citation view can show
@@ -621,6 +621,9 @@ impl ContextStore {
         let inputs = RecallInputs {
             anchors: q.anchors.clone(),
             as_of: q.as_of.clone(),
+            // Live recall asks "what holds now"; an `as_of` query asks "what did
+            // we believe then" and must keep answering it unfiltered.
+            valid_at: q.as_of.is_none().then(|| self.clock().now_rfc3339()),
             excluded_ids: excluded_ids.clone(),
             tuning: self.tuning(),
             max_frames: q.max_frames,
@@ -679,6 +682,21 @@ struct RecallInputs {
     anchors: Vec<String>,
     /// Transaction-time pin for which fact edges are visible.
     as_of: Option<String>,
+    /// World-time pin for which edges still *hold*, as distinct from which are
+    /// still *believed* (`as_of`).
+    ///
+    /// `Some(now)` on the live path, so an anchor to a file that has since been
+    /// deleted stops feeding graph adjacency the moment the staleness scan ends
+    /// its validity. Every edge written before anchors existed has
+    /// `valid_from`/`valid_to` NULL, and NULL is unbounded on both ends, so this
+    /// is a no-op for all of them — it excludes exactly the edges something
+    /// deliberately ended, and nothing else.
+    ///
+    /// `None` when the caller pinned `as_of`, which is the time-travel/audit
+    /// path: reconstructing a past belief set must not be filtered by today's
+    /// world, and that is the behaviour `as_of_ignores_world_validity_valid_from_valid_to`
+    /// pins.
+    valid_at: Option<String>,
     /// Frame-count budget — also what bounds the candidate cut.
     max_frames: u32,
     /// Token budget the packer enforces.
@@ -904,7 +922,9 @@ fn recall_blocking(
             // mentioned symbol), so they enter the list with a base weight.
             *graph_weight.entry(s).or_insert(0.0) += 1.0;
         }
-        for (neighbor, weight) in neighbors(conn, &seeds, q.as_of.as_deref())? {
+        for (neighbor, weight) in
+            neighbors_valid_at(conn, &seeds, q.as_of.as_deref(), q.valid_at.as_deref())?
+        {
             *graph_weight.entry(neighbor).or_insert(0.0) += weight;
         }
         let mut graph_scored: Vec<(i64, f64)> = graph_weight.into_iter().collect();

--- a/stella-context/src/retrieval/tests.rs
+++ b/stella-context/src/retrieval/tests.rs
@@ -1206,3 +1206,114 @@ async fn recall_work_is_bounded_by_frame_count_not_corpus_size() {
          {per_node_first:.2} at 50 nodes vs {per_node_last:.2} at 5000: {measured:?}"
     );
 }
+
+/// The load-bearing integration test for memory anchors.
+///
+/// #775 gave the store the ability to say "this stopped being true" without
+/// saying "we were wrong". That was inert on its own: retrieval read belief
+/// time only, so an anchor to a deleted file kept feeding graph adjacency
+/// forever. This asserts the two halves are actually connected — end an
+/// anchor's world validity, and live recall stops traversing it.
+///
+/// The memory is written to be unreachable by every *other* signal: its text
+/// shares no vocabulary with the query, and later memories outrank it on
+/// recency. The graph edge is the only thing that can put it in the result, so
+/// its disappearance is attributable.
+#[tokio::test]
+async fn ending_an_anchor_stops_live_recall_traversing_it() {
+    let clock = FixedClock::shared(1_000);
+    let dir = TempDir::new().unwrap();
+    let store = ContextStore::open_with(
+        dir.path().join("context.db"),
+        Arc::new(HashEmbedder::default()),
+        clock.clone(),
+    )
+    .unwrap();
+
+    // The anchored memory, plus the file it is about.
+    store
+        .upsert(
+            crate::writeback::ContextDelta::new().with_memory(
+                crate::writeback::MemoryInput::reflection(
+                    "zzz quokka marmalade tessellation",
+                    Vec::<String>::new(),
+                )
+                .with_anchors(["src/registry.rs"]),
+            ),
+        )
+        .await
+        .unwrap();
+
+    // A corpus big enough that the frame budget genuinely binds. Without this
+    // the anchored memory is one of a handful and recency alone seats it, so
+    // its presence would prove nothing about the edge.
+    for i in 0..40 {
+        clock.advance(100);
+        store
+            .upsert(crate::writeback::ContextDelta::new().with_memory(
+                crate::writeback::MemoryInput::reflection(
+                    format!("unrelated later note number {i} about deployment rollout"),
+                    Vec::<String>::new(),
+                ),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let mut q = base_query("what do we know here", "deployment note");
+    // Seed the graph expansion at the anchored file. The uri spelling must
+    // match what the write side minted.
+    q.anchors = vec!["file://src/registry.rs".into()];
+    q.max_frames = 3;
+
+    let before = store.recall(&q).await.unwrap();
+    let seen_before = before
+        .frames
+        .iter()
+        .any(|f| f.content.as_deref().unwrap_or_default().contains("quokka"));
+    assert!(
+        seen_before,
+        "the anchor should pull the memory in: {:?}",
+        before
+            .frames
+            .iter()
+            .map(|f| f.content.clone())
+            .collect::<Vec<_>>()
+    );
+
+    // The file is deleted. End world validity — belief untouched.
+    let anchor = store.open_anchors().unwrap().remove(0);
+    clock.advance(1_000);
+    let deleted_at = store.clock().now_rfc3339();
+    assert!(
+        store
+            .end_anchor_validity(anchor.edge_id, &deleted_at)
+            .unwrap()
+    );
+
+    let after = store.recall(&q).await.unwrap();
+    let seen_after = after
+        .frames
+        .iter()
+        .any(|f| f.content.as_deref().unwrap_or_default().contains("quokka"));
+    assert!(
+        !seen_after,
+        "an anchor to a deleted file must stop feeding recall: {:?}",
+        after
+            .frames
+            .iter()
+            .map(|f| f.content.clone())
+            .collect::<Vec<_>>()
+    );
+
+    // And the belief is still there to be audited — this is the whole reason
+    // it is `end_world_validity` and not `close_edge`.
+    assert!(
+        store
+            .facts_as_of(None)
+            .unwrap()
+            .iter()
+            .any(|f| f.predicate == crate::writeback::ANCHOR_REL),
+        "the anchor is still BELIEVED; only the present stops seeing it"
+    );
+}

--- a/stella-context/src/store.rs
+++ b/stella-context/src/store.rs
@@ -46,7 +46,9 @@ pub(crate) use domain::{
     domains_by_node, list_domains, node_ids_excluded_by_scope, tag_edge_domains, tag_node_domains,
     upsert_domain,
 };
-pub(crate) use edge::{close_edge, edges_as_of, insert_edge, neighbors};
+pub(crate) use edge::{
+    close_edge, edges_as_of, end_world_validity, insert_edge, neighbors_valid_at, open_anchors,
+};
 pub(crate) use embedding::{
     blob_to_vector, embedding_exists, nodes_missing_embedding, store_embedding, vector_to_blob,
 };

--- a/stella-context/src/store/edge.rs
+++ b/stella-context/src/store/edge.rs
@@ -11,17 +11,6 @@ use crate::error::ContextError;
 
 use super::sha256_hex;
 
-/// 1-hop neighbors of `seeds` over currently-believed fact edges, as
-/// `(neighbor_id, edge_weight)`. `as_of` (transaction time) pins which beliefs
-/// are visible: `None` = currently believed (`superseded_at IS NULL`).
-pub(crate) fn neighbors(
-    conn: &Connection,
-    seeds: &[i64],
-    as_of: Option<&str>,
-) -> Result<Vec<(i64, f64)>, ContextError> {
-    neighbors_valid_at(conn, seeds, as_of, None)
-}
-
 /// 1-hop neighbours over edges believed at `as_of` **and** holding in the
 /// world at `valid_at`.
 ///
@@ -182,10 +171,6 @@ pub(crate) fn close_edge(
 /// reports the edge as believed. `valid_at` is what hides it from the present.
 ///
 /// Never deletes (`L-C3`): "what was true at T1" must still answer.
-// The staleness scan that calls this lands next; the primitive and its
-// semantics are separable from the policy that decides which anchors are
-// stale, and the semantics are the part worth pinning first.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn end_world_validity(
     conn: &Connection,
     edge_id: i64,
@@ -196,6 +181,52 @@ pub(crate) fn end_world_validity(
         params![edge_id, valid_to],
     )?;
     Ok(changed > 0)
+}
+
+/// One anchor edge that is still open on both axes, with the target it names.
+#[derive(Debug, Clone)]
+pub(crate) struct OpenAnchor {
+    /// Edge rowid — what [`end_world_validity`] takes.
+    pub edge_id: i64,
+    /// The anchored node's `uri`, e.g. `file://stella-cli/src/agent.rs`.
+    pub uri: String,
+    /// The anchoring memory's content, for reporting which memory goes stale.
+    pub memory: String,
+}
+
+/// Every `rel` anchor still believed *and* still holding in the world.
+///
+/// Both axes are filtered, and for different reasons: a superseded anchor is
+/// one we no longer believe and must not re-end, and an anchor whose world
+/// validity already ended is one a previous scan already handled — re-ending it
+/// is not merely wasted work, it would move the date the file actually
+/// disappeared if `end_world_validity` were ever made unconditional.
+///
+/// Returned in edge-id order so a scan's report is stable between runs.
+pub(crate) fn open_anchors(conn: &Connection, rel: &str) -> Result<Vec<OpenAnchor>, ContextError> {
+    let mut stmt = conn.prepare(
+        "SELECT e.id, dst.uri, src.content
+         FROM edge e
+         JOIN node dst ON dst.id = e.dst_id
+         JOIN node src ON src.id = e.src_id
+         WHERE e.rel = ?1
+           AND e.superseded_at IS NULL
+           AND e.valid_to IS NULL
+           AND dst.uri IS NOT NULL
+         ORDER BY e.id",
+    )?;
+    let rows = stmt.query_map(params![rel], |r| {
+        Ok(OpenAnchor {
+            edge_id: r.get(0)?,
+            uri: r.get(1)?,
+            memory: r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
 }
 
 /// Fact edges as believed at a transaction-time instant. `as_of = None` means

--- a/stella-context/src/store/tests.rs
+++ b/stella-context/src/store/tests.rs
@@ -684,9 +684,12 @@ fn edge_pairs(conn: &Connection, as_of: Option<&str>) -> Vec<(i64, i64)> {
     v
 }
 
-/// Sorted neighbor ids of `seed` visible to `neighbors` at `as_of`.
+/// Sorted neighbor ids of `seed` believed at `as_of`, with **no** world-time
+/// filter — `valid_at = None` is the legacy behaviour these tests pin, and
+/// spelling it out here is what makes `as_of_ignores_world_validity_valid_from_valid_to`
+/// a statement about belief time rather than an accident of a wrapper's default.
 fn neighbor_ids(conn: &Connection, seed: i64, as_of: Option<&str>) -> Vec<i64> {
-    let mut v: Vec<i64> = neighbors(conn, &[seed], as_of)
+    let mut v: Vec<i64> = neighbors_valid_at(conn, &[seed], as_of, None)
         .unwrap()
         .into_iter()
         .map(|(n, _)| n)
@@ -1366,7 +1369,6 @@ fn v8_creates_the_ledger_empty() {
     );
 }
 
-
 /// A deleted file ends an anchor's world validity WITHOUT unbelieving it.
 ///
 /// The requirement this pins: a memory whose file was deleted is not wrong and
@@ -1380,14 +1382,24 @@ fn ending_world_validity_hides_the_present_and_preserves_the_past() {
     let (memory, file) = (concept(&conn, "memory"), concept(&conn, "file"));
     let props = serde_json::json!({});
     let edge = insert_edge(
-        &conn, "observed_in", memory, file, 1.0, &props,
-        Some(T0), None, T0, None,
+        &conn,
+        "observed_in",
+        memory,
+        file,
+        1.0,
+        &props,
+        Some(T0),
+        None,
+        T0,
+        None,
     )
     .unwrap();
 
     // Believed and world-valid: recalled now.
     assert_eq!(
-        neighbors_valid_at(&conn, &[memory], None, Some(T1_5)).unwrap().len(),
+        neighbors_valid_at(&conn, &[memory], None, Some(T1_5))
+            .unwrap()
+            .len(),
         1,
         "an open anchor is recallable"
     );
@@ -1397,13 +1409,17 @@ fn ending_world_validity_hides_the_present_and_preserves_the_past() {
 
     // The present no longer recalls it...
     assert!(
-        neighbors_valid_at(&conn, &[memory], None, Some(T3)).unwrap().is_empty(),
+        neighbors_valid_at(&conn, &[memory], None, Some(T3))
+            .unwrap()
+            .is_empty(),
         "after the file is gone the anchor must not be recalled"
     );
 
     // ...but it was true before, and still answers as of then.
     assert_eq!(
-        neighbors_valid_at(&conn, &[memory], None, Some(T1_5)).unwrap().len(),
+        neighbors_valid_at(&conn, &[memory], None, Some(T1_5))
+            .unwrap()
+            .len(),
         1,
         "the past is preserved: the anchor held at T1_5 and must still say so"
     );
@@ -1423,15 +1439,34 @@ fn ending_world_validity_twice_keeps_the_first_end_date() {
     let conn = store.conn();
     let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
     let props = serde_json::json!({});
-    let edge = insert_edge(&conn, "observed_in", a, b, 1.0, &props, Some(T0), None, T0, None).unwrap();
+    let edge = insert_edge(
+        &conn,
+        "observed_in",
+        a,
+        b,
+        1.0,
+        &props,
+        Some(T0),
+        None,
+        T0,
+        None,
+    )
+    .unwrap();
 
-    assert!(end_world_validity(&conn, edge, T1).unwrap(), "first close wins");
+    assert!(
+        end_world_validity(&conn, edge, T1).unwrap(),
+        "first close wins"
+    );
     assert!(
         !end_world_validity(&conn, edge, T3).unwrap(),
         "a second close must not move the date a file actually disappeared"
     );
     // Still invisible at T3, and the recorded end is T1 rather than T3.
-    assert!(neighbors_valid_at(&conn, &[a], None, Some(T2)).unwrap().is_empty());
+    assert!(
+        neighbors_valid_at(&conn, &[a], None, Some(T2))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 /// The default path is byte-for-byte the old behaviour.
@@ -1442,7 +1477,19 @@ fn valid_at_none_ignores_world_validity_exactly_as_before() {
     let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
     let props = serde_json::json!({});
     // World validity closed in the past, still believed.
-    insert_edge(&conn, "relates_to", a, b, 1.0, &props, Some(T0), Some(T1), T1, None).unwrap();
+    insert_edge(
+        &conn,
+        "relates_to",
+        a,
+        b,
+        1.0,
+        &props,
+        Some(T0),
+        Some(T1),
+        T1,
+        None,
+    )
+    .unwrap();
     assert_eq!(
         neighbors_valid_at(&conn, &[a], None, None).unwrap().len(),
         1,

--- a/stella-context/src/writeback.rs
+++ b/stella-context/src/writeback.rs
@@ -15,11 +15,20 @@ use sha2::{Digest, Sha256};
 use crate::error::ContextError;
 use crate::retrieval::RecallTier;
 use crate::store::{
-    ContextStore, NodeInput, NodeKind, close_edge, edges_as_of, embedding_exists, insert_edge,
-    insert_episode, insert_memory, node_by_id, sha256_hex, store_embedding, tag_edge_domains,
-    tag_node_domains, to_hex, upsert_domain, upsert_node,
+    ContextStore, NodeInput, NodeKind, close_edge, edges_as_of, embedding_exists,
+    end_world_validity, insert_edge, insert_episode, insert_memory, node_by_id, open_anchors,
+    sha256_hex, store_embedding, tag_edge_domains, tag_node_domains, to_hex, upsert_domain,
+    upsert_node,
 };
 use crate::warm;
+
+/// `edge.rel` for a memory-to-file anchor: *this memory is about that file*.
+///
+/// One string, exported, because three planes have to agree on it — the write
+/// side in [`ContextStore::upsert`], the staleness scan that ends its world
+/// validity, and any future recall that traverses it. A literal repeated in
+/// three crates is a rename away from anchors that silently stop matching.
+pub const ANCHOR_REL: &str = "observed_in";
 
 /// How an episode turned out. Stored as its `as_str` form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -267,6 +276,23 @@ pub struct MemoryInput {
     /// lifecycle writes process notes as [`RecallTier::Deferred`] so a durable
     /// fact about the codebase is not evicted by commentary about the turn.
     pub recall_tier: RecallTier,
+    /// Workspace-relative paths of the files this memory is *about*.
+    ///
+    /// Each becomes an `observed_in` edge from the memory's mirror node to a
+    /// [`NodeKind::File`] node, which is what turns *"what does the agent know
+    /// about `registry.py`"* into an edge traversal rather than an embedding
+    /// guess.
+    ///
+    /// The edges are written with an open `valid_from`/`valid_to`: we do not
+    /// claim to know when the memory *started* being about the file, only that
+    /// it is now. When the file is deleted, the staleness scan ends the world
+    /// validity — the belief is never retracted, because it was not wrong (see
+    /// `store::edge::end_world_validity`).
+    ///
+    /// Anchors are a claim about the *subject* of the memory, not a log of what
+    /// the turn happened to touch. A turn edits a dozen files; the lesson is
+    /// usually about one.
+    pub anchors: Vec<String>,
 }
 
 impl MemoryInput {
@@ -283,7 +309,19 @@ impl MemoryInput {
             salience: 0.0,
             lineage: None,
             recall_tier: RecallTier::Normal,
+            anchors: Vec::new(),
         }
+    }
+
+    /// Anchor this memory to the files it is about. See [`MemoryInput::anchors`].
+    #[must_use]
+    pub fn with_anchors<I, S>(mut self, anchors: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.anchors = anchors.into_iter().map(Into::into).collect();
+        self
     }
 
     /// Ask for a non-default precedence band at recall. See [`RecallTier`].
@@ -302,6 +340,7 @@ impl MemoryInput {
             salience: 0.0,
             lineage: None,
             recall_tier: RecallTier::Normal,
+            anchors: Vec::new(),
         }
     }
 
@@ -481,6 +520,27 @@ pub struct UpsertReceipt {
     pub embeddings_reused: usize,
     /// New domain-tag associations written across all records this batch.
     pub domain_tags_added: usize,
+    /// `observed_in` anchor edges inserted from a memory to a file it is about.
+    /// Re-asserting an anchor that is already open on both time axes inserts
+    /// nothing and is not counted; an anchor whose world validity was ended by
+    /// the staleness scan *is* re-opened, because a file that came back is a
+    /// new fact about the world rather than a duplicate of the old one.
+    pub anchors_written: usize,
+}
+
+/// An open memory→file anchor, as the staleness scan sees it.
+#[derive(Debug, Clone)]
+pub struct AnchorView {
+    /// Edge rowid — pass to [`ContextStore::end_anchor_validity`].
+    pub edge_id: i64,
+    /// The anchored node's full uri, e.g. `file://stella-cli/src/agent.rs`.
+    pub uri: String,
+    /// The uri with its `file://` scheme stripped: the workspace-relative path
+    /// to test for existence. Anchors are written relative (matching
+    /// `record_taxonomy`), so this joins onto the workspace root directly.
+    pub path: String,
+    /// The anchoring memory's text, so a report can name what goes stale.
+    pub memory: String,
 }
 
 /// A fact resolved to human labels for point-in-time queries (`L-C4`: cite by
@@ -646,6 +706,44 @@ impl ContextStore {
             receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, &now)?;
             receipt.nodes_upserted += 1;
             receipt.memories_written += 1;
+
+            // Anchor the memory to the files it is about. Written here rather
+            // than left to the caller as a `FactAssertion` because the mirror
+            // node's identity is minted in this loop — a caller would have to
+            // reconstruct `memory://{lineage}` by hand and would silently
+            // anchor to nothing the day that spelling changed.
+            for path in &memory.anchors {
+                let file = NodeInput::new(NodeKind::File, path.as_str())
+                    .with_uri(format!("file://{path}"))
+                    .with_domains(memory.domains.clone());
+                let dst = upsert_node(&tx, &file, &now)?;
+                receipt.domain_tags_added += tag_node_domains(&tx, dst, &file.domains, &now)?;
+                receipt.nodes_upserted += 1;
+                // Open on BOTH axes, not merely un-superseded: an anchor whose
+                // file was deleted has `valid_to` set and `superseded_at` null,
+                // and re-learning the same lesson after the file comes back
+                // must open a new interval rather than be swallowed as a
+                // duplicate. `live_triple_exists` checks belief only, which is
+                // right for `apply_fact` and wrong here.
+                if !open_anchor_exists(&tx, id, ANCHOR_REL, dst)? {
+                    insert_edge(
+                        &tx,
+                        ANCHOR_REL,
+                        id,
+                        dst,
+                        1.0,
+                        &serde_json::json!({}),
+                        // No `valid_from`: we know the memory is about this
+                        // file now, not when that started being true. NULL is
+                        // "unbounded in the past", which is the honest claim.
+                        None,
+                        None,
+                        &now,
+                        None,
+                    )?;
+                    receipt.anchors_written += 1;
+                }
+            }
         }
 
         for fact in &delta.facts {
@@ -663,6 +761,39 @@ impl ContextStore {
 
         tx.commit()?;
         Ok(receipt)
+    }
+
+    /// Every memory→file anchor still believed and still holding in the world.
+    ///
+    /// This is deliberately a *reader*, not a scan. The store knows which
+    /// anchors are open; it does not know which files exist, and it must not
+    /// learn — a workspace walk in here would put filesystem policy behind the
+    /// database's back and make the store untestable without a real tree. The
+    /// caller pairs this with [`ContextStore::end_anchor_validity`].
+    pub fn open_anchors(&self) -> Result<Vec<AnchorView>, ContextError> {
+        let conn = self.conn();
+        Ok(open_anchors(&conn, ANCHOR_REL)?
+            .into_iter()
+            .map(|a| AnchorView {
+                edge_id: a.edge_id,
+                path: a.uri.strip_prefix("file://").unwrap_or(&a.uri).to_string(),
+                uri: a.uri,
+                memory: a.memory,
+            })
+            .collect())
+    }
+
+    /// Record that an anchor stopped holding in the world at `valid_to`.
+    ///
+    /// Ends world validity only: the memory is not retracted and `as_of`
+    /// queries still report the anchor as believed, because it was never wrong
+    /// — the file simply went away. Returns `false` if the anchor had already
+    /// been ended, so a second scan cannot move the date the file disappeared.
+    ///
+    /// See `store::edge::end_world_validity` for why this is not `close_edge`.
+    pub fn end_anchor_validity(&self, edge_id: i64, valid_to: &str) -> Result<bool, ContextError> {
+        let conn = self.conn();
+        end_world_validity(&conn, edge_id, valid_to)
     }
 
     /// Fact edges as believed at a transaction-time instant, resolved to human
@@ -822,6 +953,29 @@ fn live_triple_exists(
     let n: i64 = conn.query_row(
         "SELECT COUNT(*) FROM edge
          WHERE src_id = ?1 AND rel = ?2 AND dst_id = ?3 AND superseded_at IS NULL",
+        rusqlite::params![src, rel, dst],
+        |r| r.get(0),
+    )?;
+    Ok(n > 0)
+}
+
+/// Does an anchor exist that is open on **both** time axes?
+///
+/// The belief-only test ([`live_triple_exists`]) is the right idempotence check
+/// for [`apply_fact`], where ending world validity is not a thing that happens.
+/// It is the wrong one for anchors: the staleness scan sets `valid_to` and
+/// deliberately leaves `superseded_at` null, so a deleted-then-restored file
+/// would look "live" forever and never regain an anchor.
+fn open_anchor_exists(
+    conn: &rusqlite::Connection,
+    src: i64,
+    rel: &str,
+    dst: i64,
+) -> Result<bool, ContextError> {
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM edge
+         WHERE src_id = ?1 AND rel = ?2 AND dst_id = ?3
+           AND superseded_at IS NULL AND valid_to IS NULL",
         rusqlite::params![src, rel, dst],
         |r| r.get(0),
     )?;
@@ -1069,6 +1223,127 @@ mod tests {
             beliefs.len(),
             2,
             "both dependencies are concurrently believed"
+        );
+    }
+
+    /// A memory carrying anchors writes one `observed_in` edge per file, and
+    /// the store reports them as open.
+    #[tokio::test]
+    async fn a_memory_anchors_to_the_files_it_is_about() {
+        let clock = FixedClock::shared(1_000);
+        let (_dir, store) = store_at(clock.clone());
+
+        let receipt = store
+            .upsert(
+                ContextDelta::new().with_memory(
+                    MemoryInput::reflection("handlers register in registry.rs", ["core"])
+                        .with_anchors(["src/registry.rs", "src/main.rs"]),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.anchors_written, 2);
+        let open = store.open_anchors().unwrap();
+        let mut paths: Vec<String> = open.iter().map(|a| a.path.clone()).collect();
+        paths.sort();
+        assert_eq!(paths, vec!["src/main.rs", "src/registry.rs"]);
+        assert!(
+            open.iter().all(|a| a.memory.contains("registry.rs")),
+            "each anchor names the memory it came from, so a scan can report it"
+        );
+    }
+
+    /// Re-learning the same lesson must not grow the graph. The reflection loop
+    /// re-mines paraphrases constantly, so an anchor that duplicated per turn
+    /// would make one file accumulate hundreds of identical edges.
+    #[tokio::test]
+    async fn re_anchoring_the_same_file_writes_nothing_new() {
+        let clock = FixedClock::shared(1_000);
+        let (_dir, store) = store_at(clock.clone());
+
+        let delta = || {
+            ContextDelta::new().with_memory(
+                MemoryInput::reflection("handlers register in registry.rs", ["core"])
+                    .with_anchors(["src/registry.rs"]),
+            )
+        };
+        let first = store.upsert(delta()).await.unwrap();
+        clock.advance(1_000);
+        let second = store.upsert(delta()).await.unwrap();
+
+        assert_eq!(first.anchors_written, 1);
+        assert_eq!(second.anchors_written, 0, "the anchor already held");
+        assert_eq!(store.open_anchors().unwrap().len(), 1);
+    }
+
+    /// The distinction `live_triple_exists` cannot make.
+    ///
+    /// A deleted file ends the anchor's world validity but leaves it believed.
+    /// A belief-only idempotence check therefore sees it as "already there"
+    /// forever, and a file that comes back would never regain an anchor.
+    #[tokio::test]
+    async fn an_anchor_reopens_after_its_file_comes_back() {
+        let clock = FixedClock::shared(1_000);
+        let (_dir, store) = store_at(clock.clone());
+
+        let delta = || {
+            ContextDelta::new().with_memory(
+                MemoryInput::reflection("handlers register in registry.rs", ["core"])
+                    .with_anchors(["src/registry.rs"]),
+            )
+        };
+        store.upsert(delta()).await.unwrap();
+        let anchor = store.open_anchors().unwrap().remove(0);
+
+        // The file is deleted: world validity ends, belief is untouched.
+        clock.advance(1_000);
+        let deleted_at = store.clock().now_rfc3339();
+        assert!(
+            store
+                .end_anchor_validity(anchor.edge_id, &deleted_at)
+                .unwrap()
+        );
+        assert!(
+            store.open_anchors().unwrap().is_empty(),
+            "an ended anchor is not open"
+        );
+
+        // The file comes back and the lesson is re-learned.
+        clock.advance(1_000);
+        let again = store.upsert(delta()).await.unwrap();
+        assert_eq!(
+            again.anchors_written, 1,
+            "a file that returned is a new fact about the world, not a duplicate"
+        );
+        assert_eq!(store.open_anchors().unwrap().len(), 1);
+    }
+
+    /// Ending an anchor twice must not move the date the file disappeared.
+    #[tokio::test]
+    async fn ending_an_anchor_twice_keeps_the_first_date() {
+        let clock = FixedClock::shared(1_000);
+        let (_dir, store) = store_at(clock.clone());
+        store
+            .upsert(
+                ContextDelta::new().with_memory(
+                    MemoryInput::reflection("about registry.rs", ["core"])
+                        .with_anchors(["src/registry.rs"]),
+                ),
+            )
+            .await
+            .unwrap();
+        let anchor = store.open_anchors().unwrap().remove(0);
+
+        clock.advance(1_000);
+        let first = store.clock().now_rfc3339();
+        assert!(store.end_anchor_validity(anchor.edge_id, &first).unwrap());
+
+        clock.advance(10_000);
+        let later = store.clock().now_rfc3339();
+        assert!(
+            !store.end_anchor_validity(anchor.edge_id, &later).unwrap(),
+            "a second scan reports no change rather than re-dating the deletion"
         );
     }
 }

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -50,6 +50,32 @@ Re-validate old memories against the current codebase. It scans each memory for 
 stella memory validate
 ```
 
+It also walks the **anchor edges** the reflection loop writes — the same question
+asked of the graph rather than of the text. When a lesson names a file, that file
+becomes an `observed_in` edge, so *"what do we know about `registry.py`"* is a
+traversal instead of an embedding guess.
+
+```bash
+stella memory validate --end-stale
+```
+
+`--end-stale` records that anchors pointing at deleted files stopped holding.
+This is the one write the command can make, and it is narrower than it looks:
+
+- The memory is **not retracted**. It was not wrong — the file simply went away.
+  `as_of` queries still return it, and `stella memory list` still shows it.
+- Only *world validity* ends, so live recall stops traversing that edge while
+  "what was true last March" keeps answering.
+- Running it twice is safe: the second pass reports no change rather than moving
+  the date the file disappeared.
+
+<Callout type="info">
+An anchor is only written for a file that exists at the time the lesson is
+learned, and a bare filename matching several files (`mod.rs`) is skipped rather
+than guessed. A confidently wrong edge teaches the graph something false; a
+missing one only costs a little recall precision.
+</Callout>
+
 ### `stella memory forget <id>`
 
 Stop a memory steering the agent — and stop the reflection loop re-learning it.


### PR DESCRIPTION
Builds the policy and plumbing on top of #775, whose primitives shipped with no callers.

## The problem #775 left open

#775 separated world validity from belief time, so the store can say *"this stopped being true"* without saying *"we were wrong"*. That was the hard half, and it was inert:

- nothing **wrote** anchors,
- nothing **scanned** for stale ones, and
- retrieval read belief time only, so ending an anchor's world validity changed nothing that reached a prompt.

All three land here. Any two of them would still be a no-op.

## Write side

`MemoryInput::anchors` carries the workspace-relative paths a memory is about; `upsert` mints one `observed_in` edge per path in the same transaction as the memory.

This lives in the store rather than in the caller because the memory's mirror node identity is minted inside that loop — a caller would reconstruct `memory://{lineage}` by hand and would silently anchor to nothing the day that spelling changed.

Reflection fills it from the lesson text, using the same tokens `stella memory validate` already reads. Two deliberate restrictions:

- **Anchors describe the memory's subject, not the turn's footprint.** A turn edits a dozen files; the lesson is usually about one. Anchoring to everything touched would make every one of those files recall it.
- **Only files that exist are anchored, and an ambiguous bare filename is skipped.** Picking one of two `mod.rs` files attaches the lesson to an arbitrary one. A confidently wrong edge teaches the graph something false; a missing one costs a little recall precision.

## Scan

`stella memory validate` also walks the open anchors now, and `--end-stale` records that the ones pointing at deleted files stopped holding.

The store exposes `open_anchors` and `end_anchor_validity` and deliberately does **not** walk the filesystem. "Which anchors are stale" is a question about a tree; keeping it out of the store is what lets the store be tested without one, and what keeps the semantics separable from the policy — the split #775 argued for.

Report-only by default. Ending an anchor is a write to history, and a command named `validate` should not change the store because you ran an inspection.

## Recall — the piece that made the rest real

`recall_blocking` now passes a world-time pin to `neighbors_valid_at`, so an ended anchor stops feeding graph adjacency.

Every edge written before anchors existed has NULL validity, and NULL is unbounded on both ends, so **this is a no-op for all of them**. It excludes exactly the edges something deliberately ended, and nothing else.

An `as_of` query still passes `None`: reconstructing a past belief set must not be filtered by today's world. That is what `as_of_ignores_world_validity_valid_from_valid_to` — THE DISCRIMINATOR — pins, and it is untouched.

## Two things that bit

**`live_triple_exists` checks belief only.** Right for `apply_fact`, wrong for anchors. A deleted file leaves the edge *believed*, so a belief-only idempotence check sees it as present forever and a file that came back would never regain an anchor. Anchors use an open-on-both-axes check instead, and `an_anchor_reopens_after_its_file_comes_back` pins it.

**The `file://` spelling differs between planes.** `record_taxonomy` mints workspace-relative, `stella-graph` mints absolute. Anchors follow `record_taxonomy` (same database), and a test pins that the scan resolves them back onto the workspace. Had the scan joined an absolute uri onto the workspace root it would have resolved nothing, reported every anchor stale, and deleted the whole graph on its first run.

## Tests

`ending_an_anchor_stops_live_recall_traversing_it` is the load-bearing one, and it is **negative-controlled**: reverting the `valid_at` wiring makes it fail. It is testing the connection, not restating it. The corpus is sized so the frame budget genuinely binds — with a handful of memories, recency seats the anchored one regardless and its presence would prove nothing.

Also new: anchors are written and reported; re-anchoring writes nothing; an anchor reopens after its file returns; ending twice keeps the first date; the scan ends only the gone file's anchor and leaves both believed; plus resolution tests for existence, ambiguity, and the cap.

148 stella-context + 762 stella-cli pass. `make check` clean (fmt, clippy, invariants, file-size, action-pins).

## Incidental

- `neighbors` deleted — a wrapper whose only remaining caller was a test helper, which now says `valid_at = None` explicitly.
- `memory_cmd.rs` crossed the 1500-line ceiling, so the scan moved to `memory/anchor_scan.rs` rather than taking a baseline entry.

## Summary by Sourcery

Anchor context memories to workspace files and make deleted files end those anchors while keeping past beliefs intact.

New Features:
- Add memory-to-file anchor edges based on file references in reflection text and expose them via the context store.
- Allow `stella memory validate` to optionally end anchors pointing to deleted files using a new `--end-stale` flag while remaining read-only by default.

Enhancements:
- Update live recall to respect world-time validity so anchors to deleted files no longer influence graph-based retrieval.
- Factor shared anchor extraction and resolution logic into dedicated CLI memory modules and add comprehensive tests around anchor lifecycle and validity semantics.

Documentation:
- Extend `stella memory` documentation to describe anchor edges and the new `--end-stale` behavior for validating and ending stale anchors.

Tests:
- Add integration and store-level tests to cover anchor creation, idempotent re-anchoring, reopening after file restoration, correct handling of world validity, and the effect of ending anchors on recall.
