### PR TITLE
fix(serve): make turn reclamation deadlock-proof, collision-proof and witnessed over the wire

### DIFF
--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -37,9 +37,10 @@
 //! one.
 
 use std::collections::HashMap;
+use std::collections::hash_map;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::Duration;
 
 use rand::Rng as _;
@@ -233,16 +234,26 @@ impl ServerState {
         if turns.len() >= MAX_LIVE_TURNS {
             return None;
         }
-        let session = start();
         let id = new_turn_id();
-        turns.insert(
-            id.clone(),
-            Arc::new(Entry {
-                seq: self.counter.fetch_add(1, Ordering::Relaxed),
-                pending: session.pending(),
-                session: Mutex::new(Some(session)),
-            }),
-        );
+        // Insert through the vacant entry rather than `insert`, which would
+        // *replace* on a collision: the displaced turn's `Session` would drop
+        // (cancelling a turn its owner is still using) and two callers would
+        // hold the same id. 128 random bits make this unreachable in practice;
+        // going through the entry API makes it unreachable by construction, so
+        // the guarantee does not rest on the id width alone. Refusing is
+        // fail-closed — the caller renders it as the cap's 429, which is the
+        // wrong reason for the right answer, and is preferable to either
+        // silently cancelling a live turn or panicking a request thread.
+        let slot = match turns.entry(id.clone()) {
+            hash_map::Entry::Occupied(_) => return None,
+            hash_map::Entry::Vacant(slot) => slot,
+        };
+        let session = start();
+        slot.insert(Arc::new(Entry {
+            seq: self.counter.fetch_add(1, Ordering::Relaxed),
+            pending: session.pending(),
+            session: Mutex::new(Some(session)),
+        }));
         Some(id)
     }
 
