### PR TITLE
feat(commands): TOML custom commands, Claude parity fields, and /ns:name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "stella-protocol",
  "thiserror 2.0.19",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/stella-cli/src/agents_installed.rs
+++ b/stella-cli/src/agents_installed.rs
@@ -423,6 +423,7 @@ pub fn parse_generated_agent(text: &str) -> Result<GeneratedAgent, String> {
             match diag.problem {
                 stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
                 stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
+                stella_core::extensions::ExtensionProblem::Malformed => "not valid TOML",
             }
         )
     })?;

--- a/stella-cli/src/commands_cmd.rs
+++ b/stella-cli/src/commands_cmd.rs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `stella commands` — list custom slash commands, and convert markdown ones
+//! to TOML.
+//!
+//! # Why conversion is opt-in and never part of `init`
+//!
+//! `stella init` **symlinks** `.claude/commands/` into `.stella/commands/`, so
+//! a command edited in either place stays live in both. Converting forks that:
+//! the TOML file is a copy, and the markdown original it came from keeps
+//! drifting away from it. That is a real trade — TOML buys a typed
+//! `allowed-tools` array and a delimiter-free `prompt`, and costs the live
+//! link — and it is the user's to make, per command, deliberately. So this is
+//! a command you run, never something a sync does to you.
+//!
+//! Conversion never deletes the source, and never overwrites an existing
+//! `.toml` without `--force`. The worst outcome of a mistaken run is a file
+//! the user can delete.
+
+use std::path::{Path, PathBuf};
+
+use stella_core::extensions::{CommandDef, command_from_file};
+
+/// `stella commands <cmd>`.
+#[derive(Debug, clap::Subcommand)]
+pub enum CommandsCmd {
+    /// List the custom slash commands this workspace offers, with the file
+    /// each came from.
+    List,
+    /// Convert markdown command definitions to TOML.
+    ///
+    /// Reads `<dir>` (default `.stella/commands/`), writes a `<slug>.toml`
+    /// beside each `<slug>.md`, and leaves the markdown in place.
+    Convert {
+        /// Directory to convert (default: `.stella/commands/`).
+        #[arg(value_name = "DIR")]
+        dir: Option<PathBuf>,
+        /// Show what would be written without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite a `<slug>.toml` that already exists.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+/// Run `stella commands <cmd>`. Offline: definition files only.
+pub fn run_commands(cmd: &CommandsCmd) -> Result<(), String> {
+    let root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    match cmd {
+        CommandsCmd::List => {
+            // Listing goes through the same authority-gated loader the chat
+            // surfaces use, on the REAL resolved policy — a command hidden
+            // from the composer must not appear here, and one the composer
+            // offers must not be missing here. `AuthorityPolicy::default()`
+            // would be neither: it denies project prompts unconditionally, so
+            // this would under-report every workspace that allows them.
+            let authority = crate::settings::Settings::load(&root)
+                .map(|s| s.authority_policy)
+                .unwrap_or_default();
+            let loaded =
+                crate::extensions::CustomExtensions::load_with_authority(&root, &authority);
+            if loaded.commands.is_empty() {
+                println!("no custom commands — add one under .stella/commands/");
+                return Ok(());
+            }
+            for command in &loaded.commands {
+                let hint = command.argument_hint.as_deref().unwrap_or("");
+                println!(
+                    "/{:<24} {:<40} {}",
+                    command.invocation(),
+                    truncate(&command.description, 40),
+                    hint
+                );
+                println!("  {}", command.source_path);
+            }
+            Ok(())
+        }
+        CommandsCmd::Convert {
+            dir,
+            dry_run,
+            force,
+        } => {
+            let dir = dir
+                .clone()
+                .unwrap_or_else(|| root.join(".stella").join("commands"));
+            let done = convert_dir(&dir, *dry_run, *force)?;
+            if done.is_empty() {
+                println!("no markdown commands under {}", dir.display());
+                return Ok(());
+            }
+            let mut written = 0usize;
+            for entry in &done {
+                match &entry.skipped {
+                    None => {
+                        written += 1;
+                        let verb = if *dry_run { "would write" } else { "wrote" };
+                        println!("{verb} {}", entry.target.display());
+                    }
+                    Some(why) => println!("skipped {}: {why}", entry.source.display()),
+                }
+            }
+            println!(
+                "{written}/{} converted — the markdown originals are untouched",
+                done.len()
+            );
+            Ok(())
+        }
+    }
+}
+
+fn truncate(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+/// Render one [`CommandDef`] as a TOML document.
+///
+/// Only fields the definition actually carries are emitted — a converted file
+/// full of `argument-hint = ""` would read as "this command declares an empty
+/// hint" rather than "this command has no hint", and the two mean different
+/// things to both a reader and the parser.
+///
+/// `prompt` always uses a multi-line basic string. A body containing `"""` is
+/// the one shape that would break out of it, so those are escaped; everything
+/// else is passed through byte-for-byte, because a converted prompt that is
+/// not the original prompt is a silently changed command.
+pub fn to_toml(cmd: &CommandDef) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("name = {}\n", quote(&cmd.name)));
+    out.push_str(&format!("description = {}\n", quote(&cmd.description)));
+    if let Some(hint) = &cmd.argument_hint {
+        out.push_str(&format!("argument-hint = {}\n", quote(hint)));
+    }
+    if let Some(tools) = &cmd.allowed_tools {
+        let items: Vec<String> = tools.iter().map(|t| quote(t)).collect();
+        out.push_str(&format!("allowed-tools = [{}]\n", items.join(", ")));
+    }
+    if let Some(model) = &cmd.model {
+        out.push_str(&format!("model = {}\n", quote(model)));
+    }
+    if !cmd.model_invocable {
+        out.push_str("disable-model-invocation = true\n");
+    }
+    out.push_str("\nprompt = \"\"\"\n");
+    out.push_str(&cmd.body.replace("\"\"\"", "\\\"\\\"\\\""));
+    out.push_str("\n\"\"\"\n");
+    out
+}
+
+/// A TOML basic string. Backslashes first, or the escapes added after would
+/// themselves be escaped.
+fn quote(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+    format!("\"{escaped}\"")
+}
+
+/// One conversion the run would perform or did.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Converted {
+    pub source: PathBuf,
+    pub target: PathBuf,
+    /// Why nothing was written, when nothing was.
+    pub skipped: Option<String>,
+}
+
+/// Plan (and, unless `dry_run`, perform) the conversion of every `<slug>.md`
+/// under `dir`, one level deep so namespace directories convert too.
+pub fn convert_dir(dir: &Path, dry_run: bool, force: bool) -> Result<Vec<Converted>, String> {
+    let mut out = Vec::new();
+    let mut sources = Vec::new();
+    collect_markdown(dir, &mut sources)?;
+    sources.sort();
+
+    for source in sources {
+        let target = source.with_extension("toml");
+        let raw = match std::fs::read_to_string(&source) {
+            Ok(raw) => raw,
+            Err(e) => {
+                out.push(Converted {
+                    target,
+                    skipped: Some(format!("unreadable: {e}")),
+                    source,
+                });
+                continue;
+            }
+        };
+        // Parsed, never transliterated: the converted file must mean what the
+        // loader thinks the markdown means, so it goes through the same parser
+        // the loader uses. A definition that will not load is not converted —
+        // writing a TOML copy of a broken command just makes two broken ones.
+        let cmd = match command_from_file(&source.display().to_string(), &raw) {
+            Ok(cmd) => cmd,
+            Err(diag) => {
+                out.push(Converted {
+                    target,
+                    skipped: Some(format!("does not load: {:?}", diag.problem)),
+                    source,
+                });
+                continue;
+            }
+        };
+        if target.exists() && !force {
+            out.push(Converted {
+                target,
+                skipped: Some("a .toml already exists (use --force)".to_string()),
+                source,
+            });
+            continue;
+        }
+        if !dry_run && let Err(e) = std::fs::write(&target, to_toml(&cmd)) {
+            out.push(Converted {
+                target,
+                skipped: Some(format!("could not write: {e}")),
+                source,
+            });
+            continue;
+        }
+        out.push(Converted {
+            source,
+            target,
+            skipped: None,
+        });
+    }
+    Ok(out)
+}
+
+/// Markdown definitions in `dir` and one level below it (namespaces). The
+/// nested `<slug>/COMMAND.md` layout is included; anything deeper is not,
+/// matching what the loader reads.
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let hidden = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_none_or(|n| n.starts_with('.'));
+        if hidden {
+            continue;
+        }
+        if path.extension().is_some_and(|e| e == "md") {
+            out.push(path);
+        } else if path.is_dir() {
+            for child in std::fs::read_dir(&path).into_iter().flatten().flatten() {
+                let child = child.path();
+                if child.extension().is_some_and(|e| e == "md")
+                    && child
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| !n.starts_with('.'))
+                {
+                    out.push(child);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_core::extensions::command_from_toml;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// The witness for the converter: a round trip must not change what the
+    /// command IS. Parsing the emitted TOML has to yield the same definition
+    /// the markdown yielded — otherwise converting a library silently rewrites
+    /// every command in it.
+    #[test]
+    fn a_converted_command_parses_back_to_the_same_definition() {
+        let md = "---\n\
+             name: review-pr\n\
+             description: Review a pull request\n\
+             argument-hint: <pr-number>\n\
+             allowed-tools: read_file, grep\n\
+             model: anthropic/claude-fable-5\n\
+             disable-model-invocation: true\n\
+             ---\n\
+             Review PR $1.\n\nBe thorough about \"quoted\" things.";
+        let from_md = command_from_file("/ws/.stella/commands/review-pr.md", md).unwrap();
+        let round_tripped =
+            command_from_toml("/ws/.stella/commands/review-pr.toml", &to_toml(&from_md)).unwrap();
+
+        assert_eq!(round_tripped.name, from_md.name);
+        assert_eq!(round_tripped.description, from_md.description);
+        assert_eq!(round_tripped.argument_hint, from_md.argument_hint);
+        assert_eq!(round_tripped.allowed_tools, from_md.allowed_tools);
+        assert_eq!(round_tripped.model, from_md.model);
+        assert_eq!(round_tripped.model_invocable, from_md.model_invocable);
+        assert_eq!(
+            round_tripped.body, from_md.body,
+            "the prompt must survive byte-for-byte"
+        );
+    }
+
+    /// A command with no optional fields must not gain any. An emitted
+    /// `disable-model-invocation = false` would be a capability statement the
+    /// author never made.
+    #[test]
+    fn absent_fields_are_absent_in_the_output() {
+        let cmd = command_from_file("/ws/.stella/commands/ship.md", "Ship it.").unwrap();
+        let toml_src = to_toml(&cmd);
+        assert!(!toml_src.contains("argument-hint"), "{toml_src}");
+        assert!(!toml_src.contains("allowed-tools"), "{toml_src}");
+        assert!(!toml_src.contains("model"), "{toml_src}");
+        assert!(!toml_src.contains("disable-model-invocation"), "{toml_src}");
+    }
+
+    #[test]
+    fn conversion_writes_beside_the_source_and_keeps_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("ship.md"), "Ship it.");
+        write(&dir.join("vercel/deploy.md"), "Deploy $1.");
+
+        let done = convert_dir(&dir, false, false).unwrap();
+        assert_eq!(done.len(), 2, "{done:?}");
+        assert!(done.iter().all(|c| c.skipped.is_none()), "{done:?}");
+        assert!(dir.join("ship.toml").exists());
+        assert!(
+            dir.join("vercel/deploy.toml").exists(),
+            "namespaces convert"
+        );
+        assert!(dir.join("ship.md").exists(), "the source is never deleted");
+    }
+
+    #[test]
+    fn an_existing_toml_is_never_clobbered_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("ship.md"), "Ship it.");
+        write(&dir.join("ship.toml"), "prompt = \"hand written\"\n");
+
+        let done = convert_dir(&dir, false, false).unwrap();
+        assert!(done[0].skipped.is_some(), "{done:?}");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("ship.toml")).unwrap(),
+            "prompt = \"hand written\"\n"
+        );
+
+        let forced = convert_dir(&dir, false, true).unwrap();
+        assert!(forced[0].skipped.is_none(), "{forced:?}");
+        assert!(
+            std::fs::read_to_string(dir.join("ship.toml"))
+                .unwrap()
+                .contains("Ship it.")
+        );
+    }
+
+    #[test]
+    fn a_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("ship.md"), "Ship it.");
+
+        let done = convert_dir(&dir, true, false).unwrap();
+        assert_eq!(done.len(), 1);
+        assert!(done[0].skipped.is_none());
+        assert!(!dir.join("ship.toml").exists());
+    }
+
+    /// A definition the loader rejects is reported, not converted — two broken
+    /// commands are worse than one.
+    #[test]
+    fn a_command_that_does_not_load_is_not_converted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("empty.md"), "---\nname: empty\n---\n");
+
+        let done = convert_dir(&dir, false, false).unwrap();
+        assert!(done[0].skipped.is_some(), "{done:?}");
+        assert!(!dir.join("empty.toml").exists());
+    }
+}

