### PR TITLE
feat(serve): add --version/--help, correct the as-built route table

### DIFF
--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -21,6 +21,44 @@ Oxagen ADR. That repository is private to Oxagen; this document is the
 
 ---
 
+## As built today — the only routes that exist
+
+**Read this table before writing a client.** Everything after it describes the
+*destination*; this is the surface a request actually reaches, verified end to
+end against a running binary by Oxagen's sidecar smoke test (oxagen #1132).
+Every other path in this document — including the whole `/v1/sessions/...`
+family in the diagram below — is a 404.
+
+| Method | Path | Notes |
+|---|---|---|
+| `GET` | `/healthz` | The **only** unauthenticated route. `{"status":"ok"}` |
+| `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}` |
+| `GET` | `/v1/turns/{id}/events` | SSE `data: <ServerFrame>`. Exclusive: a second subscriber gets 409 |
+| `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |
+| `POST` | `/v1/turns/{id}/tool-result` | Answers a `tool_request` |
+| `POST` | `/v1/turns/{id}/cancel` | The only teardown. There is no `DELETE` |
+
+Three corrections to prose further down that read as present tense but describe
+the destination, and which a client written from them gets wrong:
+
+- **The resource is a turn, not a session.** One `POST /v1/turns` drives exactly
+  one turn; no conversation state is retained between turns and there is no
+  session id. `/readyz` and `/metrics` do not exist either.
+- **No frame carries a `seq`.** The "Wire protocol" section calls each event's
+  `seq` monotonic; there is no such field on `ServerFrame` or `AgentEvent`, and
+  no event history is retained. A reconnect could not resume even if `?after=`
+  were parsed (it is not — the query string is split off and discarded).
+- **Reverse RPC is keyed by `request_id` on its own frame types**, not by a
+  `call_id` on a `tool_start` / `scope_review` / `ask_user` `AgentEvent`. The
+  engine emits dedicated `tool_request` / `provider_request` `ServerFrame`
+  variants whose ids are per-turn counters (`prov-0`, `tool-0`, …). This is the
+  single most dangerous drift in this document for anyone mirroring it in
+  another language: it names the wrong field on the wrong frame.
+
+Also: the tool surface is selected by the `STELLA_SERVE_TOOLS=remote`
+environment variable, not a `--tools remote` flag — the binary parses no flags
+beyond `healthcheck`, `--version` and `--help`.
+
 ## One sentence
 
 Expose the Stella engine as a long-lived, multi-session **service** — a
@@ -101,6 +139,9 @@ tokio runtime**, bridged to the async side by a `Send` oneshot
 multi-thread runtime, sessions addressed by id.
 
 ## Architecture
+
+**The route table in this diagram is the target, not the code.** See
+[As built today](#as-built-today--the-only-routes-that-exist).
 
 ```
 ┌────────────────────────── stella-serve (new crate, the sidecar) ──────────────────────────┐
@@ -214,18 +255,23 @@ per-step checkpoint and crash-resume. This is ADR-033 §6 item 1 and §4.3.
 
 ### Wire protocol
 
