### PR TITLE
docs(adr): ratify 0011 and 0012 — context records are TOML, and live in files

### DIFF
--- a/docs/adr/0011-context-records-are-toml.md
+++ b/docs/adr/0011-context-records-are-toml.md
@@ -1,9 +1,11 @@
 # ADR 0011: Context Records Are TOML (supersedes the surface decision in 0008)
 
-- Status: **Proposed** — needs repository-owner ratification. Supersedes ADR
-  0008's *surface* decision only; 0008's thesis is preserved unchanged.
-- Date: 2026-07-28
-- Deciders: (pending)
+- Status: **Accepted** — ratified by repository owner 2026-07-30 (was: Proposed).
+  Supersedes ADR 0008's *surface* decision only; 0008's thesis is preserved
+  unchanged. Ratified together with [ADR 0012](0012-context-record-field-schema.md),
+  as the closing section of this ADR requires.
+- Date: 2026-07-28 (ratified 2026-07-30)
+- Deciders: repository owner (ratified 2026-07-30)
 
 ## Context
 

--- a/docs/adr/0012-context-record-field-schema.md
+++ b/docs/adr/0012-context-record-field-schema.md
@@ -1,9 +1,13 @@
 # ADR 0012: The context-record field schema, and records-live-in-files
 
-- Status: **Proposed** — every substantive question below is resolved and
-  implemented; what remains is repository-owner sign-off on the surface.
-- Date: 2026-07-29
-- Deciders: (pending)
+- Status: **Accepted** — ratified by repository owner 2026-07-30 (was: Proposed).
+  Every substantive question below was resolved and implemented before
+  ratification; the signature is on the surface those answers already assume.
+  Ratified together with [ADR 0011](0011-context-records-are-toml.md), which
+  deferred this schema and named ratifying one without the other as the state to
+  avoid.
+- Date: 2026-07-29 (ratified 2026-07-30)
+- Deciders: repository owner (ratified 2026-07-30)
 - Follows: [ADR 0011](0011-context-records-are-toml.md), which settled the
   *format* and explicitly deferred "which fields a context record carries, and
   what their vocabularies are" to a separate decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,5 +54,5 @@ open; nothing before Phase 3 forces it.
 | [0008](0008-markdown-canonical-rules.md) | Markdown Repository Rules Remain Canonical | Accepted (Phase 0) — surface superseded by [0011](0011-context-records-are-toml.md) |
 | [0009](0009-enum-freeze-resolutions.md) | Enum-Freeze Resolutions (issue #483) | Accepted — ratified 2026-07-24 |
 | [0010](0010-incremental-authority-transfer.md) | Incremental Authority Transfer (amends 0005) | Accepted — ratified 2026-07-26 (index tables do not transfer) |
-| [0011](0011-context-records-are-toml.md) | Context Records Are TOML (supersedes 0008's surface) | **Proposed** — awaiting ratification |
-| [0012](0012-context-record-field-schema.md) | The Context-Record Field Schema, and Records-Live-in-Files | **Proposed** — resolves 0011's open question and the record-surface open questions; awaiting ratification |
+| [0011](0011-context-records-are-toml.md) | Context Records Are TOML (supersedes 0008's surface) | Accepted — ratified 2026-07-30 (hash-neutral; legacy `.md` rules keep loading) |
+| [0012](0012-context-record-field-schema.md) | The Context-Record Field Schema, and Records-Live-in-Files | Accepted — ratified 2026-07-30 (memories in the database, context records in files; `personal` → `user`) |

--- a/docs/context-record-examples/README.md
+++ b/docs/context-record-examples/README.md
@@ -1,9 +1,14 @@
 # Context record examples
 
-Worked examples of the TOML context-record surface. These are **illustrative, not
-normative** — `docs/context-pr.md` remains the canonical specification, and
-nothing here is loaded by the engine. They exist so the schema can be argued
-against concretely before it is implemented.
+Worked examples of the TOML context-record surface. For the fields they cover
+these are **the schema reference**: [ADR 0012](../adr/0012-context-record-field-schema.md)
+ratified that schema on 2026-07-30 and retired this file's former "illustrative,
+not ratified" caveat, and `stella-core/src/records/` implements it.
+
+`docs/context-pr.md` remains the canonical specification for the workflow around
+records, and none of these files is loaded by the engine — they are examples, not
+fixtures. What changed is that the shapes below are now decided rather than
+proposed, so a disagreement with one is a disagreement with a ratified ADR.
 
 ## The shape
 


### PR DESCRIPTION
Ratifies ADR 0011 and ADR 0012, which both still read `Status: Proposed` /
`Deciders: (pending)` on `main` while the behaviour they describe is already
shipped.

An ADR that documents implemented behaviour but carries no signature is worse
than an open one. Code depends on it, so the "proposed" marker tells the next
reader the question is still live and invites them to answer it again —
differently — in whichever module they happen to be in. That is the exact
failure 0012 was written to end.

## Ratified together, on purpose

0011 settled the *format* and explicitly deferred the field schema. Its closing
section names ratifying one without the other as the state to avoid: it leaves
the format decided and the contents undecided, which is how each module came to
answer the schema question for itself.

## What is now decided

**ADR 0011 — context records are TOML.** The frontmatter had grown into a typed
eleven-field record read by roughly thirty-five hand-rolled lines that silently
promote a nested key to the top level — to the point that the canonical
specification's own §6.1 example did not parse as written. TOML is already a
workspace dependency, and brings real datetimes, integers and arrays with no
implicit coercion, which is what a governance ledger needs.

The property that makes it safe: it is **hash-neutral**. `record_hash` is RFC
8785 canonical JSON over the serialised struct, and the on-disk surface never
enters the preimage — so the migration mints no revision and changes no
`record_id`. Legacy `.stella/rules/*.md` keep loading.

**ADR 0012 — the field schema, and the substrate rule.** Memories live in the
database; context records live in files, and `sharing_scope` selects *which* file
location rather than whether it is a file at all. Plus the five record-surface
questions: the surface keeps `personal` and maps to the ledger's `user`;
`applies_to.tasks` is a closed vocabulary with a loud warning rather than an open
one that swallows typos; `tags` is kept for human browsing and must never be
matched on; a statement is one independently-falsifiable sentence.

## Also in here

`docs/context-record-examples/README.md` still called the schema "illustrative,
not normative … so it can be argued against concretely **before it is
implemented**". It is implemented, and 0012's Consequences section required
retiring that caveat on ratification — left alone it would contradict the ADR it
illustrates. The ADR index table is updated too, so it cannot keep reporting two
accepted ADRs as awaiting a signature.

No decision content changed. This is the signature, the two index rows, and one
stale caveat.

`make doc-citations`, `make no-scratch` and `make invariants` all pass.


## Summary by Sourcery

Ratify ADR 0011 and ADR 0012 and align supporting documentation to reflect that the TOML context-record format and field schema are now accepted, implemented decisions.

Documentation:
- Update the context record examples README to make the examples the authoritative schema reference for covered fields and clarify their relationship to the canonical workflow spec.
- Mark ADR 0011 and ADR 0012 as accepted with ratification details, including their joint ratification and relationship to prior ADRs.
- Refresh the ADR index entries for 0011 and 0012 to show their accepted status and key consequences of each decision.
