### PR TITLE
test: probe the bench gate's skip path (throwaway, will be closed)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,5 @@ open; nothing before Phase 3 forces it.
 | [0010](0010-incremental-authority-transfer.md) | Incremental Authority Transfer (amends 0005) | Accepted — ratified 2026-07-26 (index tables do not transfer) |
 | [0011](0011-context-records-are-toml.md) | Context Records Are TOML (supersedes 0008's surface) | **Proposed** — awaiting ratification |
 | [0012](0012-context-record-field-schema.md) | The Context-Record Field Schema, and Records-Live-in-Files | **Proposed** — resolves 0011's open question and the record-surface open questions; awaiting ratification |
+
+<!-- probe: verifies the bench gate reports on a PR that touches no bench path (#968). Deleted after. -->


### PR DESCRIPTION
Throwaway probe for #968. Touches only `docs/adr/README.md` — no `bench/` path.

Verifies that `harbor_adapter + analyzer pytest` still **reports** (rather than never running) when a PR touches nothing under `bench/`. That is the precondition for making it a required context: a path-filtered workflow that does not run leaves a required check pending forever and blocks the PR.

Expected: the check reports SUCCESS, with the two pytest steps skipped.

Closed as soon as the check reports.

## Summary by Sourcery

Documentation:
- Append a temporary comment to the ADR README clarifying its role as a CI probe for bench path gating.