-- **Events (engine → host):** newline-delimited `AgentEvent` JSON over SSE,
-  identical to `stream-json`. Each carries a monotonic `seq`. **Planned, not
-  built:** the SSE endpoint is to replay from `?after=<seq>` so a reconnect
-  resumes losslessly (mirroring the Observatory's read model and Oxagen's
-  `agent_events` log discipline). At this baseline no `?after=` parameter is
-  parsed and no event history is retained, so a dropped connection loses
-  whatever was streamed while it was down.
-- **Reverse RPC (host → engine):** the engine surfaces a `tool_start` /
-  `scope_review` / `ask_user` `AgentEvent` carrying a `call_id`; the host runs
-  the governed work and POSTs the result back to
-  `/v1/sessions/:id/{tool-result,approval}` with that `call_id`. The engine's
-  `RemoteToolExecutor::execute` awaits a per-`call_id` oneshot.
+- **Events (engine → host):** `AgentEvent` JSON in SSE `data:` frames, the
+  payload identical to `stream-json`. **Planned, not built:** a monotonic `seq`
+  on each frame, and replay from `?after=<seq>` so a reconnect resumes
+  losslessly (mirroring the Observatory's read model and Oxagen's `agent_events`
+  log discipline). At this baseline **no frame carries a `seq` at all**, no
+  `?after=` parameter is parsed, and no event history is retained — so a dropped
+  connection loses whatever was streamed while it was down.
+- **Reverse RPC (host → engine):** the engine emits a dedicated
+  `ServerFrame::ToolRequest` / `ServerFrame::ProviderRequest` carrying a
+  `request_id` (a per-turn counter — `tool-0`, `prov-0`, …); the host runs the
+  governed work and POSTs the result back to
+  `/v1/turns/{id}/{tool-result,provider-result}` with that `request_id`. The
+  engine's `RemoteToolExecutor::execute` awaits a per-`request_id` oneshot.
+  **Not the same thing as** the `call_id` on a `tool_start` `AgentEvent`: that
+  id is the model's, addresses the tool call inside the transcript, and is not
+  what a resolve POST is keyed by. `scope_review` / `ask_user` have no reverse
+  endpoint at all yet.
 - **Provider deltas:** `RemoteProvider::complete_observed` forwards `text_delta`
   / `tool_call_streamed` as `AgentEvent`s so the browser gets token-level
   streaming (Anthropic + all OpenAI-compatible adapters already emit these;

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -23,6 +23,15 @@
 //!
 //! `stella-serve healthcheck` probes `/healthz` on the bind port and exits 0/1,
 //! so a container HEALTHCHECK needs no extra tooling in the runtime image.
+//!
+//! `--version` and `--help` exist for host integrations rather than for people.
+//! A host that embeds this server (Oxagen — see `docs/design/serve-surface.md`)
+//! records which release it has verified its wire contract against, and pinning
+//! is only possible if the binary will state its own version. Without it the
+//! only way to identify a build was the filename, which is not a fact about the
+//! program. `--help` is the same argument one level down: the entire
+//! configuration surface is environment variables, so a binary that answered
+//! "unknown argument" to `--help` left an operator with nowhere to look.
 
 use std::process::ExitCode;
 use std::time::Duration;
@@ -31,6 +40,46 @@ use stella_serve::{ServeConfig, serve};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const DEFAULT_BIND: &str = "127.0.0.1:8080";
+
+/// The configuration surface, printed by `--help`.
+///
+/// Deliberately not a clap definition: there are no flags to parse — every knob
+/// is an environment variable — so adding a parser would buy nothing but a
+/// dependency and a second place for the documented defaults to drift from
+/// [`DEFAULT_BIND`].
+const USAGE: &str = "\
+stella-serve — headless Stella engine server
+
+USAGE:
+    stella-serve                run the server (configured by environment)
+    stella-serve healthcheck    probe /healthz on the bind port; exit 0 if 200
+    stella-serve --version      print the version and exit
+    stella-serve --help         print this help and exit
+
+ENVIRONMENT:
+    STELLA_SERVE_BIND        address to bind (default 127.0.0.1:8080;
+                             containerized deployments bind 0.0.0.0:8080)
+    STELLA_SERVE_TOKEN_FILE  path to a file holding the bearer token; wins over
+                             STELLA_SERVE_TOKEN when both are set
+    STELLA_SERVE_TOKEN       bearer token every request must present
+    STELLA_SERVE_TOOLS       must be `remote` (the default) — every tool and
+                             model call is remoted to the host
+
+One of STELLA_SERVE_TOKEN_FILE / STELLA_SERVE_TOKEN is required.
+
+The server exposes GET /healthz unauthenticated, and POST /v1/turns,
+GET /v1/turns/{id}/events, POST /v1/turns/{id}/{provider-result,tool-result,cancel}
+behind the bearer token. See docs/design/serve-surface.md.
+";
+
+/// `stella-serve <version>` — the line `--version` prints.
+///
+/// Split out so the format is asserted by a test rather than by eyeballing
+/// stdout: a host parses this string to record which release it verified its
+/// wire contract against, so the shape is a contract, not cosmetics.
+fn version_line() -> String {
+    format!("stella-serve {}", env!("CARGO_PKG_VERSION"))
+}
 
 /// Deadline covering the healthcheck's whole connect + write + read. Kept
 /// strictly under the container `HEALTHCHECK --timeout=5s`
@@ -60,8 +109,19 @@ async fn main() -> ExitCode {
     match std::env::args().nth(1).as_deref() {
         None => run().await,
         Some("healthcheck") => healthcheck().await,
+        Some("--version" | "-V") => {
+            println!("{}", version_line());
+            ExitCode::SUCCESS
+        }
+        Some("--help" | "-h") => {
+            print!("{USAGE}");
+            ExitCode::SUCCESS
+        }
         Some(other) => {
-            eprintln!("stella-serve: unknown argument `{other}` (expected none, or `healthcheck`)");
+            eprintln!(
+                "stella-serve: unknown argument `{other}` (expected none, or one of \
+                 `healthcheck`, `--version`, `--help`)"
+            );
             ExitCode::FAILURE
         }
     }
@@ -258,6 +318,50 @@ mod tests {
             std::env::temp_dir().join(format!("stella-serve-token-{name}-{}", std::process::id()));
         std::fs::write(&path, contents).unwrap();
         path
+    }
+
+    /// A host pins the wire contract to a release by parsing this line, so its
+    /// shape is part of the integration surface: `stella-serve <semver>`, one
+    /// space, nothing else. A bare version (no program name) or an added `v`
+    /// prefix would silently break that parse.
+    #[test]
+    fn the_version_line_is_the_program_name_then_a_bare_semver() {
+        let line = version_line();
+        let rest = line
+            .strip_prefix("stella-serve ")
+            .expect("the line must be `stella-serve <version>`");
+        assert!(
+            !rest.starts_with('v'),
+            "the version must be bare semver, not v-prefixed: {rest}"
+        );
+        assert_eq!(
+            rest.split('.').count(),
+            3,
+            "expected three dot-separated semver components: {rest}"
+        );
+        assert!(
+            rest.split('.').all(|part| !part.is_empty()),
+            "no semver component may be empty: {rest}"
+        );
+    }
+
+    /// `--help` is the only place the environment surface is described to an
+    /// operator, so every variable the program actually reads must appear in it.
+    /// Adding a knob without documenting it is the failure this pins.
+    #[test]
+    fn help_documents_every_environment_variable_the_program_reads() {
+        for var in [
+            "STELLA_SERVE_BIND",
+            "STELLA_SERVE_TOKEN_FILE",
+            "STELLA_SERVE_TOKEN",
+            "STELLA_SERVE_TOOLS",
+        ] {
+            assert!(USAGE.contains(var), "`--help` omits {var}");
+        }
+        assert!(
+            USAGE.contains(DEFAULT_BIND),
+            "`--help` must state the real default bind, not a stale copy"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Companion to oxagen #1132, which drove a full two-step tool-using turn through a real `stella-serve` from a foreign-language host for the first time. Two things that verification needed and one it exposed.

## `--version` / `--help`

A host that embeds this server records which release it verified its wire contract against — that is the whole purpose of oxagen's `sidecar.config.json` pin. It could not, because the only argument the binary accepted was `healthcheck`; `--version` exited 1 with "unknown argument". The only way to identify a build was its filename, which is not a fact about the program.

`--help` is the same argument one level down. The entire configuration surface is environment variables, so a binary that answered "unknown argument" to `--help` left an operator with nowhere to look.

Deliberately not clap: there are no flags to parse, so a parser would buy nothing but a dependency and a second place for the documented default bind to drift from `DEFAULT_BIND`.

Both are pinned by tests rather than eyeballed:
- the version line's shape (`stella-serve <bare semver>`) is a parsing contract for a host, so a v-prefix or a dropped program name is a test failure;
- `--help` must name every `STELLA_SERVE_*` variable the program actually reads, so adding a knob without documenting it fails.

## The document that caused the drift

`docs/design/serve-surface.md` has always said "this describes the target surface, not all of it is built" — but its architecture diagram is a `/v1/sessions/...` route table, and Oxagen built a client from it. Every route in that client was wrong, and two claims in the prose name the wrong mechanism outright rather than merely being aspirational:

1. **"Each [event] carries a monotonic `seq`."** No frame carries a sequence number. The section correctly notes `?after=` is unbuilt, but the `seq` claim itself is false, so a reconnect could not resume even if the parameter existed.
2. **Reverse RPC keyed by `call_id` on a `tool_start` / `scope_review` / `ask_user` `AgentEvent`.** It is keyed by `request_id` on dedicated `tool_request` / `provider_request` `ServerFrame` variants. A client written from the old text keys the wrong field of the wrong frame type — the most expensive way for this document to be wrong, since it fails only at runtime and only under load-bearing use.

Also corrected: `/readyz` and `/metrics` are listed but do not exist; the tool surface is `STELLA_SERVE_TOOLS=remote`, not a `--tools remote` flag.

Fix is an **As built today** table at the top with the six routes that exist, a pointer to it from the diagram, and in-place corrections to the two false claims. The aspirational content is left intact — the problem was never that the document described a destination, it was that a reader could not tell which parts were one.

## Verification

- `make no-scratch doc-citations invariants file-size format-check` — pass
- `make lint` (clippy `-D warnings`) — pass
- `cargo test -p stella-serve` — 27 pass (8 bin, 8 lib, 11 http integration)
- `stella-serve --version` → `stella-serve 0.6.2`
- Live cross-repo round trip: 28/28 in oxagen's sidecar suite, 3 of them against this binary

No behavioural change to the server: the routes, framing and auth are untouched.


## Summary by Sourcery

Add explicit CLI support for --version/--help in stella-serve and align serve-surface documentation with the actual built HTTP routes and wire protocol.

New Features:
- Expose a --version flag that prints the stella-serve program name and bare semver for host integrations.
- Expose a --help flag that documents the environment-based configuration surface and available commands.

Enhancements:
- Document the real route surface and behavior of stella-serve in serve-surface.md, distinguishing the currently built endpoints from the aspirational design and correcting mismatches in the wire protocol description.

Tests:
- Add tests to enforce the format of the --version output and ensure --help covers all environment variables the binary reads and the true default bind.