--- a/stella-cli/src/extensions.rs
+++ b/stella-cli/src/extensions.rs
@@ -25,7 +25,7 @@ use std::path::{Component, Path, PathBuf};
 
 use stella_core::extensions::{
     AgentDef, CommandDef, ExtensionKind, SyncEntry, SyncSource, agent_from_file, command_from_file,
-    expand_command, merge_by_name, plan_extension_sync,
+    command_from_toml, expand_command, merge_by_name, plan_extension_sync,
 };
 use stella_core::skills::Skill;
 use stella_tui::SlashCommand;
@@ -73,20 +73,41 @@ fn definition_name_for(path: &Path, kind: ExtensionKind) -> String {
         .unwrap_or(fallback)
 }
 
-/// Whether the loader can read a definition out of this entry: a flat file
-/// always can (`read_definition_files` matches any `.md` extension); a
-/// directory only can when it holds the kind's nested definition file. This
-/// mirrors, exactly, the condition under which `read_definition_files`
-/// silently skips a directory — no nested file present at all, so nothing
-/// loads and nothing is diagnosed. A namespace directory such as
-/// `.claude/commands/vercel/` holding only `deploy.md` (no `COMMAND.md`) is
-/// not loadable by this measure.
+/// Whether the loader can read a definition out of this entry.
+///
+/// A flat file always can. A directory can when it holds the kind's nested
+/// definition file — or, for **commands only**, when it is a namespace
+/// directory of `.md`/`.toml` children (`.claude/commands/vercel/deploy.md`
+/// → `/vercel:deploy`), which `read_command_files` loads.
+///
+/// This must mirror, exactly, what the loaders actually read: an entry called
+/// loadable here but skipped there becomes a dead symlink with no diagnostic
+/// anywhere, and an entry called unloadable here is reported to the user as
+/// something stella cannot use. Issue #104 was the first mismatch; the
+/// commands arm is the second, in the opposite direction.
 fn is_loadable_entry(path: &Path, kind: ExtensionKind) -> bool {
-    if path.is_dir() {
-        path.join(nested_file(kind)).symlink_metadata().is_ok()
-    } else {
-        true
+    if !path.is_dir() {
+        return true;
     }
+    if path.join(nested_file(kind)).symlink_metadata().is_ok() {
+        return true;
+    }
+    // Commands only: a directory of `.md`/`.toml` files with no `COMMAND.md`
+    // is a NAMESPACE (`.claude/commands/vercel/deploy.md` → `/vercel:deploy`),
+    // and `read_command_files` now loads it. It used to be unloadable by
+    // definition — nothing read it, so linking it created a dead symlink —
+    // which is why the whole `/ns:name` convention was invisible. Skills and
+    // agents have no namespace syntax, so they keep the stricter rule.
+    kind == ExtensionKind::Commands
+        && std::fs::read_dir(path)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .any(|e| {
+                e.file_name().to_str().is_some_and(|n| {
+                    !n.starts_with('.') && (n.ends_with(".md") || n.ends_with(".toml"))
+                })
+            })
 }
 
 /// Scan one source directory for one kind (`<source_root>/<kind>`), with
@@ -385,6 +406,7 @@ fn describe_diagnostic(diag: &stella_core::extensions::ExtensionDiagnostic) -> S
     let why = match diag.problem {
         stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
         stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
+        stella_core::extensions::ExtensionProblem::Malformed => "not valid TOML",
     };
     format!("{}: {why}", diag.path)
 }
