### PR TITLE
fix(stella-tui): show `!` shell output in the session transcript

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5345,7 +5345,7 @@ The full deck command set — including `/inspect` and `/context` — is on
 **⏎** inserts a line break; **⌘⏎ / ⌃⏎** submits. Prompts queue while a turn
 runs — you never wait for the agent to finish before typing the next thing
 (**Ctrl-T** opens the queue editor). A `!`-prefixed line runs a shell command
-immediately in its own lane, skipping the queue. A single **Esc** cancels the in-flight turn;
+immediately, inline in the session transcript, skipping the queue. A single **Esc** cancels the in-flight turn;
 **double-Esc** cancels *and holds* dispatch so what you type next runs first.
 Prefer a plain line-based REPL? `stella --plain` (or `STELLA_PLAIN=1`).
 
@@ -8352,7 +8352,7 @@ Running `stella` on a real terminal opens the **Command Deck** — the tabbed
 TUI over the engine. Each prompt becomes a lead-agent turn; `/pipeline`
 toggles between staged turns (the default) and the raw step loop. The deck
 is more than a chat surface: prompts queue while a turn runs, `!` lines run
-shell commands in their own lane, `>` steers the turn in flight, Esc
+shell commands inline in the transcript, `>` steers the turn in flight, Esc
 soft-stops (both below), and tabs expose the session's
 files, diff, code graph, skills, MCP servers, the AGENTS tab with live
 executions, and the SETTINGS tab's

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -10,8 +10,8 @@
 //! agent's status live. Agent pids are the demo process's own, so the CPU/MEM
 //! columns show real numbers. Ctrl-C quits.
 //!
-//! Also demoable here: `!ls` runs a real shell command immediately on its own
-//! `shell` lane; `/` opens the command popup; `ctrl+t` (or `↑` while prompts
+//! Also demoable here: `!ls` runs a real shell command immediately, inline in
+//! the focused agent's transcript; `/` opens the command popup; `ctrl+t` (or `↑` while prompts
 //! are queued) opens the queue editor; `ctrl+r` expands collapsed thinking.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -337,6 +337,18 @@ impl WorkspaceModel {
                 }
             }
             Inbound::Event { agent, event } => self.apply_event(agent, event),
+            // Local `!` output: transcript only. See `Inbound::ShellEvent` for
+            // why this must not go through `apply_event` — the status it would
+            // derive (`Running`) has nothing to park it. An unknown id is a
+            // no-op rather than an auto-register: the caller only ever names a
+            // lane it already resolved, and the no-lane case takes the
+            // synthetic fallback instead.
+            Inbound::ShellEvent { agent, event } => {
+                if let Some(idx) = self.index_of(agent) {
+                    self.agents[idx].model.apply(event);
+                    self.agents[idx].last_activity_ms = self.now_ms;
+                }
+            }
             Inbound::Status { agent, status } => {
                 // Auto-register an unknown id, exactly like `Event`:
                 // supervisor states (`Paused`, `Killed`, …) are not

--- a/stella-tui/src/deck/tests.rs
+++ b/stella-tui/src/deck/tests.rs
@@ -785,3 +785,107 @@ fn activity_spark_pads_and_caps() {
     }
     assert_eq!(s.padded(), vec![1, 2, 3, 4]); // capped at width 4
 }
