### PR TITLE
fix: audit bug fixes round 2 (#817, #825, #828) + restore main's file-size gate

### DIFF
--- a/bench/terminal_bench_analysis/tests/test_artifact_secret_scan.py
+++ b/bench/terminal_bench_analysis/tests/test_artifact_secret_scan.py
@@ -1,5 +1,8 @@
 import base64
 import gzip
+import io
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -130,3 +133,95 @@ def test_symlink_blocks_publication(tmp_path: Path) -> None:
     findings, _ = scan_tree(tmp_path, ())
 
     assert any(finding.kind == "symlink-blocked" for finding in findings)
+
+
+# --- #828: archive coverage beyond gzip, and false-positive boundaries --------
+
+
+def test_zip_member_secret_is_blocked(tmp_path: Path) -> None:
+    secret = "zip-archived-secret-value-123456"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("inner/logs.json", f"key={secret}".encode())
+    (tmp_path / "artifact.zip").write_bytes(buf.getvalue())
+
+    findings, _ = scan_tree(
+        tmp_path,
+        environment_needles({"OPENROUTER_API_KEY": secret}),
+    )
+
+    assert findings, "a secret inside a zip member must be caught"
+    assert all(
+        secret not in finding.path and secret not in finding.kind for finding in findings
+    )
+
+
+def test_tar_member_secret_is_blocked(tmp_path: Path) -> None:
+    secret = "tar-archived-secret-value-123456"
+    payload = f"key={secret}".encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as archive:
+        info = tarfile.TarInfo("inner/logs.json")
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+    (tmp_path / "artifact.tar").write_bytes(buf.getvalue())
+
+    findings, _ = scan_tree(
+        tmp_path,
+        environment_needles({"OPENROUTER_API_KEY": secret}),
+    )
+
+    assert findings, "a secret inside a tar member must be caught"
+
+
+def test_deeply_nested_archive_hits_the_depth_limit(tmp_path: Path) -> None:
+    # A real token sits below the limit, unreachable: nesting past
+    # _MAX_ARCHIVE_DEPTH must fail closed with the depth marker, not recurse
+    # forever and not silently pass.
+    data = b"sk-or-v1-" + b"a" * 30
+    for _ in range(artifact_secret_scan._MAX_ARCHIVE_DEPTH + 2):
+        data = gzip.compress(data)
+    (tmp_path / "nested.gz").write_bytes(data)
+
+    findings, _ = scan_tree(tmp_path, ())
+
+    assert any(finding.kind == "archive-depth-limit" for finding in findings), findings
+
+
+def test_corrupt_archive_fails_closed_not_silently(tmp_path: Path) -> None:
+    # Valid zip magic over a garbage body: the scanner must surface a decode
+    # error, never fall through and scan the bytes as clean text (a silent skip
+    # is exactly how a hostile payload would hide).
+    (tmp_path / "corrupt.zip").write_bytes(b"PK\x03\x04 not really a valid zip payload")
+
+    findings, _ = scan_tree(tmp_path, ())
+
+    assert any(finding.kind == "archive-decode-error" for finding in findings), findings
+
+
+def test_token_lookalikes_below_threshold_do_not_over_match(tmp_path: Path) -> None:
+    # Every TOKEN_PATTERN has a minimum length / character class; strings that
+    # merely share a prefix must NOT match, or the scanner cries wolf on prose.
+    (tmp_path / "notes.txt").write_text(
+        "reminders: sk-or-v1-short, ghp_short, AKIAlowercasekeyxx, sk-ant-tiny — "
+        "just words that happen to mention keys, nothing to redact here."
+    )
+
+    findings, scanned = scan_tree(tmp_path, ())
+
+    assert findings == [], f"a pattern over-matched a look-alike: {findings}"
+    assert scanned == 1
+
+
+def test_short_environment_value_is_not_needled(tmp_path: Path) -> None:
+    # Values under 8 bytes are excluded from needles (they would match far too
+    # much ordinary text); a file containing one must scan clean.
+    short = "sh0rt6"  # 6 bytes < 8
+    (tmp_path / "log.txt").write_text(f"value={short} and more text")
+
+    findings, _ = scan_tree(
+        tmp_path,
+        environment_needles({"OPENROUTER_API_KEY": short}),
+    )
+
+    assert findings == [], f"a sub-8-byte env value must not be needled: {findings}"

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Guard: no NEW Rust file may exceed the 1500-line ratchet. See #629.
+# Guard: no NEW Rust or Python file may exceed the 1500-line ratchet.
+# See #629 (Rust) and #825 (Python — an 8,166-line analysis module had slipped
+# through because the guard only looked at *.rs).
 #
 # Three fleet plans asserted this limit as a standard the tree follows
 # (docs/design/serve-surface.fleet.toml, plus the since-deleted
@@ -59,9 +61,11 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi
 
-# Emit "<lines> <path>" for every tracked Rust file, NUL-safe on the git side.
+# Emit "<lines> <path>" for every tracked Rust or Python file, NUL-safe on the
+# git side. Python counts too (#825): the analyzer under bench/ grew to 8,166
+# lines while the guard watched only *.rs.
 current_sizes() {
-  git ls-files -z '*.rs' | while IFS= read -r -d '' f; do
+  git ls-files -z '*.rs' '*.py' | while IFS= read -r -d '' f; do
     printf '%s %s\n' "$(wc -l <"$f" | tr -d ' ')" "$f"
   done
 }
@@ -132,5 +136,5 @@ if [ -n "$report" ]; then
   exit 1
 fi
 
-tracked=$(git ls-files '*.rs' | wc -l | tr -d ' ')
-echo "check-file-size: OK — $tracked Rust files, none over $LIMIT lines except $(grep -cv '^#' "$baseline") grandfathered (none grew)."
+tracked=$(git ls-files '*.rs' '*.py' | wc -l | tr -d ' ')
+echo "check-file-size: OK — $tracked Rust/Python files, none over $LIMIT lines except $(grep -cv '^#' "$baseline") grandfathered (none grew)."

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,16 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-2282 stella-cli/src/agent.rs
+1746 bench/harbor_adapter/stella_harbor/__init__.py
+4230 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1704 bench/harbor_adapter/tests/test_adapter.py
+3175 bench/harbor_adapter/tests/test_secure_launcher.py
+8166 bench/terminal_bench_analysis/tb21_analysis.py
+1887 bench/terminal_bench_analysis/tb21_evidence_contract.py
+4173 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
+1615 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 1738 stella-cli/src/agent_tests.rs
+2278 stella-cli/src/agent.rs
 1627 stella-cli/src/candidate_ws.rs
 4633 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
@@ -24,11 +32,11 @@
 2399 stella-protocol/src/event.rs
 2255 stella-store/src/lib.rs
 2200 stella-store/src/tests.rs
-1897 stella-store/src/usage.rs
+1892 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
 3204 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
-1741 stella-tui/src/deck_render.rs
+1764 stella-tui/src/deck_render.rs
 4096 stella-tui/src/deck_ui.rs
 1664 stella-tui/src/model.rs
 1660 stella-tui/src/views/engine.rs

--- a/stella-cli/src/export.rs
+++ b/stella-cli/src/export.rs
@@ -28,6 +28,15 @@ pub fn export_session(workspace_root: &Path) -> Result<PathBuf, String> {
     let dumps = store
         .export_all_json()
         .map_err(|e| format!("cannot read telemetry: {e}"))?;
+    // #817: the archive leaves the machine (emailed, committed to a PR as
+    // evidence), so mask any credential that reached the telemetry — a key
+    // pasted into a prompt, printed by a tool into `args_json`, or living in a
+    // touched file's events — before it is written to the raw dumps OR embedded
+    // in the dashboard. Applied once, here, so both sinks see redacted data.
+    let dumps: Vec<TableDump> = dumps
+        .into_iter()
+        .map(|(table, json)| (table, redact_dump(&json)))
+        .collect();
 
     if dumps.iter().all(|(_, json)| json == "[]") {
         return Err("no session telemetry recorded yet — run a few turns first.".into());
@@ -95,6 +104,38 @@ pub fn export_session(workspace_root: &Path) -> Result<PathBuf, String> {
     std::fs::write(&zip_path, &bytes).map_err(|e| format!("write archive: {e}"))?;
 
     Ok(zip_path)
+}
+
+/// Redact credentials from one table's JSON dump (#817). Parses the array and
+/// runs [`stella_core::redact::redact_secrets`] over **every string value**,
+/// then re-serializes — so the output is always valid JSON and a secret
+/// embedded anywhere (a prompt, a tool's `args_json`, a touched file's events)
+/// is masked. If the dump is not the JSON shape we expect, falls back to a
+/// whole-string redaction, which is still safe (it only ever removes content).
+fn redact_dump(json: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(mut value) => {
+            redact_json_strings(&mut value);
+            serde_json::to_string(&value)
+                .unwrap_or_else(|_| stella_core::redact::redact_secrets(json).text)
+        }
+        Err(_) => stella_core::redact::redact_secrets(json).text,
+    }
+}
+
+/// Recursively replace every string value in `value` with its redacted form.
+fn redact_json_strings(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(text) => {
+            let redaction = stella_core::redact::redact_secrets(text);
+            if redaction.redacted {
+                *text = redaction.text;
+            }
+        }
+        serde_json::Value::Array(items) => items.iter_mut().for_each(redact_json_strings),
+        serde_json::Value::Object(map) => map.values_mut().for_each(redact_json_strings),
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+    }
 }
 
 /// Format an integer with comma thousands separators (e.g. `1234567` →
@@ -868,6 +909,66 @@ mod tests {
             dumps.iter().all(|(_, j)| j == "[]"),
             "an empty store exports empty arrays"
         );
+    }
+
+    #[test]
+    fn redact_dump_masks_secrets_and_keeps_valid_json() {
+        // #817: a GitHub PAT in a prompt and an AWS key inside a nested
+        // `args_json` string. Both must be gone, the dump must stay valid JSON,
+        // and the non-secret content must survive.
+        let raw = r#"[{"prompt":"deploy with ghp_016C7e4a9b2d3f5081726354ABCDabcd1234","args_json":"{\"key\":\"AKIAIOSFODNN7EXAMPLE\"}"},{"n":42}]"#;
+        let out = redact_dump(raw);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&out).expect("a redacted dump is still valid JSON");
+        assert!(parsed.is_array(), "shape preserved");
+        assert!(
+            !out.contains("ghp_016C7e4a9b2d3f5081726354"),
+            "github token leaked: {out}"
+        );
+        assert!(
+            !out.contains("AKIAIOSFODNN7EXAMPLE"),
+            "aws key leaked: {out}"
+        );
+        assert!(out.contains("[redacted]"), "placeholder present: {out}");
+        assert!(out.contains("deploy with"), "non-secret prose survives");
+        assert!(out.contains("42"), "non-string values survive");
+    }
+
+    #[test]
+    fn export_dumps_redact_a_secret_that_reached_the_telemetry() {
+        // The end-to-end guarantee: a credential recorded in real telemetry is
+        // masked by the same redaction `export_session` applies before writing.
+        let store = Store::in_memory().unwrap();
+        use stella_store::FileTouchRow;
+        store
+            .record_files_touched(
+                1,
+                &[FileTouchRow {
+                    path: "deploy.env".into(),
+                    ops: "A".into(),
+                    lines_added: 1,
+                    lines_removed: 0,
+                    events_json: r#"[{"note":"leaked ghp_016C7e4a9b2d3f5081726354ABCDabcd1234"}]"#
+                        .into(),
+                }],
+            )
+            .unwrap();
+        let dumps: Vec<TableDump> = store
+            .export_all_json()
+            .unwrap()
+            .into_iter()
+            .map(|(t, j)| (t, redact_dump(&j)))
+            .collect();
+        let files = dumps
+            .iter()
+            .find(|(t, _)| *t == "files_touched")
+            .map(|(_, j)| j.as_str())
+            .expect("files_touched present");
+        assert!(
+            !files.contains("ghp_016C7e4a9b2d3f5081726354"),
+            "secret leaked into the export: {files}"
+        );
+        assert!(files.contains("[redacted]"), "secret was masked: {files}");
     }
 
     #[test]


