### PR TITLE
ci: every gate reports, so one red step stops hiding the rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,19 +62,48 @@ jobs:
     # Bundled SQLite (stella-store, rusqlite) and tree-sitter grammars are
     # heavy C compiles on a cold cache; rust-cache keeps warm runs fast.
     timeout-minutes: 60
+    # Every gate below reports independently. A step here is a *verdict*, not a
+    # prerequisite for the next one: fmt failing tells you nothing about clippy,
+    # and the 1500-line ratchet tells you nothing about either. GitHub's default
+    # — abort the job at the first non-zero exit — collapses all of them into
+    # whichever happened to be ordered first, so a one-line baseline overage
+    # ended a run in 9s with fmt, clippy, doc, test and the release smoke never
+    # having run. You fix that, push, and only then learn what else was red:
+    # one round trip per failure, serialized, at ~10 min a lap.
+    #
+    # So every gate carries `if: !cancelled()`, which runs it whether or not an
+    # earlier gate failed. The job still goes red — these are not
+    # `continue-on-error`, each failure is still a failure and `fmt + clippy +
+    # test` is a required context — you just get the whole list in one run.
+    #
+    # Not `always()`: this workflow sets cancel-in-progress for pull_request
+    # (see the concurrency block), and `always()` would keep a superseded run
+    # grinding through the release build after a newer push had cancelled it.
+    # `!cancelled()` respects cancellation and differs from `always()` only
+    # there.
+    #
+    # Setup steps are the exception, and stay real prerequisites: the guards are
+    # meaningless without a checkout, and the cargo gates are meaningless
+    # without a toolchain — an ubuntu-latest runner ships a preinstalled Rust,
+    # so a failed `Install Rust stable` would otherwise let fmt and clippy run
+    # green on the wrong toolchain. Hence the explicit `steps.<id>.outcome`
+    # guards rather than a bare `!cancelled()` on those.
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Cheap and toolchain-free, so it runs before the Rust setup: a tracked
       # file that matches .gitignore means agent scratch reached the remote
       # (#448), or an ignore rule is too broad to ever accept new files.
       - name: no tracked file is gitignored
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-no-scratch.sh
 
       # Also toolchain-free, so it runs before the Rust setup: a floating
       # `uses:` ref lets the action's owner change what runs with this job's
       # secrets. Pinning is only durable if something re-checks it (#648).
       - name: every workflow action is pinned to a commit SHA
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-action-pins.sh
 
       # Also toolchain-free. Three fleet plans asserted a 1500-line file ratchet
@@ -83,31 +112,40 @@ jobs:
       # grandfathered with per-file ceilings; this blocks new bloat and any
       # further growth of the known ones.
       - name: no new .rs file over the 1500-line ratchet
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-file-size.sh
 
       - name: Install Rust stable
+        id: rust
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: cargo fmt --check
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo fmt --check
 
       - name: cargo clippy -D warnings
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       # Nothing gated rustdoc, so its warning count only grew — one crate's doc
       # link to a private fn had made `cargo doc` a hard failure, unnoticed
       # (#634). Gating is what stops it regrowing.
       - name: cargo doc -D warnings
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
       - name: cargo test
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo test --workspace
 
       - name: cargo build (release smoke, thin LTO)
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo build --workspace --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'
 
   supply-chain:


### PR DESCRIPTION
## What & why

A step in the `check` job is a **verdict**, not a prerequisite for the next one.
`cargo fmt` failing tells you nothing about clippy, and the 1500-line ratchet
tells you nothing about either. But GitHub's default is to abort a job at the
first non-zero exit, so all of those verdicts collapse into whichever one
happened to be ordered first.

That is not hypothetical — it is why I opened this. The ratchet runs third, and
deliberately *before* the Rust setup, so on #780 a handful of files one baseline
tick over their ceiling ended the run in **9 seconds**, with `cargo fmt`,
`clippy`, `doc`, `test` and the release smoke never having run at all. The PR
looked like it had a file-size problem. Nobody could see whether it *also* had a
test problem, because the toolchain was never even installed.

The cost is one round trip per failure, serialized, at ~10 minutes a lap.

## What changed

Every gate now carries `if: ${{ !cancelled }}` and runs whether or not an
earlier gate failed.

- These are **not** `continue-on-error`. Each failure is still a failure and the
  job still goes red, so `fmt + clippy + test` keeps working unchanged as the
  required status context (and as a merge-queue context — see the `merge_group`
  note at the top of the workflow). You just get the whole list in one run.
- **Not `always`.** This workflow sets `cancel-in-progress` for
  `pull_request`, and `always` would keep a superseded run grinding through
  the release build after a newer push had already cancelled it. `!cancelled`
  differs from `always` in exactly that case, which is the case we care about.
- **Setup steps stay real prerequisites**, via explicit `steps.<id>.outcome`
  guards rather than a bare `!cancelled`. The three script guards are
  meaningless without a checkout, and the cargo gates are meaningless without a
  toolchain — and since an `ubuntu-latest` runner ships a preinstalled Rust, a
  failed `Install Rust stable` would otherwise let fmt and clippy run *green*
  against the wrong toolchain. A false pass is worse than the abort this PR
  removes.

I deliberately did **not** split the job into one job per gate. That would give
each gate its own check context, but `fmt + clippy + test` is a required status
check by exact name on `main` (confirmed via the branch-protection API), so
splitting it would block merges on every open PR until branch protection was
updated — and it would pay for a fresh checkout and cold `rust-cache` per job.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because there is nothing
      here to unit-test; the behavior lives in GitHub's step scheduler.

How I verified instead:

- The workflow parses, and all 11 steps in `check` carry the intended condition
  (walked the parsed YAML rather than eyeballing the diff).
- Ran all three script guards locally: each exits 0, and `check-action-pins`
  still resolves **all 38** `uses:` references — worth checking explicitly,
  since this diff restructures two `uses:` steps to take an `id:`/`if:`.
- The remaining risk in a change like this is a malformed `if:` that *skips* a
  step rather than running it — a silent false green, the one dangerous
  outcome. This PR's own run rules that out: every gate must show as **run**,
  not skipped. I'll confirm that on the run this PR triggers before marking it
  ready.

## The gate

- [x] `cargo fmt --check` — unaffected (workflow-only diff; no Rust touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — unaffected
- [x] `cargo test --workspace` — unaffected
- [x] Docs updated where behavior/flags changed — the rationale is written into
      the workflow itself, as a comment above `steps:`

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The ordering is unchanged, so the cheap toolchain-free guards still run first
and still fail fast *in wall-clock terms* — they just no longer silence the
expensive gates behind them.

One consequence worth naming: a run that fails early now costs more runner
minutes than it used to, because it proceeds through `cargo build --release`
instead of stopping at step 3. That is the trade being made deliberately —
runner minutes are cheaper than a human round trip. If that turns out to bite,
the narrower version is to keep `!cancelled` on fmt/clippy/doc/test and let
the release smoke keep its implicit `success`.

## Summary by Sourcery

Ensure all CI check job gates run and report independently while still respecting cancellations and prerequisite setup steps.

CI:
- Add conditional execution to each check job gate so steps continue after failures but stop on workflow cancellation.
- Guard setup and script steps with explicit checkout and Rust installation outcomes to avoid false positives when prerequisites fail.
- Document the rationale and behavior of the new CI gating strategy directly in the workflow configuration comments.
