### PR TITLE
fix(subagent): a cancelled parent stops its children, and still pays for them (#922)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -34,7 +34,7 @@
 2204 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
-3411 stella-tools/src/registry.rs
+3422 stella-tools/src/registry.rs
 1837 stella-tools/src/scripts.rs
 1728 stella-tui/src/deck_render.rs
 4020 stella-tui/src/deck_ui.rs

--- a/stella-cli/src/fleet_cmd.rs
+++ b/stella-cli/src/fleet_cmd.rs
@@ -651,12 +651,20 @@ async fn run_task(
     cfg.workspace_root = root.to_path_buf();
     let provider = agent::build_provider(&cfg)?;
     let registry_options = agent::registry_options(&cfg);
-    let registry = agent::new_tool_registry(root.to_path_buf(), registry_options.clone()).await;
+    // `Arc` because the worker's sub-agent dispatcher holds a `Weak` back to
+    // it (`crate::subagent`) — the registry is the child's tool set.
+    let registry =
+        Arc::new(agent::new_tool_registry(root.to_path_buf(), registry_options.clone()).await);
+    // As in a deck lane: without a dispatcher the `task` tool is advertised
+    // and always refuses, and the pause gate published below has nothing to
+    // reach. A worker's children inherit its headless posture through the
+    // registry they run against.
+    crate::subagent::install_for_session(&cfg, &registry)?;
     let active_rules = crate::rules::enforce_workspace_rules(&registry, root, &cfg.authority);
     // Claim-on-first-write (crate::claims): tool-level write claims + the
     // transient build lane, coordinated across every writer in the
     // workspace. Same holder as the fleet's declared claims — re-entrant.
-    let claims = crate::claims::ClaimTap::new(&registry, claims_store, claim_holder);
+    let claims = crate::claims::ClaimTap::new(&*registry, claims_store, claim_holder);
     // A fleet worker runs the operator's tool policy, same as every other
     // driver — an isolated worktree is not a different trust posture.
     let permitted = agent::PolicyToolSet::new(&claims, agent::session_tool_policy(&cfg));
@@ -851,9 +859,8 @@ async fn run_task(
             // boundary (never mid-tool), and the stop line races the turn.
             // `Arc` so the gate can be published to the registry as well as
             // borrowed by the engine — a paused worker must not keep spending
-            // inside a sub-agent it dispatched. As in `subsession`, a fleet
-            // worker installs no dispatcher yet, so this is the standing
-            // wiring rather than a live path.
+            // inside a sub-agent it dispatched, which this worker's dispatcher
+            // (installed above) makes reachable.
             let gate: Arc<WatchGate> = Arc::new(WatchGate(pause));
             let _controls = registry.attach_turn_controls(
                 stella_core::ports::TurnControls::none().with_gate(gate.clone()),

--- a/stella-cli/src/subagent.rs
+++ b/stella-cli/src/subagent.rs
@@ -36,8 +36,8 @@
 //!
 //! Each child is carved from a session-scoped pool
 //! ([`SessionSubAgents::with_pool_limit`]), which bounds what sub-agents may
-//! cost in total. That pool is **not** what enforces `--budget`: the tool pushes
-//! every child's cost onto the registry's spend ledger, and the engine folds
+//! cost in total. That pool is **not** what enforces `--budget`: every child's
+//! cost is also pushed onto the registry's spend ledger, and the engine folds
 //! it into the *parent's* guard at the next step-boundary check
 //! (`ToolExecutor::drain_sub_agent_spend_usd`). The parent's guard stays the
 //! hard ceiling; the pool is a second, tighter bound on this one category of
@@ -48,6 +48,20 @@
 //! therefore each carve against the same headroom before either settles —
 //! an overshoot bounded by one child's cap, and caught by the parent's guard
 //! at the next step boundary regardless.
+//!
+//! ## Settling is the child's job
+//!
+//! Both ledgers are charged from the child's own thread, the moment its turn
+//! ends — not after the `wait.await` below, and not by the `task` tool after
+//! `dispatch()` returns. Those were the original homes, and both share a
+//! defect: a parent hard cancelled mid-`task` never resumes either line, so a
+//! child that had really spent money landed in *no* ledger at all. Whatever is
+//! still running when the parent goes away has to be what settles, and that is
+//! the thread. Charging late to the session is this ledger's existing doctrine
+//! ("charging the same dollars twice is worse than charging them late");
+//! never charging is not.
+//!
+//! The thread being the sole writer is also what keeps it exactly once.
 //!
 //! # Why a child runs on its own thread
 //!
@@ -98,19 +112,44 @@
 //!   destructive by contract and a child that inherited it would eat a
 //!   message the user addressed to the parent.
 //!
-//! A driver that publishes nothing is not a failure state — a child then runs
-//! bounded by its step cap and its carve, exactly as before.
+//! Every driver that runs turns installs a dispatcher and publishes what it
+//! has: the deck's lead and pipeline turns publish a steering tap (Pause is a
+//! worker-lane verb, so the lead has no gate), and deck worker lanes and fleet
+//! workers publish their `WatchGate`. A driver that publishes nothing is still
+//! not a failure state — a child then runs bounded by its step cap and its
+//! carve, exactly as before.
 //!
-//! One thing this does *not* buy: a hard cancel still cannot reach a child.
-//! The parent's turn future dropping takes the oneshot receiver with it while
-//! the child's thread runs on to its own cap. The soft stop is the
-//! interruption that arrives; that is a reason to prefer it, and it is why
-//! the deck's Esc now ends delegated work instead of orphaning it.
+//! # A cancelled parent: cascade the intent, not the mechanism
+//!
+//! A hard cancel is the *dropping of a future*. That is the entire mechanism,
+//! and it cannot propagate here: the child is an OS thread running `block_on`,
+//! deliberately off the parent's future graph (see above), and a thread cannot
+//! be killed safely in Rust. Nor should it be, even if it could — an abrupt
+//! kill can land mid-tool, which is exactly the half-finished write the
+//! step-boundary rule (L-E6) exists to prevent, and it would discard the
+//! salvaged text an aborted child is specifically designed to hand back.
+//!
+//! So the intent cascades instead of the mechanism. [`ParentGone`] is a drop
+//! guard living in the suspended `dispatch` body; when the parent's turn
+//! future is dropped, it is dropped too, and [`OrphanStop`] reports that to
+//! the child as a soft stop alongside the turn's own. The child ends at its
+//! next boundary with its work salvaged and its spend settled — an orphan
+//! bounded by the model call already in flight, rather than by its whole step
+//! cap.
+//!
+//! The one thing that genuinely cannot be recovered is the child's *report*:
+//! the oneshot receiver went with the cancelled future, so the finding is
+//! written to the event stream and nowhere else. Paying for it and stopping
+//! promptly beats paying for it and running on.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
 use async_trait::async_trait;
-use stella_core::subagent::{SubAgentDispatcher, SubAgentHost, SubAgentOutcome, SubAgentSpec};
+use stella_core::ports::TurnSteering;
+use stella_core::subagent::{
+    SubAgentDispatcher, SubAgentHost, SubAgentOutcome, SubAgentSpec, push_sub_agent_spend,
+};
 use stella_core::{BudgetGuard, Engine, EngineConfig, EventSender};
 use stella_protocol::Provider;
 use stella_tools::ToolRegistry;
@@ -125,6 +164,55 @@ use crate::runtime::TokioSleeper;
 /// parent's guard is the hard ceiling.
 pub const DEFAULT_POOL_LIMIT_USD: f64 = 2.0;
 
+/// Marks the parent's dispatch as gone once dropped.
+///
+/// A guard, because the drop has to happen on the path nothing else covers:
+/// when a hard cancel drops the parent's turn future, every local in the
+/// suspended `dispatch` body is dropped with it, and this is the only
+/// notification a detached child could ever get. On the ordinary path it drops
+/// after the child has already reported, where flipping the flag is a no-op.
+struct ParentGone(Arc<AtomicBool>);
+
+impl Drop for ParentGone {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+/// The turn's steering, plus "your parent is gone" as one more reason to stop.
+///
+/// A hard cancel cannot cascade as a hard cancel: the child is an OS thread
+/// running `block_on`, not a future in the parent's graph, and a thread cannot
+/// be killed safely — nor should it be mid-tool, which is exactly the write
+/// the boundary rule (L-E6) exists to protect. So the *intent* cascades
+/// instead: the parent's cancel becomes the child's soft stop, taken at its
+/// next step boundary with its work salvaged and its spend settled.
+///
+/// This bounds an orphan to one more model call rather than its full step cap.
+struct OrphanStop {
+    /// The turn's own tap, when its driver published one.
+    turn: Option<Arc<dyn TurnSteering>>,
+    parent_alive: Arc<AtomicBool>,
+}
+
+impl TurnSteering for OrphanStop {
+    /// Never drains the turn's tap. `ChildSteering` already refuses to call
+    /// this, but a view that sits between a child and a destructive drain has
+    /// no business forwarding it even so — the parent's queued messages are
+    /// the parent's.
+    fn drain_steering(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn soft_stop_requested(&self) -> bool {
+        !self.parent_alive.load(Ordering::SeqCst)
+            || self
+                .turn
+                .as_ref()
+                .is_some_and(|turn| turn.soft_stop_requested())
+    }
+}
+
 /// Runs sub-agents for the `task` tool. One per session.
 pub struct SessionSubAgents {
     /// `Arc`, not `Box`: the provider is moved onto each child's thread.
@@ -132,7 +220,10 @@ pub struct SessionSubAgents {
     /// Weak on purpose — the registry owns this dispatcher. See module docs.
     tools: Weak<ToolRegistry>,
     config: EngineConfig,
-    pool: Mutex<BudgetGuard>,
+    /// `Arc` so a clone rides onto the child's thread: the child settles its
+    /// own spend the moment it stops, rather than after a `.await` the parent
+    /// may never reach. See "Settling is the child's job".
+    pool: Arc<Mutex<BudgetGuard>>,
 }
 
 impl SessionSubAgents {
@@ -149,7 +240,11 @@ impl SessionSubAgents {
             provider,
             tools: Arc::downgrade(registry),
             config,
-            pool: Mutex::new(BudgetGuard::new(mode, None, Some(DEFAULT_POOL_LIMIT_USD))),
+            pool: Arc::new(Mutex::new(BudgetGuard::new(
+                mode,
+                None,
+                Some(DEFAULT_POOL_LIMIT_USD),
+            ))),
         }
     }
 
@@ -158,7 +253,7 @@ impl SessionSubAgents {
     pub fn with_pool_limit(self, limit_usd: Option<f64>) -> Self {
         let mode = self.pool.lock().unwrap_or_else(|p| p.into_inner()).mode();
         Self {
-            pool: Mutex::new(BudgetGuard::new(mode, None, limit_usd)),
+            pool: Arc::new(Mutex::new(BudgetGuard::new(mode, None, limit_usd))),
             ..self
         }
     }
@@ -237,10 +332,23 @@ impl SubAgentDispatcher for SessionSubAgents {
         let pool_view = *self.pool.lock().unwrap_or_else(|p| p.into_inner());
         let before = pool_view.session_spent_usd();
 
+        // Flipped by `ParentGone`'s drop below, which runs when this future is
+        // dropped — a hard cancel of the parent's turn. The child polls it as
+        // a soft stop, which is the whole cascade: see "A cancelled parent".
+        let parent_alive = Arc::new(AtomicBool::new(true));
+        let _parent = ParentGone(parent_alive.clone());
+        // Wrap rather than replace: the turn's own stop still has to cross,
+        // and the gate is untouched.
+        let mut controls = controls;
+        let turn = controls.steering.take();
+        controls.steering = Some(Arc::new(OrphanStop { turn, parent_alive }));
+
         // Everything crossing the thread is owned; see the module docs on
         // why the child cannot simply be awaited here.
         let provider = self.provider.clone();
         let config = self.config.clone();
+        let pool = self.pool.clone();
+        let ledger = tools.sub_agent_spend_ledger();
         let (done, wait) = tokio::sync::oneshot::channel();
         let thread = std::thread::Builder::new()
             .name(format!("stella-subagent-{}", spec.agent_id))
@@ -268,7 +376,29 @@ impl SubAgentDispatcher for SessionSubAgents {
                     &mut view,
                     &events,
                 ));
-                let _ = done.send(Ok((outcome, view.session_spent_usd())));
+
+                // Settled HERE, before reporting, and deliberately not after
+                // the `wait.await` below: a parent cancelled mid-`task` never
+                // resumes that await, and dollars this child has already
+                // spent would land in no ledger at all. Charging late to the
+                // session is the ledger's doctrine; never charging is not.
+                //
+                // Exactly once, because this is now the only writer on either
+                // side — the `task` tool no longer charges what it did not
+                // measure.
+                let spent = view.session_spent_usd() - before;
+                if spent > 0.0 {
+                    // The delta, not the view: a sibling may have folded its
+                    // own spend into the pool while this child ran, and
+                    // overwriting with a stale snapshot would erase it.
+                    pool.lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .record_spend(spent);
+                    // The parent's guard is the hard ceiling; this is what the
+                    // engine drains into it at the next step boundary.
+                    push_sub_agent_spend(&ledger, spent);
+                }
+                let _ = done.send(Ok(outcome));
             });
         if let Err(err) = thread {
             return SubAgentOutcome::Refused {
@@ -277,26 +407,15 @@ impl SubAgentDispatcher for SessionSubAgents {
         }
 
         // A child that panicked drops its sender, which lands here as a
-        // refusal rather than unwinding the parent's turn.
-        let (outcome, spent_total) = match wait.await {
-            Ok(Ok(pair)) => pair,
-            Ok(Err(reason)) => return SubAgentOutcome::Refused { reason },
-            Err(_) => {
-                return SubAgentOutcome::Refused {
-                    reason: "the sub-agent thread ended without reporting".to_string(),
-                };
-            }
-        };
-
-        // The delta, not the view: another sibling may have folded its own
-        // spend into the pool while this child ran, and overwriting with a
-        // stale snapshot would erase it.
-        let spent = spent_total - before;
-        if spent > 0.0 {
-            let mut pool = self.pool.lock().unwrap_or_else(|p| p.into_inner());
-            pool.record_spend(spent);
+        // refusal rather than unwinding the parent's turn. Nothing is settled
+        // on this side — the child already did it, on every path.
+        match wait.await {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(reason)) => SubAgentOutcome::Refused { reason },
+            Err(_) => SubAgentOutcome::Refused {
+                reason: "the sub-agent thread ended without reporting".to_string(),
+            },
         }
-        outcome
     }
 }
 

--- a/stella-cli/src/subagent/tests.rs
+++ b/stella-cli/src/subagent/tests.rs
@@ -390,3 +390,189 @@ async fn controls_come_down_with_the_turn_that_published_them() {
     );
     assert_eq!(provider.calls(), 1, "and the child actually ran");
 }
+
+// ---- a cancelled parent: bounded, and still billed ---------------------
+
+/// Returns a tool call every time, so a child left to itself runs to its step
+/// cap — which is what makes "how many calls did it make" a discriminating
+/// question. The first call parks until released, giving a test a window in
+/// which the child is provably mid-flight.
+struct LoopingPaidProvider {
+    calls: std::sync::atomic::AtomicUsize,
+    hold: tokio::sync::watch::Receiver<bool>,
+    cost_usd: f64,
+}
+
+impl LoopingPaidProvider {
+    fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Provider for LoopingPaidProvider {
+    fn id(&self) -> &str {
+        "looping-paid"
+    }
+    async fn complete_ref(
+        &self,
+        _request: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<stella_protocol::CompletionResult, stella_protocol::ProviderError> {
+        let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if n == 0 {
+            let mut rx = self.hold.clone();
+            while *rx.borrow() {
+                if rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        }
+        Ok(stella_protocol::CompletionResult {
+            text: String::new(),
+            // Distinct arguments per call: identical calls are a stuck loop,
+            // and `loop_detect` is right to abort one.
+            tool_calls: vec![stella_protocol::ToolCall {
+                call_id: format!("c{n}"),
+                name: "read_file".into(),
+                input: json!({ "path": format!("no-such-file-{n}.txt") }),
+            }],
+            usage: stella_protocol::CompletionUsage {
+                reported: true,
+                ..stella_protocol::CompletionUsage::default()
+            },
+            model: "looping-paid".into(),
+            cost_usd: self.cost_usd,
+            finish_reason: None,
+        })
+    }
+}
+
+fn paid_dispatcher(
+    cost_usd: f64,
+) -> (
+    Arc<SessionSubAgents>,
+    Arc<ToolRegistry>,
+    Arc<LoopingPaidProvider>,
+    tokio::sync::watch::Sender<bool>,
+) {
+    let (hold_tx, hold) = tokio::sync::watch::channel(true);
+    let provider = Arc::new(LoopingPaidProvider {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        hold,
+        cost_usd,
+    });
+    let registry = registry();
+    let dispatcher = Arc::new(SessionSubAgents::new(
+        provider.clone(),
+        &registry,
+        EngineConfig::default(),
+        stella_protocol::BudgetMode::Observed,
+    ));
+    (dispatcher, registry, provider, hold_tx)
+}
+
+fn looping_spec() -> SubAgentSpec {
+    SubAgentSpec {
+        // Comfortably more than one, so a child that ignored the orphan stop
+        // would be visibly distinguishable from one that took it.
+        max_steps: 6,
+        ..SubAgentSpec::read_only("orphan", "investigate")
+    }
+}
+
+/// **Cascade the intent, not the mechanism.** A hard cancel cannot propagate
+/// as a hard cancel — the child is an OS thread, not a future in the parent's
+/// graph, and killing a thread mid-tool is exactly what the step-boundary rule
+/// forbids. So the parent's cancel becomes the child's *soft stop*, and the
+/// orphan is bounded to the call already in flight instead of its whole step
+/// cap.
+#[tokio::test]
+async fn cancelling_the_parent_stops_the_child_at_its_next_boundary() {
+    let (dispatcher, _registry, provider, hold_tx) = paid_dispatcher(0.01);
+
+    let running = dispatcher.clone();
+    let child = tokio::spawn(async move { running.dispatch(looping_spec()).await });
+
+    until("the child to be inside its first model call", || {
+        provider.calls() >= 1
+    })
+    .await;
+
+    // Awaiting the aborted handle is what makes this deterministic: it
+    // resolves only once the task has actually been dropped, which is when
+    // `ParentGone` runs.
+    child.abort();
+    assert!(child.await.is_err(), "the dispatch future was cancelled");
+
+    hold_tx
+        .send(false)
+        .expect("the provider is still listening");
+    until("the orphaned child to settle", || {
+        dispatcher.pool.lock().unwrap().session_spent_usd() > 0.0
+    })
+    .await;
+
+    assert_eq!(
+        provider.calls(),
+        1,
+        "the child must stop at the boundary after the call already in \
+         flight — a child that ignored the cancel would run to its step cap"
+    );
+}
+
+/// The sharper half of the same defect. Settlement used to happen after
+/// `wait.await` in the dispatcher and after `dispatch().await` in the tool —
+/// neither of which runs when the parent is cancelled mid-`task`, so a child's
+/// real spend landed in NO ledger. Charging late to the session is the
+/// ledger's doctrine; never charging is not.
+#[tokio::test]
+async fn a_cancelled_parents_child_still_charges_what_it_spent() {
+    let (dispatcher, registry, provider, hold_tx) = paid_dispatcher(0.01);
+    let ledger = registry.sub_agent_spend_ledger();
+
+    let running = dispatcher.clone();
+    let child = tokio::spawn(async move { running.dispatch(looping_spec()).await });
+
+    until("the child to be inside its first model call", || {
+        provider.calls() >= 1
+    })
+    .await;
+    child.abort();
+    assert!(child.await.is_err());
+
+    hold_tx
+        .send(false)
+        .expect("the provider is still listening");
+    until("the orphaned child to settle", || {
+        dispatcher.pool.lock().unwrap().session_spent_usd() > 0.0
+    })
+    .await;
+
+    let charged = stella_core::subagent::drain_sub_agent_spend(&ledger);
+    assert!(
+        (charged - 0.01).abs() < 1e-9,
+        "the engine drains this into the parent's guard at the next step \
+         boundary; got {charged}"
+    );
+    assert!(
+        (dispatcher.pool.lock().unwrap().session_spent_usd() - 0.01).abs() < 1e-9,
+        "and the session pool is charged the same dollars, exactly once"
+    );
+}
+
+/// The ordinary path settles once, through the same single writer. Two
+/// writers (the tool AND the dispatcher) would double-bill every child.
+#[tokio::test]
+async fn an_uncancelled_child_is_charged_exactly_once() {
+    let (dispatcher, registry, _provider, hold_tx) = paid_dispatcher(0.01);
+    let ledger = registry.sub_agent_spend_ledger();
+    hold_tx.send(false).expect("nothing is holding yet");
+
+    dispatcher.dispatch(looping_spec()).await;
+
+    let charged = stella_core::subagent::drain_sub_agent_spend(&ledger);
+    assert!(
+        (charged - 0.06).abs() < 1e-9,
+        "six steps at a cent each, counted once; got {charged}"
+    );
+}

--- a/stella-cli/src/subsession.rs
+++ b/stella-cli/src/subsession.rs
@@ -504,8 +504,19 @@ async fn run_worker(
         Ok(p) => p,
         Err(e) => return (None, 0.0, WorkerEnd::Failed(e)),
     };
-    let registry = agent::new_tool_registry(cfg.workspace_root.clone(), registry_options).await;
+    // `Arc` because the lane's sub-agent dispatcher holds a `Weak` back to it
+    // (`crate::subagent`) — the registry is the child's tool set, so an owning
+    // handle either way would leak both.
+    let registry =
+        Arc::new(agent::new_tool_registry(cfg.workspace_root.clone(), registry_options).await);
     if let Err(error) = agent::populate_schema_index(&registry, &cfg.workspace_root) {
+        return (None, 0.0, WorkerEnd::Failed(error));
+    }
+    // A worker lane delegates research like any other turn. Without this the
+    // `task` tool is still advertised (the registry registers it
+    // unconditionally) and answers "sub-agents are unavailable" every time —
+    // and the lane's pause gate, published below, would have nothing to reach.
+    if let Err(error) = crate::subagent::install_for_session(cfg, &registry) {
         return (None, 0.0, WorkerEnd::Failed(error));
     }
     let active_rules =
@@ -549,7 +560,7 @@ async fn run_worker(
     // store's lock table — no coordinator, sub-millisecond acquire, rivals
     // named in the refusal (crate::claims).
     let claims = crate::claims::ClaimTap::new(
-        &registry,
+        &*registry,
         execution.as_ref().map(|(store, _)| store.clone()),
         format!("{session_id}/{}", spec.lane),
     );
@@ -564,10 +575,9 @@ async fn run_worker(
     // ledger described a session in which the delegated work never happened.
     registry.attach_events(stella_core::EventSender::new(tx.clone()));
     // `Arc` so the same gate can be published for the turn as well as
-    // borrowed by it: a worker parked at Pause must not keep spending inside
-    // a sub-agent it dispatched (`crate::subagent`). A worker lane installs no
-    // dispatcher today, so nothing reads this yet — it is published anyway
-    // because the gap reopens silently the day one is installed.
+    // borrowed by it: a lane parked at Pause must not keep spending inside a
+    // sub-agent it dispatched, and this lane has a dispatcher (installed
+    // above) for that to reach.
     let gate: Arc<WatchGate> = Arc::new(WatchGate(pause_rx));
     let _controls = registry
         .attach_turn_controls(stella_core::ports::TurnControls::none().with_gate(gate.clone()));

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -339,7 +339,6 @@ impl ToolRegistry {
             // on why an unattached dispatcher is still the honest shape.
             Arc::new(crate::subagent::SpawnSubAgent::new(
                 sub_agent_dispatcher.clone(),
-                sub_agent_spend.clone(),
             )),
             // SVG generation is client-side (the model authors the SVG, the
             // pipeline validates/sanitizes) — no provider key needed, so
@@ -571,6 +570,18 @@ impl ToolRegistry {
         controls: stella_core::ports::TurnControls,
     ) -> crate::subagent::TurnControlsGuard {
         crate::subagent::TurnControlsGuard::attach(&self.turn_controls, controls)
+    }
+
+    /// The ledger a dispatcher charges finished children to (cheap clone —
+    /// shared inner), drained by the engine at each step-boundary check.
+    ///
+    /// `pub` because settling is the *dispatcher's* job, per
+    /// [`stella_core::subagent::SubAgentDispatcher`]'s contract: it must
+    /// happen the moment a child stops, on the child's own thread, or a
+    /// parent cancelled mid-`task` leaves paid-for dollars in no ledger at
+    /// all.
+    pub fn sub_agent_spend_ledger(&self) -> stella_core::subagent::SubAgentSpendLedger {
+        self.sub_agent_spend.clone()
     }
 
     /// The current turn's boundary controls — empty between turns, and on a

--- a/stella-tools/src/subagent.rs
+++ b/stella-tools/src/subagent.rs
@@ -34,12 +34,18 @@
 //!
 //! # Spend
 //!
-//! The child's cost is pushed to a [`SubAgentSpendLedger`] the registry
-//! exposes through `ToolExecutor::drain_sub_agent_spend_usd`, which the
-//! engine folds into the parent's budget at the next step boundary. That
-//! ordering is what keeps `--budget` a hard ceiling: a tool cannot charge
-//! the guard directly, because the engine holds it mutably for the whole
-//! turn.
+//! The dispatcher pushes each child's cost to the
+//! [`SubAgentSpendLedger`](stella_core::subagent::SubAgentSpendLedger) the
+//! registry exposes through `ToolExecutor::drain_sub_agent_spend_usd`, which
+//! the engine folds into the parent's budget at the next step boundary. That
+//! ordering is what keeps `--budget` a hard ceiling: a tool cannot charge the
+//! guard directly, because the engine holds it mutably for the whole turn.
+//!
+//! This tool deliberately does **not** charge. It used to, on the line after
+//! `dispatch().await` — which never runs when the parent's turn is hard
+//! cancelled mid-call, leaving a child's real spend in no ledger at all.
+//! Settling belongs to whoever is still running when that happens, which is
+//! the child's own thread.
 //!
 //! # Interruption
 //!
@@ -55,9 +61,7 @@ use std::sync::{Arc, RwLock};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use stella_core::ports::TurnControls;
-use stella_core::subagent::{
-    SubAgentDispatcher, SubAgentOutcome, SubAgentSpec, SubAgentSpendLedger, push_sub_agent_spend,
-};
+use stella_core::subagent::{SubAgentDispatcher, SubAgentOutcome, SubAgentSpec};
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 
 use crate::registry::Tool;
@@ -141,13 +145,12 @@ const CHILD_SYSTEM_PROMPT: &str = "You are a research sub-agent. You have been g
 /// `task` — delegate a bounded research question to a read-only sub-agent.
 pub struct SpawnSubAgent {
     dispatcher: DispatcherSlot,
-    spend: SubAgentSpendLedger,
 }
 
 impl SpawnSubAgent {
     #[must_use]
-    pub fn new(dispatcher: DispatcherSlot, spend: SubAgentSpendLedger) -> Self {
-        Self { dispatcher, spend }
+    pub fn new(dispatcher: DispatcherSlot) -> Self {
+        Self { dispatcher }
     }
 }
 
@@ -237,11 +240,11 @@ impl Tool for SpawnSubAgent {
             ..SubAgentSpec::default()
         };
 
+        // Already settled by the time this resolves — the dispatcher charges
+        // the ledger from the child's own thread, which is the only place
+        // that still runs when a hard cancel means this `await` never
+        // resumes. Charging here too would double-bill.
         let outcome = dispatcher.dispatch(spec).await;
-        // Push before rendering: the money is owed whatever the outcome, and
-        // an early return that skipped this would silently drop it from the
-        // parent's budget.
-        push_sub_agent_spend(&self.spend, outcome.cost_usd());
         render(&outcome)
     }
 }

--- a/stella-tools/src/subagent/tests.rs
+++ b/stella-tools/src/subagent/tests.rs
@@ -7,7 +7,7 @@
 use std::sync::Mutex;
 
 use stella_core::ports::{ReadOnlyTools, ToolExecutor};
-use stella_core::subagent::{SubAgentReport, drain_sub_agent_spend};
+use stella_core::subagent::SubAgentReport;
 
 use super::*;
 
@@ -27,6 +27,9 @@ impl RecordingDispatcher {
     }
     fn spec(&self) -> SubAgentSpec {
         self.seen.lock().unwrap().clone().expect("dispatch ran")
+    }
+    fn dispatched(&self) -> bool {
+        self.seen.lock().unwrap().is_some()
     }
 }
 
@@ -52,14 +55,11 @@ fn report(summary: &str, cost_usd: f64, truncated: bool) -> SubAgentReport {
     }
 }
 
-fn tool_with(
-    outcome: SubAgentOutcome,
-) -> (SpawnSubAgent, Arc<RecordingDispatcher>, SubAgentSpendLedger) {
+fn tool_with(outcome: SubAgentOutcome) -> (SpawnSubAgent, Arc<RecordingDispatcher>) {
     let dispatcher = RecordingDispatcher::new(outcome);
     let slot: DispatcherSlot = Arc::default();
     *slot.write().unwrap() = Some(dispatcher.clone() as Arc<dyn SubAgentDispatcher>);
-    let spend: SubAgentSpendLedger = Arc::default();
-    (SpawnSubAgent::new(slot, spend.clone()), dispatcher, spend)
+    (SpawnSubAgent::new(slot), dispatcher)
 }
 
 fn call(description: &str, prompt: &str) -> Value {
@@ -67,8 +67,8 @@ fn call(description: &str, prompt: &str) -> Value {
 }
 
 #[tokio::test]
-async fn a_completed_child_returns_its_finding_and_charges_its_cost() {
-    let (tool, dispatcher, spend) = tool_with(SubAgentOutcome::Completed(report(
+async fn a_completed_child_returns_its_finding() {
+    let (tool, dispatcher) = tool_with(SubAgentOutcome::Completed(report(
         "the retry policy is in stella-core/src/retry.rs",
         0.004,
         false,
@@ -87,10 +87,6 @@ async fn a_completed_child_returns_its_finding_and_charges_its_cost() {
         }
         other => panic!("expected Ok, got {other:?}"),
     }
-    assert!(
-        (drain_sub_agent_spend(&spend) - 0.004).abs() < 1e-9,
-        "the child's cost must reach the ledger the engine drains"
-    );
     let spec = dispatcher.spec();
     assert_eq!(spec.instruction, "Which file defines the retry policy?");
     assert_eq!(spec.agent_id, "find-retry-policy");
@@ -101,7 +97,7 @@ async fn write_access_is_never_model_settable() {
     // This tool delegates *research*. A child that could edit would need the
     // parent's review gates around it, which is a different change — so the
     // model cannot ask for it, even explicitly.
-    let (tool, dispatcher, _) = tool_with(SubAgentOutcome::Completed(report("done", 0.0, false)));
+    let (tool, dispatcher) = tool_with(SubAgentOutcome::Completed(report("done", 0.0, false)));
     let mut input = call("do a thing", "go");
     input["write_access"] = json!(true);
     input["max_report_chars"] = json!(10_000_000);
@@ -120,7 +116,7 @@ async fn write_access_is_never_model_settable() {
 async fn a_partial_child_returns_its_evidence_as_ok_not_as_an_error() {
     // The salvaged text is work the parent already paid for. Burying it in an
     // error invites the model to discard it and redo the search.
-    let (tool, _, spend) = tool_with(SubAgentOutcome::Incomplete {
+    let (tool, _) = tool_with(SubAgentOutcome::Incomplete {
         report: report("found three callers so far", 0.02, false),
         reason: "step cap reached".into(),
     });
@@ -142,12 +138,11 @@ async fn a_partial_child_returns_its_evidence_as_ok_not_as_an_error() {
         }
         other => panic!("expected Ok with a partial marker, got {other:?}"),
     }
-    assert!((drain_sub_agent_spend(&spend) - 0.02).abs() < 1e-9);
 }
 
 #[tokio::test]
-async fn a_child_that_produced_nothing_is_an_error_but_still_charges() {
-    let (tool, _, spend) = tool_with(SubAgentOutcome::Incomplete {
+async fn a_child_that_produced_nothing_is_an_error() {
+    let (tool, _) = tool_with(SubAgentOutcome::Incomplete {
         report: report("", 0.01, false),
         reason: "provider unreachable".into(),
     });
@@ -156,15 +151,11 @@ async fn a_child_that_produced_nothing_is_an_error_but_still_charges() {
         .execute(&call("x", "y"), std::path::Path::new("."))
         .await;
     assert!(matches!(out, ToolOutput::Error { .. }), "{out:?}");
-    assert!(
-        (drain_sub_agent_spend(&spend) - 0.01).abs() < 1e-9,
-        "money is owed whatever the outcome"
-    );
 }
 
 #[tokio::test]
 async fn a_truncated_report_says_so_to_the_model() {
-    let (tool, _, _) = tool_with(SubAgentOutcome::Completed(report(
+    let (tool, _) = tool_with(SubAgentOutcome::Completed(report(
         "a long finding",
         0.0,
         true,
@@ -183,7 +174,7 @@ async fn a_truncated_report_says_so_to_the_model() {
 
 #[tokio::test]
 async fn an_unattached_dispatcher_tells_the_model_to_do_the_work_itself() {
-    let tool = SpawnSubAgent::new(Arc::default(), Arc::default());
+    let tool = SpawnSubAgent::new(Arc::default());
     let out = tool
         .execute(&call("x", "y"), std::path::Path::new("."))
         .await;
@@ -198,15 +189,14 @@ async fn an_unattached_dispatcher_tells_the_model_to_do_the_work_itself() {
 
 #[tokio::test]
 async fn a_missing_prompt_is_a_self_correcting_error_and_dispatches_nothing() {
-    let (tool, _, spend) = tool_with(SubAgentOutcome::Completed(report("x", 1.0, false)));
+    let (tool, dispatcher) = tool_with(SubAgentOutcome::Completed(report("x", 1.0, false)));
     let out = tool
         .execute(&json!({ "description": "x" }), std::path::Path::new("."))
         .await;
     assert!(matches!(out, ToolOutput::Error { .. }), "{out:?}");
-    assert_eq!(
-        drain_sub_agent_spend(&spend),
-        0.0,
-        "a rejected call must cost nothing"
+    assert!(
+        !dispatcher.dispatched(),
+        "a rejected call must not reach the dispatcher at all — that, not a          zero ledger, is what makes it cost nothing"
     );
 }
 
@@ -228,7 +218,7 @@ async fn a_child_structurally_cannot_spawn_a_grandchild() {
         }
     }
 
-    let (tool, _, _) = tool_with(SubAgentOutcome::Completed(report("nope", 0.0, false)));
+    let (tool, _) = tool_with(SubAgentOutcome::Completed(report("nope", 0.0, false)));
     let parent = OneTool(tool);
     assert_eq!(parent.schemas().len(), 1, "the parent can see `task`");
 
@@ -258,7 +248,7 @@ fn slug_is_stable_short_and_never_empty() {
 
 #[test]
 fn the_schema_is_not_read_only_which_is_what_makes_nesting_structural() {
-    let tool = SpawnSubAgent::new(Arc::default(), Arc::default());
+    let tool = SpawnSubAgent::new(Arc::default());
     let schema = tool.schema();
     assert_eq!(schema.name, "task");
     assert!(


### PR DESCRIPTION
Follows #984. Two commits, readable independently.

## 1. Worker lanes and fleet workers run sub-agents (`79fbb373`)

#984 published `subsession`/`fleet_cmd`'s `WatchGate` into the turn-controls slot but noted neither driver installs a dispatcher, so nothing read it. This installs one — the gate half of #984 becomes a live path.

It also fixes something already shipped: `ToolRegistry::new` registers `task` unconditionally, so a worker lane has always *advertised* delegation and always answered "sub-agents are unavailable in this session." A schema the model is told about and can never use costs it a step to discover, every time.

Both registries become `Arc` (the dispatcher holds a `Weak` back — an owning handle either way leaks both). `ClaimTap::new` takes `impl ToolExecutor`, a generic bound rather than a coercion site, so two call sites need an explicit `&*`.

## 2. A cancelled parent stops its children, and still pays for them (`0497887a`)

### Cancel cascades as intent, not as mechanism

A hard cancel *is* the dropping of a future. It cannot propagate to a child: the child is an OS thread running `block_on`, deliberately off the parent's future graph because engine turn futures are `!Send` while every `#[async_trait]` tool path requires `Send`. Rust cannot kill a thread safely — nor should it here, since an abrupt kill can land mid-tool, exactly the half-finished write the step-boundary rule (L-E6) exists to prevent, and it would discard the salvaged text an aborted child is designed to hand back.

So the intent cascades. `ParentGone` is a drop guard in the suspended `dispatch` body — when the parent's turn future is dropped, every local goes with it, which is the only notification a detached child could ever get. `OrphanStop` reports it as a soft stop, OR-ed with the turn's own. The orphan is bounded by the call already in flight rather than by its full step cap.

### The sharper half: settlement moves to the child's thread

Both settle points sat after an await the cancelled parent never resumes:

```rust
dispatch:  let (outcome, spent) = wait.await;   // ← cancel point
             pool.record_spend(spent);            //   never ran
the tool:    let outcome = dispatch(spec).await;  // ← cancel point
             push_sub_agent_spend(..);            //   never ran
```

A child cancelled mid-`task` had really spent money that reached **neither** the session pool **nor** the ledger the engine drains into the parent's guard. The orphan wasn't just running — it was spending invisibly.

Whatever is still running when the parent goes away has to be what settles, and that is the thread. Charging late to the same session is this ledger's existing doctrine ("charging the same dollars twice is worse than charging them late"); never charging is not.

`SpawnSubAgent` loses its ledger field rather than being asked not to use it, so the tool structurally **cannot** double-bill — stronger than a test, and it matches what `SubAgentDispatcher`'s doc already said settlement was.

## Verification

Both behaviors mutation-tested, since both are about code that runs when nothing else does:

| mutation | result |
| --- | --- |
| drop the `OrphanStop` wrap | child makes **6** model calls instead of 1 |
| settle after `wait.await` (the old home) | cancelled child's spend never arrives; test times out |

The tests drive cancellation through `JoinHandle::abort` and then **await** the handle, which resolves only once the task has actually been dropped — so "`ParentGone` has run" is observed, not slept on. The provider returns a tool call every time, so a child that ignored the cancel is visibly distinguishable from one that took it.

Three tools-side tests lose spend assertions, because what they asserted is now inexpressible: the tool has no ledger. One (`a_missing_prompt_…_dispatches_nothing`) gains a better assertion than it lost — that the dispatcher was never reached, which is what its name always claimed.

`make gate` green: **4857 passing, 0 failures**. `check-file-size` reports none grew; the only baseline line is `registry.rs` +11 for the ledger accessor. (The four drifted entries I flagged on #984 went in with it, so `main` is no longer red on its own gate.)

## Not fixed

A cancelled child's **report** is still lost — the oneshot receiver went with the cancelled future, so the finding reaches the event stream and nowhere else. Bounding the spend and stopping promptly is what is recoverable; documented in the module rather than left to be discovered.

Refs #922

## Summary by Sourcery

Ensure delegated sub-agents run in worker lanes and fleet workers, and that children of cancelled parents stop promptly while their spend is correctly settled and never double-charged.

New Features:
- Enable sub-agent dispatching for deck worker lanes and fleet workers via session-level installation of the dispatcher and turn controls.

Bug Fixes:
- Ensure children of hard-cancelled parents receive a soft-stop signal, stop at the next model-call boundary, and still have their spend charged to the session and parent budget.
- Fix previously shipped behavior where worker lanes advertised the `task` tool but could never successfully delegate, causing unnecessary failed sub-agent attempts.

Enhancements:
- Move sub-agent spend settlement into the child thread so costs are recorded exactly once and are not lost when a parent is cancelled mid-task.
- Expose the sub-agent spend ledger from the tool registry, and make the session sub-agent budget pool shareable so children can update it directly.
- Simplify the `task` tool so it no longer owns or writes to the spend ledger, matching the dispatcher’s contract as the sole settlement path.
- Document the sub-agent lifecycle, cancellation semantics, and settlement responsibilities more clearly in the CLI and tools subagent modules.

Tests:
- Add provider and dispatcher-focused tests that verify cancelled parents bound children to a single call, that cancelled children still charge what they spent, and that uncancelled children are charged exactly once.
- Update existing sub-agent tool tests to assert on dispatch behavior rather than ledger writes, aligning with the new settlement responsibilities.

Chores:
- Adjust tool registry and claim tap wiring to work with `Arc`-backed registries and the new sub-agent settlement model.