### PR DESCRIPTION
## Audit bug fixes — round 2

Three more cross-model-confirmed findings from round-3 `/ultraudit`, each with tests. Rust `make gate` green (fmt, clippy `-D warnings`, **4188 tests**); the Python additions pass under `pytest` (19/19).

### Closes #817 — session export leaked raw telemetry (P1)
`export_session` wrote every telemetry table (`executions.prompt`, `tool_calls.args_json`, `files_touched` events, reflections) **verbatim** into the ZIP *and* the HTML dashboard — a credential that ever reached the telemetry (a key pasted into a prompt, printed by a tool, living in a touched file) left the machine in plaintext, in an archive designed to be emailed / committed as evidence.

Fix: redact each dump through `stella_core::redact::redact_secrets` over **every string value** — parse → redact → re-serialize, so the output is always valid JSON — applied once, right after `export_all_json`, so both the raw dumps and the dashboard see masked data. Tests: the pure `redact_dump` (secret masked, JSON stays valid, non-secret content survives) and an end-to-end store→export path proving a real `ghp_…` in `files_touched` is masked.

### Closes #825 — file-size ratchet didn't cover Python
The 1500-line guard only globbed `*.rs`, which is how `tb21_analysis.py` reached **8,166 lines** unnoticed. Extend `check-file-size.sh` to `*.py` and grandfather the 8 existing Python offenders in the baseline. Per the finding, the analyzer isn't split here — the guard now blocks *new* Python bloat and makes the debt a reviewable line, exactly as it does for Rust.

