### PR TITLE
feat(stella-tui): terminal-green default theme + /theme light/dark switch

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -10,7 +10,7 @@
 2282 stella-cli/src/agent.rs
 1738 stella-cli/src/agent_tests.rs
 1627 stella-cli/src/candidate_ws.rs
-4633 stella-cli/src/command_deck.rs
+4659 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
 2125 stella-core/src/driver.rs
 2819 stella-core/src/driver/tests.rs
@@ -28,7 +28,7 @@
 1566 stella-tools/src/media.rs
 3204 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
-1741 stella-tui/src/deck_render.rs
+1783 stella-tui/src/deck_render.rs
 4096 stella-tui/src/deck_ui.rs
 1664 stella-tui/src/model.rs
 1660 stella-tui/src/views/engine.rs

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -106,6 +106,7 @@ mod authoring;
 mod forwarder;
 mod model_cmd;
 mod scope_gate;
+mod theme_cmd;
 use crate::memory::{SessionMemory, inject_recall_block};
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::subsession::{self, SubSessions, SupervisorMsg};
@@ -558,6 +559,12 @@ pub async fn run_deck_session(
         .as_ref()
         .and_then(|rs| rs.pipeline)
         .unwrap_or(true);
+    // Honour the persisted colour theme (`ui.theme`) before the deck spawns its
+    // render task, so the very first frame — the launch cinematic — is already
+    // in the chosen theme. Best-effort: an unset/unknown value keeps the
+    // default (`stella-dark`).
+    theme_cmd::apply_persisted(cfg);
+
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
         slash_commands: deck_slash_commands(&custom),
@@ -3438,6 +3445,10 @@ const DECK_BUILTINS: &[(&str, &str)] = &[
         "set the default model (persists; no arg shows current + list)",
     ),
     ("/models", "list providers & models (`refresh` re-syncs)"),
+    (
+        "/theme",
+        "switch colour theme (stella-dark · stella-light; persists; no arg shows current)",
+    ),
     ("/init", "index the workspace: domains + code graph"),
     (
         "/agents",
@@ -3901,6 +3912,9 @@ async fn run_deck_command(
         "/models" => {
             say(Config::available_models_plain(None));
         }
+        "/theme" => {
+            say(theme_cmd::current_summary(cfg));
+        }
         "/pipeline" => {
             *pipeline_on = !*pipeline_on;
             // Flip the PIPELINE stat box live — the deck renders exclusively
@@ -4031,6 +4045,18 @@ async fn run_deck_command(
                 }
                 return DeckCommand::Handled;
             }
+            // `/theme <slug>` — switch + persist the colour theme (parity with
+            // `/model`). The live switch is a buffer remap in `stella_tui`, so
+            // it lands on the next frame; here we just flip it and save.
+            if let Some(command) = theme_cmd::parse_theme_command(trimmed) {
+                match command {
+                    theme_cmd::ThemeCommand::Set(name) => match theme_cmd::set_theme(name) {
+                        Ok(msg) | Err(msg) => say(msg),
+                    },
+                    theme_cmd::ThemeCommand::Usage(arg) => say(theme_cmd::usage(&arg)),
+                }
+                return DeckCommand::Handled;
+            }
             // The `/models` argument forms first (see [`ModelsCommand`]):
             // handled model-free — a catalog refresh is part of digging out
             // of a broken model setting, so it can never be allowed to
@@ -4071,7 +4097,7 @@ async fn run_deck_command(
                 return DeckCommand::Prompt;
             }
             say(format!(
-                "unknown command `{trimmed}` — try /help, /clear, /models, /init, /agents, /pipeline, /export, /donate, /files, /diff, /graph"
+                "unknown command `{trimmed}` — try /help, /clear, /models, /theme, /init, /agents, /pipeline, /export, /donate, /files, /diff, /graph"
             ));
         }
     }

--- a/stella-cli/src/command_deck/theme_cmd.rs
+++ b/stella-cli/src/command_deck/theme_cmd.rs
@@ -1,0 +1,159 @@
+//! The `/theme` slash command — switch the deck's colour theme and persist the
+//! choice, at parity with how `/model` persists the default model. Kept out of
+//! the already-large `command_deck` dispatcher: the parser, the live switch,
+//! and the settings write live here; `command_deck` only wires them to `say`.
+//!
+//! Two themes ship. `stella-dark` (terminal green on true black) is the
+//! default; `stella-light` (the logo's ember red-orange on paper white) is its
+//! complement. The switch itself is a per-frame buffer remap in
+//! [`stella_tui::theme`], so it takes effect on the next frame with nothing to
+//! re-lay-out — this module only flips the global and writes `ui.theme`.
+
+use stella_tui::theme::ThemeName;
+
+use crate::config::Config;
+
+/// `/theme …` — the colour-theme switch.
+pub enum ThemeCommand {
+    /// `/theme <slug>` — a recognised theme to apply and persist.
+    Set(ThemeName),
+    /// `/theme <unknown>` — anything that is not a shipped theme.
+    Usage(String),
+}
+
+/// Parse `trimmed` as a [`ThemeCommand`]; `None` leaves it on the normal path.
+/// A bare `/theme` (no argument) never reaches here — it has no whitespace to
+/// split on and is handled by the exact-match arm.
+pub fn parse_theme_command(trimmed: &str) -> Option<ThemeCommand> {
+    let (head, rest) = trimmed.split_once(char::is_whitespace)?;
+    if head != "/theme" {
+        return None;
+    }
+    let arg = rest.trim();
+    match ThemeName::parse(arg) {
+        Some(name) => Some(ThemeCommand::Set(name)),
+        None => Some(ThemeCommand::Usage(arg.to_string())),
+    }
+}
+
+/// The list of themes, one per line, marking the active one — shared by the
+/// bare-`/theme` summary and the unknown-argument reply.
+fn theme_menu() -> String {
+    let active = stella_tui::theme::active_theme();
+    ThemeName::ALL
+        .iter()
+        .map(|t| {
+            let mark = if *t == active { "●" } else { "○" };
+            format!("  {mark} {:<13} {}", t.slug(), blurb(*t))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A one-line description of what each theme looks like.
+fn blurb(theme: ThemeName) -> &'static str {
+    match theme {
+        ThemeName::StellaDark => "terminal green on true black (default)",
+        ThemeName::StellaLight => "ember red-orange on paper white",
+    }
+}
+
+/// The bare-`/theme` summary: the live theme, the persisted preference (what new
+/// sessions start with), and the pickable list.
+pub fn current_summary(cfg: &Config) -> String {
+    let active = stella_tui::theme::active_theme();
+    let persisted = crate::settings::Settings::load(&cfg.workspace_root)
+        .ok()
+        .and_then(|s| s.ui_theme().and_then(ThemeName::parse))
+        .map(|t| t.slug())
+        .unwrap_or("stella-dark (default — unset)");
+    format!(
+        "theme (this session): {}\n\
+         theme (new sessions): {persisted}\n\n\
+         switch with `/theme <name>` (e.g. `/theme stella-light`):\n\n{}",
+        active.slug(),
+        theme_menu(),
+    )
+}
+
+/// Switch the live theme AND persist it to user-scope settings (`ui.theme`),
+/// through the same `save_to` the settings machinery uses elsewhere. The switch
+/// is applied first, so an unwritable settings file still recolours this
+/// session — the returned `Err` says exactly that rather than pretending
+/// nothing happened.
+pub fn set_theme(name: ThemeName) -> Result<String, String> {
+    // Live switch first — the next frame is already this theme.
+    stella_tui::theme::set_active_theme(name);
+    let ui = crate::settings::UiSettings {
+        theme: Some(name.slug().to_string()),
+    };
+    let Some(path) = crate::settings::user_settings_path() else {
+        return Err(format!(
+            "theme → {} for this session, but it could not be saved for next time: \
+             the user settings path is unavailable (is $HOME set?)",
+            name.slug()
+        ));
+    };
+    ui.save_to(&path).map_err(|e| {
+        format!(
+            "theme → {} for this session, but it could not be saved for next time: {e}",
+            name.slug()
+        )
+    })?;
+    Ok(format!(
+        "theme → {} ({}). Saved — new sessions start here too. `/theme` to see both.",
+        name.slug(),
+        blurb(name)
+    ))
+}
+
+/// The reply to `/theme <unknown>`: name the valid set rather than silently
+/// no-op'ing on a typo'd slug.
+pub fn usage(arg: &str) -> String {
+    format!(
+        "unknown theme `{arg}` — pick one of:\n\n{}\n\n(or `stella-dark`/`stella-light`)",
+        theme_menu()
+    )
+}
+
+/// Apply the persisted theme (`ui.theme`) at deck startup, before the first
+/// frame. A missing or unrecognised value leaves the compiled default
+/// (`stella-dark`) in place — the switch is best-effort chrome, never fatal.
+pub fn apply_persisted(cfg: &Config) {
+    if let Ok(settings) = crate::settings::Settings::load(&cfg.workspace_root)
+        && let Some(name) = settings.ui_theme().and_then(ThemeName::parse)
+    {
+        stella_tui::theme::set_active_theme(name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_theme_command_reads_a_slug_and_flags_junk() {
+        assert!(matches!(
+            parse_theme_command("/theme stella-light"),
+            Some(ThemeCommand::Set(ThemeName::StellaLight))
+        ));
+        assert!(matches!(
+            parse_theme_command("/theme stella-dark"),
+            Some(ThemeCommand::Set(ThemeName::StellaDark))
+        ));
+        // Case-insensitive, and the bare `light`/`dark` shorthands resolve.
+        assert!(matches!(
+            parse_theme_command("/theme LIGHT"),
+            Some(ThemeCommand::Set(ThemeName::StellaLight))
+        ));
+        // An unknown slug is a Usage (a named error), never a wasted prompt.
+        assert!(matches!(
+            parse_theme_command("/theme solarized"),
+            Some(ThemeCommand::Usage(s)) if s == "solarized"
+        ));
+        // Bare `/theme` has no whitespace to split — the exact-match arm owns it.
+        assert!(parse_theme_command("/theme").is_none());
+        // `/theme` must not swallow an unrelated head.
+        assert!(parse_theme_command("/themes list").is_none());
+    }
+}

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -138,6 +138,10 @@ pub struct Settings {
     /// changed, beside the file and cost panels. No model call. Default off.
     #[serde(default)]
     pub enable_recap: Option<Toggle>,
+    /// Appearance preferences — currently just the TUI colour theme
+    /// (`/theme`). Whole-block last-wins across scopes; carries no authority.
+    #[serde(default)]
+    pub ui: Option<UiSettings>,
     /// Adaptive-context lifecycle configuration (the `context` block).
     /// `context.lifecycle.enabled` defaults **`true`** — the lifecycle ships
     /// on, and setting it `false` restores every pre-adaptive behavior.
@@ -667,6 +671,49 @@ impl ToolsSettings {
     }
 }
 
+/// The `ui` section of settings.json — appearance preferences. All fields
+/// optional so an absent section behaves exactly as the defaults.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct UiSettings {
+    /// The TUI colour theme slug (`stella-dark` | `stella-light`). Unset — or
+    /// unrecognised — falls back to the default (`stella-dark`, terminal green).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+}
+
+impl UiSettings {
+    /// Persist THIS section as the `"ui"` key of the settings file at `path`,
+    /// preserving every other key byte-for-byte at the value level — the same
+    /// read-modify-write contract as [`ToolsSettings::save_to`] and
+    /// [`AgentEngineConfig::save_to`], so a theme write never drops
+    /// `providers`, `hooks`, or any forward-compat key. An empty section
+    /// removes the key rather than writing `{}`.
+    pub fn save_to(&self, path: &Path) -> Result<(), String> {
+        private::reject_symlink(path)?;
+        let mut root: serde_json::Value = match std::fs::read_to_string(path) {
+            Ok(contents) => serde_json::from_str(&contents)
+                .map_err(|e| format!("invalid settings file {}: {e}", path.display()))?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+            Err(e) => return Err(format!("cannot read {}: {e}", path.display())),
+        };
+        let object = root
+            .as_object_mut()
+            .ok_or_else(|| format!("settings file {} is not a JSON object", path.display()))?;
+        if self.theme.is_none() {
+            object.remove("ui");
+        } else {
+            let value =
+                serde_json::to_value(self).map_err(|e| format!("cannot serialize ui: {e}"))?;
+            object.insert("ui".to_string(), value);
+        }
+        let mut rendered = serde_json::to_string_pretty(&root)
+            .map_err(|e| format!("cannot render settings: {e}"))?;
+        rendered.push('\n');
+        let user_private = user_settings_path().as_deref() == Some(path);
+        private::write_settings(path, rendered.as_bytes(), user_private)
+    }
+}
+
 /// The `mcp` section of settings.json. All fields optional so an absent
 /// section behaves exactly as the defaults.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -694,6 +741,13 @@ impl Settings {
     /// it on (a later `"off"` turns it back off — project wins per field).
     pub fn recap_enabled(&self) -> bool {
         self.enable_recap.is_some_and(Toggle::is_on)
+    }
+
+    /// The persisted TUI colour-theme slug (`ui.theme`), if any. `None` means
+    /// no preference was saved — the caller applies the default. The value is
+    /// the raw slug; validation is the reader's job ([`stella_tui::theme`]).
+    pub fn ui_theme(&self) -> Option<&str> {
+        self.ui.as_ref().and_then(|u| u.theme.as_deref())
     }
 
     /// The configured MCP registry URL, or the official default. Applied at the

--- a/stella-cli/src/settings/merge.rs
+++ b/stella-cli/src/settings/merge.rs
@@ -118,6 +118,14 @@ impl Settings {
         if let Some(recap) = scope.enable_recap {
             self.enable_recap = Some(recap);
         }
+        // Appearance (`ui.theme`): whole-block last-wins — a higher-precedence
+        // scope that declares `ui` replaces the lower one's. Personal
+        // preference, no credential/egress authority, so no trust restoration.
+        // (Like `enable_recap` above, this must be listed explicitly or the
+        // merge silently drops it.)
+        if let Some(ui) = &scope.ui {
+            self.ui = Some(ui.clone());
+        }
         // Adaptive-context config: whole-block last-wins (a higher-precedence
         // scope that declares `context` replaces a lower one's). Inert in
         // Phase 0 — nothing reads it — so no trust restoration is needed (it

--- a/stella-cli/src/settings/tests.rs
+++ b/stella-cli/src/settings/tests.rs
@@ -270,6 +270,50 @@ fn agent_engine_config_save_preserves_other_keys_and_roundtrips() {
     assert_eq!(merged.agent_engine_config, Some(engine));
 }
 
+#[test]
+fn ui_theme_save_preserves_other_keys_and_roundtrips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write(
+        dir.path(),
+        "settings.json",
+        r#"{"providers": {"zai": {"default_model": "glm-5.2"}},
+            "enable_recap": "on",
+            "future_key": {"anything": true}}"#,
+    );
+    let ui = UiSettings {
+        theme: Some("stella-light".to_string()),
+    };
+    ui.save_to(&path).unwrap();
+
+    // Sibling keys survive byte-for-byte at the value level…
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
+    assert_eq!(raw["enable_recap"], "on");
+    assert_eq!(raw["future_key"]["anything"], true);
+    assert_eq!(raw["ui"]["theme"], "stella-light");
+
+    // …the accessor reads it back through the normal load path…
+    let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+    assert_eq!(merged.ui_theme(), Some("stella-light"));
+
+    // …a higher scope's `ui` wins whole-block (last-wins, like enable_recap)…
+    let project = write(
+        dir.path(),
+        "project.json",
+        r#"{"ui": {"theme": "stella-dark"}}"#,
+    );
+    let merged = Settings::load_from(&[path.clone(), project]).unwrap();
+    assert_eq!(merged.ui_theme(), Some("stella-dark"));
+
+    // …and clearing the theme removes the `ui` key rather than writing `{}`.
+    UiSettings::default().save_to(&path).unwrap();
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(raw.as_object().unwrap().get("ui").is_none());
+    assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
+}
+
 /// **Witness for the default flip.** With no settings at all — no file,
 /// no `tools` key, an empty `tools` object — every tool is on, `bash`
 /// included. This fails on the old code, where an absent key meant OFF.

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -47,11 +47,18 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     let area = frame.area();
     let buf = frame.buffer_mut();
 
-    // The navy-black ground is a real frame fill, not an assumption about
-    // the user's terminal background — the deck looks the same over a white
-    // terminal as over a black one. `degrade_buffer` narrows it per color
-    // depth, and NO_COLOR strips it entirely (structure survives).
-    buf.set_style(area, Style::default().bg(theme::GROUND));
+    // The ground is a real frame fill, not an assumption about the user's
+    // terminal background — the deck looks the same over a white terminal as
+    // over a black one. The base FOREGROUND is filled for the same reason:
+    // prose that sets no colour of its own must still be a real theme tone
+    // (INK/`TEXT_PRIMARY`), never the terminal default — otherwise the
+    // `stella-light` remap can't turn it to ink and body text would render
+    // white-on-white on paper. `degrade_buffer` narrows both per colour depth,
+    // and NO_COLOR strips them entirely (structure survives).
+    buf.set_style(
+        area,
+        Style::default().bg(theme::GROUND).fg(theme::TEXT_PRIMARY),
+    );
 
     // The splash owns the whole frame until it finishes / is skipped.
     if !ui.splash.is_done() {
@@ -943,21 +950,30 @@ fn render_trace_strip(model: &WorkspaceModel, area: Rect, buf: &mut Buffer) {
     if area.height < 2 {
         return;
     }
+    // A fixed left anchor so the live summary reads as a labeled "latest
+    // activity" status line rather than words floating loose under the
+    // transcript box — the churn of streaming trace rows is what made the
+    // strip look like a leak. The anchor stays put; only the value moves.
+    let anchor = Span::styled(" ▸ ", Style::default().fg(theme::TEXT_TERTIARY));
     let line = match model.trace.rows.back() {
         Some(row) => Line::from(vec![
+            anchor,
+            // The kind keeps its colour (scannable); the summary stays dim so
+            // the strip never competes with the transcript or the prompt.
             Span::styled(
-                format!(" {} ", row.kind.label()),
+                row.kind.label(),
                 Style::default().fg(theme::trace_kind_color(row.kind)),
             ),
+            Span::styled("  ", Style::default()),
             Span::styled(
-                truncate_chars(&row.summary, (area.width as usize).saturating_sub(10)),
+                truncate_chars(&row.summary, (area.width as usize).saturating_sub(12)),
                 Style::default().fg(theme::TEXT_TERTIARY),
             ),
         ]),
-        None => Line::from(Span::styled(
-            " · no activity yet",
-            Style::default().fg(theme::TEXT_TERTIARY),
-        )),
+        None => Line::from(vec![
+            anchor,
+            Span::styled("no activity yet", Style::default().fg(theme::TEXT_TERTIARY)),
+        ]),
     };
     Paragraph::new(line).render(
         Rect {
@@ -1232,7 +1248,10 @@ pub(crate) fn render_status_bar(model: &WorkspaceModel, ui: &DeckUi, area: Rect,
         .unwrap_or("idle");
     let dot_color = if ui.color_mode.is_truecolor() && !ui.no_anim {
         let t = (model.now_ms % 1200) as f64 / 1200.0;
-        theme::lighten(theme::ACCENT_DEEP, (0.5 - (t - 0.5).abs()) * 0.7)
+        // Lightened → interpolated, so read the active primary directly (the
+        // theme remap can't reach an interpolated cell). Flat `else` keeps
+        // ACCENT_DEEP, which the remap does recolour.
+        theme::lighten(theme::primary_deep(), (0.5 - (t - 0.5).abs()) * 0.7)
     } else {
         theme::ACCENT_DEEP
     };

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -426,6 +426,7 @@ pub async fn run_deck(
 
         terminal.draw(|f| {
             render_deck(&model, &mut ui, f);
+            theme::apply_theme(f.buffer_mut(), color_mode);
             theme::degrade_buffer(f.buffer_mut(), color_mode);
         })?;
 

--- a/stella-tui/src/fleet_dashboard.rs
+++ b/stella-tui/src/fleet_dashboard.rs
@@ -780,6 +780,7 @@ pub async fn run(
         let now = Instant::now();
         terminal.draw(|f| {
             render(&board, &view, now, f.area(), f.buffer_mut());
+            theme::apply_theme(f.buffer_mut(), color_mode);
             theme::degrade_buffer(f.buffer_mut(), color_mode);
         })?;
 

--- a/stella-tui/src/fx.rs
+++ b/stella-tui/src/fx.rs
@@ -57,21 +57,22 @@ pub fn dissolve_out(ms: u32) -> Effect {
     fx::dissolve(EffectTimer::from_ms(ms, Interpolation::QuadIn)).with_rng(SimpleRng::new(FX_SEED))
 }
 
-/// A brisk deep-sky sweep for tab / view switches in the deck shell: the new
+/// A brisk deep-accent sweep for tab / view switches in the deck shell: the new
 /// content sweeps in left-to-right out of the brand accent color and lands
-/// on its real style over `ms`.
+/// on its real style over `ms`. Reads the *active* theme's deep primary (green
+/// on `stella-dark`, ember on `stella-light`) at construction time.
 ///
 /// Every cell it emits mid-sweep is an interpolated `Color::Rgb` with no
-/// `crate::theme::FALLBACKS` entry, so `degrade_buffer` passes it through
-/// untouched: on a 256- or 16-color terminal the sweep still emits 24-bit SGR.
-/// Callers that must degrade cleanly should gate the effect on
-/// [`crate::theme::ColorMode::is_truecolor`].
+/// `crate::theme::FALLBACKS` entry, so `degrade_buffer` (and `apply_theme`)
+/// passes it through untouched: on a 256- or 16-color terminal the sweep still
+/// emits 24-bit SGR. Callers that must degrade cleanly should gate the effect
+/// on [`crate::theme::ColorMode::is_truecolor`].
 pub fn tab_switch(ms: u32) -> Effect {
     fx::sweep_in(
         Motion::LeftToRight,
         10,
         3,
-        theme::ACCENT_DEEP,
+        theme::primary_deep(),
         EffectTimer::from_ms(ms, Interpolation::CircOut),
     )
     .with_rng(SimpleRng::new(FX_SEED))

--- a/stella-tui/src/markdown.rs
+++ b/stella-tui/src/markdown.rs
@@ -362,14 +362,16 @@ fn heading_line(content: &str, level: usize) -> Line<'static> {
     ])
 }
 
-/// Style for inline code spans and fenced code blocks.
+/// Style for inline code spans and fenced code blocks. A calm sage
+/// [`theme::CODE`] green — code is technical, not a warning, so it no longer
+/// borrows the alarm hue that used to shout from every backticked identifier.
 fn code_style() -> Style {
-    Style::new().fg(theme::WARN)
+    Style::new().fg(theme::CODE)
 }
 
 /// One line inside a fenced code block: indented two spaces, tokenized in the
 /// fence's language when it named one we highlight (keywords/strings/numbers/
-/// comments take their syntax colors; plain runs keep the code amber), or
+/// comments take their syntax colors; plain runs keep the code sage), or
 /// rendered verbatim in the code style otherwise.
 fn code_block_line(raw: &str, lang: Option<syntax::Lang>) -> Line<'static> {
     let mut spans = vec![Span::styled("  ", code_style())];
@@ -470,12 +472,14 @@ mod tests {
     }
 
     #[test]
-    fn code_span_has_yellow_fg() {
+    fn code_span_has_the_calm_code_fg() {
         let lines = render("inline `code` here");
         // Three spans: "inline ", code, " here"
         let code_span = &lines[0].spans[1];
         assert_eq!(code_span.content, "code");
-        assert_eq!(code_span.style.fg, Some(theme::WARN));
+        // Inline code is the sage `theme::CODE`, not the old warning-orange.
+        assert_eq!(code_span.style.fg, Some(theme::CODE));
+        assert_ne!(code_span.style.fg, Some(theme::WARN));
     }
 
     #[test]
@@ -673,8 +677,8 @@ mod tests {
             lines[0]
                 .spans
                 .iter()
-                .any(|s| s.style.fg == Some(theme::WARN)),
-            "plain runs keep the amber code style: {:?}",
+                .any(|s| s.style.fg == Some(theme::CODE)),
+            "plain runs keep the sage code style: {:?}",
             lines[0].spans
         );
     }
@@ -687,7 +691,7 @@ mod tests {
             lines[0]
                 .spans
                 .iter()
-                .all(|s| s.style.fg == Some(theme::WARN)),
+                .all(|s| s.style.fg == Some(theme::CODE)),
             "no tag, no tokenizing: {:?}",
             lines[0].spans
         );

--- a/stella-tui/src/palette.rs
+++ b/stella-tui/src/palette.rs
@@ -3,7 +3,12 @@
 //! names (accent, ink, rule, status) see [`crate::theme`], which is the
 //! only module that should be referencing these directly.
 //!
-//! The identity is bright sky on black: a signal light in the dark.
+//! The default identity is **terminal green on black**: a phosphor signal in
+//! the dark. The light theme (`stella-light`) inverts to **ember on paper** --
+//! the red-orange of the wordmark on white. The token names here are
+//! hue-neutral on purpose (`BRAND`, not `SKY`): the brand hue has been
+//! recoloured before (aurora → gold → sky → green) and the name must outlive
+//! the value. Add a *value* here; name a *role* in `theme`.
 //!
 //! Mirrored by `website/src/app/tokens.css` (`--stella-*`); the two must be
 //! edited together.
@@ -12,11 +17,11 @@ use ratatui::style::Color;
 
 // ── Ground (dark) ───────────────────────────────────────────────
 //
-// True black, not a tinted navy. The accent is a light, high-chroma blue, and
-// a blue-tinted ground robs it of the contrast that makes it read as a signal
-// rather than as decoration -- so the canvas is neutral and the only colour on
-// screen is colour that means something. `surface` and `raised` step up for
-// cards and popovers.
+// True black, not a tinted navy. The accent is a bright, high-chroma green,
+// and a colour-tinted ground robs it of the contrast that makes it read as a
+// signal rather than as decoration -- so the canvas is neutral and the only
+// colour on screen is colour that means something. `surface` and `raised`
+// step up for cards and popovers.
 
 /// Deepest ground -- full-bleed backdrops, the splash, OG art.
 pub const NIGHT: Color = Color::Rgb(0x00, 0x00, 0x00);
@@ -34,20 +39,33 @@ pub const RAISED: Color = Color::Rgb(0x14, 0x1C, 0x26);
 /// the sole carrier of structure.
 pub const HAIRLINE: Color = Color::Rgb(0x24, 0x31, 0x3F);
 
-// ── Brand ───────────────────────────────────────────────────────
+// ── Brand (dark: terminal green) ────────────────────────────────
 //
-// Bright sky blue. Reserved for brand, active/running, and progress -- never a
-// general-purpose highlight. In the transcript this means exactly one thing
-// carries it: the name of the tool being called.
+// Bright phosphor green. Reserved for brand, active/running, and progress --
+// never a general-purpose highlight. In the transcript this means exactly one
+// thing carries it: the name of the tool being called. Green is close to the
+// success hue by nature; the two are kept tellable apart (a purer, brighter
+// green here; a softer green for status) and always paired with a distinct
+// glyph (▶ active vs ✓ done), so hue never carries the meaning alone.
 
-/// The brand hue. On dark ground only, or as a fill under an ink label.
-pub const SKY: Color = Color::Rgb(0x7D, 0xD3, 0xFC);
+/// The brand hue on dark ground -- terminal green.
+pub const BRAND: Color = Color::Rgb(0x00, 0xE6, 0x76);
 
 /// Pressed / gradient-deep stop, and the leading stop of the progress fill.
-pub const SKY_DEEP: Color = Color::Rgb(0x38, 0xBD, 0xF8);
+pub const BRAND_DEEP: Color = Color::Rgb(0x00, 0xB2, 0x5A);
 
-/// The ONLY brand text tone permitted on a light ground -- 8.6:1 on paper.
-pub const SKY_INK: Color = Color::Rgb(0x0B, 0x4A, 0x6F);
+// ── Brand (light: ember) ────────────────────────────────────────
+//
+// The `stella-light` primary: the red-orange of the wordmark square (#FF3D1F).
+// On paper this is the accent, the active/running signal, and the progress
+// fill -- the light-theme counterpart of the dark green. Applied by the
+// per-frame theme remap in [`crate::theme`], truecolor only.
+
+/// Ember -- the light-theme brand hue, sampled from the logo.
+pub const EMBER: Color = Color::Rgb(0xFF, 0x3D, 0x1F);
+
+/// Deep ember -- the leading stop of the light-theme progress fill.
+pub const EMBER_DEEP: Color = Color::Rgb(0xD6, 0x2E, 0x0E);
 
 // ── Text (dark ground) ──────────────────────────────────────────
 //
@@ -69,11 +87,12 @@ pub const TEXT_TERTIARY: Color = Color::Rgb(0x6C, 0x7B, 0x90);
 // Always paired with a glyph. Hue alone never carries meaning.
 
 /// Success / done / added. Also the settled cost of a finished turn -- money
-/// spent is a fact, and a fact reads green.
+/// spent is a fact, and a fact reads green. A softer green than the brand.
 pub const SUCCESS: Color = Color::Rgb(0x4A, 0xDE, 0x80);
 
-/// Warning / needs-input. Orange.
-pub const WARNING: Color = Color::Rgb(0xFF, 0x8A, 0x1F);
+/// Warning / needs-input. Amber-yellow -- caution, deliberately clear of the
+/// ember light-brand and the retired warning orange.
+pub const WARNING: Color = Color::Rgb(0xEA, 0xB3, 0x08);
 
 /// Error / failed / removed.
 pub const DANGER: Color = Color::Rgb(0xFF, 0x5C, 0x7A);
@@ -88,15 +107,16 @@ pub const DANGER: Color = Color::Rgb(0xFF, 0x5C, 0x7A);
 /// Success on a light ground -- 5.76:1 on paper.
 pub const SUCCESS_INK: Color = Color::Rgb(0x16, 0x74, 0x4F);
 
-/// Warning on a light ground -- 5.49:1 on paper. Still orange.
-pub const WARNING_INK: Color = Color::Rgb(0xB0, 0x4A, 0x00);
+/// Warning on a light ground -- amber-brown, legible on paper and clear of the
+/// ember primary.
+pub const WARNING_INK: Color = Color::Rgb(0xA1, 0x62, 0x07);
 
 /// Error on a light ground -- 5.88:1 on paper.
 pub const DANGER_INK: Color = Color::Rgb(0xC8, 0x10, 0x2E);
 
 // ── Ground (light) ──────────────────────────────────────────────
 //
-// The paper mode. Accent text here is ink, never the bright sky.
+// The paper mode. Accent here is ember, text is ink.
 
 /// Light background.
 pub const PAPER: Color = Color::Rgb(0xFF, 0xFF, 0xFF);
@@ -104,25 +124,35 @@ pub const PAPER: Color = Color::Rgb(0xFF, 0xFF, 0xFF);
 /// Light surface, one step in from paper.
 pub const SNOW: Color = Color::Rgb(0xF4, 0xF4, 0xF5);
 
-/// Primary text on paper. Also the label laid over a sky fill.
+/// Light raised surface -- popovers, selected rows on paper.
+pub const PAPER_RAISED: Color = Color::Rgb(0xE8, 0xE9, 0xEB);
+
+/// Light seam / rule -- the paper counterpart of [`HAIRLINE`].
+pub const PAPER_HAIRLINE: Color = Color::Rgb(0xD4, 0xD4, 0xD8);
+
+/// Primary text on paper.
 pub const INK: Color = Color::Rgb(0x0A, 0x0A, 0x0A);
 
 /// Secondary text on paper.
 pub const MUTED: Color = Color::Rgb(0x5B, 0x62, 0x70);
 
+/// Tertiary text on paper -- the paper counterpart of [`TEXT_TERTIARY`].
+pub const INK_DIM: Color = Color::Rgb(0x8A, 0x8F, 0x98);
+
 /// Every palette colour, paired with its token name.
 ///
 /// Lets a test walk the whole palette -- see theme.rs's colour-depth
 /// fallback coverage check -- without a hand-maintained second list.
-pub const ALL: [(&str, Color); 21] = [
+pub const ALL: [(&str, Color); 25] = [
     ("night", NIGHT),
     ("ground", GROUND),
     ("surface", SURFACE),
     ("raised", RAISED),
     ("hairline", HAIRLINE),
-    ("sky", SKY),
-    ("sky-deep", SKY_DEEP),
-    ("sky-ink", SKY_INK),
+    ("brand", BRAND),
+    ("brand-deep", BRAND_DEEP),
+    ("ember", EMBER),
+    ("ember-deep", EMBER_DEEP),
     ("text-primary", TEXT_PRIMARY),
     ("text-secondary", TEXT_SECONDARY),
     ("text-tertiary", TEXT_TERTIARY),
@@ -134,6 +164,9 @@ pub const ALL: [(&str, Color); 21] = [
     ("danger-ink", DANGER_INK),
     ("paper", PAPER),
     ("snow", SNOW),
+    ("paper-raised", PAPER_RAISED),
+    ("paper-hairline", PAPER_HAIRLINE),
     ("ink", INK),
     ("muted", MUTED),
+    ("ink-dim", INK_DIM),
 ];

--- a/stella-tui/src/progress.rs
+++ b/stella-tui/src/progress.rs
@@ -246,7 +246,7 @@ fn label_line(state: &ProgressState) -> (Vec<Span<'static>>, usize) {
         let (glyph, color, bold) = match state.segments[i] {
             SegState::Done => ("✓", theme::SUCCESS_BRIGHT, false),
             SegState::Active if state.phase == RunPhase::Error => ("✗", theme::DANGER, true),
-            SegState::Active => ("▸", theme::SKY, true),
+            SegState::Active => ("▸", theme::ACCENT, true),
             SegState::Pending => ("·", theme::TEXT_DIM, false),
         };
         let mut style = Style::default().fg(color);
@@ -409,7 +409,7 @@ fn render_track(
         if i < fill_cells {
             // The fill is a glyph (not a background), so the bar's *shape* reads
             // even under `NO_COLOR`, where every color drops to the terminal
-            // default; the ember gradient rides the glyph's foreground.
+            // default; the brand gradient rides the glyph's foreground.
             let t = if w > 1 {
                 i as f64 / (w - 1) as f64
             } else {
@@ -418,7 +418,7 @@ fn render_track(
             let mut fg = if truecolor {
                 theme::brand_gradient(t)
             } else {
-                theme::SKY
+                theme::ACCENT
             };
 
             // Shimmer: two light bands (a bright leader and a dimmer trailing
@@ -439,7 +439,7 @@ fn render_track(
                         fg = theme::lighten(fg, 0.2 * (1.0 - de / 1.5));
                     }
                 } else if i == center.round() as usize {
-                    fg = theme::SKY;
+                    fg = theme::ACCENT;
                 }
             }
 
@@ -451,7 +451,7 @@ fn render_track(
                 } else if truecolor {
                     fg = theme::lighten(fg, pulse);
                 } else {
-                    fg = theme::SKY;
+                    fg = theme::ACCENT;
                 }
             }
 
@@ -711,8 +711,8 @@ mod tests {
         // cleanly — an interpolated gradient RGB has no indexed fallback.
         render_track(&state, 1234, ColorMode::Ansi256, 0, 0, 40, &mut buf);
         let allowed = [
-            theme::SKY,
-            theme::SKY,
+            theme::ACCENT,
+            theme::ACCENT,
             theme::TEXT_DIM,
             theme::HAIRLINE,
             ratatui::style::Color::Reset,

--- a/stella-tui/src/shell.rs
+++ b/stella-tui/src/shell.rs
@@ -218,6 +218,7 @@ pub async fn run(
     loop {
         terminal.draw(|f| {
             render(&model, &mut ui, f);
+            theme::apply_theme(f.buffer_mut(), color_mode);
             theme::degrade_buffer(f.buffer_mut(), color_mode);
         })?;
 

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -10,12 +10,13 @@ use crate::deck::TraceKind;
 use crate::envelope::AgentStatus;
 use crate::palette;
 
-// ── Stella palette — "bright sky on black" ──────────────────────────────────
+// ── Stella palette — "terminal green on black" ──────────────────────────────
 //
-// A signal light in the dark. The ground is true black; the sky blue is the
-// light — reserved for brand, active/running, and progress, and for nothing
-// else. If everything is blue, nothing is: a general-purpose highlight is
-// exactly what this hue must not become.
+// A signal light in the dark. The ground is true black; the terminal green is
+// the light — reserved for brand, active/running, and progress, and for
+// nothing else. If everything is green, nothing is: a general-purpose highlight
+// is exactly what this hue must not become. (Green is the *default* accent;
+// `stella-light` swaps it for the logo's ember on paper — see [`apply_theme`].)
 //
 // The corollary the transcript actually depends on: **prose is white.** The
 // accent buys attention, so it may only be spent where attention is owed — on
@@ -23,10 +24,11 @@ use crate::palette;
 // fill. Everything else is [`INK`] (white) or [`MUTED`], and a row that wants
 // to be scannable does it with a glyph and a column, not with a hue.
 //
-// Warning is orange and success is green; status always pairs colour with a
-// glyph (see [`status_glyph`]) so hue never carries meaning alone — that is
-// also what keeps the deck readable under `NO_COLOR` and for red/green colour
-// blindness.
+// Warning is amber and success is green; the brand green and the success green
+// are the one permitted collision (both mean "good"), and status always pairs
+// colour with a glyph (see [`status_glyph`]) so hue never carries meaning alone
+// — active ▶ vs done ✓ — which is also what keeps the deck readable under
+// `NO_COLOR` and for red/green colour blindness.
 //
 // Every value below comes from [`crate::palette`] — the same source the docs
 // site's tokens.css is cut from. This module is the *semantic* layer over it:
@@ -36,7 +38,7 @@ use crate::palette;
 //
 // Every token is 24-bit; [`degrade_buffer`] narrows it to 256- or 16-color, or
 // strips it for `NO_COLOR`, once per frame for terminals that can't render
-// truecolor.
+// truecolor. A theme switch is a second per-frame pass ([`apply_theme`]).
 
 // Grounds (dark → light lift).
 /// App background — true black. Applied as a real frame fill by `render_deck`,
@@ -69,7 +71,7 @@ pub const TEXT_DIM: Color = palette::TEXT_TERTIARY;
 pub const SUCCESS: Color = palette::SUCCESS;
 /// Success (bright — text / completed fills).
 pub const SUCCESS_BRIGHT: Color = palette::SUCCESS;
-/// Warning (base). Orange — distinct from both the brand sky and danger.
+/// Warning (base). Amber-yellow — distinct from both the brand green and danger.
 pub const WARNING: Color = palette::WARNING;
 /// Warning (bright — text).
 pub const WARNING_BRIGHT: Color = palette::WARNING;
@@ -92,27 +94,28 @@ pub const DANGER_BRIGHT: Color = palette::DANGER;
 /// accent.
 pub const VIOLET: Color = Color::Rgb(0xA7, 0x8B, 0xFA);
 /// Amber — the second categorical hue: syntax keywords, file/module graph
-/// nodes. Warm on purpose. Its predecessor was an azure that sat a few dozen
-/// RGB units from the brand sky, which the palette-law test now rejects
-/// outright; retiring gold as the brand freed the warm end of the spectrum,
-/// and a categorical set is only useful to the extent its members cannot be
-/// mistaken for one another or for the accent.
+/// nodes. A warm gold, well clear of the green accent; a categorical set is
+/// only useful to the extent its members cannot be mistaken for one another or
+/// for the accent. (Distinct from the amber-yellow [`WARNING`] status, which
+/// lives in a different context — a syntax token is never a caution.)
 pub const AMBER: Color = Color::Rgb(0xE3, 0xB3, 0x41);
 /// Teal — the third categorical hue: media traces and one slot of the
-/// per-agent palette. Blue-green, so it reads apart from both the pale brand
-/// sky and the success green. It replaces a glacier blue (`AGENT_ICE`) and
-/// then a lilac, each of which drifted within confusable range of the accent.
+/// per-agent palette. Blue-green, so it reads apart from both the brand green
+/// and the success green. It replaces a glacier blue (`AGENT_ICE`) and then a
+/// lilac, each of which drifted within confusable range of the accent.
 pub const TEAL: Color = Color::Rgb(0x2D, 0xD4, 0xBF);
 
 // ── Role aliases (what the rest of the crate references) ─────────────────────
 // Role names remap onto the palette so call sites read as intent (accent,
 // ink, rule) rather than as a hue that a future recolor would falsify.
 
-/// Stella brand accent — bright sky blue. Brand, active/running, and progress
-/// only. In the transcript, the tool name and nothing else.
-pub const ACCENT: Color = palette::SKY;
+/// Stella brand accent — terminal green (ember on `stella-light`). Brand,
+/// active/running, and progress only. In the transcript, the tool name and
+/// nothing else. The active theme's actual hue is applied per-frame by
+/// [`apply_theme`]; this is the canonical dark value every call site renders.
+pub const ACCENT: Color = palette::BRAND;
 /// A deeper accent (gradient / pressed).
-pub const ACCENT_DEEP: Color = palette::SKY_DEEP;
+pub const ACCENT_DEEP: Color = palette::BRAND_DEEP;
 /// Near-white primary text.
 pub const INK: Color = TEXT_PRIMARY;
 /// Dimmed secondary text.
@@ -137,6 +140,108 @@ pub const BAD: Color = DANGER_BRIGHT;
 pub const RUN: Color = VIOLET;
 /// Paused / held — violet.
 pub const HELD: Color = VIOLET;
+
+// ── Runtime theme (the `/theme` switch) ──────────────────────────────────────
+//
+// Colours above are compile-time constants: the canonical **dark** palette
+// (terminal green on black), which is what every view renders and what ships
+// as the default. A theme switch is applied *after* the widgets draw, as a
+// per-frame value→value remap over the finished buffer ([`apply_theme`]) —
+// the exact mechanism [`degrade_buffer`] already uses for colour-depth. That
+// keeps ~700 `theme::TOKEN` call sites untouched: a theme is a substitution
+// table, not a parameter threaded through the render tree.
+//
+// The one thing a value remap can't recolour is the progress bar's *gradient*,
+// whose interpolated cells are never equal to a token; so its source
+// ([`brand_gradient`] via [`primary_stops`]) is theme-aware directly.
+
+/// The shipped themes. `stella-dark` (terminal green on black) is the default;
+/// `stella-light` (ember on paper) is its complement. The names match the
+/// `/theme` argument and the `ui.theme` settings value verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ThemeName {
+    /// Terminal green on true black. Default.
+    #[default]
+    StellaDark,
+    /// Ember (logo red-orange) on paper white.
+    StellaLight,
+}
+
+impl ThemeName {
+    /// The stable slug used by `/theme <slug>` and persisted in settings.
+    pub fn slug(self) -> &'static str {
+        match self {
+            ThemeName::StellaDark => "stella-dark",
+            ThemeName::StellaLight => "stella-light",
+        }
+    }
+
+    /// Parse a slug (case-insensitive; `_`/space tolerated for `-`). Returns
+    /// `None` for anything that isn't a shipped theme, so the command surface
+    /// can report the valid set rather than silently no-op.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s
+            .trim()
+            .to_ascii_lowercase()
+            .replace([' ', '_'], "-")
+            .as_str()
+        {
+            "stella-dark" | "dark" => Some(ThemeName::StellaDark),
+            "stella-light" | "light" => Some(ThemeName::StellaLight),
+            _ => None,
+        }
+    }
+
+    /// Every shipped theme, in menu order.
+    pub const ALL: [ThemeName; 2] = [ThemeName::StellaDark, ThemeName::StellaLight];
+}
+
+/// The active theme, as a plain index so it is lock-free to read on the render
+/// hot path (`0` = dark, `1` = light). Mirrors the single-session REPL's
+/// `ACCENT` atomic. Read via [`active_theme`], set via [`set_active_theme`].
+static ACTIVE_THEME: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// The theme every frame renders through. Defaults to [`ThemeName::StellaDark`].
+pub fn active_theme() -> ThemeName {
+    match ACTIVE_THEME.load(std::sync::atomic::Ordering::Relaxed) {
+        1 => ThemeName::StellaLight,
+        _ => ThemeName::StellaDark,
+    }
+}
+
+/// Switch the active theme. Takes effect on the next frame — the switch is a
+/// buffer remap, so nothing needs re-laying-out.
+pub fn set_active_theme(theme: ThemeName) {
+    let v = match theme {
+        ThemeName::StellaDark => 0,
+        ThemeName::StellaLight => 1,
+    };
+    ACTIVE_THEME.store(v, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The active theme's brand gradient stops, deep → bright: green on
+/// `stella-dark`, ember on `stella-light`. Feeds [`brand_gradient`] so the
+/// progress fill and wordmark sweep recolour with the theme.
+pub fn primary_stops() -> [Color; 2] {
+    match active_theme() {
+        ThemeName::StellaDark => [palette::BRAND_DEEP, palette::BRAND],
+        ThemeName::StellaLight => [palette::EMBER_DEEP, palette::EMBER],
+    }
+}
+
+/// The active theme's bright primary (green / ember). Same value the flat
+/// [`ACCENT`] remaps to, but resolved eagerly — use this only where a colour is
+/// *interpolated* (lightened, swept), since [`apply_theme`]'s value remap can't
+/// reach an interpolated cell. Flat fills should keep using [`ACCENT`].
+pub fn primary() -> Color {
+    primary_stops()[1]
+}
+
+/// The active theme's deep primary — the interpolation counterpart of
+/// [`primary`] (see its note on when to reach for these over [`ACCENT_DEEP`]).
+pub fn primary_deep() -> Color {
+    primary_stops()[0]
+}
 
 // ── Diff panel ──────────────────────────────────────────────────────────────
 
@@ -174,28 +279,36 @@ pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(102, 34, 42);
 pub const SYNTAX_KEYWORD: Color = AMBER;
 /// String / char literal.
 pub const SYNTAX_STRING: Color = Color::Rgb(126, 231, 135);
-/// Numeric literal — violet, the counterpoint to the azure keyword stop.
+/// Numeric literal — violet, the counterpoint to the amber keyword stop.
 pub const SYNTAX_NUMBER: Color = VIOLET;
 /// Line comment (rendered dimmed + italic).
 pub const SYNTAX_COMMENT: Color = Color::Rgb(118, 124, 134);
 
+/// Inline code spans and fenced-code plain runs (`crate::markdown`). A calm
+/// sage green — in the brand family so code reads as *technical*, but far
+/// enough from the neon [`ACCENT`] that it never reads as *active*. This
+/// replaces the warning-orange the transcript used to paint every `identifier`
+/// with: code is not a warning, and an alarm hue on every backticked word was
+/// the single loudest thing on the deck.
+pub const CODE: Color = Color::Rgb(0x6F, 0xBF, 0x92);
+
 // ── Brand gradient (the wordmark sweep and the progress-bar fill) ───────────
 //
-// Two stops, not three: the sweep runs deep sky → sky, left to right. An
+// Two stops, not three: the sweep runs deep → bright, left to right. An
 // earlier generation ran two separate gradients — one for brand chrome and a
 // second for the progress bar — which is precisely the split this palette
 // collapses. Progress *is* activity, activity is the brand hue, so one
-// gradient serves both.
+// gradient serves both. The stops track the ACTIVE theme (green on dark, ember
+// on light) via [`primary_stops`]: the progress fill interpolates non-token
+// cells the per-frame [`apply_theme`] remap can't see, so its source has to be
+// theme-aware directly.
 
-/// Deep sky — the sweep's leading (left) stop.
-pub const SKY_DEEP: Color = palette::SKY_DEEP;
-/// Sky — the trailing stop; also the non-truecolor fallback fill.
-pub const SKY: Color = palette::SKY;
-
-/// The brand gradient's stops, left → right: deep sky → sky. The determinate
-/// progress fill interpolates across these per cell (truecolor only; lesser
-/// terminals collapse to a solid [`SKY`] fill).
-pub const BRAND_STOPS: [Color; 2] = [SKY_DEEP, SKY];
+/// The brand gradient's stops for the *default* (dark) theme, deep → bright.
+/// [`primary_stops`] returns these for `stella-dark` and the ember pair for
+/// `stella-light`; prefer that accessor. The determinate progress fill
+/// interpolates across the active stops per cell (truecolor only; lesser
+/// terminals collapse to a solid [`ACCENT`] fill).
+pub const BRAND_STOPS: [Color; 2] = [ACCENT_DEEP, ACCENT];
 
 /// Linear-interpolate two RGB colors at `t ∈ [0, 1]`. Non-RGB inputs return
 /// `a` unchanged (the gradient only ever feeds it `Color::Rgb` stops).
@@ -208,11 +321,11 @@ pub fn lerp_rgb(a: Color, b: Color, t: f64) -> Color {
     Color::Rgb(mix(ar, br), mix(ag, bg), mix(ab, bb))
 }
 
-/// The brand gradient sampled at `t ∈ [0, 1]`: deep sky at 0, sky at 1,
-/// linearly interpolated across [`BRAND_STOPS`]. This is the run progress
-/// bar's fill and the wordmark sweep.
+/// The brand gradient sampled at `t ∈ [0, 1]`: deep at 0, bright at 1, linearly
+/// interpolated across the ACTIVE theme's [`primary_stops`]. This is the run
+/// progress bar's fill and the wordmark sweep — recolours with the theme.
 pub fn brand_gradient(t: f64) -> Color {
-    gradient_at(&BRAND_STOPS, t)
+    gradient_at(&primary_stops(), t)
 }
 
 /// Sample an n-stop gradient at `t ∈ [0, 1]`. Panics on fewer than two stops,
@@ -356,17 +469,18 @@ const FALLBACKS: &[(Color, u8, u8)] = &[
     (TEXT_PRIMARY, 255, 15),
     (TEXT_SECONDARY, 109, 7),
     (TEXT_TERTIARY, 66, 8),
-    // Sky and deep sky take *different* 256 indices (117/81) and different
-    // ANSI-16 indices (bright cyan / cyan) so the progress fill keeps a
+    // Accent and deep accent take *different* 256 indices (42/35) and different
+    // ANSI-16 indices (bright green / green) so the progress fill keeps a
     // readable head-to-tail ramp even where the gradient collapses.
-    (SKY, 117, 14),
-    (SKY_DEEP, 81, 6),
+    (ACCENT, 42, 10),
+    (ACCENT_DEEP, 35, 2),
     (SUCCESS, 78, 10),
-    (WARNING, 208, 3),
+    (WARNING, 178, 3),
     (DANGER, 204, 9),
     (VIOLET, 141, 13),
     (AMBER, 179, 3),
     (TEAL, 43, 2),
+    (CODE, 72, 2),
     (DIFF_ADD_BG, 22, 2),
     (DIFF_DEL_BG, 52, 1),
     (DIFF_ADD_BG_EMPH, 28, 2),
@@ -424,6 +538,83 @@ pub fn degrade_buffer(buf: &mut ratatui::buffer::Buffer, mode: ColorMode) {
     }
 }
 
+// ── Theme remap (the `stella-light` value substitution) ──────────────────────
+//
+// `stella-dark` is the canonical palette the widgets render, so its remap is
+// the identity. `stella-light` maps every dark token to its paper counterpart,
+// keyed by value exactly like [`FALLBACKS`]. Role aliases share a value with a
+// palette token (INK==TEXT_PRIMARY, OK==SUCCESS, SELECT_BG==RAISED, …), so one
+// entry per distinct value covers every alias — the same property that makes
+// [`FALLBACKS`] one-entry-per-value. The categorical/syntax/diff targets are
+// TUI-only (not brand tokens), so they live here inline rather than in
+// `palette`; the brand, ground, text and status targets come from `palette`.
+
+/// `stella-light`: every canonical (dark) token value → its paper counterpart.
+const LIGHT_REMAP: &[(Color, Color)] = &[
+    // Grounds → paper (NIGHT and GROUND are both black; one entry covers both).
+    (GROUND, palette::PAPER),
+    (SURFACE, palette::SNOW),
+    (RAISED, palette::PAPER_RAISED),     // also SELECT_BG
+    (HAIRLINE, palette::PAPER_HAIRLINE), // also RULE
+    // Text → ink (INK==TEXT_PRIMARY, MUTED==TEXT_SECONDARY, DIM==TERTIARY).
+    (TEXT_PRIMARY, palette::INK),
+    (TEXT_SECONDARY, palette::MUTED),
+    (TEXT_TERTIARY, palette::INK_DIM),
+    // Brand → ember (ACCENT==BRAND, ACCENT_DEEP==BRAND_DEEP).
+    (ACCENT, palette::EMBER),
+    (ACCENT_DEEP, palette::EMBER_DEEP),
+    // Status → ink variants (OK/BRIGHT share the base value).
+    (SUCCESS, palette::SUCCESS_INK),
+    (WARNING, palette::WARNING_INK),
+    (DANGER, palette::DANGER_INK),
+    // Inline code — a darker sage, legible on paper.
+    (CODE, Color::Rgb(0x2F, 0x7D, 0x55)),
+    // Categorical hues, darkened for AA on paper (RUN/HELD/NUMBER==VIOLET,
+    // KEYWORD==AMBER).
+    (VIOLET, Color::Rgb(0x6D, 0x28, 0xD9)),
+    (AMBER, Color::Rgb(0x92, 0x40, 0x0E)),
+    (TEAL, Color::Rgb(0x0D, 0x94, 0x88)),
+    // Syntax bodies.
+    (SYNTAX_STRING, Color::Rgb(0x15, 0x80, 0x3D)),
+    (SYNTAX_COMMENT, Color::Rgb(0x6B, 0x72, 0x80)),
+    // Diff tints → light washes.
+    (DIFF_ADD_BG, Color::Rgb(0xDC, 0xFC, 0xE7)),
+    (DIFF_DEL_BG, Color::Rgb(0xFE, 0xE2, 0xE2)),
+    (DIFF_ADD_BG_EMPH, Color::Rgb(0xA7, 0xF3, 0xC6)),
+    (DIFF_DEL_BG_EMPH, Color::Rgb(0xFB, 0xB4, 0xBD)),
+    (MATCH_BG, Color::Rgb(0xFE, 0xF0, 0x8A)),
+];
+
+/// Remap one colour through a theme table; unmapped colours pass through (the
+/// same contract as [`resolve`], so gradient/interpolated cells are untouched).
+fn remap_theme(color: Color, table: &[(Color, Color)]) -> Color {
+    table
+        .iter()
+        .find_map(|(from, to)| (*from == color).then_some(*to))
+        .unwrap_or(color)
+}
+
+/// Recolour the finished frame to the active theme, in place — run once per
+/// frame *before* [`degrade_buffer`]. `stella-dark` is the canonical identity
+/// (no-op). `stella-light` is a truecolor experience: on a degraded terminal we
+/// leave the canonical dark palette so `degrade_buffer` can map it to indices
+/// (the paper hues have no 256/16 fallback). See `deck_shell` / `shell` /
+/// `fleet_dashboard` for the call sites.
+pub fn apply_theme(buf: &mut ratatui::buffer::Buffer, mode: ColorMode) {
+    if !mode.is_truecolor() {
+        return;
+    }
+    let table = match active_theme() {
+        ThemeName::StellaDark => return,
+        ThemeName::StellaLight => LIGHT_REMAP,
+    };
+    for cell in buf.content.iter_mut() {
+        cell.fg = remap_theme(cell.fg, table);
+        cell.bg = remap_theme(cell.bg, table);
+        cell.underline_color = remap_theme(cell.underline_color, table);
+    }
+}
+
 // ── Styles ──────────────────────────────────────────────────────────────────
 
 /// Accent style for headings / the active tab.
@@ -477,8 +668,8 @@ pub fn status_glyph(status: AgentStatus) -> &'static str {
 
 /// Color a [`crate::graph::GraphNode`] by its `kind`, so the Graph tab's node
 /// list, detail panel, and node-edge sketch all agree on one palette:
-/// function/method violet, struct/enum/trait green, file/module azure —
-/// three distinct categorical hues, none of them the reserved brand hue.
+/// function/method violet, struct/enum/trait green, file/module amber —
+/// three distinct categorical hues, none of them the reserved brand accent.
 /// A node kind is a category, not an activity.
 pub fn graph_kind_color(kind: &str) -> Color {
     match kind {
@@ -631,14 +822,15 @@ mod tests {
         TEXT_PRIMARY,
         TEXT_SECONDARY,
         TEXT_TERTIARY,
-        SKY,
-        SKY_DEEP,
+        ACCENT,
+        ACCENT_DEEP,
         SUCCESS,
         WARNING,
         DANGER,
         VIOLET,
         AMBER,
         TEAL,
+        CODE,
         DIFF_ADD_BG,
         DIFF_DEL_BG,
         DIFF_ADD_BG_EMPH,
@@ -673,8 +865,8 @@ mod tests {
     #[test]
     fn role_aliases_track_their_palette_token() {
         // Brand roles resolve to the generated palette, not to a local literal.
-        assert_eq!(ACCENT, palette::SKY);
-        assert_eq!(ACCENT_DEEP, palette::SKY_DEEP);
+        assert_eq!(ACCENT, palette::BRAND);
+        assert_eq!(ACCENT_DEEP, palette::BRAND_DEEP);
         assert_eq!(GROUND, palette::GROUND);
         assert_eq!(INK, TEXT_PRIMARY);
         assert_eq!(MUTED, TEXT_SECONDARY);
@@ -691,33 +883,57 @@ mod tests {
 
     /// The palette law, in the form a future edit would actually break.
     ///
-    /// The guard has outlived two recolours now (aurora → gold → sky), which is
-    /// the point: each time, the *shape* of the law survived and only the hue
-    /// it names changed. Keep rewriting it rather than deleting it.
+    /// The guard has outlived three recolours now (aurora → gold → sky →
+    /// green), which is the point: each time, the *shape* of the law survived
+    /// and only the hue it names changed. Keep rewriting it rather than deleting
+    /// it.
+    ///
+    /// The green recolour changed the law in one real way. Under the sky brand,
+    /// green belonged to success alone, so "no role near the accent" could be
+    /// absolute. The brand is now green *and so is success* — the two are the
+    /// one permitted collision (both mean "good", told apart by glyph: ▶ active
+    /// vs ✓ done). So the reservation now reads: the accent is green, success
+    /// may share the green family, and **every other role** must stay clear of
+    /// the accent.
     ///
     /// What must hold now:
-    ///   1. The accent is the generated brand sky — not a local literal that
-    ///      drifted, and not one of the retired hues.
-    ///   2. The ground is neutral. A blue accent on a blue-tinted ground loses
+    ///   1. The accent is the generated brand green — not a local literal that
+    ///      drifted, not one of the retired hues, and actually green.
+    ///   2. The ground is neutral. A green accent on a green-tinted ground loses
     ///      the separation that makes it read as a signal, so the canvas may
     ///      not carry a colour cast.
-    ///   3. Status hues stay clear of the brand: warning ramps orange and
-    ///      success ramps green, so neither can be mistaken for "active".
-    ///   4. The brand hue is reserved. No categorical or status role may hold
-    ///      it, and no other role may sit close enough to be confused with it.
+    ///   3. Warning ramps warm (r > g > b — amber, not the retired orange) and
+    ///      success ramps green; success shares the family but not the value.
+    ///   4. The brand green is reserved. Every role *except* the success family
+    ///      must sit far enough from it to be told apart.
     #[test]
-    fn palette_law_sky_is_the_brand_and_nothing_else() {
+    fn palette_law_green_is_the_brand() {
         const RETIRED_AURORA_CYAN: Color = Color::Rgb(0x3F, 0xE0, 0xFF);
         const RETIRED_EMBER_FLAME: Color = Color::Rgb(0xFF, 0x7E, 0x5F);
         const RETIRED_EMBER_CRIMSON: Color = Color::Rgb(0xC2, 0x18, 0x5B);
         const RETIRED_GOLD: Color = Color::Rgb(0xFF, 0xDD, 0x00);
         const RETIRED_GOLD_DEEP: Color = Color::Rgb(0xE0, 0xB8, 0x00);
         /// The old glacier blue, retired *because* it collided with the sky
-        /// accent — the exact failure this test's clause 4 now prevents.
+        /// accent — the exact failure this test's clause 4 still prevents.
         const RETIRED_AGENT_ICE: Color = Color::Rgb(0xA8, 0xC7, 0xF0);
+        /// The sky blue this recolour retired: the brand is green now, and no
+        /// token may drift back to the old accent or its deep stop.
+        const RETIRED_SKY: Color = Color::Rgb(0x7D, 0xD3, 0xFC);
+        const RETIRED_SKY_DEEP: Color = Color::Rgb(0x38, 0xBD, 0xF8);
+        /// The warning orange the "get rid of the orange" pass removed; warning
+        /// is amber-yellow now and must not slide back to it.
+        const RETIRED_WARNING_ORANGE: Color = Color::Rgb(0xFF, 0x8A, 0x1F);
 
-        // 1. The accent comes from the palette, not a drifted local literal.
-        assert_eq!(ACCENT, palette::SKY, "the accent must be the brand sky");
+        // 1. The accent comes from the palette, not a drifted local literal, and
+        //    it is green (g dominant).
+        assert_eq!(ACCENT, palette::BRAND, "the accent must be the brand green");
+        let Color::Rgb(ar, ag, ab) = ACCENT else {
+            panic!("ACCENT must be a truecolor token");
+        };
+        assert!(
+            ag > ar && ag > ab,
+            "the brand accent must be green-dominant"
+        );
 
         // The retired hues are gone from every token and alias.
         let mut all: Vec<Color> = ALL_RGB_TOKENS.to_vec();
@@ -729,6 +945,7 @@ mod tests {
             ACCENT,
             OK,
             ACCENT_DEEP,
+            CODE,
         ]);
         all.extend(BRAND_STOPS);
         for token in &all {
@@ -739,6 +956,9 @@ mod tests {
                 (RETIRED_GOLD, "gold"),
                 (RETIRED_GOLD_DEEP, "deep gold"),
                 (RETIRED_AGENT_ICE, "agent ice"),
+                (RETIRED_SKY, "sky blue"),
+                (RETIRED_SKY_DEEP, "deep sky blue"),
+                (RETIRED_WARNING_ORANGE, "warning orange"),
             ] {
                 assert_ne!(*token, retired, "a token still holds {name}");
             }
@@ -756,28 +976,28 @@ mod tests {
             );
         }
 
-        // 3. Warning ramps orange (r > g > b) and success ramps green
-        //    (g dominant), so status never reads as the blue "active".
+        // 3. Warning ramps warm (r > g > b — amber, no longer the orange that
+        //    dominated the transcript) and success ramps green; success shares
+        //    the green family with the brand but is a distinct value, told apart
+        //    by glyph, never by hue alone.
         let Color::Rgb(wr, wg, wb) = WARNING else {
             panic!("WARNING must be a truecolor token");
         };
-        assert!(
-            wr > wg && wg > wb,
-            "warning must ramp red > green > blue (orange)"
-        );
+        assert!(wr > wg && wg > wb, "warning must ramp red > green > blue");
         let Color::Rgb(sr, sg, sb) = SUCCESS else {
             panic!("SUCCESS must be a truecolor token");
         };
         assert!(sg > sr && sg > sb, "success must be green-dominant");
+        assert_ne!(
+            OK, ACCENT,
+            "success and the brand accent must be distinct values"
+        );
 
-        // 4. The brand hue is reserved for brand / active / progress. No status
-        //    or categorical role may quietly become it — nor creep close enough
-        //    to be confused with it at a glance, which is how `AGENT_ICE` died.
-        let Color::Rgb(ar, ag, ab) = ACCENT else {
-            panic!("ACCENT must be a truecolor token");
-        };
+        // 4. The brand green is reserved for brand / active / progress. Every
+        //    role EXCEPT the success family may not sit close enough to be
+        //    confused with it at a glance — which is how `AGENT_ICE` died.
+        //    Success is the one permitted neighbour (both green, ▶ vs ✓).
         for (role, name) in [
-            (OK, "OK"),
             (WARN, "WARN"),
             (BAD, "BAD"),
             (RUN, "RUN"),
@@ -785,11 +1005,12 @@ mod tests {
             (VIOLET, "VIOLET"),
             (AMBER, "AMBER"),
             (TEAL, "TEAL"),
+            (CODE, "CODE"),
             (SYNTAX_KEYWORD, "SYNTAX_KEYWORD"),
             (SYNTAX_STRING, "SYNTAX_STRING"),
             (SYNTAX_NUMBER, "SYNTAX_NUMBER"),
         ] {
-            assert_ne!(role, ACCENT, "{name} must not be the reserved brand sky");
+            assert_ne!(role, ACCENT, "{name} must not be the reserved brand green");
             let Color::Rgb(r, g, b) = role else {
                 panic!("{name} must be a truecolor token");
             };
@@ -911,11 +1132,54 @@ mod tests {
     #[test]
     fn degrade_buffer_resolves_every_cell_when_degraded() {
         let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
-        buf.content[0].fg = ACCENT; // → 117 (256) / 14 (16)
+        buf.content[0].fg = ACCENT; // → 42 (256) / 10 (16)
         buf.content[0].bg = VIOLET; // → 141 (256) / 13 (16)
         degrade_buffer(&mut buf, ColorMode::Ansi256);
-        assert_eq!(buf.content[0].fg, Color::Indexed(117));
+        assert_eq!(buf.content[0].fg, Color::Indexed(42));
         assert_eq!(buf.content[0].bg, Color::Indexed(141));
+    }
+
+    #[test]
+    fn apply_theme_is_identity_for_dark_and_remaps_for_light() {
+        use std::sync::atomic::Ordering;
+        // remap_theme is pure — exercise it directly rather than mutating the
+        // process-global active theme (which other tests read).
+        assert_eq!(remap_theme(ACCENT, LIGHT_REMAP), palette::EMBER);
+        assert_eq!(remap_theme(GROUND, LIGHT_REMAP), palette::PAPER);
+        assert_eq!(remap_theme(TEXT_PRIMARY, LIGHT_REMAP), palette::INK);
+        assert_eq!(remap_theme(OK, LIGHT_REMAP), palette::SUCCESS_INK);
+        // An unmapped colour (an interpolated gradient cell) passes through.
+        let mid = lerp_rgb(palette::EMBER_DEEP, palette::EMBER, 0.5);
+        assert_eq!(remap_theme(mid, LIGHT_REMAP), mid);
+        // Every LIGHT_REMAP key is a distinct value (aliases share one entry).
+        for (i, (from, _)) in LIGHT_REMAP.iter().enumerate() {
+            assert!(
+                !LIGHT_REMAP[..i].iter().any(|(other, _)| other == from),
+                "duplicate LIGHT_REMAP key {from:?}"
+            );
+        }
+        // The global default is dark, so apply_theme leaves a buffer untouched.
+        assert_eq!(ACTIVE_THEME.load(Ordering::Relaxed), 0);
+        let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+        buf.content[0].bg = GROUND;
+        apply_theme(&mut buf, ColorMode::Truecolor);
+        assert_eq!(
+            buf.content[0].bg, GROUND,
+            "stella-dark must be the identity"
+        );
+    }
+
+    #[test]
+    fn theme_name_parse_round_trips_and_rejects_junk() {
+        for t in ThemeName::ALL {
+            assert_eq!(ThemeName::parse(t.slug()), Some(t));
+        }
+        assert_eq!(
+            ThemeName::parse("Stella_Light"),
+            Some(ThemeName::StellaLight)
+        );
+        assert_eq!(ThemeName::parse("dark"), Some(ThemeName::StellaDark));
+        assert_eq!(ThemeName::parse("solarized"), None);
     }
 
     #[test]
@@ -929,15 +1193,17 @@ mod tests {
     }
 
     #[test]
-    fn brand_gradient_spans_deep_sky_to_sky() {
-        assert_eq!(brand_gradient(0.0), SKY_DEEP);
-        assert_eq!(brand_gradient(1.0), SKY);
+    fn brand_gradient_spans_deep_to_bright_accent() {
+        // The default theme is `stella-dark`, so the stops are the green accent
+        // pair; `primary_stops` swaps them for ember under `stella-light`.
+        assert_eq!(brand_gradient(0.0), ACCENT_DEEP);
+        assert_eq!(brand_gradient(1.0), ACCENT);
         // Monotonic, clamped, never panics across the range.
         for i in 0..=20 {
             let _ = brand_gradient(f64::from(i) / 20.0);
         }
-        assert_eq!(brand_gradient(-1.0), SKY_DEEP);
-        assert_eq!(brand_gradient(2.0), SKY);
+        assert_eq!(brand_gradient(-1.0), ACCENT_DEEP);
+        assert_eq!(brand_gradient(2.0), ACCENT);
     }
 
     #[test]

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -3,39 +3,52 @@
  * global.css maps these onto the light/dark semantic layer, the same way
  * stella-tui's theme.rs maps palette.rs.
  *
- * The identity is bright sky on black: a signal light in the dark.
+ * The identity is terminal green on black: a signal light in the dark. The
+ * light theme (`stella-light` in the app) is ember on paper.
  *
  * This file mirrors stella-tui/src/palette.rs, which is the normative source;
  * the two must be edited together. (The header used to claim generation from
  * docs/brand/tokens.json by docs/brand/build.py — neither exists.)
+ *
+ * Note: the Rust palette renamed the brand tokens `SKY`→`BRAND` (hue-neutral,
+ * to survive recolours). The CSS var names here keep `--stella-sky*` because
+ * global.css and components reference them widely; only the *values* changed
+ * (blue → terminal green). `--stella-brand*` are added as forward aliases.
  */
 
 :root {
-  /* Ground (dark) — True black, so the pale accent keeps its contrast. */
+  /* Ground (dark) — True black, so the accent keeps its contrast. */
   --stella-night: #000000;
   --stella-ground: #000000;
   --stella-surface: #0a0e14;
   --stella-raised: #141c26;
   --stella-hairline: #24313f;
 
-  /* Brand — Bright sky blue. */
-  --stella-sky: #7dd3fc;
-  --stella-sky-deep: #38bdf8;
+  /* Brand — Terminal green (default dark theme). */
+  --stella-sky: #00e676;
+  --stella-sky-deep: #00b25a;
   --stella-sky-ink: #0b4a6f;
+  /* Forward-compat hue-neutral aliases (match palette.rs BRAND / BRAND_DEEP). */
+  --stella-brand: #00e676;
+  --stella-brand-deep: #00b25a;
+
+  /* Brand (light) — Ember, sampled from the logo square (#ff3d1f). */
+  --stella-ember: #ff3d1f;
+  --stella-ember-deep: #d62e0e;
 
   /* Text (dark ground) — Cool neutrals for the dark canvas. */
   --stella-text-primary: #f3f6fa;
   --stella-text-secondary: #98a6ba;
   --stella-text-tertiary: #6c7b90;
 
-  /* Status — Always paired with a glyph. */
+  /* Status — Always paired with a glyph. Warning is amber-yellow (no longer orange). */
   --stella-success: #4ade80;
-  --stella-warning: #ff8a1f;
+  --stella-warning: #eab308;
   --stella-danger: #ff5c7a;
 
   /* Status (light ground) — The same three meanings, darkened along their own hue until they clear AA on paper. */
   --stella-success-ink: #16744f;
-  --stella-warning-ink: #b04a00;
+  --stella-warning-ink: #a16207;
   --stella-danger-ink: #c8102e;
 
   /* Ground (light) — The paper mode. */


### PR DESCRIPTION
## What & why

Recolours the deck and adds a **runtime colour-theme system** with a `/theme` slash command. Two themes ship, switchable live and persisted:

- **`stella-dark`** (default) — **terminal green** (`#00E676`) on true black.
- **`stella-light`** — the logo's **ember red‑orange** (`#FF3D1F`, sampled from the wordmark square) on paper white.

Addresses the three asks: *get rid of the orange*, *change the blue to terminal green and make it the default*, and *a `/theme` command with light/dark categories that vary background + primary*.

## Colour changes you'll see

| | before | after |
|---|---|---|
| Brand accent (tab, progress, `>>>`, tool label, running) | sky blue `#7DD3FC` | terminal green `#00E676` |
| Inline / fenced code | warning‑**orange** `#FF8A1F` | calm sage `theme::CODE` `#6FBF92` |
| Warning status | orange `#FF8A1F` | amber‑yellow `#EAB308` |

Orange is gone from the dark theme entirely (verified: zero old‑orange SGR in a real render). `palette.rs` renames `SKY → BRAND` (hue‑neutral, so the name survives the next recolour) and adds the ember light‑brand pair.

## The theme system

- A theme = **category** (dark/light: background + text + surfaces + status) + **one primary hue**. That's the "only worry about one colour" model.
- Applied as a **per‑frame value→value remap over the finished buffer** (`theme::apply_theme`) — the same mechanism `degrade_buffer` already uses for colour depth. This keeps ~700 `theme::TOKEN` call sites untouched; a theme is a substitution table, not a parameter threaded through the render tree. The progress‑bar **gradient** (interpolated cells a value remap can't reach) reads the active primary at its source instead.
- **`/theme`** (deck): bare shows current + list; `/theme stella-light` / `/theme stella-dark` switch live (next frame) and persist to `ui.theme` in user settings, honoured at deck startup so the first frame is already themed. Mirrors the `/model` command's shape.

## Extra fixes

- **Trace micro‑summary strip** (the line under the transcript that churns reasoning words during a turn — reported as "words leaking outside the box") now has a fixed left anchor, so it reads as a labelled *latest‑activity* status line rather than floating words. (It's working‑as‑designed chrome bounded to its own band — not an overflow bug; the `>>>` chevron animation was a red herring.)
- **Latent light‑mode legibility bug:** the deck filled a base background but left the base **foreground** as the terminal default, so body prose would have rendered white‑on‑white on paper. It now fills the base fg with the primary text tone (matching the module's own "prose is white, not an assumption about the terminal" claim), which the remap turns to ink on paper.

## The palette‑law test, rewritten

`palette_law_green_is_the_brand` encodes the new law: green is the brand, **success may share the green family** (told apart by glyph — ▶ active vs ✓ done), and every *other* role must stay clear of the accent. The retired sky‑blue and warning‑orange are now guarded against re‑drift.

## Verification

- `cargo test` — stella‑tui **600** + stella‑cli **771** pass; `cargo clippy` clean; `cargo fmt --check` clean.
- New tests: theme parse/round‑trip, `apply_theme` identity(dark)/remap(light) + `LIGHT_REMAP` key‑uniqueness, and `ui.theme` persistence (save preserves sibling keys, last‑wins merge, clear‑removes‑key).
- **Real render captured from a pty** (deck demo, truecolor):
  - dark → green present, **old blue = 0**, **old orange = 0**, prose = `#F3F6FA`.
  - light → ember + paper + **ink prose** present, green & black‑bg fully remapped to 0.
- `website/src/app/tokens.css` values synced per `palette.rs`'s mirror mandate (CSS var *names* kept for the website's existing consumers; only values changed, with `--stella-brand*`/`--stella-ember*` added).

## Notes / follow‑ups

- The `/theme` switch is a **deck** feature; `shell` (single‑session REPL) and `fleet` render dark in practice (nothing sets their theme) — their `apply_theme` calls safely no‑op. Wiring those surfaces to honour a persisted light theme (they'd need a base‑fg fill + `apply_persisted`) is a clean follow‑up.
- `stella-light`'s primary (`#FF3D1F`) is the exact logo hue; used on bold UI accents it sits ~3.3:1 on white — deliberately faithful over maximally‑AA. Easy one‑line tweak if a darker ember is preferred.

## Summary by Sourcery

Introduce a runtime theming system with dark and light Stella themes, switchable via a new /theme command and persisted in settings, while recoloring the TUI to use terminal green as the primary brand accent and ember for the light theme.

New Features:
- Add a runtime theme abstraction with stella-dark and stella-light variants, including theme parsing, active-theme tracking, and per-frame buffer recoloring.
- Expose a /theme slash command in the deck to switch themes at runtime, summarize current/persisted themes, and persist the choice to user settings.
- Introduce ember-based light-theme brand and paper palette tokens in both the Rust palette and website CSS tokens, keeping names stable for existing consumers.

Bug Fixes:
- Ensure deck foreground is explicitly set so light mode renders readable prose instead of relying on terminal defaults.
- Anchor the trace micro-summary strip to a fixed label so activity text no longer appears to leak outside the transcript box.

Enhancements:
- Recolor the TUI brand accent from blue to terminal green, replace warning orange with amber, and introduce a calmer sage color for code spans, enforcing a stricter palette law that reserves green for brand and success roles.
- Make progress gradients, status indicators, and deck FX read from the active theme’s primary colors so animations and gradients follow theme changes.
- Expand and harden palette-law and theme tests, including guards against reintroducing retired hues and validating theme remap integrity and gradients.
- Update syntax, diff, and code styling to better separate categorical hues from the brand accent and improve light-mode contrast.

Documentation:
- Refresh inline documentation around palette roles, brand hues, and theme behavior, including light-theme constraints and accessibility considerations.

Tests:
- Add tests for theme parsing, active theme behavior, theme remapping identity/remap semantics, LIGHT_REMAP key uniqueness, and theme buffer application.
- Add settings tests to ensure ui.theme persistence preserves other keys, respects scope precedence, and removes the ui block when cleared.
- Update markdown rendering tests to assert the new code color and behavior for syntax-highlighted and plain code blocks.

Chores:
- Sync website CSS tokens with the updated palette, including new brand and ember variables and updated warning colors.