### PR TITLE
fix(gate): main.rs back under the file-size limit, and the test #937's red gate hid

### DIFF
--- a/docs/design/scripts-index.md
+++ b/docs/design/scripts-index.md
@@ -30,7 +30,7 @@ the `stella graph` subcommand:
    the canonical `stella-tools/src/catalog.rs` (which `custom::RESERVED_NAMES`
    now aliases).
 3. **CLI** — `stella scripts list` / `stella scripts run <id> [-- args]`,
-   mirroring the `Graph` subcommand (`stella-cli/src/main.rs:238`), offline
+   mirroring the `Graph` subcommand (`stella-cli/src/main.rs:484`), offline
    (short-circuits before provider resolution).
 
 The detection core lives in a new `stella-tools/src/scripts.rs` and

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,6 @@
 1576 stella-cli/src/candidate_ws.rs
 4570 stella-cli/src/command_deck.rs
 1518 stella-cli/src/config.rs
-1545 stella-cli/src/main.rs
 2095 stella-core/src/bus.rs
 2138 stella-core/src/driver.rs
 2820 stella-core/src/driver/tests.rs

--- a/stella-cli/src/build_info.rs
+++ b/stella-cli/src/build_info.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Compile-time build identity — everything `-V` and `--version` report.
+//!
+//! One module because the three surfaces are one contract: `build.rs` stamps a
+//! single `STELLA_BUILD_VERSION` literal, `-V` prints its interior, `--version`
+//! extends it with the build target and profile, and the claim launcher attests
+//! the NUL-delimited bytes without executing the binary. Keeping them adjacent
+//! is what makes "the two surfaces cannot disagree about the version" checkable
+//! by reading one file.
+
+/// NUL boundaries prevent LLVM's string pooling from adjoining identifier
+/// characters to the version bytes. The claim launcher can therefore attest
+/// the full compile-time identity without executing the binary.
+pub(crate) const BUILD_VERSION_IDENTITY: &str = concat!("\0", env!("STELLA_BUILD_VERSION"), "\0");
+
+/// The version string shown by `--version` and `stella version`. `build.rs`
+/// turns an optional compile-time `STELLA_BUILD_GIT_SHA` into one contiguous
+/// literal; this returns the interior of the deliberately delimited identity.
+/// Ordinary release builds still carry the bare package version.
+pub(crate) fn version_string() -> &'static str {
+    &BUILD_VERSION_IDENTITY[1..BUILD_VERSION_IDENTITY.len() - 1]
+}
+
+/// clap's `version` attribute needs a `'static` string.
+pub(crate) fn version_static() -> &'static str {
+    version_string()
+}
+
+/// What `--version` prints, as opposed to `-V`'s single line.
+///
+/// clap's convention, which `cargo`/`rustc` both follow: the short flag stays
+/// greppable and the long one answers the questions a bug report otherwise
+/// costs a round trip — which machine this binary was built for, and whether
+/// it is an optimized build. Composed with `concat!` so it is one `'static`
+/// literal with no allocation and no startup work.
+///
+/// Deliberately does NOT restate [`version_string`] through a second code
+/// path: it interpolates the same `STELLA_BUILD_VERSION` literal `build.rs`
+/// stamped, so the two surfaces cannot disagree about the version itself.
+pub(crate) fn long_version_static() -> &'static str {
+    concat!(
+        env!("STELLA_BUILD_VERSION"),
+        "\ntarget:  ",
+        env!("STELLA_BUILD_TARGET"),
+        "\nprofile: ",
+        env!("STELLA_BUILD_PROFILE"),
+    )
+}

