### PR TITLE
Backlog burn-down, final two: Rust use→file resolver (#443) + storage gate over apply_edits batches (#442)

### DIFF
--- a/docs/design/semantic-resolution-bridge.md
+++ b/docs/design/semantic-resolution-bridge.md
@@ -1,6 +1,8 @@
 # Semantic-resolution bridge — evaluation
 
-**Status:** proposed (evaluation, decision-ready). **Date:** 2026-07-23.
+**Status:** B2 shipped (#443 — `stella-graph/src/rust_resolve.rs`, plus the
+`run_tests` `scope:"impacted"` cargo `-p` mapping); B1 and the held Option A
+remain as written. **Date:** 2026-07-23, status updated 2026-07-28.
 **Owner:** Mac Anderson. **Issue:** #335 (parent #336; the Rust slice of #334
 is gated on this). Citations re-verified against the working tree at `fef8e4b`
 (§ appendix).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8103,10 +8103,11 @@ files change, for exactly as long as the session runs.
 
 > **Note**
 >
->   One honest capability gap: `importers` edges resolve for relative
->   TypeScript/JavaScript and Python imports. Rust `use` paths are indexed
->   unresolved — an empty `importers` answer for a Rust file is a limitation,
->   not a stale index.
+>   `importers` edges resolve for relative TypeScript/JavaScript and Python
+>   imports, and for Rust `use`/`mod` paths through the workspace module tree
+>   (file-level edges; external crates stay unresolved). Remaining honest
+>   gaps: Go and Java package imports, and PHP namespace `use`, are indexed
+>   unresolved.
 
 ## Exploration maps: understanding that outlives the turn
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -26,7 +26,7 @@
 2200 stella-store/src/tests.rs
 1897 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
-3140 stella-tools/src/registry.rs
+3193 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
 1708 stella-tui/src/deck_render.rs
 4096 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,8 +19,8 @@
 1780 stella-model/src/bedrock.rs
 1948 stella-model/src/openai.rs
 1738 stella-model/src/zai/tests.rs
-2523 stella-pipeline/src/pipeline.rs
-2065 stella-pipeline/src/pipeline/tests.rs
+2576 stella-pipeline/src/pipeline.rs
+2113 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2254 stella-store/src/lib.rs
 2200 stella-store/src/tests.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -26,7 +26,7 @@
 2200 stella-store/src/tests.rs
 1897 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
-3193 stella-tools/src/registry.rs
+3204 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
 1708 stella-tui/src/deck_render.rs
 4096 stella-tui/src/deck_ui.rs

--- a/stella-graph/src/import.rs
+++ b/stella-graph/src/import.rs
@@ -2,9 +2,11 @@
 //! relative specifiers to actual files.
 //!
 //! Python **relative** imports (`from . import x`, `from ..pkg import y`) resolve to
-//! real files, and TS/JS relative specifiers (`./x`, `../y`) resolve through
-//! the usual extension/`index.*` candidate ladder. Bare package specifiers
-//! (`react`, `os.path`, a Rust `use` path) are recorded **unresolved** — the
+//! real files, TS/JS relative specifiers (`./x`, `../y`) resolve through
+//! the usual extension/`index.*` candidate ladder, and Rust `use` paths /
+//! `mod` declarations resolve through the workspace module tree
+//! ([`crate::rust_resolve`], #443). Bare package specifiers (`react`,
+//! `os.path`, an external-crate `use`) are recorded **unresolved** — the
 //! edge is preserved even when its target is outside the indexed tree.
 
 use std::ffi::OsString;
@@ -75,9 +77,13 @@ pub(crate) enum ImportSpec {
         names: Vec<String>,
         text: String,
     },
-    /// A Rust `use` path — recorded unresolved (module→file resolution is
-    /// out of scope, see [`crate::queries::RUST_IMPORTS`]).
+    /// A Rust `use` path — expanded (brace groups, renames, wildcards) and
+    /// resolved through the module tree by [`crate::rust_resolve`] (#443);
+    /// external-crate paths stay unresolved.
     RustUse { specifier: String },
+    /// A declaration-only Rust `mod name;` — a dependency edge from the
+    /// declaring file to `name.rs` / `name/mod.rs`.
+    RustMod { name: String },
     /// A literal file path resolved against the importing file's directory:
     /// C's quoted `#include "x.h"`, PHP's `require`/`include`. Distinct from
     /// [`Self::TsRelative`] only in name — the resolution is the same — so
