### PR TITLE
fix(deck): a create reports what it made instead of vanishing

### DIFF
--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -110,7 +110,7 @@ mod theme_cmd;
 use crate::memory::{SessionMemory, inject_recall_block};
 use crate::runtime::{SystemClock, TokioSleeper};
 use crate::subsession::{self, SubSessions, SupervisorMsg};
-use authoring::handle_agent_create;
+use authoring::{agents_list_creating, agents_list_inbound, handle_agent_create};
 pub(crate) use forwarder::spawn_forwarder;
 use scope_gate::DeckApprovalGate;
 
@@ -1521,7 +1521,9 @@ pub async fn run_deck_session(
                         // the turn settles (see `pending_create`).
                         Some(WorkspaceInput::AgentCreate { description, scope }) => {
                             pending_create = Some((description, scope));
-                            let _ = in_tx.send(agents_list_inbound(
+                            // `creating: true`: the deck's create dialog keeps
+                            // its spinner up through this interim snapshot.
+                            let _ = in_tx.send(agents_list_creating(
                                 &cfg.workspace_root,
                                 Some(
                                     "agent creation queued — it runs when the current turn \
@@ -3738,17 +3740,6 @@ fn handle_tools_input(
 }
 
 // ── Installed-agents manager (the AGENTS tab's INSTALLED AGENTS pane) ───────
-
-/// Build an [`Inbound::AgentsList`] from the definitions on disk at both
-/// scopes. `status`, when set, replaces the pane's hint line.
-fn agents_list_inbound(workspace_root: &std::path::Path, status: Option<String>) -> Inbound {
-    let project = crate::agents_installed::project_agents_dir(workspace_root);
-    let user = crate::agents_installed::user_agents_dir();
-    Inbound::AgentsList {
-        entries: crate::agents_installed::discover(user.as_deref(), &project),
-        status,
-    }
-}
 
 /// Handle one synchronous installed-agents op (refresh / save / pin) —
 /// pure filesystem work, answered with a fresh [`Inbound::AgentsList`].

--- a/stella-cli/src/command_deck/authoring.rs
+++ b/stella-cli/src/command_deck/authoring.rs
@@ -10,7 +10,60 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::config::Config;
 use crate::memory::{ReflectionReport, SessionMemory, turn_warrants_reflection};
 
-use super::{LEAD, agents_list_inbound};
+use super::LEAD;
+
+// ── Installed-agents snapshots ─────────────────────────────────────────────
+
+/// Build an [`Inbound::AgentsList`] from the definitions on disk at both
+/// scopes. `status`, when set, replaces the pane's hint line. `creating` is
+/// false: every snapshot built here is a settled state (a parked create
+/// announces itself via [`agents_list_creating`] instead), and `created` is
+/// unset (a completed create attaches the name via [`agents_list_created`]).
+pub(super) fn agents_list_inbound(
+    workspace_root: &std::path::Path,
+    status: Option<String>,
+) -> Inbound {
+    agents_list_created(workspace_root, status, None)
+}
+
+/// [`agents_list_inbound`] with the just-created agent's name attached — the
+/// completion form a successful `WorkspaceInput::AgentCreate` answers with, so
+/// the deck's create dialog can open the detail preview on that entry.
+fn agents_list_created(
+    workspace_root: &std::path::Path,
+    status: Option<String>,
+    created: Option<String>,
+) -> Inbound {
+    let project = crate::agents_installed::project_agents_dir(workspace_root);
+    let user = crate::agents_installed::user_agents_dir();
+    Inbound::AgentsList {
+        entries: crate::agents_installed::discover(user.as_deref(), &project),
+        status,
+        creating: false,
+        created,
+    }
+}
+
+/// An [`Inbound::AgentsList`] snapshot with `creating: true` — sent when an
+/// LLM-assisted agent creation is accepted but still in flight (parked behind
+/// a running turn), so the deck's create dialog keeps its spinner up rather
+/// than reading the interim snapshot as completion.
+pub(super) fn agents_list_creating(
+    workspace_root: &std::path::Path,
+    status: Option<String>,
+) -> Inbound {
+    match agents_list_inbound(workspace_root, status) {
+        Inbound::AgentsList {
+            entries, status, ..
+        } => Inbound::AgentsList {
+            entries,
+            status,
+            creating: true,
+            created: None,
+        },
+        other => other,
+    }
+}
 
 pub(super) fn forward_reflection_events(
     in_tx: &UnboundedSender<Inbound>,
@@ -75,20 +128,27 @@ pub(super) async fn handle_agent_create(
     budget_limit: Option<f64>,
     in_tx: &UnboundedSender<Inbound>,
 ) {
-    let status = match create_agent(description, scope, cfg, provider, budget_limit).await {
-        Ok(status) => status,
-        Err(error) => format!("agent creation failed: {error}"),
-    };
-    let _ = in_tx.send(agents_list_inbound(&cfg.workspace_root, Some(status)));
+    let (status, created) =
+        match create_agent(description, scope, cfg, provider, budget_limit).await {
+            Ok((status, name)) => (status, Some(name)),
+            Err(error) => (format!("agent creation failed: {error}"), None),
+        };
+    let _ = in_tx.send(agents_list_created(
+        &cfg.workspace_root,
+        Some(status),
+        created,
+    ));
 }
 
+/// Draft + install an agent from a description. Returns
+/// `(status line, created agent name)` on success.
 async fn create_agent(
     description: &str,
     scope: AgentScope,
     cfg: &Config,
     provider: &dyn Provider,
     budget_limit: Option<f64>,
-) -> Result<String, String> {
+) -> Result<(String, String), String> {
     let request = CompletionRequest {
         messages: crate::agents_installed::creation_messages(description),
         max_output_tokens: Some(1200),
@@ -117,11 +177,14 @@ async fn create_agent(
     let agent = crate::agents_installed::parse_generated_agent(&accounted.result.text)?;
     let dir = crate::agents_installed::agents_dir_for(scope, &cfg.workspace_root)?;
     let path = crate::agents_installed::install_new_agent(&dir, &agent)?;
-    Ok(format!(
-        "created {} ({} scope) at {} — v1 pinned (${:.6})",
+    Ok((
+        format!(
+            "created {} ({} scope) at {} — v1 pinned (${:.6})",
+            agent.name,
+            scope.label(),
+            path.display(),
+            accounted.cost_usd,
+        ),
         agent.name,
-        scope.label(),
-        path.display(),
-        accounted.cost_usd,
     ))
 }

--- a/stella-cli/src/command_deck/skills.rs
+++ b/stella-cli/src/command_deck/skills.rs
@@ -21,10 +21,22 @@ pub(super) fn deck_slash_commands(
 
 /// Snapshot the installed skills across BOTH scopes into an [`Inbound::Skills`].
 pub(super) fn skills_snapshot(workspace_root: &std::path::Path, status: Option<String>) -> Inbound {
+    skills_snapshot_created(workspace_root, status, None)
+}
+
+/// [`skills_snapshot`] with the just-created skill's name attached — the
+/// completion form a successful [`SkillOp::Create`] answers with, so the
+/// deck's create dialog can open the preview on exactly that row.
+fn skills_snapshot_created(
+    workspace_root: &std::path::Path,
+    status: Option<String>,
+    created: Option<String>,
+) -> Inbound {
     Inbound::Skills(SkillsView {
         rows: crate::skill_manager::enumerate(workspace_root),
         status,
         busy: false,
+        created,
     })
 }
 
@@ -293,9 +305,10 @@ pub(super) fn extract_skill_md(text: &str) -> String {
     text.trim().to_string()
 }
 
-/// LLM-assisted creation: search the registry for the request, rank the hits,
-/// have the model assemble ONE `SKILL.md` (reusing the existing provider path),
-/// and write it into `scope` as version 1. Returns a status string.
+/// LLM-assisted skill creation: search the registry for prior art, draft one
+/// `SKILL.md` with a single accounted model call, validate, and install it as
+/// v1. Returns `(status line, created skill name)` — the name is `Some` only
+/// when the skill actually landed on disk.
 async fn create_skill_llm(
     cfg: &Config,
     registry: &SkillRegistry,
@@ -303,7 +316,7 @@ async fn create_skill_llm(
     description: &str,
     workspace_root: &std::path::Path,
     budget_limit: Option<f64>,
-) -> String {
+) -> (String, Option<String>) {
     // 1. Search existing skills for inspiration (best-effort — a registry
     //    failure just means authoring from scratch).
     let argv = SkillRegistry::render(&registry.search_cmd, "{query}", description);
@@ -313,7 +326,7 @@ async fn create_skill_llm(
     //    path the rest of the session uses — never hand-rolled HTTP).
     let provider = match agent::build_provider(cfg) {
         Ok(p) => p,
-        Err(e) => return format!("create failed: {e}"),
+        Err(e) => return (format!("create failed: {e}"), None),
     };
     let req = CompletionRequest {
         messages: vec![
@@ -340,9 +353,12 @@ async fn create_skill_llm(
     {
         Ok(result) => result,
         Err(error) => {
-            return format!(
-                "model call failed: {} (${:.6})",
-                error.message, error.cost_usd
+            return (
+                format!(
+                    "model call failed: {} (${:.6})",
+                    error.message, error.cost_usd
+                ),
+                None,
             );
         }
     };
@@ -350,15 +366,23 @@ async fn create_skill_llm(
     // 3. Validate it parses as a real skill, then write it as v1.
     let name = match stella_core::skills::skill_from_file("SKILL.md", &content) {
         Ok(s) => s.name,
-        Err(_) => return "the model did not return a valid SKILL.md — try again".to_string(),
+        Err(_) => {
+            return (
+                "the model did not return a valid SKILL.md — try again".to_string(),
+                None,
+            );
+        }
     };
     match crate::skill_manager::create(scope, &name, &content, workspace_root) {
-        Ok(n) => format!(
-            "created {n} ({}) — v1 (${:.6})",
-            scope.label(),
-            accounted.cost_usd
+        Ok(n) => (
+            format!(
+                "created {n} ({}) — v1 (${:.6})",
+                scope.label(),
+                accounted.cost_usd
+            ),
+            Some(n),
         ),
-        Err(e) => format!("create failed: {e}"),
+        Err(e) => (format!("create failed: {e}"), None),
     }
 }
 
@@ -450,10 +474,10 @@ pub(super) fn handle_skills_input(
             let description = description.clone();
             let root = root.clone();
             tokio::spawn(async move {
-                let status =
+                let (status, created) =
                     create_skill_llm(&cfg, &registry, scope, &description, &root, budget_limit)
                         .await;
-                let _ = in_tx.send(skills_snapshot(&root, Some(status)));
+                let _ = in_tx.send(skills_snapshot_created(&root, Some(status), created));
             });
         }
     }

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -183,6 +183,8 @@ async fn main() -> std::io::Result<()> {
                     let _ = react_tx.send(Inbound::AgentsList {
                         entries: vec![],
                         status: Some("the demo has no agents on disk".to_string()),
+                        creating: false,
+                        created: None,
                     });
                 }
                 // The demo has no skills engine — answer with an empty list so
@@ -192,6 +194,7 @@ async fn main() -> std::io::Result<()> {
                         rows: vec![],
                         status: Some("the demo has no skills on disk".to_string()),
                         busy: false,
+                        created: None,
                     }));
                 }
                 // The ISSUES tab talks to a real tracker through the CLI

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -94,6 +94,16 @@ pub enum InstalledMode {
     CreateDescribe,
     /// Create-from-prompt, step 2: pick the install scope (project / user).
     CreateScope,
+    /// Create-from-prompt, step 3: the LLM draft is in flight — the dialog
+    /// stays open with an animated spinner until an [`Inbound::AgentsList`]
+    /// with `creating: false` lands. Esc hides the dialog (creation
+    /// continues); every other key is swallowed.
+    Creating,
+    /// Create-from-prompt, step 4: the creation settled. The dialog shows
+    /// the just-created agent's full definition (the same markdown detail
+    /// view as the skills preview) — or the driver's error when it failed
+    /// ([`InstalledPanel::create_error`]). ↑/↓ scroll · esc / ⏎ / q close.
+    CreateDone,
     /// The version picker (`v` on a row): ⏎ re-pins the highlighted version
     /// WITHOUT creating a new one — pin changes never increment the version.
     PickVersion,
@@ -129,6 +139,14 @@ pub struct InstalledPanel {
     pub create_desc: String,
     /// Scope choice in the create flow: 0 = project, 1 = user.
     pub scope_sel: usize,
+    /// The just-created agent's name, shown by [`InstalledMode::CreateDone`]
+    /// (its entry is looked up fresh in `entries` at render time).
+    pub created_name: Option<String>,
+    /// The driver's error when the creation failed — the
+    /// [`InstalledMode::CreateDone`] dialog shows it instead of a detail view.
+    pub create_error: Option<String>,
+    /// Scroll offset of the [`InstalledMode::CreateDone`] detail view.
+    pub created_scroll: u16,
     /// Selected row in the version picker.
     pub version_sel: usize,
 }
@@ -146,6 +164,9 @@ impl Default for InstalledPanel {
             editing: None,
             create_desc: String::new(),
             scope_sel: 0,
+            created_name: None,
+            create_error: None,
+            created_scroll: 0,
             version_sel: 0,
         }
     }
@@ -190,6 +211,17 @@ pub enum SkillPrompt {
     /// Type a short description for LLM-assisted creation (then the scope
     /// picker follows).
     CreateDescription { buffer: String },
+    /// The LLM-assisted creation is running driver-side: the dialog stays
+    /// open with an animated spinner until the refreshed [`Inbound::Skills`]
+    /// snapshot lands. Esc hides the dialog (creation continues); every
+    /// other key is swallowed.
+    Creating {
+        description: String,
+        scope: SkillScope,
+    },
+    /// The LLM-assisted creation failed: the dialog stays open showing the
+    /// driver's error so the outcome can't be missed. Esc / ⏎ / q close it.
+    CreateFailed { error: String },
     /// Edit a skill's body; saving increments its version and pins the new one.
     Edit {
         scope: SkillScope,
@@ -836,9 +868,14 @@ impl DeckUi {
                 InstalledMode::CreateDescribe => {
                     push_single_line(&mut self.installed.create_desc, text);
                 }
-                // Scope / version pickers hold no text — swallow, never leak.
-                InstalledMode::CreateScope | InstalledMode::PickVersion | InstalledMode::Browse => {
-                }
+                // Scope / version pickers, the in-flight creation dialog,
+                // and the created-detail view hold no text — swallow, never
+                // leak.
+                InstalledMode::CreateScope
+                | InstalledMode::Creating
+                | InstalledMode::CreateDone
+                | InstalledMode::PickVersion
+                | InstalledMode::Browse => {}
             }
             return;
         }
@@ -901,8 +938,14 @@ impl DeckUi {
                 Some(SkillPrompt::CreateDescription { buffer }) => push_single_line(buffer, text),
                 // The edit buffer is a genuine multi-line surface: verbatim.
                 Some(SkillPrompt::Edit { buffer, .. }) => buffer.push_str(text),
-                // Scope / pin pickers hold no text.
-                Some(SkillPrompt::Scope { .. } | SkillPrompt::Pin { .. }) => {}
+                // Scope / pin pickers and the creation dialog's in-flight /
+                // failed states hold no text.
+                Some(
+                    SkillPrompt::Scope { .. }
+                    | SkillPrompt::Pin { .. }
+                    | SkillPrompt::Creating { .. }
+                    | SkillPrompt::CreateFailed { .. },
+                ) => {}
                 None if self.skills.focus == SkillsFocus::Search => {
                     push_single_line(&mut self.skills.query, text);
                 }
@@ -983,12 +1026,29 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
     // The installed-agents list is out-of-band view state too — the driver
     // owns the definitions on disk and pushes fresh snapshots here; the
     // model fold ignores them.
-    if let Inbound::AgentsList { entries, status } = inbound {
+    if let Inbound::AgentsList {
+        entries,
+        status,
+        creating,
+        created,
+    } = inbound
+    {
         ui.installed.entries = entries.clone();
         ui.installed.loaded = true;
         // A fresh list is the completion signal for a refresh / save / pin /
-        // create op — clear the working flag.
-        ui.installed.busy = false;
+        // create op — clear the working flag. The one exception: a create
+        // still in flight driver-side (`creating`, e.g. parked behind a
+        // running turn) keeps the working state and the dialog's spinner up.
+        ui.installed.busy = *creating;
+        create::settle_agents_snapshot(
+            ui,
+            create::AgentsSnapshot {
+                entries,
+                status: status.as_ref(),
+                creating: *creating,
+                created: created.as_ref(),
+            },
+        );
         ui.installed.sel = ui.installed.sel.min(entries.len().saturating_sub(1));
         // A driver-supplied status (op outcome, error) replaces the hint; a
         // plain refresh sends none, leaving any client-side line standing.
@@ -1005,6 +1065,10 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         // spinner and disarm any half-armed uninstall.
         ui.skills.searching = false;
         ui.skills.uninstall_armed = false;
+        // The LLM-assisted create keeps its dialog open while the draft runs;
+        // the refreshed snapshot is its completion signal (see
+        // [`create::settle_skills_snapshot`]).
+        create::settle_skills_snapshot(ui, view);
         if view.status.is_some() {
             ui.skills.status = view.status.clone();
         }
@@ -1333,6 +1397,7 @@ fn push_single_line(buf: &mut String, text: &str) {
 /// the global composer, so a stop must leave a typed draft untouched. A
 /// pending ask-user gate never reaches them either — it folds the agent to
 /// [`AgentStatus::WaitingInput`], which fails rule 10's `Running` check.
+mod create;
 mod nav;
 pub use nav::TranscriptSearch;
 pub(crate) use nav::is_folded;
@@ -2185,8 +2250,10 @@ fn handle_inspect_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
 fn handle_installed_modal_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     match ui.installed.mode {
         InstalledMode::Edit => handle_agent_editor_key(key, ui),
-        InstalledMode::CreateDescribe => handle_create_describe_key(key, ui),
-        InstalledMode::CreateScope => handle_create_scope_key(key, ui),
+        InstalledMode::CreateDescribe => create::handle_describe_key(key, ui),
+        InstalledMode::CreateScope => create::handle_scope_key(key, ui),
+        InstalledMode::Creating => create::handle_creating_key(key, ui),
+        InstalledMode::CreateDone => create::handle_done_key(key, ui),
         InstalledMode::PickVersion => handle_pick_version_key(key, ui),
         // Unreachable — the gate only fires for non-Browse modes.
         InstalledMode::Browse => DeckAction::Ignored,
@@ -2251,68 +2318,6 @@ fn handle_agent_editor_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             let _ = handle_edit_key(key, &mut ui.installed.editor);
             DeckAction::Handled
         }
-    }
-}
-
-/// Create-from-prompt, step 1: a one-line description buffer. ⏎ advances to
-/// the scope picker; Esc cancels the flow.
-fn handle_create_describe_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
-    match key.code {
-        KeyCode::Esc => {
-            ui.installed.mode = InstalledMode::Browse;
-            ui.installed.status = None;
-            DeckAction::Handled
-        }
-        KeyCode::Enter => {
-            if ui.installed.create_desc.trim().is_empty() {
-                ui.installed.status = Some("describe the agent first".into());
-            } else {
-                ui.installed.mode = InstalledMode::CreateScope;
-                ui.installed.status = None;
-            }
-            DeckAction::Handled
-        }
-        KeyCode::Backspace => {
-            ui.installed.create_desc.pop();
-            DeckAction::Handled
-        }
-        KeyCode::Char(c)
-            if !key
-                .modifiers
-                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
-        {
-            ui.installed.create_desc.push(c);
-            DeckAction::Handled
-        }
-        _ => DeckAction::Handled,
-    }
-}
-
-/// Create-from-prompt, step 2: the install-scope picker (project / user,
-/// mirroring the skills install flow's scope question). ⏎ dispatches the
-/// LLM-assisted creation; Esc steps back to the description.
-fn handle_create_scope_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
-    match key.code {
-        KeyCode::Esc => {
-            ui.installed.mode = InstalledMode::CreateDescribe;
-            DeckAction::Handled
-        }
-        KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right => {
-            ui.installed.scope_sel = 1 - ui.installed.scope_sel.min(1);
-            DeckAction::Handled
-        }
-        KeyCode::Enter => {
-            let description = ui.installed.create_desc.trim().to_string();
-            let scope = ui.installed.create_scope();
-            ui.installed.mode = InstalledMode::Browse;
-            ui.installed.busy = true;
-            ui.installed.status = Some(format!(
-                "drafting the agent with the session model ({} scope)…",
-                scope.label()
-            ));
-            DeckAction::Send(WorkspaceInput::AgentCreate { description, scope })
-        }
-        _ => DeckAction::Handled,
     }
 }
 
@@ -3083,23 +3088,8 @@ fn handle_skills_prompt_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
                     } else {
                         SkillScope::Project
                     };
-                    ui.skills.prompt = None;
                     ui.skills.searching = true;
-                    match action {
-                        ScopeAction::Install { id } => {
-                            ui.skills.status =
-                                Some(format!("installing {id} for {}…", scope.label()));
-                            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Install { scope, id }))
-                        }
-                        ScopeAction::Create { description } => {
-                            ui.skills.status =
-                                Some(format!("assembling a skill for {}…", scope.label()));
-                            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Create {
-                                scope,
-                                description,
-                            }))
-                        }
-                    }
+                    create::dispatch_skills_scope(ui, action, scope)
                 }
                 // Modal: swallow everything else.
                 _ => DeckAction::Handled,
@@ -3140,6 +3130,9 @@ fn handle_skills_prompt_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             }
             _ => DeckAction::Handled,
         },
+        // The create dialog's in-flight / failed states (see [`create`]).
+        Some(SkillPrompt::Creating { .. }) => create::handle_skills_creating_key(key, ui),
+        Some(SkillPrompt::CreateFailed { .. }) => create::handle_skills_failed_key(key, ui),
         // The edit buffer: a minimal textarea. ⏎ inserts a newline; ctrl+s saves
         // (a new pinned version); esc cancels.
         Some(SkillPrompt::Edit {

--- a/stella-tui/src/deck_ui/create.rs
+++ b/stella-tui/src/deck_ui/create.rs
@@ -1,0 +1,282 @@
+//! The create-from-prompt flow for agents and skills: its key table and the
+//! two snapshot transitions that settle it.
+//!
+//! Split from `deck_ui` because "describe → pick scope → watch it draft → read
+//! what landed" is one coherent four-step conversation rather than more of the
+//! deck's key table, and because both halves of it — the AGENTS tab's
+//! installed-agents pane and the SKILLS tab — run the *same* shape against
+//! different driver ops. Keeping them adjacent is what makes that symmetry
+//! checkable.
+//!
+//! The recurring rule here: **a create never settles by vanishing.** The
+//! dialog that dispatched the op is the dialog that reports its outcome — the
+//! created definition on success, the driver's error on failure — because the
+//! op is slow (a model call, sometimes parked behind a running turn) and a
+//! dialog that closed on dispatch left the reader with no idea whether
+//! anything happened. That is the usability bug this module exists to fix.
+//!
+//! Two consequences worth stating, since both are load-bearing:
+//!
+//! - **The completion signal is a driver snapshot, not the keypress.** The
+//!   in-flight states ([`super::InstalledMode::Creating`],
+//!   [`super::SkillPrompt::Creating`]) are left by
+//!   [`settle_agents_snapshot`] / [`settle_skills_snapshot`], never by a key.
+//!   An interim snapshot for a *parked* create carries `creating: true`
+//!   precisely so it cannot be mistaken for the real thing.
+//! - **Esc hides, it does not cancel.** The driver-side draft keeps running
+//!   and its snapshot still folds in; the reader has only opted out of
+//!   watching. Nothing here can abort a model call already in flight, so
+//!   nothing here pretends to.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::{DeckAction, DeckUi, InstalledMode, ScopeAction, SkillPreview, SkillPrompt};
+use crate::envelope::{InstalledAgentEntry, SkillOp, SkillScope, SkillsView, WorkspaceInput};
+
+// ── The agent create flow (the AGENTS tab's INSTALLED AGENTS pane) ──────────
+
+/// Step 1: a one-line description buffer. ⏎ advances to the scope picker;
+/// Esc cancels the flow.
+pub(super) fn handle_describe_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.status = None;
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            if ui.installed.create_desc.trim().is_empty() {
+                ui.installed.status = Some("describe the agent first".into());
+            } else {
+                ui.installed.mode = InstalledMode::CreateScope;
+                ui.installed.status = None;
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Backspace => {
+            ui.installed.create_desc.pop();
+            DeckAction::Handled
+        }
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META) =>
+        {
+            ui.installed.create_desc.push(c);
+            DeckAction::Handled
+        }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// Step 2: the install-scope picker (project / user, mirroring the skills
+/// install flow's scope question). ⏎ dispatches the LLM-assisted creation;
+/// Esc steps back to the description.
+pub(super) fn handle_scope_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc => {
+            ui.installed.mode = InstalledMode::CreateDescribe;
+            DeckAction::Handled
+        }
+        KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right => {
+            ui.installed.scope_sel = 1 - ui.installed.scope_sel.min(1);
+            DeckAction::Handled
+        }
+        KeyCode::Enter => {
+            let description = ui.installed.create_desc.trim().to_string();
+            let scope = ui.installed.create_scope();
+            // The dialog STAYS open: the creating state keeps an animated
+            // spinner up until an [`crate::envelope::Inbound::AgentsList`]
+            // with `creating: false` (the completion signal) lands.
+            ui.installed.mode = InstalledMode::Creating;
+            ui.installed.busy = true;
+            ui.installed.status = Some(format!(
+                "drafting the agent with the session model ({} scope)…",
+                scope.label()
+            ));
+            DeckAction::Send(WorkspaceInput::AgentCreate { description, scope })
+        }
+        _ => DeckAction::Handled,
+    }
+}
+
+/// Step 3: the in-flight creation dialog. Fully modal — Esc hides it and
+/// everything else is swallowed.
+///
+/// Hiding deliberately clears no progress state: the driver-side draft keeps
+/// running, `busy` stays set (so an empty list still reads "loading" rather
+/// than "no agents installed"), and `status` keeps the drafting line in the
+/// browse footer. The reader loses the spinner, not the fact of the op.
+pub(super) fn handle_creating_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if matches!(key.code, KeyCode::Esc) {
+        ui.installed.mode = InstalledMode::Browse;
+    }
+    DeckAction::Handled
+}
+
+/// Step 4: the settled dialog — the created agent's detail view (or the
+/// failure notice). ↑/↓ and PageUp/Down scroll the definition (clamped at
+/// render time, like the skills preview); esc / ⏎ / q close it.
+pub(super) fn handle_done_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    match key.code {
+        KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+            ui.installed.mode = InstalledMode::Browse;
+            ui.installed.created_name = None;
+            ui.installed.create_error = None;
+            ui.installed.created_scroll = 0;
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            ui.installed.created_scroll = ui.installed.created_scroll.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            ui.installed.created_scroll = ui.installed.created_scroll.saturating_add(1);
+        }
+        KeyCode::PageUp => {
+            ui.installed.created_scroll = ui.installed.created_scroll.saturating_sub(10);
+        }
+        KeyCode::PageDown | KeyCode::Char(' ') => {
+            ui.installed.created_scroll = ui.installed.created_scroll.saturating_add(10);
+        }
+        KeyCode::Home => ui.installed.created_scroll = 0,
+        KeyCode::End => ui.installed.created_scroll = u16::MAX,
+        _ => {}
+    }
+    DeckAction::Handled
+}
+
+/// Settle an in-flight agent create against a fresh driver snapshot.
+///
+/// A no-op unless the creating dialog is actually up and the snapshot is the
+/// completion (`creating: false`) — an interim snapshot for a create parked
+/// behind a running turn must keep the spinner going. On completion the dialog
+/// transitions **in place**: the created agent's detail view on success, the
+/// driver's `status` as the error on failure. Never silently back to Browse.
+pub(super) fn settle_agents_snapshot(ui: &mut DeckUi, snap: AgentsSnapshot<'_>) {
+    if ui.installed.mode != InstalledMode::Creating || snap.creating {
+        return;
+    }
+    ui.installed.created_name = snap.created.cloned();
+    ui.installed.create_error = if snap.created.is_some() {
+        None
+    } else {
+        Some(
+            snap.status
+                .cloned()
+                .unwrap_or_else(|| "agent creation failed".to_string()),
+        )
+    };
+    ui.installed.created_scroll = 0;
+    ui.installed.mode = InstalledMode::CreateDone;
+    // Select the new agent so the list lands on it after close.
+    if let Some(name) = snap.created
+        && let Some(idx) = snap.entries.iter().position(|e| &e.name == name)
+    {
+        ui.installed.sel = idx;
+    }
+}
+
+/// The borrowed fields of an [`crate::envelope::Inbound::AgentsList`] that
+/// [`settle_agents_snapshot`] needs. A struct rather than four positional
+/// arguments because `creating` and `created` are easy to transpose and the
+/// whole point of them is that they mean different things.
+pub(super) struct AgentsSnapshot<'a> {
+    pub entries: &'a [InstalledAgentEntry],
+    pub status: Option<&'a String>,
+    /// True while the create is still in flight driver-side — this snapshot is
+    /// interim and must NOT settle the dialog.
+    pub creating: bool,
+    /// The installed agent's name when this snapshot is a create's completion.
+    pub created: Option<&'a String>,
+}
+
+// ── The skill create flow (the SKILLS tab) ─────────────────────────────────
+
+/// Answer the SKILLS scope picker's ⏎ for whichever op it was asked about.
+///
+/// The asymmetry is the point: an **install** closes the dialog (the npx op is
+/// quick and the refreshed list is its own receipt), while a **create** leaves
+/// the dialog open in [`SkillPrompt::Creating`] so an animated spinner holds
+/// the reader's place until the refreshed snapshot settles it.
+pub(super) fn dispatch_skills_scope(
+    ui: &mut DeckUi,
+    action: ScopeAction,
+    scope: SkillScope,
+) -> DeckAction {
+    match action {
+        ScopeAction::Install { id } => {
+            ui.skills.prompt = None;
+            ui.skills.status = Some(format!("installing {id} for {}…", scope.label()));
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Install { scope, id }))
+        }
+        ScopeAction::Create { description } => {
+            ui.skills.prompt = Some(SkillPrompt::Creating {
+                description: description.clone(),
+                scope,
+            });
+            ui.skills.status = Some(format!("assembling a skill for {}…", scope.label()));
+            DeckAction::Send(WorkspaceInput::Skill(SkillOp::Create {
+                scope,
+                description,
+            }))
+        }
+    }
+}
+
+/// The skills creation-in-flight dialog: fully modal. Esc hides it (the
+/// driver-side creation keeps running and the refreshed snapshot still folds
+/// in); everything else is swallowed so keys never leak to the composer.
+pub(super) fn handle_skills_creating_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if matches!(key.code, KeyCode::Esc) {
+        ui.skills.prompt = None;
+    }
+    DeckAction::Handled
+}
+
+/// The skills creation-failed dialog: esc / ⏎ / q acknowledge and close.
+pub(super) fn handle_skills_failed_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
+        ui.skills.prompt = None;
+    }
+    DeckAction::Handled
+}
+
+/// Settle an in-flight skill create against a fresh driver snapshot.
+///
+/// A no-op unless the creating dialog is up. On success the dialog becomes the
+/// created skill's `ctrl+o` preview (title, scope subtitle, rendered
+/// `SKILL.md`) so the reader reads what actually landed; on failure it shows
+/// the driver's error — either way the outcome can't be missed.
+pub(super) fn settle_skills_snapshot(ui: &mut DeckUi, view: &SkillsView) {
+    if !matches!(ui.skills.prompt, Some(SkillPrompt::Creating { .. })) {
+        return;
+    }
+    let created = view
+        .created
+        .as_ref()
+        .and_then(|name| view.rows.iter().find(|r| &r.name == name));
+    let Some(row) = created else {
+        ui.skills.prompt = Some(SkillPrompt::CreateFailed {
+            error: view
+                .status
+                .clone()
+                .unwrap_or_else(|| "skill creation failed".to_string()),
+        });
+        return;
+    };
+    ui.skills.prompt = None;
+    ui.skills.preview = Some(SkillPreview {
+        title: row.name.clone(),
+        subtitle: format!("{} · {} · v{}", row.scope.label(), row.origin, row.version),
+        pending: None,
+        body: Some(if row.body.trim().is_empty() {
+            "*(this skill has an empty body)*".to_string()
+        } else {
+            row.body.clone()
+        }),
+        scroll: 0,
+    });
+    // Select the new skill so the list lands on it after close.
+    if let Some(idx) = view.rows.iter().position(|r| r.name == row.name) {
+        ui.skills.sel = idx;
+    }
+}

