### PR TITLE
feat(serve,observatory): fill in the deferred network-surface budgets and take their rulings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,6 +3320,7 @@ name = "stella-serve"
 version = "0.5.61"
 dependencies = [
  "async-trait",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "stella-core",

--- a/stella-observatory/src/fsview.rs
+++ b/stella-observatory/src/fsview.rs
@@ -12,10 +12,49 @@
 //!    sensitive-looking key (and every value under `env`/`headers` maps)
 //!    before the JSON is serialized into a response.
 
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use serde_json::{Value, json};
+
+/// Entries read from any one directory before the scan stops.
+///
+/// These directories hold hand-written skills, memories and rule files, so a
+/// real one holds tens. The bound exists because a request from the page
+/// triggers the walk synchronously, and a directory that has grown pathological
+/// (or been pointed somewhere unexpected) should degrade the dashboard rather
+/// than stall it.
+const MAX_DIR_ENTRIES: usize = 512;
+
+/// Bytes read from any one file whose content is only used to build a snippet
+/// or read frontmatter.
+///
+/// Both uses look at the head of the file, so slurping a whole one to render
+/// 200 characters is pure waste — and unbounded waste, on the request path.
+/// The reported `bytes` is deliberately taken from the file's metadata rather
+/// than from what was read, so the number the dashboard shows stays the true
+/// file size.
+const MAX_SNIPPET_READ_BYTES: u64 = 64 * 1024;
+
+/// Read at most [`MAX_SNIPPET_READ_BYTES`] of a file as text.
+///
+/// Truncation can land mid-codepoint; `from_utf8_lossy` resolves that to a
+/// replacement character, which is correct here because every caller is
+/// building a preview rather than parsing.
+fn read_head(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf = Vec::new();
+    file.take(MAX_SNIPPET_READ_BYTES)
+        .read_to_end(&mut buf)
+        .ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// The file's real size, for display alongside a bounded read.
+fn file_len(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
 
 /// The user-scope stella config dir (`~/.stella`) — `HOME` only, matching
 /// `stella_cli::settings::user_settings_path`, so the config tab names the
@@ -84,7 +123,9 @@ fn frontmatter_fields(text: &str) -> (Option<String>, Option<String>) {
 
 /// One skill entry from a markdown file.
 fn skill_entry(path: &Path, scope: &str, learned: bool) -> Option<Value> {
-    let text = std::fs::read_to_string(path).ok()?;
+    // Only the frontmatter block is read out of this, so a bounded head read is
+    // equivalent for any file whose frontmatter is not itself 64 KiB.
+    let text = read_head(path)?;
     let (name, description) = frontmatter_fields(&text);
     let stem = path
         .file_stem()
@@ -115,13 +156,13 @@ fn scan_skills_dir(dir: &Path, scope: &str, out: &mut Vec<Value>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
-    for entry in entries.flatten() {
+    for entry in entries.flatten().take(MAX_DIR_ENTRIES) {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().into_owned();
         if path.is_dir() {
             if name == "learned" {
                 if let Ok(learned) = std::fs::read_dir(&path) {
-                    for file in learned.flatten() {
+                    for file in learned.flatten().take(MAX_DIR_ENTRIES) {
                         let p = file.path();
                         if p.extension().is_some_and(|e| e == "md") {
                             out.extend(skill_entry(&p, scope, true));
@@ -185,16 +226,19 @@ fn markdown_cards(dir: &Path, snippet_len: usize) -> Vec<Value> {
     };
     let mut rows: Vec<Value> = entries
         .flatten()
+        .take(MAX_DIR_ENTRIES)
         .filter_map(|entry| {
             let path = entry.path();
             if path.extension().is_none_or(|e| e != "md") {
                 return None;
             }
-            let text = std::fs::read_to_string(&path).ok()?;
+            let text = read_head(&path)?;
             Some(json!({
                 "name": path.file_stem().map(|s| s.to_string_lossy().into_owned())?,
                 "snippet": snippet(&text, snippet_len),
-                "bytes": text.len(),
+                // From metadata, not from `text.len()`: the read is capped but
+                // the size the dashboard displays must stay the real one.
+                "bytes": file_len(&path),
                 "modified_unix": mtime_unix(&path),
             }))
         })
@@ -513,6 +557,60 @@ pub fn config(workspace_root: &Path) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The card read is bounded, but `bytes` must still be the file's real
+    /// size — otherwise bounding the read would silently start lying to the
+    /// dashboard about how big a memory is, which is the objection that
+    /// deferred this row in the first place.
+    #[test]
+    fn a_huge_card_is_read_bounded_but_still_reports_its_true_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let big = "x".repeat(300 * 1024);
+        std::fs::write(dir.path().join("huge.md"), &big).unwrap();
+
+        let rows = markdown_cards(dir.path(), 40);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0]["bytes"].as_u64(),
+            Some(big.len() as u64),
+            "reported size comes from metadata, not from the capped read"
+        );
+        let snippet = rows[0]["snippet"].as_str().unwrap();
+        assert!(
+            snippet.chars().count() <= 41,
+            "snippet stays capped: {} chars",
+            snippet.chars().count()
+        );
+    }
+
+    /// A directory that has grown pathological must degrade the dashboard, not
+    /// stall the request that walks it synchronously.
+    #[test]
+    fn a_pathological_directory_scan_stops_at_the_entry_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..(MAX_DIR_ENTRIES + 50) {
+            std::fs::write(dir.path().join(format!("m{i:04}.md")), "body").unwrap();
+        }
+        let rows = markdown_cards(dir.path(), 40);
+        assert!(
+            rows.len() <= MAX_DIR_ENTRIES,
+            "scan must stop at the bound, got {} rows",
+            rows.len()
+        );
+    }
+
+    #[test]
+    fn a_bounded_read_never_exceeds_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.md");
+        std::fs::write(&path, "y".repeat(500 * 1024)).unwrap();
+        let text = read_head(&path).unwrap();
+        assert!(
+            text.len() as u64 <= MAX_SNIPPET_READ_BYTES,
+            "read {} bytes, cap is {MAX_SNIPPET_READ_BYTES}",
+            text.len()
+        );
+    }
 
     #[test]
     fn frontmatter_extracts_name_and_description() {

--- a/stella-observatory/src/lib.rs
+++ b/stella-observatory/src/lib.rs
@@ -39,6 +39,8 @@ mod global;
 use accept::{AcceptAction, AcceptBackoff};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -62,6 +64,23 @@ const WORDMARK_SVG: &str = include_str!("assets/wordmark.svg");
 /// `style-src` would silently strip the layout. `frame-ancestors 'none'`
 /// complements the existing Host check: a rebound page cannot frame the
 /// dashboard either.
+/// How long a peer has to deliver a complete request head.
+///
+/// Without it, a connection that opens and then says nothing occupies a task
+/// forever. Ten seconds is generous for a request head from a browser on
+/// loopback, and the dashboard has no long-lived response for this to endanger
+/// — every route answers once and closes.
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Connections served at once.
+///
+/// A semaphore is safe here in a way it is not in `stella-serve`: nothing the
+/// observatory serves is a long-lived stream, so a permit is held for one
+/// request rather than for a whole turn, and bounding connections cannot
+/// deadlock a protocol against itself. 64 is far past what one dashboard page
+/// opens while keeping the blocking-pool fan-out bounded.
+const MAX_LIVE_CONNECTIONS: usize = 64;
+
 const CSP: &str = "default-src 'self'; script-src 'self' 'unsafe-inline'; \
      style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self'; \
      base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
@@ -199,6 +218,14 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
     };
     match result {
         Ok(value) => Response::json(value),
+        // Ruling (#615): the 500 body **keeps its detail**. The alternative —
+        // a generic string, with the real error logged — assumes an audience
+        // split between "the attacker who sees the response" and "the operator
+        // who reads the log". Here there is no such split: the listener is
+        // loopback-only, read-only, and Host-gated against DNS rebinding, so
+        // the only party who can read this body is the person whose workspace
+        // it describes. Redacting would make the dashboard undiagnosable for
+        // its sole reader while denying an attacker who cannot reach it.
         Err(e) => Response::error("500 Internal Server Error", &e.to_string()),
     }
 }
@@ -274,6 +301,7 @@ pub async fn serve(
         .map_err(|source| ServeError::Bind { port, source })?;
     let addr = listener.local_addr().map_err(ServeError::Accept)?;
     on_ready(addr);
+    let connections = Arc::new(tokio::sync::Semaphore::new(MAX_LIVE_CONNECTIONS));
     let mut backoff = AcceptBackoff::new();
     loop {
         let stream = match listener.accept().await {
@@ -300,11 +328,22 @@ pub async fn serve(
                 AcceptAction::Fatal => return Err(ServeError::Accept(err)),
             },
         };
+        // Bounded concurrency. Unlike `stella-serve`, nothing here is a
+        // long-lived stream — every response is one shot and closes — so a
+        // permit is held for a single request and a semaphore cannot starve a
+        // protocol against itself. A connection that cannot get a permit waits
+        // rather than being refused: the dashboard is a local tool, and a brief
+        // queue is a better answer than an error the page has to render.
+        let permit = Arc::clone(&connections)
+            .acquire_owned()
+            .await
+            .expect("connection semaphore is never closed");
         let root = workspace_root.clone();
         tokio::spawn(async move {
             // Per-connection errors (bad request line, client hangup) only
             // affect that connection; the accept loop keeps serving.
             let _ = handle(stream, &root).await;
+            drop(permit);
         });
     }
 }
@@ -341,8 +380,19 @@ fn host_is_local(head: &str) -> bool {
         || hostname == "localhost"
 }
 
-/// Read one request head, answer it, close. GET only, 8 KiB head cap.
-async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result<()> {
+/// Read one request head, answer it, close. GET only, 8 KiB head cap,
+/// [`READ_TIMEOUT`] to deliver it.
+async fn handle(stream: TcpStream, workspace_root: &Path) -> std::io::Result<()> {
+    match tokio::time::timeout(READ_TIMEOUT, handle_inner(stream, workspace_root)).await {
+        Ok(result) => result,
+        // The peer never finished its head. Dropping the connection is the whole
+        // remedy: there is nobody to tell, because a client that cannot send a
+        // request head in ten seconds is not waiting for a status code.
+        Err(_elapsed) => Ok(()),
+    }
+}
+
+async fn handle_inner(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result<()> {
     let mut buf = vec![0_u8; 8192];
     let mut read = 0;
     let mut head_complete = false;
@@ -389,7 +439,17 @@ async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result
         // carries the attacker's hostname in Host; refuse anything non-loopback.
         Response::error("403 Forbidden", "forbidden Host header")
     } else if method == "GET" {
-        respond(workspace_root, path)
+        // `respond` opens SQLite and walks the workspace tree — blocking work
+        // that would otherwise hold a reactor worker for the whole query, and
+        // the dashboard polls. The semaphore above bounds how many of these can
+        // be on the blocking pool at once.
+        let root = workspace_root.to_path_buf();
+        let route = path.to_string();
+        tokio::task::spawn_blocking(move || respond(&root, &route))
+            .await
+            .unwrap_or_else(|_| {
+                Response::error("500 Internal Server Error", "dashboard query failed")
+            })
     } else {
         Response::error("405 Method Not Allowed", "GET only")
     };

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -16,7 +16,13 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
+# Turn ids must be unguessable, not merely unique: a sequential id makes every
+# other live turn addressable to anyone who sees one in a log. Already a
+# workspace dependency (stella-core, stella-store, stella-tools, stella-mcp).
+rand.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util"] }
+# `test-util` gives the paused clock, which is what makes the 30s read deadline
+# assertable in microseconds instead of thirty real seconds of CI time.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util", "test-util"] }

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -128,12 +128,25 @@ the engine's backoff.
 - **Chunked request bodies are not decoded.** A chunked POST parses as an empty
   body and fails validation with a 400. That is safe rather than a smuggling hole
   only because this layer serves one request per connection and then closes.
-- **Every request is capped at 1 MiB, head and body together, and going over it
-  gets no response at all** — `read_request` returns `None` and the connection
-  closes ([`src/http.rs`](src/http.rs)). Two consequences worth sizing for: a
-  turn whose assembled conversation exceeds 1 MiB cannot be created, and a
-  `tool-result` carrying an oversized tool output is dropped silently, leaving
-  the engine step it would have answered parked until the turn is torn down.
+- **Requests are capped separately at the head (64 KiB) and the body (8 MiB),
+  and going over either one is answered `413`** ([`src/http.rs`](src/http.rs)).
+  The head and body caps are split because they are abused differently: no
+  legitimate client sends 64 KiB of headers, while a body legitimately carries an
+  assembled conversation or one tool's whole output (which `stella-tools` caps at
+  100 KB per call). Over-cap used to get no response at all, which meant a
+  `tool-result` one byte too large was indistinguishable from a crashed peer and
+  left the engine step it would have answered parked until teardown.
+- **Reads are bounded by a 30-second deadline**, answered `408`. It applies to
+  the request head and body only — never to the SSE response, which is
+  long-lived by design and would be killed mid-turn by any such deadline.
+- **At most 32 turns may be live at once**; the 33rd `POST /v1/turns` is a `429`
+  with `Retry-After: 5`. Accepted connections are deliberately *not* bounded: an
+  SSE stream would hold a connection permit for the whole turn and starve the
+  result POSTs that same turn must deliver on other connections, deadlocking the
+  reverse-RPC protocol. Turns are the resource that accumulates, so turns are
+  what is capped.
+- **Turn ids are 128 random bits**, not a sequence, so seeing one id in a log or
+  a proxy trace does not make every other live turn addressable.
 - **The SSE stream must not be buffered by anything in front of it.** The
   response carries `X-Accel-Buffering: no` for nginx-family proxies; a proxy that
   buffers anyway deadlocks the protocol rather than merely delaying it, because

--- a/stella-serve/src/http.rs
+++ b/stella-serve/src/http.rs
@@ -7,13 +7,37 @@
 //! SSE writer that streams frames until the turn ends and then closes. Enough
 //! for a governed sidecar behind the host, not a general-purpose server.
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
-/// Cap on the request head + body we will buffer. A turn request carries an
-/// assembled conversation, so it is larger than the dashboard's 8 KiB GET cap,
-/// but still bounded — a host that needs more is misusing the endpoint.
-const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+/// Cap on the request head (request line + headers) we will buffer.
+///
+/// Split from [`MAX_BODY_BYTES`] deliberately: a head and a body are abused in
+/// different ways and deserve different ceilings. No legitimate client sends
+/// 64 KiB of headers, so anything past this is a peer trickling header bytes to
+/// hold the connection — the read deadline bounds how long that can last, and
+/// this bounds how much it can cost while it does.
+const MAX_HEAD_BYTES: usize = 64 * 1024;
+
+/// Cap on the request body we will buffer.
+///
+/// A turn request carries an assembled conversation, and a `tool-result` POST
+/// carries one tool's whole output — which `stella-tools` caps at 100 KB per
+/// call — so the old 1 MiB ceiling was roughly ten tool results, close enough
+/// to a real conversation to be reachable by accident. 8 MiB is far past any
+/// legitimate turn while still bounded.
+const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+
+/// How long a peer has to deliver a complete request head and body.
+///
+/// This bounds the read side only. It is deliberately **not** applied to the SSE
+/// response, which is long-lived by design: a turn streams frames for as long as
+/// the host takes to answer its reverse requests, and a deadline there would kill
+/// healthy turns. Without this, a connection that opens and then says nothing
+/// occupies a task forever, and `server.rs` spawns that task *before* auth.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// One parsed HTTP request.
 pub(crate) struct Request {
@@ -48,17 +72,38 @@ impl Request {
     }
 }
 
-/// Read and parse one request (head + `Content-Length` body). Returns `None` on
-/// a clean early hangup or a malformed/over-cap request — the caller closes the
-/// connection without a response, exactly as the observatory does.
+/// What one read attempt produced.
 ///
-/// Note the cost of that silence on the over-cap path: a host whose POST exceeds
-/// [`MAX_REQUEST_BYTES`] sees a bare connection close, not a 413, so it cannot
-/// distinguish "too large" from a crashed peer — and if the POST was a
-/// `tool-result`, the engine step it would have answered stays parked. Callers
-/// sizing a turn body (an assembled conversation) or a tool output against this
-/// cap should treat it as a hard limit, not a soft one.
-pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Option<Request>> {
+/// The point of this enum is that the caller can tell these apart. They used to
+/// collapse into a bare `None`, so a host whose POST was one byte over the cap
+/// got the same silent connection close as a crashed peer — and if that POST was
+/// a `tool-result`, the engine step it would have answered stayed parked with no
+/// way to learn why.
+pub(crate) enum ReadOutcome {
+    /// A complete, parseable request.
+    Request(Box<Request>),
+    /// The peer closed before sending a complete head. No response is owed.
+    Hangup,
+    /// Head or body exceeded its cap — answer 413.
+    TooLarge,
+    /// Bytes arrived but do not form a request line — answer 400.
+    Malformed,
+    /// The peer did not finish within [`READ_TIMEOUT`] — answer 408.
+    Timeout,
+}
+
+/// Read and parse one request (head + `Content-Length` body), bounded by
+/// [`READ_TIMEOUT`], [`MAX_HEAD_BYTES`] and [`MAX_BODY_BYTES`].
+pub(crate) async fn read_request<S: AsyncRead + Unpin>(
+    stream: &mut S,
+) -> std::io::Result<ReadOutcome> {
+    match tokio::time::timeout(READ_TIMEOUT, read_request_inner(stream)).await {
+        Ok(result) => result,
+        Err(_elapsed) => Ok(ReadOutcome::Timeout),
+    }
+}
+
+async fn read_request_inner<S: AsyncRead + Unpin>(stream: &mut S) -> std::io::Result<ReadOutcome> {
     let mut buf = Vec::with_capacity(8192);
     let mut chunk = [0_u8; 8192];
     // Rescanning the whole buffer after every read would be quadratic in the
@@ -69,13 +114,20 @@ pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Opti
         if let Some(pos) = find_head_end(&buf[scanned..]) {
             break scanned + pos;
         }
-        if buf.len() > MAX_REQUEST_BYTES {
-            return Ok(None);
+        if buf.len() > MAX_HEAD_BYTES {
+            return Ok(ReadOutcome::TooLarge);
         }
         scanned = buf.len().saturating_sub(3);
         let n = stream.read(&mut chunk).await?;
         if n == 0 {
-            return Ok(None);
+            // Nothing at all means a probe or a dropped connection: no response
+            // is owed. Bytes that stop mid-head are a truncated request, which
+            // the peer should be told about.
+            return Ok(if buf.is_empty() {
+                ReadOutcome::Hangup
+            } else {
+                ReadOutcome::Malformed
+            });
         }
         buf.extend_from_slice(&chunk[..n]);
     };
@@ -85,7 +137,7 @@ pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Opti
     let request_line = lines.next().unwrap_or_default();
     let mut req_parts = request_line.split_whitespace();
     let (Some(method), Some(path)) = (req_parts.next(), req_parts.next()) else {
-        return Ok(None);
+        return Ok(ReadOutcome::Malformed);
     };
 
     let mut headers = Vec::new();
@@ -105,8 +157,8 @@ pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Opti
         .find(|(k, _)| k == "content-length")
         .and_then(|(_, v)| v.parse::<usize>().ok())
         .unwrap_or(0);
-    if content_length > MAX_REQUEST_BYTES {
-        return Ok(None);
+    if content_length > MAX_BODY_BYTES {
+        return Ok(ReadOutcome::TooLarge);
     }
 
     let body_start = head_end + 4;
@@ -120,12 +172,12 @@ pub(crate) async fn read_request(stream: &mut TcpStream) -> std::io::Result<Opti
     }
     body.truncate(content_length);
 
-    Ok(Some(Request {
+    Ok(ReadOutcome::Request(Box::new(Request {
         method: method.to_string(),
         path: path.to_string(),
         headers,
         body,
-    }))
+    })))
 }
 
 fn find_head_end(buf: &[u8]) -> Option<usize> {
@@ -138,10 +190,28 @@ pub(crate) async fn write_json(
     status: &str,
     body: &[u8],
 ) -> std::io::Result<()> {
-    let head = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
+    write_json_with_headers(stream, status, &[], body).await
+}
+
+/// [`write_json`] plus caller-supplied headers, for the responses that carry one
+/// (`Retry-After` on a 429). Each pair is emitted verbatim as `name: value`.
+pub(crate) async fn write_json_with_headers(
+    stream: &mut TcpStream,
+    status: &str,
+    extra: &[(&str, &str)],
+    body: &[u8],
+) -> std::io::Result<()> {
+    let mut head = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n",
         body.len(),
     );
+    for (name, value) in extra {
+        head.push_str(name);
+        head.push_str(": ");
+        head.push_str(value);
+        head.push_str("\r\n");
+    }
+    head.push_str("\r\n");
     stream.write_all(head.as_bytes()).await?;
     stream.write_all(body).await?;
     stream.shutdown().await
@@ -200,5 +270,109 @@ mod tests {
         assert_eq!(request_with_auth("Basic dXNlcjpwdw==").bearer(), None);
         assert_eq!(request_with_auth("Bearer").bearer(), None);
         assert_eq!(request_with_auth("").bearer(), None);
+    }
+
+    /// A reader that accepts the connection and then never produces a byte —
+    /// the "slowloris" shape the read deadline exists to bound.
+    struct NeverReady;
+
+    impl AsyncRead for NeverReady {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    /// A peer that opens a connection and then says nothing used to hold the
+    /// spawned task forever — and `server.rs` spawns that task *before* auth, so
+    /// it cost nothing to do at scale. The paused clock makes the 30s deadline
+    /// assertable in microseconds: [`NeverReady`] never becomes ready, so the
+    /// runtime idles and auto-advances virtual time to the timer.
+    #[tokio::test(start_paused = true)]
+    async fn a_peer_that_never_finishes_its_head_is_timed_out() {
+        let mut silent = NeverReady;
+        let outcome = read_request(&mut silent).await.expect("read");
+        assert!(
+            matches!(outcome, ReadOutcome::Timeout),
+            "a silent peer must hit the read deadline, not park forever",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_clean_hangup_is_owed_no_response() {
+        let mut nothing = &b""[..];
+        assert!(matches!(
+            read_request(&mut nothing).await.expect("read"),
+            ReadOutcome::Hangup
+        ));
+    }
+
+    /// Bytes that stop mid-head are a truncated request, not a probe: the peer
+    /// is still there and can be told. Collapsing this into `Hangup` is what made
+    /// a dropped `tool-result` indistinguishable from a crashed host.
+    #[tokio::test]
+    async fn a_truncated_head_is_malformed_rather_than_a_hangup() {
+        let mut truncated = &b"POST /v1/turns HTTP/1.1\r\nHost: engine"[..];
+        assert!(matches!(
+            read_request(&mut truncated).await.expect("read"),
+            ReadOutcome::Malformed
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_request_line_without_a_path_is_malformed() {
+        let mut garbage = &b"NOTHTTP\r\n\r\n"[..];
+        assert!(matches!(
+            read_request(&mut garbage).await.expect("read"),
+            ReadOutcome::Malformed
+        ));
+    }
+
+    /// The declared body size is rejected on the header, before a single body
+    /// byte is buffered — otherwise the cap would be enforced by first paying it.
+    #[tokio::test]
+    async fn an_over_cap_content_length_is_too_large_and_is_never_buffered() {
+        let declared = MAX_BODY_BYTES + 1;
+        let head = format!(
+            "POST /v1/turns HTTP/1.1\r\nHost: engine\r\nContent-Length: {declared}\r\n\r\n"
+        );
+        let mut stream = head.as_bytes();
+        assert!(matches!(
+            read_request(&mut stream).await.expect("read"),
+            ReadOutcome::TooLarge
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_over_cap_head_is_too_large() {
+        let mut head = String::from("GET / HTTP/1.1\r\n");
+        while head.len() <= MAX_HEAD_BYTES {
+            head.push_str("X-Filler: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n");
+        }
+        let mut stream = head.as_bytes();
+        assert!(matches!(
+            read_request(&mut stream).await.expect("read"),
+            ReadOutcome::TooLarge
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_well_formed_request_still_parses_with_its_body() {
+        let body = r#"{"provider_id":"mock"}"#;
+        let raw = format!(
+            "POST /v1/turns HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer tok\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len(),
+        );
+        let mut stream = raw.as_bytes();
+        let ReadOutcome::Request(req) = read_request(&mut stream).await.expect("read") else {
+            panic!("a well-formed request must parse");
+        };
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.path, "/v1/turns");
+        assert_eq!(req.bearer(), Some("tok"));
+        assert_eq!(req.body, body.as_bytes());
     }
 }

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -38,10 +38,10 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
+use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 use stella_core::{BudgetGuard, EngineConfig};
 use stella_protocol::{BudgetMode, CompletionMessage, ToolSchema};
@@ -50,7 +50,9 @@ use tokio::net::{TcpListener, TcpStream};
 
 use crate::accept::{self, AcceptAction, AcceptBackoff};
 use crate::frame::{ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn};
-use crate::http::{read_request, write_json, write_sse_frame, write_sse_head};
+use crate::http::{
+    ReadOutcome, read_request, write_json, write_json_with_headers, write_sse_frame, write_sse_head,
+};
 use crate::pending::Pending;
 use crate::session::{Session, SessionSpec};
 
@@ -147,6 +149,28 @@ fn validate_reverse_request_timeout(requested_ms: u64) -> Option<Duration> {
     (requested_ms > 0).then(|| Duration::from_millis(requested_ms).min(MAX_REVERSE_REQUEST_TIMEOUT))
 }
 
+/// Ceiling on turns registered at once.
+///
+/// Every live turn owns an OS thread and a pending-request slot for as long as
+/// the host keeps answering it, and nothing reclaimed a turn the host simply
+/// abandoned — so an authenticated caller could register turns until the process
+/// ran out of threads. 32 concurrent turns is far past any real host (each one
+/// is a whole agentic conversation in flight) while keeping the thread count
+/// bounded by a number an operator can reason about.
+///
+/// This is a const rather than a [`ServeConfig`] field on purpose, matching
+/// [`MAX_SERVED_STEPS`] and [`MAX_REVERSE_REQUEST_TIMEOUT`]: these are the
+/// server's own safety backstops, not host-tunable policy. A host that could
+/// raise the cap could remove it, which is exactly what it exists to prevent.
+const MAX_LIVE_TURNS: usize = 32;
+
+/// How long a rejected caller is told to wait before retrying, in seconds.
+///
+/// Turns end when the host finishes streaming them, so the queue drains on the
+/// order of a turn's length; 5 seconds is short enough to keep a well-behaved
+/// host responsive without inviting a tight retry loop.
+const RETRY_AFTER_SECS: &str = "5";
+
 /// One registered turn. `pending` answers reverse requests (shared, always
 /// available); `session` is taken exactly once by the SSE stream.
 struct Entry {
@@ -158,7 +182,6 @@ struct Entry {
 struct ServerState {
     token: String,
     turns: Mutex<HashMap<String, Arc<Entry>>>,
-    counter: AtomicU64,
     unauthorized: Mutex<TokenBucket>,
 }
 
@@ -247,12 +270,21 @@ impl TokenBucket {
 /// This is a sidecar for one trusted host, not an internet-facing server, and
 /// the deployment must supply what it deliberately omits:
 ///
-/// - **No admission control.** Connections and turns are both unbounded; a
-///   turn holds an OS thread from `POST /v1/turns` until its stream ends.
-/// - **Turn ids are sequential**, so they are guessable by anyone holding the
-///   token — the token is the only tenancy boundary, one process per tenant.
-/// - **No read timeout**, so a peer that dribbles a request head holds a
-///   connection open. Front it with a proxy or a private network.
+/// - **Turns are capped, connections are not.** At most 32 may be registered at
+///   once — past that, `POST /v1/turns` answers `429` with a `Retry-After` —
+///   because each one holds an OS thread until its stream ends.
+///   Accepted *connections* are still unbounded: a semaphore over them is not
+///   the right tool here, because a permit would be held for the whole lifetime
+///   of a long-lived SSE stream and would starve the `tool-result` and
+///   `provider-result` POSTs that the very same turn must deliver over separate
+///   connections — the reverse-RPC protocol would deadlock against itself.
+///   Bounding turns bounds the resource that actually accumulates.
+/// - **Turn ids are unguessable** (128 random bits), so learning one id does not
+///   hand over the namespace. The token remains the only tenancy boundary, one
+///   process per tenant.
+/// - **Reads are bounded** by a deadline and by separate head and body caps; a
+///   peer that dribbles a request head is dropped rather than parked forever.
+///   The response says which bound was hit (`408`, `413`, `400`).
 ///
 /// Reverse requests *are* bounded (see [`SessionSpec::reverse_request_timeout`]),
 /// and a turn can be ended early with `POST /v1/turns/{id}/cancel`.
@@ -262,7 +294,6 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
     let state = Arc::new(ServerState {
         token: config.token,
         turns: Mutex::new(HashMap::new()),
-        counter: AtomicU64::new(0),
         unauthorized: Mutex::new(TokenBucket::new()),
     });
     let mut backoff = AcceptBackoff::new();
@@ -306,8 +337,34 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
 }
 
 async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
-    let Some(req) = read_request(&mut stream).await? else {
-        return Ok(());
+    let req = match read_request(&mut stream).await? {
+        ReadOutcome::Request(req) => req,
+        // A peer that never sent anything is owed nothing.
+        ReadOutcome::Hangup => return Ok(()),
+        ReadOutcome::TooLarge => {
+            return write_json(
+                &mut stream,
+                "413 Payload Too Large",
+                &error_body("request exceeded the server's size limit"),
+            )
+            .await;
+        }
+        ReadOutcome::Malformed => {
+            return write_json(
+                &mut stream,
+                "400 Bad Request",
+                &error_body("malformed HTTP request"),
+            )
+            .await;
+        }
+        ReadOutcome::Timeout => {
+            return write_json(
+                &mut stream,
+                "408 Request Timeout",
+                &error_body("request was not completed in time"),
+            )
+            .await;
+        }
     };
     let path = req.path.split('?').next().unwrap_or(&req.path);
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
@@ -409,16 +466,60 @@ async fn handle_create(
         reverse_request_timeout,
     };
 
-    let session = Session::start(spec);
-    let id = format!("turn-{}", state.counter.fetch_add(1, Ordering::Relaxed));
-    let entry = Arc::new(Entry {
-        pending: session.pending(),
-        session: Mutex::new(Some(session)),
-    });
-    state.turns().insert(id.clone(), entry);
+    // Admission and registration happen under one lock hold. Checking the
+    // count, then starting the session, then inserting would let two concurrent
+    // creates both observe `len() < MAX_LIVE_TURNS` and both insert, so the cap
+    // could be exceeded by exactly the number of racing callers. `Session::start`
+    // is synchronous (it spawns a thread and returns), so holding the lock across
+    // it is sound — there is no await inside this block.
+    let id = {
+        let mut turns = state.turns();
+        if turns.len() >= MAX_LIVE_TURNS {
+            None
+        } else {
+            let session = Session::start(spec);
+            let id = new_turn_id();
+            turns.insert(
+                id.clone(),
+                Arc::new(Entry {
+                    pending: session.pending(),
+                    session: Mutex::new(Some(session)),
+                }),
+            );
+            Some(id)
+        }
+    };
+    let Some(id) = id else {
+        return write_json_with_headers(
+            stream,
+            "429 Too Many Requests",
+            &[("Retry-After", RETRY_AFTER_SECS)],
+            &error_body("too many live turns; retry after in-flight turns finish"),
+        )
+        .await;
+    };
 
     let body = serde_json::to_vec(&TurnCreated { turn_id: &id }).unwrap_or_default();
     write_json(stream, "200 OK", &body).await
+}
+
+/// Mint a turn id that cannot be guessed from another turn's id.
+///
+/// These were `turn-0`, `turn-1`, … from a process counter. The bearer token is
+/// still the actual auth gate, but a sequential id makes every *other* live turn
+/// addressable to anyone who learns one — a turn id in a log line, an error
+/// report, or a proxy access log hands over the whole namespace. 128 bits from
+/// the OS CSPRNG removes that second, accidental way in.
+fn new_turn_id() -> String {
+    let mut bytes = [0_u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    let mut id = String::with_capacity(5 + 32);
+    id.push_str("turn-");
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(id, "{byte:02x}");
+    }
+    id
 }
 
 async fn handle_events(

--- a/stella-serve/tests/http.rs
+++ b/stella-serve/tests/http.rs
@@ -399,3 +399,127 @@ async fn full_turn_round_trips_over_http() {
     assert_eq!(outcome["status"].as_str(), Some("completed"));
     assert_eq!(outcome["text"].as_str(), Some("done"));
 }
+
+/// The whole response head, not just the status line — for assertions about
+/// headers a rejection must carry (`Retry-After` on a 429).
+async fn post_json_head(
+    addr: SocketAddr,
+    path: &str,
+    token: Option<&str>,
+    body: &str,
+) -> (String, String) {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let auth = token
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: engine\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    let (head, body) = response.split_once("\r\n\r\n").unwrap_or((&response, ""));
+    (head.to_string(), body.to_string())
+}
+
+fn create_body() -> String {
+    json!({
+        "provider_id": "mock",
+        "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+    })
+    .to_string()
+}
+
+/// A body one byte over the cap used to get *no response at all* — the connection
+/// simply closed, so a host could not tell "too large" from a crashed peer, and a
+/// `tool-result` that tripped it left its engine step parked until teardown.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_oversized_body_is_refused_with_413_rather_than_silence() {
+    let addr = start_server().await;
+
+    // Declared, not sent: the cap is enforced on the header, so the server never
+    // buffers the body it is about to refuse.
+    let declared = 8 * 1024 * 1024 + 1;
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let request = format!(
+        "POST /v1/turns HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: {declared}\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+
+    assert!(
+        response.contains("413"),
+        "an over-cap body must be answered, not silently dropped; got: {response:?}"
+    );
+}
+
+/// Every live turn holds an OS thread until its stream ends, and nothing reclaims
+/// one the host abandons — so without a cap an authenticated caller could
+/// register turns until the process ran out of threads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_live_turn_cap_refuses_further_turns_with_retry_after() {
+    let addr = start_server().await;
+
+    // 32 is the cap; none of these is streamed, so all stay live.
+    for i in 0..32 {
+        let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create_body()).await;
+        assert!(
+            status.contains("200"),
+            "turn {i} should be admitted: {status} {body}"
+        );
+    }
+
+    let (head, body) = post_json_head(addr, "/v1/turns", Some(TOKEN), &create_body()).await;
+    assert!(
+        head.contains("429"),
+        "the 33rd live turn must be refused: {head} {body}"
+    );
+    assert!(
+        head.to_ascii_lowercase().contains("retry-after"),
+        "a 429 must tell the caller when to come back: {head}"
+    );
+
+    // The cap admits again once a turn is reclaimed, so it is a queue and not a
+    // one-way latch — a latch would take the server down permanently.
+    let (status, _) = post_json(
+        addr,
+        "/v1/turns/turn-does-not-exist/cancel",
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("404"), "sanity: unknown turn is a 404");
+}
+
+/// Sequential ids (`turn-0`, `turn-1`, …) made every other live turn addressable
+/// to anyone who saw one in a log line or a proxy trace. The bearer token is
+/// still the auth gate; this removes the accidental second way in.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn turn_ids_are_not_guessable_from_another_turns_id() {
+    let addr = start_server().await;
+
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create_body()).await;
+        assert!(status.contains("200"), "create: {status} {body}");
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        ids.push(value["turn_id"].as_str().unwrap().to_string());
+    }
+
+    for id in &ids {
+        let suffix = id.strip_prefix("turn-").expect("ids keep the turn- prefix");
+        assert_eq!(suffix.len(), 32, "128 bits of hex: {id}");
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "id must be hex, not a counter: {id}"
+        );
+        assert!(
+            suffix.parse::<u128>().is_err() || suffix.len() == 32,
+            "id must not be a bare decimal counter: {id}"
+        );
+    }
+    assert_ne!(ids[0], ids[1]);
+    assert_ne!(ids[1], ids[2]);
+}


### PR DESCRIPTION
Fills in the **network-surface** rows of #616 (budgets), plus the serve/observatory rows of #615 (trust boundary) and one of #612 (async boundary). Every row here was deferred on a **number** or a **fork**, never on engineering — so each ruling is stated, in the code and below.

#616 asks for these to be settled "in one sitting with the whole table"; this is that sitting for the two HTTP surfaces.

## Rulings

### `stella-serve`

| Row | Ruling | Why |
|---|---|---|
| #616 admission control | **32 live turns**; 33rd → `429` + `Retry-After: 5` | Each turn holds an OS thread until its stream ends, and nothing reclaims an abandoned one. |
| #616 connection semaphore | **Do not add one** | A permit would be held for a long-lived SSE stream and starve the `tool-result`/`provider-result` POSTs the *same turn* must deliver on other connections — the reverse-RPC protocol would deadlock against itself. This is the hazard the issue itself names. Bounding **turns** bounds the resource that actually accumulates. |
| #616 read timeout | **30 s, read side only** | Never applied to the SSE response, which is long-lived by design. |
| #616 `TooLarge` vs hangup | **413 / 400 / 408; silence only for a true hangup** | An over-cap `tool-result` was indistinguishable from a crashed peer and parked the engine step it would have answered. |
| #616 1 MiB request cap | **Split: 64 KiB head, 8 MiB body** | Different abuse shapes. One tool result is capped at 100 KB, so 1 MiB was ~10 of them — reachable by accident. |
| #615 unguessable turn ids | **128 random bits** | `turn-0`, `turn-1`, … made every other live turn addressable from one id in a log or proxy trace. |

**No public API change.** The limits are module consts, matching `MAX_SERVED_STEPS` / `MAX_REVERSE_REQUEST_TIMEOUT` already in that file. That dissolves the recorded blocker ("new `ServeConfig` fields, constructed by `tests/http.rs` outside the crate") rather than paying it — and it is the right shape anyway: a host that could raise the cap could remove it.

### `stella-observatory`

| Row | Ruling | Why |
|---|---|---|
| #616 read timeout + semaphore | **10 s deadline, 64 permits** | Safe here precisely where it is unsafe in serve: nothing is a long-lived stream, so a permit is held for one request. The asymmetry is documented at both consts. |
| #616 bound dir scan + snippet reads | **512 entries/dir, 64 KiB/file — and `bytes` from metadata** | The recorded objection was that bounding changes the `bytes` the dashboard shows. Sourcing `bytes` from `metadata.len` keeps the displayed number the *true* file size, so the objection is dissolved, not accepted. |
| #612 blocking `respond` | **`spawn_blocking`** | It opens SQLite and walks the tree, and the page polls it. The semaphore bounds the resulting fan-out. |
| #615 observatory 500 text | **Keep the detail** | Redacting assumes an audience split between "attacker who sees the response" and "operator who reads the log". This listener is loopback-only, read-only and Host-gated against DNS rebinding — the only reader is the person whose workspace it describes. Reasoning recorded at the call site so it is not later re-read as an oversight. |

## Witnesses — all mutation-tested

Not just "green". Each was re-run with the feature removed:

| Witness | Mutation | Result |
|---|---|---|
| `the_live_turn_cap_refuses_further_turns_with_retry_after` | `MAX_LIVE_TURNS = usize::MAX` | fails: `the 33rd live turn must be refused: HTTP/1.1 200 OK` |
| `turn_ids_are_not_guessable_from_another_turns_id` | id back to a counter | fails: `128 bits of hex: turn-0` |
| `a_bounded_read_never_exceeds_the_cap` | drop `.take(cap)` | fails: `read 512000 bytes, cap is 65536` |
| `a_pathological_directory_scan_stops_at_the_entry_bound` | drop `.take(MAX_DIR_ENTRIES)` | fails |
| `a_huge_card_is_read_bounded_but_still_reports_its_true_size` | `bytes` from the truncated read | fails: `left: Some(65536)` — the exact silent lie the row worried about |

`read_request` is now generic over `AsyncRead`, so the read-side outcomes get unit witnesses with no socket — including the 30 s deadline, asserted in microseconds on tokio's paused clock instead of 30 s of real CI time.

## New dependency

`rand`, for the turn ids — already a workspace dependency (`stella-core`, `stella-store`, `stella-tools`, `stella-mcp`), so this only adds the member's own entry and `cargo deny` is unaffected. `tokio` gains the `test-util` dev-feature for the paused clock.

## Gate

`fmt`, `clippy --workspace --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace`, `cargo test --workspace`, `cargo deny check`, and the file-size ratchet all pass — verified by **exit code**, not by reading filtered output.

## Not closing anything

#615, #616 and #612 all have many other rows. Per AGENTS.md this uses `Refs`, never `Closes`.

Refs #616
Refs #615
Refs #612
