### PR TITLE
release.minor: cut 0.6.0 — isolate flaky grep temp-dir tests

### DIFF
--- a/stella-tools/src/grep.rs
+++ b/stella-tools/src/grep.rs
@@ -369,14 +369,21 @@ mod tests {
 
     #[tokio::test]
     async fn finds_matching_lines() {
-        let dir = std::env::temp_dir();
-        let path = format!("stella_grep_{}.txt", std::process::id());
-        tokio::fs::write(dir.join(&path), "hello world\nfoo bar\nhello again\n")
-            .await
-            .unwrap();
+        // Isolated dir (auto-removed on drop) rather than the shared system
+        // temp — the same reasoning as `no_matches_returns_ok_empty`.
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("notes.txt"),
+            "hello world\nfoo bar\nhello again\n",
+        )
+        .await
+        .unwrap();
 
         let result = Grep::default()
-            .execute(&serde_json::json!({"pattern": "hello", "path": path}), &dir)
+            .execute(
+                &serde_json::json!({"pattern": "hello", "path": "notes.txt"}),
+                dir.path(),
+            )
             .await;
         match result {
             ToolOutput::Ok { content } => {
@@ -384,17 +391,29 @@ mod tests {
             }
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
-        let _ = tokio::fs::remove_file(dir.join(&path)).await;
     }
 
     #[tokio::test]
     async fn no_matches_returns_ok_empty() {
-        let dir = std::env::temp_dir();
+        // An isolated, empty dir — NOT the shared `std::env::temp_dir()`. That
+        // directory collects files from every concurrent test and every other
+        // process on the machine; a leftover `stella_candidate_*` source copy
+        // there even contains this very pattern, so scanning it found spurious
+        // hits and the test failed nondeterministically.
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("clean.txt"), "nothing to see here\n")
+            .await
+            .unwrap();
         let result = Grep::default()
-            .execute(&serde_json::json!({"pattern": "zzz_not_found_xyz"}), &dir)
+            .execute(
+                &serde_json::json!({"pattern": "zzz_not_found_xyz"}),
+                dir.path(),
+            )
             .await;
         match result {
-            ToolOutput::Ok { content } => assert!(content.contains("no matches")),
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("no matches"), "{content}")
+            }
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
     }


### PR DESCRIPTION
## Cut **0.6.0** — the minor bump that got dropped

**Merging this PR cuts `0.6.0`.** The `release.minor:` prefix on the title becomes the squash-merge commit subject, which `auto-tag` reads to compute a **minor** bump (0.5.76 → **0.6.0**, patch reset to 0), then `release.yml` builds the binaries + GitHub Release + Homebrew.

### Why it was dropped before
`ci` ignores `website/**`, `docs/**`, and `*.md`, and `auto-tag` only fires after a **successful `ci` run**. A `release.minor:` marker that rode a docs/website/markdown-only PR skipped `ci` entirely, so `auto-tag` never ran and the minor was silently lost — later code PRs just patch-bumped. This PR carries a real Rust change, so `ci` runs and the marker is honored.

### The change (release vehicle)
Isolates two `grep` tests from the shared system `std::env::temp_dir`:
- `no_matches_returns_ok_empty` and `finds_matching_lines` searched the shared temp dir, which collects files from every concurrent test and process. A leftover `stella_candidate_*` source copy there even contains the `zzz_not_found_xyz` pattern the no-match test asserts is absent — so the scan found spurious hits and failed nondeterministically (it blocked pre-push gates twice this week).
- Both now use an isolated `tempfile::tempdir`. **Verified hermetic**: they pass with the poison pattern deliberately sitting in system temp.

`make gate` green: fmt, clippy `-D warnings`, **4192 tests**.

### What 0.6.0 will contain
The minor covers **everything merged since the last 0.5.x tag** — the `/model` slash command + working-prompt animation, the audit fix rounds (#818/#820/#821/#824 and #817/#825/#828), the file-size-gate fix, and the terminal-green theme + `/theme` switch — not just this vehicle change.

> Note: this is **ready to merge**, not draft — I don't merge to `main` myself. Merge it when CI is green and 0.6.0 cuts automatically.


## Summary by Sourcery

Tests:
- Update grep integration tests to use per-test temporary directories and deterministic file names to eliminate nondeterministic failures caused by shared temp-dir contents.
