### PR TITLE
fix(build): unbreak main — the duplicate import #946 landed, and three dead CSS tokens

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,7 +20,6 @@
 1576 stella-cli/src/candidate_ws.rs
 4578 stella-cli/src/command_deck.rs
 1518 stella-cli/src/config.rs
-1539 stella-cli/src/main.rs
 2095 stella-core/src/bus.rs
 2138 stella-core/src/driver.rs
 2820 stella-core/src/driver/tests.rs

--- a/stella-cli/src/connect_cmd.rs
+++ b/stella-cli/src/connect_cmd.rs
@@ -16,7 +16,6 @@ use stella_tools::tracker_auth::{
     TrackerProvider, TrackerStore, fetch_account_label, github_device_login, linear_oauth_login,
     now_secs,
 };
-use zeroize::Zeroizing;
 
 /// Entry point for `stella connect <cmd>`.
 pub fn run(cmd: &crate::ConnectCmd) -> Result<(), String> {

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -90,6 +90,17 @@
   --stella-cta-fg: var(--stella-paper);
   --stella-cta-bg-hover: var(--stella-brand-ink-deep);
 
+  /* The other three mode-aware component tokens. They live beside
+   * `--stella-accent` because they flip with the theme for the same reason it
+   * does, and this file spends all three: `mark` on the logo cursor, `rule` on
+   * table and diagram strokes, `faint` on de-emphasised captions. An undefined
+   * custom property is invalid at computed-value time — it does not error, it
+   * silently falls back — so a missing definition here renders as a plausible
+   * wrong colour instead of failing the build. */
+  --stella-mark: var(--stella-gold-ink); /* the logo cursor — 5.5:1 on paper */
+  --stella-rule: var(--stella-paper-hairline-contrast); /* 3.3:1 — structural */
+  --stella-faint: var(--stella-ink-tertiary); /* 4.7:1 on paper */
+
   /* Light mode — paper ground, ink type. Accent text is ink; the brand accent
    * appears here only as a fill with an ink label on it. */
   --color-fd-background: var(--stella-paper);
@@ -129,6 +140,15 @@
   --stella-cta-bg: var(--stella-brand-bright);
   --stella-cta-fg: var(--stella-ink-primary);
   --stella-cta-bg-hover: var(--stella-brand-deep);
+
+  /* Dark counterparts of the three component tokens the light block sets.
+   * `rule` is the one that must clear 3:1 — it is the only seam here allowed to
+   * carry structure on its own, which is exactly what `hairline-contrast`
+   * exists for; `hairline` and `hairline-strong` measure 1.2:1 and 1.4:1 and
+   * stay decorative (BRAND.md). */
+  --stella-mark: var(--stella-gold); /* the logo cursor — 11.9:1 on ground */
+  --stella-rule: var(--stella-hairline-contrast); /* 3.1:1 — structural */
+  --stella-faint: var(--stella-text-tertiary); /* 4.8:1 on ground */
 
   --color-fd-background: var(--stella-ground);
   --color-fd-foreground: var(--stella-text-primary); /* 18.1:1 */

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -31,8 +31,11 @@
   --stella-ground: #080a0f; /* app background */
   --stella-surface: #0b0f17; /* cards, panels */
   --stella-raised: #101623; /* popovers, selected rows */
-  --stella-hairline: #182031; /* seam — decorative only */
-  --stella-hairline-strong: #232d42; /* seam where a boundary must read */
+  --stella-hairline: #182031; /* seam — decorative only, 1.2:1 */
+  --stella-hairline-strong: #232d42; /* heavier seam — 1.4:1, still decorative */
+  --stella-hairline-contrast: #525f80; /* 3.0:1 on surface, 3.1:1 on ground —
+                                        * the only dark seam that may carry
+                                        * structure alone (BRAND.md) */
 
   /* ── Ground — paper ───────────────────────────────────────────────────── */
   --stella-paper: #ffffff;


### PR DESCRIPTION
## What & why

`main` does not compile. On `493b1f51`:

```
$ cargo check -p stella-cli --all-targets ; echo $?
error[E0252]: the name `Zeroizing` is defined multiple times
  --> stella-cli/src/connect_cmd.rs:19:5
   |
12 | use zeroize::Zeroizing;
   |     ------------------ previous import of the type `Zeroizing` here
...
19 | use zeroize::Zeroizing;
   |     ^^^^^^^^^^^^^^^^^^ `Zeroizing` reimported here
101
```

Both defects here come from **#946's squash-merge resolving a conflict by keeping
both sides**. #954 caught the `stella-store` half of the same merge; these two are what
was left.

## 1. The duplicate import

`main` and the branch had each added `use zeroize::Zeroizing;` independently, at
different anchors — main's at the top beside `colored`, the branch's below the
`stella_tools` group. Two textually non-adjacent insertions of the same line merge
*cleanly*, and are a hard compile error.

Removed the second; main's placement stays.

Worth noting **why this reached `main`**: a squash-merge keeps no second parent, so
nothing in `git log` records which side each hunk came from — the only way to see it is
to compile. And `cargo` stops at the first failing crate, so while `stella-store` was
also broken this error was never even *printed*.

## 2. Three CSS custom properties, spent and defined nowhere

The same merge dropped `--stella-mark`, `--stella-rule` and `--stella-faint` from **both**
the light and the dark semantic blocks of `global.css`, while seven rules still reference
them — table borders, diagram strokes, the logo cursor, de-emphasised captions.

**Nothing failed, which is the whole problem.** An undefined custom property is invalid at
computed-value time, so it *falls back* rather than erroring: `pnpm build` stayed green at
78/78 pages and every page rendered — in the wrong colours, in both modes. The Rust half
of this merge announced itself in eleven compiler errors; the stylesheet half said nothing.

Restored in both modes, against tokens that exist, with every ratio **computed** rather
than copied across:

| token | light | | dark | |
| --- | --- | --- | --- | --- |
| `mark` | `gold-ink` | 5.5:1 on paper | `gold` | 11.9:1 on ground |
| `rule` | `paper-hairline-contrast` | 3.3:1 | `hairline-contrast` | 3.1:1 |
| `faint` | `ink-tertiary` | 4.7:1 on paper | `text-tertiary` | 4.8:1 on ground |

Dark `rule` needs `--stella-hairline-contrast`, which **BRAND.md:39 specifies**
(`#525F80`, *"the only seam that may carry structure alone"*) but `tokens.css` has never
defined. Added there — and that file's own header already says a value BRAND.md defines
belongs in it whether or not the docs site happens to spend it.

Pointing `rule` at `hairline-strong` instead would have been the tempting fix and the
wrong one: it measures **1.39:1**, and BRAND.md:38 calls it decorative. Its comment
nevertheless claimed *"seam where a boundary must read"*; restated against the published
number, along with `hairline`'s.

Verified mechanically rather than by eye — every `var(--x)` across `global.css` and
`tokens.css` now resolves to an `--x:` definition, the only exceptions being
`--font-geist-sans`/`--font-geist-mono`, which `next/font` injects in `layout.tsx`:

```
before:  --stella-faint  --stella-mark  --stella-rule   ← referenced, never defined
after:   (none)
```

And confirmed in the **built bundle**, not just the source — 2 occurrences each (light +
dark), with `--stella-hairline-contrast:#525f80` in the palette.

> That check is three lines of shell and still deserves a `scripts/check-*.sh` of its own.
> This is the second time the same defect class has landed.

## 3. One retired baseline entry

`make file-size` was red on `main` independently of the above:

```
stella-cli/src/main.rs is now 1445 lines (<= 1500) — drop its baseline entry
```

The ratchet fails on a **stale exemption** exactly as it fails on growth — an exemption
must not outlive the problem it covered. Retired the line.

Removed by hand rather than by `make file-size-update`, because a full regeneration
re-sorts the file under the running shell's collation (`en_US.UTF-8` orders
`agent_tests.rs`/`agent.rs` the opposite way from C) and would bury a one-line change in
unrelated churn.

