### PR TITLE
fix(scripts): main is red — restore the two ratchet ceilings #802's squash reverted

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,8 +19,8 @@
 1780 stella-model/src/bedrock.rs
 1948 stella-model/src/openai.rs
 1738 stella-model/src/zai/tests.rs
-2523 stella-pipeline/src/pipeline.rs
-2065 stella-pipeline/src/pipeline/tests.rs
+2576 stella-pipeline/src/pipeline.rs
+2113 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2254 stella-store/src/lib.rs
 2200 stella-store/src/tests.rs


### PR DESCRIPTION
**main is currently red.** `check-file-size` fails on two entries:

```
stella-pipeline/src/pipeline.rs grew to 2576 lines, over its baseline ceiling of 2523 (+53)
stella-pipeline/src/pipeline/tests.rs grew to 2113 lines, over its baseline ceiling of 2065 (+48)
```

Opened ready for review rather than draft, since this blocks CI for everyone.

## Nothing grew — the ceilings went backwards

| | `pipeline.rs` | `pipeline/tests.rs` | `zai/tests.rs` |
| --- | --- | --- | --- |
| actual on main | 2576 | 2113 | 1738 |
| #800 set | 2576 | 2113 | 1737 |
| #802's squash left | **2523** | **2065** | 1738 |

#802 was branched from main *before* #800 landed, so its branch still carried the pre-#800 numbers. Squashing it afterwards rewrote those two lines back to their old values, while correctly keeping its own `zai/tests.rs` raise.

No conflict was ever reported. The three entries are adjacent lines in one file, so the merge was textually clean and silently reverted another PR's bump — the failure mode where overlapping hunks interleave without conflicting. GitHub reported the PR as `MERGEABLE` throughout.

For what it's worth, I *did* merge main into that branch and resolve this exact conflict by hand before pushing; the squash appears to have been taken from the branch state before that push landed. The general lesson stands either way: a shared, line-oriented registry file like this is merge-hostile, and a clean merge is not evidence it survived.

## The fix

Restores both entries to the measured truth — 2576 / 2113, exactly what #800 set — and keeps 1738 from #802.

## Verification

- Every baseline entry walked against its file's actual line count, not just a re-run of the guard: no other entry has drifted.
- Full gate green on main + this change, by exit code: `check-file-size.sh`, `cargo fmt --check`, `clippy -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --workspace`.
- Tests from all three recently landed fixes (#794, #801, #802) pass on main, so the baseline was the *only* casualty.

## Worth considering separately

This is the second time in one day that this file caused trouble — the other being that `make file-size-update` reorders entries differently on macOS than the committed order, producing spurious diffs. A registry keyed by path but stored as sorted lines is going to keep doing this. Sorting deterministically on regen, or having the guard rewrite only the entry it flags, would remove the whole class.

## Summary by Sourcery

Bug Fixes:
- Update file-size baseline entries for stella-pipeline source and test files to match current line counts and stop check-file-size failures.