### PR TITLE
tooling: per-worktree agent environment setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,22 @@ hooks: ## Install the pre-push gate hook (runs `make gate` on every push)
 	@printf '  Actions is unavailable (an org billing hold has happened before).\n'
 	@printf '  Bypass in emergencies: \033[36mSKIP_GATE=1 git push\033[0m (or \033[36mgit push --no-verify\033[0m).\n'
 
+.PHONY: claude-env
+claude-env: ## Set this worktree up for agent work (per-worktree STELLA_HOME + target dir, tool check)
+	./scripts/setup-claude-env.sh
+
+.PHONY: claude-env-check
+claude-env-check: ## Report the agent environment without writing anything
+	./scripts/setup-claude-env.sh --check
+
+.PHONY: claude-env-prune
+claude-env-prune: ## Reclaim per-worktree caches whose worktree is gone
+	./scripts/setup-claude-env.sh --prune
+
+.PHONY: claude-env-test
+claude-env-test: ## Test the two agent-env scripts (hermetic; not part of `gate`)
+	./scripts/test-claude-env.sh
+
 .PHONY: docs
 docs: ## Build rustdoc for the workspace (skip dep docs)
 	cargo doc --workspace --no-deps

--- a/scripts/claude-rustfmt-hook.sh
+++ b/scripts/claude-rustfmt-hook.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Claude Code PostToolUse hook: keep agent-authored Rust inside the gate.
+#
+# Wired up by scripts/setup-claude-env.sh, which writes it into the worktree's
+# (gitignored) .claude/settings.json. It runs after every Edit/Write/MultiEdit
+# and does two things to a `.rs` file the agent just touched:
+#
+#   1. rustfmt it, in place. `cargo fmt --check` is a hard gate, so the tree's
+#      formatting is not negotiable — the only question is whether the agent
+#      finds out now or after a full `make gate` at push time. Formatting one
+#      file costs milliseconds; discovering it at the end costs a whole cycle.
+#
+#      Formatting as you go also closes a trap that is otherwise invisible:
+#      rustfmt's wrapping ADDS lines, so a file that sat under its
+#      file-size-baseline ceiling while unformatted can breach it the moment
+#      `cargo fmt` runs. Fixing the size gate first and formatting second means
+#      re-breaking the gate you just fixed. Formatting first makes the line
+#      count the agent sees the same one check-file-size.sh will see.
+#
+#   2. Re-run the file-size ratchet for that one file. `make gate` runs
+#      check-file-size.sh over the whole tree; this is the same rule scoped to
+#      the file in hand, so an agent that grows a grandfathered file past its
+#      ceiling is told immediately, at the edit that did it, rather than at the
+#      end of a long session with no memory of which change was responsible.
+#
+# Exit codes are the hook contract, not a normal script's:
+#   0 → silent success. The tool call proceeds.
+#   2 → stderr is fed back to Claude as actionable feedback. Used ONLY for a
+#       real ratchet breach, i.e. something `make gate` would fail on.
+# The tool call has already run by the time a PostToolUse hook fires, so a
+# nonzero exit cannot undo the edit — it can only inform. Every other failure
+# mode here (no stdin, unparseable payload, missing rustfmt, a file that does
+# not parse mid-edit) exits 0 on purpose: a hook that nags about its own
+# breakage trains the reader to ignore it.
+#
+# Deliberately NOT run: `cargo fmt`, `cargo check`, `cargo clippy`. Those are
+# workspace-scoped and take seconds to minutes; on a per-edit hook they would
+# make every edit feel broken. `make gate` remains the thing that must pass.
+#
+# bash 3.2 compatible (macOS ships 3.2, and this runs on the dev's machine).
+
+# No `set -e`: a hook must never abort a tool call by accident. Failures below
+# are handled explicitly.
+set -uo pipefail
+
+LIMIT=1500
+
+# ── Locate the repo ──────────────────────────────────────────────────────────
+# The hook's cwd is the Claude Code project dir, but resolve it properly rather
+# than assuming: worktrees make $PWD-relative guesses wrong.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$repo_root" ] || exit 0
+
+# ── Read the tool payload ────────────────────────────────────────────────────
+# Claude Code delivers a JSON object on stdin. We need exactly one field:
+# .tool_input.file_path. jq if it is available, a narrow sed otherwise — the
+# sed path is sufficient because file_path is a plain filesystem path, so it
+# contains no escaped quotes for a regex to get wrong.
+payload="$(cat 2>/dev/null || true)"
+[ -n "$payload" ] || exit 0
+
+if command -v jq >/dev/null 2>&1; then
+  file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+else
+  file="$(printf '%s' "$payload" \
+    | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -1)"
+fi
+
+[ -n "$file" ] || exit 0
+case "$file" in
+  *.rs) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file" ] || exit 0
+
+# Only touch files inside this repo. An agent editing a .rs file elsewhere on
+# the machine is none of this hook's business.
+abs_file="$(cd "$(dirname "$file")" 2>/dev/null && pwd -P)/$(basename "$file")" || exit 0
+canon_root="$(cd "$repo_root" 2>/dev/null && pwd -P)" || exit 0
+case "$abs_file" in
+  "$canon_root"/*) ;;
+  *) exit 0 ;;
+esac
+rel="${abs_file#"$canon_root"/}"
+
+# check-file-size.sh judges `git ls-files '*.rs'` — tracked files only. A
+# gitignored scratch file will never be tracked (check-no-scratch.sh enforces
+# that), so warning about one would be pure noise. An untracked-but-committable
+# file IS checked here, deliberately: it is going to be added, and hearing about
+# the limit at creation beats hearing about it at push.
+if git check-ignore -q "$abs_file" 2>/dev/null; then
+  exit 0
+fi
+
+# ── 1. Format ────────────────────────────────────────────────────────────────
+# The edition matters: without --edition, rustfmt assumes 2015 and reformats
+# 2024 code incorrectly. Read it from the workspace rather than hardcoding, so
+# this keeps working across an edition bump.
+if command -v rustfmt >/dev/null 2>&1; then
+  edition="$(sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]*\)".*/\1/p' \
+    "$canon_root/Cargo.toml" 2>/dev/null | head -1)"
+  [ -n "$edition" ] || edition=2024
+  # A file caught mid-refactor may not parse. That is not an error worth
+  # reporting — clippy and the compiler will say so far more precisely.
+  rustfmt --edition "$edition" "$abs_file" >/dev/null 2>&1 || true
+fi
+
+# ── 2. File-size ratchet, scoped to this file ────────────────────────────────
+# Same rule as scripts/check-file-size.sh: a file listed in the baseline may not
+# exceed its recorded ceiling; any other file may not exceed LIMIT.
+baseline="$canon_root/scripts/file-size-baseline.txt"
+# `wc -l`, not `awk END{print NR}` — check-file-size.sh uses wc, which counts
+# newlines. The two disagree by one on a file with no trailing newline, and a
+# hook that disagrees with the gate it is previewing is worse than no hook.
+lines="$(wc -l <"$abs_file" 2>/dev/null | tr -d ' ' || echo 0)"
+[ -n "$lines" ] && [ "$lines" -gt 0 ] 2>/dev/null || exit 0
+
+ceiling="$LIMIT"
+grandfathered=0
+if [ -f "$baseline" ]; then
+  found="$(awk -v p="$rel" '$1 !~ /^#/ && $2 == p { print $1; exit }' "$baseline" 2>/dev/null || true)"
+  if [ -n "$found" ]; then
+    ceiling="$found"
+    grandfathered=1
+  fi
+fi
+
+if [ "$lines" -le "$ceiling" ]; then
+  exit 0
+fi
+
+# Over the line. Say which rule broke and what the fix is — an agent that is
+# told "too long" without being told which of the two rules applies will guess,
+# and guessing wrong here means editing the baseline when it should be
+# splitting the file.
+{
+  if [ "$grandfathered" -eq 1 ]; then
+    echo "check-file-size: $rel is now $lines lines, over its baseline ceiling of $ceiling."
+    echo
+    echo "This file is grandfathered in scripts/file-size-baseline.txt, so it may"
+    echo "shrink freely but may not grow past $ceiling. \`make gate\` will fail as-is."
+    echo "Either move the addition into a new module, or — if the growth is"
+    echo "irreducible — run \`make file-size-update\` and commit the baseline diff so"
+    echo "the raise is visible in review."
+  else
+    echo "check-file-size: $rel is $lines lines, over the ${LIMIT}-line limit."
+    echo
+    echo "This file is NOT in scripts/file-size-baseline.txt, and new files over the"
+    echo "limit are a hard block — no baseline entry may be added for one."
+    echo "\`make gate\` will fail as-is. Split it into modules."
+  fi
+} >&2
+
+exit 2

