### PR TITLE
feat(serve): observability — a typed event at every boundary (#930)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,6 +3198,7 @@ name = "stella-serve"
 version = "0.6.12"
 dependencies = [
  "async-trait",
+ "proptest",
  "rand 0.10.2",
  "serde",
  "serde_json",

--- a/docs/design/serve-observability.md
+++ b/docs/design/serve-observability.md
@@ -1,7 +1,12 @@
 # Observability for `stella-serve` — a typed event at every boundary
 
-**Status:** Design, nothing built. Corrects audit dimension 30 (Observability,
-62/100) and closes [#930](https://github.com/macanderson/stella/issues/930).
+**Status:** **Built** — `stella-serve/src/observe/`, all four slices of §11 in
+one change. Corrects audit dimension 30 (Observability, 62/100) and closes
+[#930](https://github.com/macanderson/stella/issues/930). Two things below were
+changed *by* building them, and are marked **[amended]** where they appear:
+the per-frame debug record in §7 was dropped (it would have put model output in
+a log), and the handlers moved to a new `routes.rs` (§11). Everything else
+shipped as designed.
 **Date:** 2026-07-30. **Owner:** Mac Anderson.
 **Companion:** [`serve-surface.md`](./serve-surface.md) — the route table and
 turn lifecycle this document instruments. Read that first; everything here
@@ -294,10 +299,21 @@ Four properties this buys, in the order the memory on this pattern prescribes:
    `ConnectionFailed` alongside it. The `let _ = handle_conn(..)` at
    `server.rs:500` stops discarding anything because there is nothing left to
    discard.
-3. **Delete the escape hatch.** `ServeEvent::RequestCompleted` gets no public
-   constructor other than `RequestRecord::close`. `-D dead-code` then proves
-   there is no second path.
-4. **Prove it with a property, not examples.** §10.
+3. **Delete the escape hatch.** `RequestRecord::close` consumes `self` and is
+   the only place in the crate that constructs
+   `ServeEvent::RequestCompleted`. **[amended]** The original wording claimed
+   `-D dead-code` would *prove* there is no second path; it does not — a public
+   enum variant is constructible anywhere, and sealing it would mean a private
+   witness field that `Deserialize` then has to fabricate, which buys less than
+   it costs. What `-D dead-code` did do is real and worth keeping: it found two
+   helpers nothing reached (`RequestRecord::route`, `request_id_for`) and
+   refused to compile until they were deleted, so the module has no
+   almost-used second path lying around for a future edit to reach for. The
+   *single-record* guarantee rests on rule 4, which is where it belongs.
+4. **Prove it with a property, not examples.** §10 — and the property earned
+   its keep: injecting the classic bug (skip the emit when nothing was written,
+   i.e. forget the hangup path) fails it with `input of 0 byte(s) produced 0
+   records, not exactly 1`.
 
 ### `X-Request-Id`
 
@@ -378,8 +394,15 @@ pub struct TurnTally {
 }
 ```
 
-Per-frame records exist only at `STELLA_SERVE_LOG=debug`, which is off by
-default and documented as a development setting.
+**[amended — not built, and deliberately so.]** This section originally also
+planned individual `AgentEvent` records behind `STELLA_SERVE_LOG=debug`.
+Building it showed that to be a mistake: `AgentEvent::Text`, `TextDelta` and
+`Reasoning` carry model output verbatim, so those records would put
+prompt-adjacent content in a log file — and would make §8's no-content property
+*conditional on a verbosity flag*, which is the "safe unless you turn the knob"
+shape of invariant that fails in production. The tally supersedes it: aggregates
+answer the diagnostic questions (is this turn progressing? how many retries?)
+with no payload reaching a record, so the property holds unconditionally.
 
 That tally is also what distinguishes *wedged* from *slow* — the fourth
 situation #930 lists — because a turn whose `steps` has not advanced while its
@@ -424,6 +447,16 @@ encoder could pass every sentinel check vacuously"), the harness carries a
 **vacuity guard**: assert the capture is non-empty and that at least one record
 of each expected variant was produced. A test that observes nothing passes every
 redaction check for the wrong reason.
+
+**[amended] A sweep can also be non-vacuous and still blind.** The first version
+of this harness had a working vacuity guard and still failed to catch a planted
+leak: it asserted `!rendered.contains(&turn_id)` where `turn_id` is the
+`turn-`-prefixed form, while a record holds the *bare hex* — so a `TurnRef` that
+had been broken to emit all 32 characters sailed through. The assertion now
+compares the hex suffix, and separately asserts the first 8 characters *are*
+present, so "leaked the whole id" and "recorded no handle at all" are both
+failures. The general lesson: a sentinel sweep tests the sentinel you wrote, not
+the property you meant, unless you plant the leak and watch it fail.
 
 ---
 
@@ -505,14 +538,24 @@ alone closes most of #930.
 | **1** | `ServeEvent`, `Observer`, `JsonlSink`, `Capture`, the `Responder` fold, `X-Request-Id`, `STELLA_SERVE_LOG`. Scenarios 2–3 + exactly-one property | `observe/{mod,event,sink,record}.rs` | `server.rs` (fold + `Responder` threading), `http.rs` (signatures) |
 | **2** | Reverse-RPC events and the registry events — `ReverseDispatched`/`Answered`/`TimedOut`/`Misrouted`/`Abandoned`, `TurnCreated`/`Refused`/`Reclaimed`. Scenarios 1 + 4 | — | `pending.rs`, `remote.rs`, `server.rs` |
 | **3** | `Metrics` + `GET /v1/metrics`. Route table in `serve-surface.md` updated | `observe/metrics.rs` | `server.rs`, `docs/design/serve-surface.md` |
-| **4** | The frame tap, `TurnTally`, `TurnSettled`, `debug`-level per-frame records. The sentinel harness | `observe/tally.rs` | `session.rs`, `frame.rs` |
+| **4** | The frame tap, `TurnTally`, `TurnSettled`. The sentinel harness | `observe/tally.rs` | `session.rs` |
 
-**File-size note (constraint 5).** `server.rs` has ~240 lines of headroom and
-PRs 1–3 all touch it. Extracting `route()` into `observe/record.rs` is roughly
-size-neutral for `server.rs`; the metrics handler in PR 3 must live in
-`observe/metrics.rs` and be *called* from the route match, not written inline.
-If the ratchet still trips, the fix is to split the route match out of
-`server.rs` — not `make file-size-update`.
+**[amended] What actually shipped.** All four slices landed as one change, and
+the file-size prediction below was wrong in a useful direction.
+
+**File-size note (constraint 5).** `server.rs` had ~240 lines of headroom and
+PRs 1–3 all touch it. The prediction was that extracting `route()` would be
+roughly size-neutral and the ratchet might still trip.
+
+What happened instead: the fold is small, but *threading a `Responder` through
+every handler* is not, so the handlers moved to a new `routes.rs` — the
+endpoints and their wire types on one side, the transport (listener, fold, turn
+registry, throttle) on the other. That cut follows the concern rather than the
+line count, and it took `server.rs` from 1,257 lines to **1,072** while adding
+the fold, the route classifier and the metrics route. Both files now sit
+comfortably under the ratchet with room for the next change. The guidance holds
+and is worth restating: when the ratchet threatens, split along a seam that
+already exists — never `make file-size-update`.
 
 ---
 

--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -32,6 +32,7 @@ family in the diagram below — is a 404.
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/healthz` | The **only** unauthenticated route. `{"status":"ok"}` |
+| `GET` | `/v1/metrics` | Counters as a flat JSON object of integers. Authenticated like every other route, and **pull-only** — see [serve-observability.md](./serve-observability.md) |
 | `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}` |
 | `GET` | `/v1/turns/{id}/events` | SSE `data: <ServerFrame>`. Exclusive: a second subscriber gets 409 |
 | `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |

--- a/stella-serve/Cargo.toml
+++ b/stella-serve/Cargo.toml
@@ -26,3 +26,9 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time",
 # `test-util` gives the paused clock, which is what makes the 30s read deadline
 # assertable in microseconds instead of thirty real seconds of CI time.
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "io-util", "test-util"] }
+# Already in `[workspace.dependencies]` and already built for other crates, so
+# this adds no crate to the graph. Needed for the one property that matters
+# here: every connection produces exactly one record. The original bug this
+# guards against is always a path nobody enumerated, so hand-listed cases are
+# precisely how it would be missed.
+proptest.workspace = true

--- a/stella-serve/README.md
+++ b/stella-serve/README.md
@@ -55,11 +55,48 @@ host  ──POST /v1/turns──►  stella-serve  ──►  Session (dedicated
 | [`src/remote.rs`](src/remote.rs) | The two remoted port impls, plus `TokioSleeper` for the engine's retry backoff. |
 | [`src/pending.rs`](src/pending.rs) | `Pending`, the `request_id` → one-shot registry shared across the two runtimes. Open it when a resolve POST returns 409. |
 | [`src/frame.rs`](src/frame.rs) | The wire vocabulary: `ServerFrame`, `TurnOutcomeWire`, `ToolResultIn`, `ProviderResultIn`, `ProviderErrorWire`. Every wire-shape change starts here. |
-| [`src/server.rs`](src/server.rs) | `serve` — accept loop, bearer auth, the five `/v1/turns` routes (including `cancel`), the turn registry, and a rustdoc list of the operational limits the deployment must supply. |
+| [`src/server.rs`](src/server.rs) | `serve` — accept loop, bearer auth, the connection fold (one record per connection), route classification, the turn registry, and a rustdoc list of the operational limits the deployment must supply. |
+| [`src/routes.rs`](src/routes.rs) | The endpoint handlers and the wire types they parse — the five `/v1/turns` routes (including `cancel`), `/healthz`, `/v1/metrics`, and the host-supplied ceilings (`max_steps`, `reverse_request_timeout_ms`). |
+| [`src/observe/`](src/observe/) | Observability: `ServeEvent` (18 typed boundary events), the `Observer` port and its sinks, the request fold, the counters behind `/v1/metrics`, and the per-turn tally folded from the engine's own `AgentEvent` stream. Start at [`mod.rs`](src/observe/mod.rs); the design is [`docs/design/serve-observability.md`](../docs/design/serve-observability.md). |
 | [`src/accept.rs`](src/accept.rs) | The written `accept()` classification policy — transient vs fatal, the backoff, and the give-up streak. Byte-identical to [`stella-observatory/src/accept.rs`](../stella-observatory/src/accept.rs) (the observatory takes no `stella-*` dependency, so there is no shared crate to hold it); a drift-guard test in both crates fails if the two copies differ. Change one, change the other. |
 | [`src/http.rs`](src/http.rs) | A hand-rolled HTTP/1.1 + SSE layer following [`stella-observatory`](../stella-observatory)'s no-framework idiom, extended with request bodies, bearer auth, and long-lived responses. |
 | [`src/error.rs`](src/error.rs) | `ServeError` — the named failures at the boundary. |
-| [`src/main.rs`](src/main.rs) | The binary: env config (`STELLA_SERVE_BIND` / `_TOKEN_FILE` / `_TOKEN` / `_TOOLS`; the file supply wins, and a token under 32 chars warns rather than refusing to start) and the `healthcheck` subcommand. |
+| [`src/main.rs`](src/main.rs) | The binary: env config (`STELLA_SERVE_BIND` / `_TOKEN_FILE` / `_TOKEN` / `_TOOLS` / `_LOG`; the file supply wins, and a token under 32 chars warns rather than refusing to start) and the `healthcheck` subcommand. |
+
+### Reading the output
+
+The server writes one JSON object per line to **stderr**, and exposes the same
+information as counters at `GET /v1/metrics` (authenticated, same bearer token,
+pull-only — nothing is ever sent anywhere).
+
+```
+STELLA_SERVE_LOG = off | error | warn | info (default) | debug
+```
+
+An unrecognised value falls back to `info` rather than failing startup: a typo
+in a log knob must not take a service down. Rotation, retention and shipping are
+the supervisor's job (systemd, Docker, the host's runner) — this process only
+writes lines.
+
+Records never carry prompt text, tool payloads, model output, filesystem paths,
+raw request paths, the bearer token, or a whole turn id (a turn id is a *second
+factor*: acting on a turn needs the token **and** the id, so records carry only
+its first 8 hex characters — enough to correlate, useless for forging). That is
+enforced by a sentinel sweep in the test suite, not by convention.
+
+The four things that used to be indistinguishable from silence, and what to grep
+for now:
+
+| Situation | Record |
+|---|---|
+| a turn wedged on a reverse request nobody will answer | `"event":"reverse_timed_out"` — carries `waited_ms` and the kind |
+| a host answering with the wrong `request_id` | `"event":"reverse_misrouted"` — `fault` separates a stale id from a wrong-kind answer |
+| a 429 storm | `"event":"turn_refused"` with `reason":"at_capacity"`, plus `turns_live` |
+| a bearer-token brute force | `"event":"unauthorized"` — a non-zero `held_ms` is the throttle engaging, which is a sustained guess rather than a misconfigured client |
+
+To tell *wedged* from merely *slow*: a turn whose `turn_settled` tally shows no
+advancing `stages` while a reverse request's `waited_ms` climbs is wedged; one
+whose stages keep advancing is just long.
 
 ## Key concepts
 

--- a/stella-serve/src/http.rs
+++ b/stella-serve/src/http.rs
@@ -316,24 +316,18 @@ fn find_head_end(buf: &[u8]) -> Option<usize> {
     buf.windows(4).position(|w| w == b"\r\n\r\n")
 }
 
-/// Write a one-shot response (status, JSON content type, body) and close.
-pub(crate) async fn write_json(
-    stream: &mut TcpStream,
-    status: &str,
-    body: &[u8],
-) -> std::io::Result<()> {
-    write_json_with_headers(stream, status, &[], body).await
-}
-
-/// [`write_json`] plus caller-supplied headers, for the responses that carry one
-/// (`Retry-After` on a 429, `Allow` on a 405). Each pair is emitted verbatim as
-/// `name: value`.
+/// Write a response head plus body and close, reporting how many bytes went out.
+///
+/// The byte count is returned rather than merely written because the request
+/// fold records `bytes_out` for every response, and a count each handler had to
+/// remember to report would be wrong within one refactor. Callers go through
+/// `observe::record::Responder`, which is what actually captures it.
 pub(crate) async fn write_json_with_headers(
     stream: &mut TcpStream,
     status: &str,
     extra: &[(&str, &str)],
     body: &[u8],
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     let mut head = format!(
         "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n",
         body.len(),
@@ -345,9 +339,11 @@ pub(crate) async fn write_json_with_headers(
         head.push_str("\r\n");
     }
     head.push_str("\r\n");
+    let total = (head.len() + body.len()) as u64;
     stream.write_all(head.as_bytes()).await?;
     stream.write_all(body).await?;
-    stream.shutdown().await
+    stream.shutdown().await?;
+    Ok(total)
 }
 
 /// Write the SSE response head, leaving the connection open to stream frames.
@@ -359,9 +355,17 @@ pub(crate) async fn write_json_with_headers(
 /// `provider_request` it has not received, so the engine parks forever and the
 /// buffered stream never reaches the size that would flush it. The header is the
 /// standard opt-out and is ignored by proxies that do not honour it.
-pub(crate) async fn write_sse_head<W: AsyncWrite + Unpin>(stream: &mut W) -> std::io::Result<()> {
-    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-store\r\nX-Accel-Buffering: no\r\nConnection: close\r\n\r\n";
-    stream.write_all(head.as_bytes()).await
+/// `request_id` is echoed as `X-Request-Id` like every other response, so a host
+/// can correlate a stream with the POST that created it.
+pub(crate) async fn write_sse_head<W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    request_id: &str,
+) -> std::io::Result<u64> {
+    let head = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-store\r\nX-Accel-Buffering: no\r\nX-Request-Id: {request_id}\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(head.as_bytes()).await?;
+    Ok(head.len() as u64)
 }
 
 /// Write one SSE `data:` frame carrying a JSON payload.
@@ -372,10 +376,11 @@ pub(crate) async fn write_sse_head<W: AsyncWrite + Unpin>(stream: &mut W) -> std
 pub(crate) async fn write_sse_frame<W: AsyncWrite + Unpin>(
     stream: &mut W,
     json: &str,
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     stream.write_all(b"data: ").await?;
     stream.write_all(json.as_bytes()).await?;
-    stream.write_all(b"\n\n").await
+    stream.write_all(b"\n\n").await?;
+    Ok((b"data: ".len() + json.len() + 2) as u64)
 }
 
 #[cfg(test)]

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -56,8 +56,10 @@ mod accept;
 mod error;
 mod frame;
 mod http;
+pub mod observe;
 mod pending;
 mod remote;
+mod routes;
 mod server;
 mod session;
 
@@ -66,6 +68,7 @@ pub use frame::{
     ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn,
     TurnOutcomeWire,
 };
+pub use observe::{Metrics, Observer, ServeEvent, SharedObserver};
 pub use pending::Pending;
 pub use server::{ServeConfig, serve};
 pub use session::{Session, SessionSpec};

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -10,6 +10,11 @@
 //! STELLA_SERVE_TOKEN       bearer token every request must present
 //! STELLA_SERVE_TOOLS       must be `remote` (the default) — all tool execution is
 //!                          remoted to the host; a local tool surface is never served
+//! STELLA_SERVE_LOG         off | error | warn | info (default) | debug — verbosity of
+//!                          the JSON-per-line records on stderr. An unrecognised value
+//!                          falls back to `info`: a typo in a log knob must not take a
+//!                          service down. Counters are unaffected by this and are read
+//!                          from `GET /v1/metrics`.
 //! ```
 //!
 //! One of `STELLA_SERVE_TOKEN_FILE` / `STELLA_SERVE_TOKEN` is required. The
@@ -64,12 +69,16 @@ ENVIRONMENT:
     STELLA_SERVE_TOKEN       bearer token every request must present
     STELLA_SERVE_TOOLS       must be `remote` (the default) — every tool and
                              model call is remoted to the host
+    STELLA_SERVE_LOG         off | error | warn | info (default) | debug —
+                             verbosity of the JSON-per-line records on stderr.
+                             An unrecognised value falls back to `info`.
 
 One of STELLA_SERVE_TOKEN_FILE / STELLA_SERVE_TOKEN is required.
 
-The server exposes GET /healthz unauthenticated, and POST /v1/turns,
-GET /v1/turns/{id}/events, POST /v1/turns/{id}/{provider-result,tool-result,cancel}
-behind the bearer token. See docs/design/serve-surface.md.
+The server exposes GET /healthz unauthenticated, and GET /v1/metrics,
+POST /v1/turns, GET /v1/turns/{id}/events,
+POST /v1/turns/{id}/{provider-result,tool-result,cancel} behind the bearer
+token. See docs/design/serve-surface.md and docs/design/serve-observability.md.
 ";
 
 /// `stella-serve <version>` — the line `--version` prints.
@@ -359,6 +368,7 @@ mod tests {
             "STELLA_SERVE_TOKEN_FILE",
             "STELLA_SERVE_TOKEN",
             "STELLA_SERVE_TOOLS",
+            stella_serve::observe::LOG_LEVEL_ENV,
         ] {
             assert!(USAGE.contains(var), "`--help` omits {var}");
         }

--- a/stella-serve/src/main.rs
+++ b/stella-serve/src/main.rs
@@ -161,7 +161,11 @@ async fn run() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let config = ServeConfig { bind: addr, token };
+    // `serve` emits a `listening` record through the observer; this line stays
+    // on stdout because it is the process's readiness contract — the container
+    // healthcheck and the dev scripts parse it, and a record on stderr at a
+    // configurable level is not something a supervisor can depend on.
+    let config = ServeConfig::new(addr, token);
     match serve(config, |bound| {
         println!("stella-serve listening on {bound}")
     })

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -1,0 +1,708 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The typed vocabulary of everything this server does at a boundary.
+//!
+//! Modelled on `stella-protocol`'s [`AgentEvent`](stella_protocol::AgentEvent),
+//! deliberately: one variant per boundary, internally tagged, serde-first, and —
+//! the part that matters most — **work the server throws away gets a name**
+//! rather than vanishing into a `let _ =`. `AgentEvent::SpeculationDiscarded` is
+//! the pattern; [`ServeEvent::ReverseTimedOut`] and its neighbours are this
+//! crate's version of it.
+//!
+//! # Every field here is structurally content-free
+//!
+//! Records are written to stderr, and operators ship stderr. So no variant
+//! carries prompt text, tool arguments, tool results, model output, a
+//! filesystem path, a raw request path, or a full turn id. The only `String`s
+//! are `addr` (operator-supplied), the two `error` fields (our own
+//! [`ServeError`](crate::ServeError) / `io::Error` renderings), and the
+//! sanitized [`RequestId`]. Everything else is an enum, an integer, or a
+//! truncated [`TurnRef`].
+//!
+//! That is a property, not a convention: `observe::tests::no_content_reaches_a
+//! _record` poisons a turn with sentinels and sweeps every emitted record for
+//! them, in the shape `stella-store::content_free` uses for egress.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// How loud a record is. Ordered so filtering is a comparison: an event passes
+/// when `event.level() <= filter`.
+///
+/// Derived from the variant rather than stored on it, so a record's severity
+/// can never disagree with what happened, and adding a variant forces the
+/// author to classify it (the match in [`ServeEvent::level`] is exhaustive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Level {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+/// The configured verbosity, from `STELLA_SERVE_LOG`. [`LevelFilter::Off`]
+/// silences the sink entirely; it does **not** stop events being emitted, so
+/// counters stay correct at any verbosity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum LevelFilter {
+    Off,
+    Error,
+    Warn,
+    #[default]
+    Info,
+    Debug,
+}
+
+impl LevelFilter {
+    /// Parse `STELLA_SERVE_LOG`. Unknown values fall back to the default rather
+    /// than failing startup: a typo in a log knob must not take a service down.
+    #[must_use]
+    pub fn parse(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "silent" => Self::Off,
+            "error" => Self::Error,
+            "warn" | "warning" => Self::Warn,
+            "debug" | "trace" => Self::Debug,
+            _ => Self::Info,
+        }
+    }
+
+    /// Whether a record at `level` should be written.
+    #[must_use]
+    pub fn admits(self, level: Level) -> bool {
+        match self {
+            Self::Off => false,
+            Self::Error => level <= Level::Error,
+            Self::Warn => level <= Level::Warn,
+            Self::Info => level <= Level::Info,
+            Self::Debug => true,
+        }
+    }
+}
+
+/// Which endpoint a request reached, as a **template**.
+///
+/// The raw path is never recorded, because for five of these it contains the
+/// turn id. Serde renames each variant to its template so a record reads like
+/// an access log without any rendering step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Route {
+    #[serde(rename = "/healthz")]
+    Healthz,
+    #[serde(rename = "/v1/metrics")]
+    Metrics,
+    #[serde(rename = "/v1/turns")]
+    TurnsCreate,
+    #[serde(rename = "/v1/turns/{id}/events")]
+    TurnEvents,
+    #[serde(rename = "/v1/turns/{id}/tool-result")]
+    TurnToolResult,
+    #[serde(rename = "/v1/turns/{id}/provider-result")]
+    TurnProviderResult,
+    #[serde(rename = "/v1/turns/{id}/cancel")]
+    TurnCancel,
+    /// A path that matched no route. The path itself is deliberately dropped:
+    /// a 404 probe is attacker-controlled text, and this is a log.
+    #[serde(rename = "<unrouted>")]
+    Unrouted,
+}
+
+impl Route {
+    /// The path template, as it appears in a record.
+    #[must_use]
+    pub fn template(self) -> &'static str {
+        match self {
+            Self::Healthz => "/healthz",
+            Self::Metrics => "/v1/metrics",
+            Self::TurnsCreate => "/v1/turns",
+            Self::TurnEvents => "/v1/turns/{id}/events",
+            Self::TurnToolResult => "/v1/turns/{id}/tool-result",
+            Self::TurnProviderResult => "/v1/turns/{id}/provider-result",
+            Self::TurnCancel => "/v1/turns/{id}/cancel",
+            Self::Unrouted => "<unrouted>",
+        }
+    }
+}
+
+/// How many characters of a turn id reach a record.
+///
+/// A turn id is a **second factor**: acting on a turn needs the bearer token
+/// *and* the id, and `new_turn_id` spends 128 random bits precisely so the id
+/// cannot be guessed from another. Writing it verbatim into a file that gets
+/// shipped to a log aggregator spends that factor for nothing. Eight hex
+/// characters is 32 bits — ample to correlate records inside one process's
+/// lifetime, useless for forging a request against a live turn.
+const TURN_REF_CHARS: usize = 8;
+
+/// A turn id as it appears in a record: truncated, never whole.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TurnRef(String);
+
+impl TurnRef {
+    /// Truncate a full turn id (`turn-<32 hex>`) for recording.
+    #[must_use]
+    pub fn new(turn_id: &str) -> Self {
+        let hex = turn_id.strip_prefix("turn-").unwrap_or(turn_id);
+        Self(hex.chars().take(TURN_REF_CHARS).collect())
+    }
+}
+
+impl std::fmt::Display for TurnRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Longest host-supplied `X-Request-Id` we will echo and record.
+const MAX_REQUEST_ID_LEN: usize = 64;
+
+/// A request correlation id — echoed on the response as `X-Request-Id`.
+///
+/// A host-supplied value is **sanitized before it is stored**, not on the way
+/// out. An unsanitized header echoed into a line-oriented log is a log-forging
+/// vector: `serde_json` escaping stops a newline from splitting a record, but
+/// nothing stops a caller from making every line it touches a kilobyte wide, or
+/// from embedding text that reads like a different record to a human scanning
+/// the file. Anything failing the charset or the cap is replaced outright.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RequestId(String);
+
+impl RequestId {
+    /// Mint an unguessable id. Not security-critical — nothing is authorized by
+    /// a request id — but sequential ids would let a caller infer the server's
+    /// total request volume from two samples.
+    #[must_use]
+    pub fn generate() -> Self {
+        use rand::Rng as _;
+        let mut bytes = [0_u8; 8];
+        rand::rng().fill_bytes(&mut bytes);
+        let mut id = String::with_capacity(16);
+        for byte in bytes {
+            use std::fmt::Write as _;
+            let _ = write!(id, "{byte:02x}");
+        }
+        Self(id)
+    }
+
+    /// Accept a host-supplied `X-Request-Id`, or `None` if it is unusable.
+    ///
+    /// Conservative on purpose: `[A-Za-z0-9._-]` covers every id format in
+    /// practice (UUIDs, hex, ULIDs, `trace-span` pairs) and admits nothing that
+    /// could be mistaken for structure in a JSON line or a terminal.
+    #[must_use]
+    pub fn from_header(value: &str) -> Option<Self> {
+        let trimmed = value.trim();
+        let ok = !trimmed.is_empty()
+            && trimmed.len() <= MAX_REQUEST_ID_LEN
+            && trimmed
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+        ok.then(|| Self(trimmed.to_string()))
+    }
+
+    /// Accept a host-supplied id for *recording only*, replacing an unusable one
+    /// with a fixed marker rather than a generated id.
+    ///
+    /// Used where the id names something the host chose (a reverse-request id it
+    /// answered with) rather than something we minted. A marker beats a fresh
+    /// random id there: the point of the record is "the host sent us this", and
+    /// a plausible-looking generated id would suggest the host sent something
+    /// legitimate when it did not.
+    #[must_use]
+    pub fn sanitized(value: &str) -> Self {
+        Self::from_header(value).unwrap_or_else(|| Self("<unusable>".to_string()))
+    }
+
+    /// The value to echo in the `X-Request-Id` response header.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Longest HTTP method we will record.
+const MAX_METHOD_LEN: usize = 16;
+
+/// A request method, sanitized for recording.
+///
+/// The method is host-supplied and reaches a record on the 405/404 paths, so it
+/// gets the same treatment as [`RequestId`]: ASCII letters only, capped, and
+/// replaced wholesale when it fails. RFC 9110 §9 methods are all short and
+/// alphabetic; anything else was never going to route.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Method(String);
+
+impl Method {
+    #[must_use]
+    pub fn new(raw: &str) -> Self {
+        let usable = !raw.is_empty()
+            && raw.len() <= MAX_METHOD_LEN
+            && raw.bytes().all(|b| b.is_ascii_alphabetic());
+        if usable {
+            Self(raw.to_ascii_uppercase())
+        } else {
+            Self("<invalid>".to_string())
+        }
+    }
+}
+
+/// Why `POST /v1/turns` was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefusalReason {
+    /// The registry is at `MAX_LIVE_TURNS` and nothing could be reclaimed.
+    AtCapacity,
+    /// A freshly minted id was already registered. Unreachable in practice at
+    /// 128 bits — recorded because if it ever fires, the RNG is the story.
+    IdCollision,
+}
+
+/// How a turn ended, as the registry saw it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SettledOutcome {
+    Completed,
+    Aborted,
+}
+
+/// Why an SSE stream stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamEndReason {
+    /// The terminal `turn_complete` frame was written. The healthy ending.
+    TurnComplete,
+    /// The subscriber hung up. The turn is cancelled by the session drop.
+    PeerDisconnected,
+    /// A write to the subscriber failed mid-stream.
+    WriteFailed,
+    /// The peer sent more than the tolerated inbound bytes on a stream that
+    /// owes it nothing.
+    StrayBytes,
+    /// The session's frame channel closed without a terminal frame.
+    SessionEnded,
+}
+
+/// Which port raised a reverse request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReverseKind {
+    Provider,
+    Tool,
+}
+
+/// Why a host answer matched nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MisrouteFault {
+    /// No in-flight request under that id: already answered, already timed out,
+    /// or fabricated.
+    UnknownRequest,
+    /// A real in-flight request, answered with the wrong kind of result.
+    KindMismatch,
+}
+
+/// Why in-flight reverse requests were dropped wholesale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AbandonReason {
+    /// `POST /v1/turns/{id}/cancel`, or a dropped `Session`.
+    Cancelled,
+    /// The turn settled normally and the registry was swept.
+    Teardown,
+}
+
+/// The accept-loop condition that triggered a backoff, mirroring
+/// `accept::AcceptAction`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptKind {
+    /// Descriptor or memory exhaustion — the listener is fine, the process is
+    /// under pressure.
+    Exhaustion,
+    /// An `io::ErrorKind` this platform does not name.
+    Unnameable,
+}
+
+/// Why the server is stopping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShutdownReason {
+    /// The listener returned a fatal error, or backoff gave up.
+    ListenerFailed,
+}
+
+/// What one turn actually did, folded from the engine's own `AgentEvent`
+/// stream as it passes through.
+///
+/// Counted, never logged per event: `AgentEvent::TextDelta` fires per token, so
+/// a record per frame would make this server slower than the model it waits on.
+/// The whole tally rides one [`ServeEvent::TurnSettled`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnTally {
+    /// Pipeline stage boundaries — the progress axis. A turn whose `stages`
+    /// stopped advancing while a reverse request's wait climbs is *wedged*; one
+    /// that keeps advancing is merely slow.
+    pub stages: u32,
+    pub model_calls: u32,
+    /// Model-call retries the engine performed (`AgentEvent::Retry`).
+    pub retries: u32,
+    pub tool_calls: u32,
+    pub tools_failed: u32,
+    /// Speculative work the engine discarded — `stella-core` already names it,
+    /// so this server counts it rather than re-deriving it.
+    pub speculation_discarded: u32,
+    pub loop_detections: u32,
+}
+
+/// One thing the server did, at a boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ServeEvent {
+    // ---- process lifecycle ----
+    /// The listener is bound and accepting. Replaces the startup `println!`.
+    Listening {
+        addr: String,
+    },
+    ShuttingDown {
+        reason: ShutdownReason,
+        live_turns: usize,
+    },
+
+    // ---- the request fold: exactly one per accepted connection ----
+    /// The terminal record for one connection. Constructed **only** by
+    /// `RequestRecord::close`, so no request can exit unrecorded.
+    RequestCompleted {
+        request_id: RequestId,
+        method: Method,
+        route: Route,
+        /// `None` when the peer hung up before we answered. Absence is a
+        /// terminal state here, not a missing field.
+        status: Option<u16>,
+        duration_ms: u64,
+        bytes_in: u64,
+        bytes_out: u64,
+        turn: Option<TurnRef>,
+    },
+    /// Split out of `RequestCompleted` so a brute force is one grep. `held_ms`
+    /// is the throttle's own delay — visible to us, invisible to the guesser,
+    /// whose response is byte-identical either way.
+    Unauthorized {
+        request_id: RequestId,
+        route: Route,
+        held_ms: u64,
+    },
+
+    // ---- turn registry ----
+    TurnCreated {
+        turn: TurnRef,
+        live_turns: usize,
+    },
+    TurnRefused {
+        reason: RefusalReason,
+        live_turns: usize,
+    },
+    TurnSettled {
+        turn: TurnRef,
+        outcome: SettledOutcome,
+        duration_ms: u64,
+        tally: TurnTally,
+    },
+    StreamEnded {
+        turn: TurnRef,
+        frames_sent: u64,
+        reason: StreamEndReason,
+    },
+
+    // ---- reverse RPC: the wedge axis ----
+    ReverseDispatched {
+        turn: TurnRef,
+        request_id: RequestId,
+        kind: ReverseKind,
+    },
+    ReverseAnswered {
+        turn: TurnRef,
+        request_id: RequestId,
+        kind: ReverseKind,
+        waited_ms: u64,
+    },
+
+    // ---- work the server threw away ----
+    /// The host never answered and the port gave up at its deadline. **The**
+    /// wedge signal: before this, `Pending::abandon` was a silent `remove`.
+    ReverseTimedOut {
+        turn: TurnRef,
+        request_id: RequestId,
+        kind: ReverseKind,
+        waited_ms: u64,
+    },
+    /// A host answer that matched nothing, or matched the wrong kind.
+    ReverseMisrouted {
+        request_id: RequestId,
+        fault: MisrouteFault,
+    },
+    /// In-flight reverse requests dropped wholesale. Only emitted when
+    /// `in_flight > 0` — a clean teardown discards nothing and says nothing.
+    ReverseAbandoned {
+        turn: TurnRef,
+        in_flight: usize,
+        reason: AbandonReason,
+    },
+    /// A finished-but-unstreamed turn evicted to admit a new one, with the
+    /// frames nobody ever read.
+    TurnReclaimed {
+        turn: TurnRef,
+        buffered_frames: usize,
+    },
+    /// `encode_or_abort` substituted a terminal frame: the turn died of a bug
+    /// in our own serialization, and used to say nothing about it.
+    FrameUnencodable {
+        turn: TurnRef,
+        error: String,
+    },
+    /// The `let _ = handle_conn(..)` at the accept loop, given a name. Routine
+    /// (client hangups live here), hence `Debug`.
+    ConnectionFailed {
+        request_id: RequestId,
+        error: String,
+    },
+    AcceptBackoff {
+        kind: AcceptKind,
+        delay_ms: u64,
+        streak: u32,
+    },
+    /// The accept loop stopped retrying a condition that never cleared.
+    AcceptGaveUp {
+        kind: AcceptKind,
+        streak: u32,
+    },
+}
+
+impl ServeEvent {
+    /// This event's severity. Exhaustive by construction: a new variant does
+    /// not compile until it is classified.
+    #[must_use]
+    pub fn level(&self) -> Level {
+        match self {
+            // Routine progress.
+            Self::Listening { .. }
+            | Self::ShuttingDown { .. }
+            | Self::RequestCompleted { .. }
+            | Self::TurnCreated { .. }
+            | Self::TurnSettled { .. }
+            | Self::StreamEnded { .. } => Level::Info,
+
+            // Per model/tool call — a few dozen a turn, so off by default.
+            Self::ReverseDispatched { .. } | Self::ReverseAnswered { .. } => Level::Debug,
+            // Client hangups are ordinary and would drown the default level.
+            Self::ConnectionFailed { .. } => Level::Debug,
+
+            // Somebody is misbehaving, or the server is under pressure.
+            Self::Unauthorized { .. }
+            | Self::TurnRefused { .. }
+            | Self::TurnReclaimed { .. }
+            | Self::ReverseMisrouted { .. }
+            | Self::ReverseAbandoned { .. }
+            | Self::AcceptBackoff { .. } => Level::Warn,
+
+            // Something is broken and a human should look.
+            Self::ReverseTimedOut { .. }
+            | Self::FrameUnencodable { .. }
+            | Self::AcceptGaveUp { .. } => Level::Error,
+        }
+    }
+}
+
+/// Round a duration to whole milliseconds for a record.
+#[must_use]
+pub fn millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Invariant 4: every type crossing a crate boundary round-trips through
+    /// `serde_json` byte-for-byte.
+    #[test]
+    fn events_round_trip_byte_for_byte() {
+        let events = vec![
+            ServeEvent::Listening {
+                addr: "127.0.0.1:8080".to_string(),
+            },
+            ServeEvent::RequestCompleted {
+                request_id: RequestId("abc123".to_string()),
+                method: Method::new("POST"),
+                route: Route::TurnsCreate,
+                status: Some(200),
+                duration_ms: 3,
+                bytes_in: 512,
+                bytes_out: 48,
+                turn: Some(TurnRef::new("turn-0123456789abcdef")),
+            },
+            ServeEvent::RequestCompleted {
+                request_id: RequestId::generate(),
+                method: Method::new("GET"),
+                route: Route::Unrouted,
+                // The hung-up case: no status, and it must survive the trip.
+                status: None,
+                duration_ms: 0,
+                bytes_in: 0,
+                bytes_out: 0,
+                turn: None,
+            },
+            ServeEvent::ReverseTimedOut {
+                turn: TurnRef::new("turn-deadbeefcafe"),
+                request_id: RequestId("prov-0".to_string()),
+                kind: ReverseKind::Provider,
+                waited_ms: 300_000,
+            },
+            ServeEvent::TurnSettled {
+                turn: TurnRef::new("turn-deadbeefcafe"),
+                outcome: SettledOutcome::Aborted,
+                duration_ms: 12,
+                tally: TurnTally {
+                    stages: 4,
+                    model_calls: 2,
+                    retries: 1,
+                    tool_calls: 3,
+                    tools_failed: 1,
+                    speculation_discarded: 1,
+                    loop_detections: 0,
+                },
+            },
+        ];
+        for event in events {
+            let json = serde_json::to_string(&event).expect("serialize");
+            let back: ServeEvent = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(event, back, "round trip changed the value: {json}");
+            let again = serde_json::to_string(&back).expect("re-serialize");
+            assert_eq!(json, again, "round trip is not byte-stable");
+        }
+    }
+
+    /// A turn id is a second factor. A record must carry enough to correlate
+    /// and not enough to act.
+    #[test]
+    fn a_turn_ref_is_truncated_not_whole() {
+        let full = "turn-0123456789abcdef0123456789abcdef";
+        let reference = TurnRef::new(full);
+        assert_eq!(reference.to_string(), "01234567");
+        assert!(
+            !full.contains(&format!("{reference}0")) || full.len() > reference.to_string().len(),
+            "sanity: the reference is a strict prefix",
+        );
+        assert_eq!(reference.to_string().len(), TURN_REF_CHARS);
+    }
+
+    /// The route is a template, so no record can carry a turn id in its path.
+    #[test]
+    fn every_route_template_is_free_of_concrete_ids() {
+        for route in [
+            Route::Healthz,
+            Route::Metrics,
+            Route::TurnsCreate,
+            Route::TurnEvents,
+            Route::TurnToolResult,
+            Route::TurnProviderResult,
+            Route::TurnCancel,
+            Route::Unrouted,
+        ] {
+            let json = serde_json::to_string(&route).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", route.template()));
+            assert!(
+                !route.template().contains("turn-"),
+                "{} embeds a concrete turn id",
+                route.template()
+            );
+        }
+    }
+
+    /// Log forging: a header that could split or bloat a record is refused
+    /// outright rather than escaped and kept.
+    #[test]
+    fn a_hostile_request_id_header_is_refused() {
+        assert!(RequestId::from_header("a1b2-c3d4.e5").is_some());
+        assert!(RequestId::from_header("").is_none());
+        assert!(RequestId::from_header("   ").is_none());
+        assert!(
+            RequestId::from_header("has space").is_none(),
+            "whitespace could be read as structure by a human scanning the log"
+        );
+        assert!(RequestId::from_header("line\nbreak").is_none());
+        assert!(RequestId::from_header("quote\"brace}").is_none());
+        assert!(
+            RequestId::from_header(&"x".repeat(MAX_REQUEST_ID_LEN + 1)).is_none(),
+            "an unbounded id makes every line it touches unbounded"
+        );
+        assert!(RequestId::from_header(&"x".repeat(MAX_REQUEST_ID_LEN)).is_some());
+    }
+
+    /// A method reaches a record on the 404/405 paths, so it gets the same
+    /// treatment as a request id.
+    #[test]
+    fn a_hostile_method_is_replaced_not_recorded() {
+        assert_eq!(Method::new("post"), Method::new("POST"));
+        assert_eq!(Method::new("GET\r\nX: y"), Method("<invalid>".to_string()));
+        assert_eq!(Method::new(""), Method("<invalid>".to_string()));
+        assert_eq!(
+            Method::new(&"A".repeat(MAX_METHOD_LEN + 1)),
+            Method("<invalid>".to_string())
+        );
+    }
+
+    /// A typo in a log knob must not take the service down, and `off` must
+    /// actually silence rather than merely quieten.
+    #[test]
+    fn the_level_filter_is_forgiving_and_off_is_total() {
+        assert_eq!(LevelFilter::parse("nonsense"), LevelFilter::Info);
+        assert_eq!(LevelFilter::parse(" DEBUG "), LevelFilter::Debug);
+        assert_eq!(LevelFilter::parse("off"), LevelFilter::Off);
+        for level in [Level::Error, Level::Warn, Level::Info, Level::Debug] {
+            assert!(!LevelFilter::Off.admits(level));
+            assert!(LevelFilter::Debug.admits(level));
+        }
+        assert!(LevelFilter::Error.admits(Level::Error));
+        assert!(!LevelFilter::Error.admits(Level::Warn));
+        assert!(LevelFilter::Info.admits(Level::Info));
+        assert!(!LevelFilter::Info.admits(Level::Debug));
+    }
+
+    /// The wedge signal and its neighbours must be loud; the per-call chatter
+    /// must not be, or the default level becomes unreadable and gets turned off.
+    #[test]
+    fn severity_matches_what_an_operator_needs_to_see() {
+        let turn = TurnRef::new("turn-abcdef01");
+        let id = RequestId("r".to_string());
+        assert_eq!(
+            ServeEvent::ReverseTimedOut {
+                turn: turn.clone(),
+                request_id: id.clone(),
+                kind: ReverseKind::Tool,
+                waited_ms: 1,
+            }
+            .level(),
+            Level::Error
+        );
+        assert_eq!(
+            ServeEvent::ReverseMisrouted {
+                request_id: id.clone(),
+                fault: MisrouteFault::UnknownRequest,
+            }
+            .level(),
+            Level::Warn
+        );
+        assert_eq!(
+            ServeEvent::ReverseDispatched {
+                turn,
+                request_id: id,
+                kind: ReverseKind::Tool,
+            }
+            .level(),
+            Level::Debug
+        );
+    }
+}