+
+fn shell_ev(agent: &str, event: AgentEvent) -> Inbound {
+    Inbound::ShellEvent {
+        agent: agent.into(),
+        event,
+    }
+}
+
+fn shell_start(call_id: &str, cmd: &str) -> AgentEvent {
+    AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: call_id.into(),
+            name: "shell".into(),
+            input: serde_json::json!({ "cmd": cmd }),
+        },
+    }
+}
+
+fn shell_result(call_id: &str, out: &str) -> AgentEvent {
+    AgentEvent::ToolResult {
+        call_id: call_id.into(),
+        output: ToolOutput::Ok {
+            content: out.into(),
+        },
+        duration_ms: 1,
+        speculated: false,
+    }
+}
+
+#[test]
+fn bang_shell_output_lands_in_the_focused_session_transcript() {
+    // The whole point of `ShellEvent`: `! pwd` answers where it was asked.
+    // `views::session::render` draws only `agents[ui.focused]`, so output
+    // routed to any other lane is output the user never sees.
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+
+    w.apply_inbound(&shell_ev("lead", shell_start("shell-0-0", "pwd")));
+    w.apply_inbound(&shell_ev(
+        "lead",
+        shell_result("shell-0-0", "/Users/macanderson"),
+    ));
+
+    assert_eq!(w.agents.len(), 1, "no second lane is spawned to hide it in");
+    let transcript = &w.agents[0].model.transcript;
+    assert_eq!(transcript.len(), 2, "the tool row lands in THIS transcript");
+    match &transcript[1] {
+        crate::model::TranscriptEntry::ToolResult { ok, full, .. } => {
+            assert!(ok, "a zero exit reads as success");
+            assert!(
+                full.contains("/Users/macanderson"),
+                "the command's stdout is what gets rendered, got {full:?}"
+            );
+        }
+        other => panic!("expected a ToolResult row, got {other:?}"),
+    }
+}
+
+#[test]
+fn bang_shell_output_never_disturbs_the_agent_it_borrows() {
+    // A `!` command is user-initiated local shell, not agent activity. The
+    // lane lends its transcript and nothing else: `status_from_event` maps
+    // ToolStart/ToolResult to `Running`, and an agent flipped Running by a
+    // shell command would spin forever — no engine turn exists to park it.
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    let status = w.agents[0].status;
+    let title = w.agents[0].meta.title.clone();
+    let tokens_in = w.agents[0].tokens_in;
+    let traces = w.trace.rows.len();
+
+    w.apply_inbound(&shell_ev("lead", shell_start("shell-0-0", "pwd")));
+    w.apply_inbound(&shell_ev(
+        "lead",
+        shell_result("shell-0-0", "/Users/macanderson"),
+    ));
+
+    assert_eq!(
+        w.agents[0].status, status,
+        "the agent never flips to Running"
+    );
+    assert_eq!(w.agents[0].meta.title, title, "the session keeps its title");
+    assert_eq!(
+        w.agents[0].tokens_in, tokens_in,
+        "local shell costs nothing"
+    );
+    assert_eq!(w.trace.rows.len(), traces, "not the agent's trace activity");
+}
+
+#[test]
+fn a_bang_shell_event_for_an_unknown_lane_is_dropped_not_auto_registered() {
+    // Unlike `Event`, `ShellEvent` never conjures a lane: the no-lane case is
+    // exactly what the synthetic fallback in `spawn_shell_command` covers, and
+    // auto-registering here would resurrect the off-screen lane this fixes.
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    w.apply_inbound(&shell_ev("ghost", shell_start("shell-0-0", "pwd")));
+
+    assert_eq!(w.agents.len(), 1, "no lane is created for an unknown id");
+    assert!(
+        w.agents[0].model.transcript.is_empty(),
+        "and none is misrouted"
+    );
+}

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -29,8 +29,8 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use crate::composer::{Composer, SlashCommand};
 use crate::deck::WorkspaceModel;
 use crate::deck_render::render_deck;
-use crate::deck_ui::{DeckAction, DeckUi, handle_deck_key, ingest_inbound};
-use crate::envelope::{AgentMeta, AgentStatus, Inbound, WorkspaceInput};
+use crate::deck_ui::{DeckAction, DeckUi, focused_id, handle_deck_key, ingest_inbound};
+use crate::envelope::{AgentId, AgentMeta, AgentStatus, Inbound, WorkspaceInput};
 use crate::graph::GraphSnapshot;
 use crate::resource::ResourceMonitor;
 use crate::shell::DebugLog;
@@ -41,8 +41,11 @@ use crate::theme;
 /// gauge / elapsed timers live without busy-spinning.
 const TICK: Duration = Duration::from_millis(33);
 
-/// The synthetic agent id `!` shell commands run under — they get their own
-/// dashboard lane and transcript instead of polluting a real agent's fold.
+/// The synthetic agent id a `!` shell command falls back to when the deck has
+/// no agent registered yet. Normally a command borrows the focused agent's
+/// lane instead, so its output reads inline in the transcript the user is
+/// looking at — see [`spawn_shell_command`]. This lane exists so output is
+/// never dropped in the gap before the session registers.
 const SHELL_AGENT: &str = "shell";
 
 /// Cap on captured shell output fed back as an event. Head and tail are both