@@ -405,14 +427,137 @@ fn load_dirs(workspace_root: &Path, kind: ExtensionKind, include_workspace: bool
 fn load_commands_from(dirs: &[PathBuf], problems: &mut Vec<String>) -> Vec<CommandDef> {
     let mut parsed = Vec::new();
     for dir in dirs {
-        for (path, raw) in read_definition_files(dir, "COMMAND.md", problems) {
-            match command_from_file(&path, &raw) {
-                Ok(cmd) => parsed.push(cmd),
+        for found in read_command_files(dir, problems) {
+            let result = if found.is_toml {
+                command_from_toml(&found.path, &found.raw)
+            } else {
+                command_from_file(&found.path, &found.raw)
+            };
+            match result {
+                Ok(mut cmd) => {
+                    cmd.namespace = found.namespace;
+                    parsed.push(cmd);
+                }
                 Err(diag) => problems.push(describe_diagnostic(&diag)),
             }
         }
     }
-    merge_by_name(parsed, |c: &CommandDef| c.name.as_str())
+    // Merged on the INVOCATION, not the bare name: `/vercel:deploy` and
+    // `/fly:deploy` are two commands, and collapsing them would silently drop
+    // whichever loaded second.
+    merge_by_name(parsed, |c: &CommandDef| c.invocation())
+}
+
+/// One command definition file found on disk, with the namespace its location
+/// implies.
+struct FoundCommand {
+    path: String,
+    raw: String,
+    is_toml: bool,
+    namespace: Option<String>,
+}
+
+/// Scan one commands directory: flat `<slug>.{md,toml}`, the nested
+/// `<slug>/COMMAND.{md,toml}` layout, and — new — namespace directories whose
+/// children become `/<dir>:<slug>`.
+///
+/// The two directory shapes are told apart by what is inside, not by naming: a
+/// directory holding `COMMAND.md`/`COMMAND.toml` IS one command; anything else
+/// is a namespace and its `.md`/`.toml` children are its commands. That rule
+/// is what lets `.claude/commands/vercel/deploy.md` finally load — before this,
+/// `is_loadable_entry` classified such a directory as unloadable and the sync
+/// skipped it, so the whole `/ns:name` convention was invisible to stella.
+///
+/// One level only. Nesting deeper has no invocation syntax to reach it, and
+/// silently loading a command nobody can type is worse than not loading it.
+fn read_command_files(dir: &Path, problems: &mut Vec<String>) -> Vec<FoundCommand> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return found;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_none_or(|n| n.starts_with('.'))
+        {
+            continue;
+        }
+        if let Some(kind) = definition_extension(&path) {
+            push_command_file(&path, kind, None, &mut found, problems);
+            continue;
+        }
+        if !path.is_dir() {
+            continue;
+        }
+        // The nested single-command layout wins when its file is present.
+        if let Some((nested, kind)) = ["COMMAND.md", "COMMAND.toml"]
+            .iter()
+            .map(|f| path.join(f))
+            .find_map(|p| definition_extension(&p).map(|k| (p, k)))
+            .filter(|(p, _)| p.symlink_metadata().is_ok())
+        {
+            push_command_file(&nested, kind, None, &mut found, problems);
+            continue;
+        }
+        let Some(namespace) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Ok(children) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        let mut child_paths: Vec<PathBuf> = children.flatten().map(|e| e.path()).collect();
+        child_paths.sort();
+        for child in child_paths {
+            if child
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_none_or(|n| n.starts_with('.'))
+            {
+                continue;
+            }
+            if let Some(kind) = definition_extension(&child) {
+                push_command_file(
+                    &child,
+                    kind,
+                    Some(namespace.to_string()),
+                    &mut found,
+                    problems,
+                );
+            }
+        }
+    }
+    found
+}
+
+/// `Some(true)` for a `.toml` definition, `Some(false)` for `.md`, `None` for
+/// anything else.
+fn definition_extension(path: &Path) -> Option<bool> {
+    match path.extension()?.to_str()? {
+        "toml" => Some(true),
+        "md" => Some(false),
+        _ => None,
+    }
+}
+
+fn push_command_file(
+    path: &Path,
+    is_toml: bool,
+    namespace: Option<String>,
+    out: &mut Vec<FoundCommand>,
+    problems: &mut Vec<String>,
+) {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => out.push(FoundCommand {
+            path: path.display().to_string(),
+            raw,
+            is_toml,
+            namespace,
+        }),
+        Err(e) => problems.push(format!("{}: {e}", path.display())),
+    }
 }
 
 fn load_agents_from(dirs: &[PathBuf], problems: &mut Vec<String>) -> Vec<AgentDef> {
@@ -425,7 +570,7 @@ fn load_agents_from(dirs: &[PathBuf], problems: &mut Vec<String>) -> Vec<AgentDe
             }
         }
     }
-    merge_by_name(parsed, |a: &AgentDef| a.name.as_str())
+    merge_by_name(parsed, |a: &AgentDef| a.name.clone())
 }
 
 /// Everything custom a chat surface offers: commands (⚡ `/name`, prompt
