### PR TITLE
ADR 0011 (context records are TOML) + wire the scoreboard

### DIFF
--- a/docs/adr/0008-markdown-canonical-rules.md
+++ b/docs/adr/0008-markdown-canonical-rules.md
@@ -1,6 +1,9 @@
 # ADR 0008: Markdown Repository Rules Remain Canonical
 
-- Status: Accepted (Phase 0)
+- Status: Accepted (Phase 0) — the **surface** decision below is superseded by
+  [ADR 0011](0011-context-records-are-toml.md) (context records are TOML); the
+  thesis (Git canonical, database a derived read-only mirror) and the rejection
+  of a YAML rule surface both stand unchanged.
 - Date: 2026-07-23
 - Deciders: (Phase 0 baseline)
 

--- a/docs/adr/0011-context-records-are-toml.md
+++ b/docs/adr/0011-context-records-are-toml.md
@@ -1,0 +1,118 @@
+# ADR 0011: Context Records Are TOML (supersedes the surface decision in 0008)
+
+- Status: **Proposed** — needs repository-owner ratification. Supersedes ADR
+  0008's *surface* decision only; 0008's thesis is preserved unchanged.
+- Date: 2026-07-28
+- Deciders: (pending)
+
+## Context
+
+ADR 0008 decided that repository rules remain Markdown at `.stella/rules/*.md`,
+with the database as a derived read-only mirror, and rejected the `.yaml` rule
+surface proposed by `context-prs-spec.md`. It was careful to name that a
+*surface* conflict — "since its thesis (Git canonical, graph derived) is the
+same model."
+
+That reasoning still holds. What has changed is what the surface has to carry.
+
+**The frontmatter became a record.** When 0008 was written, a rule file was a
+`description` line and up to three guard keys. Today `stella-core/src/rules/metadata.rs`
+validates eleven required fields with enum parsing, RFC-3339 timestamp
+validation, list parsing, and duplicate-key detection. That is a typed record
+serialised into a document header.
+
+**The parser underneath it is not a YAML parser.** `stella-core/src/rules.rs`
+hand-rolls roughly thirty-five lines of line reader: `key: value` scalars, plus
+block sequences flattened into a comma-joined string. It supports no nesting,
+and a nested key is not rejected — indentation is stripped and the key is
+silently promoted to the top level.
+
+Two things follow, and both are load-bearing for this decision:
+
+1. **The canonical specification's own example does not parse as written.**
+   `docs/context-pr.md` §6.1 shows a nested `scope:` block. Against the shipped
+   reader, `scope` resolves to an empty string and `repository_id` becomes a
+   sibling of `record_id`. Nothing errors.
+2. **Adding a field means extending a bespoke parser**, not adopting a format —
+   and every extension has to re-derive nesting, typing, and error reporting
+   that a real parser provides.
+
+A surface chosen when the payload was one line is being asked to carry a
+validated record. That is the decision 0008 could not have made and this one
+has to.
+
+## Decision
+
+**Context records are TOML.** A git-tracked context record is a `.toml` file.
+
+**Documents remain Markdown.** Where the prose *is* the artifact — skills, and
+long-form guidance meant to be read — Markdown with frontmatter is retained. The
+line is: if the prose is a **field**, TOML; if the prose is the **document**,
+Markdown. Burying a rule statement in a `"""` block would make the Context PR
+diff worse, and a reviewable diff is the premise of the whole workflow.
+
+**0008's thesis is preserved.** Git remains the authoritative, human-governed
+policy ledger; the database remains a derived, read-only mirror. Nothing here
+reopens that, and the single-source-of-truth argument 0008 used against a second
+authority applies to this surface exactly as it did to Markdown.
+
+**0008's rejection of YAML stands.** This is not that decision revisited. TOML
+is chosen *over* YAML, not as a lighter spelling of it:
+
+- `toml` is already a workspace dependency (`Cargo.toml`, used across at least
+  eight modules). `serde_yaml` is not a dependency of this workspace at all, so
+  adopting YAML would add one and TOML adds none.
+- TOML has native RFC 3339 datetimes, which retires the hand-rolled byte-index
+  timestamp validator in `metadata.rs`.
+- TOML has real integers. `confidence` is specified as an integer 0–100 and is
+  currently parsed out of a string.
+- TOML has real arrays, replacing the block-sequence-to-comma-joined-string
+  round trip and its ambiguity for any value containing a comma.
+- TOML has no implicit type coercion. For a governance ledger, YAML resolving an
+  unquoted value to a boolean is a bad day, and the mitigation is quoting
+  discipline enforced by review rather than by the format.
+
+**The change is hash-neutral.** `record_hash` is RFC 8785 canonical JSON over
+the *serialised record struct*, with `record_hash` removed from the preimage
+(`stella-core/src/context_record/hash.rs`). The on-disk surface never enters
+that preimage. Moving from Markdown to TOML therefore changes no `record_id` and
+no `record_hash`, and no revision is minted by the migration itself. This is the
+property that makes the decision reversible in practice rather than only on
+paper.
+
+## Consequences
+
+- The loader gains a TOML path. **Existing `.stella/rules/*.md` continue to
+  load**: they are a shipped format with files already written against it, and
+  0008's migration language — legacy rule files imported as read-only mirror
+  rows, never promoted above Git — is unaffected.
+- The hand-rolled frontmatter parser survives only to serve that legacy path,
+  and stops being extended. New fields land in the TOML schema.
+- `render_rule_metadata`, currently exported from `stella-core` with no callers,
+  is superseded by a TOML writer rather than wired up.
+- The silent-nesting defect above should be made loud on the legacy path
+  regardless of this ADR. A parser that promotes a nested key to the top level
+  without complaint is the same failure shape as a check that reports OK for
+  inputs it skipped.
+- ADR 0008's open question — owner-routing policy, deferred to Phase 8 — is
+  untouched by this decision.
+
+## What this deliberately does not decide
+
+- **The field schema.** Which fields a context record carries, and what their
+  vocabularies are, is a separate decision constrained by ADR 0009's enum
+  freeze. This ADR settles the format and nothing about the contents.
+- **Whether `.claude/rules/` remains a live read path.** Today it is the second
+  of three rule directories the loader reads on every load. Whether it should
+  instead be an explicit import source is a behavioural question, not a format
+  one, and needs its own decision.
+
+## Open question
+
+The substrate rule that the current design assumes — context records are files,
+and `sharing_scope` selects *which* file location (repository tree, or
+`~/.stella/rules/` for personal scope) rather than whether it is a file at all —
+is not ratified anywhere. ADR 0002 covers scope versus sharing but does not
+reach storage. If this ADR is ratified, that rule should be written down too,
+because "memories live in the database, context records live in files" is the
+sentence the rest of the design leans on.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@ open; nothing before Phase 3 forces it.
 | [0005](0005-storage-authority.md) | Storage Authority | Accepted (Phase 0) |
 | [0006](0006-contextframe-vs-compiledcontextframe.md) | ContextFrame vs. CompiledContextFrame | Accepted (Phase 0) — amended 2026-07-26 (extends the step manifest) |
 | [0007](0007-immutable-promotion-history.md) | Immutable Promotion History | Accepted — ratified 2026-07-23 (enforcement 4→2); amended 2026-07-24 (`informational`→advisory) |
