### PR TITLE
fix(stella-pipeline): a blind diff probe must not complete as "nothing changed"

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,8 +27,8 @@
 1780 stella-model/src/bedrock.rs
 1948 stella-model/src/openai.rs
 1738 stella-model/src/zai/tests.rs
-2582 stella-pipeline/src/pipeline.rs
-2113 stella-pipeline/src/pipeline/tests.rs
+2614 stella-pipeline/src/pipeline.rs
+2124 stella-pipeline/src/pipeline/tests.rs
 2399 stella-protocol/src/event.rs
 2292 stella-store/src/lib.rs
 2269 stella-store/src/tests.rs

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -124,6 +124,23 @@ fn verification_honest_diff(diff_text: String, file_changes: u32) -> String {
     }
 }
 
+/// What [`Pipeline::gather_diff`] reports when the diff probe *failed* rather
+/// than found nothing.
+///
+/// `verification_honest_diff` resolves the same ambiguity from `file_changes`,
+/// but that signal is structurally unavailable to an isolated candidate: the
+/// engine emits no `FileChange` events (the deck's `FileChangeTap` synthesizes
+/// them, and it wraps only the SESSION tool stack), so inside a best-of-N or
+/// witness candidate the count is always zero. A candidate whose probe went
+/// blind therefore handed an empty string to [`crate::witness::warrant`], which
+/// read it as [`crate::NoWitnessReason::NothingChanged`] and completed the run
+/// with a PASSING verdict stating no behavior had changed — the exact
+/// verification lie the honest-diff guard exists to prevent, reached with no
+/// witness stage and no warning. Non-empty text keeps the warrant fail-closed
+/// on the one path its own guard could not see.
+const DIFF_PROBE_FAILED: &str = "[the diff probe failed; the working tree could not be read. This \
+     is NOT evidence that nothing changed — verify the result on its own merits.]";
+
 /// How many `git diff --no-index --numstat` probes [`Pipeline::gather_diff`]
 /// keeps in flight at once. High enough that the usual handful of new files
 /// costs roughly one round-trip instead of N, low enough that a turn which
@@ -2330,6 +2347,21 @@ impl<'a> Pipeline<'a> {
             return (0, String::new());
         };
         let out = surface.diagnostics.run_diagnostic(diagnostic).await;