@@ -515,10 +660,17 @@ impl CustomExtensions {
     pub fn slash_entries(&self, reserved: &[SlashCommand]) -> Vec<SlashCommand> {
         let mut taken: HashSet<String> = reserved.iter().map(|c| c.name.clone()).collect();
         let mut rows = Vec::new();
-        let commands = self
-            .commands
-            .iter()
-            .map(|c| (format!("/{}", c.name), c.description.clone()));
+        // Namespaced commands list under the name they are TYPED with — a row
+        // reading `/deploy` that only answers to `/vercel:deploy` teaches the
+        // wrong thing. The `argument-hint` rides in the description so the menu
+        // shows the shape the command expects.
+        let commands = self.commands.iter().map(|c| {
+            let description = match &c.argument_hint {
+                Some(hint) => format!("{hint} — {}", c.description),
+                None => c.description.clone(),
+            };
+            (format!("/{}", c.invocation()), description)
+        });
         let skills = self
             .skills
             .iter()
@@ -540,7 +692,9 @@ impl CustomExtensions {
     /// matching [`Self::slash_entries`].
     pub fn lookup(&self, head: &str) -> Option<Invocation<'_>> {
         let name = head.strip_prefix('/')?;
-        if let Some(cmd) = self.commands.iter().find(|c| c.name == name) {
+        // Matched on the invocation, so `/vercel:deploy` resolves and a bare
+        // `/deploy` reaches only a command that really is unnamespaced.
+        if let Some(cmd) = self.commands.iter().find(|c| c.invocation() == name) {
             return Some(Invocation::Command(cmd));
         }
         if let Some(skill) = self.skills.iter().find(|s| s.name == name) {
@@ -708,12 +862,13 @@ mod tests {
         );
     }
 
+    /// The witness for namespaced commands. This is the shape issue #104
+    /// documented as *unloadable* — `.claude/commands/vercel/deploy.md` with
+    /// no `vercel.md` and no `vercel/COMMAND.md`. It was unloadable because
+    /// nothing read it; now `read_command_files` does, so the sync links it
+    /// and it invokes as `/vercel:deploy`.
     #[test]
-    fn sync_skips_a_namespace_directory_with_no_nested_definition_file() {
-        // The exact shape from issue #104: another agent's namespaced
-        // command directory `.claude/commands/vercel/deploy.md`
-        // (`/vercel:deploy` in that agent) has neither a flat `vercel.md`
-        // nor a `vercel/COMMAND.md` — nothing stella's loader can read.
+    fn a_namespace_directory_is_adopted_and_loads_as_ns_colon_name() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         write(
@@ -727,28 +882,100 @@ mod tests {
             &[root.join(".claude"), root.join(".agents")],
         );
         assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
-        assert_eq!(
-            outcome.linked,
-            vec![(ExtensionKind::Commands, "build.md".to_string())],
-            "the namespace directory is never linked"
+        assert!(
+            outcome
+                .linked
+                .contains(&(ExtensionKind::Commands, "vercel".to_string())),
+            "the namespace directory is adopted now: {:?}",
+            outcome.linked
         );
-        // `NotLoadable` is reported through `unloadable`, not folded into
-        // the benign `skipped` count (nothing here was "already present").
-        assert_eq!(outcome.skipped, 0);
-        assert_eq!(outcome.unloadable.len(), 1, "{:?}", outcome.unloadable);
-        assert!(outcome.unloadable[0].contains("vercel"));
-        assert!(outcome.unloadable[0].contains("not loadable"));
-        assert!(!root.join(".stella/commands/vercel").exists());
+        assert!(
+            outcome.unloadable.is_empty(),
+            "nothing is unloadable any more: {:?}",
+            outcome.unloadable
+        );
+        assert!(root.join(".stella/commands/vercel").exists());
+
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[root.join(".stella/commands")], &mut problems);
+        assert!(problems.is_empty(), "{problems:?}");
+        let deploy = commands
+            .iter()
+            .find(|c| c.invocation() == "vercel:deploy")
+            .unwrap_or_else(|| {
+                panic!(
+                    "no /vercel:deploy in {:?}",
+                    commands.iter().map(|c| c.invocation()).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(deploy.name, "deploy", "the bare name keeps no prefix");
+        assert_eq!(deploy.namespace.as_deref(), Some("vercel"));
+    }
+
+    /// Two namespaces may hold the same bare name — merging on the bare name
+    /// would silently drop whichever loaded second.
+    #[test]
+    fn the_same_command_name_in_two_namespaces_is_two_commands() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("vercel/deploy.md"), "Ship to vercel.");
+        write(&dir.join("fly/deploy.toml"), "prompt = \"Ship to fly.\"");
+
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[dir], &mut problems);
+        assert!(problems.is_empty(), "{problems:?}");
+        let mut names: Vec<String> = commands.iter().map(|c| c.invocation()).collect();
+        names.sort();
+        assert_eq!(names, vec!["fly:deploy", "vercel:deploy"]);
+    }
+
+    /// A directory holding `COMMAND.md` is still ONE command, not a namespace
+    /// — the two directory shapes are told apart by content, not by naming.
+    #[test]
+    fn a_nested_command_directory_is_not_read_as_a_namespace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("deploy/COMMAND.md"), "Ship it.");
+        write(&dir.join("deploy/notes.md"), "Not a command.");
+
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[dir], &mut problems);
+        let names: Vec<String> = commands.iter().map(|c| c.invocation()).collect();
+        assert_eq!(names, vec!["deploy"], "{problems:?}");
+    }
+
+    #[test]
+    fn a_toml_command_loads_alongside_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir.join("build.md"), "Build it.");
+        write(
+            &dir.join("review.toml"),
+            "description = \"Review a PR\"\nargument-hint = \"<pr>\"\nprompt = \"Review $1.\"\n",
+        );
+
+        let mut problems = Vec::new();
+        let commands = load_commands_from(&[dir], &mut problems);
+        assert!(problems.is_empty(), "{problems:?}");
+        let review = commands.iter().find(|c| c.name == "review").unwrap();
+        assert_eq!(review.argument_hint.as_deref(), Some("<pr>"));
+        assert_eq!(expand_command(&review.body, "142"), "Review 142.");
+        assert!(commands.iter().any(|c| c.name == "build"));
     }
 
     #[test]
     fn sync_reports_an_unloadable_namespace_directory_even_when_nothing_else_is_found() {
-        // A workspace whose ONLY entry under `.claude/commands/` is a
-        // namespace directory: `outcome.summary()` is `None` since nothing
-        // linked, so this must not go silent (issue #104's actual bug).
+        // A workspace whose ONLY entry is a directory the loader cannot read:
+        // `outcome.summary()` is `None` since nothing linked, so this must not
+        // go silent (issue #104's actual bug).
+        //
+        // Uses SKILLS, not commands: a commands namespace directory is
+        // loadable now (`/vercel:deploy`), while skills and agents have no
+        // namespace syntax and keep the stricter rule. The guard being
+        // protected here is the reporting path, not the kind.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        write(&root.join(".claude/commands/vercel/deploy.md"), "Deploy.");
+        write(&root.join(".claude/skills/vercel/deploy.md"), "Deploy.");
 
         let outcome = sync_into(
             &root.join(".stella"),
@@ -953,14 +1180,31 @@ mod tests {
         assert!(problems.iter().any(|p| p.contains("dangling.md")));
     }
 
+    /// A command carrying none of the optional parity fields — the shape a
+    /// plain prompt file loads as, and what these menu/collision tests are
+    /// actually about.
+    fn bare_command(name: &str, description: &str, body: &str, source: &str) -> CommandDef {
+        CommandDef {
+            name: name.to_string(),
+            namespace: None,
+            description: description.to_string(),
+            argument_hint: None,
+            allowed_tools: None,
+            model: None,
+            model_invocable: true,
+            body: body.to_string(),
+            source_path: source.to_string(),
+        }
+    }
+
     fn custom_fixture() -> CustomExtensions {
         CustomExtensions {
-            commands: vec![CommandDef {
-                name: "fix-bug".to_string(),
-                description: "fix the named bug".to_string(),
-                body: "Fix $ARGUMENTS end to end.".to_string(),
-                source_path: "x/fix-bug.md".to_string(),
-            }],
+            commands: vec![bare_command(
+                "fix-bug",
+                "fix the named bug",
+                "Fix $ARGUMENTS end to end.",
+                "x/fix-bug.md",
+            )],
             skills: vec![Skill {
                 name: "sql-style".to_string(),
                 description: "format sql".to_string(),
@@ -983,12 +1227,10 @@ mod tests {
     #[test]
     fn slash_entries_are_custom_rows_that_never_shadow_builtins() {
         let mut custom = custom_fixture();
-        custom.commands.push(CommandDef {
-            name: "help".to_string(), // collides with the builtin /help
-            description: "shadowed".to_string(),
-            body: "body".to_string(),
-            source_path: "x/help.md".to_string(),
-        });
+        // collides with the builtin /help
+        custom
+            .commands
+            .push(bare_command("help", "shadowed", "body", "x/help.md"));
         let reserved = vec![SlashCommand::new("/help", "show commands")];
         let rows = custom.slash_entries(&reserved);
         let names: Vec<&str> = rows.iter().map(|r| r.name.as_str()).collect();
@@ -1027,12 +1269,9 @@ mod tests {
     #[test]
     fn expand_never_runs_a_custom_definition_under_a_reserved_name() {
         let mut custom = custom_fixture();
-        custom.commands.push(CommandDef {
-            name: "help".to_string(),
-            description: "shadowed".to_string(),
-            body: "hijacked".to_string(),
-            source_path: "x/help.md".to_string(),
-        });
+        custom
+            .commands
+            .push(bare_command("help", "shadowed", "hijacked", "x/help.md"));
         // Hidden from the menu AND unreachable at invocation time — the
         // argument-carrying form included, which bypasses whole-input
         // builtin matching in both surfaces.

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -31,6 +31,7 @@ mod candidate_ws;
 mod claims;
 mod cloud_drain;
 mod command_deck;
+mod commands_cmd;
 mod config;
 mod connect_cmd;
 mod contextgraph;
@@ -495,6 +496,16 @@ enum Command {
     Scripts {
         #[command(subcommand)]
         cmd: scripts_cmd::ScriptsCmd,
+    },
+
+    /// Custom slash commands: list what this workspace offers, or convert
+    /// markdown definitions to TOML. Conversion is deliberate and never part
+    /// of `init` — `init` SYMLINKS `.claude/commands/`, so a converted copy
+    /// trades the live link for a typed `allowed-tools` and a delimiter-free
+    /// `prompt`. Offline: reads and writes local files, needs no API key.
+    Commands {
+        #[command(subcommand)]
+        cmd: commands_cmd::CommandsCmd,
     },
 
     /// Inspect the storage map — every storage layer, namespace, relation,
@@ -1054,6 +1065,10 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // Reads the local index + manifest only — zero API keys.
             return storage_cmd::run_storage(cmd);
         }
+        Some(Command::Commands { cmd }) => {
+            // Reads (and, for convert, writes) definition files only.
+            return commands_cmd::run_commands(cmd);
+        }
         // Phase 3 (#714). Reads and appends to the local lifecycle ledger
         // only — no provider, no API key.
         Some(Command::Proposals { cmd }) => {
@@ -1381,6 +1396,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Graph { .. }
         | Command::Scripts { .. }
         | Command::Storage { .. }
+        | Command::Commands { .. }
         | Command::Inspect { .. }
         // Phase 3 (#714)
         | Command::Proposals { .. }

--- a/stella-core/Cargo.toml
+++ b/stella-core/Cargo.toml
@@ -13,6 +13,7 @@ stella-protocol = { path = "../stella-protocol" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 async-trait = { workspace = true }

--- a/stella-core/src/extensions.rs
+++ b/stella-core/src/extensions.rs
@@ -18,6 +18,13 @@
 //! `~/.stella/{commands,agents}/`. Files are flat `<slug>.md`; the
 //! frontmatter `name:` overrides the filename stem.
 //!
+//! Commands additionally accept **TOML** (`<slug>.toml`,
+//! [`command_from_toml`]) and **namespaces** — `commands/vercel/deploy.toml`
+//! is `/vercel:deploy`. The two formats carry the same fields and produce the
+//! same [`CommandDef`]: TOML is a spelling, not a feature tier, so a workspace
+//! may hold both and converting one to the other changes nothing about what
+//! the command does.
+//!
 //! # Adoption from other agents' directories (the sync plan)
 //!
 //! Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
@@ -34,15 +41,17 @@
 //!      user-authored or linked by a previous init — is skipped, so the sync
 //!      is idempotent and hand-written definitions always win.
 //!   3. **Never link something the loader can't read.** A directory entry
-//!      without the kind's nested definition file (`<slug>/COMMAND.md`,
-//!      `<slug>/SKILL.md`, `<slug>/AGENT.md`) — e.g. a *namespace* directory
-//!      like `.claude/commands/vercel/` holding `deploy.md` (the
-//!      `/vercel:deploy` convention some agents use) — has nothing the
-//!      loader reads: the CLI's `read_definition_files` deliberately, and
-//!      silently, skips a directory with no nested file. Linking it would
+//!      without the kind's nested definition file (`<slug>/SKILL.md`,
+//!      `<slug>/AGENT.md`) has nothing the loader reads; linking it would
 //!      create a symlink that does nothing, with no diagnostic anywhere.
-//!      Loading namespaced commands as `/ns:name` is a separate feature
-//!      decision, not this rule's concern.
+//!
+//!      **Commands are now the exception.** A directory like
+//!      `.claude/commands/vercel/` holding `deploy.md` is a *namespace*, and
+//!      the CLI's `read_command_files` loads its children as
+//!      `/vercel:deploy`. It used to be unloadable purely because nothing
+//!      read it (issue #104), so the rule and the reality have swapped: such
+//!      a directory is adopted. Skills and agents have no namespace syntax
+//!      and keep the stricter test.
 //!
 //! # No I/O in this module
 //!
@@ -87,18 +96,55 @@ impl ExtensionKind {
 // Definitions + parsing
 
 /// A custom slash command: a prompt template invoked as `/name`.
+///
+/// Authored as markdown-with-frontmatter (`<slug>.md`) or as TOML
+/// (`<slug>.toml`, [`command_from_toml`]). The two formats carry exactly the
+/// same fields and produce the same `CommandDef` — TOML is a spelling, not a
+/// feature tier, so nothing is gained or lost by converting and a workspace
+/// can hold both.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandDef {
-    /// The bare command name, **without** the leading slash (frontmatter
-    /// `name:` or the filename stem). `/`-prefixed on display.
+    /// The bare command name, **without** the leading slash and **without**
+    /// any namespace (frontmatter `name:` or the filename stem).
     pub name: String,
-    /// Menu description — frontmatter `description:`, falling back to the
-    /// body's first line (see `fallback_description`).
+    /// The containing subdirectory, when the definition lives one level down
+    /// (`commands/vercel/deploy.toml` → `Some("vercel")`), making the command
+    /// `/vercel:deploy`. See [`Self::invocation`].
+    pub namespace: Option<String>,
+    /// Menu description — `description:`, falling back to the body's first
+    /// line (see `fallback_description`).
     pub description: String,
-    /// The markdown body: the prompt template ([`expand_command`]).
+    /// What the argument slot expects, shown in the slash menu next to the
+    /// name (`<pr-number>`). Documentation only — nothing validates against
+    /// it, because a command that refuses to run on a shape its author did not
+    /// anticipate is worse than one that passes the text through.
+    pub argument_hint: Option<String>,
+    /// Tools this command's turn may use. `None` places no restriction; see
+    /// [`parse_toolbelt`] for the accepted spellings.
+    pub allowed_tools: Option<Vec<String>>,
+    /// A model pin for this command's turn (`provider/model_id`). `None` runs
+    /// on the session's model.
+    pub model: Option<String>,
+    /// Whether the model may invoke this command itself, as opposed to the
+    /// user typing it. Defaults to `true`; `disable-model-invocation = true`
+    /// turns it off for commands that should only ever be deliberate.
+    pub model_invocable: bool,
+    /// The prompt template ([`expand_command`]) — the markdown body, or the
+    /// TOML `prompt` key.
     pub body: String,
     /// The file this was loaded from.
     pub source_path: String,
+}
+
+impl CommandDef {
+    /// How the user types it, without the leading slash: `deploy`, or
+    /// `vercel:deploy` when namespaced.
+    pub fn invocation(&self) -> String {
+        match &self.namespace {
+            Some(ns) => format!("{ns}:{}", self.name),
+            None => self.name.clone(),
+        }
+    }
 }
 
 /// A custom agent definition: a persona with a system-prompt-shaped body.
@@ -130,6 +176,11 @@ pub enum ExtensionProblem {
     MissingName,
     /// The markdown body is empty — a template/persona with no content.
     EmptyBody,
+    /// A `.toml` definition that is not parseable TOML. Markdown has no
+    /// equivalent: frontmatter parsing is tolerant by design, but a TOML file
+    /// either parses or does not, and guessing at a broken one would load a
+    /// command whose author cannot tell it is broken.
+    Malformed,
 }
 
 /// A malformed definition file, skipped during loading (never fatal).
@@ -151,7 +202,10 @@ fn name_from_path(path: &str, nested_file: &str) -> String {
     if base.eq_ignore_ascii_case(nested_file) {
         return path.rsplit('/').nth(1).unwrap_or("").to_string();
     }
-    base.strip_suffix(".md").unwrap_or(base).to_string()
+    base.strip_suffix(".md")
+        .or_else(|| base.strip_suffix(".toml"))
+        .unwrap_or(base)
+        .to_string()
 }
 
 /// A one-line description from a body when the frontmatter has none: the
@@ -221,13 +275,115 @@ fn definition_from_file(
 /// is optional (many ecosystem command files carry only a body), falling
 /// back to the body's first line.
 pub fn command_from_file(path: &str, raw: &str) -> Result<CommandDef, ExtensionDiagnostic> {
-    let (_fm, name, description, body) = definition_from_file(path, raw, "COMMAND.md")?;
+    let (fm, name, description, body) = definition_from_file(path, raw, "COMMAND.md")?;
+    let get = |key: &str| fm.data.get(key).map(String::as_str);
     Ok(CommandDef {
         name,
+        namespace: None,
         description,
+        argument_hint: trimmed(get("argument-hint").or_else(|| get("argument_hint"))),
+        allowed_tools: parse_toolbelt(get("allowed-tools").or_else(|| get("allowed_tools"))),
+        model: trimmed(get("model")),
+        // Absent means invocable: the field exists to REMOVE a capability, so
+        // an unparseable value must not be read as the removal.
+        model_invocable: !get("disable-model-invocation")
+            .or_else(|| get("disable_model_invocation"))
+            .is_some_and(truthy),
         body,
         source_path: path.to_string(),
     })
+}
+
+/// Parse one TOML command file.
+///
+/// The same fields as the markdown form, spelled as keys, with the body under
+/// `prompt`. Kebab-case matches the frontmatter names contributors already
+/// know from the markdown files (and from the wider ecosystem); the
+/// snake_case spellings are accepted too so nobody loses a command to a
+/// plausible guess.
+///
+/// TOML earns its place on the fields markdown frontmatter is bad at:
+/// `allowed-tools` is a real array rather than a comma-string that four
+/// different quoting styles have to be normalized out of, and `prompt` is a
+/// multi-line string with no delimiter that the body could accidentally
+/// contain.
+pub fn command_from_toml(path: &str, raw: &str) -> Result<CommandDef, ExtensionDiagnostic> {
+    let diag = |problem| ExtensionDiagnostic {
+        path: path.to_string(),
+        problem,
+    };
+    let table: toml::Table = raw.parse().map_err(|_| diag(ExtensionProblem::Malformed))?;
+
+    let str_at = |key: &str, alt: &str| {
+        table
+            .get(key)
+            .or_else(|| table.get(alt))
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+
+    let name = str_at("name", "name").unwrap_or_else(|| name_from_path(path, "COMMAND.toml"));
+    if name.trim().is_empty() {
+        return Err(diag(ExtensionProblem::MissingName));
+    }
+    let body = str_at("prompt", "body").unwrap_or_default();
+    if body.is_empty() {
+        return Err(diag(ExtensionProblem::EmptyBody));
+    }
+
+    // An array is the native shape, but a bare string is accepted so a
+    // hand-converted frontmatter line still loads.
+    let allowed_tools = match table
+        .get("allowed-tools")
+        .or_else(|| table.get("allowed_tools"))
+    {
+        Some(toml::Value::Array(items)) => {
+            let joined = items
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .collect::<Vec<_>>()
+                .join(",");
+            parse_toolbelt(Some(joined.as_str()))
+        }
+        Some(toml::Value::String(s)) => parse_toolbelt(Some(s.as_str())),
+        _ => None,
+    };
+
+    Ok(CommandDef {
+        description: str_at("description", "description")
+            .unwrap_or_else(|| fallback_description(&body)),
+        argument_hint: str_at("argument-hint", "argument_hint"),
+        allowed_tools,
+        model: str_at("model", "model"),
+        model_invocable: !table
+            .get("disable-model-invocation")
+            .or_else(|| table.get("disable_model_invocation"))
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(false),
+        name,
+        namespace: None,
+        body,
+        source_path: path.to_string(),
+    })
+}
+
+/// A frontmatter value that means "yes". Narrow on purpose: this only ever
+/// gates `disable-model-invocation`, where anything unrecognized must leave
+/// the capability in place.
+fn truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "true" | "yes" | "on" | "1"
+    )
+}
+
+fn trimmed(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 /// Parse a frontmatter `tools:` value into the toolbelt grant. `None` means
@@ -286,8 +442,11 @@ pub const ARGUMENTS_PLACEHOLDER: &str = "$ARGUMENTS";
 /// (the ecosystem convention, so plain prompt files still take arguments).
 pub fn expand_command(body: &str, args: &str) -> String {
     let args = args.trim();
-    if body.contains(ARGUMENTS_PLACEHOLDER) {
-        return body.replace(ARGUMENTS_PLACEHOLDER, args);
+    let positional = positional_fields(args);
+    let has_positional = (1..=MAX_POSITIONAL).any(|i| body.contains(&format!("${i}")));
+
+    if body.contains(ARGUMENTS_PLACEHOLDER) || has_positional {
+        return substitute(body, args, &positional);
     }
     if args.is_empty() {
         body.to_string()
@@ -296,17 +455,99 @@ pub fn expand_command(body: &str, args: &str) -> String {
     }
 }
 
+/// Replace every placeholder in `body` in ONE left-to-right pass.
+///
+/// A pass per placeholder — `body.replace("$ARGUMENTS", …)` then a loop over
+/// `$1`..`$9` — rescans text it just substituted, so an argument containing
+/// `$1` gets expanded a second time and a user asking about `$1 today` has
+/// their prompt silently rewritten. Substituted text must never be a
+/// substitution target, and the only way to guarantee that is to emit it and
+/// move on.
+fn substitute(body: &str, args: &str, positional: &[&str]) -> String {
+    let mut out = String::with_capacity(body.len() + args.len());
+    let mut rest = body;
+    while let Some(at) = rest.find('$') {
+        out.push_str(&rest[..at]);
+        let tail = &rest[at..];
+        if let Some(after) = tail.strip_prefix(ARGUMENTS_PLACEHOLDER) {
+            out.push_str(args);
+            rest = after;
+            continue;
+        }
+        // `$1`..`$9`. A `$` followed by anything else — `$10`, `$0`, `$foo`, a
+        // bare `$` — is literal text the author wrote, and is emitted as-is.
+        let field = tail
+            .as_bytes()
+            .get(1)
+            .filter(|b| b.is_ascii_digit() && **b != b'0')
+            .map(|b| (*b - b'0') as usize);
+        match field {
+            Some(i) => {
+                out.push_str(positional.get(i - 1).copied().unwrap_or(""));
+                rest = &tail[2..];
+            }
+            None => {
+                out.push('$');
+                rest = &tail[1..];
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The highest positional field a body may reference (`$1`..`$9`) — the
+/// ecosystem's range, and past it `$10` would be ambiguous with `$1` followed
+/// by a literal `0`.
+const MAX_POSITIONAL: usize = 9;
+
+/// Split argument text into positional fields on whitespace, honoring double
+/// quotes so a single argument can contain spaces (`/deploy "my app" prod`).
+///
+/// Returns borrowed slices of `args`; a quoted field yields the text between
+/// the quotes. Unterminated quotes take the rest of the line rather than
+/// erroring — a command should still run when a user forgets a closing quote.
+fn positional_fields(args: &str) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let bytes = args.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        if bytes[i] == b'"' {
+            i += 1;
+            let start = i;
+            while i < bytes.len() && bytes[i] != b'"' {
+                i += 1;
+            }
+            fields.push(&args[start..i]);
+            i += 1; // past the closing quote (or harmlessly past the end)
+        } else {
+            let start = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            fields.push(&args[start..i]);
+        }
+    }
+    fields
+}
+
 // Name-merged loading (user-global, then workspace — workspace wins)
 
 /// Merge definitions by `key`, later entries overriding earlier ones while
 /// keeping the first-seen ordering position — the same semantics as
 /// [`crate::skills::load_skills`], so "workspace beats user-global" works by
 /// passing user-scope definitions first.
-pub fn merge_by_name<T>(items: Vec<T>, key: impl Fn(&T) -> &str) -> Vec<T> {
+pub fn merge_by_name<T>(items: Vec<T>, key: impl Fn(&T) -> String) -> Vec<T> {
     let mut order: Vec<String> = Vec::new();
     let mut by_name: std::collections::HashMap<String, T> = std::collections::HashMap::new();
     for item in items {
-        let name = key(&item).to_string();
+        let name = key(&item);
         if !by_name.contains_key(&name) {
             order.push(name.clone());
         }
@@ -495,6 +736,142 @@ mod tests {
         assert!(cmd.body.contains("$ARGUMENTS"));
     }
 
+    /// The witness for the whole format: TOML is a *spelling*, not a feature
+    /// tier. The same command authored either way must produce byte-identical
+    /// fields, or converting a library silently changes what the commands do.
+    #[test]
+    fn the_two_formats_parse_to_the_same_command() {
+        let md = "---\n\
+             name: review-pr\n\
+             description: Review a pull request\n\
+             argument-hint: <pr-number>\n\
+             allowed-tools: read_file, grep\n\
+             model: anthropic/claude-fable-5\n\
+             disable-model-invocation: true\n\
+             ---\n\
+             Review PR $1.";
+        let toml_src = "\
+             name = \"review-pr\"\n\
+             description = \"Review a pull request\"\n\
+             argument-hint = \"<pr-number>\"\n\
+             allowed-tools = [\"read_file\", \"grep\"]\n\
+             model = \"anthropic/claude-fable-5\"\n\
+             disable-model-invocation = true\n\
+             prompt = \"Review PR $1.\"\n";
+
+        let from_md = command_from_file("/ws/.stella/commands/review-pr.md", md).unwrap();
+        let from_toml = command_from_toml("/ws/.stella/commands/review-pr.toml", toml_src).unwrap();
+
+        assert_eq!(from_md.name, from_toml.name);
+        assert_eq!(from_md.description, from_toml.description);
+        assert_eq!(from_md.argument_hint, from_toml.argument_hint);
+        assert_eq!(from_md.allowed_tools, from_toml.allowed_tools);
+        assert_eq!(from_md.model, from_toml.model);
+        assert_eq!(from_md.model_invocable, from_toml.model_invocable);
+        assert_eq!(from_md.body, from_toml.body);
+        assert_eq!(
+            from_md.allowed_tools,
+            Some(vec!["read_file".to_string(), "grep".to_string()])
+        );
+        assert!(!from_md.model_invocable);
+    }
+
+    #[test]
+    fn a_command_without_the_new_fields_keeps_every_capability() {
+        let cmd = command_from_file("/ws/.stella/commands/ship.md", "Ship it.").unwrap();
+        assert_eq!(cmd.argument_hint, None);
+        assert_eq!(cmd.allowed_tools, None, "no key means no restriction");
+        assert_eq!(cmd.model, None);
+        assert!(
+            cmd.model_invocable,
+            "the flag exists to REMOVE a capability; absence must not remove it"
+        );
+    }
+
+    /// An unparseable TOML file is a named diagnostic, never a half-loaded
+    /// command — frontmatter can afford to be tolerant, TOML cannot.
+    #[test]
+    fn malformed_toml_is_reported_rather_than_guessed_at() {
+        let err = command_from_toml("/ws/.stella/commands/broken.toml", "name = \"x\"\nprompt =")
+            .unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::Malformed);
+        assert_eq!(err.path, "/ws/.stella/commands/broken.toml");
+    }
+
+    #[test]
+    fn a_toml_command_falls_back_to_the_filename_stem_and_first_line() {
+        let cmd =
+            command_from_toml("/ws/.stella/commands/deploy.toml", "prompt = \"Ship it.\"").unwrap();
+        assert_eq!(cmd.name, "deploy");
+        assert_eq!(cmd.description, "Ship it.");
+    }
+
+    #[test]
+    fn a_namespaced_command_is_typed_with_its_prefix() {
+        let mut cmd =
+            command_from_toml("/ws/.stella/commands/vercel/deploy.toml", "prompt = \"Go\"")
+                .unwrap();
+        assert_eq!(cmd.invocation(), "deploy");
+        cmd.namespace = Some("vercel".to_string());
+        assert_eq!(cmd.invocation(), "vercel:deploy");
+        assert_eq!(cmd.name, "deploy", "the bare name keeps no prefix");
+    }
+
+    // ---- expansion ----
+
+    #[test]
+    fn positional_fields_substitute_in_order() {
+        assert_eq!(
+            expand_command("PR $1 in $2", "142 stella"),
+            "PR 142 in stella"
+        );
+    }
+
+    #[test]
+    fn a_quoted_argument_stays_one_field() {
+        assert_eq!(
+            expand_command("deploy $1 to $2", "\"my app\" prod"),
+            "deploy my app to prod"
+        );
+    }
+
+    /// An unsupplied field empties rather than leaving `$3` in the prompt —
+    /// a literal placeholder reaching the model reads as an instruction.
+    #[test]
+    fn an_unsupplied_positional_empties() {
+        assert_eq!(expand_command("[$1][$2][$3]", "one"), "[one][][]");
+    }
+
+    /// `$ARGUMENTS` is substituted before the positionals, so argument text
+    /// that itself contains `$1` is passed through, never re-expanded.
+    #[test]
+    fn argument_text_is_never_expanded_a_second_time() {
+        assert_eq!(
+            expand_command("all: $ARGUMENTS", "cost is $1 today"),
+            "all: cost is $1 today"
+        );
+    }
+
+    /// Only `$1`..`$9` are fields. A `$` in front of anything else is text the
+    /// author wrote — a price, a shell variable, a regex — and passing it
+    /// through unchanged is the difference between a template and a mangler.
+    #[test]
+    fn a_dollar_that_is_not_a_field_is_left_alone() {
+        assert_eq!(
+            expand_command("$10 and $0 and $foo and $ — $1", "one two"),
+            "one0 and $0 and $foo and $ — one",
+            "$10 is $1 followed by a literal 0; the rest are untouched"
+        );
+    }
+
+    #[test]
+    fn a_body_with_no_placeholder_still_takes_arguments() {
+        assert_eq!(
+            expand_command("Review it.", "the PR"),
+            "Review it.\n\nthe PR"
+        );
+    }
+
     #[test]
     fn command_name_falls_back_to_the_filename_stem() {
         let cmd = command_from_file("/ws/.stella/commands/review-pr.md", "Review the PR.").unwrap();
@@ -681,7 +1058,7 @@ mod tests {
     #[test]
     fn merge_by_name_lets_later_entries_override_earlier_ones_in_place() {
         let items = vec![("a", 1), ("b", 2), ("a", 3)];
-        let merged = merge_by_name(items, |i| i.0);
+        let merged = merge_by_name(items, |i| i.0.to_string());
         assert_eq!(merged, vec![("a", 3), ("b", 2)]);
     }
 

--- a/stella-core/src/lib.rs
+++ b/stella-core/src/lib.rs
@@ -58,7 +58,7 @@ pub use event_sender::{EventSendError, EventSender};
 pub use extensions::{
     AgentDef, CommandDef, ExistingTargets, ExtensionDiagnostic, ExtensionKind, ExtensionProblem,
     PlannedLink, SyncEntry, SyncPlan, SyncSkip, SyncSkipReason, SyncSource, agent_from_file,
-    command_from_file, expand_command, merge_by_name, plan_extension_sync,
+    command_from_file, command_from_toml, expand_command, merge_by_name, plan_extension_sync,
 };
 pub use goal::{GoalConfig, GoalJudgeVerdict, GoalOutcome};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};


### PR DESCRIPTION
## What & why

`.stella/commands/some-command.toml` was **not a thing** — commands were markdown-only, and stella honored three of Claude Code's eight fields (`name`, `description`, `$ARGUMENTS`).

| | before | now |
|---|---|---|
| `.toml` definitions | — | load beside `.md` |
| `argument-hint` | ✗ | ✓ (shown in the slash menu) |
| `allowed-tools` | ✗ | ✓ (TOML array or comma string) |
| `model` | ✗ | ✓ |
| `disable-model-invocation` | ✗ | ✓ |
| `$1`…`$9` | ✗ | ✓ (quote-aware fields) |
| `/vercel:deploy` | deliberately skipped | ✓ |

```toml
# .stella/commands/review-pr.toml
name = "review-pr"
description = "Review a pull request"
argument-hint = "<pr-number>"
allowed-tools = ["read_file", "grep"]
model = "anthropic/claude-fable-5"

prompt = """
Review PR $1 in repo $2.
"""
```

## Parity had to land in markdown too

`stella init` **symlinks** `.claude/commands/*.md` into `.stella/commands/`, so a TOML-only implementation would have delivered the new fields only *after* converting — losing the live edit link that makes adoption worth having. Both parsers share one field-extraction path, and `the_two_formats_parse_to_the_same_command` pins them together. TOML is a spelling, not a feature tier.

## Namespaces: a rule and its reality have swapped

Issue #104 classified `.claude/commands/vercel/` as **unloadable** — correctly, because nothing read it, so linking it produced a dead symlink. `read_command_files` reads it now, so `is_loadable_entry` had to follow or the sync would keep reporting a directory it can actually use as unusable.

The two directory shapes are told apart by **content, never by naming**: a directory holding `COMMAND.md` IS one command; anything else is a namespace and its `.md`/`.toml` children are its commands. One level only — deeper has no invocation syntax to reach it.

Merging moved from the bare name to the invocation: `/vercel:deploy` and `/fly:deploy` are two commands, and the old key silently dropped one. The #104 silent-report guard is retargeted onto **skills**, which have no namespace syntax and keep the stricter test.

## `stella commands convert`

Opt-in, never part of `init`, because conversion trades the symlink's live edit for a typed `allowed-tools` and a delimiter-free `prompt` — the user's call, per command. It parses through the loader's own parser rather than munging text, so the emitted file means what the loader thought the markdown meant. Sources are never deleted; an existing `.toml` needs `--force`.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

`a_converted_command_parses_back_to_the_same_definition` — md → def → toml → def must be field-identical, prompt byte-for-byte.

`argument_text_is_never_expanded_a_second_time` **caught a real bug in the first implementation here**: `replace("$ARGUMENTS")` followed by a `$1..$9` loop rescans text it just substituted, so a user typing `cost is $1 today` had their own words expanded again. `expand_command` is now a single left-to-right pass — substituted text is emitted and never revisited. `a_dollar_that_is_not_a_field_is_left_alone` pins `$10` / `$0` / `$foo` / bare `$`.

Plus `a_namespace_directory_is_adopted_and_loads_as_ns_colon_name`, `the_same_command_name_in_two_namespaces_is_two_commands`, `a_nested_command_directory_is_not_read_as_a_namespace`, `an_existing_toml_is_never_clobbered_without_force`, `a_command_that_does_not_load_is_not_converted`, `absent_fields_are_absent_in_the_output`.

## The gate

`.githooks/pre-push` green — fmt, clippy `-D warnings`, `cargo doc -D warnings`, full test suite, plus no-scratch / action-pins / doc-citations / invariants / file-size.

Verified live: `stella commands convert` on a real workspace converted a flat and a namespaced command and left both sources in place.

## Not in this change

- `allowed-tools` and `model` **parse and reach the slash menu, but the turn does not yet clamp to them** — dispatch-time enforcement is the next slice.
- `` !`cmd` `` and `@path` are deliberately out. Arbitrary shell and file slurping at prompt-expansion time are a real security surface and need their own design pass.
- `stella commands list` is gated on project **trust** (`AuthorityPolicy::project_prompts_allowed`), not a settings key — it correctly shows nothing in an untrusted workspace. Covered by loader unit tests rather than a live run.


## Summary by Sourcery

Add TOML-based custom command definitions and namespaced command support, and introduce a CLI command for listing and converting workspace commands.

New Features:
- Support defining custom slash commands in TOML alongside markdown, with equivalent fields and behavior.
- Add namespaced command invocation (`/ns:name`) based on directory structure, including loading commands from namespace directories.
- Expose additional command metadata fields such as argument hints, allowed tools, model selection, and model-invocation control.
- Introduce `stella commands` CLI with `list` and `convert` subcommands for inspecting and converting command definitions.

Bug Fixes:
- Ensure command argument placeholders are expanded in a single pass so user-supplied `$` sequences are not reinterpreted or double-expanded.
- Align sync-time loadability checks with the command loader so namespaced command directories are adopted instead of reported as unloadable.

Enhancements:
- Unify parsing for markdown and TOML commands so both produce identical command definitions and round-trip cleanly.
- Extend command loading to treat namespace directories as collections of commands and merge commands by their full invocation name instead of bare name.
- Improve slash command menu entries to show namespaced invocations and argument hints, and make lookup honor the namespaced invocation.
- Add diagnostics for malformed TOML command files and propagate them through existing error reporting paths.

Documentation:
- Update extension documentation to describe TOML command definitions, namespaces, and the parity between markdown and TOML formats.

Tests:
- Add extensive tests covering TOML parsing, markdown/TOML parity, namespace loading and invocation, positional argument expansion semantics, and command conversion behavior (including non-clobbering and failure cases).
