### PR TITLE
fix(records): a repository record cannot disarm or self-approve a guard

### DIFF
--- a/stella-cli/src/context_cmd/validate.rs
+++ b/stella-cli/src/context_cmd/validate.rs
@@ -95,7 +95,7 @@ pub fn run_list(root: &Path, json: bool) -> Result<(), String> {
 pub fn run_validate(root: &Path, json: bool) -> Result<(), String> {
     let files = rule_files(root, true, true);
     let now = now_rfc3339();
-    let cache = probe_everything(root, &files, &now);
+    let cache = probe_everything(root, &files.all(), &now);
     let registry = registry_with_cache(root, &files, &cache, &now);
 
     if json {

--- a/stella-cli/src/context_records.rs
+++ b/stella-cli/src/context_records.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 
 use stella_core::ingest::record::{ProbeKind, Verdict};
 use stella_core::records::{
-    self, DecisionEvent, Facts, LoadedRecord, Registry, decision, load_context_file,
+    self, DecisionEvent, Facts, LoadedRecord, Registry, Trust, decision, load_context_file,
 };
 use stella_core::rules::{LoadRulesOptions, RuleFile, RuleSource, rule_search_dirs};
 
@@ -165,7 +165,7 @@ pub(crate) fn append_decision(root: &Path, event: &DecisionEvent) -> Result<(), 
 /// [`RuleSource`] reads every directory it is handed, so the filtering has to
 /// happen here, on the slice. Passing one flag for both axes reads plausibly and
 /// silently loads an untrusted repository's rules into the prompt.
-pub(crate) fn rule_files(root: &Path, include_user: bool, include_project: bool) -> Vec<RuleFile> {
+pub(crate) fn rule_files(root: &Path, include_user: bool, include_project: bool) -> TieredFiles {
     let user_rules_dir = if include_user {
         crate::settings::user_home_dir()
             .map(|home| home.join(".stella").join("rules").display().to_string())
@@ -178,12 +178,40 @@ pub(crate) fn rule_files(root: &Path, include_user: bool, include_project: bool)
         user_rules_dir,
     });
     // `rule_search_dirs` puts the user directory first, then the two project ones.
-    let visible = if include_project {
-        dirs.as_slice()
-    } else {
-        dirs.get(..1).unwrap_or(&dirs)
-    };
-    crate::rules::FsRuleSource.read_rule_files(visible)
+    let (user, project) = dirs.split_at(1);
+    TieredFiles {
+        user: crate::rules::FsRuleSource.read_rule_files(user),
+        project: if include_project {
+            crate::rules::FsRuleSource.read_rule_files(project)
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+/// This workspace's rule files, kept in their trust tiers.
+///
+/// The split is preserved all the way to [`records::registry::load`] rather than
+/// flattened here, because the merge needs it: a project record may add enforcement
+/// and may never remove a user record's. Flattening at the boundary and re-deriving
+/// the tier from path prefixes downstream would put a security decision on string
+/// matching.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TieredFiles {
+    /// `~/.stella/rules` — the user's own.
+    pub user: Vec<RuleFile>,
+    /// `<repo>/.claude/rules` and `<repo>/.stella/rules`, in precedence order.
+    pub project: Vec<RuleFile>,
+}
+
+impl TieredFiles {
+    /// Every file, tier forgotten — for the passes that only ask what is on disk,
+    /// like running due probes.
+    pub(crate) fn all(&self) -> Vec<RuleFile> {
+        let mut all = self.user.clone();
+        all.extend(self.project.iter().cloned());
+        all
+    }
 }
 
 /// The registry a **session** loads: the authority policy decides whether an
@@ -223,7 +251,7 @@ fn load_registry_with(root: &Path, include_project: bool) -> Registry {
     let files = rule_files(root, true, include_project);
     let now = now_rfc3339();
     let mut cache = SweepCache::read(root);
-    let ran = run_due_probes(root, &files, &mut cache, &now);
+    let ran = run_due_probes(root, &files.all(), &mut cache, &now);
     if ran > 0 {
         cache.write(root);
     }
@@ -231,7 +259,7 @@ fn load_registry_with(root: &Path, include_project: bool) -> Registry {
 }
 
 /// Build the registry from already-collected files and an already-swept cache.
-fn registry_from(root: &Path, files: &[RuleFile], cache: &SweepCache, now: &str) -> Registry {
+fn registry_from(root: &Path, files: &TieredFiles, cache: &SweepCache, now: &str) -> Registry {
     let states = decision::fold(&read_decisions(root));
     let mut verdicts = BTreeMap::new();
     let mut last_checked = BTreeMap::new();
@@ -241,15 +269,21 @@ fn registry_from(root: &Path, files: &[RuleFile], cache: &SweepCache, now: &str)
         }
         last_checked.insert(lineage.clone(), entry.checked_at.clone());
     }
-    let approved_blocking: BTreeSet<String> = states
+    let approved_blocking: BTreeSet<(Trust, String)> = states
         .values()
         .filter(|state| state.approved_blocking && state.decision.publishes())
         .filter_map(|state| state.published_to.clone())
-        .filter_map(|path| lineage_from_published_path(&path))
+        .filter_map(|path| {
+            Some((
+                trust_of_published_path(&path),
+                lineage_from_published_path(&path)?,
+            ))
+        })
         .collect();
 
     records::registry::load(
-        files,
+        &files.user,
+        &files.project,
         &Facts {
             verdicts,
             last_checked,
@@ -267,6 +301,28 @@ fn registry_from(root: &Path, files: &[RuleFile], cache: &SweepCache, now: &str)
 fn lineage_from_published_path(path: &str) -> Option<String> {
     let base = path.rsplit('/').next()?;
     Some(base.strip_suffix(".toml")?.to_string())
+}
+
+/// Which tier an approval was granted at, read from where the record was published.
+///
+/// An approval is a statement about one record, and a lineage does not identify one
+/// record — it is author-supplied, so a repository can name the same lineage the
+/// user's own record uses. Without this, approving your own `~/.stella/rules` guard
+/// would hand the same approval to any repository record that guessed the name.
+///
+/// Compared against the real home directory rather than by looking for
+/// `.stella/rules` in the path, which **both** tiers end with.
+fn trust_of_published_path(path: &str) -> Trust {
+    let Some(user_rules) = crate::settings::user_home_dir() else {
+        // No home directory to compare against: nothing can be established as the
+        // user's, so nothing is.
+        return Trust::Project;
+    };
+    if Path::new(path).starts_with(user_rules.join(".stella").join("rules")) {
+        Trust::User
+    } else {
+        Trust::Project
+    }
 }
 
 /// Run every probe that is due, writing results into `cache`. Returns how many ran.
@@ -357,7 +413,7 @@ pub(crate) fn probe_everything(root: &Path, files: &[RuleFile], now: &str) -> Sw
 /// sweep's older verdicts.
 pub(crate) fn registry_with_cache(
     root: &Path,
-    files: &[RuleFile],
+    files: &TieredFiles,
     cache: &SweepCache,
     now: &str,
 ) -> Registry {

--- a/stella-cli/src/context_records/tests.rs
+++ b/stella-cli/src/context_records/tests.rs
@@ -180,7 +180,7 @@ fn probe_everything_ignores_the_cadence_and_does_not_move_the_scheduled_clock() 
 
     std::fs::write(root.path().join(".nvmrc"), "22\n").unwrap();
     let files = rule_files(root.path(), false, true);
-    let fresh = probe_everything(root.path(), &files, "2026-07-20T00:00:00Z");
+    let fresh = probe_everything(root.path(), &files.all(), "2026-07-20T00:00:00Z");
     assert_eq!(
         fresh.checked["ctx.acme.web.node-version"].verdict, "refuted",
         "validate must tell the truth about now, not about the last scheduled sweep"

--- a/stella-cli/src/rules.rs
+++ b/stella-cli/src/rules.rs
@@ -441,6 +441,33 @@ mod tests {
     use super::*;
     use stella_protocol::ToolOutput;
 
+    /// A hard-guard record whose own fields claim every approval there is: authored
+    /// by a `user`, decreed, and verified by a named human. In `~/.stella/rules` that
+    /// self-approves. In a repository it proves nothing, and the tests below pin both
+    /// halves of that from the identical bytes.
+    const SELF_ATTESTING_GUARD: &str = "schema = \"context-record/v0.1\"\nset_id = \"acme.web\"\n\
+         \n[defaults]\norigin = \"user\"\nstatus = \"active\"\n\
+         \n[[record]]\nlineage_id = \"ctx.acme.web.no-force-push\"\n\
+         kind = \"constraint\"\nstatement = \"Never force-push to a shared branch.\"\n\
+         \n[record.steering]\nforce = \"must\"\n\
+         \n[record.enforcement]\nmode = \"hard\"\nguard_tool = \"Bash\"\n\
+         guard_deny_command = \"git push --force*\"\n\
+         \n[record.truth]\nbasis = \"decree\"\nverified_by = \"mac\"\n";
+
+    /// Record a local human approval for `lineage`, published to `published_to` —
+    /// what `stella context review` appends when the reviewer authorizes blocking.
+    fn approve_blocking(root: &Path, lineage: &str, published_to: &Path) {
+        let mut event = stella_core::records::DecisionEvent::keep(
+            "candidate-1",
+            lineage,
+            "mac",
+            "2026-07-20T00:00:00Z",
+            published_to.display().to_string(),
+        );
+        event.approved_blocking = true;
+        crate::context_records::append_decision(root, &event).expect("ledger appends");
+    }
+
     fn trusted_project_authority() -> crate::settings::AuthorityPolicy {
         crate::settings::AuthorityPolicy {
             project_prompts_allowed: true,
@@ -843,6 +870,50 @@ mod tests {
         assert!(!allowed.is_error(), "a non-matching command runs normally");
     }
 
+    /// A repository-published record with impeccable fields, and no local approval.
+    ///
+    /// `origin`, `basis`, and `verified_by` are written inside the file being judged.
+    /// In `~/.stella/rules` they are the author speaking about themselves; in a
+    /// checkout anyone who can open a pull request writes them, and the person the
+    /// guard would fire on has never seen them. So this must not block — otherwise
+    /// cloning a repository installs a tool-boundary deny.
+    #[tokio::test]
+    async fn a_repository_record_cannot_self_approve_through_the_wired_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        write_rule(
+            &root.path().join(".stella/rules"),
+            "ctx.acme.web.no-force-push.toml",
+            SELF_ATTESTING_GUARD,
+        );
+
+        let registry = ToolRegistry::with_backends_and_options(
+            root.path().to_path_buf(),
+            None,
+            None,
+            stella_tools::RegistryOptions::default(),
+        );
+        let rules = load_workspace_rules(root.path(), &trusted_project_authority());
+        attach_rule_guards(&registry, &rules);
+
+        // The command itself fails (this tempdir is not a repository) — what matters
+        // is that the failure is git's and not the guard's, so the assertion is about
+        // whose refusal it is rather than about whether `git push` can run.
+        let allowed = registry
+            .execute(
+                "bash",
+                &serde_json::json!({"command": "git push --force origin main"}),
+            )
+            .await;
+        let message = match &allowed {
+            ToolOutput::Error { message } => message.clone(),
+            _ => String::new(),
+        };
+        assert!(
+            !message.contains("no-force-push"),
+            "a checkout must not be able to arm a Tier-2 guard on its own say-so: {message}"
+        );
+    }
+
     /// #890's acceptance criterion, through the real tool boundary: a kept,
     /// human-approved `guard_deny_command` record blocks a matching Bash call.
     ///
@@ -850,20 +921,23 @@ mod tests {
     /// `ToolRegistry::execute` and denies the call with text the model can act on —
     /// which is the only claim that matters, and the one that would silently stop
     /// being true if the record path and the markdown path ever diverged.
+    ///
+    /// The approval is the *ledger* entry, not the record's own `verified_by`: this
+    /// record lives in the repository, so the local decision log is its only route to
+    /// the boundary. Same file as the test above; the only difference is consent.
     #[tokio::test]
     async fn an_approved_toml_record_blocks_a_matching_bash_call() {
         let root = tempfile::tempdir().unwrap();
+        let published = root.path().join(".stella/rules");
         write_rule(
-            &root.path().join(".stella/rules"),
+            &published,
             "ctx.acme.web.no-force-push.toml",
-            "schema = \"context-record/v0.1\"\nset_id = \"acme.web\"\n\
-             \n[defaults]\norigin = \"user\"\nstatus = \"active\"\n\
-             \n[[record]]\nlineage_id = \"ctx.acme.web.no-force-push\"\n\
-             kind = \"constraint\"\nstatement = \"Never force-push to a shared branch.\"\n\
-             \n[record.steering]\nforce = \"must\"\n\
-             \n[record.enforcement]\nmode = \"hard\"\nguard_tool = \"Bash\"\n\
-             guard_deny_command = \"git push --force*\"\n\
-             \n[record.truth]\nbasis = \"decree\"\nverified_by = \"mac\"\n",
+            SELF_ATTESTING_GUARD,
+        );
+        approve_blocking(
+            root.path(),
+            "ctx.acme.web.no-force-push",
+            &published.join("ctx.acme.web.no-force-push.toml"),
         );
 
         let registry = ToolRegistry::with_backends_and_options(

--- a/stella-core/src/records.rs
+++ b/stella-core/src/records.rs
@@ -49,14 +49,18 @@ pub mod handle;
 pub mod registry;
 pub mod render;
 pub mod sweep;
+pub mod trust;
 pub mod validate;
 
-pub use bridge::{BlockingRefusal, GuardDecision, guard_for, rule_from_record};
+pub use bridge::{
+    BlockingRefusal, GuardDecision, declared_hard_guard, guard_for, rule_from_record,
+};
 pub use decision::{Decision, DecisionEvent, should_repropose};
 pub use handle::assign_handles;
 pub use registry::{Entry, Facts, Registry};
 pub use render::{Channel, RenderInput, RenderedChannel, render_channel};
 pub use sweep::{Disposition, ExpiryAction, SweepInput, disposition, honored_probe, probe_is_due};
+pub use trust::Trust;
 pub use validate::{Conflict, check_record, detect_conflicts, is_suspended, validate_records};
 
 /// One record as the engine sees it: the typed record, where it came from, the
@@ -71,6 +75,11 @@ pub struct LoadedRecord {
     /// The file (or opaque source label) this record was read from. Carried into
     /// provenance so `stella context explain` can name the authority.
     pub source: String,
+    /// Which authority published it — stamped from the directory the file was read
+    /// out of, never from anything the record says about itself. [`load_context_file`]
+    /// leaves this at [`Trust::Project`]; [`registry::load`] stamps the user tier,
+    /// which is the one place that knows the difference.
+    pub trust: Trust,
     /// The `^handle` the model cites this record by. Empty until
     /// [`assign_handles`] has seen the whole loaded set — a handle is only
     /// unambiguous relative to its neighbours.
@@ -297,6 +306,9 @@ fn resolve(mut record: Record, defaults: &Defaults, set_id: &str, source: &str) 
         record,
         set_id: set_id.to_string(),
         source: source.to_string(),
+        // The lower tier, until a caller that actually knows the directory says
+        // otherwise. See [`Trust`] on why the default is the restrictive one.
+        trust: Trust::default(),
         handle: String::new(),
         findings,
     }

--- a/stella-core/src/records/bridge.rs
+++ b/stella-core/src/records/bridge.rs
@@ -25,6 +25,20 @@
 //! 3. **A human approved it.** Either the record is the user's own decree with a
 //!    named verifier, or the decision ledger records an explicit approval.
 //!
+//! # Self-approval is a property of the tier, not of the fields
+//!
+//! `origin`, `truth.basis`, and `verified_by` are all written *inside the file being
+//! judged*. In `~/.stella/rules` that is exactly right: the author, the approver, and
+//! the person the guard will fire on are the same person, so writing the file **is**
+//! the approval and demanding a second ceremony would make the solo path require a
+//! ledger. In a checkout it proves nothing — a repository can assert `origin = "user"`
+//! and `verified_by = "someone"` as easily as it can assert anything else, and the
+//! person those three fields would be approving *on behalf of* has never seen them.
+//!
+//! So self-attestation is gated on [`Trust::User`]. A repository-published record
+//! still reaches the tool boundary, but only through the decision ledger — an
+//! explicit local act by the person the guard will actually fire on.
+//!
 //! And one absolute refusal: an `imported` or `inferred` record can never *start*
 //! blocking. Content extracted from a document is a hypothesis about policy; the
 //! model that split the prose may have inverted a negation. A hypothesis may
@@ -35,7 +49,7 @@
 use super::super::context_record::kind::Origin;
 use super::super::ingest::record::{EnforcementMode, Record, TruthBasis};
 use super::super::rules::{Rule, RuleGuard};
-use super::LoadedRecord;
+use super::{LoadedRecord, Trust};
 
 /// Why a record that asked to block was not armed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,6 +60,9 @@ pub enum BlockingRefusal {
     UntrustedOrigin(Origin),
     /// No human has approved this record blocking tool calls.
     NotApproved,
+    /// The record is published in the repository, so its own `verified_by` cannot
+    /// stand in for an approval — only the local decision ledger can.
+    ProjectNeedsApproval,
 }
 
 impl std::fmt::Display for BlockingRefusal {
@@ -67,6 +84,12 @@ impl std::fmt::Display for BlockingRefusal {
                 f,
                 "asks to block but no human has approved it blocking tool calls \
                  (needs an approval decision, or a decree with a named verifier)"
+            ),
+            Self::ProjectNeedsApproval => write!(
+                f,
+                "asks to block and is published in this repository, so its own \
+                 verified_by cannot approve it — a repository record denies tool calls \
+                 only after you approve it locally (`stella context review`)"
             ),
         }
     }
@@ -101,10 +124,17 @@ fn may_block(origin: Option<Origin>) -> bool {
 }
 
 /// A record is self-approving when it is the user's own decree, verified by a named
-/// human. That is the hand-authored `.stella/rules/*.toml` case: writing the file,
-/// naming yourself, and committing it *is* the approval, and demanding a second
-/// ceremony for it would make the local-first solo path require a ledger.
-fn self_attested(record: &Record) -> bool {
+/// human, **and it is the user's own record**. That is the hand-authored
+/// `~/.stella/rules/*.toml` case: writing the file, naming yourself, and keeping it
+/// on your own disk *is* the approval, and demanding a second ceremony for it would
+/// make the local-first solo path require a ledger.
+///
+/// [`Trust::Project`] never qualifies, however impeccable the fields look — see the
+/// module docs. A repository record's route to blocking is the decision ledger.
+fn self_attested(record: &Record, trust: Trust) -> bool {
+    if trust != Trust::User {
+        return false;
+    }
     let named_human = record.truth.as_ref().is_some_and(|truth| {
         truth.basis == TruthBasis::Decree
             && truth
@@ -144,11 +174,28 @@ fn declared_guard(record: &Record) -> Option<RuleGuard> {
     concrete(&guard).then_some(guard)
 }
 
+/// The guard this record *establishes*, independent of whether it is approved yet.
+///
+/// The precedence merge needs a stable answer to "does this record set up
+/// enforcement" — stable meaning it cannot change when a ledger entry is added or a
+/// probe runs. Approval decides whether a guard **fires**; this decides whether the
+/// record is one a lower-trust record is allowed to displace.
+pub fn declared_hard_guard(record: &Record) -> Option<RuleGuard> {
+    record
+        .enforcement
+        .as_ref()
+        .filter(|enforcement| enforcement.mode == EnforcementMode::Hard)?;
+    declared_guard(record)
+}
+
 /// Decide whether `record` blocks at the tool boundary.
 ///
+/// `trust` is stamped from the directory the record was read out of, never from the
+/// record's own fields — it decides whether the record may approve itself.
 /// `ledger_approved` is the caller's own fact: a recorded human approval for this
-/// record's lineage. `stella-core` has no ledger, so the CLI supplies it.
-pub fn guard_for(record: &Record, ledger_approved: bool) -> GuardDecision {
+/// record's lineage *at this tier*. `stella-core` has no ledger, so the CLI supplies
+/// it.
+pub fn guard_for(record: &Record, trust: Trust, ledger_approved: bool) -> GuardDecision {
     let asks_to_block = record
         .enforcement
         .as_ref()
@@ -167,10 +214,18 @@ pub fn guard_for(record: &Record, ledger_approved: bool) -> GuardDecision {
             )),
         };
     }
-    if !(ledger_approved || self_attested(record)) {
+    if !(ledger_approved || self_attested(record, trust)) {
         return GuardDecision {
             guard: None,
-            refusal: Some(BlockingRefusal::NotApproved),
+            // Name the *reason this record* was refused. A project record whose
+            // fields look self-approving is refused for a different reason than a
+            // user record missing a verifier, and telling it the generic story
+            // would send its author to add a `verified_by` that cannot help.
+            refusal: Some(if trust == Trust::User {
+                BlockingRefusal::NotApproved
+            } else {
+                BlockingRefusal::ProjectNeedsApproval
+            }),
         };
     }
     match declared_guard(record) {
@@ -194,7 +249,7 @@ pub fn guard_for(record: &Record, ledger_approved: bool) -> GuardDecision {
 /// an identifier it cannot reuse, reopening the attribution gap handles exist to
 /// close.
 pub fn rule_from_record(loaded: &LoadedRecord, ledger_approved: bool) -> (Rule, GuardDecision) {
-    let decision = guard_for(&loaded.record, ledger_approved);
+    let decision = guard_for(&loaded.record, loaded.trust, ledger_approved);
     let rule = Rule {
         id: loaded.handle.clone(),
         description: loaded
@@ -253,7 +308,7 @@ mod tests {
 
     #[test]
     fn a_user_decreed_record_with_a_real_enforcer_arms_a_guard() {
-        let decision = guard_for(&user_decree_with_guard(), false);
+        let decision = guard_for(&user_decree_with_guard(), Trust::User, false);
         assert_eq!(
             decision.guard,
             Some(RuleGuard {
@@ -273,7 +328,7 @@ mod tests {
             let mut record = user_decree_with_guard();
             record.origin = Some(origin);
             for ledger_approved in [false, true] {
-                let decision = guard_for(&record, ledger_approved);
+                let decision = guard_for(&record, Trust::User, ledger_approved);
                 assert_eq!(
                     decision.guard, None,
                     "{origin:?} armed a guard with ledger_approved={ledger_approved}"
@@ -291,8 +346,8 @@ mod tests {
     fn an_origin_less_record_does_not_default_into_blocking() {
         let mut record = user_decree_with_guard();
         record.origin = None;
-        assert_eq!(guard_for(&record, false).guard, None);
-        assert!(guard_for(&record, false).refusal.is_some());
+        assert_eq!(guard_for(&record, Trust::User, false).guard, None);
+        assert!(guard_for(&record, Trust::User, false).refusal.is_some());
     }
 
     #[test]
@@ -308,7 +363,7 @@ mod tests {
             check: None,
             rubric: None,
         });
-        let decision = guard_for(&record, true);
+        let decision = guard_for(&record, Trust::User, true);
         assert_eq!(decision.guard, None, "blank guard fields are not a guard");
         assert_eq!(decision.refusal, Some(BlockingRefusal::NoEnforcer));
     }
@@ -320,7 +375,7 @@ mod tests {
             if let Some(enforcement) = record.enforcement.as_mut() {
                 enforcement.mode = mode;
             }
-            let decision = guard_for(&record, true);
+            let decision = guard_for(&record, Trust::User, true);
             assert_eq!(decision.guard, None, "{mode:?} must not block");
             assert_eq!(
                 decision.refusal, None,
@@ -337,11 +392,11 @@ mod tests {
             ..decreed_by("ignored")
         });
         assert_eq!(
-            guard_for(&record, false).refusal,
+            guard_for(&record, Trust::User, false).refusal,
             Some(BlockingRefusal::NotApproved)
         );
         assert!(
-            guard_for(&record, true).guard.is_some(),
+            guard_for(&record, Trust::User, true).guard.is_some(),
             "an explicit approval is the other way in"
         );
     }
@@ -353,7 +408,7 @@ mod tests {
             truth.basis = TruthBasis::Measured;
         }
         assert_eq!(
-            guard_for(&record, false).refusal,
+            guard_for(&record, Trust::User, false).refusal,
             Some(BlockingRefusal::NotApproved),
             "\"the world agrees\" is not \"a person authorized blocking\""
         );
@@ -362,6 +417,7 @@ mod tests {
     #[test]
     fn the_projected_rule_is_keyed_by_handle_so_a_block_is_citable() {
         let mut loaded = super::super::tests::loaded_from(user_decree_with_guard());
+        loaded.trust = Trust::User;
         loaded.handle = "no-force-push".to_string();
         let (rule, decision) = rule_from_record(&loaded, false);
         assert_eq!(rule.id, "no-force-push");

--- a/stella-core/src/records/handle.rs
+++ b/stella-core/src/records/handle.rs
@@ -167,6 +167,7 @@ mod tests {
             record,
             set_id: set_id.to_string(),
             source: format!("{set_id}.toml"),
+            trust: super::super::Trust::Project,
             handle: String::new(),
             findings: Vec::new(),
         }
@@ -222,6 +223,7 @@ mod tests {
                 },
                 set_id: "acme.web".to_string(),
                 source: "other.toml".to_string(),
+                trust: super::super::Trust::Project,
                 handle: String::new(),
                 findings: Vec::new(),
             },

--- a/stella-core/src/records/registry.rs
+++ b/stella-core/src/records/registry.rs
@@ -29,6 +29,24 @@
 //! follow exactly", so they project to `must` and ride the cached channel. That
 //! also gives them a `^handle`, which means legacy rules become citable — the
 //! attribution loop closes for them too, at no cost to the author.
+//!
+//! # Why the merge takes two lists
+//!
+//! `lineage_id` is the identity precedence acts on, and it is *author-supplied*.
+//! Over one flat list in directory order that is a hole: the project directories
+//! come last, so a repository could name its record `ctx.<something the user
+//! publishes>` and, under last-wins, replace the user's record wholesale — taking
+//! its armed guard with it. A cloned checkout could switch off a protection the
+//! person at the keyboard had set up for themselves.
+//!
+//! The markdown path never had that hole: `merge_rule_trust_tiers` in `stella-cli`
+//! keeps a user-global hard guard **monotonic** — a project rule with the same id
+//! can never remove it, and a project rule carrying a *different* guard is kept
+//! alongside so both constraints stay armed. [`load`] takes the two tiers as two
+//! arguments so the compiler asks which is which, and the tier fold applies that
+//! same invariant to records. What a project record may still do is exactly what it
+//! could always do: override a user record that established no enforcement, and add
+//! enforcement of its own.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -39,8 +57,13 @@ use super::super::ingest::record::{
 use super::super::rules::{Rule, RuleFile, rule_from_file_checked};
 use super::{
     Channel, Conflict, Disposition, GuardDecision, LoadedRecord, RecordFinding, RenderInput,
-    RenderedChannel, SweepInput, assign_handles, load_context_file, render_channel,
+    RenderedChannel, SweepInput, Trust, assign_handles, declared_hard_guard, load_context_file,
+    render_channel,
 };
+
+/// One parsed entry: the record, and the legacy `.md` rule it was projected from
+/// when it was projected from one.
+type Parsed = (LoadedRecord, Option<Rule>);
 
 /// What the registry could not load, and why. Reported rather than swallowed: a
 /// policy file that silently stopped loading is indistinguishable from a policy
@@ -144,43 +167,42 @@ pub struct Facts<'a> {
     pub verdicts: BTreeMap<String, Verdict>,
     /// When each lineage's probe last ran, keyed by `lineage_id`.
     pub last_checked: BTreeMap<String, String>,
-    /// Lineages a human explicitly approved for blocking.
-    pub approved_blocking: BTreeSet<String>,
+    /// Lineages a human explicitly approved for blocking, **qualified by the tier
+    /// the approval was granted at**.
+    ///
+    /// Keyed by tier and not by lineage alone because a lineage is author-supplied:
+    /// an approval the user granted their own `~/.stella/rules` record would
+    /// otherwise transfer, silently and automatically, to any repository record that
+    /// happened to name the same lineage.
+    pub approved_blocking: BTreeSet<(Trust, String)>,
     /// Now, RFC-3339.
     pub now: &'a str,
 }
 
-/// Resolve `files` — `.md` rules and `.toml` records, already in directory
-/// precedence order — into one registry.
-pub fn load(files: &[RuleFile], facts: &Facts<'_>) -> Registry {
+impl Facts<'_> {
+    /// Whether a human approved blocking for this record — at this record's own tier.
+    fn approves(&self, trust: Trust, lineage: &str) -> bool {
+        self.approved_blocking
+            .contains(&(trust, lineage.to_string()))
+    }
+}
+
+/// Resolve this session's rule files — `.md` rules and `.toml` records — into one
+/// registry.
+///
+/// The two tiers are separate arguments, not one list in directory order, because
+/// the merge treats them differently: see the module docs on why a repository record
+/// must not be able to displace a user record's enforcement. Within each argument,
+/// files are in directory-precedence order and later still wins.
+pub fn load(user_files: &[RuleFile], project_files: &[RuleFile], facts: &Facts<'_>) -> Registry {
     let mut diagnostics = Vec::new();
 
-    // Pass 1: parse every file into records, in directory-precedence order. Each
-    // carries the legacy markdown rule it came from, when it came from one.
-    let mut parsed: Vec<(LoadedRecord, Option<Rule>)> = Vec::new();
-    for file in files {
-        if file.path.ends_with(".toml") {
-            match load_context_file(&file.path, &file.contents) {
-                Ok(records) => parsed.extend(records.into_iter().map(|record| (record, None))),
-                Err(err) => diagnostics.push(Diagnostic {
-                    source: err.source,
-                    detail: err.detail,
-                }),
-            }
-            continue;
-        }
-        match rule_from_file_checked(&file.path, &file.contents) {
-            Ok(rule) => parsed.push((record_from_markdown(&rule), Some(rule))),
-            // A file with no statement is not a rule and never was; saying so for
-            // every README in a rules directory would be noise. The nesting and
-            // missing-id refusals are real defects and get reported.
-            Err(super::super::rules::RuleFileError::EmptyStatement) => {}
-            Err(err) => diagnostics.push(Diagnostic {
-                source: file.path.clone(),
-                detail: err.to_string(),
-            }),
-        }
-    }
+    // Pass 1: parse each tier into records, in directory-precedence order. Each
+    // carries the legacy markdown rule it came from, when it came from one, and the
+    // tier it was read out of — which is the one fact the file cannot claim about
+    // itself.
+    let user = parse_tier(user_files, Trust::User, &mut diagnostics);
+    let project = parse_tier(project_files, Trust::Project, &mut diagnostics);
 
     // Pass 2: merge by `lineage_id`, BEFORE handles are assigned.
     //
@@ -190,7 +212,7 @@ pub fn load(files: &[RuleFile], facts: &Facts<'_>) -> Registry {
     // distinct handles and both would steer, with the older one silently outliving
     // the override that was supposed to replace it. `lineage_id` is the identity that
     // survives revisions, so it is the identity precedence acts on.
-    let merged = merge_by_lineage(parsed);
+    let merged = merge_tiers(merge_by_lineage(user), merge_by_lineage(project));
 
     // Handles are only unambiguous across the surviving set, and conflicts compare
     // records against each other, so both happen once, globally. The per-record
@@ -252,14 +274,46 @@ pub fn load(files: &[RuleFile], facts: &Facts<'_>) -> Registry {
     }
 }
 
-/// Merge by `lineage_id`: a later entry replaces an earlier one with the same
-/// lineage, keeping the earlier one's position. The same semantics the markdown
-/// loader has always had (JS `Map.set` on an existing key), now over both formats.
-fn merge_by_lineage(
-    parsed: Vec<(LoadedRecord, Option<Rule>)>,
-) -> Vec<(LoadedRecord, Option<Rule>)> {
+/// Parse one trust tier's files, stamping every record with the tier it was read
+/// out of.
+fn parse_tier(files: &[RuleFile], trust: Trust, diagnostics: &mut Vec<Diagnostic>) -> Vec<Parsed> {
+    let mut parsed: Vec<Parsed> = Vec::new();
+    for file in files {
+        if file.path.ends_with(".toml") {
+            match load_context_file(&file.path, &file.contents) {
+                Ok(records) => parsed.extend(records.into_iter().map(|mut record| {
+                    record.trust = trust;
+                    (record, None)
+                })),
+                Err(err) => diagnostics.push(Diagnostic {
+                    source: err.source,
+                    detail: err.detail,
+                }),
+            }
+            continue;
+        }
+        match rule_from_file_checked(&file.path, &file.contents) {
+            Ok(rule) => parsed.push((record_from_markdown(&rule, trust), Some(rule))),
+            // A file with no statement is not a rule and never was; saying so for
+            // every README in a rules directory would be noise. The nesting and
+            // missing-id refusals are real defects and get reported.
+            Err(super::super::rules::RuleFileError::EmptyStatement) => {}
+            Err(err) => diagnostics.push(Diagnostic {
+                source: file.path.clone(),
+                detail: err.to_string(),
+            }),
+        }
+    }
+    parsed
+}
+
+/// Merge by `lineage_id` **within one tier**: a later entry replaces an earlier one
+/// with the same lineage, keeping the earlier one's position. The same semantics the
+/// markdown loader has always had (JS `Map.set` on an existing key), now over both
+/// formats.
+fn merge_by_lineage(parsed: Vec<Parsed>) -> Vec<Parsed> {
     let mut order: Vec<String> = Vec::new();
-    let mut by_lineage: BTreeMap<String, (LoadedRecord, Option<Rule>)> = BTreeMap::new();
+    let mut by_lineage: BTreeMap<String, Parsed> = BTreeMap::new();
     for entry in parsed {
         let lineage = entry.0.record.lineage_id.clone();
         if !by_lineage.contains_key(&lineage) {
@@ -271,6 +325,50 @@ fn merge_by_lineage(
         .into_iter()
         .filter_map(|lineage| by_lineage.remove(&lineage))
         .collect()
+}
+
+/// Fold the project tier into the user tier, monotonically.
+///
+/// The invariant, matching `merge_rule_trust_tiers` on the markdown side: **a
+/// project record may add enforcement and may never remove it.** Concretely, for a
+/// project record whose lineage a user record already holds:
+///
+/// | The user record | The project record | Result |
+/// | --- | --- | --- |
+/// | establishes no guard | anything | overrides, as it always has |
+/// | establishes a guard | establishes a *different* one | both kept — two constraints, neither weakened |
+/// | establishes a guard | the same one, or none | dropped — it could only weaken or duplicate |
+///
+/// The last row is the hole this closes. A `mode = "none"` record naming a user
+/// lineage used to win the merge outright and take the user's armed guard with it.
+///
+/// "Establishes a guard" is [`declared_hard_guard`] — deliberately independent of
+/// whether the guard is *approved*, so adding a ledger entry can never change which
+/// record survives the merge.
+fn merge_tiers(mut user: Vec<Parsed>, project: Vec<Parsed>) -> Vec<Parsed> {
+    for entry in project {
+        let Some(index) = user
+            .iter()
+            .position(|(loaded, _)| loaded.record.lineage_id == entry.0.record.lineage_id)
+        else {
+            user.push(entry);
+            continue;
+        };
+        let established = declared_hard_guard(&user[index].0.record);
+        let Some(established) = established else {
+            user[index] = entry;
+            continue;
+        };
+        // Keeping both is what makes this *monotonic* rather than merely
+        // protective: the project's own constraint still applies, under its own
+        // handle, subject to its own approval. Dropping it would let a user record
+        // silently switch off a repository's guard, which is the same bug pointing
+        // the other way.
+        if declared_hard_guard(&entry.0.record).is_some_and(|guard| guard != established) {
+            user.push(entry);
+        }
+    }
+    user
 }
 
 /// Why this record must not steer, when something says it must not.
@@ -328,8 +426,8 @@ fn resolve_guard(
             refusal: None,
         };
     }
-    let approved = facts.approved_blocking.contains(&record.record.lineage_id);
-    let decision = super::guard_for(&record.record, approved);
+    let approved = facts.approves(record.trust, &record.record.lineage_id);
+    let decision = super::guard_for(&record.record, record.trust, approved);
     if let Some(refusal) = decision.refusal.as_ref() {
         diagnostics.push(Diagnostic {
             source: record.source.clone(),
@@ -361,7 +459,7 @@ fn projected_rule(entry: &Entry) -> Rule {
 /// The force is `must`: markdown rules have always been rendered under "binding —
 /// follow exactly", and quietly weakening them on the way to the new renderer would
 /// change what the model is told without anyone editing a rule.
-fn record_from_markdown(rule: &Rule) -> LoadedRecord {
+fn record_from_markdown(rule: &Rule, trust: Trust) -> LoadedRecord {
     let record = Record {
         lineage_id: format!("ctx.{}", rule.id),
         record_id: None,
@@ -398,6 +496,7 @@ fn record_from_markdown(rule: &Rule) -> LoadedRecord {
         record,
         set_id: "markdown".to_string(),
         source: rule.source.clone(),
+        trust,
         handle: String::new(),
         findings: Vec::new(),
     }

--- a/stella-core/src/records/registry/tests.rs
+++ b/stella-core/src/records/registry/tests.rs
@@ -58,7 +58,7 @@ fn markdown_rules_and_toml_records_render_in_one_block() {
             ),
         ),
     ];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert!(
         registry.diagnostics.is_empty(),
         "{:?}",
@@ -95,7 +95,7 @@ fn a_later_directory_overrides_an_earlier_one_across_formats() {
             &toml_record("ctx.pkg-manager", "The project's version.", "must"),
         ),
     ];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert_eq!(
         registry.entries.len(),
         1,
@@ -115,7 +115,7 @@ fn a_nested_frontmatter_key_refuses_the_file_with_an_actionable_error() {
         ".stella/rules/api-integration-coverage.md",
         "---\nname: api-integration-coverage\nscope:\n  repository_id: repo_stella\n---\nAPI changes need integration coverage.",
     )];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert!(
         registry.entries.is_empty(),
         "a record wearing a scope nobody wrote must not load"
@@ -144,7 +144,7 @@ fn a_legacy_multi_paragraph_rule_body_still_loads() {
         ".stella/rules/long.md",
         "---\nname: long\n---\nFirst paragraph of guidance.\n\nSecond paragraph, with more detail.",
     )];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert_eq!(registry.entries.len(), 1, "{:?}", registry.diagnostics);
     assert!(
         registry.entries[0].record.findings.is_empty(),
@@ -165,7 +165,7 @@ fn a_malformed_toml_file_is_reported_and_the_rest_still_load() {
             &toml_record("ctx.acme.web.ok", "A valid record.", "must"),
         ),
     ];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert_eq!(registry.entries.len(), 1);
     assert_eq!(registry.diagnostics.len(), 1);
     assert_eq!(registry.diagnostics[0].source, ".stella/rules/broken.toml");
@@ -174,7 +174,7 @@ fn a_malformed_toml_file_is_reported_and_the_rest_still_load() {
 #[test]
 fn a_directory_of_prose_is_not_reported_as_broken_rules() {
     let files = vec![md(".stella/rules/README.md", "---\nname: readme\n---\n")];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert!(registry.entries.is_empty());
     assert!(
         registry.diagnostics.is_empty(),
@@ -190,7 +190,7 @@ fn a_shipped_markdown_guard_is_still_armed_with_no_approval_ceremony() {
         ".stella/rules/no-applied-migration.md",
         "---\nguard-tool: Edit\nguard-deny-path: migrations/*-applied/**\n---\nAdd a forward migration.",
     )];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     let entry = &registry.entries[0];
     assert!(
         entry.is_enforced(),
@@ -241,7 +241,7 @@ mode = "hard"
 guard_tool = "Bash"
 guard_deny_command = "git push --force*"
 "#;
-    let registry = load(&[md(".stella/rules/acme.web.toml", hard)], &facts());
+    let registry = load(&[], &[md(".stella/rules/acme.web.toml", hard)], &facts());
     let entry = &registry.entries[0];
     assert!(
         !entry.is_enforced(),
@@ -280,7 +280,7 @@ fn a_refuted_record_leaves_the_registry_before_anything_renders() {
             "must",
         ),
     )];
-    let registry = load(&files, &facts);
+    let registry = load(&[], &files, &facts);
     assert!(
         registry.render(Channel::Cached, None).text.is_empty(),
         "the whole point: a claim the world refuted stops steering"
@@ -343,8 +343,12 @@ mode = "none"
     let mut facts = facts();
     facts
         .approved_blocking
-        .insert("ctx.acme.web.internal-guard".to_string());
-    let registry = load(&[md(".stella/rules/acme.web.toml", conflicting)], &facts);
+        .insert((Trust::Project, "ctx.acme.web.internal-guard".to_string()));
+    let registry = load(
+        &[],
+        &[md(".stella/rules/acme.web.toml", conflicting)],
+        &facts,
+    );
 
     assert_eq!(registry.conflicts.len(), 1, "{:?}", registry.conflicts);
     assert_eq!(registry.conflicts[0].suspended, "internal-guard");
@@ -376,6 +380,221 @@ mode = "none"
     );
 }
 
+// The trust tier: a project record may add enforcement and may never remove it.
+
+/// A record that establishes a hard guard, decreed by a named human — the shape
+/// that self-approves in `~/.stella/rules` and needs a ledger entry anywhere else.
+fn guarded_record(lineage: &str, deny_command: &str) -> String {
+    format!(
+        r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "constraint"
+statement = "Never force-push to a shared branch."
+origin = "user"
+status = "active"
+
+[record.steering]
+force = "must"
+precedence = 50
+
+[record.truth]
+basis = "decree"
+verified_by = "mac"
+
+[record.enforcement]
+mode = "hard"
+guard_tool = "Bash"
+guard_deny_command = "{deny_command}"
+"#
+    )
+}
+
+/// A record naming `lineage` that enforces nothing — the shape that used to win the
+/// merge outright and take the guard it displaced with it.
+fn unguarded_record(lineage: &str) -> String {
+    format!(
+        r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "rule"
+statement = "Force-pushing is fine on this project."
+origin = "user"
+status = "active"
+
+[record.steering]
+force = "must"
+precedence = 50
+
+[record.enforcement]
+mode = "none"
+"#
+    )
+}
+
+const GUARDED: &str = "ctx.acme.web.no-force-push";
+
+#[test]
+fn a_project_record_cannot_disarm_a_user_records_guard() {
+    // The hole: `lineage_id` is author-supplied, and the project directories used to
+    // come last in one flat list. A checkout naming the user's lineage replaced the
+    // user's record wholesale — armed guard and all.
+    let user = vec![md(
+        "/home/mac/.stella/rules/no-force-push.toml",
+        &guarded_record(GUARDED, "git push --force*"),
+    )];
+    let project = vec![md(
+        ".stella/rules/permissive.toml",
+        &unguarded_record(GUARDED),
+    )];
+    let registry = load(&user, &project, &facts());
+
+    assert_eq!(
+        registry.entries.len(),
+        1,
+        "the project record could only ever weaken this lineage, so it is dropped"
+    );
+    let entry = &registry.entries[0];
+    assert_eq!(entry.record.trust, Trust::User);
+    assert!(
+        entry.is_enforced(),
+        "a cloned repository must not be able to switch off the user's own guard"
+    );
+    assert_eq!(
+        entry.record.record.statement, "Never force-push to a shared branch.",
+        "and the user's statement is the one that steers"
+    );
+}
+
+#[test]
+fn a_project_record_carrying_a_different_guard_is_kept_alongside() {
+    // Monotonic, not merely protective: the repository's own constraint still
+    // applies. Dropping it would let a user record switch off a repository guard,
+    // which is the same bug pointing the other way.
+    let user = vec![md(
+        "/home/mac/.stella/rules/no-force-push.toml",
+        &guarded_record(GUARDED, "git push --force*"),
+    )];
+    let project = vec![md(
+        ".stella/rules/stricter.toml",
+        &guarded_record(GUARDED, "git push*"),
+    )];
+    let mut facts = facts();
+    facts
+        .approved_blocking
+        .insert((Trust::Project, GUARDED.to_string()));
+    let registry = load(&user, &project, &facts);
+
+    assert_eq!(registry.entries.len(), 2, "both constraints survive");
+    assert!(
+        registry.entries.iter().all(Entry::is_enforced),
+        "neither tier weakens the other"
+    );
+    let handles: Vec<&str> = registry
+        .entries
+        .iter()
+        .map(|entry| entry.record.handle.as_str())
+        .collect();
+    assert_ne!(
+        handles[0], handles[1],
+        "two records sharing a lineage must still be separately citable"
+    );
+}
+
+#[test]
+fn a_project_record_still_overrides_a_user_record_that_enforces_nothing() {
+    // The historical override is not collateral damage of the fix. Repository policy
+    // beating personal preference is the *designed* behavior everywhere it is not
+    // removing a protection.
+    let user = vec![md(
+        "/home/mac/.stella/rules/prefs.toml",
+        &toml_record("ctx.acme.web.pkg-manager", "Personal preference.", "should"),
+    )];
+    let project = vec![md(
+        ".stella/rules/acme.web.toml",
+        &toml_record(
+            "ctx.acme.web.pkg-manager",
+            "This repository uses pnpm.",
+            "must",
+        ),
+    )];
+    let registry = load(&user, &project, &facts());
+
+    assert_eq!(registry.entries.len(), 1);
+    assert_eq!(
+        registry.entries[0].record.record.statement, "This repository uses pnpm.",
+        "the later directory still wins when there is no enforcement to protect"
+    );
+    assert_eq!(registry.entries[0].record.trust, Trust::Project);
+}
+
+#[test]
+fn a_repository_record_cannot_approve_its_own_blocking() {
+    // `origin`, `basis`, and `verified_by` are fields inside the file being judged.
+    // In `~/.stella/rules` they are the author speaking about themselves; in a
+    // checkout they are a stranger asserting the author's consent.
+    let project = vec![md(
+        ".stella/rules/no-force-push.toml",
+        &guarded_record(GUARDED, "git push --force*"),
+    )];
+    let registry = load(&[], &project, &facts());
+
+    assert!(
+        !registry.entries[0].is_enforced(),
+        "a repository record reaches the tool boundary only through the ledger"
+    );
+    assert!(
+        registry
+            .diagnostics
+            .iter()
+            .any(|d| d.detail.contains("approve it locally")),
+        "and the refusal must say what would actually help: {:?}",
+        registry.diagnostics
+    );
+}
+
+#[test]
+fn the_same_record_in_the_users_own_directory_self_approves() {
+    // The other half of the same decision — the local-first solo path must not
+    // acquire a ledger requirement.
+    let user = vec![md(
+        "/home/mac/.stella/rules/no-force-push.toml",
+        &guarded_record(GUARDED, "git push --force*"),
+    )];
+    let registry = load(&user, &[], &facts());
+    assert!(
+        registry.entries[0].is_enforced(),
+        "writing the file, naming yourself, and keeping it on your own disk IS the approval"
+    );
+}
+
+#[test]
+fn a_user_approval_does_not_transfer_to_a_project_record_of_the_same_lineage() {
+    // Approvals used to be keyed by lineage alone. A lineage does not identify a
+    // record — it is author-supplied — so an approval the user granted their own
+    // record was handed to any repository record that guessed the name.
+    let project = vec![md(
+        ".stella/rules/no-force-push.toml",
+        &guarded_record(GUARDED, "git push --force*"),
+    )];
+    let mut facts = facts();
+    facts
+        .approved_blocking
+        .insert((Trust::User, GUARDED.to_string()));
+    let registry = load(&[], &project, &facts);
+
+    assert!(
+        !registry.entries[0].is_enforced(),
+        "the approval was granted to the user's record, not to this lineage as a name"
+    );
+}
+
 // Lookup + reporting
 
 #[test]
@@ -388,7 +607,7 @@ fn by_handle_accepts_the_caret_form_the_agent_writes() {
             "must",
         ),
     )];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     assert!(registry.by_handle("^pkg-manager").is_some());
     assert!(registry.by_handle("pkg-manager").is_some());
     assert!(registry.by_handle("nope").is_none());
@@ -404,7 +623,7 @@ fn findings_are_reported_worst_first() {
             "must",
         ),
     )];
-    let registry = load(&files, &facts());
+    let registry = load(&[], &files, &facts());
     let findings = registry.findings();
     assert_eq!(findings.len(), 1);
     assert_eq!(findings[0].1, &RecordFinding::IdentityStamped);
@@ -412,7 +631,7 @@ fn findings_are_reported_worst_first() {
 
 #[test]
 fn an_empty_workspace_loads_an_empty_registry() {
-    let registry = load(&[], &facts());
+    let registry = load(&[], &[], &facts());
     assert_eq!(registry, Registry::default());
     assert!(registry.render(Channel::Cached, None).text.is_empty());
 }

--- a/stella-core/src/records/tests.rs
+++ b/stella-core/src/records/tests.rs
@@ -90,6 +90,7 @@ pub(super) fn loaded_from(mut record: Record) -> LoadedRecord {
         record,
         set_id: "acme.web".to_string(),
         source: ".stella/rules/acme.web.toml".to_string(),
+        trust: super::Trust::Project,
         handle: String::new(),
         findings: Vec::new(),
     }

--- a/stella-core/src/records/trust.rs
+++ b/stella-core/src/records/trust.rs
@@ -1,0 +1,76 @@
+//! Which authority published a record.
+//!
+//! Everything else about a record is self-described: `origin`, `truth.basis`,
+//! `verified_by` are fields *inside the file being judged*. That is fine for a
+//! record you wrote, and worthless for one that arrived with a checkout — a
+//! repository can assert `origin = "user"` about itself as easily as it can assert
+//! anything else. So the one fact the record is not allowed to claim is where it
+//! came from: [`Trust`] is stamped by the loader from **which directory the file
+//! was read out of**, and nothing in the file can change it.
+//!
+//! # Why the default is the lower tier
+//!
+//! [`Trust::Project`] is [`Default`] on purpose. A caller that forgets to stamp
+//! the tier gets the restrictive answer — a record that cannot self-approve
+//! blocking and cannot displace a user record's enforcement. The failure mode of
+//! defaulting the other way is a repository silently inheriting the user's
+//! authority, which is the whole thing this type exists to prevent.
+//!
+//! # What it is not
+//!
+//! Not a permission to *steer*. Whether an untrusted checkout's records reach the
+//! prompt at all is `stella-cli`'s `AuthorityPolicy` question, decided before any
+//! file is read. `Trust` answers a narrower one, asked of files that are already
+//! allowed to load: may this record *remove* enforcement another record
+//! established, and may it approve itself for the tool boundary.
+
+/// The authority a record was published under.
+///
+/// Ordered: `Project < User`, so `>=` reads as "at least as trusted as".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub enum Trust {
+    /// Published in the repository (`<repo>/.stella/rules`, `<repo>/.claude/rules`,
+    /// or the workspace store). Anyone who can open a pull request can write one,
+    /// so a project record may add enforcement and may never remove it.
+    #[default]
+    Project,
+    /// Published in the user's own `~/.stella/rules`. Writing the file, naming
+    /// yourself in it, and keeping it on your own disk *is* the approval — there is
+    /// no second party to ceremony against.
+    User,
+}
+
+impl Trust {
+    /// The spelling used in refusals and reports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::User => "user",
+        }
+    }
+}
+
+impl std::fmt::Display for Trust {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_is_the_lower_tier() {
+        assert_eq!(
+            Trust::default(),
+            Trust::Project,
+            "a forgotten stamp must fail toward the restrictive answer"
+        );
+    }
+
+    #[test]
+    fn user_outranks_project() {
+        assert!(Trust::User > Trust::Project);
+    }
+}


### PR DESCRIPTION
Follow-up to #957. The records engine merges by `lineage_id` — the right identity for precedence, since handles are deliberately made unique and could never merge anything — but that merge was trust-blind.

## The hole

`rule_search_dirs` orders `[~/.stella/rules, .claude/rules, .stella/rules]`, project last, and `merge_by_lineage` was last-wins over one flat list. `lineage_id` is author-supplied. So:

- The user publishes `~/.stella/rules/mine.toml` at `ctx.acme.no-force-push`, `mode = "hard"`, approved.
- A cloned repository ships `.stella/rules/anything.toml` with the same `lineage_id` and `mode = "none"`.
- The project record wins. `entries` holds only it, `records.rules` is built post-merge, and the user's guard is gone.

The markdown path never had this. `merge_rule_trust_tiers` keeps a user-global hard guard monotonic — a project rule with the same id can never remove it, and a project rule carrying a *different* guard is kept alongside under `<id>@project` so both stay armed. `boundary_rules` deliberately declined to re-express that logic inside the record merge (its comment says so, and names the one md-vs-TOML asymmetry it does handle, which fails safe). That was the right call for shipping — but it left the record merge with no such logic at all.

Two amplifiers made it worse:

1. `approved_blocking` was keyed by `lineage_id` alone, so an approval the user granted their own record transferred to whatever record later won that lineage.
2. `self_attested` reads `origin`, `truth.basis`, and `verified_by` — all fields *inside the file being judged*. A repo-committed TOML declaring `origin = "user"` + `basis = "decree"` + `verified_by = "anyone"` armed a Tier-2 deny with no ledger entry at all.

## The fix

One invariant, matching the markdown side: **a project record may add enforcement and may never remove it.**

- **`records::Trust`** — stamped from the directory a file was read out of, never from anything the record claims about itself. `Project` is `Default`, so a forgotten stamp fails toward the restrictive answer.
- **`registry::load` takes two tiers as two arguments**, not one ordered list, so the compiler asks which is which — the same reasoning that made `load_session_registry` a separate function instead of a bool parameter. The fold drops a project record that could only weaken the user's guard, keeps one carrying a *different* guard alongside (monotonic in both directions — a user record must not switch off a repository's guard either), and leaves the historical override intact wherever there is no enforcement to protect.
- **Self-approval is gated on the tier.** In `~/.stella/rules`, `verified_by` is the author speaking about themselves and writing the file *is* the approval — the local-first solo path keeps working with no ledger. In a checkout it is a stranger asserting the author's consent, so the record's route to the boundary is the decision ledger: an explicit local act by the person the guard fires on. The refusal is a distinct variant that says so (`stella context review`) rather than sending the author to add a `verified_by` that cannot help.
- **Approvals are keyed by `(tier, lineage)`.**

## What did not change

- Grandfathered markdown guards. `resolve_guard` still returns them before any gate.
- The historical project-overrides-user prompt behavior, wherever no enforcement is at stake — pinned by `a_project_record_still_overrides_a_user_record_that_enforces_nothing`.
- `boundary_rules`. The markdown trust-tier merge still passes through untouched.

## Tests

Six new registry tests. The two that cover the merge were verified to **fail** against the old flat-list behavior before being kept, so they bite rather than merely pass.

At the wired tool boundary, `an_approved_toml_record_blocks_a_matching_bash_call` used to prove #890's criterion from a self-attesting repository record — the hole itself. It now proves the same thing from the ledger, and its new sibling proves the identical bytes *without* an approval do not block.

`make gate` green: fmt, clippy, file-size, rustdoc, and the full workspace suite.

## One behavior change worth a second opinion

A repository-published TOML record can no longer arm a hard guard on its own fields; it needs a local approval per developer. That is stricter than the markdown path, where a committed `guard-deny-path:` arms for everyone — but markdown is grandfathered precisely because it shipped, and #957's own posture is that the TOML surface "can carry the stricter contract from the start". Flagging it because it does mean a team wanting a repo-wide blocking record now needs each developer to approve it once.


## Summary by Sourcery

Separate user and project rule tiers in the records registry to enforce trust-aware merging and guard approval, preventing repository records from disarming or self-approving user guards.

New Features:
- Introduce a trust tier model for records (user vs project) and propagate it through the registry and guard evaluation.
- Add support for tiered rule file loading in the CLI so user and project rules are passed separately into the registry merge.

Bug Fixes:
- Prevent repository TOML records from replacing or weakening user records that establish hard guards by making the merge monotonic across trust tiers.
- Disallow repository-published records from self-approving hard guards; they now require explicit local ledger approval keyed by both trust tier and lineage.
- Stop approvals from transferring across tiers by keying approved-blocking decisions on (trust, lineage) instead of lineage alone.

Enhancements:
- Refine guard decision logic with a new refusal variant and clearer diagnostics that explain when a repository record needs local approval.
- Align the TOML record path with the existing markdown trust-tier semantics while preserving the historical project-overrides-user behavior where no enforcement is involved.
- Add new registry and CLI tests to cover trust-tier merging, self-approval behavior, and tool-boundary blocking semantics.

Tests:
- Extend registry tests to cover trust-tier merges, enforcement monotonicity, and non-transfer of approvals between user and project records.
- Add CLI integration tests to verify repository records cannot self-approve blocking and that ledger-approved guards correctly block tool calls at the wired boundary.