--- a/stella-serve/src/observe/metrics.rs
+++ b/stella-serve/src/observe/metrics.rs
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Counters, folded from the same event stream the log sees.
+//!
+//! [`Metrics`] is an [`Observer`], not a set of instrumentation points. It has
+//! no call sites of its own: it observes [`ServeEvent`]s and derives every
+//! number from them. That is not a stylistic choice — it makes the usual
+//! hand-rolled-metrics failure *unrepresentable*. A code path that increments a
+//! counter but forgets to log, or logs but forgets to increment, cannot exist
+//! when the counter is strictly downstream of the single emission.
+//!
+//! Exposed at `GET /v1/metrics` behind the same bearer token as everything else
+//! (#930 is explicit: authenticated, not open). Pull, never push — nothing here
+//! dials out, per AGENTS.md invariant 3.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+use serde::Serialize;
+
+use super::Observer;
+use super::event::{MisrouteFault, RefusalReason, ReverseKind, ServeEvent, SettledOutcome};
+
+/// Relaxed throughout: these are independent counters read for reporting, never
+/// used to order other memory, so the cost of stronger ordering buys nothing.
+const ORDER: Ordering = Ordering::Relaxed;
+
+/// Every counter this server keeps.
+#[derive(Default)]
+pub struct Metrics {
+    requests_total: AtomicU64,
+    requests_2xx: AtomicU64,
+    requests_4xx: AtomicU64,
+    requests_5xx: AtomicU64,
+    /// Requests the peer abandoned before we answered — the `status: None`
+    /// terminal state, which without the fold would be no record at all.
+    requests_unanswered: AtomicU64,
+    request_duration_ms_total: AtomicU64,
+    bytes_in_total: AtomicU64,
+    bytes_out_total: AtomicU64,
+
+    unauthorized_total: AtomicU64,
+    /// 401s that were actually delayed by the throttle. A non-zero value here
+    /// is the signature of a sustained guess, not a misconfigured client.
+    unauthorized_throttled_total: AtomicU64,
+
+    turns_created_total: AtomicU64,
+    turns_refused_capacity_total: AtomicU64,
+    turns_refused_collision_total: AtomicU64,
+    turns_completed_total: AtomicU64,
+    turns_aborted_total: AtomicU64,
+    turns_reclaimed_total: AtomicU64,
+    turns_live: AtomicI64,
+
+    turn_duration_ms_total: AtomicU64,
+    model_calls_total: AtomicU64,
+    model_retries_total: AtomicU64,
+    tool_calls_total: AtomicU64,
+    tools_failed_total: AtomicU64,
+    speculation_discarded_total: AtomicU64,
+    loop_detections_total: AtomicU64,
+
+    reverse_dispatched_provider_total: AtomicU64,
+    reverse_dispatched_tool_total: AtomicU64,
+    reverse_answered_total: AtomicU64,
+    reverse_wait_ms_total: AtomicU64,
+    reverse_timed_out_total: AtomicU64,
+    reverse_misrouted_unknown_total: AtomicU64,
+    reverse_misrouted_kind_total: AtomicU64,
+    reverse_abandoned_total: AtomicU64,
+    reverse_in_flight: AtomicI64,
+
+    streams_ended_total: AtomicU64,
+    frames_sent_total: AtomicU64,
+    frames_unencodable_total: AtomicU64,
+    connections_failed_total: AtomicU64,
+    accept_backoff_total: AtomicU64,
+    accept_gave_up_total: AtomicU64,
+}
+
+/// The serializable shape of `GET /v1/metrics`.
+///
+/// A flat object of integers on purpose: it is a scrape target, not an API, and
+/// a flat shape is what both `jq` and a Prometheus text translator want. Nothing
+/// here is host content — every value is a count this process derived.
+#[derive(Debug, Serialize)]
+pub struct Snapshot {
+    pub requests_total: u64,
+    pub requests_2xx: u64,
+    pub requests_4xx: u64,
+    pub requests_5xx: u64,
+    pub requests_unanswered: u64,
+    pub request_duration_ms_total: u64,
+    pub bytes_in_total: u64,
+    pub bytes_out_total: u64,
+
+    pub unauthorized_total: u64,
+    pub unauthorized_throttled_total: u64,
+
+    pub turns_created_total: u64,
+    pub turns_refused_capacity_total: u64,
+    pub turns_refused_collision_total: u64,
+    pub turns_completed_total: u64,
+    pub turns_aborted_total: u64,
+    pub turns_reclaimed_total: u64,
+    pub turns_live: u64,
+
+    pub turn_duration_ms_total: u64,
+    pub model_calls_total: u64,
+    pub model_retries_total: u64,
+    pub tool_calls_total: u64,
+    pub tools_failed_total: u64,
+    pub speculation_discarded_total: u64,
+    pub loop_detections_total: u64,
+
+    pub reverse_dispatched_provider_total: u64,
+    pub reverse_dispatched_tool_total: u64,
+    pub reverse_answered_total: u64,
+    pub reverse_wait_ms_total: u64,
+    pub reverse_timed_out_total: u64,
+    pub reverse_misrouted_unknown_total: u64,
+    pub reverse_misrouted_kind_total: u64,
+    pub reverse_abandoned_total: u64,
+    pub reverse_in_flight: u64,
+
+    pub streams_ended_total: u64,
+    pub frames_sent_total: u64,
+    pub frames_unencodable_total: u64,
+    pub connections_failed_total: u64,
+    pub accept_backoff_total: u64,
+    pub accept_gave_up_total: u64,
+}
+
+impl Metrics {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Read every counter. Not a consistent snapshot across counters — each is
+    /// read independently — which is the right trade for a scrape endpoint:
+    /// locking the whole server to make thirty integers agree would cost more
+    /// than the momentary skew is worth.
+    #[must_use]
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            requests_total: self.requests_total.load(ORDER),
+            requests_2xx: self.requests_2xx.load(ORDER),
+            requests_4xx: self.requests_4xx.load(ORDER),
+            requests_5xx: self.requests_5xx.load(ORDER),
+            requests_unanswered: self.requests_unanswered.load(ORDER),
+            request_duration_ms_total: self.request_duration_ms_total.load(ORDER),
+            bytes_in_total: self.bytes_in_total.load(ORDER),
+            bytes_out_total: self.bytes_out_total.load(ORDER),
+
+            unauthorized_total: self.unauthorized_total.load(ORDER),
+            unauthorized_throttled_total: self.unauthorized_throttled_total.load(ORDER),
+
+            turns_created_total: self.turns_created_total.load(ORDER),
+            turns_refused_capacity_total: self.turns_refused_capacity_total.load(ORDER),
+            turns_refused_collision_total: self.turns_refused_collision_total.load(ORDER),
+            turns_completed_total: self.turns_completed_total.load(ORDER),
+            turns_aborted_total: self.turns_aborted_total.load(ORDER),
+            turns_reclaimed_total: self.turns_reclaimed_total.load(ORDER),
+            turns_live: gauge(&self.turns_live),
+
+            turn_duration_ms_total: self.turn_duration_ms_total.load(ORDER),
+            model_calls_total: self.model_calls_total.load(ORDER),
+            model_retries_total: self.model_retries_total.load(ORDER),
+            tool_calls_total: self.tool_calls_total.load(ORDER),
+            tools_failed_total: self.tools_failed_total.load(ORDER),
+            speculation_discarded_total: self.speculation_discarded_total.load(ORDER),
+            loop_detections_total: self.loop_detections_total.load(ORDER),
+
+            reverse_dispatched_provider_total: self.reverse_dispatched_provider_total.load(ORDER),
+            reverse_dispatched_tool_total: self.reverse_dispatched_tool_total.load(ORDER),
+            reverse_answered_total: self.reverse_answered_total.load(ORDER),
+            reverse_wait_ms_total: self.reverse_wait_ms_total.load(ORDER),
+            reverse_timed_out_total: self.reverse_timed_out_total.load(ORDER),
+            reverse_misrouted_unknown_total: self.reverse_misrouted_unknown_total.load(ORDER),
+            reverse_misrouted_kind_total: self.reverse_misrouted_kind_total.load(ORDER),
+            reverse_abandoned_total: self.reverse_abandoned_total.load(ORDER),
+            reverse_in_flight: gauge(&self.reverse_in_flight),
+
+            streams_ended_total: self.streams_ended_total.load(ORDER),
+            frames_sent_total: self.frames_sent_total.load(ORDER),
+            frames_unencodable_total: self.frames_unencodable_total.load(ORDER),
+            connections_failed_total: self.connections_failed_total.load(ORDER),
+            accept_backoff_total: self.accept_backoff_total.load(ORDER),
+            accept_gave_up_total: self.accept_gave_up_total.load(ORDER),
+        }
+    }
+}
+
+/// Read a gauge, clamping a transiently-negative value to zero.
+///
+/// The in-flight gauges are incremented and decremented from different threads,
+/// so a reader can catch a decrement that landed before its matching increment
+/// was observed. Reporting `0` beats reporting a negative count of things.
+fn gauge(value: &AtomicI64) -> u64 {
+    u64::try_from(value.load(ORDER).max(0)).unwrap_or(0)
+}
+
+impl Observer for Metrics {
+    fn emit(&self, event: &ServeEvent) {
+        match event {
+            ServeEvent::RequestCompleted {
+                status,
+                duration_ms,
+                bytes_in,
+                bytes_out,
+                ..
+            } => {
+                self.requests_total.fetch_add(1, ORDER);
+                self.request_duration_ms_total
+                    .fetch_add(*duration_ms, ORDER);
+                self.bytes_in_total.fetch_add(*bytes_in, ORDER);
+                self.bytes_out_total.fetch_add(*bytes_out, ORDER);
+                match status {
+                    Some(200..=299) => &self.requests_2xx,
+                    Some(400..=499) => &self.requests_4xx,
+                    Some(500..=599) => &self.requests_5xx,
+                    // A hung-up peer, or a status outside the classes above.
+                    _ => &self.requests_unanswered,
+                }
+                .fetch_add(1, ORDER);
+            }
+            ServeEvent::Unauthorized { held_ms, .. } => {
+                self.unauthorized_total.fetch_add(1, ORDER);
+                if *held_ms > 0 {
+                    self.unauthorized_throttled_total.fetch_add(1, ORDER);
+                }
+            }
+
+            ServeEvent::TurnCreated { live_turns, .. } => {
+                self.turns_created_total.fetch_add(1, ORDER);
+                self.turns_live.store(as_i64(*live_turns), ORDER);
+            }
+            ServeEvent::TurnRefused { reason, live_turns } => {
+                match reason {
+                    RefusalReason::AtCapacity => &self.turns_refused_capacity_total,
+                    RefusalReason::IdCollision => &self.turns_refused_collision_total,
+                }
+                .fetch_add(1, ORDER);
+                self.turns_live.store(as_i64(*live_turns), ORDER);
+            }
+            ServeEvent::TurnSettled {
+                outcome,
+                duration_ms,
+                tally,
+                ..
+            } => {
+                match outcome {
+                    SettledOutcome::Completed => &self.turns_completed_total,
+                    SettledOutcome::Aborted => &self.turns_aborted_total,
+                }
+                .fetch_add(1, ORDER);
+                self.turn_duration_ms_total.fetch_add(*duration_ms, ORDER);
+                self.model_calls_total
+                    .fetch_add(u64::from(tally.model_calls), ORDER);
+                self.model_retries_total
+                    .fetch_add(u64::from(tally.retries), ORDER);
+                self.tool_calls_total
+                    .fetch_add(u64::from(tally.tool_calls), ORDER);
+                self.tools_failed_total
+                    .fetch_add(u64::from(tally.tools_failed), ORDER);
+                self.speculation_discarded_total
+                    .fetch_add(u64::from(tally.speculation_discarded), ORDER);
+                self.loop_detections_total
+                    .fetch_add(u64::from(tally.loop_detections), ORDER);
+            }
+            ServeEvent::TurnReclaimed { .. } => {
+                self.turns_reclaimed_total.fetch_add(1, ORDER);
+            }
+
+            ServeEvent::ReverseDispatched { kind, .. } => {
+                match kind {
+                    ReverseKind::Provider => &self.reverse_dispatched_provider_total,
+                    ReverseKind::Tool => &self.reverse_dispatched_tool_total,
+                }
+                .fetch_add(1, ORDER);
+                self.reverse_in_flight.fetch_add(1, ORDER);
+            }
+            ServeEvent::ReverseAnswered { waited_ms, .. } => {
+                self.reverse_answered_total.fetch_add(1, ORDER);
+                self.reverse_wait_ms_total.fetch_add(*waited_ms, ORDER);
+                self.reverse_in_flight.fetch_sub(1, ORDER);
+            }
+            ServeEvent::ReverseTimedOut { waited_ms, .. } => {
+                self.reverse_timed_out_total.fetch_add(1, ORDER);
+                self.reverse_wait_ms_total.fetch_add(*waited_ms, ORDER);
+                self.reverse_in_flight.fetch_sub(1, ORDER);
+            }
+            ServeEvent::ReverseMisrouted { fault, .. } => {
+                match fault {
+                    MisrouteFault::UnknownRequest => &self.reverse_misrouted_unknown_total,
+                    MisrouteFault::KindMismatch => &self.reverse_misrouted_kind_total,
+                }
+                .fetch_add(1, ORDER);
+            }
+            ServeEvent::ReverseAbandoned { in_flight, .. } => {
+                self.reverse_abandoned_total
+                    .fetch_add(as_u64(*in_flight), ORDER);
+                self.reverse_in_flight.fetch_sub(as_i64(*in_flight), ORDER);
+            }
+
+            ServeEvent::StreamEnded { frames_sent, .. } => {
+                self.streams_ended_total.fetch_add(1, ORDER);
+                self.frames_sent_total.fetch_add(*frames_sent, ORDER);
+            }
+            ServeEvent::FrameUnencodable { .. } => {
+                self.frames_unencodable_total.fetch_add(1, ORDER);
+            }
+            ServeEvent::ConnectionFailed { .. } => {
+                self.connections_failed_total.fetch_add(1, ORDER);
+            }
+            ServeEvent::AcceptBackoff { .. } => {
+                self.accept_backoff_total.fetch_add(1, ORDER);
+            }
+            ServeEvent::AcceptGaveUp { .. } => {
+                self.accept_gave_up_total.fetch_add(1, ORDER);
+            }
+
+            // Lifecycle markers carry no count.
+            ServeEvent::Listening { .. } | ServeEvent::ShuttingDown { .. } => {}
+        }
+    }
+}
+
+fn as_i64(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn as_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observe::event::{
+        AbandonReason, Method, RequestId, Route, StreamEndReason, TurnRef, TurnTally,
+    };
+
+    fn request(status: Option<u16>) -> ServeEvent {
+        ServeEvent::RequestCompleted {
+            request_id: RequestId::generate(),
+            method: Method::new("POST"),
+            route: Route::TurnsCreate,
+            status,
+            duration_ms: 5,
+            bytes_in: 10,
+            bytes_out: 20,
+            turn: None,
+        }
+    }
+
+    fn turn() -> TurnRef {
+        TurnRef::new("turn-abcdef0123456789")
+    }
+
+    /// Status classes are bucketed, and the hung-up peer — the case that had no
+    /// record at all before the fold — lands in its own bucket rather than
+    /// being miscounted as a success.
+    #[test]
+    fn request_status_classes_are_bucketed_including_no_answer() {
+        let metrics = Metrics::new();
+        metrics.emit(&request(Some(200)));
+        metrics.emit(&request(Some(404)));
+        metrics.emit(&request(Some(429)));
+        metrics.emit(&request(Some(500)));
+        metrics.emit(&request(None));
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.requests_total, 5);
+        assert_eq!(snap.requests_2xx, 1);
+        assert_eq!(snap.requests_4xx, 2);
+        assert_eq!(snap.requests_5xx, 1);
+        assert_eq!(snap.requests_unanswered, 1);
+        assert_eq!(snap.request_duration_ms_total, 25);
+        assert_eq!(snap.bytes_in_total, 50);
+        assert_eq!(snap.bytes_out_total, 100);
+    }
+
+    /// A throttled 401 must be distinguishable from an ordinary one: the first
+    /// is a brute force, the second is a misconfigured client.
+    #[test]
+    fn a_throttled_401_is_counted_apart_from_an_ordinary_one() {
+        let metrics = Metrics::new();
+        for held_ms in [0, 0, 250, 500] {
+            metrics.emit(&ServeEvent::Unauthorized {
+                request_id: RequestId::generate(),
+                route: Route::TurnsCreate,
+                held_ms,
+            });
+        }
+        let snap = metrics.snapshot();
+        assert_eq!(snap.unauthorized_total, 4);
+        assert_eq!(snap.unauthorized_throttled_total, 2);
+    }
+
+    /// The in-flight gauge must return to zero across every way a reverse
+    /// request can end — answered, timed out, or dropped wholesale. A gauge
+    /// that only decrements on the happy path reads as a permanent leak.
+    #[test]
+    fn the_in_flight_gauge_balances_on_every_ending() {
+        let metrics = Metrics::new();
+        let dispatch = |kind| ServeEvent::ReverseDispatched {
+            turn: turn(),
+            request_id: RequestId::generate(),
+            kind,
+        };
+        metrics.emit(&dispatch(ReverseKind::Provider));
+        metrics.emit(&dispatch(ReverseKind::Tool));
+        metrics.emit(&dispatch(ReverseKind::Tool));
+        metrics.emit(&dispatch(ReverseKind::Tool));
+        assert_eq!(metrics.snapshot().reverse_in_flight, 4);
+
+        metrics.emit(&ServeEvent::ReverseAnswered {
+            turn: turn(),
+            request_id: RequestId::generate(),
+            kind: ReverseKind::Provider,
+            waited_ms: 40,
+        });
+        metrics.emit(&ServeEvent::ReverseTimedOut {
+            turn: turn(),
+            request_id: RequestId::generate(),
+            kind: ReverseKind::Tool,
+            waited_ms: 300_000,
+        });
+        metrics.emit(&ServeEvent::ReverseAbandoned {
+            turn: turn(),
+            in_flight: 2,
+            reason: AbandonReason::Cancelled,
+        });
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.reverse_in_flight, 0, "the gauge leaked");
+        assert_eq!(snap.reverse_dispatched_provider_total, 1);
+        assert_eq!(snap.reverse_dispatched_tool_total, 3);
+        assert_eq!(snap.reverse_answered_total, 1);
+        assert_eq!(snap.reverse_timed_out_total, 1);
+        assert_eq!(snap.reverse_abandoned_total, 2);
+        assert_eq!(snap.reverse_wait_ms_total, 300_040);
+    }
+
+    /// A decrement observed before its matching increment must read as zero,
+    /// not as a negative count of live requests.
+    #[test]
+    fn a_gauge_never_reports_a_negative_count() {
+        let metrics = Metrics::new();
+        metrics.emit(&ServeEvent::ReverseAnswered {
+            turn: turn(),
+            request_id: RequestId::generate(),
+            kind: ReverseKind::Tool,
+            waited_ms: 1,
+        });
+        assert_eq!(metrics.snapshot().reverse_in_flight, 0);
+    }
+
+    /// The engine's own tally reaches the counters through `TurnSettled`, so
+    /// retries and discarded speculation are visible without the server ever
+    /// logging a per-frame record.
+    #[test]
+    fn the_turn_tally_folds_into_engine_counters() {
+        let metrics = Metrics::new();
+        metrics.emit(&ServeEvent::TurnSettled {
+            turn: turn(),
+            outcome: SettledOutcome::Completed,
+            duration_ms: 900,
+            tally: TurnTally {
+                stages: 6,
+                model_calls: 3,
+                retries: 2,
+                tool_calls: 5,
+                tools_failed: 1,
+                speculation_discarded: 4,
+                loop_detections: 1,
+            },
+        });
+        let snap = metrics.snapshot();
+        assert_eq!(snap.turns_completed_total, 1);
+        assert_eq!(snap.turns_aborted_total, 0);
+        assert_eq!(snap.turn_duration_ms_total, 900);
+        assert_eq!(snap.model_calls_total, 3);
+        assert_eq!(snap.model_retries_total, 2);
+        assert_eq!(snap.tool_calls_total, 5);
+        assert_eq!(snap.tools_failed_total, 1);
+        assert_eq!(snap.speculation_discarded_total, 4);
+        assert_eq!(snap.loop_detections_total, 1);
+    }
+
+    /// The registry gauge tracks occupancy, and refusals are separated by
+    /// cause: capacity is an operational signal, a collision is an RNG story.
+    #[test]
+    fn registry_occupancy_and_refusal_causes_are_distinct() {
+        let metrics = Metrics::new();
+        metrics.emit(&ServeEvent::TurnCreated {
+            turn: turn(),
+            live_turns: 7,
+        });
+        assert_eq!(metrics.snapshot().turns_live, 7);
+        metrics.emit(&ServeEvent::TurnRefused {
+            reason: RefusalReason::AtCapacity,
+            live_turns: 32,
+        });
+        metrics.emit(&ServeEvent::TurnRefused {
+            reason: RefusalReason::IdCollision,
+            live_turns: 32,
+        });
+        let snap = metrics.snapshot();
+        assert_eq!(snap.turns_live, 32);
+        assert_eq!(snap.turns_refused_capacity_total, 1);
+        assert_eq!(snap.turns_refused_collision_total, 1);
+    }
+
+    /// Discarded work reaches the counters too — that is the clause the audit
+    /// contrasts `stella-serve` against `stella-core` on.
+    #[test]
+    fn discarded_work_is_counted_not_swallowed() {
+        let metrics = Metrics::new();
+        metrics.emit(&ServeEvent::TurnReclaimed {
+            turn: turn(),
+            buffered_frames: 12,
+        });
+        metrics.emit(&ServeEvent::FrameUnencodable {
+            turn: turn(),
+            error: "boom".to_string(),
+        });
+        metrics.emit(&ServeEvent::ConnectionFailed {
+            request_id: RequestId::generate(),
+            error: "reset".to_string(),
+        });
+        metrics.emit(&ServeEvent::StreamEnded {
+            turn: turn(),
+            frames_sent: 9,
+            reason: StreamEndReason::PeerDisconnected,
+        });
+        let snap = metrics.snapshot();
+        assert_eq!(snap.turns_reclaimed_total, 1);
+        assert_eq!(snap.frames_unencodable_total, 1);
+        assert_eq!(snap.connections_failed_total, 1);
+        assert_eq!(snap.streams_ended_total, 1);
+        assert_eq!(snap.frames_sent_total, 9);
+    }
+
+    /// The scrape body is a flat object of integers — no nesting, no strings,
+    /// so nothing host-supplied can ride out through the metrics endpoint.
+    #[test]
+    fn the_snapshot_is_a_flat_object_of_numbers() {
+        let metrics = Metrics::new();
+        metrics.emit(&request(Some(200)));
+        let json = serde_json::to_value(metrics.snapshot()).expect("serialize");
+        let object = json.as_object().expect("an object");
+        assert!(!object.is_empty());
+        for (key, value) in object {
+            assert!(
+                value.is_number(),
+                "`{key}` is not a number — only counts may leave this endpoint"
+            );
+        }
+    }
+}

