### PR TITLE
fix(deck): the scope card takes the reviewer's submission, not a sidecar

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7658,8 +7658,8 @@ blocks the work.
 ### 3. Scope review
 
 If the plan's blast radius crosses any of three configured thresholds, Stella
-pauses for an interactive **scope review** — you approve, trim, or abort the
-plan before any file changes:
+pauses for an interactive **scope review** — you approve, trim, revise, or
+abort the plan before any file changes:
 
     Fires when the plan has strictly more than this many steps.
     Fires when the plan's estimated files-touched count strictly exceeds this.
@@ -7669,6 +7669,14 @@ The comparison is strict `>` on every axis, so a plan sitting exactly at a
 threshold passes without a gate. Headless runs must opt in to bypass this gate
 explicitly — `agent_engine_config.headless_scope_bypass: "on"` — and there is
 no silent auto-approve: without it, a plan over the thresholds ends the run.
+
+**Answering the card.** `a` approves, `t` trims to the largest prefix that
+would not have tripped review, `x` aborts. You can also just **type what you
+want changed and press ⏎** — the plan goes back to the planner carrying your
+note, and the new plan is reviewed the same way. A bare `ok`/`yes` typed at the
+card approves it; a bare `no` aborts. Revision is bounded at two re-plans per
+turn, since each one is a fresh planner call — after that the keys are the way
+through.
 
 ### 4. Witness
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,8 +27,8 @@
 1780 stella-model/src/bedrock.rs
 1948 stella-model/src/openai.rs
 1738 stella-model/src/zai/tests.rs
-2669 stella-pipeline/src/pipeline.rs
-2141 stella-pipeline/src/pipeline/tests.rs
+2593 stella-pipeline/src/pipeline.rs
+2157 stella-pipeline/src/pipeline/tests.rs
 2487 stella-protocol/src/event.rs
 2292 stella-store/src/lib.rs
 2269 stella-store/src/tests.rs
@@ -37,7 +37,7 @@
 3204 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
 1782 stella-tui/src/deck_render.rs
-4089 stella-tui/src/deck_ui.rs
-1700 stella-tui/src/model.rs
+4009 stella-tui/src/deck_ui.rs
+1729 stella-tui/src/model.rs
 1660 stella-tui/src/views/engine.rs
 1519 stella-tui/src/views/session.rs

--- a/stella-cli/src/command_deck/scope_gate.rs
+++ b/stella-cli/src/command_deck/scope_gate.rs
@@ -66,6 +66,11 @@ impl DeckApprovalGate {
             DeckScopeDecision::Trim => ScopeDecision::Trim {
                 keep_steps: (0..self.max_steps.min(step_count)).collect(),
             },
+            // The reviewer typed a note instead of pressing a key. It passes
+            // through verbatim — the pipeline folds it into the next planner
+            // prompt, so anything this layer "helpfully" normalized would be
+            // words the human did not write.
+            DeckScopeDecision::Revise { note } => ScopeDecision::Revise { note },
         }
     }
 }

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -68,7 +68,10 @@ use crate::ports::{
     Recall, RecalledFrame, RepoStatusPort, RepoStructurePort, ScopeDecision, TestInvocation,
     TestRunner, WorkspaceError,
 };