-| [0008](0008-markdown-canonical-rules.md) | Markdown Repository Rules Remain Canonical | Accepted (Phase 0) |
+| [0008](0008-markdown-canonical-rules.md) | Markdown Repository Rules Remain Canonical | Accepted (Phase 0) — surface superseded by [0011](0011-context-records-are-toml.md) |
 | [0009](0009-enum-freeze-resolutions.md) | Enum-Freeze Resolutions (issue #483) | Accepted — ratified 2026-07-24 |
 | [0010](0010-incremental-authority-transfer.md) | Incremental Authority Transfer (amends 0005) | Accepted — ratified 2026-07-26 (index tables do not transfer) |
+| [0011](0011-context-records-are-toml.md) | Context Records Are TOML (supersedes 0008's surface) | **Proposed** — awaiting ratification |

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -22,7 +22,7 @@
 2576 stella-pipeline/src/pipeline.rs
 2113 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
-2254 stella-store/src/lib.rs
+2255 stella-store/src/lib.rs
 2200 stella-store/src/tests.rs
 1897 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -58,6 +58,7 @@ mod memory_compact;
 mod memory_index;
 mod memory_retire_cmd;
 mod model_catalog;
+mod scoreboard_cmd;
 // Phase 3 (#714): the adaptive-context proposal review surface.
 mod proposals_cmd;
 mod rules;
@@ -608,6 +609,11 @@ enum Command {
     /// files only; needs no API key.
     Ingest(ingest_cmd::IngestArgs),
 
+    /// What the work cost, and whether anyone said it was good: calls, characters
+    /// typed, follow-ups, and the verdict a merged or closed pull request implies.
+    /// Reads local state only; needs no API key, and no model judges anything.
+    Scoreboard,
+
     /// Inspect the project's memories through the citation feedback loop —
     /// most-cited first, usefulness scores, truthfulness — and promote an
     /// eligible memory to a project rule (.stella/rules/). Reads local state
@@ -1081,6 +1087,10 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // Reads local markdown only — no store, no model, no API key.
             return ingest_cmd::run(args);
         }
+        Some(Command::Scoreboard) => {
+            // Reads .stella/private/store.db only.
+            return scoreboard_cmd::run();
+        }
         Some(Command::Memory { cmd }) => {
             // Reads local stores only (list) / writes one rule file
             // (promote) — works with zero API keys.
@@ -1361,6 +1371,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Cloud { .. }
         | Command::Telemetry { .. }
         | Command::Memory { .. }
+        | Command::Scoreboard
         | Command::Ingest(_)
         | Command::Mcp { .. }
         | Command::Connect { .. }

--- a/stella-cli/src/scoreboard_cmd.rs
+++ b/stella-cli/src/scoreboard_cmd.rs
@@ -1,0 +1,250 @@
+//! `stella scoreboard` — what the work cost, and whether anyone said it was good.
+//!
+//! Four numbers per unit of work: how many times intelligence was invoked, how
+//! much a person had to type, how many times they came back, and what they
+//! thought of the result. Three are counted from rows the store already writes.
+//! The fourth is read from a pull request somebody merged or closed.
+//!
+//! No model judges anything here, which is the point. The store does carry a
+//! rating field — `execution_reflection.self_rating` — and it is deliberately
+//! not used: it is the model grading its own homework.
+//!
+//! The arithmetic lives in [`stella_core::scoreboard`] and is unit-tested there.
+//! This module reads rows, maps a PR status to a verdict, and renders.
+
+use colored::Colorize;
+
+use stella_core::scoreboard::{Event, Scoreboard, Trend, Verdict, VerdictSource, summarize};
+use stella_store::Store;
+use stella_store::scoreboard::SessionRollup;
+
+/// Map a pull-request status to a person's verdict.
+///
+/// `draft` and `open` are not verdicts. Work still in flight has not been
+/// judged, and counting it as anything would be inventing an opinion nobody
+/// expressed — which is the failure this whole surface exists to avoid.
+fn verdict_of(status: &str) -> Option<(Verdict, VerdictSource)> {
+    match status {
+        "merged" => Some((Verdict::Good, VerdictSource::PrMerged)),
+        "closed" => Some((Verdict::Bad, VerdictSource::PrAbandoned)),
+        _ => None,
+    }
+}
+
+/// Rebuild the event sequence a rollup summarises, so the shared, tested
+/// arithmetic in `stella-core` produces the numbers rather than this module
+/// re-deriving them.
+///
+/// Every execution begins with something a person typed, so N executions are N
+/// human inputs and N model calls — which makes follow-ups `N - 1`. The prompt
+/// characters are already summed by the query, so they ride on the first input;
+/// the scoreboard totals them either way.
+///
+/// `interrupted` is never set: nothing in the store distinguishes a human
+/// cancellation from a provider error today. See the note in
+/// `stella_store::scoreboard`.
+fn events_for(rollup: &SessionRollup) -> Vec<Event> {
+    let mut events = Vec::new();
+    for index in 0..rollup.executions {
+        events.push(Event::HumanInput {
+            chars: if index == 0 { rollup.prompt_chars } else { 0 },
+            interrupted: false,
+        });
+        events.push(Event::ModelCall);
+    }
+    for _ in 0..rollup.tool_calls {
+        events.push(Event::ToolCall);
+    }
+    events
+}
+
+fn board_for(rollup: &SessionRollup) -> Scoreboard {
+    let board = Scoreboard::from_events(&events_for(rollup));
+    match rollup.pr_status.as_deref().and_then(verdict_of) {
+        Some((verdict, source)) => board.rated(verdict, source),
+        None => board,
+    }
+}
+
+fn verdict_cell(board: &Scoreboard) -> String {
+    match board.verdict {
+        Some((Verdict::Good, _)) => "good".green().to_string(),
+        Some((Verdict::Mixed, _)) => "mixed".yellow().to_string(),
+        Some((Verdict::Bad, _)) => "bad".red().to_string(),
+        None => "unrated".dimmed().to_string(),
+    }
+}
+
+fn render(rollups: &[SessionRollup], boards: &[Scoreboard], trend: &Trend) {
+    println!("\n{}", "Delivery scoreboard".bold());
+    println!(
+        "{}",
+        format!(
+            "{} task{}, {} rated ({:.0}% coverage)",
+            trend.tasks,
+            if trend.tasks == 1 { "" } else { "s" },
+            trend.tasks - trend.unrated,
+            trend.coverage() * 100.0
+        )
+        .dimmed()
+    );
+
+    println!(
+        "\n  {:<26} {:>6} {:>7} {:>10} {:>10}  {}",
+        "SESSION".dimmed(),
+        "CALLS".dimmed(),
+        "TOOLS".dimmed(),
+        "TYPED".dimmed(),
+        "FOLLOW-UPS".dimmed(),
+        "VERDICT".dimmed()
+    );
+    for (rollup, board) in rollups.iter().zip(boards) {
+        let session: String = rollup.session_id.chars().take(26).collect();
+        println!(
+            "  {session:<26} {:>6} {:>7} {:>10} {:>10}  {}",
+            board.model_calls,
+            board.tool_calls,
+            board.supplied_chars,
+            board.follow_ups,
+            verdict_cell(board)
+        );
+    }
+
+    if trend.unrated == trend.tasks {
+        println!(
+            "\n{}",
+            "Nothing is rated yet, so no averages are shown. Open a pull request from a \
+             session and its merge decision becomes that session's verdict."
+                .dimmed()
+        );
+    } else {
+        println!("\n{}", "Averages, over rated tasks only".bold());
+        println!(
+            "  {:<22}{:.1}\n  {:<22}{:.0}\n  {:<22}{:.1}\n  {:<22}{} of {}",
+            "calls",
+            trend.mean_model_calls,
+            "characters typed",
+            trend.mean_supplied_chars,
+            "follow-ups",
+            trend.mean_follow_ups,
+            "delivered first try",
+            trend.one_shot,
+            trend.tasks - trend.unrated
+        );
+    }
+
+    // Stated, not implied. A number missing from a scoreboard is indistinguishable
+    // from a number that is zero unless the scoreboard says which it is.
+    println!(
+        "\n{}",
+        "Interrupts are not counted: the store records a human cancellation and a \
+         provider error as the same outcome."
+            .dimmed()
+    );
+}
+
+/// Entry point for `stella scoreboard`.
+pub fn run() -> Result<(), String> {
+    let root =
+        std::env::current_dir().map_err(|e| format!("cannot read working directory: {e}"))?;
+    let store = Store::open(&root).map_err(|e| format!("cannot open the workspace store: {e}"))?;
+    let rollups = store
+        .session_rollups()
+        .map_err(|e| format!("cannot read session rollups: {e}"))?;
+
+    if rollups.is_empty() {
+        println!("No finished sessions in this workspace yet.");
+        return Ok(());
+    }
+
+    let boards: Vec<Scoreboard> = rollups.iter().map(board_for).collect();
+    let trend = summarize(&boards);
+    render(&rollups, &boards, &trend);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rollup(session: &str, executions: u32, chars: u64, pr: Option<&str>) -> SessionRollup {
+        SessionRollup {
+            session_id: session.to_string(),
+            executions,
+            tool_calls: 3,
+            prompt_chars: chars,
+            pr_status: pr.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn a_merged_pull_request_is_a_good_verdict_and_a_closed_one_is_bad() {
+        assert_eq!(
+            verdict_of("merged"),
+            Some((Verdict::Good, VerdictSource::PrMerged))
+        );
+        assert_eq!(
+            verdict_of("closed"),
+            Some((Verdict::Bad, VerdictSource::PrAbandoned))
+        );
+    }
+
+    /// Work still in flight has not been judged. Counting it would invent an
+    /// opinion nobody expressed.
+    #[test]
+    fn an_open_or_draft_pull_request_is_not_a_verdict() {
+        assert_eq!(verdict_of("open"), None);
+        assert_eq!(verdict_of("draft"), None);
+        assert_eq!(verdict_of("anything-else"), None);
+    }
+
+    #[test]
+    fn a_session_with_no_pull_request_stays_unrated() {
+        let board = board_for(&rollup("s", 2, 40, None));
+        assert!(!board.is_rated());
+        assert!(!board.was_one_shot(), "unrated work read as one-shot");
+    }
+
+    #[test]
+    fn the_first_execution_is_not_a_follow_up() {
+        assert_eq!(board_for(&rollup("s", 1, 10, None)).follow_ups, 0);
+        assert_eq!(board_for(&rollup("s", 4, 10, None)).follow_ups, 3);
+    }
+
+    #[test]
+    fn calls_tools_and_typed_characters_survive_the_round_trip() {
+        let board = board_for(&rollup("s", 3, 250, Some("merged")));
+        assert_eq!(board.model_calls, 3);
+        assert_eq!(board.tool_calls, 3);
+        assert_eq!(board.supplied_chars, 250);
+        assert!(board.is_rated());
+    }
+
+    #[test]
+    fn interrupts_are_never_synthesised() {
+        let board = board_for(&rollup("s", 5, 99, Some("merged")));
+        assert_eq!(
+            board.interrupts, 0,
+            "an interrupt was invented from data that cannot express one"
+        );
+    }
+
+    #[test]
+    fn coverage_reflects_only_sessions_with_a_decided_pull_request() {
+        let boards: Vec<Scoreboard> = [
+            rollup("a", 1, 10, Some("merged")),
+            rollup("b", 1, 10, Some("open")),
+            rollup("c", 1, 10, None),
+            rollup("d", 1, 10, Some("closed")),
+        ]
+        .iter()
+        .map(board_for)
+        .collect();
+        let trend = summarize(&boards);
+        assert_eq!(trend.tasks, 4);
+        assert_eq!(trend.unrated, 2, "open/absent PRs counted as rated");
+        assert_eq!(trend.good, 1);
+        assert_eq!(trend.bad, 1);
+        assert_eq!(trend.coverage(), 0.5);
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -159,6 +159,7 @@ pub mod integrity;
 pub mod journal;
 pub mod notify;
 pub mod prune;
+pub mod scoreboard;
 pub mod sessions;
 pub mod usage;
 

--- a/stella-store/src/scoreboard.rs
+++ b/stella-store/src/scoreboard.rs
@@ -1,0 +1,177 @@
+//! Per-session rollups for the delivery scoreboard.
+//!
+//! Three of the scoreboard's four numbers are countable from rows this store
+//! already writes: model calls and the characters a person typed come from
+//! `executions`, tool calls from `tool_calls`, and the verdict — when the work
+//! produced a pull request — from `pull_requests.status`.
+//!
+//! Nothing here judges anything. The rollup is arithmetic over recorded events,
+//! and the one subjective field is read from a PR that a human merged or closed.
+//!
+//! # What is deliberately absent
+//!
+//! **Interrupts.** A follow-up that stopped the agent mid-flight is the one
+//! correction signal needing no interpretation, and nothing in this store
+//! records it — `executions.outcome` collapses a human cancellation and a
+//! provider error into `aborted`. [`SessionRollup`] therefore does not carry an
+//! interrupt count at all, rather than carrying a zero that would read as "none
+//! happened".
+
+use rusqlite::Result;
+
+use crate::Store;
+
+/// One session's countable facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRollup {
+    pub session_id: String,
+    /// Executions in the session. Each is one invocation of the model, and each
+    /// begins with something a person typed.
+    pub executions: u32,
+    /// Tool calls across those executions.
+    pub tool_calls: u32,
+    /// Characters a person typed, summed over the executions' prompts.
+    pub prompt_chars: u64,
+    /// The status of a pull request produced by this session, when there is
+    /// one: `draft` | `open` | `merged` | `closed`.
+    pub pr_status: Option<String>,
+}
+
+impl Store {
+    /// Roll up every session that has at least one finished execution.
+    ///
+    /// Ordered by session id so the output is stable across runs — a scoreboard
+    /// whose row order moves is one nobody can diff.
+    ///
+    /// Sessions are the unit here because they are the only span this store
+    /// already delimits. That is a placeholder for a configurable unit, not a
+    /// claim that a session is the right one: the unit that matters is whatever
+    /// a person forms an opinion about, which is why the PR join exists.
+    pub fn session_rollups(&self) -> Result<Vec<SessionRollup>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT e.session_id,
+                    COUNT(DISTINCT e.id),
+                    COALESCE(SUM(LENGTH(e.prompt)), 0),
+                    (SELECT COUNT(*) FROM tool_calls tc
+                       JOIN executions e2 ON e2.id = tc.execution_id
+                      WHERE e2.session_id = e.session_id),
+                    (SELECT p.status FROM pull_requests p
+                      WHERE p.session_id = e.session_id
+                      ORDER BY p.updated_at DESC LIMIT 1)
+               FROM executions e
+              WHERE e.session_id IS NOT NULL
+                AND e.session_id <> ''
+                AND e.outcome IS NOT NULL
+              GROUP BY e.session_id
+              ORDER BY e.session_id ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(SessionRollup {
+                session_id: row.get(0)?,
+                executions: row.get::<_, i64>(1)?.try_into().unwrap_or(u32::MAX),
+                prompt_chars: row.get::<_, i64>(2)?.try_into().unwrap_or(0),
+                tool_calls: row.get::<_, i64>(3)?.try_into().unwrap_or(u32::MAX),
+                pr_status: row.get(4)?,
+            })
+        })?;
+        rows.collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Store;
+
+    fn store(dir: &tempfile::TempDir) -> Store {
+        Store::open(dir.path()).expect("open")
+    }
+
+    fn finished(store: &Store, session: &str, prompt: &str) -> i64 {
+        let id = store
+            .begin_execution("chat", prompt, "anthropic", "claude")
+            .expect("begin");
+        store.set_execution_session(id, session).expect("session");
+        store
+            .finish_execution_accounted(id, "completed", 0.0, true)
+            .expect("finish");
+        id
+    }
+
+    #[test]
+    fn a_session_with_no_finished_execution_is_not_rolled_up() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let s = store(&dir);
+        let id = s
+            .begin_execution("chat", "hello", "anthropic", "claude")
+            .expect("begin");
+        s.set_execution_session(id, "sess-open").expect("session");
+        assert!(s.session_rollups().expect("rollup").is_empty());
+    }
+
+    #[test]
+    fn executions_and_prompt_chars_are_summed_per_session() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let s = store(&dir);
+        finished(&s, "sess-a", "12345");
+        finished(&s, "sess-a", "123");
+        finished(&s, "sess-b", "1");
+
+        let rollups = s.session_rollups().expect("rollup");
+        assert_eq!(rollups.len(), 2, "{rollups:?}");
+        assert_eq!(rollups[0].session_id, "sess-a");
+        assert_eq!(rollups[0].executions, 2);
+        assert_eq!(rollups[0].prompt_chars, 8);
+        assert_eq!(rollups[1].session_id, "sess-b");
+        assert_eq!(rollups[1].executions, 1);
+    }
+
+    #[test]
+    fn a_session_without_a_pull_request_has_no_verdict_source() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let s = store(&dir);
+        finished(&s, "sess-a", "hello");
+        assert_eq!(s.session_rollups().expect("rollup")[0].pr_status, None);
+    }
+
+    #[test]
+    fn the_most_recent_pull_request_status_wins() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let s = store(&dir);
+        finished(&s, "sess-a", "hello");
+        s.upsert_pull_request(
+            Some("sess-a"),
+            "https://x/pull/1",
+            Some(1),
+            "open",
+            None,
+            100,
+        )
+        .expect("open");
+        s.upsert_pull_request(
+            Some("sess-a"),
+            "https://x/pull/1",
+            Some(1),
+            "merged",
+            None,
+            200,
+        )
+        .expect("merged");
+        assert_eq!(
+            s.session_rollups().expect("rollup")[0].pr_status.as_deref(),
+            Some("merged")
+        );
+    }
+
+    #[test]
+    fn rollups_are_ordered_and_deterministic() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let s = store(&dir);
+        finished(&s, "sess-z", "z");
+        finished(&s, "sess-a", "a");
+        let first = s.session_rollups().expect("rollup");
+        let ids: Vec<&str> = first.iter().map(|r| r.session_id.as_str()).collect();
+        assert_eq!(ids, vec!["sess-a", "sess-z"]);
+        assert_eq!(first, s.session_rollups().expect("rollup"));
+    }
+}