+        // `git diff` exits 0 on a clean tree, so a non-zero exit with nothing on
+        // stdout is the machinery failing to READ the tree, never a report that
+        // the tree is unchanged. Observed in the wild as a candidate shadow
+        // whose worktree registration was gone by the time it was probed
+        // (`git add -A` → "fatal: not a git repository"). See
+        // [`DIFF_PROBE_FAILED`] for why the empty string could not be left to
+        // `verification_honest_diff` to catch. Scoped to `GitDiff` because
+        // `--no-index --numstat` exits 1 whenever the files differ, which is
+        // that probe's ordinary success.
+        if matches!(diagnostic, DiagnosticInvocation::GitDiff)
+            && !out.passed()
+            && out.stdout_tail.trim().is_empty()
+        {
+            return (0, DIFF_PROBE_FAILED.to_string());
+        }
         let mut lines = count_diff_lines(&out.stdout_tail);
         let mut text = out.stdout_tail;
         if matches!(diagnostic, DiagnosticInvocation::GitDiff) {

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -230,6 +230,9 @@ struct ScriptedRunner {
     /// What a failing run prints. Configurable so a test can plant a
     /// distinctive token and assert on where it does — and does not — travel.
     failure_tail: String,
+    /// Exit code the `GitDiff` probe reports. Non-zero models a tree the diff
+    /// machinery could not read at all, which is not the same as a clean one.
+    diff_exit_code: i32,
 }
 impl ScriptedRunner {
     fn new(test_results: Vec<bool>, diff: &str) -> Self {
@@ -238,7 +241,15 @@ impl ScriptedRunner {
             diff: diff.to_string(),
             untracked: Vec::new(),
             failure_tail: "test failed".to_string(),
+            diff_exit_code: 0,
         }
+    }
+    /// A diff probe that FAILS: no stdout and a non-zero exit, the shape a
+    /// candidate whose worktree registration vanished actually produces.
+    fn with_blind_diff(mut self) -> Self {
+        self.diff = String::new();
+        self.diff_exit_code = 128;
+        self
     }
     fn with_failure_tail(mut self, tail: &str) -> Self {
         self.failure_tail = tail.to_string();
@@ -270,7 +281,7 @@ impl DiagnosticRunner for ScriptedRunner {
         }
         if matches!(invocation, DiagnosticInvocation::GitDiff) {
             return CmdOutcome {
-                exit_code: 0,
+                exit_code: self.diff_exit_code,
                 stdout_tail: self.diff.clone(),
                 stderr_tail: String::new(),
             };

--- a/stella-pipeline/src/pipeline/tests/warrant.rs
+++ b/stella-pipeline/src/pipeline/tests/warrant.rs
@@ -87,3 +87,84 @@ async fn a_docs_only_change_completes_without_buying_a_judge_call() {
         verdict.summary
     );
 }
+
+/// The witness: a diff probe that FAILED must never complete as "nothing
+/// changed".
+///
+/// `warrant` is documented fail-closed — anything the diff machinery could not
+/// see buys the test. Its one guard against a blind probe is `file_changes`,
+/// and that count is structurally zero inside an isolated candidate (the engine
+/// emits no `FileChange`; the deck's tap wraps only the session tool stack). So
+/// a candidate whose worktree registration had vanished — the observed failure,
+/// `git add -A` → "fatal: not a git repository" — reported an empty diff, which
+/// read as `NothingChanged`, which completed the run with a PASSING
+/// deterministic verdict asserting no behavior had changed. No witness stage,
+/// no warning, and a false green.
+///
+/// Scripts a third provider response so the escalation this must produce has a
+/// judge to reach; before the fix the run stopped at two and the third was
+/// never drawn.
+#[tokio::test]
+async fn a_blind_diff_probe_never_completes_as_nothing_changed() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"),
+        text_result("PASS — the change is sound"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], DOCS_DIFF).with_blind_diff();
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            witness_writer: false,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("Fix the progress bar reset", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    let verdict = outcome.verdict.expect("a reasoned verdict, not silence");
+    assert!(
+        !verdict.summary.contains("no files changed"),
+        "a probe that could not read the tree is not a report that the tree is clean: {}",
+        verdict.summary
+    );
+    assert!(
+        !verdict.deterministic,
+        "nothing deterministic was observed — the diff is the thing that failed"
+    );
+    assert!(
+        stages(&drain(&mut rx)).contains(&StageKind::Judge),
+        "an unreadable diff must escalate, not self-certify"
+    );
+}


### PR DESCRIPTION
## What & why

`warrant` is documented fail-closed: anything the diff machinery could not see buys the witness test. Its only guard against a blind probe is `file_changes` — and that count is **structurally zero inside an isolated candidate**. The engine emits no `FileChange` events; the deck's `FileChangeTap` synthesizes them and wraps only the *session* tool stack, while candidates run on `ws.tools`.

So a candidate whose worktree registration had vanished reported an empty diff → `NothingChanged` → `warranted_completion` emitted a **passing deterministic verdict asserting no behavior had changed**. No witness stage, no warning, and a false green.

This was found in a real session (`.stella/private/store.db`, execution 10 — triage said `WITNESS: yes`, no witness stage was emitted, and the run died on):

```
candidate could not be sealed for verification: `git add -A` failed:
fatal: not a git repository (or any of the parent directories): .git
```

## The change

`gather_diff` distinguishes a probe that **failed** from one that **found nothing**. `git diff` exits 0 on a clean tree, so a non-zero exit with empty stdout is the machinery failing to read the tree. Scoped to `GitDiff`: `--no-index --numstat` exits 1 whenever files differ, which is that probe's ordinary success.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_blind_diff_probe_never_completes_as_nothing_changed` — a failing probe must not self-certify. On the previous code all three assertions fail: the verdict summary reads "no files changed", it is marked deterministic, and no Judge stage is emitted.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-pipeline --all-targets -- -D warnings`
- [x] `cargo test -p stella-pipeline` — 254 tests, 0 failures
- [x] `scripts/check-file-size.sh` — baseline `pipeline.rs` +32, `tests.rs` +11 via `make file-size-update`

## Follow-up, not in this change

The deeper asymmetry stands: candidates never emit `FileChange`, so `verification_honest_diff` is inert for every best-of-N and witness candidate. This closes the path that actually produced a false green; giving candidates a tapped tool stack is the larger fix.


## Summary by Sourcery

Ensure the pipeline treats failing git diff probes as failures rather than as evidence of no changes, preventing blind diff probes from self-certifying.

Bug Fixes:
- Distinguish a failing git diff probe from a clean tree and surface a failure message instead of an empty diff when the working tree cannot be read.

Enhancements:
- Extend the scripted diagnostic runner to model non-zero git diff exit codes and support tests for blind diff scenarios.

Tests:
- Add a warrant test ensuring a blind diff probe never results in a deterministic 'nothing changed' verdict and correctly escalates to a judge stage.