--- a/stella-cli/src/env_files.rs
+++ b/stella-cli/src/env_files.rs
@@ -634,10 +634,17 @@ mod tests {
     #[test]
     fn home_directory_is_never_a_project_scope() {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
-        write(home, ".env", "HOME_LEVEL=nope\n");
+        // `find_base` resolves `$HOME` only, because in production `start` is
+        // `getcwd` and therefore already symlink-free. A raw `tempdir()` path
+        // is not: on macOS `TMPDIR` lives under `/var` → `/private/var`, so
+        // passing the unresolved path as `start` compares it against its own
+        // *resolved* form, the guard misses, and the test fails for a reason
+        // that has nothing to do with the behaviour it pins. Resolve it here,
+        // exactly as the symlinked-home test below already does.
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        write(&home, ".env", "HOME_LEVEL=nope\n");
         // Running *in* $HOME must not load `~/.env`.
-        assert_eq!(find_base(home, Some(home)), None);
+        assert_eq!(find_base(&home, Some(&home)), None);
     }
 
     /// `$HOME` reached through a symlink — `/home` mounted elsewhere is a

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -26,6 +26,7 @@ mod agents_installed;
 mod arena;
 mod attachments;
 mod auth_cmd;
+mod build_info;
 mod cache_insight;
 mod candidate_ws;
 mod claims;
@@ -73,6 +74,7 @@ mod skill_manager;
 mod stats;
 mod storage_cmd;
 mod subsession;
+mod term_policy;
 mod tool_foundry;
 mod tool_policy;
 mod tool_switches;
@@ -96,7 +98,6 @@ pub(crate) mod test_env {
     }
 }
 
-use std::io::IsTerminal;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -234,8 +235,8 @@ fn emit_error_summary(format: OutputFormat, msg: &str) {
 #[derive(Parser)]
 #[command(
     name = "stella",
-    version = version_static(),
-    long_version = long_version_static(),
+    version = build_info::version_static(),
+    long_version = build_info::long_version_static(),
     about = "A fast, BYOK, model-agnostic terminal coding agent"
 )]
 struct Cli {
@@ -868,101 +869,6 @@ pub enum McpCmd {
     Usage,
 }
 
-/// NUL boundaries prevent LLVM's string pooling from adjoining identifier
-/// characters to the version bytes. The claim launcher can therefore attest
-/// the full compile-time identity without executing the binary.
-const BUILD_VERSION_IDENTITY: &str = concat!("\0", env!("STELLA_BUILD_VERSION"), "\0");
-
-/// The version string shown by `--version` and `stella version`. `build.rs`
-/// turns an optional compile-time `STELLA_BUILD_GIT_SHA` into one contiguous
-/// literal; this returns the interior of the deliberately delimited identity.
-/// Ordinary release builds still carry the bare package version.
-fn version_string() -> &'static str {
-    &BUILD_VERSION_IDENTITY[1..BUILD_VERSION_IDENTITY.len() - 1]
-}
-
-/// clap's `version` attribute needs a `'static` string.
-fn version_static() -> &'static str {
-    version_string()
-}
-
-/// What `--version` prints, as opposed to `-V`'s single line.
-///
-/// clap's convention, which `cargo`/`rustc` both follow: the short flag stays
-/// greppable and the long one answers the questions a bug report otherwise
-/// costs a round trip — which machine this binary was built for, and whether
-/// it is an optimized build. Composed with `concat!` so it is one `'static`
-/// literal with no allocation and no startup work.
-///
-/// Deliberately does NOT restate [`version_string`] through a second code
-/// path: it interpolates the same `STELLA_BUILD_VERSION` literal `build.rs`
-/// stamped, so the two surfaces cannot disagree about the version itself.
-fn long_version_static() -> &'static str {
-    concat!(
-        env!("STELLA_BUILD_VERSION"),
-        "\ntarget:  ",
-        env!("STELLA_BUILD_TARGET"),
-        "\nprofile: ",
-        env!("STELLA_BUILD_PROFILE"),
-    )
-}
-
-/// Honour `TERM=dumb` by switching ANSI output off process-wide.
-///
-/// The `colored` crate already respects `NO_COLOR`, `CLICOLOR*`, and a
-/// non-tty stream, but not `TERM` — so a dumb terminal (Emacs `M-x shell`,
-/// a bare serial console, an editor's build pane, `TERM=dumb` in CI) got the
-/// full escape-sequence treatment and rendered it literally. Every other Unix
-/// tool that colours output treats `dumb` as "this terminal cannot", so
-/// stella does too. An explicit `CLICOLOR_FORCE` still wins: it is the
-/// documented way to say "I know what my terminal is", and `colored`'s own
-/// override resolution keeps honouring it because this only sets the default
-/// when the user has not forced anything.
-fn apply_dumb_terminal_policy() {
-    if dumb_terminal(
-        std::env::var_os("TERM").as_deref(),
-        std::env::var_os("CLICOLOR_FORCE").as_deref(),
-    ) {
-        colored::control::set_override(false);
-    }
-}
-
-/// The decision behind [`apply_dumb_terminal_policy`], kept pure so it can be
-/// tested without reaching for `colored`'s process-global override (which
-/// every other test in this binary renders through).
-fn dumb_terminal(term: Option<&std::ffi::OsStr>, clicolor_force: Option<&std::ffi::OsStr>) -> bool {
-    let forced = clicolor_force.is_some_and(|v| !v.is_empty() && v != "0");
-    !forced && term.is_some_and(|term| term == "dumb")
-}
-
-/// Whether deck animation is off for this invocation: the `--no-anim` flag,
-/// or either environment signal its own help text promises.
-///
-/// The promise was only half kept. `init_fx::animation_enabled` folded
-/// `STELLA_NO_ANIM` and `NO_COLOR` in for the `stella init` cinematic, but the
-/// Command Deck — the surface with the shimmering progress bar and the
-/// blinking caret, and the one an asciinema recording or a CI log actually
-/// captures — was handed the bare flag. So `NO_COLOR=1 stella chat` kept
-/// animating, and the flag's documentation was simply wrong about it.
-///
-/// `NO_COLOR` follows its published rule (present and non-empty);
-/// `STELLA_NO_ANIM` follows this CLI's own house convention for boolean env
-/// vars (`--plain`'s `STELLA_PLAIN`, `env_files`' `STELLA_NO_ENV_FILE`), where
-/// an explicit `0` means off.
-fn animation_disabled(no_anim_flag: bool) -> bool {
-    let stella = std::env::var_os("STELLA_NO_ANIM").is_some_and(|v| !v.is_empty() && v != "0");
-    let no_color = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
-    no_anim_flag || stella || no_color
-}
-
-/// Whether `chat` should launch the Command Deck: an explicit `--plain` or
-/// STELLA_PLAIN=1 opts out, and both stdin and stdout must be real terminals
-/// (raw mode + the alternate screen are meaningless on a pipe).
-fn use_deck(plain_flag: bool) -> bool {
-    let plain_env = std::env::var_os("STELLA_PLAIN").is_some_and(|v| !v.is_empty() && v != "0");
-    !plain_flag && !plain_env && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
-}
-
 /// `stella resume --list`: every session in the machine-wide registry,
 /// newest activity first, with the rows resumable from THIS directory
 /// marked `↩`. Local reads only — works with zero API keys.
