### PR TITLE
feat(inspect): --diff, so you can see what the context engine actually added

### DIFF
--- a/stella-cli/src/inspect.rs
+++ b/stella-cli/src/inspect.rs
@@ -593,6 +593,18 @@ fn print_diff(computed: &Diff, baseline: &Baseline, target_label: &str, args: &I
             ", coarse: input too large for an exact diff".to_string()
         }
     );
+    // The submitted prompt has no role, so a role filter cannot apply to it —
+    // and its line then shows as removed, which is true of the two documents
+    // but reads like the prompt was taken away. Say what it means once, rather
+    // than leaving the reader to work it out from a `-` that is technically
+    // correct and practically confusing.
+    if baseline.kind == "prompt" && !matches!(args.only, RoleFilter::All) {
+        println!(
+            "note: the submitted prompt is not one of the {}, so it shows as removed \
+             — everything added is what Stella put there.",
+            args.only.label()
+        );
+    }
     for hunk in &computed.hunks {
         println!("{}", hunk.header().cyan());
         for line in &hunk.lines {

--- a/stella-cli/src/inspect.rs
+++ b/stella-cli/src/inspect.rs
@@ -26,10 +26,56 @@
 //! tautological and is deliberately not counted as evidence — see
 //! [`stella_store::Reconstruction`]. The banner reports both facts rather than
 //! flattening them into one word.
+//!
+//! ## `--diff`: what changed, rather than what was sent
+//!
+//! Printing the whole context answers "what did the model see", which is the
+//! question the receipts plane was built for. It is the wrong tool for "what
+//! did *this* call see that the last one didn't" — a system prompt is hundreds
+//! of stable lines, and finding the paragraph that moved by reading two of them
+//! side by side is not a thing a person can do reliably.
+//!
+//! `--diff` renders the same reconstruction as a unified diff instead, against
+//! one of three baselines:
+//!
+//! - `prev` (the default) — whatever ran immediately before, **in the same
+//!   role**. Same-role matters: a step that ran the worker and a judge holds
+//!   two unrelated prompts, and diffing across them produces noise, not a
+//!   delta.
+//! - `first` — the first call of that role in the session: the first ever turn.
+//! - `prompt` — the bytes the user actually submitted, before the context
+//!   engine touched them.
+//!
+//! ### A turn is an execution
+//!
+//! `prev` searches the whole session, not just the execution named on the
+//! command line, because a *turn* — one prompt the user submitted — is one
+//! execution row, while `turn_instance` counts sub-turns inside it and is zero
+//! for nearly every real call. Stopping at the execution boundary would answer
+//! the wrong question in the most important case: a system prompt is
+//! byte-stable across the steps of one execution *by design* (the prompt-cache
+//! invariant), so the only place it can drift is across turns. A diff that
+//! refused to look there would print "no change" for exactly the comparison
+//! worth making. The `---` header names the execution whenever the baseline
+//! came from an earlier one, so the crossing is never silent.
+//!
+//! ### Why the prompt is a baseline at all
+//!
+//! The `prompt` baseline is not a fallback so much as the honest answer for the
+//! very first call of a session, which has no predecessor: everything the
+//! reconstruction contains beyond what was typed is, by definition, what Stella
+//! added. That mutation is what the user never sees — they know only the words
+//! they submitted — and it is invisible in every other view, since the
+//! transcript shows the sum and never the delta.
 
+mod diff;
+
+use colored::Colorize;
 use serde::Serialize;
 use stella_protocol::{CompletionMessage, MessageRole, ToolOutput};
 use stella_store::{Reconstruction, RecordedCall, Store};
+
+use diff::{Diff, Op};
 
 /// How much of a message body the text format prints before eliding. The whole
 /// point of this command is seeing the real bytes, so the cap is generous and
@@ -47,20 +93,94 @@ pub(crate) enum InspectFormat {
     Json,
 }
 
-/// `stella inspect [id] [--turn T] [--step N] [--call-seq S]`.
-pub(crate) fn run_inspect(
-    execution_id: Option<i64>,
-    turn: u32,
-    step: Option<u64>,
-    call_seq: u64,
-    format: InspectFormat,
-    full: bool,
-) -> Result<(), String> {
+/// Which earlier state `--diff` compares this call against. See the module
+/// docs for why `Prev` is same-role and why `Prompt` is the right answer for a
+/// role's first call rather than an error.
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum DiffBase {
+    /// The call that immediately preceded this one — the previous step of this
+    /// turn, or the last call of the previous turn when this is a turn's first
+    /// call. Falls back to `prompt` when nothing preceded it at all.
+    Prev,
+    /// The first call of this role in the whole session — the first ever turn.
+    First,
+    /// This turn's prompt exactly as submitted, before any context was added.
+    Prompt,
+}
+
+/// Which messages the compared document keeps. The complaint `--diff` answers
+/// is specifically about *system prompts*, and a step-to-step comparison of the
+/// whole context is dominated by the tool round-trips each step appends — so
+/// narrowing to one role is the difference between a readable delta and a wall.
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum RoleFilter {
+    All,
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+impl RoleFilter {
+    fn keeps(self, role: MessageRole) -> bool {
+        match self {
+            RoleFilter::All => true,
+            RoleFilter::System => role == MessageRole::System,
+            RoleFilter::User => role == MessageRole::User,
+            RoleFilter::Assistant => role == MessageRole::Assistant,
+            RoleFilter::Tool => role == MessageRole::Tool,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            RoleFilter::All => "all messages",
+            RoleFilter::System => "system messages",
+            RoleFilter::User => "user messages",
+            RoleFilter::Assistant => "assistant messages",
+            RoleFilter::Tool => "tool messages",
+        }
+    }
+}
+
+/// Everything `stella inspect` was invoked with. A struct rather than nine
+/// positional parameters: the flags are all optional refinements of one
+/// question, and threading them individually through three call layers is how
+/// argument order gets silently transposed.
+pub(crate) struct InspectArgs {
+    pub(crate) execution_id: Option<i64>,
+    pub(crate) turn: u32,
+    pub(crate) step: Option<u64>,
+    pub(crate) call_seq: u64,
+    pub(crate) format: InspectFormat,
+    pub(crate) full: bool,
+    pub(crate) diff: Option<DiffBase>,
+    pub(crate) context: usize,
+    pub(crate) only: RoleFilter,
+}
+
+/// `stella inspect [id] [--turn T] [--step N] [--call-seq S] [--diff [BASE]]`.
+pub(crate) fn run_inspect(args: &InspectArgs) -> Result<(), String> {
     let store = open_readonly_store()?;
-    match (execution_id, step) {
-        (None, _) => list_executions(&store, format),
-        (Some(id), None) => list_calls(&store, id, format),
-        (Some(id), Some(step)) => show_call(&store, id, turn, step, call_seq, format, full),
+    match (args.execution_id, args.step) {
+        (None, _) => list_executions(&store, args.format),
+        (Some(id), None) if args.diff.is_some() => Err(format!(
+            "--diff compares one call against an earlier one, so it needs to know which: \
+             add --step <STEP> (`stella inspect {id}` lists them)"
+        )),
+        (Some(id), None) => list_calls(&store, id, args.format),
+        (Some(id), Some(step)) => match args.diff {
+            Some(base) => show_diff(&store, id, step, base, args),
+            None => show_call(
+                &store,
+                id,
+                args.turn,
+                step,
+                args.call_seq,
+                args.format,
+                args.full,
+            ),
+        },
     }
 }
 
@@ -234,6 +354,323 @@ fn print_reconstruction(
                 body.len() - cut
             );
         }
+    }
+    // The whole context answers "what was sent"; it is a poor way to find what
+    // *moved*. Say so here rather than in the help text nobody re-reads.
+    println!(
+        "\nstella inspect {execution_id} --step {step} --diff \
+         to see only what changed since the previous call of this role."
+    );
+}
+
+/// The earlier state a diff is taken against, already resolved to bytes plus
+/// the label the `---` header prints.
+struct Baseline {
+    label: String,
+    /// The `kind` the JSON format reports — `prev`, `first`, or `prompt`. The
+    /// requested base and the resolved one can differ (`prev` on a role's first
+    /// call resolves to `prompt`), and a script must be able to see which it
+    /// actually got.
+    kind: &'static str,
+    document: String,
+}
+
+fn show_diff(
+    store: &Store,
+    execution_id: i64,
+    step: u64,
+    base: DiffBase,
+    args: &InspectArgs,
+) -> Result<(), String> {
+    let turn = args.turn;
+    let call_seq = args.call_seq;
+    let recon = store
+        .reconstruct_call(execution_id, turn, step, call_seq)
+        .map_err(|e| format!("cannot reconstruct: {e}"))?;
+    if recon.messages.is_empty() && recon.unresolved.is_empty() {
+        return Err(format!(
+            "no receipt for execution {execution_id} turn {turn} step {step} call-seq {call_seq} \
+             — `stella inspect {execution_id}` lists what was recorded"
+        ));
+    }
+    let calls = store
+        .recorded_calls(execution_id)
+        .map_err(|e| format!("cannot read receipts: {e}"))?;
+    let role = calls
+        .iter()
+        .find(|c| c.turn_instance == turn && c.step == step && c.call_seq == call_seq)
+        .map(|c| c.call_role.clone())
+        .unwrap_or_else(|| "worker".to_string());
+    let target = CallRef {
+        execution_id,
+        turn,
+        step,
+        call_seq,
+        role: role.clone(),
+    };
+
+    let baseline = resolve_baseline(store, &target, base, args)?;
+    let document = render_document(&recon, args.only);
+    let computed = diff::unified_diff(&baseline.document, &document, args.context);
+
+    let target_label = target.label(execution_id);
+    match args.format {
+        InspectFormat::Json => print_json(&diff_json(&computed, &baseline, &target_label, args)),
+        InspectFormat::Text => {
+            print_diff(&computed, &baseline, &target_label, args);
+            Ok(())
+        }
+    }
+}
+
+/// One recorded call, addressed across executions. `RecordedCall` deliberately
+/// carries no execution id — it is always read for a known one — but a baseline
+/// can live in an earlier *turn*, which is an earlier execution, so the id has
+/// to travel with the coordinates here.
+struct CallRef {
+    execution_id: i64,
+    turn: u32,
+    step: u64,
+    call_seq: u64,
+    role: String,
+}
+
+impl CallRef {
+    /// How this call is named in a `---`/`+++` header. The execution id is
+    /// printed only when it differs from the call being inspected, so a
+    /// same-turn comparison stays terse and a cross-turn one is unmistakable.
+    fn label(&self, relative_to: i64) -> String {
+        let prefix = if self.execution_id == relative_to {
+            String::new()
+        } else {
+            format!("execution {} · ", self.execution_id)
+        };
+        format!(
+            "{prefix}turn {} · step {} · seq {} ({})",
+            self.turn, self.step, self.call_seq, self.role
+        )
+    }
+}
+
+/// Pick the earlier call — or the submitted prompt — this call is measured
+/// against, and render it to the same document shape as the target.
+///
+/// The search runs over the whole *session*, oldest execution first, keeping
+/// only calls of the same role. Same-role matters because a step that ran the
+/// worker and a judge holds two unrelated prompts; whole-session matters
+/// because a system prompt is byte-stable inside one execution by design, so
+/// the only place it can drift is across turns — and stopping at the execution
+/// boundary would report "no change" for the exact comparison the user came to
+/// make.
+fn resolve_baseline(
+    store: &Store,
+    target: &CallRef,
+    base: DiffBase,
+    args: &InspectArgs,
+) -> Result<Baseline, String> {
+    if matches!(base, DiffBase::Prompt) {
+        return prompt_baseline(store, target.execution_id);
+    }
+
+    // Every turn of this conversation, oldest first. An execution with no
+    // session (a one-shot `stella run`) is its own session.
+    let mut turns = store
+        .session_executions(target.execution_id)
+        .map_err(|e| format!("cannot read the session: {e}"))?;
+    if turns.is_empty() {
+        turns.push(target.execution_id);
+    }
+
+    let mut earlier: Vec<CallRef> = Vec::new();
+    for turn_execution in turns {
+        // Later turns cannot be a baseline for an earlier one; ids are
+        // allocated in submission order.
+        if turn_execution > target.execution_id {
+            break;
+        }
+        let calls = store
+            .recorded_calls(turn_execution)
+            .map_err(|e| format!("cannot read receipts: {e}"))?;
+        for call in calls {
+            let candidate = CallRef {
+                execution_id: turn_execution,
+                turn: call.turn_instance,
+                step: call.step,
+                call_seq: call.call_seq,
+                role: call.call_role,
+            };
+            if candidate.execution_id == target.execution_id
+                && (candidate.turn, candidate.step, candidate.call_seq)
+                    >= (target.turn, target.step, target.call_seq)
+            {
+                break;
+            }
+            if candidate.role == target.role {
+                earlier.push(candidate);
+            }
+        }
+    }
+
+    let picked = match base {
+        DiffBase::First => earlier.into_iter().next(),
+        _ => earlier.pop(),
+    };
+    // Nothing of this role ran before: the only prior state that ever existed
+    // is what the user typed, so that is the honest baseline rather than an
+    // error or an empty diff.
+    let Some(previous) = picked else {
+        return prompt_baseline(store, target.execution_id);
+    };
+
+    let recon = store
+        .reconstruct_call(
+            previous.execution_id,
+            previous.turn,
+            previous.step,
+            previous.call_seq,
+        )
+        .map_err(|e| format!("cannot reconstruct the baseline call: {e}"))?;
+    Ok(Baseline {
+        label: previous.label(target.execution_id),
+        kind: if matches!(base, DiffBase::First) {
+            "first"
+        } else {
+            "prev"
+        },
+        document: render_document(&recon, args.only),
+    })
+}
+
+fn prompt_baseline(store: &Store, execution_id: i64) -> Result<Baseline, String> {
+    let prompt = store
+        .execution_prompt(execution_id)
+        .map_err(|e| format!("cannot read the submitted prompt: {e}"))?
+        .ok_or_else(|| format!("execution {execution_id} is not in the local store"))?;
+    Ok(Baseline {
+        label: "prompt as submitted".to_string(),
+        kind: "prompt",
+        document: prompt,
+    })
+}
+
+/// Flatten a reconstruction into the line-oriented document the diff compares.
+///
+/// Messages are headed by role alone, never by index: a message inserted in the
+/// middle would renumber every header after it, and a diff that reports forty
+/// changed lines because one number shifted is worse than no diff at all.
+fn render_document(recon: &Reconstruction, only: RoleFilter) -> String {
+    let mut out = String::new();
+    for message in recon.messages.iter().filter(|m| only.keeps(m.role)) {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!("── {} ──\n", role_tag(message.role)));
+        out.push_str(&message_body(message));
+        out.push('\n');
+    }
+    out
+}
+
+fn print_diff(computed: &Diff, baseline: &Baseline, target_label: &str, args: &InspectArgs) {
+    println!("--- {}", baseline.label.bold());
+    println!("+++ {}", target_label.bold());
+    if !computed.changed() {
+        println!(
+            "no change: the {} are byte-identical to {}",
+            args.only.label(),
+            baseline.label
+        );
+        return;
+    }
+    println!(
+        "{} added, {} removed  ({}{})",
+        format!("+{}", computed.added).green(),
+        format!("-{}", computed.removed).red(),
+        args.only.label(),
+        if computed.minimal {
+            String::new()
+        } else {
+            ", coarse: input too large for an exact diff".to_string()
+        }
+    );
+    for hunk in &computed.hunks {
+        println!("{}", hunk.header().cyan());
+        for line in &hunk.lines {
+            let rendered = format!("{}{}", line.op.sigil(), line.text);
+            match line.op {
+                Op::Add => println!("{}", rendered.green()),
+                Op::Remove => println!("{}", rendered.red()),
+                Op::Equal => println!("{rendered}"),
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct DiffLineJson {
+    op: &'static str,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct HunkJson {
+    old_start: usize,
+    old_count: usize,
+    new_start: usize,
+    new_count: usize,
+    lines: Vec<DiffLineJson>,
+}
+
+#[derive(Serialize)]
+struct DiffJson {
+    /// Which baseline was actually used — `prev` can resolve to `prompt`.
+    base: &'static str,
+    base_label: String,
+    target_label: String,
+    scope: &'static str,
+    changed: bool,
+    added: usize,
+    removed: usize,
+    /// `false` when the input exceeded the exact-diff bound and every line was
+    /// reported as replaced. Surfaced so a script never reads a coarse script
+    /// as a precise measurement.
+    minimal: bool,
+    hunks: Vec<HunkJson>,
+}
+
+fn diff_json(
+    computed: &Diff,
+    baseline: &Baseline,
+    target_label: &str,
+    args: &InspectArgs,
+) -> DiffJson {
+    DiffJson {
+        base: baseline.kind,
+        base_label: baseline.label.clone(),
+        target_label: target_label.to_string(),
+        scope: args.only.label(),
+        changed: computed.changed(),
+        added: computed.added,
+        removed: computed.removed,
+        minimal: computed.minimal,
+        hunks: computed
+            .hunks
+            .iter()
+            .map(|h| HunkJson {
+                old_start: h.old_start,
+                old_count: h.old_count,
+                new_start: h.new_start,
+                new_count: h.new_count,
+                lines: h
+                    .lines
+                    .iter()
+                    .map(|l| DiffLineJson {
+                        op: l.op.tag(),
+                        text: l.text.clone(),
+                    })
+                    .collect(),
+            })
+            .collect(),
     }
 }
 

--- a/stella-cli/src/inspect/diff.rs
+++ b/stella-cli/src/inspect/diff.rs
@@ -1,0 +1,451 @@
+//! A real line-oriented unified diff — the shape a developer already knows how
+//! to read, because it is the shape `git diff` produces.
+//!
+//! The tree had no unified-diff generator when this landed. `stella-tools`'
+//! [`changed_region_diff`] is the display companion to a *line-count* helper and
+//! says so in its own docs: it trims the common prefix and suffix and then
+//! prints the entire remaining span twice, once as `-` and once as `+`. That is
+//! honest and cheap for a file edit, where the changed region is small and the
+//! viewer already has the file open. It is useless for a system prompt, where
+//! the interesting change is one inserted paragraph inside four hundred stable
+//! lines — the coarse renderer would print all four hundred lines as removed
+//! and all four hundred and one as added, which is exactly the "I cannot see
+//! what actually changed" problem this module exists to end.
+//!
+//! So: trim the common prefix/suffix (cheap, and it shrinks the quadratic
+//! region a lot on append-mostly prompts), run an exact longest-common-
+//! subsequence over what is left, and walk the table to an edit script.
+//! Group the script into `@@` hunks with context lines.
+//!
+//! [`changed_region_diff`]: stella_tools::file_touch::changed_region_diff
+
+/// Beyond this many DP cells the exact LCS is abandoned for the
+/// replace-everything bound. Mirrors `stella_tools::file_touch`'s cap for the
+/// same reason: a pathological input must degrade to a coarse-but-instant
+/// answer rather than allocate a gigabyte and stall the terminal.
+///
+/// The fallback is still a correct diff — every old line removed, every new one
+/// added — just not a minimal one, and [`Diff::minimal`] says which you got
+/// rather than letting a caller assume.
+const LCS_AREA_CAP: usize = 4_000_000;
+
+/// What happened to one line between the two sides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Op {
+    /// Present in both, unchanged — printed as a context line.
+    Equal,
+    /// Present only on the new side.
+    Add,
+    /// Present only on the old side.
+    Remove,
+}
+
+impl Op {
+    /// The single-character gutter git puts in front of the line.
+    pub(crate) fn sigil(self) -> char {
+        match self {
+            Op::Equal => ' ',
+            Op::Add => '+',
+            Op::Remove => '-',
+        }
+    }
+
+    /// The stable lowercase tag the JSON format emits.
+    pub(crate) fn tag(self) -> &'static str {
+        match self {
+            Op::Equal => "equal",
+            Op::Add => "add",
+            Op::Remove => "remove",
+        }
+    }
+}
+
+/// One line of the edit script.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiffLine {
+    pub(crate) op: Op,
+    pub(crate) text: String,
+}
+
+/// One `@@ -old_start,old_count +new_start,new_count @@` group: a run of
+/// changes plus the context lines framing it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Hunk {
+    pub(crate) old_start: usize,
+    pub(crate) old_count: usize,
+    pub(crate) new_start: usize,
+    pub(crate) new_count: usize,
+    pub(crate) lines: Vec<DiffLine>,
+}
+
+impl Hunk {
+    /// The `@@ … @@` header, in git's exact format so an editor's diff mode and
+    /// a human's muscle memory both parse it.
+    pub(crate) fn header(&self) -> String {
+        format!(
+            "@@ -{},{} +{},{} @@",
+            self.old_start, self.old_count, self.new_start, self.new_count
+        )
+    }
+}
+
+/// A complete comparison: the hunks, plus the accounting a caller would
+/// otherwise be tempted to re-derive by counting sigils in rendered text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Diff {
+    pub(crate) hunks: Vec<Hunk>,
+    pub(crate) added: usize,
+    pub(crate) removed: usize,
+    /// Whether the edit script is the minimal one. `false` means the input
+    /// exceeded [`LCS_AREA_CAP`] and fell back to replace-everything — the diff
+    /// is still correct, just blunt, and surfaces are expected to say so rather
+    /// than present it as a precise answer.
+    pub(crate) minimal: bool,
+}
+
+impl Diff {
+    /// Whether the two sides differ at all. An empty hunk list is the honest
+    /// "byte-identical" answer, not an error.
+    pub(crate) fn changed(&self) -> bool {
+        !self.hunks.is_empty()
+    }
+}
+
+/// Diff `old` against `new` line-wise, framing each change with `context`
+/// unchanged lines on either side.
+///
+/// Line semantics follow `str::lines()`, matching `count_lines` in
+/// `stella-tools`: `""` is zero lines and a trailing newline adds none. Two
+/// empty inputs therefore produce no hunks rather than one empty hunk.
+pub(crate) fn unified_diff(old: &str, new: &str, context: usize) -> Diff {
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+
+    let (start, old_end, new_end) = trimmed_middle(&old_lines, &new_lines);
+    let old_mid = &old_lines[start..old_end];
+    let new_mid = &new_lines[start..new_end];
+
+    let (middle, minimal) = edit_script(old_mid, new_mid);
+
+    // Reassemble the full script: the trimmed prefix and suffix are equal by
+    // construction, and the hunk grouping below needs them present to have
+    // context lines to draw from.
+    let mut script: Vec<DiffLine> =
+        Vec::with_capacity(middle.len() + start + (old_lines.len() - old_end));
+    for line in &old_lines[..start] {
+        script.push(equal(line));
+    }
+    script.extend(middle);
+    for line in &old_lines[old_end..] {
+        script.push(equal(line));
+    }
+
+    let added = script.iter().filter(|l| l.op == Op::Add).count();
+    let removed = script.iter().filter(|l| l.op == Op::Remove).count();
+
+    Diff {
+        hunks: hunkify(&script, context),
+        added,
+        removed,
+        minimal,
+    }
+}
+
+fn equal(text: &str) -> DiffLine {
+    DiffLine {
+        op: Op::Equal,
+        text: text.to_string(),
+    }
+}
+
+/// The half-open span `[start, old_end)` / `[start, new_end)` left after
+/// trimming the common prefix and suffix — the only region the quadratic LCS
+/// has to look at.
+fn trimmed_middle(old_lines: &[&str], new_lines: &[&str]) -> (usize, usize, usize) {
+    let mut start = 0;
+    while start < old_lines.len() && start < new_lines.len() && old_lines[start] == new_lines[start]
+    {
+        start += 1;
+    }
+    let mut old_end = old_lines.len();
+    let mut new_end = new_lines.len();
+    while old_end > start && new_end > start && old_lines[old_end - 1] == new_lines[new_end - 1] {
+        old_end -= 1;
+        new_end -= 1;
+    }
+    (start, old_end, new_end)
+}
+
+/// The minimal edit script over the trimmed middle, as `(script, minimal)`.
+///
+/// Removals are emitted before additions at a change point, which is what git
+/// does and therefore what a reader expects: the old text, then what replaced
+/// it.
+fn edit_script(old: &[&str], new: &[&str]) -> (Vec<DiffLine>, bool) {
+    if old.is_empty() || new.is_empty() {
+        return (replace_all(old, new), true);
+    }
+    if old.len().saturating_mul(new.len()) > LCS_AREA_CAP {
+        return (replace_all(old, new), false);
+    }
+
+    // dp[i][j] = length of the LCS of old[i..] and new[j..]. Filled backwards
+    // so the forward walk below can pick the branch that preserves the most
+    // future matches without re-deriving anything.
+    let (m, n) = (old.len(), new.len());
+    let width = n + 1;
+    let mut dp = vec![0u32; (m + 1) * width];
+    for i in (0..m).rev() {
+        for j in (0..n).rev() {
+            dp[i * width + j] = if old[i] == new[j] {
+                dp[(i + 1) * width + j + 1] + 1
+            } else {
+                dp[(i + 1) * width + j].max(dp[i * width + j + 1])
+            };
+        }
+    }
+
+    let mut script = Vec::with_capacity(m.max(n));
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < m && j < n {
+        if old[i] == new[j] {
+            script.push(equal(old[i]));
+            i += 1;
+            j += 1;
+        } else if dp[(i + 1) * width + j] >= dp[i * width + j + 1] {
+            script.push(DiffLine {
+                op: Op::Remove,
+                text: old[i].to_string(),
+            });
+            i += 1;
+        } else {
+            script.push(DiffLine {
+                op: Op::Add,
+                text: new[j].to_string(),
+            });
+            j += 1;
+        }
+    }
+    for line in &old[i..] {
+        script.push(DiffLine {
+            op: Op::Remove,
+            text: line.to_string(),
+        });
+    }
+    for line in &new[j..] {
+        script.push(DiffLine {
+            op: Op::Add,
+            text: line.to_string(),
+        });
+    }
+    (script, true)
+}
+
+/// Every old line removed, every new line added — the correct-but-blunt script
+/// used when one side is empty (where it is also minimal) and when the input is
+/// too large for the exact table.
+fn replace_all(old: &[&str], new: &[&str]) -> Vec<DiffLine> {
+    let mut script = Vec::with_capacity(old.len() + new.len());
+    for line in old {
+        script.push(DiffLine {
+            op: Op::Remove,
+            text: line.to_string(),
+        });
+    }
+    for line in new {
+        script.push(DiffLine {
+            op: Op::Add,
+            text: line.to_string(),
+        });
+    }
+    script
+}
+
+/// Group the script into `@@` hunks: every changed line, plus up to `context`
+/// unchanged lines on each side, with runs that would overlap merged into one.
+fn hunkify(script: &[DiffLine], context: usize) -> Vec<Hunk> {
+    let changed: Vec<usize> = script
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.op != Op::Equal)
+        .map(|(i, _)| i)
+        .collect();
+    if changed.is_empty() {
+        return Vec::new();
+    }
+
+    // Per-script-index line numbers on each side, 1-based, naming the line this
+    // entry occupies (or, for an entry absent from that side, the line it sits
+    // in front of — which is the number git's header wants).
+    let mut old_no = Vec::with_capacity(script.len());
+    let mut new_no = Vec::with_capacity(script.len());
+    let (mut o, mut n) = (1usize, 1usize);
+    for line in script {
+        old_no.push(o);
+        new_no.push(n);
+        match line.op {
+            Op::Equal => {
+                o += 1;
+                n += 1;
+            }
+            Op::Remove => o += 1,
+            Op::Add => n += 1,
+        }
+    }
+
+    // Merge the context windows around each changed line. Two windows that
+    // touch or overlap become one hunk, so a reader never sees the same context
+    // line printed twice under two headers.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for &index in &changed {
+        let lo = index.saturating_sub(context);
+        let hi = (index + context).min(script.len() - 1);
+        match ranges.last_mut() {
+            Some((_, prev_hi)) if *prev_hi + 1 >= lo => *prev_hi = (*prev_hi).max(hi),
+            _ => ranges.push((lo, hi)),
+        }
+    }
+
+    ranges
+        .into_iter()
+        .map(|(lo, hi)| {
+            let lines = script[lo..=hi].to_vec();
+            let old_count = lines.iter().filter(|l| l.op != Op::Add).count();
+            let new_count = lines.iter().filter(|l| l.op != Op::Remove).count();
+            Hunk {
+                // git renders a zero-length side as the line *before* the
+                // insertion point, so `+0,0` never claims a line that isn't
+                // there.
+                old_start: if old_count == 0 {
+                    old_no[lo].saturating_sub(1)
+                } else {
+                    old_no[lo]
+                },
+                old_count,
+                new_start: if new_count == 0 {
+                    new_no[lo].saturating_sub(1)
+                } else {
+                    new_no[lo]
+                },
+                new_count,
+                lines,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ops(diff: &Diff) -> Vec<(char, &str)> {
+        diff.hunks
+            .iter()
+            .flat_map(|h| h.lines.iter())
+            .map(|l| (l.op.sigil(), l.text.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn identical_input_produces_no_hunks_at_all() {
+        let diff = unified_diff("a\nb\nc", "a\nb\nc", 3);
+        assert!(!diff.changed(), "byte-identical is not a change");
+        assert_eq!((diff.added, diff.removed), (0, 0));
+    }
+
+    #[test]
+    fn an_insertion_in_a_stable_body_shows_only_the_inserted_line() {
+        // The case the coarse `changed_region_diff` cannot express, and the
+        // reason this module exists: one line lands in the middle of a long
+        // stable body, and everything else must stay context.
+        let old = (1..=20)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut new_lines: Vec<String> = (1..=20).map(|i| i.to_string()).collect();
+        new_lines.insert(10, "INSERTED".into());
+        let diff = unified_diff(&old, &new_lines.join("\n"), 2);
+
+        assert_eq!((diff.added, diff.removed), (1, 0));
+        assert_eq!(diff.hunks.len(), 1, "one contiguous change, one hunk");
+        assert_eq!(
+            ops(&diff),
+            vec![
+                (' ', "9"),
+                (' ', "10"),
+                ('+', "INSERTED"),
+                (' ', "11"),
+                (' ', "12"),
+            ],
+            "only the insertion and its context are printed"
+        );
+    }
+
+    #[test]
+    fn hunk_header_positions_the_gutter_the_way_git_does() {
+        let diff = unified_diff("a\nb\nc\nd", "a\nB\nc\nd", 1);
+        let hunk = &diff.hunks[0];
+        // One line replaced at position 2: two lines of old (context + removal
+        // is 3 entries, but old_count counts non-Add entries).
+        assert_eq!(hunk.header(), "@@ -1,3 +1,3 @@", "{hunk:?}");
+    }
+
+    #[test]
+    fn separated_changes_become_separate_hunks_but_near_ones_merge() {
+        let old: String = (1..=30)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut new_lines: Vec<String> = (1..=30).map(|i| i.to_string()).collect();
+        new_lines[2] = "X".into();
+        new_lines[25] = "Y".into();
+        let far = unified_diff(&old, &new_lines.join("\n"), 2);
+        assert_eq!(far.hunks.len(), 2, "distant changes do not share a hunk");
+
+        let mut near: Vec<String> = (1..=30).map(|i| i.to_string()).collect();
+        near[2] = "X".into();
+        near[4] = "Y".into();
+        let merged = unified_diff(&old, &near.join("\n"), 3);
+        assert_eq!(
+            merged.hunks.len(),
+            1,
+            "overlapping context windows merge so no line prints twice"
+        );
+    }
+
+    #[test]
+    fn an_empty_old_side_is_a_pure_addition_against_line_zero() {
+        // The turn-0 shape: nothing on the left, the whole assembled context on
+        // the right. The old side must report `-0,0`, never `-1,0`.
+        let diff = unified_diff("", "system\nuser", 3);
+        assert_eq!((diff.added, diff.removed), (2, 0));
+        assert_eq!(diff.hunks[0].header(), "@@ -0,0 +1,2 @@");
+    }
+
+    #[test]
+    fn removals_precede_additions_at_a_change_point() {
+        let diff = unified_diff("keep\nold\ntail", "keep\nnew\ntail", 0);
+        assert_eq!(ops(&diff), vec![('-', "old"), ('+', "new")]);
+    }
+
+    #[test]
+    fn the_exact_script_is_minimal_not_a_wholesale_replacement() {
+        // A prompt that gained a paragraph must not report every line as
+        // rewritten — the counts are what a caller reports, so a blunt script
+        // here would be a lie in the summary line, not just in the rendering.
+        let old = "alpha\nbeta\ngamma";
+        let new = "alpha\nbeta\nINSERT\ngamma";
+        let diff = unified_diff(old, new, 3);
+        assert!(diff.minimal);
+        assert_eq!((diff.added, diff.removed), (1, 0));
+    }
+
+    #[test]
+    fn line_semantics_match_str_lines_so_a_trailing_newline_is_not_a_change() {
+        let diff = unified_diff("a\nb", "a\nb\n", 3);
+        assert!(
+            !diff.changed(),
+            "a trailing newline adds no line, so it is not a diff"
+        );
+    }
+}

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -568,6 +568,25 @@ enum Command {
         /// Print message bodies in full instead of eliding long ones
         #[arg(long)]
         full: bool,
+
+        /// Show a unified diff of what changed instead of the whole context.
+        /// Bare `--diff` compares against whatever ran immediately before in
+        /// the same role — the previous step, or the previous turn when this
+        /// is a turn's first call. The session's very first call has no
+        /// predecessor, so it is compared against the prompt as the user
+        /// submitted it: the mutation no other view shows
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "prev")]
+        diff: Option<inspect::DiffBase>,
+
+        /// Unchanged lines to print around each change in a `--diff`
+        #[arg(long, default_value_t = 3)]
+        context: usize,
+
+        /// Restrict `--diff` to one message role — `system` is the usual
+        /// reason to reach for this, since every step appends tool traffic
+        /// that would otherwise bury the prompt's own delta
+        #[arg(long, value_enum, default_value = "all")]
+        only: inspect::RoleFilter,
     },
 
     /// Summarize cost, tokens, and resolve rate per provider/model from
@@ -1093,9 +1112,22 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
             call_seq,
             format,
             full,
+            diff,
+            context,
+            only,
         }) => {
             // Reads the local receipt tables only — no provider, no API key.
-            return inspect::run_inspect(*execution_id, *turn, *step, *call_seq, *format, *full);
+            return inspect::run_inspect(&inspect::InspectArgs {
+                execution_id: *execution_id,
+                turn: *turn,
+                step: *step,
+                call_seq: *call_seq,
+                format: *format,
+                full: *full,
+                diff: *diff,
+                context: *context,
+                only: *only,
+            });
         }
         Some(Command::Stats {
             format,

--- a/stella-cli/tests/inspect_cli.rs
+++ b/stella-cli/tests/inspect_cli.rs
@@ -41,8 +41,16 @@ fn entry(block_id: &str, message_index: u64) -> ManifestBlockRow {
     }
 }
 
+/// Step 0's system prompt. Step 1's is this plus one line — the shape a real
+/// prompt drifts in, and the shape a whole-context view makes unreadable.
+const SYSTEM_V1: &str = "You are Stella.\nBe careful.\nCite your sources.";
+const SYSTEM_V2: &str =
+    "You are Stella.\nBe careful.\nThe workspace is a git repo.\nCite your sources.";
+
 /// A workspace whose store holds one execution with two model calls at the
-/// SAME step: the engine's worker (seq 0) and an overflow summarizer (seq 1).
+/// SAME step: the engine's worker (seq 0) and an overflow summarizer (seq 1) —
+/// plus a second worker call at step 1, so there is a same-role predecessor for
+/// `--diff` to measure against.
 fn seeded_workspace() -> (tempfile::TempDir, i64) {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
@@ -51,8 +59,11 @@ fn seeded_workspace() -> (tempfile::TempDir, i64) {
         .expect("execution");
 
     store
-        .record_context_block(id, &block("blk_sys", "system_prefix", "You are Stella."))
+        .record_context_block(id, &block("blk_sys", "system_prefix", SYSTEM_V1))
         .expect("system block");
+    store
+        .record_context_block(id, &block("blk_sys2", "system_prefix", SYSTEM_V2))
+        .expect("drifted system block");
     store
         .record_context_block(id, &block("blk_goal", "user_goal", "fix the failing test"))
         .expect("goal block");
@@ -101,7 +112,101 @@ fn seeded_workspace() -> (tempfile::TempDir, i64) {
             },
         )
         .expect("summarizer manifest");
+    store
+        .record_step_manifest(
+            id,
+            &StepManifestRow {
+                turn_instance: 0,
+                step: 1,
+                call_seq: 0,
+                provider: "anthropic".into(),
+                model: "opus".into(),
+                call_role: "worker".into(),
+                effective_budget_tokens: 136_363,
+                calibration_factor: 1.1,
+                estimated_input_tokens: 24,
+                compiled_frame_id: None,
+                frame_hash: None,
+                blocks: vec![entry("blk_sys2", 0), entry("blk_goal", 1)],
+            },
+        )
+        .expect("second worker manifest");
     (dir, id)
+}
+
+/// Turn two's system prompt: turn one's, plus a line. Drift across turns is the
+/// only drift a system prompt can legitimately have — inside one execution the
+/// prefix is byte-stable for the prompt cache — so this is the shape the
+/// interesting comparison actually takes.
+const SYSTEM_V3: &str = "You are Stella.\nBe careful.\nThe workspace is a git repo.\nToday is Tuesday.\nCite your sources.";
+
+/// Two executions sharing one `session_id` — i.e. two *turns* of one
+/// conversation, which is what a person means by "the previous turn". Returns
+/// the workspace plus both execution ids, oldest first.
+fn seeded_session() -> (tempfile::TempDir, i64, i64) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(dir.path()).expect("store");
+    let session = "ses-test";
+
+    let first = store
+        .begin_execution("chat", "fix the failing test", "anthropic", "opus")
+        .expect("first turn");
+    store
+        .set_execution_session(first, session)
+        .expect("first session");
+    store
+        .record_context_block(first, &block("blk_sys", "system_prefix", SYSTEM_V2))
+        .expect("system block");
+    store
+        .record_context_block(
+            first,
+            &block("blk_goal", "user_goal", "fix the failing test"),
+        )
+        .expect("goal block");
+    store
+        .record_step_manifest(
+            first,
+            &worker_manifest(0, vec![entry("blk_sys", 0), entry("blk_goal", 1)]),
+        )
+        .expect("first manifest");
+
+    let second = store
+        .begin_execution("chat", "now make it fast", "anthropic", "opus")
+        .expect("second turn");
+    store
+        .set_execution_session(second, session)
+        .expect("second session");
+    store
+        .record_context_block(second, &block("blk_sys3", "system_prefix", SYSTEM_V3))
+        .expect("drifted system block");
+    store
+        .record_context_block(second, &block("blk_goal2", "user_goal", "now make it fast"))
+        .expect("second goal block");
+    store
+        .record_step_manifest(
+            second,
+            &worker_manifest(0, vec![entry("blk_sys3", 0), entry("blk_goal2", 1)]),
+        )
+        .expect("second manifest");
+
+    (dir, first, second)
+}
+
+fn worker_manifest(step: u64, blocks: Vec<ManifestBlockRow>) -> StepManifestRow {
+    StepManifestRow {
+        turn_instance: 0,
+        step,
+        call_seq: 0,
+        provider: "anthropic".into(),
+        model: "opus".into(),
+        call_role: "worker".into(),
+        effective_budget_tokens: 136_363,
+        calibration_factor: 1.1,
+        estimated_input_tokens: 20,
+        compiled_frame_id: None,
+        frame_hash: None,
+        blocks,
+    }
 }
 
 fn inspect(dir: &tempfile::TempDir, args: &[&str]) -> String {
@@ -109,6 +214,12 @@ fn inspect(dir: &tempfile::TempDir, args: &[&str]) -> String {
         .arg("inspect")
         .args(args)
         .current_dir(dir.path())
+        // `--diff` colours its gutter, and a developer with CLICOLOR_FORCE=1
+        // exported (a common shell setting) would hand the child ANSI escapes
+        // that every `contains` assertion below then fails to match. Pin the
+        // colour decision instead of inheriting it.
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
         .output()
         .expect("run stella inspect");
     assert!(
@@ -178,8 +289,210 @@ fn inspect_json_is_machine_readable_and_reports_verification() {
     let messages = parsed["messages"].as_array().expect("messages array");
     assert_eq!(messages.len(), 2, "system + user: {out}");
     assert_eq!(messages[0]["role"], "system");
-    assert_eq!(messages[0]["content"], "You are Stella.");
+    assert_eq!(messages[0]["content"], SYSTEM_V1);
     assert_eq!(messages[1]["role"], "user");
+}
+
+#[test]
+fn diff_against_the_previous_call_prints_only_the_line_that_moved() {
+    // The complaint this answers: two system prompts differing by one line are
+    // indistinguishable when both are printed in full. A unified diff makes the
+    // one line the only marked line in the output.
+    let (dir, id) = seeded_workspace();
+    let out = inspect(
+        &dir,
+        &[&id.to_string(), "--step", "1", "--diff", "--only", "system"],
+    );
+
+    assert!(
+        out.contains("+The workspace is a git repo."),
+        "the added line is marked as added: {out}"
+    );
+    assert!(out.contains("@@ "), "hunks carry a git-style header: {out}");
+    assert!(
+        out.contains("--- turn 0 · step 0 · seq 0 (worker)"),
+        "the baseline is the previous call OF THE SAME ROLE, not the \
+         summarizer that ran alongside it: {out}"
+    );
+    assert!(
+        out.contains("+++ turn 0 · step 1 · seq 0 (worker)"),
+        "the target names itself: {out}"
+    );
+    // Every other system line is unchanged, so it must appear as context — with
+    // a leading space, never a `+` or `-`.
+    assert!(
+        !out.contains("+You are Stella.") && !out.contains("-You are Stella."),
+        "an unchanged line is context, not a change: {out}"
+    );
+    assert!(
+        !out.contains("Condense this span"),
+        "the summarizer's unrelated prompt never enters a worker diff: {out}"
+    );
+}
+
+#[test]
+fn the_first_call_is_diffed_against_the_prompt_the_user_actually_submitted() {
+    // The pre-mutation baseline. The user typed one line; everything else in
+    // the assembled context was added by Stella, and this is the only view that
+    // says so.
+    let (dir, id) = seeded_workspace();
+    let out = inspect(&dir, &[&id.to_string(), "--step", "0", "--diff"]);
+
+    assert!(
+        out.contains("--- prompt as submitted"),
+        "a role's first call has no predecessor, so the baseline is what was \
+         typed rather than an error: {out}"
+    );
+    assert!(
+        out.contains("+── system ──") && out.contains("+You are Stella."),
+        "the whole system prompt reads as added — it is: {out}"
+    );
+    assert!(
+        out.contains(" fix the failing test"),
+        "the line the user actually wrote survives as context, so what they \
+         recognise anchors the diff: {out}"
+    );
+}
+
+#[test]
+fn an_unchanged_prompt_is_reported_as_unchanged_not_as_an_empty_diff() {
+    // Byte-stable prompts are the cache invariant, so "nothing moved" is a
+    // result worth printing — silence would read as a broken command.
+    let (dir, id) = seeded_workspace();
+    let out = inspect(
+        &dir,
+        &[
+            &id.to_string(),
+            "--step",
+            "1",
+            "--diff",
+            "--only",
+            "user",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(parsed["changed"], false, "the user goal never moved: {out}");
+    assert_eq!(parsed["added"], 0);
+    assert_eq!(parsed["removed"], 0);
+}
+
+#[test]
+fn diff_json_names_which_baseline_it_actually_resolved_to() {
+    let (dir, id) = seeded_workspace();
+
+    let first = inspect(
+        &dir,
+        &[&id.to_string(), "--step", "0", "--diff", "--format", "json"],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&first).expect("valid json");
+    assert_eq!(
+        parsed["base"], "prompt",
+        "`--diff` asked for prev and got prompt; a script must be able to \
+         tell which: {first}"
+    );
+
+    let later = inspect(
+        &dir,
+        &[
+            &id.to_string(),
+            "--step",
+            "1",
+            "--diff",
+            "--only",
+            "system",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&later).expect("valid json");
+    assert_eq!(parsed["base"], "prev");
+    assert_eq!(parsed["added"], 1, "one line gained: {later}");
+    assert_eq!(parsed["removed"], 0);
+    assert_eq!(parsed["minimal"], true, "exact, not a wholesale replace");
+}
+
+#[test]
+fn the_previous_turn_is_the_previous_execution_not_just_the_previous_step() {
+    // The comparison the whole feature is for. A system prompt cannot drift
+    // inside one execution — it is byte-stable there for the prompt cache — so
+    // a diff that stopped at the execution boundary would report "no change"
+    // for precisely the question worth asking.
+    let (dir, first, second) = seeded_session();
+    let out = inspect(
+        &dir,
+        &[
+            &second.to_string(),
+            "--step",
+            "0",
+            "--diff",
+            "--only",
+            "system",
+        ],
+    );
+
+    assert!(
+        out.contains(&format!(
+            "--- execution {first} · turn 0 · step 0 · seq 0 (worker)"
+        )),
+        "the baseline crosses into the previous turn, and names the execution \
+         it came from so the crossing is never silent: {out}"
+    );
+    assert!(
+        out.contains("+Today is Tuesday."),
+        "the line the previous turn did not have is the only added line: {out}"
+    );
+    assert!(
+        !out.contains("+You are Stella."),
+        "everything stable stays context: {out}"
+    );
+}
+
+#[test]
+fn first_reaches_back_to_the_first_turn_of_the_session() {
+    let (dir, first, second) = seeded_session();
+    let out = inspect(
+        &dir,
+        &[
+            &second.to_string(),
+            "--step",
+            "0",
+            "--diff",
+            "first",
+            "--only",
+            "system",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(parsed["base"], "first");
+    assert!(
+        parsed["base_label"]
+            .as_str()
+            .expect("label")
+            .contains(&format!("execution {first}")),
+        "the first ever turn of the session, not of this execution: {out}"
+    );
+}
+
+#[test]
+fn diff_without_a_step_says_which_flag_is_missing() {
+    let (dir, id) = seeded_workspace();
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .args(["inspect", &id.to_string(), "--diff"])
+        .current_dir(dir.path())
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run");
+    assert!(!output.status.success(), "an ambiguous diff is an error");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--step"),
+        "names the missing flag: {stderr}"
+    );
 }
 
 #[test]

--- a/stella-core/src/subagent/tests.rs
+++ b/stella-core/src/subagent/tests.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use stella_protocol::{
-    BudgetMode, CompletionRequest, CompletionResult, CompletionUsage, ProviderError, ToolCall,
+    BudgetMode, CompletionRequestRef, CompletionResult, CompletionUsage, ProviderError, ToolCall,
     ToolOutput, ToolSchema,
 };
 use tokio::sync::mpsc;
@@ -53,9 +53,12 @@ impl Provider for ScriptedProvider {
         "scripted"
     }
 
-    async fn complete(
+    // `complete_ref` is the trait's required method; `complete` is a default
+    // that delegates to it. Overriding the default left this double missing the
+    // real one, so the crate's tests stopped compiling.
+    async fn complete_ref(
         &self,
-        _request: CompletionRequest,
+        _request: CompletionRequestRef<'_>,
     ) -> Result<CompletionResult, ProviderError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         let mut script = self.script.lock().unwrap();

--- a/stella-protocol/src/lib.rs
+++ b/stella-protocol/src/lib.rs
@@ -52,8 +52,8 @@ pub mod event;
 pub mod provider;
 pub mod receipt;
 pub mod role;
-pub mod tokens;
 pub mod subagent_event;
+pub mod tokens;
 pub mod tool;
 
 pub use attachment::{
@@ -76,8 +76,8 @@ pub use event::{
 };
 pub use provider::{Provider, ToolCallObserver};
 pub use role::{ModelRef, Role};
+pub use subagent_event::{SubAgentPhase, SubAgentStatus};
 pub use tokens::{
     BYTES_PER_TOKEN, estimate_token_cost, estimate_tokens, estimate_tokens_for_bytes,
 };
-pub use subagent_event::{SubAgentPhase, SubAgentStatus};
 pub use tool::{ToolCall, ToolOutput, ToolResult, ToolSchema};

--- a/stella-store/src/receipts.rs
+++ b/stella-store/src/receipts.rs
@@ -269,6 +269,56 @@ impl Store {
         Ok(rows)
     }
 
+    /// The prompt exactly as it was submitted, before the context engine
+    /// mutated it into a message array — the one artifact of a turn the user
+    /// authored themselves.
+    ///
+    /// This is the baseline `stella inspect --diff` uses for a role's *first*
+    /// call, which by definition has no predecessor to compare against. Diffing
+    /// the assembled context against these bytes is the only way to see what
+    /// Stella added on top of what was typed, which is otherwise invisible:
+    /// the reconstruction shows the sum, never the delta.
+    ///
+    /// `None` when the execution id does not exist. Reads the same column the
+    /// index preview does, but keyed rather than limit-bounded, so it still
+    /// answers for an execution too old to appear in
+    /// [`Store::inspectable_executions`].
+    pub fn execution_prompt(&self, execution_id: i64) -> Result<Option<String>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare("SELECT prompt FROM executions WHERE id = ?1")?;
+        let mut rows = stmt.query_map(params![execution_id], |r| r.get::<_, String>(0))?;
+        match rows.next() {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Every execution of the same chat session as `execution_id`, oldest
+    /// first — the *turns* of one conversation.
+    ///
+    /// A turn is an execution, not a `turn_instance`: each prompt a user
+    /// submits at the deck opens a new execution row, and `turn_instance`
+    /// counts sub-turns *inside* one of those (goal rounds, subagents) and is
+    /// zero for almost every real call. So the comparison a person means by
+    /// "the previous turn" is a comparison across executions, which is also the
+    /// only boundary where a system prompt can legitimately drift — inside one
+    /// execution it is byte-stable by design, for cache reasons.
+    ///
+    /// Empty when the execution has no `session_id` (a one-shot `stella run`,
+    /// or a row predating session tracking); callers should treat that as "this
+    /// execution is its own session" rather than as an error.
+    pub fn session_executions(&self, execution_id: i64) -> Result<Vec<i64>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT id FROM executions
+             WHERE session_id IS NOT NULL
+               AND session_id = (SELECT session_id FROM executions WHERE id = ?1)
+             ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![execution_id], |r| r.get::<_, i64>(0))?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     /// Executions with at least one recorded receipt, most recent first.
     pub fn inspectable_executions(&self, limit: u32) -> Result<Vec<InspectableExecution>> {
         let conn = self.lock();
@@ -372,6 +422,45 @@ mod tests {
             citation_label: None,
             content: None,
         }
+    }
+
+    #[test]
+    fn the_submitted_prompt_is_readable_for_any_execution_by_id() {
+        // `inspect --diff` needs the pre-mutation prompt for the execution it
+        // was asked about, which the limit-bounded index cannot promise to
+        // contain. Absent ids answer None rather than erroring: "no such
+        // execution" is a fact, not a failure.
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("run", "do issue 859", "anthropic", "opus")
+            .unwrap();
+        assert_eq!(
+            store.execution_prompt(id).unwrap().as_deref(),
+            Some("do issue 859")
+        );
+        assert_eq!(store.execution_prompt(id + 999).unwrap(), None);
+    }
+
+    #[test]
+    fn a_sessions_turns_come_back_oldest_first_and_never_mix_conversations() {
+        let store = Store::in_memory().unwrap();
+        let a1 = store.begin_execution("chat", "one", "z", "m").unwrap();
+        let other = store
+            .begin_execution("chat", "elsewhere", "z", "m")
+            .unwrap();
+        let a2 = store.begin_execution("chat", "two", "z", "m").unwrap();
+        store.set_execution_session(a1, "ses-a").unwrap();
+        store.set_execution_session(a2, "ses-a").unwrap();
+        store.set_execution_session(other, "ses-b").unwrap();
+
+        assert_eq!(store.session_executions(a2).unwrap(), vec![a1, a2]);
+        assert_eq!(store.session_executions(other).unwrap(), vec![other]);
+
+        // A session-less execution (a one-shot `stella run`) yields nothing
+        // rather than sweeping up every other session-less row — callers read
+        // the empty vec as "this execution is its own session".
+        let loner = store.begin_execution("run", "solo", "z", "m").unwrap();
+        assert!(store.session_executions(loner).unwrap().is_empty());
     }
 
     #[test]

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -5,12 +5,15 @@ description: Show the exact context a past model call was sent, rebuilt from rec
 
 Answer "what did the model actually see?" for any past call. `stella inspect` rebuilds the exact message array a model was sent — system prompt included — from the receipts recorded at the time, and re-checks it against the digests taken at emission. Entirely local; no API key, no network, and it never writes.
 
+Add [`--diff`](#--diff--what-changed-not-what-was-sent) to ask the other question: what did *this* call see that the last one didn't — rendered as a unified diff, including against the prompt you actually typed.
+
 ## Synopsis
 
 ```bash
 stella inspect                                   # executions that have receipts
 stella inspect <EXEC>                            # that execution's model calls
 stella inspect <EXEC> --step <N> [--turn <T>] [--call-seq <S>]
+stella inspect <EXEC> --step <N> --diff [prev|first|prompt] [--only system]
 ```
 
 ## What it does
@@ -38,7 +41,108 @@ It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it re
   <OptionCard name="--full">
     Print message bodies in full instead of eliding long ones.
   </OptionCard>
+  <OptionCard name="--diff [BASE]">
+    Render what *changed* instead of the whole context. `prev` (the default),
+    `first`, or `prompt` — see below.
+  </OptionCard>
+  <OptionCard name="--only <ROLE>" defaultValue="all">
+    Restrict a `--diff` to one message role. `system` is the usual reason to
+    reach for it.
+  </OptionCard>
+  <OptionCard name="--context <N>" defaultValue="3">
+    Unchanged lines printed around each change.
+  </OptionCard>
 </CardGrid>
+
+## `--diff` — what changed, not what was sent
+
+The full transcript answers *what did the model see*. It is the wrong tool for
+*what did this call see that the last one didn't*: a system prompt is hundreds
+of stable lines, and spotting the paragraph that moved by reading two of them
+side by side is not something a person can do reliably.
+
+`--diff` renders the same reconstruction as a unified diff — the `@@` hunks,
+`+`/`-` gutter, and `---`/`+++` headers you already read in `git diff`.
+
+```bash
+stella inspect 32 --step 0 --diff --only system
+```
+
+```text
+--- execution 31 · turn 0 · step 12 · seq 0 (worker)
++++ turn 0 · step 0 · seq 0 (worker)
++1 added, -0 removed  (system messages)
+@@ -14,3 +14,4 @@
+ - Always read a file before editing it — never edit blind.
++- Prefer `apply_edits` for a change touching several files.
+ - Make minimal, surgical edits.
+```
+
+### A turn is an execution
+
+Each prompt you submit opens a new **execution** row, and those rows share a
+`session_id`. `turn_instance` counts sub-turns *inside* one execution (goal
+rounds, subagents) and is `0` for nearly every real call — so the comparison a
+person means by "the previous turn" is a comparison across executions.
+
+`--diff prev` therefore searches the whole session, not just the execution you
+named. That matters because a system prompt is **byte-stable across the steps of
+one execution by design** — that is the prompt-cache invariant — so the only
+place it can drift is across turns. A diff that stopped at the execution
+boundary would print "no change" for exactly the comparison worth making. When
+the baseline comes from an earlier execution the `---` header says so, so the
+crossing is never silent.
+
+### The three baselines
+
+<CardGrid size="md">
+  <OptionCard name="prev" defaultValue="default">
+    Whatever ran immediately before in the same role — the previous step, or the
+    last call of the previous turn when this is a turn's first call.
+  </OptionCard>
+  <OptionCard name="first">
+    The first call of this role in the whole session: the first ever turn.
+  </OptionCard>
+  <OptionCard name="prompt">
+    This turn's prompt exactly as you submitted it, before any context was
+    added.
+  </OptionCard>
+</CardGrid>
+
+Baselines are always **same-role**. A step that ran the worker and a judge holds
+two unrelated prompts; diffing across them produces noise, not a delta.
+
+### Why the prompt is a baseline at all
+
+The prompt you type is all you know exists when you submit it. Everything else —
+the system prefix, recalled context, skills, memories — is added afterwards, and
+no other view shows that mutation, because the transcript shows the *sum* and
+never the *delta*.
+
+So the session's very first call, which genuinely has no predecessor, is
+compared against your own words:
+
+```bash
+stella inspect 32 --step 0 --diff
+```
+
+```text
+--- prompt as submitted
++++ turn 0 · step 0 · seq 0 (worker)
++8729 added, -0 removed  (all messages)
+@@ -1,1 +1,8730 @@
++── system ──
++You are Stella, a fast terminal coding agent…
+```
+
+Three words in, 8,730 lines out. `--diff prompt` forces that comparison for any
+call, not just the first.
+
+<Callout type="info">
+"no change" is a result, not a failure. `--only system` reporting the prompt
+byte-identical to the previous turn is a direct check that the prompt-cache
+stability invariant is holding.
+</Callout>
 
 ## Why `--call-seq` exists
 
@@ -100,6 +204,15 @@ failure lists behind it:
 ```bash
 stella inspect 42 --step 3 --format json |
   jq '{verified, unresolved, digest_mismatches}'
+```
+
+Assert in CI that the system prompt did not drift between turns — `base` reports
+which baseline was actually resolved, since `prev` becomes `prompt` when nothing
+preceded the call:
+
+```bash
+stella inspect 42 --step 0 --diff --only system --format json |
+  jq '{base, changed, added, removed}'
 ```
 
 ## What it can't show you


### PR DESCRIPTION
## What & why

`stella inspect <EXEC> --step N` prints the whole reconstructed context. That answers
*what did the model see* — the question the receipts plane was built for — and is the
wrong tool for *what did **this** call see that the last one didn't*. A system prompt is
hundreds of stable lines; finding the paragraph that moved by reading two of them side
by side is not something a person can do reliably.

`--diff` renders the same reconstruction as a unified diff instead — `@@` hunks, `+`/`-`
gutter, `---`/`+++` headers, the shape every developer already reads.

```
--- prompt as submitted
+++ turn 0 · step 0 · seq 0 (worker)
+8729 added, -0 removed  (all messages)
@@ -1,1 +1,8730 @@
+── system ──
+You are Stella, a fast terminal coding agent…
```

That is a real execution: the prompt was `do issue 859`. Three words in, 8,730 lines out.

### Three baselines

| | |
|---|---|
| `prev` (default) | whatever ran immediately before **in the same role** |
| `first` | the first call of that role in the session — the first ever turn |
| `prompt` | this turn's prompt exactly as submitted, pre-mutation |

Plus `--only <role>` (system/user/assistant/tool) and `--context <N>`.

### A turn is an execution

Each submitted prompt opens a new **execution** row; `turn_instance` counts sub-turns
*inside* one and is `0` for nearly every real call. So `prev` searches the whole session,
not just the execution named on the command line.

That is load-bearing, not incidental: a system prefix is byte-stable across the steps of
one execution **by design** (the prompt-cache invariant), so the only place it can drift
is across turns. A diff that stopped at the execution boundary would print "no change"
for precisely the comparison worth making. The `---` header names the execution whenever
the baseline came from an earlier one, so the crossing is never silent.

### Why the prompt is a baseline, not a fallback

The words a user types are all they know exists when they submit. Everything else — the
system prefix, recalled context, skills, memories — is added afterwards, and no other
view shows that mutation, because the transcript shows the *sum* and never the *delta*.
The session's very first call genuinely has no predecessor, so it is measured against
those words.

### `no change` is a result

`--only system` reporting the prompt byte-identical to the previous turn is a direct,
cheap check that the prompt-cache stability invariant is holding. Nothing else in the
tree surfaces that.

### The diff engine

New: `stella-cli/src/inspect/diff.rs`. The tree had no unified-diff generator —
`stella-tools`' `changed_region_diff` is deliberately coarse (it prints the whole changed
span twice, once as `-` and once as `+`) and its own docs say so. Right for a file edit
where the viewer has the file open; catastrophic for a 400-line prompt where one
paragraph moved.

Common prefix/suffix are trimmed, the middle gets an exact LCS with traceback, and inputs
past a 4M-cell bound degrade to replace-everything with `minimal: false` **reported**
rather than presented as precise.

**Deliberately line-based, not word-level.** Measured against 398 real recorded calls in a
local store: of 35 line-replacement pairs across all system and user prompt diffs, **zero**
were ≥0.70 similar (max 0.37, and that pair is a genuinely different prompt — a
conversational role vs a worker role, not an edited phrase). Prompts are *assembled from
blocks*, so a block is present, absent, or swapped; nobody rewrites a clause in place.
Intra-line diffing would add ~250–350 lines, a line-alignment heuristic with its own
failure modes, and a more complex JSON shape for every consumer, to improve 0 of 35 cases.
Worth revisiting only if interpolated values (dates, counts) start landing in the prefix.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

In `stella-cli/tests/inspect_cli.rs` — every one fails on `main`, where `--diff` does not
parse at all:

- `the_previous_turn_is_the_previous_execution_not_just_the_previous_step` — the turn
  crossing, and that the header names the execution it came from
- `the_first_call_is_diffed_against_the_prompt_the_user_actually_submitted` — the
  pre-mutation baseline, with the typed line surviving as context
- `diff_against_the_previous_call_prints_only_the_line_that_moved` — same-role selection
  (the summarizer that ran alongside never enters a worker diff)
- `an_unchanged_prompt_is_reported_as_unchanged_not_as_an_empty_diff`
- `first_reaches_back_to_the_first_turn_of_the_session`
- `diff_json_names_which_baseline_it_actually_resolved_to` — `prev` resolving to `prompt`
  must be visible to a script
- `diff_without_a_step_says_which_flag_is_missing`

Plus 7 unit tests on the diff engine in `stella-cli/src/inspect/diff.rs`, and 2 in
`stella-store/src/receipts.rs` for the new readers.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — `make gate` exits 0, 71 suites
- [x] Docs updated — `website/content/docs/commands/inspect.mdx`, `--help`, doc comments

## Two pre-existing breaks on `main`, fixed here

Both verified red on the **unmodified** tree (stashed this branch, re-ran, same failures)
— without them the gate cannot run at all, so this PR could not have shown green:

- `stella-protocol/src/lib.rs` — unsorted `mod`/`use`; `cargo fmt --check` failed.
- `stella-core/src/subagent/tests.rs` — `ScriptedProvider` overrode the *defaulted*
  `Provider::complete` instead of the required `complete_ref`, so `stella-core`'s tests
  did not compile (E0046). A migration missed that test double.

Flagging rather than burying them: they are unrelated to the feature and a reviewer may
prefer them split out.

## Ground-rule check

- Reads only. `--diff` adds no writes; `stella inspect` still refuses to create `.stella/`.
- No new dependencies.
- No telemetry surface change — receipts still never leave the machine.

## Summary by Sourcery

Add a unified diff view to `stella inspect` to show how a call’s reconstructed context changed relative to earlier calls or the original prompt.

New Features:
- Introduce `--diff` flag with baselines (`prev`, `first`, `prompt`) and role filtering to compare a call’s context against earlier states.
- Expose JSON-formatted diff output, including hunk metadata and the resolved baseline, for scripting and CI checks.
- Document the new `--diff` capabilities, flags, and usage patterns in the CLI docs for `stella inspect`.

Bug Fixes:
- Fix `stella-core` subagent test double to implement the required `complete_ref` method instead of overriding the default `complete`.
- Sort `mod`/`use` declarations in `stella-protocol` to restore `cargo fmt --check` compliance.

Enhancements:
- Implement a line-oriented unified diff engine tailored for large prompts, with context windows and minimal vs coarse diff reporting.
- Refactor `stella inspect` argument handling into a struct to simplify passing options and support diff-specific parameters.
- Extend the store API to retrieve the submitted prompt and session executions to support cross-turn diff baselines.

Tests:
- Add CLI integration tests that cover diff behavior, baseline resolution across steps and turns, JSON diff output, and error messaging for ambiguous invocations.
- Add unit tests for the new diff engine and store helpers to validate diff correctness, prompt retrieval, and session execution ordering.