### PR DESCRIPTION
## What & why

Two changes. I intended to ship these as separate PRs and pushed them to one branch — flagging that rather than force-pushing to tidy it. They are independent commits, and the ADR being **Proposed** blocks nothing here, so merging them together does not couple the decisions.

---

# 1. ADR 0011 — Context Records Are TOML

Supersedes the *surface* decision in ADR 0008 and preserves its thesis. Filed as **Proposed**, not Accepted: every ratified ADR in this tree records who ratified it and when, so this one needs the repository owner rather than self-ratification.

### Why 0008 needs superseding now

0008 chose Markdown and rejected the `.yaml` surface, and was careful to call that a *surface* conflict because the thesis was shared. That reasoning still holds. What changed is what the surface has to carry.

When 0008 was written, a rule file was a `description` line and up to three guard keys. Today `rules/metadata.rs` validates **eleven required fields** with enum parsing, RFC-3339 timestamps, list parsing and duplicate detection — a typed record serialised into a document header.

The parser underneath it is not a YAML parser. It hand-rolls ~35 lines: `key: value` scalars plus block sequences flattened to a comma-joined string. No nesting — and a nested key is **silently promoted to the top level**, not rejected.

Two consequences carry the decision:

1. **`docs/context-pr.md` §6.1's own example does not parse as written.** Its nested `scope:` block flattens and nothing errors.
2. **Adding a field means extending a bespoke parser**, not adopting a format.

