### PR TITLE
docs(context): worked TOML examples for the context-record schema

### DIFF
--- a/docs/context-record-examples/01-constraint-decreed.toml
+++ b/docs/context-record-examples/01-constraint-decreed.toml
@@ -50,7 +50,12 @@ tags        = ["build", "tooling"]
   [record.enforcement]
   mode               = "hard"
   guard_tool         = "Bash"
-  guard_deny_command = "npm install*|npm ci*|yarn *"
+  # `*` is the matcher's only wildcard — every other character is a literal
+  # (stella-core/src/glob.rs). There is no alternation, so this cannot also
+  # cover yarn; that needs its own record. An earlier draft of this file used
+  # "npm install*|npm ci*|yarn *", which is syntactically fine, reads correctly,
+  # renders as [enforced], and matches no real command. See 08-witness.toml.
+  guard_deny_command = "npm *"
   severity           = "error"
   on_violation       = "Use pnpm. If a foreign lockfile was created, delete it and run `pnpm install`."
 

--- a/docs/context-record-examples/01-constraint-decreed.toml
+++ b/docs/context-record-examples/01-constraint-decreed.toml
@@ -1,0 +1,113 @@
+# A hard constraint: steers strongly, machine-enforceable, true by decree.
+#
+# Note what enforcement does NOT contain: no `command`, no `autofix`. Guards are
+# deny-shaped — they block a tool call at the boundary and can never cause one.
+# "Remove the foreign lockfile" is prose for the agent to act on, not a script
+# the engine runs.
+#
+# Note also that this is TWO records, not one. The original CLAUDE.md sentence
+# asserted both "pnpm is the only package manager" and "a foreign lockfile
+# breaks CI on the install job". Those fail independently — CI could be
+# reconfigured tomorrow without pnpm changing — so under the one-verdict test
+# they are separate records, joined by a `supports` link.
+
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+status        = "active"
+origin        = "user"
+review_every  = "P90D"
+
+[defaults.provenance]
+source_kind   = "document"
+source_uri    = "CLAUDE.md"
+source_digest = "sha256:6b1f9d0e4a7c8823b5e1f00d92aa41c7cc55e1930b2d7f4a6e88c1029dd3c021"
+repo          = "git@github.com:acme/web.git"
+commit        = "9f2c1ab"
+extracted_at  = 2026-07-27T09:00:00Z
+extractor     = "claude-opus-5"
+
+
+[[record]]
+lineage_id  = "ctx.acme.web.pkg-manager"
+record_id   = "rec_pkg_manager_a41f9c2b71d4"
+record_hash = "sha256:a41f9c2b71d4e6038f5b1c9270ae4d8813f6c05be2917a4d0cc38e5b74a29f16"
+kind        = "constraint"
+title       = "pnpm is the only package manager"
+summary     = "Use pnpm. Never npm or yarn."
+statement   = "This repository uses pnpm exclusively; npm and yarn must not be used."
+tags        = ["build", "tooling"]
+
+  [record.provenance]
+  source_lines = [14, 16]
+
+  [record.steering]
+  force         = "must"
+  precedence    = 100
+  inject        = "always"
+  budget_tokens = 24
+  applies_to    = { paths = ["**"], tasks = ["install", "build", "ci"] }
+
+  [record.enforcement]
+  mode               = "hard"
+  guard_tool         = "Bash"
+  guard_deny_command = "npm install*|npm ci*|yarn *"
+  severity           = "error"
+  on_violation       = "Use pnpm. If a foreign lockfile was created, delete it and run `pnpm install`."
+
+  [record.truth]
+  basis       = "decree"
+  confidence  = 100
+  verified_by = "@dana"
+  verified_at = 2026-07-20T00:00:00Z
+  valid_from  = 2026-01-04T00:00:00Z
+
+    # A decree is unrefutable by construction — it is true because an owner said
+    # so, not because the world agrees. The honest probe is a human recheck.
+    [record.truth.probe]
+    kind = "manual"
+    note = "Confirm with the platform owner at each quarterly review."
+
+
+[[record]]
+lineage_id  = "ctx.acme.web.foreign-lockfile-breaks-ci"
+record_id   = "rec_foreign_lockfile_3c80ba17ff29"
+record_hash = "sha256:3c80ba17ff2941d6a0e7c5b83e2149f70dd6a8c41b95e0327fa6d418cc07b2e5"
+kind        = "fact"
+title       = "A foreign lockfile fails CI before any test runs"
+summary     = "package-lock.json or yarn.lock fails the `install` job."
+statement   = "The CI `install` job fails when package-lock.json or yarn.lock is present, before any test job runs."
+tags        = ["build", "ci"]
+
+  [record.provenance]
+  source_lines = [17, 18]
+
+  [record.steering]
+  force         = "info"
+  precedence    = 30
+  inject        = "on-match"
+  budget_tokens = 18
+  applies_to    = { paths = ["**"], tasks = ["ci", "debug"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis       = "measured"
+  confidence  = 95
+  verified_at = 2026-07-20T00:00:00Z
+  review_every = "P30D"
+
+    # Ungated: reads a tracked file, executes nothing.
+    [record.truth.probe]
+    kind    = "file_contains"
+    path    = ".github/workflows/ci.yml"
+    pattern = "pnpm-lock.yaml"
+
+  # This record is why the constraint above is worth enforcing. The link makes
+  # that relationship explicit instead of burying it in one compound statement.
+  [[record.link]]
+  relation = "supports"
+  target   = "ctx.acme.web.pkg-manager"

--- a/docs/context-record-examples/01-constraint-decreed.toml
+++ b/docs/context-record-examples/01-constraint-decreed.toml
@@ -35,8 +35,6 @@ lineage_id  = "ctx.acme.web.pkg-manager"
 record_id   = "rec_pkg_manager_a41f9c2b71d4"
 record_hash = "sha256:a41f9c2b71d4e6038f5b1c9270ae4d8813f6c05be2917a4d0cc38e5b74a29f16"
 kind        = "constraint"
-title       = "pnpm is the only package manager"
-summary     = "Use pnpm. Never npm or yarn."
 statement   = "This repository uses pnpm exclusively; npm and yarn must not be used."
 tags        = ["build", "tooling"]
 
@@ -47,7 +45,6 @@ tags        = ["build", "tooling"]
   force         = "must"
   precedence    = 100
   inject        = "always"
-  budget_tokens = 24
   applies_to    = { paths = ["**"], tasks = ["install", "build", "ci"] }
 
   [record.enforcement]
@@ -76,8 +73,6 @@ lineage_id  = "ctx.acme.web.foreign-lockfile-breaks-ci"
 record_id   = "rec_foreign_lockfile_3c80ba17ff29"
 record_hash = "sha256:3c80ba17ff2941d6a0e7c5b83e2149f70dd6a8c41b95e0327fa6d418cc07b2e5"
 kind        = "fact"
-title       = "A foreign lockfile fails CI before any test runs"
-summary     = "package-lock.json or yarn.lock fails the `install` job."
 statement   = "The CI `install` job fails when package-lock.json or yarn.lock is present, before any test job runs."
 tags        = ["build", "ci"]
 
@@ -88,7 +83,6 @@ tags        = ["build", "ci"]
   force         = "info"
   precedence    = 30
   inject        = "on-match"
-  budget_tokens = 18
   applies_to    = { paths = ["**"], tasks = ["ci", "debug"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/01-constraint-decreed.toml
+++ b/docs/context-record-examples/01-constraint-decreed.toml
@@ -44,7 +44,6 @@ tags        = ["build", "tooling"]
   [record.steering]
   force         = "must"
   precedence    = 100
-  inject        = "always"
   applies_to    = { paths = ["**"], tasks = ["install", "build", "ci"] }
 
   [record.enforcement]
@@ -87,7 +86,6 @@ tags        = ["build", "ci"]
   [record.steering]
   force         = "info"
   precedence    = 30
-  inject        = "on-match"
   applies_to    = { paths = ["**"], tasks = ["ci", "debug"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/02-fact-observed.toml
+++ b/docs/context-record-examples/02-fact-observed.toml
@@ -41,7 +41,6 @@ tags        = ["environments"]
   [record.steering]
   force         = "info"
   precedence    = 20
-  inject        = "on-match"
   applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "env"] }
 
   [record.enforcement]
@@ -84,7 +83,6 @@ tags        = ["environments", "tooling"]
   [record.steering]
   force         = "info"
   precedence    = 20
-  inject        = "on-match"
   applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "docker"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/02-fact-observed.toml
+++ b/docs/context-record-examples/02-fact-observed.toml
@@ -32,8 +32,6 @@ lineage_id  = "ctx.acme.web.staging-endpoint"
 record_id   = "rec_staging_endpoint_77de1049ba3c"
 record_hash = "sha256:77de1049ba3c8f21e6570cd4192ab8e3357f0c6d9b41e2a80fd35c7169ae4b28"
 kind        = "fact"
-title       = "Staging API is remote, not local"
-summary     = "Staging lives at api.staging.acme.dev."
 statement   = "The staging API is served from https://api.staging.acme.dev."
 tags        = ["environments"]
 
@@ -44,7 +42,6 @@ tags        = ["environments"]
   force         = "info"
   precedence    = 20
   inject        = "on-match"
-  budget_tokens = 16
   applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "env"] }
 
   [record.enforcement]
@@ -78,8 +75,6 @@ lineage_id  = "ctx.acme.web.no-local-staging"
 record_id   = "rec_no_local_staging_5b2ec8f0d613"
 record_hash = "sha256:5b2ec8f0d61374a9c02e8b15fd3760ea94c1d8b207f6539ae4c0182bb7d95f43"
 kind        = "fact"
-title       = "There is no local staging container"
-summary     = "`docker compose up` starts dev only."
 statement   = "The docker-compose stack defines a dev environment only; it has no staging service."
 tags        = ["environments", "tooling"]
 
@@ -90,7 +85,6 @@ tags        = ["environments", "tooling"]
   force         = "info"
   precedence    = 20
   inject        = "on-match"
-  budget_tokens = 14
   applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "docker"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/02-fact-observed.toml
+++ b/docs/context-record-examples/02-fact-observed.toml
@@ -1,0 +1,113 @@
+# A fact: weak steering, no enforcement — but it rots, so the truth axis does
+# the work. This is the class of record that makes ingest dangerous: a stale
+# fact from a two-year-old CLAUDE.md reads exactly like a fresh one.
+#
+# `http_ok` would be the natural probe here and is deliberately NOT used: this
+# record's origin is `imported`, and a gated probe is never honored on an
+# imported record. What is checked instead is the tracked infrastructure file
+# that would have to change if the endpoint moved — weaker, but safe and still
+# genuinely falsifying.
+
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+status        = "active"
+origin        = "imported"
+
+[defaults.provenance]
+source_kind   = "document"
+source_uri    = "CLAUDE.md"
+source_digest = "sha256:6b1f9d0e4a7c8823b5e1f00d92aa41c7cc55e1930b2d7f4a6e88c1029dd3c021"
+repo          = "git@github.com:acme/web.git"
+commit        = "9f2c1ab"
+ingest_run_id = "ing_01J8XQ4M2K7ZP3VN5T0R9WB6HC"
+extracted_at  = 2026-07-27T09:00:00Z
+extractor     = "claude-opus-5"
+
+
+[[record]]
+lineage_id  = "ctx.acme.web.staging-endpoint"
+record_id   = "rec_staging_endpoint_77de1049ba3c"
+record_hash = "sha256:77de1049ba3c8f21e6570cd4192ab8e3357f0c6d9b41e2a80fd35c7169ae4b28"
+kind        = "fact"
+title       = "Staging API is remote, not local"
+summary     = "Staging lives at api.staging.acme.dev."
+statement   = "The staging API is served from https://api.staging.acme.dev."
+tags        = ["environments"]
+
+  [record.provenance]
+  source_lines = [61, 62]
+
+  [record.steering]
+  force         = "info"
+  precedence    = 20
+  inject        = "on-match"
+  budget_tokens = 16
+  applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "env"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis        = "measured"
+  confidence   = 90
+  verified_at  = 2026-07-25T11:30:00Z
+  ttl          = "P14D"
+  on_expiry    = "stale"    # stale = keep citing, with a warning | drop | block
+  review_every = "P14D"
+
+    # Ungated. The endpoint is declared in tracked Terraform, so the repo can
+    # falsify this claim without touching the network.
+    [record.truth.probe]
+    kind    = "file_contains"
+    path    = "infra/terraform/staging.tf"
+    pattern = "api.staging.acme.dev"
+
+  [[record.link]]
+  relation = "supports"
+  target   = "evidence:infra/terraform/staging.tf#L42"
+
+
+# The second half of the original sentence — "there is no local staging
+# container" — is a separate claim about docker-compose that can rot on its own
+# schedule, so it is a separate record with its own probe.
+[[record]]
+lineage_id  = "ctx.acme.web.no-local-staging"
+record_id   = "rec_no_local_staging_5b2ec8f0d613"
+record_hash = "sha256:5b2ec8f0d61374a9c02e8b15fd3760ea94c1d8b207f6539ae4c0182bb7d95f43"
+kind        = "fact"
+title       = "There is no local staging container"
+summary     = "`docker compose up` starts dev only."
+statement   = "The docker-compose stack defines a dev environment only; it has no staging service."
+tags        = ["environments", "tooling"]
+
+  [record.provenance]
+  source_lines = [62, 63]
+
+  [record.steering]
+  force         = "info"
+  precedence    = 20
+  inject        = "on-match"
+  budget_tokens = 14
+  applies_to    = { tasks = ["debug", "integration-test"], keywords = ["staging", "docker"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis        = "measured"
+  confidence   = 85
+  verified_at  = 2026-07-25T11:30:00Z
+  review_every = "P30D"
+
+    [record.truth.probe]
+    kind    = "file_contains"
+    path    = "docker-compose.yml"
+    pattern = "^\\s*staging:"
+    expect  = "absent"
+
+  [[record.link]]
+  relation = "refines"
+  target   = "ctx.acme.web.staging-endpoint"

--- a/docs/context-record-examples/03-preference-asserted.toml
+++ b/docs/context-record-examples/03-preference-asserted.toml
@@ -33,7 +33,6 @@ tags       = ["review", "writing"]
   [record.steering]
   force         = "should"
   precedence    = 40
-  inject        = "on-match"
   applies_to    = { tasks = ["open-pr", "write-pr-description"] }
 
   [record.enforcement]
@@ -71,7 +70,6 @@ statement     = "When reviewing a PR, read the test changes before the implement
   [record.steering]
   force      = "may"
   precedence = 10
-  inject     = "on-match"
   applies_to = { tasks = ["review-pr"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/03-preference-asserted.toml
+++ b/docs/context-record-examples/03-preference-asserted.toml
@@ -1,0 +1,91 @@
+# A preference: real steering force, but nothing in the repository can refute
+# it. "PR descriptions should lead with the why" has no fact of the matter to
+# check — only compliance to measure.
+#
+# This is the honest shape for the majority of useful steering, and the reason
+# the refutation verdict must be three-valued. A refuter that returned
+# pass/fail here would return "pass" for a claim it never examined.
+#
+# Hand-authored: `record_id` and `record_hash` are absent on purpose. The loader
+# computes and stamps them on first validation. A later semantic edit whose
+# stored hash no longer matches the recomputed one creates a new revision rather
+# than silently overwriting the old record.
+
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+status        = "active"
+origin        = "user"
+
+[defaults.provenance]
+source_kind = "authored"
+authored_by = "@dana"
+
+
+[[record]]
+lineage_id = "ctx.acme.web.pr-descriptions"
+kind       = "preference"
+title      = "PR descriptions lead with the why"
+summary    = "Open a PR description with motivation, not a diff summary."
+statement  = "A PR description's first paragraph states why the change exists and what breaks without it."
+tags       = ["review", "writing"]
+
+  [record.steering]
+  force         = "should"
+  precedence    = 40
+  inject        = "on-match"
+  budget_tokens = 22
+  applies_to    = { tasks = ["open-pr", "write-pr-description"] }
+
+  [record.enforcement]
+  mode     = "soft"
+  check    = "model"
+  rubric   = "First paragraph states motivation or consequence-of-inaction, not a file list."
+  severity = "warn"
+  on_violation = "Rewrite the opening paragraph to lead with intent."
+
+  [record.truth]
+  basis      = "asserted"
+  confidence = 80
+  owner      = "@dana"
+  valid_from = 2026-03-11T00:00:00Z
+
+    # The only honest probe for a normative claim. `unfalsifiable` is a verdict,
+    # not a failure — it tells a reviewer this record's accuracy was never
+    # machine-checked and never will be.
+    [record.truth.probe]
+    kind    = "manual"
+    verdict = "unfalsifiable"
+    note    = "Normative preference. Measure compliance over merged PRs; do not attempt refutation."
+
+
+# A personal record, in the same shape. `sharing_scope = "personal"` is the only
+# thing that keeps it out of git — it lives in .stella/private/context.db and is
+# never materialized to a file. It appears here only to show that the record
+# type is universal and scope alone decides the substrate.
+[[record]]
+lineage_id    = "ctx.acme.web.my-review-order"
+kind          = "preference"
+sharing_scope = "personal"
+title         = "Review tests before implementation"
+summary       = "Read the test diff first."
+statement     = "When reviewing a PR, read the test changes before the implementation changes."
+
+  [record.steering]
+  force      = "may"
+  precedence = 10
+  inject     = "on-match"
+  applies_to = { tasks = ["review-pr"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis      = "asserted"
+  confidence = 70
+
+    [record.truth.probe]
+    kind    = "manual"
+    verdict = "unfalsifiable"

--- a/docs/context-record-examples/03-preference-asserted.toml
+++ b/docs/context-record-examples/03-preference-asserted.toml
@@ -27,8 +27,6 @@ authored_by = "@dana"
 [[record]]
 lineage_id = "ctx.acme.web.pr-descriptions"
 kind       = "preference"
-title      = "PR descriptions lead with the why"
-summary    = "Open a PR description with motivation, not a diff summary."
 statement  = "A PR description's first paragraph states why the change exists and what breaks without it."
 tags       = ["review", "writing"]
 
@@ -36,7 +34,6 @@ tags       = ["review", "writing"]
   force         = "should"
   precedence    = 40
   inject        = "on-match"
-  budget_tokens = 22
   applies_to    = { tasks = ["open-pr", "write-pr-description"] }
 
   [record.enforcement]
@@ -69,8 +66,6 @@ tags       = ["review", "writing"]
 lineage_id    = "ctx.acme.web.my-review-order"
 kind          = "preference"
 sharing_scope = "personal"
-title         = "Review tests before implementation"
-summary       = "Read the test diff first."
 statement     = "When reviewing a PR, read the test changes before the implementation changes."
 
   [record.steering]

--- a/docs/context-record-examples/04-procedure-atomic-set.toml
+++ b/docs/context-record-examples/04-procedure-atomic-set.toml
@@ -47,8 +47,6 @@ lineage_id  = "ctx.acme.web.capability-contract-format"
 record_id   = "rec_cap_contract_format_9e1d40c7ab52"
 record_hash = "sha256:9e1d40c7ab52f8360b7e4295cd1a83f07be6205d9c4a17f83b0e6cd21947f5aa"
 kind        = "fact"
-title       = "Capability contracts are YAML"
-summary     = "Each agent capability is declared in a YAML contract."
 statement   = "An agent capability's contract is written as a YAML file."
 tags        = ["capabilities", "contracts"]
 
@@ -56,7 +54,6 @@ tags        = ["capabilities", "contracts"]
   force         = "info"
   precedence    = 35
   inject        = "on-match"
-  budget_tokens = 14
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]
@@ -78,8 +75,6 @@ lineage_id  = "ctx.acme.web.capability-contract-location"
 record_id   = "rec_cap_contract_loc_2f77b9c318ea"
 record_hash = "sha256:2f77b9c318ea6d05948c1f3b7ea20d64c85e1a97403fb2d68c05a3e719bf4d80"
 kind        = "fact"
-title       = "Capability contracts live in capabilities/contracts/"
-summary     = "Contracts are stored under capabilities/contracts/."
 statement   = "Capability contract files are stored in the capabilities/contracts/ directory."
 tags        = ["capabilities", "contracts"]
 
@@ -87,7 +82,6 @@ tags        = ["capabilities", "contracts"]
   force         = "info"
   precedence    = 35
   inject        = "on-match"
-  budget_tokens = 14
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]
@@ -109,8 +103,6 @@ lineage_id  = "ctx.acme.web.ship-a-capability"
 record_id   = "rec_ship_capability_c604af8b1d7e"
 record_hash = "sha256:c604af8b1d7ec2951403d7ba6e8f0257cd913b46a0e7f2185cb39d0ea4715f62"
 kind        = "procedure"
-title       = "Shipping a new agent capability"
-summary     = "Declare a contract, place it with the others, then implement."
 statement   = "To ship an agent capability, write its contract file and place it with the other contracts before implementing the capability."
 tags        = ["capabilities", "contracts"]
 
@@ -118,7 +110,6 @@ tags        = ["capabilities", "contracts"]
   force         = "must"
   precedence    = 70
   inject        = "on-match"
-  budget_tokens = 38
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/04-procedure-atomic-set.toml
+++ b/docs/context-record-examples/04-procedure-atomic-set.toml
@@ -1,0 +1,151 @@
+# One sentence, three records.
+#
+# The source sentence was:
+#
+#   "every capability we ship to an agent ships as a contract defined in a yaml
+#    file and also goes into path/to/some/folder"
+#
+# It looks like one instruction and is three claims that fail independently:
+#
+#   1. contracts are YAML                  — could become TOML next quarter
+#   2. contracts live in a known directory — could be relocated
+#   3. the procedure for shipping one      — could gain a codegen step
+#
+# Migrating contracts to TOML refutes (1) and leaves (2) and (3) standing. Under
+# the one-verdict test that is three records.
+#
+# The procedure is NOT the parent of the two facts — it does not contain them,
+# and neither is subordinate to it. It *cites* them, which is a typed link.
+# That is the whole argument against a `parent_id` field: the natural
+# relationship here is reference, and the three records are siblings from one
+# extraction, which shared provenance already expresses for free.
+
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+status        = "active"
+origin        = "imported"
+review_every  = "P90D"
+
+[defaults.provenance]
+source_kind   = "document"
+source_uri    = "AGENTS.md"
+source_digest = "sha256:0a4c73e18b26d59fc0871ee4a3b95d20c7f6182ab4de930517cc82f6b0e4a3d9"
+source_lines  = [88, 90]
+repo          = "git@github.com:acme/web.git"
+commit        = "9f2c1ab"
+ingest_run_id = "ing_01J8XQ4M2K7ZP3VN5T0R9WB6HC"
+extracted_at  = 2026-07-27T09:00:00Z
+extractor     = "claude-opus-5"
+
+
+# ── 1. Format ────────────────────────────────────────────────────────────────
+[[record]]
+lineage_id  = "ctx.acme.web.capability-contract-format"
+record_id   = "rec_cap_contract_format_9e1d40c7ab52"
+record_hash = "sha256:9e1d40c7ab52f8360b7e4295cd1a83f07be6205d9c4a17f83b0e6cd21947f5aa"
+kind        = "fact"
+title       = "Capability contracts are YAML"
+summary     = "Each agent capability is declared in a YAML contract."
+statement   = "An agent capability's contract is written as a YAML file."
+tags        = ["capabilities", "contracts"]
+
+  [record.steering]
+  force         = "info"
+  precedence    = 35
+  inject        = "on-match"
+  budget_tokens = 14
+  applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis       = "measured"
+  confidence  = 95
+  verified_at = 2026-07-27T09:00:00Z
+
+    [record.truth.probe]
+    kind = "path_exists"
+    path = "capabilities/contracts/*.yaml"
+
+
+# ── 2. Location ──────────────────────────────────────────────────────────────
+[[record]]
+lineage_id  = "ctx.acme.web.capability-contract-location"
+record_id   = "rec_cap_contract_loc_2f77b9c318ea"
+record_hash = "sha256:2f77b9c318ea6d05948c1f3b7ea20d64c85e1a97403fb2d68c05a3e719bf4d80"
+kind        = "fact"
+title       = "Capability contracts live in capabilities/contracts/"
+summary     = "Contracts are stored under capabilities/contracts/."
+statement   = "Capability contract files are stored in the capabilities/contracts/ directory."
+tags        = ["capabilities", "contracts"]
+
+  [record.steering]
+  force         = "info"
+  precedence    = 35
+  inject        = "on-match"
+  budget_tokens = 14
+  applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis       = "measured"
+  confidence  = 95
+  verified_at = 2026-07-27T09:00:00Z
+
+    [record.truth.probe]
+    kind = "path_exists"
+    path = "capabilities/contracts/"
+
+
+# ── 3. Procedure ─────────────────────────────────────────────────────────────
+[[record]]
+lineage_id  = "ctx.acme.web.ship-a-capability"
+record_id   = "rec_ship_capability_c604af8b1d7e"
+record_hash = "sha256:c604af8b1d7ec2951403d7ba6e8f0257cd913b46a0e7f2185cb39d0ea4715f62"
+kind        = "procedure"
+title       = "Shipping a new agent capability"
+summary     = "Declare a contract, place it with the others, then implement."
+statement   = "To ship an agent capability, write its contract file and place it with the other contracts before implementing the capability."
+tags        = ["capabilities", "contracts"]
+
+  [record.steering]
+  force         = "must"
+  precedence    = 70
+  inject        = "on-match"
+  budget_tokens = 38
+  applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
+
+  [record.enforcement]
+  mode         = "soft"
+  check        = "model"
+  rubric       = "A new capability's diff includes a contract file alongside its implementation."
+  severity     = "warn"
+  on_violation = "Add the capability's contract before implementing it."
+
+  [record.truth]
+  basis       = "decree"
+  confidence  = 100
+  verified_by = "@dana"
+  verified_at = 2026-07-27T09:00:00Z
+
+    [record.truth.probe]
+    kind = "manual"
+    note = "Procedural decree. Re-confirm with the capability owner each quarter."
+
+  # The procedure depends on both facts. If either is refuted, this record's
+  # wording is stale even though the procedure itself was never wrong — which is
+  # exactly the signal a reviewer wants, and exactly what a compound record
+  # would have hidden.
+  [[record.link]]
+  relation = "requires"
+  target   = "ctx.acme.web.capability-contract-format"
+
+  [[record.link]]
+  relation = "requires"
+  target   = "ctx.acme.web.capability-contract-location"

--- a/docs/context-record-examples/04-procedure-atomic-set.toml
+++ b/docs/context-record-examples/04-procedure-atomic-set.toml
@@ -53,7 +53,6 @@ tags        = ["capabilities", "contracts"]
   [record.steering]
   force         = "info"
   precedence    = 35
-  inject        = "on-match"
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]
@@ -81,7 +80,6 @@ tags        = ["capabilities", "contracts"]
   [record.steering]
   force         = "info"
   precedence    = 35
-  inject        = "on-match"
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]
@@ -109,7 +107,6 @@ tags        = ["capabilities", "contracts"]
   [record.steering]
   force         = "must"
   precedence    = 70
-  inject        = "on-match"
   applies_to    = { paths = ["capabilities/**"], tasks = ["add-capability"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/05-imported-proposals.toml
+++ b/docs/context-record-examples/05-imported-proposals.toml
@@ -56,7 +56,6 @@ eligibility   = "explicit_instruction"
     [proposal.record.steering]
     force      = "must"
     precedence = 100
-    inject     = "always"
     applies_to = { paths = ["**"], tasks = ["install", "build", "ci"] }
 
     [proposal.record.enforcement]
@@ -95,7 +94,6 @@ eligibility   = "explicit_instruction"
     [proposal.record.steering]
     force      = "must"
     precedence = 90
-    inject     = "always"
     applies_to = { paths = ["**"] }
 
     [proposal.record.enforcement]
@@ -140,7 +138,6 @@ eligibility   = "explicit_instruction"
     [proposal.record.steering]
     force      = "should"
     precedence = 40
-    inject     = "on-match"
     applies_to = { tasks = ["open-pr"] }
 
     [proposal.record.enforcement]
@@ -182,7 +179,6 @@ dismissed_reason = "quarantined_executable"
     [proposal.record.steering]
     force      = "may"
     precedence = 15
-    inject     = "on-demand"
     applies_to = { tasks = ["fix-env"] }
 
     [proposal.record.enforcement]

--- a/docs/context-record-examples/05-imported-proposals.toml
+++ b/docs/context-record-examples/05-imported-proposals.toml
@@ -1,0 +1,234 @@
+# What `stella ingest CLAUDE.md` produces.
+#
+# Ingest mints PROPOSALS, never published records. The reason is not ceremony:
+# some fraction of any ingested document is already stale at the moment it is
+# read, and the split into atomic claims is a model call even when the source
+# text is an explicit human instruction. The content may be authoritative; the
+# extraction is always inferred.
+#
+# Each proposal carries the record it would create, the evidence for it, and a
+# refutation verdict. The reviewer runs `stella proposals keep|edit|ignore`.
+#
+# Three things this file is built to show:
+#
+#   * a refuted claim  — the document was stale before it was ever ingested
+#   * an unfalsifiable claim — no probe could judge it, and that is visible
+#   * a quarantined executable — the source asked for shell; ingest refused
+
+schema        = "context-record/v0.1"
+set_id        = "acme.web"
+ingest_run_id = "ing_01J8XQ4M2K7ZP3VN5T0R9WB6HC"
+
+[defaults]
+sharing_scope = "repository"
+origin        = "imported"
+
+[defaults.provenance]
+source_kind   = "document"
+source_uri    = "CLAUDE.md"
+source_digest = "sha256:6b1f9d0e4a7c8823b5e1f00d92aa41c7cc55e1930b2d7f4a6e88c1029dd3c021"
+repo          = "git@github.com:acme/web.git"
+commit        = "9f2c1ab"
+extracted_at  = 2026-07-27T09:00:00Z
+extractor     = "claude-opus-5"
+
+
+# ── Eligible: explicit instruction, probe agrees ─────────────────────────────
+[[proposal]]
+candidate_id  = "pkg-manager-a41f9c2b"
+proposal_kind = "directive"
+status        = "eligible"
+confidence    = 95
+observed_at   = 2026-07-27T09:00:00Z
+# Imported content is gated differently from mined behavior: an explicit
+# instruction in a tracked repo file is top-tier evidence and does not need the
+# distinct-task threshold that an inferred pattern must clear.
+eligibility   = "explicit_instruction"
+
+  [proposal.record]
+  lineage_id = "ctx.acme.web.pkg-manager"
+  kind       = "constraint"
+  title      = "pnpm is the only package manager"
+  statement  = "This repository uses pnpm exclusively; npm and yarn must not be used."
+
+    [proposal.record.provenance]
+    source_lines = [14, 16]
+
+    [proposal.record.steering]
+    force      = "must"
+    precedence = 100
+    inject     = "always"
+    applies_to = { paths = ["**"], tasks = ["install", "build", "ci"] }
+
+    [proposal.record.enforcement]
+    mode               = "hard"
+    guard_tool         = "Bash"
+    guard_deny_command = "npm install*|npm ci*|yarn *"
+
+    [proposal.record.truth]
+    basis      = "decree"
+    confidence = 95
+
+  [proposal.refutation]
+  verdict     = "supported"
+  checked_at  = 2026-07-27T09:00:04Z
+  probe_kind  = "path_exists"
+  detail      = "pnpm-lock.yaml present; no package-lock.json or yarn.lock in tree."
+
+
+# ── Refuted: the document was already stale ──────────────────────────────────
+[[proposal]]
+candidate_id  = "node-version-88b1e5df"
+proposal_kind = "directive"
+status        = "eligible"
+confidence    = 90
+observed_at   = 2026-07-27T09:00:00Z
+eligibility   = "explicit_instruction"
+
+  [proposal.record]
+  lineage_id = "ctx.acme.web.node-version"
+  kind       = "constraint"
+  title      = "Pin Node to 20.x"
+  statement  = "All development happens on Node 20.x."
+
+    [proposal.record.provenance]
+    source_lines = [22, 22]
+
+    [proposal.record.steering]
+    force      = "must"
+    precedence = 90
+    inject     = "always"
+    applies_to = { paths = ["**"] }
+
+    [proposal.record.enforcement]
+    mode = "soft"
+
+    [proposal.record.truth]
+    basis      = "decree"
+    confidence = 90
+
+  # This is the case that justifies the whole design. CLAUDE.md says 20.x;
+  # .nvmrc has said 22.x since June. Publishing this record would have taught
+  # the agent something false, with a `must`, on every single turn.
+  [proposal.refutation]
+  verdict     = "refuted"
+  checked_at  = 2026-07-27T09:00:05Z
+  probe_kind  = "file_contains"
+  detail      = ".nvmrc contains 22.11.0; package.json engines.node is >=22. Source document is stale."
+  recommend   = "ignore"
+
+    [[proposal.refutation.link]]
+    relation = "contradicts"
+    target   = "evidence:.nvmrc#L1"
+
+
+# ── Unfalsifiable: nothing could judge it, and that is said out loud ─────────
+[[proposal]]
+candidate_id  = "pr-descriptions-1d09fa77"
+proposal_kind = "directive"
+status        = "eligible"
+confidence    = 80
+observed_at   = 2026-07-27T09:00:00Z
+eligibility   = "explicit_instruction"
+
+  [proposal.record]
+  lineage_id = "ctx.acme.web.pr-descriptions"
+  kind       = "preference"
+  title      = "PR descriptions lead with the why"
+  statement  = "A PR description's first paragraph states why the change exists and what breaks without it."
+
+    [proposal.record.provenance]
+    source_lines = [102, 105]
+
+    [proposal.record.steering]
+    force      = "should"
+    precedence = 40
+    inject     = "on-match"
+    applies_to = { tasks = ["open-pr"] }
+
+    [proposal.record.enforcement]
+    mode   = "soft"
+    check  = "model"
+    rubric = "First paragraph states motivation or consequence-of-inaction, not a file list."
+
+    [proposal.record.truth]
+    basis      = "asserted"
+    confidence = 80
+
+  # Not a failure. The reviewer needs to know this claim's accuracy was never
+  # machine-checked — folding it into "supported" would launder it.
+  [proposal.refutation]
+  verdict    = "unfalsifiable"
+  checked_at = 2026-07-27T09:00:05Z
+  probe_kind = "none"
+  detail     = "Normative preference; no probe kind can judge it. Measure compliance instead."
+
+
+# ── Quarantined: the source asked for shell, ingest refused ──────────────────
+[[proposal]]
+candidate_id  = "reset-env-4ba7c012"
+proposal_kind = "directive"
+status        = "dismissed"
+confidence    = 40
+observed_at   = 2026-07-27T09:00:00Z
+eligibility   = "explicit_instruction"
+dismissed_reason = "quarantined_executable"
+
+  [proposal.record]
+  lineage_id = "ctx.acme.web.reset-env"
+  kind       = "procedure"
+  title      = "Resetting a broken local environment"
+  statement  = "A broken local environment is reset by clearing node_modules and reinstalling."
+
+    [proposal.record.provenance]
+    source_lines = [140, 143]
+
+    [proposal.record.steering]
+    force      = "may"
+    precedence = 15
+    inject     = "on-demand"
+    applies_to = { tasks = ["fix-env"] }
+
+    [proposal.record.enforcement]
+    mode = "none"
+
+    [proposal.record.truth]
+    basis      = "asserted"
+    confidence = 40
+
+  # The source document contained a command. A model extracted it faithfully.
+  # Honoring it would mean a document ingested from anywhere — a dependency's
+  # README, a pasted gist — could put `rm -rf` in front of the agent. The text
+  # is preserved verbatim for a human to read and ratify; it is not a field the
+  # engine will ever execute.
+  [proposal.quarantine]
+  reason       = "executable_content_from_imported_origin"
+  field        = "enforcement.autofix"
+  raw          = "rm -rf node_modules && pnpm install --force"
+  requires     = "human ratification; basis must be decree and verified_by set"
+  never_honored_when = ["origin = imported", "origin = inferred"]
+
+
+# ── Rejected by the atomicity validator ──────────────────────────────────────
+[[proposal]]
+candidate_id  = "deploy-compound-70cc9a31"
+proposal_kind = "directive"
+status        = "dismissed"
+confidence    = 60
+observed_at   = 2026-07-27T09:00:00Z
+dismissed_reason = "compound_claim"
+
+  [proposal.record]
+  lineage_id = "ctx.acme.web.deploy"
+  kind       = "procedure"
+  title      = "Deploys run from main on Tuesdays via make ship"
+  statement  = "Deploys run from main, happen on Tuesdays, and are triggered with make ship."
+
+  # Three independently refutable assertions in one statement. The release day
+  # could change without the branch or the command changing. A single verdict
+  # cannot describe it, so the record cannot be refuted at all.
+  [proposal.validation]
+  rule    = "one_verdict_per_record"
+  verdict = "compound"
+  detail  = "3 independently falsifiable assertions: source branch, cadence, command."
+  action  = "re-extract as 3 records"

--- a/docs/context-record-examples/05-imported-proposals.toml
+++ b/docs/context-record-examples/05-imported-proposals.toml
@@ -62,7 +62,7 @@ eligibility   = "explicit_instruction"
     [proposal.record.enforcement]
     mode               = "hard"
     guard_tool         = "Bash"
-    guard_deny_command = "npm install*|npm ci*|yarn *"
+    guard_deny_command = "npm *"
 
     [proposal.record.truth]
     basis      = "decree"

--- a/docs/context-record-examples/05-imported-proposals.toml
+++ b/docs/context-record-examples/05-imported-proposals.toml
@@ -48,7 +48,6 @@ eligibility   = "explicit_instruction"
   [proposal.record]
   lineage_id = "ctx.acme.web.pkg-manager"
   kind       = "constraint"
-  title      = "pnpm is the only package manager"
   statement  = "This repository uses pnpm exclusively; npm and yarn must not be used."
 
     [proposal.record.provenance]
@@ -88,7 +87,6 @@ eligibility   = "explicit_instruction"
   [proposal.record]
   lineage_id = "ctx.acme.web.node-version"
   kind       = "constraint"
-  title      = "Pin Node to 20.x"
   statement  = "All development happens on Node 20.x."
 
     [proposal.record.provenance]
@@ -134,7 +132,6 @@ eligibility   = "explicit_instruction"
   [proposal.record]
   lineage_id = "ctx.acme.web.pr-descriptions"
   kind       = "preference"
-  title      = "PR descriptions lead with the why"
   statement  = "A PR description's first paragraph states why the change exists and what breaks without it."
 
     [proposal.record.provenance]
@@ -177,7 +174,6 @@ dismissed_reason = "quarantined_executable"
   [proposal.record]
   lineage_id = "ctx.acme.web.reset-env"
   kind       = "procedure"
-  title      = "Resetting a broken local environment"
   statement  = "A broken local environment is reset by clearing node_modules and reinstalling."
 
     [proposal.record.provenance]
@@ -221,7 +217,6 @@ dismissed_reason = "compound_claim"
   [proposal.record]
   lineage_id = "ctx.acme.web.deploy"
   kind       = "procedure"
-  title      = "Deploys run from main on Tuesdays via make ship"
   statement  = "Deploys run from main, happen on Tuesdays, and are triggered with make ship."
 
   # Three independently refutable assertions in one statement. The release day

--- a/docs/context-record-examples/06-lineage-supersession.toml
+++ b/docs/context-record-examples/06-lineage-supersession.toml
@@ -40,8 +40,6 @@ record_id   = "rec_node_version_11a7ce30d482"
 record_hash = "sha256:11a7ce30d4826b0f95e13c8a70df42b6810c95fe2a7d640b3e18cc0592af7b13"
 kind        = "constraint"
 status      = "archived"
-title       = "Pin Node to 20.x"
-summary     = "Development runs on Node 20.x."
 statement   = "Development runs on Node 20.x."
 
 superseded_by = "rec_node_version_84f0b2ed6a95"
@@ -75,8 +73,6 @@ record_id   = "rec_node_version_84f0b2ed6a95"
 record_hash = "sha256:84f0b2ed6a951c73d0e825bf4a6013cc79ed2b8f50a4917e63cb0d21fa8e7c40"
 kind        = "constraint"
 status      = "active"
-title       = "Pin Node to 22.x"
-summary     = "Development runs on Node 22.x."
 statement   = "Development runs on Node 22.x."
 
 supersedes = "rec_node_version_11a7ce30d482"
@@ -89,7 +85,6 @@ supersedes = "rec_node_version_11a7ce30d482"
   force         = "must"
   precedence    = 90
   inject        = "always"
-  budget_tokens = 12
   applies_to    = { paths = ["**"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/06-lineage-supersession.toml
+++ b/docs/context-record-examples/06-lineage-supersession.toml
@@ -1,0 +1,120 @@
+# Revision identity without an allocated version counter.
+#
+# Both records below share one `lineage_id` and differ in `record_id`, which is
+# derived from each revision's own content hash. Nothing had to read the store
+# to decide "this is version 2" — which is what keeps extraction idempotent:
+# re-ingesting unchanged content recomputes the same `record_id`, and the
+# ledger's append becomes a no-op instead of a duplicate.
+#
+# That property is the entire refresh story. Re-running ingest IS refresh:
+#
+#   unchanged claim → same record_id → append no-ops
+#   edited claim    → new record_id, same lineage_id → superseding revision
+#   removed claim   → absent from extraction → status archived, never deleted
+#
+# Nothing is ever deleted, so `ut_` use records, `pev_` promotion events, and
+# proposals' supporting-observation references never dangle.
+#
+# Note there is no `superseded` status: RecordStatus is frozen at active /
+# retracted / archived. A replaced record is `archived` and points forward with
+# `superseded_by`. `retracted` is reserved for a claim that was *wrong* — the
+# distinction matters, because an archived record was true for its window and
+# `as_of` queries should still return it.
+
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+origin        = "user"
+
+[defaults.provenance]
+source_kind = "authored"
+repo        = "git@github.com:acme/web.git"
+
+
+# ── The superseded revision, retained so old citations still resolve ─────────
+[[record]]
+lineage_id  = "ctx.acme.web.node-version"
+record_id   = "rec_node_version_11a7ce30d482"
+record_hash = "sha256:11a7ce30d4826b0f95e13c8a70df42b6810c95fe2a7d640b3e18cc0592af7b13"
+kind        = "constraint"
+status      = "archived"
+title       = "Pin Node to 20.x"
+summary     = "Development runs on Node 20.x."
+statement   = "Development runs on Node 20.x."
+
+superseded_by = "rec_node_version_84f0b2ed6a95"
+archived_at   = 2026-06-02T00:00:00Z
+
+  [record.provenance]
+  commit      = "3ab77e1"
+  authored_by = "@dana"
+
+  [record.steering]
+  force      = "must"
+  precedence = 90
+  inject     = "never"      # archived records are cited, never injected
+  applies_to = { paths = ["**"] }
+
+  [record.enforcement]
+  mode = "none"             # an archived record enforces nothing
+
+  [record.truth]
+  basis       = "decree"
+  confidence  = 100
+  verified_by = "@dana"
+  valid_from  = 2025-04-18T00:00:00Z
+  valid_until = 2026-06-02T00:00:00Z   # exclusive: true right up to this instant
+
+
+# ── The live revision ────────────────────────────────────────────────────────
+[[record]]
+lineage_id  = "ctx.acme.web.node-version"
+record_id   = "rec_node_version_84f0b2ed6a95"
+record_hash = "sha256:84f0b2ed6a951c73d0e825bf4a6013cc79ed2b8f50a4917e63cb0d21fa8e7c40"
+kind        = "constraint"
+status      = "active"
+title       = "Pin Node to 22.x"
+summary     = "Development runs on Node 22.x."
+statement   = "Development runs on Node 22.x."
+
+supersedes = "rec_node_version_11a7ce30d482"
+
+  [record.provenance]
+  commit      = "9f2c1ab"
+  authored_by = "@dana"
+
+  [record.steering]
+  force         = "must"
+  precedence    = 90
+  inject        = "always"
+  budget_tokens = 12
+  applies_to    = { paths = ["**"] }
+
+  [record.enforcement]
+  mode         = "soft"
+  check        = "model"
+  rubric       = "Toolchain references target Node 22.x."
+  severity     = "warn"
+  on_violation = "Update the toolchain reference to Node 22.x."
+
+  [record.truth]
+  basis        = "decree"
+  confidence   = 100
+  verified_by  = "@dana"
+  verified_at  = 2026-06-02T00:00:00Z
+  valid_from   = 2026-06-02T00:00:00Z
+  review_every = "P180D"
+
+    [record.truth.probe]
+    kind    = "file_contains"
+    path    = ".nvmrc"
+    pattern = "^22\\."
+
+  # Records the governance decision that replaced the old revision. The
+  # corresponding immutable `pev_` promotion event carries actor, reason, and
+  # timestamp; this link is the projection of it that lives in git.
+  [[record.link]]
+  relation = "supports"
+  target   = "evidence:pev_01J7Y2N8C4Q1XR5M0B3KD9WE6T"

--- a/docs/context-record-examples/06-lineage-supersession.toml
+++ b/docs/context-record-examples/06-lineage-supersession.toml
@@ -52,7 +52,6 @@ archived_at   = 2026-06-02T00:00:00Z
   [record.steering]
   force      = "must"
   precedence = 90
-  inject     = "never"      # archived records are cited, never injected
   applies_to = { paths = ["**"] }
 
   [record.enforcement]
@@ -84,7 +83,6 @@ supersedes = "rec_node_version_11a7ce30d482"
   [record.steering]
   force         = "must"
   precedence    = 90
-  inject        = "always"
   applies_to    = { paths = ["**"] }
 
   [record.enforcement]

--- a/docs/context-record-examples/07-agent-projection.md
+++ b/docs/context-record-examples/07-agent-projection.md
@@ -16,6 +16,14 @@ Measured across the ten live records in this directory:
 
 ## The rendered block
 
+It arrives in **two blocks**, because `force` decides the channel.
+
+### Cached — every turn, byte-identical
+
+`must` and `should` records. This block sits in the system prefix, built once per
+session and reused verbatim (`stella-cli/src/agent.rs:698`). It does not depend on
+the prompt, so it never changes and never invalidates the cache.
+
 ```text
 ## Workspace rules
 
@@ -28,21 +36,33 @@ Measured across the ten live records in this directory:
 ### Should
 - A PR description's first paragraph states why the change exists and what breaks
   without it. ^pr-descriptions
+```
 
-### Context
+### Volatile — selected per turn, alongside memories
+
+`may` and `info` records, chosen by relevance and injected after the stable prefix
+(`inject_recall_block`). Facts are only worth tokens when they apply, which is how
+memories already behave — so they share the channel.
+
+```text
+## Relevant context
 - Capability contract files are stored in the capabilities/contracts/ directory.
   ^capability-contract-location
 - An agent capability's contract is written as a YAML file. ^capability-contract-format
 ```
 
-Six records, not seven. The selector also chose `^staging-endpoint`, which the
-token budget then dropped — so it never reached the model, and the block above is
-what *survived* selection rather than what was selected. That gap is invisible
-unless the ledger distinguishes the two stages; see "Why the handle exists" below.
+Two facts, not three. The selector also chose `^staging-endpoint`, which the token
+budget then dropped — so it never reached the model, and the volatile block is what
+*survived* selection rather than what was selected. That gap is invisible unless
+the ledger distinguishes the two stages; see "Why the handle exists" below.
 
-Of the ten live records in this directory, three others were never selected at
-all: two are `on-match` facts whose `applies_to` did not match an endpoint task,
-and one is `sharing_scope = "personal"` and scoped to PR review.
+Of the ten live records here, three others were never selected: two facts whose
+`applies_to` did not match an endpoint task, and one `personal` record scoped to
+PR review.
+
+Note what the split buys. A `must` record can never be silently dropped by a
+relevance miss — a mistyped task name costs you scoring accuracy, not enforcement.
+Only facts are ever selected, and a fact going missing is survivable.
 
 Everything else — `record_id`, `record_hash`, all of `[record.provenance]`,
 `[record.truth]`, `applies_to`, `precedence`, `status` — stays out.
@@ -75,14 +95,15 @@ of repeating it per line, and stops the renderer overstating what a record is.
 
 ### Byte-stability is a hard constraint
 
-Rules ride the **system prefix**, which is built once per session and reused
-verbatim under a prompt-cache contract (`stella-cli/src/agent.rs:698`). Memories
-ride the separate volatile recall block injected per turn
-(`inject_recall_block`).
+This is what forces the two-block split. The system prefix is built once per
+session and reused verbatim under a prompt-cache contract
+(`stella-cli/src/agent.rs:698`). Anything selected per turn cannot live there
+without rebuilding the cache every turn — which is why `must`/`should` are
+unconditional and only facts are relevance-gated.
 
-So this block must be byte-identical across turns. No timestamps, no "verified 3
-weeks ago", no confidence that drifts as citations accumulate — anything carrying
-a clock invalidates the cache every turn.
+So the cached block must be byte-identical across turns. No timestamps, no
+"verified 3 weeks ago", no confidence that drifts as citations accumulate —
+anything carrying a clock invalidates the cache every turn.
 
 Staleness is therefore resolved **before** rendering, never expressed in it. A
 record is fresh enough to inject at its stated force, demoted to a weaker force,

--- a/docs/context-record-examples/07-agent-projection.md
+++ b/docs/context-record-examples/07-agent-projection.md
@@ -1,0 +1,206 @@
+# What the agent actually sees
+
+The records in `01`–`06` are governance artifacts: git-tracked, hashable,
+reviewable, auditable. None of that belongs in a prompt. This file shows the
+**projection** — the bytes the model receives — beside the machinery that turns
+a handle in that projection back into an attribution signal.
+
+Measured across the ten live records in this directory:
+
+| | bytes | per record |
+| --- | --- | --- |
+| full record | 6274 | 627 |
+| projection | 1013 | 101 |
+
+**The agent sees ~16% of the record.**
+
+## The rendered block
+
+```text
+## Workspace rules
+
+### Must
+- This repository uses pnpm exclusively; npm and yarn must not be used. ^pkg-manager [enforced]
+- Development runs on Node 22.x. ^node-version
+- To ship an agent capability, write its contract file and place it with the other
+  contracts before implementing the capability. ^ship-a-capability
+
+### Should
+- A PR description's first paragraph states why the change exists and what breaks
+  without it. ^pr-descriptions
+
+### Context
+- Capability contract files are stored in the capabilities/contracts/ directory.
+  ^capability-contract-location
+- An agent capability's contract is written as a YAML file. ^capability-contract-format
+```
+
+Six records, not seven. The selector also chose `^staging-endpoint`, which the
+token budget then dropped — so it never reached the model, and the block above is
+what *survived* selection rather than what was selected. That gap is invisible
+unless the ledger distinguishes the two stages; see "Why the handle exists" below.
+
+Of the ten live records in this directory, three others were never selected at
+all: two are `on-match` facts whose `applies_to` did not match an endpoint task,
+and one is `sharing_scope = "personal"` and scoped to PR review.
+
+Everything else — `record_id`, `record_hash`, all of `[record.provenance]`,
+`[record.truth]`, `applies_to`, `precedence`, `status` — stays out.
+
+### Why each omission
+
+**`applies_to` and `precedence` are consumed by the selector.** They decide
+whether a record appears at all and which of two conflicting records won. Passing
+them through afterward is waste: the answer is already baked into what is in the
+prompt.
+
+**Provenance is expanded by the engine, not the agent.** The agent emits
+`^pkg-manager`; the engine already knows the file, commit, and merged PR behind
+that handle. The commit sha never needs to enter the prompt.
+
+**`record_hash` is unverifiable by a model.** It is an integrity field for the
+loader.
+
+**`confidence` invites false precision.** Whether to defer is already encoded in
+which heading the record renders under.
+
+### Why grouping by force matters
+
+The current renderer (`stella-core/src/rules.rs:387`) emits every rule under one
+header — `## Workspace rules (binding — follow exactly; guarded rules are
+hard-blocked)` — so a `may`-force preference and a `must`-force constraint are
+indistinguishable, and a fact about a staging URL is presented as something to
+"follow exactly." Grouping amortises the force marker across many records instead
+of repeating it per line, and stops the renderer overstating what a record is.
+
+### Byte-stability is a hard constraint
+
+Rules ride the **system prefix**, which is built once per session and reused
+verbatim under a prompt-cache contract (`stella-cli/src/agent.rs:698`). Memories
+ride the separate volatile recall block injected per turn
+(`inject_recall_block`).
+
+So this block must be byte-identical across turns. No timestamps, no "verified 3
+weeks ago", no confidence that drifts as citations accumulate — anything carrying
+a clock invalidates the cache every turn.
+
+Staleness is therefore resolved **before** rendering, never expressed in it. A
+record is fresh enough to inject at its stated force, demoted to a weaker force,
+or dropped. The decision reaches the prompt; the reasoning does not.
+
+## Why the handle exists
+
+Not for explainability. The handle is the **attribution key**, and without it the
+feedback loop cannot close.
+
+`ContextUseKind` (`stella-core/src/context_record/context_use.rs:19`) is a
+three-stage funnel:
+
+| Stage | Means | Deterministic? |
+| --- | --- | --- |
+| `selected` | the selector chose it | yes — the engine decided |
+| `rendered` | it survived into the prompt bytes | yes — the engine emitted it |
+| `cited` | the agent named it in its output | yes to **observe**, but see below |
+
+The `selected` → `rendered` gap is a real and silent bug class: a record chosen
+by the selector and then dropped by a token budget looks identical, from the
+ledger, to one that was never chosen. `MissingContextKind::NotRendered` exists to
+name exactly that.
+
+**`cited` is unreachable today.** `render_rules_section` emits no identifier, so
+the model cannot name what it followed, so the third stage of the funnel can never
+be populated. The handle is what makes that stage observable at all.
+
+## Injected is not useful
+
+The record type that carries the judgement is `ContextUseFeedback`
+(`context_use.rs:260`), and its most important field is not the verdict:
+
+```rust
+/// Whether the record had a real opportunity to influence the task.
+pub had_opportunity: bool,
+```
+
+Without it, silence is ambiguous — a record that was rendered and not cited might
+have been ignored, or might simply have been irrelevant to that turn. Punishing a
+record for being irrelevant would decay every specific rule toward retirement
+purely because most turns do not touch its domain.
+
+With it, you get a clean deterministic negative:
+
+> `had_opportunity = true` **and** not cited **and** no observable effect
+> → this record cost tokens and steered nothing.
+
+That is the signal worth acting on, and it is available without asking a model to
+judge anything.
+
+## Where determinism stops
+
+`selected`, `rendered`, and `cited` are all deterministic to record. **"Helpful"
+is not** — it is a judgement, and the schema already treats it as one:
+
+- `ContextUseEvaluation` — `helpful` / `not_helpful` / `neutral`
+- `attribution_confidence` — a `Confidence`, not a boolean
+- `evaluation_method` — **required for a `not_helpful` verdict**, so a negative
+  judgement must say how it was reached
+- `observable_effect_refs` — "post-task, observable only"
+
+That last field is the determinism anchor. It is the difference between *the model
+said this helped* and *here is the diff hunk that changed because of it*.
+
+### The confabulation hazard
+
+A model asked which context it used will produce plausible citations whether or
+not they influenced anything. Self-reported citation measures **plausibility, not
+influence**.
+
+This matters concretely because promotion is citation-gated: `stella memory
+promote` requires more than ten consecutive positive citations since the last
+negative remark. If those citations are confabulated, the gate promotes on vibes —
+a signal that looks like it measures usefulness while measuring resemblance.
+
+Mitigations, in order of strength:
+
+1. **Require an observable effect for a positive.** A citation with an empty
+   `observable_effect_refs` is `neutral`, not `helpful`.
+2. **Prefer mechanical compliance where it exists.** For a guarded rule, the guard
+   firing or not firing is ground truth and needs no self-report at all.
+3. **Use the deterministic negative.** `had_opportunity && !cited` needs no model
+   judgement and is the cheapest reliable signal in the system.
+4. **Withhold occasionally.** The only genuinely causal signal is a counterfactual
+   — drop a record from the projection and see whether behaviour changes. Safe for
+   `info` and `should`; not for `must`.
+
+## One turn, end to end
+
+Records rendered: the seven above. Task: add an endpoint under `src/api/`.
+
+| Handle | Stage reached | had_opportunity | Evaluation | Why |
+| --- | --- | --- | --- | --- |
+| `^pkg-manager` | `rendered` | no | `neutral` | task ran no package manager; silence is not a negative |
+| `^ship-a-capability` | `cited` | yes | `helpful` | agent wrote the contract first; `observable_effect_refs` points at the contract file in the diff |
+| `^capability-contract-location` | `cited` | yes | `helpful` | contract landed in the right directory |
+| `^capability-contract-format` | `rendered` | yes | `not_helpful` | had its chance and was not followed — contract was written as JSON; `evaluation_method` records how that was determined |
+| `^pr-descriptions` | `rendered` | no | `neutral` | no PR opened this turn |
+| `^staging-endpoint` | `selected` | — | — | selected, then dropped by the token budget → `MissingContextKind::NotRendered` |
+| `^node-version` | `rendered` | no | `neutral` | no toolchain interaction |
+
+Three things this table is meant to make obvious:
+
+- **Two of the seven were genuinely evaluable.** The rest had no opportunity, and
+  recording them as negatives would be noise dressed as data.
+- **`^capability-contract-format` is the interesting row.** It had an opportunity,
+  was not followed, and that is a real signal about the record — possibly that it
+  is stale, possibly that it is badly worded, possibly that it should be enforced
+  rather than advisory.
+- **`^staging-endpoint` never reached the model at all.** Without the
+  `selected`/`rendered` distinction that is invisible, and the record would look
+  like it was ignored when it was never shown.
+
+## Open question
+
+Handle collisions. `^pkg-manager` is the last segment of
+`ctx.acme.web.pkg-manager`. Two record sets in one workspace can both end in
+`pkg-manager`, and the agent has no way to disambiguate. Either the handle carries
+enough of the lineage to be unique within a rendered block, or the renderer
+detects collisions and lengthens only the handles that need it.

--- a/docs/context-record-examples/08-witness.toml
+++ b/docs/context-record-examples/08-witness.toml
@@ -1,0 +1,225 @@
+# Enforceable context ships with a witness.
+#
+# Stella's definition of done, from .github/PULL_REQUEST_TEMPLATE.md, is "a test
+# that fails on the old code and passes on the new." A Context PR that promotes a
+# rule to `blocking` is shipping enforcement logic, so it is held to the same bar.
+#
+# This file exists because the guard in 01-constraint-decreed.toml was wrong when
+# it was written, and nothing could have told us. It said:
+#
+#     guard_deny_command = "npm install*|npm ci*|yarn *"
+#
+# stella-core's matcher supports `*` and nothing else — "every other character is
+# a literal" (stella-core/src/glob.rs:1-6). So `|` is a literal pipe, and that
+# pattern matches no real command. The rule advertised Tier 2 enforcement, showed
+# up in the prompt marked [enforced], and blocked exactly zero tool calls. A
+# two-line witness would have caught it before it was ever committed.
+#
+# The witness is safe to require even on ingested records: evaluate_guards is a
+# pure function over ProposedAction { tool, path, command }, so a guard witness is
+# a table of inputs and expected verdicts, not a script. Checking one executes no
+# shell and touches no network.
+
+schema = "context-witness/v0.1"
+set_id = "acme.web"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. A correct, bidirectional witness
+#
+# Both directions are mandatory. A witness that only asserts the deny case is
+# worthless — an over-broad glob passes it while blocking the world (see C).
+# ─────────────────────────────────────────────────────────────────────────────
+[[record]]
+lineage_id = "ctx.acme.web.pkg-manager"
+statement  = "This repository uses pnpm exclusively; npm and yarn must not be used."
+
+  [record.enforcement]
+  mode               = "hard"
+  guard_tool         = "Bash"
+  guard_deny_command = "npm *"
+
+  # Positive: the thing the rule exists to stop.
+  [[record.witness]]
+  tool    = "Bash"
+  command = "npm install --save-dev typescript"
+  expect  = "blocked"
+
+  [[record.witness]]
+  tool    = "Bash"
+  command = "npm ci"
+  expect  = "blocked"
+
+  # Negative: the thing the rule must not stop. Without these, C passes.
+  [[record.witness]]
+  tool    = "Bash"
+  command = "pnpm install"
+  expect  = "allowed"
+
+  [[record.witness]]
+  tool    = "Bash"
+  command = "pnpm add -D typescript"
+  expect  = "allowed"
+
+  # A different tool entirely must be unaffected by a Bash guard.
+  [[record.witness]]
+  tool   = "Edit"
+  path   = "package.json"
+  expect = "allowed"
+
+  # Known gap, asserted rather than left to chance: `npm *` requires the trailing
+  # space, so a bare `npm` is not blocked. Writing it down as an expectation means
+  # a future glob change that "fixes" this fails the witness and gets reviewed,
+  # instead of silently widening enforcement.
+  [[record.witness]]
+  tool    = "Bash"
+  command = "npm"
+  expect  = "allowed"
+
+  # Yarn needs its own record. The matcher has no alternation, so one guard
+  # cannot express "npm or yarn" — a constraint that is invisible until you try
+  # to write the witness for it.
+  [record.coverage]
+  note = "yarn is not covered by this record; see ctx.acme.web.no-yarn"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. The inert guard, caught
+#
+# This is 01's original pattern. It is syntactically fine, reads correctly to a
+# human, renders as [enforced], and matches nothing.
+# ─────────────────────────────────────────────────────────────────────────────
+[[broken]]
+lineage_id = "ctx.acme.web.pkg-manager"
+failure    = "inert_guard"
+reason     = "`|` is a literal character; the matcher's only wildcard is `*`."
+
+  [broken.enforcement]
+  guard_tool         = "Bash"
+  guard_deny_command = "npm install*|npm ci*|yarn *"
+
+  [[broken.witness]]
+  tool     = "Bash"
+  command  = "npm install --save-dev typescript"
+  expect   = "blocked"
+  actual   = "allowed"     # ← the witness fails here, which is the point
+
+  [[broken.witness]]
+  tool     = "Bash"
+  command  = "yarn add typescript"
+  expect   = "blocked"
+  actual   = "allowed"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. Over-broad guard: passes its positive case, fails its negative one
+#
+# This is why one-directional witnesses are worthless. Every deny assertion below
+# passes. The rule still blocks every Bash call in the repository.
+# ─────────────────────────────────────────────────────────────────────────────
+[[broken]]
+lineage_id = "ctx.acme.web.no-force-push"
+failure    = "over_broad_guard"
+reason     = "A bare `*` command glob blocks the tool entirely, not just force pushes."
+
+  [broken.enforcement]
+  guard_tool         = "Bash"
+  guard_deny_command = "*"
+
+  [[broken.witness]]
+  tool    = "Bash"
+  command = "git push --force origin main"
+  expect  = "blocked"
+  actual  = "blocked"      # positive case passes — and proves nothing
+
+  [[broken.witness]]
+  tool    = "Bash"
+  command = "cargo test"
+  expect  = "allowed"
+  actual  = "blocked"      # ← only the negative case exposes it
+
+  [[broken.witness]]
+  tool    = "Bash"
+  command = "git push origin main"
+  expect  = "allowed"
+  actual  = "blocked"
+
+  # The correct pattern, with the witness it would need.
+  [broken.suggested]
+  guard_deny_command = "git push --force*"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. The mutation check
+#
+# A witness that passes with the rule removed is not testing the rule. Normally
+# mutation testing is expensive; here the mutation is dropping one element from
+# the rule slice before calling evaluate_guards, so the engine can run this
+# automatically on every Context PR.
+#
+# Run each `blocked` expectation twice: once with the record present, once with
+# it removed. The second run must fail.
+# ─────────────────────────────────────────────────────────────────────────────
+[mutation]
+applies_to = "every witness case with expect = \"blocked\""
+rule       = "with the record removed from the rule slice, the case must NOT be blocked"
+rationale  = "otherwise some other record is doing the blocking and this witness proves nothing about this record"
+
+  # A witness that survives its own mutation — the failure this catches.
+  [[mutation.example]]
+  lineage_id = "ctx.acme.web.no-npm-audit"
+  guard_deny_command = "npm audit*"
+  case       = "npm audit fix"
+  with_record    = "blocked"
+  without_record = "blocked"   # ← ctx.acme.web.pkg-manager's `npm *` already blocks it
+  verdict    = "witness_not_discriminating"
+  note       = "The record is redundant with an existing broader guard. Merge or drop it."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E. `required` rules: a fixture set, and a weaker guarantee
+#
+# A `required` rule is Tier 1 plus a completion check. It is not guard-evaluable,
+# so its witness cannot be a pure-function table — it is a graded fixture set
+# judged by a model.
+#
+# That is evidence, not proof, and it is labelled as such for the same reason
+# `unfalsifiable` is a visible verdict rather than a hidden one: a weaker
+# guarantee that looks like a strong one is worse than no guarantee.
+# ─────────────────────────────────────────────────────────────────────────────
+[[record]]
+lineage_id = "ctx.acme.web.pr-descriptions"
+statement  = "A PR description's first paragraph states why the change exists and what breaks without it."
+
+  [record.enforcement]
+  mode     = "soft"
+  check    = "model"
+  rubric   = "First paragraph states motivation or consequence-of-inaction, not a file list."
+
+  [record.witness]
+  kind      = "fixture_set"
+  guarantee = "evidence"      # never "proof" — a model grades these
+  agreement_threshold = 80    # % of fixtures the grader must classify correctly
+
+    [[record.witness.fixture]]
+    label  = "motivation-first"
+    text   = "Refund webhooks silently drop retries, so customers see duplicate charges. This adds idempotency keys."
+    expect = "pass"
+
+    [[record.witness.fixture]]
+    label  = "file-list"
+    text   = "Updates refunds.ts, adds a test, bumps the changelog."
+    expect = "fail"
+
+    [[record.witness.fixture]]
+    label  = "consequence-of-inaction"
+    text   = "Without this, the nightly job keeps timing out and on-call gets paged."
+    expect = "pass"
+
+    # The adversarial fixture. A grader that pattern-matches on the word
+    # "because" rather than reading for motivation passes the first three and
+    # fails this one.
+    [[record.witness.fixture]]
+    label  = "because-but-still-a-file-list"
+    text   = "Because we needed to, this changes refunds.ts, refunds.test.ts, and the changelog."
+    expect = "fail"

--- a/docs/context-record-examples/09-effect-witness.toml
+++ b/docs/context-record-examples/09-effect-witness.toml
@@ -1,0 +1,171 @@
+# Did this record actually help?
+#
+# 08 tests whether a rule is CORRECT — does it block the right things.
+# This file tests whether a record is USEFUL — did it change what the agent did.
+#
+# Each record declares three things:
+#
+#   applies_when — did this record even get a chance to matter this turn?
+#   passes_when  — what does it look like when it worked?
+#   requires     — the change itself has to be good, or nobody gets credit
+#
+# The first one is the important one. Right now "did this record have a chance
+# to matter" is a guess someone has to make. Written as a check over the diff or
+# the call log, it is just a query — which means a narrow record stops losing
+# points on every turn that never touched its subject.
+#
+# Two things get checked, because an agent's turn produces two kinds of trace:
+#
+#   the diff       — what files changed  (files_touched, git)
+#   the call log   — what the agent did  (tool_calls: name + args_json + ok
+#                                         + duration_ms, one row per call)
+#
+# The call log is what makes it possible to score a record whose whole value is
+# stopping a wasted turn. Nothing shows up in the diff when the agent DOESN'T
+# waste 30 seconds on localhost, but there is a very visible missing row.
+
+schema = "context-effect/v0.1"
+set_id = "acme.web"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. Scored from the diff
+#
+# "Contracts live in capabilities/contracts/" — if it worked, a contract file
+# shows up in the right place.
+# ─────────────────────────────────────────────────────────────────────────────
+[[record]]
+lineage_id = "ctx.acme.web.capability-contract-location"
+statement  = "Capability contract files are stored in the capabilities/contracts/ directory."
+
+  [record.effect]
+  source       = "diff"
+  applies_when = { diff_touches = ["capabilities/**"] }
+  passes_when  = { diff_adds = ["capabilities/contracts/*.yaml"] }
+  requires     = "pr_witness_passes"
+  note = "No credit if the PR's own test fails. Steering someone neatly into a broken change is not help."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. Scored from the call log — the wasted turn that didn't happen
+#
+# This is the one I said couldn't be tested. It can. The evidence is a row that
+# is not in tool_calls.
+# ─────────────────────────────────────────────────────────────────────────────
+[[record]]
+lineage_id = "ctx.acme.web.staging-endpoint"
+statement  = "The staging API is served from https://api.staging.acme.dev."
+
+  [record.effect]
+  source       = "tool_calls"
+  applies_when = { prompt_mentions = ["staging"] }
+  requires     = "turn_succeeded"
+
+    # What a wasted turn looks like. If any of these ran, the record did not land.
+    [record.effect.must_not_call]
+    args_match = ["*localhost*", "*127.0.0.1*", "docker compose up*"]
+
+    # What success looks like: the agent went straight to the right place.
+    [record.effect.must_call]
+    args_match = ["*api.staging.acme.dev*"]
+
+  # Bonus signal, free from the same table: a wrong turn that errored has a
+  # duration and a byte count, so this record's value can be stated in seconds
+  # saved rather than as a vague "helpful".
+  [record.effect.value]
+  measure = "duration_ms of avoided failing calls"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. Looked helpful, wasn't
+#
+# The case worth seeing. The effect check passes — the contract landed in the
+# right directory. But the task itself said where to put it, so the agent would
+# have done that with or without the record.
+#
+# The only way to tell is to run the task again with the record removed. Do that
+# once, when deciding whether to promote it — not every turn.
+# ─────────────────────────────────────────────────────────────────────────────
+[[check]]
+lineage_id = "ctx.acme.web.capability-contract-format"
+kind       = "would_have_done_it_anyway"
+
+  [check.turn]
+  prompt          = "Add a refunds capability. Put its YAML contract in capabilities/contracts/."
+  applies_when    = "met"       # diff touched capabilities/**
+  passes_when     = "met"       # capabilities/contracts/refunds.yaml added
+  requires        = "met"       # PR witness passed
+  naive_verdict   = "helpful"
+
+  [check.without_record]
+  outcome         = "identical — contract still landed in capabilities/contracts/"
+  reason          = "the prompt named the directory; the record added nothing"
+  actual_verdict  = "neutral"
+
+  [check.rule]
+  text = "An effect check that still passes with the record removed proves nothing about that record."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. What the verdicts look like over four turns
+#
+# Note that only two of these needed anyone to judge anything.
+# ─────────────────────────────────────────────────────────────────────────────
+[[turn]]
+id             = "exec_4471"
+prompt         = "Add a refunds capability"
+record         = "ctx.acme.web.capability-contract-location"
+applies_when   = "met"
+passes_when    = "met"
+requires       = "met"
+without_record = "contract landed in src/contracts/ — wrong place"
+verdict        = "helpful"
+why            = "the record changed where the file went; removing it broke that"
+
+[[turn]]
+id             = "exec_4472"
+prompt         = "Fix the failing refund test"
+record         = "ctx.acme.web.capability-contract-location"
+applies_when   = "not met"
+verdict        = "neutral"
+why            = "task never touched capabilities/**; no chance to matter, so no score either way"
+
+[[turn]]
+id             = "exec_4473"
+prompt         = "Add a webhooks capability"
+record         = "ctx.acme.web.capability-contract-location"
+applies_when   = "met"
+passes_when    = "not met"
+verdict        = "not_helpful"
+why            = "contract went to src/webhooks/contract.yaml — the record had its chance and was ignored"
+note           = "This one is reliable on its own. No second run needed: the agent had the record, had the opportunity, and did it wrong."
+
+[[turn]]
+id             = "exec_4474"
+prompt         = "Debug the staging 502s"
+record         = "ctx.acme.web.staging-endpoint"
+applies_when   = "met"
+passes_when    = "met"
+requires       = "met"
+without_record = "agent ran `curl localhost:3000/healthz`, failed, then retried against staging"
+verdict        = "helpful"
+value          = "saved one failed call, 1840ms"
+why            = "the wasted turn is visible in tool_calls when the record is absent and missing when it is present"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E. What still can't be scored this way
+#
+# Smaller than it first looked, but not empty.
+# ─────────────────────────────────────────────────────────────────────────────
+[[unscorable]]
+lineage_id = "ctx.acme.web.pr-descriptions"
+reason     = "Changes the wording of a PR description. No file moves, no call is avoided."
+fallback   = "model-graded fixture set, same as 08 section E — evidence, not proof"
+
+[[unscorable]]
+reason     = "Anything whose only effect is that the agent explained something more accurately."
+fallback   = "human review, or accept that it stays neutral forever"
+
+[limits]
+outputs_not_stored = "tool_calls records call arguments but deliberately not results, so a check can ask 'did the agent try this' and not 'what came back'."

--- a/docs/context-record-examples/09-effect-witness.toml
+++ b/docs/context-record-examples/09-effect-witness.toml
@@ -29,6 +29,52 @@ set_id = "acme.web"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# The trigger, and the four verdicts
+# ─────────────────────────────────────────────────────────────────────────────
+[scoring]
+# Tests run when the record HAD A CHANCE to matter, not when the agent cited it.
+#
+# Citation is the wrong trigger. A record the agent ignored is never cited, so
+# citation-triggered scoring would never test the one case that needs no second
+# run and no model judgement — the record that was present, was relevant, and
+# was passed over. That is the most reliable signal in the system and citing
+# would hide it.
+#
+# Citation is still recorded. It is evidence, not the gate.
+trigger = "applies_when"
+
+# Two questions, four answers.
+#
+#                      | outcome good   | outcome bad
+#   ------------------ | -------------- | -----------
+#   record followed    | helpful*       | HARMFUL
+#   record ignored     | not_helpful    | not_helpful
+#
+#   * subject to the without-record check in section C — following a record and
+#     succeeding does not prove the record caused it.
+#
+#   No chance to matter at all → neutral. No signal, no penalty.
+
+  [scoring.verdict.helpful]
+  means  = "had a chance, was followed, and changed the outcome for the better"
+  action = "counts toward promotion"
+
+  [scoring.verdict.not_helpful]
+  means  = "had a chance and changed nothing — ignored, or redundant with what the agent would have done anyway"
+  action = "counts toward retirement, slowly"
+
+  [scoring.verdict.harmful]
+  means  = "had a chance, was followed, and the outcome was worse for it"
+  action = "retract now — this is not a slow cleanup"
+  note   = "A harmful record is worse than no record. Without it the agent would have looked the answer up; with it, it confidently did the wrong thing on every turn the record was injected."
+
+  [scoring.verdict.neutral]
+  means  = "no chance to matter this turn"
+  action = "none — do not count it either way"
+  note   = "This is what stops a narrow record from decaying toward retirement just because most turns never touch its subject."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # A. Scored from the diff
 #
 # "Contracts live in capabilities/contracts/" — if it worked, a contract file
@@ -100,7 +146,8 @@ kind       = "would_have_done_it_anyway"
   [check.without_record]
   outcome         = "identical — contract still landed in capabilities/contracts/"
   reason          = "the prompt named the directory; the record added nothing"
-  actual_verdict  = "neutral"
+  actual_verdict  = "not_helpful"
+  note = "not neutral. The record had its chance and changed nothing, which is the same value to the user as being ignored. One redundant turn does not retire a record — accumulated ones should."
 
   [check.rule]
   text = "An effect check that still passes with the record removed proves nothing about that record."
@@ -151,6 +198,20 @@ without_record = "agent ran `curl localhost:3000/healthz`, failed, then retried 
 verdict        = "helpful"
 value          = "saved one failed call, 1840ms"
 why            = "the wasted turn is visible in tool_calls when the record is absent and missing when it is present"
+
+
+[[turn]]
+id             = "exec_4475"
+prompt         = "Set up the toolchain for a fresh checkout"
+record         = "ctx.acme.web.node-version"
+applies_when   = "met"
+passes_when    = "met"
+requires       = "not met"
+without_record = "agent read .nvmrc and installed Node 22 — correct"
+verdict        = "harmful"
+why            = "the agent did exactly what the record said and installed Node 20; the build then failed on an engines check"
+note = "This is the Node 20 record that 05 catches and refuses at ingest. This turn is what publishing it would have looked like. Note the shape: the record was FOLLOWED and the outcome was WORSE, which is the only combination that produces harmful — and note that removing the record gives a better result, not merely a different one."
+action         = "retract, not retire"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -62,10 +62,20 @@ coupling — any record may override.
 call, never cause one. Truth probes use a closed, declarative vocabulary rather
 than arbitrary shell. See "Probe kinds" below.
 
-**Substrate follows `sharing_scope`.** `personal` records live only in
-`.stella/private/context.db` and are never materialized to a file.
-`repository` and `organization` records are git-tracked TOML. The record type is
-universal; scope alone decides where the bytes land.
+**Memories live in the database. Context records live in files.** One place
+each, and no record is stored twice.
+
+A memory is fetched per turn by relevance and is not cached. A context record is
+a file: the project's git tree for `repository` and `organization` scope,
+`~/.stella/rules/` for `personal` scope — which the loader already reads
+(`rule_search_dirs`, `stella-core/src/rules.rs:345`). `sharing_scope` chooses
+*which* file location, not whether it is a file at all.
+
+Promotion is how a memory becomes a context record.
+
+An earlier draft of this file said personal records stay in the database. That
+was wrong: it would have meant one record type stored two different ways, and a
+personal record that could never be cached.
 
 ## Vocabularies
 

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -31,6 +31,7 @@ steering and cheaply checked, or weakly steering and hard-blocked.
 | `05-imported-proposals.toml`   | Ingest output: proposals, per-record provenance, quarantined executables, three-valued refutation |
 | `06-lineage-supersession.toml` | Revision identity without allocated version numbers                                               |
 | `07-agent-projection.md`       | What the model actually receives (~16% of the record), and how a handle closes the feedback loop   |
+| `08-witness.toml`              | Enforceable context ships with a test — bidirectional guard tables, and the mutation check         |
 
 ## Rules encoded in these examples
 

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -10,26 +10,26 @@ against concretely before it is implemented.
 A context record is the smallest quotable unit of agent context. Every record
 carries three orthogonal axes:
 
-| Axis | Answers | Table |
-| --- | --- | --- |
-| **Steering** | how hard does this push behavior, and when is it injected? | `[record.steering]` |
-| **Enforcement** | how is a violation detected, and what happens? | `[record.enforcement]` |
-| **Truth** | is the claim still accurate, and how would you know? | `[record.truth]` |
+| Axis            | Answers                                                    | Table                  |
+| --------------- | ---------------------------------------------------------- | ---------------------- |
+| **Steering**    | how hard does this push behavior, and when is it injected? | `[record.steering]`    |
+| **Enforcement** | how is a violation detected, and what happens?             | `[record.enforcement]` |
+| **Truth**       | is the claim still accurate, and how would you know?       | `[record.truth]`       |
 
 Separating these matters because the current engine conflates the first two —
-enforcement level *is* authority level today, so a rule cannot be strongly
+enforcement level _is_ authority level today, so a rule cannot be strongly
 steering and cheaply checked, or weakly steering and hard-blocked.
 
 ## Files
 
-| File | Demonstrates |
-| --- | --- |
-| `01-constraint-decreed.toml` | Hard constraint, human decree, deny-shaped guard enforcement |
-| `02-fact-observed.toml` | A claim that rots — declarative probe, TTL, `on_expiry` |
-| `03-preference-asserted.toml` | Real steering force, unfalsifiable claim, model-judged rubric |
-| `04-procedure-atomic-set.toml` | One sentence → three atomic records joined by typed links |
-| `05-imported-proposals.toml` | Ingest output: proposals, per-record provenance, quarantined executables, three-valued refutation |
-| `06-lineage-supersession.toml` | Revision identity without allocated version numbers |
+| File                           | Demonstrates                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `01-constraint-decreed.toml`   | Hard constraint, human decree, deny-shaped guard enforcement                                      |
+| `02-fact-observed.toml`        | A claim that rots — declarative probe, TTL, `on_expiry`                                           |
+| `03-preference-asserted.toml`  | Real steering force, unfalsifiable claim, model-judged rubric                                     |
+| `04-procedure-atomic-set.toml` | One sentence → three atomic records joined by typed links                                         |
+| `05-imported-proposals.toml`   | Ingest output: proposals, per-record provenance, quarantined executables, three-valued refutation |
+| `06-lineage-supersession.toml` | Revision identity without allocated version numbers                                               |
 
 ## Rules encoded in these examples
 
@@ -72,8 +72,8 @@ a superseding ADR.
 - `origin` — **frozen**: `user`, `system`, `observed`, `inferred`, `imported`
 - `status` — **frozen**: `active`, `retracted`, `archived`
   (there is deliberately no `superseded` — a replaced record is `archived` and
-  carries `superseded_by`; `retracted` means the claim was *wrong*, `archived`
-  means it was *replaced*)
+  carries `superseded_by`; `retracted` means the claim was _wrong_, `archived`
+  means it was _replaced_)
 - `kind` — `memory`, `fact`, `rule`, `preference`, `constraint`, `procedure`
 - `sharing_scope` — `personal`, `repository`, `organization`
 - `steering.force` — `must`, `should`, `may`, `info`
@@ -94,13 +94,13 @@ to keep the two axes unambiguous when both appear on one record.
 
 A probe answers "does this claim still hold?" without executing arbitrary code:
 
-| `kind` | Checks | Gated? |
-| --- | --- | --- |
-| `path_exists` / `path_absent` | a path in the repo | no |
-| `file_contains` | a pattern in a tracked file | no |
-| `manual` | a human re-verifies on a schedule | no |
-| `command_succeeds` | exit status of a command | **yes** |
-| `http_ok` | an HTTP endpoint responds | **yes** |
+| `kind`                        | Checks                            | Gated?  |
+| ----------------------------- | --------------------------------- | ------- |
+| `path_exists` / `path_absent` | a path in the repo                | no      |
+| `file_contains`               | a pattern in a tracked file       | no      |
+| `manual`                      | a human re-verifies on a schedule | no      |
+| `command_succeeds`            | exit status of a command          | **yes** |
+| `http_ok`                     | an HTTP endpoint responds         | **yes** |
 
 Gated probes are honored **only** when `basis = "decree"` and a human
 `verified_by` is recorded, and **never** on a record whose `origin` is
@@ -133,13 +133,33 @@ mechanism alongside typed links, forces a single parent where a DAG is needed,
 and leaks into selection and retirement semantics ("does retiring a parent
 retire its children?"). Co-derivation is answered by shared provenance
 (`source_uri` + `source_lines` + `ingest_run_id`) for free; genuine
-relationships get typed links. Where hierarchy is real it is *derived* — general
+relationships get typed links. Where hierarchy is real it is _derived_ — general
 versus specific falls out of `applies_to.paths` containment, which cannot go
 stale or contradict itself.
 
 **No `uri` field.** It is fully derivable from `set_id` + `lineage_id` +
 revision, so storing it creates state that can disagree with its own components.
 Compute it at read time.
+
+**No `title` or `summary` — one text field, `statement`.** Atomicity makes both
+redundant: a record that can receive exactly one refutation verdict is already
+one sentence, and there is nothing in one sentence to summarize. Across these
+examples `title` + `summary` cost 987 bytes against 1152 bytes of `statement` —
+an 86% overhead on the text payload for no added meaning.
+
+The cost is not only tokens. A summary that drops a qualifier ("in CI", "for new
+code") changes what the agent does, so two fields that can disagree about what a
+rule says is a correctness hazard, not just duplication. And `docs/context-pr.md`
+§6.2 already excludes presentational `name` / `description` from the canonical
+record — by that logic they are not part of the record's meaning at all.
+
+A display label is a read-time concern: list views can truncate `statement`, and
+the stable handle across revisions is `lineage_id`, which is already present.
+
+**No `budget_tokens`.** Same principle as `uri` — measure the rendered
+`statement` rather than storing an author-declared number that drifts from it.
+If injection cost needs managing, the lever is selecting fewer records, not
+compressing each one.
 
 **No float confidence.** `confidence` is an integer 0–100.
 
@@ -153,5 +173,6 @@ Compute it at read time.
    unrecognized names.
 3. `review_every` (recurring) versus the existing `review_after` (one-shot).
    The recurring form is better, but it is a change to a shipped field.
-4. Should `budget_tokens` be author-declared or measured? A declared number will
-   drift from the real cost of the rendered record.
+4. `tags` overlaps `applies_to`. It is cheap (8 bytes per record here) and aimed
+   at human browsing rather than matching, but if nothing consumes it, it is the
+   next field to cut.

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -30,6 +30,7 @@ steering and cheaply checked, or weakly steering and hard-blocked.
 | `04-procedure-atomic-set.toml` | One sentence → three atomic records joined by typed links                                         |
 | `05-imported-proposals.toml`   | Ingest output: proposals, per-record provenance, quarantined executables, three-valued refutation |
 | `06-lineage-supersession.toml` | Revision identity without allocated version numbers                                               |
+| `07-agent-projection.md`       | What the model actually receives (~16% of the record), and how a handle closes the feedback loop   |
 
 ## Rules encoded in these examples
 

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -32,6 +32,7 @@ steering and cheaply checked, or weakly steering and hard-blocked.
 | `06-lineage-supersession.toml` | Revision identity without allocated version numbers                                               |
 | `07-agent-projection.md`       | What the model actually receives (~16% of the record), and how a handle closes the feedback loop   |
 | `08-witness.toml`              | Enforceable context ships with a test — bidirectional guard tables, and the mutation check         |
+| `09-effect-witness.toml`       | Did the record actually help? Scored from the diff and from the tool-call log                      |
 
 ## Rules encoded in these examples
 

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -1,0 +1,157 @@
+# Context record examples
+
+Worked examples of the TOML context-record surface. These are **illustrative, not
+normative** — `docs/context-pr.md` remains the canonical specification, and
+nothing here is loaded by the engine. They exist so the schema can be argued
+against concretely before it is implemented.
+
+## The shape
+
+A context record is the smallest quotable unit of agent context. Every record
+carries three orthogonal axes:
+
+| Axis | Answers | Table |
+| --- | --- | --- |
+| **Steering** | how hard does this push behavior, and when is it injected? | `[record.steering]` |
+| **Enforcement** | how is a violation detected, and what happens? | `[record.enforcement]` |
+| **Truth** | is the claim still accurate, and how would you know? | `[record.truth]` |
+
+Separating these matters because the current engine conflates the first two —
+enforcement level *is* authority level today, so a rule cannot be strongly
+steering and cheaply checked, or weakly steering and hard-blocked.
+
+## Files
+
+| File | Demonstrates |
+| --- | --- |
+| `01-constraint-decreed.toml` | Hard constraint, human decree, deny-shaped guard enforcement |
+| `02-fact-observed.toml` | A claim that rots — declarative probe, TTL, `on_expiry` |
+| `03-preference-asserted.toml` | Real steering force, unfalsifiable claim, model-judged rubric |
+| `04-procedure-atomic-set.toml` | One sentence → three atomic records joined by typed links |
+| `05-imported-proposals.toml` | Ingest output: proposals, per-record provenance, quarantined executables, three-valued refutation |
+| `06-lineage-supersession.toml` | Revision identity without allocated version numbers |
+
+## Rules encoded in these examples
+
+**Atomicity is functional, not stylistic.** A record is atomic if it can receive
+exactly one refutation verdict. If you can construct a world where half the claim
+holds and half does not, it is compound and must be split. `04` shows the split;
+`05` shows the validator rejecting a compound extraction.
+
+**Identity is derived, never allocated.** `lineage_id` is a stable slug;
+`record_id` is derived from the record's own content hash; `record_hash` is the
+JCS hash of the canonical record with `record_hash` itself omitted from the
+preimage. There is no monotonic `version` counter — allocating one would require
+reading the store before extracting, which breaks replay-idempotence and with it
+the property that re-ingesting unchanged content is a no-op.
+
+A hand-authored record omits `record_id` and `record_hash`; the loader stamps
+them on first validation. `03` is written that way on purpose.
+
+**Provenance lives on the record, not on the file.** One source document yields
+N records, records get hand-edited after ingest, and records regroup by topic.
+A file-level origin block would weld file boundaries to source-document
+boundaries forever. `[defaults.provenance]` keeps the ergonomics without the
+coupling — any record may override.
+
+**Records describe; they never execute.** Enforcement is deny-shaped
+(`guard_tool`, `guard_deny_path`, `guard_deny_command`) — it can block a tool
+call, never cause one. Truth probes use a closed, declarative vocabulary rather
+than arbitrary shell. See "Probe kinds" below.
+
+**Substrate follows `sharing_scope`.** `personal` records live only in
+`.stella/private/context.db` and are never materialized to a file.
+`repository` and `organization` records are git-tracked TOML. The record type is
+universal; scope alone decides where the bytes land.
+
+## Vocabularies
+
+Values marked **frozen** are ratified in ADR 0009 and cannot be extended without
+a superseding ADR.
+
+- `origin` — **frozen**: `user`, `system`, `observed`, `inferred`, `imported`
+- `status` — **frozen**: `active`, `retracted`, `archived`
+  (there is deliberately no `superseded` — a replaced record is `archived` and
+  carries `superseded_by`; `retracted` means the claim was *wrong*, `archived`
+  means it was *replaced*)
+- `kind` — `memory`, `fact`, `rule`, `preference`, `constraint`, `procedure`
+- `sharing_scope` — `personal`, `repository`, `organization`
+- `steering.force` — `must`, `should`, `may`, `info`
+- `steering.inject` — `always`, `on-match`, `on-demand`
+- `enforcement.mode` — `hard` (block), `soft` (warn), `none` (advisory)
+- `truth.basis` — `decree`, `measured`, `derived`, `asserted`
+- `link.relation` — `derived_from`, `refines`, `requires`, `supports`, `contradicts`
+
+### Why `measured` and not `observed`
+
+`origin` and `truth.basis` answer different questions — where a record came from
+versus why it is believed true. A record can be `origin = "imported"` (extracted
+from CLAUDE.md) and `basis = "decree"` (true because a human said so). But
+`observed` appears in the frozen `origin` set, so the truth axis uses `measured`
+to keep the two axes unambiguous when both appear on one record.
+
+### Probe kinds
+
+A probe answers "does this claim still hold?" without executing arbitrary code:
+
+| `kind` | Checks | Gated? |
+| --- | --- | --- |
+| `path_exists` / `path_absent` | a path in the repo | no |
+| `file_contains` | a pattern in a tracked file | no |
+| `manual` | a human re-verifies on a schedule | no |
+| `command_succeeds` | exit status of a command | **yes** |
+| `http_ok` | an HTTP endpoint responds | **yes** |
+
+Gated probes are honored **only** when `basis = "decree"` and a human
+`verified_by` is recorded, and **never** on a record whose `origin` is
+`imported` or `inferred`. Ingest is the headline path here: a model extracting
+records from arbitrary markdown must not be able to mint a record that runs a
+command or fetches a URL. An `http_ok` probe pointed at an attacker-chosen host
+is an exfiltration channel — anything interesting fits in a query string. `05`
+shows a would-be shell probe quarantined rather than honored.
+
+## Refutation is evidence, not a boolean
+
+A refutation attaches as a typed link with relation `contradicts` and a
+timestamp, so "refuted Tuesday, true again Friday" is representable on the
+existing bitemporal model. Verdicts are three-valued:
+
+- `supported` — the probe ran and the claim held
+- `refuted` — the probe ran and the claim did not hold
+- `unfalsifiable` — no probe could judge this claim
+
+`unfalsifiable` must stay visible in review surfaces and must never be folded
+into "passed." A refuter that reports OK for claims it never checked launders
+unvalidated content with a validated stamp — the same failure shape as a guard
+script that prints OK while silently skipping most of its inputs.
+
+## What is deliberately absent
+
+**No `parent_id` / hierarchy.** Records co-derived from one sentence are
+siblings, not parent and child. Hierarchy would be a second relationship
+mechanism alongside typed links, forces a single parent where a DAG is needed,
+and leaks into selection and retirement semantics ("does retiring a parent
+retire its children?"). Co-derivation is answered by shared provenance
+(`source_uri` + `source_lines` + `ingest_run_id`) for free; genuine
+relationships get typed links. Where hierarchy is real it is *derived* — general
+versus specific falls out of `applies_to.paths` containment, which cannot go
+stale or contradict itself.
+
+**No `uri` field.** It is fully derivable from `set_id` + `lineage_id` +
+revision, so storing it creates state that can disagree with its own components.
+Compute it at read time.
+
+**No float confidence.** `confidence` is an integer 0–100.
+
+## Open questions
+
+1. Is `set_id` stable enough to appear in citations? It is a repo slug today,
+   and forks or renames would invalidate every citation that embeds it.
+2. `applies_to.tasks` is an open vocabulary. An unknown or misspelled task name
+   means the record silently never matches — the failure mode this design
+   otherwise works hard to avoid. Ratify the task vocabulary, or warn loudly on
+   unrecognized names.
+3. `review_every` (recurring) versus the existing `review_after` (one-shot).
+   The recurring form is better, but it is a change to a shipped field.
+4. Should `budget_tokens` be author-declared or measured? A declared number will
+   drift from the real cost of the rendered record.

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -62,6 +62,25 @@ coupling — any record may override.
 call, never cause one. Truth probes use a closed, declarative vocabulary rather
 than arbitrary shell. See "Probe kinds" below.
 
+**Two channels, chosen by `force`.** `must` and `should` records are **always**
+injected and live in the byte-stable system prefix, so they ride the prompt cache
+(`stella-cli/src/agent.rs:698`). `may` and `info` records are selected by
+relevance and ride the volatile block alongside memories
+(`inject_recall_block`).
+
+A binding rule should always bind, so it cannot be relevance-gated without
+breaking the cache every turn. A fact is only worth tokens when it applies, and
+that is exactly how memories already behave — so facts belong in the memory
+channel.
+
+There is no `inject` field. The channel is derived from `force`, and an archived
+record is not loaded at all, so `status` covers the rest.
+
+This is why `applies_to` has one meaning and two consumers. It answers "when does
+this record apply." For a volatile record that drives **selection**; for a cached
+record it drives **scoring** — whether the record had a chance to matter this turn
+(see `09-effect-witness.toml`).
+
 **Memories live in the database. Context records live in files.** One place
 each, and no record is stored twice.
 
@@ -90,7 +109,7 @@ a superseding ADR.
 - `kind` — `memory`, `fact`, `rule`, `preference`, `constraint`, `procedure`
 - `sharing_scope` — `personal`, `repository`, `organization`
 - `steering.force` — `must`, `should`, `may`, `info`
-- `steering.inject` — `always`, `on-match`, `on-demand`
+- (there is no `steering.inject` — the channel follows from `force`, see below)
 - `enforcement.mode` — `hard` (block), `soft` (warn), `none` (advisory)
 - `truth.basis` — `decree`, `measured`, `derived`, `asserted`
 - `link.relation` — `derived_from`, `refines`, `requires`, `supports`, `contradicts`
@@ -180,10 +199,10 @@ compressing each one.
 
 1. Is `set_id` stable enough to appear in citations? It is a repo slug today,
    and forks or renames would invalidate every citation that embeds it.
-2. `applies_to.tasks` is an open vocabulary. An unknown or misspelled task name
-   means the record silently never matches — the failure mode this design
-   otherwise works hard to avoid. Ratify the task vocabulary, or warn loudly on
-   unrecognized names.
+2. `applies_to.tasks` is an open vocabulary. A misspelled task name no longer
+   hides a rule from the agent — `must`/`should` records inject regardless — but
+   it still skews scoring, because the record looks like it never had a chance to
+   matter. Ratify the vocabulary, or warn on unrecognized names.
 3. `review_every` (recurring) versus the existing `review_after` (one-shot).
    The recurring form is better, but it is a change to a shipped field.
 4. `tags` overlaps `applies_to`. It is cheap (8 bytes per record here) and aimed


### PR DESCRIPTION
## What & why

Six worked TOML context-record examples plus a README, under
`docs/context-record-examples/`. **Illustrative, not normative** — nothing here is
loaded by the engine, and `docs/context-pr.md` remains canonical. They exist so the
schema can be argued against concretely before anything is implemented.

| File | Demonstrates |
| --- | --- |
| `01-constraint-decreed.toml` | Hard constraint, human decree, deny-shaped guard enforcement |
| `02-fact-observed.toml` | A claim that rots — declarative probe, TTL, `on_expiry` |
| `03-preference-asserted.toml` | Real steering force, unfalsifiable claim, model-judged rubric |
| `04-procedure-atomic-set.toml` | One sentence → three atomic records joined by typed links |
| `05-imported-proposals.toml` | Ingest output: proposals, provenance, quarantined executables, three-valued refutation |
| `06-lineage-supersession.toml` | Revision identity without allocated version numbers |

### Design decisions encoded

- **Three orthogonal axes** — `[record.steering]` / `[record.enforcement]` /
  `[record.truth]`. The shipped engine conflates the first two: enforcement level
  *is* authority level today, so a rule cannot be strongly steering and cheaply
  checked, or weakly steering and hard-blocked.
- **`truth.basis` drives refutability** — `decree` is unrefutable by construction,
  `measured` carries a probe. Named `measured` rather than `observed` because the
  frozen `Origin` enum already uses `observed`, and both axes can appear on one record.
- **Atomicity is functional** — a record is atomic if it can receive exactly one
  refutation verdict. `04` shows the split; `05` shows the validator rejecting a
  compound extraction.
- **Identity derived, never allocated** — `lineage_id` + content-derived `record_id`
  + `record_hash`, and no `version` counter. Allocating one would mean reading the
  store before extracting, which breaks replay-idempotence and with it the property
  that re-ingesting unchanged content is a no-op. Re-running ingest *is* refresh.
- **Provenance on the record, not the file** — one document yields N records that get
  edited and regrouped afterward; a file-level origin block would weld file boundaries
  to source-document boundaries permanently.
- **Records describe, never execute** — guards stay deny-shaped; truth probes use a
  closed declarative vocabulary (`path_exists`, `file_contains`, …). `command_succeeds`
  and `http_ok` are refused outright on `imported` / `inferred` origins. Ingest is the
  headline path, and a model extracting records from arbitrary markdown must not be
  able to mint one that runs a command or fetches a URL.
- **Substrate follows `sharing_scope`** — `personal` records never reach git.
- **No `parent_id`** — co-derived records are siblings, not children. Co-derivation is
  answered by shared provenance for free; real relationships are typed links; and
  general-vs-specific *derives* from `applies_to.paths` containment, so it cannot go
  stale or contradict itself.

### Conforms to frozen vocabularies

Rather than inventing values: `Origin` is the five-value set (`imported` already
exists), `RecordStatus` is `active` / `retracted` / `archived` — there is deliberately
no `superseded`, so a replaced record is `archived` with `superseded_by` — and
`confidence` is an integer 0–100, not a float.

### Open questions (also listed in the README)

1. `set_id` appears in citations but is a repo slug — forks and renames invalidate them.
2. `applies_to.tasks` is an open vocabulary; an unknown task name means the record
   silently never matches, which is the failure mode this design otherwise avoids.
3. `review_every` (recurring) vs the shipped `review_after` (one-shot).
4. Should `budget_tokens` be author-declared or measured?

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: docs only; no code
      paths added, changed, or removed. Nothing in the engine reads this directory.

Verified instead by parsing all six files with `tomllib` and asserting the parsed
structure — that each `[record.steering]` / `[record.enforcement]` / `[record.truth]`
sub-table attached to its intended record, that `[[record.link]]` targets resolve, and
that the two revisions in `06` share one `lineage_id`. Checked, not assumed.

## The gate

Not applicable — no Rust changed. `cargo fmt --check` and the workspace tests are
unaffected by this PR.

## Summary by Sourcery

Add illustrative TOML examples and documentation for the context-record schema to clarify steering, enforcement, truth axes, provenance, atomicity, and revision lineage.

New Features:
- Provide six worked TOML context-record examples demonstrating constraints, facts, preferences, procedures, ingest proposals, and revision supersession semantics.

Documentation:
- Document the context-record model, its vocabularies, and design rules in a new README with links to worked examples.