--- a/stella-serve/src/observe/mod.rs
+++ b/stella-serve/src/observe/mod.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Observability for the serve layer: a typed event at every boundary.
+//!
+//! Before this module the crate's entire observable surface was its startup
+//! banner and its exit code — ten print statements, all in `main.rs`, and
+//! nothing at all from the library. Four situations produced identical output
+//! (none): a turn wedged on a reverse request nobody will answer, a host
+//! answering with the wrong `request_id`, a 429 storm, and a bearer-token brute
+//! force. See #930 and `docs/design/serve-observability.md`.
+//!
+//! # Emission and sink are separate decisions
+//!
+//! The audit dimension this closes contrasts `stella-serve` against
+//! `stella-core`, which scores well with **no logging framework at all** — it
+//! scores on `AgentEvent`: a typed event at every boundary, with discarded work
+//! named rather than dropped. That is what is copied here.
+//!
+//! - **What is emitted** — [`event::ServeEvent`], 18 variants, serde-first.
+//!   Testable, because a test asserts on a typed value instead of scraping text.
+//! - **Where it goes** — the [`Observer`] port. This is the part that would cost
+//!   a dependency, and keeping it a trait is what makes that decision
+//!   reversible: adopting `tracing` later is one more impl in [`sink`], with no
+//!   emit site touched.
+//!
+//! # Nothing here egresses
+//!
+//! AGENTS.md invariant 3. Records go to stderr; counters are exposed at
+//! `GET /v1/metrics` behind the same bearer token as every other route — pull,
+//! never push. No sink opens a connection. And no record carries prompt text,
+//! tool payloads, model output, paths, raw request paths, or a whole turn id;
+//! `tests/observe.rs` proves that with a sentinel sweep in the shape
+//! `stella-store::content_free` uses for egress.
+
+pub mod event;
+pub mod metrics;
+pub(crate) mod record;
+pub mod sink;
+pub(crate) mod tally;
+
+pub use event::{
+    AbandonReason, AcceptKind, Level, LevelFilter, Method, MisrouteFault, RefusalReason, RequestId,
+    ReverseKind, Route, ServeEvent, SettledOutcome, ShutdownReason, StreamEndReason, TurnRef,
+    TurnTally,
+};
+pub use metrics::{Metrics, Snapshot};
+pub use sink::{Capture, Fanout, JsonlSink, LOG_LEVEL_ENV, NullSink};
+
+/// Where [`ServeEvent`]s go.
+///
+/// Deliberately one method taking a reference: an observer must be cheap enough
+/// to call from the turn's hot path and from every request, must never block the
+/// caller on anything it cannot control, and must never fail *upwards* — losing
+/// a record is not a reason to lose a turn (invariant 5). Implementations
+/// swallow their own I/O errors.
+pub trait Observer: Send + Sync + 'static {
+    fn emit(&self, event: &ServeEvent);
+}
+
+/// The shared handle every emit site holds.
+pub type SharedObserver = std::sync::Arc<dyn Observer>;
+
+/// An observer that discards everything — the default for callers that use
+/// [`Session`](crate::Session) as a library type without wiring a sink.
+#[must_use]
+pub fn null_observer() -> SharedObserver {
+    std::sync::Arc::new(NullSink)
+}
+
+/// The standard production wiring: counters plus a JSONL sink on stderr, as one
+/// observer.
+///
+/// Returns the [`Metrics`] separately because `GET /v1/metrics` has to read it.
+/// The counters are *inside* the fanout, not alongside it, which is what makes a
+/// counter incapable of disagreeing with the log — see [`metrics`].
+#[must_use]
+pub fn standard() -> (SharedObserver, std::sync::Arc<Metrics>) {
+    let metrics = std::sync::Arc::new(Metrics::new());
+    let observer: SharedObserver = std::sync::Arc::new(Fanout::new(vec![
+        metrics.clone(),
+        std::sync::Arc::new(JsonlSink::from_env()),
+    ]));
+    (observer, metrics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// The standard wiring must route to the counters, or `/v1/metrics` reports
+    /// zeros forever while the log looks healthy — the exact disagreement this
+    /// module's shape exists to prevent.
+    #[test]
+    fn the_standard_wiring_feeds_the_counters() {
+        let (observer, metrics) = standard();
+        observer.emit(&ServeEvent::TurnCreated {
+            turn: TurnRef::new("turn-0123456789abcdef"),
+            live_turns: 1,
+        });
+        assert_eq!(metrics.snapshot().turns_created_total, 1);
+    }
+
+    /// A null observer is a real observer: emit sites must not branch on
+    /// whether anyone is listening.
+    #[test]
+    fn the_null_observer_accepts_everything_silently() {
+        let observer = null_observer();
+        observer.emit(&ServeEvent::Listening {
+            addr: "127.0.0.1:0".to_string(),
+        });
+    }
+
+    /// `Observer` has to be usable as a shared trait object from both the
+    /// server runtime and a session thread, so this must compile.
+    #[test]
+    fn an_observer_is_shareable_across_threads() {
+        let capture = Arc::new(Capture::new());
+        let observer: SharedObserver = capture.clone();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                observer.emit(&ServeEvent::Listening {
+                    addr: "elsewhere".to_string(),
+                });
+            });
+        });
+        assert_eq!(capture.events().len(), 1);
+    }
+}

--- a/stella-serve/src/observe/record.rs
+++ b/stella-serve/src/observe/record.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The request fold: one record per connection, produced where the connection
+//! ends rather than at the sixteen places it can exit.
+//!
+//! `handle_conn` has fifteen `return`s and a tail expression. Emitting a record
+//! before each is the obvious implementation and it is the wrong one — this
+//! project has already been burned by that shape and written it down. The PROOF
+//! rail (#901, "the proof rail resolves on every path, not just the happy one")
+//! was a surface that reported only on the paths someone remembered, and hung
+//! on `pending` forever on the ones they did not.
+//!
+//! So the record lives here, in four moves:
+//!
+//! 1. **Declare before anything can fail.** [`RequestRecord::opening`] runs
+//!    before the first byte is parsed, so a request that dies inside
+//!    `read_head` still has an identity and a start time.
+//! 2. **Make "unreported" a terminal state.** [`RequestRecord::close`] turns
+//!    "no response was written" into `status: None` and an `Err` return into a
+//!    named [`ServeEvent::ConnectionFailed`] — the `let _ = handle_conn(..)` in
+//!    the accept loop has nothing left to discard.
+//! 3. **One construction site.** [`ServeEvent::RequestCompleted`] is built
+//!    here and nowhere else in the crate, and `close` consumes `self`.
+//! 4. **Prove it with a property.** `exactly_one_record_per_connection` in
+//!    `tests/observe.rs` drives arbitrary bytes at a live server and asserts
+//!    the count, because the original bug is always a path nobody enumerated.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::net::TcpStream;
+
+use super::Observer;
+use super::event::{Method, RequestId, Route, ServeEvent, TurnRef, millis};
+use crate::http;
+
+/// What a response actually turned out to be. `None` on a [`Responder`] that
+/// was never written to is itself meaningful — see [`RequestRecord::close`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Wrote {
+    pub status: u16,
+    pub bytes: u64,
+}
+
+/// The write half of one connection, and the only thing that writes to it.
+///
+/// Every response goes through here, so `status` and `bytes_out` are captured
+/// **by construction** rather than by each handler remembering to report them.
+/// It also owns the `X-Request-Id` echo, so no route can forget that either.
+pub(crate) struct Responder<'a> {
+    stream: &'a mut TcpStream,
+    request_id: RequestId,
+    wrote: Option<Wrote>,
+}
+
+impl<'a> Responder<'a> {
+    pub(crate) fn new(stream: &'a mut TcpStream, request_id: RequestId) -> Self {
+        Self {
+            stream,
+            request_id,
+            wrote: None,
+        }
+    }
+
+    /// A one-shot JSON response.
+    pub(crate) async fn json(&mut self, status: &str, body: &[u8]) -> std::io::Result<()> {
+        self.json_with_headers(status, &[], body).await
+    }
+
+    /// [`Responder::json`] plus caller-supplied headers (`Retry-After` on a 429,
+    /// `Allow` on a 405). `X-Request-Id` is appended here, so every response
+    /// carries it whether or not the route thought about it.
+    pub(crate) async fn json_with_headers(
+        &mut self,
+        status: &str,
+        extra: &[(&str, &str)],
+        body: &[u8],
+    ) -> std::io::Result<()> {
+        let mut headers: Vec<(&str, &str)> = Vec::with_capacity(extra.len() + 1);
+        headers.extend_from_slice(extra);
+        headers.push(("X-Request-Id", self.request_id.as_str()));
+        let written = http::write_json_with_headers(self.stream, status, &headers, body).await;
+        // Record what we *attempted*, even when the write failed: a peer that
+        // vanished mid-response still received a decision from this server, and
+        // that decision is what a reader of the log needs.
+        self.record(status, written.as_ref().copied().unwrap_or(0));
+        written.map(|_| ())
+    }
+
+    /// Open an SSE stream. The head is a `200`; body bytes accrue through
+    /// [`Responder::add_bytes`] as frames are written.
+    pub(crate) async fn sse_head(&mut self) -> std::io::Result<()> {
+        let written = http::write_sse_head(self.stream, self.request_id.as_str()).await;
+        self.record("200 OK", written.as_ref().copied().unwrap_or(0));
+        written.map(|_| ())
+    }
+
+    /// The raw stream, for the SSE loop's read/write split. Callers that write
+    /// through this must report what they wrote with [`Responder::add_bytes`].
+    pub(crate) fn stream_mut(&mut self) -> &mut TcpStream {
+        self.stream
+    }
+
+    /// Add bytes written outside [`Responder::json`] — i.e. SSE frames.
+    pub(crate) fn add_bytes(&mut self, bytes: u64) {
+        if let Some(wrote) = self.wrote.as_mut() {
+            wrote.bytes = wrote.bytes.saturating_add(bytes);
+        }
+    }
+
+    /// What this connection was answered with, if anything.
+    pub(crate) fn wrote(&self) -> Option<Wrote> {
+        self.wrote
+    }
+
+    /// Parse the numeric status out of a `"404 Not Found"` literal.
+    ///
+    /// The statuses are all crate-internal literals, so an unparseable one is a
+    /// bug in this crate rather than host input; `0` records it as "we answered
+    /// with something unrecognisable" instead of dropping the record.
+    fn record(&mut self, status: &str, bytes: u64) {
+        let code = status
+            .split_whitespace()
+            .next()
+            .and_then(|code| code.parse::<u16>().ok())
+            .unwrap_or(0);
+        match self.wrote.as_mut() {
+            // A second write on one connection only happens on the SSE path
+            // (head, then frames); keep the first status and accumulate bytes.
+            Some(wrote) => wrote.bytes = wrote.bytes.saturating_add(bytes),
+            None => {
+                self.wrote = Some(Wrote {
+                    status: code,
+                    bytes,
+                })
+            }
+        }
+    }
+}
+
+/// The accumulating identity of one in-flight request.
+///
+/// Opened before parsing, filled in as routing learns more, and closed exactly
+/// once. Nothing here is optional-by-accident: a field that is still `None` at
+/// close time means the request died before that fact was known, and the record
+/// says so.
+pub(crate) struct RequestRecord {
+    request_id: RequestId,
+    started: Instant,
+    method: Option<Method>,
+    route: Option<Route>,
+    turn: Option<TurnRef>,
+    bytes_in: u64,
+}
+
+impl RequestRecord {
+    /// Open a record. Runs before the request head is read, so a peer that
+    /// never completes one still produces a record with an identity, a start
+    /// time, and — after `close` — a `status: None`.
+    pub(crate) fn opening(request_id: RequestId) -> Self {
+        Self {
+            request_id,
+            started: Instant::now(),
+            method: None,
+            route: None,
+            turn: None,
+            bytes_in: 0,
+        }
+    }
+
+    pub(crate) fn request_id(&self) -> &RequestId {
+        &self.request_id
+    }
+
+    /// Replace the generated id with the peer's, once a head has parsed and
+    /// carried a usable `X-Request-Id`.
+    ///
+    /// The record opens with a generated id rather than waiting for the header,
+    /// because a peer that never completes a head must still be recorded — so
+    /// adoption is a second step rather than a precondition.
+    pub(crate) fn adopt_request_id(&mut self, request_id: RequestId) {
+        self.request_id = request_id;
+    }
+
+    pub(crate) fn set_method(&mut self, method: &str) {
+        self.method = Some(Method::new(method));
+    }
+
+    pub(crate) fn set_route(&mut self, route: Route) {
+        self.route = Some(route);
+    }
+
+    /// Attach the turn this request concerns, truncated for recording.
+    pub(crate) fn set_turn(&mut self, turn_id: &str) {
+        self.turn = Some(TurnRef::new(turn_id));
+    }
+
+    pub(crate) fn set_bytes_in(&mut self, bytes: u64) {
+        self.bytes_in = bytes;
+    }
+
+    /// Close the record and emit it. **The only** construction site of
+    /// [`ServeEvent::RequestCompleted`] in this crate.
+    ///
+    /// Consumes `self`, takes the response outcome from the [`Responder`] that
+    /// owns the write half, and additionally emits a
+    /// [`ServeEvent::ConnectionFailed`] when the connection ended in an I/O
+    /// error — the thing the accept loop's `let _ =` used to swallow.
+    pub(crate) fn close(
+        self,
+        observer: &Arc<dyn Observer>,
+        wrote: Option<Wrote>,
+        outcome: &std::io::Result<()>,
+    ) {
+        if let Err(err) = outcome {
+            observer.emit(&ServeEvent::ConnectionFailed {
+                request_id: self.request_id.clone(),
+                error: err.to_string(),
+            });
+        }
+        observer.emit(&ServeEvent::RequestCompleted {
+            request_id: self.request_id,
+            method: self.method.unwrap_or_else(|| Method::new("")),
+            route: self.route.unwrap_or(Route::Unrouted),
+            status: wrote.map(|wrote| wrote.status),
+            duration_ms: millis(self.started.elapsed()),
+            bytes_in: self.bytes_in,
+            bytes_out: wrote.map_or(0, |wrote| wrote.bytes),
+            turn: self.turn,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observe::sink::Capture;
+
+    fn observer(capture: &Arc<Capture>) -> Arc<dyn Observer> {
+        capture.clone()
+    }
+
+    /// A request that died before we answered must still produce a record —
+    /// with `status: None`, which is a *terminal state*, not a missing field.
+    /// This is the case the accept loop's `let _ =` used to erase entirely.
+    #[test]
+    fn an_unanswered_connection_still_reports() {
+        let capture = Arc::new(Capture::new());
+        let record = RequestRecord::opening(RequestId::generate());
+        record.close(&observer(&capture), None, &Ok(()));
+
+        let events = capture.events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ServeEvent::RequestCompleted { status, route, .. } => {
+                assert_eq!(*status, None, "silence must be recorded as silence");
+                assert_eq!(*route, Route::Unrouted);
+            }
+            other => panic!("expected a request record, got {other:?}"),
+        }
+    }
+
+    /// An I/O failure produces *both* the named failure and the terminal
+    /// record — the failure is no longer discarded, and the record still
+    /// accounts for the connection.
+    #[test]
+    fn a_failed_connection_is_named_and_still_accounted() {
+        let capture = Arc::new(Capture::new());
+        let mut record = RequestRecord::opening(RequestId::generate());
+        record.set_method("POST");
+        record.set_route(Route::TurnsCreate);
+        let err = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "peer reset");
+        record.close(
+            &observer(&capture),
+            Some(Wrote {
+                status: 200,
+                bytes: 12,
+            }),
+            &Err(err),
+        );
+
+        let events = capture.events();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ServeEvent::ConnectionFailed { .. }));
+        match &events[1] {
+            ServeEvent::RequestCompleted {
+                status,
+                bytes_out,
+                route,
+                ..
+            } => {
+                assert_eq!(*status, Some(200));
+                assert_eq!(*bytes_out, 12);
+                assert_eq!(*route, Route::TurnsCreate);
+            }
+            other => panic!("expected a request record, got {other:?}"),
+        }
+    }
+
+    /// The turn a request concerns is correlatable but not actionable.
+    #[test]
+    fn a_record_carries_a_truncated_turn_not_the_id() {
+        let capture = Arc::new(Capture::new());
+        let full = "turn-0123456789abcdef0123456789abcdef";
+        let mut record = RequestRecord::opening(RequestId::generate());
+        record.set_route(Route::TurnCancel);
+        record.set_turn(full);
+        record.close(&observer(&capture), None, &Ok(()));
+
+        let json = serde_json::to_string(&capture.events()[0]).expect("serialize");
+        assert!(!json.contains(full), "the whole turn id reached a record");
+        assert!(json.contains("01234567"));
+        assert!(
+            json.contains("/v1/turns/{id}/cancel"),
+            "the route must be a template: {json}"
+        );
+    }
+
+    /// The status literals used across the crate must all parse, or the
+    /// recorded status silently becomes 0 for a whole class of responses.
+    #[test]
+    fn every_status_literal_this_crate_writes_parses() {
+        for status in [
+            "200 OK",
+            "400 Bad Request",
+            "401 Unauthorized",
+            "404 Not Found",
+            "405 Method Not Allowed",
+            "408 Request Timeout",
+            "409 Conflict",
+            "413 Payload Too Large",
+            "429 Too Many Requests",
+            "501 Not Implemented",
+        ] {
+            let code = status
+                .split_whitespace()
+                .next()
+                .and_then(|code| code.parse::<u16>().ok());
+            assert!(code.is_some(), "`{status}` does not parse");
+            assert!(matches!(code, Some(200..=599)));
+        }
+    }
+}