@@ -87,8 +93,14 @@ pub(crate) enum ImportSpec {
 
 /// Resolve a file's raw import specifiers to edges. `root` must already be
 /// canonicalized (see [`crate::graph::CodeGraph`]); `file_abs` is the
-/// importing file's absolute path.
-pub(crate) fn resolve(specs: Vec<ImportSpec>, root: &Path, file_abs: &Path) -> Vec<ImportEdge> {
+/// importing file's absolute path. `rust_layout` is the per-pass lazy crate
+/// layout — first Rust file pays the manifest scan, non-Rust passes never do.
+pub(crate) fn resolve(
+    specs: Vec<ImportSpec>,
+    root: &Path,
+    file_abs: &Path,
+    rust_layout: &std::cell::OnceCell<crate::rust_resolve::RustLayout>,
+) -> Vec<ImportEdge> {
     let file_dir = file_abs.parent().unwrap_or(root);
     let mut edges = Vec::with_capacity(specs.len());
     for spec in specs {
@@ -96,8 +108,33 @@ pub(crate) fn resolve(specs: Vec<ImportSpec>, root: &Path, file_abs: &Path) -> V
             ImportSpec::Bare { specifier } => {
                 edges.push(ImportEdge::unresolved(specifier, ImportKind::Bare));
             }
-            ImportSpec::PyAbsolute { specifier } | ImportSpec::RustUse { specifier } => {
+            ImportSpec::PyAbsolute { specifier } => {
                 edges.push(ImportEdge::unresolved(specifier, ImportKind::Absolute));
+            }
+            // One raw `use` argument may expand to several paths
+            // (`use crate::{a, b}`); each gets its own edge, resolved when
+            // it stays inside the workspace's module tree (#443). The kind
+            // remains `Absolute` — that classifies the specifier form, and
+            // resolution now fills `to_path` where it can.
+            ImportSpec::RustUse { specifier } => {
+                let layout =
+                    rust_layout.get_or_init(|| crate::rust_resolve::RustLayout::load(root));
+                for path in crate::rust_resolve::expand_use_groups(&specifier) {
+                    let to_path = crate::rust_resolve::resolve_use(layout, &path, root, file_abs);
+                    edges.push(ImportEdge {
+                        specifier: path,
+                        to_path,
+                        kind: ImportKind::Absolute,
+                    });
+                }
+            }
+            ImportSpec::RustMod { name } => {
+                let to_path = crate::rust_resolve::resolve_mod_decl(&name, root, file_abs);
+                edges.push(ImportEdge {
+                    specifier: format!("mod {name}"),
+                    to_path,
+                    kind: ImportKind::Relative,
+                });
             }
             ImportSpec::TsRelative { specifier } | ImportSpec::PathRelative { specifier } => {
                 let to_path = resolve_ts_relative(&specifier, file_dir, root);

--- a/stella-graph/src/lib.rs
+++ b/stella-graph/src/lib.rs
@@ -59,6 +59,7 @@ mod lang;
 pub mod manifest;
 mod parse;
 mod queries;
+mod rust_resolve;
 pub mod storage;
 mod store;
 mod symbol;

--- a/stella-graph/src/parse.rs
+++ b/stella-graph/src/parse.rs
@@ -234,12 +234,17 @@ fn extract_rust_imports(query: &Query, root: Node, src: &[u8]) -> Vec<ImportSpec
     let mut matches = cursor.matches(query, root, src);
     while let Some(m) = matches.next() {
         for cap in m.captures {
-            if names[cap.index as usize] == "use"
-                && let Ok(text) = cap.node.utf8_text(src)
-            {
-                out.push(ImportSpec::RustUse {
+            let Ok(text) = cap.node.utf8_text(src) else {
+                continue;
+            };
+            match names[cap.index as usize] {
+                "use" => out.push(ImportSpec::RustUse {
                     specifier: text.to_string(),
-                });
+                }),
+                "mod" => out.push(ImportSpec::RustMod {
+                    name: text.to_string(),
+                }),
+                _ => {}
             }
         }
     }
@@ -1119,6 +1124,7 @@ mod added_language_tests {
                 | ImportSpec::PyAbsolute { specifier }
                 | ImportSpec::RustUse { specifier } => specifier.clone(),
                 ImportSpec::PyRelative { text, .. } => text.clone(),
+                ImportSpec::RustMod { name } => format!("mod {name}"),
             })
             .collect()
     }

--- a/stella-graph/src/queries.rs
+++ b/stella-graph/src/queries.rs
@@ -33,12 +33,16 @@ pub const RUST_SYMBOLS: &str = r#"
 (impl_item body: (declaration_list (function_item name: (_) @name) @method))
 "#;
 
-/// `use` declarations. Rust module→file resolution (the `mod` tree, `lib.rs`
-/// vs `mod.rs`, re-exports) is genuinely non-trivial and out of scope for
-/// this cut, so the raw `use` path is recorded as an unresolved edge; see
+/// `use` declarations and declaration-only `mod` items (`!body` excludes
+/// inline `mod x { … }`, whose contents live in this same file). `use` paths
+/// resolve through the module tree (`crate::rust_resolve`, #443) at the file
+/// level; a `mod foo;` declaration is itself a dependency edge to `foo.rs` /
+/// `foo/mod.rs`. Item-level identity and re-export chasing stay out of
+/// scope; unresolvable paths keep the unresolved-edge shape, see
 /// `crate::import::resolve`.
 pub const RUST_IMPORTS: &str = r#"
 (use_declaration argument: (_) @use)
+(mod_item name: (_) @mod !body)
 "#;
 
 // Python

--- a/stella-graph/src/rust_resolve.rs
+++ b/stella-graph/src/rust_resolve.rs
@@ -1,0 +1,458 @@
+//! Pure-Rust `use`→file resolution over the module tree (#443, option B2 of
+//! `docs/design/semantic-resolution-bridge.md`).
+//!
+//! File-level edges only, by design: a `use crate::a::b::Item` resolves to
+//! the **file defining the deepest path segment that names a module file**
+//! (`b.rs`, or `a.rs` when `b` is an item or inline module inside it). Item
+//! identity, trait dispatch, and `pub use` re-export chasing are explicit
+//! non-goals — an edge to the re-exporting file is still a true dependency
+//! edge. External crates (`std`, `serde`, anything not in the workspace
+//! layout) stay unresolved, which is the pre-#443 behavior for every Rust
+//! edge and remains visible in the stored `kind`/NULL `to_path` shape.
+//!
+//! Documented gaps, resolved to whichever file exists or left unresolved:
+//! `#[path]` overrides, macro-generated modules, and `cfg`-divergent module
+//! sets.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::import::rel_to_slash;
+
+/// How deep below the workspace root the manifest scan descends. Cargo
+/// workspaces nest members a level or two down (`bench/loop-bench`); five
+/// covers real layouts without walking a monorepo's unrelated depths.
+const MANIFEST_SCAN_DEPTH: usize = 5;
+
+/// The workspace's Rust crate layout: package name (underscore-normalized,
+/// as it appears in `use` paths) → the crate root source file. Loaded once
+/// per index pass, like the storage manifest.
+pub(crate) struct RustLayout {
+    roots: HashMap<String, PathBuf>,
+}
+
+impl RustLayout {
+    /// Scan for `Cargo.toml` manifests under `root` (bounded depth, heavy
+    /// build/VCS directories skipped) and record each `[package]`'s crate
+    /// root. `src/lib.rs` wins over `src/main.rs` for the name mapping —
+    /// a `use <crate>::…` path always refers to the library target.
+    pub(crate) fn load(root: &Path) -> Self {
+        let mut roots = HashMap::new();
+        let mut stack = vec![(root.to_path_buf(), 0usize)];
+        while let Some((dir, depth)) = stack.pop() {
+            let manifest = dir.join("Cargo.toml");
+            if manifest.is_file()
+                && let Some(name) = package_name(&manifest)
+                && let Some(crate_root) = crate_root_file(&dir)
+            {
+                roots.insert(name.replace('-', "_"), crate_root);
+            }
+            if depth >= MANIFEST_SCAN_DEPTH {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let skip = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_none_or(|n| n.starts_with('.') || n == "target" || n == "node_modules");
+                if !skip {
+                    stack.push((path, depth + 1));
+                }
+            }
+        }
+        RustLayout { roots }
+    }
+
+    fn crate_root(&self, name: &str) -> Option<&PathBuf> {
+        self.roots.get(&name.replace('-', "_"))
+    }
+}
+
+/// The `name = "…"` under `[package]`, read without a full toml parse — the
+/// only two facts needed are "is there a `[package]` table" and its name,
+/// and a manifest broken enough to defeat this scan should simply not
+/// contribute a crate root (never abort the index pass).
+fn package_name(manifest: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(manifest).ok()?;
+    let mut in_package = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(section) = line.strip_prefix('[') {
+            in_package = section.trim_end_matches(']').trim() == "package";
+            continue;
+        }
+        if in_package
+            && let Some(rest) = line.strip_prefix("name")
+            && let Some(value) = rest.trim_start().strip_prefix('=')
+        {
+            return Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+    None
+}
+
+/// A crate directory's root source file: `src/lib.rs`, else `src/main.rs`.
+fn crate_root_file(crate_dir: &Path) -> Option<PathBuf> {
+    let lib = crate_dir.join("src/lib.rs");
+    if lib.is_file() {
+        return Some(lib);
+    }
+    let main = crate_dir.join("src/main.rs");
+    main.is_file().then_some(main)
+}
+
+/// Expand one raw `use` argument into simple `::`-separated paths: brace
+/// groups (nested), `as` renames dropped, a trailing `::*` wildcard reduced
+/// to its module path, and a group's `self` leaf reduced to the group prefix
+/// itself (`a::{self, b}` → `a`, `a::b`).
+pub(crate) fn expand_use_groups(spec: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    expand(spec, "", &mut out);
+    out
+}
+
+fn expand(spec: &str, prefix: &str, out: &mut Vec<String>) {
+    let spec = spec.trim();
+    if let Some(open) = spec.find('{') {
+        let Some(inner) = spec[open..].strip_prefix('{').and_then(strip_matched) else {
+            return; // unbalanced braces: not a shape tree-sitter emits
+        };
+        let head = spec[..open].trim().trim_end_matches("::");
+        let prefix = join_path(prefix, head);
+        for part in split_top_level(inner) {
+            expand(part, &prefix, out);
+        }
+        return;
+    }
+    // Leaf: drop an `as` rename, reduce a wildcard to its module path.
+    let leaf = spec.split(" as ").next().unwrap_or(spec).trim();
+    let leaf = leaf
+        .strip_suffix("::*")
+        .or(leaf.strip_suffix('*'))
+        .unwrap_or(leaf);
+    let leaf = leaf.trim_end_matches("::");
+    let path = if leaf == "self" {
+        prefix.to_string()
+    } else {
+        join_path(prefix, leaf)
+    };
+    if !path.is_empty() {
+        out.push(path);
+    }
+}
+
+/// The content inside an already-opened brace, requiring the close to be the
+/// final character (tree-sitter's `use_list` shape).
+fn strip_matched(after_open: &str) -> Option<&str> {
+    let mut depth = 1usize;
+    for (i, c) in after_open.char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return after_open[i + 1..]
+                        .trim()
+                        .is_empty()
+                        .then(|| &after_open[..i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Split a brace group's content on commas at depth zero.
+fn split_top_level(inner: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (i, c) in inner.char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(&inner[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&inner[start..]);
+    parts
+        .into_iter()
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+fn join_path(prefix: &str, tail: &str) -> String {
+    match (prefix.is_empty(), tail.is_empty()) {
+        (true, _) => tail.to_string(),
+        (_, true) => prefix.to_string(),
+        _ => format!("{prefix}::{tail}"),
+    }
+}
+
+/// Resolve one expanded `use` path to a workspace-relative file, or `None`
+/// (external crate, unresolvable prefix, or a walk that never leaves the
+/// importing file — a self-edge says nothing).
+pub(crate) fn resolve_use(
+    layout: &RustLayout,
+    path: &str,
+    root: &Path,
+    file_abs: &Path,
+) -> Option<String> {
+    let mut segments = path.split("::").map(str::trim).peekable();
+    let first = segments.next()?;
+    let mut current: PathBuf = match first {
+        "crate" => owning_crate_root(file_abs)?,
+        "self" => file_abs.to_path_buf(),
+        "super" => {
+            let mut cur = parent_module_file(file_abs)?;
+            while segments.peek() == Some(&"super") {
+                segments.next();
+                cur = parent_module_file(&cur)?;
+            }
+            cur
+        }
+        // `use ::x::…` — an explicit extern prefix; the crate name follows.
+        "" => layout.crate_root(segments.next()?)?.clone(),
+        name => layout.crate_root(name)?.clone(),
+    };
+    for segment in segments {
+        if segment == "self" || segment.is_empty() {
+            continue;
+        }
+        match child_module_file(&current, segment) {
+            Some(child) => current = child,
+            // An item, inline module, or `#[path]` child: the deepest module
+            // FILE reached is the honest file-level edge.
+            None => break,
+        }
+    }
+    if current == file_abs {
+        return None;
+    }
+    let canonical = current.canonicalize().ok()?;
+    Some(rel_to_slash(canonical.strip_prefix(root).ok()?))
+}
+
+/// Resolve a `mod name;` declaration to the child module file it brings into
+/// the tree — `name.rs` or `name/mod.rs` in the declaring file's child dir.
+pub(crate) fn resolve_mod_decl(name: &str, root: &Path, file_abs: &Path) -> Option<String> {
+    let child = child_module_file(file_abs, name)?;
+    let canonical = child.canonicalize().ok()?;
+    Some(rel_to_slash(canonical.strip_prefix(root).ok()?))
+}
+
+/// The directory a module file's children live in: the file's own directory
+/// for the roots (`lib.rs` / `main.rs`) and `mod.rs`, else a directory named
+/// after the file (`foo.rs` → `foo/`, the 2018-edition layout).
+fn child_dir(file: &Path) -> Option<PathBuf> {
+    let name = file.file_name()?.to_str()?;
+    let dir = file.parent()?;
+    if matches!(name, "lib.rs" | "main.rs" | "mod.rs") {
+        return Some(dir.to_path_buf());
+    }
+    Some(dir.join(file.file_stem()?.to_str()?))
+}
+
+/// The child module `name`'s file under `parent`'s child dir, if it exists.
+fn child_module_file(parent: &Path, name: &str) -> Option<PathBuf> {
+    let dir = child_dir(parent)?;
+    let flat = dir.join(format!("{name}.rs"));
+    if flat.is_file() {
+        return Some(flat);
+    }
+    let nested = dir.join(name).join("mod.rs");
+    nested.is_file().then_some(nested)
+}
+
+/// The crate root file owning `file`: the nearest ancestor directory holding
+/// a `Cargo.toml`, then its `src/lib.rs` / `src/main.rs`. A file under
+/// `src/bin/` belongs to its own binary target, whose root is itself.
+fn owning_crate_root(file: &Path) -> Option<PathBuf> {
+    if file.parent().and_then(|d| d.file_name()) == Some(std::ffi::OsStr::new("bin")) {
+        return Some(file.to_path_buf());
+    }
+    let mut dir = file.parent()?;
+    loop {
+        if dir.join("Cargo.toml").is_file() {
+            return crate_root_file(dir);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// The file defining the module that DECLARES `file`'s module — `None` at a
+/// crate root, which has no parent. `d/mod.rs` is the module named `d`,
+/// declared by whatever owns `d`'s parent directory; any other `d/f.rs` is
+/// declared by whatever owns `d` itself.
+fn parent_module_file(file: &Path) -> Option<PathBuf> {
+    let name = file.file_name()?.to_str()?;
+    if matches!(name, "lib.rs" | "main.rs") {
+        return None;
+    }
+    let dir = file.parent()?;
+    if name == "mod.rs" {
+        module_for_dir(dir.parent()?)
+    } else {
+        module_for_dir(dir)
+    }
+}
+
+/// The module file whose children live in `dir`: a crate `src` root's own
+/// root file, else the sibling `<dir>.rs`, else `dir/mod.rs`.
+fn module_for_dir(dir: &Path) -> Option<PathBuf> {
+    for root_name in ["lib.rs", "main.rs"] {
+        let candidate = dir.join(root_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    let name = dir.file_name()?.to_str()?;
+    if let Some(parent) = dir.parent() {
+        let flat = parent.join(format!("{name}.rs"));
+        if flat.is_file() {
+            return Some(flat);
+        }
+    }
+    let nested = dir.join("mod.rs");
+    nested.is_file().then_some(nested)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    /// A two-crate workspace exercising every layout rule: lib root, flat
+    /// module, dir module (`mod.rs`), nested child, and a binary crate.
+    fn fixture() -> tempfile::TempDir {
+        let ws = tempfile::tempdir().unwrap();
+        let r = ws.path();
+        write(
+            r,
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"alpha\", \"beta-core\"]\n",
+        );
+        write(
+            r,
+            "alpha/Cargo.toml",
+            "[package]\nname = \"alpha\"\nversion = \"0.0.0\"\n",
+        );
+        write(r, "alpha/src/lib.rs", "pub mod util;\npub mod deep;\n");
+        write(r, "alpha/src/util.rs", "pub fn helper() {}\n");
+        write(r, "alpha/src/deep/mod.rs", "pub mod inner;\n");
+        write(r, "alpha/src/deep/inner.rs", "pub struct Inner;\n");
+        write(
+            r,
+            "beta-core/Cargo.toml",
+            "[package]\nname = \"beta-core\"\nversion = \"0.0.0\"\n",
+        );
+        write(r, "beta-core/src/main.rs", "mod local;\nfn main() {}\n");
+        write(r, "beta-core/src/local.rs", "pub fn here() {}\n");
+        ws
+    }
+
+    #[test]
+    fn group_expansion_covers_braces_wildcards_renames_and_self() {
+        assert_eq!(
+            expand_use_groups("std::collections::HashMap"),
+            vec!["std::collections::HashMap"]
+        );
+        assert_eq!(
+            expand_use_groups("crate::a::{b, c::d}"),
+            vec!["crate::a::b", "crate::a::c::d"]
+        );
+        assert_eq!(expand_use_groups("a::{self, b}"), vec!["a", "a::b"]);
+        assert_eq!(expand_use_groups("super::util::*"), vec!["super::util"]);
+        assert_eq!(expand_use_groups("crate::x as y"), vec!["crate::x"]);
+        assert_eq!(
+            expand_use_groups("a::{b::{c, d}, e}"),
+            vec!["a::b::c", "a::b::d", "a::e"]
+        );
+    }
+
+    #[test]
+    fn use_paths_resolve_across_the_module_tree_and_workspace() {
+        let ws = fixture();
+        let root = ws.path().canonicalize().unwrap();
+        let layout = RustLayout::load(&root);
+        let lib = root.join("alpha/src/lib.rs");
+        let inner = root.join("alpha/src/deep/inner.rs");
+        let beta = root.join("beta-core/src/main.rs");
+
+        // crate:: from the lib root, through both module layouts.
+        assert_eq!(
+            resolve_use(&layout, "crate::util::helper", &root, &inner).as_deref(),
+            Some("alpha/src/util.rs")
+        );
+        assert_eq!(
+            resolve_use(&layout, "crate::deep::inner::Inner", &root, &lib).as_deref(),
+            Some("alpha/src/deep/inner.rs")
+        );
+        // The deepest MODULE file wins when the tail is an item.
+        assert_eq!(
+            resolve_use(&layout, "crate::util", &root, &lib).as_deref(),
+            Some("alpha/src/util.rs")
+        );
+        // super:: climbs from a dir-module child to its mod.rs, then out.
+        assert_eq!(
+            resolve_use(&layout, "super::super::util::helper", &root, &inner).as_deref(),
+            Some("alpha/src/util.rs")
+        );
+        // A bare workspace crate name resolves cross-crate, hyphen-normalized.
+        assert_eq!(
+            resolve_use(&layout, "alpha::util::helper", &root, &beta).as_deref(),
+            Some("alpha/src/util.rs")
+        );
+        assert_eq!(
+            resolve_use(&layout, "beta_core::local", &root, &lib).as_deref(),
+            Some("beta-core/src/local.rs")
+        );
+        // External crates stay unresolved — the pre-#443 shape.
+        assert_eq!(
+            resolve_use(&layout, "std::collections::HashMap", &root, &lib),
+            None
+        );
+        assert_eq!(resolve_use(&layout, "serde::Serialize", &root, &lib), None);
+        // A walk that never leaves the importing file is no edge at all.
+        assert_eq!(resolve_use(&layout, "crate::SomeItem", &root, &lib), None);
+    }
+
+    #[test]
+    fn mod_declarations_resolve_to_both_child_layouts() {
+        let ws = fixture();
+        let root = ws.path().canonicalize().unwrap();
+        let lib = root.join("alpha/src/lib.rs");
+        let mod_rs = root.join("alpha/src/deep/mod.rs");
+        assert_eq!(
+            resolve_mod_decl("util", &root, &lib).as_deref(),
+            Some("alpha/src/util.rs")
+        );
+        assert_eq!(
+            resolve_mod_decl("deep", &root, &lib).as_deref(),
+            Some("alpha/src/deep/mod.rs")
+        );
+        assert_eq!(
+            resolve_mod_decl("inner", &root, &mod_rs).as_deref(),
+            Some("alpha/src/deep/inner.rs")
+        );
+        assert_eq!(resolve_mod_decl("phantom", &root, &lib), None);
+    }
+}

--- a/stella-graph/src/store.rs
+++ b/stella-graph/src/store.rs
@@ -227,6 +227,9 @@ pub(crate) fn index_tree(
     // to the implicit layer / no-op filter, never aborts the batch (L-L1).
     let manifest = StorageManifest::load(root).ok().flatten();
     let generated_filter = GeneratedFilter::load(root);
+    // The Rust crate layout is lazy per pass: the first Rust file pays the
+    // manifest scan, a pass with none never does (#443).
+    let rust_layout = std::cell::OnceCell::new();
     let tx = conn.transaction()?;
 
     let mut current: HashSet<String> = HashSet::with_capacity(files.len());
@@ -238,6 +241,7 @@ pub(crate) fn index_tree(
             grammars,
             manifest.as_ref(),
             &generated_filter,
+            &rust_layout,
             abs,
             &mut stats,
         )?;
@@ -260,6 +264,7 @@ pub(crate) fn apply_changes(
     let mut stats = IndexStats::default();
     let manifest = StorageManifest::load(root).ok().flatten();
     let generated_filter = GeneratedFilter::load(root);
+    let rust_layout = std::cell::OnceCell::new();
     let tx = conn.transaction()?;
     for abs in changed {
         if abs.is_file() {
@@ -272,6 +277,7 @@ pub(crate) fn apply_changes(
                 grammars,
                 manifest.as_ref(),
                 &generated_filter,
+                &rust_layout,
                 abs,
                 &mut stats,
             )?;
@@ -297,12 +303,14 @@ pub(crate) fn apply_changes(
 /// Index one file into an open transaction. Every failure mode here
 /// (unreadable, non-UTF-8, unparseable) is recorded in `stats` and skipped —
 /// never propagated — so one bad file cannot abort the batch (L-L1).
+#[allow(clippy::too_many_arguments)] // two call sites, both index passes
 fn index_one(
     tx: &Transaction,
     root: &Path,
     grammars: &Grammars,
     manifest: Option<&StorageManifest>,
     generated_filter: &GeneratedFilter,
+    rust_layout: &std::cell::OnceCell<crate::rust_resolve::RustLayout>,
     abs: &Path,
     stats: &mut IndexStats,
 ) -> Result<(), GraphError> {
@@ -373,7 +381,7 @@ fn index_one(
     };
     stats.files_parsed += 1;
 
-    let edges = import::resolve(parsed.imports, root, abs);
+    let edges = import::resolve(parsed.imports, root, abs, rust_layout);
     let file_id = upsert_file(tx, &rel, lang.tag(), &sha, mtime_ns(abs))?;
     tx.execute(
         "DELETE FROM code_graph_symbols WHERE file_id = ?1",

--- a/stella-graph/tests/languages.rs
+++ b/stella-graph/tests/languages.rs
@@ -84,6 +84,78 @@ fn rust_symbols_indexed() {
     assert!(has_label_starting(&fx.def_labels("new"), "fn new ("));
 }
 
+/// #443's exit criterion, end to end: Rust `use` paths and `mod`
+/// declarations resolve through the module tree, so `importers` on a Rust
+/// file returns the real dependent set — including a cross-crate importer —
+/// while external-crate paths stay unresolved.
+#[test]
+fn rust_use_paths_resolve_through_the_module_tree() {
+    let fx = Fixture::build(&[
+        (
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"alpha\", \"beta\"]\n",
+        ),
+        (
+            "alpha/Cargo.toml",
+            "[package]\nname = \"alpha\"\nversion = \"0.0.0\"\n",
+        ),
+        (
+            "alpha/src/lib.rs",
+            "pub mod util;\npub mod deep;\nuse crate::util::helper;\nuse std::collections::HashMap;\n\npub fn run() { helper(); }\n",
+        ),
+        ("alpha/src/util.rs", "pub fn helper() {}\n"),
+        ("alpha/src/deep/mod.rs", "pub mod inner;\n"),
+        (
+            "alpha/src/deep/inner.rs",
+            "use crate::util::{helper, self as u};\npub struct Inner;\n",
+        ),
+        (
+            "beta/Cargo.toml",
+            "[package]\nname = \"beta\"\nversion = \"0.0.0\"\n",
+        ),
+        (
+            "beta/src/lib.rs",
+            "use alpha::util::helper;\npub fn go() { helper(); }\n",
+        ),
+    ]);
+
+    // Forward edges: the module tree resolves; std stays unresolved.
+    let targets = fx.import_targets("alpha/src/lib.rs");
+    assert!(
+        targets.iter().any(|t| t == "alpha/src/util.rs"),
+        "`use crate::util::helper` should resolve; got {targets:?}"
+    );
+    assert!(
+        targets.iter().any(|t| t == "alpha/src/deep/mod.rs"),
+        "`mod deep;` should resolve to the dir-module file; got {targets:?}"
+    );
+    assert!(
+        targets.iter().any(|t| t == "std::collections::HashMap"),
+        "external paths stay recorded unresolved; got {targets:?}"
+    );
+
+    // The reverse edge — the whole point: importers of util.rs is the real
+    // dependent set, across module layouts AND across crates.
+    let importers: Vec<String> = fx
+        .graph
+        .importers_of(Path::new("alpha/src/util.rs"))
+        .unwrap()
+        .into_iter()
+        .flat_map(|f| f.relations)
+        .filter_map(|r| r.display_name)
+        .collect();
+    for expected in [
+        "alpha/src/lib.rs",
+        "alpha/src/deep/inner.rs",
+        "beta/src/lib.rs",
+    ] {
+        assert!(
+            importers.iter().any(|i| i == expected),
+            "importers of util.rs must include {expected}; got {importers:?}"
+        );
+    }
+}
+
 #[test]
 fn python_relative_imports_resolve_to_files() {
     // `from . import sibling` and `from ..pkg import y` must resolve to actual

--- a/stella-tools/src/apply_edits.rs
+++ b/stella-tools/src/apply_edits.rs
@@ -20,7 +20,7 @@
 //!
 //! Storage-definition files ride the registry's schema gate like any other
 //! write (#442): the gate simulates the batch's composed edits per touched
-//! schema file — via [`simulate_batch`], the same in-order composition the
+//! schema file — via `simulate_batch`, the same in-order composition the
 //! validate phase performs — and judges each result before anything lands.
 //! The transactional path is not a way around the storage map.
 

--- a/stella-tools/src/apply_edits.rs
+++ b/stella-tools/src/apply_edits.rs
@@ -18,10 +18,11 @@
 //! parallelized, so a five-file rename is five sequential steps today and
 //! one step through this tool.
 //!
-//! Storage-definition files (the schema gate's territory) are refused
-//! loudly: the gate judges one simulated post-edit file per call, and
-//! bypassing it through a batch would un-guard the storage map. `edit_file`
-//! remains the (gated) path for schema files.
+//! Storage-definition files ride the registry's schema gate like any other
+//! write (#442): the gate simulates the batch's composed edits per touched
+//! schema file — via [`simulate_batch`], the same in-order composition the
+//! validate phase performs — and judges each result before anything lands.
+//! The transactional path is not a way around the storage map.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -111,6 +112,32 @@ fn parse_edits(input: &Value) -> Result<Vec<ParsedEdit>, String> {
             Ok(parsed)
         })
         .collect()
+}
+
+/// The batch's composed post-edit content for one `path` — the SAME
+/// in-order composition (and the same zero-match / ambiguous-match refusals)
+/// the validate phase applies, shared with the registry's storage gate
+/// (#442) so the gate judges exactly the bytes apply would write. `None`
+/// when the input doesn't parse, no edit targets `path`, or any edit to it
+/// fails to resolve — the tool itself then reports the failure, unwritten,
+/// and an ungated failing batch writes nothing.
+pub(crate) fn simulate_batch(input: &Value, path: &str, current: &str) -> Option<String> {
+    let edits = parse_edits(input).ok()?;
+    let mut content = current.to_string();
+    let mut touched = false;
+    for edit in edits.iter().filter(|e| e.path == path) {
+        touched = true;
+        let count = content.matches(&edit.old_string).count();
+        if count == 0 || (count > 1 && !edit.replace_all) {
+            return None;
+        }
+        content = if edit.replace_all {
+            content.replace(&edit.old_string, &edit.new_string)
+        } else {
+            content.replacen(&edit.old_string, &edit.new_string, 1)
+        };
+    }
+    touched.then_some(content)
 }
 
 #[async_trait]
@@ -268,38 +295,6 @@ impl Tool for ApplyEdits {
             };
         }
 
-        // Storage-gate territory check: the registry's schema gate judges ONE
-        // simulated post-edit file per `write_file`/`edit_file` call; a batch
-        // that lands storage definitions would slip past it. Mirror the
-        // gate's own firing condition (extraction of the proposed content is
-        // non-empty) and refuse loudly — `edit_file` remains the gated path.
-        // Plain code files extract empty (the adapters are marker-gated) and
-        // pass through untouched.
-        if let Some(extractor) = crate::schema_gate::extractor() {
-            let storage_hits: Vec<&str> = order
-                .iter()
-                .filter_map(|key| {
-                    let (path, _, _, simulated) = &files[key];
-                    (crate::schema_gate::is_schema_file(path)
-                        && !extractor.extract(path, simulated).is_empty())
-                    .then_some(path.as_str())
-                })
-                .collect();
-            if !storage_hits.is_empty() {
-                return ToolOutput::Error {
-                    message: format!(
-                        "batch touches storage definitions in {} — the storage gate judges \
-                         single edits only, so apply these through edit_file; NOTHING was \
-                         written",
-                        storage_hits
-                            .iter()
-                            .map(|p| format!("`{p}`"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
-                };
-            }
-        }
         if dry_run {
             return ToolOutput::Ok {
                 content: format!(
@@ -533,32 +528,26 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn refuses_storage_definitions_loudly() {
-        let dir = tempfile::tempdir().unwrap();
-        let rel = "migrations/001_init.sql";
-        std::fs::create_dir_all(dir.path().join("migrations")).unwrap();
-        std::fs::write(dir.path().join(rel), "CREATE TABLE t (id int);\n").unwrap();
-
-        let result = ApplyEdits::default()
-            .execute(
-                &serde_json::json!({ "edits": [edit(rel, "int", "bigint")] }),
-                dir.path(),
-            )
-            .await;
-        match result {
-            ToolOutput::Error { message } => {
-                assert!(
-                    message.contains("storage definitions"),
-                    "storage DDL must be refused toward edit_file: {message}"
-                );
-            }
-            ToolOutput::Ok { content } => panic!("expected refusal, got: {content}"),
-        }
+    #[test]
+    fn simulate_batch_composes_edits_exactly_like_validate() {
+        let input = serde_json::json!({ "edits": [
+            edit("a.sql", "one", "two"),
+            edit("a.sql", "two three", "four"),
+            edit("b.sql", "x", "y"),
+        ]});
+        // Edits to one file compose in order — the second targets the
+        // intermediate content the first produced.
         assert_eq!(
-            std::fs::read_to_string(dir.path().join(rel)).unwrap(),
-            "CREATE TABLE t (id int);\n"
+            simulate_batch(&input, "a.sql", "one three").as_deref(),
+            Some("four")
         );
+        assert_eq!(simulate_batch(&input, "b.sql", "x").as_deref(), Some("y"));
+        // A path the batch never touches simulates to nothing.
+        assert_eq!(simulate_batch(&input, "c.sql", "zzz"), None);
+        // The validate phase's refusals mirror exactly: zero matches and
+        // ambiguous multi-matches both fail the simulation.
+        assert_eq!(simulate_batch(&input, "a.sql", "nope"), None);
+        assert_eq!(simulate_batch(&input, "b.sql", "x x"), None);
     }
 
     #[tokio::test]

--- a/stella-tools/src/graph.rs
+++ b/stella-tools/src/graph.rs
@@ -264,18 +264,22 @@ pub(crate) fn run_query_with(
     };
 
     match result {
-        // Importer edges only exist where import resolution succeeds
-        // (relative TS/JS and Python paths). Rust `use` paths and bare
-        // package specifiers are indexed unresolved, so an empty importers
-        // answer for such a file is a capability gap, not a stale index —
-        // saying "re-index" would send the agent down a useless `stella
-        // init` retry.
-        Ok(frames) if frames.is_empty() && op == "importers" && !target.ends_with(".py") => {
+        // Importer edges only exist where import resolution succeeds:
+        // relative TS/JS and Python paths, and Rust `use`/`mod` paths
+        // through the module tree (#443). For everything else (Go, Java,
+        // bare package specifiers) an empty importers answer is a
+        // capability gap, not a stale index — saying "re-index" would send
+        // the agent down a useless `stella init` retry.
+        Ok(frames)
+            if frames.is_empty()
+                && op == "importers"
+                && !(target.ends_with(".py") || target.ends_with(".rs")) =>
+        {
             ToolOutput::Ok {
                 content: format!(
                     "no importers found for `{target}` — importer edges exist only where \
-                     import resolution succeeds (relative TS/JS/Python imports); Rust `use` \
-                     paths are indexed unresolved. Try `references` on the module name instead."
+                     import resolution succeeds (relative TS/JS/Python imports and Rust \
+                     `use`/`mod` paths). Try `references` on the module name instead."
                 ),
             }
         }

--- a/stella-tools/src/impact.rs
+++ b/stella-tools/src/impact.rs
@@ -6,15 +6,15 @@
 //! The selection is pure over (change set × importer edges): diff the
 //! working tree (`git status --porcelain -uall`), walk the graph's
 //! reverse-dependency relation transitively from each changed file, and
-//! keep every reachable file that looks like a test file — including
-//! changed test files themselves. Only languages whose import edges the
-//! graph actually resolves participate (relative TS/JS and Python imports,
-//! see `stella_graph`'s resolver); a change touching anything else makes
+//! keep every reachable test-bearing file — including changed test files
+//! themselves. Only languages whose import edges the graph actually
+//! resolves participate (relative TS/JS and Python imports, and Rust
+//! `use`/`mod` paths through the module tree since #443 — see
+//! `stella_graph`'s resolvers); a change touching anything else makes
 //! the selection untrustworthy, and the answer is then the WHOLE suite with
 //! a one-line note. The posture throughout: fail loudly to over-testing,
 //! never silently under-test — a skipped test that should have run is a
-//! correctness hole (Rust selection is gated on #335's resolved `use`
-//! edges).
+//! correctness hole.
 
 use std::collections::{BTreeSet, VecDeque};
 use std::path::Path;
@@ -29,8 +29,11 @@ const GIT_STATUS_TIMEOUT_SECS: u64 = 60;
 /// selection is a named answer, never a silent no-op.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ImpactSelection {
-    /// Test files (root-relative, forward-slash, sorted) that transitively
-    /// import a changed file — including changed test files themselves.
+    /// Test-bearing files (root-relative, forward-slash, sorted) that
+    /// transitively import a changed file — named test files for TS/JS and
+    /// Python (including changed test files themselves), and every impacted
+    /// `.rs` file for Rust, whose unit tests live inside the source
+    /// ([`cargo_packages`] maps those to `-p` selections downstream).
     Selected { tests: Vec<String>, changed: usize },
     /// The walk completed over fully-resolved edges and no test file
     /// reaches the change (`changed == 0` means the tree itself is clean).
@@ -40,10 +43,11 @@ pub(crate) enum ImpactSelection {
 }
 
 /// Extensions whose import edges the graph resolves to real files (relative
-/// TS/JS specifiers and Python relative imports — `stella_graph::import`).
-/// A changed file outside this set may be depended on through edges the
-/// graph cannot see, so its presence stands the whole selection down.
-const RESOLVED_EXTS: [&str; 7] = ["ts", "tsx", "js", "jsx", "mjs", "cjs", "py"];
+/// TS/JS specifiers, Python relative imports, and Rust `use`/`mod` paths —
+/// `stella_graph::import` + `rust_resolve`, #443). A changed file outside
+/// this set may be depended on through edges the graph cannot see, so its
+/// presence stands the whole selection down.
+const RESOLVED_EXTS: [&str; 8] = ["ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rs"];
 
 fn extension(path: &str) -> &str {
     Path::new(path)
@@ -70,6 +74,16 @@ pub(crate) fn is_test_file(path: &str) -> bool {
     base.contains(".test.") || base.contains(".spec.") || in_dir("__tests__")
 }
 
+/// Whether a reachable file's tests must run when it is impacted. TS/JS and
+/// Python NAME their test files; Rust unit tests live inside ordinary source
+/// files (`#[cfg(test)]`), so every impacted `.rs` file is test-bearing —
+/// dropping non-test-named Rust files here would silently under-test, the
+/// one failure the module contract forbids. The cargo mapping downstream
+/// turns the file set into `-p` package selections.
+fn test_bearing(path: &str) -> bool {
+    extension(path) == "rs" || is_test_file(path)
+}
+
 /// Stella's own workspace state — never a test input, and always present as
 /// an untracked/dirty path once the graph index exists, so it must not
 /// poison the change set.
@@ -94,10 +108,6 @@ pub(crate) fn shell_safe(path: &str) -> bool {
 /// resolved import edges — named per ecosystem so the reader learns *why*.
 fn unresolved_note(path: &str) -> String {
     match extension(path) {
-        "rs" => format!(
-            "impact selection unavailable for Rust (`{path}`) until import resolution \
-             lands (#335) — ran the full suite"
-        ),
         "go" => format!(
             "impact selection unavailable for Go (`{path}`): bare imports are indexed \
              unresolved — ran the full suite"
@@ -150,7 +160,7 @@ fn walk(changed: &[String], importers: &mut dyn FnMut(&str) -> Vec<String>) -> I
             }
         }
     }
-    let tests: Vec<String> = visited.into_iter().filter(|p| is_test_file(p)).collect();
+    let tests: Vec<String> = visited.into_iter().filter(|p| test_bearing(p)).collect();
     if tests.is_empty() {
         return ImpactSelection::NothingImpacted {
             changed: changed.len(),
@@ -180,6 +190,54 @@ pub(crate) fn select(
         Err(early) => early,
         Ok(relevant) => walk(&relevant, importers),
     }
+}
+
+/// Map a selection's `.rs` files to their owning cargo package names (the
+/// nearest ancestor `Cargo.toml` carrying a `[package]`), deduped and
+/// sorted — what `run_tests` turns into `cargo test -p …` flags. `None`
+/// when any Rust file cannot be mapped: a packageless stray means the
+/// selection must widen loudly, never guess.
+pub(crate) fn cargo_packages(root: &Path, selected: &[String]) -> Option<Vec<String>> {
+    let mut packages: BTreeSet<String> = BTreeSet::new();
+    for rel in selected.iter().filter(|p| extension(p) == "rs") {
+        let file = root.join(rel);
+        let mut dir = file.parent();
+        let mut found = None;
+        while let Some(d) = dir {
+            if let Some(name) = package_name(&d.join("Cargo.toml")) {
+                found = Some(name);
+                break;
+            }
+            if d == root {
+                break;
+            }
+            dir = d.parent();
+        }
+        packages.insert(found?);
+    }
+    Some(packages.into_iter().collect())
+}
+
+/// The `name = "…"` under `[package]`, by line scan — a manifest broken
+/// enough to defeat this simply fails the mapping (→ full suite), and a
+/// workspace-only root manifest has no `[package]` and contributes nothing.
+fn package_name(manifest: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(manifest).ok()?;
+    let mut in_package = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(section) = line.strip_prefix('[') {
+            in_package = section.trim_end_matches(']').trim() == "package";
+            continue;
+        }
+        if in_package
+            && let Some(rest) = line.strip_prefix("name")
+            && let Some(value) = rest.trim_start().strip_prefix('=')
+        {
+            return Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+    None
 }
 
 /// Changed paths parsed from `git status --porcelain` output. Rename rows
@@ -404,14 +462,6 @@ mod tests {
 
     #[test]
     fn unresolved_languages_stand_down_to_the_full_suite_loudly() {
-        match run_select(&["src/lib.rs"], &[]) {
-            ImpactSelection::FullSuite { note } => {
-                assert!(note.contains("Rust"), "{note}");
-                assert!(note.contains("#335"), "{note}");
-                assert!(note.contains("full suite"), "{note}");
-            }
-            other => panic!("Rust must stand down loudly: {other:?}"),
-        }
         match run_select(&["pkg/main.go"], &[]) {
             ImpactSelection::FullSuite { note } => {
                 assert!(note.contains("Go"), "{note}");
@@ -426,6 +476,64 @@ mod tests {
             }
             other => panic!("mixed change must stand down: {other:?}"),
         }
+    }
+
+    /// #443: Rust participates in selection, and every impacted `.rs` file
+    /// is test-bearing — unit tests live inside the sources, so dropping a
+    /// non-test-named Rust file would silently under-test.
+    #[test]
+    fn rust_changes_select_impacted_source_files() {
+        let selection = run_select(
+            &["src/util.rs"],
+            &[("src/util.rs", &["src/lib.rs"]), ("src/lib.rs", &[])],
+        );
+        match selection {
+            ImpactSelection::Selected { tests, changed } => {
+                assert_eq!(changed, 1);
+                assert_eq!(tests, vec!["src/lib.rs", "src/util.rs"]);
+            }
+            other => panic!("Rust selection must keep impacted sources: {other:?}"),
+        }
+    }
+
+    /// The file→package mapping behind `cargo test -p …`: names come from
+    /// the nearest `[package]` manifest, deduped; an unmappable file fails
+    /// the whole mapping (widen, never guess).
+    #[test]
+    fn cargo_packages_map_files_to_their_owning_crates() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("alpha/src")).unwrap();
+        std::fs::create_dir_all(root.join("stray")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"alpha\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("alpha/Cargo.toml"),
+            "[package]\nname = \"alpha-core\"\nversion = \"0.0.0\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            cargo_packages(
+                root,
+                &["alpha/src/lib.rs".into(), "alpha/src/util.rs".into()]
+            ),
+            Some(vec!["alpha-core".to_string()]),
+            "two files in one crate dedup to its package name"
+        );
+        assert_eq!(
+            cargo_packages(root, &["stray/orphan.rs".into()]),
+            None,
+            "a packageless file fails the mapping — selection must widen"
+        );
+        assert_eq!(
+            cargo_packages(root, &["web/app.test.ts".into()]),
+            Some(Vec::new()),
+            "non-Rust selections contribute no packages"
+        );
     }
 
     #[test]

--- a/stella-tools/src/project.rs
+++ b/stella-tools/src/project.rs
@@ -166,7 +166,31 @@ impl Tool for RunTests {
                 }
                 ImpactSelection::FullSuite { note: n } => note = n,
                 ImpactSelection::Selected { tests, changed } => {
-                    if matches!(primary, "npm" | "pnpm" | "yarn" | "bun" | "uv" | "poetry") {
+                    if primary == "cargo" {
+                        // Rust selection is file→package (#443): unit tests
+                        // live inside the impacted sources, so the honest
+                        // narrowing is `-p` over their owning crates, never
+                        // a per-file filter.
+                        match crate::impact::cargo_packages(root, &tests) {
+                            Some(packages) if !packages.is_empty() => {
+                                let note = format!(
+                                    "scope:\"impacted\": selected {} package(s) for {changed} \
+                                     changed file(s)",
+                                    packages.len()
+                                );
+                                let command = cargo_impacted_command(kind, &packages);
+                                return with_note(
+                                    &note,
+                                    run_and_report(&command, root, timeout_secs).await,
+                                );
+                            }
+                            _ => {
+                                note = "impact selection could not map every impacted file \
+                                        to a cargo package — ran the full suite"
+                                    .into();
+                            }
+                        }
+                    } else if matches!(primary, "npm" | "pnpm" | "yarn" | "bun" | "uv" | "poetry") {
                         note = format!(
                             "scope:\"impacted\": selected {} test file(s) for {} changed \
                              file(s)",
@@ -276,6 +300,23 @@ impl SafeFilter {
 impl std::fmt::Display for SafeFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+/// The `scope:"impacted"` cargo command: `--workspace` narrowed to the
+/// impacted packages, mirroring [`test_command`]'s per-`kind` target
+/// selection. Package names come from the workspace's own manifests, but
+/// they are still shell-quoted — one escaper, no exceptions.
+fn cargo_impacted_command(kind: &str, packages: &[String]) -> String {
+    let flags = packages
+        .iter()
+        .map(|p| format!("-p {}", shell_quote(p)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    match kind {
+        "unit" => format!("cargo test {flags} --lib --bins"),
+        "e2e" => format!("cargo test {flags} --test '*'"),
+        _ => format!("cargo test {flags}"),
     }
 }
 
@@ -924,13 +965,13 @@ mod tests {
         );
     }
 
-    /// Rust has no resolved import edges yet (#335): a changed `.rs` file
-    /// stands selection down to the WHOLE suite with a one-line note —
-    /// loudly over-testing, never silently under-testing.
+    /// #443's exit criterion at the tool level: a one-file Rust change
+    /// selects its owning package and runs `cargo test -p <package>` — no
+    /// longer the pre-#443 full-suite stand-down.
     #[tokio::test]
-    async fn impacted_scope_falls_back_loudly_to_the_full_suite_for_rust() {
+    async fn impacted_scope_narrows_a_rust_change_to_its_package() {
         if !git_available().await {
-            eprintln!("skipping impacted-scope fallback test: `git` not available");
+            eprintln!("skipping impacted-scope test: `git` not available");
             return;
         }
         let dir = tempfile::tempdir().unwrap();
@@ -953,13 +994,16 @@ mod tests {
             ToolOutput::Error { message } => message.clone(),
         };
         assert!(
-            text.contains("impact selection unavailable for Rust"),
-            "{text}"
+            text.contains("selected 1 package(s)"),
+            "the selection provenance note rides the report: {text}"
         );
-        assert!(text.contains("#335"), "{text}");
         assert!(
-            text.contains("cargo test --workspace"),
-            "the full suite actually ran: {text}"
+            text.contains("cargo test -p 'impactfix'"),
+            "the narrowed command actually ran: {text}"
+        );
+        assert!(
+            !text.contains("--workspace"),
+            "the full suite must NOT run for a mapped change: {text}"
         );
     }
 

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -602,90 +602,136 @@ impl ToolRegistry {
             })
             .collect();
 
-        // Storage gate (docs/design/storage-map.md §8): if the target is a
-        // storage-definition file, parse the proposed content with the SAME
-        // adapter extraction the indexer uses and judge it against the live
-        // storage map before the write/edit lands. Objects the target file
-        // already defines on disk are exempt — rewriting an existing
-        // migration in place is not a duplicate.
-        let mut pending_storage: Option<crate::schema_gate::GatePass> = None;
+        // Storage gate (docs/design/storage-map.md §8): if the call targets
+        // storage-definition files, parse each proposed post-write content
+        // with the SAME adapter extraction the indexer uses and judge it
+        // against the live storage map before anything lands. Objects a
+        // target file already defines on disk are exempt — rewriting an
+        // existing migration in place is not a duplicate. `write_file` /
+        // `edit_file` carry one target; an `apply_edits` batch may carry
+        // several (#442), each judged with the same check, so the
+        // transactional path is not a way around the gate. `storage_intent`
+        // is per CALL: one declaration covers every object the batch lands,
+        // exactly as it covers a whole `write_file`.
+        let mut pending_storage: Vec<crate::schema_gate::GatePass> = Vec::new();
         let mut declared_intent: Option<String> = None;
-        if let Some(path) = input.get("path").and_then(|v| v.as_str())
-            && matches!(name, "write_file" | "edit_file")
-            && crate::schema_gate::is_schema_file(path)
-            && let Some(extractor) = crate::schema_gate::extractor()
-        {
-            // write_file carries the full file in `content`. For edit_file
-            // the post-edit file is simulated (current content with the
-            // replacement applied) so whole-file adapters see the resulting
-            // definitions — a Prisma model gaining a field is invisible in
-            // `new_string` alone. Falls back to the fragment when the edit
-            // cannot be simulated (the tool itself will then error anyway).
-            let current = crate::resolve_within_root(&self.root, path)
-                .and_then(|p| std::fs::read_to_string(p).ok());
-            let proposed_src: Option<String> = match name {
-                "write_file" => input
-                    .get("content")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string),
-                _ => {
-                    let new_string = input.get("new_string").and_then(|v| v.as_str());
-                    let old_string = input.get("old_string").and_then(|v| v.as_str());
-                    match (new_string, old_string, &current) {
-                        (Some(new), Some(old), Some(cur))
-                            if !old.is_empty() && cur.contains(old) =>
-                        {
-                            let replace_all = input
-                                .get("replace_all")
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false);
-                            Some(if replace_all {
-                                cur.replace(old, new)
-                            } else {
-                                cur.replacen(old, new, 1)
-                            })
-                        }
-                        (Some(new), _, _) => Some(new.to_string()),
-                        _ => None,
+        if let Some(extractor) = crate::schema_gate::extractor() {
+            // (path, current on-disk content, simulated post-write source).
+            // The post-write file is simulated — for edit_file the current
+            // content with the replacement applied, for apply_edits the
+            // batch's composed edits (`apply_edits::simulate_batch`, the
+            // validate phase's own composition) — so whole-file adapters see
+            // the resulting definitions; a Prisma model gaining a field is
+            // invisible in `new_string` alone. A failed simulation falls
+            // back to the fragment / stays unjudged: the tool itself then
+            // returns the named error and writes nothing.
+            let mut targets: Vec<(String, Option<String>, Option<String>)> = Vec::new();
+            match name {
+                "write_file" | "edit_file" => {
+                    if let Some(path) = input.get("path").and_then(|v| v.as_str())
+                        && crate::schema_gate::is_schema_file(path)
+                    {
+                        let current = crate::resolve_within_root(&self.root, path)
+                            .and_then(|p| std::fs::read_to_string(p).ok());
+                        let proposed_src: Option<String> = match name {
+                            "write_file" => input
+                                .get("content")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                            _ => {
+                                let new_string = input.get("new_string").and_then(|v| v.as_str());
+                                let old_string = input.get("old_string").and_then(|v| v.as_str());
+                                match (new_string, old_string, &current) {
+                                    (Some(new), Some(old), Some(cur))
+                                        if !old.is_empty() && cur.contains(old) =>
+                                    {
+                                        let replace_all = input
+                                            .get("replace_all")
+                                            .and_then(|v| v.as_bool())
+                                            .unwrap_or(false);
+                                        Some(if replace_all {
+                                            cur.replace(old, new)
+                                        } else {
+                                            cur.replacen(old, new, 1)
+                                        })
+                                    }
+                                    (Some(new), _, _) => Some(new.to_string()),
+                                    _ => None,
+                                }
+                            }
+                        };
+                        targets.push((path.to_string(), current, proposed_src));
                     }
                 }
-            };
-            let proposed = proposed_src
-                .as_deref()
-                .map(|src| extractor.extract(path, src))
-                .unwrap_or_default();
-            if !proposed.is_empty() {
-                let own = current
+                "apply_edits" => {
+                    let mut seen = HashSet::new();
+                    for path in input
+                        .get("edits")
+                        .and_then(|v| v.as_array())
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|e| e.get("path").and_then(|v| v.as_str()))
+                    {
+                        if !crate::schema_gate::is_schema_file(path)
+                            || !seen.insert(path.to_string())
+                        {
+                            continue;
+                        }
+                        let current = crate::resolve_within_root(&self.root, path)
+                            .and_then(|p| std::fs::read_to_string(p).ok());
+                        let proposed_src = current
+                            .as_deref()
+                            .and_then(|cur| crate::apply_edits::simulate_batch(input, path, cur));
+                        targets.push((path.to_string(), current, proposed_src));
+                    }
+                }
+                _ => {}
+            }
+            // The persisted snapshot opens SQLite, so it goes to the blocking
+            // pool (#549) — loaded once for the whole call, and only when a
+            // target actually extracts definitions. The `.await` happens
+            // BEFORE the overlay merge takes the `storage_index` std mutex —
+            // a guard held across an await would make this future non-`Send`.
+            let mut snapshot: Option<stella_graph::StorageSnapshot> = None;
+            for (path, current, proposed_src) in targets {
+                let proposed = proposed_src
                     .as_deref()
-                    .map(|content| extractor.extract(path, content))
+                    .map(|src| extractor.extract(&path, src))
                     .unwrap_or_default();
-                // The persisted half opens SQLite, so it goes to the blocking
-                // pool (#549). The `.await` happens BEFORE the overlay merge
-                // takes the `storage_index` std mutex — a guard held across an
-                // await would make this future non-`Send`.
-                let persisted = {
-                    let root = self.root.clone();
-                    tokio::task::spawn_blocking(move || crate::graph::load_storage_snapshot(&root))
+                if proposed.is_empty() {
+                    continue;
+                }
+                if snapshot.is_none() {
+                    let persisted = {
+                        let root = self.root.clone();
+                        tokio::task::spawn_blocking(move || {
+                            crate::graph::load_storage_snapshot(&root)
+                        })
                         .await
                         .unwrap_or_else(|_| Err("the storage map load was cancelled".into()))
-                };
-                let snapshot = match persisted {
-                    Ok(persisted) => self.merge_storage_overlay(persisted),
-                    Err(message) => return ToolOutput::Error { message },
-                };
-                let manifest_layer = crate::schema_gate::manifest_layer_for(&self.root, path);
+                    };
+                    snapshot = match persisted {
+                        Ok(persisted) => Some(self.merge_storage_overlay(persisted)),
+                        Err(message) => return ToolOutput::Error { message },
+                    };
+                }
+                let own = current
+                    .as_deref()
+                    .map(|content| extractor.extract(&path, content))
+                    .unwrap_or_default();
+                let manifest_layer = crate::schema_gate::manifest_layer_for(&self.root, &path);
                 let intent = input.get("storage_intent").and_then(|v| v.as_str());
                 match crate::schema_gate::check(&crate::schema_gate::GateRequest {
-                    path,
+                    path: &path,
                     manifest_layer: manifest_layer.as_deref(),
                     proposed: &proposed,
                     own: &own,
-                    snapshot: &snapshot,
+                    snapshot: snapshot.as_ref().expect("loaded above"),
                     storage_intent: intent,
                 }) {
                     Ok(pass) => {
                         declared_intent = intent.map(str::to_string);
-                        pending_storage = Some(pass);
+                        pending_storage.push(pass);
                     }
                     Err(message) => return ToolOutput::Error { message },
                 }
@@ -756,9 +802,10 @@ impl ToolRegistry {
         if !output.is_error() {
             // The write landed, so the objects it creates now exist: grow
             // the session overlay so a duplicate later this session
-            // conflicts even before any re-index from the code graph.
-            if let Some(pass) = pending_storage {
-                self.record_storage_objects(&pass, declared_intent.as_deref());
+            // conflicts even before any re-index from the code graph. One
+            // pass per gated file — a batch records each (#442).
+            for pass in &pending_storage {
+                self.record_storage_objects(pass, declared_intent.as_deref());
             }
             for (pending, pre_content) in pending_ops.into_iter().zip(pre_contents) {
                 self.record_touch(pending, pre_content, name, input, bus.as_ref());
@@ -1544,6 +1591,10 @@ mod private_state_tests;
 mod fence_tests;
 
 #[cfg(test)]
+#[path = "registry/gate_batch_tests.rs"]
+mod gate_batch_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -2112,7 +2163,9 @@ mod tests {
 
     /// A baseline snapshot with the given tables in the implicit `sql`
     /// layer, `default` namespace — the shape `stella init` would seed.
-    fn seeded_snapshot(tables: &[&str]) -> stella_graph::StorageSnapshot {
+    /// `pub(super)` so the batch-gate witnesses (`gate_batch_tests`) reuse
+    /// the same fixture instead of growing a drifting copy.
+    pub(super) fn seeded_snapshot(tables: &[&str]) -> stella_graph::StorageSnapshot {
         stella_graph::StorageSnapshot {
             layers: vec![],
             relations: tables

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -803,9 +803,20 @@ impl ToolRegistry {
             // The write landed, so the objects it creates now exist: grow
             // the session overlay so a duplicate later this session
             // conflicts even before any re-index from the code graph. One
-            // pass per gated file — a batch records each (#442).
-            for pass in &pending_storage {
-                self.record_storage_objects(pass, declared_intent.as_deref());
+            // pass per gated file — a batch records each (#442). A `dry_run`
+            // batch returns Ok but writes NOTHING, so its passes must not
+            // touch the overlay (or the manifest via a declared intent) — a
+            // later real write of the same object would be falsely rejected
+            // as a duplicate of a phantom.
+            let dry_run = name == "apply_edits"
+                && input
+                    .get("dry_run")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+            if !dry_run {
+                for pass in &pending_storage {
+                    self.record_storage_objects(pass, declared_intent.as_deref());
+                }
             }
             for (pending, pre_content) in pending_ops.into_iter().zip(pre_contents) {
                 self.record_touch(pending, pre_content, name, input, bus.as_ref());

--- a/stella-tools/src/registry/gate_batch_tests.rs
+++ b/stella-tools/src/registry/gate_batch_tests.rs
@@ -1,0 +1,132 @@
+//! Witnesses for the storage gate over `apply_edits` batches (#442): the
+//! transactional path is judged by the SAME schema gate as `write_file` /
+//! `edit_file` — per touched schema file, on the batch's composed content —
+//! instead of the old blanket refusal.
+
+use super::tests::seeded_snapshot;
+use super::*;
+
+fn fixture(files: &[(&str, &str)]) -> (tempfile::TempDir, ToolRegistry) {
+    let dir = tempfile::tempdir().unwrap();
+    for (rel, content) in files {
+        let path = dir.path().join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+    let reg = ToolRegistry::with_issue_backend(dir.path().to_path_buf(), None);
+    reg.update_storage_index(seeded_snapshot(&["users"]));
+    (dir, reg)
+}
+
+/// The old shape was a blanket refusal; the new shape is a real judgment —
+/// a batch whose composed content re-creates an indexed table is blocked by
+/// the gate, with nothing written.
+#[tokio::test]
+async fn a_batch_landing_a_duplicate_table_is_blocked_by_the_gate() {
+    let original = "CREATE TABLE orders (id INT);\n";
+    let (dir, reg) = fixture(&[("migrations/002.sql", original)]);
+
+    let result = reg
+        .execute(
+            "apply_edits",
+            &serde_json::json!({ "edits": [
+                { "path": "migrations/002.sql", "old_string": "orders", "new_string": "users" },
+            ]}),
+        )
+        .await;
+    match result {
+        ToolOutput::Error { message } => {
+            assert!(
+                message.contains("users"),
+                "the gate names the duplicate: {message}"
+            );
+        }
+        ToolOutput::Ok { content } => panic!("duplicate must be blocked: {content}"),
+    }
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/002.sql")).unwrap(),
+        original,
+        "a blocked batch writes nothing"
+    );
+}
+
+/// Every schema file in the batch is judged, and one bad file blocks the
+/// whole call — the batch stays all-or-nothing through the gate too.
+#[tokio::test]
+async fn one_duplicate_in_a_batch_blocks_every_file_in_it() {
+    let clean = "CREATE TABLE payments_draft (id INT);\n";
+    let dup = "CREATE TABLE orders (id INT);\n";
+    let (dir, reg) = fixture(&[("migrations/a.sql", clean), ("migrations/b.sql", dup)]);
+
+    let result = reg
+        .execute(
+            "apply_edits",
+            &serde_json::json!({ "edits": [
+                { "path": "migrations/a.sql", "old_string": "payments_draft", "new_string": "payments" },
+                { "path": "migrations/b.sql", "old_string": "orders", "new_string": "users" },
+            ]}),
+        )
+        .await;
+    assert!(
+        result.is_error(),
+        "the bad half blocks the call: {result:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/a.sql")).unwrap(),
+        clean,
+        "the CLEAN half of a blocked batch must not land either"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/b.sql")).unwrap(),
+        dup
+    );
+}
+
+/// The other direction, which the old refusal made impossible: a legitimate
+/// multi-file schema batch passes the gate, lands transactionally, and
+/// grows the session overlay — a later duplicate of what it created is
+/// blocked without any re-index.
+#[tokio::test]
+async fn a_clean_batch_applies_and_grows_the_index() {
+    let (dir, reg) = fixture(&[
+        (
+            "migrations/003.sql",
+            "CREATE TABLE invoices_draft (id INT);\n",
+        ),
+        ("src/billing.rs", "pub fn charge() {}\n"),
+    ]);
+
+    let result = reg
+        .execute(
+            "apply_edits",
+            &serde_json::json!({ "edits": [
+                { "path": "migrations/003.sql", "old_string": "invoices_draft", "new_string": "invoices" },
+                { "path": "src/billing.rs", "old_string": "charge", "new_string": "charge_card" },
+            ]}),
+        )
+        .await;
+    assert!(!result.is_error(), "a clean batch applies: {result:?}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/003.sql")).unwrap(),
+        "CREATE TABLE invoices (id INT);\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("src/billing.rs")).unwrap(),
+        "pub fn charge_card() {}\n"
+    );
+
+    // The overlay grew: re-creating `invoices` elsewhere is now a duplicate.
+    let dup = reg
+        .execute(
+            "write_file",
+            &serde_json::json!({
+                "path": "migrations/004.sql",
+                "content": "CREATE TABLE invoices (id INT);\n"
+            }),
+        )
+        .await;
+    assert!(
+        dup.is_error(),
+        "the batch's created objects must be indexed: {dup:?}"
+    );
+}

--- a/stella-tools/src/registry/gate_batch_tests.rs
+++ b/stella-tools/src/registry/gate_batch_tests.rs
@@ -82,6 +82,44 @@ async fn one_duplicate_in_a_batch_blocks_every_file_in_it() {
     );
 }
 
+/// A `dry_run` batch is judged by the gate but writes nothing — so it must
+/// not grow the session overlay either: the same edit applied FOR REAL
+/// afterwards has to pass, not be rejected as a duplicate of the phantom
+/// the dry run never created.
+#[tokio::test]
+async fn a_dry_run_batch_leaves_the_overlay_untouched() {
+    let (dir, reg) = fixture(&[(
+        "migrations/005.sql",
+        "CREATE TABLE ledger_draft (id INT);\n",
+    )]);
+    let edits = serde_json::json!({ "edits": [
+        { "path": "migrations/005.sql", "old_string": "ledger_draft", "new_string": "ledger" },
+    ]});
+
+    let dry = reg
+        .execute(
+            "apply_edits",
+            &serde_json::json!({ "edits": edits["edits"], "dry_run": true }),
+        )
+        .await;
+    assert!(!dry.is_error(), "the dry run validates cleanly: {dry:?}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/005.sql")).unwrap(),
+        "CREATE TABLE ledger_draft (id INT);\n",
+        "a dry run writes nothing"
+    );
+
+    let real = reg.execute("apply_edits", &edits).await;
+    assert!(
+        !real.is_error(),
+        "the real batch must not collide with the dry run's phantom: {real:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("migrations/005.sql")).unwrap(),
+        "CREATE TABLE ledger (id INT);\n"
+    );
+}
+
 /// The other direction, which the old refusal made impossible: a legitimate
 /// multi-file schema batch passes the gate, lands transactionally, and
 /// grows the session overlay — a later duplicate of what it created is

--- a/stella-tools/src/repo.rs
+++ b/stella-tools/src/repo.rs
@@ -352,7 +352,12 @@ impl RepoBackend for GitCli {
             patch_args.push("--");
             patch_args.extend(&path_refs);
         }
-        let patch = Self::git_ok(root, "repo_diff", &patch_args).await?;
+        // stdout alone, like the numstat read above (#801's last missed call
+        // site): the patch is rendered verbatim AND its emptiness is what
+        // makes a clean tree say "no changes" — stderr chatter (advice
+        // hints, `GIT_TRACE` lines) merged into it polluted the shown diff
+        // and turned a clean tree into "0 files changed" plus noise.
+        let patch = Self::git_ok_stdout(root, "repo_diff", &patch_args).await?;
         Ok(RepoDiff { files, patch })
     }
 
@@ -1296,6 +1301,43 @@ mod tests {
         assert!(
             out.status.success(),
             "feature/traced must exist on the remote"
+        );
+    }
+
+    /// The flake #801's chatter test exposed in CI: with `GIT_TRACE` set
+    /// (process-global, so ANY concurrent test leaking it counts), the diff
+    /// patch was read from the MERGED stream — a clean tree's empty diff
+    /// came back as trace chatter, `render_diff` skipped its "no changes"
+    /// branch, and the report read "0 files changed" plus noise. Both the
+    /// clean and dirty answers must be chatter-proof.
+    #[tokio::test]
+    async fn stderr_chatter_never_pollutes_the_diff_patch() {
+        if !git_available().await {
+            eprintln!("skipping repo_diff trace test: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let ws = fixture(dir.path()).await;
+        let _trace = crate::subprocess_env::test_support::ScopedEnvVar::set("GIT_TRACE", "1");
+
+        let clean = RepoDiffTool(backend()).execute(&Value::Null, &ws).await;
+        let ToolOutput::Ok { content } = clean else {
+            panic!("clean diff must succeed: {clean:?}");
+        };
+        assert!(
+            content.contains("no unstaged changes"),
+            "a clean tree stays clean under chatter: {content}"
+        );
+
+        std::fs::write(ws.join("README.md"), "traced edit\n").unwrap();
+        let dirty = RepoDiffTool(backend()).execute(&Value::Null, &ws).await;
+        let ToolOutput::Ok { content } = dirty else {
+            panic!("dirty diff must succeed: {dirty:?}");
+        };
+        assert!(content.contains("+traced edit"), "{content}");
+        assert!(
+            !content.contains("trace:"),
+            "the shown patch must be stdout alone: {content}"
         );
     }
 

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -272,10 +272,11 @@ An in-process file watcher (200 ms debounce, no daemon) keeps it fresh as
 files change, for exactly as long as the session runs.
 
 <Callout type="info">
-  One honest capability gap: `importers` edges resolve for relative
-  TypeScript/JavaScript and Python imports. Rust `use` paths are indexed
-  unresolved — an empty `importers` answer for a Rust file is a limitation,
-  not a stale index.
+  `importers` edges resolve for relative TypeScript/JavaScript and Python
+  imports, and for Rust `use`/`mod` paths through the workspace module tree
+  (file-level edges; external crates stay unresolved). Remaining honest
+  gaps: Go and Java package imports, and PHP namespace `use`, are indexed
+  unresolved.
 </Callout>
 
 ## Exploration maps: understanding that outlives the turn


### PR DESCRIPTION
## What & why

The last two implementable issues from the backlog burn-down, both P2 features triaged "confirmed outstanding":

**#443 — pure-Rust `use`→file resolver (option B2 of `docs/design/semantic-resolution-bridge.md`).** `stella-graph` gains `rust_resolve`: a per-index-pass `RustLayout` (workspace `Cargo.toml` scan → crate-name→root mapping, hyphens normalized, lazy so non-Rust passes never pay), a `use`-argument expander (brace groups incl. nested, `as` renames, wildcards, group `self`), and a module-tree walker covering `crate::` / `self::` / `super::` / bare-crate prefixes across both module layouts (`foo.rs` and `foo/mod.rs`). Declaration-only `mod foo;` items are captured as dependency edges too. File-level edges only; external crates stay recorded unresolved; `#[path]`/macro/`cfg` modules are documented gaps. Downstream, `run_tests` `scope:"impacted"` switches Rust from the loud full-suite fallback to real selection: every impacted `.rs` file is test-bearing (unit tests live inside sources) and `cargo_packages` maps the selection to owning crates for `cargo test -p …` — an unmappable file widens loudly, never guesses. `graph_query`'s canned Rust empty-importers apology is retired, and the design doc's status is updated to "B2 shipped".

**#442 — the storage gate judges `apply_edits` batches.** The v1 blanket refusal cost the transactional path for legitimate multi-hunk schema work. The registry's gate section now judges a list of targets — one for `write_file`/`edit_file` exactly as before, and for `apply_edits` every distinct schema file the batch touches, each simulated with the batch's composed edits via `apply_edits::simulate_batch` (the validate phase's own in-order composition, same zero-match/ambiguous-match refusals), so the gate judges exactly the bytes apply would write. Snapshot loads once per call; `record_storage_objects` records one `GatePass` per gated file; `storage_intent` stays per-call. The tool-side refusal is gone.

Also carries the file-size baseline rows for `stella-pipeline` growth that reached `main` without a bump — the gate is red on the base branch without them.

Closes #443
Closes #442

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here):
  - #443: `rust_resolve` unit tests (expansion, walk, both layouts, cross-crate, external-stays-unresolved, self-edge suppression); `languages.rs::rust_use_paths_resolve_through_the_module_tree` (the design doc's exit criterion — `importers` of `util.rs` returns the real dependent set incl. a cross-crate importer); `impacted_scope_narrows_a_rust_change_to_its_package` (`cargo test -p 'impactfix'` actually runs; the old fallback witnesses failed on the new code and were converted).
  - #442: `registry/gate_batch_tests.rs` — a batch re-creating an indexed table is blocked with nothing written; one duplicate blocks every file in the batch; a clean multi-file schema batch applies and grows the session overlay so a later duplicate is blocked. `simulate_batch`'s composition mirror is pinned in `apply_edits` tests.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — stella-graph and stella-tools suites green locally; full run re-verified by CI
- [x] Docs updated where behavior changed (`context-engine.mdx` importers callout, design-doc status, module docs)
- [x] CLA signed
- [x] `Closes #N` appears both above and as commit trailers

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (the resolver is std-only; the manifest scan is a bounded line reader)
- [x] No new outbound network calls

## Anything reviewers should know?

The Rust resolver deliberately claims file-level edges only — resolved references, a true call graph, and safe rename remain Option A territory per the evaluation; B1 (call edges) is the next increment there. `ImportKind` stays `Absolute` for `use` edges (it classifies the specifier form; resolution now fills `to_path`). For `scope:"impacted"`, a mixed rs+ts change under a cargo-primary workspace maps only the `.rs` files to packages — the TS test files in the selection are reported in the note but need their own runner, same as before. The pipeline baseline rows fix a pre-existing red on `main`'s file-size gate (grew without a bump, likely an admin-bypass merge).

---

## Summary by Sourcery

Implement Rust module-tree resolution for import edges and update impact-based Rust test selection, while extending the storage gate to judge apply_edits batches per touched schema file instead of refusing them outright.

New Features:
- Add a pure-Rust module-tree resolver that maps Rust use and mod paths to file-level edges across workspace crates.
- Enable impact-based Rust test selection by treating impacted .rs files as test-bearing and mapping them to owning Cargo packages for scoped cargo test runs.

Bug Fixes:
- Ensure apply_edits batches that touch storage-definition files are evaluated by the storage gate per affected schema file so transactional edits cannot bypass duplicate protection.

Enhancements:
- Refine import resolution to record Rust use and mod edges as resolved where possible while keeping external-crate references unresolved.
- Cache the Rust crate layout lazily per index pass so non-Rust indexing work avoids manifest scans.
- Improve importers query behavior and user-facing messaging now that Rust import edges are resolved.
- Share a simulate_batch helper between apply_edits validation and the storage gate so both judge the same composed post-edit content.

Documentation:
- Update context-engine documentation and the semantic-resolution bridge design doc to reflect the shipped Rust resolver and its current capabilities and gaps.

Tests:
- Add end-to-end and unit tests for Rust import resolution, impact selection, cargo package mapping, and importer behavior.
- Add registry gate witnesses and apply_edits tests to cover gated schema batches, overlay growth, and batch composition semantics.

Chores:
- Refresh file-size baselines to account for recent stella-pipeline growth so the size gate passes on the main branch.
