### PR TITLE
test(core): pin the mid-turn steering invariants across a tool boundary

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,10 +18,10 @@
 1738 stella-cli/src/agent_tests.rs
 2278 stella-cli/src/agent.rs
 1627 stella-cli/src/candidate_ws.rs
-4659 stella-cli/src/command_deck.rs
+4650 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
 2125 stella-core/src/driver.rs
-2819 stella-core/src/driver/tests.rs
+2820 stella-core/src/driver/tests.rs
 1759 stella-fleet/src/fleet.rs
 1609 stella-model/src/anthropic/tests.rs
 1780 stella-model/src/bedrock.rs
@@ -37,7 +37,7 @@
 3204 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
 1783 stella-tui/src/deck_render.rs
-4096 stella-tui/src/deck_ui.rs
+4089 stella-tui/src/deck_ui.rs
 1664 stella-tui/src/model.rs
 1660 stella-tui/src/views/engine.rs
-1510 stella-tui/src/views/session.rs
+1509 stella-tui/src/views/session.rs

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -2816,4 +2816,5 @@ async fn a_none_ceiling_leaves_tool_dispatch_unbounded() {
 mod audit_fixes;
 mod budget_boundaries;
 mod compute_passes;
+mod steer_midturn;
 mod usage_completeness;

--- a/stella-core/src/driver/tests/steer_midturn.rs
+++ b/stella-core/src/driver/tests/steer_midturn.rs
@@ -1,0 +1,150 @@
+//! Mid-turn steering across a tool-call boundary. The existing witness
+//! (`steered_messages_inject_before_the_next_model_call`) steers a turn that
+//! never calls a tool, so it only proves the append happens. The interesting
+//! case is the one the deck actually produces: the user types `>` while a tool
+//! round is in flight, so the steer lands on a transcript whose tail is a
+//! `Tool` message answering an assistant `tool_use`.
+//!
+//! Two invariants have to hold there. Every tool result must still be paired
+//! with the call that produced it (an orphaned `tool_use` is a hard provider
+//! 400 that fails the whole turn), and the steer must be positioned so the
+//! next model call actually observes it.
+
+use super::*;
+
+/// A [`crate::ports::TurnSteering`] that withholds its queue until the Nth
+/// drain, so the steer lands at a chosen step boundary rather than the first.
+struct SteerAtDrain {
+    queue: std::sync::Mutex<Vec<String>>,
+    fire_on_drain: u32,
+    drains: AtomicU32,
+}
+
+impl crate::ports::TurnSteering for SteerAtDrain {
+    fn drain_steering(&self) -> Vec<String> {
+        let n = self.drains.fetch_add(1, Ordering::SeqCst) + 1;
+        if n == self.fire_on_drain {
+            std::mem::take(&mut *self.queue.lock().unwrap())
+        } else {
+            Vec::new()
+        }
+    }
+    fn soft_stop_requested(&self) -> bool {
+        false
+    }
+}
+
+#[tokio::test]
+async fn a_steer_after_a_tool_round_keeps_every_call_paired_with_its_result() {
+    // Step 0 calls a tool; step 1's boundary is where the steer lands, so the
+    // transcript it appends to ends with the Tool message from step 0.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("c1", "bash")),
+            Ok(text_result("done, and I read the tests too")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let steering = SteerAtDrain {
+        queue: std::sync::Mutex::new(vec!["also check the tests".into()]),
+        fire_on_drain: 2,
+        drains: AtomicU32::new(0),
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+        .with_steering(&steering);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "a steer arriving mid-tool-round must not fail the turn: {outcome:?}"
+    );
+
+    // The invariant a provider enforces with a 400: no tool result may precede
+    // the call it answers, and no call may be left unanswered.
+    assert_tool_pairing(&messages);
+
+    let steer_idx = messages
+        .iter()
+        .position(|m| m.role == MessageRole::User && m.content == "also check the tests")
+        .expect("the steer must enter the conversation");
+    let tool_idx = messages
+        .iter()
+        .position(|m| m.role == MessageRole::Tool)
+        .expect("step 0's tool result");
+    assert!(
+        tool_idx < steer_idx,
+        "the steer must land AFTER the tool result it interrupted, never between \
+         the assistant tool_use and its answer — that orphans the call"
+    );
+
+    // And the model must actually have seen it: the reply that answers the
+    // steer is committed after it.
+    let last_assistant = messages
+        .iter()
+        .rposition(|m| m.role == MessageRole::Assistant)
+        .expect("final assistant reply");
+    assert!(
+        steer_idx < last_assistant,
+        "the steer must precede the model call that answers it"
+    );
+}
+
+/// The shape the steer actually produces on the wire: two consecutive
+/// user-role turns, because Stella renders a `Tool` message as a user turn
+/// carrying `tool_result` blocks. This is legal on the Anthropic Messages API
+/// (consecutive same-role turns are combined), and this witness pins the
+/// transcript shape so a provider adapter that cannot tolerate it is caught
+/// here rather than at runtime.
+#[tokio::test]
+async fn a_mid_tool_round_steer_leaves_a_tool_message_immediately_before_it() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(tool_call_result("c1", "bash")),
+            Ok(text_result("done")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let steering = SteerAtDrain {
+        queue: std::sync::Mutex::new(vec!["actually, stop after this".into()]),
+        fire_on_drain: 2,
+        drains: AtomicU32::new(0),
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+        .with_steering(&steering);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let _ = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    let steer_idx = messages
+        .iter()
+        .position(|m| m.role == MessageRole::User && m.content == "actually, stop after this")
+        .expect("the steer must enter the conversation");
+    assert_eq!(
+        messages[steer_idx - 1].role,
+        MessageRole::Tool,
+        "the steer lands directly on the tool answer, so the rendered request \
+         carries two consecutive user turns: {:?}",
+        messages.iter().map(|m| m.role).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Why

Investigating a report that *"a prompt taken mid-run blows up the whole turn."* I could not reproduce a turn-killing failure at the engine level — but I found that the case which *would* kill a turn had **zero test coverage**, so this PR pins it.

The only existing steering witness (`steered_messages_inject_before_the_next_model_call`) scripts a turn that never calls a tool. It proves the append happens and nothing else. The case the deck actually produces is different: the user types `>` while a tool round is in flight, so the steer lands on a transcript whose tail is a `Tool` message answering an assistant `tool_use`.

## What is pinned

Two invariants, both passing on today's driver:

1. **Tool pairing survives the steer.** An orphaned `tool_use` is a hard provider 400 that fails the whole turn — precisely the reported failure mode. `assert_tool_pairing` now covers the steer path.
2. **The steer is correctly positioned** — after the tool answer it interrupted, before the model call that responds to it.

They pass because the drain sits at the *top* of the step loop, after the previous step's `dispatch_completion` has already appended its assistant + `Tool` pair. A steer therefore cannot land between a call and its answer. That ordering was load-bearing and untested; now it is a witness.

The second test also pins the resulting wire shape: two consecutive user-role turns (Stella renders a `Tool` message as a `user` turn carrying `tool_result` blocks). This is legal on the Anthropic Messages API — consecutive same-role turns are combined — so a provider adapter that cannot tolerate it gets caught here rather than at runtime.

## Gates

- `cargo test -p stella-core` — 605 passed, 0 failed
- `cargo clippy -p stella-core --all-targets -- -D warnings` — exit 0
- `cargo fmt --all -- --check` — exit 0
- `scripts/check-file-size.sh` — exit 0 after baseline refresh

## Baseline note

`scripts/file-size-baseline.txt` is refreshed. The new `mod steer_midturn;` declaration pushes `driver/tests.rs` +1 over its ceiling — the irreducible case the gate's own message calls out. The diff also carries three unrelated entries that had drifted *smaller* than their recorded ceiling (`command_deck.rs`, `deck_ui.rs`, `views/session.rs`), which is ratchet tightening.

## Not addressed here

Best-of-N shares one `SteeringTap` across all candidate engines (`pipeline.rs:1510-1512`), and `drain_steering` is a `std::mem::take`. Candidates run sequentially (`pipeline.rs:1280`), so candidate 1 consumes the steer and candidates 2..N never see it — if the judge picks a later candidate, the steer is silently dropped from the winning transcript. Left for a separate change since it needs a design call (fan the steer to every candidate, or scope a tap per candidate).


## Summary by Sourcery

Add targeted tests to pin mid-turn steering behavior across tool-call boundaries and ensure tool pairing and transcript ordering remain valid.

Tests:
- Add SteerAtDrain-based tests to verify mid-turn steering preserves tool-call/result pairing and does not fail the turn.
- Pin the expected transcript shape where a tool result precedes a mid-turn steer, yielding consecutive user-role turns for provider adapters.

Chores:
- Update driver test module declarations and refresh file size baseline to account for the new steering test module and tightened ceilings.