## The gate

Each taken from `$?`. **This matters in this repo:** forced ANSI in pipes defeats
`rg "^error"`, and a `| tail` reports *tail's* status rather than cargo's.

| Gate | `main` `493b1f51` | this branch |
| --- | --- | --- |
| `cargo build --workspace --all-targets` | **101** | **0** |
| `cargo fmt --all --check` | 0 | **0** |
| `cargo clippy --workspace --all-targets -- -D warnings` | — | **0** |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | — | **0** |
| `cargo test --workspace --no-fail-fast` | — | **0** |
| `make file-size` | **1** | **0** |
| `make no-scratch action-pins doc-citations invariants` | 0 | **0** each |
| `pnpm build` (website) | 0 *(wrong colours)* | **0**, 78/78 pages |

## The witness

- [x] The build itself: `cargo check -p stella-cli` goes 101 → 0, and the E0252 output
      above is the whole argument for the one-line deletion.
- [x] The CSS is witnessed by the reference-vs-definition diff going from three dangling
      tokens to zero, checked against the built bundle rather than the source.

## Left alone, deliberately

- #948 already fixed `home_directory_is_never_a_project_scope` (the macOS-only `/var` vs
  canonicalized `/private/var` comparison).
- #954 already fixed the duplicate `tool_calls` methods and the `set_task_id` intra-doc
  link.
- Three `stella-tools` `custom::tests` hit their **5000 ms** deadline when the whole
  workspace runs in parallel on a loaded machine, and pass in 9.61s with the crate run
  alone (`518 passed; 0 failed`). That is a spawn budget rather than an assertion;
  widening it belongs in its own change.


## Summary by Sourcery

Restore missing styling tokens and fix build regressions to bring main back to a clean, passing state.

Bug Fixes:
- Remove a duplicate Zeroizing import in stella-cli connect command that prevented the crate from compiling.
- Reintroduce mode-aware CSS custom properties for mark, rule, and faint so existing components no longer render with unintended fallback colours.
- Add the missing dark theme hairline-contrast token to the design palette and align hairline comments with documented contrast ratios.
- Retire an obsolete file-size baseline entry now that stella-cli main.rs is back under the threshold, restoring the ratchet gate.