### TOML over YAML

Not 0008's rejection revisited — that stands, and the ADR says so. `toml` is already a workspace dependency and `serde_yaml` is not one at all; TOML brings native RFC 3339 datetimes (retiring the hand-rolled byte-index validator), real integers for a `confidence` specified 0–100, real arrays, and no implicit coercion.

### Hash-neutral

`record_hash` is RFC 8785 canonical JSON over the *serialised struct*. The on-disk surface never enters the preimage, so no `record_id` changes and no revision is minted by the format change itself.

### Scope

Explicitly **not** decided: the field schema (constrained by 0009's enum freeze), and whether `.claude/rules/` stays a live read path. 0008 is annotated in place, body untouched — the ADR README is explicit that rewriting a record to cite what came later falsifies it.

---

# 2. Wire the scoreboard

The `stella_core::scoreboard` module has had no callers since it landed. This connects it, **with no schema change** — every number it needs is already in the store.

| number | source |
| --- | --- |
| calls, characters typed | `executions` |
| tool calls | `tool_calls` |
| verdict | `pull_requests.status` for the session |

**The verdict is free.** A merged PR is a person saying the work was acceptable; a closed one is a person saying it wasn't. `draft` and `open` map to *no verdict* — work in flight has not been judged, and counting it would invent an opinion nobody expressed.

Driven against a seeded workspace:

```
Delivery scoreboard
3 tasks, 2 rated (67% coverage)

  SESSION                     CALLS   TOOLS      TYPED FOLLOW-UPS  VERDICT
  ship-ingest                     2       0         46          1  good
  spike-idea                      3       0         37          2  bad
  write-adr                       1       0         30          0  unrated

Averages, over rated tasks only
  calls                 2.5
  characters typed      42
  follow-ups            1.5
  delivered first try   0 of 2

Interrupts are not counted: the store records a human cancellation and a
provider error as the same outcome.
```

The open PR correctly sits out of the averages while still counting toward the total.

**Deliberately unused:** `execution_reflection.self_rating`. That is the model grading its own homework.

**Interrupts are still not counted, and the output says so** rather than printing a zero. `executions.outcome` collapses a human cancellation and a provider error into `aborted`, so the store cannot express the difference. `SessionRollup` carries no interrupt field at all rather than one that would always read zero — a number missing from a scoreboard is indistinguishable from a number that is zero unless the scoreboard says which it is.

**Sessions are the unit** because they are the only span the store already delimits. That is a placeholder for a configurable unit, documented as such, not a claim that a session is right.

## The witness

- [x] Witness tests included — 12 new (5 store, 7 CLI), asserting both directions.

The load-bearing ones: an open or draft PR is **not** a verdict; a session with no PR stays unrated and does not read as one-shot; coverage counts only decided PRs; and `interrupts_are_never_synthesised`, which fails if the mapping ever invents an interrupt from data that cannot express one.

Verified by driving the binary against a seeded workspace, not only unit tests.

## The gate

- [x] `cargo fmt --check` · `clippy -D warnings` · `cargo doc -D warnings` · `cargo test --workspace` · `check-file-size` · `check-no-scratch` — full `make gate` green (65 test binaries).

The one-line baseline raise is `stella-store/src/lib.rs` gaining a `pub mod scoreboard;` declaration — the irreducible case `check-file-size` names.
