### PR TITLE
feat(tui): a live thought follows its tail instead of freezing on its head

### DIFF
--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -578,7 +578,7 @@ pub struct DeckUi {
     /// Selected row in the slash popup (clamped to the matches at use time).
     pub slash_selected: usize,
     /// Whether reasoning renders in full on the Session tab. Off by default —
-    /// collapsed thinking shows a one-line live tail; `ctrl+r` toggles.
+    /// a collapsed thought follows its live tail; `ctrl+r` toggles.
     pub thinking_expanded: bool,
     /// Whether the queue editor popup is open (`ctrl+t`, or `↑` from an empty
     /// composer on the Session tab while prompts are queued).

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -41,7 +41,7 @@ use crate::{diff, theme};
 // The transcript content builders moved to `entry` when this file crossed the
 // 1500-line guard; re-exported so `crate::render::transcript_lines` and
 // `::entry_lines` still resolve for `ui.rs` and `deck_ui.rs`.
-pub(crate) use entry::{entry_lines, transcript_lines};
+pub(crate) use entry::{entry_lines, reasoning_is_live, streaming_lines, transcript_lines};
 pub(crate) use row::*;
 
 /// Draw the whole TUI for one frame. Records the panels' viewport sizes back

--- a/stella-tui/src/render/entry.rs
+++ b/stella-tui/src/render/entry.rs
@@ -41,28 +41,65 @@ pub(crate) fn transcript_lines(
     width: usize,
 ) -> Vec<Line<'static>> {
     let mut out = Vec::new();
-    for entry in &model.transcript {
+    let live = reasoning_is_live(&model.transcript, &model.streaming_text);
+    let last = model.transcript.len().saturating_sub(1);
+    for (i, entry) in model.transcript.iter().enumerate() {
         entry_lines(
             entry,
             &model.files,
             expand_thinking,
             expand_thinking,
+            live && i == last,
             width,
             &mut out,
         );
     }
-    if !model.streaming_text.is_empty() {
-        let preview = TranscriptEntry::Text(model.streaming_text.clone());
-        entry_lines(
-            &preview,
-            &model.files,
-            expand_thinking,
-            expand_thinking,
-            width,
-            &mut out,
-        );
-    }
+    streaming_lines(
+        &model.streaming_text,
+        &model.files,
+        expand_thinking,
+        width,
+        &mut out,
+    );
     out
+}
+
+/// Fold the in-flight answer preview
+/// ([`SessionModel::streaming_text`](crate::model::SessionModel::streaming_text))
+/// as a trailing agent block, or nothing at all when there is none.
+///
+/// Both transcript renderers end on exactly this step, so it lives here rather
+/// than twice: neither of `entry_lines`' two view flags means anything for a
+/// preview (it cannot be selected, and tail-follow is a *thinking* affordance),
+/// and getting that pair wrong in one caller and not the other is the kind of
+/// drift that only shows up mid-stream.
+pub(crate) fn streaming_lines(
+    streaming: &str,
+    files: &[FileState],
+    expand_thinking: bool,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    if streaming.is_empty() {
+        return;
+    }
+    let preview = TranscriptEntry::Text(streaming.to_string());
+    entry_lines(&preview, files, expand_thinking, false, false, width, out);
+}
+
+/// Whether the trailing transcript entry is a thought *still being written* —
+/// the one thing a collapsed thinking block needs in order to follow its tail
+/// instead of showing its head (see the `TranscriptEntry::Reasoning` arm of
+/// [`entry_body`]).
+///
+/// Positional, so it stays a pure function of the fold with no liveness flag to
+/// set and no timer to reset. A thought stops being live the instant anything
+/// lands after it, and *everything* that ends one appends its own entry: a tool
+/// call, the authoritative `Text`, `Complete`, `Error`. The streaming answer
+/// preview is the one end that has no entry yet — it is the earliest evidence
+/// the thought is over, arriving a beat before the `Text` that coalesces it.
+pub(crate) fn reasoning_is_live(transcript: &[TranscriptEntry], streaming: &str) -> bool {
+    matches!(transcript.last(), Some(TranscriptEntry::Reasoning(_))) && streaming.is_empty()
 }
 
 /// Whether an entry closes a readable block, and so is followed by a spacer.
@@ -82,15 +119,20 @@ fn closes_block(entry: &TranscriptEntry) -> bool {
     )
 }
 
