### PR TITLE
chore(cgp): repin to CGP HEAD, verify conformance, gate the representation seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 [[package]]
 name = "contextgraph-conformance"
 version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=6f8d7ef13b2528c26913c6472405408ba2584a85#6f8d7ef13b2528c26913c6472405408ba2584a85"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=eeba49cef9a7604bd910d4faa871702869144ed0#eeba49cef9a7604bd910d4faa871702869144ed0"
 dependencies = [
  "async-trait",
  "clap",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "contextgraph-host"
 version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=6f8d7ef13b2528c26913c6472405408ba2584a85#6f8d7ef13b2528c26913c6472405408ba2584a85"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=eeba49cef9a7604bd910d4faa871702869144ed0#eeba49cef9a7604bd910d4faa871702869144ed0"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "contextgraph-trace"
 version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=6f8d7ef13b2528c26913c6472405408ba2584a85#6f8d7ef13b2528c26913c6472405408ba2584a85"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=eeba49cef9a7604bd910d4faa871702869144ed0#eeba49cef9a7604bd910d4faa871702869144ed0"
 dependencies = [
  "contextgraph-types",
  "serde",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "contextgraph-types"
 version = "0.1.0"
-source = "git+https://github.com/macanderson/context-graph-protocol?rev=6f8d7ef13b2528c26913c6472405408ba2584a85#6f8d7ef13b2528c26913c6472405408ba2584a85"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=eeba49cef9a7604bd910d4faa871702869144ed0#eeba49cef9a7604bd910d4faa871702869144ed0"
 dependencies = [
  "serde",
 ]

--- a/docs/context-reuse.md
+++ b/docs/context-reuse.md
@@ -1,12 +1,12 @@
 # Context reuse: identity, accounting, consent, and verification
 
-<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ 6f8d7ef (contextgraph/1.0-draft) -->
+<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ eeba49c (contextgraph/1.0-draft) -->
 
 <!--
   VENDORED — do not edit this copy.
 
   Source: macanderson/context-graph-protocol, docs/context-reuse.md
-  Rev:    6f8d7ef13b2528c26913c6472405408ba2584a85
+  Rev:    eeba49cef9a7604bd910d4faa871702869144ed0
 
   This is the normative contract cited by 23 rustdoc comments across five
   crates (stella-cli, stella-context, stella-graph, stella-pipeline,

--- a/docs/design/context-frame-spec.md
+++ b/docs/design/context-frame-spec.md
@@ -1,6 +1,6 @@
 # Context Frame Specification
 
-<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ 6f8d7ef (contextgraph/1.0-draft) -->
+<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ eeba49c (contextgraph/1.0-draft) -->
 
 > **Normative home — read this first.** The *atomic* Context Frame (one retrieval
 > envelope: a single snippet/symbol/fact/doc/memory/episode/graph node with its
@@ -12,10 +12,12 @@
 > repository**, not this one: `SPEC.md`, `docs/adr/0007-protocol-product-boundary.md`,
 > and the reconciliation delta table `docs/adaptive-context-reconciliation.md`.
 > The latter two are the outcome of
-> [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27)
-> and are **not yet published at the revision pinned above** — until #27 lands
-> they name the intended home of that decision rather than a document you can
-> open. Do not read `docs/adr/0007-…` as this workspace's `docs/adr/0007-immutable-promotion-history.md`.
+> [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27),
+> which has **landed**: all three are published at the revision pinned above and
+> are documents you can open. (They were unpublished when this header was first
+> written, which is why it used to say so.) Do not read `docs/adr/0007-…` as this
+> workspace's `docs/adr/0007-immutable-promotion-history.md` — different repo,
+> colliding number.
 >
 > **What this document is.** A host-side design doc for Stella's *adaptive-context
 > runtime*. The "Context Frame" it describes below is the **task-wide compiled

--- a/docs/design/directive-schema.md
+++ b/docs/design/directive-schema.md
@@ -1,6 +1,6 @@
 # Directive schema
 
-<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ 6f8d7ef (contextgraph/1.0-draft) -->
+<!-- NORMATIVE-HOME: macanderson/context-graph-protocol @ eeba49c (contextgraph/1.0-draft) -->
 
 > **Superseded — do not implement from the six-type table below.** Those six types
 > (`memory, fact, rule, preference, constraint, procedure`) predate the
@@ -11,10 +11,11 @@
 > `knowledge` kind). Portable directive semantics are owned by the **Context Graph
 > Protocol** exchange-provider profile (CGP #28), not by this document. Kept for
 > history; see, **in the CGP repository**, `docs/adaptive-context-reconciliation.md`
-> and `docs/adr/0007-protocol-product-boundary.md` — neither is published at the
-> revision pinned above (they land with
-> [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27)),
-> and neither is this workspace's `docs/adr/0007-immutable-promotion-history.md`.
+> and `docs/adr/0007-protocol-product-boundary.md` — both are published at the
+> revision pinned above, now that
+> [context-graph-protocol#27](https://github.com/macanderson/context-graph-protocol/issues/27)
+> has landed, and neither is this workspace's
+> `docs/adr/0007-immutable-promotion-history.md`.
 
 A **Directive** is the single, typed unit of information in the context engine. It represents information that may affect an agent's decisions or behavior without calling the unit itself "context."
 

--- a/stella-cli/Cargo.toml
+++ b/stella-cli/Cargo.toml
@@ -23,11 +23,11 @@ formula = "stella"
 
 [dependencies]
 stella-protocol = { path = "../stella-protocol" }
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
-contextgraph-host = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
+contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
+contextgraph-host = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
 # The host execution-trace journal + replay oracles (sketch stage) — the
 # vocabulary `stella arena` records for the arena-bench runner to judge.
-contextgraph-trace = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
+contextgraph-trace = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
 stella-core = { path = "../stella-core" }
 stella-model = { path = "../stella-model" }
 stella-tools = { path = "../stella-tools" }
@@ -62,7 +62,7 @@ rpassword.workspace = true
 # makes conformance an install/enable-time ADMISSION GATE for external
 # stdio/HTTP providers, so a non-conformant source is refused before it can
 # serve a turn. The same suite still audits the in-tree providers in tests.
-contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
+contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/stella-cli/src/contextgraph.rs
+++ b/stella-cli/src/contextgraph.rs
@@ -311,6 +311,18 @@ pub enum Admission {
     NonConformant { id: String, failures: String },
     /// The transport could not be established (spawn failed, handshake
     /// refused, endpoint unreachable).
+    ///
+    /// Also where a **C7** refusal would land if it reached here — a plaintext
+    /// `http://` URL to a non-loopback provider, which `contextgraph-host`
+    /// refuses before any bytes leave the machine. In practice it does not
+    /// reach here: [`conformance_refusal`] connects first, so the same refusal
+    /// surfaces as [`Self::NonConformant`] with the C7 message in the failing
+    /// `handshake` check's evidence. That is safe but misattributing — it blames
+    /// the provider for what is an operator typo. Reporting it honestly needs
+    /// CGP to export its loopback rule (today `is_loopback_host` is private to
+    /// `contextgraph-host::http`), because the alternative — reimplementing
+    /// "which hosts are loopback" in Stella — would duplicate a normative
+    /// protocol rule in the host, where the two copies can drift.
     Unreachable { id: String, error: String },
     /// The provider declares off-machine egress scopes with no recorded
     /// consent.
@@ -455,10 +467,17 @@ async fn conformance_refusal(id: &str, target: ProviderTarget) -> Option<Admissi
 }
 
 /// Establish the transport and register the provider on the session host.
+///
+/// The HTTP leg passes **no credential** (C8). Stella has never had a way to
+/// declare one in `context_providers`, so there is no bearer token for the host
+/// to attach — and therefore none it could leak into a log or an error. If
+/// credentialed providers are ever configurable, the token belongs in
+/// `contextgraph_host::http::Credential`, which the host is required to keep out
+/// of its own diagnostics, not in a URL Stella prints in an [`Admission`].
 async fn connect(host: &mut Host, id: &str, endpoint: &ProviderEndpoint) -> Result<(), String> {
     let result = match endpoint {
         ProviderEndpoint::Stdio { program, args } => host.add_stdio(id, program, args).await,
-        ProviderEndpoint::Http { url } => host.add_http(id, url.clone()).await,
+        ProviderEndpoint::Http { url } => host.add_http(id, url.clone(), None).await,
     };
     result.map_err(|error| error.to_string())
 }

--- a/stella-cli/src/contextgraph/tests.rs
+++ b/stella-cli/src/contextgraph/tests.rs
@@ -889,3 +889,48 @@ fn pinned_protocol_version_is_the_expected_draft() {
         "CGP protocol version changed — re-verify the conformance suite before bumping the pin"
     );
 }
+
+/// `stella_core::context_record::Representation` is a **second** declaration of
+/// the representation vocabulary CGP owns normatively (ADR 0005, `SPEC.md` §6.4
+/// P1–P5). It exists because `stella-core` deliberately carries no
+/// `contextgraph-types` dependency — the record/lifecycle layer is host-owned
+/// per ADR 0007, and keeping the core crate protocol-free is the layering that
+/// makes that true.
+///
+/// The cost of that independence is that the two enums can silently disagree,
+/// and one of them is a wire vocabulary: these strings are what a provider sends
+/// and a host parses. A rename in `stella-core` alone would compile, pass its own
+/// tests, and produce frames no conformant peer understands.
+///
+/// So this is the seam's gate. It lives here because `stella-cli` is the only
+/// crate that sees both types, and it asserts agreement in the only direction
+/// that matters — the serialized form, not the Rust identifiers. If it fails,
+/// the fix is to change whichever side drifted from CGP, never to loosen the
+/// assertion: `stella-core` does not get a vote on protocol spelling.
+#[test]
+fn the_host_record_layer_spells_representations_the_way_the_protocol_does() {
+    use contextgraph_types::Representation as Wire;
+    use stella_core::context_record::Representation as Record;
+
+    for (record, wire) in [
+        (Record::Full, Wire::Full),
+        (Record::Compact, Wire::Compact),
+        (Record::Reference, Wire::Reference),
+    ] {
+        let wire_json = serde_json::to_value(wire).expect("wire representation serializes");
+        let record_json = serde_json::to_value(record).expect("record representation serializes");
+        assert_eq!(
+            record_json, wire_json,
+            "stella-core's `{record:?}` serializes as {record_json} but CGP spells it \
+             {wire_json} — the host record layer drifted from the protocol vocabulary"
+        );
+        // `as_str` is what Stella's own surfaces render and compare on, so it
+        // has to agree with the serialized form too — otherwise the drift just
+        // moves one layer inward instead of being caught.
+        assert_eq!(
+            serde_json::Value::String(record.as_str().to_string()),
+            wire_json,
+            "stella-core's `{record:?}::as_str()` disagrees with CGP's wire spelling"
+        );
+    }
+}

--- a/stella-context/Cargo.toml
+++ b/stella-context/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
+contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/stella-graph/Cargo.toml
+++ b/stella-graph/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "6f8d7ef13b2528c26913c6472405408ba2584a85" }
+contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "eeba49cef9a7604bd910d4faa871702869144ed0" }
 # For the workspace's single durable-write + schema-version contract
 # (`stella_store::durable`, #617) — one implementation of temp + fsync +
 # rename, not one per crate.


### PR DESCRIPTION
## What this is

An evaluation of the Context Graph Protocol's current state and Stella's
conformance to it, plus the fixes the evaluation turned up. The headline: Stella
was building against a CGP revision that predated the entire pre-freeze
normative campaign, so it was conforming to a spec that had moved out from under
it.

## The pin gap

Stella pinned `contextgraph-*` at `6f8d7ef` (CGP PR #45). CGP main is `eeba49c`
— thirteen commits later, including #60, #61, #62, #63, #64, #65, #66. What
landed in between:

| Surface | Change since Stella's pin |
|---|---|
| `SPEC.md` | +389 lines; new §13 Extensibility (U1–U4) and §14 Attribution (A1–A3) |
| `contextgraph-types` | new `attribution` (342 lines) and `validate` modules |
| `contextgraph-host` | new `verify` module (546 lines); C7/C8 transport security |
| `contextgraph-conformance` | new **host-side** suite (596 lines) + reference vectors |

`PROTOCOL_VERSION` is unchanged (`contextgraph/1.0-draft`), so this is a
pre-freeze catch-up, not a version migration.

## The one breaking change

`Host::add_http` now takes `Option<Credential>` — part of the C7/C8 work. Stella
has no way to declare a credential in `context_providers`, so it passes `None`:
there is no bearer token to attach and therefore none the host could leak (C8).
Repinning also buys C7 enforcement for free — `contextgraph-host` now refuses a
plaintext `http://` transport to a non-loopback provider before any bytes leave
the machine.

**The canary already knew.** CGP's downstream canary caught this exact break on
2026-07-29 and emitted a `::warning::` — but it runs `continue-on-error`
(deliberately advisory, so a downstream repo can't block a CGP merge), so the
run reported `success` and nobody saw it.

## Verified, not assumed

Rather than reason about conformance, this branch repins and runs it. Against the
**expanded** suite at CGP HEAD:

- `workspace_memory_provider_is_cgp_conformant` — passes
- `code_graph_provider_is_cgp_conformant` — passes

Both are constructed exactly as `session_host` builds them, so the suite audits
what actually ships. **1092 tests green** across `stella-cli`, `stella-context`,
`stella-graph`; clippy `-D warnings`, `cargo fmt --check`, `check-file-size`, and
`check-normative-home` all clean.

## The drift gate (commit 2)

`stella_core::context_record::Representation` is a *second*, independent
declaration of the full/compact/reference vocabulary CGP owns normatively (ADR
0005, §6.4 P1–P5), in a crate that carries no `contextgraph-types` dependency and
no pointer to the normative home.

The independence is correct — the record/lifecycle layer is host-owned per ADR
0007. The cost is that one of those enums is a *wire* vocabulary: a rename in
`stella-core` alone would compile, pass its own tests, and emit frames no
conformant peer understands. This adds the seam's gate in `stella-cli` (the only
crate that sees both types), asserting agreement on the serialized form. Both
sides agree today, so it lands green as a tripwire.

ADR 0007 opens by diagnosing the original drift as "at its root, a name
collision" between two things called `ContextFrame`. This is the same failure
mode one layer down, caught before it fires.

## Boundary assessment: healthy

ADR 0007's two-name rule is genuinely respected, not just documented:

- `docs/design/context-frame-spec.md` correctly declares that the thing it
  describes is the host-owned `CompiledContextFrame`, **not** the protocol's
  atomic `ContextFrame`.
- `stella-graph` is implemented *as* a CGP provider; recall reaches it through
  the host, not a side channel.
- Both in-tree providers are held to the same conformance gate Stella applies to
  third-party providers.
- `check-normative-home.sh` works — it caught two design docs this branch's first
  pass missed.

Docs whose pins moved also get a stale caveat corrected: CGP's ADR 0007 and
`docs/adaptive-context-reconciliation.md` are published at this revision now that
CGP #27 has landed, where the headers still said they were not.

## Deliberately not done

- **C7 refusals misattribute.** A plaintext non-loopback URL surfaces as
  `Admission::NonConformant` rather than a config error, because
  `conformance_refusal` connects first — so it blames the provider for an
  operator typo. Fixing it honestly needs CGP to export its loopback rule
  (`is_loopback_host` is private to `contextgraph-host::http`). Reimplementing
  "which hosts are loopback" in Stella would duplicate a normative protocol rule
  in the host, where the copies can drift — so the gap is documented on the
  variant instead of papered over.
- **§14 Attribution (A1–A3) is unadopted.** Worth its own issue: CGP's
  attribution module cites Stella by name as its motivating case ("a host in this
  ecosystem already A/B-suppresses recall … entirely outside the protocol").
  Stella's `stella-core` `ContextUse` is keyed by `context_record_id`, not
  `FrameId`, so A3's "naming a frame the paired usage report actually billed" is
  not achievable today — and `to_context_usage` drops the report's `served_frames`
  drill-down. Adopting this is a design change, not a pin bump.
- **Host conformance is not parameterized.** `run_host_conformance` takes no
  arguments and drives CGP's own reference `Host`, so a downstream host cannot
  self-certify. Stella inherits the guarantees it delegates, but its
  cross-provider merge in `recall_via_host` is a *second* budget pass that the
  suite structurally cannot reach. That's a CGP-side enhancement.


## Summary by Sourcery

Repin Stella to the latest Context Graph Protocol revision, verify host/provider conformance, and add a guard to keep the host record representation aligned with the protocol vocabulary.

Enhancements:
- Update all contextgraph-* dependencies to the current CGP HEAD and adapt HTTP provider connection to the new credential-aware host API.
- Clarify how C7/C8 transport security and credential handling are surfaced through provider admissions without duplicating protocol logic in Stella.

Build:
- Bump git revisions for contextgraph-types, contextgraph-host, contextgraph-trace, and contextgraph-conformance to the latest CGP commit across crates.

Documentation:
- Refresh normative-home pointers and explanatory text in design docs and vendored CGP documentation to match the new CGP revision and published ADRs.

Tests:
- Add a conformance gate test ensuring the host record layer's representation enum serializes identically to the CGP wire representation and its string form.
