### PR TITLE
fix(deck): no bare keystroke commits a plan — the scope card is not modal

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,7 @@
 1576 stella-cli/src/candidate_ws.rs
 4570 stella-cli/src/command_deck.rs
 1518 stella-cli/src/config.rs
-1545 stella-cli/src/main.rs
+1548 stella-cli/src/main.rs
 2095 stella-core/src/bus.rs
 2138 stella-core/src/driver.rs
 2820 stella-core/src/driver/tests.rs
@@ -38,7 +38,7 @@
 1566 stella-tools/src/media.rs
 3271 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
-1704 stella-tui/src/deck_render.rs
+1723 stella-tui/src/deck_render.rs
 3999 stella-tui/src/deck_ui.rs
 1802 stella-tui/src/model.rs
 1602 stella-tui/src/theme.rs

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -1651,7 +1651,7 @@ pub async fn run_deck_session(
                         }
                         // Scope review IS engine-driven now: the pipeline's
                         // `DeckApprovalGate` parks on this channel, so the
-                        // card's a/t/x keypress becomes its `ScopeDecision`.
+                        // reviewer's answer becomes its `ScopeDecision`.
                         Some(WorkspaceInput::ToAgent {
                             input: UserInput::ScopeDecision(decision), ..
                         }) => {
@@ -4270,7 +4270,7 @@ async fn run_lead_turn(
 /// Deck-mode seams, all named:
 /// - **Scope review is interactive** ([`DeckApprovalGate`]). A plan over the
 ///   thresholds raises the deck's approval card and the turn parks until the
-///   user answers (a/t/x) — the deck runs `headless: false` because it *can*
+///   user answers at the card — the deck runs `headless: false` because it *can*
 ///   ask. It fails closed only if the deck itself goes away mid-gate.
 /// - **The session's system prompt stays.** It was assembled once at deck
 ///   startup (byte-stable for the cache prefix, L-E8); toggling `/pipeline`

--- a/stella-cli/src/command_deck/scope_gate.rs
+++ b/stella-cli/src/command_deck/scope_gate.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 /// than 5 steps, 8 files, or $1.00 — a dead end: the turn aborted with advice
 /// to set `headless_scope_bypass`, a setting only `stella run` reads, so
 /// following the advice changed nothing. Meanwhile the TUI's approval card
-/// and its a/t/x keys were fully built and wired to nothing.
+/// and its decision keys were fully built and wired to nothing.
 ///
 /// This closes that loop the same way `DeckAskUserIo` closes `ask_user`: emit
 /// the card, park on a channel, let the input pump deliver the keypress. The
@@ -145,6 +145,24 @@ mod tests {
             gate(5).decide(DeckScopeDecision::Trim, 9),
             ScopeDecision::Trim {
                 keep_steps: vec![0, 1, 2, 3, 4]
+            }
+        );
+    }
+
+    /// A note passes through verbatim. This layer must not normalize it: the
+    /// pipeline folds it into the next planner prompt, so any "helpful" rewrite
+    /// here puts words the human did not write in front of the planner.
+    #[test]
+    fn a_revision_note_passes_through_untouched() {
+        assert_eq!(
+            gate(5).decide(
+                DeckScopeDecision::Revise {
+                    note: "  only the Ctrl+O dialog — skip Ctrl+W!  ".to_string()
+                },
+                9
+            ),
+            ScopeDecision::Revise {
+                note: "  only the Ctrl+O dialog — skip Ctrl+W!  ".to_string()
             }
         );
     }

--- a/stella-cli/src/env_files.rs
+++ b/stella-cli/src/env_files.rs
@@ -634,10 +634,17 @@ mod tests {
     #[test]
     fn home_directory_is_never_a_project_scope() {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
-        write(home, ".env", "HOME_LEVEL=nope\n");
+        // Resolved, like the sibling symlink test and for the same reason:
+        // `find_base` takes `start` as `getcwd` — already free of symlinks —
+        // and only canonicalizes `home`. A raw `tempfile` path breaks that
+        // contract wherever the temp root is itself a symlink, which on macOS
+        // it always is (`/var` → `/private/var`), so the guard compared
+        // `/var/folders/…` against `/private/var/folders/…`, never matched, and
+        // this test failed for every macOS developer while passing in CI.
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        write(&home, ".env", "HOME_LEVEL=nope\n");
         // Running *in* $HOME must not load `~/.env`.
-        assert_eq!(find_base(home, Some(home)), None);
+        assert_eq!(find_base(&home, Some(&home)), None);
     }
 
     /// `$HOME` reached through a symlink — `/home` mounted elsewhere is a

--- a/stella-pipeline/src/pipeline/scope_stage.rs
+++ b/stella-pipeline/src/pipeline/scope_stage.rs
@@ -62,8 +62,8 @@ impl Pipeline<'_> {
                     // The cap is on *re-planning*, not on the card: the run
                     // that hits it has already shown the reviewer a card they
                     // can still approve, trim, or abort. Only a further note
-                    // is refused, and the refusal says which keys still work
-                    // rather than ending on an unexplained abort.
+                    // is refused, and the refusal says what still works rather
+                    // than ending on an unexplained abort.
                     if spent_revisions >= MAX_SCOPE_REVISIONS {
                         self.emit(AgentEvent::Error {
                             message: format!(

--- a/stella-pipeline/src/scope.rs
+++ b/stella-pipeline/src/scope.rs
@@ -113,7 +113,8 @@ pub fn apply_trim(plan: &[PlanStep], keep_steps: &[usize]) -> Vec<PlanStep> {
 /// different scope. Bounded because each revision is a fresh planner call: an
 /// unbounded loop would let a gate meant to *contain* spend become a way to
 /// spend without ever executing. Two is enough for "narrower" then "narrower
-/// still"; past that the card's approve/trim/abort keys are the honest answer.
+/// still"; past that, approving/trimming/aborting the plan on screen is the
+/// honest answer.
 pub const MAX_SCOPE_REVISIONS: usize = 2;
 
 /// What one pass of the scope gate settled on. Distinct from

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -1549,6 +1549,19 @@ fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
             ("←", "SESSIONS overlay — every session on this machine"),
             ("→", "CONTEXT overlay — active skills + MCP servers"),
             ("ctrl-g", "INSPECT — the context sent on any recorded call"),
+            // The overlay had no row for answering a card at all, while the
+            // global `⏎` row below promised the prompt would "run as its own
+            // agent" — so a reviewer typing at a scope card had every reason to
+            // expect the sidecar they got. Both halves are documented now.
+            (
+                "a / t / x",
+                "scope card: approve · trim · abort — type it, then ⏎",
+            ),
+            (
+                "text ⏎",
+                "scope card: what to change — the plan is re-planned from it",
+            ),
+            ("esc", "scope card: abort it (the one key that acts alone)"),
         ],
         DeckTab::Agents => &[
             ("← →", "switch panes — executions / installed"),
@@ -1620,7 +1633,13 @@ const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
     // `composer::classify_enter`): a bare ⏎ dispatches, a *modified* ⏎ breaks
     // the line. The composer footer advertises the same pair — these rows must
     // not drift from it.
-    ("⏎", "queue the prompt — mid-turn it runs as its own agent"),
+    // The parenthetical is load-bearing: the unqualified promise ("runs as its
+    // own agent") is what a reviewer read while a scope card was waiting, and
+    // the sidecar it describes is exactly what swallowed their answer.
+    (
+        "⏎",
+        "queue the prompt — mid-turn it runs as its own agent (unless a card waits)",
+    ),
     ("⌘⏎ / ⌃⏎ / ⌥⏎", "insert a line break in the prompt"),
     ("!cmd", "run a shell command NOW (skips the queue)"),
     ("/", "slash commands — ↑↓ pick · tab completes · ⏎ runs"),

--- a/stella-tui/src/deck_ui/gates.rs
+++ b/stella-tui/src/deck_ui/gates.rs
@@ -22,35 +22,42 @@ pub(super) fn handle_focused_gates(
     let composer_empty = ui.composer.buffer().is_empty();
 
     // Scope review, while UNANSWERED — the pending gate clears on the engine's
-    // follow-on event, so the latch is what stops a second press re-sending the
+    // follow-on event, so the latch is what stops a second submit re-sending the
     // decision during that round-trip; the card reads "decision sent" until
-    // then and the keys type into the composer as usual.
+    // then and keys type into the composer as usual.
     //
-    // Two ways in, exactly like `ask_user` below: a/t/x/Esc from an empty
-    // composer, or the submit chord over typed text. The typed path is what
-    // makes the card answerable at all once the user has started writing — the
-    // decision keys are ordinary prompt characters, so they cannot claim a
-    // non-empty composer, and without a submit path the reviewer's line fell
-    // through to the driver, which reads a mid-turn prompt as a *new request*
-    // and spawns a sidecar sub-session for it. The gate stayed parked, the
-    // words went to a stranger agent, and the only key that still reached the
-    // card was Esc — which aborts. That is the whole bug: a review nobody could
-    // answer by typing, whose recovery gesture killed the turn.
+    // **Only non-text keys act on their own.** `Esc` aborts immediately; every
+    // other answer — `a`, `t`, `x`, `ok`, or a sentence describing a different
+    // scope — is typed into the composer and sent with the submit chord, read by
+    // [`ScopeDecision::from_typed`].
     //
-    // Known sharp edge, unchanged by this fix and deliberately not widened
-    // here: the single-key decisions claim the *first* keystroke into an empty
-    // composer, so a note that opens with a/t/x sends that decision instead of
-    // starting a note ("also do X" approves). It is survivable mostly by
-    // accident — the words most likely to open such a note are "approve",
-    // "abort" and "trim", which map to the same decision the key sent — but a
-    // note beginning "add…" or "also…" is a silent approve. Fixing it means
-    // deciding whether the card's advertised keys should require ⏎, which is a
-    // change to how every reviewer approves, not a bug fix.
+    // A single unmodified letter used to commit from an empty composer, and that
+    // is wrong for *this* surface. A single-key commit is fine where the prompt
+    // is modal (git's `y/n`, a permission dialog) because nothing else wants the
+    // letter. Here the composer is an unconditional band, always live, and
+    // typing a note is now the advertised way to ask for a different scope — so
+    // the card was competing with the text field for `a`, and losing either way:
+    // a note opening "also do X" silently approved an eight-step plan, while a
+    // reviewer who typed past that first letter had no way to send what they
+    // wrote (it fell through to the driver, which reads a mid-turn prompt as a
+    // *new request* and spawns a sidecar sub-session for it — the gate stayed
+    // parked, the words went to a stranger agent, and the only key still
+    // reaching the card was Esc, which aborts).
+    //
+    // `Esc` keeps acting immediately because it cannot collide with prose, and
+    // because it is the direction that *stops* work rather than starting it.
+    // The one keystroke this costs buys deliberate consent at the one gate whose
+    // whole purpose is deliberate consent.
+    //
+    // Esc is claimed with a *non-empty* composer too, which the letter keys
+    // never are. Otherwise "type a note, change your mind, press Esc" fell past
+    // the gate into the turn-stop chain — and for a pipeline turn that is a hard
+    // cancel, so the same gesture ended the turn cleanly or violently depending
+    // on whether the user had started typing. While a card is up, Esc means one
+    // thing: get out of this card.
     if entry.model.pending_scope_review.is_some() && !ui.scope_answered.contains(agent) {
         let decision = match key.code {
-            KeyCode::Char('a') if composer_empty => Some(ScopeDecision::Approve),
-            KeyCode::Char('t') if composer_empty => Some(ScopeDecision::Trim),
-            KeyCode::Char('x') | KeyCode::Esc if composer_empty => Some(ScopeDecision::Abort),
+            KeyCode::Esc => Some(ScopeDecision::Abort),
             // A `!` line is a shell command even while a gate is pending — it
             // must run immediately, not be read as the decision (same carve-out
             // as `ask_user`).

--- a/stella-tui/src/deck_ui/tests.rs
+++ b/stella-tui/src/deck_ui/tests.rs
@@ -1071,7 +1071,10 @@ fn focused_scope_gate_routes_decision_to_that_agent() {
         },
     });
     let mut ui = ready_ui();
-    let action = handle_deck_key(ch('a'), &model, &mut ui);
+    // `a` is typed then sent — no letter commits on its own (see
+    // `deck_ui::gates` for why).
+    handle_deck_key(ch('a'), &model, &mut ui);
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
     assert_eq!(
         action,
         DeckAction::Send(WorkspaceInput::ToAgent {
@@ -1098,33 +1101,37 @@ fn scope_decision_latches_until_a_fresh_review_rearms() {
     let mut ui = ready_ui();
     ingest_inbound(&scope_review, &mut model, &mut ui);
 
+    handle_deck_key(ch('a'), &model, &mut ui);
     assert_eq!(
-        handle_deck_key(ch('a'), &model, &mut ui),
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
         DeckAction::Send(WorkspaceInput::ToAgent {
             agent: "lead".into(),
             input: UserInput::ScopeDecision(ScopeDecision::Approve),
         })
     );
     // The gate stays pending until the engine's follow-on event, but the
-    // latch keeps a second press from re-sending — it types instead.
+    // latch keeps a second submit from re-sending — it enqueues as an ordinary
+    // prompt instead, which is the correct reading once the card is answered.
     assert!(model.agents[0].model.pending_scope_review.is_some());
     handle_deck_key(ch('a'), &model, &mut ui);
     assert_eq!(
-        ui.composer.buffer(),
-        "a",
-        "second press types, never re-sends"
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Enqueue { text: "a".into() }),
+        "an answered card does not take a second decision"
     );
 
-    // A FRESH review re-arms the decision keys.
-    handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    // A FRESH review re-arms the gate.
     ingest_inbound(&scope_review, &mut model, &mut ui);
+    for c in "x".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
     assert_eq!(
-        handle_deck_key(ch('x'), &model, &mut ui),
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
         DeckAction::Send(WorkspaceInput::ToAgent {
             agent: "lead".into(),
             input: UserInput::ScopeDecision(ScopeDecision::Abort),
         }),
-        "a new card re-arms the decision keys"
+        "a new card re-arms the gate"
     );
 }
 

--- a/stella-tui/src/deck_ui/tests/gates.rs
+++ b/stella-tui/src/deck_ui/tests/gates.rs
@@ -39,8 +39,6 @@ fn a_typed_note_at_a_scope_card_answers_the_card_instead_of_spawning_a_sidecar()
     let mut ui = ready_ui();
     ingest_inbound(&scope_card(), &mut model, &mut ui);
 
-    // Opens with 'o', not a decision key — see the sharp-edge note in
-    // `handle_focused_gates` about a/t/x claiming the first keystroke.
     type_str("only the ctrl+O dialog", &model, &mut ui);
     let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
 
@@ -154,25 +152,74 @@ fn a_whitespace_only_note_keeps_the_card_up() {
     assert!(!ui.scope_answered.contains("lead"));
 }
 
-/// The rule the decision keys already followed must survive: once text exists,
-/// a/t/x are prompt characters. Only the first keystroke into an empty composer
-/// commits (see the sharp-edge note in `handle_focused_gates`).
+/// No letter answers the card, from any composer state — the rule that lets a
+/// note begin with any word at all. `a`/`t`/`x` are ordinary prompt characters,
+/// and a card that claimed them from a live text field turned a note opening
+/// "also do X" into a silent approve of an eight-step plan.
 #[test]
-fn decision_letters_type_into_a_non_empty_composer() {
+fn no_bare_letter_answers_the_scope_card() {
     let mut model = model_with(&["lead"]);
     let mut ui = ready_ui();
     ingest_inbound(&scope_card(), &mut model, &mut ui);
 
-    type_str("keep", &model, &mut ui);
+    // From an EMPTY composer — the keystroke that used to commit.
     for c in ['a', 't', 'x'] {
         assert_eq!(
             handle_deck_key(ch(c), &model, &mut ui),
             DeckAction::Handled,
-            "{c} must type once a note is being written"
+            "{c} types; it must not answer the card on its own"
         );
     }
-    assert_eq!(ui.composer.buffer(), "keepatx");
+    assert_eq!(ui.composer.buffer(), "atx");
     assert!(!ui.scope_answered.contains("lead"));
+}
+
+/// The case that named the rule: "also do the tests" is a revision, and its
+/// first letter used to approve the plan it was arguing with.
+#[test]
+fn a_note_opening_with_a_decision_letter_is_a_revision_not_an_approval() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+
+    type_str("also do the tests", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::ToAgent {
+            agent: "lead".into(),
+            input: UserInput::ScopeDecision(ScopeDecision::Revise {
+                note: "also do the tests".into()
+            }),
+        })
+    );
+}
+
+/// `Esc` is the one key that still acts alone — it cannot collide with prose,
+/// and it stops work rather than starting it. It means the same thing with a
+/// half-typed note in the composer: without that, "type a note, change your
+/// mind, press Esc" fell past the card into the turn-stop chain, which for a
+/// pipeline turn is a *hard cancel* — the same gesture ending the turn cleanly
+/// or violently depending on whether the user had started typing.
+#[test]
+fn esc_aborts_the_card_whether_or_not_a_note_is_half_typed() {
+    let abort = DeckAction::Send(WorkspaceInput::ToAgent {
+        agent: "lead".into(),
+        input: UserInput::ScopeDecision(ScopeDecision::Abort),
+    });
+
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+    assert_eq!(handle_deck_key(key(KeyCode::Esc), &model, &mut ui), abort);
+
+    let mut ui = ready_ui();
+    ingest_inbound(&scope_card(), &mut model, &mut ui);
+    type_str("only the dial", &model, &mut ui);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui),
+        abort,
+        "a half-typed note must not turn Esc into a turn cancel"
+    );
 }
 
 /// With no card pending, a submission is still a prompt — the sidecar path is

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -492,28 +492,32 @@ pub(crate) fn render_scope_review(
                 .add_modifier(Modifier::ITALIC),
         ))
     } else {
+        // Every answer is typed and sent, so the legend reads as what to type
+        // rather than as keys that fire on their own — `[a]` looked like a
+        // one-press command, which is exactly the reading that made a note
+        // opening "also…" approve an eight-step plan. The bracket styling stays
+        // for scannability; the trailing "then ⏎" is the whole contract.
+        //
+        // The typed path is named here because it is now the only way to say
+        // "not like that — do this", and an affordance nobody is told about is
+        // one the next reviewer discovers by having their words routed
+        // somewhere they did not expect.
         Line::from(vec![
-            Span::styled(
-                "[a]",
-                Style::new().fg(theme::OK).add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("type ", Style::new().fg(theme::TEXT_TERTIARY)),
+            Span::styled("a", Style::new().fg(theme::OK).add_modifier(Modifier::BOLD)),
             Span::styled("pprove  ", Style::new().fg(theme::INK)),
             Span::styled(
-                "[t]",
+                "t",
                 Style::new().fg(theme::WARN).add_modifier(Modifier::BOLD),
             ),
             Span::styled("rim  ", Style::new().fg(theme::INK)),
             Span::styled(
-                "[x]",
+                "x",
                 Style::new().fg(theme::DANGER).add_modifier(Modifier::BOLD),
             ),
             Span::styled("abort", Style::new().fg(theme::INK)),
-            // The typed path has to be on the card. It is now the only way to
-            // say "not like that — do this", and an affordance nobody is told
-            // about is one the next reviewer discovers by having their words
-            // routed somewhere they did not expect.
             Span::styled(
-                "  ·  or type what to change and ⏎ to re-plan",
+                "  ·  or what to change  —  then ⏎",
                 Style::new().fg(theme::TEXT_TERTIARY),
             ),
         ])

--- a/stella-tui/src/render/tests.rs
+++ b/stella-tui/src/render/tests.rs
@@ -406,13 +406,21 @@ fn scope_card_renders_the_decision_legend_when_unanswered() {
     let text = draw(&model, &mut ui, 100, 30);
     assert!(text.contains("refactor auth"), "card summary:\n{text}");
     assert!(text.contains("pprove"), "shows approve legend:\n{text}");
-    // The typed path is now the only way to ask for a *different* scope, so the
-    // card has to name it. An affordance nobody is told about is one the next
+    // The typed path is the only way to ask for a *different* scope, so the card
+    // has to name it. An affordance nobody is told about is one the next
     // reviewer discovers by having their words routed somewhere unexpected.
     assert!(
-        text.contains("re-plan"),
+        text.contains("what to change"),
         "offers the typed revision path:\n{text}"
     );
+    // And the legend must say that answers are *sent*, not fired: nothing here
+    // commits on a bare keystroke, and a legend implying otherwise is what made
+    // a note opening "also…" approve the plan.
+    assert!(
+        text.contains("type "),
+        "frames the answers as typed:\n{text}"
+    );
+    assert!(text.contains('⏎'), "names the submit key:\n{text}");
     // Once answered, the legend flips to the awaiting message.
     ui.scope_answered = true;
     let text2 = draw(&model, &mut ui, 100, 30);

--- a/stella-tui/src/ui.rs
+++ b/stella-tui/src/ui.rs
@@ -265,17 +265,18 @@ pub fn handle_key(key: KeyEvent, model: &SessionModel, ui: &mut UiState) -> Shel
         return ShellAction::Handled;
     }
 
-    // A pending, unanswered scope card is modal-ish: a/t/x/Esc decide it — but
-    // only from an empty composer. The decision keys are ordinary prompt
-    // characters, so once the user starts typing a message (e.g. "add a table")
-    // the keys must build the prompt, not silently approve/trim/abort the gate.
-    // Mirrors the deck (`crate::deck_ui`) and the ask_user quick-pick's
-    // "only when nothing is typed" rule.
+    // A pending, unanswered scope card owns the user's submission: whatever is
+    // typed — `a`, `x`, `ok`, or a sentence asking for a different scope — is
+    // sent to the card by the submit chord, and only `Esc` acts without one.
+    // Mirrors the deck (`crate::deck_ui::gates`, where the rule is stated in
+    // full).
     //
-    // The submit chord then sends that typed message *to the card* — the other
-    // half of the same rule, and the half that was missing. Without it the keys
-    // build a prompt the gate never sees, which on the deck meant a sidecar
-    // sub-session ran with the reviewer's words while the review sat parked.
+    // Both halves of that rule were missing here in different ways. The decision
+    // keys are ordinary prompt characters, so a card that claimed them turned a
+    // message beginning "add a table" into a silent approve; and with no submit
+    // path, a reviewer who typed past that first letter had built a prompt the
+    // gate would never see — which on the deck meant a sidecar sub-session ran
+    // with the reviewer's words while the review sat parked.
     if model.pending_scope_review.is_some()
         && !ui.scope_answered
         && let Some(action) = handle_scope_key(key, ui)
@@ -348,16 +349,21 @@ fn handle_ask_user_key(
     }
 }
 
-/// The scope-card key bindings: `a`/`t`/`x`/`Esc` from an empty composer, or
-/// the submit chord over typed text (read by [`ScopeDecision::from_typed`]).
-/// Returns `None` to fall through to normal composer editing, so a note can be
-/// typed and can span lines.
+/// The scope-card key bindings. `Esc` from an empty composer aborts; every
+/// other answer — `a`, `t`, `x`, `ok`, or a sentence asking for a different
+/// scope — is typed and sent with the submit chord, read by
+/// [`ScopeDecision::from_typed`]. Returns `None` to fall through to normal
+/// composer editing, so a note can be typed and can span lines.
+///
+/// Only non-text keys act on their own: the composer is always live here, so a
+/// bare letter that committed the gate was competing with the text field for
+/// `a` — see the rule stated in full in [`crate::deck_ui::gates`].
 fn handle_scope_key(key: KeyEvent, ui: &mut UiState) -> Option<ShellAction> {
-    let empty = ui.composer.buffer().is_empty();
     let decision = match key.code {
-        KeyCode::Char('a') if empty => ScopeDecision::Approve,
-        KeyCode::Char('t') if empty => ScopeDecision::Trim,
-        KeyCode::Char('x') | KeyCode::Esc if empty => ScopeDecision::Abort,
+        // Claimed with a typed note too, unlike the letters: "type a note,
+        // change your mind, press Esc" must not fall past the card into the
+        // turn-stop chain. While a card is up, Esc means get out of the card.
+        KeyCode::Esc => ScopeDecision::Abort,
         KeyCode::Enter if classify_enter(&key) == EnterAction::Submit => {
             match ui.composer.take_submission() {
                 Some(submission) => ScopeDecision::from_typed(&submission.text),
@@ -725,60 +731,84 @@ mod tests {
     fn scope_card_keys_submit_a_decision_once() {
         let model = model_with_scope();
         let mut ui = UiState::default();
-        let action = handle_key(ch('a'), &model, &mut ui);
+        // `a` types, then the submit chord sends it — no bare letter commits.
+        assert_eq!(handle_key(ch('a'), &model, &mut ui), ShellAction::Handled);
         assert_eq!(
-            action,
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
             ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Approve))
         );
         assert!(ui.scope_answered);
-        // A second key no longer submits a decision — it types instead (the
-        // guard prevents a double-answer).
-        let action2 = handle_key(ch('a'), &model, &mut ui);
-        assert_eq!(action2, ShellAction::Handled);
-        assert_eq!(ui.composer.buffer(), "a");
+        // A second submit no longer answers the card — the guard prevents a
+        // double-answer, so it is an ordinary prompt again.
+        handle_key(ch('a'), &model, &mut ui);
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Submit(UserInput::Prompt {
+                text: "a".into(),
+                attachments: vec![]
+            })
+        );
     }
 
+    /// `Esc` is the one key that still acts alone: it cannot collide with prose,
+    /// and it stops work rather than starting it. `x` goes through ⏎ like every
+    /// other typed answer.
     #[test]
-    fn scope_card_esc_and_x_abort() {
-        for code in [KeyCode::Char('x'), KeyCode::Esc] {
-            let model = model_with_scope();
-            let mut ui = UiState::default();
-            assert_eq!(
-                handle_key(key(code), &model, &mut ui),
-                ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Abort))
-            );
-        }
+    fn scope_card_esc_aborts_immediately_and_typed_x_aborts_on_submit() {
+        let model = model_with_scope();
+        let mut ui = UiState::default();
+        assert_eq!(
+            handle_key(key(KeyCode::Esc), &model, &mut ui),
+            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Abort))
+        );
+
+        let mut ui = UiState::default();
+        handle_key(ch('x'), &model, &mut ui);
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Abort))
+        );
     }
 
+    /// No letter commits the gate, from any composer state. The decision keys
+    /// are ordinary prompt characters, and a card that stole them from a live
+    /// text field turned a note opening "also do X" into a silent approve of an
+    /// eight-step plan. Every answer is typed; ⏎ sends it.
     #[test]
-    fn scope_card_keys_yield_to_a_prompt_being_typed() {
-        // THE scope-key P1: the decision keys (a/t/x) are ordinary prompt
-        // letters and used to fire even mid-prompt, so typing a message like
-        // "add a table" while a scope card was up silently approved/aborted the
-        // gate. They must defer to a non-empty composer — same rule the deck and
-        // the ask_user quick-pick already use.
+    fn no_bare_letter_answers_the_scope_card() {
         let model = model_with_scope();
         let mut ui = UiState::default();
 
-        // A leading non-decision char types and makes the composer non-empty.
-        assert_eq!(handle_key(ch('f'), &model, &mut ui), ShellAction::Handled);
-        assert!(!ui.scope_answered, "typing must not answer the gate");
-
-        // Now a/t/x build the prompt instead of deciding.
+        // From an EMPTY composer — the case that used to commit on the first
+        // keystroke — a/t/x type like any other character.
         for c in "atx".chars() {
             assert_eq!(handle_key(ch(c), &model, &mut ui), ShellAction::Handled);
         }
-        assert!(
-            !ui.scope_answered,
-            "no decision submitted while a prompt is typed"
-        );
-        assert_eq!(ui.composer.buffer(), "fatx");
+        assert!(!ui.scope_answered, "typing must not answer the gate");
+        assert_eq!(ui.composer.buffer(), "atx");
 
-        // From an empty composer the gate still decides on a single key.
-        ui.composer.clear();
+        // And mid-prompt, unchanged.
+        for c in " also do the tests".chars() {
+            handle_key(ch(c), &model, &mut ui);
+        }
+        assert!(!ui.scope_answered);
+        assert_eq!(ui.composer.buffer(), "atx also do the tests");
+    }
+
+    /// The note that names the whole reason for the rule: "also do X" is a
+    /// revision, and it used to approve on its first letter.
+    #[test]
+    fn a_note_opening_with_a_decision_letter_is_a_revision_not_an_approval() {
+        let model = model_with_scope();
+        let mut ui = UiState::default();
+        for c in "also do the tests".chars() {
+            handle_key(ch(c), &model, &mut ui);
+        }
         assert_eq!(
-            handle_key(ch('a'), &model, &mut ui),
-            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Approve))
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            ShellAction::Submit(UserInput::ScopeDecision(ScopeDecision::Revise {
+                note: "also do the tests".into()
+            }))
         );
     }
 

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -83,13 +83,19 @@ threshold passes without a gate. Headless runs must opt in to bypass this gate
 explicitly — `agent_engine_config.headless_scope_bypass: "on"` — and there is
 no silent auto-approve: without it, a plan over the thresholds ends the run.
 
-**Answering the card.** `a` approves, `t` trims to the largest prefix that
-would not have tripped review, `x` aborts. You can also just **type what you
-want changed and press ⏎** — the plan goes back to the planner carrying your
-note, and the new plan is reviewed the same way. A bare `ok`/`yes` typed at the
-card approves it; a bare `no` aborts. Revision is bounded at two re-plans per
-turn, since each one is a fresh planner call — after that the keys are the way
-through.
+**Answering the card.** Everything you type goes to the card, and `⏎` sends it:
+`a` approves, `t` trims to the largest prefix that would not have tripped
+review, `x` aborts — and so do the words themselves (`ok`, `yes`, `no`,
+`trim`). Anything longer than one of those is read as **what you want changed**:
+the plan goes back to the planner carrying your note, and the new plan is
+reviewed the same way. Revision is bounded at two re-plans per turn, since each
+one is a fresh planner call.
+
+No bare keystroke commits the plan. The composer is live the whole time the card
+is up, so a letter that answered on its own was competing with the text you were
+typing — a note beginning "also do X" would have approved the plan it was
+arguing with. `Esc` is the one exception, because it cannot be mistaken for
+prose and it stops work rather than starting it.
 
 ### 4. Witness
 


### PR DESCRIPTION
Follow-up to #907 (merged), and the call it left open to the reviewer:

> `a`/`t`/`x` still commit on the first keystroke into an empty composer, so a note starting "also do X" approves instead of starting a note. Changing that means making the card's advertised keys require ⏎ — that's a change to how everyone approves, not a bug fix, so it's your call.

The call came back as "do whatever a careful shop would do". This is that.

## The argument

A single-keystroke commit is right where the prompt is **modal** — git's `y/n`, a permission dialog — because nothing else wants the letter. This card is not modal. `render` pushes the composer as an **unconditional band**, so the text field is live the entire time the card is up, and after #907 typing a note is the advertised way to ask for a different scope.

So the card was competing with the composer for `a`, and losing in both directions:

- a note opening "also do X" **silently approved an eight-step plan** on its first letter;
- a reviewer who typed past that letter had no way to send what they wrote (that was #907).

The rule, statable in one line: **only non-text keys act on their own.** Every answer — `a`, `t`, `x`, `ok`, or a sentence — is typed and sent with `⏎`, read by the one parser `ScopeDecision::from_typed` already provides. One extra keystroke buys deliberate consent at the one gate whose whole purpose is deliberate consent.

## Two things the rule exposed

**`Esc` now claims a non-empty composer too**, unlike the letters. It only fired on an empty one, so "type a note, change your mind, press Esc" fell past the card into the turn-stop chain — which for a pipeline turn is a *hard cancel*. The same gesture ended the turn cleanly or violently depending on whether the user had started typing. While a card is up, `Esc` means one thing: get out of this card.

**The help overlay was part of the cause, not just stale docs.** The Session tab had *no* row for answering a card, while the global row read `⏎ → "queue the prompt — mid-turn it runs as its own agent"` — an unqualified promise of exactly the sidecar that swallowed the answer in #907. Both fixed; the `⏎` row now ends "(unless a card waits)".

The legend stops implying one-press keys:

```
before:  [a]pprove  [t]rim  [x]abort  ·  or type what to change and ⏎ to re-plan
after:   type approve  trim  abort  ·  or what to change  —  then ⏎
```

## Deliberately not changed

`ask_user`'s digit quick-pick. A digit in a numbered, on-screen list refers to something the reviewer is looking at; that is not the same thing as `a` being one of the most common initial letters in English. Different call, and not the one that was asked.

## Tests

Updated to the new contract rather than deleted, and two now prove the point directly on **both** surfaces (deck + single-session REPL):

- `no_bare_letter_answers_the_scope_card` — a/t/x type from an *empty* composer, the keystroke that used to commit
- `a_note_opening_with_a_decision_letter_is_a_revision_not_an_approval` — the case that named the rule
- `esc_aborts_the_card_whether_or_not_a_note_is_half_typed`
- `scope_card_esc_aborts_immediately_and_typed_x_aborts_on_submit`
- `a_revision_note_passes_through_untouched` — the deck→pipeline mapping, previously untested

## Two notes for review

**1. The second commit is unrelated and pre-existing.** `env_files::tests::home_directory_is_never_a_project_scope` fails on `origin/main` at 0eeb8d4d with the same assertion — verified by running it against a pristine checkout, not inferred. `find_base` documents `start` as `getcwd` (already symlink-free) and canonicalizes only `home`; the test passed a raw `tempfile` path, so on macOS (`/var` → `/private/var`) the guard compared `/var/folders/…` against `/private/var/folders/…`, never matched, and returned the directory it exists to refuse. Fixed in the test, matching the sibling symlink test directly below it. Production was never affected. Included because `make gate` cannot pass on macOS without it.

**2. The baseline diff carries someone else's line.** `scripts/file-size-baseline.txt` has two changes:

| file | change | whose |
|---|---|---|
| `stella-tui/src/deck_render.rs` | 1704 → 1723 | mine — the help-overlay rows |
| `stella-cli/src/main.rs` | 1545 → 1548 | **inherited** — #937 landed 1548 lines against a 1545 ceiling, so `make file-size` is red on main itself |

Hand-edited rather than regenerated, so the diff is exactly those two numbers (a full `--update` also reshuffles `agent.rs`/`agent_tests.rs` on locale-dependent sort order).

`make gate` is green end to end (`GATE_EXIT=0`, zero test failures): tests, clippy `-D warnings`, fmt, file-size, invariants, doc-citations, action-pins, no-scratch, rustdoc.

Docs: `inference-pipeline.mdx` rewritten for the new contract. Note `docs/llms.txt` and the `make llms-txt` target were both deleted from main by the docs rework, so there is nothing to regenerate.


## Summary by Sourcery

Require typed, submitted answers for scope review cards across deck and session surfaces, update UI/help/docs to reflect the new contract, and fix a macOS-only test failure around home-directory project scope detection.

New Features:
- Standardize scope card interaction so all decisions and revision notes are typed into the composer and submitted, with Esc as the only immediate abort key.
- Document scope card behavior and revision flow in the deck help overlays, global shortcuts, and inference pipeline docs.

Bug Fixes:
- Prevent bare decision letters (a/t/x) from silently committing scope cards or diverting typed revision notes into sidecar sessions.
- Ensure Esc consistently aborts an active scope card regardless of whether a note is partially typed, avoiding unintended turn cancellation.
- Fix the home_directory_is_never_a_project_scope test to work on macOS by resolving symlinked temp directories before comparison.

Enhancements:
- Clarify comments and legends around scope review gating, making the deliberate consent model and revision limits explicit.
- Add a test guaranteeing that revision notes pass through the deck layer unchanged before reaching the pipeline.

Tests:
- Expand deck and session tests to cover typed scope decisions, bare-letter behavior, Esc handling, answered-card latching, and untouched revision note propagation.
