### PR TITLE
feat(tool-foundry): capability-gap detector proposes tools in /inbox (#830 first slice)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -30,8 +30,8 @@
 2582 stella-pipeline/src/pipeline.rs
 2113 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
-2255 stella-store/src/lib.rs
-2200 stella-store/src/tests.rs
+2292 stella-store/src/lib.rs
+2269 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
 3204 stella-tools/src/registry.rs

--- a/stella-cli/src/agent/persistence.rs
+++ b/stella-cli/src/agent/persistence.rs
@@ -178,6 +178,11 @@ pub(crate) fn record_execution_end(
         .finish_execution_accounted(execution_id, outcome_label, cost_usd, audit_complete)
         .is_ok();
     let _ = store.materialize_tool_calls(execution_id);
+    // Now that this turn's `bash` receipts are materialized, mine recent
+    // history for a repeated command shape and, if found, surface a *proposed*
+    // tool to `/inbox` (#830, first slice — proposes only, installs nothing).
+    // Best-effort: a mining failure must never fail the turn.
+    let _ = crate::tool_foundry::surface_tool_gaps(store);
     let _ = store.finalize_execution_reflection(execution_id);
     let _ = store.sync_to_usage_default(execution_id);
     let _ = crate::enterprise_telemetry::enqueue_finalized_execution(store, execution_id);

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -72,6 +72,7 @@ mod skill_manager;
 mod stats;
 mod storage_cmd;
 mod subsession;
+mod tool_foundry;
 mod tool_policy;
 mod tool_switches;
 mod tui;

--- a/stella-cli/src/tool_foundry.rs
+++ b/stella-cli/src/tool_foundry.rs
@@ -1,0 +1,279 @@
+//! Tool Foundry wiring — the I/O half of the capability-gap detector
+//! (issue #830, first slice).
+//!
+//! The decision logic is a pure function in `stella-core`
+//! ([`stella_core::detect_tool_gaps`]); this module is its adapter: it reads
+//! the durable `bash` receipt log from the store, hands the commands to the
+//! detector, and surfaces each newly-proposed tool to the user's `/inbox` as a
+//! [`stella_store::Notification`]. Nothing is installed and no manifest is
+//! written — the first slice *proposes only*, so a human decides whether a
+//! suggestion ever becomes a tool. It runs best-effort at end of execution
+//! (`agent::persistence::record_execution_end`); a failed pass never fails a
+//! turn.
+
+use std::collections::HashSet;
+
+use stella_core::{GapDetectionConfig, ProposedTool, ShellInvocation, detect_tool_gaps};
+use stella_store::{Notification, NotificationStore, Store, ToolCallRow};
+
+/// How many recent `bash` receipts to mine per pass. A few hundred is plenty:
+/// the detector only needs enough history to see a shape recur, and the read
+/// is index-backed and cheap.
+const HISTORY_WINDOW: usize = 200;
+
+/// The `source` stamped on every foundry inbox item (shown dimmed in the
+/// inbox) — also the human-readable marker for where a proposal came from.
+const SOURCE: &str = "tool-foundry";
+
+/// Mine recent `bash` history, detect capability gaps, and push a deduped
+/// `/inbox` notification for each newly-proposed tool. Best-effort and
+/// side-effect-only: returns the number of *new* proposals surfaced, and never
+/// propagates an error.
+pub(crate) fn surface_tool_gaps(store: &Store) -> usize {
+    surface_tool_gaps_into(
+        store,
+        &NotificationStore::open_default(),
+        GapDetectionConfig::default(),
+    )
+}
+
+/// The testable core of [`surface_tool_gaps`], with the inbox and detector
+/// config injected so a test can point at a temp directory and an in-memory
+/// store.
+pub(crate) fn surface_tool_gaps_into(
+    store: &Store,
+    inbox: &NotificationStore,
+    config: GapDetectionConfig,
+) -> usize {
+    let Ok(rows) = store.recent_tool_calls("bash", HISTORY_WINDOW) else {
+        return 0;
+    };
+    let invocations: Vec<ShellInvocation> =
+        rows.into_iter().filter_map(invocation_from_row).collect();
+    let proposals = detect_tool_gaps(&invocations, config);
+    if proposals.is_empty() {
+        return 0;
+    }
+
+    // Dedup against everything already in the inbox (read or unread) so the
+    // same gap is surfaced at most once, however many turns keep the shape in
+    // the mining window.
+    let existing: HashSet<String> = inbox.list().into_iter().map(|n| n.id).collect();
+    let mut pushed = 0;
+    for proposal in &proposals {
+        let id = notification_id(&proposal.signature);
+        if existing.contains(&id) {
+            continue;
+        }
+        let mut note = Notification::new(
+            format!("Proposed tool: `{}`", proposal.name),
+            proposal_body(proposal),
+            SOURCE,
+        );
+        // A deterministic id from the shape is what makes dedup survive across
+        // sessions — `Notification::new` would otherwise mint a fresh id each
+        // pass and re-surface the same proposal forever.
+        note.id = id;
+        if inbox.push(&note).is_ok() {
+            pushed += 1;
+        }
+    }
+    pushed
+}
+
+/// Parse a `bash` `tool_calls` row into a [`ShellInvocation`]: the `command`
+/// field of `args_json`, plus whether the call succeeded. Rows without a
+/// string `command` (a malformed payload, or a non-bash row that somehow
+/// slipped the name filter) are dropped rather than guessed at.
+fn invocation_from_row(row: ToolCallRow) -> Option<ShellInvocation> {
+    let value: serde_json::Value = serde_json::from_str(&row.args_json).ok()?;
+    let command = value.get("command")?.as_str()?.to_string();
+    if command.trim().is_empty() {
+        return None;
+    }
+    Some(ShellInvocation {
+        command,
+        succeeded: row.ok,
+    })
+}
+
+/// A stable, filesystem-safe notification id derived from the proposal
+/// signature, so one gap maps to exactly one inbox item forever.
+fn notification_id(signature: &str) -> String {
+    format!("ntf-toolfoundry-{:016x}", fnv1a(signature))
+}
+
+/// A tiny FNV-1a hash — enough to key dedup deterministically, and it keeps
+/// this module free of a hashing dependency.
+fn fnv1a(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// The inbox body: what the gap is, the proposed shape, the parameters with a
+/// sample value each, the commands actually seen, and the guardrail that
+/// nothing was installed.
+fn proposal_body(p: &ProposedTool) -> String {
+    let params = if p.parameters.is_empty() {
+        "  (none)".to_string()
+    } else {
+        p.parameters
+            .iter()
+            .map(|param| {
+                let sample = param
+                    .examples
+                    .first()
+                    .map(|e| format!(" (e.g. {e})"))
+                    .unwrap_or_default();
+                format!("  {} : {}{}", param.name, param.kind.placeholder(), sample)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let examples = p
+        .examples
+        .iter()
+        .map(|e| format!("  $ {e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "{desc}\n\nProposed command:\n  {template}\n\nParameters:\n{params}\n\nSeen:\n{examples}\n\n\
+         This is a suggestion only — no tool was installed. Review it before authoring one.",
+        desc = p.description,
+        template = p.command_template,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bash_row(call_id: &str, command: &str, ok: bool) -> ToolCallRow {
+        ToolCallRow {
+            call_id: call_id.into(),
+            name: "bash".into(),
+            surface: "native".into(),
+            args_json: serde_json::json!({ "command": command }).to_string(),
+            args_digest: call_id.into(),
+            reason: String::new(),
+            ok,
+            error: String::new(),
+            bytes_out: 0,
+            duration_ms: 1,
+        }
+    }
+
+    /// A store seeded with the given bash commands under one execution.
+    fn store_with(commands: &[(&str, &str, bool)]) -> Store {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "zai", "glm-5.2")
+            .expect("execution");
+        let rows: Vec<ToolCallRow> = commands
+            .iter()
+            .map(|(cid, cmd, ok)| bash_row(cid, cmd, *ok))
+            .collect();
+        store.record_tool_calls(id, &rows).expect("record");
+        store
+    }
+
+    #[test]
+    fn a_recurring_shape_is_surfaced_once_and_deduped() {
+        let store = store_with(&[
+            ("c1", "jq '.a' a.json", true),
+            ("c2", "jq '.b' b.json", true),
+            ("c3", "jq '.c' c.json", true),
+        ]);
+        let dir = tempfile::tempdir().expect("tmp");
+        let inbox = NotificationStore::open(dir.path());
+
+        let pushed = surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default());
+        assert_eq!(pushed, 1, "one recurring shape → one proposal");
+
+        let items = inbox.list();
+        assert_eq!(items.len(), 1);
+        let note = &items[0];
+        assert_eq!(note.source, SOURCE);
+        assert!(note.id.starts_with("ntf-toolfoundry-"));
+        assert!(note.title.contains("Proposed tool"));
+        assert!(
+            note.body.contains("no tool was installed"),
+            "body must carry the not-installed guardrail"
+        );
+        assert!(
+            note.body.contains("jq {p1} {p2}"),
+            "body shows the template"
+        );
+
+        // A second pass over the same history surfaces nothing new.
+        let again = surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default());
+        assert_eq!(again, 0, "dedup: same gap is not re-surfaced");
+        assert_eq!(inbox.list().len(), 1);
+    }
+
+    #[test]
+    fn no_pattern_surfaces_nothing() {
+        // One-off commands: nothing recurs, so the inbox stays empty.
+        let store = store_with(&[
+            ("c1", "ls -la", true),
+            ("c2", "pwd", true),
+            ("c3", "whoami", true),
+        ]);
+        let dir = tempfile::tempdir().expect("tmp");
+        let inbox = NotificationStore::open(dir.path());
+        assert_eq!(
+            surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default()),
+            0
+        );
+        assert!(inbox.list().is_empty());
+    }
+
+    #[test]
+    fn malformed_and_empty_rows_are_ignored() {
+        let store = Store::in_memory().expect("store");
+        let id = store.begin_execution("run", "p", "z", "m").expect("exec");
+        store
+            .record_tool_calls(
+                id,
+                &[
+                    ToolCallRow {
+                        call_id: "c1".into(),
+                        name: "bash".into(),
+                        surface: "native".into(),
+                        args_json: "not json".into(),
+                        args_digest: "c1".into(),
+                        reason: String::new(),
+                        ok: true,
+                        error: String::new(),
+                        bytes_out: 0,
+                        duration_ms: 1,
+                    },
+                    bash_row("c2", "   ", true),
+                ],
+            )
+            .expect("record");
+        let dir = tempfile::tempdir().expect("tmp");
+        let inbox = NotificationStore::open(dir.path());
+        // Must not panic and must surface nothing.
+        assert_eq!(
+            surface_tool_gaps_into(&store, &inbox, GapDetectionConfig::default()),
+            0
+        );
+    }
+
+    #[test]
+    fn dedup_id_is_stable_for_a_signature() {
+        assert_eq!(
+            notification_id("jq <str> <path>"),
+            notification_id("jq <str> <path>")
+        );
+        assert_ne!(
+            notification_id("jq <str> <path>"),
+            notification_id("sed <str> <path>")
+        );
+    }
+}

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod skills;
 pub(crate) mod speculation;
 mod summarize;
 pub mod tasks;
+pub mod tool_foundry;
 
 pub use budget::{BudgetGuard, BudgetOutcome};
 // `bus::HookEvent` (the extension-bus envelope) stays module-qualified: the
@@ -83,3 +84,6 @@ pub use skills::{
     mine_skill_candidates, render_skills_section, select_skills,
 };
 pub use tasks::{SpawnRequest, TaskBoard, TaskBoardError};
+pub use tool_foundry::{
+    GapDetectionConfig, ParamKind, ProposedTool, ShellInvocation, ToolParameter, detect_tool_gaps,
+};

--- a/stella-core/src/tool_foundry.rs
+++ b/stella-core/src/tool_foundry.rs
@@ -1,0 +1,1062 @@
+//! Tool Foundry — the capability-gap detector: pure synchronous analysis of
+//! recent shell invocations that proposes a reusable, parameterized tool when
+//! the same shell *shape* keeps getting reconstructed by hand.
+//!
+//! This is the first slice of self-improvement issue #830 ("stella authors,
+//! tests, and installs its own tools at runtime"): the **gap detector only**,
+//! which *proposes* a tool spec and installs nothing. Authorship, witness
+//! proofs, and registry installation are later slices — the issue's explicit
+//! instruction is to "prove the detector before granting authorship."
+//!
+//! It is a sibling of [`crate::loop_detect`] and follows the same discipline:
+//! plain synchronous functions over owned data, no I/O, no provider SDK, no
+//! `regex` — easy to property-test against fakes. The caller (the CLI) reads
+//! the durable `tool_calls` receipt log, hands the recent `bash` commands in
+//! as [`ShellInvocation`]s, and surfaces any [`ProposedTool`] to the user's
+//! `/inbox`. This module never reads the store and never writes a manifest.
+//!
+//! **How it differs from loop detection.** [`crate::loop_detect`] flags a
+//! *stuck* turn — the same call, byte-identical, producing byte-identical
+//! output, over and over — so the driver can abort early. The foundry looks
+//! for the opposite of stuck: a command shape reused *with variation* often
+//! enough that a parameterized tool would replace the hand-reconstruction.
+//! The two are deliberately complementary — an exact repeat is loop
+//! detection's territory, so a foundry proposal requires **at least two
+//! distinct argument sets** (see [`GapDetectionConfig::min_distinct_arguments`]).
+//!
+//! **Normalization is the whole game.** "Near-identical" is decided by
+//! reducing each command to a *signature*: a skeleton of the invariant parts
+//! (program name, subcommands, flag names, shell operators) with the varying
+//! *values* (quoted strings, paths, numbers) replaced by typed holes. Two
+//! commands with the same signature are the same shape. The holes become the
+//! proposed tool's parameters. A small hand-rolled tokenizer does this — a
+//! full shell parser is neither available (no `regex` in this crate) nor
+//! warranted for a *proposal* whose job is to start a conversation, not to
+//! execute.
+//!
+//! **Precision over recall, on purpose.** A false proposal erodes trust in
+//! the inbox, so the detector only templatizes tokens that are *structurally*
+//! value-like — quoted, path-like, or numeric. A plain bareword (`git status`,
+//! `kubectl get pods`) stays part of the skeleton, so distinct subcommands are
+//! never merged. The cost is that a value carried as a plain bareword
+//! (`-n my-namespace`) is not recognized as a hole; that is an accepted
+//! first-slice limitation, not a bug.
+
+use std::collections::BTreeMap;
+
+/// The kind of value a parameter hole stands for. Kept deliberately small:
+/// these are the only three token shapes the detector recognizes as
+/// structurally "a value that varies," and each renders to one placeholder
+/// in a signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParamKind {
+    /// A quoted argument (`'.items[]'`, `"error: %s"`) — almost always a
+    /// value, whatever its contents.
+    Str,
+    /// A filesystem-path-shaped argument: contains `/`, starts with `~`, or
+    /// carries a short file extension (`a.json`, `src/lib.rs`, `~/notes`).
+    /// URLs land here too — they contain `/` — which is fine for a proposal.
+    Path,
+    /// A numeric argument, including a leading-sign form used as a flag value
+    /// (`-5`, `10`, `12.3`).
+    Number,
+}
+
+impl ParamKind {
+    /// The placeholder this kind renders to inside a [`ProposedTool::signature`].
+    pub fn placeholder(self) -> &'static str {
+        match self {
+            ParamKind::Str => "<str>",
+            ParamKind::Path => "<path>",
+            ParamKind::Number => "<num>",
+        }
+    }
+}
+
+/// One recorded shell invocation the detector mines — the command string and
+/// whether it succeeded. Owned so the analysis stays a pure function over data
+/// the caller already holds (materialized `tool_calls` rows, or the in-turn
+/// event stream); the detector never learns where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellInvocation {
+    /// The verbatim command line, as passed to the `bash` tool's `command`
+    /// input.
+    pub command: String,
+    /// Whether the invocation exited successfully. A shape that never once
+    /// worked is not a tool worth minting (see
+    /// [`GapDetectionConfig::require_success`]).
+    pub succeeded: bool,
+}
+
+impl ShellInvocation {
+    /// Convenience constructor for a successful invocation (the common case in
+    /// tests and callers that only kept the command string).
+    pub fn ok(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            succeeded: true,
+        }
+    }
+}
+
+/// One parameter of a [`ProposedTool`] — a hole in the command shape, with the
+/// concrete values observed at that position as evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolParameter {
+    /// Positional name, `p1`, `p2`, … — the order the holes appear in the
+    /// command. Mechanical on purpose; a human/author step renames them.
+    pub name: String,
+    /// What kind of value this position carries.
+    pub kind: ParamKind,
+    /// A few distinct concrete values seen at this position (capped by
+    /// [`GapDetectionConfig::max_examples`]), so the reviewer can see what the
+    /// hole actually stood for.
+    pub examples: Vec<String>,
+}
+
+/// A proposed reusable tool, synthesized from a cluster of near-identical
+/// shell invocations. **Nothing is installed** — this is a suggestion carried
+/// to the inbox for a human to accept, refine, or dismiss.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposedTool {
+    /// A valid-by-construction candidate tool name (`^[a-z][a-z0-9_]{1,63}$`),
+    /// derived mechanically from the skeleton. It does **not** check the
+    /// built-in reserved names — this crate cannot depend on `stella-tools`;
+    /// the caller is responsible for collision handling before any authorship.
+    pub name: String,
+    /// A short, human- and model-readable explanation of the gap and what the
+    /// tool would replace.
+    pub description: String,
+    /// The normalized command skeleton with typed placeholders — the cluster
+    /// key that made these invocations "the same shape" (`jq <str> <path>`).
+    pub signature: String,
+    /// The skeleton rendered with numbered `{p1}`-style holes, a sketch of the
+    /// command the tool would run (`jq {p1} {p2}`).
+    pub command_template: String,
+    /// The holes, in command order.
+    pub parameters: Vec<ToolParameter>,
+    /// Total matching invocations observed (evidence strength).
+    pub occurrences: usize,
+    /// How many *distinct* argument sets were seen — the proof the shape is
+    /// reused with variation rather than stuck-repeated.
+    pub distinct_arguments: usize,
+    /// A few distinct example command lines (capped by
+    /// [`GapDetectionConfig::max_examples`]).
+    pub examples: Vec<String>,
+}
+
+/// Thresholds for [`detect_tool_gaps`]. `Default` gives sensible starting
+/// values; callers may tune per workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GapDetectionConfig {
+    /// Matching invocations required before a shape is worth proposing. `0`
+    /// or `1` disable detection — a shape used once is not a pattern.
+    pub min_occurrences: usize,
+    /// Distinct argument sets required. `2` is the load-bearing default: it is
+    /// what separates a *reusable, parameterized shape* (the foundry's job)
+    /// from an *exact repeat* (loop detection's job). `min_distinct_arguments`
+    /// of `2` also guarantees a proposal always has at least one parameter —
+    /// zero-hole commands can only ever produce one distinct (empty) argument
+    /// set.
+    pub min_distinct_arguments: usize,
+    /// Require at least one *successful* invocation in the cluster. A shape
+    /// that never worked is a different kind of gap (a failing operation), not
+    /// a tool to mint from — so the first slice skips it by default.
+    pub require_success: bool,
+    /// Cap on example command lines per proposal and example values per
+    /// parameter, so a hot shape can't produce an unbounded inbox item.
+    pub max_examples: usize,
+}
+
+impl Default for GapDetectionConfig {
+    /// Three occurrences across at least two distinct argument sets, at least
+    /// one of which succeeded — enough to rule out coincidence and to prove
+    /// the shape is genuinely reused with variation. `3` mirrors the "same
+    /// incantation reconstructed three times" framing of the driving issue and
+    /// [`crate::loop_detect::LoopDetectionConfig`]'s own rule-of-thumb.
+    fn default() -> Self {
+        Self {
+            min_occurrences: 3,
+            min_distinct_arguments: 2,
+            require_success: true,
+            max_examples: 3,
+        }
+    }
+}
+
+/// Inspect a window of recent shell invocations and propose a reusable tool
+/// for every command shape that recurs with variation.
+///
+/// `invocations` is a recent window of `bash` commands in any order — the
+/// caller decides how much history to hand in. The result is deterministic:
+/// proposals are sorted by evidence strength (occurrences, then distinct
+/// argument count, both descending) and finally by name, so the same history
+/// always yields byte-identical output. Never panics on any input — empty
+/// history, unparseable commands, and a zeroed-out `config` all yield an empty
+/// `Vec`.
+pub fn detect_tool_gaps(
+    invocations: &[ShellInvocation],
+    config: GapDetectionConfig,
+) -> Vec<ProposedTool> {
+    if config.min_occurrences < 2 {
+        // A shape seen fewer than twice cannot be a pattern; `0`/`1` disable.
+        return Vec::new();
+    }
+
+    // Cluster by signature. BTreeMap keeps iteration order stable so the final
+    // sort is a total order even when two clusters tie on every metric.
+    let mut clusters: BTreeMap<String, Cluster> = BTreeMap::new();
+    for inv in invocations {
+        let Some(analyzed) = analyze(&inv.command) else {
+            continue; // empty/whitespace-only command — nothing to mine.
+        };
+        let entry = clusters
+            .entry(analyzed.signature.clone())
+            .or_insert_with(|| Cluster::new(analyzed.literals.clone(), analyzed.holes.len()));
+        entry.observe(inv, &analyzed, config.max_examples);
+    }
+
+    let mut proposals: Vec<ProposedTool> = clusters
+        .into_iter()
+        .filter_map(|(signature, cluster)| cluster.into_proposal(signature, config))
+        .collect();
+
+    // Strongest evidence first; name breaks ties for total determinism.
+    proposals.sort_by(|a, b| {
+        b.occurrences
+            .cmp(&a.occurrences)
+            .then(b.distinct_arguments.cmp(&a.distinct_arguments))
+            .then(a.name.cmp(&b.name))
+    });
+    proposals
+}
+
+/// A signature and the raw material to build a proposal from it: the invariant
+/// skeleton words (for naming) and the per-position holes.
+struct Analyzed {
+    signature: String,
+    /// Skeleton words worth naming from (program, subcommands, flag names) —
+    /// operators and holes excluded.
+    literals: Vec<String>,
+    /// One entry per hole, in command order: its kind and concrete value.
+    holes: Vec<Hole>,
+}
+
+#[derive(Clone)]
+struct Hole {
+    kind: ParamKind,
+    value: String,
+}
+
+/// Accumulated evidence for one command shape.
+struct Cluster {
+    literals: Vec<String>,
+    hole_count: usize,
+    occurrences: usize,
+    successes: usize,
+    /// Distinct argument tuples seen (each tuple is the ordered hole values),
+    /// mapped to nothing — a set, kept as a map for `BTreeMap` determinism.
+    distinct_args: BTreeMap<Vec<String>, ()>,
+    /// Per-position distinct example values and their kind, in order.
+    params: Vec<ParamAccum>,
+    /// Distinct example command lines.
+    examples: Vec<String>,
+}
+
+struct ParamAccum {
+    kind: ParamKind,
+    examples: Vec<String>,
+}
+
+impl Cluster {
+    fn new(literals: Vec<String>, hole_count: usize) -> Self {
+        Self {
+            literals,
+            hole_count,
+            occurrences: 0,
+            successes: 0,
+            distinct_args: BTreeMap::new(),
+            params: Vec::with_capacity(hole_count),
+            examples: Vec::new(),
+        }
+    }
+
+    fn observe(&mut self, inv: &ShellInvocation, analyzed: &Analyzed, max_examples: usize) {
+        self.occurrences += 1;
+        if inv.succeeded {
+            self.successes += 1;
+        }
+        let arg_tuple: Vec<String> = analyzed.holes.iter().map(|h| h.value.clone()).collect();
+        self.distinct_args.entry(arg_tuple).or_default();
+
+        for (i, hole) in analyzed.holes.iter().enumerate() {
+            if self.params.len() <= i {
+                self.params.push(ParamAccum {
+                    kind: hole.kind,
+                    examples: Vec::new(),
+                });
+            }
+            push_distinct_capped(&mut self.params[i].examples, &hole.value, max_examples);
+        }
+        push_distinct_capped(&mut self.examples, &inv.command, max_examples);
+    }
+
+    fn into_proposal(self, signature: String, config: GapDetectionConfig) -> Option<ProposedTool> {
+        let distinct_arguments = self.distinct_args.len();
+        if self.occurrences < config.min_occurrences
+            || distinct_arguments < config.min_distinct_arguments
+            || self.hole_count == 0
+            || (config.require_success && self.successes == 0)
+        {
+            return None;
+        }
+
+        let name = synthesize_name(&self.literals);
+        let parameters: Vec<ToolParameter> = self
+            .params
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| ToolParameter {
+                name: format!("p{}", i + 1),
+                kind: p.kind,
+                examples: p.examples,
+            })
+            .collect();
+        let command_template = render_template(&signature);
+        let description = format!(
+            "You ran this shell shape {} times across {} distinct argument sets. \
+             A reusable `{}` tool taking {} parameter(s) would replace the hand-built \
+             `{}`. Proposed only — not installed.",
+            self.occurrences,
+            distinct_arguments,
+            name,
+            parameters.len(),
+            signature,
+        );
+
+        Some(ProposedTool {
+            name,
+            description,
+            signature,
+            command_template,
+            parameters,
+            occurrences: self.occurrences,
+            distinct_arguments,
+            examples: self.examples,
+        })
+    }
+}
+
+/// Push `value` onto `into` if absent, up to `cap` entries — preserves
+/// first-seen order and never grows without bound.
+fn push_distinct_capped(into: &mut Vec<String>, value: &str, cap: usize) {
+    if into.len() >= cap || into.iter().any(|v| v == value) {
+        return;
+    }
+    into.push(value.to_string());
+}
+
+/// A lexed shell token, before value/skeleton classification.
+struct RawToken {
+    text: String,
+    quoted: bool,
+    operator: bool,
+}
+
+/// Split a command line into raw tokens: whitespace separates, single/double
+/// quotes group (the inner text is the token, marked `quoted`), and a maximal
+/// run of shell-operator characters is one operator token. Not a real shell
+/// parser — good enough to recognize command shape without a `regex` dep.
+fn tokenize(command: &str) -> Vec<RawToken> {
+    let mut tokens = Vec::new();
+    let mut chars = command.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if c == '\'' || c == '"' {
+            chars.next(); // opening quote
+            let mut text = String::new();
+            for qc in chars.by_ref() {
+                if qc == c {
+                    break; // closing quote (unterminated just takes the rest)
+                }
+                text.push(qc);
+            }
+            tokens.push(RawToken {
+                text,
+                quoted: true,
+                operator: false,
+            });
+            continue;
+        }
+        if is_operator_char(c) {
+            let mut text = String::new();
+            while let Some(&oc) = chars.peek() {
+                if is_operator_char(oc) {
+                    text.push(oc);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            tokens.push(RawToken {
+                text,
+                quoted: false,
+                operator: true,
+            });
+            continue;
+        }
+        // A bareword: up to the next whitespace, operator, or quote.
+        let mut text = String::new();
+        while let Some(&wc) = chars.peek() {
+            if wc.is_whitespace() || is_operator_char(wc) || wc == '\'' || wc == '"' {
+                break;
+            }
+            text.push(wc);
+            chars.next();
+        }
+        tokens.push(RawToken {
+            text,
+            quoted: false,
+            operator: false,
+        });
+    }
+    tokens
+}
+
+fn is_operator_char(c: char) -> bool {
+    matches!(c, '|' | '&' | ';' | '>' | '<')
+}
+
+/// An operator that ends one command and starts another, so the next bareword
+/// is a fresh command head (a program name to keep literally). Redirections
+/// (`>`, `>>`, `<`) do *not* — the token after them is a value (the target).
+fn is_command_separator(op: &str) -> bool {
+    matches!(op, "|" | "||" | "&&" | ";" | "&" | "|&")
+}
+
+/// Reduce a command to its signature, skeleton words, and holes. Returns
+/// `None` for an empty/whitespace-only command.
+fn analyze(command: &str) -> Option<Analyzed> {
+    let raws = tokenize(command);
+    if raws.is_empty() {
+        return None;
+    }
+
+    let mut signature_parts: Vec<String> = Vec::new();
+    let mut literals: Vec<String> = Vec::new();
+    let mut holes: Vec<Hole> = Vec::new();
+    // The first non-operator token is a command head; so is the first after
+    // any command-separating operator.
+    let mut expect_head = true;
+
+    for raw in &raws {
+        if raw.operator {
+            signature_parts.push(raw.text.clone());
+            expect_head = is_command_separator(&raw.text);
+            continue;
+        }
+
+        if expect_head {
+            // Program / command head — always literal, even if quoted.
+            signature_parts.push(raw.text.clone());
+            literals.push(raw.text.clone());
+            expect_head = false;
+            continue;
+        }
+
+        classify_argument(raw, &mut signature_parts, &mut literals, &mut holes);
+    }
+
+    if signature_parts.is_empty() {
+        return None;
+    }
+    Some(Analyzed {
+        signature: signature_parts.join(" "),
+        literals,
+        holes,
+    })
+}
+
+/// Classify a non-head argument token into skeleton text and/or a hole,
+/// appending to the running signature, skeleton words, and holes.
+fn classify_argument(
+    raw: &RawToken,
+    signature_parts: &mut Vec<String>,
+    literals: &mut Vec<String>,
+    holes: &mut Vec<Hole>,
+) {
+    // A quoted argument is a value, whatever it contains.
+    if raw.quoted {
+        push_hole(ParamKind::Str, &raw.text, None, signature_parts, holes);
+        return;
+    }
+
+    let word = &raw.text;
+
+    // A flag: `-v`, `--oneline`, `-5` (numeric), or `--depth=5` (with value).
+    if word.starts_with('-') {
+        if is_numberish(word) {
+            // A leading-sign numeric flag value like `-5` in `head -5`.
+            push_hole(ParamKind::Number, word, None, signature_parts, holes);
+            return;
+        }
+        if let Some((flag, value)) = split_once_eq(word) {
+            let prefix = format!("{flag}=");
+            let kind = value_kind(value, false);
+            push_hole(kind, value, Some(&prefix), signature_parts, holes);
+            return;
+        }
+        // A plain flag is part of the skeleton.
+        signature_parts.push(word.clone());
+        literals.push(word.clone());
+        return;
+    }
+
+    // A `NAME=value` assignment (env var, `KEY=production`): keep the name as
+    // skeleton, the value as a hole.
+    if let Some((name, value)) = split_once_eq(word)
+        && !name.is_empty()
+    {
+        let prefix = format!("{name}=");
+        let kind = value_kind(value, false);
+        push_hole(kind, value, Some(&prefix), signature_parts, holes);
+        return;
+    }
+
+    // A plain positional argument: a hole only if it is structurally value-like
+    // (path or number); otherwise a bareword that stays in the skeleton.
+    match value_kind_positional(word) {
+        Some(kind) => push_hole(kind, word, None, signature_parts, holes),
+        None => {
+            signature_parts.push(word.clone());
+            literals.push(word.clone());
+        }
+    }
+}
+
+/// Append a hole to the signature (as `prefix<placeholder>`) and record its
+/// value. `prefix` handles `--flag=` / `NAME=` forms so the flag name stays in
+/// the skeleton without a stray space.
+fn push_hole(
+    kind: ParamKind,
+    value: &str,
+    prefix: Option<&str>,
+    signature_parts: &mut Vec<String>,
+    holes: &mut Vec<Hole>,
+) {
+    let placeholder = kind.placeholder();
+    match prefix {
+        Some(p) => signature_parts.push(format!("{p}{placeholder}")),
+        None => signature_parts.push(placeholder.to_string()),
+    }
+    holes.push(Hole {
+        kind,
+        value: value.to_string(),
+    });
+}
+
+/// Split a word on its first `=`, returning `(before, after)`. `None` when
+/// there is no `=`.
+fn split_once_eq(word: &str) -> Option<(&str, &str)> {
+    word.split_once('=')
+}
+
+/// Classify a positional (unquoted, non-flag) value: a hole kind if it is
+/// structurally value-like, else `None` (keep it in the skeleton).
+fn value_kind_positional(word: &str) -> Option<ParamKind> {
+    if is_numberish(word) {
+        return Some(ParamKind::Number);
+    }
+    if looks_like_path(word) {
+        return Some(ParamKind::Path);
+    }
+    None
+}
+
+/// Classify a value that is *known* to be a value (the right-hand side of a
+/// `=`, where a plain word is still a value, not skeleton). `quoted` forces
+/// [`ParamKind::Str`].
+fn value_kind(value: &str, quoted: bool) -> ParamKind {
+    if quoted {
+        return ParamKind::Str;
+    }
+    if is_numberish(value) {
+        return ParamKind::Number;
+    }
+    if looks_like_path(value) {
+        return ParamKind::Path;
+    }
+    ParamKind::Str
+}
+
+/// Is this a number — optionally signed, with at most one decimal point?
+/// `-5`, `+3`, `10`, `12.3` are numbers; `-`, `1a`, `1.2.3` are not.
+fn is_numberish(word: &str) -> bool {
+    let body = word.strip_prefix(['-', '+']).unwrap_or(word);
+    if body.is_empty() {
+        return false;
+    }
+    let mut seen_dot = false;
+    for c in body.chars() {
+        if c == '.' {
+            if seen_dot {
+                return false;
+            }
+            seen_dot = true;
+        } else if !c.is_ascii_digit() {
+            return false;
+        }
+    }
+    // A lone "." (body == ".") is not a number.
+    body.chars().any(|c| c.is_ascii_digit())
+}
+
+/// Does this look like a filesystem path or URL: contains `/`, starts with
+/// `~`, or carries a short trailing file extension (`a.json`, `x.tar.gz`)?
+fn looks_like_path(word: &str) -> bool {
+    if word.contains('/') || word.starts_with('~') {
+        return true;
+    }
+    has_file_extension(word)
+}
+
+/// A trailing `.ext` where `ext` is 1..=8 ASCII-alphanumeric chars and the dot
+/// is not the first character (so `.gitignore` and `..` are not "extensions").
+fn has_file_extension(word: &str) -> bool {
+    let Some(dot) = word.rfind('.') else {
+        return false;
+    };
+    if dot == 0 {
+        return false;
+    }
+    let ext = &word[dot + 1..];
+    !ext.is_empty() && ext.len() <= 8 && ext.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Render a signature into a numbered command template: each `<...>` hole
+/// becomes `{pN}` in order, so `jq <str> <path>` → `jq {p1} {p2}`.
+fn render_template(signature: &str) -> String {
+    let mut out = String::with_capacity(signature.len());
+    let mut n = 0usize;
+    let mut rest = signature;
+    while let Some(open) = rest.find('<') {
+        if let Some(close_rel) = rest[open..].find('>') {
+            let close = open + close_rel;
+            out.push_str(&rest[..open]);
+            n += 1;
+            out.push_str(&format!("{{p{n}}}"));
+            rest = &rest[close + 1..];
+            continue;
+        }
+        break;
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Build a valid tool name (`^[a-z][a-z0-9_]{1,63}$`) from the skeleton words:
+/// strip flag dashes and trailing `=`, keep `[a-z0-9]`, join the first few
+/// with `_`, and guarantee the length and leading-letter rules by
+/// construction. Mechanical by design — a downstream author step renames it.
+fn synthesize_name(literals: &[String]) -> String {
+    let mut words: Vec<String> = Vec::new();
+    for lit in literals {
+        let trimmed = lit.trim_start_matches('-').trim_end_matches('=');
+        let cleaned: String = trimmed
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .map(|c| c.to_ascii_lowercase())
+            .collect();
+        if !cleaned.is_empty() {
+            words.push(cleaned);
+        }
+        if words.len() >= 4 {
+            break; // enough to name; keep it short.
+        }
+    }
+
+    let mut name = words.join("_");
+    if name.is_empty() {
+        name = "tool".to_string();
+    }
+    // Must start with a lowercase letter.
+    if !name.starts_with(|c: char| c.is_ascii_lowercase()) {
+        name = format!("t_{name}");
+    }
+    // Must be 2..=64 chars.
+    if name.len() < 2 {
+        name = format!("{name}_tool");
+    }
+    if name.len() > 64 {
+        name.truncate(64);
+        // Truncation can't break the charset (all chars are already valid) but
+        // could leave a trailing `_`; that is still a valid name.
+    }
+    name
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// A hand-rolled matcher for the tool-name contract, so tests do not need
+    /// the `regex` crate this module deliberately avoids.
+    fn is_valid_tool_name(name: &str) -> bool {
+        let len = name.chars().count();
+        if !(2..=64).contains(&len) {
+            return false;
+        }
+        let mut chars = name.chars();
+        let first = chars.next().unwrap();
+        if !first.is_ascii_lowercase() {
+            return false;
+        }
+        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    }
+
+    fn ok(command: &str) -> ShellInvocation {
+        ShellInvocation::ok(command)
+    }
+
+    fn failed(command: &str) -> ShellInvocation {
+        ShellInvocation {
+            command: command.into(),
+            succeeded: false,
+        }
+    }
+
+    #[test]
+    fn empty_history_yields_no_proposals() {
+        assert!(detect_tool_gaps(&[], GapDetectionConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn the_motivating_jq_case_is_proposed() {
+        // The issue's own example: `extract_json_path`-shaped hand-work.
+        let history = vec![
+            ok("jq '.items[0]' a.json"),
+            ok("jq '.name' b.json"),
+            ok("jq '.error.code' c.json"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1, "one shape, one proposal");
+        let p = &proposals[0];
+        assert_eq!(p.signature, "jq <str> <path>");
+        assert_eq!(p.command_template, "jq {p1} {p2}");
+        assert_eq!(p.occurrences, 3);
+        assert_eq!(p.distinct_arguments, 3);
+        assert_eq!(p.parameters.len(), 2);
+        assert_eq!(p.parameters[0].kind, ParamKind::Str);
+        assert_eq!(p.parameters[1].kind, ParamKind::Path);
+        assert!(is_valid_tool_name(&p.name), "name `{}` invalid", p.name);
+        assert_eq!(p.name, "jq");
+    }
+
+    #[test]
+    fn numeric_flag_values_cluster() {
+        // `git log --oneline -N`: the count varies, the shape does not.
+        let history = vec![
+            ok("git log --oneline -5"),
+            ok("git log --oneline -10"),
+            ok("git log --oneline -20"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1);
+        let p = &proposals[0];
+        assert_eq!(p.signature, "git log --oneline <num>");
+        assert_eq!(p.name, "git_log_oneline");
+        assert_eq!(p.parameters.len(), 1);
+        assert_eq!(p.parameters[0].kind, ParamKind::Number);
+    }
+
+    #[test]
+    fn flag_with_value_keeps_flag_in_skeleton() {
+        let history = vec![
+            ok("curl --retry=3 https://a.test/x"),
+            ok("curl --retry=5 https://b.test/y"),
+            ok("curl --retry=1 https://c.test/z"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1);
+        let p = &proposals[0];
+        assert_eq!(p.signature, "curl --retry=<num> <path>");
+        // The `--retry=` flag stays in the skeleton; only its value is a hole.
+        assert_eq!(p.command_template, "curl --retry={p1} {p2}");
+    }
+
+    #[test]
+    fn a_pipeline_shape_is_preserved() {
+        let history = vec![
+            ok("jq '.a' one.json | head"),
+            ok("jq '.b' two.json | head"),
+            ok("jq '.c' three.json | head"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].signature, "jq <str> <path> | head");
+    }
+
+    #[test]
+    fn identical_repeats_are_not_proposed() {
+        // Byte-identical every time: distinct_arguments == 1. That is loop
+        // detection's territory, not the foundry's — never proposed.
+        let history = vec![ok("jq '.x' a.json"); 5];
+        assert!(detect_tool_gaps(&history, GapDetectionConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn a_shape_below_the_occurrence_threshold_is_not_proposed() {
+        let history = vec![ok("jq '.x' a.json"), ok("jq '.y' b.json")];
+        assert!(detect_tool_gaps(&history, GapDetectionConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn distinct_subcommands_do_not_merge() {
+        // `git log` and `git status` are different shapes — plain barewords stay
+        // in the skeleton, so nothing here clusters to three of one shape.
+        let history = vec![
+            ok("git log --oneline -5"),
+            ok("git status --short"),
+            ok("git log --oneline -9"),
+            ok("git status --short"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        // `git status --short` is byte-identical twice (distinct == 1); the two
+        // `git log` differ but occur only twice. Neither qualifies.
+        assert!(
+            proposals.is_empty(),
+            "unexpected proposals: {:?}",
+            proposals.iter().map(|p| &p.signature).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn always_failing_shape_is_skipped_by_default() {
+        let history = vec![
+            failed("weirdcmd --flag a.json"),
+            failed("weirdcmd --flag b.json"),
+            failed("weirdcmd --flag c.json"),
+        ];
+        assert!(detect_tool_gaps(&history, GapDetectionConfig::default()).is_empty());
+        // …but a caller can opt in to failing shapes.
+        let permissive = GapDetectionConfig {
+            require_success: false,
+            ..GapDetectionConfig::default()
+        };
+        assert_eq!(detect_tool_gaps(&history, permissive).len(), 1);
+    }
+
+    #[test]
+    fn one_success_in_the_cluster_is_enough() {
+        let history = vec![
+            failed("jq '.x' a.json"),
+            ok("jq '.y' b.json"),
+            failed("jq '.z' c.json"),
+        ];
+        assert_eq!(
+            detect_tool_gaps(&history, GapDetectionConfig::default()).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn examples_are_capped() {
+        let history: Vec<ShellInvocation> = (0..20)
+            .map(|i| ok(&format!("jq '.f{i}' file{i}.json")))
+            .collect();
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1);
+        let p = &proposals[0];
+        assert!(
+            p.examples.len() <= 3,
+            "examples not capped: {}",
+            p.examples.len()
+        );
+        for param in &p.parameters {
+            assert!(param.examples.len() <= 3, "param examples not capped");
+        }
+        // Evidence counts still reflect the full history.
+        assert_eq!(p.occurrences, 20);
+        assert_eq!(p.distinct_arguments, 20);
+    }
+
+    #[test]
+    fn output_is_deterministic_and_sorted_by_evidence() {
+        // Two shapes: `jq` seen 4×, `sed` seen 3×. Strongest first.
+        let history = vec![
+            ok("jq '.a' a.json"),
+            ok("sed 's/a/b/' one.txt"),
+            ok("jq '.b' b.json"),
+            ok("sed 's/c/d/' two.txt"),
+            ok("jq '.c' c.json"),
+            ok("sed 's/e/f/' three.txt"),
+            ok("jq '.d' d.json"),
+        ];
+        let a = detect_tool_gaps(&history, GapDetectionConfig::default());
+        let b = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(a, b, "detection must be deterministic");
+        assert_eq!(a.len(), 2);
+        assert_eq!(a[0].signature, "jq <str> <path>");
+        assert!(a[0].occurrences >= a[1].occurrences);
+    }
+
+    #[test]
+    fn zeroed_config_disables_detection() {
+        let history = vec![
+            ok("jq '.x' a.json"),
+            ok("jq '.y' b.json"),
+            ok("jq '.z' c.json"),
+        ];
+        let disabled = GapDetectionConfig {
+            min_occurrences: 0,
+            ..GapDetectionConfig::default()
+        };
+        assert!(detect_tool_gaps(&history, disabled).is_empty());
+    }
+
+    #[test]
+    fn env_assignment_keeps_var_name_in_skeleton() {
+        // Only the RUST_LOG value varies; the rest of the line is identical, so
+        // all three cluster to one shape. (Plain barewords like `cargo`/`test`
+        // stay in the skeleton — that is what keeps distinct shapes apart, so
+        // the trailing words must match for these to cluster.)
+        let history = vec![
+            ok("env RUST_LOG=debug cargo test"),
+            ok("env RUST_LOG=trace cargo test"),
+            ok("env RUST_LOG=info cargo test"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].signature, "env RUST_LOG=<str> cargo test");
+        assert_eq!(proposals[0].parameters.len(), 1);
+    }
+
+    #[test]
+    fn names_are_always_valid() {
+        // A pathological program name that is all punctuation still yields a
+        // valid synthesized name.
+        let history = vec![
+            ok("./weird-script.sh a.json"),
+            ok("./weird-script.sh b.json"),
+            ok("./weird-script.sh c.json"),
+        ];
+        let proposals = detect_tool_gaps(&history, GapDetectionConfig::default());
+        for p in &proposals {
+            assert!(is_valid_tool_name(&p.name), "invalid name: {}", p.name);
+        }
+    }
+
+    #[test]
+    fn tokenizer_handles_unterminated_quote() {
+        // Must not panic or loop forever on a dangling quote.
+        let history = vec![
+            ok("grep 'unterminated a.rs"),
+            ok("grep 'still open b.rs"),
+            ok("grep 'again c.rs"),
+        ];
+        let _ = detect_tool_gaps(&history, GapDetectionConfig::default());
+    }
+
+    #[test]
+    fn dotfiles_and_double_dots_are_not_extensions() {
+        assert!(!has_file_extension(".gitignore"));
+        assert!(!has_file_extension(".."));
+        assert!(has_file_extension("a.json"));
+        assert!(has_file_extension("archive.tar.gz"));
+    }
+
+    #[test]
+    fn numberish_edge_cases() {
+        assert!(is_numberish("-5"));
+        assert!(is_numberish("10"));
+        assert!(is_numberish("12.3"));
+        assert!(is_numberish("+3"));
+        assert!(!is_numberish("-"));
+        assert!(!is_numberish("1a"));
+        assert!(!is_numberish("1.2.3"));
+        assert!(!is_numberish("."));
+    }
+
+    #[test]
+    fn render_template_numbers_holes_in_order() {
+        assert_eq!(render_template("jq <str> <path>"), "jq {p1} {p2}");
+        assert_eq!(
+            render_template("git log --oneline <num>"),
+            "git log --oneline {p1}"
+        );
+        assert_eq!(render_template("ls"), "ls");
+    }
+
+    /// A small, deliberately overlapping alphabet so property runs actually
+    /// exercise clustering rather than almost always generating unique shapes.
+    fn arb_invocation() -> impl Strategy<Value = ShellInvocation> {
+        (0..4usize, 0..4usize, any::<bool>()).prop_map(|(prog, arg, succeeded)| {
+            let progs = ["jq", "sed", "grep", "git log"];
+            let args = ["'.x' a.json", "'.y' b.json", "-5", "--flag=1 c.json"];
+            ShellInvocation {
+                command: format!("{} {}", progs[prog], args[arg]),
+                succeeded,
+            }
+        })
+    }
+
+    proptest! {
+        /// `detect_tool_gaps` never panics, for any history and any config,
+        /// including the degenerate zero thresholds.
+        #[test]
+        fn never_panics(
+            history in proptest::collection::vec(arb_invocation(), 0..40),
+            min_occurrences in 0usize..6,
+            min_distinct_arguments in 0usize..6,
+            require_success in any::<bool>(),
+            max_examples in 0usize..6,
+        ) {
+            let config = GapDetectionConfig {
+                min_occurrences,
+                min_distinct_arguments,
+                require_success,
+                max_examples,
+            };
+            let _ = detect_tool_gaps(&history, config);
+        }
+
+        /// Every proposal is well-formed: a valid name, a non-empty parameter
+        /// list, and evidence at or above the configured thresholds.
+        #[test]
+        fn proposals_respect_their_contract(
+            history in proptest::collection::vec(arb_invocation(), 0..60),
+            min_occurrences in 2usize..6,
+            min_distinct_arguments in 2usize..6,
+        ) {
+            let config = GapDetectionConfig {
+                min_occurrences,
+                min_distinct_arguments,
+                require_success: true,
+                max_examples: 3,
+            };
+            for p in detect_tool_gaps(&history, config) {
+                prop_assert!(is_valid_tool_name(&p.name), "invalid name {}", p.name);
+                prop_assert!(!p.parameters.is_empty(), "zero-parameter proposal");
+                prop_assert!(p.occurrences >= min_occurrences);
+                prop_assert!(p.distinct_arguments >= min_distinct_arguments);
+                prop_assert!(p.examples.len() <= 3);
+                // Parameter count matches the placeholder count in the template.
+                let holes = p.command_template.matches("{p").count();
+                prop_assert_eq!(holes, p.parameters.len());
+            }
+        }
+
+        /// Detection is deterministic: the same history yields the same output.
+        #[test]
+        fn deterministic(history in proptest::collection::vec(arb_invocation(), 0..40)) {
+            let a = detect_tool_gaps(&history, GapDetectionConfig::default());
+            let b = detect_tool_gaps(&history, GapDetectionConfig::default());
+            prop_assert_eq!(a, b);
+        }
+    }
+}

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -1302,6 +1302,43 @@ impl Store {
         Ok(n)
     }
 
+    /// The most recent `tool_calls` rows for one tool, newest first, capped at
+    /// `limit`. Reads through the `tool_calls_by_name` index. The Tool Foundry
+    /// gap detector consumes this for `name = "bash"` to mine repeated command
+    /// shapes (`stella_core::detect_tool_gaps`); it is a general reader, not
+    /// bash-specific. `limit == 0` returns an empty vec.
+    pub fn recent_tool_calls(&self, name: &str, limit: usize) -> Result<Vec<ToolCallRow>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT call_id, name, surface, args_json, args_digest, reason, \
+                    ok, error, bytes_out, duration_ms \
+             FROM tool_calls WHERE name = ?1 \
+             ORDER BY execution_id DESC, seq DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![name, limit as i64], |r| {
+            Ok(ToolCallRow {
+                call_id: r.get(0)?,
+                name: r.get(1)?,
+                surface: r.get(2)?,
+                args_json: r.get(3)?,
+                args_digest: r.get(4)?,
+                reason: r.get(5)?,
+                ok: r.get::<_, i64>(6)? != 0,
+                error: r.get(7)?,
+                bytes_out: r.get(8)?,
+                duration_ms: r.get(9)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Derive and record the objective half of this turn's
     /// `execution_reflection` — prompt, plus `produced_output` / `wrote_files`
     /// / `truncated` computed from the event and file-touch logs. The model's

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -2198,3 +2198,72 @@ fn a_failing_file_touch_row_rolls_its_whole_batch_back() {
         "the row written before the failure must roll back with it"
     );
 }
+
+/// Helper: a minimal successful `ToolCallRow` for the reader tests.
+#[cfg(test)]
+fn bash_row(call_id: &str, command: &str, ok: bool) -> ToolCallRow {
+    ToolCallRow {
+        call_id: call_id.into(),
+        name: "bash".into(),
+        surface: "native".into(),
+        args_json: format!(
+            "{{\"command\":{}}}",
+            serde_json::to_string(command).unwrap()
+        ),
+        args_digest: call_id.into(),
+        reason: String::new(),
+        ok,
+        error: String::new(),
+        bytes_out: 0,
+        duration_ms: 1,
+    }
+}
+
+#[test]
+fn recent_tool_calls_filters_by_name_and_returns_newest_first() {
+    let store = Store::in_memory().unwrap();
+    let e1 = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+    store
+        .record_tool_calls(
+            e1,
+            &[
+                bash_row("c1", "jq '.a' a.json", true),
+                ToolCallRow {
+                    call_id: "c2".into(),
+                    name: "read_file".into(),
+                    surface: "native".into(),
+                    args_json: "{}".into(),
+                    args_digest: "c2".into(),
+                    reason: String::new(),
+                    ok: true,
+                    error: String::new(),
+                    bytes_out: 0,
+                    duration_ms: 1,
+                },
+                bash_row("c3", "jq '.b' b.json", true),
+            ],
+        )
+        .unwrap();
+    let e2 = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+    store
+        .record_tool_calls(e2, &[bash_row("c4", "jq '.c' c.json", true)])
+        .unwrap();
+
+    // Newest execution first, then newest seq within an execution; read_file
+    // is filtered out.
+    let rows = store.recent_tool_calls("bash", 10).unwrap();
+    let ids: Vec<&str> = rows.iter().map(|r| r.call_id.as_str()).collect();
+    assert_eq!(ids, ["c4", "c3", "c1"]);
+    assert!(rows.iter().all(|r| r.name == "bash"));
+    assert!(rows[0].args_json.contains("jq '.c' c.json"));
+
+    // The limit caps the window; 0 is empty.
+    assert_eq!(store.recent_tool_calls("bash", 1).unwrap().len(), 1);
+    assert!(store.recent_tool_calls("bash", 0).unwrap().is_empty());
+    assert!(
+        store
+            .recent_tool_calls("nonexistent", 10)
+            .unwrap()
+            .is_empty()
+    );
+}


### PR DESCRIPTION
## Tool Foundry — first slice: the capability-gap detector

Implements the **first slice** of #830 (Self-improvement: Tool Foundry). The
issue scopes this deliberately:

> **First slice.** Gap detector only: mine receipts for repeated `bash`
> patterns and *propose* a tool spec (no auto-install) surfaced in `/inbox`.
> Prove the detector before granting authorship.

So this PR **proposes only** — it authors nothing, registers nothing, and
installs nothing. Authorship, witness proofs, `schema_gate`/`policy` gating,
and registry install are later slices.

### What it does

When the same shell **shape** keeps getting reconstructed by hand — e.g.
`jq '.items[0]' a.json`, `jq '.name' b.json`, `jq '.error.code' c.json` — the
foundry recognizes the shared shape, synthesizes a candidate parameterized
tool, and drops a suggestion in `/inbox`:

```
Proposed tool: `jq`
Proposed command:
  jq {p1} {p2}
Parameters:
  p1 : <str> (e.g. .items[0])
  p2 : <path> (e.g. a.json)
...
This is a suggestion only — no tool was installed. Review it before authoring one.
```

### How it's built (respecting the crate invariants)

- **`stella-core::tool_foundry`** — the detector is a **pure, no-I/O, no-regex**
  module, a sibling of `loop_detect`. It normalizes each command to a
  *signature*: the invariant skeleton (program, subcommands, flag names, shell
  operators) with varying values (quoted strings, paths, numbers) replaced by
  typed holes, then clusters by signature. A shape is proposed only when it
  recurs (`>= 3` by default) across **at least two distinct argument sets** —
  an exact repeat is `loop_detect`'s territory, not the foundry's — and
  succeeded at least once. Output is deterministic; synthesized names are valid
  by construction (`^[a-z][a-z0-9_]{1,63}$`). Unit **and** property tests.
- **`stella-store::recent_tool_calls(name, limit)`** — an index-backed reader
  over the existing `tool_calls` receipt log (no row-returning reader existed
  before). Reuses the `tool_calls_by_name` index.
- **`stella-cli::tool_foundry`** — the I/O adapter: reads recent `bash`
  receipts, runs the detector, and pushes a **deduped** `/inbox` notification
  per novel proposal (deterministic id derived from the shape, so a gap is
  surfaced at most once across turns/sessions). Wired best-effort into
  `record_execution_end` right after `materialize_tool_calls`; a mining failure
  never fails a turn.

### Guardrails / invariants

- **Proposes only.** Every inbox item states "no tool was installed."
- **No engine I/O** — the detector is a pure function; all I/O lives in the CLI
  adapter.
- **No new dependencies**, no telemetry egress, no new hub columns/encoders.
- Precision over recall on purpose: only structurally value-like tokens
  (quoted / path / number) become holes, so distinct subcommands never merge.
  A value carried as a plain bareword (`-n my-namespace`) is not yet recognized
  — an accepted first-slice limitation, noted in the module docs.

### Verification

- Witness discipline: `detect_tool_gaps` / `recent_tool_calls` are genuinely
  absent on `main`, so the new tests fail there and pass here.
- `stella-core` 588, `stella-store` 277, `stella-cli` 777 (+ integration)
  tests green; workspace `clippy -D warnings`, `fmt --check`, `rustdoc -D
  warnings`, file-size ratchet, invariants, doc-citations, no-scratch all pass.
- The `stella-store/src/{lib,tests}.rs` file-size baseline entries were raised
  for the additive reader + its test (hand-edited to avoid the macOS
  regen reorder).

Refs #830


## Summary by Sourcery

Introduce a capability-gap detector that mines recent bash tool receipts to propose reusable parameterized tools and surfaces them as deduplicated inbox notifications without installing anything.

New Features:
- Add a pure tool_foundry module in stella-core that normalizes shell commands, clusters recurring shapes, and proposes parameterized tools via detect_tool_gaps.
- Expose a recent_tool_calls reader in stella-store to fetch the latest tool_calls rows for a given tool name, ordered by recency, for use by the gap detector.
- Wire a new tool_foundry adapter into the CLI to mine recent bash history at the end of each execution and emit structured inbox notifications describing proposed tools.

Enhancements:
- Ensure proposed tool names, command templates, and parameters are synthesized deterministically and conform to naming constraints, favoring precision over recall in how arguments are generalized into holes.
- Deduplicate tool-foundry inbox notifications by a stable, hash-based id derived from the command shape so each gap is surfaced at most once across sessions.

Tests:
- Add unit and property-based tests for the core gap detector covering normalization, clustering behavior, configuration thresholds, determinism, and name validity.
- Add store-level tests for recent_tool_calls to verify name filtering, ordering, and limit handling.
- Add CLI-level tests to verify gap proposals are surfaced once, malformed rows are ignored, and notification ids are stable for a given command shape.

Chores:
- Update file-size baseline entries to account for the new tool_foundry module and store reader additions.