--- a/stella-serve/src/observe/sink.rs
+++ b/stella-serve/src/observe/sink.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where [`ServeEvent`]s go: the sinks behind the [`Observer`] port.
+//!
+//! Three of them, none needing a dependency the crate did not already have:
+//! [`JsonlSink`] (one JSON object per line on stderr), [`Fanout`] (several
+//! observers as one), and [`Capture`] (test-only, the thing that makes the
+//! acceptance criteria assertable on typed values instead of scraped text).
+//!
+//! The port is the whole point. Emission is typed and every site talks to
+//! [`Observer`], so adopting `tracing` later is one more impl in this file and
+//! **no emit site changes** — see `docs/design/serve-observability.md` §9 for
+//! why that deferral is a decision with an expiry rather than an omission.
+
+use std::io::Write as _;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use super::Observer;
+use super::event::{Level, LevelFilter, ServeEvent};
+
+/// The environment variable that sets the sink's verbosity.
+pub const LOG_LEVEL_ENV: &str = "STELLA_SERVE_LOG";
+
+/// One line of the log, as it is actually written.
+///
+/// `ts` is epoch milliseconds — the workspace's existing convention
+/// (`stella-store::sessions`), so this needs no time crate. `flatten` merges
+/// the event's own internally-tagged map, which is why a record reads as one
+/// flat object rather than a nested `{"event":{...}}`.
+#[derive(Serialize)]
+struct Line<'a> {
+    ts: u128,
+    level: Level,
+    #[serde(flatten)]
+    event: &'a ServeEvent,
+}
+
+/// One JSON object per line, on stderr.
+///
+/// stderr, not a file, on purpose: rotation, retention and shipping belong to
+/// the supervisor (systemd, Docker, Oxagen's runner), and reimplementing them
+/// inside the process is the first thing a real logging framework does better.
+pub struct JsonlSink {
+    filter: LevelFilter,
+    /// Serializes whole lines. Two connections writing concurrently would
+    /// otherwise interleave mid-record and produce unparseable output.
+    out: Mutex<std::io::Stderr>,
+}
+
+impl JsonlSink {
+    #[must_use]
+    pub fn new(filter: LevelFilter) -> Self {
+        Self {
+            filter,
+            out: Mutex::new(std::io::stderr()),
+        }
+    }
+
+    /// Build from `STELLA_SERVE_LOG`, defaulting to `info`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let filter = std::env::var(LOG_LEVEL_ENV)
+            .map_or(LevelFilter::default(), |value| LevelFilter::parse(&value));
+        Self::new(filter)
+    }
+}
+
+impl Observer for JsonlSink {
+    fn emit(&self, event: &ServeEvent) {
+        let level = event.level();
+        if !self.filter.admits(level) {
+            return;
+        }
+        let line = Line {
+            ts: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |since| since.as_millis()),
+            level,
+            event,
+        };
+        let Ok(mut json) = serde_json::to_vec(&line) else {
+            // Unreachable: every field is serde-clean. Silence beats a panic
+            // here — invariant 5, and losing a log line must never lose a turn.
+            return;
+        };
+        json.push(b'\n');
+        // A failed write is dropped deliberately: stderr being closed or full
+        // is not a reason to fail a request that otherwise succeeded.
+        if let Ok(mut out) = self.out.lock() {
+            let _ = out.write_all(&json);
+        }
+    }
+}
+
+/// Several observers as one. The server holds exactly one of these, so adding a
+/// sink never touches an emit site.
+pub struct Fanout {
+    observers: Vec<std::sync::Arc<dyn Observer>>,
+}
+
+impl Fanout {
+    #[must_use]
+    pub fn new(observers: Vec<std::sync::Arc<dyn Observer>>) -> Self {
+        Self { observers }
+    }
+}
+
+impl Observer for Fanout {
+    fn emit(&self, event: &ServeEvent) {
+        for observer in &self.observers {
+            observer.emit(event);
+        }
+    }
+}
+
+/// Discards everything. The default when a caller does not care, and what keeps
+/// `Session` usable as a library type without wiring a sink.
+pub struct NullSink;
+
+impl Observer for NullSink {
+    fn emit(&self, _event: &ServeEvent) {}
+}
+
+/// Records events in memory for assertions.
+///
+/// This is what makes #930's acceptance criteria testable: a test matches on
+/// `ServeEvent::ReverseTimedOut { .. }` rather than grepping stderr for a
+/// phrase, so the assertion survives any change to how records are rendered.
+#[derive(Default)]
+pub struct Capture {
+    events: Mutex<Vec<ServeEvent>>,
+}
+
+impl Capture {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every event emitted so far, in order.
+    #[must_use]
+    pub fn events(&self) -> Vec<ServeEvent> {
+        self.events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
+    /// How many events match `predicate`.
+    pub fn count(&self, predicate: impl Fn(&ServeEvent) -> bool) -> usize {
+        self.events().iter().filter(|e| predicate(e)).count()
+    }
+
+    /// The first event matching `predicate`, if any.
+    pub fn find(&self, predicate: impl Fn(&ServeEvent) -> bool) -> Option<ServeEvent> {
+        self.events().into_iter().find(|e| predicate(e))
+    }
+}
+
+impl Observer for Capture {
+    fn emit(&self, event: &ServeEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(event.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observe::event::{Method, RequestId, Route, ServeEvent, TurnRef};
+    use std::sync::Arc;
+
+    fn a_request() -> ServeEvent {
+        ServeEvent::RequestCompleted {
+            request_id: RequestId::generate(),
+            method: Method::new("GET"),
+            route: Route::Healthz,
+            status: Some(200),
+            duration_ms: 1,
+            bytes_in: 0,
+            bytes_out: 15,
+            turn: None,
+        }
+    }
+
+    /// The rendered line must be one object per line, flat, with the event's
+    /// own fields alongside `ts`/`level` rather than nested under a key.
+    #[test]
+    fn a_record_renders_as_one_flat_json_line() {
+        let event = a_request();
+        let line = Line {
+            ts: 1_753_876_543_210,
+            level: event.level(),
+            event: &event,
+        };
+        let json = serde_json::to_string(&line).expect("serialize");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(value["ts"], 1_753_876_543_210_u64);
+        assert_eq!(value["level"], "info");
+        assert_eq!(value["event"], "request_completed");
+        assert_eq!(value["route"], "/healthz");
+        assert_eq!(value["status"], 200);
+        assert!(!json.contains('\n'), "a record must not span lines");
+    }
+
+    /// Filtering is the sink's job, not the emit site's — so the counters
+    /// downstream of the same stream stay correct at any verbosity.
+    #[test]
+    fn the_filter_drops_records_without_suppressing_emission() {
+        let capture = Arc::new(Capture::new());
+        let fanout = Fanout::new(vec![capture.clone()]);
+        fanout.emit(&a_request());
+        fanout.emit(&ServeEvent::ReverseMisrouted {
+            request_id: RequestId::generate(),
+            fault: crate::observe::event::MisrouteFault::UnknownRequest,
+        });
+        assert_eq!(capture.events().len(), 2);
+
+        // The sink at `error` would print neither of those, but `Capture` — the
+        // stand-in for the metrics fold — still saw both.
+        assert!(!LevelFilter::Error.admits(Level::Info));
+        assert!(!LevelFilter::Error.admits(Level::Warn));
+    }
+
+    /// A fanout with several sinks delivers to all of them, in order.
+    #[test]
+    fn a_fanout_reaches_every_observer() {
+        let first = Arc::new(Capture::new());
+        let second = Arc::new(Capture::new());
+        let fanout = Fanout::new(vec![first.clone(), second.clone()]);
+        fanout.emit(&a_request());
+        fanout.emit(&a_request());
+        assert_eq!(first.events().len(), 2);
+        assert_eq!(second.events().len(), 2);
+    }
+
+    /// `TurnRef` is what reaches a record, so a full turn id must not appear in
+    /// rendered output even when the emitting code holds one.
+    #[test]
+    fn a_rendered_record_never_carries_a_whole_turn_id() {
+        let full = "turn-0123456789abcdef0123456789abcdef";
+        let event = ServeEvent::TurnCreated {
+            turn: TurnRef::new(full),
+            live_turns: 1,
+        };
+        let line = Line {
+            ts: 0,
+            level: event.level(),
+            event: &event,
+        };
+        let json = serde_json::to_string(&line).expect("serialize");
+        assert!(
+            !json.contains(full),
+            "the whole turn id reached the record: {json}"
+        );
+        assert!(json.contains("01234567"), "no correlation handle: {json}");
+    }
+}

--- a/stella-serve/src/observe/tally.rs
+++ b/stella-serve/src/observe/tally.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Folding the engine's own event stream into one per-turn tally.
+//!
+//! `ServerFrame::Event { event: AgentEvent }` already flows through this crate
+//! on every turn — stages, retries, tool timings, loop detections, discarded
+//! speculation. #930 suggests a span in `stella-core`'s step loop "would pay for
+//! itself"; those signals already exist, typed and wire-stable, and this server
+//! simply was not listening. So the answer needs no engine change at all.
+//!
+//! Two details make the tap correct rather than merely appealing.
+//!
+//! **It taps where frames are produced, not where they are streamed.** The
+//! obvious home is the SSE loop in `server.rs`, and it is wrong: a turn nobody
+//! streams buffers its frames and the tap never runs — and unstreamed turns are
+//! precisely the abandoned ones worth observing. So the fold lives on the
+//! session thread's forwarder, which every turn runs.
+//!
+//! **It counts; it does not log.** `AgentEvent::TextDelta` fires per token, so a
+//! record per frame would make this server slower than the model it waits on.
+//! The whole fold rides one [`ServeEvent::TurnSettled`](super::event::ServeEvent).
+//!
+//! # Why there is no per-frame debug record
+//!
+//! `docs/design/serve-observability.md` §7 planned individual `AgentEvent`
+//! records behind `STELLA_SERVE_LOG=debug`. Building it showed that to be a
+//! mistake: `AgentEvent::Text`, `TextDelta` and `Reasoning` carry model output
+//! verbatim, so such a record would put prompt-adjacent content in a log file —
+//! and would make the crate's no-content property conditional on a verbosity
+//! flag, which is exactly the kind of "safe unless you turn the knob" invariant
+//! that fails in production. The tally supersedes it: aggregates answer the
+//! diagnostic questions (is this turn progressing? how many retries?) without
+//! any payload reaching a record.
+
+use stella_protocol::AgentEvent;
+
+use super::event::TurnTally;
+
+/// Accumulates a [`TurnTally`] from the engine's event stream.
+#[derive(Debug, Default)]
+pub(crate) struct TallyFold {
+    tally: TurnTally,
+}
+
+impl TallyFold {
+    /// Fold one engine event. Cheap by construction — integer increments only,
+    /// no allocation, no I/O — because this runs on the turn's hot path.
+    pub(crate) fn observe(&mut self, event: &AgentEvent) {
+        let tally = &mut self.tally;
+        match event {
+            // The progress axis. A turn whose stages stop advancing while a
+            // reverse request's wait climbs is wedged; one that keeps advancing
+            // is merely slow. That distinction is the whole point of counting.
+            AgentEvent::Stage { .. } => tally.stages = tally.stages.saturating_add(1),
+            // "One committed model call — the metering record", emitted exactly
+            // once per step that lands.
+            AgentEvent::StepUsage { .. } => tally.model_calls = tally.model_calls.saturating_add(1),
+            AgentEvent::Retry { .. } => tally.retries = tally.retries.saturating_add(1),
+            // A doomed sequence reports its whole run at once instead of a
+            // `Retry` per attempt, so count the retries it stands for: the
+            // initial call is attempt 1 and is not itself a retry.
+            AgentEvent::RetriesExhausted { attempts, .. } => {
+                tally.retries = tally.retries.saturating_add(attempts.saturating_sub(1));
+            }
+            AgentEvent::ToolStart { .. } => tally.tool_calls = tally.tool_calls.saturating_add(1),
+            AgentEvent::ToolResult { output, .. } if output.is_error() => {
+                tally.tools_failed = tally.tools_failed.saturating_add(1);
+            }
+            // `stella-core` already names its discarded speculative work, so
+            // this server counts it rather than re-deriving it.
+            AgentEvent::SpeculationDiscarded { .. } => {
+                tally.speculation_discarded = tally.speculation_discarded.saturating_add(1);
+            }
+            AgentEvent::LoopDetected { .. } => {
+                tally.loop_detections = tally.loop_detections.saturating_add(1);
+            }
+            // Everything else — text, deltas, reasoning, budget ticks — is
+            // either payload we deliberately never record or a signal with no
+            // counterpart here. `AgentEvent` is forward-compatible, so an
+            // unknown variant must be inert rather than a compile error.
+            _ => {}
+        }
+    }
+
+    /// The accumulated tally.
+    pub(crate) fn finish(self) -> TurnTally {
+        self.tally
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::{StageKind, ToolCall, ToolOutput};
+
+    fn tool_call(id: &str) -> ToolCall {
+        ToolCall {
+            call_id: id.to_string(),
+            name: "read".to_string(),
+            input: serde_json::json!({}),
+        }
+    }
+
+    /// The signals an operator needs are counted, and each from the event that
+    /// actually means it.
+    #[test]
+    fn the_fold_counts_the_signals_that_distinguish_wedged_from_slow() {
+        let mut fold = TallyFold::default();
+        fold.observe(&AgentEvent::Stage {
+            name: StageKind::Execute,
+        });
+        fold.observe(&AgentEvent::Stage {
+            name: StageKind::Verify,
+        });
+        fold.observe(&AgentEvent::Retry {
+            attempt: 1,
+            reason: "429".to_string(),
+        });
+        fold.observe(&AgentEvent::ToolStart {
+            call: tool_call("a"),
+        });
+        fold.observe(&AgentEvent::ToolResult {
+            call_id: "a".to_string(),
+            output: ToolOutput::Error {
+                message: "nope".to_string(),
+            },
+            duration_ms: 3,
+            speculated: false,
+        });
+        fold.observe(&AgentEvent::ToolStart {
+            call: tool_call("b"),
+        });
+        fold.observe(&AgentEvent::ToolResult {
+            call_id: "b".to_string(),
+            output: ToolOutput::Ok {
+                content: "fine".to_string(),
+            },
+            duration_ms: 4,
+            speculated: false,
+        });
+        fold.observe(&AgentEvent::SpeculationDiscarded {
+            call_id: "c".to_string(),
+            name: "read".to_string(),
+            reason: "harvest_mismatch".to_string(),
+        });
+
+        let tally = fold.finish();
+        assert_eq!(tally.stages, 2);
+        assert_eq!(tally.tool_calls, 2);
+        assert_eq!(tally.tools_failed, 1, "only the error arm counts as failed");
+        assert_eq!(tally.retries, 1);
+        assert_eq!(tally.speculation_discarded, 1);
+    }
+
+    /// A doomed retry sequence reports once, for the whole run — so counting
+    /// it as a single retry would undercount a turn that burned five attempts.
+    #[test]
+    fn an_exhausted_retry_sequence_counts_every_retry_it_stands_for() {
+        let mut fold = TallyFold::default();
+        fold.observe(&AgentEvent::RetriesExhausted {
+            turn_instance: 0,
+            attempts: 4,
+            reasons: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+        });
+        // Four dispatched attempts is one initial call plus three retries.
+        assert_eq!(fold.finish().retries, 3);
+    }
+
+    /// Payload-bearing events must be inert: they are the reason there is no
+    /// per-frame debug record, and they must not sneak into a count either.
+    #[test]
+    fn payload_events_are_inert() {
+        let mut fold = TallyFold::default();
+        fold.observe(&AgentEvent::Text {
+            delta: "secret".to_string(),
+        });
+        fold.observe(&AgentEvent::TextDelta {
+            text: "secret".to_string(),
+        });
+        fold.observe(&AgentEvent::Reasoning {
+            delta: "secret".to_string(),
+        });
+        fold.observe(&AgentEvent::Steered {
+            text: "secret".to_string(),
+        });
+        assert_eq!(fold.finish(), TurnTally::default());
+    }
+
+    /// The fold must survive a turn long enough to overflow a `u32` counter
+    /// without panicking in a release-mode-divergent way.
+    #[test]
+    fn counters_saturate_rather_than_wrap() {
+        let mut fold = TallyFold::default();
+        fold.tally.stages = u32::MAX;
+        fold.observe(&AgentEvent::Stage {
+            name: StageKind::Execute,
+        });
+        assert_eq!(fold.finish().stages, u32::MAX);
+    }
+}

--- a/stella-serve/src/pending.rs
+++ b/stella-serve/src/pending.rs
@@ -21,6 +21,8 @@ use stella_protocol::{CompletionResult, ProviderError, ToolOutput};
 use tokio::sync::oneshot;
 
 use crate::error::ServeError;
+use crate::observe::SharedObserver;
+use crate::observe::event::{AbandonReason, MisrouteFault, RequestId, ServeEvent, TurnRef};
 
 /// The reply channel a parked provider step awaits: either the host's completed
 /// model call, or the failure class it wants the engine's retry logic to see.
@@ -33,7 +35,7 @@ enum PendingReply {
 }
 
 /// A cloneable handle to the shared registry. Cloning shares the same map.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Pending {
     inner: Arc<Mutex<HashMap<String, PendingReply>>>,
     /// Latched by [`Pending::cancel`]. The registry is the natural home for the
@@ -41,9 +43,33 @@ pub struct Pending {
     /// that both the HTTP side and the engine thread hold, and cancellation
     /// means exactly "stop waiting on reverse requests".
     cancelled: Arc<AtomicBool>,
+    /// Where this registry's discarded work is reported. Every drop below —
+    /// a misrouted answer, a cancel, a teardown — used to be silent.
+    observer: SharedObserver,
+    turn: TurnRef,
 }
 
 impl Pending {
+    /// A registry that reports what it discards.
+    #[must_use]
+    pub fn new(observer: SharedObserver, turn: TurnRef) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            observer,
+            turn,
+        }
+    }
+
+    /// The observer this registry reports through, for the ports that share it.
+    pub(crate) fn observer(&self) -> &SharedObserver {
+        &self.observer
+    }
+
+    /// This turn's truncated id, for the ports that share it.
+    pub(crate) fn turn(&self) -> &TurnRef {
+        &self.turn
+    }
     /// Register a tool reply channel under `id`. Called by the engine thread
     /// before it emits the request frame, so the entry always exists by the
     /// time the host can answer.
@@ -84,7 +110,7 @@ impl Pending {
     pub fn resolve_tool(&self, id: &str, output: ToolOutput) -> Result<(), ServeError> {
         // A receive-side drop (the engine step was cancelled) is not an error to
         // the host: the request is simply gone.
-        let _ = self.take_tool(id)?.send(output);
+        let _ = self.report_misroute(id, self.take_tool(id))?.send(output);
         Ok(())
     }
 
@@ -95,8 +121,38 @@ impl Pending {
         id: &str,
         result: Result<CompletionResult, ProviderError>,
     ) -> Result<(), ServeError> {
-        let _ = self.take_provider(id)?.send(result);
+        let _ = self
+            .report_misroute(id, self.take_provider(id))?
+            .send(result);
         Ok(())
+    }
+
+    /// Record a host answer that matched nothing, then hand the result back.
+    ///
+    /// This is one of the four situations #930 names as indistinguishable from
+    /// silence: a host answering with the wrong `request_id` got a `409` that
+    /// nobody counted, while the engine step it was meant to answer stayed
+    /// parked until its deadline. The `409` is unchanged — what changes is that
+    /// the server now says so.
+    fn report_misroute<T>(&self, id: &str, taken: Result<T, ServeError>) -> Result<T, ServeError> {
+        if let Err(err) = &taken {
+            let fault = match err {
+                ServeError::UnknownRequest(_) => MisrouteFault::UnknownRequest,
+                ServeError::RequestKindMismatch(..) => MisrouteFault::KindMismatch,
+                // The other variants are session-lifecycle failures and never
+                // reach a resolve; recording them as unknown is the honest
+                // fallback rather than inventing a class.
+                _ => MisrouteFault::UnknownRequest,
+            };
+            self.observer.emit(&ServeEvent::ReverseMisrouted {
+                // Host-supplied, so it goes through the same sanitizer as an
+                // `X-Request-Id`: this value came off the wire, and a log is
+                // exactly where an unsanitized echo becomes a forging vector.
+                request_id: RequestId::sanitized(id),
+                fault,
+            });
+        }
+        taken
     }
 
     /// Drop every in-flight request. Their receivers observe a channel close,
@@ -105,7 +161,28 @@ impl Pending {
     /// outlives it. Teardown mid-turn goes through [`Pending::cancel`] instead:
     /// a bare clear wakes a parked step with a *retryable* error.
     pub(crate) fn clear(&self) {
-        self.lock().clear();
+        self.clear_reporting(AbandonReason::Teardown);
+    }
+
+    /// Drop every in-flight request and report how many were discarded.
+    ///
+    /// Reported only when the count is non-zero: a clean turn leaves nothing
+    /// parked, and an event on every teardown would be noise that trains a
+    /// reader to skip the one that matters.
+    fn clear_reporting(&self, reason: AbandonReason) {
+        let in_flight = {
+            let mut map = self.lock();
+            let count = map.len();
+            map.clear();
+            count
+        };
+        if in_flight > 0 {
+            self.observer.emit(&ServeEvent::ReverseAbandoned {
+                turn: self.turn.clone(),
+                in_flight,
+                reason,
+            });
+        }
     }
 
     /// Cancel the turn: latch the flag, then drop every in-flight request so any
@@ -123,7 +200,7 @@ impl Pending {
     /// always observes the flag already set.
     pub fn cancel(&self) {
         self.cancelled.store(true, Ordering::SeqCst);
-        self.clear();
+        self.clear_reporting(AbandonReason::Cancelled);
     }
 
     /// Whether [`Pending::cancel`] has been called for this turn.
@@ -189,6 +266,125 @@ impl Pending {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observe::Capture;
+
+    fn test_pending() -> Pending {
+        Pending::new(
+            crate::observe::null_observer(),
+            TurnRef::new("turn-test0000"),
+        )
+    }
+
+    fn observed_pending() -> (Pending, Arc<Capture>) {
+        let capture = Arc::new(Capture::new());
+        let pending = Pending::new(capture.clone(), TurnRef::new("turn-test0000"));
+        (pending, capture)
+    }
+
+    /// A host that answers with an id nobody is waiting on must be visible.
+    /// Before this, the `409` it received was the only trace, and the engine
+    /// step it meant to answer stayed parked until its deadline with nothing
+    /// in the server's output to say why.
+    #[test]
+    fn a_misrouted_answer_is_recorded_with_its_fault() {
+        let (pending, capture) = observed_pending();
+        let (tx, _rx) = oneshot::channel();
+        assert!(pending.register_provider("prov-0".to_string(), tx));
+
+        // Fabricated id: nothing is registered under it.
+        assert!(
+            pending
+                .resolve_tool(
+                    "nope-1",
+                    ToolOutput::Ok {
+                        content: String::new()
+                    }
+                )
+                .is_err()
+        );
+        // Real id, wrong kind: a provider request answered with a tool result.
+        assert!(
+            pending
+                .resolve_tool(
+                    "prov-0",
+                    ToolOutput::Ok {
+                        content: String::new()
+                    }
+                )
+                .is_err()
+        );
+
+        let faults: Vec<MisrouteFault> = capture
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                ServeEvent::ReverseMisrouted { fault, .. } => Some(fault),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            faults,
+            vec![MisrouteFault::UnknownRequest, MisrouteFault::KindMismatch],
+            "the two ways a host can misroute must be distinguishable"
+        );
+    }
+
+    /// A request id comes off the wire, so it is sanitized before it reaches a
+    /// record — a log is exactly where an unsanitized echo forges lines.
+    #[test]
+    fn a_hostile_request_id_never_reaches_a_record_verbatim() {
+        let (pending, capture) = observed_pending();
+        let hostile = "x\n{\"event\":\"listening\"}";
+        assert!(
+            pending
+                .resolve_tool(
+                    hostile,
+                    ToolOutput::Ok {
+                        content: String::new()
+                    }
+                )
+                .is_err()
+        );
+        let json = serde_json::to_string(&capture.events()[0]).expect("serialize");
+        assert!(!json.contains('\n'), "a record must not span lines: {json}");
+        assert!(
+            json.contains("<unusable>"),
+            "an unusable id is replaced, not escaped and kept: {json}"
+        );
+    }
+
+    /// Cancelling a turn with work in flight discards it — and says how much.
+    /// A clean teardown discards nothing and stays quiet, so the event means
+    /// something when it does appear.
+    #[test]
+    fn abandoned_work_is_counted_and_a_clean_teardown_is_silent() {
+        let (pending, capture) = observed_pending();
+        let (tx, _rx) = oneshot::channel();
+        assert!(pending.register_provider("prov-0".to_string(), tx));
+        let (tx, _rx) = oneshot::channel();
+        assert!(pending.register_tool("tool-0".to_string(), tx));
+
+        pending.cancel();
+        let abandoned: Vec<(usize, AbandonReason)> = capture
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                ServeEvent::ReverseAbandoned {
+                    in_flight, reason, ..
+                } => Some((in_flight, reason)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(abandoned, vec![(2, AbandonReason::Cancelled)]);
+
+        // Nothing left to discard, so nothing more is said.
+        pending.clear();
+        assert_eq!(
+            capture.count(|e| matches!(e, ServeEvent::ReverseAbandoned { .. })),
+            1,
+            "an empty registry must not emit — noise trains readers to skip"
+        );
+    }
 
     /// A cancel that has fully run before a port registers must refuse the
     /// registration: its wake-everyone clear has already happened, so an entry
@@ -196,7 +392,7 @@ mod tests {
     /// deadline with nobody left to wake it.
     #[test]
     fn registration_is_refused_once_cancelled() {
-        let pending = Pending::default();
+        let pending = test_pending();
         pending.cancel();
 
         let (tx, rx) = oneshot::channel();
@@ -217,7 +413,7 @@ mod tests {
     /// (non-retryable), not as an ordinary transport failure.
     #[test]
     fn cancel_after_registration_wakes_the_parked_sender() {
-        let pending = Pending::default();
+        let pending = test_pending();
         let (tx, rx) = oneshot::channel();
         assert!(pending.register_provider("prov-0".to_string(), tx));
 

--- a/stella-serve/src/remote.rs
+++ b/stella-serve/src/remote.rs
@@ -13,7 +13,7 @@
 //! server runtime. That cross-runtime wake is the `!Send`-future bridge.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -25,7 +25,47 @@ use stella_protocol::{
 use tokio::sync::{mpsc, oneshot};
 
 use crate::frame::ServerFrame;
+use crate::observe::event::{RequestId, ReverseKind, ServeEvent, millis};
 use crate::pending::Pending;
+
+/// Record that a reverse request reached the host, and start its clock.
+///
+/// Emitted *after* the frame is sent, never before: a request the host never
+/// received was not dispatched, and counting it as such would leave the
+/// in-flight gauge permanently short of an answer.
+fn dispatched(pending: &Pending, request_id: &str, kind: ReverseKind) -> Instant {
+    pending.observer().emit(&ServeEvent::ReverseDispatched {
+        turn: pending.turn().clone(),
+        request_id: RequestId::sanitized(request_id),
+        kind,
+    });
+    Instant::now()
+}
+
+/// Record that the host answered, and how long the engine step waited.
+fn answered(pending: &Pending, request_id: &str, kind: ReverseKind, started: Instant) {
+    pending.observer().emit(&ServeEvent::ReverseAnswered {
+        turn: pending.turn().clone(),
+        request_id: RequestId::sanitized(request_id),
+        kind,
+        waited_ms: millis(started.elapsed()),
+    });
+}
+
+/// Record that the host never answered and the port gave up.
+///
+/// **The** wedge signal. This is the moment a turn has burned its whole
+/// reverse-request deadline waiting on a host that said nothing, and before this
+/// it was a silent `HashMap::remove` inside `Pending::abandon` — the single most
+/// diagnostic event this service can produce, and it produced nothing.
+fn timed_out(pending: &Pending, request_id: &str, kind: ReverseKind, started: Instant) {
+    pending.observer().emit(&ServeEvent::ReverseTimedOut {
+        turn: pending.turn().clone(),
+        request_id: RequestId::sanitized(request_id),
+        kind,
+        waited_ms: millis(started.elapsed()),
+    });
+}
 
 /// How long a reverse request waits for the host before the port gives up.
 ///
@@ -119,16 +159,23 @@ impl Provider for RemoteProvider {
                 "serve host disconnected before the model call could be dispatched".to_string(),
             ));
         }
+        let started = dispatched(&self.pending, &request_id, ReverseKind::Provider);
         match tokio::time::timeout(self.timeout, rx).await {
-            Ok(Ok(result)) => result,
+            Ok(Ok(result)) => {
+                answered(&self.pending, &request_id, ReverseKind::Provider, started);
+                result
+            }
             // Sender dropped. Cancellation is the deliberate case and reports
-            // itself as such; otherwise the session is being torn down.
+            // itself as such; otherwise the session is being torn down. Either
+            // way `Pending`'s own clear reports the discard, so there is no
+            // per-request event here.
             Ok(Err(_)) if self.pending.is_cancelled() => Err(ProviderError::Cancelled),
             Ok(Err(_)) => Err(ProviderError::Transport(
                 "serve host dropped the model call without answering".to_string(),
             )),
             Err(_) => {
                 self.pending.abandon(&request_id);
+                timed_out(&self.pending, &request_id, ReverseKind::Provider, started);
                 // Deliberately `Terminal`, not `Transport`: `Transport` is
                 // retryable, so a host that is simply not answering would be
                 // handed the same unbounded wait again once per retry —
@@ -213,8 +260,12 @@ impl ToolExecutor for RemoteToolExecutor {
                     .to_string(),
             };
         }
+        let started = dispatched(&self.pending, &request_id, ReverseKind::Tool);
         match tokio::time::timeout(self.timeout, rx).await {
-            Ok(Ok(output)) => output,
+            Ok(Ok(output)) => {
+                answered(&self.pending, &request_id, ReverseKind::Tool, started);
+                output
+            }
             Ok(Err(_)) if self.pending.is_cancelled() => ToolOutput::Error {
                 message: "turn cancelled while the tool call was in flight".to_string(),
             },
@@ -223,6 +274,7 @@ impl ToolExecutor for RemoteToolExecutor {
             },
             Err(_) => {
                 self.pending.abandon(&request_id);
+                timed_out(&self.pending, &request_id, ReverseKind::Tool, started);
                 ToolOutput::Error {
                     message: format!(
                         "serve host did not answer the `{name}` tool call within {:?} \

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The endpoint handlers, and the wire types they parse.
+//!
+//! Split out of `server.rs`, which keeps the transport: the listener, the
+//! connection fold, the turn registry and the 401 throttle. The cut follows the
+//! concern — everything here answers *one route*, everything there is about
+//! connections and shared state — and it is what keeps both files clear of the
+//! 1500-line ratchet (`scripts/check-file-size.sh`) now that every response also
+//! carries a record.
+//!
+//! Every handler writes through [`Responder`], never to the socket directly, so
+//! status and `bytes_out` are captured for the record by construction rather
+//! than by each handler remembering to report them.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use stella_core::{BudgetGuard, EngineConfig};
+use stella_protocol::{BudgetMode, CompletionMessage, ToolSchema};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::frame::{
+    ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn, TurnOutcomeWire,
+};
+use crate::http::{Request, discard_body, write_sse_frame};
+use crate::observe::event::{ServeEvent, StreamEndReason, TurnRef};
+use crate::observe::record::{RequestRecord, Responder};
+use crate::server::ServerState;
+use crate::session::{Session, SessionSpec};
+
+/// Body of `POST /v1/turns`. The host owns prompt assembly, model selection, and
+/// the tool set; engine knobs are optional overrides on top of the defaults.
+#[derive(Debug, Deserialize)]
+struct TurnRequest {
+    provider_id: String,
+    #[serde(default)]
+    tools: Vec<ToolSchema>,
+    messages: Vec<CompletionMessage>,
+    #[serde(default)]
+    budget: BudgetSpec,
+    #[serde(default)]
+    max_steps: Option<usize>,
+    /// Per-reverse-request deadline override, in milliseconds. Omitted means
+    /// [`SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT`].
+    #[serde(default)]
+    reverse_request_timeout_ms: Option<u64>,
+}
+
+/// Spend policy for a turn — the serializable projection of a [`BudgetGuard`].
+#[derive(Debug, Deserialize)]
+struct BudgetSpec {
+    #[serde(default = "budget_mode_off")]
+    mode: BudgetMode,
+    #[serde(default)]
+    turn_limit_usd: Option<f64>,
+    #[serde(default)]
+    session_limit_usd: Option<f64>,
+}
+
+impl Default for BudgetSpec {
+    fn default() -> Self {
+        Self {
+            mode: BudgetMode::Off,
+            turn_limit_usd: None,
+            session_limit_usd: None,
+        }
+    }
+}
+
+fn budget_mode_off() -> BudgetMode {
+    BudgetMode::Off
+}
+
+/// Response to `POST /v1/turns`.
+#[derive(Debug, Serialize)]
+struct TurnCreated<'a> {
+    turn_id: &'a str,
+}
+
+/// Ceiling on a host-supplied [`TurnRequest::max_steps`].
+///
+/// The step cap is the engine's belt-and-suspenders backstop against a turn
+/// that never terminates, and the host also supplies the budget mode (which may
+/// be `Off`), so an unclamped `max_steps` lets a caller remove the last bound on
+/// a turn that already holds an OS thread. `EngineConfig::default` uses 200;
+/// 10 000 is fifty times that — far above any turn a real agentic task runs,
+/// while still terminating in bounded time.
+const MAX_SERVED_STEPS: usize = 10_000;
+
+/// Validate a host-supplied step cap: `None` when it is unusable (`0` produces
+/// a zero-iteration turn that aborts with the misleading "reached the step cap
+/// (0)"), otherwise the value clamped down to [`MAX_SERVED_STEPS`].
+fn validate_max_steps(requested: usize) -> Option<usize> {
+    (requested > 0).then(|| requested.min(MAX_SERVED_STEPS))
+}
+
+/// Ceiling on a host-supplied reverse-request deadline: one hour.
+///
+/// Same reasoning as [`MAX_SERVED_STEPS`]. The deadline is what bounds a turn
+/// holding an OS thread on a host that never answers, so letting a caller set it
+/// to `u64::MAX` would hand back the unbounded wait it exists to remove. An hour
+/// is far past any legitimate model call or tool run.
+const MAX_REVERSE_REQUEST_TIMEOUT: Duration = Duration::from_secs(3600);
+
+/// Validate a host-supplied reverse-request deadline: `None` when it is unusable
+/// (`0` would expire every reverse request before the host could possibly
+/// answer, making the turn fail rather than run), otherwise clamped down to
+/// [`MAX_REVERSE_REQUEST_TIMEOUT`].
+fn validate_reverse_request_timeout(requested_ms: u64) -> Option<Duration> {
+    (requested_ms > 0).then(|| Duration::from_millis(requested_ms).min(MAX_REVERSE_REQUEST_TIMEOUT))
+}
+
+/// How long a rejected caller is told to wait before retrying, in seconds.
+///
+/// Turns end when the host finishes streaming them, so the queue drains on the
+/// order of a turn's length; 5 seconds is short enough to keep a well-behaved
+/// host responsive without inviting a tight retry loop.
+const RETRY_AFTER_SECS: &str = "5";
+
+/// `405` naming the methods this path accepts, per RFC 9110 §15.5.6 (the
+/// `Allow` header is mandatory on a 405 — a status that says "wrong verb"
+/// without saying which verb is right is half an answer).
+pub(crate) async fn method_not_allowed(
+    res: &mut Responder<'_>,
+    req: &mut Request,
+    allow: &str,
+) -> std::io::Result<()> {
+    discard_body(res.stream_mut(), req).await;
+    res.json_with_headers(
+        "405 Method Not Allowed",
+        &[("Allow", allow)],
+        &error_body(&format!("method not allowed; this path accepts {allow}")),
+    )
+    .await
+}
+
+/// `GET /healthz` — the only unauthenticated route.
+pub(crate) async fn handle_health(res: &mut Responder<'_>) -> std::io::Result<()> {
+    res.json("200 OK", br#"{"status":"ok"}"#).await
+}
+
+/// `GET /v1/metrics` — the counters, behind the same bearer token as everything
+/// else.
+///
+/// Authenticated on purpose (#930 asks for exactly this): occupancy, 401 counts
+/// and reverse-request timings describe the host's traffic, and an open metrics
+/// endpoint is a free reconnaissance surface. Pull, never push — nothing here
+/// dials out, per AGENTS.md invariant 3.
+pub(crate) async fn handle_metrics(
+    res: &mut Responder<'_>,
+    state: &ServerState,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(&state.metrics().snapshot()).unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
+pub(crate) async fn handle_create(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let turn: TurnRequest = match serde_json::from_slice(body) {
+        Ok(turn) => turn,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid turn request: {err}")),
+                )
+                .await;
+        }
+    };
+
+    let mut config = EngineConfig::default();
+    if let Some(max_steps) = turn.max_steps {
+        let Some(effective) = validate_max_steps(max_steps) else {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body("max_steps must be at least 1"),
+                )
+                .await;
+        };
+        config.max_steps = effective;
+    }
+    let mut reverse_request_timeout = SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT;
+    if let Some(requested_ms) = turn.reverse_request_timeout_ms {
+        let Some(effective) = validate_reverse_request_timeout(requested_ms) else {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body("reverse_request_timeout_ms must be at least 1"),
+                )
+                .await;
+        };
+        reverse_request_timeout = effective;
+    }
+
+    // Admission, reclamation and registration all happen under one lock hold
+    // inside `register_turn` — see there for why. The closure receives the
+    // minted id so the session can carry its own `TurnRef` into every record it
+    // will emit: the id has to exist before the session starts, and only the
+    // registry can mint it.
+    let observer = state.observer().clone();
+    let registered = state.register_turn(move |turn_id| {
+        Session::start(SessionSpec {
+            provider_id: turn.provider_id,
+            tools: turn.tools,
+            messages: turn.messages,
+            config,
+            budget: BudgetGuard::new(
+                turn.budget.mode,
+                turn.budget.turn_limit_usd,
+                turn.budget.session_limit_usd,
+            ),
+            reverse_request_timeout,
+            turn: TurnRef::new(turn_id),
+            observer,
+        })
+    });
+    let Some(id) = registered else {
+        return res
+            .json_with_headers(
+                "429 Too Many Requests",
+                &[("Retry-After", RETRY_AFTER_SECS)],
+                &error_body("too many live turns; retry after in-flight turns finish"),
+            )
+            .await;
+    };
+
+    let body = serde_json::to_vec(&TurnCreated { turn_id: &id }).unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
+pub(crate) async fn handle_events(
+    res: &mut Responder<'_>,
+    record: &mut RequestRecord,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    // Take the session out in its own scope so the (non-`Send`) mutex guard is
+    // dropped before any `.await` — the connection future must stay `Send`.
+    let taken = {
+        entry
+            .session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+    };
+    let Some(mut session) = taken else {
+        return res
+            .json(
+                "409 Conflict",
+                &error_body("events are already being streamed for this turn"),
+            )
+            .await;
+    };
+
+    // From here the session is out of the registry entry and owned by this
+    // connection, so every exit path must also drop the registry entry —
+    // otherwise a turn whose stream never opened lingers in the map forever.
+    if let Err(err) = res.sse_head().await {
+        state.turns().remove(id);
+        return Err(err);
+    }
+
+    let turn = TurnRef::new(id);
+    let mut frames_sent = 0_u64;
+    let mut bytes_out = 0_u64;
+    let reason = stream_frames(
+        res,
+        state,
+        &mut session,
+        &turn,
+        &mut frames_sent,
+        &mut bytes_out,
+    )
+    .await;
+    res.add_bytes(bytes_out);
+    record.set_turn(id);
+    state.observer().emit(&ServeEvent::StreamEnded {
+        turn,
+        frames_sent,
+        reason,
+    });
+
+    // Drop the session *before* the socket teardown: `Drop for Session`
+    // cancels the turn, so a stream that ended early (client gone, stray
+    // bytes) releases the engine thread now rather than at the end of scope.
+    drop(session);
+    // The turn is finished streaming; drop it so its thread and registry entry
+    // are reclaimed.
+    state.turns().remove(id);
+    res.stream_mut().shutdown().await
+}
+
+/// The SSE frame loop, split out so `handle_events` can report *why* it ended.
+///
+/// Watching the read half while waiting is not an optimization. A turn parked on
+/// a reverse request produces nothing to write, so a host that vanished would
+/// otherwise go unnoticed until the reverse-request deadline expired — up to an
+/// hour of an OS thread and a registry slot held for a client that is provably
+/// gone, with the host billed for whatever the engine went on to ask for.
+async fn stream_frames(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    session: &mut Session,
+    turn: &TurnRef,
+    frames_sent: &mut u64,
+    bytes_out: &mut u64,
+) -> StreamEndReason {
+    let (mut peer, mut out) = res.stream_mut().split();
+    let mut scratch = [0_u8; 1024];
+    // A GET on a `Connection: close` stream has nothing left to send, so
+    // inbound bytes are a protocol violation. Tolerate a little (a client
+    // library that pipelines a probe) but never spin discarding an unbounded
+    // stream of them.
+    let mut stray = 0_usize;
+    const MAX_STRAY_BYTES: usize = 8 * 1024;
+    loop {
+        let frame = tokio::select! {
+            read = peer.read(&mut scratch) => match read {
+                // EOF or a reset: the subscriber is gone. Stop streaming;
+                // dropping `session` cancels the turn.
+                Ok(0) | Err(_) => return StreamEndReason::PeerDisconnected,
+                Ok(n) => {
+                    stray += n;
+                    if stray > MAX_STRAY_BYTES {
+                        return StreamEndReason::StrayBytes;
+                    }
+                    continue;
+                }
+            },
+            frame = session.next_frame() => match frame {
+                Some(frame) => frame,
+                None => return StreamEndReason::SessionEnded,
+            },
+        };
+        let done = matches!(frame, ServerFrame::TurnComplete { .. });
+        let (json, unencodable) = encode_or_abort(&frame);
+        if let Some(error) = unencodable {
+            // The turn just died of a bug in our own serialization. It used to
+            // say nothing at all — the host got a synthesized terminal frame
+            // and the server kept no record that it had happened.
+            state.observer().emit(&ServeEvent::FrameUnencodable {
+                turn: turn.clone(),
+                error,
+            });
+        }
+        match write_sse_frame(&mut out, &json).await {
+            Ok(written) => {
+                *frames_sent += 1;
+                *bytes_out = bytes_out.saturating_add(written);
+            }
+            Err(_) => return StreamEndReason::WriteFailed,
+        }
+        if done {
+            return StreamEndReason::TurnComplete;
+        }
+    }
+}
+
+/// Render one frame as the JSON payload of an SSE `data:` line, reporting
+/// whether the fallback had to be used.
+///
+/// Every [`ServerFrame`] is built from serde-clean types, so the failure arm is
+/// unreachable in practice — but "unreachable" is not "harmless". It used to
+/// emit `{}`, a frame with no `type` at all: a host would skip it silently, and
+/// if the frame it replaced was the terminal `TurnComplete`, the stream would
+/// simply end with the turn's outcome and settled cost never reported. A
+/// synthesized terminal frame keeps the stream's contract — every turn ends with
+/// exactly one `turn_complete` — and names the cause instead of losing it.
+///
+/// The second element is `Some(error)` when the fallback fired, so the caller
+/// can record it. Returning it rather than emitting here keeps this function
+/// pure and directly testable.
+fn encode_or_abort<T: Serialize>(value: &T) -> (String, Option<String>) {
+    match serde_json::to_string(value) {
+        Ok(json) => (json, None),
+        Err(err) => {
+            let reason = format!("the engine produced a frame the server could not encode: {err}");
+            let json = serde_json::to_string(&ServerFrame::TurnComplete {
+                outcome: TurnOutcomeWire::Aborted {
+                    reason: reason.clone(),
+                    cost_usd: 0.0,
+                },
+            })
+            // The fallback's fallback: a literal that is valid on the wire, so
+            // the stream still terminates with a `turn_complete` no matter what.
+            .unwrap_or_else(|_| {
+                r#"{"type":"turn_complete","outcome":{"status":"aborted","reason":"frame encoding failed","cost_usd":0.0}}"#
+                    .to_string()
+            });
+            (json, Some(err.to_string()))
+        }
+    }
+}
+
+pub(crate) async fn handle_tool_result(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    let result: ToolResultIn = match serde_json::from_slice(body) {
+        Ok(result) => result,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid tool result: {err}")),
+                )
+                .await;
+        }
+    };
+    match entry
+        .pending
+        .resolve_tool(&result.request_id, result.output)
+    {
+        Ok(()) => res.json("200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => {
+            res.json("409 Conflict", &error_body(&err.to_string()))
+                .await
+        }
+    }
+}
+
+pub(crate) async fn handle_provider_result(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    let posted: ProviderResultIn = match serde_json::from_slice(body) {
+        Ok(posted) => posted,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid provider result: {err}")),
+                )
+                .await;
+        }
+    };
+    let result = match posted.outcome {
+        ProviderOutcomeIn::Ok { result } => Ok(result),
+        ProviderOutcomeIn::Error { error } => Err(error.into()),
+    };
+    match entry.pending.resolve_provider(&posted.request_id, result) {
+        Ok(()) => res.json("200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => {
+            res.json("409 Conflict", &error_body(&err.to_string()))
+                .await
+        }
+    }
+}
+
+/// `POST /v1/turns/{id}/cancel` — end an in-flight turn.
+///
+/// Answers once the turn is *signalled*, not once it has unwound: the parked
+/// engine step wakes immediately, but the turn still needs a moment to produce
+/// its terminal frame, and a host streaming `/events` is the one that observes
+/// that. Blocking this response on it would deadlock a single-connection client.
+pub(crate) async fn handle_cancel(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    // Remove and signal, so a second cancel — or a late result POST — gets an
+    // honest 404 rather than silently doing nothing. Scoped so the (non-`Send`)
+    // guard is dropped before the await below.
+    let removed = { state.turns().remove(id) };
+    let Some(entry) = removed else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    entry.pending.cancel();
+    // Dropping our `Arc` here is what reclaims a turn whose stream never opened:
+    // the registry no longer holds it, so this may be the last handle, and
+    // `Drop for Session` releases the engine thread. A turn that *is* streaming
+    // keeps its own handle and unwinds through `handle_events` as usual.
+    drop(entry);
+    res.json("200 OK", br#"{"status":"cancelled"}"#).await
+}
+
+pub(crate) fn error_body(message: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({ "error": message })).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A zero step cap produces a turn that aborts before it runs, blaming a
+    /// cap the caller never meant to set. Refusing it names the real problem.
+    #[test]
+    fn zero_steps_is_refused_rather_than_silently_accepted() {
+        assert_eq!(validate_max_steps(0), None);
+        assert_eq!(validate_max_steps(1), Some(1));
+    }
+
+    #[test]
+    fn step_cap_is_clamped_to_the_ceiling() {
+        assert_eq!(validate_max_steps(MAX_SERVED_STEPS), Some(MAX_SERVED_STEPS));
+        assert_eq!(
+            validate_max_steps(MAX_SERVED_STEPS + 1),
+            Some(MAX_SERVED_STEPS)
+        );
+        assert_eq!(
+            validate_max_steps(usize::MAX),
+            Some(MAX_SERVED_STEPS),
+            "an unbounded step loop must not be reachable from the wire"
+        );
+    }
+
+    /// A value whose `Serialize` always fails, standing in for the frame
+    /// encoding failure that real [`ServerFrame`]s cannot produce. Without it
+    /// the fallback would be untestable — and an untested fallback on the one
+    /// path that carries a turn's outcome is how `{}` sat on the wire.
+    struct Unserializable;
+
+    impl Serialize for Unserializable {
+        fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("nope"))
+        }
+    }
+
+    /// A frame that cannot be encoded must still leave the stream terminated:
+    /// the old `{}` fallback was a frame with no `type`, so a host skipped it
+    /// silently and — when the lost frame was the terminal one — never learned
+    /// the turn's outcome or its settled cost.
+    #[test]
+    fn an_unencodable_frame_becomes_a_terminal_aborted_frame_not_an_empty_object() {
+        let (json, unencodable) = encode_or_abort(&Unserializable);
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON on the wire");
+        assert_eq!(value["type"], "turn_complete", "{json}");
+        assert_eq!(value["outcome"]["status"], "aborted", "{json}");
+        assert!(
+            value["outcome"]["reason"]
+                .as_str()
+                .is_some_and(|r| r.contains("nope")),
+            "the cause must survive, not be swallowed: {json}"
+        );
+        assert!(
+            unencodable.is_some_and(|err| err.contains("nope")),
+            "the failure must be reportable, not merely papered over on the wire"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_frame_encodes_unchanged() {
+        let (json, unencodable) = encode_or_abort(&ServerFrame::TurnComplete {
+            outcome: TurnOutcomeWire::Completed {
+                text: "done".to_string(),
+                cost_usd: 0.5,
+            },
+        });
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["outcome"]["text"], "done");
+        assert_eq!(value["outcome"]["cost_usd"], 0.5);
+        assert!(unencodable.is_none(), "a clean encode reports no failure");
+    }
+
+    #[test]
+    fn zero_reverse_request_deadline_is_refused() {
+        // A 0 ms deadline expires before the host could possibly answer, so
+        // every turn would fail on its first reverse request.
+        assert_eq!(validate_reverse_request_timeout(0), None);
+    }
+
+    #[test]
+    fn reverse_request_deadline_is_clamped_to_the_ceiling() {
+        assert_eq!(
+            validate_reverse_request_timeout(50),
+            Some(Duration::from_millis(50))
+        );
+        assert_eq!(
+            validate_reverse_request_timeout(300_000),
+            Some(Duration::from_secs(300)),
+            "the default is expressible from the wire"
+        );
+        assert_eq!(
+            validate_reverse_request_timeout(MAX_REVERSE_REQUEST_TIMEOUT.as_millis() as u64),
+            Some(MAX_REVERSE_REQUEST_TIMEOUT)
+        );
+        assert_eq!(
+            validate_reverse_request_timeout(u64::MAX),
+            Some(MAX_REVERSE_REQUEST_TIMEOUT),
+            "a caller must not be able to restore the unbounded wait the \
+             deadline exists to remove"
+        );
+    }
+}

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
 //! The HTTP/SSE transport over [`Session`].
 //!
 //! Endpoints (all under a bearer token except `/healthz`):
@@ -5,18 +8,29 @@
 //! | Method + path | Purpose |
 //! |---|---|
 //! | `GET /healthz` | liveness |
-//! | `POST /v1/turns` | start a turn ([`TurnRequest`] body) → `{ "turn_id": … }` |
+//! | `GET /v1/metrics` | counters ([`crate::observe::Snapshot`]) — authenticated, pull-only |
+//! | `POST /v1/turns` | start a turn (`TurnRequest` body) → `{ "turn_id": … }` |
 //! | `GET /v1/turns/{id}/events` | SSE stream of [`ServerFrame`]s until `turn_complete` |
-//! | `POST /v1/turns/{id}/tool-result` | answer a `tool_request` ([`ToolResultIn`]) |
-//! | `POST /v1/turns/{id}/provider-result` | answer a `provider_request` ([`ProviderResultIn`]) |
+//! | `POST /v1/turns/{id}/tool-result` | answer a `tool_request` (`ToolResultIn`) |
+//! | `POST /v1/turns/{id}/provider-result` | answer a `provider_request` (`ProviderResultIn`) |
 //! | `POST /v1/turns/{id}/cancel` | end an in-flight turn → `{ "status": "cancelled" }` |
 //!
 //! Any other method on one of those paths is a `405` carrying `Allow`; any
-//! other path is a `404`.
+//! other path is a `404`. The handlers themselves live in `src/routes.rs`; this
+//! module is the transport — listener, connection fold, turn registry, throttle.
 //!
 //! The SSE stream is the engine → host direction; the two result POSTs are the
 //! host → engine direction. Together they are the reverse tool-call protocol —
 //! the engine never runs a model or tool call itself.
+//!
+//! # Every connection produces exactly one record
+//!
+//! [`handle_conn`] is a fold, not a router: it opens a `RequestRecord` before
+//! the first byte is parsed, delegates to [`route`], and emits the terminal
+//! record on the way out — including when the peer hung up unanswered, and
+//! including when the connection failed. The router's sixteen exits do not know
+//! a record exists. See `src/observe/record.rs` for why that indirection is
+//! load-bearing rather than decorative.
 //!
 //! # A stream is a subscription, not a fire-and-forget
 //!
@@ -57,24 +71,20 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::Duration;
 
 use rand::Rng as _;
-use serde::{Deserialize, Serialize};
-use stella_core::{BudgetGuard, EngineConfig};
-use stella_protocol::{BudgetMode, CompletionMessage, ToolSchema};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::accept::{self, AcceptAction, AcceptBackoff};
-use crate::frame::{
-    ProviderOutcomeIn, ProviderResultIn, ServerFrame, ToolResultIn, TurnOutcomeWire,
+use crate::http::{BodyOutcome, ReadOutcome, discard_body, read_body, read_head};
+use crate::observe::event::{
+    AcceptKind, RefusalReason, RequestId, Route, ServeEvent, ShutdownReason, TurnRef, millis,
 };
-use crate::http::{
-    BodyOutcome, ReadOutcome, Request, discard_body, read_body, read_head, write_json,
-    write_json_with_headers, write_sse_frame, write_sse_head,
-};
+use crate::observe::record::{RequestRecord, Responder};
+use crate::observe::{Metrics, SharedObserver};
 use crate::pending::Pending;
-use crate::session::{Session, SessionSpec};
+use crate::routes::{self, error_body};
+use crate::session::Session;
 
-/// How to bind and authenticate the server.
+/// How to bind, authenticate, and observe the server.
 pub struct ServeConfig {
     /// Address to bind. `127.0.0.1:0` picks a free loopback port (tests); a
     /// containerized deployment binds `0.0.0.0:<port>`.
@@ -83,88 +93,28 @@ pub struct ServeConfig {
     /// the auth gate — the server may bind a non-loopback address behind the
     /// host's private network.
     pub token: String,
+    /// Where boundary events go. `crate::observe::standard()` is the production
+    /// wiring (counters + a JSONL sink on stderr); tests substitute a
+    /// `Capture` so they can assert on typed events.
+    pub observer: SharedObserver,
+    /// The counters `GET /v1/metrics` reports. Must be the same `Metrics` that
+    /// is inside `observer`, or the endpoint reports zeros while the log looks
+    /// healthy — [`ServeConfig::new`] wires both correctly.
+    pub metrics: Arc<Metrics>,
 }
 
-/// Body of `POST /v1/turns`. The host owns prompt assembly, model selection, and
-/// the tool set; engine knobs are optional overrides on top of the defaults.
-#[derive(Debug, Deserialize)]
-struct TurnRequest {
-    provider_id: String,
-    #[serde(default)]
-    tools: Vec<ToolSchema>,
-    messages: Vec<CompletionMessage>,
-    #[serde(default)]
-    budget: BudgetSpec,
-    #[serde(default)]
-    max_steps: Option<usize>,
-    /// Per-reverse-request deadline override, in milliseconds. Omitted means
-    /// [`SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT`].
-    #[serde(default)]
-    reverse_request_timeout_ms: Option<u64>,
-}
-
-/// Spend policy for a turn — the serializable projection of a [`BudgetGuard`].
-#[derive(Debug, Deserialize)]
-struct BudgetSpec {
-    #[serde(default = "budget_mode_off")]
-    mode: BudgetMode,
-    #[serde(default)]
-    turn_limit_usd: Option<f64>,
-    #[serde(default)]
-    session_limit_usd: Option<f64>,
-}
-
-impl Default for BudgetSpec {
-    fn default() -> Self {
+impl ServeConfig {
+    /// The production wiring: bind, token, and the standard observability stack.
+    #[must_use]
+    pub fn new(bind: SocketAddr, token: String) -> Self {
+        let (observer, metrics) = crate::observe::standard();
         Self {
-            mode: BudgetMode::Off,
-            turn_limit_usd: None,
-            session_limit_usd: None,
+            bind,
+            token,
+            observer,
+            metrics,
         }
     }
-}
-
-fn budget_mode_off() -> BudgetMode {
-    BudgetMode::Off
-}
-
-/// Response to `POST /v1/turns`.
-#[derive(Debug, Serialize)]
-struct TurnCreated<'a> {
-    turn_id: &'a str,
-}
-
-/// Ceiling on a host-supplied [`TurnRequest::max_steps`].
-///
-/// The step cap is the engine's belt-and-suspenders backstop against a turn
-/// that never terminates, and the host also supplies the budget mode (which may
-/// be `Off`), so an unclamped `max_steps` lets a caller remove the last bound on
-/// a turn that already holds an OS thread. `EngineConfig::default` uses 200;
-/// 10 000 is fifty times that — far above any turn a real agentic task runs,
-/// while still terminating in bounded time.
-const MAX_SERVED_STEPS: usize = 10_000;
-
-/// Validate a host-supplied step cap: `None` when it is unusable (`0` produces
-/// a zero-iteration turn that aborts with the misleading "reached the step cap
-/// (0)"), otherwise the value clamped down to [`MAX_SERVED_STEPS`].
-fn validate_max_steps(requested: usize) -> Option<usize> {
-    (requested > 0).then(|| requested.min(MAX_SERVED_STEPS))
-}
-
-/// Ceiling on a host-supplied reverse-request deadline: one hour.
-///
-/// Same reasoning as [`MAX_SERVED_STEPS`]. The deadline is what bounds a turn
-/// holding an OS thread on a host that never answers, so letting a caller set it
-/// to `u64::MAX` would hand back the unbounded wait it exists to remove. An hour
-/// is far past any legitimate model call or tool run.
-const MAX_REVERSE_REQUEST_TIMEOUT: Duration = Duration::from_secs(3600);
-
-/// Validate a host-supplied reverse-request deadline: `None` when it is unusable
-/// (`0` would expire every reverse request before the host could possibly
-/// answer, making the turn fail rather than run), otherwise clamped down to
-/// [`MAX_REVERSE_REQUEST_TIMEOUT`].
-fn validate_reverse_request_timeout(requested_ms: u64) -> Option<Duration> {
-    (requested_ms > 0).then(|| Duration::from_millis(requested_ms).min(MAX_REVERSE_REQUEST_TIMEOUT))
 }
 
 /// Ceiling on turns registered at once.
@@ -183,49 +133,52 @@ fn validate_reverse_request_timeout(requested_ms: u64) -> Option<Duration> {
 /// keeps it a queue — see there for why reclamation is driven by this cap
 /// rather than by a ceiling of its own.
 ///
-/// This is a const rather than a [`ServeConfig`] field on purpose, matching
-/// [`MAX_SERVED_STEPS`] and [`MAX_REVERSE_REQUEST_TIMEOUT`]: these are the
-/// server's own safety backstops, not host-tunable policy. A host that could
-/// raise the cap could remove it, which is exactly what it exists to prevent.
+/// This is a const rather than a [`ServeConfig`] field on purpose, matching the
+/// ceilings in `routes.rs`: these are the server's own safety backstops, not
+/// host-tunable policy. A host that could raise the cap could remove it, which
+/// is exactly what it exists to prevent.
 const MAX_LIVE_TURNS: usize = 32;
-
-/// How long a rejected caller is told to wait before retrying, in seconds.
-///
-/// Turns end when the host finishes streaming them, so the queue drains on the
-/// order of a turn's length; 5 seconds is short enough to keep a well-behaved
-/// host responsive without inviting a tight retry loop.
-const RETRY_AFTER_SECS: &str = "5";
 
 /// One registered turn. `pending` answers reverse requests (shared, always
 /// available); `session` is taken exactly once by the SSE stream.
-struct Entry {
+pub(crate) struct Entry {
     /// Registration order, so reclamation can name the *oldest* abandoned turn.
     ///
     /// Deliberately not derived from the turn id: ids are 128 random bits (see
     /// [`new_turn_id`]) precisely so that nothing can be inferred from one, and
     /// that includes age. This counter is internal and never leaves the process.
     seq: u64,
-    pending: Pending,
-    session: Mutex<Option<Session>>,
+    pub(crate) pending: Pending,
+    pub(crate) session: Mutex<Option<Session>>,
 }
 
 /// Shared server state across connections.
-struct ServerState {
+pub(crate) struct ServerState {
     token: String,
     turns: Mutex<HashMap<String, Arc<Entry>>>,
     /// Monotonic source of [`Entry::seq`]. Registration ordering only — the
     /// turn id is random and owes nothing to this.
     counter: AtomicU64,
     unauthorized: Mutex<TokenBucket>,
+    observer: SharedObserver,
+    metrics: Arc<Metrics>,
 }
 
 impl ServerState {
-    fn turns(&self) -> MutexGuard<'_, HashMap<String, Arc<Entry>>> {
+    pub(crate) fn turns(&self) -> MutexGuard<'_, HashMap<String, Arc<Entry>>> {
         self.turns.lock().unwrap_or_else(|p| p.into_inner())
     }
 
-    fn lookup(&self, id: &str) -> Option<Arc<Entry>> {
+    pub(crate) fn lookup(&self, id: &str) -> Option<Arc<Entry>> {
         self.turns().get(id).cloned()
+    }
+
+    pub(crate) fn observer(&self) -> &SharedObserver {
+        &self.observer
+    }
+
+    pub(crate) fn metrics(&self) -> &Metrics {
+        &self.metrics
     }
 
     /// Admit a turn and hand back its id, or `None` when the server is at
@@ -238,39 +191,68 @@ impl ServerState {
     /// insert, so the cap could be exceeded by exactly the number of racing
     /// callers.
     ///
+    /// `start` receives the minted id: a session has to carry its own
+    /// [`TurnRef`] into every record it emits, and only this function — holding
+    /// the registry lock — can mint one.
+    ///
     /// The session is started by `start` *inside* the lock, and only once a slot
     /// is known to be free. `Session::start` is synchronous (it spawns a thread
     /// and returns), so holding the lock across it is sound — there is no await
     /// in this block. Starting it before the cap check would spawn, then
     /// immediately drop, a thread for every refused request, which hands a
     /// caller the very thread churn the cap exists to prevent.
-    fn register_turn(&self, start: impl FnOnce() -> Session) -> Option<String> {
-        let mut turns = self.turns();
-        reclaim_finished_unstreamed(&mut turns, MAX_LIVE_TURNS);
-        if turns.len() >= MAX_LIVE_TURNS {
-            return None;
-        }
-        let id = new_turn_id();
-        // Insert through the vacant entry rather than `insert`, which would
-        // *replace* on a collision: the displaced turn's `Session` would drop
-        // (cancelling a turn its owner is still using) and two callers would
-        // hold the same id. 128 random bits make this unreachable in practice;
-        // going through the entry API makes it unreachable by construction, so
-        // the guarantee does not rest on the id width alone. Refusing is
-        // fail-closed — the caller renders it as the cap's 429, which is the
-        // wrong reason for the right answer, and is preferable to either
-        // silently cancelling a live turn or panicking a request thread.
-        let slot = match turns.entry(id.clone()) {
-            hash_map::Entry::Occupied(_) => return None,
-            hash_map::Entry::Vacant(slot) => slot,
+    pub(crate) fn register_turn(&self, start: impl FnOnce(&str) -> Session) -> Option<String> {
+        let outcome = {
+            let mut turns = self.turns();
+            reclaim_finished_unstreamed(&mut turns, MAX_LIVE_TURNS, &self.observer);
+            if turns.len() >= MAX_LIVE_TURNS {
+                Err((RefusalReason::AtCapacity, turns.len()))
+            } else {
+                let id = new_turn_id();
+                // Insert through the vacant entry rather than `insert`, which
+                // would *replace* on a collision: the displaced turn's `Session`
+                // would drop (cancelling a turn its owner is still using) and
+                // two callers would hold the same id. 128 random bits make this
+                // unreachable in practice; going through the entry API makes it
+                // unreachable by construction, so the guarantee does not rest on
+                // the id width alone. Refusing is fail-closed — the caller
+                // renders it as the cap's 429, which is the wrong reason for the
+                // right answer, and is preferable to either silently cancelling
+                // a live turn or panicking a request thread. It is also the one
+                // refusal worth recording separately: if it ever fires, the RNG
+                // is the story.
+                match turns.entry(id.clone()) {
+                    hash_map::Entry::Occupied(_) => Err((RefusalReason::IdCollision, turns.len())),
+                    hash_map::Entry::Vacant(slot) => {
+                        let session = start(&id);
+                        slot.insert(Arc::new(Entry {
+                            seq: self.counter.fetch_add(1, Ordering::Relaxed),
+                            pending: session.pending(),
+                            session: Mutex::new(Some(session)),
+                        }));
+                        Ok(id)
+                    }
+                }
+            }
         };
-        let session = start();
-        slot.insert(Arc::new(Entry {
-            seq: self.counter.fetch_add(1, Ordering::Relaxed),
-            pending: session.pending(),
-            session: Mutex::new(Some(session)),
-        }));
-        Some(id)
+        // Emitted outside the registry lock: an observer is caller-supplied and
+        // may do I/O, and holding the one lock every route contends on across
+        // someone else's `write` is how a log sink becomes a latency spike.
+        let live_turns = self.turns().len();
+        match outcome {
+            Ok(id) => {
+                self.observer.emit(&ServeEvent::TurnCreated {
+                    turn: TurnRef::new(&id),
+                    live_turns,
+                });
+                Some(id)
+            }
+            Err((reason, _)) => {
+                self.observer
+                    .emit(&ServeEvent::TurnRefused { reason, live_turns });
+                None
+            }
+        }
     }
 
     /// How long this 401 should be held before it is answered. `Duration::ZERO`
@@ -307,6 +289,10 @@ impl ServerState {
 /// only dropped when its slot is the difference between admitting the next turn
 /// and answering `429`. A reclaimed id answers an honest `404`.
 ///
+/// Every eviction is reported ([`ServeEvent::TurnReclaimed`]), with the count of
+/// frames nobody ever read. This used to be a silent `HashMap::remove`, which
+/// made a host that abandons turns indistinguishable from one that does not.
+///
 /// Lock order is registry → session, the same direction `handle_events` uses
 /// (its registry lookup releases the registry lock before it takes the session
 /// slot). This function is the one place that holds *both*, and it never blocks
@@ -321,7 +307,11 @@ impl ServerState {
 /// Bounding that is a backpressure change in `Session`, not a registry one.
 /// What is bounded here is the count — at most [`MAX_LIVE_TURNS`] turns' worth
 /// of buffered frames can be pinned at once, instead of one per create forever.
-fn reclaim_finished_unstreamed(turns: &mut HashMap<String, Arc<Entry>>, target: usize) {
+fn reclaim_finished_unstreamed(
+    turns: &mut HashMap<String, Arc<Entry>>,
+    target: usize,
+    observer: &SharedObserver,
+) {
     // Below the target there is nothing to make room for, so the common path
     // costs one length check and allocates nothing.
     if turns.len() < target {
@@ -357,7 +347,23 @@ fn reclaim_finished_unstreamed(turns: &mut HashMap<String, Arc<Entry>>, target: 
         .map(|(_, id)| id.to_string())
         .collect();
     for id in doomed {
+        // Count what is being thrown away *before* removing it: the entry owns
+        // the buffered frames, so after the remove there is nothing left to ask.
+        let buffered_frames = turns
+            .get(&id)
+            .map_or(0, |entry| match entry.session.try_lock() {
+                Ok(session) => session.as_ref().map_or(0, Session::buffered_frames),
+                Err(TryLockError::WouldBlock) => 0,
+                Err(TryLockError::Poisoned(poisoned)) => poisoned
+                    .into_inner()
+                    .as_ref()
+                    .map_or(0, Session::buffered_frames),
+            });
         turns.remove(&id);
+        observer.emit(&ServeEvent::TurnReclaimed {
+            turn: TurnRef::new(&id),
+            buffered_frames,
+        });
     }
 }
 
@@ -420,7 +426,8 @@ impl TokenBucket {
 /// listener that is structurally unusable — or one that has accepted nothing for
 /// the whole give-up streak — returns. `src/accept.rs` holds the full
 /// classification and the reasoning; `stella-observatory` applies the same policy
-/// from its own copy.
+/// from its own copy, and the two files are guarded byte-identical, so the
+/// reporting added here lives at the call site rather than in that module.
 ///
 /// # Operational limits
 ///
@@ -453,20 +460,34 @@ impl TokenBucket {
 ///
 /// Reverse requests *are* bounded (see [`SessionSpec::reverse_request_timeout`]),
 /// and a turn can be ended early with `POST /v1/turns/{id}/cancel`.
+///
+/// [`SessionSpec::reverse_request_timeout`]: crate::SessionSpec::reverse_request_timeout
 pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> std::io::Result<()> {
     let listener = TcpListener::bind(config.bind).await?;
-    on_ready(listener.local_addr()?);
+    let bound = listener.local_addr()?;
     let state = Arc::new(ServerState {
         token: config.token,
         turns: Mutex::new(HashMap::new()),
         counter: AtomicU64::new(0),
         unauthorized: Mutex::new(TokenBucket::new()),
+        observer: config.observer,
+        metrics: config.metrics,
     });
+    state.observer.emit(&ServeEvent::Listening {
+        addr: bound.to_string(),
+    });
+    on_ready(bound);
     let mut backoff = AcceptBackoff::new();
+    // Mirrors `AcceptBackoff`'s own streak. Kept here rather than exposed from
+    // `accept.rs` because that file is guarded byte-identical against
+    // `stella-observatory`'s copy — reporting is this server's concern, not the
+    // shared policy's.
+    let mut streak = 0_u32;
     loop {
         let stream = match listener.accept().await {
             Ok((stream, _)) => {
                 backoff.succeeded();
+                streak = 0;
                 stream
             }
             Err(err) => match accept::classify(&err) {
@@ -474,18 +495,37 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
                 // listener is fine, and this cannot spin (see `accept`).
                 AcceptAction::Retry => {
                     backoff.succeeded();
+                    streak = 0;
                     continue;
                 }
                 // Exhaustion, or a condition `io::ErrorKind` cannot name. Sleep
                 // so it cannot busy-loop, and give up if it never clears.
-                AcceptAction::Backoff => match backoff.next_delay() {
-                    Some(delay) => {
-                        tokio::time::sleep(delay).await;
-                        continue;
+                AcceptAction::Backoff => {
+                    streak += 1;
+                    let kind = accept_kind(&err);
+                    match backoff.next_delay() {
+                        Some(delay) => {
+                            state.observer.emit(&ServeEvent::AcceptBackoff {
+                                kind,
+                                delay_ms: millis(delay),
+                                streak,
+                            });
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        }
+                        None => {
+                            state
+                                .observer
+                                .emit(&ServeEvent::AcceptGaveUp { kind, streak });
+                            shutting_down(&state);
+                            return Err(err);
+                        }
                     }
-                    None => return Err(err),
-                },
-                AcceptAction::Fatal => return Err(err),
+                }
+                AcceptAction::Fatal => {
+                    shutting_down(&state);
+                    return Err(err);
+                }
             },
         };
         // Nagle off. Every frame on this wire gates the next engine step — a
@@ -495,15 +535,61 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
         let _ = stream.set_nodelay(true);
         let state = Arc::clone(&state);
         // Per-connection errors (client hangup, bad request) stay local to the
-        // connection; the accept loop keeps serving.
+        // connection; the accept loop keeps serving. The error is no longer
+        // discarded — `RequestRecord::close` names it before this returns.
         tokio::spawn(async move {
             let _ = handle_conn(stream, state).await;
         });
     }
 }
 
-/// Serve one connection: read the head, authenticate, then — and only then —
-/// read the body and route.
+/// Which exhaustion class an accept error belongs to, mirroring `accept.rs`'s
+/// own split without modifying that (drift-guarded) file.
+fn accept_kind(err: &std::io::Error) -> AcceptKind {
+    match err.kind() {
+        std::io::ErrorKind::OutOfMemory => AcceptKind::Exhaustion,
+        // EMFILE/ENFILE/ENOBUFS have no `ErrorKind`, so they land here too —
+        // "unnameable" is the honest label for what we can actually tell.
+        _ => AcceptKind::Unnameable,
+    }
+}
+
+fn shutting_down(state: &Arc<ServerState>) {
+    state.observer.emit(&ServeEvent::ShuttingDown {
+        reason: ShutdownReason::ListenerFailed,
+        live_turns: state.turns().len(),
+    });
+}
+
+/// Serve one connection, and report it exactly once.
+///
+/// The record is opened before the head is read and closed after the router
+/// returns, so there is no path — malformed request, oversized head, timeout,
+/// silent hangup, I/O failure mid-response — that produces no record. That is
+/// the whole reason [`route`] exists as a separate function: distributing
+/// "remember to report" across its sixteen exits is one refactor away from
+/// being silently false, which is exactly how the PROOF rail (#901) shipped a
+/// surface that reported only on the happy path.
+async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
+    let mut record = RequestRecord::opening(RequestId::generate());
+    // Read the head first so the peer's correlation id can be adopted, but note
+    // the record already exists: a peer that never completes a head still gets
+    // one, with the generated id and a `status: None`.
+    let head = read_head(&mut stream).await;
+    if let Ok(ReadOutcome::Request(req)) = &head
+        && let Some(supplied) = req.header("x-request-id").and_then(RequestId::from_header)
+    {
+        record.adopt_request_id(supplied);
+    }
+    let mut responder = Responder::new(&mut stream, record.request_id().clone());
+    let outcome = route(&mut responder, &mut record, &state, head).await;
+    let wrote = responder.wrote();
+    record.close(state.observer(), wrote, &outcome);
+    outcome
+}
+
+/// Route one request: authenticate on the head, then — and only then — read the
+/// body and dispatch.
 ///
 /// The two-phase read is the whole point of the ordering here. Buffering the
 /// body first meant an *unauthenticated* peer could make the server hold up to
@@ -513,52 +599,66 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
 /// request costs one 8 KiB drain buffer. The body is still taken off the socket
 /// before the response is written: closing with unread bytes in flight makes the
 /// kernel RST, and a peer that gets an RST mid-send never reads its 401.
-async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io::Result<()> {
-    let mut req = match read_head(&mut stream).await? {
+///
+/// Knows nothing about records beyond filling in what it learns. Its caller owns
+/// the reporting.
+async fn route(
+    res: &mut Responder<'_>,
+    record: &mut RequestRecord,
+    state: &Arc<ServerState>,
+    head: std::io::Result<ReadOutcome>,
+) -> std::io::Result<()> {
+    let mut req = match head? {
         ReadOutcome::Request(req) => req,
-        // A peer that never sent anything is owed nothing.
+        // A peer that never sent anything is owed nothing — but it is still
+        // recorded, as a request with no status.
         ReadOutcome::Hangup => return Ok(()),
         ReadOutcome::TooLarge => {
-            return write_json(
-                &mut stream,
-                "413 Payload Too Large",
-                &error_body("request exceeded the server's size limit"),
-            )
-            .await;
+            return res
+                .json(
+                    "413 Payload Too Large",
+                    &error_body("request exceeded the server's size limit"),
+                )
+                .await;
         }
         ReadOutcome::Malformed => {
-            return write_json(
-                &mut stream,
-                "400 Bad Request",
-                &error_body("malformed HTTP request"),
-            )
-            .await;
+            return res
+                .json("400 Bad Request", &error_body("malformed HTTP request"))
+                .await;
         }
         ReadOutcome::UnsupportedTransferEncoding => {
-            return write_json(
-                &mut stream,
-                "501 Not Implemented",
-                &error_body(
-                    "chunked transfer-encoding is not supported; send a Content-Length body",
-                ),
-            )
-            .await;
+            return res
+                .json(
+                    "501 Not Implemented",
+                    &error_body(
+                        "chunked transfer-encoding is not supported; send a Content-Length body",
+                    ),
+                )
+                .await;
         }
         ReadOutcome::Timeout => {
-            return write_json(
-                &mut stream,
-                "408 Request Timeout",
-                &error_body("request was not completed in time"),
-            )
-            .await;
+            return res
+                .json(
+                    "408 Request Timeout",
+                    &error_body("request was not completed in time"),
+                )
+                .await;
         }
     };
+    record.set_method(&req.method);
+
     let path = req.path.split('?').next().unwrap_or(&req.path).to_string();
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let (route, turn_id) = classify(&segs);
+    record.set_route(route);
+    let turn_id = turn_id.map(str::to_string);
+    if let Some(id) = turn_id.as_deref() {
+        record.set_turn(id);
+    }
 
-    if req.method == "GET" && segs.as_slice() == ["healthz"] {
-        discard_body(&mut stream, &mut req).await;
-        return write_json(&mut stream, "200 OK", br#"{"status":"ok"}"#).await;
+    if route == Route::Healthz && req.method == "GET" {
+        discard_body(res.stream_mut(), &mut req).await;
+        return routes::handle_health(res).await;
     }
     // Compared in constant time: `==` on a `&str` stops at the first differing
     // byte, which leaks the shared secret one byte at a time to a caller that
@@ -569,175 +669,119 @@ async fn handle_conn(mut stream: TcpStream, state: Arc<ServerState>) -> std::io:
         None => false,
     };
     if !authorized {
-        discard_body(&mut stream, &mut req).await;
+        discard_body(res.stream_mut(), &mut req).await;
         // Rate-limited by holding the response, never by changing it: the
         // body and status a guesser sees are identical whether or not the
         // bucket was empty, so the throttle leaks nothing about its own state.
         // The sleep is `tokio::time::sleep` on this connection's task, so a
-        // held 401 costs one task, not a runtime thread.
+        // held 401 costs one task, not a runtime thread. `held_ms` is recorded
+        // because that asymmetry — invisible outside, visible inside — is
+        // precisely what makes a sustained guess identifiable.
         let delay = state.unauthorized_delay();
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        return write_json(
-            &mut stream,
-            "401 Unauthorized",
-            br#"{"error":"missing or invalid bearer token"}"#,
-        )
-        .await;
+        state.observer().emit(&ServeEvent::Unauthorized {
+            request_id: record.request_id().clone(),
+            route,
+            held_ms: millis(delay),
+        });
+        return res
+            .json(
+                "401 Unauthorized",
+                br#"{"error":"missing or invalid bearer token"}"#,
+            )
+            .await;
     }
 
     // Routes that carry no body are matched before the body is read, so a GET
     // with a stray `Content-Length` is drained rather than parsed.
-    match (req.method.as_str(), segs.as_slice()) {
-        ("GET", ["v1", "turns", id, "events"]) => {
-            let id = (*id).to_string();
-            discard_body(&mut stream, &mut req).await;
-            return handle_events(&mut stream, &state, &id).await;
+    match (req.method.as_str(), route) {
+        ("GET", Route::Metrics) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_metrics(res, state).await;
         }
-        ("POST", ["v1", "turns", id, "cancel"]) => {
-            let id = (*id).to_string();
-            discard_body(&mut stream, &mut req).await;
-            return handle_cancel(&mut stream, &state, &id).await;
+        ("GET", Route::TurnEvents) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_events(
+                res,
+                record,
+                state,
+                turn_id.as_deref().unwrap_or_default(),
+            )
+            .await;
+        }
+        ("POST", Route::TurnCancel) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_cancel(res, state, turn_id.as_deref().unwrap_or_default()).await;
         }
         // The body-bearing routes fall through to the read below.
-        ("POST", ["v1", "turns"] | ["v1", "turns", _, "tool-result" | "provider-result"]) => {}
+        ("POST", Route::TurnsCreate | Route::TurnToolResult | Route::TurnProviderResult) => {}
+        (_, Route::Unrouted) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return res.json("404 Not Found", br#"{"error":"not found"}"#).await;
+        }
         // A known resource reached with the wrong method is a 405 naming what
         // it does accept, not a 404 claiming the route does not exist — the
         // difference between "you typed the path wrong" and "you used the
         // wrong verb" is the whole diagnostic value of the status code.
-        (_, ["healthz"]) => return method_not_allowed(&mut stream, &mut req, "GET").await,
-        (_, ["v1", "turns"]) => return method_not_allowed(&mut stream, &mut req, "POST").await,
-        (_, ["v1", "turns", _, "events"]) => {
-            return method_not_allowed(&mut stream, &mut req, "GET").await;
-        }
-        (
-            _,
-            [
-                "v1",
-                "turns",
-                _,
-                "tool-result" | "provider-result" | "cancel",
-            ],
-        ) => {
-            return method_not_allowed(&mut stream, &mut req, "POST").await;
-        }
-        _ => {
-            discard_body(&mut stream, &mut req).await;
-            return write_json(&mut stream, "404 Not Found", br#"{"error":"not found"}"#).await;
-        }
+        (_, known) => return routes::method_not_allowed(res, &mut req, allowed(known)).await,
     }
 
-    if let BodyOutcome::Timeout = read_body(&mut stream, &mut req).await? {
-        return write_json(
-            &mut stream,
-            "408 Request Timeout",
-            &error_body("request was not completed in time"),
-        )
-        .await;
+    if let BodyOutcome::Timeout = read_body(res.stream_mut(), &mut req).await? {
+        return res
+            .json(
+                "408 Request Timeout",
+                &error_body("request was not completed in time"),
+            )
+            .await;
     }
+    record.set_bytes_in(req.body.len() as u64);
 
-    match segs.as_slice() {
-        ["v1", "turns"] => handle_create(&mut stream, &state, &req.body).await,
-        ["v1", "turns", id, "tool-result"] => {
-            handle_tool_result(&mut stream, &state, id, &req.body).await
-        }
-        ["v1", "turns", id, "provider-result"] => {
-            handle_provider_result(&mut stream, &state, id, &req.body).await
+    let id = turn_id.as_deref().unwrap_or_default();
+    match route {
+        Route::TurnsCreate => routes::handle_create(res, state, &req.body).await,
+        Route::TurnToolResult => routes::handle_tool_result(res, state, id, &req.body).await,
+        Route::TurnProviderResult => {
+            routes::handle_provider_result(res, state, id, &req.body).await
         }
         // Unreachable: the match above admits exactly the three body-bearing
         // routes. Answering rather than panicking keeps a future edit that
         // widens that match from taking down a request thread.
-        _ => write_json(&mut stream, "404 Not Found", br#"{"error":"not found"}"#).await,
+        _ => res.json("404 Not Found", br#"{"error":"not found"}"#).await,
     }
 }
 
-/// `405` naming the methods this path accepts, per RFC 9110 §15.5.6 (the
-/// `Allow` header is mandatory on a 405 — a status that says "wrong verb"
-/// without saying which verb is right is half an answer).
-async fn method_not_allowed(
-    stream: &mut TcpStream,
-    req: &mut Request,
-    allow: &str,
-) -> std::io::Result<()> {
-    discard_body(stream, req).await;
-    write_json_with_headers(
-        stream,
-        "405 Method Not Allowed",
-        &[("Allow", allow)],
-        &error_body(&format!("method not allowed; this path accepts {allow}")),
-    )
-    .await
+/// Map a path to its route template and, where it has one, the turn id.
+///
+/// Classification is deliberately independent of the method, so a `405` records
+/// which resource was addressed rather than collapsing to "unrouted" — the
+/// difference between "you used the wrong verb on `/v1/turns`" and "you asked
+/// for a path that does not exist" is exactly what makes a record diagnostic.
+fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
+    match segs {
+        ["healthz"] => (Route::Healthz, None),
+        ["v1", "metrics"] => (Route::Metrics, None),
+        ["v1", "turns"] => (Route::TurnsCreate, None),
+        ["v1", "turns", id, "events"] => (Route::TurnEvents, Some(id)),
+        ["v1", "turns", id, "tool-result"] => (Route::TurnToolResult, Some(id)),
+        ["v1", "turns", id, "provider-result"] => (Route::TurnProviderResult, Some(id)),
+        ["v1", "turns", id, "cancel"] => (Route::TurnCancel, Some(id)),
+        _ => (Route::Unrouted, None),
+    }
 }
 
-async fn handle_create(
-    stream: &mut TcpStream,
-    state: &ServerState,
-    body: &[u8],
-) -> std::io::Result<()> {
-    let turn: TurnRequest = match serde_json::from_slice(body) {
-        Ok(turn) => turn,
-        Err(err) => {
-            return write_json(
-                stream,
-                "400 Bad Request",
-                &error_body(&format!("invalid turn request: {err}")),
-            )
-            .await;
-        }
-    };
-
-    let mut config = EngineConfig::default();
-    if let Some(max_steps) = turn.max_steps {
-        let Some(effective) = validate_max_steps(max_steps) else {
-            return write_json(
-                stream,
-                "400 Bad Request",
-                &error_body("max_steps must be at least 1"),
-            )
-            .await;
-        };
-        config.max_steps = effective;
+/// The `Allow` header value for a known route.
+fn allowed(route: Route) -> &'static str {
+    match route {
+        Route::Healthz | Route::Metrics | Route::TurnEvents => "GET",
+        Route::TurnsCreate
+        | Route::TurnToolResult
+        | Route::TurnProviderResult
+        | Route::TurnCancel => "POST",
+        // Never reached: `Unrouted` is answered as a 404 before this is called.
+        Route::Unrouted => "",
     }
-    let mut reverse_request_timeout = SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT;
-    if let Some(requested_ms) = turn.reverse_request_timeout_ms {
-        let Some(effective) = validate_reverse_request_timeout(requested_ms) else {
-            return write_json(
-                stream,
-                "400 Bad Request",
-                &error_body("reverse_request_timeout_ms must be at least 1"),
-            )
-            .await;
-        };
-        reverse_request_timeout = effective;
-    }
-    let spec = SessionSpec {
-        provider_id: turn.provider_id,
-        tools: turn.tools,
-        messages: turn.messages,
-        config,
-        budget: BudgetGuard::new(
-            turn.budget.mode,
-            turn.budget.turn_limit_usd,
-            turn.budget.session_limit_usd,
-        ),
-        reverse_request_timeout,
-    };
-
-    // Admission, reclamation and registration all happen under one lock hold
-    // inside `register_turn` — see there for why.
-    let Some(id) = state.register_turn(|| Session::start(spec)) else {
-        return write_json_with_headers(
-            stream,
-            "429 Too Many Requests",
-            &[("Retry-After", RETRY_AFTER_SECS)],
-            &error_body("too many live turns; retry after in-flight turns finish"),
-        )
-        .await;
-    };
-
-    let body = serde_json::to_vec(&TurnCreated { turn_id: &id }).unwrap_or_default();
-    write_json(stream, "200 OK", &body).await
 }
 
 /// Mint a turn id that cannot be guessed from another turn's id.
@@ -746,7 +790,8 @@ async fn handle_create(
 /// still the actual auth gate, but a sequential id makes every *other* live turn
 /// addressable to anyone who learns one — a turn id in a log line, an error
 /// report, or a proxy access log hands over the whole namespace. 128 bits from
-/// the OS CSPRNG removes that second, accidental way in.
+/// the OS CSPRNG removes that second, accidental way in. Records carry only a
+/// truncated [`TurnRef`], so this server's own log is not that leak either.
 fn new_turn_id() -> String {
     let mut bytes = [0_u8; 16];
     rand::rng().fill_bytes(&mut bytes);
@@ -757,218 +802,6 @@ fn new_turn_id() -> String {
         let _ = write!(id, "{byte:02x}");
     }
     id
-}
-
-async fn handle_events(
-    stream: &mut TcpStream,
-    state: &ServerState,
-    id: &str,
-) -> std::io::Result<()> {
-    let Some(entry) = state.lookup(id) else {
-        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
-    };
-    // Take the session out in its own scope so the (non-`Send`) mutex guard is
-    // dropped before any `.await` — the connection future must stay `Send`.
-    let taken = {
-        entry
-            .session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .take()
-    };
-    let mut session = match taken {
-        Some(session) => session,
-        None => {
-            return write_json(
-                stream,
-                "409 Conflict",
-                &error_body("events are already being streamed for this turn"),
-            )
-            .await;
-        }
-    };
-
-    // From here the session is out of the registry entry and owned by this
-    // connection, so every exit path must also drop the registry entry —
-    // otherwise a turn whose stream never opened lingers in the map forever.
-    if let Err(err) = write_sse_head(stream).await {
-        state.turns().remove(id);
-        return Err(err);
-    }
-    {
-        // Split so the frame loop can watch the *read* half while it waits.
-        // Without that, a host that vanishes mid-turn is only noticed at the
-        // next write — and the engine may be parked on a reverse request for
-        // the whole `reverse_request_timeout` (up to an hour) before it
-        // produces one. The turn would keep an OS thread and a registry slot
-        // for a client that is provably gone, and the host would be billed for
-        // whatever the engine went on to ask for. Watching for EOF turns that
-        // into a cancellation within one poll.
-        let (mut peer, mut out) = stream.split();
-        let mut scratch = [0_u8; 1024];
-        // A GET on a `Connection: close` stream has nothing left to send, so
-        // inbound bytes are a protocol violation. Tolerate a little (a client
-        // library that pipelines a probe) but never spin discarding an
-        // unbounded stream of them.
-        let mut stray = 0_usize;
-        const MAX_STRAY_BYTES: usize = 8 * 1024;
-        loop {
-            let frame = tokio::select! {
-                read = peer.read(&mut scratch) => match read {
-                    // EOF or a reset: the subscriber is gone. Stop streaming;
-                    // dropping `session` below cancels the turn.
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        stray += n;
-                        if stray > MAX_STRAY_BYTES {
-                            break;
-                        }
-                        continue;
-                    }
-                },
-                frame = session.next_frame() => match frame {
-                    Some(frame) => frame,
-                    None => break,
-                },
-            };
-            let done = matches!(frame, ServerFrame::TurnComplete { .. });
-            if write_sse_frame(&mut out, &sse_json(&frame)).await.is_err() {
-                break;
-            }
-            if done {
-                break;
-            }
-        }
-    }
-    // Drop the session *before* the socket teardown: `Drop for Session`
-    // cancels the turn, so a stream that ended early (client gone, stray
-    // bytes) releases the engine thread now rather than at the end of scope.
-    drop(session);
-    // The turn is finished streaming; drop it so its thread and registry entry
-    // are reclaimed.
-    state.turns().remove(id);
-    stream.shutdown().await
-}
-
-/// Render one frame as the JSON payload of an SSE `data:` line.
-///
-/// Every [`ServerFrame`] is built from serde-clean types, so the failure arm is
-/// unreachable in practice — but "unreachable" is not "harmless". It used to
-/// emit `{}`, a frame with no `type` at all: a host would skip it silently, and
-/// if the frame it replaced was the terminal `TurnComplete`, the stream would
-/// simply end with the turn's outcome and settled cost never reported. A
-/// synthesized terminal frame keeps the stream's contract — every turn ends with
-/// exactly one `turn_complete` — and names the cause instead of losing it.
-fn sse_json(frame: &ServerFrame) -> String {
-    encode_or_abort(frame)
-}
-
-fn encode_or_abort<T: Serialize>(value: &T) -> String {
-    match serde_json::to_string(value) {
-        Ok(json) => json,
-        Err(err) => serde_json::to_string(&ServerFrame::TurnComplete {
-            outcome: TurnOutcomeWire::Aborted {
-                reason: format!("the engine produced a frame the server could not encode: {err}"),
-                cost_usd: 0.0,
-            },
-        })
-        // The fallback's fallback: a literal that is valid on the wire, so the
-        // stream still terminates with a `turn_complete` no matter what.
-        .unwrap_or_else(|_| {
-            r#"{"type":"turn_complete","outcome":{"status":"aborted","reason":"frame encoding failed","cost_usd":0.0}}"#
-                .to_string()
-        }),
-    }
-}
-
-async fn handle_tool_result(
-    stream: &mut TcpStream,
-    state: &ServerState,
-    id: &str,
-    body: &[u8],
-) -> std::io::Result<()> {
-    let Some(entry) = state.lookup(id) else {
-        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
-    };
-    let result: ToolResultIn = match serde_json::from_slice(body) {
-        Ok(result) => result,
-        Err(err) => {
-            return write_json(
-                stream,
-                "400 Bad Request",
-                &error_body(&format!("invalid tool result: {err}")),
-            )
-            .await;
-        }
-    };
-    match entry
-        .pending
-        .resolve_tool(&result.request_id, result.output)
-    {
-        Ok(()) => write_json(stream, "200 OK", br#"{"status":"ok"}"#).await,
-        Err(err) => write_json(stream, "409 Conflict", &error_body(&err.to_string())).await,
-    }
-}
-
-async fn handle_provider_result(
-    stream: &mut TcpStream,
-    state: &ServerState,
-    id: &str,
-    body: &[u8],
-) -> std::io::Result<()> {
-    let Some(entry) = state.lookup(id) else {
-        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
-    };
-    let posted: ProviderResultIn = match serde_json::from_slice(body) {
-        Ok(posted) => posted,
-        Err(err) => {
-            return write_json(
-                stream,
-                "400 Bad Request",
-                &error_body(&format!("invalid provider result: {err}")),
-            )
-            .await;
-        }
-    };
-    let result = match posted.outcome {
-        ProviderOutcomeIn::Ok { result } => Ok(result),
-        ProviderOutcomeIn::Error { error } => Err(error.into()),
-    };
-    match entry.pending.resolve_provider(&posted.request_id, result) {
-        Ok(()) => write_json(stream, "200 OK", br#"{"status":"ok"}"#).await,
-        Err(err) => write_json(stream, "409 Conflict", &error_body(&err.to_string())).await,
-    }
-}
-
-/// `POST /v1/turns/{id}/cancel` — end an in-flight turn.
-///
-/// Answers once the turn is *signalled*, not once it has unwound: the parked
-/// engine step wakes immediately, but the turn still needs a moment to produce
-/// its terminal frame, and a host streaming `/events` is the one that observes
-/// that. Blocking this response on it would deadlock a single-connection client.
-async fn handle_cancel(
-    stream: &mut TcpStream,
-    state: &ServerState,
-    id: &str,
-) -> std::io::Result<()> {
-    // Remove and signal, so a second cancel — or a late result POST — gets an
-    // honest 404 rather than silently doing nothing. Scoped so the (non-`Send`)
-    // guard is dropped before the await below.
-    let removed = { state.turns().remove(id) };
-    let Some(entry) = removed else {
-        return write_json(stream, "404 Not Found", &error_body("unknown turn")).await;
-    };
-    entry.pending.cancel();
-    // Dropping our `Arc` here is what reclaims a turn whose stream never opened:
-    // the registry no longer holds it, so this may be the last handle, and
-    // `Drop for Session` releases the engine thread. A turn that *is* streaming
-    // keeps its own handle and unwinds through `handle_events` as usual.
-    drop(entry);
-    write_json(stream, "200 OK", br#"{"status":"cancelled"}"#).await
-}
-
-fn error_body(message: &str) -> Vec<u8> {
-    serde_json::to_vec(&serde_json::json!({ "error": message })).unwrap_or_default()
 }
 
 /// Compare two secrets without an early exit, so the time taken does not depend
@@ -988,6 +821,11 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observe::Capture;
+    use crate::observe::event::ServeEvent;
+    use crate::session::SessionSpec;
+    use stella_core::{BudgetGuard, EngineConfig};
+    use stella_protocol::{BudgetMode, CompletionMessage};
 
     /// A brute-force run against the only credential this service has must
     /// stop being free after the burst. Driven over an injected `Instant` so
@@ -996,87 +834,56 @@ mod tests {
     fn sustained_401s_are_throttled_once_the_burst_is_spent() {
         let start = std::time::Instant::now();
         let mut bucket = TokenBucket::new();
-
-        for i in 0..UNAUTHORIZED_BURST as usize {
+        for attempt in 0..UNAUTHORIZED_BURST as usize {
             assert_eq!(
                 bucket.take(start),
                 Duration::ZERO,
-                "401 #{i} is within the burst and must not be delayed"
+                "attempt {attempt} is within the burst and must not be delayed"
             );
         }
         assert_eq!(
             bucket.take(start),
             UNAUTHORIZED_PENALTY,
-            "the first 401 past the burst pays the penalty"
+            "the first attempt past the burst is held"
+        );
+        // Half a second of refill at 2/sec is exactly one token.
+        assert_eq!(
+            bucket.take(start + Duration::from_millis(500)),
+            Duration::ZERO
         );
         assert_eq!(
-            bucket.take(start),
+            bucket.take(start + Duration::from_millis(500)),
             UNAUTHORIZED_PENALTY,
-            "and it keeps paying while the bucket is empty"
+            "and it is spent again immediately"
         );
+    }
 
-        // One second later the bucket has refilled by UNAUTHORIZED_REFILL_PER_SEC.
-        let later = start + Duration::from_secs(1);
-        for _ in 0..UNAUTHORIZED_REFILL_PER_SEC as usize {
+    #[test]
+    fn refill_is_capped_at_the_burst_size() {
+        let start = std::time::Instant::now();
+        let mut bucket = TokenBucket::new();
+        // An hour idle must not bank an hour of tokens.
+        let later = start + Duration::from_secs(3600);
+        for _ in 0..UNAUTHORIZED_BURST as usize {
             assert_eq!(bucket.take(later), Duration::ZERO);
         }
         assert_eq!(bucket.take(later), UNAUTHORIZED_PENALTY);
     }
 
-    /// The bucket must not bank credit indefinitely: an idle server does not
-    /// hand a later attacker an unbounded free run.
-    #[test]
-    fn refill_is_capped_at_the_burst_size() {
-        let start = std::time::Instant::now();
-        let mut bucket = TokenBucket::new();
-        for _ in 0..UNAUTHORIZED_BURST as usize {
-            assert_eq!(bucket.take(start), Duration::ZERO);
-        }
-        let much_later = start + Duration::from_secs(3600);
-        for i in 0..UNAUTHORIZED_BURST as usize {
-            assert_eq!(bucket.take(much_later), Duration::ZERO, "burst slot {i}");
-        }
-        assert_eq!(
-            bucket.take(much_later),
-            UNAUTHORIZED_PENALTY,
-            "an hour idle buys one burst, not an hour's worth of attempts"
-        );
-    }
-
-    #[test]
-    fn zero_steps_is_refused_rather_than_silently_accepted() {
-        // `for step in 0..0` runs no iterations and aborts with "reached the
-        // step cap (0)" — a turn that never called the model reporting the
-        // backstop that never fired.
-        assert_eq!(validate_max_steps(0), None);
-    }
-
-    #[test]
-    fn step_cap_is_clamped_to_the_ceiling() {
-        assert_eq!(validate_max_steps(1), Some(1));
-        assert_eq!(validate_max_steps(200), Some(200));
-        assert_eq!(validate_max_steps(MAX_SERVED_STEPS), Some(MAX_SERVED_STEPS));
-        assert_eq!(
-            validate_max_steps(MAX_SERVED_STEPS + 1),
-            Some(MAX_SERVED_STEPS)
-        );
-        assert_eq!(
-            validate_max_steps(usize::MAX),
-            Some(MAX_SERVED_STEPS),
-            "an unbounded step loop must not be reachable from the wire"
-        );
-    }
-
-    fn test_state() -> ServerState {
-        ServerState {
+    fn test_state() -> (ServerState, Arc<Capture>) {
+        let capture = Arc::new(Capture::new());
+        let state = ServerState {
             token: String::new(),
             turns: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(0),
             unauthorized: Mutex::new(TokenBucket::new()),
-        }
+            observer: capture.clone(),
+            metrics: Arc::new(Metrics::new()),
+        };
+        (state, capture)
     }
 
-    fn test_spec() -> SessionSpec {
+    fn test_spec(turn_id: &str) -> SessionSpec {
         SessionSpec {
             provider_id: "mock".to_string(),
             tools: Vec::new(),
@@ -1084,13 +891,15 @@ mod tests {
             config: EngineConfig::default(),
             budget: BudgetGuard::new(BudgetMode::Off, None, None),
             reverse_request_timeout: SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT,
+            turn: TurnRef::new(turn_id),
+            observer: crate::observe::null_observer(),
         }
     }
 
     /// A session that has already produced its terminal frame: cancelled
     /// before it can park, then waited on until its thread exits.
-    fn finished_session() -> Session {
-        let session = Session::start(test_spec());
+    fn finished_session(turn_id: &str) -> Session {
+        let session = Session::start(test_spec(turn_id));
         session.cancel();
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         while !session.is_finished() {
@@ -1110,7 +919,7 @@ mod tests {
     /// forever.
     #[test]
     fn a_finished_unstreamed_turn_is_reclaimed_to_admit_a_new_one() {
-        let state = test_state();
+        let (state, capture) = test_state();
         let ids: Vec<String> = (0..MAX_LIVE_TURNS)
             .map(|_| {
                 state
@@ -1138,6 +947,21 @@ mod tests {
             "only as many as needed are reclaimed — the second-oldest stays"
         );
         assert!(state.lookup(&next).is_some(), "the new turn is registered");
+
+        // The eviction is *reported*. It used to be a silent `HashMap::remove`,
+        // which is what made a host that abandons turns indistinguishable from
+        // one that does not.
+        let reclaimed = capture.find(|e| matches!(e, ServeEvent::TurnReclaimed { .. }));
+        assert!(
+            reclaimed.is_some(),
+            "reclaiming a turn must not be silent — that is the discarded work \
+             this dimension is scored on"
+        );
+        assert_eq!(
+            capture.count(|e| matches!(e, ServeEvent::TurnCreated { .. })),
+            MAX_LIVE_TURNS + 1,
+            "every admitted turn is recorded"
+        );
     }
 
     /// Reclamation must never touch a live turn: a still-running turn parked on
@@ -1145,9 +969,9 @@ mod tests {
     /// oldest entry in the registry.
     #[test]
     fn a_live_turn_is_never_reclaimed() {
-        let state = test_state();
+        let (state, _capture) = test_state();
         let live = state
-            .register_turn(|| Session::start(test_spec()))
+            .register_turn(|id| Session::start(test_spec(id)))
             .expect("the first turn is always admitted");
         for _ in 0..MAX_LIVE_TURNS {
             state
@@ -1165,93 +989,84 @@ mod tests {
 
     /// When nothing can be reclaimed, the cap holds: a registry full of *live*
     /// turns refuses the next one rather than dropping a turn out from under a
-    /// host that is still using it.
+    /// host that is still using it — and says so, because a 429 storm that
+    /// produces no record is one of the four situations #930 names.
     #[test]
     fn a_registry_full_of_live_turns_refuses_the_next() {
-        let state = test_state();
+        let (state, capture) = test_state();
         for _ in 0..MAX_LIVE_TURNS {
             state
-                .register_turn(|| Session::start(test_spec()))
+                .register_turn(|id| Session::start(test_spec(id)))
                 .expect("the registry has room");
         }
         assert!(
             state
-                .register_turn(|| Session::start(test_spec()))
+                .register_turn(|id| Session::start(test_spec(id)))
                 .is_none(),
             "no live turn may be reclaimed, so the cap must refuse"
         );
-    }
-
-    /// A value whose `Serialize` always fails, standing in for the frame
-    /// encoding failure that real [`ServerFrame`]s cannot produce. Without it
-    /// the fallback would be untestable — and an untested fallback on the one
-    /// path that carries a turn's outcome is how `{}` sat on the wire.
-    struct Unserializable;
-
-    impl Serialize for Unserializable {
-        fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
-            Err(serde::ser::Error::custom("nope"))
-        }
-    }
-
-    /// A frame that cannot be encoded must still leave the stream terminated:
-    /// the old `{}` fallback was a frame with no `type`, so a host skipped it
-    /// silently and — when the lost frame was the terminal one — never learned
-    /// the turn's outcome or its settled cost.
-    #[test]
-    fn an_unencodable_frame_becomes_a_terminal_aborted_frame_not_an_empty_object() {
-        let json = encode_or_abort(&Unserializable);
-        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON on the wire");
-        assert_eq!(value["type"], "turn_complete", "{json}");
-        assert_eq!(value["outcome"]["status"], "aborted", "{json}");
         assert!(
-            value["outcome"]["reason"]
-                .as_str()
-                .is_some_and(|r| r.contains("nope")),
-            "the cause must survive, not be swallowed: {json}"
+            capture
+                .find(|e| matches!(
+                    e,
+                    ServeEvent::TurnRefused {
+                        reason: RefusalReason::AtCapacity,
+                        ..
+                    }
+                ))
+                .is_some(),
+            "a refusal at capacity must be visible from outside the process"
         );
     }
 
+    /// A path is classified independently of its method, so a 405 still records
+    /// which resource was addressed.
     #[test]
-    fn an_ordinary_frame_encodes_unchanged() {
-        let json = sse_json(&ServerFrame::TurnComplete {
-            outcome: TurnOutcomeWire::Completed {
-                text: "done".to_string(),
-                cost_usd: 0.5,
-            },
-        });
-        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(value["outcome"]["text"], "done");
-        assert_eq!(value["outcome"]["cost_usd"], 0.5);
+    fn paths_classify_to_templates_and_surrender_their_turn_id() {
+        let split = |path: &'static str| -> Vec<&'static str> {
+            path.split('/').filter(|s| !s.is_empty()).collect()
+        };
+        assert_eq!(classify(&split("/healthz")), (Route::Healthz, None));
+        assert_eq!(classify(&split("/v1/metrics")), (Route::Metrics, None));
+        assert_eq!(classify(&split("/v1/turns")), (Route::TurnsCreate, None));
+        assert_eq!(
+            classify(&split("/v1/turns/turn-abc/events")),
+            (Route::TurnEvents, Some("turn-abc"))
+        );
+        assert_eq!(
+            classify(&split("/v1/turns/turn-abc/tool-result")),
+            (Route::TurnToolResult, Some("turn-abc"))
+        );
+        assert_eq!(
+            classify(&split("/v1/turns/turn-abc/provider-result")),
+            (Route::TurnProviderResult, Some("turn-abc"))
+        );
+        assert_eq!(
+            classify(&split("/v1/turns/turn-abc/cancel")),
+            (Route::TurnCancel, Some("turn-abc"))
+        );
+        assert_eq!(classify(&split("/nope")), (Route::Unrouted, None));
+        assert_eq!(classify(&split("/v1/turns/a/b/c")), (Route::Unrouted, None));
     }
 
+    /// Every routable path must name a verb in its `Allow` header, or a 405 is
+    /// half an answer.
     #[test]
-    fn zero_reverse_request_deadline_is_refused() {
-        // A 0 ms deadline expires before the host could possibly answer, so
-        // every turn would fail on its first reverse request.
-        assert_eq!(validate_reverse_request_timeout(0), None);
-    }
-
-    #[test]
-    fn reverse_request_deadline_is_clamped_to_the_ceiling() {
-        assert_eq!(
-            validate_reverse_request_timeout(50),
-            Some(Duration::from_millis(50))
-        );
-        assert_eq!(
-            validate_reverse_request_timeout(300_000),
-            Some(Duration::from_secs(300)),
-            "the default is expressible from the wire"
-        );
-        assert_eq!(
-            validate_reverse_request_timeout(MAX_REVERSE_REQUEST_TIMEOUT.as_millis() as u64),
-            Some(MAX_REVERSE_REQUEST_TIMEOUT)
-        );
-        assert_eq!(
-            validate_reverse_request_timeout(u64::MAX),
-            Some(MAX_REVERSE_REQUEST_TIMEOUT),
-            "a caller must not be able to restore the unbounded wait the \
-             deadline exists to remove"
-        );
+    fn every_known_route_names_an_allowed_method() {
+        for route in [
+            Route::Healthz,
+            Route::Metrics,
+            Route::TurnsCreate,
+            Route::TurnEvents,
+            Route::TurnToolResult,
+            Route::TurnProviderResult,
+            Route::TurnCancel,
+        ] {
+            assert!(
+                matches!(allowed(route), "GET" | "POST"),
+                "{} has no allowed method",
+                route.template()
+            );
+        }
     }
 }

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -14,7 +14,7 @@
 //! this without changing the transport.
 
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use stella_core::{BudgetGuard, Engine, EngineConfig};
 use stella_protocol::{
@@ -25,6 +25,9 @@ use tokio::sync::mpsc;
 
 use crate::error::ServeError;
 use crate::frame::{ServerFrame, TurnOutcomeWire};
+use crate::observe::SharedObserver;
+use crate::observe::event::{ServeEvent, SettledOutcome, TurnRef, TurnTally, millis};
+use crate::observe::tally::TallyFold;
 use crate::pending::Pending;
 use crate::remote::{
     DEFAULT_REVERSE_REQUEST_TIMEOUT, RemoteProvider, RemoteToolExecutor, TokioSleeper,
@@ -51,6 +54,15 @@ pub struct SessionSpec {
     /// reverse request from parking an OS thread forever. Defaults to
     /// [`SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT`].
     pub reverse_request_timeout: Duration,
+    /// This turn's truncated id, carried into every record the session emits.
+    ///
+    /// Supplied by the caller rather than derived here because only the turn
+    /// registry can mint an id, and it does so under the lock that admits the
+    /// turn — see `ServerState::register_turn`.
+    pub turn: TurnRef,
+    /// Where this session's boundary events go. `observe::null_observer()` for
+    /// callers using [`Session`] as a library type without a sink.
+    pub observer: SharedObserver,
 }
 
 impl SessionSpec {
@@ -77,12 +89,14 @@ impl Session {
     /// drives one code path either way.
     pub fn start(spec: SessionSpec) -> Session {
         let (frame_tx, frame_rx) = mpsc::unbounded_channel::<ServerFrame>();
-        let pending = Pending::default();
+        let pending = Pending::new(spec.observer.clone(), spec.turn.clone());
         // Fallible spawn on purpose: a host that opens more turns than the OS
         // will grant threads must see a cleanly aborted turn on the wire, not
         // the panic bare `std::thread::spawn` raises when creation fails.
         // Naming the thread also makes a wedged session legible in a dump.
         let abort_tx = frame_tx.clone();
+        let abort_observer = spec.observer.clone();
+        let abort_turn = spec.turn.clone();
         let thread_pending = pending.clone();
         let builder = std::thread::Builder::new().name("stella-serve-session".to_string());
         let spawned = builder.spawn(move || run_session(spec, frame_tx, thread_pending));
@@ -94,6 +108,15 @@ impl Session {
                         reason: ServeError::SessionThreadFailed(err.to_string()).to_string(),
                         cost_usd: 0.0,
                     },
+                });
+                // A turn that never got a thread still settled, and still has
+                // to say so: reporting only the turns that started is exactly
+                // the shape of silence this crate is being fixed for.
+                abort_observer.emit(&ServeEvent::TurnSettled {
+                    turn: abort_turn,
+                    outcome: SettledOutcome::Aborted,
+                    duration_ms: 0,
+                    tally: TurnTally::default(),
                 });
                 None
             }
@@ -161,6 +184,15 @@ impl Session {
     pub fn is_finished(&self) -> bool {
         self.thread.as_ref().is_none_or(JoinHandle::is_finished)
     }
+
+    /// How many frames are buffered for a stream that has not opened.
+    ///
+    /// Read when the registry evicts a finished-but-unstreamed turn, so the
+    /// record can say how much the host threw away by never subscribing.
+    #[must_use]
+    pub fn buffered_frames(&self) -> usize {
+        self.frames.len()
+    }
 }
 
 impl Drop for Session {
@@ -182,6 +214,9 @@ impl Drop for Session {
 /// The body of the session thread: build a current-thread runtime, construct the
 /// remoted ports, and drive one turn to its outcome.
 fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, pending: Pending) {
+    let observer = spec.observer.clone();
+    let turn = spec.turn.clone();
+    let started = Instant::now();
     let runtime = match Builder::new_current_thread().enable_time().build() {
         Ok(runtime) => runtime,
         Err(err) => {
@@ -190,6 +225,12 @@ fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, 
                     reason: ServeError::RuntimeBuild(err.to_string()).to_string(),
                     cost_usd: 0.0,
                 },
+            });
+            observer.emit(&ServeEvent::TurnSettled {
+                turn,
+                outcome: SettledOutcome::Aborted,
+                duration_ms: millis(started.elapsed()),
+                tally: TurnTally::default(),
             });
             return;
         }
@@ -215,14 +256,24 @@ fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, 
         // reverse-RPC request frames bypass this and go straight to `frame_tx`
         // from the ports, so a starved forwarder never stalls the turn — it only
         // affects UI-event latency.
+        //
+        // This is also where the engine's stream is *tapped* for the turn's
+        // tally. It has to be here, on the producing side: tapping in the SSE
+        // loop would miss every turn nobody streams, and those are precisely the
+        // abandoned ones worth observing. The fold only increments integers —
+        // `AgentEvent::TextDelta` fires per token, so anything costlier here
+        // would make this server slower than the model it waits on.
         let (event_tx, mut event_rx) = mpsc::unbounded_channel::<AgentEvent>();
         let forward_tx = frame_tx.clone();
         let forwarder = tokio::spawn(async move {
+            let mut fold = TallyFold::default();
             while let Some(event) = event_rx.recv().await {
+                fold.observe(&event);
                 if forward_tx.send(ServerFrame::Event { event }).is_err() {
                     break;
                 }
             }
+            fold.finish()
         });
 
         let mut messages = spec.messages;
@@ -232,13 +283,25 @@ fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, 
         // Close the event channel so the forwarder drains and exits before the
         // terminal frame — a well-behaved host thus sees every event first.
         drop(event_tx);
-        let _ = forwarder.await;
+        // A forwarder that panicked still leaves a turn that must be reported;
+        // an empty tally is the honest answer for a fold that did not survive.
+        let tally = forwarder.await.unwrap_or_default();
 
-        let _ = frame_tx.send(ServerFrame::TurnComplete {
-            outcome: outcome.into(),
+        let wire: TurnOutcomeWire = outcome.into();
+        let settled = match &wire {
+            TurnOutcomeWire::Completed { .. } => SettledOutcome::Completed,
+            TurnOutcomeWire::Aborted { .. } => SettledOutcome::Aborted,
+        };
+        let _ = frame_tx.send(ServerFrame::TurnComplete { outcome: wire });
+        observer.emit(&ServeEvent::TurnSettled {
+            turn,
+            outcome: settled,
+            duration_ms: millis(started.elapsed()),
+            tally,
         });
         // A clean turn leaves nothing parked; belt-and-suspenders for an aborted
-        // one, so no reverse-RPC one-shot outlives the session.
+        // one, so no reverse-RPC one-shot outlives the session. Anything still
+        // registered here is work being thrown away, and `clear` reports it.
         pending.clear();
     });
 }

--- a/stella-serve/tests/bridge.rs
+++ b/stella-serve/tests/bridge.rs
@@ -11,6 +11,7 @@ use stella_protocol::{
     BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, ToolCall, ToolOutput,
     ToolSchema,
 };
+use stella_serve::observe::TurnRef;
 use stella_serve::{ServerFrame, Session, SessionSpec, TurnOutcomeWire};
 
 /// Build a mock model result carrying a final text answer and no tool calls —
@@ -65,6 +66,8 @@ fn spec_for(prompt: &str) -> SessionSpec {
         config: EngineConfig::default(),
         budget: BudgetGuard::new(BudgetMode::Off, None, None),
         reverse_request_timeout: SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT,
+        turn: TurnRef::new("turn-bridgetest0"),
+        observer: stella_serve::observe::null_observer(),
     }
 }
 

--- a/stella-serve/tests/http.rs
+++ b/stella-serve/tests/http.rs
@@ -5,10 +5,15 @@
 //! `!Send` bridge.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde_json::json;
 use stella_protocol::{CompletionMessage, ToolSchema};
+use stella_serve::observe::{
+    Capture, Fanout, Metrics, MisrouteFault, ReverseKind, ServeEvent, SettledOutcome,
+    SharedObserver,
+};
 use stella_serve::{ServeConfig, serve};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -28,18 +33,34 @@ fn echo_tool() -> serde_json::Value {
 
 /// Start the server on an ephemeral loopback port; returns its address.
 async fn start_server() -> SocketAddr {
+    start_observed_server().await.0
+}
+
+/// Start the server with a [`Capture`] wired in place of the JSONL sink, so a
+/// test can assert on the **typed** events the server emitted rather than
+/// scraping stderr. That indirection is the point: an assertion on
+/// `ServeEvent::ReverseTimedOut { .. }` survives any change to how records are
+/// rendered, and a phrase-matching one does not.
+async fn start_observed_server() -> (SocketAddr, Arc<Capture>) {
+    let capture = Arc::new(Capture::new());
+    let observer = capture.clone();
+    let metrics = Arc::new(Metrics::new());
     let (tx, rx) = oneshot::channel();
+    let fanout: SharedObserver = Arc::new(Fanout::new(vec![observer, metrics.clone()]));
     tokio::spawn(async move {
         let config = ServeConfig {
             bind: "127.0.0.1:0".parse().unwrap(),
             token: TOKEN.to_string(),
+            observer: fanout,
+            metrics,
         };
         let _ = serve(config, move |addr| {
             let _ = tx.send(addr);
         })
         .await;
     });
-    rx.await.expect("server reported its bound address")
+    let addr = rx.await.expect("server reported its bound address");
+    (addr, capture)
 }
 
 /// POST a JSON body and read the whole response (server sends `Connection:
@@ -734,4 +755,587 @@ async fn turn_ids_are_not_guessable_from_another_turns_id() {
     }
     assert_ne!(ids[0], ids[1]);
     assert_ne!(ids[1], ids[2]);
+}
+
+// ---------------------------------------------------------------------------
+// Observability (#930)
+//
+// The acceptance bar is behavioural: "a wedged turn, a misrouted `request_id`,
+// and a token brute-force are each identifiable from the server's output alone,
+// without attaching a debugger." So these drive the real server over a real
+// socket and assert on the **typed** events it emitted, never on scraped text —
+// an assertion on `ServeEvent::ReverseTimedOut { .. }` survives any change to
+// how a record is rendered, and a phrase-matching one does not.
+// ---------------------------------------------------------------------------
+
+/// Poll until `capture` holds at least `want` events matching `predicate`.
+///
+/// A record is emitted as the connection future returns, which is just after
+/// the client observes EOF — so asserting immediately races the server by
+/// microseconds. Polling closes that window without making the test sleep for a
+/// fixed guess.
+async fn await_events(
+    capture: &Arc<Capture>,
+    predicate: impl Fn(&ServeEvent) -> bool + Copy,
+    want: usize,
+    label: &str,
+) -> Vec<ServeEvent> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let found: Vec<ServeEvent> = capture.events().into_iter().filter(predicate).collect();
+        if found.len() >= want {
+            return found;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {want} `{label}` event(s); saw {}",
+            found.len()
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// #930, situation 1: a turn wedged on a reverse request that will never be
+/// answered. Before this, it and a healthy turn produced identical output —
+/// none. The wedge signal was a silent `HashMap::remove` inside
+/// `Pending::abandon`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_wedged_turn_is_identifiable_from_the_servers_output_alone() {
+    let (addr, capture) = start_observed_server().await;
+
+    let create = json!({
+        "provider_id": "mock",
+        "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+        "reverse_request_timeout_ms": 50,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    let turn_id = serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Stream the turn but never answer its provider request.
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    while next_event(&mut sse).await.is_some() {}
+
+    let timed_out = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::ReverseTimedOut { .. }),
+        1,
+        "reverse_timed_out",
+    )
+    .await;
+    match &timed_out[0] {
+        ServeEvent::ReverseTimedOut {
+            kind,
+            waited_ms,
+            turn,
+            ..
+        } => {
+            assert_eq!(*kind, ReverseKind::Provider);
+            assert!(*waited_ms >= 50, "the wait must be reported: {waited_ms}ms");
+            assert!(
+                turn_id.contains(&turn.to_string()),
+                "the record must correlate to the turn it wedged"
+            );
+        }
+        other => panic!("expected a timeout record, got {other:?}"),
+    }
+
+    // Wedged, not merely slow: the turn settled without its stages advancing
+    // past the first model call. That distinction is the whole reason the
+    // tally is folded from the engine's own event stream.
+    let settled = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::TurnSettled { .. }),
+        1,
+        "turn_settled",
+    )
+    .await;
+    match &settled[0] {
+        ServeEvent::TurnSettled { outcome, tally, .. } => {
+            assert_eq!(*outcome, SettledOutcome::Aborted);
+            assert_eq!(
+                tally.model_calls, 0,
+                "no model call ever committed — that is what wedged means"
+            );
+        }
+        other => panic!("expected a settle record, got {other:?}"),
+    }
+}
+
+/// #930, situation 2: a host answering with the wrong `request_id`. The `409`
+/// it receives is unchanged; what changes is that the server says so, and
+/// distinguishes "no such request" from "right request, wrong kind".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_misrouted_request_id_is_recorded_with_its_fault() {
+    let (addr, capture) = start_observed_server().await;
+
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [echo_tool()],
+        "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+        "reverse_request_timeout_ms": 3000,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    let turn_id = serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    while let Some(event) = next_event(&mut sse).await {
+        if event["type"].as_str() == Some("provider_request") {
+            let real_id = event["request_id"].as_str().unwrap().to_string();
+
+            // (a) An id nobody is waiting on.
+            let fabricated = json!({
+                "request_id": "prov-999",
+                "status": "ok",
+                "result": model_result("done"),
+            })
+            .to_string();
+            let (status, _) = post_json(
+                addr,
+                &format!("/v1/turns/{turn_id}/provider-result"),
+                Some(TOKEN),
+                &fabricated,
+            )
+            .await;
+            assert!(status.contains("409"), "a stale id is a 409: {status}");
+
+            // (b) A real id, answered with the wrong kind of result.
+            let miskinded = json!({
+                "request_id": real_id,
+                "output": { "ok": { "content": "x" } },
+            })
+            .to_string();
+            let (status, _) = post_json(
+                addr,
+                &format!("/v1/turns/{turn_id}/tool-result"),
+                Some(TOKEN),
+                &miskinded,
+            )
+            .await;
+            assert!(
+                status.contains("409"),
+                "a mis-kinded answer is a 409: {status}"
+            );
+
+            // Now answer properly so the turn unwinds instead of running out
+            // its deadline.
+            let good = json!({
+                "request_id": real_id,
+                "status": "ok",
+                "result": model_result("done"),
+            })
+            .to_string();
+            let _ = post_json(
+                addr,
+                &format!("/v1/turns/{turn_id}/provider-result"),
+                Some(TOKEN),
+                &good,
+            )
+            .await;
+        }
+    }
+
+    let misroutes = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::ReverseMisrouted { .. }),
+        2,
+        "reverse_misrouted",
+    )
+    .await;
+    let faults: Vec<MisrouteFault> = misroutes
+        .iter()
+        .filter_map(|e| match e {
+            ServeEvent::ReverseMisrouted { fault, .. } => Some(*fault),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        faults.contains(&MisrouteFault::UnknownRequest),
+        "a fabricated id must be named as unknown: {faults:?}"
+    );
+    assert!(
+        faults.contains(&MisrouteFault::KindMismatch),
+        "a right-id/wrong-kind answer must be named as a mismatch: {faults:?}"
+    );
+}
+
+/// #930, situation 4: someone brute-forcing the bearer token.
+///
+/// Also asserts the throttle stays invisible to the guesser: every response is
+/// byte-identical whether or not the bucket was empty, so the only place the
+/// asymmetry shows is the server's own record.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_token_brute_force_is_visible_inside_and_invisible_outside() {
+    let (addr, capture) = start_observed_server().await;
+
+    // The burst allowance is 8; go past it so the throttle engages.
+    const ATTEMPTS: usize = 11;
+    let mut responses = Vec::new();
+    for attempt in 0..ATTEMPTS {
+        let guess = format!("wrong-token-{attempt}");
+        responses.push(get_json_authed(addr, "/v1/turns", &guess).await);
+    }
+
+    for (status, body) in &responses {
+        assert!(status.contains("401"), "every guess is a 401: {status}");
+        assert_eq!(
+            body, &responses[0].1,
+            "the body must not vary with the throttle's state — that would \
+             tell a guesser they had been noticed"
+        );
+    }
+
+    let unauthorized = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::Unauthorized { .. }),
+        ATTEMPTS,
+        "unauthorized",
+    )
+    .await;
+    let held: Vec<u64> = unauthorized
+        .iter()
+        .filter_map(|e| match e {
+            ServeEvent::Unauthorized { held_ms, .. } => Some(*held_ms),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(held.len(), ATTEMPTS);
+    assert!(
+        held.iter().any(|ms| *ms > 0),
+        "a sustained guess must be distinguishable from a misconfigured \
+         client — some attempts have to show as held: {held:?}"
+    );
+    assert!(
+        held.iter().take(4).all(|ms| *ms == 0),
+        "the burst must stay free, so a restarting host is not punished: {held:?}"
+    );
+}
+
+/// The counters are behind the same token as everything else, and they agree
+/// with what the log saw — because `Metrics` folds the *same* event stream
+/// rather than being incremented at its own call sites.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_are_authenticated_and_agree_with_the_records() {
+    let (addr, capture) = start_observed_server().await;
+
+    let (status, _) = get_json(addr, "/v1/metrics").await;
+    assert!(
+        status.contains("401"),
+        "metrics describe the host's traffic; an open endpoint is free \
+         reconnaissance: {status}"
+    );
+
+    // Two turns, so the counters have something to disagree about.
+    for _ in 0..2 {
+        let create = json!({
+            "provider_id": "mock",
+            "messages": [serde_json::to_value(CompletionMessage::user("hi")).unwrap()],
+            "reverse_request_timeout_ms": 30,
+        })
+        .to_string();
+        let (status, _) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+        assert!(status.contains("200"));
+    }
+
+    let created = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::TurnCreated { .. }),
+        2,
+        "turn_created",
+    )
+    .await;
+
+    let (status, body) = get_json_authed(addr, "/v1/metrics", TOKEN).await;
+    assert!(status.contains("200"), "metrics: {status} {body}");
+    let snapshot: serde_json::Value = serde_json::from_str(&body).expect("metrics is JSON");
+    assert_eq!(
+        snapshot["turns_created_total"].as_u64(),
+        Some(created.len() as u64),
+        "a counter must never disagree with the log: {body}"
+    );
+    assert!(
+        snapshot["requests_total"].as_u64().unwrap_or(0) >= 3,
+        "the metrics request itself and the creates are counted: {body}"
+    );
+    for (key, value) in snapshot.as_object().expect("a flat object") {
+        assert!(
+            value.is_number(),
+            "`{key}` is not a number — only counts may leave this endpoint"
+        );
+    }
+}
+
+/// Every response carries `X-Request-Id`, and a host-supplied one is honoured
+/// so a caller can correlate across the boundary — unless it is unsafe, in
+/// which case it is replaced rather than echoed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_request_id_is_echoed_and_a_hostile_one_is_replaced() {
+    let addr = start_server().await;
+
+    let head = raw_request(
+        addr,
+        "GET /healthz HTTP/1.1\r\nHost: engine\r\nX-Request-Id: abc-123\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    assert!(
+        head.contains("X-Request-Id: abc-123"),
+        "a usable id must be echoed for correlation: {head}"
+    );
+
+    let head = raw_request(
+        addr,
+        "GET /healthz HTTP/1.1\r\nHost: engine\r\nX-Request-Id: has space and \"quotes\"\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    assert!(
+        !head.contains("has space"),
+        "an unsafe id must be replaced, not echoed: {head}"
+    );
+    assert!(
+        head.contains("X-Request-Id: "),
+        "and a generated one takes its place: {head}"
+    );
+}
+
+/// Write raw bytes, half-close, and read the whole response.
+async fn raw_request(addr: SocketAddr, request: &str) -> String {
+    raw_bytes(addr, request.as_bytes()).await
+}
+
+/// The byte-level version, for input that is not valid UTF-8 or not a request
+/// at all.
+async fn raw_bytes(addr: SocketAddr, request: &[u8]) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let _ = stream.write_all(request).await;
+    // Half-close so the server sees EOF rather than waiting out its 30-second
+    // read deadline on input that will never be completed.
+    let _ = stream.shutdown().await;
+    let mut buf = Vec::new();
+    let _ = stream.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// **The** property: for *any* bytes a peer can put on a connection —
+/// malformed, truncated, oversized, unauthenticated, well-formed, or nothing at
+/// all — the server emits exactly one terminal record.
+///
+/// Hand-listed cases are how the original gap was missed: the bug is always a
+/// path nobody enumerated. Distributing an `emit()` across `route`'s sixteen
+/// exits would pass every example test anyone thought to write and still fail
+/// here the first time a refactor added a seventeenth.
+#[test]
+fn exactly_one_record_per_connection_for_any_input() {
+    use proptest::prelude::*;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let (addr, capture) = runtime.block_on(start_observed_server());
+
+    let count = |capture: &Arc<Capture>| {
+        capture.count(|e| matches!(e, ServeEvent::RequestCompleted { .. }))
+    };
+
+    let config = ProptestConfig {
+        cases: 64,
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    };
+    proptest!(config, |(raw in proptest::collection::vec(any::<u8>(), 0..320))| {
+        let before = count(&capture);
+        runtime.block_on(async {
+            raw_bytes(addr, &raw).await;
+            // The record lands as the connection future returns, just after the
+            // client sees EOF. Wait for it rather than guessing a sleep.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while count(&capture) == before && Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            // Then give a duplicate a chance to appear, so "exactly one" is a
+            // real claim and not just "at least one".
+            tokio::time::sleep(Duration::from_millis(15)).await;
+        });
+        let after = count(&capture);
+        prop_assert_eq!(
+            after - before,
+            1,
+            "input of {} byte(s) produced {} records, not exactly 1",
+            raw.len(),
+            after - before
+        );
+    });
+}
+
+/// No record carries content, and the sweep is not vacuous.
+///
+/// The shape `stella-store::content_free` uses for egress, applied here to a
+/// surface that does not egress but is routinely shipped: operators collect
+/// stderr. A turn is poisoned at every point host data enters — the prompt, the
+/// tool's advertised name, the model's output text, the tool result — and every
+/// emitted record is swept for those markers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_content_reaches_a_record() {
+    const PROMPT_SENTINEL: &str = "STELLA-SENTINEL-CONTENT.prompt";
+    const OUTPUT_SENTINEL: &str = "STELLA-SENTINEL-CONTENT.model-output";
+    const TOOL_RESULT_SENTINEL: &str = "STELLA-SENTINEL-CONTENT.tool-result";
+    const PATH_SENTINEL: &str = "/stella-sentinel-path/must-never-egress";
+
+    let (addr, capture) = start_observed_server().await;
+
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [echo_tool()],
+        "messages": [
+            serde_json::to_value(CompletionMessage::user(
+                format!("{PROMPT_SENTINEL} at {PATH_SENTINEL}")
+            )).unwrap()
+        ],
+        "reverse_request_timeout_ms": 3000,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    let turn_id = serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let mut provider_calls = 0;
+    while let Some(event) = next_event(&mut sse).await {
+        match event["type"].as_str().unwrap_or_default() {
+            "provider_request" => {
+                provider_calls += 1;
+                let request_id = event["request_id"].as_str().unwrap();
+                let result = if provider_calls == 1 {
+                    model_wants_echo()
+                } else {
+                    model_result(OUTPUT_SENTINEL)
+                };
+                let body = json!({
+                    "request_id": request_id,
+                    "status": "ok",
+                    "result": result,
+                })
+                .to_string();
+                let _ = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &body,
+                )
+                .await;
+            }
+            "tool_request" => {
+                let request_id = event["request_id"].as_str().unwrap();
+                let body = json!({
+                    "request_id": request_id,
+                    "output": { "ok": { "content": TOOL_RESULT_SENTINEL } },
+                })
+                .to_string();
+                let _ = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/tool-result"),
+                    Some(TOKEN),
+                    &body,
+                )
+                .await;
+            }
+            _ => {}
+        }
+    }
+
+    let events = await_events(
+        &capture,
+        |e| matches!(e, ServeEvent::TurnSettled { .. }),
+        1,
+        "turn_settled",
+    )
+    .await;
+    assert!(!events.is_empty());
+
+    // --- the vacuity guard -------------------------------------------------
+    //
+    // Without this, an encoder — or a test — passes every sentinel check by
+    // recording nothing at all. `content_free.rs` learned this the same way.
+    let all = capture.events();
+    assert!(
+        all.len() >= 4,
+        "the sweep is vacuous: only {} record(s) were emitted",
+        all.len()
+    );
+    for (label, seen) in [
+        (
+            "request_completed",
+            all.iter()
+                .any(|e| matches!(e, ServeEvent::RequestCompleted { .. })),
+        ),
+        (
+            "turn_created",
+            all.iter()
+                .any(|e| matches!(e, ServeEvent::TurnCreated { .. })),
+        ),
+        (
+            "reverse_dispatched",
+            all.iter()
+                .any(|e| matches!(e, ServeEvent::ReverseDispatched { .. })),
+        ),
+        (
+            "reverse_answered",
+            all.iter()
+                .any(|e| matches!(e, ServeEvent::ReverseAnswered { .. })),
+        ),
+        (
+            "turn_settled",
+            all.iter()
+                .any(|e| matches!(e, ServeEvent::TurnSettled { .. })),
+        ),
+    ] {
+        assert!(seen, "no `{label}` record — the sweep would pass vacuously");
+    }
+
+    // --- the sweep ---------------------------------------------------------
+    let rendered = serde_json::to_string(&all).expect("records serialize");
+    for sentinel in [
+        PROMPT_SENTINEL,
+        OUTPUT_SENTINEL,
+        TOOL_RESULT_SENTINEL,
+        PATH_SENTINEL,
+        "STELLA-SENTINEL-CONTENT",
+    ] {
+        assert!(
+            !rendered.contains(sentinel),
+            "`{sentinel}` reached a record. That is a privacy incident, not a \
+             test failure: records go to stderr, and operators ship stderr."
+        );
+    }
+    // Check the *hex suffix*, not the `turn-` prefixed id: a record holds the
+    // bare hex, so asserting on the prefixed form would let a full-length
+    // `TurnRef` through — which is exactly what it did the first time.
+    let hex = turn_id.strip_prefix("turn-").expect("ids keep the prefix");
+    assert!(
+        !rendered.contains(hex),
+        "the whole turn id reached a record — it is a second factor (token AND \
+         id), and only a truncated `TurnRef` may be written"
+    );
+    assert!(
+        rendered.contains(&hex[..8]),
+        "records must still correlate to the turn: no handle at all is the \
+         opposite failure"
+    );
+    assert!(
+        !rendered.contains(TOKEN),
+        "the bearer token reached a record"
+    );
 }


### PR DESCRIPTION
Implements `docs/design/serve-observability.md` (merged as #967). Closes #930 and corrects audit dimension 30 (Observability, 62/100).

## What was wrong

The crate's entire observable surface was its startup banner and its exit code. All ten print statements lived in `main.rs`; the 3,423-line library emitted **nothing**. So these four produced identical output — none:

- a turn wedged on a reverse request nobody will answer
- a host answering with the wrong `request_id`
- a 429 storm
- a bearer-token brute force

Nine sites discarded work outright. The worst was `Pending::abandon` — it runs exactly when a turn has burned its whole five-minute deadline on a host that never answered, the single most diagnostic event this service can produce, and it was a silent `HashMap::remove`.

## The shape

**No new dependency.** `tracing` stays deferred, with the expiry §9 names, because emission and sink are now separate concerns: 18 typed `ServeEvent` variants behind an `Observer` port. Adopting a facade later is one impl in `observe/sink.rs` with **no emit site touched**. This copies what the audit actually rewards — `stella-core` scores well on this dimension with no logger at all; it scores on `AgentEvent`.

Three things are structural rather than conventional:

- **The request record is a fold.** `handle_conn` opens it before the first byte is parsed and closes it after `route` returns, so `route`'s sixteen exits do not know a record exists. A `Responder` owns the write half, making status/`bytes_out` captured by construction and "nothing was written" a *named terminal state* rather than an absence.
- **`Metrics` is itself an `Observer`**, folding the same stream the log sees. A counter cannot disagree with the log because it is strictly downstream of the single emission.
- **The frame tap is on the producing side** (`session.rs`), not the SSE loop. Tapping where frames are *streamed* would miss every unstreamed turn — and those are the abandoned ones worth watching. It folds into atomics and emits one `TurnSettled`, because `AgentEvent::TextDelta` fires per token and a record per frame would make the server slower than the model.

## Two deviations from the design, both found by building it

- **No per-frame debug records.** `AgentEvent::Text`/`TextDelta`/`Reasoning` carry model output verbatim, so that feature would have put content in a log file and made the no-content property *conditional on a verbosity flag*. The tally supersedes it.
- **Handlers moved to `routes.rs`.** Adding the fold to `server.rs` would have eaten its ratchet headroom; the split took it **1257 → 1072** while adding the fold, the route classifier and the metrics route.

Both are marked `[amended]` in the design doc rather than left to diverge.

## Invariants

Invariant 3 holds: nothing egresses, `/v1/metrics` is authenticated pull on the same socket, route templates replace raw paths, and turn ids are truncated to 8 of 32 hex — an id is a *second factor* (token **and** id), not a correlation key. Invariant 2 is untouched: `stella-core` gains and loses nothing.

## Proof

**Both properties verified non-vacuous by planting the bug and watching them fail** — not just asserted:

- Skipping the emit when nothing was written (i.e. forgetting the hangup path, the classic version of this bug) fails the property with `input of 0 byte(s) produced 0 records, not exactly 1`.
- A deliberately full-length `TurnRef` fails the sentinel sweep.

The second one is worth flagging to a reviewer: **the first version of the sweep did not catch that leak.** It compared the `turn-`-prefixed id against records that hold bare hex, so a full-length ref sailed through a sweep that had a working vacuity guard. Fixed to compare the suffix, and to assert the 8-char handle *is* present so "leaked everything" and "recorded nothing" are both failures. That lesson is now in §8.

Plus the four #930 acceptance scenarios, each driving the real server over a real socket and asserting on typed events rather than scraped stderr.

## Verification

`make gate` — **exit 0**, whole workspace: fmt, clippy `-D warnings`, doc, file-size ratchet, all guards, all tests. `stella-serve` is 114 tests, up from 107.

Rebased onto current `main` (`454987d0`); #968 fixed the file-size ratchet that was blocking every PR, so this branch is green rather than inheriting a red.


## Summary by Sourcery

Introduce a typed observability layer for stella-serve, emitting structured ServeEvent records at all HTTP and session boundaries, adding authenticated metrics and reorganizing server routing to ensure every connection and turn is observable without leaking content.

New Features:
- Add ServeEvent event vocabulary, Observer trait, and pluggable sinks (JSONL, metrics, test capture) to provide structured logging and metrics for stella-serve.
- Expose authenticated GET /v1/metrics endpoint backed by Metrics observer that derives counters from the same event stream as logs.
- Implement a per-turn tally folded from AgentEvent to report turn progress and outcomes via TurnSettled events.
- Introduce RequestRecord/Responder fold so every connection produces exactly one RequestCompleted record, with X-Request-Id correlation and byte counts.

Enhancements:
- Refactor server routing into a new routes.rs module, separating transport concerns from endpoint handlers and reducing server.rs size.
- Add detailed observability around reverse RPC lifecycle (dispatch, answer, timeout, misroute, abandonment) and turn registry events (created, refused, reclaimed, stream ended).
- Wire observability through Session, Pending, RemoteProvider, and RemoteToolExecutor so discarded work, timeouts, and cancellations are all named events.
- Document the observability design and update serve-surface and README to describe metrics, logging controls, and non-content guarantees.

Build:
- Add proptest as a dev dependency for property-based testing of the request fold’s exactly-one-record-per-connection property.

Tests:
- Add extensive HTTP and property-based tests to verify one record per connection, no-content in records via sentinel sweeps, authenticated metrics consistency, request-id sanitization, and coverage of #930 scenarios (wedged turns, misrouted request_ids, brute-force tokens, 429 storms).