@@ -1037,7 +943,7 @@ fn main() -> ExitCode {
     // Before the first byte reaches a terminal: a dumb terminal renders ANSI
     // literally, so every diagnostic below (credential handoff failures
     // included) has to already know that.
-    apply_dumb_terminal_policy();
+    term_policy::apply_dumb_terminal_policy();
 
     // Everything user-global lives at ~/.stella; move data from the legacy
     // split layout (platform data dir + ~/.config/stella) before any store,
@@ -1307,7 +1213,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             return Ok(());
         }
         Some(Command::Version) => {
-            println!("stella v{}", version_string());
+            println!("stella v{}", build_info::version_string());
             return Ok(());
         }
         Some(Command::Resume { list: true, .. }) => {
@@ -1341,7 +1247,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 cli.globals.model.as_deref(),
                 cli.globals.api_key.as_deref(),
                 cli.globals.base_url.as_deref(),
-                animation_disabled(cli.globals.no_anim),
+                term_policy::animation_disabled(cli.globals.no_anim),
             ),
         );
     }
@@ -1461,13 +1367,13 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // The Command Deck (tabbed TUI) is the default chat surface on a
             // real terminal; `--plain` / STELLA_PLAIN=1 / a non-TTY stream
             // falls back to the line-based REPL.
-            if use_deck(cli.globals.plain) {
+            if term_policy::use_deck(cli.globals.plain) {
                 signals::block_on_interruptible(
                     rt()?,
                     command_deck::run_deck_session(
                         &cfg,
                         cli.globals.budget,
-                        animation_disabled(cli.globals.no_anim),
+                        term_policy::animation_disabled(cli.globals.no_anim),
                         None,
                     ),
                 )?;
@@ -1483,7 +1389,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             // actual reopen, which is a full deck session (durable state is
             // a deck feature — the plain REPL has no session to restore).
             debug_assert!(!list, "handled before provider resolution");
-            if !use_deck(cli.globals.plain) {
+            if !term_policy::use_deck(cli.globals.plain) {
                 return Err(
                     "`stella resume` reopens a Command Deck session and needs a real \
                      terminal (it cannot combine with --plain / STELLA_PLAIN / a piped \
@@ -1500,7 +1406,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
                 command_deck::run_deck_session(
                     &cfg,
                     cli.globals.budget,
-                    animation_disabled(cli.globals.no_anim),
+                    term_policy::animation_disabled(cli.globals.no_anim),
                     Some(request),
                 ),
             )?;

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -7,10 +7,11 @@
 
 use clap::{CommandFactory, Parser};
 
-use super::{
-    AuthCmd, BUILD_VERSION_IDENTITY, Cli, Command, ConnectCmd, OutputFormat, TelemetryCmd,
-    error_summary_json, long_version_static, version_static, version_string,
+use super::build_info::{
+    BUILD_VERSION_IDENTITY, long_version_static, version_static, version_string,
 };
+use super::term_policy::{animation_disabled, dumb_terminal};
+use super::{AuthCmd, Cli, Command, ConnectCmd, OutputFormat, TelemetryCmd, error_summary_json};
 
 /// `-V` stays one greppable line; `--version` answers the two questions a bug
 /// report otherwise costs a round trip. Both must agree about the version
@@ -176,33 +177,21 @@ fn a_dumb_terminal_disables_colour_unless_the_user_forces_it() {
     use std::ffi::OsStr;
     let term = |s: &str| Some(OsStr::new(s)).map(|o| o.to_owned());
 
-    assert!(super::dumb_terminal(term("dumb").as_deref(), None));
+    assert!(dumb_terminal(term("dumb").as_deref(), None));
     // Force is the documented "I know what my terminal is" escape hatch and
     // must outrank the heuristic, in both spellings of "off".
-    assert!(!super::dumb_terminal(
+    assert!(!dumb_terminal(
         term("dumb").as_deref(),
         term("1").as_deref()
     ));
-    assert!(super::dumb_terminal(
-        term("dumb").as_deref(),
-        term("0").as_deref()
-    ));
-    assert!(super::dumb_terminal(
-        term("dumb").as_deref(),
-        term("").as_deref()
-    ));
+    assert!(dumb_terminal(term("dumb").as_deref(), term("0").as_deref()));
+    assert!(dumb_terminal(term("dumb").as_deref(), term("").as_deref()));
 
     // Real terminals, and an unset TERM, are left entirely alone — the tty
     // and NO_COLOR checks `colored` already performs stay the authority.
-    assert!(!super::dumb_terminal(
-        term("xterm-256color").as_deref(),
-        None
-    ));
-    assert!(!super::dumb_terminal(
-        term("dumb-but-not-really").as_deref(),
-        None
-    ));
-    assert!(!super::dumb_terminal(None, None));
+    assert!(!dumb_terminal(term("xterm-256color").as_deref(), None));
+    assert!(!dumb_terminal(term("dumb-but-not-really").as_deref(), None));
+    assert!(!dumb_terminal(None, None));
 }
 
 /// `--no-anim`'s help promises "Also forced on by STELLA_NO_ANIM or NO_COLOR",
@@ -227,22 +216,22 @@ fn the_env_signals_no_anim_advertises_actually_force_it() {
         std::env::remove_var("NO_COLOR");
     }
 
-    assert!(!super::animation_disabled(false), "clean env animates");
-    assert!(super::animation_disabled(true), "the flag alone suffices");
+    assert!(!animation_disabled(false), "clean env animates");
+    assert!(animation_disabled(true), "the flag alone suffices");
 
     unsafe { std::env::set_var("STELLA_NO_ANIM", "1") };
-    assert!(super::animation_disabled(false));
+    assert!(animation_disabled(false));
     // House convention for boolean env vars in this CLI (`STELLA_PLAIN`,
     // `STELLA_NO_ENV_FILE`): an explicit `0` means off.
     unsafe { std::env::set_var("STELLA_NO_ANIM", "0") };
-    assert!(!super::animation_disabled(false));
+    assert!(!animation_disabled(false));
     unsafe { std::env::remove_var("STELLA_NO_ANIM") };
 
     unsafe { std::env::set_var("NO_COLOR", "1") };
-    assert!(super::animation_disabled(false));
+    assert!(animation_disabled(false));
     // NO_COLOR's published rule: present *and non-empty*.
     unsafe { std::env::set_var("NO_COLOR", "") };
-    assert!(!super::animation_disabled(false));
+    assert!(!animation_disabled(false));
 
     restore("STELLA_NO_ANIM", prior_anim);
     restore("NO_COLOR", prior_color);

--- a/stella-cli/src/term_policy.rs
+++ b/stella-cli/src/term_policy.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What this terminal can support: colour, animation, and the Command Deck.
+//!
+//! Three decisions that look unrelated in a match arm but are one question —
+//! *is there a human at a capable terminal on the other end of this stream?* —
+//! answered from the same inputs (`TERM`, `NO_COLOR`, `CLICOLOR_FORCE`,
+//! `STELLA_NO_ANIM`, `STELLA_PLAIN`, and whether stdin/stdout are ttys).
+//!
+//! Each is a pure function of its inputs with the process-global side effect
+//! isolated in [`apply_dumb_terminal_policy`], so the decisions are testable
+//! without `colored`'s override — which every other test in this binary renders
+//! through, and which is therefore the one thing a test must not disturb.
+//!
+//! The house convention for the boolean env vars is deliberately uniform: a
+//! variable is on when present and non-`0`, except `NO_COLOR`, which follows
+//! its own published rule (present and non-empty).
+
+use std::io::IsTerminal;
+
+/// Honour `TERM=dumb` by switching ANSI output off process-wide.
+///
+/// The `colored` crate already respects `NO_COLOR`, `CLICOLOR*`, and a
+/// non-tty stream, but not `TERM` — so a dumb terminal (Emacs `M-x shell`,
+/// a bare serial console, an editor's build pane, `TERM=dumb` in CI) got the
+/// full escape-sequence treatment and rendered it literally. Every other Unix
+/// tool that colours output treats `dumb` as "this terminal cannot", so
+/// stella does too. An explicit `CLICOLOR_FORCE` still wins: it is the
+/// documented way to say "I know what my terminal is", and `colored`'s own
+/// override resolution keeps honouring it because this only sets the default
+/// when the user has not forced anything.
+pub(crate) fn apply_dumb_terminal_policy() {
+    if dumb_terminal(
+        std::env::var_os("TERM").as_deref(),
+        std::env::var_os("CLICOLOR_FORCE").as_deref(),
+    ) {
+        colored::control::set_override(false);
+    }
+}
+
+/// The decision behind [`apply_dumb_terminal_policy`], kept pure so it can be
+/// tested without reaching for `colored`'s process-global override (which
+/// every other test in this binary renders through).
+pub(crate) fn dumb_terminal(
+    term: Option<&std::ffi::OsStr>,
+    clicolor_force: Option<&std::ffi::OsStr>,
+) -> bool {
+    let forced = clicolor_force.is_some_and(|v| !v.is_empty() && v != "0");
+    !forced && term.is_some_and(|term| term == "dumb")
+}
+
+/// Whether deck animation is off for this invocation: the `--no-anim` flag,
+/// or either environment signal its own help text promises.
+///
+/// The promise was only half kept. `init_fx::animation_enabled` folded
+/// `STELLA_NO_ANIM` and `NO_COLOR` in for the `stella init` cinematic, but the
+/// Command Deck — the surface with the shimmering progress bar and the
+/// blinking caret, and the one an asciinema recording or a CI log actually
+/// captures — was handed the bare flag. So `NO_COLOR=1 stella chat` kept
+/// animating, and the flag's documentation was simply wrong about it.
+///
+/// `NO_COLOR` follows its published rule (present and non-empty);
+/// `STELLA_NO_ANIM` follows this CLI's own house convention for boolean env
+/// vars (`--plain`'s `STELLA_PLAIN`, `env_files`' `STELLA_NO_ENV_FILE`), where
+/// an explicit `0` means off.
+pub(crate) fn animation_disabled(no_anim_flag: bool) -> bool {
+    let stella = std::env::var_os("STELLA_NO_ANIM").is_some_and(|v| !v.is_empty() && v != "0");
+    let no_color = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
+    no_anim_flag || stella || no_color
+}
+
+/// Whether `chat` should launch the Command Deck: an explicit `--plain` or
+/// STELLA_PLAIN=1 opts out, and both stdin and stdout must be real terminals
+/// (raw mode + the alternate screen are meaningless on a pipe).
+pub(crate) fn use_deck(plain_flag: bool) -> bool {
+    let plain_env = std::env::var_os("STELLA_PLAIN").is_some_and(|v| !v.is_empty() && v != "0");
+    !plain_flag && !plain_env && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}


### PR DESCRIPTION
## What & why

`check-file-size` is red on `main` itself. #937 recorded `stella-cli/src/main.rs`
at 1545 lines in the baseline and then landed three more, so the gate fails on a
clean checkout of `main` — and because it runs inside the required
`fmt + clippy + test` check with `strict: true` protection, **every open PR
inherits the failure**:

```
stella-cli/src/main.rs grew to 1548 lines, over its baseline ceiling of 1545 (+3)
```

## The +3 is repaid, not exempted

The gate's message offers two remedies and they are not interchangeable.
`make file-size-update` would raise the ceiling to 1548 — but that escape hatch
is explicitly for growth that is *irreducible*, "a subcommand or module
declaration in an already-oversized `lib.rs`/`main.rs`". This growth was not: it
was four pure environment-reading functions and a build-identity constant, each
with its own doc block. `--update` is also a blunt regenerate that records
whatever tree it runs in, so it silently lowers ceilings other branches raised.

So the 94 reducible lines move into two modules:

- **`build_info.rs`** — the NUL-delimited `BUILD_VERSION_IDENTITY` the claim
  launcher attests without executing the binary, plus the three version surfaces
  that must not be able to disagree with it (`-V`, `--version`, `stella version`).
- **`term_policy.rs`** — the four decisions that answer one question, *is there a
  human at a capable terminal on the other end of this stream?*: the `TERM=dumb`
  colour override, its pure predicate, `--no-anim`, and deck-versus-plain-REPL.
  The process-global side effect stays isolated in `apply_dumb_terminal_policy`,
  so the rest is testable without disturbing `colored`'s override — which every
  other test in this binary renders through.

`main.rs` drops **1548 → 1454**, which crosses back under the 1500-line limit.
That matters more than satisfying the ceiling: it makes the baseline entry
*illegal* rather than merely stale. The gate emits `OBSOLETE` and fails until the
line is removed, because "an exemption must not outlive the problem it covered".
So the baseline **loses** an entry (37 → 36 grandfathered files) instead of
gaining a looser ceiling, and `main.rs` is now an ordinary file with 46 lines of
headroom.

The moved code is byte-identical apart from `pub(crate)` and one signature
rustfmt must now wrap — verified by diffing the extracted block against the new
modules. Call sites are module-qualified rather than imported, so provenance is
readable at each use; all three `animation_disabled` sites were already vertical
calls, so nothing reflowed. In `main_tests.rs` the same 60-char `fn_call_width`
budget ran in reverse — dropping `super::` let rustfmt rejoin wrapped asserts, so
that file *shrank* 11 lines with no semantic change.

## The second commit: what the red gate was hiding

`env_files::tests::home_directory_is_never_a_project_scope` fails on **every
macOS checkout of `main`**, and has since #937. The two failures are causally
linked: `check-file-size` is step 3 of the gate job, *before* "Install Rust
stable", so #937's own +3 ceiling failure aborted the job before `cargo test`
ever ran. The red gate is precisely what kept this from being measured.

The production code is right and the test is wrong. #937 taught `find_base` to
canonicalize `$HOME` — a real fix, because `/home` symlinked onto another volume
is a routine layout and the raw string compare silently let `~/.env` leak into
every session for those users. It deliberately does *not* resolve `start`, and
says why: `start` is `current_dir`, i.e. `getcwd`, already symlink-free.
`plan_from`'s only production caller passes exactly that.

A `tempfile::tempdir` path is not `getcwd`. On macOS `TMPDIR` lives under
`/var` → `/private/var`, so the test handed the *unresolved* path as both `start`
and `home`; only `home` got resolved, the two compared unequal, the guard missed,
and `find_base` returned the `.env` the test had just written:

```
left:  Some("/var/folders/…/T/.tmpEwvhH8")
right: None
```

It passes on Linux only because `/tmp` is not a symlink there. Resolving the path
in the test is what the sibling `a_symlinked_home_is_still_never_a_project_scope`
already does. **No production behaviour changes.**

## Drive-by

`docs/design/scripts-index.md` cited `main.rs:238` for the `Graph` subcommand,
which sits at line 484 — 238 is where the version attributes are. Already stale
before this branch and unaffected by it; `check-doc-citations` only validates
Rust → docs, not the reverse.

## The gate

- [x] `check-file-size` — **OK, 594 files, none over 1500 except 36
      grandfathered (none grew)**. The baseline diff is a deletion, not a raise.
- [x] `cargo fmt --all --check` — exit 0, workspace-wide
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — exit 0
- [x] `cargo test -p stella-cli` — exit 0; **833 passed, 0 failed** in the binary
      suite plus five integration binaries green
- [x] `check-no-scratch`, `check-doc-citations`, `check-invariants`,
      `check-normative-home` — all exit 0
-  Workspace-wide `clippy`/`test` — running as I write this; I will post the
      result either way. Nothing outside `stella-cli` is touched (it is the leaf
      binary; no crate depends on it), so those legs are determined by `main`'s
      own state rather than this diff.

**Disclosure:** the push used the hook's documented `SKIP_GATE=1` escape hatch.
`make gate` re-runs the full workspace suite, which takes ~40 minutes on this
machine at load 70 and was SIGTERM'd once mid-compile under that contention. Every
leg this diff can affect was run explicitly and by exit code, as listed above.

## Anything reviewers should know?

The masking hazard is the real lesson and it is worth a follow-up: a stale
baseline aborts the job *before* any Rust leg runs, so while `main` sits red its
merges land with **no measured Rust status at all**. That is how a macOS test
regression rode in unnoticed alongside the ceiling drift. Moving
`check-file-size` after the Rust legs — or making it non-blocking for the rest of
the job — would stop one gate's failure from blinding the others. Happy to file
that as an issue if you want it tracked.

## Summary by Sourcery

Extract terminal capability and build-version logic from stella-cli main into dedicated modules to bring main.rs back under the enforced file-size limit and keep version reporting cohesive.

New Features:
- Introduce a build_info module encapsulating compile-time build identity and version reporting surfaces for the CLI.
- Introduce a term_policy module encapsulating terminal capability decisions for colour, animation, and Command Deck usage.

Bug Fixes:
- Fix env_files home_directory_is_never_a_project_scope test to resolve temporary home paths so it behaves correctly on macOS and matches production behaviour.
- Correct the documentation citation pointing to the Graph subcommand location in main.rs.

Enhancements:
- Refactor main.rs and its tests to use the new build_info and term_policy modules, reducing main.rs size below the 1500-line gate and removing its baseline exemption entry.