### Closes #828 — secret-scanner tests only covered gzip
The fail-closed scanner handles zip/tar/bz2/xz, nested archives, and member/size/depth limits, but the tests exercised only gzip and had **no near-miss negatives**. Added: zip- and tar-member secret detection, a deep-nesting **depth-limit** case, a **corrupt-archive** fail-closed case (`archive-decode-error`), and false-positive boundaries — token look-alikes below each pattern's threshold (`sk-or-v1-short`, `ghp_short`, `AKIA`+lowercase, `sk-ant-tiny`) and a sub-8-byte env value — so an over-matching pattern fails a test.

### ⚠️ Also restores `main`'s file-size gate
`#815` (audit) and `#829` (features) **both** grew `stella-tui/src/deck_render.rs` and squash-merged their growth (the file is now 1764 lines) while the baseline only carried one bump (1741) — so `make gate` / pre-push on `main` **currently fails `check-file-size`** (`deck_render.rs grew … +23`). The baseline regen here corrects it (and tightens two other entries — `agent.rs`, `usage.rs` — that had drifted high). Worth merging promptly to unblock `main`.


## Summary by Sourcery

Redact secrets from exported telemetry and strengthen safeguards around file sizes and secret scanning.

Bug Fixes:
- Ensure exported session telemetry JSON is redacted so secrets in prompts, tool arguments, and file-touch events do not leave the machine in plaintext.
- Extend the secret-scanner tests to cover additional archive formats, depth limits, corrupt archives, and near-miss token patterns to prevent regressions.

Enhancements:
- Add a JSON-wide redaction helper used by session export to preserve structure while masking sensitive strings.
- Expand the file-size gate to enforce the 1500-line limit on Python files in addition to Rust and refresh the baseline to reflect current large files.

Tests:
- Add unit and end-to-end tests verifying JSON dump redaction removes secrets while preserving valid JSON and non-sensitive content.
- Add tests for detecting secrets inside zip and tar members, enforcing archive-depth limits, handling corrupt archives, and avoiding false positives for token lookalikes and short environment values.
