### PR TITLE
feat(tui): startup notices are a transient dialog, not transcript rows

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,7 +18,7 @@
 1788 stella-cli/src/agent_tests.rs
 2292 stella-cli/src/agent.rs
 1576 stella-cli/src/candidate_ws.rs
-4578 stella-cli/src/command_deck.rs
+4596 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
 2138 stella-core/src/driver.rs
 2820 stella-core/src/driver/tests.rs
@@ -36,7 +36,7 @@
 1566 stella-tools/src/media.rs
 3290 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
-1723 stella-tui/src/deck_render.rs
-3999 stella-tui/src/deck_ui.rs
+1728 stella-tui/src/deck_render.rs
+4020 stella-tui/src/deck_ui.rs
 1660 stella-tui/src/views/engine.rs
 1524 stella-tui/src/views/session.rs

--- a/stella-cli/src/command_deck.rs
+++ b/stella-cli/src/command_deck.rs
@@ -146,6 +146,23 @@ fn chrome_note(text: String) -> Inbound {
     }
 }
 
+/// A **session-startup system notification**: the deck talking about the
+/// session itself — a resumable predecessor, what the code-graph pass
+/// indexed, an `mcp.toml` that went untrusted. Shown in a transient dialog
+/// ([`stella_tui::notice`]); never in the transcript.
+///
+/// Contrast [`chrome_note`], which fabricates an `AgentEvent::Text` and so
+/// reads as though the agent had said it. That is still right for a notice
+/// ANSWERING A USER ACTION mid-session (an `mcp` subcommand's result, "cannot
+/// resume `{id}`") — a reply belongs where the user was looking. Startup
+/// chrome is nobody's reply, and the transcript is the home for agent and
+/// user messages only. Corollary for the call sites: the model fold ignores
+/// this variant, so unlike `chrome_note` it never folds the lead to
+/// `AgentStatus::Running`.
+fn system_notice(text: String) -> Inbound {
+    Inbound::Notice(text)
+}
+
 /// `STELLA_DEBUG=1` → the structured deck log path (L-T8), mirroring the
 /// location `stella_tui::shell::RunOptions` documents. `None` otherwise, and
 /// on any failure to create the directory — a lost debug log never gates the
