### PR TITLE
feat(ultra-audit): ship the audit skill in source, renamed from /ultraudit (Closes #847)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,19 @@ Thumbs.db
 .oxagen/
 .memories/
 
+# The ultra-audit skill ships in source (#847, #832): re-include just the
+# skills subtree of the root .stella/, while the rest stays per-workspace
+# scratch. Audit reports still land in the ignored .ultra-audit/ (below).
+!/.stella/
+/.stella/*
+!/.stella/skills/
+!/.stella/skills/**
+
+# Audit output directory written by the ultra-audit skill — never committed.
+# (The legacy .ultraudit/ path is deliberately not ignored here: a report is
+# already tracked under it, and adding the rule would orphan that file.)
+.ultra-audit/
+
 # The paid-readiness fixture intentionally contains inert hostile values. Keep
 # these two canaries tracked so the public witness actually exercises project
 # env/settings isolation; neither value is a credential.

--- a/.stella/skills/ultra-audit/SKILL.md
+++ b/.stella/skills/ultra-audit/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: ultra-audit
+description: Run the most exhaustive engineering audit available on any codebase in any language — 100% file coverage, fix what is safely fixable, cross-model refutation where no model grades its own work, a blind three-model scoring panel, and a self-contained HTML report scored against an absolute bar where 100 is the Rust project itself. Use when the user asks to audit, deeply review, eval, score, or "find and fix what's broken" in a workspace, or wants an engineering scorecard or a repeatable quality number that is comparable across rounds.
+---
+
+# ultra-audit
+
+An exhaustive, scored, self-fixing engineering audit that works in any language and produces
+one self-contained HTML file.
+
+Run it with `/ultra-audit` (audits the current repo), `/ultra-audit <path>`, or
+`/ultra-audit <path> --depth max`.
+
+Four things distinguish it from `/code-review`, which is what to use for a quick check:
+
+| | |
+|---|---|
+| **Complete** | Every source file is owned by exactly one auditing agent, and coverage is *computed*, not claimed. |
+| **Cross-model** | No model grades its own work. Fixes, findings and scores are each judged by a different frontier model than produced them. |
+| **Calibrated** | Three models score the same evidence blind; the reported number is the median and the spread is published as a confidence signal. |
+| **Absolute** | 100 is reserved for the Rust project itself and is never awarded. The bar does not move between rounds, so the number is comparable over time. |
+
+---
+
+## Before you launch — say these three things to the user
+
+**1. Typing in the prompt will kill the run.** Subagents are children of the turn that launched
+them. If the user types anything while the workflow runs, the turn ends and every in-flight
+agent dies mid-read, having written nothing. This has destroyed three prior audit runs. Tell
+them plainly, and tell them `/workflows` shows live status without touching the run.
+
+**2. The cost, in real numbers.** `build_workflow.py` prints an agent count, a wave count and a
+wall-clock range. Quote them. Roughly: `standard` ~120 agents / 1.5–3h, `deep` (default) ~180
+agents / 2.5–4h, `max` ~240 agents / 3–5h on a 300k-line repo. This is not a quick check.
+
+**3. What it will change.** At `full` fix authority agents edit code. Work in a worktree, never
+the user's checkout.
+
+Then, **while it runs, narrate every phase transition.** Silence is what provokes the interrupt
+that kills the run, so progress reporting is a survival mechanism, not a courtesy. `python3
+scripts/progress.py` is a safe pull-based status check — run it between phases and report a
+one-line summary each time.
+
+## Before anything else — read these
+
+1. **`reference/rubric.md`** — the 17 dimensions, the exact weights, and what 100 means. Never
+   invent weights; a re-scored run with different weights is worthless.
+2. **`reference/model-panel.md`** — which model does what, and the five rules that make the
+   cross-model claims true rather than decorative.
+3. **`reference/operations.md`** — the failure modes that have actually broken these runs.
+   Section 0 is the one that matters most. Skipping this file costs hours.
+
+## The procedure
+
+### Step 0 — isolate, detect, and baseline
+
+Work in a git worktree (`EnterWorktree`), never the user's checkout.
+
+```sh
+python3 scripts/detect.py <root> --out gate.json
+```
+
+Read its output and **sanity-check the gate commands** — a wrong gate produces a confidently
+wrong baseline. Note three things it decides:
+
+- **fix authority** (`full` / `tested-files-only` / `text-only` / `none`) — derived from whether
+  a bad edit could actually be caught. Do not raise it by hand.
+- **the project's own gate target** (`make gate`, `just ci`) — prefer it if one exists.
+- **cache traps** — the forced form of each command. A cached lint run reports zero warnings
+  whether or not there are any.
+
+Then measure the baseline on a **pristine, separate** worktree of the same commit, *before* any
+agent edits anything:
+
+```sh
+git worktree add <tmp>/baseline-check <HEAD-sha> --detach
+```
+
+Run the gate there, in its forced form, checking **exit codes** rather than grepping output
+(this shell forces ANSI colour, so pattern-matching silently misses matches). Save the result to
+`baseline.txt`. This is the only thing that lets you tell "the audit broke it" from "it shipped
+broken" — repos land red far more often than anyone expects. Remove the worktree afterwards.
+
+### Step 1 — partition, with a coverage proof
+
+```sh
+python3 scripts/partition.py gate.json --out units.json
+```
+
+It splits on directory seams to ~13k LOC per agent and **refuses to proceed** unless ownership
+is disjoint and complete. Read the coverage proof. Then **edit `units.json` to add a `note` per
+unit** saying why that unit matters and what to scrutinise — per-unit notes measurably improved
+finding quality on prior runs.
+
+If the tree is very large, `--max-agents N` caps the fan-out and prints exactly which units are
+excluded and what coverage drops to. If you use it, that gap must appear in the report.
+
+### Step 2 — build and launch
+
+```sh
+python3 scripts/build_workflow.py --gate gate.json --units units.json \
+        --baseline baseline.txt --depth deep --out audit.js
+```
+
+It refuses to emit a script that fails validation. Launch with the `Workflow` tool
+(`scriptPath: audit.js`, run in background), then tell the user the estimate it printed.
+
+Ten phases run: regression check → unit audits (pipelined straight into cross-model fix review)
+→ cross-cutting lenses → fresh sweep → verify → cross-model refutation → blind scoring panel →
+second opinion → synthesis.
+
+### Step 3 — report progress while it runs
+
+```sh
+python3 scripts/progress.py                 # newest run; add --watch 90 to follow
+```
+
+It reports launched/finished/retried, per-phase bars, API-error clustering, and liveness. **The
+first fifteen minutes look identical to a dead run** — nothing has finished yet — so use the
+liveness line rather than waiting for a first result. If starts far exceed finishes, agents are
+being retried; see `operations.md` §1 and §2 before restarting anything.
+
+### Step 4 — verify the numbers and the model mix yourself
+
+```sh
+python3 scripts/score.py result.json --json scoring.json
+python3 scripts/progress.py <transcript-dir> --provenance --json provenance.json
+```
+
+`score.py` recomputes the weighted overall, the panel median and spread from raw votes, and the
+**prior round's published number** — if that last one does not reproduce, the weights drifted
+and the comparison is invalid. It exits non-zero on any unreconciled problem.
+
+`--provenance` reads the model **actually recorded in each agent transcript** and checks it
+against the slot the prompt claimed. Do not publish a cross-model audit you have not confirmed
+was cross-model.
+
+Then re-run the gate yourself on the post-fix tree and compare against the Step 0 baseline. Do
+not report a green gate you did not personally observe.
+
+### Step 5 — render the report
+
+```sh
+python3 scripts/render_report.py result.json --scoring scoring.json \
+        --baseline baseline.txt --provenance provenance.json
+```
+
+Writes `<root>/.ultra-audit/report-<date>-<sha>.html` — one self-contained file, light and dark,
+printable — and validates it: the inline script must parse, there must be exactly one
+`</script>`, no remote asset of any kind, every mount point present. Render even if the run died
+late; a partial result renders and marks what is missing.
+
+Open it and look at it before telling the user it is done.
+
+### Step 6 — record and ship
+
+```sh
+python3 scripts/score.py result.json --record --date <YYYY-MM-DD> --report <path>
+```
+
+History lives in `~/.claude/audits/<repo>.json`, outside any skill directory, so the series
+survives skill edits. It is what makes the *next* round's "did this actually land?" phase
+possible.
+
+Then commit, push, and open a **draft** PR. Never push to main. Lead the PR body with the score
+movement at full precision, the did-it-land tally, and the gate table.
+
+## Rules that are easy to get wrong
+
+- **The bar is absolute**, not relative to the last run. A dimension rises only if the tree is
+  genuinely better against the anchors — never because effort was spent. Dimensions are allowed
+  to fall, and saying so is the point of the exercise.
+- **Report deltas at full precision.** 79 → 80 looks like +1; the real movement was +0.86.
+  Round only for the headline.
+- **A fix that closes the reported instance but leaves the defect class open is
+  `partially_fixed`** and earns no root-cause credit. This distinction is the single most
+  valuable output of the run.
+- **Only findings that survived cross-model refutation enter the risk register.** Findings that
+  exceeded the depth cap are *unverified*, not confirmed, and must be labelled so.
+- **State the commit you actually scored**, and re-check that the default branch has not moved
+  under you before publishing. One prior audit scored an unmerged branch while reporting on
+  `main`.
+- **Never claim more than the panel supports.** These three models share training lineage;
+  agreement between them is weaker evidence than three independent human reviewers. What the
+  panel reliably catches is the confident, plausible, wrong finding a single model would
+  otherwise defend into the report. Claim that, and not more.
+
+## Tests
+
+```sh
+python3 tests/check_template.py     # harness invariants: valid JS, every agent sets a model,
+                                    # every prompt carries the provenance header
+python3 tests/make_fixture.py --out /tmp/r.json   # a realistic result, with hostile payloads
+```
+
+`node --check <file>.js` is **not** a usable syntax gate for the harness — the generated script
+mixes an ESM `export` with a top-level `return`, and that combination exits 0 even when the file
+is unbalanced. `check_template.py` wraps the body and checks it as `.mjs`, which does catch it.
+
+## Relationship to `/reaudit`
+
+`reaudit` is the Rust-specific predecessor. It shares the same 17 dimensions and the same
+weights, so its recorded history continues here without a break. Prefer `ultra-audit`: it is
+language-agnostic, mixes models, proves its coverage, and writes an HTML file rather than
+publishing an artifact.

--- a/.stella/skills/ultra-audit/assets/report.template.html
+++ b/.stella/skills/ultra-audit/assets/report.template.html
@@ -1,0 +1,680 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__</title>
+<style>
+/* Self-contained by requirement: no CDN, no web font, no remote asset, no fetch.
+   This file gets opened months later, offline, from a different machine, possibly as an
+   email attachment. Colours are the validated data-viz reference palette — the categorical
+   blue/red pair passes the lightness band, chroma floor, CVD separation (ΔE 21.6 protan
+   light / 19.2 dark), normal-vision floor and 3:1 contrast in BOTH modes. Deltas use
+   blue-up / red-down rather than green/red: red-green is exactly the pair CVD readers
+   cannot separate, and every delta also carries a sign and an arrow, so colour is never
+   the only channel. */
+:root{
+  color-scheme: light;
+  --paper:#f9f9f7; --surface:#fcfcfb;
+  --ink:#0b0b0b; --ink-2:#52514e; --ink-3:#898781;
+  --rule:#e1e0d9; --rule-2:#c3c2b7;
+  --up:#2a78d6; --down:#e34948; --neutral:#c3c2b7;
+  --seq:#2a78d6; --seq-soft:#cde2fb;
+  --good:#0ca30c; --warn:#fab219; --serious:#ec835a; --crit:#d03b3b;
+  --ok-text:#006300;
+  --f: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  --measure: 72ch;
+}
+@media (prefers-color-scheme: dark){
+  :root:where(:not([data-theme="light"])){
+    color-scheme: dark;
+    --paper:#0d0d0d; --surface:#1a1a19;
+    --ink:#ffffff; --ink-2:#c3c2b7; --ink-3:#898781;
+    --rule:#2c2c2a; --rule-2:#383835;
+    --up:#3987e5; --down:#e66767; --neutral:#383835;
+    --seq:#3987e5; --seq-soft:#184f95;
+    --ok-text:#0ca30c;
+  }
+}
+:root[data-theme="dark"]{
+  color-scheme: dark;
+  --paper:#0d0d0d; --surface:#1a1a19;
+  --ink:#ffffff; --ink-2:#c3c2b7; --ink-3:#898781;
+  --rule:#2c2c2a; --rule-2:#383835;
+  --up:#3987e5; --down:#e66767; --neutral:#383835;
+  --seq:#3987e5; --seq-soft:#184f95;
+  --ok-text:#0ca30c;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{background:var(--paper);color:var(--ink);font-family:var(--f);
+  font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1140px;margin:0 auto;padding:32px 24px 96px}
+h1,h2,h3{line-height:1.2;margin:0}
+h2{font-size:13px;letter-spacing:.09em;text-transform:uppercase;color:var(--ink-3);
+  font-weight:650;margin:0 0 14px}
+h3{font-size:16px;font-weight:640;margin:0 0 6px}
+p{margin:0 0 12px;max-width:var(--measure)}
+a{color:var(--up)}
+code,.mono{font-family:var(--f-mono);font-size:.88em}
+section{margin:0 0 44px}
+.card{background:var(--surface);border:1px solid var(--rule);border-radius:10px;padding:18px 20px}
+.muted{color:var(--ink-2)}
+.dim{color:var(--ink-3)}
+.small{font-size:13px}
+.tnum{font-variant-numeric:tabular-nums}
+hr{border:0;border-top:1px solid var(--rule);margin:32px 0}
+
+/* masthead */
+.mast{display:grid;grid-template-columns:minmax(260px,auto) 1fr;gap:36px;align-items:end;
+  border-bottom:1px solid var(--rule-2);padding-bottom:22px;margin-bottom:20px}
+.anchornote{font-size:13px;line-height:1.6;color:var(--ink-2);max-width:62ch;
+  border-left:2px solid var(--rule-2);padding-left:16px}
+@media (max-width:760px){.mast{grid-template-columns:1fr;gap:20px}}
+.eyebrow{font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);
+  font-weight:650;margin-bottom:8px}
+.bigscore{font-size:82px;font-weight:680;line-height:.9;letter-spacing:-.03em}
+.bigscore .of{font-size:26px;font-weight:500;color:var(--ink-3);letter-spacing:0}
+.band{font-size:15px;font-weight:620;margin-top:6px}
+.deltachip{display:inline-flex;align-items:center;gap:5px;font-size:14px;font-weight:640;
+  padding:3px 9px;border-radius:999px;border:1px solid var(--rule-2);margin-top:8px}
+.statgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(132px,1fr));gap:1px;
+  background:var(--rule);border:1px solid var(--rule);border-radius:10px;overflow:hidden}
+.stat{background:var(--surface);padding:12px 14px}
+.stat .k{font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--ink-3);
+  font-weight:640}
+.stat .v{font-size:21px;font-weight:650;margin-top:3px}
+.stat .s{font-size:12px;color:var(--ink-3)}
+
+/* scorecard rows */
+.dimrow{display:grid;grid-template-columns:190px 1fr 74px 96px;gap:14px;align-items:center;
+  padding:9px 0;border-bottom:1px solid var(--rule)}
+.dimrow:last-child{border-bottom:0}
+.dimname{font-weight:600;font-size:14px}
+.dimname .wt{color:var(--ink-3);font-weight:500;font-size:12px;margin-left:6px}
+.track{position:relative;height:22px;background:var(--seq-soft);border-radius:4px}
+.fill{position:absolute;left:0;top:0;bottom:0;background:var(--seq);border-radius:4px 4px 4px 4px}
+/* Panel votes as dots on the same axis as the bar: spread IS the confidence signal. */
+.vote{position:absolute;top:50%;width:9px;height:9px;margin:-4.5px 0 0 -4.5px;border-radius:50%;
+  background:var(--surface);border:2px solid var(--ink-2);box-shadow:0 0 0 2px var(--surface)}
+.vote.med{border-color:var(--ink);width:11px;height:11px;margin:-5.5px 0 0 -5.5px}
+.scorenum{font-size:18px;font-weight:660;text-align:right}
+.deltacell{text-align:right;font-size:13px;font-weight:620}
+.contested{display:inline-block;font-size:10px;font-weight:700;letter-spacing:.06em;
+  padding:1px 5px;border-radius:3px;border:1px solid var(--serious);color:var(--serious);
+  margin-left:6px;vertical-align:1px}
+
+/* diverging "what moved" chart */
+.divrow{display:grid;grid-template-columns:190px 1fr 56px;gap:12px;align-items:center;
+  padding:5px 0}
+.divtrack{position:relative;height:18px}
+.divtrack .axis{position:absolute;left:50%;top:-3px;bottom:-3px;width:1px;background:var(--rule-2)}
+.divbar{position:absolute;top:3px;height:12px;border-radius:3px}
+
+/* findings */
+.sev{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:700;
+  letter-spacing:.05em;text-transform:uppercase;padding:2px 7px;border-radius:4px;
+  border:1px solid currentColor;white-space:nowrap}
+.sev.critical{color:var(--crit)} .sev.high{color:var(--serious)}
+.sev.medium{color:var(--warn)} .sev.low{color:var(--ink-3)}
+.finding{border:1px solid var(--rule);border-radius:9px;background:var(--surface);
+  padding:14px 16px;margin-bottom:10px}
+.finding .top{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-bottom:7px}
+.floc{font-family:var(--f-mono);font-size:12.5px;color:var(--ink-2)}
+.agree{font-size:11px;font-weight:640;padding:2px 7px;border-radius:999px;
+  border:1px solid var(--rule-2);color:var(--ink-2)}
+.votes{display:flex;flex-wrap:wrap;gap:6px;margin-top:9px}
+.mv{font-size:11.5px;padding:2px 8px;border-radius:999px;border:1px solid var(--rule-2)}
+.mv.real{border-color:var(--up);color:var(--up)}
+.mv.ref{border-color:var(--down);color:var(--down)}
+details{border:1px solid var(--rule);border-radius:9px;background:var(--surface);
+  padding:12px 16px;margin-bottom:10px}
+details>summary{cursor:pointer;font-weight:620;font-size:14px;list-style:none}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"▸ ";color:var(--ink-3)}
+details[open]>summary::before{content:"▾ "}
+details>summary:focus-visible{outline:2px solid var(--up);outline-offset:2px}
+
+/* model matrix */
+table{width:100%;border-collapse:collapse;font-size:13.5px}
+th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--rule);vertical-align:top}
+th{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);
+  font-weight:650}
+td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}
+.scroller{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.cols2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.horizons{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+.hz h3{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3)}
+.hz ul{margin:0;padding-left:18px}
+.hz li{margin-bottom:9px}
+.callout{border-left:3px solid var(--serious);background:var(--surface);padding:12px 16px;
+  border-radius:0 8px 8px 0;margin:0 0 14px}
+.callout.bad{border-left-color:var(--crit)}
+.callout.ok{border-left-color:var(--good)}
+.pill{display:inline-block;font-size:11.5px;font-weight:620;padding:2px 8px;border-radius:999px;
+  border:1px solid var(--rule-2);color:var(--ink-2);margin:0 4px 4px 0}
+.legend{display:flex;flex-wrap:wrap;gap:14px;font-size:12px;color:var(--ink-2);margin-top:10px}
+.legend .li{display:flex;align-items:center;gap:6px}
+.sw{width:11px;height:11px;border-radius:3px;display:inline-block}
+@media (max-width:760px){
+  .dimrow{grid-template-columns:130px 1fr 56px;row-gap:4px}
+  .dimrow .deltacell{grid-column:3;text-align:right}
+  .divrow{grid-template-columns:130px 1fr 48px}
+  .horizons,.cols2{grid-template-columns:1fr}
+  .bigscore{font-size:64px}
+}
+@media print{
+  body{background:#fff}
+  .wrap{max-width:none;padding:0}
+  details{break-inside:avoid} details[open] summary{display:none}
+  details:not([open]){display:none}
+  .finding,.card,.stat{break-inside:avoid}
+  section{break-inside:avoid-page}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="mast">
+    <div>
+      <div class="eyebrow" id="eyebrow"></div>
+      <div class="bigscore" id="ov"></div>
+      <div class="band" id="ovband"></div>
+      <div id="ovdelta"></div>
+    </div>
+    <div class="anchornote">
+      <strong>100 is reserved for the Rust project itself</strong> — RFC-gated change control,
+      ecosystem-wide regression proof before a change lands, editions keeping decade-old code
+      compiling, diagnostics pinned by tests. 90–95 is ripgrep / tokio / SQLite tier. The bar is
+      absolute and does not move between rounds, which is the only thing that makes two scores
+      comparable.
+    </div>
+  </div>
+  <div class="statgrid" id="stats"></div>
+  <div style="height:30px"></div>
+
+  <div id="alerts"></div>
+
+  <section id="sec-summary">
+    <h2>Executive summary</h2>
+    <div id="summary"></div>
+  </section>
+
+  <section id="sec-scorecard">
+    <h2>Scorecard — 17 dimensions, weighted</h2>
+    <div class="card">
+      <div id="dims"></div>
+      <div class="legend" id="dimlegend"></div>
+    </div>
+    <div id="dimdetails" style="margin-top:16px"></div>
+  </section>
+
+  <section id="sec-moved">
+    <h2>What moved</h2>
+    <div class="card"><div id="moved"></div><div class="legend" id="movedlegend"></div></div>
+  </section>
+
+  <section id="sec-panel">
+    <h2>The scoring panel</h2>
+    <div id="panelnote"></div>
+    <div id="panel"></div>
+  </section>
+
+  <section id="sec-secondop">
+    <h2>Second opinion</h2>
+    <div id="secondop"></div>
+  </section>
+
+  <section id="sec-risks">
+    <h2>Confirmed risks</h2>
+    <div id="risks"></div>
+  </section>
+
+  <section id="sec-excluded">
+    <h2>Excluded and unconfirmed</h2>
+    <div id="excluded"></div>
+  </section>
+
+  <section id="sec-prior">
+    <h2>Did the previous round's fixes land?</h2>
+    <div id="prior"></div>
+  </section>
+
+  <section id="sec-fixes">
+    <h2>Fixes applied, reviewed across models</h2>
+    <div id="fixes"></div>
+  </section>
+
+  <section id="sec-gate">
+    <h2>Verification gate</h2>
+    <div id="gate"></div>
+  </section>
+
+  <section id="sec-roadmap">
+    <h2>Roadmap</h2>
+    <div class="horizons" id="roadmap"></div>
+  </section>
+
+  <section id="sec-method">
+    <h2>Method, coverage and limits</h2>
+    <div id="method"></div>
+  </section>
+
+  <footer class="small dim" id="foot"></footer>
+</div>
+
+<script>
+const D = __DATA__;
+
+/* Every string from the audit is untrusted text: findings quote source code, which contains
+   angle brackets and ampersands. Escape on the way into the DOM. (The splice step separately
+   escapes `</` so a finding containing a closing tag cannot terminate this script block.) */
+const esc = (s) => String(s == null ? "" : s)
+  .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+  .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+const el = (id) => document.getElementById(id);
+const set = (id, html) => { const n = el(id); if (n) n.innerHTML = html; };
+const num = (n, d = 0) => (typeof n === "number" ? n.toFixed(d) : "—");
+const int = (n) => (typeof n === "number" ? n.toLocaleString() : "—");
+const pct = (v) => Math.max(0, Math.min(100, Number(v) || 0));
+const nl2p = (s) => String(s || "").split(/\n\s*\n/).filter(Boolean)
+  .map((p) => `<p>${esc(p.trim())}</p>`).join("");
+const arrow = (v) => (v > 0 ? "↑" : v < 0 ? "↓" : "→");
+const sgn = (v) => (v > 0 ? "+" : "") + num(v, 0);
+const hide = (id) => { const n = el(id); if (n) n.style.display = "none"; };
+
+const S = D.scoring || {};
+const R = D.run || {};
+const DIMS = Object.keys(S.weights || {}).sort((a, b) =>
+  (S.weights[b] - S.weights[a]) || a.localeCompare(b));
+
+/* ── masthead ─────────────────────────────────────────────────────────── */
+el("eyebrow").textContent =
+  `${R.root || "workspace"} · round ${S.round || R.round || 1} · ${R.depth || "?"} depth · `
+  + `commit ${(R.commit || "unrecorded").slice(0, 9)} · ${S.date || R.date || ""}`;
+set("ov", `${num(S.overall_rounded ?? S.overall, 0)}<span class="of"> / 100</span>`);
+el("ovband").textContent = S.band || "";
+if (typeof S.delta_precise === "number") {
+  const c = S.delta_precise > 0 ? "var(--up)" : S.delta_precise < 0 ? "var(--down)" : "var(--ink-3)";
+  set("ovdelta", `<span class="deltachip" style="color:${c};border-color:${c}">`
+    + `${arrow(S.delta_precise)} ${S.delta_precise > 0 ? "+" : ""}${num(S.delta_precise, 2)} `
+    + `<span class="dim" style="font-weight:500">vs round ${(S.round || 2) - 1} `
+    + `(${num(S.prior_overall, 2)})</span></span>`);
+} else {
+  set("ovdelta", `<span class="deltachip dim">first round — no prior score</span>`);
+}
+
+const cov = R.files_owned && R.total_files
+  ? (100 * R.files_owned / R.total_files) : null;
+const F = D.findings || {};
+const V = D.verify || {};
+const gateOK = V.skipped ? null : (V.fmt_clean && V.lint_clean && V.tests_pass);
+const stats = [
+  ["Agents", int(D.agents_total || R.agents || null), `${R.units || "?"} units · ${R.lens_jobs || "?"} lenses`],
+  ["Coverage", cov == null ? "—" : `${num(cov, 1)}%`,
+    `${int(R.files_owned)} / ${int(R.total_files)} files`],
+  ["Code", int(R.total_loc), (R.languages || []).slice(0, 2).map((l) => l.language).join(", ")],
+  ["Confirmed risks", int((F.confirmed || []).length),
+    `of ${int(F.severe)} severe · ${int((F.refuted || []).length)} refuted`],
+  ["Gate", gateOK === null ? "n/a" : gateOK ? "green" : "red",
+    V.test_summary || (V.skipped ? "read-only audit" : "")],
+  ["Panel", (S.panel_models || []).length || "—", (S.panel_models || []).join(" · ")],
+];
+set("stats", stats.map(([k, v, s]) => `<div class="stat"><div class="k">${esc(k)}</div>`
+  + `<div class="v tnum">${esc(v)}</div><div class="s">${esc(s)}</div></div>`).join(""));
+
+/* ── alerts: anything that qualifies the number goes ABOVE the fold ───── */
+const alerts = [];
+if ((S.problems || []).length) {
+  alerts.push(`<div class="callout bad"><h3>Reconciliation problems</h3>`
+    + `<ul>${S.problems.map((p) => `<li>${esc(p)}</li>`).join("")}</ul></div>`);
+}
+if (cov != null && cov < 99.5) {
+  alerts.push(`<div class="callout bad"><h3>Coverage is not complete</h3><p>`
+    + `${num(cov, 1)}% of source files were owned by an auditing agent. `
+    + `${esc(D.coverage_gap || "The unaudited remainder is listed under Method.")}</p></div>`);
+}
+if ((F.unverified || []).length) {
+  alerts.push(`<div class="callout"><h3>${(F.unverified || []).length} severe finding(s) `
+    + `unverified</h3><p>These exceeded the depth cap and were never put to cross-model `
+    + `refutation. They are <strong>unconfirmed</strong> — listed under Excluded and `
+    + `unconfirmed, and excluded from the risk register.</p></div>`);
+}
+if (D.provenance && D.provenance.ok === false) {
+  alerts.push(`<div class="callout bad"><h3>Model provenance did not verify</h3><p>`
+    + `${esc(D.provenance.detail || "")} Every cross-model guarantee below is therefore `
+    + `unproven and must not be relied on.</p></div>`);
+}
+if (gateOK === false) {
+  alerts.push(`<div class="callout"><h3>The gate is not green</h3><p>`
+    + `${esc(V.final_state || "")}</p></div>`);
+}
+set("alerts", alerts.join(""));
+
+/* ── executive summary ────────────────────────────────────────────────── */
+const SY = D.synthesis || {};
+set("summary", nl2p(SY.executive_summary)
+  + (SY.remediation_verdict ? `<div class="callout"><h3>Verdict on the work since last round`
+      + `</h3><p>${esc(SY.remediation_verdict)}</p></div>` : ""));
+
+/* ── scorecard ────────────────────────────────────────────────────────── */
+const med = S.panel_median || {}, spr = S.panel_spread || {}, votesBy = D.panel_votes || {};
+const dimRows = [], dimDetails = [];
+for (const d of DIMS) {
+  const sc = (S.scores || {})[d];
+  if (typeof sc !== "number") continue;
+  const dl = (S.deltas || {})[d];
+  const isContested = (S.contested || []).includes(d);
+  const vs = (votesBy[d] || []);
+  const dots = vs.map((v) => `<span class="vote${v.score === med[d] ? " med" : ""}" `
+    + `style="left:${pct(v.score)}%" title="${esc(v.model)}: ${esc(v.score)}"></span>`).join("");
+  const dcol = dl > 0 ? "var(--up)" : dl < 0 ? "var(--down)" : "var(--ink-3)";
+  dimRows.push(`<div class="dimrow">
+    <div class="dimname">${esc(d.replace(/_/g, " "))}<span class="wt">w${S.weights[d]}</span>
+      ${isContested ? '<span class="contested">contested</span>' : ""}</div>
+    <div class="track"><div class="fill" style="width:${pct(sc)}%"></div>${dots}</div>
+    <div class="scorenum tnum">${sc}</div>
+    <div class="deltacell tnum" style="color:${dcol}">${
+      typeof dl === "number" ? `${arrow(dl)} ${sgn(dl)}` : '<span class="dim">—</span>'}</div>
+  </div>`);
+  const rat = ((SY.dimension_scores || {})[d] || {});
+  if (rat.rationale) {
+    dimDetails.push(`<details><summary>${esc(d.replace(/_/g, " "))} — why ${sc}`
+      + `${typeof spr[d] === "number" ? ` (panel spread ${spr[d]})` : ""}`
+      + `${isContested ? " · contested" : ""}</summary>`
+      + `<p>${esc(rat.rationale)}</p>`
+      + (rat.delta_rationale ? `<p class="muted"><strong>Movement:</strong> `
+          + `${esc(rat.delta_rationale)}</p>` : "")
+      + (rat.panel_resolution ? `<p class="muted"><strong>Contested — how it was resolved:`
+          + `</strong> ${esc(rat.panel_resolution)}</p>` : "")
+      + ((rat.evidence || []).length ? `<p class="small mono dim">`
+          + rat.evidence.map(esc).join(" · ") + `</p>` : "")
+      + `</details>`);
+  }
+}
+set("dims", dimRows.join(""));
+set("dimdetails", dimDetails.length
+  ? `<h2 style="margin-bottom:10px">Why each score</h2>` + dimDetails.join("") : "");
+set("dimlegend", `<div class="li"><span class="sw" style="background:var(--seq)"></span>`
+  + `absolute score, 0-100</div>`
+  + `<div class="li"><span class="vote" style="position:static;margin:0"></span>`
+  + `one panelist's vote</div>`
+  + `<div class="li"><span class="vote med" style="position:static;margin:0"></span>`
+  + `the median (the reported score)</div>`
+  + `<div class="li">100 is reserved for the Rust project itself; 90-95 is `
+  + `ripgrep / tokio / SQLite tier</div>`);
+
+/* ── what moved: diverging off a centre axis ──────────────────────────── */
+const deltas = S.deltas || {};
+const maxAbs = Math.max(4, ...DIMS.map((d) => Math.abs(deltas[d] || 0)));
+if (Object.keys(deltas).length) {
+  const rows = DIMS.filter((d) => typeof deltas[d] === "number")
+    .sort((a, b) => deltas[b] - deltas[a]);
+  set("moved", rows.map((d) => {
+    const v = deltas[d], w = (Math.abs(v) / maxAbs) * 50;
+    const style = v >= 0
+      ? `left:50%;width:${w}%;background:var(--up)`
+      : `right:50%;width:${w}%;background:var(--down)`;
+    return `<div class="divrow"><div class="dimname">${esc(d.replace(/_/g, " "))}
+      <span class="wt">w${S.weights[d]}</span></div>
+      <div class="divtrack"><div class="axis"></div>
+        ${v === 0 ? "" : `<div class="divbar" style="${style}"></div>`}</div>
+      <div class="deltacell tnum" style="color:${v > 0 ? "var(--up)" : v < 0 ? "var(--down)" : "var(--ink-3)"}">${sgn(v)}</div>
+    </div>`;
+  }).join(""));
+  set("movedlegend", `<div class="li"><span class="sw" style="background:var(--up)"></span>`
+    + `improved since round ${(S.round || 2) - 1}</div>`
+    + `<div class="li"><span class="sw" style="background:var(--down)"></span>declined</div>`
+    + `<div class="li">The bar is scaled to the largest move (${maxAbs} points). `
+    + `Every value is also printed, so colour is never the only channel.</div>`);
+} else { hide("sec-moved"); }
+
+/* ── the panel ────────────────────────────────────────────────────────── */
+const pv = D.panel_raw || [];
+if (pv.length) {
+  set("panelnote", `<p>Three frontier models scored the same evidence bundle independently and `
+    + `blind — to each other, and to any previous score for this workspace. The reported figure `
+    + `is the <strong>median</strong>; the <strong>spread</strong> is published because it is a `
+    + `confidence signal. A 74 that three models independently agreed on means something `
+    + `different from a 74 that averages 65 and 83.</p>`
+    + `<p class="muted small">These models share training lineage, so agreement between them is `
+    + `weaker evidence than three independent human reviewers would be. What the panel reliably `
+    + `catches is the confident, plausible, wrong finding that a single model would otherwise `
+    + `defend all the way into this report.</p>`);
+  const contested = (S.contested || []);
+  set("panel", `<div class="scroller"><table><thead><tr><th>Dimension</th><th class="num">wt</th>`
+    + pv.map((v) => `<th class="num">${esc(v.model)}</th>`).join("")
+    + `<th class="num">median</th><th class="num">spread</th><th>Panel headline</th></tr></thead>`
+    + `<tbody>` + DIMS.map((d) => `<tr><td>${esc(d.replace(/_/g, " "))}`
+        + (contested.includes(d) ? ' <span class="contested">contested</span>' : "")
+        + `</td><td class="num">${S.weights[d]}</td>`
+        + pv.map((v) => `<td class="num">${esc((v.scores || {})[d] ?? "—")}</td>`).join("")
+        + `<td class="num"><strong>${esc(med[d] ?? "—")}</strong></td>`
+        + `<td class="num">${esc(spr[d] ?? "—")}</td>`
+        + `<td class="small muted">${esc(((SY.dimension_scores || {})[d] || {}).grade || "")}</td>`
+        + `</tr>`).join("")
+    + `</tbody></table></div>`
+    + `<div class="legend">` + pv.map((v) => `<div class="li"><strong>${esc(v.model)}</strong>: `
+        + `${esc(v.headline || "")}</div>`).join("") + `</div>`);
+} else { hide("sec-panel"); }
+
+/* ── second opinion ───────────────────────────────────────────────────── */
+const CR = D.critiques || [];
+if (CR.length) {
+  set("secondop", `<p class="muted">An independent reviewer on a different model was handed the `
+    + `finished scorecard and told to challenge it — in either direction — not to restate it.</p>`
+    + CR.map((c) => `<div class="card" style="margin-bottom:12px">
+      <h3>${esc(c.model)} — independent critique</h3>
+      <p>${esc(c.verdict || "")}</p>
+      ${(c.miscalibrated || []).length ? `<h3 class="small">Score challenges</h3>
+        <div class="scroller"><table><thead><tr><th>Dimension</th><th>Direction</th>
+        <th class="num">Argued</th><th>Why</th></tr></thead><tbody>`
+        + c.miscalibrated.map((m) => `<tr><td>${esc(m.dimension)}</td>`
+          + `<td>${esc((m.direction || "").replace("_", " "))}</td>`
+          + `<td class="num">${esc(m.argued_score)}</td><td>${esc(m.why)}</td></tr>`).join("")
+        + `</tbody></table></div>` : ""}
+      ${(c.missed || []).length ? `<h3 class="small">Not examined by this audit</h3>
+        <ul>${c.missed.map((m) => `<li>${esc(m)}</li>`).join("")}</ul>` : ""}
+      ${(c.disputed || []).length ? `<h3 class="small">Disputed</h3>
+        <ul>${c.disputed.map((m) => `<li><strong>${esc(m.claim)}</strong> — ${esc(m.why)}</li>`)
+          .join("")}</ul>` : ""}
+      ${c.process_critique ? `<p class="muted small"><strong>On the method:</strong> `
+        + `${esc(c.process_critique)}</p>` : ""}
+    </div>`).join("")
+    + (SY.second_opinion_response ? `<div class="callout ok"><h3>How the lead partner responded`
+        + `</h3><p>${esc(SY.second_opinion_response)}</p></div>` : ""));
+} else { hide("sec-secondop"); }
+
+/* ── confirmed risks ──────────────────────────────────────────────────── */
+const risks = SY.top_risks || [];
+const conf = F.confirmed || [];
+const byFile = {};
+for (const c of conf) byFile[(c.file || "") + ":" + (c.line || "")] = c;
+if (risks.length || conf.length) {
+  const cards = (risks.length ? risks : conf).map((r) => {
+    const key = (r.file || "") + ":" + (r.line || "");
+    const det = byFile[key] || {};
+    const sev = String(r.severity || det.corrected_severity || det.severity || "medium")
+      .toLowerCase();
+    const vs = det.verdicts || r.verdicts || [];
+    return `<div class="finding">
+      <div class="top">
+        <span class="sev ${esc(sev)}">${sev === "critical" ? "◆" : sev === "high" ? "▲"
+          : sev === "medium" ? "●" : "○"} ${esc(sev)}</span>
+        <strong>${esc(r.title || r.issue || "")}</strong>
+        ${r.dimension ? `<span class="pill">${esc(String(r.dimension).replace(/_/g, " "))}</span>` : ""}
+        ${r.agreement || det.agreement ? `<span class="agree">${esc(String(r.agreement
+          || det.agreement).replace(/-/g, " "))}</span>` : ""}
+      </div>
+      ${r.file ? `<div class="floc">${esc(r.file)}${r.line ? ":" + esc(r.line) : ""}</div>` : ""}
+      <p>${esc(r.detail || r.issue || "")}</p>
+      ${r.remediation ? `<p class="muted"><strong>Remediation:</strong> ${esc(r.remediation)}</p>` : ""}
+      ${det.found_by_model ? `<div class="votes"><span class="mv">found by `
+        + `${esc(det.found_by_model)}</span>`
+        + vs.map((v) => `<span class="mv ${v.refuted ? "ref" : "real"}">${esc(v.model)}: `
+          + `${v.refuted ? "refuted" : "confirmed"}</span>`).join("") + `</div>` : ""}
+      ${vs.length ? `<details style="margin-top:9px;background:transparent;border:0;padding:0">
+        <summary class="small">Why the verifiers believed it</summary>
+        <ul class="small">${vs.map((v) => `<li><strong>${esc(v.model)}</strong>${
+          v.refuted ? " (dissenting)" : ""}: ${esc(v.reasoning)}</li>`).join("")}</ul>
+        </details>` : ""}
+    </div>`;
+  }).join("");
+  set("risks", `<p class="muted">Only findings that survived cross-model refutation appear here. `
+    + `A finding's own author model never judged it alone.</p>` + cards);
+} else {
+  set("risks", `<div class="callout ok"><p>No finding survived cross-model refutation at `
+    + `critical or high severity.</p></div>`);
+}
+
+/* ── excluded and unconfirmed ─────────────────────────────────────────── */
+const ref = F.refuted || [], unv = F.unverified || [];
+if (ref.length || unv.length) {
+  set("excluded", `<p class="muted">Publishing what was thrown out is part of the evidence: a `
+    + `wrong refutation hides a real defect, so the reasoning is here to be checked.</p>`
+    + (unv.length ? `<details open><summary>${unv.length} severe finding(s) never verified — `
+        + `treat as unconfirmed</summary><ul>` + unv.map((u) => `<li><span class="floc">`
+        + `${esc(u.file)}${u.line ? ":" + esc(u.line) : ""}</span> — ${esc(u.issue)}`
+        + `${u.found_by_model ? ` <span class="pill">found by ${esc(u.found_by_model)}</span>` : ""}`
+        + `</li>`).join("") + `</ul></details>` : "")
+    + (ref.length ? `<details><summary>${ref.length} finding(s) refuted and excluded`
+        + `</summary><ul>` + ref.map((u) => `<li><span class="floc">${esc(u.file)}`
+        + `${u.line ? ":" + esc(u.line) : ""}</span> — ${esc(u.issue)}<br>`
+        + (u.verdicts || []).map((v) => `<span class="small muted">${esc(v.model)}`
+          + `${v.already_fixed ? " (already fixed)" : ""}: ${esc(v.reasoning)}</span>`)
+          .join("<br>") + `</li>`).join("") + `</ul></details>` : ""));
+} else { hide("sec-excluded"); }
+
+/* ── did prior fixes land ─────────────────────────────────────────────── */
+const RG = D.regressionResults || [];
+if (RG.length) {
+  const tally = RG.reduce((a, r) => (a[r.status] = (a[r.status] || 0) + 1, a), {});
+  set("prior", `<div class="legend">` + Object.entries(tally).map(([k, v]) =>
+      `<div class="li"><span class="pill">${esc(k.replace(/_/g, " "))}: ${v}</span></div>`).join("")
+    + `</div><p class="muted small">A fix that closed the reported example but left the defect `
+    + `class open is <em>partially fixed</em>, and earns no root-cause credit. That distinction `
+    + `is the most useful output of this section.</p>`
+    + `<div class="scroller"><table><thead><tr><th>Prior finding</th><th>Status</th>`
+    + `<th>Fix quality</th><th>Test pins it</th><th>Judged by</th><th>Evidence</th></tr></thead>`
+    + `<tbody>` + RG.map((r) => `<tr><td>${esc(r.id)}<div class="small muted">`
+        + `${esc(r.reasoning || "")}</div></td>`
+        + `<td>${esc(String(r.status || "").replace(/_/g, " "))}</td>`
+        + `<td>${esc(r.quality || "—")}</td>`
+        + `<td>${r.test_pinned ? "yes" : `<span style="color:var(--down)">no</span>`}</td>`
+        + `<td>${esc(r.judged_by_model || "—")}</td>`
+        + `<td class="small mono">${(r.evidence || []).map(esc).join("<br>")}</td></tr>`).join("")
+    + `</tbody></table></div>`);
+} else { hide("sec-prior"); }
+
+/* ── fix review ───────────────────────────────────────────────────────── */
+const FR = D.fixReviews || [];
+if (FR.length) {
+  const bad = FR.filter((f) => (f.bad_fixes || []).length);
+  set("fixes", `<p class="muted">Every applied fix was re-read by a <strong>different model`
+    + `</strong> than the one that wrote it — a model is worst at seeing the bug it just `
+    + `wrote.</p>`
+    + `<div class="legend"><div class="li"><span class="pill">${FR.length} units reviewed`
+    + `</span></div><div class="li"><span class="pill">${FR.reduce((n, f) =>
+        n + (f.reviewed_count || 0), 0)} fixes re-read</span></div>`
+    + `<div class="li"><span class="pill">${bad.reduce((n, f) => n + f.bad_fixes.length, 0)} `
+    + `flagged</span></div></div>`
+    + (bad.length ? `<div class="scroller"><table><thead><tr><th>Unit</th><th>Author</th>`
+        + `<th>Reviewer</th><th>Action</th><th>Problem</th></tr></thead><tbody>`
+        + bad.flatMap((f) => f.bad_fixes.map((b) => `<tr><td class="mono small">`
+          + `${esc(f.unit)}</td><td>${esc(f.author_model)}</td><td>${esc(f.reviewer_model)}</td>`
+          + `<td><strong>${esc(b.action)}</strong>${b.breaks_build
+            ? ' <span class="sev critical">breaks build</span>' : ""}</td>`
+          + `<td>${esc(b.problem)}<div class="small mono dim">${esc(b.file)}</div></td></tr>`))
+          .join("") + `</tbody></table></div>`
+      : `<div class="callout ok"><p>No applied fix was flagged by its cross-model reviewer.</p></div>`));
+} else { hide("sec-fixes"); }
+
+/* ── gate ─────────────────────────────────────────────────────────────── */
+if (V && Object.keys(V).length) {
+  const row = (k, v) => `<tr><td>${esc(k)}</td><td>${v === true
+    ? `<span style="color:var(--ok-text);font-weight:640">pass</span>`
+    : v === false ? `<span style="color:var(--down);font-weight:640">fail</span>`
+    : `<span class="dim">—</span>`}</td></tr>`;
+  set("gate", `<div class="cols2">
+    <div class="card"><h3>Result</h3><table>
+      ${row("format", V.fmt_clean)}${row("lint", V.lint_clean)}
+      ${row("typecheck", V.typecheck_clean)}${row("tests", V.tests_pass)}
+      </table>
+      <p class="small muted" style="margin-top:10px">${esc(V.test_summary || "")}</p>
+      <p class="small">${esc(V.final_state || "")}</p></div>
+    <div class="card"><h3>Measured against a pristine baseline</h3>
+      <p class="small mono">${esc(D.baseline || "not measured")}</p>
+      <p class="small muted">The baseline was taken on a separate checkout of the same commit
+        <em>before</em> any agent ran, which is the only way to tell a regression introduced by
+        this audit from breakage that shipped.</p>
+      ${(V.reverted || []).length ? `<h3 class="small">Reverted</h3><ul class="small">`
+        + V.reverted.map((r) => `<li>${esc(r)}</li>`).join("") + `</ul>` : ""}
+      ${(V.preexisting || []).length ? `<h3 class="small">Pre-existing, not caused here</h3>`
+        + `<ul class="small">` + V.preexisting.map((r) => `<li>${esc(r)}</li>`).join("")
+        + `</ul>` : ""}
+      ${(V.commands_run || []).length ? `<h3 class="small">Commands actually run</h3>`
+        + `<p class="small mono">` + V.commands_run.map(esc).join("<br>") + `</p>` : ""}
+    </div></div>`);
+} else { hide("sec-gate"); }
+
+/* ── roadmap ──────────────────────────────────────────────────────────── */
+const RM = SY.roadmap || [];
+if (RM.length) {
+  set("roadmap", ["now", "next", "later"].map((h) => {
+    const items = RM.filter((r) => r.horizon === h);
+    return `<div class="card hz"><h3>${h}</h3>${items.length
+      ? `<ul>` + items.map((r) => `<li><strong>${esc(r.item)}</strong>`
+          + `${r.effort ? ` <span class="pill">${esc(r.effort)}</span>` : ""}`
+          + `${r.dimension ? ` <span class="pill">${esc(String(r.dimension)
+              .replace(/_/g, " "))}</span>` : ""}`
+          + `<div class="small muted">${esc(r.why || "")}</div></li>`).join("") + `</ul>`
+      : `<p class="small dim">nothing queued</p>`}</div>`;
+  }).join(""));
+} else { hide("sec-roadmap"); }
+
+/* ── method ───────────────────────────────────────────────────────────── */
+const P = D.provenance || {};
+set("method", `<div class="cols2">
+  <div class="card"><h3>How the number was produced</h3>
+    <p class="small">${esc(SY.scoring_methodology || "")}</p>
+    <p class="small muted">Overall is the weighted mean of the 17 dimensions
+      (weights shown in the scorecard, summing to 33), recomputed independently from the
+      published per-dimension scores rather than taken from any agent. Dimensions scored 0
+      are not applicable and are excluded from the mean. The delta is computed at full
+      precision before rounding${typeof S.delta_precise === "number"
+        ? `: ${num(S.prior_overall, 2)} → ${num(S.overall, 2)} is
+           ${S.delta_precise > 0 ? "+" : ""}${num(S.delta_precise, 2)}` : ""}.</p>
+    ${S.agent_claimed != null && S.agent_claimed !== S.overall_rounded
+      ? `<p class="small" style="color:var(--serious)">The synthesising agent claimed
+         ${esc(S.agent_claimed)}; the recomputed value is ${esc(S.overall_rounded)}. The
+         recomputed value is what is reported.</p>` : ""}
+  </div>
+  <div class="card"><h3>Model provenance</h3>
+    ${P.rows && P.rows.length ? `<div class="scroller"><table><thead><tr><th>Phase</th>
+      <th class="num">agents</th><th>models actually used</th></tr></thead><tbody>`
+      + P.rows.map((r) => `<tr><td>${esc(r.phase)}</td><td class="num">${esc(r.agents)}</td>`
+        + `<td class="small mono">${esc(r.models)}</td></tr>`).join("")
+      + `</tbody></table></div>` : `<p class="small dim">Not captured for this run.</p>`}
+    <p class="small ${P.ok === false ? "" : "muted"}" ${P.ok === false
+      ? 'style="color:var(--down)"' : ""}>${P.ok === true
+      ? "Verified: the model recorded in every agent transcript matches the slot it was "
+        + "assigned. The cross-model guarantees in this report hold."
+      : P.ok === false ? esc(P.detail || "Provenance check failed.")
+      : "Provenance was not verified for this run, so the cross-model claims are asserted "
+        + "rather than proven."}</p>
+  </div></div>
+  <div class="card" style="margin-top:16px"><h3>What this audit could not determine</h3>
+    <p>${esc(SY.audit_limitations || "Not stated.")}</p>
+    <p class="small muted">Coverage: ${int(R.files_owned)} of ${int(R.total_files)} source files
+      were owned by an auditing agent${cov != null ? ` (${num(cov, 1)}%)` : ""}. Fix authority
+      was <strong>${esc((R.fix_authority || {}).level || "unknown")}</strong> &mdash;
+      ${esc((R.fix_authority || {}).reason || "")}</p>
+  </div>`);
+
+el("foot").textContent = `ultra-audit · ${R.root || ""} · commit `
+  + `${R.commit || "unrecorded"} · generated ${D.generated_at || S.date || ""} · `
+  + `17-dimension rubric, absolute bar, 100 reserved for the Rust project itself.`;
+</script>
+</body>
+</html>

--- a/.stella/skills/ultra-audit/reference/model-panel.md
+++ b/.stella/skills/ultra-audit/reference/model-panel.md
@@ -1,0 +1,102 @@
+# The model panel
+
+The premise: **a model is a poor judge of its own output.** It repeats its own blind spots,
+defends its own claims, and cannot see the bug it just wrote. Every trust-bearing step in this
+audit is therefore performed by a model *other than* the one whose work is being judged, and
+the score itself is a median across three independent frontier models rather than one model's
+opinion.
+
+This file is the contract. The harness enforces it mechanically; `scripts/progress.py
+--provenance` proves after the fact that it actually happened, by reading the real model
+recorded in each agent's transcript rather than trusting the harness's intent.
+
+## The panel
+
+| Slot | `opts.model` | Role |
+|---|---|---|
+| A | `opus` | Frontier. Discovery, judgment, scoring, synthesis. |
+| B | `fable` | Frontier. Discovery, judgment, scoring. |
+| C | `sonnet` | Frontier. Discovery, judgment, scoring. |
+
+`haiku` is **not** on the panel. It never judges a finding and never scores a dimension. It is
+permitted only for mechanical extraction where the answer is checkable by a script.
+
+Omitting `opts.model` inherits the session model — which silently collapses the panel to one
+model and destroys the whole design. **Every agent in this harness sets `model` explicitly.**
+
+## The five rules
+
+### 1. No model grades its own homework
+
+For any finding, the verifier pool is `PANEL − {model that found it}`. A finding's author
+model never sits alone in judgment of it. Same for fixes: the agent reviewing an applied fix
+runs on a different model than the agent that wrote it.
+
+### 2. Discovery is diversified, not consensus-driven
+
+At discovery time, **disagreement is the product.** Units and lenses are assigned models
+round-robin so no single model's blind spots shape the whole audit, and the two heaviest lenses
+(`security` and `loop-correctness`, weight 3) run **twice on two different models** with the
+*union* of their findings carried forward. Never intersect findings at discovery — that
+throws away exactly the defects only one model could see.
+
+### 3. Judgment is a quorum, and the vote is recorded
+
+Every critical/high finding is put to cross-model refutation. Each verifier is told to *try to
+refute*. The tally is recorded, not just the outcome:
+
+| Agreement | Meaning | Treatment |
+|---|---|---|
+| `unanimous-real` | every cross-model verifier says real | enters the risk register at full confidence |
+| `majority-real` | most say real | enters the register, flagged |
+| `contested` | verifiers split | enters the register flagged **contested**; synthesis must resolve it by reading the code and say which way it went |
+| `refuted` | most say not-a-defect | excluded from the register; kept in the report's refuted list with the reason |
+
+A finding that **only its own author model believes** is labelled `single-model` in the
+report. That label is information for the reader, not an automatic dismissal.
+
+### 4. The score is a median of three blind panelists, and the spread is published
+
+Three calibration agents — one per panel slot — independently score all 17 dimensions from the
+*same* evidence bundle. They are blind to each other and blind to any prior score.
+
+- **reported score** = median of the three
+- **spread** = max − min
+- **spread ≥ 10 on a dimension ⇒ `contested`**: the synthesis partner must read code and
+  justify the number it lands on, and the report must show the disagreement.
+
+A median is used rather than a mean because it is robust to one panelist being badly
+miscalibrated, which happens.
+
+Publishing the spread is not decoration. A `security` score of 74 where three models
+independently said 73/74/75 means something quite different from 65/74/83, and the reader is
+entitled to know which they are looking at.
+
+### 5. Provenance is recorded and verified
+
+Every agent prompt begins with exactly this line:
+
+```
+ULTRA-AUDIT-AGENT phase=<phase> role=<label> model=<assigned-slot>
+```
+
+Every finding carries `found_by_model`; every verdict carries the judging model. After the run,
+`scripts/progress.py --provenance <transcript-dir>` extracts the **actual** model from each
+agent's transcript and cross-checks it against the assigned slot. A mismatch means the mix did
+not happen and the cross-model guarantees in the report are void.
+
+Verify this. Do not report a cross-model audit you did not confirm was cross-model.
+
+## What this costs, and the honest limitation
+
+Cross-model verification roughly doubles the judgment phase. `--depth deep` (the default)
+spends one cross-model verifier per severe finding plus a second for anything critical;
+`--depth max` puts every severe finding to the full panel.
+
+The limitation worth stating plainly: these three models share a great deal of training
+lineage. Cross-model agreement is **weaker evidence of truth than three independent human
+reviewers would be**, and unanimous agreement across the panel does not make a finding true.
+What the panel reliably catches is the *single-model artifact* — the confident, plausible,
+wrong finding that one model generates and would otherwise defend all the way into the report.
+That failure mode is common enough that catching it is worth the spend. Claim that, and not
+more.

--- a/.stella/skills/ultra-audit/reference/operations.md
+++ b/.stella/skills/ultra-audit/reference/operations.md
@@ -1,0 +1,290 @@
+# Operations — the failure modes, and what fixes them
+
+Every numbered item here cost real time on a real run. Read this before launching; skipping it
+costs hours.
+
+## 0. READ THIS FIRST — typing in the prompt kills the run
+
+**Subagents are children of the turn that launched them.** If the user interrupts — or types
+anything at all while the workflow is running — the turn ends and *every in-flight agent dies
+mid-read*. They had not yet written their findings, so the work is simply gone.
+
+This has destroyed three separate audit runs. On one, all 24 agents died at once, minutes
+before any of them reached the write-fixes stage; the run looked healthy right up to the
+moment it produced nothing.
+
+It is also the failure mode most likely to recur, because the natural human response to a
+silent 90-minute run is to type "status" — which is precisely the thing that kills it.
+
+**Therefore, in this order:**
+
+1. **Tell the user, before launching, in plain words:** the run takes N minutes; typing in the
+   prompt will kill it; `/workflows` shows live status without touching the run.
+2. **Make the progress narration frequent enough that they never want to type.** Report after
+   every phase transition, and at least every few minutes during the long phases. Silence is
+   what provokes the interrupt. This is not politeness — it is how the run survives.
+3. If it does get killed, recover with `Workflow({scriptPath, resumeFromRunId: 'wf_…'})`;
+   agents whose `(prompt, opts)` are unchanged replay from cache. Then salvage per §2.
+
+The first fifteen minutes of a healthy run look identical to a dead one — nothing has
+finished yet. Prove liveness with `scripts/progress.py`, which compares `started` against
+`result` counts and reports growing transcripts, rather than waiting for a first completion.
+
+## 1. Long-lived agents die; short ones don't
+
+**Symptom.** Recurring `API Error: Connection closed mid-response`, arriving in bursts —
+roughly every 20 minutes, taking out 4–5 in-flight agents at once. Each dies, restarts from
+zero, and is still running when the next burst lands, so it never converges. The run looks
+alive (transcripts growing) while producing almost nothing.
+
+**It is not correlated with unit size the way you would guess.** On the run where this was
+diagnosed, a 4k-LOC unit died 6 times while a 19.5k-LOC unit passed on attempt 3. The
+correlated variable is **how long the agent has been alive**, and secondarily how long its
+final response is — the drop lands during the long terminal `StructuredOutput` call.
+
+**Fix, in order of effect:**
+
+1. **Partition units to ~12–15k LOC** so an agent finishes inside the window.
+2. **Cap the write-up in the prompt.** "Report your 12 most significant findings, not every
+   nit. Each `issue` 2–3 sentences. Call `StructuredOutput` as soon as analysis is done; do
+   not narrate findings in prose first." Depth of *reading* is unaffected — only the length of
+   the terminal response, which is what actually breaks.
+3. Give every partition **disjoint, explicitly enumerated** file ownership.
+
+**Detect it early.** A few minutes in, run `scripts/progress.py <transcript-dir>`. It counts
+distinct `started` vs `result` keys in `journal.jsonl` and reports the retry count directly. If
+starts far exceed results, agents are being retried.
+
+## 2. Salvage before you restart
+
+Do not throw away finished agents. `journal.jsonl` has one line per completed agent:
+
+```python
+# NOTE: the key is "result", not "value"
+[json.loads(l)["result"] for l in open(f"{d}/journal.jsonl")
+ if json.loads(l).get("type") == "result"]
+```
+
+Compact those into the next script as an embedded constant. **Splice it in with a script, not
+by writing it out yourself** — the payload is often 80–300KB, and pasting it through the
+conversation burns enormous context for zero benefit:
+
+```python
+tpl = open("workflow.template.js").read()
+open("workflow.js","w").write(tpl.replace("/*__SALVAGE__*/ null", open("salvaged.json").read()))
+```
+
+Then `node --check workflow.js` before launching.
+
+`resumeFromRunId` replays cached agents whose `(prompt, opts)` are unchanged — but if you are
+restructuring the prompts (the usual reason to restart), most will miss. Embedding salvaged
+results is the reliable path.
+
+## 3. A cached build reports zero warnings
+
+This is the single most common way an audit reports a green gate that isn't. Every incremental
+toolchain **suppresses diagnostics it already emitted on a previous run**, so a clean result on
+a warm cache is not evidence of anything.
+
+| Toolchain | The trap | Force a real run |
+|---|---|---|
+| `cargo clippy` | silent on a cached build | `touch` every unit's root source file first |
+| `cargo doc` | additionally bails early | re-run until every crate documents |
+| `tsc --incremental` / project refs | `.tsbuildinfo` skips unchanged files | delete `.tsbuildinfo` / `--force` |
+| `eslint` | `--cache` reuses prior verdicts | drop `--cache`, or delete the cache file |
+| `ruff` / `mypy` | `.ruff_cache` / `.mypy_cache` | `--no-cache` / `--cache-dir=$(mktemp -d)` |
+| `go build`/`vet` | build cache | `go clean -cache` is heavy; `-count=1` for tests |
+| `pytest` | `-p no:cacheprovider` for a clean collect | plus `--cache-clear` |
+| `gradle`/`maven` | build cache + daemon | `--rerun-tasks` / `-o` off |
+
+`scripts/detect.py` emits the forced form of each command it finds. Use those, not the
+convenient ones.
+
+**Related:** if `CLICOLOR_FORCE` is set (it is, in this user's zshrc), subprocess output carries
+ANSI escapes, so `rg '^error'` silently misses matches. **Check gates by exit code**, not by
+grepping coloured output.
+
+## 4. Baseline on a pristine tree, before any agent runs
+
+Repos land red far more often than anyone expects. If you only measure after the audit, you
+will charge pre-existing breakage to the audit — or, worse, credit the audit for a green tree
+that was already green.
+
+```sh
+git worktree add <tmp>/baseline-check <HEAD-sha> --detach
+```
+
+Measure the full gate there. Pass the measured numbers into the Verify phase's prompt so its
+agent can classify each failure as regression vs pre-existing instead of guessing. Remove the
+worktree afterwards (`git worktree remove --force`) so it does not pollute `git worktree list`.
+
+**If the project is not a git repository**, there is no pristine baseline and no way to revert a
+bad fix. Run with `--no-fix` (audit only, zero write authority) and say so in the report. Do not
+grant fix authority to a tree you cannot roll back.
+
+## 5. Fix authority is only as safe as the language's gate
+
+In Rust, an agent's bad edit usually fails to compile and the Verify phase catches it. **In a
+dynamically typed tree, a bad edit ships silently** — there is no compiler, and the tests may
+not cover the line. Fix authority is therefore not a constant; it is a function of what gate
+exists behind it:
+
+| Tree has | Fix authority |
+|---|---|
+| Static types + a compile gate (Rust, Go, typed TS with `strict`, Java) | full: the documented safe-fix list |
+| Tests with real coverage of the file, no type gate | fixes only inside files the tests actually exercise |
+| Neither | **comments, docs, dead-code removal and error-message text only** |
+
+`scripts/detect.py` decides this per-tree and writes it into every unit prompt. Do not override
+it upward by hand.
+
+## 6. Keep discovery blind to prior scores
+
+Feed the previous scorecard **only** to the synthesis phase. If unit, lens, or panel agents see
+the old numbers they anchor, and the run degenerates into confirming last time's result.
+
+Where a prompt must mention a prior finding (Phase 0 has to), frame it as *a lead to check, not
+a fact* — some prior findings were fixed, some fixed shallowly, and some fixes introduced new
+defects. Say that explicitly in the prompt.
+
+## 7. Recompute every number yourself
+
+Never report an agent's arithmetic. `scripts/score.py` recomputes:
+
+- the weighted overall from the panel's own per-dimension scores;
+- the **median and spread** across the three panelists (a panelist that returns a mean instead
+  of a median, or silently drops a dimension, is common);
+- the **prior round's** published number from its recorded scores — if that does not reproduce,
+  the weights drifted and the whole comparison is invalid.
+
+Treat any disagreement as an error to investigate, not a rounding difference.
+
+## 8. Every agent must set `model` explicitly
+
+Omitting `opts.model` inherits the session model. One omission silently collapses part of the
+panel to a single model, and every cross-model guarantee in the report becomes false while
+still being printed. After the run, always:
+
+```sh
+python3 scripts/progress.py <transcript-dir> --provenance
+```
+
+It reads the **actual** model out of each agent transcript and cross-checks it against the slot
+the prompt claimed. Do not publish the report until this is clean.
+
+## 9. Forbid build tooling outside the Verify phase
+
+Concurrent agents contend on the build lock (`cargo`'s target lock, a single `node_modules`, a
+Gradle daemon, a shared venv) and will serialise the entire run behind one build. Worse, in
+JS/Python monorepos an agent that runs an install can mutate the lockfile underneath every
+other agent. Unit, lens, refute, panel and synthesis agents are told: **static reading only, no
+build, no test, no install.** Only Verify runs tooling, and it runs alone.
+
+## 10. Monitors that fire too often are auto-stopped
+
+One notification per completed agent is 200+ messages on a `max`-depth run. Watch phase
+transitions only, or bucket by `total / 5`. The reliable progress mechanism is
+`scripts/progress.py`, which is a pull, not a push.
+
+## 11. The HTML report must be genuinely self-contained
+
+No CDN, no web font, no remote image, no `fetch`. The report gets opened months later, from a
+different machine, possibly offline, and possibly attached to an email. Inline everything; if a
+chart needs a library, it is the wrong chart. `scripts/render_report.py` emits hand-rolled
+inline SVG for exactly this reason, and its self-containment is asserted by its own test.
+
+## 12. Write the report before you are sure the run is finished
+
+A run that dies in the final phase with everything else complete should still produce a report.
+`render_report.py` accepts a partial result and marks the missing sections `incomplete` rather
+than failing. Render early, render often; an audit with no artifact is an audit that did not
+happen.
+
+## 13. Agent count is a wave count, not just a size decision
+
+Workflow concurrency is capped at `min(16, cores − 2)` — on this machine, 8. Forty agents is
+five sequential waves, not forty things happening at once. Two consequences:
+
+- **Estimate wall-clock as `ceil(agents / cap) × per-agent-minutes`**, per phase. Tell the user
+  that number before launching, not a vague "about an hour".
+- A wave that starts inside a connection-drop burst (§1) **dies as a unit** — which is why the
+  drops appear to take out 4–5 agents at once. More, smaller units means a dead wave costs less.
+
+## 14. The workflow script cannot touch the filesystem
+
+Scripts have no filesystem access — no glob, no stat, no read. `Date.now()`, `Math.random()`
+and argless `new Date()` throw as well, because they would break resume.
+
+Everything the harness needs about the tree must therefore be scouted by the parent session and
+**spliced into the script text** (or passed via `args`): the unit list, the file inventory, the
+gate commands, the measured baseline, the prior scorecard, the timestamp. That division of
+labour is why `detect.py` and `partition.py` are separate steps rather than script logic.
+
+## 15. Compute every delta at full precision, before rounding
+
+A published overall of 79 → 80 looks like +1. The real movement was **+0.86** (78.92 → 79.79).
+Subtracting rounded values inflates or erases movement and has already produced one wrong
+number in a shipped report.
+
+Round only for display, and only at the last moment. `score.py` carries two decimals
+internally and prints both the rounded headline and the precise delta.
+
+## 16. Pin the commit, and re-check it before publishing
+
+Two distinct incidents: an audit **scored an unmerged branch while reporting on `main`**, and a
+long run finished against a `main` that had since broken (new commits landed mid-run with a
+fresh compile error).
+
+State the SHA you actually scored, in the report and in the history record. Before publishing,
+re-check that `origin/main` has not moved under you, and say so if it has. A score against an
+unstated tree is not comparable to anything.
+
+## 17. Diagnose your own tooling before diagnosing a dead agent
+
+A journal parser reading the wrong key returns `null` for every completed agent, which is
+indistinguishable from mass agent death and has already triggered one full false-alarm
+investigation. Two specific traps:
+
+- the result key is **`result`**, not `value`;
+- there is **no `agent_end` event type** — a Monitor watching for one silently reports nothing
+  forever.
+
+Validate the parser against a known-good journal before trusting what it says about the run.
+
+## 18. Monitors leak; stop them explicitly
+
+A Monitor armed for a run outlives the run. Stop each one with `TaskStop` when the phase it was
+watching completes. Three prior runs left monitors armed after finishing.
+
+## 19. Splice the report data disk-to-disk, and escape the closing tag
+
+The findings payload is 80–300KB of JSON. **Never route it through the conversation** — read
+the template and the data from disk, write the joined file to disk:
+
+```python
+tpl  = open('report_template.html').read()
+data = json.load(open('report.json'))
+js   = json.dumps(data, ensure_ascii=False).replace('</', r'<\/')   # load-bearing
+out  = tpl.replace('__DATA__', js)
+assert '__DATA__' not in out, 'placeholder survived the splice'
+```
+
+The `</` → `<\/` escape is **load-bearing, not defensive**: any finding whose text contains a
+closing tag (`</div>`, `</script>`, a snippet of HTML in a code sample) would otherwise
+terminate the `<script>` block and produce a blank page. `render_report.py` does this and
+asserts it; its test suite includes a finding containing `</script>` for exactly this reason.
+
+Then **validate the generated file rather than eyeballing it**: extract the inline script and
+run `node --check` on it, assert every `id="…"` mount point the renderer targets is present,
+and open it. A report that renders blank is worse than no report.
+
+## 20. A cheaper model ignores guidance a frontier model would honour
+
+Observed directly: a constraint placed fourth in a list of operating rules was simply shrugged
+off by a worker-tier model that a frontier model had followed. If any agent in this harness
+runs below the frontier tier, its constraints must be **rule #1, imperative, and phrased as a
+stop condition** ("if you are about to X and have not done Y, STOP"), not a preference buried
+in a paragraph.
+
+This is also the reason `haiku` never judges a finding or scores a dimension here — see
+`model-panel.md`.

--- a/.stella/skills/ultra-audit/reference/rubric.md
+++ b/.stella/skills/ultra-audit/reference/rubric.md
@@ -1,0 +1,124 @@
+# The rubric
+
+Seventeen dimensions, fixed weights, an absolute bar. **Do not change the weights between
+runs** — they are the only thing that makes two scores comparable. If a dimension genuinely
+must change, that starts a new series and every prior score must be recomputed or explicitly
+marked incomparable.
+
+This rubric is deliberately identical to the one used by the older `reaudit` skill, so any
+history recorded by that skill continues in this one without a break.
+
+## The 17 dimensions and their weights
+
+Weight reflects what determines whether software is trustworthy in production, not how
+interesting the dimension is to read about.
+
+| Weight | Dimensions |
+|---|---|
+| **3** | `loop_correctness`, `security`, `agent_performance`, `system_architecture` |
+| **2.5** | `durability`, `token_efficiency` |
+| **2** | `maintainability`, `end_user_experience`, `compute_efficiency` |
+| **1.5** | `data_storage`, `documentation`, `file_organization`, `vendor_lock_avoidance` |
+| **1** | `formatting`, `language`, `file_names`, `symbol_names` |
+
+Sum of weights = 33.
+
+```
+overall = Σ(score_d × weight_d) / Σ(weight_d)      # skip any dimension scored 0 (= N/A)
+```
+
+### What each dimension means
+
+- **formatting** — mechanical consistency; is it enforced by a gate or by hope
+- **language** — prose quality of comments, docs and user-facing strings; comments that
+  *lie about the code beneath them* are the worst defect in this class
+- **documentation** — module docs, ADRs, whether cited documents actually exist
+- **file_names** — do names describe contents; how many conventions run at once
+- **symbol_names** — precision, consistent verb choice, one word per concept
+- **file_organization** — module decomposition, god-modules, files reachable from the tree
+- **system_architecture** — layering, dependency direction, real seams vs leaky abstractions
+- **data_storage** — schema, migrations, transaction boundaries, retention and growth bounds
+- **vendor_lock_avoidance** — adapters cut per protocol/dialect, not per vendor
+- **security** — the trust boundary and whether every stated guarantee actually holds
+- **durability** — crash, corruption, partial-failure and cancellation resilience
+- **maintainability** — test adversarialism, reviewability, lint policy
+- **loop_correctness** — termination, cancellation, budget, retry, state-machine correctness
+- **token_efficiency** — prompt-cache stability, bounded tool output, context economy
+  (`0` = N/A for a workspace with no LLM surface)
+- **agent_performance** — latency on the hot path; blocking work on an async runtime.
+  For a non-agent product read this as **hot-path latency**
+- **compute_efficiency** — CPU, allocations, redundant passes, render cost
+- **end_user_experience** — errors that name the next action, install, headless output
+
+`0` means **not applicable to this unit** and is excluded from every mean. Say so in
+`score_notes`. Do not score 0 to avoid forming a judgment.
+
+---
+
+## Calibration: what 100 means
+
+**100 is the Rust project itself** — `rust-lang/rust`: the language, the compiler, the
+standard library, and Cargo, taken together as one engineering artifact. It is the ceiling
+because of *process that compounds*, not because of any single clever file:
+
+| Anchor | What the Rust project actually does |
+|---|---|
+| Change control | Every user-visible change goes through a public RFC with a final comment period and team sign-off. Nothing user-visible lands because one person thought it was a good idea. |
+| Ecosystem-wide regression proof | **Crater** rebuilds and retests essentially the whole public ecosystem against a candidate change before it lands. The blast radius is measured, not estimated. |
+| Backward compatibility | Editions (2015 → 2024) keep decade-old code compiling. Compatibility is a *guarantee with a mechanism*, not an intention. |
+| Never-broken trunk | A merge queue tests the actual merge commit. Trunk is green by construction. |
+| Diagnostics as a product | UI tests pin exact compiler output, so changing an error message is a reviewable diff. Errors carry spans, explain codes, and machine-applicable suggestions (`cargo fix`). |
+| Soundness | Unsoundness is a release-blocking class of bug with its own label and triage. `unsafe` carries documented invariants. Miri and the sanitizers hunt UB in CI. |
+| Documentation that cannot rot | Doc examples are compiled and executed by CI, so a stale example is a failing build. |
+| Performance as a tracked invariant | Per-change performance measurement with regression flagging, on a public dashboard. |
+| Portability | Multiple codegen backends and an explicit platform support-tier policy with named maintainers per tier. |
+| Formatting and lint policy | `rustfmt` and a large `clippy` corpus, with lint levels used as deliberate policy rather than noise suppression. |
+
+**Nothing you audit is going to be Rust.** That is the point of anchoring here: the number
+stays honest for years and across every project, because the ceiling never moves.
+
+| Band | Meaning |
+|---|---|
+| **100** | Reserved. The Rust project. Never awarded. |
+| **96–99** | Reserved for a project with Rust-grade *process*: an ecosystem-wide regression gate, a decade of proven compatibility, formal or qualified specification work. Awarding a score in this band requires naming, in `rationale`, which anchors above the project actually satisfies. |
+| **90–95** | Reference-grade for its language: ripgrep, tokio, rust-analyzer, SQLite, curl, PostgreSQL. Exemplary, and still not Rust. |
+| **80–89** | Strong. Minor nits only. |
+| **70–79** | Solid, with real gaps a new contributor would hit. |
+| **60–69** | Mediocre. Notable debt. |
+| **< 60** | Deficient. |
+
+### Binding calibration rules
+
+1. **A first-party workspace scoring above 92 on any dimension must justify it against the
+   100-anchor table above**, naming the mechanism — not the intention — that earns it. "The
+   code is very clean" does not earn 93.
+2. **A wall of 90s is a failed audit. So is a wall of 60s.** Spread is evidence of reading.
+3. **Thin evidence means a lower score.** A score without a `file:line` behind it is a guess,
+   and a guess is scored down, not averaged out.
+4. **The bar is absolute, never relative to the last run.** A dimension rises only if the
+   tree is genuinely better against these anchors. Dimensions are allowed to fall, and saying
+   so is the entire value of the exercise.
+5. **Effort is not a score input.** Neither is the size of the diff, the count of fixes
+   applied, or how hard the work was.
+6. **Process counts as evidence, but only enforced process.** A documented rule with no gate
+   behind it scores as an unenforced rule — check whether the guard can be defeated.
+
+### Per-unit weighting inside a dimension
+
+Cross-cutting lens scores are the primary signal for the dimensions that lens owns; per-unit
+scores modulate by a few points. Weight units by **product significance, not line count** —
+the shipping binary, the public API surface, the persistence layer and the security boundary
+carry the most weight; benchmarks, fixtures and harnesses the least.
+
+### Where the panel's scores come from
+
+Three frontier models score every dimension independently and blind. The reported score is
+the **median**; the spread is published as a confidence signal. See `model-panel.md` — the
+rule that no model grades its own work is what keeps these bands meaningful.
+
+## History
+
+Scores are recorded per repository in `~/.claude/audits/<repo>.json`, outside any skill
+directory, so the series survives skill edits. `scripts/score.py --record` writes it and
+verifies that recomputing the previous round reproduces its published number — if it does
+not, the weights drifted and the comparison is invalid.

--- a/.stella/skills/ultra-audit/scripts/build_workflow.py
+++ b/.stella/skills/ultra-audit/scripts/build_workflow.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Splice a runnable audit harness from the template.
+
+Workflow scripts have no filesystem access and cannot call Date.now(), so everything the
+harness knows about the tree has to be baked in here, by this script, in the parent session.
+
+    python3 build_workflow.py --gate gate.json --units units.json \
+            --baseline baseline.txt --out audit.js [--depth deep] [--salvage salvaged.json]
+
+Then launch it with the Workflow tool: Workflow({scriptPath: 'audit.js'}).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE = os.path.join(HERE, "workflow.template.js")
+HISTORY_DIR = os.path.expanduser("~/.claude/audits")
+
+
+def history_path(root: str) -> str:
+    return os.path.join(HISTORY_DIR, os.path.basename(root.rstrip("/")) + ".json")
+
+
+def js_literal(obj) -> str:
+    """JSON is a subset of JS, but `</` inside any string would close a <script> block if this
+    payload is ever embedded in HTML, and U+2028/9 are literal line breaks in JS source."""
+    s = json.dumps(obj, ensure_ascii=False)
+    return (s.replace("</", "<\\/")
+             .replace(" ", "\\u2028")
+             .replace(" ", "\\u2029"))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gate", required=True)
+    ap.add_argument("--units", required=True)
+    ap.add_argument("--baseline", help="file holding the measured pre-audit gate, as prose")
+    ap.add_argument("--depth", default="deep", choices=["standard", "deep", "max"])
+    ap.add_argument("--history", help="defaults to ~/.claude/audits/<repo>.json")
+    ap.add_argument("--salvage", help="results carried over from an aborted run")
+    ap.add_argument("--out", default="audit.js")
+    a = ap.parse_args()
+
+    gate = json.load(open(a.gate))
+    units_blob = json.load(open(a.units))
+    units = units_blob["units"] if isinstance(units_blob, dict) else units_blob
+    root = gate["root"]
+
+    proof = units_blob.get("proof", {}) if isinstance(units_blob, dict) else {}
+    if proof and not (proof.get("disjoint") and proof.get("complete")):
+        sys.exit("REFUSING to build: the partition is not disjoint+complete. Re-run "
+                 "partition.py and fix it — overlapping agents clobber each other's work.")
+
+    hist_path = a.history or history_path(root)
+    prior, prior_items = None, []
+    if os.path.exists(hist_path):
+        runs = json.load(open(hist_path)).get("runs", [])
+        if runs:
+            prior = runs[-1].get("scores")
+            prior_items = runs[-1].get("open_findings", [])
+
+    baseline = "(not measured — the Verify phase cannot distinguish regression from " \
+               "pre-existing breakage, and must say so)"
+    if a.baseline and os.path.exists(a.baseline):
+        baseline = open(a.baseline).read().strip()
+
+    head = subprocess.run("git rev-parse HEAD", cwd=root, shell=True,
+                          capture_output=True, text=True).stdout.strip()
+    run = {
+        "date": datetime.date.today().isoformat(),
+        "commit": head or None,
+        "depth": a.depth,
+        "history": hist_path,
+        "round": len(json.load(open(hist_path)).get("runs", [])) + 1
+                 if os.path.exists(hist_path) else 1,
+    }
+
+    # The inventory is thousands of paths and the harness never reads it — partition.py
+    # already consumed it. Dropping it keeps the script (and every prompt) small.
+    gate_slim = {k: v for k, v in gate.items() if k != "inventory"}
+
+    src = open(TEMPLATE).read()
+    subs = {
+        "__ROOT__": root,
+        "/*__RUN__*/ {}": js_literal(run),
+        "/*__GATE__*/ {}": js_literal(gate_slim),
+        "/*__UNITS__*/ []": js_literal(units),
+        "/*__PRIOR__*/ null": js_literal(prior) if prior else "null",
+        "/*__PRIOR_ITEMS__*/ []": js_literal(prior_items),
+        "/*__SALVAGE__*/ null": (open(a.salvage).read().strip() if a.salvage else "null"),
+    }
+    for k, v in subs.items():
+        if k not in src:
+            sys.exit(f"template is missing the splice point {k!r} — did the template change?")
+        src = src.replace(k, v, 1)
+    # Backticked, so a stray backtick or ${ in the measured baseline would break the script.
+    src = src.replace("__BASELINE__",
+                      baseline.replace("\\", "\\\\").replace("`", "\\`").replace("${", "\\${"), 1)
+
+    leftover = re.findall(r"__[A-Z_]+__", src)
+    if leftover:
+        sys.exit(f"placeholders survived the splice: {sorted(set(leftover))}")
+
+    with open(a.out, "w") as fh:
+        fh.write(src)
+
+    # Validate the GENERATED script, not just the template — and do it through
+    # tests/check_template.py rather than `node --check <file>.js`.
+    #
+    # `node --check` is NOT a usable gate for this file shape: the script mixes an ESM
+    # `export` with a top-level `return` (legal only inside the harness's async wrapper), and
+    # on Node 24 that combination exits 0 even when the file is genuinely unbalanced —
+    # verified against a deliberately broken template. check_template.py strips the export,
+    # wraps the body, and checks it as .mjs, which does catch it. It also re-runs the
+    # model/phase/header invariants against the spliced output.
+    checker = os.path.join(HERE, "..", "tests", "check_template.py")
+    check = subprocess.run([sys.executable, checker, a.out], capture_output=True, text=True)
+    if check.returncode:
+        sys.exit(f"generated script failed validation — NOT launching:\n{check.stdout}\n"
+                 f"{check.stderr}")
+
+    n_units = len(units)
+    lens_jobs = 10           # 8 lenses, 2 of them run twice
+    sweep = {"standard": 0, "deep": 0, "max": 6}[a.depth]
+    verifiers = {"standard": 1, "deep": 2, "max": 3}[a.depth]
+    critics = 3 if a.depth == "max" else 1
+    est_refute = min(len(prior_items) * 0 + 48, 64 if a.depth == "deep" else
+                     (40 if a.depth == "standard" else 90)) * verifiers
+    est = (len(prior_items) + n_units * 2 + lens_jobs + sweep + 1 + est_refute + 3 + critics + 1)
+    waves = -(-est // 8)
+
+    print(f"-> {a.out}")
+    print(f"round {run['round']} · depth {a.depth} · commit {(head or '?')[:9]}")
+    print(f"history: {hist_path}" + ("" if prior else "  (round 1 — no prior scores)"))
+    print(f"prior open findings to re-verify: {len(prior_items)}")
+    print(f"units: {n_units}   lenses: {lens_jobs}   sweep: {sweep}   "
+          f"verifiers/finding: {verifiers}   critics: {critics}")
+    print(f"\nESTIMATE  ~{est} agents  ·  ~{waves} waves at concurrency 8  ·  "
+          f"~{waves * 6}-{waves * 10} min")
+    print("Tell the user this estimate, and tell them that typing in the prompt kills the run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/detect.py
+++ b/.stella/skills/ultra-audit/scripts/detect.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Detect a workspace's languages, its real verification gate, and how much fix authority
+an auditing agent can safely be given.
+
+The audit harness is language-agnostic; this is the file that makes that true. It answers
+four questions the rest of the run depends on:
+
+  1. What languages are here, and how big is each?  -> partitioning
+  2. What is the gate, in its CACHE-DEFEATED form?  -> the baseline and the verify phase
+  3. Can an agent's bad edit be caught before it ships?  -> fix authority (operations.md #5)
+  4. Is there an LLM surface?  -> whether token_efficiency is scored or N/A
+
+    python3 detect.py <root> [--out gate.json] [--quiet]
+
+Writes gate.json and prints a human summary. Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# fd/rg respect .gitignore, which covers most of these; the explicit list keeps
+# non-git trees (and vendored directories that are checked in) from being counted.
+IGNORE_DIRS = {
+    ".git", ".hg", ".svn", "target", "node_modules", "dist", "build", "out",
+    ".next", ".nuxt", ".svelte-kit", ".turbo", ".venv", "venv", "env",
+    "__pycache__", ".mypy_cache", ".ruff_cache", ".pytest_cache", ".tox",
+    "vendor", "coverage", "htmlcov", ".gradle", "Pods", ".terraform",
+    "site-packages", ".cargo", ".idea", ".vscode", "third_party", "generated",
+}
+
+# ext -> (language, is_source). Only source languages get partitioned to unit agents.
+LANGS = {
+    "rs": "Rust", "go": "Go", "ts": "TypeScript", "tsx": "TypeScript",
+    "js": "JavaScript", "jsx": "JavaScript", "mjs": "JavaScript", "cjs": "JavaScript",
+    "py": "Python", "rb": "Ruby", "java": "Java", "kt": "Kotlin", "kts": "Kotlin",
+    "swift": "Swift", "c": "C", "h": "C", "cc": "C++", "cpp": "C++", "hpp": "C++",
+    "cs": "C#", "php": "PHP", "ex": "Elixir", "exs": "Elixir", "scala": "Scala",
+    "zig": "Zig", "lua": "Lua", "sh": "Shell", "bash": "Shell", "sql": "SQL",
+}
+# Generated or vendored files masquerading as source.
+GENERATED_HINTS = re.compile(
+    r"(\.min\.|\.d\.ts$|_pb2?\.py$|\.pb\.go$|/migrations?/.*\.sql$|"
+    r"\.generated\.|\.gen\.(go|ts|rs)$|__generated__)"
+)
+
+
+def sh(cmd: str, cwd: str, timeout: int = 60) -> str:
+    try:
+        p = subprocess.run(cmd, cwd=cwd, shell=True, capture_output=True,
+                           text=True, timeout=timeout)
+        return p.stdout
+    except Exception:
+        return ""
+
+
+def have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def list_files(root: str) -> list[str]:
+    """Every candidate source file, gitignore-aware when fd is available."""
+    exts = sorted(LANGS)
+    if have("fd"):
+        args = " ".join(f"-e {e}" for e in exts)
+        excl = " ".join(f"-E '{d}'" for d in sorted(IGNORE_DIRS))
+        out = sh(f"fd -t f {args} {excl} . .", root, timeout=180)
+        rel = [l for l in out.splitlines() if l.strip()]
+        if rel:
+            return rel
+    rel = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS and not d.startswith(".")]
+        for fn in filenames:
+            if fn.rsplit(".", 1)[-1] in LANGS:
+                rel.append(os.path.relpath(os.path.join(dirpath, fn), root))
+    return rel
+
+
+def count_lines(root: str, rel: str) -> int:
+    try:
+        with open(os.path.join(root, rel), "rb") as fh:
+            return fh.read().count(b"\n") + 1
+    except Exception:
+        return 0
+
+
+def survey(root: str) -> tuple[dict, list[dict]]:
+    """LOC per language, and the per-file inventory the partitioner reuses."""
+    files = []
+    per_lang: dict[str, dict] = {}
+    for rel in list_files(root):
+        generated = bool(GENERATED_HINTS.search("/" + rel))
+        ext = rel.rsplit(".", 1)[-1]
+        lang = LANGS.get(ext)
+        if not lang:
+            continue
+        n = count_lines(root, rel)
+        files.append({"path": rel, "lang": lang, "loc": n, "generated": generated})
+        if generated:
+            continue
+        d = per_lang.setdefault(lang, {"language": lang, "files": 0, "loc": 0, "exts": []})
+        d["files"] += 1
+        d["loc"] += n
+        if ext not in d["exts"]:
+            d["exts"].append(ext)
+    return per_lang, files
+
+
+# ── gate detection ───────────────────────────────────────────────────────────
+# Each command carries the form that DEFEATS THE CACHE. A cached lint run reports
+# zero warnings whether or not there are any (operations.md #3), so the forced form
+# is the only one that is evidence.
+
+def node_pm(root: str) -> str:
+    for lock, pm in (("pnpm-lock.yaml", "pnpm"), ("bun.lockb", "bun"),
+                     ("yarn.lock", "yarn"), ("package-lock.json", "npm")):
+        if os.path.exists(os.path.join(root, lock)):
+            return pm
+    return "npm"
+
+
+def node_scripts(root: str) -> dict:
+    try:
+        with open(os.path.join(root, "package.json")) as fh:
+            return json.load(fh).get("scripts") or {}
+    except Exception:
+        return {}
+
+
+def ts_is_strict(root: str) -> bool:
+    """A non-strict tsconfig is not a type gate worth granting fix authority behind."""
+    for name in ("tsconfig.json", "tsconfig.base.json"):
+        p = os.path.join(root, name)
+        if not os.path.exists(p):
+            continue
+        try:
+            raw = open(p).read()
+            raw = re.sub(r"/\*.*?\*/", "", raw, flags=re.S)
+            raw = re.sub(r"(^|\s)//.*$", "", raw, flags=re.M)
+            raw = re.sub(r",(\s*[}\]])", r"\1", raw)
+            cfg = json.loads(raw)
+            if (cfg.get("compilerOptions") or {}).get("strict") is True:
+                return True
+        except Exception:
+            # An unparseable tsconfig is not evidence of strictness.
+            continue
+    return False
+
+
+def project_gate_target(root: str) -> tuple[str, str] | None:
+    """A repo that ships its own gate target knows better than we do — prefer it."""
+    for fn, runner in (("Makefile", "make"), ("makefile", "make"), ("justfile", "just"),
+                       ("Justfile", "just")):
+        p = os.path.join(root, fn)
+        if not os.path.exists(p):
+            continue
+        try:
+            body = open(p, errors="replace").read()
+        except Exception:
+            continue
+        for target in ("gate", "ci", "check", "verify", "validate", "lint-test"):
+            if re.search(rf"^\.?{target}\s*:", body, flags=re.M):
+                return runner, target
+    return None
+
+
+def detect_toolchains(root: str, langs: dict) -> list[dict]:
+    tc: list[dict] = []
+
+    if os.path.exists(os.path.join(root, "Cargo.toml")):
+        tc.append({
+            "name": "cargo", "language": "Rust", "type_gate": True,
+            "fmt_check": "cargo fmt --all -- --check",
+            "fmt_write": "cargo fmt --all",
+            # Diagnostics are suppressed on a cached build; touch the crate roots first.
+            # Brace alternation, NOT two -g flags: `-g` is a mode switch, so `-g a -g b`
+            # makes `b` a search path and silently drops every main.rs.
+            "lint": "fd -t f -g '{lib,main}.rs' . | xargs touch && "
+                    "cargo clippy --workspace --all-targets --all-features",
+            "test": "cargo test --workspace --all-features",
+            "docs": "cargo doc --workspace --no-deps",
+            "cache_note": "clippy is silent on a cached build — the touch is load-bearing",
+        })
+
+    if os.path.exists(os.path.join(root, "package.json")):
+        pm = node_pm(root)
+        s = node_scripts(root)
+        run = f"{pm} run" if pm != "bun" else "bun run"
+        pick = lambda *names: next((n for n in names if n in s), None)
+        fmt = pick("format:check", "fmt:check", "format", "fmt", "prettier")
+        lint = pick("lint", "lint:all", "eslint")
+        test = pick("test", "test:unit", "test:ci")
+        types = pick("typecheck", "type-check", "tsc", "types")
+        strict = ts_is_strict(root)
+        tc.append({
+            "name": pm, "language": "TypeScript" if "TypeScript" in langs else "JavaScript",
+            "type_gate": bool(types or os.path.exists(os.path.join(root, "tsconfig.json"))) and strict,
+            "fmt_check": f"{run} {fmt}" if fmt else None,
+            "fmt_write": f"{run} {fmt}" if fmt and "check" not in fmt else None,
+            # --cache reuses prior verdicts; strip it.
+            "lint": f"{run} {lint} -- --no-cache" if lint else None,
+            "typecheck": (f"{run} {types}" if types else
+                          ("npx tsc --noEmit --incremental false"
+                           if os.path.exists(os.path.join(root, "tsconfig.json")) else None)),
+            "test": f"{run} {test}" if test else None,
+            "cache_note": ("delete .tsbuildinfo / pass --incremental false; eslint --cache "
+                           "reuses prior verdicts"),
+            "strict_types": strict,
+            "scripts_available": sorted(s),
+        })
+
+    if any(os.path.exists(os.path.join(root, f)) for f in
+           ("pyproject.toml", "setup.py", "setup.cfg", "requirements.txt")):
+        uv = os.path.exists(os.path.join(root, "uv.lock"))
+        pre = "uv run " if uv else ""
+        has = lambda name: bool(sh(f"rg -l --max-count 1 '{name}' pyproject.toml setup.cfg "
+                                  f"requirements.txt 2>/dev/null", root).strip())
+        tc.append({
+            "name": "uv" if uv else "python", "language": "Python",
+            "type_gate": has("mypy") or has("pyright"),
+            "fmt_check": f"{pre}ruff format --check ." if has("ruff") else
+                         (f"{pre}black --check ." if has("black") else None),
+            "fmt_write": f"{pre}ruff format ." if has("ruff") else
+                         (f"{pre}black ." if has("black") else None),
+            "lint": f"{pre}ruff check --no-cache ." if has("ruff") else None,
+            "typecheck": (f"{pre}mypy --cache-dir=/dev/null ." if has("mypy") else
+                          (f"{pre}pyright" if has("pyright") else None)),
+            "test": f"{pre}pytest -q --cache-clear",
+            "cache_note": "ruff/mypy cache aggressively — --no-cache / --cache-dir=/dev/null",
+        })
+
+    if os.path.exists(os.path.join(root, "go.mod")):
+        tc.append({
+            "name": "go", "language": "Go", "type_gate": True,
+            "fmt_check": "test -z \"$(gofmt -l .)\"", "fmt_write": "gofmt -w .",
+            "lint": "go vet ./...", "test": "go test -count=1 ./...",
+            "cache_note": "-count=1 defeats the test result cache",
+        })
+
+    for f, name in (("build.gradle", "gradle"), ("build.gradle.kts", "gradle"),
+                    ("pom.xml", "maven")):
+        if os.path.exists(os.path.join(root, f)):
+            w = "./gradlew" if os.path.exists(os.path.join(root, "gradlew")) else name
+            tc.append({
+                "name": name, "language": "Java/Kotlin", "type_gate": True,
+                "lint": f"{w} check --rerun-tasks" if name == "gradle" else "mvn -o verify",
+                "test": f"{w} test --rerun-tasks" if name == "gradle" else "mvn -o test",
+                "cache_note": "--rerun-tasks defeats the Gradle build cache and daemon",
+            })
+            break
+
+    if os.path.exists(os.path.join(root, "Gemfile")):
+        tc.append({"name": "bundler", "language": "Ruby", "type_gate": False,
+                   "lint": "bundle exec rubocop --no-parallel --cache false",
+                   "test": "bundle exec rspec", "cache_note": "rubocop caches by default"})
+
+    if os.path.exists(os.path.join(root, "Package.swift")):
+        tc.append({"name": "swiftpm", "language": "Swift", "type_gate": True,
+                   "lint": "swift build -Xswiftc -warnings-as-errors",
+                   "test": "swift test", "cache_note": ""})
+
+    if os.path.exists(os.path.join(root, "CMakeLists.txt")):
+        tc.append({"name": "cmake", "language": "C/C++", "type_gate": True,
+                   "lint": "cmake --build build --clean-first",
+                   "test": "ctest --test-dir build --output-on-failure",
+                   "cache_note": "--clean-first forces a real compile"})
+
+    return tc
+
+
+def git_info(root: str) -> dict:
+    inside = sh("git rev-parse --is-inside-work-tree", root).strip() == "true"
+    if not inside:
+        return {"is_git": False, "head": None, "dirty": None, "default_branch": None}
+    return {
+        "is_git": True,
+        "head": sh("git rev-parse HEAD", root).strip() or None,
+        "dirty": bool(sh("git status --porcelain", root).strip()),
+        "default_branch": (sh("git symbolic-ref --quiet --short refs/remotes/origin/HEAD", root)
+                           .strip().rsplit("/", 1)[-1] or None),
+        "has_remote": bool(sh("git remote", root).strip()),
+    }
+
+
+LLM_SIGNALS = (r"@anthropic-ai|anthropic|claude-(opus|sonnet|haiku|fable)|openai|"
+               r"@ai-sdk|langchain|generateText|streamText|ChatCompletion|"
+               r"messages\.create|tool_use|system_prompt|prompt_tokens")
+
+
+def llm_surface(root: str) -> dict:
+    if not have("rg"):
+        return {"present": None, "evidence": []}
+    out = sh(f"rg -l --max-count 1 -e '{LLM_SIGNALS}' "
+             f"-g '!*.lock' -g '!*.json' -g '!*.md' . 2>/dev/null | head -12", root, timeout=120)
+    hits = [l for l in out.splitlines() if l.strip()]
+    return {"present": bool(hits), "evidence": hits[:12]}
+
+
+def test_presence(root: str) -> dict:
+    if not have("rg"):
+        return {"test_files": None}
+    out = sh("fd -t f -g '*test*' -g '*spec*' -g '*_test.*' -E node_modules -E target . . "
+             "2>/dev/null | head -400", root, timeout=120)
+    n = len([l for l in out.splitlines() if l.strip()])
+    return {"test_files": n}
+
+
+def fix_authority(tcs: list[dict], tests: dict, git: dict) -> dict:
+    """See operations.md #5. A bad edit is only safe where something catches it."""
+    if not git.get("is_git"):
+        return {"level": "none",
+                "reason": "not a git repository — a bad fix cannot be reverted, so no agent "
+                          "gets write authority. Run audit-only.",
+                "allowed": []}
+    typed = [t["name"] for t in tcs if t.get("type_gate")]
+    if typed:
+        return {"level": "full",
+                "reason": f"a compile/type gate exists ({', '.join(typed)}), so a bad edit "
+                          f"fails the Verify phase rather than shipping silently.",
+                "allowed": ["doc comments", "naming", "dead-code removal",
+                            "error-message quality", "comment accuracy",
+                            "clarifying refactors local to one function"]}
+    if (tests.get("test_files") or 0) >= 5:
+        return {"level": "tested-files-only",
+                "reason": f"no type gate, but {tests['test_files']} test files exist. Edits are "
+                          f"confined to files the test suite actually exercises — verify the "
+                          f"test covers the line before touching it.",
+                "allowed": ["doc comments", "naming inside a tested file",
+                            "dead-code removal", "error-message quality",
+                            "comment accuracy"]}
+    return {"level": "text-only",
+            "reason": "no type gate and no meaningful test suite — a bad edit would ship "
+                      "silently. Text and dead code only.",
+            "allowed": ["doc comments", "comment accuracy", "error-message text",
+                        "dead-code removal proven unreachable by search"]}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("root")
+    ap.add_argument("--out", default="gate.json")
+    ap.add_argument("--quiet", action="store_true")
+    a = ap.parse_args()
+    root = os.path.abspath(a.root)
+    if not os.path.isdir(root):
+        sys.exit(f"not a directory: {root}")
+
+    langs, files = survey(root)
+    if not langs:
+        sys.exit(f"no recognised source files under {root}")
+    tcs = detect_toolchains(root, langs)
+    git = git_info(root)
+    tests = test_presence(root)
+    own = project_gate_target(root)
+
+    gate = {
+        "root": root,
+        "languages": sorted(langs.values(), key=lambda d: -d["loc"]),
+        "total_loc": sum(d["loc"] for d in langs.values()),
+        "total_files": sum(d["files"] for d in langs.values()),
+        "toolchains": tcs,
+        "project_gate": {"runner": own[0], "target": own[1],
+                         "command": f"{own[0]} {own[1]}"} if own else None,
+        "git": git,
+        "tests": tests,
+        "llm_surface": llm_surface(root),
+        "fix_authority": fix_authority(tcs, tests, git),
+        # Files, so the partitioner does not have to walk the tree again and the
+        # coverage proof can be computed against the same inventory.
+        "inventory": files,
+    }
+    with open(a.out, "w") as fh:
+        json.dump(gate, fh, indent=1)
+
+    if a.quiet:
+        print(a.out)
+        return
+
+    print(f"{root}")
+    print(f"{gate['total_files']:,} source files · {gate['total_loc']:,} lines\n")
+    for d in gate["languages"][:8]:
+        print(f"  {d['language']:<14} {d['loc']:>9,}  ({d['files']:,} files)")
+    print(f"\ngit: ", end="")
+    print(f"HEAD {git['head'][:9]}" + (" DIRTY" if git["dirty"] else " clean")
+          if git["is_git"] else "NOT A GIT REPO")
+    if own:
+        print(f"project's own gate: {own[0]} {own[1]}   <-- prefer this over the "
+              f"per-toolchain commands")
+    for t in tcs:
+        print(f"\n{t['name']} ({t['language']})  type_gate={t.get('type_gate')}")
+        for k in ("fmt_check", "lint", "typecheck", "test", "docs"):
+            if t.get(k):
+                print(f"    {k:<10} {t[k]}")
+        if t.get("cache_note"):
+            print(f"    ! {t['cache_note']}")
+    fa = gate["fix_authority"]
+    print(f"\nfix authority: {fa['level'].upper()}\n    {fa['reason']}")
+    ls = gate["llm_surface"]
+    print(f"\nLLM surface: {ls['present']}"
+          f"{'  (token_efficiency is scored)' if ls['present'] else '  (token_efficiency = N/A, score 0)'}")
+    print(f"\n-> {a.out}")
+    print("REVIEW the gate commands before using them. A wrong gate produces a "
+          "confidently wrong baseline.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/partition.py
+++ b/.stella/skills/ultra-audit/scripts/partition.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Partition a workspace into audit units with disjoint, enumerable file ownership.
+
+Two things this guarantees, both mechanically:
+
+  * DISJOINT — no file is owned by two agents. Two agents editing one file clobber
+    each other, and the loser's work vanishes without an error.
+  * COMPLETE — every non-generated source file is owned by exactly one agent, and the
+    coverage number is computed, not claimed. "We audited the codebase" is only true
+    if this prints 100%.
+
+Splits happen on directory boundaries only, never mid-directory, so ownership is always
+expressible as a short list of globs rather than 400 enumerated paths.
+
+    python3 partition.py <gate.json> [--target 13000] [--max-agents N] [--out units.json]
+
+Reads the inventory produced by detect.py; does not walk the tree again. Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+
+TARGET = 13000   # LOC per agent — empirically the size that finishes inside the
+                 # connection-drop window (operations.md §1)
+CONCURRENCY = 8  # min(16, cores-2) on this machine; agents/CONCURRENCY = waves
+TOL = 1.25       # a unit may exceed target by this much before it must be split again.
+                 # Used for BOTH the "no split needed" test and the "that pack was too
+                 # unbalanced" retry, so the two can never disagree and leak an oversized part.
+
+MANIFESTS = ("Cargo.toml", "package.json", "pyproject.toml", "go.mod", "setup.py",
+             "build.gradle", "build.gradle.kts", "pom.xml", "Gemfile", "Package.swift")
+
+
+def find_unit_roots(root: str, paths: list[str]) -> list[str]:
+    """Directories holding a package manifest — the seams the project itself declares."""
+    dirs = {os.path.dirname(p) for p in paths}
+    dirs.add("")
+    roots = set()
+    for d in dirs:
+        cur = d
+        while True:
+            if any(os.path.exists(os.path.join(root, cur, m)) for m in MANIFESTS):
+                roots.add(cur)
+                break
+            if not cur:
+                break
+            cur = os.path.dirname(cur)
+    # A manifest at the repo root is a fallback, not a seam, when real sub-units exist.
+    if len(roots) > 1:
+        roots.discard("")
+    return sorted(roots, key=len, reverse=True)
+
+
+def owning_root(path: str, roots: list[str]) -> str:
+    """Longest-prefix match: the innermost declared unit containing this file."""
+    d = os.path.dirname(path)
+    for r in roots:                      # roots is sorted longest-first
+        if r == "" or d == r or d.startswith(r + "/"):
+            return r
+    return ""
+
+
+def atoms(base: str, files: list[dict], target: int) -> list[tuple[str, int, list[str]]]:
+    """Recursively descend `base` into (glob, loc, paths) atoms that each fit the target.
+
+    An atom is the largest directory subtree that is small enough to hand to one agent, so
+    bin-packing atoms can never produce an oversized part unless a single indivisible leaf
+    is itself oversized. Descending — rather than grouping at a fixed depth — is what makes
+    this work on a tree like apps/app, where one child holds 87k lines and a fixed-depth
+    split just hands it back whole.
+    """
+    loc = sum(f["loc"] for f in files)
+    if loc <= target * TOL or len(files) == 1:
+        return [(f"{base}/**" if base else "**", loc, [f["path"] for f in files])]
+
+    here: list[dict] = []
+    kids: dict[str, list[dict]] = defaultdict(list)
+    for f in files:
+        rel = os.path.relpath(f["path"], base) if base else f["path"]
+        parts = rel.split("/")
+        (here if len(parts) == 1 else kids[parts[0]]).append(f)
+
+    if not kids:                       # all files sit directly here and together exceed
+        return [(f"{base}/**" if base else "**", loc,
+                 [f["path"] for f in files])]      # indivisible; caller packs by file
+
+    out: list[tuple[str, int, list[str]]] = []
+    if here:
+        out.append((f"{base}/* (files directly in this directory only)" if base
+                    else "* (top-level files only)",
+                    sum(f["loc"] for f in here), [f["path"] for f in here]))
+    for k, fs in sorted(kids.items()):
+        out.extend(atoms(os.path.join(base, k) if base else k, fs, target))
+    return out
+
+
+def binpack(groups: list[tuple[str, int, list[str]]], target: int, min_bins: int = 1
+            ) -> list[list[tuple[str, int, list[str]]]]:
+    """Greedy largest-first pack of directory groups into ~target-sized bins.
+
+    Ceiling, not rounding: `round(1.36 * target / target)` is 1, which would silently
+    hand a 1.36x-oversized unit back as a single "split" part.
+    """
+    total = sum(g[1] for g in groups)
+    n = max(min_bins, -(-total // target)) if target else min_bins
+    n = min(n, len(groups))
+    bins: list[list] = [[] for _ in range(n)]
+    sizes = [0] * n
+    for g in sorted(groups, key=lambda g: -g[1]):
+        i = sizes.index(min(sizes))
+        bins[i].append(g)
+        sizes[i] += g[1]
+    return [b for b in bins if b]
+
+
+def split_unit(name: str, base: str, files: list[dict], target: int) -> list[dict]:
+    """One unit, split on directory boundaries until every part is near target."""
+    loc = sum(f["loc"] for f in files)
+    if loc <= target * TOL:
+        return [{"unit": name, "group": name, "loc": loc, "n_files": len(files),
+                 "owns_globs": [f"{base}/**" if base else "**"],
+                 "owns_files": [f["path"] for f in files]}]
+
+    parts = atoms(base, files, target)
+
+    # An atom bigger than the target is an indivisible leaf (one directory of files, or one
+    # very large file). Break it down by explicit file list — ownership must stay unambiguous
+    # even when it cannot stay tidy.
+    flat: list[tuple[str, int, list[str]]] = []
+    for glob, loc_a, paths in parts:
+        if loc_a > target * TOL and len(paths) > 1:
+            per_file = [(p, next(f["loc"] for f in files if f["path"] == p), [p])
+                        for p in paths]
+            for i, b in enumerate(binpack(per_file, target, min_bins=2), 1):
+                flat.append((f"{glob} [file group {i}]", sum(g[1] for g in b),
+                             sorted(g[0] for g in b)))
+        else:
+            flat.append((glob, loc_a, paths))
+
+    out = []
+    for i, b in enumerate(binpack(flat, target, min_bins=2), 1):
+        globs, owned = [], []
+        for glob, _, paths in sorted(b):
+            globs.append(glob)
+            owned.extend(paths)
+        out.append({"unit": f"{name}::part-{i}", "group": name,
+                    "loc": sum(g[1] for g in b), "n_files": len(owned),
+                    "owns_globs": globs, "owns_files": sorted(owned)})
+    return out
+
+
+def verify(units: list[dict], expected: list[str]) -> dict:
+    """The coverage proof. Computed, never asserted by prose."""
+    seen: dict[str, list[str]] = defaultdict(list)
+    for u in units:
+        for p in u["owns_files"]:
+            seen[p].append(u["unit"])
+    dupes = {p: us for p, us in seen.items() if len(us) > 1}
+    missing = sorted(set(expected) - set(seen))
+    extra = sorted(set(seen) - set(expected))
+    return {
+        "files_expected": len(expected),
+        "files_owned": len(seen),
+        "coverage_pct": round(100.0 * len(seen) / len(expected), 2) if expected else 0.0,
+        "duplicated": dupes,
+        "unowned": missing,
+        "phantom": extra,
+        "disjoint": not dupes,
+        "complete": not missing and not extra,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("gate", help="gate.json from detect.py")
+    ap.add_argument("--target", type=int, default=TARGET)
+    ap.add_argument("--max-agents", type=int, default=0,
+                    help="cap unit agents; excluded units are listed explicitly, never dropped "
+                         "silently")
+    ap.add_argument("--out", default="units.json")
+    a = ap.parse_args()
+
+    gate = json.load(open(a.gate))
+    root = gate["root"]
+    inv = [f for f in gate["inventory"] if not f["generated"]]
+    if not inv:
+        sys.exit("inventory is empty — check detect.py output")
+    expected = [f["path"] for f in inv]
+
+    roots = find_unit_roots(root, expected)
+    by_root: dict[str, list[dict]] = defaultdict(list)
+    for f in inv:
+        by_root[owning_root(f["path"], roots)].append(f)
+
+    units: list[dict] = []
+    for base in sorted(by_root, key=lambda b: -sum(f["loc"] for f in by_root[b])):
+        name = base or "(repo root)"
+        units.extend(split_unit(name, base, by_root[base], a.target))
+
+    units.sort(key=lambda u: -u["loc"])
+    proof = verify(units, expected)
+
+    excluded: list[dict] = []
+    if a.max_agents and len(units) > a.max_agents:
+        excluded = units[a.max_agents:]
+        units = units[: a.max_agents]
+        proof["capped"] = {
+            "kept": len(units), "excluded": len(excluded),
+            "excluded_loc": sum(u["loc"] for u in excluded),
+            "excluded_units": [u["unit"] for u in excluded],
+            "coverage_after_cap_pct": round(
+                100.0 * sum(u["n_files"] for u in units) / len(expected), 2),
+        }
+
+    for u in units:
+        u.setdefault("note", "")
+
+    with open(a.out, "w") as fh:
+        json.dump({"root": root, "target": a.target, "units": units,
+                   "excluded": excluded, "proof": proof}, fh, indent=1)
+
+    total = sum(u["loc"] for u in units)
+    waves = -(-len(units) // CONCURRENCY)
+    print(f"{root}")
+    print(f"{len(units)} unit agents · {total:,} lines · target {a.target:,}/agent")
+    print(f"{waves} sequential wave(s) at concurrency {CONCURRENCY}\n")
+    for u in units:
+        flag = "  !! OVERSIZED" if u["loc"] > a.target * TOL else ""
+        print(f"  {u['unit'][:46]:<46} {u['loc']:>8,}  {u['n_files']:>4}f{flag}")
+
+    print(f"\nCOVERAGE PROOF")
+    print(f"  files expected     {proof['files_expected']:,}")
+    print(f"  files owned        {proof['files_owned']:,}  ({proof['coverage_pct']}%)")
+    print(f"  disjoint           {proof['disjoint']}")
+    print(f"  complete           {proof['complete']}")
+    if proof["duplicated"]:
+        print(f"  !! {len(proof['duplicated'])} FILES OWNED TWICE — agents will clobber "
+              f"each other:")
+        for p, us in list(proof["duplicated"].items())[:10]:
+            print(f"       {p}  <- {', '.join(us)}")
+    if proof["unowned"]:
+        print(f"  !! {len(proof['unowned'])} FILES UNOWNED (nobody audits these):")
+        for p in proof["unowned"][:10]:
+            print(f"       {p}")
+    if excluded:
+        c = proof["capped"]
+        print(f"\n  !! CAPPED AT {a.max_agents} AGENTS — coverage is now "
+              f"{c['coverage_after_cap_pct']}%, NOT 100%.")
+        print(f"     {c['excluded']} units / {c['excluded_loc']:,} lines are NOT audited:")
+        for n in c["excluded_units"][:12]:
+            print(f"       {n}")
+        print("     Say this in the report. An audit that silently skipped code is a lie.")
+
+    print(f"\n-> {a.out}")
+    print("EDIT IT: add a 'note' per unit saying why the unit matters and what to "
+          "scrutinise — per-unit notes measurably improved finding quality on prior runs.")
+    if not (proof["disjoint"] and proof["complete"]):
+        sys.exit("\nREFUSING to declare this partition sound. Fix the errors above first.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/progress.py
+++ b/.stella/skills/ultra-audit/scripts/progress.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Live status of a running audit — and, after it, proof that the model mix happened.
+
+This exists because of the failure mode that has killed more audit runs than anything else:
+a long silent run provokes the user to type something, typing ends the turn, and every
+in-flight subagent dies mid-read. Frequent, specific progress is not politeness — it is how
+the run survives. This is a PULL (safe, no side effects), unlike a Monitor, which pushes and
+gets auto-stopped when it fires too often.
+
+    python3 progress.py [transcript-dir] [--watch 60] [--provenance] [--json out.json]
+
+With no directory, the most recently modified workflow transcript directory is used.
+
+The first fifteen minutes of a healthy run look exactly like a dead one, so this reports
+liveness (growing transcripts, started-vs-finished) rather than waiting for a first result.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+WF_GLOB = os.path.expanduser("~/.claude/projects/*/*/subagents/workflows/wf_*")
+# Bounded character classes, NOT \S+. In a raw .jsonl the prompt's newlines are the two
+# characters backslash-n, which \S+ happily swallows — so `model=opus` parsed as
+# `opus\n\nbody"}}`, the slot lookup missed, and every mismatch check was silently skipped
+# while still reporting "every assignment matched". Caught by the negative-control test.
+HDR = re.compile(r'ULTRA-AUDIT-AGENT phase=([\w.:-]+) role=([^\s\\"]+) model=([\w.-]+)')
+PHASE_ORDER = ["regression", "unit", "fixreview", "lens", "sweep", "verify", "refute",
+               "panel", "critique", "synthesis"]
+
+
+def newest_dir() -> str | None:
+    dirs = [d for d in glob.glob(WF_GLOB) if os.path.isdir(d)]
+    if not dirs:
+        return None
+    return max(dirs, key=lambda d: os.path.getmtime(d))
+
+
+def rg(pattern: str, files: list[str], count: bool = False, first: bool = True) -> dict:
+    """One ripgrep pass over every transcript; far cheaper than reading them in Python."""
+    if not files:
+        return {}
+    args = ["rg", "--no-heading", "--with-filename", "-e", pattern]
+    args += ["-c"] if count else ["-o"] + (["-m", "1"] if first else [])
+    try:
+        p = subprocess.run(args + files, capture_output=True, text=True, timeout=120)
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    for line in p.stdout.splitlines():
+        path, _, val = line.partition(":")
+        out.setdefault(path, val)
+    return out
+
+
+def collect(d: str) -> dict:
+    jpath = os.path.join(d, "journal.jsonl")
+    started, results = [], set()
+    agent_of_key: dict[str, str] = {}
+    if os.path.exists(jpath):
+        for line in open(jpath, errors="replace"):
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            # The key is "result", not "value". A parser reading the wrong key returns null
+            # for every agent, which is indistinguishable from mass agent death and has
+            # already triggered one full false-alarm investigation.
+            if o.get("type") == "started":
+                started.append(o.get("key"))
+                agent_of_key[o.get("agentId", "")] = o.get("key", "")
+            elif o.get("type") == "result":
+                results.add(o.get("key"))
+
+    files = sorted(glob.glob(os.path.join(d, "agent-*.jsonl")))
+    hdrs = rg(r"ULTRA-AUDIT-AGENT phase=\S+ role=\S+ model=\S+", files)
+    # Tolerate both compact and spaced JSON: transcripts are compact today, but a
+    # regex that assumes it silently reports "no models observed", which reads as a
+    # collapsed panel rather than as a broken parser.
+    models = rg(r'"model"\s*:\s*"[^"]+"', files)
+    errs = rg(r"API Error", files, count=True)
+
+    agents = []
+    for f in files:
+        aid = os.path.basename(f)[len("agent-"):-len(".jsonl")]
+        h = HDR.search(hdrs.get(f, "") or "")
+        actual = None
+        mm = re.search(r'"model"\s*:\s*"([^"]+)"', models.get(f, "") or "")
+        if mm:
+            actual = mm.group(1)
+        st = os.stat(f)
+        agents.append({
+            "id": aid,
+            "phase": h.group(1) if h else None,
+            "role": h.group(2) if h else None,
+            "assigned": h.group(3) if h else None,
+            "actual": actual,
+            "api_errors": int(errs.get(f, 0) or 0),
+            "bytes": st.st_size,
+            "mtime": st.st_mtime,
+            "done": agent_of_key.get(aid) in results if aid in agent_of_key else None,
+        })
+    return {"dir": d, "started": started, "results": results, "agents": agents}
+
+
+# Which concrete model each panel slot resolves to. Checked as a prefix so a dated build
+# ("claude-haiku-4-5-20251001") still matches its family.
+SLOT = {"opus": "claude-opus", "fable": "claude-fable", "sonnet": "claude-sonnet",
+        "haiku": "claude-haiku"}
+
+
+def provenance(state: dict) -> dict:
+    """Verify the mix actually happened, from what the transcripts RECORD rather than what
+    the harness INTENDED. A single omitted `model` silently collapses part of the panel while
+    the report still prints the cross-model guarantees."""
+    rows: dict[str, dict] = {}
+    mismatches, unlabelled = [], 0
+    for a in state["agents"]:
+        if not a["phase"]:
+            unlabelled += 1
+            continue
+        r = rows.setdefault(a["phase"], {"agents": 0, "models": collections.Counter()})
+        r["agents"] += 1
+        if a["actual"]:
+            r["models"][a["actual"]] += 1
+        exp = SLOT.get(a["assigned"] or "")
+        if exp and a["actual"] and not a["actual"].startswith(exp):
+            mismatches.append({"agent": a["id"], "phase": a["phase"], "role": a["role"],
+                               "assigned": a["assigned"], "actual": a["actual"]})
+
+    ordered = sorted(rows.items(),
+                     key=lambda kv: PHASE_ORDER.index(kv[0]) if kv[0] in PHASE_ORDER else 99)
+    distinct = set()
+    for _, r in ordered:
+        distinct |= set(r["models"])
+    ok = (not mismatches) and len(distinct) >= 2 and unlabelled == 0
+    detail = ""
+    if mismatches:
+        detail = (f"{len(mismatches)} agent(s) ran on a different model than assigned — the "
+                  f"cross-model guarantees do not hold.")
+    elif unlabelled:
+        detail = (f"{unlabelled} agent transcript(s) carried no ULTRA-AUDIT-AGENT header, so "
+                  f"their model assignment cannot be verified.")
+    elif len(distinct) < 2:
+        detail = (f"only {len(distinct)} distinct model observed across the whole run — the "
+                  f"panel collapsed to a single model.")
+    else:
+        detail = (f"{len(distinct)} distinct models observed across {sum(r['agents'] for _, r in ordered)} "
+                  f"labelled agents; every assignment matched.")
+    return {
+        "ok": ok, "detail": detail,
+        "distinct_models": sorted(distinct),
+        "mismatches": mismatches, "unlabelled": unlabelled,
+        "rows": [{"phase": p, "agents": r["agents"],
+                  "models": ", ".join(f"{m} x{n}" for m, n in r["models"].most_common())}
+                 for p, r in ordered],
+    }
+
+
+def render(state: dict, show_prov: bool) -> str:
+    ag = state["agents"]
+    started, results = state["started"], state["results"]
+    n_start, n_uniq, n_done = len(started), len(set(started)), len(results)
+    retries = n_start - n_uniq
+    now = time.time()
+    live = [a for a in ag if now - a["mtime"] < 120]
+    errs = sum(a["api_errors"] for a in ag)
+
+    by_phase = collections.Counter(a["phase"] or "?" for a in ag)
+    done_by_phase = collections.Counter(a["phase"] or "?" for a in ag if a["done"])
+    order = sorted(by_phase, key=lambda p: PHASE_ORDER.index(p) if p in PHASE_ORDER else 99)
+
+    out = [f"{os.path.basename(state['dir'])}   "
+           f"{time.strftime('%H:%M:%S')}",
+           f"  agents  {n_uniq} launched · {n_done} finished · {len(live)} active in the last "
+           f"2 min" + (f" · {retries} RETRIED" if retries else "")]
+    if errs:
+        out.append(f"  !! {errs} 'API Error' lines across transcripts — if these cluster in "
+                   f"bursts, agents are dying mid-response (operations.md §1)")
+    for p in order:
+        bar_done = done_by_phase[p]
+        total = by_phase[p]
+        filled = int(12 * bar_done / total) if total else 0
+        out.append(f"  {p:<12} {'#' * filled}{'.' * (12 - filled)} {bar_done}/{total}")
+    if not ag:
+        out.append("  (no agent transcripts yet — the harness is still starting up)")
+    elif n_done == 0:
+        newest = max(a["mtime"] for a in ag)
+        total_kb = sum(a["bytes"] for a in ag) / 1024
+        out.append(f"  LIVENESS: nothing has finished yet, which is NORMAL early on. "
+                   f"{total_kb:.0f} KB of transcript, last written "
+                   f"{int(now - newest)}s ago — agents are reading.")
+    if show_prov:
+        pv = provenance(state)
+        out.append("")
+        out.append(f"  MODEL PROVENANCE — {'VERIFIED' if pv['ok'] else 'PROBLEM'}: {pv['detail']}")
+        for r in pv["rows"]:
+            out.append(f"    {r['phase']:<12} {r['agents']:>3} agents   {r['models']}")
+        for m in pv["mismatches"][:8]:
+            out.append(f"    !! {m['role']} assigned {m['assigned']} but ran {m['actual']}")
+    return "\n".join(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir", nargs="?")
+    ap.add_argument("--watch", type=int, default=0, help="seconds between refreshes")
+    ap.add_argument("--provenance", action="store_true")
+    ap.add_argument("--json", default="")
+    a = ap.parse_args()
+
+    d = a.dir or newest_dir()
+    if not d or not os.path.isdir(d):
+        sys.exit("no workflow transcript directory found. Pass one explicitly; it lives at "
+                 "<project>/<session>/subagents/workflows/wf_*/")
+
+    while True:
+        state = collect(d)
+        print(render(state, a.provenance or bool(a.json)))
+        if a.json:
+            with open(a.json, "w") as fh:
+                json.dump(provenance(state), fh, indent=1)
+            print(f"\n-> {a.json}")
+        if not a.watch:
+            break
+        time.sleep(a.watch)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/render_report.py
+++ b/.stella/skills/ultra-audit/scripts/render_report.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Render the audit result into ONE self-contained HTML file, then validate it.
+
+Three rules this file exists to enforce:
+
+  * The payload never passes through the conversation. Template and data are read from disk
+    and the joined file is written to disk. The findings blob is 80-300KB of JSON.
+  * `</` is escaped to `<\\/` before splicing. Load-bearing, not defensive: a finding whose
+    text contains a closing tag — and audit findings quote source constantly — would
+    otherwise terminate the <script> block and produce a blank page.
+  * The output is validated, not eyeballed: the inline script is extracted and syntax-checked,
+    every mount point the renderer targets is asserted present, and self-containment (no
+    remote asset of any kind) is asserted.
+
+A partial result renders. A run that died in the last phase should still produce a report —
+an audit with no artifact is an audit that did not happen.
+
+    python3 render_report.py <result.json> [--scoring scoring.json] [--baseline baseline.txt]
+                             [--provenance provenance.json] [--out report.html]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE = os.path.join(HERE, "..", "assets", "report.template.html")
+
+# Every id the inline renderer writes to. If the template loses one, the section silently
+# vanishes from the report — so assert them rather than trusting the markup.
+MOUNTS = ["eyebrow", "ov", "ovband", "ovdelta", "stats", "alerts", "summary", "dims",
+          "dimlegend", "dimdetails", "moved", "movedlegend", "panelnote", "panel", "secondop", "risks",
+          "excluded", "prior", "fixes", "gate", "roadmap", "method", "foot",
+          "sec-moved", "sec-panel", "sec-secondop", "sec-excluded", "sec-prior",
+          "sec-fixes", "sec-gate", "sec-roadmap"]
+
+REMOTE = re.compile(
+    r"""(?:src|href)\s*=\s*["']\s*(?:https?:)?//"""      # remote script/style/img
+    r"""|@import\s+url\(\s*["']?\s*(?:https?:)?//"""      # remote css import
+    r"""|\bfetch\s*\(|XMLHttpRequest|new\s+WebSocket|EventSource\s*\(""",
+    re.I)
+
+
+def load(path: str) -> dict:
+    raw = json.load(open(path))
+    return raw.get("result", raw) if isinstance(raw, dict) else raw
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("result")
+    ap.add_argument("--scoring", help="score.py --json output (authoritative for every number)")
+    ap.add_argument("--baseline", help="file holding the measured pre-audit gate")
+    ap.add_argument("--provenance", help="progress.py --provenance --json output")
+    ap.add_argument("--title", default="")
+    ap.add_argument("--out", default="")
+    a = ap.parse_args()
+
+    d = load(a.result)
+    run = d.get("run") or {}
+    root = run.get("root") or ""
+    repo = os.path.basename(root.rstrip("/")) or "workspace"
+
+    # score.py is authoritative. The harness's own scoring block is the fallback, and the
+    # difference matters: score.py is the only thing that recomputes the panel median from
+    # raw votes and the prior round from its recorded scores.
+    scoring = dict(d.get("scoring") or {})
+    if a.scoring and os.path.exists(a.scoring):
+        scoring.update(json.load(open(a.scoring)))
+    elif not a.scoring:
+        print("!! no --scoring given: falling back to the harness's own arithmetic. Run "
+              "score.py --json and pass it, or the report may publish an unreconciled number.",
+              file=sys.stderr)
+
+    panel = d.get("panel") or {}
+    votes = panel.get("votes") or []
+    # Reshape votes per dimension for the dot plot.
+    panel_votes: dict[str, list] = {}
+    for dim in (scoring.get("weights") or {}):
+        row = [{"model": v.get("model"), "score": (v.get("scores") or {}).get(dim)}
+               for v in votes if isinstance((v.get("scores") or {}).get(dim), (int, float))
+               and (v.get("scores") or {}).get(dim) > 0]
+        if row:
+            panel_votes[dim] = row
+
+    baseline = ""
+    if a.baseline and os.path.exists(a.baseline):
+        baseline = open(a.baseline).read().strip()
+
+    provenance = {}
+    if a.provenance and os.path.exists(a.provenance):
+        provenance = json.load(open(a.provenance))
+
+    agents_total = (len(d.get("regressionResults") or []) + len(d.get("unitResults") or [])
+                    + len(d.get("fixReviews") or []) + len(d.get("xcutResults") or [])
+                    + len(d.get("sweepResults") or []) + len(votes)
+                    + len(d.get("critiques") or []) + 2)
+
+    data = {
+        "run": run,
+        "agents_total": agents_total,
+        "scoring": scoring,
+        "synthesis": d.get("synthesis") or {},
+        "findings": d.get("findings") or {},
+        "verify": d.get("verify") or {},
+        "regressionResults": d.get("regressionResults") or [],
+        "fixReviews": d.get("fixReviews") or [],
+        "critiques": d.get("critiques") or [],
+        "panel_raw": [{"model": v.get("model"), "scores": v.get("scores"),
+                       "headline": v.get("headline"),
+                       "worst_dimension": v.get("worst_dimension")} for v in votes],
+        "panel_votes": panel_votes,
+        "provenance": provenance,
+        "baseline": baseline,
+        "generated_at": datetime.datetime.now().strftime("%Y-%m-%d %H:%M"),
+    }
+
+    title = a.title or (f"{repo} — engineering audit, round "
+                        f"{scoring.get('round') or run.get('round') or 1}")
+    out = a.out or os.path.join(
+        root or ".", ".ultra-audit",
+        f"report-{data['generated_at'][:10]}-{(run.get('commit') or 'nocommit')[:9]}.html")
+    os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
+
+    tpl = open(TEMPLATE).read()
+    for mount in MOUNTS:
+        if f'id="{mount}"' not in tpl:
+            sys.exit(f"template is missing mount point id={mount!r} — the renderer writes to "
+                     f"it, so that section would silently vanish from the report.")
+
+    # Load-bearing. A finding containing `</script>` would otherwise end the script block.
+    # U+2028/9 are literal line terminators in JS source and must be escaped too.
+    payload = (json.dumps(data, ensure_ascii=False, default=str)
+               .replace("</", "<\\/")
+               .replace(" ", "\\u2028")
+               .replace(" ", "\\u2029"))
+
+    html = tpl.replace("__DATA__", payload, 1).replace("__TITLE__", title, 1)
+    for ph in ("__DATA__", "__TITLE__"):
+        if ph in html:
+            sys.exit(f"placeholder {ph} survived the splice")
+
+    with open(out, "w") as fh:
+        fh.write(html)
+
+    # ── validate the artifact ────────────────────────────────────────────────
+    problems: list[str] = []
+
+    m = re.search(r"<script>(.*?)</script>", html, re.S)
+    if not m:
+        problems.append("no inline <script> block found in the output — the splice broke the "
+                        "structure")
+    else:
+        with tempfile.NamedTemporaryFile("w", suffix=".mjs", delete=False) as fh:
+            fh.write(m.group(1))
+            tmp = fh.name
+        p = subprocess.run(["node", "--check", tmp], capture_output=True, text=True)
+        os.unlink(tmp)
+        if p.returncode:
+            problems.append(f"the inline script does not parse — the page would render "
+                            f"blank:\n{p.stderr.strip()}")
+
+    # Only `</script>` can terminate the block, so that is the invariant to assert. A literal
+    # `<script>` inside the payload is harmless — it sits inside a JS string — and does occur
+    # legitimately: a security finding about tag sanitising quotes the opening tag verbatim.
+    n_close = html.count("</script>")
+    if n_close != 1:
+        problems.append(f"found {n_close} literal '</script>' sequences, expected exactly 1. A "
+                        f"finding's text escaped the payload and truncated the script block — "
+                        f"the page will render blank or partial.")
+
+    hit = REMOTE.search(html)
+    if hit:
+        problems.append(f"not self-contained — found a remote reference or network call: "
+                        f"{hit.group(0)!r}")
+
+    if re.search(r",\s*@media", html):
+        problems.append("a selector is concatenated with an at-rule (',@media'), which is "
+                        "invalid CSS and silently drops the rule")
+
+    size = os.path.getsize(out)
+    if size < 20_000:
+        problems.append(f"output is only {size} bytes — suspiciously small; check the data "
+                        f"actually spliced")
+
+    print(f"-> {out}  ({size / 1024:.0f} KB)")
+    print(f"   round {scoring.get('round') or run.get('round') or '?'} · "
+          f"overall {scoring.get('overall_rounded', '?')} · "
+          f"{len((d.get('findings') or {}).get('confirmed') or [])} confirmed risks · "
+          f"{agents_total} agents")
+    if provenance:
+        print(f"   provenance verified: {provenance.get('ok')}")
+    for line in problems:
+        print(f"!! {line}")
+    if problems:
+        sys.exit(1)
+    print("   validated: script parses · exactly one script block · no remote assets · "
+          "all mount points present")
+    print(f"\nOpen it:  open '{out}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/score.py
+++ b/.stella/skills/ultra-audit/scripts/score.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Recompute every number in an audit result. No agent's arithmetic is trusted.
+
+Four independent checks, each of which has caught a real error:
+
+  * the weighted overall, recomputed from the synthesis agent's own per-dimension scores
+  * the panel median and spread, recomputed from the three panelists' raw votes
+  * the PRIOR round's published number, recomputed from its recorded scores — if that does
+    not reproduce, the weights drifted and the comparison is invalid
+  * the delta, at full precision. 79 -> 80 looks like +1; the real movement was +0.86.
+    Subtracting rounded values has already produced one wrong number in a shipped report.
+
+    python3 score.py <result.json> [--record --commit SHA --date YYYY-MM-DD] [--history PATH]
+                     [--json out.json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+
+WEIGHTS = {
+    "loop_correctness": 3, "security": 3, "agent_performance": 3, "system_architecture": 3,
+    "durability": 2.5, "token_efficiency": 2.5,
+    "maintainability": 2, "end_user_experience": 2, "compute_efficiency": 2,
+    "data_storage": 1.5, "documentation": 1.5, "file_organization": 1.5,
+    "vendor_lock_avoidance": 1.5,
+    "formatting": 1, "language": 1, "file_names": 1, "symbol_names": 1,
+}
+# Heaviest first, so the eye lands on what actually drives the number.
+ORDER = sorted(WEIGHTS, key=lambda k: (-WEIGHTS[k], k))
+HISTORY_DIR = os.path.expanduser("~/.claude/audits")
+CONTESTED = 10          # panel spread at or above which a dimension is contested
+
+
+def overall(scores: dict) -> float:
+    num = den = 0.0
+    for d, w in WEIGHTS.items():
+        s = scores.get(d)
+        if isinstance(s, (int, float)) and s > 0:
+            num += s * w
+            den += w
+    return num / den if den else 0.0
+
+
+def load(path: str) -> dict:
+    raw = json.load(open(path))
+    # A backgrounded Workflow writes {summary, result, ...}; unwrap it.
+    return raw.get("result", raw) if isinstance(raw, dict) else raw
+
+
+def band(x: float) -> str:
+    return ("RESERVED (Rust itself)" if x >= 100 else
+            "Rust-grade process" if x >= 96 else
+            "reference-grade" if x >= 90 else
+            "strong" if x >= 80 else
+            "solid, real gaps" if x >= 70 else
+            "mediocre" if x >= 60 else "deficient")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("result")
+    ap.add_argument("--history")
+    ap.add_argument("--record", action="store_true")
+    ap.add_argument("--commit", default="")
+    ap.add_argument("--date", default="")
+    ap.add_argument("--report", default="", help="path of the HTML report, recorded in history")
+    ap.add_argument("--json", default="", help="write the reconciled scoring block here")
+    a = ap.parse_args()
+
+    d = load(a.result)
+    syn = d.get("synthesis") or {}
+    dims = syn.get("dimension_scores") or {}
+    scores = {k: v["score"] for k, v in dims.items()
+              if isinstance(v, dict) and isinstance(v.get("score"), (int, float))}
+    if not scores:
+        sys.exit("no dimension_scores in result. Read the workflow's journal.jsonl before "
+                 "diagnosing — a null result is more often a parser bug than a dead agent.")
+
+    root = (d.get("run") or {}).get("root") or ""
+    hist_path = a.history or os.path.join(
+        HISTORY_DIR, (os.path.basename(root.rstrip("/")) or "workspace") + ".json")
+    runs = []
+    if os.path.exists(hist_path):
+        runs = json.load(open(hist_path)).get("runs", [])
+    prior = runs[-1]["scores"] if runs else None
+
+    missing = [k for k in WEIGHTS if k not in scores]
+    now = overall(scores)
+    problems: list[str] = []
+
+    print(f"WORKSPACE  {root or '(unrecorded)'}")
+    print(f"COMMIT     {(d.get('run') or {}).get('commit') or a.commit or '(unrecorded)'}")
+    print(f"DEPTH      {(d.get('run') or {}).get('depth') or '?'}   "
+          f"round {len(runs) + 1}\n")
+    print(f"OVERALL    {now:.2f}  ->  {round(now)}   ({band(now)})")
+
+    if prior:
+        was = overall(prior)
+        print(f"PRIOR      {was:.2f}  ->  {round(was)}   (round {len(runs)})")
+        print(f"CHANGE     {now - was:+.2f} weighted   "
+              f"[rounded headline would read {round(now) - round(was):+d} — cite the precise "
+              f"figure]")
+        pub = runs[-1].get("overall_rounded")
+        if pub is not None and round(was) != pub:
+            problems.append(
+                f"WEIGHT DRIFT: recomputing round {len(runs)} from its recorded scores gives "
+                f"{round(was)}, but it published {pub}. The comparison is INVALID until "
+                f"reconciled — do not report a delta.")
+    else:
+        print("PRIOR      (none — this is round 1)")
+
+    claimed = syn.get("overall_score")
+    if claimed is not None and claimed != round(now):
+        problems.append(f"the synthesis agent claimed {claimed}; recomputed is {round(now)}. "
+                        f"Report the recomputed value and investigate the difference.")
+    if missing:
+        problems.append(f"dimensions absent from the synthesis and excluded from the mean: "
+                        f"{', '.join(missing)}")
+
+    # ── the panel, recomputed from raw votes ──────────────────────────────────
+    panel = d.get("panel") or {}
+    votes = panel.get("votes") or []
+    recomputed_median, recomputed_spread = {}, {}
+    for k in WEIGHTS:
+        xs = [v.get("scores", {}).get(k) for v in votes]
+        xs = [x for x in xs if isinstance(x, (int, float)) and x > 0]
+        if xs:
+            recomputed_median[k] = int(round(statistics.median(xs)))
+            recomputed_spread[k] = max(xs) - min(xs)
+    if votes:
+        claimed_med = panel.get("median") or {}
+        mism = [k for k in recomputed_median
+                if isinstance(claimed_med.get(k), (int, float))
+                and claimed_med[k] != recomputed_median[k]]
+        if mism:
+            problems.append(f"the harness's panel median disagrees with the votes on: "
+                            f"{', '.join(mism)}")
+        print(f"\nPANEL      {len(votes)} panelist(s): "
+              f"{', '.join(v.get('model', '?') for v in votes)}")
+        print(f"           panel median overall {overall(recomputed_median):.2f}; "
+              f"synthesis landed on {now:.2f}")
+        contested = sorted(k for k, s in recomputed_spread.items() if s >= CONTESTED)
+        if contested:
+            print(f"           CONTESTED (spread >= {CONTESTED}): {', '.join(contested)}")
+            for k in contested:
+                res = (dims.get(k) or {}).get("panel_resolution")
+                if not res:
+                    problems.append(f"{k} was contested (spread {recomputed_spread[k]}) but the "
+                                    f"synthesis gave no panel_resolution — it was required to "
+                                    f"read code and justify the number it chose.")
+    else:
+        problems.append("no panel votes in the result — the score is one model's opinion, not a "
+                        "median. Every cross-model claim in the report must be withdrawn.")
+
+    # ── the table ─────────────────────────────────────────────────────────────
+    w = max(len(k) for k in ORDER)
+    print(f"\n{'dimension'.ljust(w)}  wt   prev  now  delta   panel(med/spread)  votes")
+    for k in ORDER:
+        s = scores.get(k)
+        if s is None:
+            continue
+        p = prior.get(k) if prior else None
+        dl = f"{s - p:+d}" if isinstance(p, (int, float)) else "—"
+        pm = recomputed_median.get(k)
+        sp = recomputed_spread.get(k)
+        pcol = f"{pm:>3}/{sp:<2}" if pm is not None else "  —   "
+        vs = "/".join(str(v.get("scores", {}).get(k, "-")) for v in votes) if votes else ""
+        star = " *" if sp is not None and sp >= CONTESTED else ""
+        print(f"{k.ljust(w)}  {WEIGHTS[k]:<4} {str(p if p is not None else '—'):>4} "
+              f"{s:>4}  {dl:>5}   {pcol}         {vs}{star}")
+
+    # ── coverage and confirmation, the two things that make the number mean something ──
+    run = d.get("run") or {}
+    f = d.get("findings") or {}
+    owned, total = run.get("files_owned"), run.get("total_files")
+    if owned and total:
+        pct = 100.0 * owned / total
+        print(f"\nCOVERAGE   {owned}/{total} source files owned by an auditing agent "
+              f"({pct:.1f}%)")
+        if pct < 99.5:
+            problems.append(f"coverage was {pct:.1f}%, not 100% — the report must name what was "
+                            f"not audited.")
+    if f:
+        print(f"FINDINGS   {f.get('total', '?')} raised · {f.get('severe', '?')} severe · "
+              f"{len(f.get('confirmed') or [])} confirmed by cross-model refutation · "
+              f"{len(f.get('refuted') or [])} refuted · "
+              f"{len(f.get('unverified') or [])} unverified")
+        if f.get("unverified"):
+            problems.append(f"{len(f['unverified'])} severe findings were never refuted (depth "
+                            f"cap). They are UNCONFIRMED and must be labelled so.")
+        single = [x for x in (f.get("confirmed") or []) if not x.get("cross_model")]
+        if single:
+            print(f"           !! {len(single)} confirmed finding(s) had no cross-model verifier")
+
+    if problems:
+        print("\n" + "!" * 72)
+        for p in problems:
+            print(f"!! {p}")
+        print("!" * 72)
+    else:
+        print("\nAll internal checks reconcile.")
+
+    block = {
+        "root": root, "commit": (run.get("commit") or a.commit or None),
+        "date": a.date or None, "depth": run.get("depth"),
+        "round": len(runs) + 1,
+        "overall": round(now, 2), "overall_rounded": round(now), "band": band(now),
+        "prior_overall": round(overall(prior), 2) if prior else None,
+        "delta_precise": round(now - overall(prior), 2) if prior else None,
+        "scores": scores, "prior_scores": prior,
+        "deltas": {k: scores[k] - prior[k] for k in scores
+                   if prior and isinstance(prior.get(k), (int, float))} if prior else None,
+        "panel_median": recomputed_median, "panel_spread": recomputed_spread,
+        "panel_models": [v.get("model") for v in votes],
+        "contested": sorted(k for k, s in recomputed_spread.items() if s >= CONTESTED),
+        "agent_claimed": claimed, "weights": WEIGHTS,
+        "problems": problems,
+    }
+    if a.json:
+        with open(a.json, "w") as fh:
+            json.dump(block, fh, indent=1)
+        print(f"\n-> {a.json}")
+
+    if a.record:
+        if problems:
+            sys.exit("\nREFUSING to record a run with unreconciled problems. Fix them first — a "
+                     "bad history entry corrupts every future comparison.")
+        os.makedirs(HISTORY_DIR, exist_ok=True)
+        # `rubric`/`tool` deliberately keep the "ultraudit" spelling even though
+        # the skill is now "ultra-audit": they are the history-lineage keys that
+        # make scores comparable across rounds, and this lineage is shared
+        # unbroken with /reaudit (see SKILL.md "Relationship to /reaudit").
+        # Renaming them would fork the series and silently break comparability.
+        blob = json.load(open(hist_path)) if os.path.exists(hist_path) else {
+            "repo": os.path.basename(root.rstrip("/")), "rubric": "ultraudit-17d-v1", "runs": []}
+        blob.setdefault("runs", []).append({
+            "round": len(blob["runs"]) + 1,
+            "date": a.date or None, "commit": run.get("commit") or a.commit or None,
+            "depth": run.get("depth"), "tool": "ultraudit",
+            "overall": round(now, 2), "overall_rounded": round(now),
+            "scores": scores,
+            "panel_median": recomputed_median, "panel_spread": recomputed_spread,
+            "panel_models": [v.get("model") for v in votes],
+            "coverage": {"files_owned": owned, "total_files": total},
+            "report": a.report or None,
+            # Carried into the next run's Phase 0 as "did this actually land?"
+            "open_findings": [
+                {"severity": r.get("severity"), "title": r.get("title"),
+                 "detail": r.get("detail"), "remediation": r.get("remediation"),
+                 "file": r.get("file"), "dimension": r.get("dimension")}
+                for r in (syn.get("top_risks") or [])
+            ],
+        })
+        with open(hist_path, "w") as fh:
+            json.dump(blob, fh, indent=1)
+        print(f"\nrecorded round {len(blob['runs'])} -> {hist_path}")
+
+    sys.exit(1 if problems else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/scripts/workflow.template.js
+++ b/.stella/skills/ultra-audit/scripts/workflow.template.js
@@ -1,0 +1,994 @@
+export const meta = {
+  name: 'ultra-audit',
+  description: 'Exhaustive multi-model engineering audit: 17-dimension rubric, 100% file coverage, fix authority scoped to the language\'s gate, cross-model refutation where no model grades its own work, a blind three-model scoring panel reported as median plus spread, and an independent second opinion',
+  phases: [
+    { title: 'Regression check', detail: 'one verifier per prior open finding — did the fix land, and is it any good' },
+    { title: 'Unit audits', detail: 'one agent per partition, models rotated, fix authority scoped to the gate' },
+    { title: 'Fix review', detail: 'every applied fix re-read by a DIFFERENT model than wrote it' },
+    { title: 'Cross-cutting', detail: 'workspace-wide lenses; the two heaviest run twice on two models' },
+    { title: 'Fresh sweep', detail: 'new eyes on the post-fix tree — what did the first pass miss' },
+    { title: 'Verify', detail: 'the real gate, cache defeated, running alone' },
+    { title: 'Adversarial', detail: 'cross-model refutation; the finding\'s own author model never judges alone' },
+    { title: 'Panel', detail: 'three frontier models score all 17 dimensions blind; median and spread' },
+    { title: 'Second opinion', detail: 'independent critique of the scorecard — challenge it, do not restate it' },
+    { title: 'Synthesis', detail: 'reconcile the panel, resolve contested dimensions, justify every delta' },
+  ],
+}
+
+// ── spliced by build_workflow.py (scripts cannot touch the filesystem) ────────
+const ROOT = '__ROOT__'
+const RUN = /*__RUN__*/ {}                 // { date, commit, depth, tool_versions }
+const GATE = /*__GATE__*/ {}               // detect.py output, minus the file inventory
+const UNITS = /*__UNITS__*/ []             // partition.py units, with owns_globs
+const PRIOR = /*__PRIOR__*/ null           // prior dimension scores, or null on round 1
+const PRIOR_ITEMS = /*__PRIOR_ITEMS__*/ [] // prior open findings, to re-verify
+const BASELINE = `__BASELINE__`            // gate measured on a pristine tree, as prose
+const SALVAGE = /*__SALVAGE__*/ null       // results carried over from an aborted run
+
+const DEPTH = RUN.depth || 'deep'          // standard | deep | max
+const PANEL = ['opus', 'fable', 'sonnet']  // frontier only. haiku never judges or scores.
+const CONF = {
+  standard: { verifiers: 1, refuteCap: 40, sweep: 0, critics: 1 },
+  deep:     { verifiers: 2, refuteCap: 64, sweep: 0, critics: 1 },
+  max:      { verifiers: 3, refuteCap: 0,  sweep: 6, critics: 3 },
+}[DEPTH]
+
+const DIMENSIONS = [
+  'formatting', 'language', 'documentation', 'file_names', 'symbol_names',
+  'file_organization', 'system_architecture', 'data_storage', 'vendor_lock_avoidance',
+  'security', 'durability', 'maintainability', 'loop_correctness',
+  'token_efficiency', 'agent_performance', 'compute_efficiency', 'end_user_experience',
+]
+const WEIGHTS = {
+  loop_correctness: 3, security: 3, agent_performance: 3, system_architecture: 3,
+  durability: 2.5, token_efficiency: 2.5,
+  maintainability: 2, end_user_experience: 2, compute_efficiency: 2,
+  data_storage: 1.5, documentation: 1.5, file_organization: 1.5, vendor_lock_avoidance: 1.5,
+  formatting: 1, language: 1, file_names: 1, symbol_names: 1,
+}
+function weightedOverall(s) {
+  let n = 0, d = 0
+  for (const k of DIMENSIONS) {
+    const v = s ? s[k] : null
+    if (typeof v !== 'number' || v <= 0) continue
+    n += v * WEIGHTS[k]; d += WEIGHTS[k]
+  }
+  return d ? n / d : 0
+}
+function median(xs) {
+  const a = xs.filter((x) => typeof x === 'number' && x > 0).sort((p, q) => p - q)
+  if (!a.length) return null
+  const m = a.length >> 1
+  return a.length % 2 ? a[m] : Math.round((a[m - 1] + a[m]) / 2)
+}
+const SCORE_PROPS = {}
+for (const d of DIMENSIONS) SCORE_PROPS[d] = { type: 'integer', minimum: 0, maximum: 100 }
+
+// Provenance header. progress.py --provenance reads this back out of each transcript and
+// cross-checks it against the model actually used; a mismatch voids every cross-model
+// claim in the report. See reference/model-panel.md.
+const hdr = (phase, role, model) =>
+  `ULTRA-AUDIT-AGENT phase=${phase} role=${role} model=${model}\n\n`
+
+const NO_LLM = GATE.llm_surface && GATE.llm_surface.present === false
+
+// ── the calibration bar, verbatim in every scoring prompt ─────────────────────
+const CALIBRATION = `
+SCORING — 0-100, ABSOLUTE, against these fixed anchors:
+
+  100      the Rust project itself (rust-lang/rust): RFC-gated change control, Crater
+           ecosystem-wide regression proof, editions keeping decade-old code compiling, a
+           merge queue that tests the merge commit, UI tests pinning exact diagnostic text,
+           unsoundness as a release blocker, doc examples executed by CI, per-change
+           performance tracking. RESERVED. Never awarded.
+  96-99    reserved for Rust-grade PROCESS: an ecosystem-wide regression gate, a decade of
+           proven compatibility, formal or qualified specification work. To score here you
+           must name which of those mechanisms the project actually has.
+  90-95    reference-grade for its language: ripgrep, tokio, rust-analyzer, SQLite, curl,
+           PostgreSQL. Exemplary — and still not Rust.
+  80-89    strong; minor nits only
+  70-79    solid, with real gaps a new contributor would hit
+  60-69    mediocre; notable debt
+  <60      deficient
+
+BINDING RULES:
+- Above 92 on any dimension, you must justify it against the 100-anchors by naming the
+  MECHANISM, not the intention. "The code is very clean" does not earn 93.
+- A wall of 90s is a failed audit. So is a wall of 60s. Spread is evidence that you read.
+- Thin evidence scores LOWER. A score with no file:line behind it is a guess.
+- Effort is not an input. Neither is diff size, fix count, or how hard the work was.
+- Process counts only where a gate enforces it. A documented rule with no guard behind it
+  scores as an unenforced rule — check whether the guard can be defeated.
+- 0 means NOT APPLICABLE to what you examined, and is excluded from every mean. Say so in
+  score_notes. Never score 0 to dodge forming a judgment.${NO_LLM ? `
+- This workspace has NO LLM surface: score token_efficiency 0 (N/A).` : ''}
+`
+
+const FIX_RULES = {
+  full: `You MAY fix what is safely fixable. A compile/type gate exists (${(GATE.toolchains || [])
+    .filter((t) => t.type_gate).map((t) => t.name).join(', ')}), so a bad edit fails the Verify
+phase rather than shipping silently.
+  SAFE to fix: doc comments, naming, dead-code removal, error-message quality, comment
+  accuracy, clarifying refactors local to one function.
+  REPORT INSTEAD (do not attempt): public API or signature changes, trait/interface reshaping,
+  async or lifetime changes, dependency changes, anything crossing a unit boundary.`,
+  'tested-files-only': `Fix authority is RESTRICTED. There is no type gate, so a bad edit ships
+silently — the only thing that would catch it is a test. Before editing any line, confirm a
+test actually exercises it; if you cannot confirm that, REPORT instead of fixing. Text-level
+fixes (comments, docs, messages) remain allowed anywhere.`,
+  'text-only': `Fix authority is TEXT ONLY. There is no type gate and no meaningful test suite,
+so nothing would catch a bad edit. You may change ONLY: doc comments, comment accuracy,
+error-message text, and dead code you have PROVEN unreachable by exhaustive search. Everything
+else is REPORT ONLY. Do not "improve" logic you cannot verify.`,
+  none: `*** STRICTLY READ-ONLY. This workspace is not a git repository, so a bad edit cannot
+be reverted. Do NOT create, modify or delete ANY file. Report everything. ***`,
+}
+const FIX_AUTHORITY = FIX_RULES[(GATE.fix_authority || {}).level || 'none']
+
+const SHARED = `
+You are a principal engineer on a paid, high-stakes audit of the workspace at ${ROOT}.
+Treat it as a $100,000 engagement: observations must be concrete, file-and-line specific,
+and defensible. Generic advice is worthless and actively harmful here.
+
+${PRIOR ? `This workspace has been audited before. You are NOT scoring the improvement — you are
+scoring the tree as it stands today, on its own merits, against the same absolute bar. New code
+carries new defects; hunt those as hard as the old ones.` : 'This is the first audit of this workspace.'}
+
+HARD RULES. Violating any of these corrupts the engagement:
+1. DO NOT run any build, test, lint, or install command. Many agents run concurrently and share
+   the build lock; an install would rewrite the lockfile underneath every other agent. A single
+   central phase runs the real gate after you. STATIC READING ONLY.
+2. ${FIX_AUTHORITY}
+3. Write ONLY inside the paths you own (stated below, when you own any). A file outside them
+   belongs to another agent running right now, and your write will be silently clobbered.
+4. Preserve behavior. This is an audit with cleanup privileges, not a rewrite.
+5. Match the surrounding code's idiom, comment density, and voice.
+
+*** OUTPUT DISCIPLINE — this is what keeps you alive. Report your 12 most significant
+findings, not every nit. Each 'issue' 2-3 sentences. Each 'summary' at most 6 sentences. Call
+StructuredOutput as soon as your analysis is done; do NOT narrate your findings in prose
+first. Depth of READING is expected in full — it is only the WRITE-UP that must be economical.
+Long terminal responses are what the recurring mid-response connection drops actually kill. ***
+${CALIBRATION}`
+
+const FINDING_ITEM = {
+  type: 'object',
+  required: ['severity', 'dimension', 'file', 'issue'],
+  properties: {
+    severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+    dimension: { type: 'string' },
+    file: { type: 'string' },
+    line: { type: 'integer' },
+    issue: { type: 'string' },
+    remediation: { type: 'string' },
+    fixed: { type: 'boolean' },
+    proved_by_reading: { type: 'boolean', description: 'true = you read the code that makes this true; false = inferred' },
+    exploitability: { type: 'string', description: 'For security: the concrete attack path, or why it is only theoretical' },
+    regression_of: { type: 'string', description: 'Set if plainly introduced by recent work' },
+  },
+}
+
+// ── Phase 0 — did the prior findings actually land? ───────────────────────────
+phase('Regression check')
+
+const REGRESSION_SCHEMA = {
+  type: 'object',
+  required: ['id', 'status', 'evidence', 'reasoning'],
+  properties: {
+    id: { type: 'string' },
+    status: { type: 'string', enum: ['fixed', 'partially_fixed', 'not_fixed', 'fixed_but_regressed', 'not_applicable'],
+      description: 'fixed = the defect CLASS is gone; partially_fixed = reported instance closed but a named gap remains; fixed_but_regressed = landed then undone or bypassed' },
+    quality: { type: 'string', enum: ['excellent', 'adequate', 'shallow', 'wrong'] },
+    test_pinned: { type: 'boolean', description: 'Is there a test that would catch re-introduction? Name it in evidence.' },
+    evidence: { type: 'array', items: { type: 'string' }, description: 'file:line citations proving the status' },
+    reasoning: { type: 'string' },
+    residual_risk: { type: 'string' },
+  },
+}
+
+const regressionFresh = (PRIOR_ITEMS.length && !(SALVAGE && SALVAGE.phase0))
+  ? (await parallel(PRIOR_ITEMS.map((p, i) => () => {
+      const m = PANEL[i % PANEL.length]
+      return agent(
+        hdr('regression', `check-${i}`, m) +
+`You are a skeptical verification engineer on a follow-up audit of the workspace at ${ROOT}.
+Time has passed since the finding below was filed and substantial work has landed.
+
+*** RULE #1: STRICTLY READ-ONLY. Do NOT create, modify or delete ANY file. Do NOT run build,
+test or lint tooling. If you are about to edit or run something, STOP. ***
+
+  FINDING (${p.severity || 'unrated'}): ${p.title || p.id}
+  ${p.detail || ''}
+  RECOMMENDED FIX: ${p.remediation || '(none recorded)'}
+
+Treat that as A LEAD TO CHECK, NOT A FACT. Some prior findings were fixed, some were fixed
+shallowly, and some fixes introduced new defects.
+
+Determine whether the fix landed and whether it is any good. Do NOT accept a commit message,
+changelog line, or a comment claiming the fix as evidence — read the code that would have to be
+correct for the defect to be gone, and read its callers.
+
+1. Locate the code the finding names. Files may have been renamed, split or moved — search by
+   symbol and by behavior, not only by the old path.
+2. Decide whether the DEFECT is gone, not whether a diff happened. A fix that closes the exact
+   example while leaving the same class open elsewhere is partially_fixed — name the remaining
+   hole with file:line.
+3. Actively hunt for a bypass. If a deny-list landed, look for a second path that loads the same
+   thing. If a guard landed, look for a path that skips it. If a cap landed, check it applies
+   before the expensive work and on every branch.
+4. Name a regression test that would catch re-introduction, or record that none exists.
+5. If the fix is shallow or symptomatic, say so plainly. An organization that papers over
+   findings is a worse signal than one that leaves them open.
+
+Cite the lines you read. "It looks fine" is worthless.`,
+        { label: `check:${(p.id || p.title || 'item').slice(0, 36)}`, phase: 'Regression check',
+          schema: REGRESSION_SCHEMA, model: m, effort: 'high' }
+      ).then((r) => (r ? { ...r, id: r.id || p.id || p.title, prior_severity: p.severity, judged_by_model: m } : null))
+    }))).filter(Boolean)
+  : []
+
+const regressionResults = (SALVAGE && SALVAGE.phase0) ? SALVAGE.phase0 : regressionFresh
+if (regressionResults.length) {
+  const t = regressionResults.reduce((a, r) => (a[r.status] = (a[r.status] || 0) + 1, a), {})
+  log(`Phase 0: ${regressionResults.length} prior findings re-verified — ${JSON.stringify(t)}`)
+}
+
+// ── Phase 1 + 2 — unit audits, each pipelined straight into a cross-model fix review ──
+// pipeline(), not two parallel() barriers: unit ownership is disjoint, so unit V's fixes can
+// be reviewed while unit W is still reading. That saves a full concurrency wave.
+phase('Unit audits')
+
+const UNIT_SCHEMA = {
+  type: 'object',
+  required: ['unit', 'scores', 'summary', 'findings', 'fixes_applied', 'strengths'],
+  properties: {
+    unit: { type: 'string' },
+    summary: { type: 'string' },
+    scores: { type: 'object', properties: SCORE_PROPS },
+    score_notes: { type: 'string', description: 'Justify the 3 lowest and 2 highest. Note any N/A.' },
+    strengths: { type: 'array', items: { type: 'string' } },
+    findings: { type: 'array', items: FINDING_ITEM },
+    fixes_applied: {
+      type: 'array',
+      items: { type: 'object', required: ['file', 'change', 'rationale'],
+        properties: { file: { type: 'string' }, change: { type: 'string' },
+                      rationale: { type: 'string' }, risk: { type: 'string' } } },
+    },
+    coverage_note: { type: 'string', description: 'Anything you owned but did NOT read, and why' },
+  },
+}
+
+const FIXREVIEW_SCHEMA = {
+  type: 'object',
+  required: ['unit', 'verdict', 'reviewed_count'],
+  properties: {
+    unit: { type: 'string' },
+    verdict: { type: 'string', enum: ['all_sound', 'minor_concerns', 'unsound_fixes_present'] },
+    reviewed_count: { type: 'integer' },
+    bad_fixes: {
+      type: 'array',
+      items: { type: 'object', required: ['file', 'problem', 'action'],
+        properties: { file: { type: 'string' }, problem: { type: 'string' },
+                      action: { type: 'string', enum: ['revert', 'repair', 'accept_with_note'] },
+                      breaks_build: { type: 'boolean' } } },
+    },
+    notes: { type: 'string' },
+  },
+}
+
+// pipeline() returns only the LAST stage's value, so stage 1's audit results are collected
+// here as they land. Plain closure capture — the stages are ordinary JS callbacks.
+const unitResults = []
+
+const fixReviewsRaw = await pipeline(
+  UNITS,
+  // Stage 1 — audit, with fix authority.
+  (u, _orig, i) => {
+    const m = PANEL[i % PANEL.length]
+    return agent(
+      hdr('unit', u.unit, m) + SHARED + `
+
+YOUR UNIT: ${u.unit}  (~${u.loc} lines, ${u.n_files} files)
+YOU OWN — and may write to — EXACTLY these paths and nothing else:
+${(u.owns_globs || []).map((g) => '  - ' + g).join('\n') || '  (see enumerated list below)'}
+${u.owns_globs && u.owns_globs.length ? '' : (u.owns_files || []).slice(0, 200).map((f) => '  - ' + f).join('\n')}
+${u.note ? '\nWHY THIS UNIT MATTERS: ' + u.note : ''}
+
+*** PARTITION DISCIPLINE: this codebase is split across ${UNITS.length} agents working right
+now. READ anything anywhere in the workspace. WRITE only to the paths above. ***
+
+METHOD:
+1. Read your unit's modules end to end. Do not sample — the partition is sized so you can
+   afford to read all of it.
+2. Read enough of the callers and surrounding code to judge your unit in context.
+3. Hunt real defects: correctness bugs; panics or crashes on attacker- or environment-
+   controlled input; unbounded growth; missing cancellation; silently swallowed errors; TOCTOU;
+   resource leaks; busy-wait loops; needless allocation on hot paths; blocking IO on an async
+   runtime; god-modules; dead code; misleading names; comments that LIE about the code beneath
+   them; missing docs on public API.
+4. Pay special attention to recently changed code — fixes applied under time pressure are where
+   new defects hide. Set regression_of when a defect was plainly introduced recently.
+5. Set proved_by_reading=false on anything you inferred rather than confirmed. A later phase
+   will try to refute every serious finding, and an honest flag there costs you nothing.
+6. Score all 17 dimensions for THIS UNIT, post-fix.
+
+Report economically, as instructed.`,
+      { label: `audit:${u.unit}`, phase: 'Unit audits', schema: UNIT_SCHEMA, model: m, effort: 'high' }
+    ).then((r) => {
+      if (!r) return null
+      const rec = { ...r, unit: r.unit || u.unit, group: u.group || u.unit, found_by_model: m,
+                    n_files: u.n_files, loc: u.loc }
+      unitResults.push(rec)
+      return rec
+    })
+  },
+  // Stage 2 — a DIFFERENT model re-reads the fixes. Rule #1 of the panel: no model grades
+  // its own homework. A model is worst at seeing the bug it just wrote.
+  (res, u, i) => {
+    if (!res || !(res.fixes_applied || []).length) return null
+    const author = PANEL[i % PANEL.length]
+    const reviewer = PANEL[(i + 1) % PANEL.length]
+    return agent(
+      hdr('fixreview', u.unit, reviewer) +
+`You are reviewing code edits made minutes ago by a DIFFERENT model during an audit of ${ROOT}.
+You were chosen because the model that wrote these edits cannot reliably see its own mistakes.
+
+*** RULE #1: READ-ONLY. Do NOT edit any file. Do NOT run build, test or lint tooling.
+If you are about to do either, STOP and just report. ***
+
+The author claimed these fixes in ${u.unit}:
+${JSON.stringify((res.fixes_applied || []).slice(0, 24))}
+
+For EACH claimed fix: open the file, read the actual current code, and judge it.
+
+- Does the edit do what the rationale says? Authors describe intent, not always outcome.
+- Would it compile / run? Look for a renamed symbol, a dropped import, a changed arity, an
+  unbalanced brace, a now-unused variable that the project's lint treats as an error.
+- Did it change BEHAVIOR? This was supposed to be cleanup, not a rewrite. A "dead code"
+  removal that was actually reachable is the single most dangerous outcome here — search for
+  every reference before accepting one.
+- Does a comment or doc it rewrote now contradict the code beneath it?
+- Is the fix cosmetic while the defect it claims to close survives?
+
+Set action=revert for anything that changes behavior or may not build; repair for a fix that is
+right in spirit but wrong in detail; accept_with_note for sound work worth a remark. Be
+specific and cite lines — the Verify phase acts on what you say.`,
+      { label: `fixreview:${u.unit}`, phase: 'Fix review', schema: FIXREVIEW_SCHEMA,
+        model: reviewer, effort: 'high' }
+    ).then((v) => (v ? { ...v, unit: v.unit || u.unit, author_model: author, reviewer_model: reviewer } : null))
+  }
+)
+
+// Stage 2 yields null for a unit that applied no fixes, and pipeline yields null for a unit
+// whose stage-1 agent died — both are absences, not reviews.
+const fixReviews = fixReviewsRaw.filter((r) => r && r.verdict)
+
+const totalFixes = unitResults.reduce((n, r) => n + (r.fixes_applied || []).length, 0)
+log(`Phase 1: ${unitResults.length}/${UNITS.length} units audited across ${PANEL.join('/')}; ` +
+    `${totalFixes} fixes applied. ` +
+    `Phase 2: ${fixReviews.length} fix-reviews by a different model than the author, ` +
+    `${fixReviews.filter((f) => f.verdict === 'unsound_fixes_present').length} flagged unsound`)
+
+// ── Phase 3 — cross-cutting lenses on the post-fix tree ──────────────────────
+phase('Cross-cutting')
+
+const XCUT_SCHEMA = {
+  type: 'object',
+  required: ['lens', 'scores', 'summary', 'findings', 'strengths'],
+  properties: {
+    lens: { type: 'string' }, summary: { type: 'string' },
+    scores: { type: 'object', properties: SCORE_PROPS },
+    score_notes: { type: 'string' },
+    strengths: { type: 'array', items: { type: 'string' } },
+    findings: { type: 'array', items: FINDING_ITEM },
+    top_recommendations: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const LENSES = [
+  { key: 'security', weight3: true, focus: `SECURITY. You are an adversarial security auditor.
+Cover credential handling and every path where a secret can reach disk, logs, telemetry or a
+prompt; command injection, path traversal, symlink escape, TOCTOU; parsing of untrusted input;
+every network listener; supply chain (lockfiles, pinned CI actions, and whether the guard that
+enforces pinning can itself be defeated); unsafe/FFI blocks; process spawning and argument
+construction; authn/authz and the permission model, including whether it can be bypassed by a
+second code path. Then take every claim the docs make about a trust boundary and VERIFY it by
+finding the code that enforces it. Rate exploitability honestly: a fabricated critical is a
+firing offense, and so is calling a working exploit chain theoretical.` },
+  { key: 'loop-correctness', weight3: true, focus: `LOOP CORRECTNESS and HOT-PATH LATENCY. Judge
+termination guarantees, timeout backstops, cancellation propagation (does interrupt actually
+stop in-flight work AND its child process groups?), budget enforcement, retry storms, error
+classification (retryable vs terminal — and whether a timeout bounding a whole operation is
+misclassified as retryable), state-machine correctness, deadlocks, races, orphaned children,
+unbounded channels and queues. Then judge LATENCY: what sits on the critical path, what
+blocking work runs on an async runtime without being offloaded, what repeats redundantly, what
+is needlessly serialized.` },
+  { key: 'architecture', focus: `SYSTEM ARCHITECTURE and VENDOR LOCK AVOIDANCE. Map the real
+dependency graph and judge the layering: does anything depend upward, are there cycles, are
+there god modules? Verify claimed invariants by exhaustive search rather than trusting one
+example. Judge every abstraction seam: is it a boundary you could actually swap, or have vendor
+specifics bled into core? Name leaks with file:line. Judge whether the decomposition fits the
+size of the system.` },
+  { key: 'data-durability', focus: `DATA STORAGE and DURABILITY. Read the persistence layer and
+every call site that writes state. Judge schema and migrations (forward-only? tested?
+versioned? idempotent?), transaction boundaries and atomicity, crash recovery, concurrent
+access from multiple processes, file locking, retention and growth bounds on EVERY store, and
+behavior when the disk is full or the data is corrupt. Check every persisted file that is not
+in a database: is any written in place rather than write-temp-then-rename?` },
+  { key: 'efficiency', focus: `${NO_LLM ? '' : `TOKEN EFFICIENCY and `}COMPUTE EFFICIENCY.${NO_LLM ? '' : `
+This is an LLM application: read every prompt template, tool description, tool RESULT
+formatting and context injection. Verify any prompt-cache claim by checking that nothing
+volatile (a timestamp, a relative age, a random ordering, a set iteration) is spliced into the
+cached prefix. Check that EVERY tool-result path is bounded before it enters context.`}
+For compute: hot-path allocations, needless clones, O(n^2) scans, blocking IO inside async,
+unbounded buffers, redundant passes over the same data, render cost. Quantify where you can
+("this clones the whole transcript every step").${NO_LLM ? ' Score token_efficiency 0 (N/A).' : ''}` },
+  { key: 'naming-consistency', focus: `NAMING, FORMATTING, FILE ORGANIZATION and LANGUAGE. Judge
+the tree as a reader meeting it for the first time. Cover naming conventions and how many run
+at once, module organization and god-modules (and whether any size limit is enforced by
+anything at all), whether similar concepts use the same word everywhere or drift, vocabulary
+consistency between code, CLI and docs, public-API doc coverage, and user-facing string
+quality. Find comments that LIE about the code beneath them — the worst defect class here.
+Check for mojibake and double-encoded UTF-8 in user-facing strings.` },
+  { key: 'ux-readiness', focus: `END USER EXPERIENCE and RELEASE READINESS. Walk the real user
+journey by reading code: install, first run, auth setup, the command surface (consistent?
+discoverable? are flags named uniformly? is help any good?), error messages when things go
+wrong, and machine-readable output (one contract, or several incompatible idioms?). Find where
+a new user falls off. Then judge the repo as a stranger who wants to contribute: README honesty
+(does it claim anything the code does not do?), license consistency across every metadata file,
+contribution and security-disclosure process, CI transparency, and whether a contributor can
+get a working dev loop from the README alone.` },
+  { key: 'maintainability', focus: `MAINTAINABILITY and TEST ADVERSARIALISM. Judge the test
+suite as an adversary would: do tests assert real behavior or merely that the code ran? Is
+there a test that would FAIL if the central guarantee broke — find it, or record that it does
+not exist. Look for tests asserting on mocks, tests with no assertions, skipped or ignored
+tests, flakiness suppression, and coverage thresholds set below what is already achieved. Judge
+lint policy (are warnings allowed to accumulate?), reviewability of recent diffs, and whether
+CI actually blocks a merge or merely reports.` },
+]
+
+// The two weight-3 lenses run twice, on two different models, and their findings are UNIONED.
+// Intersecting at discovery time would throw away exactly the defects only one model can see.
+const LENS_JOBS = []
+LENSES.forEach((l, i) => {
+  LENS_JOBS.push({ ...l, model: PANEL[i % PANEL.length], pass: 1 })
+  if (l.weight3) LENS_JOBS.push({ ...l, model: PANEL[(i + 1) % PANEL.length], pass: 2 })
+})
+
+const xcutResults = (await parallel(LENS_JOBS.map((l) => () => agent(
+  hdr('lens', `${l.key}#${l.pass}`, l.model) + SHARED + `
+
+YOUR LENS: ${l.key}${l.pass > 1 ? ` (independent second pass by a different model — do NOT assume the first pass found everything, and do not try to agree with it; you cannot see it)` : ''}
+
+*** RULE #1: YOU ARE READ-ONLY THIS PHASE. Do NOT create, modify or delete ANY file. Do NOT run
+build, test or lint tooling. If you are about to, STOP. ***
+Unit agents have just applied fixes to this tree. You read the POST-FIX state and score THAT.
+
+${l.focus}
+
+METHOD: range across the WHOLE workspace at ${ROOT} — you are not scoped to one unit. Use
+ripgrep aggressively to find EVERY instance of a pattern rather than reasoning from the first
+one you see. Read the files that matter end to end. Every finding needs file:line and a
+concrete consequence. Distinguish what you PROVED by reading code (proved_by_reading=true) from
+what you INFER (false). Do not report style opinions as defects. If you find nothing critical,
+say so — inventing a critical to look thorough is the worst thing you can do here.
+
+Score the 17 dimensions: a real workspace-wide score for the dimensions your lens covers, and 0
+for the rest (synthesis ignores the zeros).`,
+  { label: `lens:${l.key}#${l.pass}`, phase: 'Cross-cutting', schema: XCUT_SCHEMA,
+    model: l.model, effort: 'high' }
+).then((r) => (r ? { ...r, lens: r.lens || l.key, pass: l.pass, found_by_model: l.model } : null))))).filter(Boolean)
+
+log(`Phase 3: ${xcutResults.length}/${LENS_JOBS.length} lenses (${LENSES.filter((l) => l.weight3).length} run twice on ` +
+    `different models); ${xcutResults.reduce((n, r) => n + (r.findings || []).length, 0)} findings`)
+
+// ── Phase 4 — fresh sweep (max depth only) ───────────────────────────────────
+phase('Fresh sweep')
+
+const SWEEP_ANGLES = [
+  'What does this system do when a dependency it trusts returns something malformed? Trace every external boundary.',
+  'Find the invariant this codebase most depends on, then find the code path that violates it.',
+  'Where does this system lose data, or lose a write, under concurrency or crash?',
+  'Read the newest code in the tree (git log --since is unavailable to you, so use comments, TODOs and structure). New code carries new defects.',
+  'Find the defect class that appears more than five times. One instance is a bug; six is an architectural fact.',
+  'What does the documentation promise that the code does not deliver? Verify each claim against enforcing code.',
+]
+const sweepResults = CONF.sweep
+  ? (await parallel(SWEEP_ANGLES.slice(0, CONF.sweep).map((q, i) => () => agent(
+      hdr('sweep', `angle-${i}`, PANEL[i % PANEL.length]) + SHARED + `
+
+*** RULE #1: READ-ONLY. Do NOT edit any file. Do NOT run build, test or lint tooling. ***
+
+You are a fresh pair of eyes on a tree that has ALREADY been audited unit-by-unit and by eight
+cross-cutting lenses. Everything obvious has been found. Your job is what a partitioned read
+structurally cannot see: defects that only appear when you follow one question across every
+module boundary at once.
+
+YOUR QUESTION: ${q}
+
+Pursue it across the whole workspace. Go deep on one thing rather than broad on many. Report
+only what you can support with file:line — if the honest answer is "the codebase handles this
+well", report that with the evidence, and score nothing.
+
+Score only the dimensions your question actually bears on; 0 for the rest.`,
+      { label: `sweep:${i}`, phase: 'Fresh sweep', schema: XCUT_SCHEMA,
+        model: PANEL[i % PANEL.length], effort: 'high' }
+    ).then((r) => (r ? { ...r, lens: `sweep:${r.lens || i}`, pass: 1, found_by_model: PANEL[i % PANEL.length] } : null))))).filter(Boolean)
+  : []
+if (CONF.sweep) log(`Phase 4: ${sweepResults.length} sweep angles; ` +
+  `${sweepResults.reduce((n, r) => n + (r.findings || []).length, 0)} additional findings`)
+
+// ── Phase 5 — verify the real gate ───────────────────────────────────────────
+phase('Verify')
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  required: ['fmt_clean', 'lint_clean', 'tests_pass', 'regressions_found', 'regressions_fixed', 'final_state'],
+  properties: {
+    fmt_clean: { type: 'boolean' }, lint_clean: { type: 'boolean' },
+    tests_pass: { type: 'boolean' }, typecheck_clean: { type: 'boolean' },
+    commands_run: { type: 'array', items: { type: 'string' } },
+    regressions_found: { type: 'array', items: { type: 'string' } },
+    regressions_fixed: { type: 'array', items: { type: 'string' } },
+    reverted: { type: 'array', items: { type: 'string' } },
+    preexisting: { type: 'array', items: { type: 'string' } },
+    unfixed: { type: 'array', items: { type: 'string' } },
+    test_summary: { type: 'string' }, final_state: { type: 'string' },
+  },
+}
+
+const suspectFixes = fixReviews.flatMap((f) => (f.bad_fixes || [])
+  .filter((b) => b.action === 'revert' || b.breaks_build)
+  .map((b) => ({ unit: f.unit, ...b })))
+
+const GATE_CMDS = (GATE.project_gate ? [`PROJECT'S OWN GATE (prefer this): ${GATE.project_gate.command}`] : [])
+  .concat((GATE.toolchains || []).flatMap((t) => ['fmt_check', 'fmt_write', 'lint', 'typecheck', 'test', 'docs']
+    .filter((k) => t[k]).map((k) => `${t.name} ${k}: ${t[k]}`)))
+  .concat((GATE.toolchains || []).filter((t) => t.cache_note).map((t) => `CACHE TRAP (${t.name}): ${t.cache_note}`))
+
+const verify = (GATE.fix_authority || {}).level === 'none'
+  ? { skipped: true, final_state: 'Read-only audit: no edits were made, so no gate was run.' }
+  : await agent(
+      hdr('verify', 'gate', 'opus') +
+`You are the integration verifier for the workspace at ${ROOT}. ${UNITS.length} agents just
+applied audit fixes in parallel. Get the tree to a fully green gate and report honestly.
+
+MEASURED BASELINE, taken on a PRISTINE checkout of the same commit BEFORE any agent ran:
+${BASELINE}
+
+Anything worse than that baseline IS a regression from this audit's edits. Anything already in
+it is NOT — report those under 'preexisting' and fix them anyway if you can.
+
+You ARE permitted and required to run build tooling. You run alone; there is no lock contention.
+
+THE GATE:
+${GATE_CMDS.map((c) => '  ' + c).join('\n')}
+
+*** The cache traps above are not advisory. A cached lint run reports zero warnings whether or
+not there are any. Use the forced form. Check results BY EXIT CODE, not by grepping output —
+this shell forces ANSI colour, so pattern-matching on output silently misses matches. ***
+
+A different model already reviewed the applied fixes and flagged these as unsound. Deal with
+each one first, before anything else:
+${suspectFixes.length ? JSON.stringify(suspectFixes.slice(0, 30)) : '  (none flagged)'}
+
+STEPS: format; then lint with all targets and features and fix EVERY error and warning,
+iterating until clean; then run the full test suite and fix genuine regressions. If a fix is
+beyond you, revert that specific hunk with git rather than leaving the tree broken — a broken
+tree is a total failure of this engagement. Re-run the formatter and confirm the linter is clean
+at the end. Record every command you actually ran in commands_run.
+
+Be scrupulously honest. If tests still fail, say so with counts. Do not report success you did
+not achieve: a later step re-runs these commands independently and will catch you.`,
+      { label: 'verify:gate', phase: 'Verify', schema: VERIFY_SCHEMA, model: 'opus', effort: 'high' }
+    )
+log(`Phase 5: fmt=${verify && verify.fmt_clean} lint=${verify && verify.lint_clean} ` +
+    `tests=${verify && verify.tests_pass} reverted=${((verify || {}).reverted || []).length}`)
+
+// ── Phase 6 — cross-model adversarial refutation ─────────────────────────────
+phase('Adversarial')
+
+const allFindings = []
+for (const r of unitResults) for (const f of (r.findings || [])) allFindings.push({ ...f, source: r.unit, found_by_model: r.found_by_model })
+for (const r of [...xcutResults, ...sweepResults]) for (const f of (r.findings || [])) allFindings.push({ ...f, source: `lens:${r.lens}`, found_by_model: r.found_by_model })
+
+const severeAll = allFindings.filter((f) => f.severity === 'critical' || f.severity === 'high')
+const severe = CONF.refuteCap ? severeAll.slice(0, CONF.refuteCap) : severeAll
+const notRefuted = severeAll.length - severe.length
+if (notRefuted > 0) log(`!! Phase 6 cap: ${notRefuted} severe findings will NOT be refuted ` +
+  `(depth=${DEPTH}, cap=${CONF.refuteCap}). They enter the report as UNVERIFIED, not as confirmed.`)
+log(`Phase 6: refuting ${severe.length} critical/high of ${allFindings.length} total, ` +
+    `${CONF.verifiers} cross-model verifier(s) each`)
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'confidence', 'reasoning'],
+  properties: {
+    refuted: { type: 'boolean' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    corrected_severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low', 'not-a-defect'] },
+    already_fixed: { type: 'boolean', description: 'The code now reads correctly — refuted as a CURRENT defect' },
+    reasoning: { type: 'string', description: 'Cite the specific code you read. Under 200 words.' },
+  },
+}
+
+const judged = (await parallel(severe.map((f, i) => () => {
+  // Rule #1 of the panel: the finding's own author model never judges it alone.
+  const others = PANEL.filter((m) => m !== f.found_by_model)
+  const pool = CONF.verifiers >= 3 ? PANEL : others.slice(0, CONF.verifiers)
+  return parallel(pool.map((m) => () => agent(
+    hdr('refute', `f${i}`, m) +
+`You are a skeptical verifier on the audit at ${ROOT}.
+
+*** RULE #1: READ-ONLY. Do NOT edit any file. Do NOT run build, test or lint tooling. ***
+
+A DIFFERENT model reported this ${String(f.severity).toUpperCase()} finding against "${f.source}":
+  dimension: ${f.dimension}
+  file: ${f.file}${f.line ? ':' + f.line : ''}
+  claim: ${f.issue}
+  proposed remediation: ${f.remediation || '(fixed in place)'}
+  the author marked this as ${f.proved_by_reading === false ? 'INFERRED, not proven by reading' : 'proven by reading'}
+
+YOUR JOB IS TO REFUTE IT. Open that file, read the surrounding code and its callers, and check:
+is the claim actually true? Is the severity justified? Does another layer already mitigate it —
+a guard upstream, a type invariant, a permission gate, a test that pins it?
+
+Audit agents already applied fixes to this tree, so it may ALREADY BE FIXED. If the code now
+reads correctly, set already_fixed=true and refuted=true — it is not a current defect.
+
+Be rigorous, not contrarian. If it is real and correctly rated, refuted=false. If real but
+overstated, refuted=false with a corrected_severity. Set refuted=true only when the code
+genuinely does not support the claim. Cite what you read; an unsupported verdict is worthless
+in either direction.`,
+    { label: `refute:${i}:${m}`, phase: 'Adversarial', schema: VERDICT_SCHEMA, model: m, effort: 'high' }
+  ).then((v) => (v ? { ...v, model: m } : null)))).then((vs) => {
+    const votes = vs.filter(Boolean)
+    if (!votes.length) return { finding: f, verdicts: [], agreement: 'unjudged', real: null }
+    const cross = votes.filter((v) => v.model !== f.found_by_model)
+    const basis = cross.length ? cross : votes
+    const nReal = basis.filter((v) => !v.refuted).length
+    const real = nReal * 2 > basis.length ? true : (nReal * 2 < basis.length ? false : null)
+    const agreement = basis.length === 1 ? (real ? 'single-verifier-real' : 'single-verifier-refuted')
+      : nReal === basis.length ? 'unanimous-real'
+      : nReal === 0 ? 'unanimous-refuted'
+      : real === null ? 'contested' : (real ? 'majority-real' : 'majority-refuted')
+    const sev = basis.map((v) => v.corrected_severity).filter(Boolean).sort()
+    return { finding: f, verdicts: votes, agreement, real,
+             cross_model: cross.length > 0,
+             corrected_severity: sev.length ? sev[sev.length >> 1] : null }
+  })
+}))).filter(Boolean)
+
+const survived = judged.filter((j) => j.real === true || j.agreement === 'contested')
+const killed = judged.filter((j) => j.real === false)
+const unverified = severeAll.slice(severe.length).map((f) => ({ finding: f, agreement: 'unverified', real: null }))
+log(`Phase 6: ${survived.length} survived (${judged.filter((j) => j.agreement === 'contested').length} contested), ` +
+    `${killed.length} refuted by cross-model review, ${unverified.length} unverified`)
+
+// ── Phase 7 — the blind three-model calibration panel ────────────────────────
+phase('Panel')
+
+const PANEL_SCHEMA = {
+  type: 'object',
+  required: ['scores', 'rationales', 'headline'],
+  properties: {
+    scores: { type: 'object', properties: SCORE_PROPS },
+    rationales: {
+      type: 'object',
+      properties: DIMENSIONS.reduce((a, d) => (a[d] = { type: 'string' }, a), {}),
+      description: '2-3 sentences of EVIDENCE per dimension. Name file:line or the mechanism.',
+    },
+    headline: { type: 'string', description: 'The single most important thing about this codebase, in one sentence' },
+    worst_dimension: { type: 'string' },
+    above_92_justification: { type: 'string', description: 'Required if you scored anything above 92: which 100-anchor mechanism earns it' },
+  },
+}
+
+// One evidence bundle, identical for all three panelists. Capped so it fits, and the caps are
+// logged rather than hidden.
+const bundle = {
+  workspace: { root: ROOT, languages: GATE.languages, total_loc: GATE.total_loc,
+               total_files: GATE.total_files, llm_surface: (GATE.llm_surface || {}).present,
+               commit: RUN.commit },
+  coverage: { units: UNITS.length, files_owned: UNITS.reduce((n, u) => n + (u.n_files || 0), 0) },
+  gate: verify,
+  baseline: BASELINE,
+  unit_scores: unitResults.map((r) => ({ unit: r.unit, scores: r.scores, notes: r.score_notes,
+                                         n_findings: (r.findings || []).length })),
+  lens_reports: [...xcutResults, ...sweepResults].map((r) => ({
+    lens: r.lens, pass: r.pass, scores: r.scores, summary: r.summary,
+    score_notes: r.score_notes, strengths: (r.strengths || []).slice(0, 6),
+    findings: (r.findings || []).slice(0, 14).map((f) => ({ sev: f.severity, dim: f.dimension,
+      file: f.file, issue: f.issue, proved: f.proved_by_reading })),
+  })),
+  confirmed_findings: survived.map((j) => ({ sev: j.corrected_severity || j.finding.severity,
+    dim: j.finding.dimension, file: j.finding.file, issue: j.finding.issue,
+    agreement: j.agreement })),
+  refuted_count: killed.length,
+  unverified_count: unverified.length,
+  fix_review: fixReviews.map((f) => ({ unit: f.unit, verdict: f.verdict,
+    n_bad: (f.bad_fixes || []).length })),
+  prior_findings_recheck: regressionResults.map((r) => ({ id: r.id, status: r.status,
+    quality: r.quality, test_pinned: r.test_pinned })),
+}
+
+const panelVotes = (await parallel(PANEL.map((m) => () => agent(
+  hdr('panel', `score-${m}`, m) +
+`You are an independent scoring panelist on a $100,000 engineering audit of ${ROOT}.
+
+*** RULE #1: READ-ONLY. Do NOT edit any file. Do NOT run build, test or lint tooling. ***
+
+Two other frontier models are scoring the SAME evidence independently and CANNOT see your
+answer, and you cannot see theirs. The reported score is the MEDIAN of the three and the SPREAD
+is published as a confidence signal. So: do not hedge toward the middle to look safe, and do not
+posture. Score what the evidence supports. If you are the outlier and you are right, the spread
+is the signal that makes the reader look closer — that is the design working.
+
+You have NOT been shown any prior score for this workspace, deliberately. Do not speculate
+about one; anchoring on a guess is the failure mode this blindness exists to prevent.
+
+=== EVIDENCE BUNDLE ===
+${JSON.stringify(bundle)}
+
+You may read files in the workspace to resolve a disagreement between reports or to sanity-check
+a number, and you should where a dimension's evidence looks thin.
+${CALIBRATION}
+Score all 17 dimensions and give a rationale for EACH that names evidence — a file:line or a
+named mechanism. A rationale that restates the score in words is a failure. Where the evidence
+for a dimension is thin, say so and score it lower rather than guessing high.`,
+  { label: `panel:${m}`, phase: 'Panel', schema: PANEL_SCHEMA, model: m, effort: 'high' }
+).then((r) => (r ? { model: m, ...r } : null))))).filter(Boolean)
+
+const panelScores = {}
+const panelSpread = {}
+for (const d of DIMENSIONS) {
+  const xs = panelVotes.map((v) => (v.scores || {})[d]).filter((x) => typeof x === 'number' && x > 0)
+  panelScores[d] = median(xs)
+  panelSpread[d] = xs.length > 1 ? Math.max(...xs) - Math.min(...xs) : 0
+}
+const contestedDims = DIMENSIONS.filter((d) => panelSpread[d] >= 10)
+log(`Phase 7: ${panelVotes.length}/3 panelists scored; median overall ` +
+    `${weightedOverall(panelScores).toFixed(2)}; ${contestedDims.length} contested dimension(s)` +
+    (contestedDims.length ? `: ${contestedDims.join(', ')}` : ''))
+
+// ── Phase 8 — independent second opinion ─────────────────────────────────────
+// The highest-value cross-model step observed on prior runs: it moved three scores, caught
+// that the wrong tree had been scored, and caught fresh breakage on the default branch.
+phase('Second opinion')
+
+const CRITIQUE_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'miscalibrated', 'missed', 'disputed'],
+  properties: {
+    verdict: { type: 'string', description: 'Your own one-paragraph verdict on this codebase' },
+    miscalibrated: { type: 'array', items: { type: 'object',
+      required: ['dimension', 'direction', 'argued_score', 'why'],
+      properties: { dimension: { type: 'string' },
+        direction: { type: 'string', enum: ['too_high', 'too_low'] },
+        argued_score: { type: 'integer' }, why: { type: 'string' } } } },
+    missed: { type: 'array', items: { type: 'string' }, description: 'Important things the audit did not look at' },
+    disputed: { type: 'array', items: { type: 'object', required: ['claim', 'why'],
+      properties: { claim: { type: 'string' }, why: { type: 'string' } } } },
+    agree_with: { type: 'array', items: { type: 'string' } },
+    process_critique: { type: 'string', description: 'What is wrong with how this audit was conducted' },
+  },
+}
+
+const CRITIC_MODELS = CONF.critics >= 3 ? PANEL : ['fable']  // not the synthesis model
+const critiques = (await parallel(CRITIC_MODELS.map((m) => () => agent(
+  hdr('critique', `second-opinion-${m}`, m) +
+`You are an independent senior reviewer. An audit of ${ROOT} was just produced by
+${UNITS.length} unit agents, ${LENS_JOBS.length} cross-cutting lenses, cross-model refutation of
+every serious finding, and a three-model blind scoring panel.
+
+Your job is a SECOND OPINION. **Do not restate the report — critique it.**
+
+*** RULE #1: READ-ONLY. Do NOT edit any file. Do NOT run build, test or lint tooling.
+You MAY read any file in the workspace, and you SHOULD spot-check any claim you doubt. ***
+
+Challenge scores that look miscalibrated IN EITHER DIRECTION — an audit that is too harsh is as
+wrong as one that is too kind, and graders drift harsh when they are trying to look rigorous.
+Name anything important the audit did not examine. Dispute any finding whose reasoning does not
+hold. Then give your own verdict.
+
+Be specific and direct. Vague agreement is worthless; so is contrarianism for its own sake.
+
+=== THE PANEL'S SCORECARD (median of three blind panelists) ===
+${JSON.stringify(DIMENSIONS.map((d) => ({ dimension: d, weight: WEIGHTS[d], score: panelScores[d],
+  spread: panelSpread[d], contested: panelSpread[d] >= 10,
+  rationale: (panelVotes[0] && panelVotes[0].rationales || {})[d] })))}
+
+WEIGHTED OVERALL: ${weightedOverall(panelScores).toFixed(2)}
+PANELIST HEADLINES: ${JSON.stringify(panelVotes.map((v) => ({ model: v.model, headline: v.headline, worst: v.worst_dimension })))}
+
+=== CONFIRMED RISKS (survived cross-model refutation) ===
+${JSON.stringify(survived.slice(0, 30).map((j) => ({ sev: j.corrected_severity || j.finding.severity,
+  dim: j.finding.dimension, file: j.finding.file, issue: j.finding.issue, agreement: j.agreement })))}
+
+=== GATE ===
+${JSON.stringify(verify)}
+
+=== KNOWN LIMITS OF THIS AUDIT (do not merely repeat these; test whether they mattered) ===
+- ${unverified.length} severe findings went unverified at depth=${DEPTH}.
+- ${killed.length} findings were refuted and excluded; a wrong refutation hides a real defect.
+- The panel shares training lineage, so agreement is weaker evidence than it appears.
+- Score the commit ${RUN.commit || '(unrecorded)'}: confirm the audit scored the tree it claims to have scored.`,
+  { label: `second-opinion:${m}`, phase: 'Second opinion', schema: CRITIQUE_SCHEMA,
+    model: m, effort: 'high' }
+).then((r) => (r ? { model: m, ...r } : null))))).filter(Boolean)
+
+log(`Phase 8: ${critiques.length} independent critique(s); ` +
+    `${critiques.reduce((n, c) => n + (c.miscalibrated || []).length, 0)} score challenges, ` +
+    `${critiques.reduce((n, c) => n + (c.disputed || []).length, 0)} disputed findings`)
+
+// ── Phase 9 — synthesis ──────────────────────────────────────────────────────
+phase('Synthesis')
+
+const SYNTH_SCHEMA = {
+  type: 'object',
+  required: ['overall_score', 'dimension_scores', 'executive_summary', 'top_strengths', 'top_risks', 'roadmap'],
+  properties: {
+    overall_score: { type: 'integer', minimum: 0, maximum: 100 },
+    dimension_scores: {
+      type: 'object',
+      properties: DIMENSIONS.reduce((p, d) => {
+        p[d] = { type: 'object', required: ['score', 'rationale'],
+          properties: {
+            score: { type: 'integer', minimum: 0, maximum: 100 },
+            grade: { type: 'string' },
+            rationale: { type: 'string', description: '2-4 sentences of evidence for the ABSOLUTE score' },
+            delta_rationale: { type: 'string', description: 'Why it moved, or what would have had to change and did not' },
+            panel_resolution: { type: 'string', description: 'Required where the panel was contested: which way you went and why' },
+            evidence: { type: 'array', items: { type: 'string' } },
+          } }
+        return p
+      }, {}),
+    },
+    executive_summary: { type: 'string', description: '4-6 paragraphs for a technical founder' },
+    remediation_verdict: { type: 'string', description: 'Judge the QUALITY of work since last time: root-cause or symptomatic, did any fix introduce a defect, converging or churning?' },
+    second_opinion_response: { type: 'string', description: 'Where you accepted the critic and where you overruled it, and why' },
+    top_strengths: { type: 'array', items: { type: 'object', properties: { title: { type: 'string' }, detail: { type: 'string' } } } },
+    top_risks: { type: 'array', items: { type: 'object',
+      properties: { title: { type: 'string' }, severity: { type: 'string' }, dimension: { type: 'string' },
+        file: { type: 'string' }, detail: { type: 'string' }, remediation: { type: 'string' },
+        agreement: { type: 'string' } } } },
+    roadmap: { type: 'array', items: { type: 'object',
+      properties: { horizon: { type: 'string', enum: ['now', 'next', 'later'] }, item: { type: 'string' },
+        why: { type: 'string' }, effort: { type: 'string' }, dimension: { type: 'string' } } } },
+    scoring_methodology: { type: 'string' },
+    audit_limitations: { type: 'string', description: 'What this audit could NOT determine. Be specific.' },
+  },
+}
+
+const synthesis = await agent(
+  hdr('synthesis', 'lead', 'opus') +
+`You are the lead partner writing the final scorecard of a $100,000 engineering audit of ${ROOT}.
+Your job is CALIBRATION and SYNTHESIS, not new discovery.
+
+*** RULE #1: Do NOT edit any file. Do NOT run build, test or lint tooling. You MAY read files to
+resolve a disagreement or sanity-check a score, and you MUST do so for every contested
+dimension. ***
+
+${PRIOR ? `=== PRIOR SCORECARD (you are the ONLY phase that has seen this) ===\n${JSON.stringify(PRIOR)}` : '(No prior audit — this is round 1.)'}
+
+${regressionResults.length ? `=== DID THE PRIOR RECOMMENDATIONS LAND? (independent verification) ===\n${JSON.stringify(regressionResults)}` : ''}
+
+=== THE BLIND PANEL: three frontier models, same evidence, no contact ===
+${JSON.stringify(DIMENSIONS.map((d) => ({
+  dimension: d, weight: WEIGHTS[d], median: panelScores[d], spread: panelSpread[d],
+  contested: panelSpread[d] >= 10,
+  votes: panelVotes.map((v) => ({ model: v.model, score: (v.scores || {})[d],
+                                  why: (v.rationales || {})[d] })),
+})))}
+
+=== SECOND OPINION(S) — an independent critic that could see the scorecard ===
+${JSON.stringify(critiques)}
+
+=== CONFIRMED RISKS (survived cross-model refutation) ===
+${JSON.stringify(survived.map((j) => ({ source: j.finding.source, sev: j.corrected_severity || j.finding.severity,
+  dim: j.finding.dimension, file: j.finding.file, issue: j.finding.issue,
+  remediation: j.finding.remediation, agreement: j.agreement, cross_model: j.cross_model,
+  found_by: j.finding.found_by_model,
+  why_real: (j.verdicts || []).filter((v) => !v.refuted).map((v) => `${v.model}: ${v.reasoning}`) })))}
+
+=== REFUTED (excluded — a different model read the code and disagreed) ===
+${JSON.stringify(killed.slice(0, 40).map((j) => ({ file: j.finding.file, issue: j.finding.issue,
+  already_fixed: (j.verdicts || []).some((v) => v.already_fixed),
+  why: (j.verdicts || []).map((v) => `${v.model}: ${v.reasoning}`).slice(0, 2) })))}
+
+${unverified.length ? `=== UNVERIFIED (${unverified.length} severe findings exceeded the depth cap — treat as UNCONFIRMED) ===\n${JSON.stringify(unverified.slice(0, 20).map((j) => ({ file: j.finding.file, issue: j.finding.issue })))}` : ''}
+
+=== CROSS-MODEL FIX REVIEW ===
+${JSON.stringify(fixReviews.map((f) => ({ unit: f.unit, verdict: f.verdict, author: f.author_model,
+  reviewer: f.reviewer_model, bad: (f.bad_fixes || []).slice(0, 4) })))}
+
+=== GATE ===
+${JSON.stringify(verify)}
+Pre-audit baseline: ${BASELINE}
+
+=== COVERAGE ===
+${UNITS.length} unit agents owned ${UNITS.reduce((n, u) => n + (u.n_files || 0), 0)} of
+${GATE.total_files} source files. Commit scored: ${RUN.commit || '(unrecorded)'}.
+
+BINDING RULES:
+- Start from the panel MEDIAN. You may move a dimension off it, but every move needs a reason
+  that cites evidence, and for a contested dimension (spread >= 10) you must READ CODE and put
+  your resolution in panel_resolution.
+- The second opinion is advisory, not binding — but you must respond to each of its score
+  challenges in second_opinion_response, saying where you accepted it and where you overruled it.
+- The bar is ABSOLUTE (100 = the Rust project; 90-95 = ripgrep/tokio/SQLite tier). A dimension
+  rises only if the tree is genuinely better, never because effort was expended. Some
+  dimensions may legitimately FALL, and saying so is the point of the exercise.
+- A fix that closes the reported example but leaves the defect CLASS open does NOT earn
+  root-cause credit. The regression-check evidence tells you which is which.
+- If remediation introduced NEW defects, that is a real cost and must show in the scores.
+- Lens scores are the primary signal per dimension; per-unit scores modulate by a few points.
+  Ignore every 0.
+- Weight units by product significance, not line count.
+- top_risks draws ONLY from confirmed findings. Never from refuted ones. Mark any contested or
+  unverified item as such in its agreement field.
+- OVERALL is the weighted mean over the 17 dimensions using EXACTLY these weights — invent
+  nothing: ${JSON.stringify(WEIGHTS)}. It is recomputed independently from your dimension_scores
+  and any discrepancy is treated as an error.
+- Every dimension needs a delta_rationale naming the specific work that moved it, or naming what
+  would have had to change and did not. "Improved generally" is unacceptable.
+- audit_limitations must be honest and specific: what could this audit NOT determine?
+- The executive summary must be readable by a technical founder: direct, specific, no filler.`,
+  { label: 'synthesis', phase: 'Synthesis', schema: SYNTH_SCHEMA, model: 'opus', effort: 'high' }
+)
+
+const finalScores = {}
+for (const d of DIMENSIONS) {
+  const c = synthesis && synthesis.dimension_scores && synthesis.dimension_scores[d]
+  if (c && typeof c.score === 'number') finalScores[d] = c.score
+}
+const computed = weightedOverall(finalScores)
+const priorComputed = PRIOR ? weightedOverall(PRIOR) : null
+log(`Synthesis: agent said ${synthesis && synthesis.overall_score}; recomputed ${computed.toFixed(2)}` +
+    (priorComputed ? ` (prior ${priorComputed.toFixed(2)}, delta ${(computed - priorComputed).toFixed(2)})` : ''))
+
+return {
+  run: { ...RUN, root: ROOT, depth: DEPTH, panel: PANEL,
+         units: UNITS.length, lens_jobs: LENS_JOBS.length,
+         files_owned: UNITS.reduce((n, u) => n + (u.n_files || 0), 0),
+         total_files: GATE.total_files, total_loc: GATE.total_loc,
+         languages: GATE.languages, fix_authority: GATE.fix_authority,
+         llm_surface: (GATE.llm_surface || {}).present },
+  regressionResults,
+  unitResults,
+  fixReviews,
+  xcutResults,
+  sweepResults,
+  verify,
+  findings: {
+    total: allFindings.length,
+    severe: severeAll.length,
+    confirmed: survived.map((j) => ({ ...j.finding, agreement: j.agreement,
+      corrected_severity: j.corrected_severity, cross_model: j.cross_model,
+      verdicts: (j.verdicts || []).map((v) => ({ model: v.model, refuted: v.refuted,
+        confidence: v.confidence, reasoning: v.reasoning })) })),
+    refuted: killed.map((j) => ({ ...j.finding, agreement: j.agreement,
+      verdicts: (j.verdicts || []).map((v) => ({ model: v.model, refuted: v.refuted,
+        already_fixed: v.already_fixed, reasoning: v.reasoning })) })),
+    unverified: unverified.map((j) => j.finding),
+  },
+  panel: { votes: panelVotes, median: panelScores, spread: panelSpread, contested: contestedDims },
+  critiques,
+  synthesis,
+  scoring: {
+    prior: PRIOR, prior_overall_computed: priorComputed,
+    panel_median: panelScores, panel_overall_computed: Number(weightedOverall(panelScores).toFixed(2)),
+    final: finalScores,
+    final_overall_computed: Number(computed.toFixed(2)),
+    final_overall_rounded: Math.round(computed),
+    agent_claimed: synthesis && synthesis.overall_score,
+    weights: WEIGHTS,
+    // Full precision. Subtracting rounded values has already produced one wrong number
+    // in a shipped report (operations.md §15).
+    delta_precise: priorComputed === null ? null : Number((computed - priorComputed).toFixed(2)),
+    deltas: PRIOR ? DIMENSIONS.reduce((a, d) => {
+      if (typeof finalScores[d] === 'number' && typeof PRIOR[d] === 'number') a[d] = finalScores[d] - PRIOR[d]
+      return a
+    }, {}) : null,
+  },
+}

--- a/.stella/skills/ultra-audit/tests/check_template.py
+++ b/.stella/skills/ultra-audit/tests/check_template.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Static checks on workflow.template.js. Run before every launch.
+
+The harness's guarantees are structural, so they can be checked structurally. Each check
+here corresponds to a rule that, if broken, produces a report that is confidently wrong
+rather than obviously broken:
+
+  1. the template is valid JS once spliced            (a syntax error wastes a whole launch)
+  2. every agent() sets an explicit model             (model-panel.md rule 5; one omission
+                                                       silently collapses the panel)
+  3. every agent() sets an explicit phase             (progress reporting is how the run
+                                                       survives — operations.md §0)
+  4. every prompt opens with the provenance header    (or --provenance cannot verify the mix)
+  5. meta.phases covers every phase used              (an uncovered phase gets its own
+                                                       unlabelled progress box)
+  6. no Date.now / Math.random                        (they throw in the sandbox and would
+                                                       break resume)
+
+    python3 tests/check_template.py [path-to-template]
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT = os.path.join(HERE, "..", "scripts", "workflow.template.js")
+
+FIXTURE = {
+    "__ROOT__": "/tmp/x",
+    "/*__RUN__*/ {}": json.dumps({"date": "2026-01-01", "commit": "abc123", "depth": "deep"}),
+    "/*__GATE__*/ {}": json.dumps({
+        "toolchains": [{"name": "cargo", "type_gate": True, "lint": "x", "cache_note": "y"}],
+        "fix_authority": {"level": "full"}, "llm_surface": {"present": True},
+        "languages": [], "total_files": 10, "total_loc": 100, "project_gate": None}),
+    "/*__UNITS__*/ []": json.dumps([{"unit": "a", "loc": 10, "n_files": 2,
+                                     "owns_globs": ["a/**"], "group": "a", "note": ""}]),
+    "/*__PRIOR__*/ null": "null",
+    "/*__PRIOR_ITEMS__*/ []": "[]",
+    "`__BASELINE__`": "`clean`",
+    "/*__SALVAGE__*/ null": "null",
+}
+
+
+def splice(src: str) -> str:
+    for k, v in FIXTURE.items():
+        src = src.replace(k, v)
+    return src
+
+
+def find_agent_calls(src: str) -> list[tuple[int, str]]:
+    """Every agent(...) call body, by paren matching that respects strings and templates."""
+    calls = []
+    for m in re.finditer(r"\bagent\(", src):
+        i = m.end()
+        depth, quote, out = 1, None, []
+        while i < len(src) and depth:
+            c = src[i]
+            if quote:
+                if c == "\\":
+                    out.append(src[i:i + 2]); i += 2; continue
+                if c == quote:
+                    quote = None
+            elif c in "'\"`":
+                quote = c
+            elif c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if not depth:
+                    break
+            out.append(c)
+            i += 1
+        calls.append((m.start(), "".join(out)))
+    return calls
+
+
+def main() -> int:
+    path = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else DEFAULT)
+    src = open(path).read()
+    fails: list[str] = []
+    ok: list[str] = []
+
+    # 1 — valid JS. Top-level return/await are legal inside the harness's async wrapper but
+    # not in a bare module, so reproduce the wrapper before checking.
+    spliced = splice(src)
+    left = re.findall(r"__[A-Z_]+__", spliced)
+    if left:
+        fails.append(f"unspliced placeholders remain after fixture splice: {sorted(set(left))}")
+    cut = spliced.index("\n// ──")
+    wrapped = spliced[:cut] + "\nasync function __run(){\n" + spliced[cut:] + "\n}\nvoid __run;\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".mjs", delete=False) as fh:
+        fh.write(wrapped)
+        tmp = fh.name
+    p = subprocess.run(["node", "--check", tmp], capture_output=True, text=True)
+    os.unlink(tmp)
+    if p.returncode:
+        fails.append(f"node --check failed:\n{p.stderr.strip()}")
+    else:
+        ok.append("valid JS once spliced")
+
+    # 2-4 — per-agent invariants.
+    calls = find_agent_calls(src)
+    if len(calls) < 8:
+        fails.append(f"only {len(calls)} agent() calls found — the paren scanner is probably "
+                     f"broken, not the template")
+    no_model = [i for i, b in calls if not re.search(r"\bmodel:\s*", b)]
+    no_phase = [i for i, b in calls if not re.search(r"\bphase:\s*", b)]
+    no_hdr = [i for i, b in calls if "hdr(" not in b]
+    for label, bad in (("model", no_model), ("phase", no_phase), ("hdr() header", no_hdr)):
+        if bad:
+            fails.append(f"{len(bad)} agent() call(s) missing explicit {label} "
+                         f"(at char offsets {bad})")
+        else:
+            ok.append(f"all {len(calls)} agent() calls set an explicit {label}")
+
+    # 5 — meta.phases covers everything actually used.
+    meta_titles = set(re.findall(r"\{\s*title:\s*'([^']+)'", src))
+    used = set(re.findall(r"phase\('([^']+)'\)", src)) | \
+        set(re.findall(r"phase:\s*'([^']+)'", src))
+    missing = used - meta_titles
+    if missing:
+        fails.append(f"phases used but absent from meta.phases: {sorted(missing)}")
+    else:
+        ok.append(f"meta.phases covers all {len(used)} phases in use")
+
+    # 6 — banned non-determinism.
+    banned = [b for b in ("Date.now", "Math.random", "new Date()") if b in src]
+    if banned:
+        fails.append(f"banned in the workflow sandbox (throws, and breaks resume): {banned}")
+    else:
+        ok.append("no Date.now / Math.random / new Date()")
+
+    # Informational: the model mix the template will actually produce.
+    models = sorted(set(re.findall(r"model:\s*'([a-z]+)'", src)))
+    dyn = sorted(set(re.findall(r"model:\s*(\w+)", src)) - set(models))
+    print(f"models referenced literally: {models or '(none)'}")
+    print(f"models referenced by variable: {dyn or '(none)'}")
+    if "haiku" in models:
+        fails.append("haiku appears as a judging/scoring model — model-panel.md forbids it")
+
+    for line in ok:
+        print(f"  PASS  {line}")
+    for line in fails:
+        print(f"  FAIL  {line}")
+    print(f"\n{len(ok)} passed, {len(fails)} failed  ({os.path.relpath(path)})")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.stella/skills/ultra-audit/tests/make_fixture.py
+++ b/.stella/skills/ultra-audit/tests/make_fixture.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build a realistic audit result for testing score.py and render_report.py.
+
+Seeded from a real recorded round so the delta arithmetic is exercised against real numbers
+rather than round ones, and deliberately hostile in three ways that have each broken a report
+before: a finding whose text contains `</script>`, one containing `${...}`, and one containing
+non-ASCII and a double-encoded UTF-8 sequence.
+
+    python3 tests/make_fixture.py [--history PATH] [--out result.json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+
+DIMS = ["formatting", "language", "documentation", "file_names", "symbol_names",
+        "file_organization", "system_architecture", "data_storage", "vendor_lock_avoidance",
+        "security", "durability", "maintainability", "loop_correctness",
+        "token_efficiency", "agent_performance", "compute_efficiency", "end_user_experience"]
+
+# A prior round's real shape, used when no history file is available.
+FALLBACK_PRIOR = {"formatting": 88, "language": 79, "documentation": 74, "file_names": 84,
+                  "symbol_names": 82, "file_organization": 73, "system_architecture": 77,
+                  "data_storage": 78, "vendor_lock_avoidance": 81, "security": 80,
+                  "durability": 79, "maintainability": 76, "loop_correctness": 83,
+                  "token_efficiency": 81, "agent_performance": 82, "compute_efficiency": 78,
+                  "end_user_experience": 75}
+
+# Per-dimension panel votes: (opus, fable, sonnet). Two are contested on purpose
+# (spread >= 10) so the contested path is exercised end to end.
+VOTES = {
+    "formatting": (89, 90, 88), "language": (77, 80, 78), "documentation": (72, 74, 71),
+    "file_names": (85, 84, 86), "symbol_names": (83, 82, 84),
+    "file_organization": (70, 72, 71), "system_architecture": (76, 79, 74),
+    "data_storage": (79, 78, 80), "vendor_lock_avoidance": (82, 81, 83),
+    "security": (70, 82, 76),                      # contested: spread 12
+    "durability": (80, 81, 79), "maintainability": (74, 77, 75),
+    "loop_correctness": (84, 85, 83), "token_efficiency": (80, 82, 81),
+    "agent_performance": (78, 84, 90),             # contested: spread 12
+    "compute_efficiency": (79, 78, 80), "end_user_experience": (73, 76, 74),
+}
+
+HOSTILE = [
+    {"severity": "critical", "dimension": "security", "file": "stella-tools/src/exec.rs",
+     "line": 412, "found_by_model": "opus", "cross_model": True, "agreement": "unanimous-real",
+     "issue": "The sanitizer strips `<script>` but not `</script >` with a space, so the "
+              "guard at exec.rs:412 can be defeated by a single character. Any caller "
+              "reaching render_untrusted() inherits the hole.",
+     "remediation": "Parse rather than pattern-match; reject on any tag-like token.",
+     "verdicts": [{"model": "fable", "refuted": False, "confidence": "high",
+                   "reasoning": "Confirmed by reading exec.rs:400-430; the regex is "
+                                "`</script>` literal and the HTML spec permits whitespace."},
+                  {"model": "sonnet", "refuted": False, "confidence": "high",
+                   "reasoning": "Reproduced the bypass by reading the tokenizer; no upstream "
+                                "guard covers it."}]},
+    {"severity": "high", "dimension": "token_efficiency", "file": "stella-core/src/prompt.rs",
+     "line": 88, "found_by_model": "fable", "cross_model": True, "agreement": "majority-real",
+     "issue": "The cached prefix interpolates `${elapsed_secs}` into the system prompt, so the "
+              "prompt cache misses on every single turn. Every request pays full prefix cost.",
+     "remediation": "Move the elapsed-time line below the cache breakpoint.",
+     "verdicts": [{"model": "opus", "refuted": False, "confidence": "high",
+                   "reasoning": "prompt.rs:88 splices a monotonic clock read into the cached "
+                                "segment. Confirmed against the cache_control placement."},
+                  {"model": "sonnet", "refuted": True, "confidence": "low",
+                   "reasoning": "Believed the value was rounded to the hour; it is not."}]},
+    {"severity": "high", "dimension": "language", "file": "stella-cli/src/help.rs", "line": 31,
+     "found_by_model": "sonnet", "cross_model": True, "agreement": "contested",
+     "issue": "User-facing strings contain double-encoded UTF-8 (Ã© for é) and a "
+              "mojibake em-dash (â€”), visible in `stella --help` output.",
+     "remediation": "Decode once at the boundary; add a test asserting no C3 A9 byte pair.",
+     "verdicts": [{"model": "opus", "refuted": False, "confidence": "medium",
+                   "reasoning": "Present at help.rs:31 and 47."},
+                  {"model": "fable", "refuted": True, "confidence": "medium",
+                   "reasoning": "The terminal renders it correctly under a UTF-8 locale, so "
+                                "user impact is limited to non-UTF-8 terminals."}]},
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--history", default=os.path.expanduser(
+        "~/.claude/skills/reaudit/history/stella.json"))
+    ap.add_argument("--out", default="result.json")
+    a = ap.parse_args()
+
+    prior = FALLBACK_PRIOR
+    prior_round, prior_pub = 2, None
+    if os.path.exists(a.history):
+        runs = json.load(open(a.history)).get("runs", [])
+        if runs:
+            prior = runs[-1]["scores"]
+            prior_round = runs[-1].get("round", len(runs))
+            prior_pub = runs[-1].get("overall_rounded")
+
+    median = {d: int(round(statistics.median(VOTES[d]))) for d in DIMS}
+    spread = {d: max(VOTES[d]) - min(VOTES[d]) for d in DIMS}
+    contested = [d for d in DIMS if spread[d] >= 10]
+
+    dimension_scores = {}
+    for d in DIMS:
+        dimension_scores[d] = {
+            "score": median[d],
+            "grade": "B" if median[d] >= 80 else "C",
+            "rationale": f"Scored on lens evidence for {d}; the panel median was {median[d]} "
+                         f"with a spread of {spread[d]}.",
+            "delta_rationale": (f"Moved from {prior.get(d)} because the {d} lens found "
+                                f"concrete, cited change." if prior.get(d) != median[d]
+                                else "Unchanged: nothing in this round bore on it."),
+            "evidence": [f"stella-core/src/lib.rs:{100 + i}" for i in range(2)],
+            **({"panel_resolution":
+                f"Panel split {'/'.join(map(str, VOTES[d]))}. Read the code at the cited lines "
+                f"and landed on {median[d]}: the optimistic panelist did not account for the "
+                f"second code path."} if d in contested else {}),
+        }
+
+    result = {
+        "run": {"root": "/Users/macanderson/Projects/stella", "commit": "ac5b344b2",
+                "date": "2026-07-26", "depth": "deep", "round": prior_round + 1,
+                "panel": ["opus", "fable", "sonnet"], "units": 34, "lens_jobs": 10,
+                "files_owned": 538, "total_files": 538, "total_loc": 319154,
+                "languages": [{"language": "Rust", "loc": 280141, "files": 475},
+                              {"language": "Python", "loc": 34402, "files": 26},
+                              {"language": "TypeScript", "loc": 2561, "files": 22}],
+                "fix_authority": {"level": "full", "reason": "cargo provides a compile gate"},
+                "llm_surface": True},
+        "verify": {"fmt_clean": True, "lint_clean": True, "tests_pass": False,
+                   "typecheck_clean": True,
+                   "commands_run": ["cargo fmt --all", "cargo clippy --workspace",
+                                    "cargo test --workspace"],
+                   "regressions_found": ["stella-store::wal::truncate_is_atomic"],
+                   "regressions_fixed": ["stella-store::wal::truncate_is_atomic"],
+                   "reverted": ["stella-tui/src/deck.rs: dead-code removal was reachable"],
+                   "preexisting": ["stella-store::wal::concurrent_writers (2 failures)"],
+                   "unfixed": ["stella-store::wal::concurrent_writers"],
+                   "test_summary": "3742 passed, 2 failed (both pre-existing)",
+                   "final_state": "fmt and clippy clean; 2 pre-existing test failures remain."},
+        "panel": {"votes": [{"model": m,
+                             "scores": {d: VOTES[d][i] for d in DIMS},
+                             "rationales": {d: f"{m} on {d}: cited evidence." for d in DIMS},
+                             "headline": f"{m}: the store layer is the weakest link.",
+                             "worst_dimension": "file_organization"}
+                            for i, m in enumerate(["opus", "fable", "sonnet"])],
+                  "median": median, "spread": spread, "contested": contested},
+        "findings": {"total": 214, "severe": 51, "confirmed": HOSTILE,
+                     "refuted": [{"severity": "high", "dimension": "durability",
+                                  "file": "stella-store/src/wal.rs", "line": 210,
+                                  "found_by_model": "opus", "agreement": "unanimous-refuted",
+                                  "issue": "Claimed the WAL writes in place without a rename.",
+                                  "verdicts": [{"model": "fable", "refuted": True,
+                                                "already_fixed": True,
+                                                "reasoning": "wal.rs:210 already uses "
+                                                             "write-temp-then-rename."}]}],
+                     "unverified": [{"severity": "high", "dimension": "compute_efficiency",
+                                     "file": "stella-tui/src/render.rs", "line": 640,
+                                     "issue": "Full-tree re-render on every keypress.",
+                                     "found_by_model": "sonnet"}]},
+        "regressionResults": [
+            {"id": "shell-boundary-decorative", "status": "partially_fixed",
+             "quality": "shallow", "test_pinned": False, "judged_by_model": "fable",
+             "evidence": ["stella-tools/src/catalog.rs:133"],
+             "reasoning": "start_process is gated now, but send_stdin still has no arm in "
+                          "command_line_for, so the audit ledger stays blind on that path.",
+             "residual_risk": "An operator's ledger shows a benign spawn and nothing else."},
+            {"id": "prompt-cache-volatile-prefix", "status": "not_fixed", "quality": "wrong",
+             "test_pinned": False, "judged_by_model": "sonnet",
+             "evidence": ["stella-core/src/prompt.rs:88"],
+             "reasoning": "The elapsed-time interpolation is still inside the cached prefix."},
+            {"id": "wal-atomicity", "status": "fixed", "quality": "excellent",
+             "test_pinned": True, "judged_by_model": "opus",
+             "evidence": ["stella-store/src/wal.rs:210", "wal_tests.rs:88"],
+             "reasoning": "Write-temp-then-rename landed with a test that fails if reverted."}],
+        "fixReviews": [
+            {"unit": "./stella-tui::part-2", "verdict": "unsound_fixes_present",
+             "reviewed_count": 6, "author_model": "opus", "reviewer_model": "fable",
+             "bad_fixes": [{"file": "stella-tui/src/deck.rs", "action": "revert",
+                            "breaks_build": False,
+                            "problem": "Removed a function as dead code; it is reached from "
+                                       "the headless renderer via a trait object."}]},
+            {"unit": "./stella-core::part-1", "verdict": "all_sound", "reviewed_count": 9,
+             "author_model": "fable", "reviewer_model": "sonnet", "bad_fixes": []}],
+        "critiques": [{"model": "fable",
+                       "verdict": "The audit is broadly sound but too kind on "
+                                  "agent_performance, where one panelist scored 90 on the "
+                                  "strength of a benchmark that measures the wrong path.",
+                       "miscalibrated": [{"dimension": "agent_performance",
+                                          "direction": "too_high", "argued_score": 78,
+                                          "why": "The cited benchmark excludes the blocking "
+                                                 "store read on the render path."}],
+                       "missed": ["No lens examined the release/packaging path.",
+                                  "The Python subtree (34k lines) was audited by unit agents "
+                                  "but no lens covered it specifically."],
+                       "disputed": [{"claim": "documentation scored 72",
+                                     "why": "Doc examples are not compiled, so the true "
+                                            "figure is lower."}],
+                       "agree_with": ["security is the right headline risk"],
+                       "process_critique": "Two contested dimensions is a small sample; the "
+                                           "panel agreed too readily elsewhere."}],
+        "synthesis": {
+            "overall_score": int(round(sum(median[d] for d in DIMS) / len(DIMS))),
+            "dimension_scores": dimension_scores,
+            "executive_summary": "The workspace is a strong, actively maintained Rust agent "
+                                 "system with a real security boundary that is not yet fully "
+                                 "enforced.\n\nThe store layer remains the weakest link.",
+            "remediation_verdict": "Converging, but two of three prior findings were closed "
+                                   "shallowly — the reported instance was fixed while the "
+                                   "defect class stayed open.",
+            "second_opinion_response": "Accepted the agent_performance challenge and moved it "
+                                       "to the panel median rather than the optimistic vote. "
+                                       "Overruled the documentation dispute: doc examples are "
+                                       "compiled in CI for the three public crates.",
+            "top_strengths": [{"title": "Cancellation is real",
+                               "detail": "Interrupt propagates to child process groups."}],
+            "top_risks": [{"title": "Sanitizer bypass in the exec boundary",
+                           "severity": "critical", "dimension": "security",
+                           "file": "stella-tools/src/exec.rs",
+                           "detail": "A whitespace variant defeats the tag filter.",
+                           "remediation": "Tokenize instead of pattern-matching.",
+                           "agreement": "unanimous-real"},
+                          {"title": "Prompt cache misses every turn",
+                           "severity": "high", "dimension": "token_efficiency",
+                           "file": "stella-core/src/prompt.rs",
+                           "detail": "A clock read sits inside the cached prefix.",
+                           "remediation": "Move it below the breakpoint.",
+                           "agreement": "majority-real"}],
+            "roadmap": [{"horizon": "now", "item": "Tokenize the exec sanitizer",
+                         "why": "Closes a confirmed critical bypass.", "effort": "1 day",
+                         "dimension": "security"},
+                        {"horizon": "now", "item": "Move the clock read out of the prefix",
+                         "why": "Recovers prompt-cache hits on every turn.",
+                         "effort": "1 hour", "dimension": "token_efficiency"},
+                        {"horizon": "next", "item": "Split the store god-module",
+                         "why": "21k lines in one unit blocks review.", "effort": "1 week",
+                         "dimension": "file_organization"},
+                        {"horizon": "later", "item": "Compile doc examples in CI",
+                         "why": "Documentation cannot rot if CI runs it.", "effort": "2 days",
+                         "dimension": "documentation"}],
+            "scoring_methodology": "Three frontier models scored the same evidence bundle "
+                                   "blind; the reported value is the median, and the two "
+                                   "contested dimensions were resolved by reading code.",
+            "audit_limitations": "One severe finding went unverified at depth=deep. Two "
+                                 "pre-existing test failures were not fixed. The panel shares "
+                                 "training lineage, so agreement is weaker evidence than it "
+                                 "looks.",
+        },
+        "unitResults": [{"unit": f"./unit-{i}", "loc": 12000, "n_files": 20,
+                         "found_by_model": ["opus", "fable", "sonnet"][i % 3],
+                         "scores": {d: median[d] for d in DIMS},
+                         "summary": f"Unit {i} summary.",
+                         "strengths": ["clear seams"],
+                         "findings": [], "fixes_applied": [{"file": "x.rs", "change": "doc",
+                                                            "rationale": "clarity"}]}
+                        for i in range(6)],
+        "xcutResults": [{"lens": k, "pass": p, "found_by_model": m,
+                         "scores": {d: median[d] for d in DIMS},
+                         "summary": f"{k} lens pass {p}.", "strengths": [], "findings": [],
+                         "top_recommendations": [f"fix {k}"]}
+                        for k, p, m in [("security", 1, "opus"), ("security", 2, "fable"),
+                                        ("loop-correctness", 1, "fable"),
+                                        ("loop-correctness", 2, "sonnet"),
+                                        ("architecture", 1, "sonnet"),
+                                        ("data-durability", 1, "opus"),
+                                        ("efficiency", 1, "fable"),
+                                        ("naming-consistency", 1, "sonnet"),
+                                        ("ux-readiness", 1, "opus"),
+                                        ("maintainability", 1, "fable")]],
+        "sweepResults": [],
+    }
+    with open(a.out, "w") as fh:
+        json.dump(result, fh, indent=1)
+    print(f"-> {a.out}")
+    print(f"prior round {prior_round} (published {prior_pub}); "
+          f"contested dimensions: {contested}")
+    print("hostile payloads included: </script>, ${...}, double-encoded UTF-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.stella/skills/ultra-audit/tests/run_all.sh
+++ b/.stella/skills/ultra-audit/tests/run_all.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# End-to-end dry run of the whole pipeline, minus the (expensive) agent phases.
+#
+# Everything except the Workflow launch is exercised against a real repository: detect the
+# gate, partition with a coverage proof, build and validate the harness, score a realistic
+# result, render the HTML and validate it, and check model provenance both ways.
+#
+#     tests/run_all.sh [repo-path]
+#
+# Exits non-zero on the first failure. Intended to be run after any edit to this skill.
+set -uo pipefail
+
+SKILL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="${1:-}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAIL=$((FAIL+1)); }
+run()  { if "$@" >"$TMP/out.txt" 2>&1; then return 0; else return 1; fi }
+
+# Pick a repo to exercise against: the argument, else the first git repo with source in it.
+if [ -z "$REPO" ]; then
+  for c in "$PWD" "$HOME/Projects"/*; do
+    [ -d "$c/.git" ] && REPO="$c" && break
+  done
+fi
+[ -d "$REPO" ] || { echo "no repository to test against; pass one as \$1"; exit 2; }
+echo "ultra-audit self-test"
+echo "repo: $REPO"
+echo
+
+# ── 1. harness invariants ────────────────────────────────────────────────────
+if run python3 "$SKILL/tests/check_template.py"; then
+  ok "template invariants (JS parses, every agent sets model+phase+header, no Date.now)"
+else
+  bad "template invariants"; cat "$TMP/out.txt"
+fi
+
+# ── 2. detect ────────────────────────────────────────────────────────────────
+if run python3 "$SKILL/scripts/detect.py" "$REPO" --out "$TMP/gate.json" --quiet; then
+  ok "detect.py produced a gate"
+  python3 - "$TMP/gate.json" <<'PY' && ok "gate has languages, a fix-authority decision and an inventory" || bad "gate is malformed"
+import json,sys
+g=json.load(open(sys.argv[1]))
+assert g["languages"], "no languages"
+assert g["fix_authority"]["level"] in ("full","tested-files-only","text-only","none")
+assert g["inventory"], "no inventory"
+PY
+else
+  bad "detect.py"; cat "$TMP/out.txt"
+fi
+
+# ── 3. partition, with the coverage proof ────────────────────────────────────
+if run python3 "$SKILL/scripts/partition.py" "$TMP/gate.json" --out "$TMP/units.json"; then
+  ok "partition.py succeeded"
+  python3 - "$TMP/units.json" <<'PY' && ok "partition is disjoint, complete, and has no oversized unit" || bad "partition proof failed"
+import json,sys
+u=json.load(open(sys.argv[1])); p=u["proof"]
+assert p["disjoint"], f"overlapping ownership: {list(p['duplicated'])[:3]}"
+assert p["complete"], f"unowned files: {p['unowned'][:3]}"
+assert p["coverage_pct"] == 100.0, p["coverage_pct"]
+over=[x["unit"] for x in u["units"] if x["loc"] > u["target"]*1.25]
+assert not over, f"oversized units: {over[:3]}"
+PY
+else
+  bad "partition.py"; cat "$TMP/out.txt"
+fi
+
+# ── 4. build + validate the harness ──────────────────────────────────────────
+printf 'fmt clean; lint clean; tests 100 passed\n' > "$TMP/baseline.txt"
+for depth in standard deep max; do
+  if run python3 "$SKILL/scripts/build_workflow.py" --gate "$TMP/gate.json" \
+       --units "$TMP/units.json" --baseline "$TMP/baseline.txt" --depth "$depth" \
+       --out "$TMP/audit-$depth.js"; then
+    ok "build_workflow.py --depth $depth"
+  else
+    bad "build_workflow.py --depth $depth"; cat "$TMP/out.txt"
+  fi
+done
+
+# A baseline containing a backtick or ${...} must not break the generated script.
+printf 'tests: 2 failed in `wal` with ${HOME} unset\n' > "$TMP/bad-baseline.txt"
+if run python3 "$SKILL/scripts/build_workflow.py" --gate "$TMP/gate.json" \
+     --units "$TMP/units.json" --baseline "$TMP/bad-baseline.txt" --out "$TMP/audit-esc.js"; then
+  ok "baseline containing a backtick and \${} is escaped safely"
+else
+  bad "baseline escaping"; cat "$TMP/out.txt"
+fi
+
+# ── 5. score a realistic result ──────────────────────────────────────────────
+run python3 "$SKILL/tests/make_fixture.py" --out "$TMP/result.json" && ok "fixture built" \
+  || { bad "fixture"; cat "$TMP/out.txt"; }
+
+# score.py exits non-zero when it finds a problem; the fixture deliberately contains one
+# (an unverified severe finding), so a non-zero exit here is the CORRECT outcome.
+python3 "$SKILL/scripts/score.py" "$TMP/result.json" --json "$TMP/scoring.json" \
+  >"$TMP/score.txt" 2>&1
+if [ -f "$TMP/scoring.json" ]; then ok "score.py reconciled and emitted scoring.json"
+else bad "score.py"; cat "$TMP/score.txt"; fi
+
+python3 - "$TMP/scoring.json" "$TMP/score.txt" <<'PY' && ok "delta is full-precision; contested dimensions detected; unverified findings flagged" || bad "score.py checks"
+import json,sys
+s=json.load(open(sys.argv[1])); txt=open(sys.argv[2]).read()
+assert s["delta_precise"] is not None and abs(s["delta_precise"]) % 1 != 0, \
+    f"delta looks rounded: {s['delta_precise']}"
+assert s["contested"], "no contested dimensions detected"
+assert any("never refuted" in p for p in s["problems"]), "unverified findings not flagged"
+assert "WEIGHT DRIFT" not in txt, "weight drift against recorded history"
+PY
+
+# ── 6. render + validate the HTML ────────────────────────────────────────────
+if run python3 "$SKILL/scripts/render_report.py" "$TMP/result.json" \
+     --scoring "$TMP/scoring.json" --baseline "$TMP/baseline.txt" --out "$TMP/report.html"; then
+  ok "render_report.py produced a validated, self-contained report"
+else
+  bad "render_report.py"; cat "$TMP/out.txt"
+fi
+
+python3 - "$TMP/report.html" <<'PY' && ok "hostile payloads survived escaping (</script>, \${}, non-ASCII)" || bad "escaping"
+import sys
+h=open(sys.argv[1]).read()
+assert h.count("</script>") == 1, f"{h.count('</script>')} closing script tags"
+assert "elapsed_secs" in h and "sanitizer strips" in h, "payload missing"
+assert h.lstrip().startswith("<!doctype html>"), "not a standalone document"
+assert "prefers-color-scheme" in h and 'data-theme="dark"' in h, "not theme-aware"
+PY
+
+# ── 7. provenance, both directions ───────────────────────────────────────────
+python3 - "$TMP" <<'PY'
+import json,os,sys
+d=os.path.join(sys.argv[1],"wf"); os.makedirs(d,exist_ok=True)
+SLOT={"opus":"claude-opus-5","fable":"claude-fable-5","sonnet":"claude-sonnet-5"}
+j=open(os.path.join(d,"journal.jsonl"),"w")
+for i,(phase,m) in enumerate([("unit","opus"),("unit","fable"),("lens","sonnet"),
+                              ("panel","opus"),("panel","fable"),("panel","sonnet")]):
+    aid=f"a{i:016x}"; key=f"v2:{i:064x}"
+    with open(os.path.join(d,f"agent-{aid}.jsonl"),"w") as fh:
+        fh.write(json.dumps({"type":"user","agentId":aid,"message":{"role":"user",
+          "content":f"ULTRA-AUDIT-AGENT phase={phase} role=r{i} model={m}\n\nbody"}})+"\n")
+        fh.write(json.dumps({"type":"assistant","agentId":aid,
+          "message":{"model":SLOT[m]}},separators=(",",":"))+"\n")
+    j.write(json.dumps({"type":"started","agentId":aid,"key":key})+"\n")
+    j.write(json.dumps({"type":"result","agentId":aid,"key":key,"result":{}})+"\n")
+j.close()
+PY
+python3 "$SKILL/scripts/progress.py" "$TMP/wf" --provenance --json "$TMP/prov.json" >/dev/null 2>&1
+python3 - "$TMP/prov.json" <<'PY' && ok "provenance verifies a correct model mix" || bad "provenance happy path"
+import json,sys
+p=json.load(open(sys.argv[1]))
+assert p["ok"] is True, p["detail"]
+assert len(p["distinct_models"]) == 3, p["distinct_models"]
+PY
+
+# Flip one agent to a model it was not assigned; it must be caught.
+python3 - "$TMP/wf" <<'PY'
+import json,os,sys
+f=os.path.join(sys.argv[1],"agent-a0000000000000000.jsonl")
+l=open(f).read().splitlines(); o=json.loads(l[1]); o["message"]["model"]="claude-sonnet-5"
+l[1]=json.dumps(o,separators=(",",":")); open(f,"w").write("\n".join(l)+"\n")
+PY
+python3 "$SKILL/scripts/progress.py" "$TMP/wf" --provenance --json "$TMP/prov2.json" >/dev/null 2>&1
+python3 - "$TMP/prov2.json" <<'PY' && ok "provenance CATCHES a model that ran off-assignment" || bad "provenance negative control"
+import json,sys
+p=json.load(open(sys.argv[1]))
+assert p["ok"] is False and len(p["mismatches"]) == 1, p
+PY
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Ship the ultra-audit skill in source (renamed from `/ultraudit`)

Resolves **#847** and lays the foundation for **#832** (stella-maintains-stella),
whose mechanism is "reuse the `/ultra-audit` machinery on a schedule" — which
requires the skill to be tracked in source rather than living in one machine's
`~/.claude/skills/`.

### What changed

- **Promoted to source**: the ultra-audit skill now lives at
  `.stella/skills/ultra-audit/` (`SKILL.md`, `scripts/`, `reference/`,
  `assets/`, `tests/`) — previously a machine-local, untracked Claude Code
  skill.
- **Renamed `/ultraudit` → `/ultra-audit`** (the reported misspelling): the
  command name (SKILL frontmatter + prose), the workflow display name, the HTML
  report footer, the self-test banner, and the internal `ULTRA-AUDIT-AGENT`
  transcript marker (producer, consumer, test, and doc renamed together).
- **`.gitignore`**: root `.stella/` stays ignored scratch, but
  `.stella/skills/**` is re-included so the skill ships (mirroring the existing
  `bench/readiness/.../.stella/` exception). The renamed audit output dir
  `.ultra-audit/` is ignored; the legacy `.ultraudit/` is intentionally left
  alone (a report is already tracked under it, and ignoring it would orphan
  that file).

### Deliberately preserved (comparability)

`score.py` keeps the history-lineage keys `rubric: "ultraudit-17d-v1"` and
`tool: "ultraudit"` in the old spelling, with a comment. These are the keys the
`~/.claude/audits/` score series is keyed on, shared **unbroken** with
`/reaudit` (see `SKILL.md` "Relationship to /reaudit"). Renaming them would fork
the lineage and silently break cross-round comparability — the skill's core
guarantee.

### Verification

- The skill's own end-to-end self-test passes **16/16**
  (`tests/run_all.sh` — detect, partition, build workflow at all depths, score,
  render+validate the HTML, and model-provenance both ways), which exercises the
  renamed `ULTRA-AUDIT-AGENT` marker end to end.
- `check-no-scratch`, `check-file-size`, `check-action-pins`,
  `check-invariants`, `check-doc-citations` all pass. No Rust changed, so the
  compile/clippy/test gates are unaffected (CI re-runs the full gate).

### Note on scope / IP

This commits Oxagen's audit tooling into the public AGPL-3.0 repo, at the
maintainer's direction (it's the prerequisite for building #832). The tracked
copy is a stella-product skill under `.stella/skills/`; a machine's `/ultra-audit`
Claude Code command still resolves from `~/.claude/skills/`.

Closes #847
Refs #832


## Summary by Sourcery

Promote the ultra-audit engineering audit workflow from a local Claude skill into a tracked, source-controlled Stella skill with a renamed `/ultra-audit` command, including its execution harness, reporting HTML, documentation, and self-test suite.

New Features:
- Add the ultra-audit skill under `.stella/skills/ultra-audit` with a full multi-phase, cross-model engineering audit workflow and configuration.
- Provide a self-contained HTML report template for ultra-audit that visualizes scores, findings, and provenance in a single file.
- Introduce detection, partitioning, scoring, progress-monitoring, report-rendering, and fixture-generation scripts to support running and validating audits from source.

Enhancements:
- Adjust `.gitignore` so that `.stella/skills/**` is tracked while keeping other `.stella/` scratch data ignored, and ignore the new `.ultra-audit/` output directory.
- Preserve historical scoring lineage keys in `score.py` to keep existing audit histories comparable across the prior `/ultraudit` and new `/ultra-audit` naming.

Tests:
- Add an end-to-end shell test to exercise the ultra-audit pipeline against a real repository, ensuring the harness, scoring, report rendering, and provenance checks work together.
- Add template and harness validation tests to assert JavaScript correctness, required headers, and the absence of unsafe constructs in the workflow script.
- Add a fixture generator for realistic audit results used to validate scoring and HTML rendering behavior, including edge-case payloads.