--- a/scripts/setup-claude-env.sh
+++ b/scripts/setup-claude-env.sh
@@ -1,0 +1,446 @@
+#!/usr/bin/env bash
+#
+# Prepare this checkout (or worktree) for agent-driven work on stella.
+#
+#   ./scripts/setup-claude-env.sh              # set up + report
+#   ./scripts/setup-claude-env.sh --check      # report only, no writes
+#   ./scripts/setup-claude-env.sh --install    # also install what is missing
+#   ./scripts/setup-claude-env.sh --prune      # reclaim caches for dead worktrees
+#
+# Idempotent. Safe to re-run, and safe to run in every worktree — it is in fact
+# meant to be run in every worktree, because the isolation it sets up is
+# per-worktree.
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+#
+# Running several agents against several worktrees of this repo at once breaks
+# in three ways that all look like flaky tests, and none of which are:
+#
+#   1. `~/.stella` is machine-global. stella_home() (stella-store/src/home.rs)
+#      resolves STELLA_HOME, else $HOME/.stella — and usage.db, catalog.db,
+#      media-operations.db, sessions/ and notifications/ all live under it. Two
+#      worktrees running `cargo test --workspace` contend on one set of SQLite
+#      files, keyed by nothing but $HOME. The media-operation journal
+#      (stella-cli/src/agent/tools.rs) is the one that bites most often.
+#
+#      Setting STELLA_HOME per worktree fixes it, and — checked, not assumed —
+#      does NOT cost you provider auth: credentials.toml resolves through
+#      $HOME/.stella directly (stella-model/src/credential.rs), not through
+#      stella_home(), so keys keep working while the mutable state separates.
+#
+#   2. One CARGO_TARGET_DIR shared by N worktrees means cargo's build lock
+#      serializes them: worktree B's test run blocks until A's finishes, which
+#      reads exactly like a hang. Per-worktree target dirs cost disk instead of
+#      wall-clock — hence --prune, below, which is the other half of that trade.
+#
+#   3. Neither of the above is discoverable from a failure. You get a flaky
+#      test, not a message about shared state.
+#
+# The rest is the boring half: verify the tools the gate actually needs, wire
+# the pre-push hook, and print the one thing that is genuinely easy to get
+# wrong — where `make gate` and CI disagree.
+#
+# ── What it writes ───────────────────────────────────────────────────────────
+#
+#   <worktree>/.claude/settings.json   env + the per-edit rustfmt hook
+#   <worktree>/.claude/.stella-env-stamp
+#   ~/.cache/stella-env/<slug>/{home,target}
+#   git config core.hooksPath=.githooks   (shared across worktrees, like `make hooks`)
+#
+# .claude/ is gitignored in this repo, so nothing here can reach the remote —
+# and nothing here is tracked, so it cannot trip check-no-scratch.sh.
+#
+# bash 3.2 compatible (macOS ships 3.2), POSIX tools only. No associative
+# arrays, no mapfile.
+
+set -euo pipefail
+
+SETUP_VERSION=1
+CACHE_ROOT="${STELLA_ENV_CACHE:-$HOME/.cache/stella-env}"
+
+MODE=setup       # setup | check | prune
+DO_INSTALL=0
+DO_HOOKS=1
+
+usage() {
+  cat <<'EOF'
+setup-claude-env.sh — prepare this worktree for agent-driven work on stella.
+
+Gives the worktree its own STELLA_HOME and CARGO_TARGET_DIR (so parallel
+worktrees stop contending on ~/.stella and on cargo's build lock), verifies the
+tools the gate needs, wires the pre-push hook, and writes a Claude Code
+settings.json that carries all of it. Idempotent; run it in every worktree.
+
+Usage: ./scripts/setup-claude-env.sh [options]
+
+Options:
+  --check        Report only. Writes nothing. Exits 1 if a required tool is missing.
+  --install      Install missing tools via brew / cargo install / rustup.
+  --prune        Delete per-worktree caches whose worktree no longer exists, then exit.
+  --no-hooks     Skip the per-edit rustfmt hook in the generated settings.json.
+  -h, --help     This text.
+
+Environment:
+  STELLA_ENV_CACHE   Where per-worktree caches live (default ~/.cache/stella-env).
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) MODE=check ;;
+    --prune) MODE=prune ;;
+    --install) DO_INSTALL=1 ;;
+    --no-hooks) DO_HOOKS=0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "setup-claude-env: unknown option '$1' (try --help)" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# ── Output helpers ───────────────────────────────────────────────────────────
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RESET=$'\033[0m'; C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'
+  C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'
+else
+  C_RESET=; C_DIM=; C_BOLD=; C_GREEN=; C_YELLOW=; C_RED=
+fi
+
+hdr()  { printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_RESET"; }
+ok()   { printf '  %sok%s    %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+warn() { printf '  %swarn%s  %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
+bad()  { printf '  %smiss%s  %s\n' "$C_RED" "$C_RESET" "$1"; }
+note() { printf '        %s%s%s\n' "$C_DIM" "$1" "$C_RESET"; }
+
+# ── Locate the checkout ──────────────────────────────────────────────────────
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "setup-claude-env: not inside a git checkout of stella." >&2
+  exit 1
+fi
+repo_root="$(cd "$repo_root" && pwd -P)"
+
+if [ ! -f "$repo_root/rust-toolchain.toml" ] || [ ! -d "$repo_root/stella-core" ]; then
+  echo "setup-claude-env: $repo_root does not look like the stella workspace." >&2
+  exit 1
+fi
+
+# A linked worktree has --git-dir != --git-common-dir. Worth reporting, because
+# "which worktree am I in" is the question behind most cross-worktree confusion.
+git_dir="$(git rev-parse --absolute-git-dir)"
+git_common="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+if [ "$git_dir" = "$git_common" ]; then
+  worktree_kind="main checkout"
+else
+  worktree_kind="linked worktree"
+fi
+
+# Slug: stable per absolute path, readable at a glance. cksum is POSIX, so this
+# needs neither shasum nor md5 — both of which differ across platforms.
+path_hash="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
+slug="$(basename "$repo_root")-$path_hash"
+
+# ── --prune ──────────────────────────────────────────────────────────────────
+# Only ever removes directories carrying our own .owner marker whose recorded
+# worktree is gone. A cache dir this script did not create is never touched —
+# that matters on a machine with a hand-rolled target-dir scheme already in
+# place, where a broad `rm` would eat someone's warm build cache.
+if [ "$MODE" = prune ]; then
+  hdr "Pruning $CACHE_ROOT"
+  if [ ! -d "$CACHE_ROOT" ]; then
+    note "nothing to prune (no cache dir yet)"
+    exit 0
+  fi
+  reclaimed=0
+  kept=0
+  for dir in "$CACHE_ROOT"/*; do
+    [ -d "$dir" ] || continue
+    marker="$dir/.owner"
+    if [ ! -f "$marker" ]; then
+      warn "$(basename "$dir") — no .owner marker, leaving alone"
+      continue
+    fi
+    owner="$(cat "$marker" 2>/dev/null || true)"
+    if [ -n "$owner" ] && [ -d "$owner" ]; then
+      kept=$((kept + 1))
+      continue
+    fi
+    size="$(du -sh "$dir" 2>/dev/null | awk '{print $1}')"
+    rm -rf "$dir"
+    ok "removed $(basename "$dir") ($size) — worktree ${owner:-?} is gone"
+    reclaimed=$((reclaimed + 1))
+  done
+  printf '\n'
+  note "$reclaimed removed, $kept still live"
+  [ -d "$CACHE_ROOT" ] && note "cache now: $(du -sh "$CACHE_ROOT" 2>/dev/null | awk '{print $1}')"
+  exit 0
+fi
+
+hdr "stella agent environment"
+note "$worktree_kind: $repo_root"
+note "branch:        $(git rev-parse --abbrev-ref HEAD)"
+note "cache slug:    $slug"
+
+# ── Toolchain ────────────────────────────────────────────────────────────────
+hdr "Rust toolchain"
+missing_required=0
+
+channel="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+  "$repo_root/rust-toolchain.toml" | head -1)"
+
+if ! command -v rustup >/dev/null 2>&1; then
+  bad "rustup — rust-toolchain.toml pins $channel; without rustup you get whatever cargo is on PATH"
+  note "install: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  missing_required=$((missing_required + 1))
+elif rustup toolchain list 2>/dev/null | grep -q "^$channel"; then
+  ok "toolchain $channel installed"
+  for comp in clippy rustfmt; do
+    if rustup component list --toolchain "$channel" 2>/dev/null \
+       | grep -q "^$comp.* (installed)"; then
+      ok "component $comp"
+    else
+      bad "component $comp — \`make lint\` / \`make format-check\` need it"
+      if [ "$DO_INSTALL" -eq 1 ]; then
+        note "installing..."
+        rustup component add "$comp" --toolchain "$channel"
+      else
+        note "install: rustup component add $comp --toolchain $channel"
+      fi
+    fi
+  done
+else
+  bad "toolchain $channel not installed"
+  if [ "$DO_INSTALL" -eq 1 ]; then
+    note "installing..."
+    rustup toolchain install "$channel" --component clippy --component rustfmt
+  else
+    note "install: rustup toolchain install $channel --component clippy --component rustfmt"
+    missing_required=$((missing_required + 1))
+  fi
+fi
+
+# ── Tools ────────────────────────────────────────────────────────────────────
+# git and cargo are deliberately absent from this table: we could not have
+# reached this line without git (repo detection above uses it), and cargo is
+# covered by the toolchain section. A row for either would be unreachable.
+# The hard-failure count therefore comes from the toolchain section alone —
+# nothing below is fatal, because `make gate` runs without all of it.
+#
+# Tiers, in the order they will actually cost you:
+#   ci    — a REQUIRED GitHub check you cannot reproduce locally without it
+#   agent — assumed by the repo's agent workflow / this machine's conventions
+#   opt   — one subsystem only; absence is fine until you touch that subsystem
+#
+# Format: name|tier|why|installer|package
+tool_table() {
+  cat <<'EOF'
+cargo-deny|ci|CI job "cargo deny + cargo audit" is a required check; make deny|cargo|cargo-deny
+cargo-audit|ci|same required check; make vuln-scan|cargo|cargo-audit
+gh|agent|PR + release flow (scripts/release.sh hard-requires it)|brew|gh
+rg|agent|repo convention: rg over grep, and it is gitignore-aware|brew|ripgrep
+fd|agent|repo convention: fd over find|brew|fd
+jq|agent|lets the Claude hook parse tool payloads exactly instead of by regex|brew|jq
+cargo-watch|opt|make watch / watch-core / watch-lint (hard-errors without it)|cargo|cargo-watch
+docker|opt|make serve-image + scripts/smoke-serve-image.sh|manual|
+node|opt|make llms-txt and the website/ docs build|brew|node
+pnpm|opt|website/ uses pnpm exclusively (never npm)|brew|pnpm
+uv|opt|make bench-test (bench/harbor_adapter, bench/terminal_bench_analysis)|brew|uv
+gsed|opt|scripts/release.sh + release.yml use GNU-only sed ranges; BSD sed no-ops them|brew|gnu-sed
+zig|opt|scripts/release.sh cross-builds via cargo-zigbuild|brew|zig
+EOF
+}
+
+hdr "Tools"
+brew_wanted=""
+cargo_wanted=""
+
+while IFS='|' read -r name tier why installer pkg; do
+  [ -n "$name" ] || continue
+  if command -v "$name" >/dev/null 2>&1; then
+    ok "$name"
+    continue
+  fi
+  case "$tier" in
+    ci) bad "$name — $why" ;;
+    *)  warn "$name — $why" ;;
+  esac
+  case "$installer" in
+    brew)  note "install: brew install $pkg";        brew_wanted="$brew_wanted $pkg" ;;
+    cargo) note "install: cargo install --locked $pkg"; cargo_wanted="$cargo_wanted $pkg" ;;
+    *)     note "install: (manual)" ;;
+  esac
+done <<EOF
+$(tool_table)
+EOF
+
+if [ "$DO_INSTALL" -eq 1 ]; then
+  if [ -n "$brew_wanted" ]; then
+    if command -v brew >/dev/null 2>&1; then
+      hdr "Installing via brew"
+      # Unquoted on purpose: $brew_wanted is a space-separated package list.
+      # shellcheck disable=SC2086
+      brew install $brew_wanted
+    else
+      warn "brew not found; skipping:$brew_wanted"
+    fi
+  fi
+  if [ -n "$cargo_wanted" ]; then
+    hdr "Installing via cargo"
+    for pkg in $cargo_wanted; do
+      cargo install --locked "$pkg"
+    done
+  fi
+fi
+
+if [ "$MODE" = check ]; then
+  hdr "Check only — nothing written"
+  if [ "$missing_required" -gt 0 ]; then
+    printf '  %s%d required tool(s) missing%s\n' "$C_RED" "$missing_required" "$C_RESET"
+    exit 1
+  fi
+  ok "all required tools present"
+  exit 0
+fi
+
+# ── Per-worktree isolation ───────────────────────────────────────────────────
+hdr "Per-worktree isolation"
+wt_cache="$CACHE_ROOT/$slug"
+stella_home="$wt_cache/home"
+target_dir="$wt_cache/target"
+
+mkdir -p "$stella_home" "$target_dir"
+printf '%s\n' "$repo_root" > "$wt_cache/.owner"
+
+ok "STELLA_HOME       $stella_home"
+note "isolates usage.db / catalog.db / media-operations.db / sessions/ from other worktrees"
+note "provider keys still come from \$HOME/.stella/credentials.toml — unaffected"
+ok "CARGO_TARGET_DIR  $target_dir"
+note "no build-lock contention with sibling worktrees; reclaim with --prune"
+
+# ── Git hooks ────────────────────────────────────────────────────────────────
+hdr "Git hooks"
+current_hooks="$(git config --get core.hooksPath 2>/dev/null || true)"
+if [ "$current_hooks" = ".githooks" ]; then
+  ok "core.hooksPath = .githooks"
+else
+  git config core.hooksPath .githooks
+  chmod +x "$repo_root"/.githooks/* 2>/dev/null || true
+  ok "core.hooksPath set to .githooks (pre-push runs \`make gate\`)"
+fi
+note "bypass for a WIP push: SKIP_GATE=1 git push"
+
+# ── Claude Code settings ─────────────────────────────────────────────────────
+hdr "Claude Code settings"
+claude_dir="$repo_root/.claude"
+settings="$claude_dir/settings.json"
+stamp="$claude_dir/.stella-env-stamp"
+mkdir -p "$claude_dir"
+
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+hook_block=""
+if [ "$DO_HOOKS" -eq 1 ] && [ -x "$repo_root/scripts/claude-rustfmt-hook.sh" ]; then
+  hook_block=",
+  \"hooks\": {
+    \"PostToolUse\": [
+      {
+        \"matcher\": \"Edit|Write|MultiEdit\",
+        \"hooks\": [
+          {
+            \"type\": \"command\",
+            \"command\": \"$(json_escape "$repo_root/scripts/claude-rustfmt-hook.sh")\",
+            \"timeout\": 30
+          }
+        ]
+      }
+    ]
+  }"
+fi
+
+generated="$(cat <<EOF
+{
+  "env": {
+    "STELLA_HOME": "$(json_escape "$stella_home")",
+    "CARGO_TARGET_DIR": "$(json_escape "$target_dir")",
+    "RUST_BACKTRACE": "1",
+    "CARGO_TERM_COLOR": "never"
+  }$hook_block
+}
+EOF
+)"
+
+write_fresh() { printf '%s\n' "$generated" > "$settings"; }
+
+if [ ! -f "$settings" ]; then
+  write_fresh
+  ok "wrote $settings"
+elif [ -f "$stamp" ]; then
+  write_fresh
+  ok "refreshed $settings (previously generated by this script)"
+else
+  # Somebody hand-wrote settings for this worktree. Never silently clobber it.
+  backup="$settings.bak.$$"
+  cp "$settings" "$backup"
+  if command -v jq >/dev/null 2>&1; then
+    # `*` merges objects recursively; our keys win. Arrays are replaced, not
+    # appended — so a pre-existing PostToolUse array is superseded, which is why
+    # the backup above is unconditional.
+    if printf '%s' "$generated" | jq --slurpfile cur "$settings" '$cur[0] * .' > "$settings.tmp" 2>/dev/null; then
+      mv "$settings.tmp" "$settings"
+      ok "merged into your existing $settings"
+      note "backup: $backup"
+    else
+      rm -f "$settings.tmp"
+      write_fresh
+      warn "existing settings.json was not valid JSON — replaced it"
+      note "backup: $backup"
+    fi
+  else
+    write_fresh
+    warn "replaced a hand-written settings.json (no jq available to merge)"
+    note "backup: $backup"
+  fi
+fi
+
+printf 'setup-claude-env v%s slug=%s\n' "$SETUP_VERSION" "$slug" > "$stamp"
+
+if [ "$DO_HOOKS" -eq 1 ]; then
+  if [ -x "$repo_root/scripts/claude-rustfmt-hook.sh" ]; then
+    ok "per-edit hook: rustfmt + file-size ratchet on every .rs edit"
+  else
+    warn "scripts/claude-rustfmt-hook.sh missing or not executable — hook not wired"
+  fi
+fi
+
+# ── The part that is easy to get wrong ───────────────────────────────────────
+hdr "make gate vs CI"
+cat <<'EOF'
+  make gate  runs: no-scratch, action-pins, doc-citations, invariants, file-size,
+             doc-warnings (RUSTDOCFLAGS=-D warnings), fmt --check, clippy, test.
+             It stops at the FIRST failure; CI reports all of them in one run.
+
+  make check is the fast subset — it skips tests, doc-citations AND rustdoc.
+             Passing `make check` does not mean CI will pass.
+
+  Green locally, red in CI, three ways:
+    - release smoke   CI also runs `cargo build --workspace --release`
+                      (thin LTO). Not in any make target.
+    - normative-home  scripts/check-normative-home.sh runs in CI only.
+    - supply chain    `cargo deny` + `cargo audit` are a SEPARATE required
+                      check. `make gate` does not run them; `make supply-chain` does.
+EOF
+
+hdr "Next"
+cat <<EOF
+  make gate                          full local gate (what pre-push runs)
+  make supply-chain                  the other required CI check
+  ./scripts/setup-claude-env.sh --prune   reclaim caches for deleted worktrees
+EOF
+
+if [ -d "$CACHE_ROOT" ]; then
+  note "cache total: $(du -sh "$CACHE_ROOT" 2>/dev/null | awk '{print $1}') in $CACHE_ROOT"
+fi
+
+if [ "$missing_required" -gt 0 ]; then
+  printf '\n  %s%d required tool(s) still missing — see above%s\n' \
+    "$C_RED" "$missing_required" "$C_RESET"
+  exit 1
+fi

--- a/scripts/test-claude-env.sh
+++ b/scripts/test-claude-env.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# Tests for setup-claude-env.sh and claude-rustfmt-hook.sh.
+#
+#   ./scripts/test-claude-env.sh
+#
+# Run it after touching either script. Not part of `make gate`: it shells out to
+# rustfmt and git a few dozen times and takes a couple of seconds, which is not
+# worth adding to every push for two developer-tooling scripts.
+#
+# ── Why a fixture instead of the real checkout ───────────────────────────────
+#
+# Every mutating case here runs against a synthetic stella-shaped repo in a temp
+# dir, never against the worktree you invoked it from. The hook's failure modes
+# can only be tested by breaking things — writing 1600-line files into a crate,
+# appending bogus entries to the file-size baseline, replacing settings.json
+# with garbage — and a test suite that does that to your live worktree is one
+# early exit away from leaving a probe file in stella-core/src or a corrupted
+# baseline staged for commit. The fixture makes the blast radius a directory
+# that gets deleted on exit, including on failure (see the trap).
+#
+# The scripts under test are COPIED into the fixture, so this exercises the real
+# code, not a reimplementation of it.
+#
+# ── What "tested" means here ─────────────────────────────────────────────────
+#
+# Mostly negative cases. A hook that exits 0 on everything would sail through a
+# suite that only checks the happy path, so each guard has a case that must fail
+# and a neighbouring case that must not — H8/H9 straddle a baseline ceiling,
+# H12/H13 straddle the line-counting rule. H13 in particular is the only case
+# that can tell `wc -l` from `awk END{NR}`; without it that distinction is
+# untested, because the two agree on every file that ends in a newline.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT INT TERM
+
+pass=0
+fail=0
+
+check() { # check <name> <want-exit> <got-exit> [want-substring] [output]
+  local name="$1" want="$2" got="$3" substr="${4:-}" out="${5:-}"
+  if [ "$want" != "$got" ]; then
+    printf 'FAIL  %-46s exit want=%s got=%s\n' "$name" "$want" "$got"
+    fail=$((fail + 1)); return
+  fi
+  if [ -n "$substr" ] && ! printf '%s' "$out" | grep -qF "$substr"; then
+    printf 'FAIL  %-46s missing: %s\n' "$name" "$substr"
+    fail=$((fail + 1)); return
+  fi
+  printf 'ok    %s\n' "$name"
+  pass=$((pass + 1))
+}
+
+# Two assertion forms, because the things being asserted come in two shapes.
+# `assert` takes the exit code of a real command or pipeline that already ran
+# (grep, jq, ls). `assert_cmd` takes a command to run — used wherever the
+# assertion is a bare test, since reading `$?` straight after `[ ... ]` is the
+# pattern shellcheck flags as SC2319 and is genuinely easy to get wrong when a
+# line is later inserted between the condition and the read.
+assert() { # assert <name> <exit-code>
+  if [ "$2" -eq 0 ]; then printf 'ok    %s\n' "$1"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n' "$1"; fail=$((fail + 1)); fi
+}
+
+assert_cmd() { # assert_cmd <name> <command...>
+  local name="$1"; shift
+  if "$@"; then printf 'ok    %s\n' "$name"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n' "$name"; fail=$((fail + 1)); fi
+}
+
+# ── Fixture: a minimal repo shaped enough like stella to satisfy the scripts ──
+REPO="$FIX/stella"
+mkdir -p "$REPO/stella-core/src" "$REPO/scripts" "$REPO/.githooks"
+cp "$repo_root/scripts/setup-claude-env.sh" "$repo_root/scripts/claude-rustfmt-hook.sh" \
+   "$REPO/scripts/"
+chmod +x "$REPO/scripts/"*.sh
+
+# Same pinned channel as the real tree, so the toolchain probe resolves the same
+# way here as it does for a developer.
+cp "$repo_root/rust-toolchain.toml" "$REPO/rust-toolchain.toml"
+printf '[workspace]\nmembers = ["stella-core"]\n\n[workspace.package]\nedition = "2024"\n' \
+  > "$REPO/Cargo.toml"
+cat > "$REPO/scripts/file-size-baseline.txt" <<'EOF'
+# Synthetic baseline for tests. Format: <ceiling> <path>.
+2282 stella-core/src/grandfathered.rs
+EOF
+
+git -C "$REPO" init -q .
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+printf 'target/\nscratch/\n' > "$REPO/.gitignore"
+git -C "$REPO" add -A >/dev/null 2>&1
+git -C "$REPO" commit -qm init >/dev/null 2>&1
+
+HOOK="$REPO/scripts/claude-rustfmt-hook.sh"
+SETUP="$REPO/scripts/setup-claude-env.sh"
+CACHE="$FIX/cache"
+export STELLA_ENV_CACHE="$CACHE"
+
+payload() { printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1"; }
+pad() { # pad <count> ; emits <count> newline-terminated comment lines
+  awk -v n="$1" 'BEGIN { for (i = 0; i < n; i++) print "// pad " i }'
+}
+
+echo "=== hook: inputs it must ignore ==="
+out=$(payload "$REPO/Cargo.toml" | "$HOOK" 2>&1); check "H1  non-.rs file" 0 $? "" "$out"
+echo 'fn main() {}' > "$FIX/outside.rs"
+out=$(payload "$FIX/outside.rs" | "$HOOK" 2>&1); check "H2  .rs outside the repo" 0 $? "" "$out"
+out=$(printf '' | "$HOOK" 2>&1); check "H3  empty stdin" 0 $? "" "$out"
+out=$(printf 'not json' | "$HOOK" 2>&1); check "H4  unparseable payload" 0 $? "" "$out"
+out=$(payload "$REPO/stella-core/src/nope.rs" | "$HOOK" 2>&1); check "H5  nonexistent file" 0 $? "" "$out"
+
+echo
+echo "=== hook: formatting ==="
+probe="$REPO/stella-core/src/probe.rs"
+printf 'fn  main( ) {\nlet x=1;\n   let y   =   2;\n}\n' > "$probe"
+out=$(cd "$REPO" && payload "$probe" | "$HOOK" 2>&1); check "H6  small file passes" 0 $? "" "$out"
+grep -q 'let x = 1;' "$probe"; assert "H6b rustfmt actually rewrote it" $?
+
+echo
+echo "=== hook: file-size ratchet ==="
+big="$REPO/stella-core/src/big.rs"
+pad 1600 > "$big"
+out=$(cd "$REPO" && payload "$big" | "$HOOK" 2>&1); rc=$?
+check "H7  new file over 1500 blocks" 2 $rc "NOT in scripts/file-size-baseline.txt" "$out"
+
+gf="$REPO/stella-core/src/grandfathered.rs"
+pad 2400 > "$gf"   # baseline ceiling is 2282
+out=$(cd "$REPO" && payload "$gf" | "$HOOK" 2>&1); rc=$?
+check "H8  grandfathered past ceiling blocks" 2 $rc "over its baseline ceiling of 2282" "$out"
+
+pad 2000 > "$gf"   # same file, now under its ceiling
+out=$(cd "$REPO" && payload "$gf" | "$HOOK" 2>&1); rc=$?
+check "H9  grandfathered under ceiling passes" 0 $rc "" "$out"
+
+mkdir -p "$REPO/scratch"
+cp "$big" "$REPO/scratch/ignored.rs"
+out=$(cd "$REPO" && payload "$REPO/scratch/ignored.rs" | "$HOOK" 2>&1); rc=$?
+check "H10 gitignored file skipped" 0 $rc "" "$out"
+
+# The gate judges tracked files with `wc -l`. These two cases straddle that:
+# H12 confirms the number the hook reports is wc's, H13 confirms it is not
+# awk's NR, which differs by one when the file lacks a trailing newline.
+out=$(cd "$REPO" && payload "$big" | "$HOOK" 2>&1)
+printf '%s' "$out" | grep -qF "$(wc -l <"$big" | tr -d ' ') lines"
+assert "H12 reported count == wc -l" $?
+
+edge="$REPO/stella-core/src/edge.rs"
+# 1500 terminated lines + an unterminated final line: wc -l = 1500 (allowed),
+# awk NR = 1501 (would block). The final line is invalid Rust on purpose so
+# rustfmt bails and leaves the missing newline in place.
+{ pad 1500; printf 'fn broken('; } > "$edge"
+assert_cmd "H13a fixture really is 1500 by wc" \
+  test "$(wc -l <"$edge" | tr -d ' ')" = "1500"
+out=$(cd "$REPO" && payload "$edge" | "$HOOK" 2>&1); rc=$?
+check "H13 unterminated last line counted as wc does" 0 $rc "" "$out"
+
+echo
+echo "=== setup: argument + location handling ==="
+out=$("$SETUP" --bogus 2>&1); check "S1  unknown option" 2 $? "unknown option" "$out"
+out=$(cd "$FIX" && "$SETUP" --check 2>&1); check "S2  outside a git repo" 1 $? "not inside a git checkout" "$out"
+mkdir -p "$FIX/other" && git -C "$FIX/other" init -q .
+out=$(cd "$FIX/other" && "$SETUP" --check 2>&1); check "S3  a git repo that is not stella" 1 $? "does not look like the stella workspace" "$out"
+
+# The only genuinely fatal class: no usable Rust toolchain. git stays on PATH,
+# since the script cannot even locate the repo without it.
+BIN="$FIX/bin"; mkdir -p "$BIN"
+for b in bash sh sed awk cksum grep cat basename dirname pwd du rm mkdir cp mv \
+         chmod tr head printf wc env sort git jq; do
+  src="$(command -v "$b" 2>/dev/null)" && ln -sf "$src" "$BIN/$b"
+done
+out=$(cd "$REPO" && env PATH="$BIN" "$SETUP" --check 2>&1); rc=$?
+check "S4  no rustup is fatal" 1 $rc "required tool(s) missing" "$out"
+printf '%s' "$out" | grep -qF "pins $(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO/rust-toolchain.toml")"
+assert "S4b names the pinned channel" $?
+
+echo
+echo "=== setup: writes ==="
+out=$(cd "$REPO" && "$SETUP" --check 2>&1)
+assert_cmd "S5  --check writes nothing" test ! -f "$REPO/.claude/settings.json"
+
+(cd "$REPO" && "$SETUP" >/dev/null 2>&1); rc1=$?
+(cd "$REPO" && "$SETUP" >/dev/null 2>&1); rc2=$?
+assert_cmd "S6  full run is idempotent" test "$rc1$rc2" = "00"
+if command -v jq >/dev/null 2>&1; then
+  jq -e '(.env.STELLA_HOME|length > 0) and (.env.CARGO_TARGET_DIR|length > 0)' \
+    "$REPO/.claude/settings.json" >/dev/null 2>&1
+  assert "S6b settings.json is valid JSON with the isolation env" $?
+fi
+
+# STELLA_HOME and CARGO_TARGET_DIR must differ per worktree — that is the whole
+# point of the script, so it gets an explicit case rather than being assumed.
+home_a="$(jq -r .env.STELLA_HOME "$REPO/.claude/settings.json" 2>/dev/null)"
+REPO2="$FIX/stella2"
+cp -R "$REPO" "$REPO2"
+rm -rf "$REPO2/.claude"
+(cd "$REPO2" && "$SETUP" >/dev/null 2>&1)
+home_b="$(jq -r .env.STELLA_HOME "$REPO2/.claude/settings.json" 2>/dev/null)"
+differing_homes() { [ -n "$home_a" ] && [ -n "$home_b" ] && [ "$home_a" != "$home_b" ]; }
+assert_cmd "S6c two checkouts get different STELLA_HOME" differing_homes
+
+echo
+echo "=== setup: existing settings.json ==="
+rm -f "$REPO/.claude/.stella-env-stamp"
+printf '{ "model": "claude-opus-5", "env": { "MY_OWN_VAR": "keepme" } }\n' > "$REPO/.claude/settings.json"
+(cd "$REPO" && "$SETUP" >/dev/null 2>&1)
+if command -v jq >/dev/null 2>&1; then
+  jq -e '.model == "claude-opus-5" and .env.MY_OWN_VAR == "keepme" and (.env.STELLA_HOME|length > 0)' \
+    "$REPO/.claude/settings.json" >/dev/null 2>&1
+  assert "S7  hand-written keys survive the merge" $?
+fi
+ls "$REPO/.claude/settings.json.bak."* >/dev/null 2>&1; assert "S7b a backup was written" $?
+rm -f "$REPO/.claude/settings.json.bak."*
+
+rm -f "$REPO/.claude/.stella-env-stamp"
+printf '{ this is not json\n' > "$REPO/.claude/settings.json"
+out=$(cd "$REPO" && "$SETUP" 2>&1)
+if command -v jq >/dev/null 2>&1; then
+  jq -e . "$REPO/.claude/settings.json" >/dev/null 2>&1; assert "S8  invalid JSON is replaced" $?
+fi
+printf '%s' "$out" | grep -qF 'not valid JSON'; assert "S8b and the replacement is announced" $?
+rm -f "$REPO/.claude/settings.json.bak."*
+
+(cd "$REPO" && "$SETUP" --no-hooks >/dev/null 2>&1)
+if command -v jq >/dev/null 2>&1; then
+  jq -e 'has("hooks") | not' "$REPO/.claude/settings.json" >/dev/null 2>&1
+  assert "S9  --no-hooks omits the hook block" $?
+fi
+
+echo
+echo "=== setup: --prune ==="
+mkdir -p "$CACHE/dead/target" "$CACHE/live/target" "$CACHE/unowned/target"
+printf '%s\n' "$FIX/deleted-worktree" > "$CACHE/dead/.owner"
+printf '%s\n' "$REPO" > "$CACHE/live/.owner"
+# "unowned" carries no .owner marker: it stands in for a cache directory some
+# other tool created, which prune must never touch.
+out=$(cd "$REPO" && "$SETUP" --prune 2>&1)
+assert_cmd "P1  cache for a deleted worktree is removed" test ! -d "$CACHE/dead"
+assert_cmd "P2  cache for a live worktree is kept" test -d "$CACHE/live"
+assert_cmd "P3  unmarked cache is left alone" test -d "$CACHE/unowned"
+printf '%s' "$out" | grep -qF 'no .owner marker, leaving alone'; assert "P4  and says so" $?
+
+echo
+printf 'passed=%d failed=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Three scripts plus four `make` targets that make this repo safe and pleasant to
work in with Claude Code, especially with several agents in several worktrees.

| | |
|---|---|
| `scripts/setup-claude-env.sh` | per-worktree isolation + tool doctor + hook wiring |
| `scripts/claude-rustfmt-hook.sh` | PostToolUse hook: rustfmt + file-size ratchet per `.rs` edit |
| `scripts/test-claude-env.sh` | hermetic tests for both |

```
make claude-env         # set this worktree up
make claude-env-check   # report only, writes nothing
make claude-env-prune   # reclaim caches for deleted worktrees
make claude-env-test    # test the scripts
```

## Why

Parallel agent work on this repo fails in three ways that all look like flaky
tests, and none of which are:

1. **`~/.stella` is machine-global.** `stella_home` resolves `STELLA_HOME`,
   else `$HOME/.stella` — and `usage.db`, `catalog.db`, `media-operations.db`,
   `sessions/` and `notifications/` all live under it. Two worktrees running
   `cargo test --workspace` contend on one set of SQLite files keyed by nothing
   but `$HOME`. The media-operation journal is the one that bites most often.
2. **One `CARGO_TARGET_DIR` across worktrees** makes cargo's build lock
   serialize them, which reads as a hang rather than as contention.
3. **Neither is discoverable from the failure.** You get a flaky test, not a
   message about shared state.

`setup-claude-env.sh` gives each worktree its own `STELLA_HOME` and
`CARGO_TARGET_DIR` and writes them into that worktree's (gitignored)
`.claude/settings.json`.

**Isolating `STELLA_HOME` does not cost you provider auth** — checked, not
assumed: `credentials.toml` resolves through `$HOME/.stella` directly in
`stella-model/src/credential.rs`, not through `stella_home`. Keys keep
working while the mutable state separates.

Per-worktree target dirs trade disk for wall-clock, so `--prune` is the other
half. It only ever removes directories carrying its own `.owner` marker whose
worktree is gone, so a hand-rolled target-dir scheme on the same machine is
left untouched.

The script also names, for each missing tool, the target that actually wants it,
and prints the three ways a green `make gate` still goes red in CI: the release
smoke build, `check-normative-home.sh`, and the separate `cargo deny` /
`cargo audit` check.

## The edit hook

Runs on every agent `.rs` edit: rustfmt, then the file-size ratchet for that one
file. `cargo fmt --check` is a hard gate, so the only question is whether the
agent finds out now or after a full `make gate`.

Formatting as you go also closes a trap that is otherwise invisible: rustfmt's
wrapping **adds** lines, so a file that sat under its baseline ceiling while
unformatted can breach it the moment `cargo fmt` runs — fix the size gate first
and format second, and you re-break the gate you just fixed.

Two details chosen to match the real guard rather than approximate it: it counts
with `wc -l` (what `check-file-size.sh` uses — `awk END{NR}` differs by one on a
file with no trailing newline), and it skips gitignored files (that guard judges
`git ls-files` only). It never runs `cargo fmt`/`check`/`clippy`; workspace-scoped
commands on a per-edit hook would make every edit feel broken.

## Testing

`make claude-env-test` — 32 cases, hermetic. Every mutating case runs against a
synthetic stella-shaped repo in a temp dir, never the live checkout: the failure
modes can only be tested by writing 1600-line files into a crate and corrupting
the baseline, and a suite that does that to your worktree is one early exit away
from leaving a probe file in `stella-core/src`.

Mostly negative cases, each guard paired with a neighbour that must *not* fire —
H8/H9 straddle a baseline ceiling, H12/H13 straddle the line-counting rule.

**Mutation-verified.** Reverting each of the four behaviours fails the suite:

| mutation | caught by |
|---|---|
| `wc -l` → `awk END{NR}` | H13 |
| drop the gitignore skip | H10 |
| ignore the baseline ceiling | H8, H9 |
| skip rustfmt | H6b |

Also run: `no-scratch`, `action-pins`, `invariants`, `doc-citations`,
`file-size` — all pass; `shellcheck` clean on all three new scripts.

No `.rs` file changes, so clippy/test/rustdoc results are identical to `main`.
Pushed with `SKIP_GATE=1` on that basis; CI runs the full gate here.

## Note

`gsed` was the one thing missing on this machine — `release.sh` and
`release.yml` use GNU-only `sed` ranges that silently no-op under BSD sed.
The doctor now flags it.

## Summary by Sourcery

Add tooling to set up per-worktree agent environments and enforce Rust formatting and file-size constraints during Claude Code usage.

New Features:
- Introduce scripts to configure per-worktree STELLA_HOME and CARGO_TARGET_DIR and generate Claude Code settings for agent-driven work.
- Add a Claude Code PostToolUse hook that runs rustfmt and applies the existing file-size ratchet to edited Rust files.
- Provide a dedicated test runner for the agent-environment setup and hook scripts, with hermetic fixture repos.
- Expose make targets to set up, check, prune, and test the Claude-focused development environment.

Tests:
- Add a hermetic bash test suite covering setup-claude-env, the Claude rustfmt/file-size hook, and cache pruning semantics.