@@ -409,7 +426,7 @@ pub async fn run_deck_session(
         match stella_store::journal::SessionJournal::open(&sidecar_dir) {
             Ok(j) => Some(j),
             Err(e) => {
-                let _ = deck_tx.send(chrome_note(format!(
+                let _ = deck_tx.send(system_notice(format!(
                     "session journaling unavailable — this session will not be resumable ({e})"
                 )));
                 None
@@ -457,12 +474,12 @@ pub async fn run_deck_session(
         .with_pid(std::process::id());
     lead_meta.model = Some(format!("{}/{}", cfg.provider.id, cfg.model_id));
     let _ = in_tx.send(Inbound::Register(lead_meta));
-    // Custom definitions that failed to load are reported into the
-    // transcript up front — stdout belongs to the alternate screen, and a
+    // Custom definitions that failed to load are reported in the startup
+    // dialog — stdout belongs to the alternate screen, and a
     // silently-missing /command is otherwise undiagnosable. Session chrome:
     // re-checked every boot, so it never journals.
     if let Some(report) = custom.problems_report() {
-        let _ = deck_tx.send(chrome_note(report));
+        let _ = deck_tx.send(system_notice(report));
     }
     // Honest degradation (#266): a user who pinned a reasoning effort for the
     // lead but chose a provider whose adapter has no reasoning control gets a
@@ -478,10 +495,11 @@ pub async fn run_deck_session(
             .and_then(|e| e.agent(crate::settings::EngineAgentKind::Default))
             .and_then(|a| a.effort),
     ) {
-        let _ = deck_tx.send(chrome_note(notice));
+        let _ = deck_tx.send(system_notice(notice));
     }
-    // An idle lead is waiting on the human, not queued behind a supervisor
-    // (sent after the problems report — a Text event folds to `Running`).
+    // An idle lead is waiting on the human, not queued behind a supervisor —
+    // asserted outright, since the startup chrome above no longer folds it to
+    // `Running` (see `system_notice`).
     let _ = in_tx.send(Inbound::Status {
         agent: LEAD.to_string(),
         status: AgentStatus::WaitingInput,
@@ -510,21 +528,21 @@ pub async fn run_deck_session(
                     text: text.clone(),
                 });
             }
-            let _ = deck_tx.send(chrome_note(format!(
+            let _ = deck_tx.send(system_notice(format!(
                 "session restored — {} prompt(s) waiting, dispatch held. Submit anything to \
                  run it first (then the backlog), or ctrl+t to edit the queue.",
                 restored.len()
             )));
             queue.adopt(sidecar_dir.clone(), restored);
         } else {
-            let _ = deck_tx.send(chrome_note(
+            let _ = deck_tx.send(system_notice(
                 "session restored — the conversation continues where it left off.".to_string(),
             ));
         }
     } else if session_registry.latest_resumable(&workspace_path).is_some() {
         // A fresh session in a workspace that has something to go back to:
         // one pointer, so "navigate back in" is discoverable.
-        let _ = deck_tx.send(chrome_note(
+        let _ = deck_tx.send(system_notice(
             "◂ a previous session is resumable — ← (on an empty prompt) opens SESSIONS, ⏎ \
              reopens one; or run `stella resume`."
                 .to_string(),
@@ -614,12 +632,12 @@ pub async fn run_deck_session(
         &cfg.workspace_root,
         registry.clone(),
         Box::new(move |line| {
-            let _ = status_tx.send(chrome_note(line));
+            let _ = status_tx.send(system_notice(line));
         }),
         Box::new(move || {
             // Populate the Graph tab now the index exists (it opened on the
-            // "run stella init" hint), and restore the lead to idle — the
-            // status Text events above fold it to `Running`.
+            // "run stella init" hint), and assert the lead is idle — the
+            // index progress above no longer folds it to `Running`.
             if let Some(snapshot) = agent::graph_snapshot(&ready_root) {
                 let _ = ready_tx.send(Inbound::GraphSnapshot(snapshot));
             }
@@ -1946,14 +1964,14 @@ fn spawn_mcp_connect(
         match plan {
             agent::McpPlan::None => {}
             agent::McpPlan::Invalid(reason) => {
-                let _ = chrome_tx.send(chrome_note(reason));
+                let _ = chrome_tx.send(system_notice(reason));
                 let _ = in_tx.send(Inbound::Status {
                     agent: LEAD.to_string(),
                     status: AgentStatus::WaitingInput,
                 });
             }
             agent::McpPlan::Servers(servers) => {
-                let _ = chrome_tx.send(chrome_note(format!(
+                let _ = chrome_tx.send(system_notice(format!(
                     "connecting {} MCP server(s)…",
                     servers.len()
                 )));
@@ -1967,7 +1985,7 @@ fn spawn_mcp_connect(
                             Some(auth),
                         )
                         .await;
-                        let _ = chrome_tx.send(chrome_note(crate::mcp_cmd::mcp_outcome_report(
+                        let _ = chrome_tx.send(system_notice(crate::mcp_cmd::mcp_outcome_report(
                             &set.connected_names(),
                             set.failed_servers(),
                             &set.over_advertising_servers(),
@@ -1979,14 +1997,14 @@ fn spawn_mcp_connect(
                         let _ = slot.set(Arc::new(set));
                     }
                     Err(error) => {
-                        let _ = chrome_tx.send(chrome_note(format!(
+                        let _ = chrome_tx.send(system_notice(format!(
                             "MCP authentication unavailable: {error} — continuing with native tools only"
                         )));
                     }
                 }
-                // The Text events above fold the lead to `Running`, but no
-                // turn is in flight — restore the idle status or the
-                // dashboard would show a busy lead forever.
+                // No turn is in flight — assert the idle status so the
+                // dashboard cannot show a busy lead. (The chrome above no
+                // longer folds it to `Running`; see `system_notice`.)
                 let _ = in_tx.send(Inbound::Status {
                     agent: LEAD.to_string(),
                     status: AgentStatus::WaitingInput,

--- a/stella-tui/src/deck.rs
+++ b/stella-tui/src/deck.rs
@@ -503,7 +503,11 @@ impl WorkspaceModel {
             | Inbound::RecordedCalls(_)
             | Inbound::InspectedCall(_)
             | Inbound::ShowHelp
-            | Inbound::Splash(_) => {}
+            | Inbound::Splash(_)
+            // The whole point of `Notice`: a system notification is not agent
+            // or user speech, so the fold must NOT give it a transcript row.
+            // It is view state only (`DeckUi::notice`).
+            | Inbound::Notice(_) => {}
         }
     }
 

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -20,7 +20,7 @@ use crate::deck::{DeckTab, PrInfo, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::render::{render_slash_popup, scroll_window_start, slash_popup_area};
 use crate::textline::{self, pr_status_label, stage_label};
-use crate::{splash, theme, views};
+use crate::{notice, splash, theme, views};
 
 /// The accent prompt prefix on every composer row. Chrome, not content — it
 /// is never part of the submitted string and the caret cannot enter it.
@@ -135,6 +135,11 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     }
     // (The former ENGINE overlay is gone: the engine panel is the full-width
     // body of the SETTINGS tab — see `views::settings::render`.)
+
+    // Startup system notifications: a transient dialog over the deck, drawn
+    // last but one so help — which the user asked for — still wins the top.
+    // It is a no-op once dismissed or expired, so it costs a branch per frame.
+    notice::render(&ui.notice, area, buf);
 
     if ui.help_open {
         render_help(ui, area, buf);

--- a/stella-tui/src/deck_shell.rs
+++ b/stella-tui/src/deck_shell.rs
@@ -569,7 +569,19 @@ pub async fn run_deck(
                     Some(Event::Paste(text)) => {
                         ui.paste(&text);
                     }
-                    // Resize / mouse: the next draw picks them up.
+                    // Any mouse event dismisses the startup notice, exactly as
+                    // any key does.
+                    //
+                    // NOTE: mouse capture is OFF by default (L-T2 — enabling
+                    // it takes the terminal's own text selection away), so
+                    // this arm only fires for sessions that opted in via
+                    // `DeckOptions::mouse_capture`. On a default session the
+                    // keypress and the dwell timer are the dismissal paths,
+                    // and no click ever reaches the process to be handled.
+                    Some(Event::Mouse(_)) => {
+                        ui.notice.dismiss();
+                    }
+                    // Resize / focus change: the next draw picks them up.
                     Some(_) => {}
                     // Reader thread ended (stdin closed).
                     None => break 'run,

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -40,6 +40,7 @@ use crate::envelope::{
 };
 use crate::graph::GraphSnapshot;
 use crate::input::{ScopeDecision, UserInput};
+use crate::notice::NoticeState;
 use crate::scroll::ScrollState;
 use crate::splash::SplashState;
 use crate::views::mcp::{AuthPrompt, AuthStep, McpMode};
@@ -567,6 +568,9 @@ pub struct DeckUi {
     /// The one global composer — typing works from any tab.
     pub composer: Composer,
     pub splash: SplashState,
+    /// Startup system notifications, shown as a transient dialog rather than
+    /// as transcript rows (see [`crate::notice`]).
+    pub notice: NoticeState,
     pub help_open: bool,
     /// Vertical scroll for the help overlay (↑/↓, PageUp/Down, Home/End). Kept
     /// separate from the transcript scroll since the overlay is a different
@@ -763,6 +767,7 @@ impl Default for DeckUi {
             issues: IssuesPanel::default(),
             composer: Composer::with_paste_threshold(crate::composer::DECK_PASTE_LINE_THRESHOLD),
             splash: SplashState::new(),
+            notice: NoticeState::new(),
             help_open: false,
             help_scroll: ScrollState::default(),
             focused: 0,
@@ -1257,6 +1262,13 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
         }
         return;
     }
+    // A system notification goes to the transient dialog, never to the
+    // transcript — the transcript is agent and user messages only. Out-of-band
+    // view state like the cue above: the model fold never sees it.
+    if let Inbound::Notice(text) = inbound {
+        ui.notice.push(text.clone());
+        return;
+    }
     // A deregister removes a dashboard row, shifting every index after it:
     // fold it, then repair the focus so the focused AGENT stays focused when
     // an earlier row vanishes. When the focused row itself is removed, its
@@ -1433,6 +1445,15 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
     if !ui.splash.is_done() {
         ui.splash.skip();
         return DeckAction::Handled;
+    }
+
+    // The startup notice is informational, not modal: any key dismisses it,
+    // and — unlike the splash above — the key then goes on to do its normal
+    // job. Swallowing it would eat the first character the user types, and
+    // this dialog is at its most visible in exactly the second or two when
+    // they are most likely to start typing. Dismiss, then fall through.
+    if ui.notice.is_visible() {
+        ui.notice.dismiss();
     }
 
     // Help overlay is modal: scrolling keys drive it, `q`/Esc close it. Only

--- a/stella-tui/src/deck_ui/tests.rs
+++ b/stella-tui/src/deck_ui/tests.rs
@@ -513,6 +513,52 @@ fn splash_cues_replay_and_release_the_launch_mark() {
     assert!(ui.splash.is_done(), "release cuts straight to the deck");
 }
 
+/// The invariant this whole path exists for: the transcript is the home for
+/// agent and user messages ONLY. Session chrome used to ride an
+/// `AgentEvent::Text`, which auto-registered a lead lane and gave the notice a
+/// transcript row indistinguishable from the model speaking.
+#[test]
+fn a_system_notice_goes_to_the_dialog_and_never_to_the_transcript() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+
+    let text = "◂ a previous session is resumable — ← opens SESSIONS";
+    ingest_inbound(&Inbound::Notice(text.to_string()), &mut model, &mut ui);
+
+    assert_eq!(ui.notice.entries(), [text], "the dialog holds the notice");
+    assert!(ui.notice.is_visible(), "and shows it");
+    assert!(
+        model.agents.is_empty(),
+        "a notice must not conjure an agent lane — an Event would have, and \
+         that lane's transcript is exactly where chrome does not belong"
+    );
+}
+
+/// Dismissal is total but not greedy: the notice goes, the keystroke lands.
+/// Swallowing it would eat the first character typed, in precisely the second
+/// or two when the dialog is up and the user is most likely to start typing.
+#[test]
+fn any_key_dismisses_the_startup_notice_without_eating_the_keystroke() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    ingest_inbound(
+        &Inbound::Notice("indexing…".to_string()),
+        &mut model,
+        &mut ui,
+    );
+    assert!(ui.notice.is_visible());
+
+    handle_deck_key(key(KeyCode::Char('a')), &model, &mut ui);
+    assert!(!ui.notice.is_visible(), "any key dismisses the dialog");
+    assert_eq!(
+        ui.composer.buffer(),
+        "a",
+        "and the keystroke still reaches the composer"
+    );
+}
+
 #[test]
 fn no_anim_sessions_ignore_splash_replays() {
     let mut model = WorkspaceModel::new();

--- a/stella-tui/src/envelope.rs
+++ b/stella-tui/src/envelope.rs
@@ -276,6 +276,23 @@ pub enum Inbound {
     /// straight to `DeckUi::splash` by [`crate::deck_ui::ingest_inbound`],
     /// ignored by the model fold — like [`Inbound::ShowHelp`].
     Splash(SplashCue),
+    /// A **system notification** — the deck telling the user something about
+    /// the session itself: that a previous session is resumable, what the
+    /// code-graph index pass found, that an `mcp.toml` went untrusted.
+    ///
+    /// Deliberately not [`Inbound::Event`] with an [`AgentEvent::Text`]: the
+    /// transcript is the home for agent and user messages **only**, and
+    /// routing chrome through it made the deck render machine chatter as
+    /// though the agent had said it — then kept it in the scrollback for the
+    /// rest of the session. This is out-of-band view state, applied straight
+    /// to `DeckUi::notice` by [`crate::deck_ui::ingest_inbound`] and ignored
+    /// by the model fold, like [`Inbound::ShowHelp`] and [`Inbound::Splash`].
+    ///
+    /// The deck shows these as a transient dialog ([`crate::notice`]) that any
+    /// key or mouse event dismisses and that expires on its own; it never
+    /// touches the transcript, so nothing here can be mistaken for the model
+    /// speaking.
+    Notice(String),
     /// A refreshed snapshot of the **cross-process session registry** for the
     /// SESSIONS overlay (empty-prompt `←`). Every running stella session on
     /// this machine, grouped by [`SessionPhase`]. Out-of-band view state like

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -54,6 +54,7 @@ pub mod envelope;
 pub mod fleet_dashboard;
 pub mod graph;
 pub mod markdown;
+pub mod notice;
 pub mod palette;
 pub mod progress;
 pub mod proof;

--- a/stella-tui/src/notice.rs
+++ b/stella-tui/src/notice.rs
@@ -1,0 +1,474 @@
+//! Startup system notifications, shown as a transient dialog.
+//!
+//! **The transcript is the home for agent and user messages only.** A system
+//! notification — "a previous session is resumable", the code-graph index
+//! totals, an `mcp.toml` that was not trusted — is neither, so it must never
+//! become a transcript row. Before this module the driver fabricated an
+//! `AgentEvent::Text` for each one (`command_deck::chrome_note`), which made
+//! the deck render machine chatter as though the agent had said it, and left
+//! it in the scrollback for the rest of the session.
+//!
+//! They surface here instead: one small centered dialog that stands for
+//! [`DWELL`] past its most recent line and then gets out of the way.
+//! Dismissal is deliberately cheap and total — any key, any mouse event, or
+//! simply waiting.
+//!
+//! Two behaviours are worth stating because they are choices, not accidents:
+//!
+//! * **The dwell restarts on every new line.** Startup notices do not all
+//!   arrive at once: the code-graph totals land seconds after launch, once the
+//!   background index pass finishes, and MCP connect results later still. A
+//!   timer anchored to the *first* line would expire before the only line most
+//!   users actually want. Anchoring to the *latest* line means the dialog is
+//!   readable for a full [`DWELL`] after the last thing it has to say.
+//! * **An explicit dismiss is final for the session.** Once the user has
+//!   waved it away, a late-arriving line does not pop it back up — a dialog
+//!   that reappears after you dismissed it is worse than one that never
+//!   showed. Late lines are dropped rather than queued.
+//!
+//! Like [`crate::splash`], the visible state is a pure function of elapsed
+//! time, so two renders at the same instant produce byte-identical buffers.
+
+use std::time::{Duration, Instant};
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
+
+use crate::render::row::wrap_one_indent;
+use crate::theme;
+
+/// How long the dialog stands after its most recent line. Long enough to read
+/// a two-line summary, short enough that nobody reaches for the keyboard to
+/// clear it.
+pub const DWELL: Duration = Duration::from_secs(3);
+
+/// The dialog never grows past this, however wide the terminal is — long
+/// measures are hard to read, and this is glanceable text.
+const MAX_WIDTH: u16 = 72;
+
+/// Column the headline of each notice starts at.
+const HEAD_INDENT: usize = 2;
+
+/// Column the detail clauses (and every wrap continuation) start at. The step
+/// in from [`HEAD_INDENT`] is what makes a multi-clause notice scannable
+/// instead of a run-on sentence.
+const DETAIL_INDENT: usize = 6;
+
+/// Ephemeral dialog state. Not part of the model — pure presentation, exactly
+/// like [`crate::splash::SplashState`].
+#[derive(Debug, Clone, Default)]
+pub struct NoticeState {
+    /// Notices in arrival order, each still the driver's raw one-line string.
+    /// Splitting and wrapping happen at render time, where the frame width is
+    /// known.
+    entries: Vec<String>,
+    /// When the most recent line landed — the dwell is measured from here, not
+    /// from the first line (see the module docs).
+    last_at: Option<Instant>,
+    /// Set by [`Self::dismiss`]. Final for the session.
+    dismissed: bool,
+}
+
+impl NoticeState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one system notification. A no-op once dismissed, and blank text
+    /// is dropped rather than rendered as an empty row.
+    pub fn push(&mut self, text: impl Into<String>) {
+        if self.dismissed {
+            return;
+        }
+        let text = text.into();
+        if text.trim().is_empty() {
+            return;
+        }
+        self.entries.push(text);
+        self.last_at = Some(Instant::now());
+    }
+
+    /// Dismiss now — any key, any mouse event. Idempotent, and permanent for
+    /// the session: later notices will not reopen the dialog.
+    pub fn dismiss(&mut self) {
+        self.dismissed = true;
+    }
+
+    /// Whether the dialog should be on screen this frame.
+    pub fn is_visible(&self) -> bool {
+        if self.dismissed || self.entries.is_empty() {
+            return false;
+        }
+        self.last_at.is_some_and(|at| at.elapsed() < DWELL)
+    }
+
+    /// The notices collected so far, newest last. Exposed for tests and for
+    /// any surface that wants to re-show them (nothing does yet).
+    pub fn entries(&self) -> &[String] {
+        &self.entries
+    }
+}
+
+/// Break one run-on notice into a headline plus indented detail clauses.
+///
+/// Every notice the driver emits shares a shape: a short claim, then
+/// em-dash-separated elaboration, sometimes with a trailing parenthetical of
+/// counts. `"✓ code graph: 14157 symbols, 5991 imports across 640 files (150
+/// re-parsed, 490 unchanged this pass) — skipped 2 generated files"` becomes
+/// the claim, then the counts, then the skip note — three scannable rows
+/// instead of one sentence that runs off the edge.
+///
+/// Splitting happens **here, at the presentation edge**, rather than by
+/// reshaping the driver's format strings: the same strings are the CLI's
+/// single-line stdout for `stella init`, where one line is correct.
+pub(crate) fn split_clauses(text: &str) -> (String, Vec<String>) {
+    let mut clauses = text
+        .split(" — ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let Some(head) = clauses.next() else {
+        return (String::new(), Vec::new());
+    };
+    let mut details: Vec<String> = clauses.collect();
+    // A trailing "(…)" on the headline is a parenthetical of counts, not part
+    // of the claim — lift it to its own row so the claim reads clean. Only
+    // when something precedes it: a notice that is *entirely* parenthesised
+    // has no claim to separate it from.
+    if let Some(rest) = head.strip_suffix(')')
+        && let Some(open) = rest.rfind('(')
+        && !rest[..open].trim().is_empty()
+    {
+        let inner = rest[open + 1..].trim().to_string();
+        let claim = rest[..open].trim().to_string();
+        if !inner.is_empty() {
+            details.insert(0, inner);
+            return (claim, details);
+        }
+    }
+    (head, details)
+}
+
+/// Lay one notice out as a headline row plus one row per detail clause, each
+/// wrapped with a hanging indent so continuations line up under their clause
+/// rather than under the left border.
+fn notice_lines(text: &str, width: usize) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    // The driver's multi-line notices (the MCP outcome report) are already
+    // structured; treat each of their lines as its own notice.
+    for source in text.lines().map(str::trim).filter(|s| !s.is_empty()) {
+        let (head, details) = split_clauses(source);
+        if !head.is_empty() {
+            let line = Line::from(vec![
+                Span::raw(" ".repeat(HEAD_INDENT)),
+                Span::styled(head, theme::heading()),
+            ]);
+            wrap_one_indent(line, width, DETAIL_INDENT, &mut out);
+        }
+        for detail in details {
+            let line = Line::from(vec![
+                Span::raw(" ".repeat(DETAIL_INDENT)),
+                Span::styled(detail, theme::muted()),
+            ]);
+            wrap_one_indent(line, width, DETAIL_INDENT, &mut out);
+        }
+    }
+    out
+}
+
+/// Draw the dialog. A no-op when it is not visible, so callers can call it
+/// unconditionally.
+///
+/// A pure function of `(state.entries, state.last_at, area)` — two calls at
+/// the same instant write byte-identical buffers.
+pub fn render(state: &NoticeState, area: Rect, buf: &mut Buffer) {
+    if !state.is_visible() || area.width == 0 || area.height == 0 {
+        return;
+    }
+    let outer_w = area.width.min(MAX_WIDTH);
+    // Two columns of border, and the text is laid out against what is left.
+    let inner_w = outer_w.saturating_sub(2) as usize;
+    if inner_w == 0 {
+        return;
+    }
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (i, entry) in state.entries.iter().enumerate() {
+        // A blank row between notices, never before the first or after the
+        // last — the dialog should not open or close on empty space.
+        if i > 0 {
+            lines.push(Line::default());
+        }
+        lines.extend(notice_lines(entry, inner_w));
+    }
+    if lines.is_empty() {
+        return;
+    }
+
+    // Height is content-driven, capped to the frame. When startup produced
+    // more than fits, keep the TAIL: the newest line is the one that just
+    // restarted the dwell, so it is what the user is being shown for.
+    let max_inner = area.height.saturating_sub(2) as usize;
+    if max_inner == 0 {
+        return;
+    }
+    if lines.len() > max_inner {
+        lines.drain(..lines.len() - max_inner);
+    }
+    let outer_h = (lines.len() as u16).saturating_add(2).min(area.height);
+
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(outer_w)) / 2,
+        y: area.y + (area.height.saturating_sub(outer_h)) / 2,
+        width: outer_w,
+        height: outer_h,
+    };
+    Clear.render(popup, buf);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(" startup · any key dismisses ");
+    let inner = block.inner(popup);
+    block.render(popup, buf);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    Paragraph::new(lines).render(inner, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    /// The four notices from a real launch, verbatim — the run-on sentence
+    /// this module exists to break up.
+    const GRAPH: &str = "✓ code graph: 14157 symbols, 5991 imports across 640 files \
+                         (150 re-parsed, 490 unchanged this pass) — skipped 2 generated files";
+    const RESUMABLE: &str = "◂ a previous session is resumable — ← (on an empty prompt) opens \
+                             SESSIONS, ⏎ reopens one; or run `stella resume`.";
+
+    fn buffer_rows(buf: &Buffer) -> Vec<String> {
+        let area = *buf.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn draw(state: &NoticeState, w: u16, h: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal
+            .draw(|f| render(state, f.area(), f.buffer_mut()))
+            .unwrap();
+        buffer_rows(terminal.backend().buffer())
+    }
+
+    fn has_non_space(rows: &[String]) -> bool {
+        rows.iter().any(|row| row.chars().any(|c| c != ' '))
+    }
+
+    /// Backdates `last_at` so the dwell reads as expired without a real sleep
+    /// — the same trick `splash::tests::state_at` uses, and legal for the same
+    /// reason (this module owns the private fields).
+    fn aged(entries: &[&str], ms: u64) -> NoticeState {
+        NoticeState {
+            entries: entries.iter().map(|s| s.to_string()).collect(),
+            last_at: Some(Instant::now() - Duration::from_millis(ms)),
+            dismissed: false,
+        }
+    }
+
+    #[test]
+    fn a_fresh_notice_shows_and_expires_after_the_dwell() {
+        assert!(aged(&[GRAPH], 0).is_visible());
+        assert!(aged(&[GRAPH], DWELL.as_millis() as u64 - 100).is_visible());
+        assert!(!aged(&[GRAPH], DWELL.as_millis() as u64 + 100).is_visible());
+    }
+
+    #[test]
+    fn the_dwell_is_three_seconds() {
+        assert_eq!(DWELL, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn an_empty_notice_state_is_invisible() {
+        assert!(!NoticeState::new().is_visible());
+        assert!(!has_non_space(&draw(&NoticeState::new(), 80, 24)));
+    }
+
+    #[test]
+    fn blank_text_is_dropped_rather_than_shown_as_an_empty_row() {
+        let mut state = NoticeState::new();
+        state.push("   ");
+        state.push("\n");
+        assert!(state.entries().is_empty());
+        assert!(!state.is_visible());
+    }
+
+    #[test]
+    fn any_key_dismisses_immediately() {
+        let mut state = aged(&[GRAPH], 0);
+        assert!(state.is_visible());
+        state.dismiss();
+        assert!(!state.is_visible());
+        assert!(
+            !has_non_space(&draw(&state, 80, 24)),
+            "a dismissed dialog must leave the frame to the deck"
+        );
+    }
+
+    /// The late-arrival rule: the code-graph totals land seconds after launch,
+    /// so a new line must reopen the dwell window rather than inherit an
+    /// almost-expired one.
+    #[test]
+    fn a_new_line_restarts_the_dwell() {
+        let mut state = aged(&[RESUMABLE], DWELL.as_millis() as u64 + 500);
+        assert!(!state.is_visible(), "the first line has aged out");
+        state.push(GRAPH);
+        assert!(state.is_visible(), "the new line reopens the window");
+    }
+
+    /// …but not past an explicit dismiss. A dialog that pops back up after you
+    /// waved it away is worse than one that never showed.
+    #[test]
+    fn a_dismissed_dialog_stays_shut_when_a_late_notice_lands() {
+        let mut state = aged(&[RESUMABLE], 0);
+        state.dismiss();
+        state.push(GRAPH);
+        assert!(!state.is_visible());
+        assert_eq!(
+            state.entries().len(),
+            1,
+            "a late notice is dropped, not queued behind the dismiss"
+        );
+    }
+
+    #[test]
+    fn the_run_on_graph_line_splits_into_claim_counts_and_skips() {
+        let (head, details) = split_clauses(GRAPH);
+        assert_eq!(
+            head,
+            "✓ code graph: 14157 symbols, 5991 imports across 640 files"
+        );
+        assert_eq!(
+            details,
+            vec![
+                "150 re-parsed, 490 unchanged this pass".to_string(),
+                "skipped 2 generated files".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_resumable_line_splits_claim_from_its_keybindings() {
+        let (head, details) = split_clauses(RESUMABLE);
+        assert_eq!(head, "◂ a previous session is resumable");
+        assert_eq!(details.len(), 1);
+        assert!(details[0].starts_with('←'));
+    }
+
+    #[test]
+    fn a_notice_with_no_em_dash_is_all_headline() {
+        let (head, details) = split_clauses("◈ indexing code graph…");
+        assert_eq!(head, "◈ indexing code graph…");
+        assert!(details.is_empty());
+    }
+
+    /// Guard on the parenthetical lift: with nothing before the "(" there is
+    /// no claim to separate, so the text stays whole.
+    #[test]
+    fn a_wholly_parenthesised_notice_keeps_its_text() {
+        let (head, details) = split_clauses("(nothing to report)");
+        assert_eq!(head, "(nothing to report)");
+        assert!(details.is_empty());
+    }
+
+    #[test]
+    fn details_are_indented_further_than_their_headline() {
+        let lines = notice_lines(GRAPH, 68);
+        let rendered: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        assert!(
+            rendered[0].starts_with(&" ".repeat(HEAD_INDENT)),
+            "headline sits at the head column: {:?}",
+            rendered[0]
+        );
+        assert!(
+            !rendered[0].starts_with(&" ".repeat(DETAIL_INDENT)),
+            "headline is NOT at the detail column: {:?}",
+            rendered[0]
+        );
+        for row in &rendered[1..] {
+            assert!(
+                row.starts_with(&" ".repeat(DETAIL_INDENT)),
+                "detail rows are stepped in: {row:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_dialog_draws_its_content_inside_a_border() {
+        let rows = draw(&aged(&[GRAPH, RESUMABLE], 0), 80, 24);
+        let text = rows.join("\n");
+        assert!(text.contains("code graph"), "graph notice renders:\n{text}");
+        assert!(text.contains("resumable"), "resume notice renders:\n{text}");
+        assert!(
+            text.contains('┌') && text.contains('┘'),
+            "bordered:\n{text}"
+        );
+        assert!(
+            text.contains("any key dismisses"),
+            "the dismiss affordance is stated:\n{text}"
+        );
+    }
+
+    /// The property the whole design rests on: same state, same frame.
+    #[test]
+    fn two_renders_at_the_same_instant_are_byte_identical() {
+        let state = aged(&[GRAPH, RESUMABLE], 40);
+        assert_eq!(draw(&state, 80, 24), draw(&state, 80, 24));
+    }
+
+    #[test]
+    fn more_notices_than_fit_keep_the_newest() {
+        let many: Vec<String> = (0..40).map(|i| format!("notice number {i}")).collect();
+        let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+        let rows = draw(&aged(&refs, 0), 80, 12);
+        let text = rows.join("\n");
+        assert!(
+            text.contains("notice number 39"),
+            "newest survives:\n{text}"
+        );
+        assert!(
+            !text.contains("notice number 0\n"),
+            "oldest is clipped:\n{text}"
+        );
+        for row in &rows {
+            assert_eq!(row.chars().count(), 80, "no row overflows the frame");
+        }
+    }
+
+    #[test]
+    fn render_does_not_panic_at_any_size() {
+        for &(w, h) in &[
+            (80_u16, 24_u16),
+            (44, 14),
+            (30, 5),
+            (0, 0),
+            (1, 1),
+            (3, 3),
+            (2, 2),
+            (200, 60),
+        ] {
+            let _ = draw(&aged(&[GRAPH, RESUMABLE], 0), w, h);
+            let _ = draw(&NoticeState::new(), w, h);
+        }
+    }
+}

--- a/stella-tui/src/render.rs
+++ b/stella-tui/src/render.rs
@@ -36,7 +36,10 @@ use crate::textline::{self, budget_mode_label, stage_label};
 use crate::ui::{PanelFocus, UiState, ViewportMetrics};
 
 mod entry;
-mod row;
+// `pub(crate)` for `wrap_one_indent` alone: the startup-notice dialog
+// (`crate::notice`) wraps its detail clauses with the same hanging indent the
+// transcript uses, rather than growing a second wrapper beside it.
+pub(crate) mod row;
 use crate::{diff, theme};
 // The transcript content builders moved to `entry` when this file crossed the
 // 1500-line guard; re-exported so `crate::render::transcript_lines` and


### PR DESCRIPTION
## What

The startup message that lands in the transcript on every `stella` launch is now a **transient dialog** instead of transcript rows, and it is formatted with line breaks and indentation instead of being one run-on sentence.

```
┌ startup · any key dismisses ─────────────────────────────────────────┐
│  ◂ a previous session is resumable                                   │
│      ← (on an empty prompt) opens SESSIONS, ⏎ reopens one; or        │
│      run `stella resume`.                                            │
│                                                                      │
│  ◈ indexing code graph…                                              │
│                                                                      │
│  /Users/macanderson/Projects/stella/.stella/mcp.toml was NOT loaded  │
│      set STELLA_TRUST_PROJECT=1 to let this repo start its MCP       │
│      servers (they run commands / open connections on your machine)  │
│                                                                      │
│  ✓ code graph: 14157 symbols, 5991 imports across 640 files          │
│      150 re-parsed, 490 unchanged this pass                          │
│      skipped 2 generated files                                       │
└──────────────────────────────────────────────────────────────────────┘
```

Dismisses on **any key**, on **any mouse event**, or **on its own after 3 seconds**.

## Why

`command_deck::chrome_note` fabricated an `AgentEvent::Text` for every system notice. The transcript is the home for agent and user messages only, so this was a category error with real side effects beyond the visual noise:

- the deck rendered session chrome as though the **model had said it**;
- it **auto-registered an agent lane** for the notice;
- it **folded the lead to `Running`**, which surrounding code then had to *undo* with a compensating `Status::WaitingInput`. Those sends are now plain assertions.

## How

A new out-of-band `Inbound::Notice` that the model fold **explicitly ignores** — the fold's exhaustive `match` forces that declaration, so a transcript-bypassing message cannot silently acquire a transcript row later.

`NoticeState` (`stella-tui/src/notice.rs`) is modeled on `SplashState`: a pure function of elapsed time, so its timing tests backdate an `Instant` rather than sleeping.

### Decisions worth reviewing

| Decision | Rationale |
|---|---|
| Dwell restarts on each **new** line | Graph totals and MCP results land seconds after launch; a timer anchored to the first line would expire before the only line most users want. |
| Explicit dismiss is **final** for the session | A dialog that reappears after you waved it away is worse than one that never showed. Late notices are dropped, not queued. |
| The dismissing key is **not swallowed** | Unlike the splash. The dialog is up in exactly the seconds a user is most likely to start typing; eating the first character would be a worse papercut than the dialog. Pinned by a test. |
| Clause splitting lives at the **presentation edge** | Splits on `" — "` plus a lifted trailing parenthetical. The driver's format strings are also `stella init`'s single-line stdout, where one line is correct — so they are unchanged. |
| Mid-session notices **stay** in the transcript | `mcp` subcommand results, "cannot resume `{id}`", "a turn is running" all *answer a user action* — a reply belongs where the user was looking. 8 `chrome_note` sites deliberately untouched. |

## Caveat: the mouse path is inert by default

Mouse capture is **off by default** (L-T2 — enabling it takes away the terminal's own text selection). The `Event::Mouse` dismiss is wired and works for sessions that opt in via `DeckOptions::mouse_capture`, but on a default session no click reaches the process. Key and dwell are the default dismissals. Turning capture on globally would have traded native copy/paste for this, which did not seem worth it — happy to revisit.

## Tests

- 16 new tests in `notice.rs` (dwell, restart, dismiss finality, clause splitting, indentation, tail-clipping, byte-identical re-render, no panic at any size).
- 2 new invariant tests in `deck_ui/tests.rs`: a notice **never conjures an agent lane**, and any key dismisses **without eating the keystroke**.

`make gate` green end to end (exit 0). One earlier run failed on `stella-tools` `custom::` tests — a known 5s-spawn-budget flake under parallel load, verified by re-running all 35 in isolation (pass) and by `stella-tools` having no changes on this branch.

## File-size baseline

`scripts/file-size-baseline.txt` moves by 44 lines across three already-grandfathered files. That growth is pure wiring — one struct field, an init line, an ingest arm, a render call, a key branch; the 430-line feature is its own new module, which is what the gate asks for.


## Summary by Sourcery

Show startup system notifications as a transient TUI dialog instead of transcript rows, keeping them out of the conversation history while preserving key and mouse-driven dismissal.

New Features:
- Introduce a startup system-notice dialog driven by a new Inbound::Notice variant and NoticeState, rendered over the deck and dismissed by any key, mouse event, or dwell timeout.

Enhancements:
- Route session-startup chrome (resumable sessions, code-graph indexing, MCP outcomes, journaling issues) through the new system notice path instead of fabricating agent text events so they no longer create transcript rows or agent lanes.
- Ensure the model fold explicitly ignores system notices so they cannot affect agent status or transcript state, and cap dialog width and height for readability.

Tests:
- Add unit and rendering tests for notice timing, dismissal semantics, clause splitting, formatting, clipping, and size robustness, plus deck UI tests that enforce notices never create agent lanes and that keystrokes dismiss the dialog without being swallowed.