@@ -282,29 +293,55 @@ impl ServerState {
 ///
 /// Lock order is registry → session, the same direction `handle_events` uses
 /// (its registry lookup releases the registry lock before it takes the session
-/// slot), so holding both here cannot deadlock.
+/// slot). This function is the one place that holds *both*, and it never blocks
+/// for the second: it takes each session slot with `try_lock` and treats a
+/// contended one as not-reclaimable. So the ordering is not merely observed by
+/// convention here — it cannot be violated, even if a future caller acquires
+/// these locks the other way around.
+///
+/// What this bounds, and what it does not: reclamation frees a settled turn's
+/// entry and the frames it buffered, but the frame channel itself is unbounded,
+/// so *one* abandoned turn can still buffer arbitrarily much before it settles.
+/// Bounding that is a backpressure change in `Session`, not a registry one.
+/// What is bounded here is the count — at most [`MAX_LIVE_TURNS`] turns' worth
+/// of buffered frames can be pinned at once, instead of one per create forever.
 fn reclaim_finished_unstreamed(turns: &mut HashMap<String, Arc<Entry>>, target: usize) {
+    // Below the target there is nothing to make room for, so the common path
+    // costs one length check and allocates nothing.
     if turns.len() < target {
         return;
     }
-    let mut finished: Vec<(u64, String)> = turns
+    let mut finished: Vec<(u64, &str)> = turns
         .iter()
         .filter(|(_, entry)| {
-            entry
-                .session
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .as_ref()
-                .is_some_and(Session::is_finished)
+            // `try_lock`, not `lock`: this runs while the registry lock is held,
+            // and blocking on a session lock here would invert the one ordering
+            // this module relies on (registry → session, see the doc above).
+            let session = match entry.session.try_lock() {
+                Ok(session) => session,
+                // Held. The only writer is `handle_events` taking the session
+                // out to stream it, so contention *means* a stream is opening —
+                // skipping is the right answer, not a compromise.
+                Err(TryLockError::WouldBlock) => return false,
+                // A panic while holding this mutex must not make the entry
+                // immortal, so poisoning is recovered rather than propagated —
+                // the same posture as every other lock in this file.
+                Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+            };
+            session.as_ref().is_some_and(Session::is_finished)
         })
-        .map(|(id, entry)| (entry.seq, id.clone()))
+        .map(|(id, entry)| (entry.seq, id.as_str()))
         .collect();
+    // Oldest first, so a late stream is most likely to still find its turn.
     finished.sort_unstable();
-    for (_, id) in &finished {
-        if turns.len() < target {
-            return;
-        }
-        turns.remove(id);
+    let excess = turns.len() - target + 1;
+    let doomed: Vec<String> = finished
+        .into_iter()
+        .take(excess)
+        .map(|(_, id)| id.to_string())
+        .collect();
+    for id in doomed {
+        turns.remove(&id);
     }
 }
 

--- a/stella-serve/tests/http.rs
+++ b/stella-serve/tests/http.rs
@@ -5,6 +5,7 @@
 //! `!Send` bridge.
 
 use std::net::SocketAddr;
+use std::time::{Duration, Instant};
 
 use serde_json::json;
 use stella_protocol::{CompletionMessage, ToolSchema};
@@ -482,7 +483,9 @@ async fn the_live_turn_cap_refuses_further_turns_with_retry_after() {
     );
 
     // The cap admits again once a turn is reclaimed, so it is a queue and not a
-    // one-way latch — a latch would take the server down permanently.
+    // one-way latch — a latch would take the server down permanently. That the
+    // registry *can* drain is proven over the wire by
+    // `abandoned_finished_turns_do_not_wedge_the_cap` below.
     let (status, _) = post_json(
         addr,
         "/v1/turns/turn-does-not-exist/cancel",
@@ -491,6 +494,57 @@ async fn the_live_turn_cap_refuses_further_turns_with_retry_after() {
     )
     .await;
     assert!(status.contains("404"), "sanity: unknown turn is a 404");
+}
+
+/// The cap counts registry entries, and a turn that *finished* without ever
+/// being streamed still holds one. A stream ending and an explicit cancel are
+/// the only other reclaimers, and an abandoned turn reaches neither — so
+/// without `reclaim_finished_unstreamed` a host that creates turns and walks
+/// away drives the server into a permanent `429`, no matter how long anyone
+/// waits. The test above states that this cannot happen; this one proves it,
+/// end to end, over a socket.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn abandoned_finished_turns_do_not_wedge_the_cap() {
+    let addr = start_server().await;
+
+    // Nothing answers the reverse request these turns park on, so each aborts
+    // on its own 50 ms deadline — settled, and never streamed by anyone.
+    let abandoned = json!({
+        "provider_id": "mock",
+        "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+        "reverse_request_timeout_ms": 50,
+    })
+    .to_string();
+
+    for i in 0..32 {
+        let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &abandoned).await;
+        assert!(
+            status.contains("200"),
+            "turn {i} should be admitted: {status} {body}"
+        );
+    }
+
+    // Poll rather than sleep a tuned interval: the turns settle on their own
+    // schedule, and the claim under test is "eventually admitted", not
+    // "admitted within N ms". The deadline is what makes a server that never
+    // reclaims fail here instead of hanging.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &abandoned).await;
+        if status.contains("200") {
+            break;
+        }
+        assert!(
+            status.contains("429"),
+            "the only legitimate refusal here is the cap: {status} {body}"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "a registry full of finished, unstreamed turns never admitted a new \
+             one — the live-turn cap is a one-way latch"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 }
 
 /// Sequential ids (`turn-0`, `turn-1`, …) made every other live turn addressable


### PR DESCRIPTION
fix(serve): make turn reclamation deadlock-proof, collision-proof and witnessed over the wire

Three things the reconciliation asserted but did not guarantee.

**The lock ordering was a convention, now it is structural.**
`reclaim_finished_unstreamed` runs while holding the registry lock and takes
each entry's session lock to ask whether the turn has finished. It used a
blocking `lock`, so the whole module's registry → session ordering rested on
every other call site being careful — `handle_events` is (it scopes its guard
and drops it before touching the registry again), but nothing enforced it, and
the next caller to get it backwards would deadlock the server.

It now uses `try_lock`, and a contended entry is skipped. That is not a
weakening: the only writer of that mutex is `handle_events` taking the session
out to stream it, so contention *means* a stream is opening, and a turn about
to be streamed must not be reclaimed. Skipping is the correct answer and the
inversion becomes impossible rather than merely unobserved. Poisoning is
recovered via `into_inner` rather than skipped, so a panic cannot make an
entry immortal — matching the posture of every other lock in the file.

**Registration could silently cancel a live turn.**
`turns.insert(id, ..)` *replaces* on a collision: the displaced turn's
`Session` would drop — cancelling a turn its owner is still using — and two
callers would hold the same id. 128 random bits put this at ~2^-123, but the
guarantee rested entirely on the id width. Registration now goes through the
vacant-entry API, so overwriting is impossible by construction. The occupied
branch is fail-closed (refuse, which the caller renders as the cap's 429 —
the wrong reason for the right answer) rather than silently corrupting or
panicking a request thread.

**The latch fix had no end-to-end witness.**
#779 proved its cap over a socket; the complement — that the cap drains and is
not a one-way latch — was only unit-tested against `register_turn`. #779's own
integration test even states the claim in a comment without asserting it.
`abandoned_finished_turns_do_not_wedge_the_cap` now proves it over the wire:
fill the registry with 32 turns that abort on a 50 ms reverse-request deadline
and are never streamed, then require that a new create is eventually admitted.
It polls to a bounded deadline rather than sleeping a tuned interval, so a
server that never reclaims fails the assertion instead of hanging.

Mutation-tested, as the others were: with the reclaim call removed this test
fails after the full 10 s with "the live-turn cap is a one-way latch", and the
two unit reclamation tests fail while the cap test still passes.

Also corrects an overclaim in the rustdoc. Reclamation bounds the *number* of
settled turns pinning buffered frames, not the memory itself — the frame
channel is unbounded, so one abandoned turn can still buffer arbitrarily much
before it settles. Bounding that is a backpressure change in `Session`, not a
registry one, and is now named as such instead of being implied away.

Gates, all by exit code: cargo fmt --check, clippy --workspace --all-targets
-D warnings, RUSTDOCFLAGS=-D warnings cargo doc --workspace, cargo test
--workspace (63 suites, 0 failures), check-file-size.sh.

## Summary by Sourcery

Strengthen live-turn lifecycle handling to make reclamation safe under contention, prevent ID-collision turn cancellation, and prove the turn-cap drains end to end.

Bug Fixes:
- Prevent deadlocks between registry and session locks during turn reclamation by making lock ordering structurally safe and non-blocking.
- Avoid silent cancellation of an existing live turn when a randomly generated turn ID collides during registration.

Enhancements:
- Tighten reclamation semantics so finished, unstreamed turns are reclaimed without risking immortal entries or late streams losing their turn.
- Clarify documentation on what reclamation actually bounds, distinguishing the number of pinned turns from the unbounded frame channel.

Tests:
- Add an integration test that fills the registry with abandoned, finished turns and asserts that the live-turn cap eventually admits new turns, proving the cap is not a one-way latch.