@@ -84,12 +87,24 @@ fn now_ms() -> u64 {
 
 /// Run one `!` shell command **immediately** on the local event lane.
 ///
-/// The command gets the synthetic [`SHELL_AGENT`] lane: a `Register` (idempotent
-/// — re-registering only refreshes the title to the latest command), a
-/// `ToolStart` so the invocation is visible the instant it launches, and a
-/// `ToolResult` + terminal `Status` when it finishes. stdout and stderr are
-/// both captured; a non-zero exit reports as a tool error. The TUI never
-/// blocks on the child — it runs on a spawned task and reports back over `tx`.
+/// `target` is the lane the output belongs to. `Some(agent)` — the normal
+/// case — is the lane the user is actually reading (the focused agent), so a
+/// `!` command reads inline in the session transcript exactly like Claude
+/// Code's bash mode. Those events go out as [`Inbound::ShellEvent`], which
+/// folds into the transcript and nothing else; the lane gets no `Register`
+/// (re-registering an existing agent overwrites its meta, renaming the
+/// session to `! cmd` and restyling it as a shell row) and no terminal
+/// `Status` (which would clobber the real agent's own lifecycle).
+///
+/// `None` — only when the deck has no agent registered yet — falls back to
+/// the synthetic [`SHELL_AGENT`] lane and its original shape: a `Register`
+/// (idempotent — re-registering only refreshes the title to the latest
+/// command), a `ToolStart`, and a `ToolResult` + terminal `Status`. Output is
+/// never dropped just because no session lane exists yet.
+///
+/// Either way stdout and stderr are both captured; a non-zero exit reports as
+/// a tool error. The TUI never blocks on the child — it runs on a spawned
+/// task and reports back over `tx`.
 ///
 /// `active` counts shell commands currently in flight on the shared
 /// [`SHELL_AGENT`] lane. Because immediate `!` commands can overlap (a second
@@ -102,8 +117,24 @@ fn spawn_shell_command(
     tx: UnboundedSender<Inbound>,
     started_ms: u64,
     active: Arc<AtomicUsize>,
+    target: Option<AgentId>,
 ) {
     use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+
+    // A synthetic lane owns its whole lifecycle (register + park); a real
+    // lane owns none of it and only lends its transcript.
+    let synthetic = target.is_none();
+    let agent_id: AgentId = target.unwrap_or_else(|| SHELL_AGENT.to_string());
+    // Route by lane kind: `ShellEvent` is transcript-only (safe for a live
+    // agent), `Event` carries the full fold the synthetic lane still wants so
+    // its row shows Running while the child is alive.
+    let envelope = move |agent: AgentId, event: AgentEvent| {
+        if synthetic {
+            Inbound::Event { agent, event }
+        } else {
+            Inbound::ShellEvent { agent, event }
+        }
+    };
 
     // `started_ms` is the deck's tick clock (~33ms granularity), so two
     // overlapping `!` commands can share a timestamp — and the fold pairs
@@ -113,19 +144,24 @@ fn spawn_shell_command(
     let seq = SHELL_CALL_SEQ.fetch_add(1, Ordering::Relaxed);
     let call_id = format!("shell-{started_ms}-{seq}");
     active.fetch_add(1, Ordering::SeqCst);
-    let _ = tx.send(Inbound::Register(
-        AgentMeta::new(SHELL_AGENT, format!("! {cmd}"), started_ms).with_role("shell"),
-    ));
-    let _ = tx.send(Inbound::Event {
-        agent: SHELL_AGENT.to_string(),
-        event: AgentEvent::ToolStart {
+    // Only the synthetic lane is registered. Sending this for a real agent
+    // would overwrite its meta — `WorkspaceModel::register` replaces `meta`
+    // wholesale on a known id — retitling the session `! cmd`.
+    if synthetic {
+        let _ = tx.send(Inbound::Register(
+            AgentMeta::new(SHELL_AGENT, format!("! {cmd}"), started_ms).with_role("shell"),
+        ));
+    }
+    let _ = tx.send(envelope(
+        agent_id.clone(),
+        AgentEvent::ToolStart {
             call: ToolCall {
                 call_id: call_id.clone(),
                 name: "shell".to_string(),
                 input: serde_json::json!({ "cmd": cmd }),
             },
         },
-    });
+    ));
 
     tokio::spawn(async move {
         let started = std::time::Instant::now();
@@ -184,22 +220,26 @@ fn spawn_shell_command(
         } else {
             ToolOutput::Error { message: content }
         };
-        let _ = tx.send(Inbound::Event {
-            agent: SHELL_AGENT.to_string(),
-            event: AgentEvent::ToolResult {
+        let _ = tx.send(envelope(
+            agent_id.clone(),
+            AgentEvent::ToolResult {
                 call_id,
                 output,
                 duration_ms: started.elapsed().as_millis() as u64,
                 speculated: false,
             },
-        });
+        ));
         // Park the lane so it never reads as still-working (a lingering
         // Running shell agent would keep the spinner alive forever) — but
         // only once this was the last command in flight; `fetch_sub` returns
         // the pre-decrement count, so `1` means we just brought it to zero.
-        if active.fetch_sub(1, Ordering::SeqCst) == 1 {
+        // Only the synthetic lane is ever parked: a real agent's status is
+        // the engine's to own, and stamping Done/Failed on it here would
+        // report the shell command's exit as the agent's own outcome.
+        let last = active.fetch_sub(1, Ordering::SeqCst) == 1;
+        if last && synthetic {
             let _ = tx.send(Inbound::Status {
-                agent: SHELL_AGENT.to_string(),
+                agent: agent_id,
                 status: if ok {
                     AgentStatus::Done
                 } else {
@@ -457,12 +497,21 @@ pub async fn run_deck(
                                 // `!` commands run NOW — never queued, never
                                 // waiting on the engine. Output returns on the
                                 // local lane as ordinary events.
+                                //
+                                // It lands in the transcript the user is
+                                // reading — the focused agent's — so `! pwd`
+                                // answers where they asked, like Claude Code.
+                                // Before any agent registers there is no such
+                                // lane, and only then does it fall back to the
+                                // synthetic one.
                                 debug.note(&format!("shell: {cmd}"));
+                                let target = focused_id(&model, &ui);
                                 spawn_shell_command(
                                     cmd,
                                     local_tx.clone(),
                                     model.now_ms,
                                     shell_active.clone(),
+                                    target,
                                 );
                             }
                             DeckAction::Handled | DeckAction::Ignored => {}
@@ -594,7 +643,7 @@ mod tests {
         let _guard = rt.enter();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let active = Arc::new(AtomicUsize::new(0));
-        spawn_shell_command("echo hi".into(), tx, 42, active);
+        spawn_shell_command("echo hi".into(), tx, 42, active, None);
         match rx.try_recv() {
             Ok(Inbound::Register(meta)) => {
                 assert_eq!(meta.id, SHELL_AGENT);
@@ -615,6 +664,39 @@ mod tests {
     }
 
     #[test]
+    fn a_targeted_shell_command_borrows_the_lane_without_registering_or_parking_it() {
+        // The real-lane shape: no `Register` (it would overwrite the agent's
+        // meta) and no terminal `Status` (it would report the command's exit
+        // as the agent's own outcome). Just transcript-only `ShellEvent`s.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let active = Arc::new(AtomicUsize::new(0));
+        spawn_shell_command("echo hi".into(), tx, 42, active, Some("lead".into()));
+
+        match rx.try_recv() {
+            Ok(Inbound::ShellEvent { agent, .. }) => assert_eq!(agent, "lead"),
+            other => panic!("expected a ShellEvent ToolStart first, got {other:?}"),
+        }
+        // Drain the async completion, then assert on everything that landed.
+        rt.block_on(async {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await;
+        });
+        let mut rest = Vec::new();
+        while let Ok(inbound) = rx.try_recv() {
+            rest.push(inbound);
+        }
+        assert!(
+            !rest.iter().any(|i| matches!(i, Inbound::Register(_))),
+            "a real lane is never re-registered: {rest:?}"
+        );
+        assert!(
+            !rest.iter().any(|i| matches!(i, Inbound::Status { .. })),
+            "a real lane is never parked by a `!` command: {rest:?}"
+        );
+    }
+
+    #[test]
     fn overlapping_shell_commands_within_one_tick_get_distinct_call_ids() {
         // Two `!` commands dispatched inside the same 33ms tick share
         // `started_ms`; the fold pairs ToolResult to ToolStart by `call_id`,
@@ -623,8 +705,8 @@ mod tests {
         let _guard = rt.enter();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let active = Arc::new(AtomicUsize::new(0));
-        spawn_shell_command("echo one".into(), tx.clone(), 42, active.clone());
-        spawn_shell_command("echo two".into(), tx, 42, active);
+        spawn_shell_command("echo one".into(), tx.clone(), 42, active.clone(), None);
+        spawn_shell_command("echo two".into(), tx, 42, active, None);
 
         let mut call_ids = Vec::new();
         while let Ok(inbound) = rx.try_recv() {
@@ -653,8 +735,8 @@ mod tests {
         let _guard = rt.enter();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let active = Arc::new(AtomicUsize::new(0));
-        spawn_shell_command("echo fast".into(), tx.clone(), 1, active.clone());
-        spawn_shell_command("sleep 0.2 && echo slow".into(), tx, 2, active);
+        spawn_shell_command("echo fast".into(), tx.clone(), 1, active.clone(), None);
+        spawn_shell_command("sleep 0.2 && echo slow".into(), tx, 2, active, None);
 
         rt.block_on(async {
             let mut statuses = Vec::new();

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -3240,8 +3240,8 @@ fn handle_skills_prompt_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
-/// The id of the focused agent, if any.
-fn focused_id(model: &WorkspaceModel, ui: &DeckUi) -> Option<AgentId> {
+/// The id of the focused agent, if any — also the lane a `!` command borrows.
+pub(crate) fn focused_id(model: &WorkspaceModel, ui: &DeckUi) -> Option<AgentId> {
     model.agents.get(ui.focused).map(|a| a.meta.id.clone())
 }
 

--- a/stella-tui/src/deck_ui/tests/queue.rs
+++ b/stella-tui/src/deck_ui/tests/queue.rs
@@ -460,3 +460,28 @@ fn a_refreshed_graph_snapshot_updates_the_view_out_of_band() {
     );
     assert_eq!(ui.graph.as_ref(), Some(&snapshot));
 }
+
+#[test]
+fn a_bang_command_targets_the_lane_the_reader_is_looking_at() {
+    // `deck_shell` resolves a `!` command's output lane with `focused_id`, so
+    // the output lands in the transcript being rendered. With several agents
+    // that must follow the focus, not default to the first row.
+    let model = model_with(&["lead", "worker"]);
+    let mut ui = ready_ui();
+    assert_eq!(focused_id(&model, &ui).as_deref(), Some("lead"));
+    ui.focus_agent(1);
+    assert_eq!(
+        focused_id(&model, &ui).as_deref(),
+        Some("worker"),
+        "`! pwd` answers in the transcript the user is reading"
+    );
+}
+
+#[test]
+fn a_bang_command_has_no_lane_to_borrow_before_any_agent_registers() {
+    // The one case that still needs the synthetic shell lane — output must
+    // not be dropped just because the session has not registered yet.
+    let model = model_with(&[]);
+    let ui = ready_ui();
+    assert_eq!(focused_id(&model, &ui), None);
+}

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -125,6 +125,21 @@ pub enum Inbound {
     Deregister { agent: AgentId },
     /// An `AgentEvent` belonging to one agent.
     Event { agent: AgentId, event: AgentEvent },
+    /// A local `!` shell command's output, folded into an EXISTING lane's
+    /// transcript so it reads inline in the session the user is looking at.
+    ///
+    /// Deliberately not [`Inbound::Event`]: that path derives agent status
+    /// from the event, and `ToolStart`/`ToolResult` both mean
+    /// [`AgentStatus::Running`] — so routing a `!` command through it would
+    /// flip an idle agent to Running and leave it spinning forever (nothing
+    /// parks a lane the engine never started). This variant touches the
+    /// transcript ONLY: no status, no token/cost counters, no trace row. A
+    /// `!` command is user-initiated local shell, not agent activity.
+    ///
+    /// Folding an unknown id is a no-op — unlike `Event`, it never
+    /// auto-registers, because a lane that does not exist is precisely the
+    /// case the synthetic fallback lane already covers.
+    ShellEvent { agent: AgentId, event: AgentEvent },
     /// A supervisor lifecycle transition not carried by the event stream.
     Status { agent: AgentId, status: AgentStatus },
     /// The dispatcher took the oldest queued prompt and handed it to an

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -210,7 +210,7 @@ Running `stella` on a real terminal opens the **Command Deck** — the tabbed
 TUI over the engine. Each prompt becomes a lead-agent turn; `/pipeline`
 toggles between staged turns (the default) and the raw step loop. The deck
 is more than a chat surface: prompts queue while a turn runs, `!` lines run
-shell commands in their own lane, `>` steers the turn in flight, Esc
+shell commands inline in the transcript, `>` steers the turn in flight, Esc
 soft-stops (both below), and tabs expose the session's
 files, diff, code graph, skills, MCP servers, the AGENTS tab with live
 executions, and the SETTINGS tab's

--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -102,7 +102,7 @@ The full deck command set — including `/inspect` and `/context` — is on
 **⏎** inserts a line break; **⌘⏎ / ⌃⏎** submits. Prompts queue while a turn
 runs — you never wait for the agent to finish before typing the next thing
 (**Ctrl-T** opens the queue editor). A `!`-prefixed line runs a shell command
-immediately in its own lane, skipping the queue. A single **Esc** cancels the in-flight turn;
+immediately, inline in the session transcript, skipping the queue. A single **Esc** cancels the in-flight turn;
 **double-Esc** cancels *and holds* dispatch so what you type next runs first.
 Prefer a plain line-based REPL? `stella --plain` (or `STELLA_PLAIN=1`).
 


### PR DESCRIPTION
## The bug

Typing `! pwd` into the deck prompt appeared to do nothing.

The command actually ran. Its output was just invisible: `spawn_shell_command`
registered a synthetic `shell` agent and emitted the ToolStart/ToolResult into
*that* lane, while `views::session::render` draws only
`model.agents.get(ui.focused)` — and nothing ever moves focus to the shell
lane. The output landed in a lane the reader never sees.

Everything upstream was already correct: `!` dispatch, argument stripping,
beating a pending ask-user gate, the process spawn and the env scrub. Only the
destination was wrong. (This is why it reproduces on a stock `stella` — the
single-session REPL in `ui.rs`/`shell.rs` is dead code; `command_deck`
delegates to the deck shell.)

## The fix

Route a `!` command's output to the focused agent's lane, so it reads inline in
the transcript where it was typed — Claude Code's bash-mode behaviour.

Retargeting is not simply "send it to the focused agent". Two traps, both
guarded by tests:

- `WorkspaceModel::register` replaces `meta` wholesale on a known id, so a
  `Register` for a live lane would retitle the session to `! cmd` and restyle
  it as a shell row. Only the synthetic lane is registered now.
- `status_from_event` maps ToolStart/ToolResult to `Running`, and the terminal
  `Status` parks the lane. Routed through the normal `Event` fold, a `!`
  command would flip an idle agent to Running with **no engine turn to park
  it** — an endless spinner — and stamp the command's exit as the agent's own
  outcome.

So `Inbound::ShellEvent` folds into the transcript and nothing else: no status,
no token/cost counters, no trace row. A `!` command is user-initiated local
shell, not agent activity. Unknown ids are dropped rather than auto-registered,
because the no-lane case is exactly what the synthetic fallback covers — still
used before any agent registers, so early output is never lost.

## Verification

Drove the **real deck** in a pty (`deck_demo`, 200x50), typed `! expr 424242 + 1`,
and rendered the final screen:

```
│● shell        expr 424242 + 1
│  ⎿ 424243                                    9ms
```

Inline in the focused transcript, beside the agent's own tool rows. The probe
checks the needle is absent *before* Enter, so it can't pass on the echoed
command text — and the identical probe against the pre-fix build finds
nothing on screen, reproducing the reported symptom.

Both fold behaviours are mutation-tested: no-op'ing the fold kills the
transcript test, and routing through `apply_event` (the naive fix) trips the
"never flips to Running" guard.

`make gate` passes (fmt, clippy `-D warnings`, doc-warnings, invariants,
file-size ratchet not raised, 591 stella-tui tests).

## Note

Docs described the old lane in three places (`deck_demo` header, two MDX
pages); updated, and `docs/llms.txt` regenerated via `make llms-txt`.

## Summary by Sourcery

Route `!` shell command output into the focused session transcript instead of an off-screen synthetic lane, while preserving a fallback lane before any agents register.

Bug Fixes:
- Fix `!` shell commands appearing to do nothing by ensuring their output is rendered inline in the focused agent's transcript.

Enhancements:
- Introduce a dedicated `ShellEvent` inbound variant that appends shell output to an existing lane's transcript without affecting agent status, tokens, or traces.
- Use the focused agent id as the target lane for `!` commands and restrict auto-registration to the synthetic shell lane only.

Documentation:
- Update deck demo and documentation to describe `!` commands as running inline in the session transcript and regenerate `docs/llms.txt`.

Tests:
- Add workspace, deck UI, and shell command tests to cover focused-lane routing, non-interference with agent state, dropping unknown shell lanes, and overlapping command behavior.