-use crate::scope::{ScopeEstimate, apply_trim, build_proposal, needs_scope_review};
+use crate::scope::{
+    MAX_SCOPE_REVISIONS, PlannedScope, ScopeEstimate, ScopeVerdict, apply_trim, build_proposal,
+    needs_scope_review,
+};
 use crate::triage::{
     TaskAssessment, TaskClass, parse_triage_response, resolve_conversational, resolve_task_class,
     resolve_witness, triage_prompt,
@@ -90,6 +93,7 @@ use crate::witness::{
 mod disclosure;
 mod raw_usage;
 mod run_error;
+mod scope_stage;
 mod stage_budget;
 mod witness_stage;
 use raw_usage::{RawCall, RawCallError};
@@ -679,36 +683,21 @@ impl<'a> Pipeline<'a> {
                 .await;
         }
 
-        // --- 3. Plan (skipped for simple/single-task). ---------------------
+        // --- 3+4. Plan, then scope review — one phase, because a reviewer who
+        // asks for a different scope sends us back to the planner. -----------
         let plan: Option<Vec<PlanStep>> = if task_class.plans() {
-            let repo_structure = self.repo.structure_summary().await;
             match self
-                .plan_stage(goal, &frames, &repo_structure, budget, &mut total_cost)
+                .plan_with_review(goal, &frames, budget, &mut total_cost)
                 .await
             {
-                Ok(plan) => Some(plan),
-                Err(abort) => {
-                    return Ok(self.aborted_before_execute(task_class, total_cost, &abort.reason));
+                Ok(PlannedScope::Steps(steps)) => Some(steps),
+                Ok(PlannedScope::Ended { reason }) => {
+                    return Ok(self.aborted_before_execute(task_class, total_cost, &reason));
                 }
+                Err(cause) => return Err(PipelineRunError::new(cause, total_cost)),
             }
         } else {
             None
-        };
-        // --- 4. Scope review (only for planned work above thresholds). -----
-        let plan = match plan {
-            Some(steps) => match self.scope_review(goal, steps).await {
-                Ok(Some(steps)) => Some(steps),
-                Ok(None) => {
-                    // User aborted (or trimmed to nothing) at the gate.
-                    return Ok(self.aborted_before_execute(
-                        task_class,
-                        total_cost,
-                        "aborted at scope review",
-                    ));
-                }
-                Err(cause) => return Err(PipelineRunError::new(cause, total_cost)),
-            },
-            None => None,
         };
 
         // --- 5. Witness + execute + verify (single-shot or best-of-N). ------
@@ -1108,11 +1097,14 @@ impl<'a> Pipeline<'a> {
 
     // Stage: plan
 
+    /// `revision` is the reviewer's note from a rejected scope card, or `None`
+    /// for a turn's first plan.
     async fn plan_stage(
         &self,
         goal: &str,
         recall: &[RecalledFrame],
         repo_structure: &str,
+        revision: Option<&str>,
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> Result<Vec<PlanStep>, PipelineBudgetAbort> {
@@ -1129,7 +1121,7 @@ impl<'a> Pipeline<'a> {
             self.emit_fallback(fb);
         }
 
-        let prompt = build_planner_prompt(goal, recall, repo_structure);
+        let prompt = build_planner_prompt(goal, recall, repo_structure, revision);
         // Plan rides the worker's settings (same router tier, same tuning).
         let worker_overrides = RoleCallOverrides::default();
         let result = match self
@@ -1184,74 +1176,6 @@ impl<'a> Pipeline<'a> {
         // Degrade to a single-step plan rather than failing — a planner that
         // won't produce a parseable plan must still let the work proceed.
         Ok(fallback_plan())
-    }
-
-    // Stage: scope review
-
-    /// Returns `Ok(Some(plan))` to proceed (possibly trimmed), `Ok(None)` if
-    /// the user aborted/emptied the plan, or `Err` if headless without bypass.
-    async fn scope_review(
-        &self,
-        goal: &str,
-        plan: Vec<PlanStep>,
-    ) -> Result<Option<Vec<PlanStep>>, PipelineError> {
-        // Coarse blast-radius estimate: one file per step is a deliberately
-        // rough proxy until the planner emits per-step file hints (a
-        // documented follow-up). Cost estimate is left to the caller/planner.
-        let estimate = ScopeEstimate {
-            estimated_files: plan.len() as u32,
-            estimated_cost_usd: None,
-        };
-        if !needs_scope_review(&plan, &estimate, &self.config.scope_thresholds) {
-            return Ok(Some(plan));
-        }
-
-        if self.config.headless && self.config.headless_bypass_scope_review {
-            // Bypass means proceed, not "ask a gate that always says no".
-            // The headless approval port is `AlwaysAbortGate`, so running the
-            // review anyway would empty the plan and end the turn having done
-            // nothing — the same zero-work outcome as the error below, just
-            // spelled differently.
-            return Ok(Some(plan));
-        }
-        if self.config.headless {
-            // Say why the run is ending. This error leaves through the
-            // `Result`, not the event stream, so without this the stream just
-            // stops mid-plan: a consumer reading only events sees a run that
-            // vanished with no terminal event and no explanation.
-            self.emit(AgentEvent::Error {
-                message: format!(
-                    "this plan needs scope review ({} steps, ~{} files) and a headless \
-                     run has nobody to ask; set `headless_scope_bypass: on` where the \
-                     working tree is disposable, or raise the scope thresholds",
-                    plan.len(),
-                    estimate.estimated_files
-                ),
-                retryable: false,
-            });
-            return Err(PipelineError::ScopeReviewRequiredHeadless);
-        }
-
-        self.emit(AgentEvent::Stage {
-            name: StageKind::ScopeReview,
-        });
-        let proposal = build_proposal(goal, &plan, &estimate);
-        self.emit(AgentEvent::ScopeReview {
-            proposal: proposal.clone(),
-        });
-
-        match self.approvals.review(&proposal).await {
-            ScopeDecision::Approve => Ok(Some(plan)),
-            ScopeDecision::Trim { keep_steps } => {
-                let trimmed = apply_trim(&plan, &keep_steps);
-                if trimmed.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(trimmed))
-                }
-            }
-            ScopeDecision::Abort => Ok(None),
-        }
     }
 
     // Stage: execute + verify — candidate generation and selection

--- a/stella-pipeline/src/pipeline/scope_stage.rs
+++ b/stella-pipeline/src/pipeline/scope_stage.rs
@@ -1,0 +1,168 @@
+//! The plan → scope-review phase: build a plan, take it through the gate, and
+//! plan again when the reviewer asks for a different scope.
+//!
+//! One module because the loop is the point. `ScopeDecision::Revise` — the
+//! reviewer typing "not like that, do this" instead of pressing a key — is a
+//! jump back into the planner, so the two stages cannot be read, or bounded,
+//! independently. Split out of `pipeline.rs` on the same grounds as
+//! `witness_stage`: a stage with its own control flow reads better beside its
+//! own doc than buried in `run`.
+
+use super::*;
+
+impl Pipeline<'_> {
+    /// Plan the goal and take it through the scope gate, re-planning while the
+    /// reviewer keeps asking for a different scope (bounded by
+    /// [`MAX_SCOPE_REVISIONS`]).
+    ///
+    /// Plan and review are one method because [`ScopeDecision::Revise`] is a
+    /// loop back into the planner: a reviewer's "not like that — do this" is
+    /// only answerable by planning again with what they said. `Err` is still
+    /// only the headless-without-bypass case; everything a human can choose
+    /// comes back as [`PlannedScope`].
+    pub(super) async fn plan_with_review(
+        &self,
+        goal: &str,
+        frames: &[RecalledFrame],
+        budget: &mut BudgetGuard,
+        total: &mut f64,
+    ) -> Result<PlannedScope, PipelineError> {
+        let repo_structure = self.repo.structure_summary().await;
+        let mut revision: Option<String> = None;
+        let mut spent_revisions = 0usize;
+
+        loop {
+            let plan = match self
+                .plan_stage(
+                    goal,
+                    frames,
+                    &repo_structure,
+                    revision.as_deref(),
+                    budget,
+                    total,
+                )
+                .await
+            {
+                Ok(plan) => plan,
+                Err(abort) => {
+                    return Ok(PlannedScope::Ended {
+                        reason: abort.reason,
+                    });
+                }
+            };
+
+            match self.scope_review(goal, plan).await? {
+                ScopeVerdict::Run(steps) => return Ok(PlannedScope::Steps(steps)),
+                ScopeVerdict::Stop => {
+                    return Ok(PlannedScope::Ended {
+                        reason: "aborted at scope review".to_string(),
+                    });
+                }
+                ScopeVerdict::Revise { note } => {
+                    // The cap is on *re-planning*, not on the card: the run
+                    // that hits it has already shown the reviewer a card they
+                    // can still approve, trim, or abort. Only a further note
+                    // is refused, and the refusal says which keys still work
+                    // rather than ending on an unexplained abort.
+                    if spent_revisions >= MAX_SCOPE_REVISIONS {
+                        self.emit(AgentEvent::Error {
+                            message: format!(
+                                "scope review: {MAX_SCOPE_REVISIONS} re-plans did not settle on a \
+                                 scope you accepted, so this note was not sent to the planner \
+                                 again — approve, trim, or abort the plan on screen, or start a \
+                                 fresh turn with the goal restated"
+                            ),
+                            retryable: false,
+                        });
+                        return Ok(PlannedScope::Ended {
+                            reason: "aborted at scope review — revision limit reached".to_string(),
+                        });
+                    }
+                    spent_revisions += 1;
+                    // Name the loop-back. Without it a second PLAN stage
+                    // appears with no stated cause, which reads as the
+                    // pipeline having restarted itself.
+                    self.emit(AgentEvent::Text {
+                        delta: format!(
+                            "\n[re-planning ({spent_revisions}/{MAX_SCOPE_REVISIONS}) with your \
+                             note: {note}]\n"
+                        ),
+                    });
+                    revision = Some(note);
+                }
+            }
+        }
+    }
+
+    /// One pass of the scope gate over an already-built `plan`. `Err` is the
+    /// headless-without-bypass case only.
+    pub(super) async fn scope_review(
+        &self,
+        goal: &str,
+        plan: Vec<PlanStep>,
+    ) -> Result<ScopeVerdict, PipelineError> {
+        // Coarse blast-radius estimate: one file per step is a deliberately
+        // rough proxy until the planner emits per-step file hints (a
+        // documented follow-up). Cost estimate is left to the caller/planner.
+        let estimate = ScopeEstimate {
+            estimated_files: plan.len() as u32,
+            estimated_cost_usd: None,
+        };
+        if !needs_scope_review(&plan, &estimate, &self.config.scope_thresholds) {
+            return Ok(ScopeVerdict::Run(plan));
+        }
+
+        if self.config.headless && self.config.headless_bypass_scope_review {
+            // Bypass means proceed, not "ask a gate that always says no".
+            // The headless approval port is `AlwaysAbortGate`, so running the
+            // review anyway would empty the plan and end the turn having done
+            // nothing — the same zero-work outcome as the error below, just
+            // spelled differently.
+            return Ok(ScopeVerdict::Run(plan));
+        }
+        if self.config.headless {
+            // Say why the run is ending. This error leaves through the
+            // `Result`, not the event stream, so without this the stream just
+            // stops mid-plan: a consumer reading only events sees a run that
+            // vanished with no terminal event and no explanation.
+            self.emit(AgentEvent::Error {
+                message: format!(
+                    "this plan needs scope review ({} steps, ~{} files) and a headless \
+                     run has nobody to ask; set `headless_scope_bypass: on` where the \
+                     working tree is disposable, or raise the scope thresholds",
+                    plan.len(),
+                    estimate.estimated_files
+                ),
+                retryable: false,
+            });
+            return Err(PipelineError::ScopeReviewRequiredHeadless);
+        }
+
+        self.emit(AgentEvent::Stage {
+            name: StageKind::ScopeReview,
+        });
+        let proposal = build_proposal(goal, &plan, &estimate);
+        self.emit(AgentEvent::ScopeReview {
+            proposal: proposal.clone(),
+        });
+
+        match self.approvals.review(&proposal).await {
+            ScopeDecision::Approve => Ok(ScopeVerdict::Run(plan)),
+            ScopeDecision::Trim { keep_steps } => {
+                let trimmed = apply_trim(&plan, &keep_steps);
+                if trimmed.is_empty() {
+                    // Trimmed to nothing is a choice to run nothing, not a
+                    // revision — there is no note to re-plan from.
+                    Ok(ScopeVerdict::Stop)
+                } else {
+                    Ok(ScopeVerdict::Run(trimmed))
+                }
+            }
+            // A blank note is an empty submission, not an instruction: it
+            // would re-plan from nothing and produce the same rejected plan.
+            ScopeDecision::Revise { note } if note.trim().is_empty() => Ok(ScopeVerdict::Stop),
+            ScopeDecision::Revise { note } => Ok(ScopeVerdict::Revise { note }),
+            ScopeDecision::Abort => Ok(ScopeVerdict::Stop),
+        }
+    }
+}

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -172,12 +172,21 @@ impl RepoStatusPort for SeqRepoStatus {
 /// one ordered queue (the resolver hands the same provider to every role).
 struct ScriptedProvider {
     script: TokioMutex<VecDeque<CompletionResult>>,
+    /// Every prompt this provider was asked to complete, in order — so a test
+    /// can assert what actually reached the model, not just what came back.
+    seen: std::sync::Mutex<Vec<String>>,
 }
 impl ScriptedProvider {
     fn new(results: Vec<CompletionResult>) -> Self {
         Self {
             script: TokioMutex::new(results.into_iter().collect()),
+            seen: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    /// The message text of each request, one joined string per call.
+    fn prompts(&self) -> Vec<String> {
+        self.seen.lock().unwrap().clone()
     }
 }
 #[async_trait]
@@ -185,7 +194,14 @@ impl Provider for ScriptedProvider {
     fn id(&self) -> &str {
         "scripted"
     }
-    async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResult, ProviderError> {
+        self.seen.lock().unwrap().push(
+            req.messages
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         let mut q = self.script.lock().await;
         q.pop_front()
             .ok_or_else(|| ProviderError::Terminal("scripted provider exhausted".into()))

--- a/stella-pipeline/src/pipeline/tests/scope_gate_interactive.rs
+++ b/stella-pipeline/src/pipeline/tests/scope_gate_interactive.rs
@@ -6,6 +6,41 @@
 
 use super::*;
 
+/// A gate that answers differently each time it is consulted — needed for the
+/// revision loop, where the whole point is that the reviewer's second answer
+/// differs from the first. Records the proposals it saw so a test can assert
+/// the re-planned card actually changed. Runs out by aborting (fail-closed),
+/// so a loop bug shows up as an abort instead of hanging the test.
+struct ScriptedGate {
+    answers: std::sync::Mutex<std::collections::VecDeque<ScopeDecision>>,
+    seen: std::sync::Mutex<Vec<ScopeProposal>>,
+}
+
+impl ScriptedGate {
+    fn new(answers: Vec<ScopeDecision>) -> Self {
+        Self {
+            answers: std::sync::Mutex::new(answers.into()),
+            seen: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn cards_raised(&self) -> Vec<ScopeProposal> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ApprovalGate for ScriptedGate {
+    async fn review(&self, proposal: &ScopeProposal) -> ScopeDecision {
+        self.seen.lock().unwrap().push(proposal.clone());
+        self.answers
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(ScopeDecision::Abort)
+    }
+}
+
 /// The deck's configuration: NOT headless, with a real approval gate. The
 /// same 6-step plan that returns `ScopeReviewRequiredHeadless` for a headless
 /// run must instead raise a `ScopeReview` card and, on approve, carry on into
@@ -83,4 +118,183 @@ async fn interactive_scope_review_approve_proceeds_past_the_gate() {
         stages(&events).contains(&StageKind::Execute),
         "an approved plan proceeds into execution"
     );
+}
+
+/// The reviewer's third answer. A note at the card must send the *goal* back to
+/// the planner carrying that note, raise a fresh card for the new plan, and —
+/// once approved — execute the revised plan. Before this, a typed line at the
+/// card could not reach the gate at all: on the deck it was read as a new
+/// mid-turn request and spawned a sidecar sub-session while the review sat
+/// parked, so the only reachable key was Esc, which aborts.
+#[tokio::test]
+async fn a_revision_note_re_plans_and_gates_again() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("multi"),
+        // First plan: 6 steps, over the 5-step threshold, so it gates.
+        text_result(r#"["s1","s2","s3","s4","s5","s6"]"#),
+        // Re-plan after the note: still over the threshold, so it gates again
+        // (a revision does not skip review — the new scope is also unreviewed).
+        text_result(r#"["only the dialog","wire the key","test it","doc it","tidy","ship"]"#),
+        text_result("working"),
+        text_result("done"),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = ScriptedGate::new(vec![
+        ScopeDecision::Revise {
+            note: "only the ctrl+O dialog, skip the rest".to_string(),
+        },
+        ScopeDecision::Approve,
+    ]);
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let _ = pipeline
+        .run("add issue keybindings", &mut messages, &mut budget)
+        .await;
+
+    let events = drain(&mut rx);
+    let cards = approvals.cards_raised();
+    assert_eq!(
+        cards.len(),
+        2,
+        "the revised plan must be reviewed too — a note is not an approval"
+    );
+    assert!(
+        cards[1].steps.iter().any(|s| s.contains("only the dialog")),
+        "the second card must show the RE-PLANNED steps, not the rejected ones: {:?}",
+        cards[1].steps
+    );
+    // The planner ran twice: the loop went back through PLAN rather than
+    // patching the plan locally.
+    assert_eq!(
+        stages(&events)
+            .iter()
+            .filter(|s| **s == StageKind::Plan)
+            .count(),
+        2,
+        "a revision re-runs the planner"
+    );
+    assert!(
+        stages(&events).contains(&StageKind::Execute),
+        "the approved revision executes"
+    );
+    // The reviewer's own words reached the planner.
+    assert!(
+        provider
+            .prompts()
+            .iter()
+            .any(|p| p.contains("only the ctrl+O dialog, skip the rest")),
+        "the note must be folded into the re-plan prompt"
+    );
+}
+
+/// The loop is bounded. A reviewer who keeps typing notes cannot spend a turn's
+/// budget on planner calls forever — and the refusal must say what still works,
+/// because the alternative is a run that ends on an unexplained abort.
+#[tokio::test]
+async fn endless_revision_notes_stop_at_the_cap_and_say_why() {
+    // One more note than the cap allows, all of them answered with a note.
+    let answers: Vec<ScopeDecision> = (0..MAX_SCOPE_REVISIONS + 1)
+        .map(|i| ScopeDecision::Revise {
+            note: format!("try again {i}"),
+        })
+        .collect();
+    // A plan for every gated round: the first plan plus one per allowed
+    // revision. Each stays over the threshold so every round raises a card.
+    let mut script = vec![text_result("multi")];
+    for _ in 0..=MAX_SCOPE_REVISIONS {
+        script.push(text_result(r#"["s1","s2","s3","s4","s5","s6"]"#));
+    }
+    let provider = ScriptedProvider::new(script);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = ScriptedGate::new(answers);
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig::default(),
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run("do a large thing", &mut messages, &mut budget)
+        .await;
+
+    // The cap is on re-planning, so the reviewer still got a card for every
+    // plan that was made — one first plan plus MAX_SCOPE_REVISIONS re-plans.
+    assert_eq!(approvals.cards_raised().len(), MAX_SCOPE_REVISIONS + 1);
+    let events = drain(&mut rx);
+    assert!(
+        !stages(&events).contains(&StageKind::Execute),
+        "nothing executes — no scope was ever accepted"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, .. }
+                if message.contains("approve, trim, or abort")
+        )),
+        "the refusal must name the keys that still work: {events:?}"
+    );
+    match outcome {
+        Ok(o) => assert!(
+            matches!(&o.status, PipelineStatus::Aborted { reason } if reason.contains("revision limit")),
+            "the outcome must name the cap as the cause: {:?}",
+            o.status
+        ),
+        Err(e) => panic!("a hit cap is an abort, not a pipeline error: {e:?}"),
+    }
 }

--- a/stella-pipeline/src/plan.rs
+++ b/stella-pipeline/src/plan.rs
@@ -197,7 +197,19 @@ fn balanced_span(text: &str, open: char, close: char) -> Option<&str> {
 /// **Never** includes the running transcript — the whole point of the split.
 /// The recall frames are cited by label (L-C4), and their content is included
 /// as grounding.
-pub fn build_planner_prompt(goal: &str, recall: &[RecalledFrame], repo_structure: &str) -> String {
+///
+/// `revision` is the reviewer's note from a rejected scope card
+/// ([`crate::ScopeDecision::Revise`]) — `None` on the first plan of a turn. It
+/// is placed *after* the goal and marked as overriding, because the plan it is
+/// correcting was already a defensible reading of the goal alone: a planner
+/// that weighs the two equally tends to re-emit the plan the human just
+/// rejected.
+pub fn build_planner_prompt(
+    goal: &str,
+    recall: &[RecalledFrame],
+    repo_structure: &str,
+    revision: Option<&str>,
+) -> String {
     let mut prompt = String::new();
     prompt.push_str(
         "You are the planner for a coding agent. Produce a short ordered plan of \
@@ -209,6 +221,17 @@ pub fn build_planner_prompt(goal: &str, recall: &[RecalledFrame], repo_structure
     prompt.push_str("## Goal\n");
     prompt.push_str(goal.trim());
     prompt.push_str("\n\n");
+
+    if let Some(note) = revision.map(str::trim).filter(|n| !n.is_empty()) {
+        prompt.push_str(
+            "## Revision requested (overrides the goal where they disagree)\n\
+             A human reviewed your previous plan for this goal, rejected it, and \
+             asked for this instead. Follow it exactly — do not re-emit the \
+             rejected plan, and do not add steps it did not ask for.\n",
+        );
+        prompt.push_str(note);
+        prompt.push_str("\n\n");
+    }
 
     if !recall.is_empty() {
         prompt.push_str("## Recalled context\n");
@@ -345,6 +368,7 @@ mod tests {
             "Fix the failing budget test",
             &recall,
             "crates/\n  stella-core/src/budget.rs",
+            None,
         );
         assert!(prompt.contains("Fix the failing budget test"));
         assert!(prompt.contains("engine driver (driver.rs)"));
@@ -355,9 +379,44 @@ mod tests {
 
     #[test]
     fn planner_prompt_omits_empty_recall_and_structure_sections() {
-        let prompt = build_planner_prompt("goal", &[], "");
+        let prompt = build_planner_prompt("goal", &[], "", None);
         assert!(!prompt.contains("Recalled context"));
         assert!(!prompt.contains("Repository structure"));
+    }
+
+    /// A turn's first plan must not mention a revision — the section only
+    /// exists once a human has rejected something.
+    #[test]
+    fn planner_prompt_omits_the_revision_section_without_a_note() {
+        let prompt = build_planner_prompt("goal", &[], "", None);
+        assert!(!prompt.contains("Revision requested"));
+    }
+
+    /// The reviewer's note reaches the planner verbatim, marked as overriding
+    /// the goal — the plan it replaces was already a fair reading of the goal.
+    #[test]
+    fn planner_prompt_carries_the_revision_note_and_marks_it_overriding() {
+        let prompt = build_planner_prompt(
+            "add issue keybindings",
+            &[],
+            "",
+            Some("only the ctrl+O dialog, skip the rest"),
+        );
+        assert!(prompt.contains("Revision requested"));
+        assert!(prompt.contains("overrides the goal"));
+        assert!(prompt.contains("only the ctrl+O dialog, skip the rest"));
+        // The goal survives alongside it — a revision narrows the goal, it
+        // does not replace the reason the turn exists.
+        assert!(prompt.contains("add issue keybindings"));
+    }
+
+    /// A whitespace-only note is not an instruction. Emitting the section for
+    /// it would tell the planner a human had asked for something and then hand
+    /// it nothing to act on.
+    #[test]
+    fn planner_prompt_treats_a_blank_revision_as_no_revision() {
+        let prompt = build_planner_prompt("goal", &[], "", Some("   \n  "));
+        assert!(!prompt.contains("Revision requested"));
     }
 
     #[test]

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -490,6 +490,17 @@ pub enum ScopeDecision {
     /// Execute only the steps at these indices (into the proposed step list),
     /// in the given order. Out-of-range indices are ignored by the pipeline.
     Trim { keep_steps: Vec<usize> },
+    /// Re-plan: the reviewer rejected *this* scope and said what they want
+    /// instead. `note` is their own words, folded into the planner's next
+    /// prompt; the fresh plan is gated again (bounded — see
+    /// `MAX_SCOPE_REVISIONS` in `crate::pipeline`).
+    ///
+    /// Approve/Trim/Abort are the three answers a *yes-or-no* gate can take,
+    /// and a review is not a yes-or-no question: the common human reply to a
+    /// plan is neither "run it" nor "run less of it" but "not like that — do
+    /// this". Without this variant every such reply has to be spelled as an
+    /// abort, which throws away both the turn and the reviewer's reasoning.
+    Revise { note: String },
     /// Abandon the turn cleanly — no execution happens.
     Abort,
 }
@@ -561,14 +572,19 @@ impl ApprovalGate for AlwaysAbortGate {
     }
 }
 
-/// An [`ApprovalGate`] that prints the proposal to stdout and reads a y/n
-/// answer from stdin: `y`/`yes` approves, **everything else — including EOF,
-/// a read error, and the empty line — aborts**. Deliberately fail-closed, and
-/// deliberately without a [`ScopeDecision::Trim`] path: per-step selection
+/// An [`ApprovalGate`] that prints the proposal to stdout and reads an answer
+/// from stdin: `y`/`yes` approves, a bare `n`/`no`/empty line aborts, **EOF and
+/// read errors abort** (fail-closed), and any other typed line is the
+/// reviewer's revision note ([`ScopeDecision::Revise`]) — the same reading the
+/// TUI's card gives typed text, so the two interactive surfaces answer the gate
+/// the same way.
+///
+/// Deliberately without a [`ScopeDecision::Trim`] path: per-step selection
 /// needs a real prompt, and half-implementing it here would let a typo drop
-/// steps silently. For interactive text mode only — headless runs use
-/// [`AlwaysAbortGate`] (with the config bypass skipping the gate outright),
-/// and the TUI supplies its own gate.
+/// steps silently. (A note asking for fewer steps reaches the same place by
+/// re-planning, without inventing an index syntax over a `read_line`.) For
+/// interactive text mode only — headless runs use [`AlwaysAbortGate`] (with the
+/// config bypass skipping the gate outright), and the TUI supplies its own gate.
 ///
 /// Note that [`ApprovalGate::review`] is `async` while this reads stdin with
 /// blocking I/O, so it parks the calling runtime thread until the user
@@ -590,9 +606,12 @@ impl ApprovalGate for StdioApprovalGate {
             println!("  │ est. cost: ${cost:.4}");
         }
         println!("  └──────────────────────────────────────────────");
-        // `[y/N]`, not `[y/N/a=bort]`: there is no third branch below, so
-        // offering one told the user about a choice that does not exist.
-        print!("  Approve? [y/N]: ");
+        // Every branch offered below exists: `y` approves, a bare no/empty
+        // aborts, and anything else is read as a note (which is why the
+        // prompt has to say so — a reviewer who types a sentence at a
+        // `[y/N]` prompt would otherwise expect it to be ignored, not to
+        // become the instruction the next plan is built from).
+        print!("  Approve? [y/N, or type what to change]: ");
         let _ = io::stdout().flush();
 
         let stdin = io::stdin();
@@ -600,9 +619,13 @@ impl ApprovalGate for StdioApprovalGate {
         if stdin.lock().read_line(&mut line).is_err() {
             return ScopeDecision::Abort;
         }
-        match line.trim().to_ascii_lowercase().as_str() {
+        let answer = line.trim();
+        match answer.to_ascii_lowercase().as_str() {
             "y" | "yes" => ScopeDecision::Approve,
-            _ => ScopeDecision::Abort,
+            "" | "n" | "no" => ScopeDecision::Abort,
+            _ => ScopeDecision::Revise {
+                note: answer.to_string(),
+            },
         }
     }
 }

--- a/stella-pipeline/src/scope.rs
+++ b/stella-pipeline/src/scope.rs
@@ -109,6 +109,38 @@ pub fn apply_trim(plan: &[PlanStep], keep_steps: &[usize]) -> Vec<PlanStep> {
         .collect()
 }
 
+/// How many times one turn will re-plan for a reviewer who keeps asking for a
+/// different scope. Bounded because each revision is a fresh planner call: an
+/// unbounded loop would let a gate meant to *contain* spend become a way to
+/// spend without ever executing. Two is enough for "narrower" then "narrower
+/// still"; past that the card's approve/trim/abort keys are the honest answer.
+pub const MAX_SCOPE_REVISIONS: usize = 2;
+
+/// What one pass of the scope gate settled on. Distinct from
+/// [`crate::ScopeDecision`], which is what the *human* chose: `Trim` has
+/// already been applied here, and both "abort" and "trimmed to nothing"
+/// collapse into [`ScopeVerdict::Stop`] because the pipeline does the same
+/// thing for each.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopeVerdict {
+    /// Execute these steps.
+    Run(Vec<PlanStep>),
+    /// Plan again with the reviewer's note.
+    Revise { note: String },
+    /// End the turn before execute, having done nothing.
+    Stop,
+}
+
+/// The result of the whole plan-then-review phase, after any re-plans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedScope {
+    /// Execute these steps.
+    Steps(Vec<PlanStep>),
+    /// Nothing will execute. `reason` is already user-facing — it becomes the
+    /// aborted outcome's reason verbatim.
+    Ended { reason: String },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/stella-tui/examples/deck_demo.rs
+++ b/stella-tui/examples/deck_demo.rs
@@ -125,10 +125,15 @@ async fn main() -> std::io::Result<()> {
                             },
                         });
                         // Any non-ScopeReview stage clears the pending gate;
-                        // an abort ends the run instead.
+                        // an abort ends the run instead. A revision sends the
+                        // demo back to PLAN, which is what the real pipeline
+                        // does with the note.
                         let next = match decision {
                             ScopeDecision::Approve | ScopeDecision::Trim => AgentEvent::Stage {
                                 name: StageKind::Execute,
+                            },
+                            ScopeDecision::Revise { .. } => AgentEvent::Stage {
+                                name: StageKind::Plan,
                             },
                             ScopeDecision::Abort => AgentEvent::Complete {
                                 model: "glm-5.2".into(),

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -32,6 +32,7 @@ use crate::composer::{
     handle_slash_popup_key, slash_popup_matches,
 };
 use crate::deck::{DeckTab, WorkspaceModel};
+use crate::deck_ui::gates::handle_focused_gates;
 use crate::envelope::{
     AgentControl, AgentId, AgentScope, AgentStatus, EntityField, EntityHit, Inbound,
     InstalledAgentEntry, IssueAction, IssueRow, Secret, SkillOp, SkillScope, SkillSearchHit,
@@ -1398,6 +1399,7 @@ fn push_single_line(buf: &mut String, text: &str) {
 /// pending ask-user gate never reaches them either — it folds the agent to
 /// [`AgentStatus::WaitingInput`], which fails rule 10's `Running` check.
 mod create;
+mod gates;
 mod nav;
 pub use nav::TranscriptSearch;
 pub(crate) use nav::is_folded;
@@ -3236,88 +3238,6 @@ fn handle_skills_prompt_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
 /// The id of the focused agent, if any — also the lane a `!` command borrows.
 pub(crate) fn focused_id(model: &WorkspaceModel, ui: &DeckUi) -> Option<AgentId> {
     model.agents.get(ui.focused).map(|a| a.meta.id.clone())
-}
-
-/// Scope-review / ask-user gates for the focused agent. Returns `Some` to
-/// short-circuit; `None` to fall through to normal editing.
-fn handle_focused_gates(
-    key: KeyEvent,
-    model: &WorkspaceModel,
-    ui: &mut DeckUi,
-    agent: &AgentId,
-) -> Option<DeckAction> {
-    let entry = model.agents.get(ui.focused)?;
-    let composer_empty = ui.composer.buffer().is_empty();
-
-    // Scope review: a/t/x/Esc decide it (only when nothing is typed, and only
-    // while UNANSWERED — the pending gate clears on the engine's follow-on
-    // event, so the latch is what stops a second press re-sending the
-    // decision during that round-trip; the card reads "decision sent" until
-    // then and the keys type into the composer as usual).
-    if entry.model.pending_scope_review.is_some()
-        && !ui.scope_answered.contains(agent)
-        && composer_empty
-    {
-        let decision = match key.code {
-            KeyCode::Char('a') => Some(ScopeDecision::Approve),
-            KeyCode::Char('t') => Some(ScopeDecision::Trim),
-            KeyCode::Char('x') | KeyCode::Esc => Some(ScopeDecision::Abort),
-            _ => None,
-        };
-        if let Some(decision) = decision {
-            ui.scope_answered.insert(agent.clone());
-            return Some(DeckAction::Send(WorkspaceInput::ToAgent {
-                agent: agent.clone(),
-                input: UserInput::ScopeDecision(decision),
-            }));
-        }
-    }
-
-    // Ask-user: digit quick-pick when nothing typed; Enter submits free text.
-    // Same latch: the answer returns as the tool's own ToolResult, and until
-    // it lands a second digit/Enter must not re-answer the question.
-    if let Some(prompt) = &entry.model.pending_ask_user
-        && !ui.ask_answered.contains(agent)
-    {
-        match key.code {
-            KeyCode::Char(d @ '1'..='9') if composer_empty => {
-                let idx = (d as usize) - ('1' as usize);
-                if let Some(option) = prompt.options.get(idx) {
-                    let answer = option.clone();
-                    let id = prompt.id.clone();
-                    ui.ask_answered.insert(agent.clone());
-                    return Some(DeckAction::Send(WorkspaceInput::ToAgent {
-                        agent: agent.clone(),
-                        input: UserInput::AskUserAnswer { id, answer },
-                    }));
-                }
-            }
-            // The submit chord dispatches the typed free text as the answer.
-            // A plain `⏎` is NOT claimed — it falls through to composer
-            // editing, so the answer can span lines. A `!` line is a shell
-            // command even while a question is pending — it must run
-            // immediately, not be swallowed as the answer.
-            KeyCode::Enter
-                if classify_enter(&key) == EnterAction::Submit
-                    && !ui.composer.buffer().trim_start().starts_with('!') =>
-            {
-                if let Some(submission) = ui.composer.take_submission() {
-                    let id = prompt.id.clone();
-                    ui.ask_answered.insert(agent.clone());
-                    return Some(DeckAction::Send(WorkspaceInput::ToAgent {
-                        agent: agent.clone(),
-                        input: UserInput::AskUserAnswer {
-                            id,
-                            answer: submission.text,
-                        },
-                    }));
-                }
-                return Some(DeckAction::Ignored); // force an explicit answer
-            }
-            _ => {}
-        }
-    }
-    None
 }
 
 /// MCP tab keys. Three sub-modes: Browse (navigate the configured servers and

--- a/stella-tui/src/deck_ui/gates.rs
+++ b/stella-tui/src/deck_ui/gates.rs
@@ -1,0 +1,134 @@
+//! The focused agent's blocking gates: the scope-review card and the
+//! `ask_user` question.
+//!
+//! Both follow one rule — a pending, unanswered gate owns the user's next
+//! submission. That rule is what makes a card answerable at all: the deck's
+//! driver reads any other mid-turn submission as a *new request* and spawns a
+//! sidecar sub-session for it, so a gate that does not claim the submit chord
+//! watches the reviewer's words go to a different agent while it stays parked.
+//! Split out of `deck_ui.rs` beside `nav`/`create` (#458).
+
+use super::*;
+
+/// Scope-review / ask-user gates for the focused agent. Returns `Some` to
+/// short-circuit; `None` to fall through to normal editing.
+pub(super) fn handle_focused_gates(
+    key: KeyEvent,
+    model: &WorkspaceModel,
+    ui: &mut DeckUi,
+    agent: &AgentId,
+) -> Option<DeckAction> {
+    let entry = model.agents.get(ui.focused)?;
+    let composer_empty = ui.composer.buffer().is_empty();
+
+    // Scope review, while UNANSWERED — the pending gate clears on the engine's
+    // follow-on event, so the latch is what stops a second press re-sending the
+    // decision during that round-trip; the card reads "decision sent" until
+    // then and the keys type into the composer as usual.
+    //
+    // Two ways in, exactly like `ask_user` below: a/t/x/Esc from an empty
+    // composer, or the submit chord over typed text. The typed path is what
+    // makes the card answerable at all once the user has started writing — the
+    // decision keys are ordinary prompt characters, so they cannot claim a
+    // non-empty composer, and without a submit path the reviewer's line fell
+    // through to the driver, which reads a mid-turn prompt as a *new request*
+    // and spawns a sidecar sub-session for it. The gate stayed parked, the
+    // words went to a stranger agent, and the only key that still reached the
+    // card was Esc — which aborts. That is the whole bug: a review nobody could
+    // answer by typing, whose recovery gesture killed the turn.
+    //
+    // Known sharp edge, unchanged by this fix and deliberately not widened
+    // here: the single-key decisions claim the *first* keystroke into an empty
+    // composer, so a note that opens with a/t/x sends that decision instead of
+    // starting a note ("also do X" approves). It is survivable mostly by
+    // accident — the words most likely to open such a note are "approve",
+    // "abort" and "trim", which map to the same decision the key sent — but a
+    // note beginning "add…" or "also…" is a silent approve. Fixing it means
+    // deciding whether the card's advertised keys should require ⏎, which is a
+    // change to how every reviewer approves, not a bug fix.
+    if entry.model.pending_scope_review.is_some() && !ui.scope_answered.contains(agent) {
+        let decision = match key.code {
+            KeyCode::Char('a') if composer_empty => Some(ScopeDecision::Approve),
+            KeyCode::Char('t') if composer_empty => Some(ScopeDecision::Trim),
+            KeyCode::Char('x') | KeyCode::Esc if composer_empty => Some(ScopeDecision::Abort),
+            // A `!` line is a shell command even while a gate is pending — it
+            // must run immediately, not be read as the decision (same carve-out
+            // as `ask_user`).
+            KeyCode::Enter
+                if classify_enter(&key) == EnterAction::Submit
+                    && !ui.composer.buffer().trim_start().starts_with('!') =>
+            {
+                match ui.composer.take_submission() {
+                    // A plain `⏎` is NOT claimed above (`classify_enter` only
+                    // answers Submit for the submit chord), so a note can span
+                    // lines before it is sent.
+                    Some(submission) => Some(ScopeDecision::from_typed(&submission.text)),
+                    // An empty submit while a card is pending: force an
+                    // explicit answer rather than sending a blank note.
+                    None => return Some(DeckAction::Ignored),
+                }
+            }
+            _ => None,
+        };
+        // A blank note is not an answer — keep the card up (the composer is
+        // already drained, so this is the "typed only whitespace" case).
+        if let Some(ScopeDecision::Revise { note }) = &decision
+            && note.is_empty()
+        {
+            return Some(DeckAction::Ignored);
+        }
+        if let Some(decision) = decision {
+            ui.scope_answered.insert(agent.clone());
+            return Some(DeckAction::Send(WorkspaceInput::ToAgent {
+                agent: agent.clone(),
+                input: UserInput::ScopeDecision(decision),
+            }));
+        }
+    }
+
+    // Ask-user: digit quick-pick when nothing typed; Enter submits free text.
+    // Same latch: the answer returns as the tool's own ToolResult, and until
+    // it lands a second digit/Enter must not re-answer the question.
+    if let Some(prompt) = &entry.model.pending_ask_user
+        && !ui.ask_answered.contains(agent)
+    {
+        match key.code {
+            KeyCode::Char(d @ '1'..='9') if composer_empty => {
+                let idx = (d as usize) - ('1' as usize);
+                if let Some(option) = prompt.options.get(idx) {
+                    let answer = option.clone();
+                    let id = prompt.id.clone();
+                    ui.ask_answered.insert(agent.clone());
+                    return Some(DeckAction::Send(WorkspaceInput::ToAgent {
+                        agent: agent.clone(),
+                        input: UserInput::AskUserAnswer { id, answer },
+                    }));
+                }
+            }
+            // The submit chord dispatches the typed free text as the answer.
+            // A plain `⏎` is NOT claimed — it falls through to composer
+            // editing, so the answer can span lines. A `!` line is a shell
+            // command even while a question is pending — it must run
+            // immediately, not be swallowed as the answer.
+            KeyCode::Enter
+                if classify_enter(&key) == EnterAction::Submit
+                    && !ui.composer.buffer().trim_start().starts_with('!') =>
+            {
+                if let Some(submission) = ui.composer.take_submission() {
+                    let id = prompt.id.clone();
+                    ui.ask_answered.insert(agent.clone());
+                    return Some(DeckAction::Send(WorkspaceInput::ToAgent {
+                        agent: agent.clone(),
+                        input: UserInput::AskUserAnswer {
+                            id,
+                            answer: submission.text,
+                        },
+                    }));
+                }
+                return Some(DeckAction::Ignored); // force an explicit answer
+            }
+            _ => {}
+        }
+    }
+    None
+}

--- a/stella-tui/src/deck_ui/tests.rs
+++ b/stella-tui/src/deck_ui/tests.rs
@@ -10,6 +10,7 @@ use super::*;
 use crate::envelope::AgentMeta;
 use stella_protocol::AgentEvent;
 
+mod gates;
 mod graph;
 mod help;
 mod issues;

--- a/stella-tui/src/deck_ui/tests/gates.rs
+++ b/stella-tui/src/deck_ui/tests/gates.rs
@@ -1,0 +1,192 @@
+//! The focused-agent gates: the scope-review card and the `ask_user` question,
+//! and specifically who owns the reviewer's *submission* while one is pending.
+//!
+//! The rule both gates follow: a pending, unanswered card claims the submit
+//! chord. Without that, typing is a way to make a gate unanswerable — the deck
+//! reads a mid-turn submission as a new request and spawns a sidecar
+//! sub-session for it, leaving the gate parked with nobody answering it.
+
+use super::*;
+
+/// A pending scope card, raised on the lead.
+fn scope_card() -> Inbound {
+    Inbound::Event {
+        agent: "lead".into(),
+        event: AgentEvent::ScopeReview {
+            proposal: stella_protocol::ScopeProposal {
+                summary: "8 steps to accomplish: add issue keybindings".into(),
+                steps: vec!["s1".into(), "s2".into()],
+                estimated_files: 8,
+                estimated_cost_usd: None,
+            },
+        },
+    }
+}
+
+fn type_str(s: &str, model: &WorkspaceModel, ui: &mut DeckUi) {
+    for c in s.chars() {
+        handle_deck_key(ch(c), model, ui);
+    }
+}
+
+/// The reported bug, as a test. A reviewer typed a line at the scope card and
+/// hit ⏎; the deck read it as a new mid-turn request and enqueued it, which the
+/// driver drains into a sidecar sub-session ("req:1 started in parallel…") while
+/// the gate stays parked. The submission belongs to the gate.
+#[test]
+fn a_typed_note_at_a_scope_card_answers_the_card_instead_of_spawning_a_sidecar() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    // Opens with 'o', not a decision key — see the sharp-edge note in
+    // `handle_focused_gates` about a/t/x claiming the first keystroke.
+    type_str("only the ctrl+O dialog", &model, &mut ui);
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::ToAgent {
+            agent: "lead".into(),
+            input: UserInput::ScopeDecision(ScopeDecision::Revise {
+                note: "only the ctrl+O dialog".into()
+            }),
+        }),
+        "the note answers the review; it must never become an Enqueue"
+    );
+    assert!(
+        !matches!(action, DeckAction::Send(WorkspaceInput::Enqueue { .. })),
+        "an Enqueue here is what the driver turns into a sidecar sub-session"
+    );
+}
+
+/// The literal second submission from the report: the reviewer typed "ok",
+/// meaning approve. It spawned a second sidecar instead.
+#[test]
+fn typing_ok_at_a_scope_card_approves_it() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("ok", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::ToAgent {
+            agent: "lead".into(),
+            input: UserInput::ScopeDecision(ScopeDecision::Approve),
+        })
+    );
+}
+
+/// A note can span lines: the newline chord composes, only the submit chord
+/// answers. Otherwise a multi-line revision would be impossible to write.
+#[test]
+fn the_newline_chord_composes_a_multi_line_note_without_answering() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("only the dialog", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(cmd_enter(), &model, &mut ui),
+        DeckAction::Handled,
+        "the newline chord edits — it does not answer the card"
+    );
+    type_str("and nothing else", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::ToAgent {
+            agent: "lead".into(),
+            input: UserInput::ScopeDecision(ScopeDecision::Revise {
+                note: "only the dialog\nand nothing else".into()
+            }),
+        })
+    );
+}
+
+/// `!` is a shell command even while a gate is pending — the same carve-out
+/// `ask_user` makes. A reviewer checking `!git status` before deciding must not
+/// have it read as their revision note.
+#[test]
+fn a_shell_line_still_runs_while_a_scope_card_is_pending() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("!git status", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Shell("git status".into())
+    );
+    assert!(
+        !ui.scope_answered.contains("lead"),
+        "running a shell command must not answer the review"
+    );
+}
+
+/// An empty submit is not an answer — the card stays up rather than sending a
+/// blank note the planner would have nothing to do with.
+#[test]
+fn an_empty_submit_at_a_scope_card_keeps_the_card_up() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Ignored
+    );
+    assert!(!ui.scope_answered.contains("lead"));
+}
+
+/// Whitespace-only is the same case, after the composer has been drained.
+#[test]
+fn a_whitespace_only_note_keeps_the_card_up() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("   ", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Ignored
+    );
+    assert!(!ui.scope_answered.contains("lead"));
+}
+
+/// The rule the decision keys already followed must survive: once text exists,
+/// a/t/x are prompt characters. Only the first keystroke into an empty composer
+/// commits (see the sharp-edge note in `handle_focused_gates`).
+#[test]
+fn decision_letters_type_into_a_non_empty_composer() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("keep", &model, &mut ui);
+    for c in ['a', 't', 'x'] {
+        assert_eq!(
+            handle_deck_key(ch(c), &model, &mut ui),
+            DeckAction::Handled,
+            "{c} must type once a note is being written"
+        );
+    }
+    assert_eq!(ui.composer.buffer(), "keepatx");
+    assert!(!ui.scope_answered.contains("lead"));
+}
+
+/// With no card pending, a submission is still a prompt — the sidecar path is
+/// correct behavior and must not be collateral damage of this fix.
+#[test]
+fn without_a_pending_card_a_submission_is_still_an_ordinary_prompt() {
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+
+    type_str("go look at the graph", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Enqueue {
+            text: "go look at the graph".into()
+        })
+    );
+}

--- a/stella-tui/src/input.rs
+++ b/stella-tui/src/input.rs
@@ -30,13 +30,164 @@ pub enum UserInput {
     Cancel,
 }
 
-/// The three answers a scope-review card offers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The answers a scope-review card offers. Three are keystrokes (`a`/`t`/`x`);
+/// the fourth is whatever the reviewer typed instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScopeDecision {
     /// Run the plan as proposed.
     Approve,
     /// Approve, but trim the plan down first.
     Trim,
+    /// Re-plan with this note — the reviewer wants a different scope.
+    Revise { note: String },
     /// Abort the plan.
     Abort,
+}
+
+impl ScopeDecision {
+    /// Read a line typed at the scope card as a decision.
+    ///
+    /// A *bare* word that means yes/trim/no is that decision — a reviewer who
+    /// types "ok" and hits ⏎ means approve, and making them find the `a` key
+    /// instead is the kind of small refusal that teaches people the card is
+    /// broken. Anything longer is a [`ScopeDecision::Revise`] note, because a
+    /// sentence is an instruction: "no, don't touch the tests" starts with
+    /// "no" but reading it as `Abort` would throw away the half that says what
+    /// to do instead.
+    ///
+    /// Trailing `.`/`!`/`,` are stripped before matching, so "yes!" is still
+    /// bare. Case-insensitive. A blank line yields `Revise` with an empty note,
+    /// which callers reject before it reaches the engine — a blank submission
+    /// is not an answer.
+    ///
+    /// A single leading `>` is dropped first. Elsewhere that marker means
+    /// "steer the running turn", and a turn parked at a scope card *is* steered
+    /// by answering the card — so `> narrow it down` is this note, not a note
+    /// whose first word is a punctuation mark the planner has to guess at.
+    pub fn from_typed(text: &str) -> Self {
+        let text = text
+            .trim()
+            .strip_prefix('>')
+            .map(str::trim_start)
+            .unwrap_or_else(|| text.trim());
+        let bare = text
+            .trim()
+            .trim_end_matches(['.', '!', ','])
+            .trim()
+            .to_ascii_lowercase();
+        match bare.as_str() {
+            "a" | "y" | "yes" | "yep" | "yeah" | "ok" | "okay" | "approve" | "approved" | "go"
+            | "go ahead" | "do it" | "ship it" | "lgtm" | "sure" | "proceed" | "continue" => {
+                Self::Approve
+            }
+            "t" | "trim" | "smaller" | "less" | "fewer" | "trim it" => Self::Trim,
+            "x" | "n" | "no" | "nope" | "abort" | "cancel" | "stop" | "quit" | "nevermind"
+            | "never mind" => Self::Abort,
+            _ => Self::Revise {
+                note: text.trim().to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reported case: the user typed "ok" at a scope card and it became a
+    /// sidecar sub-session's prompt instead of an approval.
+    #[test]
+    fn a_bare_yes_word_approves() {
+        for word in ["ok", "OK", "yes", "y", "sure", "do it", "lgtm", "yes!"] {
+            assert_eq!(
+                ScopeDecision::from_typed(word),
+                ScopeDecision::Approve,
+                "{word:?} should approve"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_no_word_aborts() {
+        for word in ["no", "n", "x", "abort", "cancel", "stop", "never mind"] {
+            assert_eq!(
+                ScopeDecision::from_typed(word),
+                ScopeDecision::Abort,
+                "{word:?} should abort"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_trim_word_trims() {
+        for word in ["t", "trim", "smaller", "fewer"] {
+            assert_eq!(
+                ScopeDecision::from_typed(word),
+                ScopeDecision::Trim,
+                "{word:?} should trim"
+            );
+        }
+    }
+
+    /// The distinction that matters: a sentence beginning with a decision word
+    /// is a note, not the decision. Reading "no, just the dialog" as `Abort`
+    /// would keep the half the user cared about and discard the rest.
+    #[test]
+    fn a_sentence_is_a_note_even_when_it_starts_with_a_decision_word() {
+        assert_eq!(
+            ScopeDecision::from_typed("no, just the ctrl+O dialog"),
+            ScopeDecision::Revise {
+                note: "no, just the ctrl+O dialog".to_string()
+            }
+        );
+        assert_eq!(
+            ScopeDecision::from_typed("yes but skip the tests"),
+            ScopeDecision::Revise {
+                note: "yes but skip the tests".to_string()
+            }
+        );
+    }
+
+    /// The note keeps the user's own casing and punctuation — it is going into
+    /// a planner prompt, not a keyword match.
+    #[test]
+    fn a_note_is_preserved_verbatim_apart_from_surrounding_whitespace() {
+        assert_eq!(
+            ScopeDecision::from_typed("  Only Ctrl+O. Skip Ctrl+W!  \n"),
+            ScopeDecision::Revise {
+                note: "Only Ctrl+O. Skip Ctrl+W!".to_string()
+            }
+        );
+    }
+
+    /// `>` steers the running turn everywhere else. A turn parked at a card is
+    /// steered by answering the card, so the marker is dropped rather than
+    /// carried into the planner prompt.
+    #[test]
+    fn a_leading_steer_marker_is_dropped_from_the_note() {
+        assert_eq!(
+            ScopeDecision::from_typed("> narrow it down"),
+            ScopeDecision::Revise {
+                note: "narrow it down".to_string()
+            }
+        );
+        assert_eq!(ScopeDecision::from_typed("> ok"), ScopeDecision::Approve);
+        // Only the first one: a note that is *about* a `>` keeps it.
+        assert_eq!(
+            ScopeDecision::from_typed(">> use >> for redirects"),
+            ScopeDecision::Revise {
+                note: "> use >> for redirects".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_blank_line_is_an_empty_note_for_the_caller_to_reject() {
+        assert_eq!(
+            ScopeDecision::from_typed("   "),
+            ScopeDecision::Revise {
+                note: String::new()
+            }
+        );
+    }
 }

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -24,6 +24,7 @@ use stella_protocol::{
 
 use std::collections::VecDeque;
 
+mod error_rows;
 pub mod file_state;
 #[cfg(test)]
 pub use file_state::DIFF_HISTORY;
@@ -674,10 +675,14 @@ impl SessionModel {
                 // An aborted model call never commits its text — without
                 // this the un-committed preview would linger indefinitely.
                 self.streaming_text.clear();
-                self.transcript.push(TranscriptEntry::Error {
-                    message: message.clone(),
-                    retryable: *retryable,
-                });
+                // One failure, one row — see `error_rows` for why the same
+                // error can arrive twice.
+                if !error_rows::repeats_the_last_row(&self.transcript, message, *retryable) {
+                    self.transcript.push(TranscriptEntry::Error {
+                        message: message.clone(),
+                        retryable: *retryable,
+                    });
+                }
             }
             AgentEvent::Complete { model, cost_usd } => {
                 self.hud.stage = Some(StageKind::Complete);
@@ -1354,6 +1359,29 @@ mod tests {
             model.apply(&terminal);
             assert!(model.pending_scope_review.is_none());
         }
+    }
+
+    /// One abort, one row. The pipeline emits `Error` for an abort it decided
+    /// and also returns `Aborted`, which the host re-emits — the reported
+    /// screenshot showed "aborted at scope review" twice and it read as two
+    /// failed attempts.
+    #[test]
+    fn an_identical_error_repeated_immediately_is_reported_once() {
+        let mut model = SessionModel::new();
+        let err = AgentEvent::Error {
+            message: "aborted at scope review".into(),
+            retryable: false,
+        };
+        model.apply(&err);
+        model.apply(&err);
+        assert_eq!(
+            model
+                .transcript
+                .iter()
+                .filter(|e| matches!(e, TranscriptEntry::Error { .. }))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/stella-tui/src/model/error_rows.rs
+++ b/stella-tui/src/model/error_rows.rs
@@ -1,0 +1,91 @@
+//! Whether an incoming `Error` event is a row the transcript already shows.
+//!
+//! One failure can be reported twice at the engine/host seam. The pipeline
+//! emits `AgentEvent::Error` for an abort it decided itself — "aborted at scope
+//! review" — *and* returns `PipelineStatus::Aborted`, which the host maps to a
+//! failed turn and emits as an `Error` again. The reader saw the same red row
+//! twice and read it, reasonably, as two failures: two aborted attempts, or a
+//! retry that failed the same way.
+//!
+//! The rule is deliberately narrow. Only an *adjacent* duplicate collapses, and
+//! only when the retryable flag matches too:
+//!
+//!   - a repeat with anything in between is a genuinely separate event, and
+//!     collapsing those would hide a loop — the exact failure mode a reader
+//!     most needs the transcript to show;
+//!   - a retryable warning and a terminal failure with the same text are
+//!     different events, so the flag is part of a row's identity.
+//!
+//! Nothing is lost: an identical row sitting directly under its twin carries no
+//! information the first one does not.
+
+use super::TranscriptEntry;
+
+/// Does `(message, retryable)` restate the transcript's last row verbatim?
+pub(super) fn repeats_the_last_row(
+    transcript: &[TranscriptEntry],
+    message: &str,
+    retryable: bool,
+) -> bool {
+    matches!(
+        transcript.last(),
+        Some(TranscriptEntry::Error {
+            message: prev,
+            retryable: prev_retryable,
+        }) if prev == message && *prev_retryable == retryable
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn err(message: &str, retryable: bool) -> TranscriptEntry {
+        TranscriptEntry::Error {
+            message: message.to_string(),
+            retryable,
+        }
+    }
+
+    /// The reported screenshot: "aborted at scope review" twice, which read as
+    /// two failed attempts at the review.
+    #[test]
+    fn the_identical_error_immediately_after_itself_repeats() {
+        let rows = vec![err("aborted at scope review", false)];
+        assert!(repeats_the_last_row(
+            &rows,
+            "aborted at scope review",
+            false
+        ));
+    }
+
+    #[test]
+    fn a_different_message_is_not_a_repeat() {
+        let rows = vec![err("aborted at scope review", false)];
+        assert!(!repeats_the_last_row(&rows, "provider timeout", false));
+    }
+
+    /// A retryable warning and a terminal failure with the same text are
+    /// different events.
+    #[test]
+    fn the_same_message_with_a_different_retryable_flag_is_not_a_repeat() {
+        let rows = vec![err("rate limited", true)];
+        assert!(!repeats_the_last_row(&rows, "rate limited", false));
+    }
+
+    /// Only adjacency collapses. The same failure recurring after other
+    /// activity is a second event, and hiding it would hide a loop.
+    #[test]
+    fn an_error_separated_by_other_activity_is_not_a_repeat() {
+        let rows = vec![
+            err("provider timeout", true),
+            TranscriptEntry::Text("retrying".to_string()),
+        ];
+        assert!(!repeats_the_last_row(&rows, "provider timeout", true));
+    }
+
+    #[test]
+    fn an_empty_transcript_never_repeats() {
+        assert!(!repeats_the_last_row(&[], "anything", false));
+    }
+}

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -507,6 +507,14 @@ pub(crate) fn render_scope_review(
                 Style::new().fg(theme::DANGER).add_modifier(Modifier::BOLD),
             ),
             Span::styled("abort", Style::new().fg(theme::INK)),
+            // The typed path has to be on the card. It is now the only way to
+            // say "not like that — do this", and an affordance nobody is told
+            // about is one the next reviewer discovers by having their words
+            // routed somewhere they did not expect.
+            Span::styled(
+                "  ·  or type what to change and ⏎ to re-plan",
+                Style::new().fg(theme::TEXT_TERTIARY),
+            ),
         ])
     });
     // Warning, not the accent. A scope gate is the deck waiting on *you*, and

--- a/stella-tui/src/render/tests.rs
+++ b/stella-tui/src/render/tests.rs
@@ -402,6 +402,13 @@ fn scope_card_renders_the_decision_legend_when_unanswered() {
     let text = draw(&model, &mut ui, 100, 30);
     assert!(text.contains("refactor auth"), "card summary:\n{text}");
     assert!(text.contains("pprove"), "shows approve legend:\n{text}");
+    // The typed path is now the only way to ask for a *different* scope, so the
+    // card has to name it. An affordance nobody is told about is one the next
+    // reviewer discovers by having their words routed somewhere unexpected.
+    assert!(
+        text.contains("re-plan"),
+        "offers the typed revision path:\n{text}"
+    );
     // Once answered, the legend flips to the awaiting message.
     ui.scope_answered = true;
     let text2 = draw(&model, &mut ui, 100, 30);

--- a/stella-tui/src/shell.rs
+++ b/stella-tui/src/shell.rs
@@ -279,17 +279,27 @@ pub async fn run(
                     // (the guard enabled it), so the composer can fold it
                     // into a chip instead of replaying N raw Enter keys.
                     Some(Event::Paste(text)) => {
-                        // Modal gates swallow paste like any other non-gate
-                        // input — never queue text into the hidden composer.
-                        if model.pending_scope_review.is_none() && model.pending_ask_user.is_none()
-                        {
+                        // A pending gate takes typed free text as its answer —
+                        // a scope-review note, an `ask_user` reply — and the
+                        // composer stays on screen throughout (it is an
+                        // unconditional band; see `render`). So paste lands in
+                        // the composer here too: swallowing it meant a reviewer
+                        // could *type* a note but not paste one, which is the
+                        // same answer arriving by a different key.
+                        //
+                        // Verbatim text while a gate is pending, though — no
+                        // attachment probe. A pasted path is part of the
+                        // sentence being written ("only the file at src/x.rs"),
+                        // and a gate answer carries no attachments, so turning
+                        // it into a chip would silently drop it on submit.
+                        let gated = model.pending_scope_review.is_some()
+                            || model.pending_ask_user.is_some();
+                        match (gated, crate::attach::probe_path_attachment(&text)) {
                             // A paste that names a media file on disk (drag &
                             // drop) attaches the file itself; anything else
                             // stays literal text.
-                            match crate::attach::probe_path_attachment(&text) {
-                                Some(att) => ui.composer.attach(att),
-                                None => ui.composer.paste(&text),
-                            }
+                            (false, Some(att)) => ui.composer.attach(att),
+                            _ => ui.composer.paste(&text),
                         }
                     }
                     // Resize/other events: the next draw picks them up.

--- a/stella-tui/src/ui.rs
+++ b/stella-tui/src/ui.rs
@@ -271,13 +271,16 @@ pub fn handle_key(key: KeyEvent, model: &SessionModel, ui: &mut UiState) -> Shel
     // the keys must build the prompt, not silently approve/trim/abort the gate.
     // Mirrors the deck (`crate::deck_ui`) and the ask_user quick-pick's
     // "only when nothing is typed" rule.
+    //
+    // The submit chord then sends that typed message *to the card* — the other
+    // half of the same rule, and the half that was missing. Without it the keys
+    // build a prompt the gate never sees, which on the deck meant a sidecar
+    // sub-session ran with the reviewer's words while the review sat parked.
     if model.pending_scope_review.is_some()
         && !ui.scope_answered
-        && ui.composer.buffer().is_empty()
-        && let Some(decision) = scope_decision_for(key.code)
+        && let Some(action) = handle_scope_key(key, ui)
     {
-        ui.scope_answered = true;
-        return ShellAction::Submit(UserInput::ScopeDecision(decision));
+        return action;
     }
 
     // A pending, unanswered `ask_user` question: a number key quick-picks an
@@ -345,14 +348,32 @@ fn handle_ask_user_key(
     }
 }
 
-/// The scope-card key bindings, or `None` for a key that isn't a decision.
-fn scope_decision_for(code: KeyCode) -> Option<ScopeDecision> {
-    match code {
-        KeyCode::Char('a') => Some(ScopeDecision::Approve),
-        KeyCode::Char('t') => Some(ScopeDecision::Trim),
-        KeyCode::Char('x') | KeyCode::Esc => Some(ScopeDecision::Abort),
-        _ => None,
+/// The scope-card key bindings: `a`/`t`/`x`/`Esc` from an empty composer, or
+/// the submit chord over typed text (read by [`ScopeDecision::from_typed`]).
+/// Returns `None` to fall through to normal composer editing, so a note can be
+/// typed and can span lines.
+fn handle_scope_key(key: KeyEvent, ui: &mut UiState) -> Option<ShellAction> {
+    let empty = ui.composer.buffer().is_empty();
+    let decision = match key.code {
+        KeyCode::Char('a') if empty => ScopeDecision::Approve,
+        KeyCode::Char('t') if empty => ScopeDecision::Trim,
+        KeyCode::Char('x') | KeyCode::Esc if empty => ScopeDecision::Abort,
+        KeyCode::Enter if classify_enter(&key) == EnterAction::Submit => {
+            match ui.composer.take_submission() {
+                Some(submission) => ScopeDecision::from_typed(&submission.text),
+                // An empty submit while a card is pending: force an explicit
+                // answer rather than sending a blank one.
+                None => return Some(ShellAction::Ignored),
+            }
+        }
+        _ => return None,
+    };
+    // Whitespace-only text is not an answer — keep the card up.
+    if matches!(&decision, ScopeDecision::Revise { note } if note.is_empty()) {
+        return Some(ShellAction::Ignored);
     }
+    ui.scope_answered = true;
+    Some(ShellAction::Submit(UserInput::ScopeDecision(decision)))
 }
 
 fn handle_composer_key(key: KeyEvent, ui: &mut UiState) -> ShellAction {
@@ -759,6 +780,55 @@ mod tests {
             handle_key(ch('a'), &model, &mut ui),
             ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Approve))
         );
+    }
+
+    /// The other half of that rule, and the half that was missing: the typed
+    /// message has to reach the card when it is submitted. Deferring the keys
+    /// to the composer only helps if the composer's contents can still answer
+    /// the review — otherwise typing is a way to make the gate unanswerable.
+    #[test]
+    fn a_typed_message_is_submitted_to_the_scope_card_as_a_revision() {
+        let model = model_with_scope();
+        let mut ui = UiState::default();
+        for c in "only the dialog".chars() {
+            handle_key(ch(c), &model, &mut ui);
+        }
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Revise {
+                note: "only the dialog".into()
+            }))
+        );
+        assert!(ui.scope_answered, "the card is answered, not bypassed");
+    }
+
+    /// A bare yes word typed at the card approves it — the reviewer who types
+    /// "ok" and hits ⏎ means approve, and sending them to hunt for `a` is the
+    /// kind of small refusal that teaches people the card is broken.
+    #[test]
+    fn a_bare_yes_typed_at_the_scope_card_approves() {
+        let model = model_with_scope();
+        let mut ui = UiState::default();
+        for c in "ok".chars() {
+            handle_key(ch(c), &model, &mut ui);
+        }
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Approve))
+        );
+    }
+
+    /// An empty submit forces an explicit answer rather than sending a blank
+    /// note — and, critically, must not fall through to the prompt path.
+    #[test]
+    fn an_empty_submit_at_the_scope_card_is_ignored() {
+        let model = model_with_scope();
+        let mut ui = UiState::default();
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Ignored
+        );
+        assert!(!ui.scope_answered);
     }
 
     #[test]

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -63,8 +63,8 @@ blocks the work.
 ### 3. Scope review
 
 If the plan's blast radius crosses any of three configured thresholds, Stella
-pauses for an interactive **scope review** — you approve, trim, or abort the
-plan before any file changes:
+pauses for an interactive **scope review** — you approve, trim, revise, or
+abort the plan before any file changes:
 
 <CardGrid size="sm">
   <OptionCard name="max_steps" defaultValue="5">
@@ -82,6 +82,14 @@ The comparison is strict `>` on every axis, so a plan sitting exactly at a
 threshold passes without a gate. Headless runs must opt in to bypass this gate
 explicitly — `agent_engine_config.headless_scope_bypass: "on"` — and there is
 no silent auto-approve: without it, a plan over the thresholds ends the run.
+
+**Answering the card.** `a` approves, `t` trims to the largest prefix that
+would not have tripped review, `x` aborts. You can also just **type what you
+want changed and press ⏎** — the plan goes back to the planner carrying your
+note, and the new plan is reviewed the same way. A bare `ok`/`yes` typed at the
+card approves it; a bare `no` aborts. Revision is bounded at two re-plans per
+turn, since each one is a fresh planner call — after that the keys are the way
+through.
 
 ### 4. Witness
 


### PR DESCRIPTION
## The report

> reviewing scope in stella became impossible because my submission automatically opened a sidecar session which in theory is what should happen but NOT when the agent is asking the user for input

From the screenshot: a scope card was up (`⏸ scope  8 steps to accomplish: …`), and the two things typed at it became sub-sessions —

```
▸ req:1 started in parallel — i am testing to see what you do with this command make …
▸ req:2 started in parallel — ok
× error  aborted at scope review
× error  aborted at scope review
```

Note the second submission was literally `ok`. The reviewer was trying to approve.

## Root cause

Two gates, two different contracts.

`pending_ask_user` **claims the submit chord** — typed text becomes the answer. `pending_scope_review` claimed only `a`/`t`/`x`/`Esc`, and only `if composer_empty`. So a typed line at the scope card fell through to `dispatch_submission` → `Enqueue` → `subsession::drain_queue`, which is the sidecar. The gate stayed parked on its channel with nobody answering it.

The trap then closes on the recovery gesture: after the submit the composer *is* empty, so `Esc` **is** claimed → `ScopeDecision::Abort` → "aborted at scope review".

Proven, not assumed — the new test against the unfixed handler:

```
assertion `left == right` failed: the note answers the review; it must never become an Enqueue
  left: Send(Enqueue { text: "only the ctrl+O dialog" })
 right: Send(ToAgent { agent: "lead", input: ScopeDecision(Revise { note: "only the ctrl+O dialog" }) })
```

## The fix

**One rule, both surfaces:** a pending, unanswered gate owns the user's next submission. The deck and the single-session REPL now route the submit chord to the card through one shared parser (`ScopeDecision::from_typed`):

| typed | read as |
|---|---|
| `ok`, `yes`, `a`, `lgtm`, `do it` | Approve |
| `trim`, `smaller`, `fewer` | Trim |
| `no`, `abort`, `x`, `cancel` | Abort |
| anything longer | **Revise** — a note |
| `!git status` | shell command (unchanged) |
| empty / whitespace | card stays up, nothing sent |

A *bare* word is a decision; a sentence is an instruction. `no, just the dialog` is a note, not an abort — reading it as `Abort` would discard the half that says what to do instead.

**`ScopeDecision::Revise { note }`** gives free text somewhere to go: the pipeline folds the note into the planner prompt (marked as overriding the goal — the rejected plan was already a fair reading of the goal alone), re-plans, and gates the new plan the same way. Bounded at `MAX_SCOPE_REVISIONS = 2` per turn, since each revision is a fresh planner call; hitting the cap names the keys that still work rather than ending on an unexplained abort.

Approve/trim/abort are the three answers a *yes-or-no* gate can take, and a review isn't a yes-or-no question — the common human reply to a plan is "not like that — do this".

**Also fixed** (same screenshot): one abort printed two identical rows. The pipeline emits `Error` for an abort it decided *and* returns `PipelineStatus::Aborted`, which the host maps to a failed turn and emits again. Collapsed in `model::error_rows` — but only an *adjacent* identical row, and only when the retryable flag matches: a repeat with anything in between is a separate event, and hiding those would hide a loop.

Two smaller consistency fixes in the same class:
- `>` at a card is dropped from the note — a turn parked at a gate is steered by answering the gate, so `> narrow it down` is that note, not a note starting with a punctuation mark.
- Paste while a gate is pending now lands in the composer. It was swallowed to "never queue text into the hidden composer", but the composer is an unconditional band — you could type a note and not paste one.

## Known sharp edge (pre-existing, deliberately not widened)

The single-key decisions still claim the *first* keystroke into an empty composer, so a note opening with `a`/`t`/`x` sends that decision instead of starting a note — `also do X` approves. It survives mostly by accident (the likeliest such words are "approve"/"abort"/"trim", which map to the same decision the key sent), but `add…`/`also…` is a silent approve. Fixing it means deciding whether the card's advertised keys should require ⏎ — a change to how every reviewer approves, not a bug fix. Documented in `deck_ui/gates.rs`; say the word and it's a one-line follow-up.

## Tests

- `deck_ui/tests/gates.rs` — the reported sequence (note → gate, not Enqueue), `ok` approves, multi-line notes compose, `!` still shells, empty/whitespace keeps the card up, decision letters still type into a non-empty composer, and **no-card submissions are still ordinary prompts** (the sidecar path is correct behavior and must not be collateral damage).
- `pipeline/tests/scope_gate_interactive.rs` — a note re-plans and gates again (asserts the *second* card shows the re-planned steps and that the note reached the planner prompt), and the cap aborts with a message naming the keys.
- `input.rs` — the parser's bare-word/sentence boundary.
- `model/error_rows.rs` — adjacency and the retryable flag as part of a row's identity.

## Notes for review

`make gate` is green end to end (exit 0): tests, clippy `-D warnings`, fmt, file-size, invariants, doc-citations, action-pins, no-scratch, rustdoc.

The file-size baseline diff is worth a look — **two ceilings went down**: the plan+review loop moved to `pipeline/scope_stage.rs` (2669 → 2593) and the gate handler to `deck_ui/gates.rs` (4089 → 4009), both beside existing submodules (`witness_stage`, `nav`/`create`). Two went up slightly: `pipeline/tests.rs` +16 (a shared test double gained request recording) and `model.rs` +29 (the wiring plus one end-to-end test).

Docs: `inference-pipeline.mdx` updated with how to answer the card, `docs/llms.txt` regenerated from it (no unrelated drift).


## Summary by Sourcery

Unify scope review handling across the pipeline, TUI, and deck so that pending scope cards own the next user submission, support revision notes that re-plan, and cap endless revisions with clear abort messaging.

New Features:
- Allow reviewers to type revision notes at scope review cards that trigger re-planning with the note folded into the planner prompt.
- Support a Revise scope decision across pipeline ports, TUI, deck, CLI, and stdin approval, keeping typed notes verbatim.
- Record provider prompts in scripted tests to assert that revision notes reach the planner.

Bug Fixes:
- Route typed submissions at scope review cards to the gate instead of spawning sidecar sub-sessions, including bare approvals like "ok".
- Ensure scope review aborts are displayed once in the transcript rather than duplicated adjacent error rows.
- Allow paste while gates are pending to land in the composer instead of being swallowed.

Enhancements:
- Refactor the plan and scope review control flow into a dedicated scope_stage with explicit PlannedScope and ScopeVerdict types and a bounded revision loop.
- Extend scope decision parsing to interpret bare approval/trim/abort words and treat longer sentences as revision notes, harmonizing deck and REPL behavior.
- Improve planner prompts to include optional revision sections that override the goal when re-planning.
- Update TUI scope card rendering and key handling so typed answers submit as scope decisions, multi-line notes are supported, and shell lines still run.
- Clarify stdin scope approval prompts to describe revision notes as an option and align behavior with the TUI card.

Documentation:
- Update inference-pipeline documentation and regenerated llms.txt to describe revise behavior, keyboard shortcuts, and the bounded re-plan loop.

Tests:
- Add pipeline tests for interactive scope review revisions and revision caps, including verifying planner prompts carry reviewer notes and re-run plan stages.
- Add unit tests for ScopeDecision parsing and planner prompt revision handling.
- Add deck UI gate tests to validate that typed submissions answer scope cards, preserve shell commands, keep cards up on empty submissions, and keep normal prompt behavior without cards.
- Add TUI tests to ensure typed scope answers are submitted correctly, bare yes words approve, and empty submits are ignored.
- Add transcript error-row tests to ensure only adjacent duplicate errors are collapsed.