+/// `live` marks the one entry that is still being written to — the trailing
+/// entry of an in-flight turn, per [`reasoning_is_live`]. Only a collapsed
+/// reasoning block reads it, and only to follow its tail instead of showing its
+/// head; every settled entry passes `false`.
 pub(crate) fn entry_lines(
     entry: &TranscriptEntry,
     files: &[FileState],
     expand_thinking: bool,
     expanded: bool,
+    live: bool,
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
-    entry_body(entry, files, expand_thinking, expanded, width, out);
+    entry_body(entry, files, expand_thinking, expanded, live, width, out);
     if closes_block(entry) {
         push_gap(out);
     }
@@ -135,11 +177,29 @@ fn plural(n: u64, one: &str, many: &str) -> String {
     }
 }
 
+/// Visual rows a collapsed reasoning block spends on content.
+///
+/// A *row* budget, not a line budget: a chain of thought is usually a handful
+/// of paragraph-long logical lines, so a five-*line* window on a wrapped
+/// thought is most of the pane, and how much of it you got would depend on how
+/// the model happened to punctuate. Counting rows is also what keeps the block
+/// the same height whether it is following a live thought or previewing a
+/// settled one — the stream stopping must not resize the block under the
+/// reader.
+const THINKING_ROWS: usize = 5;
+
+/// The fold marker on a collapsed reasoning block. Sits *below* a settled
+/// preview (there is more after what you can see) and *above* a live tail
+/// (there is more before it) — so the newest text is always the last row of a
+/// thought still being written.
+const THINKING_FOLD_HINT: &str = "⋯ ctrl+o expands this thought · ctrl+r all";
+
 fn entry_body(
     entry: &TranscriptEntry,
     files: &[FileState],
     expand_thinking: bool,
     expanded: bool,
+    live: bool,
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
@@ -201,22 +261,41 @@ fn entry_body(
                     block.push(Line::from(Span::styled(l.to_owned(), reasoning_style)));
                 }
             } else {
-                let preview_count = 3;
-                let mut shown = 0;
-                for l in text.lines() {
-                    if shown >= preview_count {
-                        break;
-                    }
-                    if !l.trim().is_empty() {
-                        block.push(Line::from(Span::styled(l.to_owned(), reasoning_style)));
-                        shown += 1;
-                    }
+                // Pre-wrap every non-blank line to the note's body column so
+                // the budget below is spent in visual rows. Blank lines are
+                // dropped rather than wrapped: in a window this small a
+                // paragraph break costs a row of thought and says nothing.
+                let mut rows: Vec<Line<'static>> = Vec::new();
+                for l in text.lines().filter(|l| !l.trim().is_empty()) {
+                    wrap_one_indent(
+                        Line::from(Span::styled(l.to_owned(), reasoning_style)),
+                        width.saturating_sub(LEAD),
+                        0,
+                        &mut rows,
+                    );
                 }
-                if total_lines > preview_count {
-                    block.push(Line::from(Span::styled(
-                        "⋯ ctrl+o expands this thought · ctrl+r all",
-                        Style::new().fg(theme::TEXT_TERTIARY),
-                    )));
+                let folded = rows.len().saturating_sub(THINKING_ROWS);
+                let hint = Line::from(Span::styled(
+                    THINKING_FOLD_HINT,
+                    Style::new().fg(theme::TEXT_TERTIARY),
+                ));
+                if live {
+                    // Follow the tail. A long turn is mostly spent inside one
+                    // thought, and a preview frozen on its opening lines reads
+                    // as a stalled session — the newest row is both the most
+                    // informative one and the only proof anything is moving.
+                    if folded > 0 {
+                        block.push(hint);
+                    }
+                    block.extend(rows.split_off(folded));
+                } else {
+                    // Settled: the head, which is where a thought states what
+                    // it is about. Scrollback is read top-down.
+                    rows.truncate(THINKING_ROWS);
+                    block.extend(rows);
+                    if folded > 0 {
+                        block.push(hint);
+                    }
                 }
             }
             push_note_block(

--- a/stella-tui/src/render/tests.rs
+++ b/stella-tui/src/render/tests.rs
@@ -13,6 +13,8 @@ use stella_protocol::{
 };
 use stella_protocol::{CiStatus, PrStatus};
 
+mod thinking;
+
 /// Flatten a `TestBackend` buffer to one `String` per row (styling
 /// stripped — content is what we assert on, never raw ANSI, per L-T6).
 fn buffer_rows(buf: &Buffer) -> Vec<String> {
@@ -218,7 +220,7 @@ fn every_transcript_entry_renders_on_a_rail() {
             | TranscriptEntry::Complete { .. } => {}
         }
         let mut lines = Vec::new();
-        entry_lines(entry, &[], false, false, 0, &mut lines);
+        entry_lines(entry, &[], false, false, false, 0, &mut lines);
         let first = lines
             .first()
             .unwrap_or_else(|| panic!("{entry:?} renders no lines"));
@@ -382,84 +384,6 @@ fn diff_viewer_shows_the_selected_files_diff() {
     assert!(
         text.contains("+1 addition") && text.contains("-1 removal"),
         "counts in the footer rule:\n{text}"
-    );
-}
-
-#[test]
-fn thinking_is_collapsed_by_default_and_expands_with_the_toggle() {
-    let mut model = SessionModel::new();
-    model.apply(&AgentEvent::Reasoning {
-        delta: "alpha\nbeta\ngamma".into(),
-    });
-    let mut ui = UiState::default();
-    let collapsed = draw(&model, &mut ui, 100, 24);
-    // A system note is its own rail: the `⏵ thinking` label already opens
-    // with a glyph in column 0, so it indexes the margin without a second
-    // marker (and without the old right-aligned `[…]: ` tag column).
-    assert!(
-        collapsed.contains("⏵ thinking  3 lines"),
-        "collapsed header:\n{collapsed}"
-    );
-    // Collapsed = header + 3 preview lines (all 3 fit within preview count),
-    // then the spacer every block-closing entry ends on.
-    let c_lines = transcript_lines(&model, false, 0);
-    assert_eq!(c_lines.len(), 5, "header + 3 preview lines + block spacer");
-    // Preview shows the reasoning content.
-    let c_text: String = c_lines
-        .iter()
-        .flat_map(|l| l.spans.iter())
-        .map(|s| s.content.as_ref())
-        .collect();
-    assert!(
-        c_text.contains("alpha"),
-        "collapsed shows first line:\n{c_text}"
-    );
-
-    ui.thinking_expanded = true;
-    let expanded = draw(&model, &mut ui, 100, 24);
-    assert!(
-        expanded.contains("alpha") && expanded.contains("gamma"),
-        "expanded shows the full reasoning:\n{expanded}"
-    );
-    // Expanded = header + 3 content lines + the same block spacer.
-    assert_eq!(transcript_lines(&model, true, 0).len(), 5);
-}
-
-#[test]
-fn collapsed_thinking_shows_preview_lines_not_the_full_wall() {
-    let mut model = SessionModel::new();
-    let long = format!("{}THE-TAIL", "reasoning noise ".repeat(20));
-    model.apply(&AgentEvent::Reasoning { delta: long });
-    let lines = transcript_lines(&model, false, 0);
-    // 1 line of text → header + 1 preview, then the block spacer.
-    assert_eq!(lines.len(), 3);
-    // The preview should be visible.
-    let text: String = lines
-        .iter()
-        .flat_map(|l| l.spans.iter())
-        .map(|s| s.content.as_ref())
-        .collect();
-    assert!(text.contains("reasoning"), "preview shows content:\n{text}");
-}
-
-#[test]
-fn collapsed_thinking_preview_updates_as_deltas_stream() {
-    let mut model = SessionModel::new();
-    model.apply(&AgentEvent::Reasoning {
-        delta: "planning the refactor".into(),
-    });
-    let before = transcript_lines(&model, false, 0);
-    model.apply(&AgentEvent::Reasoning {
-        delta: " now checking tests".into(),
-    });
-    let after = transcript_lines(&model, false, 0);
-    // Both produce header + 1 preview + the block spacer.
-    assert_eq!(before.len(), 3);
-    assert_eq!(after.len(), 3, "still header + 1 preview line");
-    // The preview line (index 1) visibly changes with each delta.
-    assert_ne!(
-        before[1], after[1],
-        "the preview visibly changes with each delta"
     );
 }
 
@@ -992,6 +916,7 @@ fn expanded_detail_rows_align_at_the_content_column() {
         &[],
         false,
         true,
+        false,
         120,
         &mut result_rows,
     );
@@ -1026,6 +951,7 @@ fn expanded_detail_rows_align_at_the_content_column() {
         &[],
         false,
         true,
+        false,
         120,
         &mut start_rows,
     );
@@ -1096,7 +1022,7 @@ fn flat_text(lines: &[Line<'_>]) -> String {
 fn collapsed_tool_result_shows_a_capped_syntax_highlighted_inline_diff() {
     let (entry, files) = mutation_entry_and_files();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, false, 120, &mut out);
+    entry_lines(&entry, &files, false, false, false, 120, &mut out);
     let text = flat_text(&out);
 
     // No path rule and no counts footer inline, unlike the standalone diff
@@ -1153,7 +1079,7 @@ fn collapsed_tool_result_shows_a_capped_syntax_highlighted_inline_diff() {
 fn expanded_tool_result_shows_the_full_inline_diff() {
     let (entry, files) = mutation_entry_and_files();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, true, 120, &mut out);
+    entry_lines(&entry, &files, false, true, false, 120, &mut out);
     let text = flat_text(&out);
     assert!(
         text.contains(&format!("+let x{FIXTURE_ADDS} = {FIXTURE_ADDS};")),
@@ -1188,7 +1114,7 @@ fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
         .map(|seq| (seq, format!("@@ -0,0 +1,1 @@\n+later_edit_{seq}\n")))
         .collect();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, false, 120, &mut out);
+    entry_lines(&entry, &files, false, false, false, 120, &mut out);
     let text = flat_text(&out);
     assert!(
         !text.contains("+let x1 = 1;"),
@@ -1205,7 +1131,7 @@ fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
 
     // A ref whose path is no longer tracked resolves to nothing at all.
     let mut out = Vec::new();
-    entry_lines(&entry, &[], false, false, 120, &mut out);
+    entry_lines(&entry, &[], false, false, false, 120, &mut out);
     assert!(
         !flat_text(&out).contains("+let x1 = 1;"),
         "unknown path renders no diff"
@@ -1218,6 +1144,7 @@ fn eviction_marker_renders_as_a_one_line_system_note() {
     entry_lines(
         &TranscriptEntry::Evicted { count: 1234 },
         &[],
+        false,
         false,
         false,
         80,
@@ -1243,7 +1170,7 @@ fn eviction_marker_renders_as_a_one_line_system_note() {
 fn no_transcript_row_carries_a_raw_ansi_colour() {
     for entry in sample_entries() {
         let mut lines = Vec::new();
-        entry_lines(&entry, &[], true, true, 80, &mut lines);
+        entry_lines(&entry, &[], true, true, false, 80, &mut lines);
         for line in &lines {
             for span in &line.spans {
                 for (slot, colour) in [("fg", span.style.fg), ("bg", span.style.bg)] {
@@ -1273,6 +1200,7 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
     entry_lines(
         &TranscriptEntry::User("fix the `parser` bug\nand **ship** it".to_string()),
         &[],
+        false,
         false,
         false,
         80,
@@ -1324,7 +1252,7 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
 fn transcript_prefix_colors_stay_in_the_brand_family() {
     let prefix_fg = |entry: &TranscriptEntry| -> Option<Color> {
         let mut out = Vec::new();
-        entry_lines(entry, &[], false, false, 80, &mut out);
+        entry_lines(entry, &[], false, false, false, 80, &mut out);
         out[0].spans[0].style.fg
     };
     assert_eq!(

--- a/stella-tui/src/render/tests/thinking.rs
+++ b/stella-tui/src/render/tests/thinking.rs
@@ -1,0 +1,291 @@
+//! How a chain of thought renders — the collapsed window, the live tail, and
+//! the expanded whole.
+//!
+//! Split out of `render/tests.rs` when that file crossed the 1500-line guard.
+//! One topic per file: these are the only tests that care what a
+//! `TranscriptEntry::Reasoning` looks like, and between them they pin the
+//! contract in both directions — a thought still being written follows its
+//! tail so the newest text is always the bottom row, and a settled one reverts
+//! to its head, because scrollback is read top-down.
+
+use super::*;
+
+#[test]
+fn thinking_is_collapsed_by_default_and_expands_with_the_toggle() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: "alpha\nbeta\ngamma".into(),
+    });
+    let mut ui = UiState::default();
+    let collapsed = draw(&model, &mut ui, 100, 24);
+    // A system note is its own rail: the `⏵ thinking` label already opens
+    // with a glyph in column 0, so it indexes the margin without a second
+    // marker (and without the old right-aligned `[…]: ` tag column).
+    assert!(
+        collapsed.contains("⏵ thinking  3 lines"),
+        "collapsed header:\n{collapsed}"
+    );
+    // Collapsed = header + 3 preview lines (all 3 fit within preview count),
+    // then the spacer every block-closing entry ends on.
+    let c_lines = transcript_lines(&model, false, 0);
+    assert_eq!(c_lines.len(), 5, "header + 3 preview lines + block spacer");
+    // Preview shows the reasoning content.
+    let c_text: String = c_lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(
+        c_text.contains("alpha"),
+        "collapsed shows first line:\n{c_text}"
+    );
+
+    ui.thinking_expanded = true;
+    let expanded = draw(&model, &mut ui, 100, 24);
+    assert!(
+        expanded.contains("alpha") && expanded.contains("gamma"),
+        "expanded shows the full reasoning:\n{expanded}"
+    );
+    // Expanded = header + 3 content lines + the same block spacer.
+    assert_eq!(transcript_lines(&model, true, 0).len(), 5);
+}
+
+#[test]
+fn collapsed_thinking_shows_preview_lines_not_the_full_wall() {
+    let mut model = SessionModel::new();
+    let long = format!("{}THE-TAIL", "reasoning noise ".repeat(20));
+    model.apply(&AgentEvent::Reasoning { delta: long });
+    let lines = transcript_lines(&model, false, 0);
+    // 1 line of text → header + 1 preview, then the block spacer.
+    assert_eq!(lines.len(), 3);
+    // The preview should be visible.
+    let text: String = lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(text.contains("reasoning"), "preview shows content:\n{text}");
+}
+
+#[test]
+fn collapsed_thinking_preview_updates_as_deltas_stream() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: "planning the refactor".into(),
+    });
+    let before = transcript_lines(&model, false, 0);
+    model.apply(&AgentEvent::Reasoning {
+        delta: " now checking tests".into(),
+    });
+    let after = transcript_lines(&model, false, 0);
+    // Both produce header + 1 preview + the block spacer.
+    assert_eq!(before.len(), 3);
+    assert_eq!(after.len(), 3, "still header + 1 preview line");
+    // The preview line (index 1) visibly changes with each delta.
+    assert_ne!(
+        before[1], after[1],
+        "the preview visibly changes with each delta"
+    );
+}
+
+/// Flatten transcript rows to one trimmed string per row. Trimmed because
+/// these tests assert *which* rows a thought shows and in what order — the
+/// body indent is `push_note_block`'s job and has its own coverage.
+fn row_texts(lines: &[Line<'static>]) -> Vec<String> {
+    lines
+        .iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+                .trim()
+                .to_string()
+        })
+        .collect()
+}
+
+/// The rows up to the block spacer that closes the first entry.
+fn first_block(rows: &[String]) -> &[String] {
+    let end = rows.iter().position(|r| r.is_empty()).unwrap_or(rows.len());
+    &rows[..end]
+}
+
+/// A thought long enough to overflow the collapsed row budget, one logical
+/// line per numbered step.
+fn numbered_thought(steps: usize) -> String {
+    (1..=steps)
+        .map(|i| format!("step-{i}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The whole point of the change: on a long turn the agent sits inside one
+/// thought for minutes, and a preview pinned to its opening lines is
+/// indistinguishable from a hung session. While the thought is live the block
+/// follows its tail, so the bottom row is always the newest text.
+#[test]
+fn a_live_thought_follows_its_tail_and_ends_on_the_newest_row() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: numbered_thought(9),
+    });
+    assert!(
+        reasoning_is_live(&model.transcript, &model.streaming_text),
+        "nothing has landed after it"
+    );
+    let rows = row_texts(&transcript_lines(&model, false, 0));
+    // header + fold hint + 5 tail rows + block spacer.
+    assert_eq!(rows.len(), 8, "rows:\n{rows:#?}");
+    assert!(rows[0].contains("9 lines"), "header counts them all");
+    assert!(rows[1].contains("⋯"), "the fold marker sits *above* a tail");
+    let window: Vec<&str> = rows[2..7].iter().map(String::as_str).collect();
+    assert_eq!(
+        window,
+        ["step-5", "step-6", "step-7", "step-8", "step-9"],
+        "the last five steps, in order — and the head has scrolled off"
+    );
+}
+
+/// Streaming the next step scrolls the window by exactly one row — the tail
+/// keeps moving rather than the block keeping growing.
+#[test]
+fn the_live_tail_scrolls_as_each_new_line_arrives() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: numbered_thought(9),
+    });
+    let before = row_texts(&transcript_lines(&model, false, 0));
+    model.apply(&AgentEvent::Reasoning {
+        delta: "\nstep-10".into(),
+    });
+    let after = row_texts(&transcript_lines(&model, false, 0));
+    assert_eq!(before.len(), after.len(), "same height");
+    assert_eq!(
+        after[after.len() - 2],
+        "step-10",
+        "the newest line is the last row:\n{after:#?}"
+    );
+    assert_eq!(&after[2..6], &before[3..7], "the window slid by one row");
+}
+
+/// Once anything lands after the thought it is settled scrollback, and
+/// scrollback is read top-down: back to the head preview, fold marker below it.
+#[test]
+fn a_settled_thought_reverts_to_its_head() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: numbered_thought(9),
+    });
+    model.apply(&AgentEvent::Text {
+        delta: "here is the answer".into(),
+    });
+    assert!(
+        !reasoning_is_live(&model.transcript, &model.streaming_text),
+        "the answer displaced it"
+    );
+    let rows = row_texts(&transcript_lines(&model, false, 0));
+    assert_eq!(rows[1], "step-1", "the head is back:\n{rows:#?}");
+    assert_eq!(rows[5], "step-5");
+    assert!(
+        rows[6].contains("⋯"),
+        "and the fold marker moved below it:\n{rows:#?}"
+    );
+}
+
+/// A turn that ends *on* a thought — no answer text, no tool call — settles
+/// too, and this is what lets liveness stay purely positional: every terminal
+/// event appends an entry of its own, so "is anything after it" already answers
+/// "is the turn over". If `Complete` or `Error` ever stopped landing an entry,
+/// a finished thought would tail-follow forever — hence the assertion on both.
+#[test]
+fn a_terminal_event_settles_a_trailing_thought() {
+    for terminal in [
+        AgentEvent::Complete {
+            model: "glm-5.2".into(),
+            cost_usd: 0.01,
+        },
+        AgentEvent::Error {
+            message: "upstream 500".into(),
+            retryable: false,
+        },
+    ] {
+        let mut model = SessionModel::new();
+        model.apply(&AgentEvent::Reasoning {
+            delta: numbered_thought(9),
+        });
+        assert!(reasoning_is_live(&model.transcript, &model.streaming_text));
+        model.apply(&terminal);
+        assert!(
+            !reasoning_is_live(&model.transcript, &model.streaming_text),
+            "{terminal:?} left the thought looking live"
+        );
+    }
+}
+
+/// The budget is spent in *visual rows*, not logical lines. A chain of thought
+/// is usually a few paragraph-long lines, so a three-*line* window on a
+/// wrapped thought is most of the pane — and the block has to be the same
+/// height before and after the stream stops or it resizes under the reader.
+#[test]
+fn the_collapsed_row_budget_survives_a_single_paragraph_thought() {
+    let mut model = SessionModel::new();
+    // One logical line, far wider than the pane.
+    let para = format!("{}THE-TAIL", "reasoning noise ".repeat(40));
+    model.apply(&AgentEvent::Reasoning { delta: para });
+    let live = row_texts(&transcript_lines(&model, false, 60));
+    let live_block = first_block(&live).to_vec();
+    assert_eq!(live_block.len(), 7, "header + hint + 5 rows:\n{live:#?}");
+    assert!(
+        live_block[live_block.len() - 1].contains("THE-TAIL"),
+        "the newest text is on screen, not 600 chars above it:\n{live:#?}"
+    );
+    // Settling must not change the height.
+    model.apply(&AgentEvent::Text {
+        delta: "done".into(),
+    });
+    let settled = row_texts(&transcript_lines(&model, false, 60));
+    let settled_block = first_block(&settled);
+    assert_eq!(
+        settled_block.len(),
+        live_block.len(),
+        "same block height once settled:\n{settled:#?}"
+    );
+    assert!(
+        !settled_block.iter().any(|r| r.contains("THE-TAIL")),
+        "showing the head now:\n{settled_block:#?}"
+    );
+}
+
+/// A short thought needs no window at all — no fold marker, and identical
+/// live or settled.
+#[test]
+fn a_thought_inside_the_budget_renders_whole_either_way() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: "alpha\nbeta".into(),
+    });
+    let live = row_texts(&transcript_lines(&model, false, 0));
+    assert_eq!(live, vec!["⏵ thinking  2 lines", "alpha", "beta", ""]);
+    model.apply(&AgentEvent::Text { delta: "x".into() });
+    let settled = row_texts(&transcript_lines(&model, false, 0));
+    assert_eq!(&settled[..4], &live[..4], "no marker, no reflow");
+}
+
+/// The expanded view is unconditional: ctrl+r shows the whole thought whether
+/// it is live or settled, blank lines and all.
+#[test]
+fn expanding_a_live_thought_still_shows_all_of_it() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Reasoning {
+        delta: numbered_thought(9),
+    });
+    let rows = row_texts(&transcript_lines(&model, true, 0));
+    assert!(rows[0].contains("⏶"), "chevron flips:\n{rows:#?}");
+    assert_eq!(rows[1], "step-1");
+    assert_eq!(rows[9], "step-9");
+    assert!(
+        !rows.iter().any(|r| r.contains('⋯')),
+        "nothing is folded:\n{rows:#?}"
+    );
+}

--- a/stella-tui/src/ui.rs
+++ b/stella-tui/src/ui.rs
@@ -62,6 +62,11 @@ pub struct ViewportMetrics {
 /// `Reasoning` entry (see [`crate::model::SessionModel`]): `len` catches every
 /// append and `trailing_stream_len` catches the growing tail. No earlier entry
 /// is ever mutated, so no earlier change can slip past this pair.
+///
+/// A trailing thought settling — which flips it from tail-follow to head
+/// preview (`render::reasoning_is_live`) — needs no term of its own: every way
+/// out of live either appends an entry (`len`) or fills the answer preview
+/// (`streaming_len`).
 #[derive(Debug, Clone)]
 struct TranscriptCache {
     len: usize,
@@ -109,8 +114,9 @@ pub struct UiState {
     /// Selected row in the slash popup while it is open (clamped to the
     /// filtered matches at use time).
     pub slash_selected: usize,
-    /// Whether reasoning entries render in full. Off by default — collapsed
-    /// thinking shows a one-line live tail; `ctrl+r` toggles.
+    /// Whether reasoning entries render in full. Off by default — a collapsed
+    /// thought follows its tail while it streams and shows its head once
+    /// settled (`render::entry_lines`); `ctrl+r` toggles.
     pub thinking_expanded: bool,
     /// Whether the terminal is a *legacy* one (no kitty keyboard protocol).
     /// Enter semantics are universal now — bare `⏎` submits, a modified `⏎`

--- a/stella-tui/src/views/session.rs
+++ b/stella-tui/src/views/session.rs
@@ -20,8 +20,8 @@ use crate::deck::{AgentEntry, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::model::{FileState, TranscriptEntry};
 use crate::render::{
-    entry_lines, inner_height, inner_width, render_ask_user, render_hud, render_scope_review,
-    render_transcript_window,
+    entry_lines, inner_height, inner_width, reasoning_is_live, render_ask_user, render_hud,
+    render_scope_review, render_transcript_window, streaming_lines,
 };
 use crate::theme;
 use crate::transcript_nav::TurnDigest;
@@ -239,6 +239,7 @@ impl SessionFold {
                     files,
                     thinking,
                     expand_all || expanded.contains(&i),
+                    false,
                     width,
                     &mut self.prefix,
                 );
@@ -258,15 +259,13 @@ impl SessionFold {
                     files,
                     thinking,
                     expand_all || expanded.contains(&target),
+                    reasoning_is_live(transcript, streaming),
                     width,
                     &mut self.tail,
                 );
             }
         }
-        if !streaming.is_empty() {
-            let preview = TranscriptEntry::Text(streaming.to_string());
-            entry_lines(&preview, files, thinking, false, width, &mut self.tail);
-        }
+        streaming_lines(streaming, files, thinking, width, &mut self.tail);
     }
 
     /// Total visual rows (settled prefix + live tail).


### PR DESCRIPTION
## The problem

A collapsed thinking block showed the **first** 3 non-blank lines of the reasoning entry and then never moved. On a long turn the agent sits inside one thought for minutes, so the transcript froze on an opening line that had stopped being the interesting one — visually indistinguishable from a hung session.

## The change

While a thought is **still being written**, the block follows its tail:

```
⏵ thinking  6 lines
  ⋯ ctrl+o expands this thought · ctrl+r all     ← marker moves ABOVE the window
  rows, not logical lines.
  Otherwise one paragraph-long thought fills
  the whole pane on its own.
  Now checking how the deck's incremental
  fold caches settled entries.                  ← newest text, always the last row
```

Once it settles, it reverts to the head preview — scrollback is read top-down, and the opening is where a thought states what it is about (marker moves back below).

## Design notes

**Liveness is positional.** `reasoning_is_live` asks only *"is the trailing entry a `Reasoning`, and has the answer preview not started"*. Everything that ends a thought appends its own entry — a tool call, the authoritative `Text`, `Complete`, `Error` — so there is no flag to set and no timer to reset. The deck's incremental fold gets it for free: the tail re-folds per frame, and an entry only enters the cached prefix once something already follows it. Neither memo fingerprint needs a new term for the same reason: every exit from live moves `len` or `streaming_len`.

**The budget is now visual rows, not logical lines.** A chain of thought is usually a handful of paragraph-long lines, so a 5-*line* window on a wrapped thought was most of the pane, and how much you got depended on how the model happened to punctuate. Rows also keep the block the **same height** live or settled, so the stream stopping doesn't resize it under the reader.

One `entry_lines` arm governs every surface that renders reasoning content — both transcript renderers share it; everything else (trace ticker, traces tab, fleet dashboard) is a one-line 80-char `snip`, and the plain CLI surface prints nothing at all.

## Drive-bys

- Folds the two renderers' duplicated streaming-preview step into one `streaming_lines` (they were passing different view flags for the same thing).
- Moves the reasoning tests to `render/tests/thinking.rs` — the parent crossed the 1500-line guard.
- Corrects two doc comments that already claimed "collapsed thinking shows a one-line live tail" while the code showed the head.

## Verification

- `stella-tui`: **607 tests pass** (600 before, +7 new covering tail-follow, the one-row scroll per delta, reverting on settle, terminal events settling, the row budget under a single-paragraph thought, short thoughts needing no window, and expand-while-live).
- `make check` (no-scratch, action-pins, invariants, file-size, fmt, clippy `-D warnings`): **exit 0**.
- Rustdoc `-D warnings`: clean (run twice — `cargo doc` bails early).
- Rendered both code paths by hand: the classic `render` transcript at three stream positions, and the deck's `SessionFold` — including the case that matters, the *same* cache instance advancing the thought from live tail into the cached prefix (correctly re-folds to the head, no stale tail).
- Full workspace run has 6 pre-existing failures in `stella-tools/src/custom.rs` (5s process-spawn timeouts, load-sensitive) — they pass in isolation both here and on `main`, and that crate is untouched.


## Summary by Sourcery

Make collapsed reasoning blocks in the TUI follow the live tail while a thought is streaming, then revert to a fixed head preview once settled, using a shared row-based preview helper across transcript renderers.

Enhancements:
- Base reasoning preview height on visual rows instead of logical lines so collapsed thoughts keep a consistent size and show a more informative window.
- Introduce a positional liveness check for reasoning entries and share a single streaming preview fold between the classic transcript renderer and the deck session fold.
- Clarify comments and field docs around thinking expansion and liveness behaviour in the TUI.

Tests:
- Move reasoning-specific render tests into a dedicated thinking test module and add coverage for live tail-follow behaviour, row-budgeting, settling on terminal events, and expand-while-live.