--- a/stella-tui/src/deck_ui/tests/graph.rs
+++ b/stella-tui/src/deck_ui/tests/graph.rs
@@ -226,6 +226,8 @@ fn agents_list_ingest_updates_the_panel_out_of_band_and_clamps() {
         &Inbound::AgentsList {
             entries: vec![installed_entry("reviewer", 1)],
             status: Some("saved".into()),
+            creating: false,
+            created: None,
         },
         &mut model,
         &mut ui,
@@ -326,8 +328,147 @@ fn create_flow_describes_picks_scope_and_dispatches_the_llm_draft() {
             scope: AgentScope::Project,
         })
     );
-    assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    assert_eq!(
+        ui.installed.mode,
+        InstalledMode::Creating,
+        "the dialog stays open with the in-flight spinner"
+    );
     assert!(ui.installed.busy);
+}
+
+#[test]
+fn agent_creating_dialog_survives_a_queued_snapshot_and_ends_in_the_detail_view() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = installed_ui(vec![]);
+    ui.installed.mode = InstalledMode::Creating;
+    ui.installed.busy = true;
+
+    // Fully modal: printable keys and ⏎ are swallowed.
+    for k in [ch('n'), key(KeyCode::Enter)] {
+        assert_eq!(handle_deck_key(k, &model, &mut ui), DeckAction::Handled);
+    }
+    assert_eq!(ui.installed.mode, InstalledMode::Creating);
+    assert_eq!(ui.composer.buffer(), "");
+
+    // A parked create's interim snapshot (`creating: true`) must NOT read as
+    // completion — the dialog and its spinner stay up.
+    ingest_inbound(
+        &Inbound::AgentsList {
+            entries: vec![],
+            status: Some("agent creation queued — it runs when the current turn finishes".into()),
+            creating: true,
+            created: None,
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert_eq!(
+        ui.installed.mode,
+        InstalledMode::Creating,
+        "a queued interim snapshot keeps the spinner up"
+    );
+    assert!(ui.installed.busy);
+
+    // The settled snapshot naming the created agent transitions the dialog
+    // into the detail view of exactly that entry (the ctrl+o treatment).
+    ingest_inbound(
+        &Inbound::AgentsList {
+            entries: vec![installed_entry("older", 1), installed_entry("drafted", 1)],
+            status: Some("created drafted (project scope) — v1 pinned".into()),
+            creating: false,
+            created: Some("drafted".into()),
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert_eq!(
+        ui.installed.mode,
+        InstalledMode::CreateDone,
+        "the dialog shows the created agent, not Browse"
+    );
+    assert_eq!(ui.installed.created_name.as_deref(), Some("drafted"));
+    assert!(ui.installed.create_error.is_none());
+    assert_eq!(ui.installed.sel, 1, "the list lands on the new agent");
+    assert!(!ui.installed.busy);
+
+    // ⏎ acknowledges and returns to Browse.
+    handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    assert!(ui.installed.created_name.is_none());
+}
+
+#[test]
+fn agent_create_done_view_scrolls_like_the_skills_preview() {
+    let model = model_with(&["lead"]);
+    let mut ui = installed_ui(vec![installed_entry("drafted", 1)]);
+    ui.installed.mode = InstalledMode::CreateDone;
+    ui.installed.created_name = Some("drafted".into());
+
+    // ↓ / PageDown advance the offset (render clamps it to content);
+    // ↑ / Home walk it back — the same verbs as the ctrl+o skill preview.
+    handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+    handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+    assert_eq!(ui.installed.created_scroll, 2);
+    handle_deck_key(key(KeyCode::PageDown), &model, &mut ui);
+    assert_eq!(ui.installed.created_scroll, 12);
+    handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+    assert_eq!(ui.installed.created_scroll, 11);
+    handle_deck_key(key(KeyCode::Home), &model, &mut ui);
+    assert_eq!(ui.installed.created_scroll, 0);
+    // The view is still up throughout — scrolling never closes it.
+    assert_eq!(ui.installed.mode, InstalledMode::CreateDone);
+    // `q` closes it and clears the transient state, like the preview.
+    handle_deck_key(ch('q'), &model, &mut ui);
+    assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    assert!(ui.installed.created_name.is_none());
+    assert_eq!(ui.installed.created_scroll, 0);
+}
+
+#[test]
+fn agent_failed_create_shows_the_error_in_the_dialog() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = installed_ui(vec![]);
+    ui.installed.mode = InstalledMode::Creating;
+    ui.installed.busy = true;
+    // A settled snapshot WITHOUT a created name is a failure — the dialog
+    // shows the driver's status as the error instead of vanishing.
+    ingest_inbound(
+        &Inbound::AgentsList {
+            entries: vec![],
+            status: Some("agent creation failed: draft call failed: boom".into()),
+            creating: false,
+            created: None,
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert_eq!(ui.installed.mode, InstalledMode::CreateDone);
+    assert!(
+        ui.installed
+            .create_error
+            .as_deref()
+            .is_some_and(|e| e.contains("draft call failed: boom")),
+        "the failure stays in the dialog: {:?}",
+        ui.installed.create_error
+    );
+    // Esc acknowledges and closes.
+    handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+    assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    assert!(ui.installed.create_error.is_none());
+}
+
+#[test]
+fn agent_creating_dialog_esc_hides_but_the_op_stays_busy() {
+    let model = model_with(&["lead"]);
+    let mut ui = installed_ui(vec![]);
+    ui.installed.mode = InstalledMode::Creating;
+    ui.installed.busy = true;
+    handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+    assert_eq!(ui.installed.mode, InstalledMode::Browse);
+    assert!(
+        ui.installed.busy,
+        "hiding the dialog does not cancel the driver-side create"
+    );
 }
 
 #[test]

--- a/stella-tui/src/deck_ui/tests/skills.rs
+++ b/stella-tui/src/deck_ui/tests/skills.rs
@@ -95,6 +95,7 @@ fn skills_ctrl_o_on_installed_opens_preview_with_local_body() {
         rows: vec![r],
         status: None,
         busy: false,
+        created: None,
     };
     // ctrl+o must NOT toggle chain-of-thought on the SKILLS tab — it opens
     // the preview, with the body on hand (no driver round-trip).
@@ -203,6 +204,7 @@ fn skills_space_toggles_and_two_ctrl_x_uninstalls() {
         rows: vec![a_row("sql-style", SkillScope::Project, true)],
         status: None,
         busy: false,
+        created: None,
     };
     let a = handle_deck_key(ch(' '), &model, &mut ui);
     assert_eq!(
@@ -238,6 +240,7 @@ fn skills_e_opens_edit_overlay_and_ctrl_s_saves() {
         rows: vec![r],
         status: None,
         busy: false,
+        created: None,
     };
     handle_deck_key(ch('e'), &model, &mut ui);
     assert!(matches!(
@@ -272,6 +275,7 @@ fn skills_manage_hotkeys_yield_to_a_nonempty_composer() {
         rows: vec![r],
         status: None,
         busy: false,
+        created: None,
     };
 
     // 'r' is not a hotkey → it falls through to the composer, so the
@@ -312,6 +316,7 @@ fn skills_p_opens_pin_picker_and_enter_pins() {
         rows: vec![r],
         status: None,
         busy: false,
+        created: None,
     };
     handle_deck_key(ch('p'), &model, &mut ui);
     assert!(matches!(
@@ -364,6 +369,133 @@ fn skills_n_creates_via_description_then_scope() {
             description: "extract tables from pdfs".into(),
         }))
     );
+    // The dialog does NOT close on dispatch: the creating state keeps an
+    // animated spinner up until the refreshed skills snapshot folds in.
+    assert!(
+        matches!(ui.skills.prompt, Some(SkillPrompt::Creating { .. })),
+        "dispatch keeps the dialog open in the creating state: {:?}",
+        ui.skills.prompt
+    );
+}
+
+#[test]
+fn skills_creating_dialog_becomes_the_preview_of_the_created_skill() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = skills_ui();
+    ui.skills.prompt = Some(SkillPrompt::Creating {
+        description: "extract tables from pdfs".into(),
+        scope: SkillScope::Project,
+    });
+    ui.skills.searching = true;
+
+    // Fully modal: printable keys and ⏎ are swallowed — nothing re-dispatches
+    // and nothing leaks into the composer.
+    for k in [ch('x'), key(KeyCode::Enter)] {
+        assert_eq!(handle_deck_key(k, &model, &mut ui), DeckAction::Handled);
+    }
+    assert!(matches!(
+        ui.skills.prompt,
+        Some(SkillPrompt::Creating { .. })
+    ));
+    assert_eq!(ui.composer.buffer(), "");
+
+    // The refreshed snapshot naming the created skill is the completion
+    // signal: the dialog becomes the ctrl+o preview of exactly that skill.
+    let mut created = a_row("pdf-tables", SkillScope::Project, true);
+    created.body = "# PDF Tables\nextract tables".into();
+    let view = SkillsView {
+        rows: vec![a_row("other", SkillScope::User, true), created],
+        status: Some("created pdf-tables (project) — v1".into()),
+        busy: false,
+        created: Some("pdf-tables".into()),
+    };
+    ingest_inbound(&Inbound::Skills(view), &mut model, &mut ui);
+    assert!(ui.skills.prompt.is_none(), "the create dialog is done");
+    assert!(!ui.skills.searching);
+    let preview = ui.skills.preview.as_ref().expect("the preview opened");
+    assert_eq!(preview.title, "pdf-tables");
+    assert_eq!(
+        preview.body.as_deref(),
+        Some("# PDF Tables\nextract tables"),
+        "the created skill's body shows — same as ctrl+o on the row"
+    );
+    assert_eq!(ui.skills.sel, 1, "the list lands on the new skill");
+}
+
+#[test]
+fn skills_failed_create_shows_the_error_in_the_dialog() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = skills_ui();
+    ui.skills.prompt = Some(SkillPrompt::Creating {
+        description: "d".into(),
+        scope: SkillScope::Project,
+    });
+    ui.skills.searching = true;
+    // A completion snapshot WITHOUT a created name is a failure: the dialog
+    // shows the driver's status as the error instead of vanishing.
+    let view = SkillsView {
+        rows: vec![],
+        status: Some("the model did not return a valid SKILL.md — try again".into()),
+        busy: false,
+        created: None,
+    };
+    ingest_inbound(&Inbound::Skills(view), &mut model, &mut ui);
+    assert!(
+        matches!(
+            ui.skills.prompt,
+            Some(SkillPrompt::CreateFailed { ref error })
+                if error.contains("did not return a valid SKILL.md")
+        ),
+        "the failure stays in the dialog: {:?}",
+        ui.skills.prompt
+    );
+    assert!(ui.skills.preview.is_none(), "no preview on failure");
+    // Fully modal: other printable keys are swallowed, never re-dispatched
+    // and never leaked into the composer.
+    for k in [ch('x'), ch('n')] {
+        assert_eq!(handle_deck_key(k, &model, &mut ui), DeckAction::Handled);
+    }
+    assert!(matches!(
+        ui.skills.prompt,
+        Some(SkillPrompt::CreateFailed { .. })
+    ));
+    assert_eq!(ui.composer.buffer(), "");
+    // Esc acknowledges and closes.
+    handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+    assert!(ui.skills.prompt.is_none());
+}
+
+#[test]
+fn skills_creating_dialog_esc_hides_but_creation_still_folds_in() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = skills_ui();
+    ui.skills.prompt = Some(SkillPrompt::Creating {
+        description: "d".into(),
+        scope: SkillScope::User,
+    });
+    ui.skills.searching = true;
+    // Esc hides the dialog — the driver-side creation keeps running.
+    handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+    assert!(ui.skills.prompt.is_none());
+    assert!(
+        ui.skills.searching,
+        "hiding the dialog does not stop the op"
+    );
+    // The snapshot still folds in normally — with the dialog gone, no
+    // preview pops (the user opted out of watching).
+    let view = SkillsView {
+        rows: vec![a_row("d-skill", SkillScope::User, true)],
+        status: Some("created d-skill (user) — v1".into()),
+        busy: false,
+        created: Some("d-skill".into()),
+    };
+    ingest_inbound(&Inbound::Skills(view), &mut model, &mut ui);
+    assert!(!ui.skills.searching);
+    assert!(ui.skills.preview.is_none(), "no surprise popup after esc");
+    assert_eq!(
+        ui.skills.status.as_deref(),
+        Some("created d-skill (user) — v1")
+    );
 }
 
 #[test]
@@ -375,6 +507,7 @@ fn skills_snapshot_ingest_updates_view_and_clears_searching() {
         rows: vec![a_row("a", SkillScope::Project, true)],
         status: Some("done".into()),
         busy: false,
+        created: None,
     };
     ingest_inbound(&Inbound::Skills(view), &mut model, &mut ui);
     assert_eq!(ui.skills.view.rows.len(), 1);

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -218,6 +218,18 @@ pub enum Inbound {
     AgentsList {
         entries: Vec<InstalledAgentEntry>,
         status: Option<String>,
+        /// True while an LLM-assisted agent creation is still in flight
+        /// driver-side (e.g. parked behind a running turn). The create
+        /// dialog keeps its spinner up until a list arrives with this
+        /// `false` — a queued interim snapshot must not read as done.
+        creating: bool,
+        /// The name of the agent a just-completed
+        /// [`WorkspaceInput::AgentCreate`] installed, when this snapshot is
+        /// that op's completion. The create dialog transitions into the
+        /// detail preview of exactly this entry; `None` on a failed create
+        /// (the dialog shows `status` as the error) and on every other
+        /// snapshot.
+        created: Option<String>,
     },
     /// A refreshed snapshot of the installed skills for the SKILLS tab. The
     /// driver owns the skills on disk (both scopes), their enabled/version/pin
@@ -1080,6 +1092,12 @@ pub struct SkillsView {
     /// True while a driver op (npx search/install, LLM create) is in flight,
     /// so the tab can show a working state.
     pub busy: bool,
+    /// The name of the skill a just-completed [`SkillOp::Create`] wrote,
+    /// when this snapshot is that op's completion. The create dialog
+    /// transitions into the ctrl+o preview of exactly this row; `None` on a
+    /// failed create (the dialog shows `status` as the error) and on every
+    /// other snapshot.
+    pub created: Option<String>,
 }
 
 /// A SKILLS-tab operation routed to the driver, which owns the disk + npx +

--- a/stella-tui/src/views/agents.rs
+++ b/stella-tui/src/views/agents.rs
@@ -51,7 +51,7 @@ pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buf
     let body = bands[1];
     match ui.agents_pane {
         AgentsPane::Executions => render_executions(model, ui, body, buf),
-        AgentsPane::Installed => crate::views::installed::render(ui, body, buf),
+        AgentsPane::Installed => crate::views::installed::render(ui, model.now_ms, body, buf),
     }
 }
 

--- a/stella-tui/src/views/installed.rs
+++ b/stella-tui/src/views/installed.rs
@@ -23,7 +23,7 @@ use crate::theme;
 /// Column headers for the browse list, matching `widths` in [`render_list`].
 const HEADERS: [&str; 5] = ["Agent", "Scope", "Ver", "Description", "Toolbelt"];
 
-pub fn render(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+pub fn render(ui: &mut DeckUi, now_ms: u64, area: Rect, buf: &mut Buffer) {
     if area.height == 0 || area.width == 0 {
         return;
     }
@@ -32,6 +32,8 @@ pub fn render(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
         InstalledMode::Edit => render_editor(&ui.installed, area, buf),
         InstalledMode::CreateDescribe => render_create_describe(&ui.installed, area, buf),
         InstalledMode::CreateScope => render_create_scope(&ui.installed, area, buf),
+        InstalledMode::Creating => render_creating(&ui.installed, now_ms, ui.no_anim, area, buf),
+        InstalledMode::CreateDone => render_create_done(&mut ui.installed, area, buf),
         InstalledMode::PickVersion => render_version_picker(&ui.installed, area, buf),
     }
 }
@@ -241,6 +243,159 @@ fn render_create_scope(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
     }
 }
 
+/// Create-from-prompt, step 3: the in-flight creation dialog. Stays up —
+/// with an animated spinner driven by the deck clock — until the driver's
+/// completing [`crate::envelope::Inbound::AgentsList`] folds in. The status
+/// line carries the driver's progress notes (e.g. "queued behind the
+/// running turn").
+fn render_creating(
+    panel: &InstalledPanel,
+    now_ms: u64,
+    no_anim: bool,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" New Agent — creating… · esc hides (creation continues) ")
+        .border_style(Style::default().fg(theme::ACCENT));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 {
+        return;
+    }
+    let spinner = crate::views::spinner_glyph(now_ms, no_anim);
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(
+                format!("{spinner} "),
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(
+                    "Drafting the agent with the session model ({} scope)…",
+                    panel.create_scope().label()
+                ),
+                theme::body(),
+            ),
+        ]),
+        Line::default(),
+        Line::from(Span::styled(
+            format!("“{}”", panel.create_desc.trim()),
+            theme::muted(),
+        )),
+        Line::default(),
+        Line::from(Span::styled(
+            "the new agent appears here the moment the draft installs",
+            theme::muted(),
+        )),
+    ];
+    if let Some(status) = &panel.status {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(status.clone(), theme::muted())));
+    }
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .render(inner, buf);
+}
+
+/// Create-from-prompt, step 4: the settled creation dialog. On success the
+/// just-created agent's full definition renders through Stella's own
+/// markdown renderer — the SAME detail treatment as the skills tab's ctrl+o
+/// preview — scrollable and clamped to content here (the key handler only
+/// increments the offset). On failure the driver's error shows instead.
+fn render_create_done(panel: &mut InstalledPanel, area: Rect, buf: &mut Buffer) {
+    // Failure: the error dialog. The outcome must be impossible to miss.
+    if let Some(error) = panel.create_error.clone() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" New Agent — creation failed · esc / ⏎ close ")
+            .border_style(Style::default().fg(theme::DANGER));
+        let inner = block.inner(area);
+        block.render(area, buf);
+        if inner.height == 0 {
+            return;
+        }
+        let lines = vec![
+            Line::from(vec![
+                Span::styled(
+                    "✖ ",
+                    Style::default()
+                        .fg(theme::DANGER)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("The agent was not created", theme::body()),
+            ]),
+            Line::default(),
+            Line::from(Span::styled(error, Style::default().fg(theme::DANGER))),
+        ];
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(inner, buf);
+        return;
+    }
+
+    // Success: the created agent's detail view, looked up fresh in the
+    // driver's snapshot (never a stale copy).
+    let entry = panel
+        .created_name
+        .as_ref()
+        .and_then(|name| panel.entries.iter().find(|e| &e.name == name))
+        .cloned();
+    let Some(entry) = entry else {
+        // The name vanished between snapshots — degrade honestly.
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" New Agent — created · esc / ⏎ close ")
+            .border_style(Style::default().fg(theme::ACCENT));
+        let inner = block.inner(area);
+        block.render(area, buf);
+        Paragraph::new("created — but the entry is not in the latest list (press r to reload)")
+            .style(theme::muted())
+            .render(inner, buf);
+        return;
+    };
+
+    let title = format!(" ✓ created {} — ↑/↓ scroll · esc / ⏎ close ", entry.name);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(theme::ACCENT));
+    let inner = block.inner(area);
+    block.render(area, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+    // A dim subtitle line (scope · version · toolbelt), then the scrollable
+    // definition below — the skills preview's exact layout.
+    let bands = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(inner);
+    Paragraph::new(Line::from(Span::styled(
+        format!(
+            "{} · v{} · {}",
+            entry.scope.label(),
+            entry.version,
+            toolbelt_label(&entry.tools)
+        ),
+        theme::muted(),
+    )))
+    .render(bands[0], buf);
+    let body_area = bands[1];
+    // Render through Stella's own theme-obeying markdown renderer (the same
+    // one the transcript and the skills ctrl+o preview use), then clamp the
+    // scroll to content so the last page stays reachable.
+    let text = ratatui::text::Text::from(crate::markdown::render(&entry.content));
+    let content_h = text.height();
+    let max_scroll = content_h.saturating_sub(body_area.height as usize) as u16;
+    let scroll = panel.created_scroll.min(max_scroll);
+    panel.created_scroll = scroll;
+    Paragraph::new(text)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0))
+        .render(body_area, buf);
+}
+
 /// The version picker: every version on disk, the pinned one marked. ⏎
 /// re-pins WITHOUT writing a new version.
 fn render_version_picker(panel: &InstalledPanel, area: Rect, buf: &mut Buffer) {
@@ -367,7 +522,7 @@ mod tests {
         ]);
         let area = Rect::new(0, 0, 120, 10);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains("reviewer"), "name shown:\n{text}");
         assert!(
@@ -388,7 +543,7 @@ mod tests {
         let mut ui = ui_with(vec![]);
         let area = Rect::new(0, 0, 80, 8);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(
             text.contains("press n to create one from a prompt"),
@@ -404,7 +559,7 @@ mod tests {
         ui.installed.editor.load("---\nname: reviewer\n---\nbody");
         let area = Rect::new(0, 0, 90, 10);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains("Edit reviewer"), "{text}");
         assert!(
@@ -424,7 +579,7 @@ mod tests {
             .load("---\nname: reviewer\n---\n# Reviewer\nplain prose");
         let area = Rect::new(0, 0, 90, 10);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         assert_eq!(
             style_at(&buf, "---").fg,
             Some(theme::SYNTAX_COMMENT),
@@ -454,7 +609,7 @@ mod tests {
         ui.installed.version_sel = 0;
         let area = Rect::new(0, 0, 80, 8);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains("v1"), "{text}");
         assert!(text.contains("v2  2026-07-16  ● pinned"), "{text}");
@@ -471,16 +626,93 @@ mod tests {
         ui.installed.create_desc = "reviews diffs".into();
         let area = Rect::new(0, 0, 100, 8);
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains("reviews diffs"), "{text}");
         assert!(text.contains("describe what it should do"), "{text}");
 
         ui.installed.mode = InstalledMode::CreateScope;
         let mut buf = Buffer::empty(area);
-        render(&mut ui, area, &mut buf);
+        render(&mut ui, 0, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains(".stella/agents"), "{text}");
         assert!(text.contains("~/.stella/agents"), "{text}");
+    }
+
+    #[test]
+    fn creating_view_shows_an_animated_spinner_and_the_description() {
+        let mut ui = ui_with(vec![]);
+        ui.installed.mode = InstalledMode::Creating;
+        ui.installed.create_desc = "reviews diffs".into();
+        ui.installed.status =
+            Some("agent creation queued — it runs when the current turn finishes".into());
+        let area = Rect::new(0, 0, 100, 10);
+
+        let mut buf_a = Buffer::empty(area);
+        render(&mut ui, 0, area, &mut buf_a);
+        let text_a = buffer_text(&buf_a);
+        assert!(text_a.contains("Drafting the agent"), "{text_a}");
+        assert!(
+            text_a.contains("reviews diffs"),
+            "the description stays visible:\n{text_a}"
+        );
+        assert!(
+            text_a.contains("creation queued"),
+            "the driver's progress status shows:\n{text_a}"
+        );
+
+        // One spinner period later the frame differs — the spinner animates
+        // off the deck clock the shell tick advances.
+        let mut buf_b = Buffer::empty(area);
+        render(&mut ui, 80, area, &mut buf_b);
+        assert_ne!(
+            buffer_text(&buf_a),
+            buffer_text(&buf_b),
+            "the spinner must advance with the deck clock"
+        );
+
+        // `--no-anim` pins it.
+        ui.no_anim = true;
+        let mut buf_c = Buffer::empty(area);
+        render(&mut ui, 80, area, &mut buf_c);
+        let mut buf_d = Buffer::empty(area);
+        render(&mut ui, 160, area, &mut buf_d);
+        assert_eq!(buffer_text(&buf_c), buffer_text(&buf_d));
+    }
+
+    #[test]
+    fn create_done_view_renders_the_created_agents_definition() {
+        let mut ui = ui_with(vec![entry("reviewer", None), entry("drafted", None)]);
+        ui.installed.mode = InstalledMode::CreateDone;
+        ui.installed.created_name = Some("drafted".into());
+        let area = Rect::new(0, 0, 100, 12);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, 0, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("created drafted"), "title in border:\n{text}");
+        assert!(
+            text.contains("project · v2 · all tools"),
+            "scope/version/toolbelt subtitle:\n{text}"
+        );
+        assert!(
+            text.contains("name: drafted"),
+            "the definition body renders — the ctrl+o detail treatment:\n{text}"
+        );
+    }
+
+    #[test]
+    fn create_done_view_shows_the_error_on_failure() {
+        let mut ui = ui_with(vec![]);
+        ui.installed.mode = InstalledMode::CreateDone;
+        ui.installed.create_error = Some("agent creation failed: draft call failed: boom".into());
+        let area = Rect::new(0, 0, 100, 10);
+        let mut buf = Buffer::empty(area);
+        render(&mut ui, 0, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("creation failed"), "{text}");
+        assert!(
+            text.contains("draft call failed: boom"),
+            "the driver's error is on screen:\n{text}"
+        );
     }
 }

--- a/stella-tui/src/views/mod.rs
+++ b/stella-tui/src/views/mod.rs
@@ -12,6 +12,23 @@
 //! carry a dead one — it has no model-derived state and no key handler of
 //! its own, deck_ui.rs routes its keys directly.)
 
+/// The braille spinner's frames — the classic 10-frame dot cycle.
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// One spinner frame advance per ~80ms.
+const SPINNER_PERIOD_MS: u64 = 80;
+
+/// The animated in-flight spinner glyph, a pure function of the deck clock
+/// (`model.now_ms`, advanced by the shell's ~30 fps tick) — no timer state.
+/// `no_anim` (`--no-anim` / `NO_COLOR`) pins it to a static glyph so
+/// recordings stay byte-stable.
+pub(crate) fn spinner_glyph(now_ms: u64, no_anim: bool) -> &'static str {
+    if no_anim {
+        return SPINNER_FRAMES[0];
+    }
+    SPINNER_FRAMES[((now_ms / SPINNER_PERIOD_MS) as usize) % SPINNER_FRAMES.len()]
+}
+
 pub mod agents;
 pub mod engine;
 pub mod files;

--- a/stella-tui/src/views/skills.rs
+++ b/stella-tui/src/views/skills.rs
@@ -20,7 +20,7 @@ use crate::deck_ui::{DeckUi, SkillPrompt, SkillsFocus};
 use crate::syntax;
 use crate::theme;
 
-pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     // Two panes over a status line.
     let bands = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
     let panes = Layout::horizontal([Constraint::Percentage(55), Constraint::Percentage(45)])
@@ -30,9 +30,10 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     render_search(ui, panes[1], buf);
     render_status(ui, bands[1], buf);
 
-    // Overlays (scope picker / create / edit / pin) float above the panes.
+    // Overlays (scope picker / create / creating spinner / edit / pin) float
+    // above the panes. The creating overlay animates off the deck clock.
     if ui.skills.prompt.is_some() {
-        render_overlay(ui, area, buf);
+        render_overlay(ui, model.now_ms, area, buf);
     }
     // The ctrl+o markdown preview is the topmost overlay (mutually exclusive
     // with the prompts at the key layer, but drawn last defensively).
@@ -263,8 +264,9 @@ fn render_status(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     Paragraph::new(line).render(area, buf);
 }
 
-/// Draw the active overlay centered over the panes.
-fn render_overlay(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+/// Draw the active overlay centered over the panes. `now_ms` is the deck
+/// clock — the creating dialog's spinner is a pure function of it.
+fn render_overlay(ui: &DeckUi, now_ms: u64, area: Rect, buf: &mut Buffer) {
     match &ui.skills.prompt {
         Some(SkillPrompt::Scope { action, user }) => {
             let verb = match action {
@@ -322,6 +324,64 @@ fn render_overlay(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
                 Line::from(Span::styled("⏎ continue · esc cancel", theme::muted())),
             ];
             popup(" new skill (LLM-assisted) ", lines, area, buf);
+        }
+        Some(SkillPrompt::Creating { description, scope }) => {
+            let spinner = crate::views::spinner_glyph(now_ms, ui.no_anim);
+            let lines = vec![
+                Line::from(vec![
+                    Span::styled(
+                        format!("{spinner} "),
+                        Style::default()
+                            .fg(theme::ACCENT)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("Creating the skill ({} scope)…", scope.label()),
+                        theme::body(),
+                    ),
+                ]),
+                Line::default(),
+                Line::from(Span::styled(
+                    format!("“{}”", truncate(description, 70)),
+                    theme::muted(),
+                )),
+                Line::default(),
+                Line::from(Span::styled(
+                    "the agent searches the registry, ranks matches, and",
+                    theme::muted(),
+                )),
+                Line::from(Span::styled(
+                    "assembles one skill — it appears here when done",
+                    theme::muted(),
+                )),
+                Line::default(),
+                Line::from(Span::styled(
+                    "esc hides (creation continues)",
+                    theme::muted(),
+                )),
+            ];
+            popup(" creating skill… ", lines, area, buf);
+        }
+        Some(SkillPrompt::CreateFailed { error }) => {
+            let lines = vec![
+                Line::from(vec![
+                    Span::styled(
+                        "✖ ",
+                        Style::default()
+                            .fg(theme::DANGER)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled("The skill was not created", theme::body()),
+                ]),
+                Line::default(),
+                Line::from(Span::styled(
+                    error.clone(),
+                    Style::default().fg(theme::DANGER),
+                )),
+                Line::default(),
+                Line::from(Span::styled("esc / ⏎ close", theme::muted())),
+            ];
+            popup(" skill creation failed ", lines, area, buf);
         }
         Some(SkillPrompt::Pin {
             name, latest, sel, ..
@@ -606,6 +666,7 @@ mod tests {
             ],
             status: None,
             busy: false,
+            created: None,
         };
         let area = Rect::new(0, 0, 120, 12);
         let mut buf = Buffer::empty(area);
@@ -728,6 +789,70 @@ mod tests {
             style_at(&buf, "plain prose").fg,
             theme::body().fg,
             "prose keeps the body style"
+        );
+    }
+
+    #[test]
+    fn creating_overlay_shows_an_animated_spinner_until_completion() {
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
+        ui.skills.prompt = Some(SkillPrompt::Creating {
+            description: "extract tables from pdfs".into(),
+            scope: SkillScope::Project,
+        });
+        let area = Rect::new(0, 0, 90, 16);
+
+        // Two deck-clock instants one spinner period apart render DIFFERENT
+        // glyphs — the spinner genuinely animates off the tick loop.
+        let mut model = WorkspaceModel::new();
+        model.now_ms = 0;
+        let mut buf_a = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf_a);
+        let text_a = buffer_text(&buf_a);
+        assert!(text_a.contains("Creating the skill"), "{text_a}");
+        assert!(
+            text_a.contains("extract tables from pdfs"),
+            "the description stays visible:\n{text_a}"
+        );
+
+        model.now_ms = 80; // one spinner frame later
+        let mut buf_b = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf_b);
+        assert_ne!(
+            buffer_text(&buf_a),
+            buffer_text(&buf_b),
+            "the spinner must advance with the deck clock"
+        );
+
+        // `--no-anim` pins the glyph: consecutive ticks render identically.
+        ui.no_anim = true;
+        let mut buf_c = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf_c);
+        model.now_ms = 160;
+        let mut buf_d = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf_d);
+        assert_eq!(buffer_text(&buf_c), buffer_text(&buf_d));
+    }
+
+    #[test]
+    fn create_failed_overlay_shows_the_error() {
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
+        ui.skills.prompt = Some(SkillPrompt::CreateFailed {
+            error: "the model did not return a valid SKILL.md — try again".into(),
+        });
+        let area = Rect::new(0, 0, 90, 16);
+        let mut buf = Buffer::empty(area);
+        render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("skill creation failed"), "{text}");
+        assert!(
+            text.contains("did not return a valid SKILL.md"),
+            "the driver's error is on screen:\n{text}"
         );
     }
 


### PR DESCRIPTION
## The problem

Creating an agent (AGENTS tab) or a skill (SKILLS tab) from a prompt closed its dialog the instant it dispatched. The op behind it is an LLM draft — a model call that can also be **parked behind a running turn** — so the flow reported nothing while it ran and nothing when it finished. The reader was dropped back onto a list that looked unchanged, with no way to tell whether a draft was in flight, had landed, or had failed.

Failure was worse than invisible: the only trace was a status line the next snapshot overwrote.

## The fix

The dialog that dispatches an op now reports that op's outcome.

| state | what the reader sees |
|---|---|
| **in flight** | the dialog stays up with a braille spinner, the description still on screen, and the driver's progress note ("queued — it runs when the current turn finishes") |
| **landed** | it becomes the created definition's detail view — the agent's full markdown through Stella's own renderer, or the skill's `ctrl+o` preview — scrollable, with the list selection landing on the new row |
| **failed** | it shows the driver's error and waits to be acknowledged |

`Esc` **hides** the dialog; it never cancels, because nothing client-side can abort a model call already in flight. Hiding clears no progress state — `busy` stays set and the drafting line stays in the browse footer, so the reader loses the spinner, not the fact of the op.

## Why two new envelope fields

- `Inbound::AgentsList.creating` distinguishes a *parked* create's interim snapshot from a real completion, so a queued draft can't be mistaken for a finished one. Without it, the interim refresh a parked create sends would read as "done" and close the dialog immediately — the original bug, just faster.
- `created` (on both `AgentsList` and `SkillsView`) names what actually landed, so the dialog previews the right row and a missing name is unambiguously a failure.

Both driver-side create paths had been throwing that name away — they returned a formatted status string and nothing else — so each now returns `(status, created_name)`.

## Refactor riding along

The create flow moves to `stella-tui/src/deck_ui/create.rs` and the installed-agents snapshot builders to `command_deck/authoring.rs`. This keeps both host files under the file-size ratchet (#629) — `deck_ui.rs` was exactly at its 4096-line ceiling — and puts the agent and skill halves of one flow side by side, where their shared shape is checkable. Pure code movement; no behavior change.

## Verification

`make gate` green end to end: no-scratch, action-pins, doc-citations, invariants, file-size, rustdoc, fmt-check, clippy `-D warnings`, and 65 test binaries — zero failures, zero warnings.

New coverage at both layers:

- **state machine** — a `creating: true` snapshot keeps the spinner up; a settled one opens the detail view on exactly the created row; a settled one with no name shows the error; `Esc` hides without cancelling; both dialogs are fully modal (keys never leak to the composer).
- **render** — the spinner advances with the deck clock and `--no-anim` pins it to a static frame (recordings stay byte-stable).

The spinner follows the house rule `progress.rs` already sets: animation is a pure function of `model.now_ms`, so it repaints on the existing ~30fps tick with no timer of its own and renders identically on replay.

## Note on provenance

This started as uncommitted work in the primary checkout. It was replayed onto current `main` (`c8249788`) — applied cleanly — then finished here: file-size gate resolved via the extraction above, plus one stale duplicated doc comment on `create_skill_llm` removed (it still claimed "Returns a status string" after the signature changed).

Left behind deliberately: an unrelated deletion of `.ultraudit/report-2026-07-28-7a1753754.html`, which is still sitting uncommitted in the primary checkout.


## Summary by Sourcery

Report the outcome of LLM-assisted agent and skill creation directly in the deck UI instead of closing the dialog on dispatch, ensuring progress, success, and failure are clearly visible and test-covered.

New Features:
- Add in-flight creation dialogs with animated spinners and completion views for agents and skills that remain open until driver snapshots confirm success or failure.
- Show the full created agent definition and created skill preview when LLM-assisted creation succeeds, and display clear error dialogs when it fails.

Enhancements:
- Extend inbound envelopes and skills views with creation metadata so the UI can distinguish queued, successful, and failed creates.
- Refine installed-agents and skills key handling so create dialogs are fully modal, Esc hides without canceling, and scroll behavior matches existing previews.
- Introduce a shared spinner glyph helper driven purely by the deck clock and wire it through agents and skills views for deterministic animation.

Tests:
- Add state-machine and rendering tests covering the new creating and completion states for agents and skills, including spinner animation, error handling, and scroll behavior.
