### PR TITLE
docs(memory): restore the doc lines the duplicate-field fix over-deleted

### DIFF
--- a/stella-cli/src/memory.rs
+++ b/stella-cli/src/memory.rs
@@ -223,6 +223,13 @@ pub struct SessionMemory {
     /// that produced them. `None` on any path that has not adopted
     /// [`SessionMemory::set_execution_id`], which files id-less rows exactly
     /// as every row was filed before.
+    ///
+    /// The post-turn self-review is stored 1:1 with an execution, so without
+    /// this the loop has nothing to key the write on — which is why
+    /// `execution_reflection.self_rating` was NULL on every row ever written,
+    /// and the Observatory's self-improve panels had no data to show. `None`
+    /// degrades exactly as before: lessons still mine, the self-review is
+    /// dropped rather than written against a guessed row.
     execution_id: Option<i64>,
     /// A/B recall control (Proposal 4): when true, recall is suppressed
     /// entirely on this turn so the outcome can be compared against recalled
@@ -236,8 +243,8 @@ pub struct SessionMemory {
     /// this is off the learning loop runs exactly the lexical path that ships
     /// today and writes nothing to the lifecycle ledger.
     lifecycle_enabled: bool,
-    /// The `executions` row this session's next reflection belongs to, set by
-    /// the turn that opened it.
+    /// The volatile context-record channel — `may`/`info` records and anything the
+    /// truth sweep demoted (epic #897).
     ///
     /// It rides the recall block rather than the cached system prefix because that
     /// is what `force` means: `must`/`should` are unconditional and cacheable,


### PR DESCRIPTION
## What & why

`454987d0` removed the duplicated `SessionMemory::execution_id` declaration and unbroke the build — that part is correct and `main` compiles (`cargo check --release -p stella-cli`, exit 0).

But it deleted a **10-line range where only 7 lines were the duplicate**. The extra 3 were the *head* of the next field's doc comment, so `record_channel` is currently documented as:

> The `executions` row this session's next reflection belongs to, set by the turn that opened it.

— which describes `execution_id`, not `record_channel`. Its own summary line (*the volatile context-record channel — `may`/`info` records and anything the truth sweep demoted, epic #897*) is gone from `memory.rs` entirely.

### Why no gate caught it

Doc comments desugar to `#[doc]` attributes that only `rustdoc` reads, so `rustc` is indifferent to which lines the deletion landed on. `cargo doc -D warnings` is green too — the surviving `[`Self::set_record_channel`]` intra-doc link still resolves (`memory/recall.rs:45`). The doc is **wrong, not malformed**, and nothing in the gate can tell the difference.

The underlying trap: in this struct each field's `///` block sits *above* it, and `rustc` points at the **field** (`memory.rs:248`). "Delete upward from the reported line" therefore walks through the duplicate's docs and straight into the previous field's.

## What this does

Restores both halves of the collateral deletion, and keeps the duplicate field removed:

- **`record_channel`** gets its own summary line back.
- **`execution_id`** gets back the rationale #945 wrote for it — why `execution_reflection.self_rating` was NULL on every row ever written — folded in as a second paragraph under the surviving lead from #970. Both doc blocks were legitimate; the merge just kept two copies of the *field*.

Docs only. No behavior change, no signature change.

## The gate

- [x] `cargo check -p stella-cli` — exit 0
- [x] `cargo fmt --check -p stella-cli` — exit 0
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps --document-private-items` — exit 0
- [x] Full `make gate` via the pre-push hook — passed
- [x] File-size gate unaffected: `memory.rs` is 599 lines against the 1500 ratchet and is not in `scripts/file-size-baseline.txt`

## Anything reviewers should know?

**How the duplicate got there in the first place** (context, not a change here). PR #970 branched from `de37eba4`, where `execution_id` genuinely had no declaration — its own body documents unbreaking that. But `f0e2598c` (#968) landed the same repair first. The two insertions were textually non-adjacent, so git merged both cleanly and the duplicate surfaced only at `rustc` as `E0124`. Same family as the doubled `use zeroize::Zeroizing;` in `493b1f51`.

**One flaky-gate note.** The first push attempt failed the gate on 5 `stella-tools` `custom::tests` — all 5 reported `timed out after 5000ms`, none an assertion mismatch. Re-run in isolation: 35 passed, 0 failed, exit 0, 2.6s. The retry's full gate passed. Unrelated to this diff (which touches only `stella-cli` doc comments), but those tests' 5s subprocess budget keeps blocking pushes under parallel load and probably deserves its own issue.


## Summary by Sourcery

Restore correct documentation for SessionMemory fields without changing behavior or signatures.

Documentation:
- Clarify the purpose and impact of the SessionMemory.execution_id field by restoring its full doc comment.
- Restore the distinct summary documentation for SessionMemory.record_channel so it no longer inherits execution_id’s description.
