### PR TITLE
feat(self-tuning): A/B the worker effort knob, auto-select + rollback (#831 first slice)

### DIFF
--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -75,6 +75,7 @@ mod subsession;
 mod tool_policy;
 mod tool_switches;
 mod tui;
+mod tune_cmd;
 mod usage_cmd;
 
 /// Serializes tests that mutate process environment variables. `setenv` /
@@ -517,6 +518,17 @@ enum Command {
     Proposals {
         #[command(subcommand)]
         cmd: proposals_cmd::ProposalsCmd,
+    },
+
+    /// Eval-driven self-tuning of stella's own policy (#831): A/B one knob
+    /// (worker reasoning effort) over two loop-bench `--json` result files,
+    /// auto-select the winner, and — with `--promote` — write it to settings
+    /// with a reversible rollback record. `rollback` reverts the last
+    /// promotion; `status` shows the ledger. Offline: reads result files and
+    /// the local ledger, writes settings only on `--promote`. No API key.
+    Tune {
+        #[command(subcommand)]
+        cmd: tune_cmd::TuneCmd,
     },
 
     /// Show the exact context a past model call was sent — the reconstructed
@@ -1046,6 +1058,11 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         Some(Command::Proposals { cmd }) => {
             return proposals_cmd::run_proposals(cmd);
         }
+        // #831 first slice. Reads loop-bench result files + the local ledger;
+        // writes settings only on `--promote`. No provider, no API key.
+        Some(Command::Tune { cmd }) => {
+            return tune_cmd::run_tune(cmd);
+        }
         Some(Command::Inspect {
             execution_id,
             turn,
@@ -1366,6 +1383,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Inspect { .. }
         // Phase 3 (#714)
         | Command::Proposals { .. }
+        // #831 first slice
+        | Command::Tune { .. }
         | Command::Stats { .. }
         | Command::Usage { .. }
         | Command::Cloud { .. }

--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -68,6 +68,7 @@ mod recall;
 // Phase 4 (#715): reversible retirement of context that stops helping.
 pub(crate) mod retirement;
 pub(crate) mod rules_mining;
+pub(crate) mod self_tuning;
 #[path = "memory/skills.rs"]
 mod skill_files;
 mod suppression;

--- a/stella-cli/src/memory/self_tuning.rs
+++ b/stella-cli/src/memory/self_tuning.rs
@@ -1,0 +1,565 @@
+//! Self-tuning — the I/O half of the eval-driven effort bandit (#831, first
+//! slice). It sits beside [`crate::memory::rules_mining`]: the pure selection
+//! math is [`stella_core::self_tuning`]; this module reads loop-bench results,
+//! folds each trial into a reward sample, asks the core which arm won, and — on
+//! a confident win — writes the winning worker reasoning-effort to settings and
+//! appends a reversible [`RollbackRecord`] to an append-only ledger under
+//! `.stella/private/`.
+//!
+//! **Why loop-bench.** loop-bench already emits a per-trial verifier reward in
+//! its `--json` output; each arm is one loop-bench run (over a fixed held-out
+//! task list) at a fixed worker effort, and its samples are those per-trial
+//! rewards. The shipping CLI does **not** depend on the dev-only `loop-bench`
+//! crate — it parses the JSON with the minimal [`BenchTrial`] view below.
+//!
+//! **The `effort_auto` gotcha.** A pinned `agents.worker.effort` is ignored
+//! while `effort_auto: on` (the auto table picks the effort instead). So a
+//! promotion also turns `effort_auto` off in the target scope, and the rollback
+//! record captures the prior `effort_auto` so a rollback restores it exactly.
+//! Worker effort is not safety-relevant policy (authority, scope-review, and
+//! budget are), so this is within the allowed blast radius — and it is fully
+//! reversible.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use stella_core::self_tuning::{
+    ArmSamples, ArmStats, Decision, RewardWeights, RollbackRecord, SelectionConfig, TaskOutcome,
+    reward, select_winner,
+};
+use stella_protocol::completion::ReasoningEffort;
+
+use crate::settings::{
+    AgentEngineAgent, AgentEngineConfig, EngineAgentKind, Toggle, project_settings_path,
+    user_settings_path,
+};
+
+/// The settings path the effort knob lives at — the `knob` field of every
+/// ledger record, and what a rollback restores.
+pub(crate) const WORKER_EFFORT_KNOB: &str = "agent_engine_config.agents.worker.effort";
+
+/// The append-only self-tuning ledger, under `.stella/private/` (git-ignored).
+const LEDGER: &str = "self_tuning.jsonl";
+
+/// Which settings scope a promotion writes to and a rollback restores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SettingsScope {
+    /// `<workspace>/.stella/settings.json` — the default (highest precedence,
+    /// so a pinned effort always binds).
+    Project,
+    /// `~/.stella/settings.json`.
+    User,
+}
+
+impl SettingsScope {
+    fn path(self, workspace_root: &Path) -> Result<PathBuf, String> {
+        match self {
+            SettingsScope::Project => Ok(project_settings_path(workspace_root)),
+            SettingsScope::User => user_settings_path()
+                .ok_or_else(|| "HOME is not set; cannot resolve user settings".to_string()),
+        }
+    }
+}
+
+/// The minimal view of a loop-bench `TrialReport` this module needs. loop-bench
+/// serializes with the Rust field names verbatim; unknown fields are ignored,
+/// and every field we read defaults so a shape change there degrades gracefully
+/// rather than failing the parse. `reward` is `Option<f64>`: `None` means the
+/// trial never reached the verifier and is **excluded** (it is not a zero).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BenchTrial {
+    #[serde(default)]
+    pub reward: Option<f64>,
+    #[serde(default)]
+    pub spend_usd: f64,
+    #[serde(default)]
+    pub loop_detected: u32,
+}
+
+/// The result of one A/B experiment: the decision plus each arm's stats, ready
+/// to print and to append to the ledger as a receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ExperimentReport {
+    pub knob: String,
+    pub decision: Decision,
+    pub baseline: ArmStats,
+    pub candidate: ArmStats,
+}
+
+/// One line of the self-tuning ledger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "entry", rename_all = "snake_case")]
+pub(crate) enum LedgerEntry {
+    /// An A/B was evaluated (whatever the decision) — the published receipt.
+    /// Boxed: the report carries two [`ArmStats`] and a [`Decision`], far larger
+    /// than the other variants, so boxing keeps every `LedgerEntry` small.
+    Experiment {
+        report: Box<ExperimentReport>,
+        at_ms: u64,
+    },
+    /// A winner was promoted to settings.
+    Promotion {
+        rollback: RollbackRecord,
+        /// The `effort_auto` value before the promotion (`None` = absent), so a
+        /// rollback restores it exactly.
+        previous_effort_auto: Option<bool>,
+        scope: SettingsScope,
+        at_ms: u64,
+    },
+    /// A promotion was reverted.
+    Rolledback {
+        knob: String,
+        restored_value: Option<String>,
+        restored_effort_auto: Option<bool>,
+        scope: SettingsScope,
+        at_ms: u64,
+    },
+}
+
+/// Parse a reasoning-effort label. Accepts exactly the five settings spellings.
+pub(crate) fn parse_effort(label: &str) -> Result<ReasoningEffort, String> {
+    match label {
+        "low" => Ok(ReasoningEffort::Low),
+        "medium" => Ok(ReasoningEffort::Medium),
+        "high" => Ok(ReasoningEffort::High),
+        "xhigh" => Ok(ReasoningEffort::Xhigh),
+        "max" => Ok(ReasoningEffort::Max),
+        other => Err(format!(
+            "unknown reasoning effort `{other}` (expected low|medium|high|xhigh|max)"
+        )),
+    }
+}
+
+/// The settings label for an effort (the inverse of [`parse_effort`]).
+pub(crate) fn effort_label(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+        ReasoningEffort::Xhigh => "xhigh",
+        ReasoningEffort::Max => "max",
+    }
+}
+
+/// Fold one arm's loop-bench trials into reward samples. A trial that never
+/// reached the verifier (`reward == None`) is excluded — it is missing data,
+/// not a zero. `succeeded` mirrors loop-bench's own "solved" bar (verifier
+/// reward `>= 1.0`); cost and loop events feed the (weighted) penalties.
+fn arm_from_trials(
+    id: &str,
+    value: &str,
+    trials: &[BenchTrial],
+    weights: &RewardWeights,
+) -> ArmSamples {
+    let rewards = trials
+        .iter()
+        .filter(|t| t.reward.is_some())
+        .map(|t| {
+            let outcome = TaskOutcome {
+                succeeded: t.reward.is_some_and(|r| r >= 1.0),
+                cost_usd: t.spend_usd,
+                // loop-bench does not expose per-trial token counts; the token
+                // weight is inert here and lives for the general receipts path.
+                tokens: 0,
+                retries: t.loop_detected,
+            };
+            reward(&outcome, weights)
+        })
+        .collect();
+    ArmSamples {
+        id: id.to_string(),
+        value: value.to_string(),
+        rewards,
+    }
+}
+
+/// Run the A/B: score both arms' loop-bench trials and ask the core selector
+/// whether the candidate confidently beats the baseline. Pure — no I/O — so it
+/// is testable with synthetic trials.
+pub(crate) fn run_experiment(
+    baseline_trials: &[BenchTrial],
+    baseline_effort: &str,
+    candidate_trials: &[BenchTrial],
+    candidate_effort: &str,
+    weights: &RewardWeights,
+    config: &SelectionConfig,
+) -> ExperimentReport {
+    let baseline_arm = arm_from_trials("baseline", baseline_effort, baseline_trials, weights);
+    let candidate_arm = arm_from_trials("candidate", candidate_effort, candidate_trials, weights);
+    let baseline = ArmStats::from_samples(&baseline_arm);
+    let candidate = ArmStats::from_samples(&candidate_arm);
+    let decision = select_winner(&[baseline_arm, candidate_arm], "baseline", config);
+    ExperimentReport {
+        knob: WORKER_EFFORT_KNOB.to_string(),
+        decision,
+        baseline,
+        candidate,
+    }
+}
+
+/// Read the current `agent_engine_config` block from one scope file, or the
+/// default when the file/key is absent. Only that block is loaded; `save_to`
+/// preserves every other key when writing back.
+fn load_scope_engine_config(path: &Path) -> AgentEngineConfig {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+        .and_then(|v| v.get("agent_engine_config").cloned())
+        .and_then(|v| serde_json::from_value::<AgentEngineConfig>(v).ok())
+        .unwrap_or_default()
+}
+
+/// Milliseconds since the Unix epoch (best-effort; `0` if the clock is before
+/// the epoch). Only used to timestamp ledger lines.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Append one entry to the self-tuning ledger.
+fn append_entry(workspace_root: &Path, entry: &LedgerEntry) -> Result<(), String> {
+    let line = serde_json::to_string(entry).map_err(|e| e.to_string())?;
+    stella_store::append_workspace_private_line(workspace_root, LEDGER, &line)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Read every parseable ledger entry (bad lines skipped), oldest first.
+pub(crate) fn read_ledger(workspace_root: &Path) -> Vec<LedgerEntry> {
+    let Ok(path) = stella_store::workspace_private_state_path(workspace_root, LEDGER) else {
+        return Vec::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<LedgerEntry>(l).ok())
+        .collect()
+}
+
+/// The promotion currently in effect for the effort knob: the last
+/// [`LedgerEntry::Promotion`] not since reverted by a [`LedgerEntry::Rolledback`].
+fn active_promotion(
+    workspace_root: &Path,
+) -> Option<(RollbackRecord, Option<bool>, SettingsScope)> {
+    let mut active = None;
+    for entry in read_ledger(workspace_root) {
+        match entry {
+            LedgerEntry::Promotion {
+                rollback,
+                previous_effort_auto,
+                scope,
+                ..
+            } if rollback.knob == WORKER_EFFORT_KNOB => {
+                active = Some((rollback, previous_effort_auto, scope));
+            }
+            LedgerEntry::Rolledback { knob, .. } if knob == WORKER_EFFORT_KNOB => {
+                active = None;
+            }
+            _ => {}
+        }
+    }
+    active
+}
+
+/// Publish an experiment receipt to the ledger (called whatever the decision).
+pub(crate) fn publish_experiment(
+    workspace_root: &Path,
+    report: &ExperimentReport,
+) -> Result<(), String> {
+    append_entry(
+        workspace_root,
+        &LedgerEntry::Experiment {
+            report: Box::new(report.clone()),
+            at_ms: now_ms(),
+        },
+    )
+}
+
+/// The prior state captured before a promotion, so the caller can report and
+/// so a rollback can restore it.
+pub(crate) struct PriorState {
+    pub effort: Option<String>,
+    pub effort_auto: Option<bool>,
+}
+
+/// Write `chosen` worker effort to `scope`, disabling `effort_auto` so the
+/// pinned value binds, and append a promotion record. Returns the prior state
+/// captured for rollback. `save_to` preserves every other settings key.
+pub(crate) fn promote(
+    workspace_root: &Path,
+    scope: SettingsScope,
+    chosen: ReasoningEffort,
+    promotion: &stella_core::self_tuning::Promotion,
+) -> Result<PriorState, String> {
+    let path = scope.path(workspace_root)?;
+    let mut cfg = load_scope_engine_config(&path);
+
+    let prior_effort = cfg
+        .agent(EngineAgentKind::Worker)
+        .and_then(|a| a.effort)
+        .map(|e| effort_label(e).to_string());
+    let prior_auto = cfg.effort_auto.map(Toggle::is_on);
+
+    let agents = cfg.agents.get_or_insert_with(Default::default);
+    let worker = agents
+        .get_mut(EngineAgentKind::Worker)
+        .get_or_insert_with(AgentEngineAgent::default);
+    worker.effort = Some(chosen);
+    // Disable auto-effort so the pinned worker effort actually takes effect.
+    cfg.effort_auto = Some(Toggle::Off);
+
+    cfg.save_to(&path)?;
+
+    let record =
+        RollbackRecord::from_promotion(WORKER_EFFORT_KNOB, prior_effort.clone(), promotion);
+    append_entry(
+        workspace_root,
+        &LedgerEntry::Promotion {
+            rollback: record,
+            previous_effort_auto: prior_auto,
+            scope,
+            at_ms: now_ms(),
+        },
+    )?;
+
+    Ok(PriorState {
+        effort: prior_effort,
+        effort_auto: prior_auto,
+    })
+}
+
+/// The outcome of a rollback attempt.
+pub(crate) enum RollbackOutcome {
+    /// Nothing to roll back — no active promotion.
+    Nothing,
+    /// Restored the worker effort to the given prior value (`None` = cleared
+    /// back to auto/default), in the named scope.
+    Restored {
+        knob: String,
+        restored: Option<String>,
+        scope: SettingsScope,
+    },
+}
+
+/// Revert the last effort promotion: restore the worker effort and the
+/// `effort_auto` value that were in place before it, in the scope it wrote.
+pub(crate) fn rollback(workspace_root: &Path) -> Result<RollbackOutcome, String> {
+    let Some((record, prior_auto, scope)) = active_promotion(workspace_root) else {
+        return Ok(RollbackOutcome::Nothing);
+    };
+    let path = scope.path(workspace_root)?;
+    let mut cfg = load_scope_engine_config(&path);
+
+    // Restore worker effort to its prior value (or clear it entirely).
+    let restored_effort = match &record.previous_value {
+        Some(label) => Some(parse_effort(label)?),
+        None => None,
+    };
+    let agents = cfg.agents.get_or_insert_with(Default::default);
+    let worker = agents
+        .get_mut(EngineAgentKind::Worker)
+        .get_or_insert_with(AgentEngineAgent::default);
+    worker.effort = restored_effort;
+
+    // Restore effort_auto exactly (absent stays absent).
+    cfg.effort_auto = prior_auto.map(|on| if on { Toggle::On } else { Toggle::Off });
+
+    cfg.save_to(&path)?;
+
+    append_entry(
+        workspace_root,
+        &LedgerEntry::Rolledback {
+            knob: record.knob.clone(),
+            restored_value: record.previous_value.clone(),
+            restored_effort_auto: prior_auto,
+            scope,
+            at_ms: now_ms(),
+        },
+    )?;
+
+    Ok(RollbackOutcome::Restored {
+        knob: record.knob,
+        restored: record.previous_value,
+        scope,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trial(reward: Option<f64>) -> BenchTrial {
+        BenchTrial {
+            reward,
+            spend_usd: 0.0,
+            loop_detected: 0,
+        }
+    }
+
+    fn trials(rewards: &[Option<f64>]) -> Vec<BenchTrial> {
+        rewards.iter().copied().map(trial).collect()
+    }
+
+    fn worker_effort_in(path: &Path) -> Option<String> {
+        let cfg = load_scope_engine_config(path);
+        cfg.agent(EngineAgentKind::Worker)
+            .and_then(|a| a.effort)
+            .map(|e| effort_label(e).to_string())
+    }
+
+    #[test]
+    fn parse_and_label_round_trip() {
+        for label in ["low", "medium", "high", "xhigh", "max"] {
+            assert_eq!(effort_label(parse_effort(label).unwrap()), label);
+        }
+        assert!(parse_effort("turbo").is_err());
+    }
+
+    #[test]
+    fn none_reward_trials_are_excluded_not_zeroed() {
+        let arm = arm_from_trials(
+            "candidate",
+            "high",
+            &trials(&[Some(1.0), None, Some(1.0)]),
+            &RewardWeights::default(),
+        );
+        // Two finished trials (both solved), the unfinished one dropped.
+        assert_eq!(arm.rewards, vec![1.0, 1.0]);
+    }
+
+    #[test]
+    fn a_clean_win_promotes_and_rollback_restores() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let baseline = trials(&[Some(0.0); 6]);
+        let candidate = trials(&[Some(1.0); 6]);
+        let report = run_experiment(
+            &baseline,
+            "medium",
+            &candidate,
+            "high",
+            &RewardWeights::default(),
+            &SelectionConfig::default(),
+        );
+        assert!(report.decision.is_promotion(), "clean win should promote");
+        publish_experiment(root, &report).unwrap();
+
+        let Decision::Promote(p) = &report.decision else {
+            unreachable!()
+        };
+        let chosen = parse_effort(&p.winner.value).unwrap();
+        let prior = promote(root, SettingsScope::Project, chosen, p).unwrap();
+        assert_eq!(prior.effort, None, "worker effort was unset before");
+
+        let settings = project_settings_path(root);
+        assert_eq!(worker_effort_in(&settings).as_deref(), Some("high"));
+        // effort_auto was forced off so the pinned effort binds.
+        let cfg = load_scope_engine_config(&settings);
+        assert_eq!(cfg.effort_auto, Some(Toggle::Off));
+
+        // The ledger carries the experiment receipt and the promotion.
+        let entries = read_ledger(root);
+        assert!(
+            entries
+                .iter()
+                .any(|e| matches!(e, LedgerEntry::Promotion { .. }))
+        );
+
+        // Rollback restores the prior (unset) worker effort.
+        match rollback(root).unwrap() {
+            RollbackOutcome::Restored { restored, .. } => assert_eq!(restored, None),
+            RollbackOutcome::Nothing => panic!("expected a rollback"),
+        }
+        assert_eq!(
+            worker_effort_in(&settings),
+            None,
+            "effort cleared on rollback"
+        );
+
+        // A second rollback is a no-op (the promotion is already reverted).
+        assert!(matches!(rollback(root).unwrap(), RollbackOutcome::Nothing));
+    }
+
+    #[test]
+    fn rollback_restores_a_prior_effort_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let settings = project_settings_path(root);
+
+        // Seed a prior worker effort of "low".
+        let mut seed = AgentEngineConfig::default();
+        let agents = seed.agents.get_or_insert_with(Default::default);
+        agents
+            .get_mut(EngineAgentKind::Worker)
+            .get_or_insert_with(AgentEngineAgent::default)
+            .effort = Some(ReasoningEffort::Low);
+        seed.save_to(&settings).unwrap();
+
+        let report = run_experiment(
+            &trials(&[Some(0.0); 6]),
+            "low",
+            &trials(&[Some(1.0); 6]),
+            "high",
+            &RewardWeights::default(),
+            &SelectionConfig::default(),
+        );
+        let Decision::Promote(p) = &report.decision else {
+            panic!("expected promotion")
+        };
+        let prior = promote(
+            root,
+            SettingsScope::Project,
+            parse_effort(&p.winner.value).unwrap(),
+            p,
+        )
+        .unwrap();
+        assert_eq!(prior.effort.as_deref(), Some("low"));
+        assert_eq!(worker_effort_in(&settings).as_deref(), Some("high"));
+
+        rollback(root).unwrap();
+        assert_eq!(
+            worker_effort_in(&settings).as_deref(),
+            Some("low"),
+            "rollback restores the pre-promotion effort"
+        );
+    }
+
+    #[test]
+    fn an_inconclusive_experiment_does_not_promote() {
+        let noisy_a = trials(&[
+            Some(1.0),
+            Some(0.0),
+            Some(1.0),
+            Some(0.0),
+            Some(1.0),
+            Some(0.0),
+        ]);
+        let noisy_b = trials(&[
+            Some(1.0),
+            Some(0.0),
+            Some(1.0),
+            Some(1.0),
+            Some(0.0),
+            Some(1.0),
+        ]);
+        let report = run_experiment(
+            &noisy_a,
+            "medium",
+            &noisy_b,
+            "high",
+            &RewardWeights::default(),
+            &SelectionConfig::default(),
+        );
+        assert!(
+            !report.decision.is_promotion(),
+            "overlapping noisy arms must not promote"
+        );
+    }
+}

--- a/stella-cli/src/tune_cmd.rs
+++ b/stella-cli/src/tune_cmd.rs
@@ -1,0 +1,304 @@
+//! `stella tune` — eval-driven self-tuning of stella's own policy (#831, first
+//! slice: the worker reasoning-effort knob).
+//!
+//! The flow is A/B on loop-bench, offline in this command: run loop-bench twice
+//! over a fixed held-out task list — once at the baseline worker effort, once at
+//! the candidate — capture each run's `--json` output, then:
+//!
+//! ```text
+//! stella tune effort --baseline base.json --candidate cand.json \
+//!     --baseline-effort medium --candidate-effort high [--promote]
+//! ```
+//!
+//! It scores each arm from the per-trial rewards, and promotes the candidate
+//! **only** when it confidently beats the baseline (see
+//! [`stella_core::self_tuning`]). Without `--promote` it reports and records the
+//! A/B receipt but changes nothing; with `--promote` it writes the winning
+//! effort to settings and records a reversible rollback. `stella tune rollback`
+//! reverts the last promotion; `stella tune status` shows the ledger.
+//!
+//! Offline: reads two result files and the local ledger, writes settings only
+//! on `--promote`. No provider, no API key.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, ValueEnum};
+use colored::Colorize;
+use stella_core::self_tuning::{Decision, KeepReason, RewardWeights, SelectionConfig};
+
+use crate::memory::self_tuning::{
+    self as engine, BenchTrial, ExperimentReport, LedgerEntry, RollbackOutcome, SettingsScope,
+};
+
+/// Settings scope for `--scope`.
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum ScopeArg {
+    Project,
+    User,
+}
+
+impl From<ScopeArg> for SettingsScope {
+    fn from(s: ScopeArg) -> Self {
+        match s {
+            ScopeArg::Project => SettingsScope::Project,
+            ScopeArg::User => SettingsScope::User,
+        }
+    }
+}
+
+/// Subcommands under `stella tune`.
+#[derive(Subcommand, Clone)]
+pub enum TuneCmd {
+    /// A/B the worker reasoning-effort knob over two loop-bench `--json` result
+    /// files and select the winner. Reports only unless `--promote` is given.
+    Effort {
+        /// loop-bench `--json` output for the baseline arm.
+        #[arg(long)]
+        baseline: PathBuf,
+        /// loop-bench `--json` output for the candidate arm.
+        #[arg(long)]
+        candidate: PathBuf,
+        /// The worker effort the baseline arm ran at.
+        #[arg(long, default_value = "medium")]
+        baseline_effort: String,
+        /// The worker effort the candidate arm ran at.
+        #[arg(long, default_value = "high")]
+        candidate_effort: String,
+        /// Apply the winner to settings (default: report only).
+        #[arg(long)]
+        promote: bool,
+        /// Which settings scope to write on `--promote`.
+        #[arg(long, value_enum, default_value = "project")]
+        scope: ScopeArg,
+        /// Minimum trials required in every arm before any promotion.
+        #[arg(long, default_value_t = 5)]
+        min_samples: usize,
+    },
+    /// Revert the last effort promotion, restoring the prior worker effort.
+    Rollback,
+    /// Show the self-tuning ledger — experiments run and the promotion in effect.
+    Status,
+}
+
+/// Dispatch a `stella tune` subcommand. Offline; workspace root is the CWD,
+/// matching the other local-only commands (`proposals`, `stats`).
+pub fn run_tune(cmd: &TuneCmd) -> Result<(), String> {
+    let workspace_root = std::env::current_dir().map_err(|e| e.to_string())?;
+    match cmd {
+        TuneCmd::Effort {
+            baseline,
+            candidate,
+            baseline_effort,
+            candidate_effort,
+            promote,
+            scope,
+            min_samples,
+        } => run_effort(
+            &workspace_root,
+            baseline,
+            candidate,
+            baseline_effort,
+            candidate_effort,
+            *promote,
+            (*scope).into(),
+            *min_samples,
+        ),
+        TuneCmd::Rollback => run_rollback(&workspace_root),
+        TuneCmd::Status => run_status(&workspace_root),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_effort(
+    workspace_root: &Path,
+    baseline_path: &Path,
+    candidate_path: &Path,
+    baseline_effort: &str,
+    candidate_effort: &str,
+    promote: bool,
+    scope: SettingsScope,
+    min_samples: usize,
+) -> Result<(), String> {
+    // Validate the effort labels up front so a typo fails before any I/O.
+    engine::parse_effort(baseline_effort)?;
+    engine::parse_effort(candidate_effort)?;
+
+    let baseline_trials = read_trials(baseline_path)?;
+    let candidate_trials = read_trials(candidate_path)?;
+
+    let config = SelectionConfig {
+        min_samples_per_arm: min_samples,
+        ..SelectionConfig::default()
+    };
+    let report = engine::run_experiment(
+        &baseline_trials,
+        baseline_effort,
+        &candidate_trials,
+        candidate_effort,
+        &RewardWeights::default(),
+        &config,
+    );
+
+    print_report(&report);
+    // Always publish the receipt — a kept baseline is evidence too.
+    engine::publish_experiment(workspace_root, &report)?;
+
+    match &report.decision {
+        Decision::Promote(p) => {
+            if promote {
+                let chosen = engine::parse_effort(&p.winner.value)?;
+                let prior = engine::promote(workspace_root, scope, chosen, p)?;
+                println!(
+                    "\n{} worker effort → {} (was {}) in {} settings.",
+                    "promoted".green().bold(),
+                    p.winner.value.bold(),
+                    prior.effort.as_deref().unwrap_or("unset/auto"),
+                    scope_label(scope),
+                );
+                if prior.effort_auto == Some(true) {
+                    println!(
+                        "  note: disabled effort_auto so the pinned worker effort binds \
+                         (restored on rollback)."
+                    );
+                }
+                println!("  revert with: {}", "stella tune rollback".cyan());
+            } else {
+                println!(
+                    "\n{}: candidate `{}` beats baseline `{}`. Re-run with {} to apply.",
+                    "winner".green().bold(),
+                    p.winner.value.bold(),
+                    p.baseline.value,
+                    "--promote".cyan(),
+                );
+            }
+        }
+        Decision::Keep(reason) => {
+            println!(
+                "\n{}: {}",
+                "kept baseline".yellow().bold(),
+                describe_keep(reason)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_rollback(workspace_root: &Path) -> Result<(), String> {
+    match engine::rollback(workspace_root)? {
+        RollbackOutcome::Nothing => {
+            println!("nothing to roll back — no effort promotion is in effect.");
+        }
+        RollbackOutcome::Restored {
+            knob,
+            restored,
+            scope,
+        } => {
+            println!(
+                "{} {} → {} in {} settings.",
+                "rolled back".green().bold(),
+                knob,
+                restored.as_deref().unwrap_or("unset/auto"),
+                scope_label(scope),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_status(workspace_root: &Path) -> Result<(), String> {
+    let entries = engine::read_ledger(workspace_root);
+    if entries.is_empty() {
+        println!("no self-tuning history yet. Run `stella tune effort --help`.");
+        return Ok(());
+    }
+    let experiments = entries
+        .iter()
+        .filter(|e| matches!(e, LedgerEntry::Experiment { .. }))
+        .count();
+    let promotions = entries
+        .iter()
+        .filter(|e| matches!(e, LedgerEntry::Promotion { .. }))
+        .count();
+    let rollbacks = entries
+        .iter()
+        .filter(|e| matches!(e, LedgerEntry::Rolledback { .. }))
+        .count();
+    println!(
+        "self-tuning ledger: {experiments} experiment(s), {promotions} promotion(s), \
+         {rollbacks} rollback(s)."
+    );
+
+    // The promotion currently in effect, if any.
+    let active = entries.iter().rev().find_map(|e| match e {
+        LedgerEntry::Promotion { rollback, .. } => Some(rollback),
+        LedgerEntry::Rolledback { .. } => None,
+        _ => None,
+    });
+    match active {
+        Some(r) => println!(
+            "in effect: {} = {} (was {}), lift {:+.3}.",
+            r.knob,
+            r.promoted_value.bold(),
+            r.previous_value.as_deref().unwrap_or("unset/auto"),
+            r.lift,
+        ),
+        None => println!("in effect: none (baseline)."),
+    }
+    Ok(())
+}
+
+/// Read a loop-bench `--json` result file into trials.
+fn read_trials(path: &Path) -> Result<Vec<BenchTrial>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    serde_json::from_str::<Vec<BenchTrial>>(&contents).map_err(|e| {
+        format!(
+            "cannot parse {} as a loop-bench --json array of trial reports: {e}",
+            path.display()
+        )
+    })
+}
+
+fn print_report(report: &ExperimentReport) {
+    println!("A/B: {}", report.knob);
+    println!(
+        "  baseline {:<6} n={:<3} mean={:.3} ± {:.3}",
+        report.baseline.value, report.baseline.n, report.baseline.mean, report.baseline.std_error,
+    );
+    println!(
+        "  candidate {:<5} n={:<3} mean={:.3} ± {:.3}",
+        report.candidate.value,
+        report.candidate.n,
+        report.candidate.mean,
+        report.candidate.std_error,
+    );
+}
+
+fn describe_keep(reason: &KeepReason) -> String {
+    match reason {
+        KeepReason::InsufficientSamples { arm, n, required } => {
+            format!("arm `{arm}` has only {n} trials; {required} required per arm")
+        }
+        KeepReason::MissingBaseline { baseline_id } => {
+            format!("no baseline arm `{baseline_id}` in the results")
+        }
+        KeepReason::BaselineIsBest { baseline_mean } => {
+            format!("baseline already leads (mean {baseline_mean:.3})")
+        }
+        KeepReason::BelowMinEffect { lift, min_effect } => {
+            format!("lift {lift:+.3} is below the min effect {min_effect:.3}")
+        }
+        KeepReason::LiftNotConfident {
+            lift,
+            observed_z,
+            threshold_z,
+        } => format!("lift {lift:+.3} is not confident (z={observed_z:.2}, need {threshold_z:.2})"),
+    }
+}
+
+fn scope_label(scope: SettingsScope) -> &'static str {
+    match scope {
+        SettingsScope::Project => "project",
+        SettingsScope::User => "user",
+    }
+}

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod retry;
 pub mod router;
 pub mod rules;
 pub mod scoreboard;
+pub mod self_tuning;
 pub mod skills;
 pub(crate) mod speculation;
 mod summarize;

--- a/stella-core/src/self_tuning.rs
+++ b/stella-core/src/self_tuning.rs
@@ -1,0 +1,662 @@
+//! Self-tuning — the eval-driven policy selector: pure synchronous analysis of
+//! A/B outcomes that decides whether one variant of a decision knob is
+//! *confidently* better than the current baseline, and only then recommends
+//! promoting it.
+//!
+//! This is the first slice of self-improvement issue #831 ("a bandit over
+//! stella's own prompts, policies, and routing"): **one knob (worker reasoning
+//! effort) A/B'd with automatic winner selection and a rollback record.** The
+//! knob here is opaque — an arm is just an id, a human-readable `value`, and a
+//! bag of per-trial reward samples — so the same engine generalizes to any
+//! future knob (prompt templates, routing, effort defaults) without change.
+//!
+//! Like [`crate::scoreboard`] and [`crate::loop_detect`], this module does no
+//! I/O: the caller (the CLI) runs the benchmark, folds each trial into a reward
+//! ([`reward`]), and hands the per-arm samples to [`select_winner`]. The result
+//! is a typed [`Decision`] the caller acts on — write the winning overlay to
+//! settings and append a [`RollbackRecord`], or keep the baseline with a stated
+//! reason. The arithmetic is a deterministic function of the samples and is
+//! unit-testable without a store, a provider, or a benchmark run.
+//!
+//! **"Improvement proven, not asserted."** A promotion is gated on two things,
+//! both required:
+//!
+//! 1. **Enough evidence** — every arm needs at least
+//!    [`SelectionConfig::min_samples_per_arm`] trials, so a lucky run of two
+//!    can't flip the policy.
+//! 2. **A confident lift** — the winner's mean must beat the baseline's by a
+//!    margin large relative to the noise in *both* arms. The test is a
+//!    Welch-style two-sample z on the difference of means
+//!    (`z = (mean_w - mean_b) / sqrt(se_w² + se_b²)`); the lift is credited
+//!    only when `z >= confidence_z` **and** the raw lift clears
+//!    [`SelectionConfig::min_effect`].
+//!
+//! Because a promotion fires *only* when the candidate is confidently better,
+//! "no regression" is a property of the rule, not a separate check: the
+//! baseline is never replaced by something merely tied or noisily different.
+//! The conservative direction is deliberate — this changes stella's own
+//! behavior, so the bar to move it is high and the move is always reversible
+//! via the [`RollbackRecord`].
+
+use serde::{Deserialize, Serialize};
+
+/// One task's outcome, distilled from receipts into the ingredients the reward
+/// function weighs. The caller builds this from whatever outcome record it has
+/// (a benchmark trial, a stored execution rollup); the reward is a pure
+/// function of it.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    /// Did the task succeed (verifier passed, goal met)? The dominant signal.
+    pub succeeded: bool,
+    /// USD spent on the task — a cost the reward can penalize.
+    pub cost_usd: f64,
+    /// Total tokens spent on the task.
+    pub tokens: u64,
+    /// How many times the task had to retry / was detected looping — a
+    /// friction signal distinct from outright failure.
+    pub retries: u32,
+}
+
+/// Weights turning a [`TaskOutcome`] into a scalar reward (higher is better).
+/// The default is **pure success** — reward is `1.0` for a solved task and
+/// `0.0` otherwise — so an A/B over the default weights is a straight
+/// pass-rate comparison. Callers dial in cost/token/retry penalties to make
+/// the reward cost-aware.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RewardWeights {
+    /// Reward added for a successful task.
+    pub success: f64,
+    /// Reward subtracted per USD spent.
+    pub cost_usd: f64,
+    /// Reward subtracted per 1,000 tokens spent.
+    pub per_1k_tokens: f64,
+    /// Reward subtracted per retry / loop event.
+    pub per_retry: f64,
+}
+
+impl Default for RewardWeights {
+    fn default() -> Self {
+        Self {
+            success: 1.0,
+            cost_usd: 0.0,
+            per_1k_tokens: 0.0,
+            per_retry: 0.0,
+        }
+    }
+}
+
+/// Score one task outcome into a scalar reward under `weights`. Pure and
+/// total: success contributes `weights.success`; cost, tokens, and retries
+/// each subtract their weighted amount. With [`RewardWeights::default`] this
+/// is exactly the success indicator (`1.0` / `0.0`).
+pub fn reward(outcome: &TaskOutcome, weights: &RewardWeights) -> f64 {
+    let success = if outcome.succeeded {
+        weights.success
+    } else {
+        0.0
+    };
+    success
+        - weights.cost_usd * outcome.cost_usd
+        - weights.per_1k_tokens * (outcome.tokens as f64 / 1000.0)
+        - weights.per_retry * outcome.retries as f64
+}
+
+/// One arm of the experiment: a knob variant and the reward samples observed
+/// for it (one per benchmark trial).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArmSamples {
+    /// Stable id of the arm (e.g. `"baseline"` / `"candidate"`).
+    pub id: String,
+    /// The knob value this arm represents, for display and the rollback record
+    /// (e.g. an effort label `"high"`).
+    pub value: String,
+    /// One reward per trial, in any order.
+    pub rewards: Vec<f64>,
+}
+
+/// The summary statistics of one arm's samples. Serialized into the A/B
+/// receipt so a promotion's evidence is auditable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArmStats {
+    /// The arm id.
+    pub id: String,
+    /// The knob value.
+    pub value: String,
+    /// Number of samples.
+    pub n: usize,
+    /// Mean reward.
+    pub mean: f64,
+    /// Sample standard deviation (Bessel-corrected; `0.0` for `n < 2`).
+    pub std_dev: f64,
+    /// Standard error of the mean (`std_dev / sqrt(n)`).
+    pub std_error: f64,
+}
+
+impl ArmStats {
+    /// Fold an arm's samples into its summary statistics. Never panics: an
+    /// empty arm yields `n = 0`, `mean = 0.0`, and zero spread.
+    pub fn from_samples(arm: &ArmSamples) -> Self {
+        let n = arm.rewards.len();
+        let mean = if n == 0 {
+            0.0
+        } else {
+            arm.rewards.iter().sum::<f64>() / n as f64
+        };
+        let std_dev = if n >= 2 {
+            let ss: f64 = arm.rewards.iter().map(|x| (x - mean).powi(2)).sum();
+            (ss / (n as f64 - 1.0)).sqrt()
+        } else {
+            0.0
+        };
+        let std_error = if n >= 1 {
+            std_dev / (n as f64).sqrt()
+        } else {
+            0.0
+        };
+        Self {
+            id: arm.id.clone(),
+            value: arm.value.clone(),
+            n,
+            mean,
+            std_dev,
+            std_error,
+        }
+    }
+}
+
+/// Thresholds for [`select_winner`]. `Default` is a conservative bar suited to
+/// auto-promotion of stella's own behavior.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelectionConfig {
+    /// Minimum trials required in **every** arm before any promotion. A knob
+    /// change is never made on a handful of samples.
+    pub min_samples_per_arm: usize,
+    /// The z multiplier the difference of means must clear. `1.96` is roughly a
+    /// 97.5% one-sided bound — the winner is very likely genuinely better, not
+    /// noise.
+    pub confidence_z: f64,
+    /// Minimum raw lift (winner mean − baseline mean) required regardless of
+    /// significance, so a statistically-real-but-trivial gain is not promoted.
+    /// `0.0` leaves the z-test as the only gate.
+    pub min_effect: f64,
+}
+
+impl Default for SelectionConfig {
+    fn default() -> Self {
+        Self {
+            min_samples_per_arm: 5,
+            confidence_z: 1.96,
+            min_effect: 0.0,
+        }
+    }
+}
+
+/// The winning arm and the evidence that it beat the baseline confidently.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Promotion {
+    /// Stats of the winning arm.
+    pub winner: ArmStats,
+    /// Stats of the baseline it beat.
+    pub baseline: ArmStats,
+    /// Raw lift: `winner.mean - baseline.mean`.
+    pub lift: f64,
+    /// The observed Welch z of the difference of means. `None` when both arms
+    /// had zero variance and the arms separated cleanly — an unbounded
+    /// (deterministic) confidence that has no finite z. (JSON has no infinity,
+    /// so `None`/`null` is the round-trippable spelling of "certain".)
+    pub observed_z: Option<f64>,
+    /// The z bar it had to clear (`SelectionConfig::confidence_z`).
+    pub threshold_z: f64,
+}
+
+/// Why [`select_winner`] declined to promote. Every reason names the evidence
+/// so the caller can surface an honest "kept the baseline because …".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum KeepReason {
+    /// An arm had fewer than `required` samples.
+    InsufficientSamples {
+        arm: String,
+        n: usize,
+        required: usize,
+    },
+    /// The named baseline arm was not present in the input.
+    MissingBaseline { baseline_id: String },
+    /// The baseline already has the highest mean — nothing to promote.
+    BaselineIsBest { baseline_mean: f64 },
+    /// A candidate led on the mean, but the lift did not clear `min_effect`.
+    BelowMinEffect { lift: f64, min_effect: f64 },
+    /// A candidate led, but the lift was not statistically confident.
+    LiftNotConfident {
+        lift: f64,
+        observed_z: f64,
+        threshold_z: f64,
+    },
+}
+
+/// The outcome of a selection: promote the winner, or keep the baseline with a
+/// stated reason.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum Decision {
+    /// Promote the winning arm.
+    Promote(Promotion),
+    /// Keep the baseline; no confident improvement.
+    Keep(KeepReason),
+}
+
+impl Decision {
+    /// `true` only for [`Decision::Promote`].
+    pub fn is_promotion(&self) -> bool {
+        matches!(self, Decision::Promote(_))
+    }
+}
+
+/// Decide whether any arm confidently beats `baseline_id`.
+///
+/// `arms` are the experiment's arms (two for the first slice, but N is fine).
+/// Returns [`Decision::Promote`] only when the highest-mean arm is not the
+/// baseline **and** its lift over the baseline is both large enough
+/// ([`SelectionConfig::min_effect`]) and statistically confident
+/// ([`SelectionConfig::confidence_z`]); otherwise [`Decision::Keep`] with the
+/// reason. Never panics — empty arms, a missing baseline, under-sampled arms,
+/// and non-finite samples all resolve to a `Keep`.
+pub fn select_winner(arms: &[ArmSamples], baseline_id: &str, config: &SelectionConfig) -> Decision {
+    let stats: Vec<ArmStats> = arms.iter().map(ArmStats::from_samples).collect();
+
+    let Some(baseline) = stats.iter().find(|s| s.id == baseline_id).cloned() else {
+        return Decision::Keep(KeepReason::MissingBaseline {
+            baseline_id: baseline_id.to_string(),
+        });
+    };
+
+    // Every arm must clear the sample floor before we trust any comparison.
+    for s in &stats {
+        if s.n < config.min_samples_per_arm {
+            return Decision::Keep(KeepReason::InsufficientSamples {
+                arm: s.id.clone(),
+                n: s.n,
+                required: config.min_samples_per_arm,
+            });
+        }
+    }
+
+    // Winner = highest mean. `partial_cmp` guards against NaN (treated equal),
+    // so a NaN mean can never win by accident.
+    let Some(winner) = stats
+        .iter()
+        .max_by(|a, b| {
+            a.mean
+                .partial_cmp(&b.mean)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .cloned()
+    else {
+        // Unreachable given a present baseline, but stay total.
+        return Decision::Keep(KeepReason::MissingBaseline {
+            baseline_id: baseline_id.to_string(),
+        });
+    };
+
+    if winner.id == baseline.id {
+        return Decision::Keep(KeepReason::BaselineIsBest {
+            baseline_mean: baseline.mean,
+        });
+    }
+
+    let lift = winner.mean - baseline.mean;
+    // A non-finite lift (NaN samples slipped through) is never a promotion.
+    if !lift.is_finite() || lift < config.min_effect {
+        return Decision::Keep(KeepReason::BelowMinEffect {
+            lift,
+            min_effect: config.min_effect,
+        });
+    }
+
+    let se_diff = (winner.std_error.powi(2) + baseline.std_error.powi(2)).sqrt();
+    let (confident, observed_z) = if se_diff > 0.0 {
+        let z = lift / se_diff;
+        (z >= config.confidence_z, Some(z))
+    } else if lift > 0.0 {
+        // Zero combined variance with a positive lift is a clean, deterministic
+        // separation — maximally confident, and with no finite z.
+        (true, None)
+    } else {
+        // Zero variance and a zero lift is a tie, not a win.
+        (false, Some(0.0))
+    };
+
+    if !confident {
+        return Decision::Keep(KeepReason::LiftNotConfident {
+            lift,
+            observed_z: observed_z.unwrap_or(0.0),
+            threshold_z: config.confidence_z,
+        });
+    }
+
+    Decision::Promote(Promotion {
+        winner,
+        baseline,
+        lift,
+        observed_z,
+        threshold_z: config.confidence_z,
+    })
+}
+
+/// A durable, reversible record of a promotion: what knob changed, from what to
+/// what, and the evidence that justified it. The caller persists this (a JSONL
+/// line under `.stella/private/`) so a promotion can be rolled back to
+/// `previous_value` and the A/B evidence is auditable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RollbackRecord {
+    /// The settings path the knob lives at (e.g.
+    /// `"agent_engine_config.agents.worker.effort"`).
+    pub knob: String,
+    /// The value before promotion (`None` when the knob was unset / on auto).
+    pub previous_value: Option<String>,
+    /// The value promoted to.
+    pub promoted_value: String,
+    /// Baseline mean reward at promotion time.
+    pub baseline_mean: f64,
+    /// Winner mean reward at promotion time.
+    pub winner_mean: f64,
+    /// The credited lift.
+    pub lift: f64,
+    /// The observed confidence z (`None` for a zero-variance clean separation).
+    pub observed_z: Option<f64>,
+    /// Samples the baseline was measured on.
+    pub baseline_samples: usize,
+    /// Samples the winner was measured on.
+    pub winner_samples: usize,
+}
+
+impl RollbackRecord {
+    /// Build a rollback record from a [`Promotion`] and the knob's prior value.
+    pub fn from_promotion(
+        knob: impl Into<String>,
+        previous_value: Option<String>,
+        promotion: &Promotion,
+    ) -> Self {
+        Self {
+            knob: knob.into(),
+            previous_value,
+            promoted_value: promotion.winner.value.clone(),
+            baseline_mean: promotion.baseline.mean,
+            winner_mean: promotion.winner.mean,
+            lift: promotion.lift,
+            observed_z: promotion.observed_z,
+            baseline_samples: promotion.baseline.n,
+            winner_samples: promotion.winner.n,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn arm(id: &str, value: &str, rewards: &[f64]) -> ArmSamples {
+        ArmSamples {
+            id: id.into(),
+            value: value.into(),
+            rewards: rewards.to_vec(),
+        }
+    }
+
+    #[test]
+    fn reward_default_is_the_success_indicator() {
+        let w = RewardWeights::default();
+        let solved = TaskOutcome {
+            succeeded: true,
+            cost_usd: 3.0,
+            tokens: 50_000,
+            retries: 4,
+        };
+        let failed = TaskOutcome {
+            succeeded: false,
+            cost_usd: 0.0,
+            tokens: 0,
+            retries: 0,
+        };
+        assert_eq!(reward(&solved, &w), 1.0);
+        assert_eq!(reward(&failed, &w), 0.0);
+    }
+
+    #[test]
+    fn reward_penalizes_cost_tokens_and_retries() {
+        let w = RewardWeights {
+            success: 1.0,
+            cost_usd: 0.5,
+            per_1k_tokens: 0.01,
+            per_retry: 0.1,
+        };
+        let outcome = TaskOutcome {
+            succeeded: true,
+            cost_usd: 1.0,
+            tokens: 2_000,
+            retries: 3,
+        };
+        // 1.0 - 0.5*1.0 - 0.01*2 - 0.1*3 = 1.0 - 0.5 - 0.02 - 0.3 = 0.18
+        assert!((reward(&outcome, &w) - 0.18).abs() < 1e-9);
+        // More retries strictly lowers reward; success strictly raises it.
+        let more_retries = TaskOutcome {
+            retries: 4,
+            ..outcome
+        };
+        assert!(reward(&more_retries, &w) < reward(&outcome, &w));
+        let unsolved = TaskOutcome {
+            succeeded: false,
+            ..outcome
+        };
+        assert!(reward(&unsolved, &w) < reward(&outcome, &w));
+    }
+
+    #[test]
+    fn a_confident_lift_is_promoted() {
+        // Candidate solves every task, baseline solves none: a clean, maximal
+        // separation.
+        let arms = vec![
+            arm("baseline", "medium", &[0.0, 0.0, 0.0, 0.0, 0.0]),
+            arm("candidate", "high", &[1.0, 1.0, 1.0, 1.0, 1.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        match decision {
+            Decision::Promote(p) => {
+                assert_eq!(p.winner.id, "candidate");
+                assert_eq!(p.winner.value, "high");
+                assert!((p.lift - 1.0).abs() < 1e-9);
+                // Zero-variance clean separation → unbounded confidence.
+                assert!(p.observed_z.is_none());
+            }
+            other => panic!("expected promotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_marginal_noisy_lift_is_not_promoted() {
+        // Candidate leads on the mean, but both arms are noisy and overlapping:
+        // the difference is not confident.
+        let arms = vec![
+            arm("baseline", "medium", &[1.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
+            arm("candidate", "high", &[1.0, 0.0, 1.0, 1.0, 0.0, 1.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        assert!(
+            !decision.is_promotion(),
+            "a noisy overlapping lead must not promote: {decision:?}"
+        );
+    }
+
+    #[test]
+    fn insufficient_samples_keeps_the_baseline() {
+        let arms = vec![
+            arm("baseline", "medium", &[0.0, 0.0]),
+            arm("candidate", "high", &[1.0, 1.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        match decision {
+            Decision::Keep(KeepReason::InsufficientSamples { required, .. }) => {
+                assert_eq!(required, 5)
+            }
+            other => panic!("expected InsufficientSamples, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn baseline_already_best_is_kept() {
+        let arms = vec![
+            arm("baseline", "medium", &[1.0, 1.0, 1.0, 1.0, 1.0]),
+            arm("candidate", "high", &[0.0, 0.0, 0.0, 0.0, 0.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        assert!(matches!(
+            decision,
+            Decision::Keep(KeepReason::BaselineIsBest { .. })
+        ));
+    }
+
+    #[test]
+    fn a_tie_is_kept_not_promoted() {
+        let arms = vec![
+            arm("baseline", "medium", &[1.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
+            arm("candidate", "high", &[1.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        assert!(!decision.is_promotion(), "an exact tie must not promote");
+    }
+
+    #[test]
+    fn missing_baseline_is_reported() {
+        let arms = vec![arm("candidate", "high", &[1.0, 1.0, 1.0, 1.0, 1.0])];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        assert!(matches!(
+            decision,
+            Decision::Keep(KeepReason::MissingBaseline { .. })
+        ));
+    }
+
+    #[test]
+    fn min_effect_gate_blocks_a_trivial_confident_lift() {
+        // A large, perfectly-clean but tiny-magnitude lift: confident yet below
+        // a min_effect bar.
+        let arms = vec![
+            arm("baseline", "medium", &[0.50; 8]),
+            arm("candidate", "high", &[0.51; 8]),
+        ];
+        let strict = SelectionConfig {
+            min_effect: 0.05,
+            ..SelectionConfig::default()
+        };
+        match select_winner(&arms, "baseline", &strict) {
+            Decision::Keep(KeepReason::BelowMinEffect { min_effect, .. }) => {
+                assert!((min_effect - 0.05).abs() < 1e-9)
+            }
+            other => panic!("expected BelowMinEffect, got {other:?}"),
+        }
+        // With the default (min_effect 0.0) the same clean separation promotes.
+        assert!(select_winner(&arms, "baseline", &SelectionConfig::default()).is_promotion());
+    }
+
+    #[test]
+    fn nan_samples_never_promote() {
+        let arms = vec![
+            arm("baseline", "medium", &[0.0, 0.0, 0.0, 0.0, 0.0]),
+            arm("candidate", "high", &[f64::NAN, 1.0, 1.0, 1.0, 1.0]),
+        ];
+        let decision = select_winner(&arms, "baseline", &SelectionConfig::default());
+        assert!(!decision.is_promotion(), "NaN must not produce a promotion");
+    }
+
+    #[test]
+    fn rollback_record_round_trips_and_captures_evidence() {
+        let arms = vec![
+            arm("baseline", "medium", &[0.0, 0.0, 0.0, 0.0, 0.0]),
+            arm("candidate", "high", &[1.0, 1.0, 1.0, 1.0, 1.0]),
+        ];
+        let Decision::Promote(p) = select_winner(&arms, "baseline", &SelectionConfig::default())
+        else {
+            panic!("expected promotion");
+        };
+        let record = RollbackRecord::from_promotion(
+            "agent_engine_config.agents.worker.effort",
+            Some("medium".to_string()),
+            &p,
+        );
+        assert_eq!(record.previous_value.as_deref(), Some("medium"));
+        assert_eq!(record.promoted_value, "high");
+        assert_eq!(record.baseline_samples, 5);
+        assert_eq!(record.winner_samples, 5);
+
+        // Invariant #4: serde round-trip is byte-stable.
+        let json = serde_json::to_string(&record).unwrap();
+        let back: RollbackRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, back);
+    }
+
+    #[test]
+    fn decision_serializes_with_a_tag() {
+        let keep = Decision::Keep(KeepReason::MissingBaseline {
+            baseline_id: "baseline".into(),
+        });
+        let json = serde_json::to_string(&keep).unwrap();
+        assert!(json.contains("\"decision\":\"keep\""));
+        assert!(json.contains("\"reason\":\"missing_baseline\""));
+    }
+
+    /// A small overlapping alphabet so property runs exercise real comparisons
+    /// (including under-sampled and lopsided arms) rather than trivially
+    /// distinct ones.
+    fn arb_arm(id: &'static str) -> impl Strategy<Value = ArmSamples> {
+        proptest::collection::vec(0.0f64..1.0, 0..12).prop_map(move |rewards| arm(id, id, &rewards))
+    }
+
+    proptest! {
+        /// `select_winner` never panics for any pair of arms and any config,
+        /// including empty arms and degenerate thresholds.
+        #[test]
+        fn select_never_panics(
+            a in arb_arm("baseline"),
+            b in arb_arm("candidate"),
+            min_samples in 0usize..10,
+            confidence_z in 0.0f64..4.0,
+            min_effect in 0.0f64..1.0,
+        ) {
+            let config = SelectionConfig { min_samples_per_arm: min_samples, confidence_z, min_effect };
+            let _ = select_winner(&[a, b], "baseline", &config);
+        }
+
+        /// A promotion is only ever the arm with the strictly higher mean, and
+        /// always carries a lift at or above `min_effect`.
+        #[test]
+        fn promotions_are_well_formed(
+            a in arb_arm("baseline"),
+            b in arb_arm("candidate"),
+        ) {
+            let config = SelectionConfig::default();
+            if let Decision::Promote(p) = select_winner(&[a, b], "baseline", &config) {
+                prop_assert!(p.winner.mean > p.baseline.mean);
+                prop_assert!(p.lift >= config.min_effect);
+                // A finite z must clear the bar; `None` means unbounded (certain).
+                if let Some(z) = p.observed_z {
+                    prop_assert!(z >= config.confidence_z);
+                }
+                prop_assert!(p.winner.n >= config.min_samples_per_arm);
+                prop_assert!(p.baseline.n >= config.min_samples_per_arm);
+            }
+        }
+
+        /// Selection is deterministic: same input, same decision.
+        #[test]
+        fn select_is_deterministic(
+            a in arb_arm("baseline"),
+            b in arb_arm("candidate"),
+        ) {
+            let config = SelectionConfig::default();
+            let d1 = select_winner(&[a.clone(), b.clone()], "baseline", &config);
+            let d2 = select_winner(&[a, b], "baseline", &config);
+            prop_assert_eq!(d1, d2);
+        }
+    }
+}


### PR DESCRIPTION
## Self-tuning — first slice: A/B the worker effort knob, auto-select, rollback

Implements the **first slice** of #831 (eval-driven self-tuning — a bandit over
stella's own policy). The issue scopes it precisely:

> **First slice.** One knob (worker reasoning effort) A/B'd on loop-bench with
> automatic winner selection and a rollback record.

Behavior changes only when the evidence says so — and every change is
report-first, capped in blast radius, and reversible.

### The flow

Run loop-bench twice over a fixed held-out task list — once at the baseline
worker effort, once at the candidate — capturing each run's `--json`, then:

```
stella tune effort --baseline base.json --candidate cand.json \
    --baseline-effort medium --candidate-effort high [--promote]
```

Without `--promote` it reports the A/B and records the receipt but changes
nothing. With `--promote` it writes the winning effort to settings **only if the
candidate confidently wins**, and records a reversible rollback.
`stella tune rollback` reverts the last promotion; `stella tune status` shows the
ledger.

### How it's built (respecting the crate invariants)

- **`stella-core::self_tuning`** — the selection math is a **pure, no-I/O**
  module, a sibling of `scoreboard`/`loop_detect` (no A/B or stats code existed
  anywhere before this). `reward` scores a task outcome from receipts
  (success, cost, tokens, retries). `select_winner` promotes a variant over
  the baseline **only** on a *confident* lift: a Welch two-sample z on the
  difference of means (`z = Δmean / sqrt(se_w² + se_b²)`) clearing
  `confidence_z` (default 1.96), plus a per-arm sample floor (default 5) and an
  optional `min_effect`. Because it promotes only when the candidate is
  confidently better, **"no regression" is a property of the rule**, not a
  separate check. Deterministic; unit **and** property tested.
- **`RollbackRecord`** captures the knob, the from/to values, and the A/B
  evidence, and round-trips through serde (a zero-variance clean win serializes
  `observed_z` as `null`, since JSON has no infinity).
- **`stella-cli::memory::self_tuning`** (beside `rules_mining`) parses
  loop-bench's `--json` `TrialReport` with a minimal local struct — the
  shipping binary does **not** depend on the dev-only `loop-bench` crate — folds
  each trial into a reward sample (a trial that never reached the verifier is
  excluded, not zeroed), runs the core selector, and on a confident win writes
  the winning worker effort via `AgentEngineConfig::save_to` (which preserves
  every other settings key).
- **The `effort_auto` gotcha**: a pinned `agents.worker.effort` is ignored while
  `effort_auto: on`, so a promotion also turns `effort_auto` off and the ledger
  records the prior `effort_auto` so a rollback restores it exactly.
- **`stella tune effort|rollback|status`** mirrors the `proposals` command —
  offline, no API key. The A/B ledger is an append-only JSONL under the
  git-ignored `.stella/private/`.

### Guardrails (from the issue)

- **Shadow-first / report-first**: promotion is off by default; `--promote` is
  required to write anything.
- **Reversible**: every promotion writes a rollback record; `stella tune
  rollback` restores the prior effort *and* prior `effort_auto`.
- **Capped blast radius**: only the worker-effort knob changes.
- **Never touches safety policy**: authority, scope-review, and budget are
  untouched.
- **Receipts published**: every A/B (kept or promoted) is appended to the
  ledger.

### Scope notes

- Samples come from loop-bench's existing per-trial verifier reward; loop-bench
  itself needs Docker + harbor + a provider key + a Linux `stella` binary, so it
  is run by the operator (it cannot run in CI) and this command consumes its
  JSON. A dedicated held-out/guard task split is a natural next slice — for now
  the operator runs the A/B over a fixed held-out `--tasks` list.
- The engine is knob-generic (an arm is just an id + value + reward samples), so
  the next knobs (prompt templates, routing) reuse it unchanged.

### Verification

- Witness discipline: `stella_core::self_tuning::*` and `stella tune` are
  genuinely absent on `main`, so the new tests fail there and pass here.
- `stella-core` self_tuning: 15 tests (unit + property + serde round-trip);
  `stella-cli` self_tuning: promote→rollback restore, inconclusive-keeps,
  exclusion of unverified trials, effort parse/label — all with temp settings +
  temp ledger. Workspace `clippy -D warnings`, `fmt --check`, `rustdoc -D
  warnings`, file-size, invariants, doc-citations, no-scratch all pass.

Refs #831


## Summary by Sourcery

Introduce a self-tuning system that A/B tests worker reasoning effort using loop-bench results, auto-selects a winning configuration under strict statistical criteria, and records reversible promotions in a local ledger.

New Features:
- Add a core self_tuning module that converts task outcomes into rewards, compares experimental arms, and decides when to promote a variant based on configurable statistical thresholds.
- Expose a new `stella tune` CLI command with `effort`, `rollback`, and `status` subcommands to run offline A/B experiments, apply winning worker effort settings, and inspect history.
- Add a self-tuning memory layer that parses loop-bench JSON results, maps them into reward samples, updates worker effort in project/user settings, and maintains an append-only JSONL ledger for experiments, promotions, and rollbacks.

Tests:
- Add unit, property, and serde round-trip tests for the core self_tuning logic, including reward scoring, winner selection, and rollback record stability.
- Add CLI-level tests covering trial filtering, promotion and rollback behavior, inconclusive experiments, and effort parsing/labeling using temporary settings and ledgers.
