### PR TITLE
docs: task-shaped entry point + true up stale/missing pages (#929)

### DIFF
--- a/website/content/docs/commands/completions.mdx
+++ b/website/content/docs/commands/completions.mdx
@@ -1,0 +1,82 @@
+---
+title: stella completions
+description: Print a shell completion script for stella to stdout — bash, zsh, fish, PowerShell, or elvish. Offline, writes nothing, needs no API key.
+---
+
+Print a shell completion script for `stella` to **stdout**. It writes nothing
+itself — where the script lands is your shell's business, and yours.
+
+Offline, and needs no API key.
+
+## Synopsis
+
+```bash
+stella completions <shell>
+```
+
+<CardGrid size="sm">
+  <OptionCard name="bash">
+    Sourced from a completion directory, conventionally `/etc/bash_completion.d/`.
+  </OptionCard>
+  <OptionCard name="zsh">
+    A `_stella` file on your `$fpath`.
+  </OptionCard>
+  <OptionCard name="fish">
+    A `.fish` file under `~/.config/fish/completions/`.
+  </OptionCard>
+  <OptionCard name="powershell">
+    Evaluated from your profile.
+  </OptionCard>
+  <OptionCard name="elvish">
+    Sourced from your `rc.elv`.
+  </OptionCard>
+</CardGrid>
+
+## Installing it
+
+Each shell expects the script somewhere different:
+
+```bash
+# bash
+stella completions bash > /etc/bash_completion.d/stella
+
+# zsh — the first directory on your $fpath
+stella completions zsh > "${fpath[1]}/_stella"
+
+# fish
+stella completions fish > ~/.config/fish/completions/stella.fish
+```
+
+```powershell
+# PowerShell — append to your profile
+stella completions powershell | Out-String | Invoke-Expression
+```
+
+Open a new shell afterwards, or re-source your profile.
+
+## What you get
+
+Completion covers the whole CLI surface: every subcommand, every flag, and the
+value enums behind them — so `stella inspect --format <TAB>` offers `text` and
+`json` rather than nothing, and `stella completions <TAB>` offers the five
+shells above.
+
+The [global flags](/docs/commands#global-flags) are registered with every
+subcommand, so they complete in either position — before the subcommand or after
+it.
+
+<Callout type="info">
+The script is generated from the same command definitions the binary parses with,
+so completions cannot drift away from the flags that actually exist. Re-run the
+command after upgrading Stella to pick up new subcommands.
+</Callout>
+
+## Not sure it took?
+
+```bash
+stella completions zsh | head -5    # confirm a script is actually produced
+```
+
+If the output looks right but completion still does nothing, the problem is
+placement rather than generation — check that the target directory is on your
+shell's completion path, and that you started a fresh shell.

--- a/website/content/docs/commands/context.mdx
+++ b/website/content/docs/commands/context.mdx
@@ -1,0 +1,208 @@
+---
+title: stella context
+description: Review, publish, and explain context records — the reviewable steering stella ingest extracts from documents you already wrote. Offline; local files only, no API key.
+---
+
+`stella ingest` writes proposals. `stella context` is what acts on them.
+
+Extraction turns markdown you already wrote into atomic, probed claims sitting in
+`.stella/proposals/*.toml`. Until you decide on one, it steers nothing. This
+command is the deciding surface: read what was proposed and what its truth probe
+found, publish the claims that are actually true, decline the ones that are not,
+and afterwards ask any live record why it applied.
+
+Every subcommand reads and writes **local files only** — no API key, no network.
+
+## Synopsis
+
+```bash
+stella context review [--all]
+stella context keep <candidate> [--enforce]
+stella context edit <candidate> --statement <text> [--enforce]
+stella context ignore <candidate> [--reason <why>] [--cooldown <ISO-8601>]
+stella context list [--json]
+stella context validate [--json]
+stella context explain <rule>
+stella context propose <rule> [--commit]
+```
+
+`<candidate>` is a proposal's candidate id, or any unique prefix of it.
+`<rule>` is a published record's `^handle` (the caret is optional) or its
+lineage id.
+
+## The usual pass
+
+```bash
+stella ingest AGENTS.md      # extract claims from a document you already wrote
+stella context review        # read them, with each claim's probe verdict
+stella context keep a1b2c3   # publish the ones that are true
+stella context list          # confirm what now steers this workspace
+```
+
+## Subcommands
+
+### `stella context review [--all]`
+
+What ingest proposed, with the evidence behind each claim and the verdict its
+truth probe returned. Nothing steers until you keep it, so this is a reading
+surface with no side effects.
+
+`--all` additionally shows the **dismissed** proposals — the compound claims
+extraction refused to split, and the executable content it quarantined. Those
+are worth a look when a document you expected to produce ten records produced
+six.
+
+### `stella context keep <candidate> [--enforce]`
+
+Publish a proposal as a record the engine loads. It writes
+`.stella/rules/<lineage>.toml` — or `~/.stella/rules/` for a personal record —
+and **never overwrites an existing file**.
+
+<Callout type="info">
+`--enforce` is a **separate grant on purpose**. Keeping a record means the engine
+loads it as steering. Authorizing it to *block a matching tool call* is a
+different decision with a different blast radius, so it is a different flag
+rather than a property of keeping.
+</Callout>
+
+### `stella context edit <candidate> --statement <text> [--enforce]`
+
+Publish your wording instead of the extractor's. The claim keeps its lineage and
+its evidence; only the statement becomes yours. Use it when the claim is right
+but the phrasing was inherited from prose that said it badly.
+
+### `stella context ignore <candidate> [--reason <why>] [--cooldown <ISO-8601>]`
+
+Decline a proposal. This records **negative evidence** and a re-proposal
+cooldown — default `P90D` — so the next ingest of the same document does not ask
+again.
+
+Supply `--reason`. A decline with no reason is evidence nobody can act on later,
+including you.
+
+### `stella context list [--json]`
+
+What currently steers this workspace: every loaded record, its handle, its
+force, and whether it actually blocks anything.
+
+**Force** selects the injection channel, which is also its cost:
+
+<CardGrid size="md">
+  <OptionCard name="must">
+    Binding. Always injected into the cached system prefix.
+  </OptionCard>
+  <OptionCard name="should">
+    Strong. Always injected into the cached system prefix.
+  </OptionCard>
+  <OptionCard name="may">
+    Relevant-when-selected. Rides the volatile block after the prefix.
+  </OptionCard>
+  <OptionCard name="info">
+    Informational. Rides the volatile block.
+  </OptionCard>
+</CardGrid>
+
+`must` and `should` are always present, which is what makes them binding — and
+also what makes them the ones to be sparing with. `may` and `info` are selected
+by relevance.
+
+**Enforcement** is orthogonal to force:
+
+<CardGrid size="sm">
+  <OptionCard name="hard">
+    Blocked at the tool boundary by a guard.
+  </OptionCard>
+  <OptionCard name="soft">
+    Warned, not blocked.
+  </OptionCard>
+  <OptionCard name="none">
+    Advisory only.
+  </OptionCard>
+</CardGrid>
+
+### `stella context validate [--json]`
+
+Re-run every claim's truth probe now and report the result, plus every
+validation finding and every equal-precedence conflict. It **exits non-zero when
+something must not steer**, which makes it usable as a gate:
+
+```bash
+stella context validate || echo "steering needs review before this merges"
+```
+
+This is the answer to the problem inherited documentation always has: a record
+extracted from a README that was true in 2024 is a confident, wrong instruction
+today. The probe is declarative and runs against the tree, so staleness is
+detected rather than assumed away.
+
+### `stella context explain <rule>`
+
+Why did that rule apply? Prints provenance, evidence, enforcement, and efficacy
+for one record.
+
+```bash
+stella context explain ^pnpm-only
+stella context explain ctx.acme.web.pkg-manager
+```
+
+Truth basis is part of that answer, and the four values are meaningfully
+different:
+
+<CardGrid size="sm">
+  <OptionCard name="decree">
+    True because an owner said so — unrefutable by construction.
+  </OptionCard>
+  <OptionCard name="measured">
+    True because the world was measured and agreed.
+  </OptionCard>
+  <OptionCard name="derived">
+    True because it follows from other records.
+  </OptionCard>
+  <OptionCard name="asserted">
+    Asserted without a machine-checkable basis.
+  </OptionCard>
+</CardGrid>
+
+### `stella context propose <rule> [--commit]`
+
+Turn a record into a reviewable change: a branch, a single-concern diff, and a
+PR body. Without `--commit` it prints the plan; with it, the branch and commit
+are created locally.
+
+This exists because steering that changes how an agent behaves for a whole team
+deserves the same review as code that does — and a single-concern diff is what
+makes that review possible.
+
+## Two proposal substrates, deliberately separate
+
+<Callout type="warn">
+`stella context` and [`stella proposals`](/docs/commands/proposals) review
+different things and do not share storage.
+
+- **`stella context`** reviews **file-based** proposals extracted from documents,
+  in `.stella/proposals/*.toml`.
+- **`stella proposals`** reviews **behavioral** proposals mined from what the
+  agent actually did, in `.stella/private/context.db`.
+
+The split is about **authority**, not plumbing. An explicit instruction in a
+tracked file is eligible immediately; a pattern mined from sessions must first
+clear a distinct-task threshold. One review surface over both would apply one of
+those two gates to content it does not fit.
+</Callout>
+
+## Related
+
+<CardGrid size="sm">
+  <SpecCard title="stella ingest" href="/docs/commands/ingest">
+    The extraction half — what produces the proposals this command reviews.
+  </SpecCard>
+  <SpecCard title="stella proposals" href="/docs/commands/proposals">
+    The adaptive-context ledger: behavioral proposals, a separate substrate.
+  </SpecCard>
+  <SpecCard title="Context engine" href="/docs/context-engine">
+    How records become recall, and the two injection channels force selects.
+  </SpecCard>
+  <SpecCard title="Unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
+    Where ingest and context fit when you inherit a repository.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/commands/graph.mdx
+++ b/website/content/docs/commands/graph.mdx
@@ -37,8 +37,16 @@ stella graph <op> <target>
 </CardGrid>
 
 <Callout type="info">
-Run [`stella init`](/docs/commands/init) first. The graph is only as current as the last `init` — if you have moved or renamed a lot of code since, re-run `init` to rebuild `.stella/private/codegraph.db`.
+You do not have to run [`stella init`](/docs/commands/init) first. `stella graph` **builds the index on first use** if it isn't there, and every query runs a catch-up pass over files that changed since the last one — so answers track your working tree without a manual re-index. Running `init` up front just means the first query doesn't pay for the full build, and it also produces the domain taxonomy, which querying alone does not.
 </Callout>
+
+If the catch-up pass fails, the query still answers — from whatever the index already held — and says so rather than hiding it:
+
+```text
+warning: the code graph index pass failed — answering from what the index already holds, which may be stale
+```
+
+That is the one case where a re-`init` is the fix.
 
 ## Examples
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -62,6 +62,11 @@ stella chat
     `[paths...]` — scan the workspace for markdown steering, or extract named documents into
     reviewable context-record proposals.
   </SpecCard>
+  <SpecCard title="stella context" href="/docs/commands/context">
+    `<review|keep|edit|ignore|list|validate|explain|propose>` — decide on the context
+    records `stella ingest` extracted, and ask a live one why it applied. Offline, no
+    API key.
+  </SpecCard>
   <SpecCard title="stella proposals" href="/docs/commands/proposals">
     `<list|keep|edit|ignore|refresh>` — review what the adaptive-context loop wants to make
     durable, before it lands. Offline, no API key.
@@ -119,6 +124,10 @@ stella chat
   <SpecCard title="stella doctor" href="/docs/commands/doctor">
     Check the local state stella owns and exit non-zero if any check fails. `--repair`
     moves a corrupt `store.db` aside — renamed, never deleted.
+  </SpecCard>
+  <SpecCard title="stella completions" href="/docs/commands/completions">
+    `<shell>` — print a shell completion script to stdout. bash, zsh, fish, PowerShell,
+    or elvish.
   </SpecCard>
   <SpecCard title="stella version" href="/docs/commands/version">
     Print the version and exit.

--- a/website/content/docs/commands/ingest.mdx
+++ b/website/content/docs/commands/ingest.mdx
@@ -99,15 +99,31 @@ This matters because the input is prose of unknown provenance. A README that say
 
 ## Reviewing what it produced
 
-Ingest writes **files**, and you review them as files — read `.stella/proposals/<source-slug>.toml` and edit or delete entries before anything is adopted.
+[`stella context`](/docs/commands/context) is the other half. Ingest extracts; context
+decides.
+
+```bash
+stella context review        # what was proposed, with each claim's probe verdict
+stella context keep a1b2c3   # publish one as a record the engine loads
+stella context ignore d4e5f6 --reason "we moved off this in Q2"
+stella context list          # what actually steers this workspace now
+```
+
+The proposals are plain TOML at `.stella/proposals/<source-slug>.toml`, so editing or
+deleting entries by hand still works — but `stella context` is the surface that shows
+you the probe verdicts, records a decline as reusable negative evidence with a
+cooldown, and writes the published record into `.stella/rules/` for you.
 
 <Callout type="warn">
-`stella ingest` and [`stella proposals`](/docs/commands/proposals) are two different review surfaces with two different authority models, and they do not share storage. Ingest writes TOML proposals to `.stella/proposals/`. `stella proposals` reviews the *adaptive-context* ledger in `.stella/private/context.db` — what the reflection loop induced from your sessions. A document you ingest will not appear in `stella proposals list`.
+`stella context` and [`stella proposals`](/docs/commands/proposals) are two different review surfaces with two different authority models, and they do not share storage. Ingest writes TOML proposals to `.stella/proposals/`, reviewed by `stella context`. `stella proposals` reviews the *adaptive-context* ledger in `.stella/private/context.db` — what the reflection loop induced from your sessions. A document you ingest will not appear in `stella proposals list`.
 </Callout>
 
 ## Related
 
 <CardGrid size="sm">
+  <SpecCard title="stella context" href="/docs/commands/context">
+    The review surface for what ingest extracted — keep, edit, ignore, validate, explain.
+  </SpecCard>
   <SpecCard title="stella proposals" href="/docs/commands/proposals">
     The review surface for the adaptive-context ledger — a separate substrate from ingest's
     TOML files.

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Commands",
-  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "proposals", "tune", "scoreboard", "stats", "usage", "cloud", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "version"]
+  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "context", "proposals", "tune", "scoreboard", "stats", "usage", "cloud", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "completions", "version"]
 }

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -7,6 +7,12 @@ Pick the profile that matches the keys you hold, paste its file whole, and verif
 `stella config`. Every snippet below is a complete `~/.stella/settings.json`, not a
 fragment.
 
+<Callout type="info">
+This page answers *how do I set Stella up*. For *how do I get this done* — a red CI
+run, an unfamiliar repository, a budget you have to hold — see the
+**[Guides](/docs/guides)**.
+</Callout>
+
 ## Pick a profile
 
 | Profile | Keys needed | Worker | Judge | Triage | Medium task |

--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -116,6 +116,25 @@ stella --model zai/glm-5.2 goal "CI is green on the current branch"
 
 ## Where to go next
 
+The fastest next step is a real task rather than another reference page:
+
+<CardGrid size="sm">
+  <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
+    Walk a red branch to green, and see what "verified" actually buys you.
+  </SpecCard>
+  <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
+    Where `stella init` and the code graph earn their place.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    Put a ceiling on it before you find out what it cost.
+  </SpecCard>
+  <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
+    Config that isn't applying, a key that won't resolve — by symptom.
+  </SpecCard>
+</CardGrid>
+
+Then, when you want the underlying account:
+
 - **[Providers &amp; models](/docs/getting-started/providers)** — the full provider matrix and the
   credential chain.
 - **[The inference pipeline](/docs/inference-pipeline)** — how work gets verified, not just done.

--- a/website/content/docs/guides/budget.mdx
+++ b/website/content/docs/guides/budget.mdx
@@ -1,0 +1,220 @@
+---
+title: Work within a budget
+description: A hard dollar ceiling, and what Stella does as it approaches one — where the abort lands, what the scope gate stops before you spend anything, and what compaction does when the transcript outgrows the window.
+---
+
+You have a number in mind and you do not want to find out you passed it
+afterwards. This guide is about the mechanisms that hold a ceiling, in the order
+they fire — one of them before any money is spent at all.
+
+## The flag
+
+```bash
+stella --budget 2.00 run "port the utils module to the new API"
+```
+
+`--budget` is a [global flag](/docs/commands#global-flags), so it can go on
+either side of the subcommand — but the habit of putting it first is a good one,
+because it reads as a property of the whole invocation, which is what it is.
+
+<CardGrid size="md">
+  <SpecCard title="Observed — no --budget">
+    The default. Spend is metered for the end-of-run cost summary and the local store,
+    but never blocks. Use it to find out what a class of task actually costs before
+    picking a ceiling for it.
+  </SpecCard>
+  <SpecCard title="Enforced — --budget <usd>">
+    A hard cap on the **whole run or session** — not per turn, not per round. Must be
+    positive and finite.
+  </SpecCard>
+</CardGrid>
+
+Set it once for a shell or a CI job instead:
+
+```bash
+export STELLA_BUDGET=5
+```
+
+## Where the abort lands
+
+This is the part worth trusting, because it determines whether a tripped budget
+leaves you with work or with wreckage.
+
+The meter is checked **between steps and stages** — never in the middle of a
+tool call. An abort therefore never leaves a half-applied edit, a partially
+written file, or a tool whose side effects landed but whose result never made it
+back into the transcript. Work already committed to disk stays; nothing is
+rolled back.
+
+The exit code is `1`, the same as any other failure. If you need to distinguish
+*budget stopped this* from *this failed*, read the JSON:
+
+```bash
+stella --budget 2.00 --output-format json run "…" | jq '{status, cost_usd, verdict}'
+```
+
+<Callout type="info">
+`--budget` is metered against **catalog prices**. Local and air-gapped models
+have no catalog price, so the dollar columns read zero and a budget has nothing
+to meter against. Bound those runs with `--test-command` and goal-mode round caps
+instead — see [Local and air-gapped](/docs/examples#local-and-air-gapped).
+</Callout>
+
+## The gate that fires *before* you spend
+
+A budget stops a run partway. The [scope review](/docs/inference-pipeline#3-scope-review)
+stops it *before the first edit*, which is usually the outcome you actually
+wanted.
+
+When a plan's blast radius crosses any of three thresholds, Stella pauses and
+shows you the plan:
+
+<CardGrid size="sm">
+  <OptionCard name="max_steps" defaultValue="5">
+    More than this many steps in the plan.
+  </OptionCard>
+  <OptionCard name="max_files" defaultValue="8">
+    Estimated files-touched count above this.
+  </OptionCard>
+  <OptionCard name="max_cost_usd" defaultValue="1.00">
+    Estimated cost above this.
+  </OptionCard>
+</CardGrid>
+
+Every comparison is a strict `>`, so a plan sitting exactly on a threshold
+passes without a gate. At the card, `a` approves, `t` trims to the largest
+prefix that would not have tripped review, `x` aborts — and anything longer than
+one of those words is read as *what you want changed*, sending the plan back to
+the planner with your note attached.
+
+<Callout type="warn">
+Headless runs must opt in to bypassing this gate explicitly —
+`agent_engine_config.headless_scope_bypass: "on"`. Without it there is no silent
+auto-approve: a plan over the thresholds **ends the run**. That is deliberate,
+because a scope gate that quietly approves itself in CI is not a scope gate.
+</Callout>
+
+## What the money is actually spent on
+
+Before tuning anything, know the shape of the bill — most attempts to economize
+target the wrong stage.
+
+| Stage | Model calls | Cost share |
+| --- | --- | --- |
+| Triage | 1 | negligible |
+| Plan | 1 (+1 repair, rarely) | small |
+| Witness | ~1 engine turn | only when you pass no `--test-command` |
+| **Execute** | **5–40+ steps** | **most of the bill** |
+| Verify | 0 | free — the deterministic ladder |
+| Judge | 0–1 per verification | cents |
+
+Three consequences follow, and they are most of what you need:
+
+1. **The worker's output price dominates.** Moving the worker to a cheaper model
+   changes the bill several-fold. Moving the judge barely changes it at all.
+2. **A flagship judge is cheap insurance.** One judge call is a few thousand
+   input tokens and under a thousand out. Keep it in a *different family* than
+   the worker.
+3. **`--test-command` is the strongest cost flag on the CLI.** It arms the
+   deterministic flip oracle, so most runs finish on evidence alone with the
+   **judge skipped entirely** — and it skips the witness-author call too.
+
+```bash
+# Cheapest correct shape: deterministic oracle armed, hard ceiling on top.
+stella --budget 1.50 run --test-command "cargo test -p api" \
+  "add cursor pagination to /orders"
+```
+
+## The multipliers
+
+A ceiling only helps if you know what is pushing against it.
+
+<CardGrid size="md">
+  <OptionCard name="Goal mode">
+    Repeats judged rounds until the objective is met, up to **8**. Each round is a
+    full working turn. `stella monitor` is goal mode, so it has the same shape.
+  </OptionCard>
+  <OptionCard name="Fleets">
+    One pipeline per task. Worker spend meters into the **parent** budget, so
+    `--budget` is a single shared ceiling across the whole fan-out rather than a
+    per-worker allowance — and the run stops early once it trips.
+  </OptionCard>
+  <OptionCard name="Best-of-N">
+    Generates N candidate executions and keeps the best by verification score, at N×
+    the execution cost. Strictly opt-in, for exactly this reason.
+  </OptionCard>
+  <OptionCard name="Revisions">
+    A failed verification sends the worker back with the evidence, bounded at 2
+    revision turns by default.
+  </OptionCard>
+</CardGrid>
+
+## When the transcript outgrows the window
+
+A long run's cost is not only what it does — it is how much conversation it
+carries while doing it. When the transcript approaches the compaction budget
+(**150,000 tokens** by default), Stella compacts it and keeps going, rather than
+failing or silently truncating.
+
+Compaction applies four mechanisms, **least-lossy first**:
+
+1. **Dedup.** A byte-identical tool output appearing more than once keeps only
+   its earliest copy; later ones become a pointer to it.
+2. **Supersession.** When the same call ran twice with identical input, only the
+   latest result reflects current state — the older ones are stale by
+   construction and get stubbed.
+3. **Aging.** Still over budget, large old outputs are middle-out truncated to
+   head plus tail. The head carries the tool's framing (a `PASSED`/`FAILED` line,
+   file headers) and the tail carries the errors, so what survives is the part
+   worth reading.
+4. **Eviction.** Only then are the oldest large tool outputs replaced with a
+   stub — and a result whose call is still the most recent one is never evicted.
+
+The system message and the latest user message are never touched.
+
+<Callout type="info">
+Dedup keeps the **earliest** copy on purpose. Byte-identical content is
+position-independent, so stubbing the later one puts the change in the *newest*
+part of the conversation and leaves the provider's prompt-cache prefix
+byte-identical. Compacting the other way around would save tokens and then lose
+far more money to a cold cache than it saved.
+</Callout>
+
+If a conversation is still over budget after all four passes, an **overflow
+summarizer** runs — a real extra model call, recorded at `--call-seq 1` for that
+step. Seeing those in [`stella inspect`](/docs/commands/inspect) is the sign a
+run's transcript, not its work, is what got expensive.
+
+## Picking the number
+
+Budget by observation, not by intuition. Run the class of task once unbounded,
+read what it cost, then set a ceiling with headroom:
+
+```bash
+stella run "the representative task"      # observed mode
+stella stats --format table               # what it actually cost
+stella --budget 2.00 run "the next one"   # now with a ceiling
+```
+
+The number to steer on over time is **$/resolved**, not sticker price — a cheap
+model that needs three attempts is not cheap. The
+[Observatory](/docs/telemetry/dashboard) tracks it per model, and
+[Examples & recipes](/docs/examples) has complete configurations at four
+different price points.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="Telemetry & budget" href="/docs/telemetry#budget-observed-vs-enforced">
+    The reference for observed vs. enforced, and what the local store records.
+  </SpecCard>
+  <SpecCard title="Examples & recipes" href="/docs/examples">
+    Complete settings files from dirt-cheap to maximum-quality, with cost estimates.
+  </SpecCard>
+  <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
+    Accounting for a run after the fact, down to the individual model call.
+  </SpecCard>
+  <SpecCard title="Inference pipeline" href="/docs/inference-pipeline">
+    Every stage, what it costs, and when it is skipped.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/fix-failing-ci.mdx
+++ b/website/content/docs/guides/fix-failing-ci.mdx
@@ -1,0 +1,215 @@
+---
+title: Fix a failing CI run
+description: A branch is red. Walk it to green with stella monitor — what it does each round, what happens when a fix doesn't hold, and why "green" here means a run somebody else can see.
+---
+
+You pushed a branch and CI went red. You want it green, you would rather not
+read four thousand lines of log to find out why, and you want the fix to be a
+real fix rather than a test deletion.
+
+This is the task [`stella monitor`](/docs/commands/monitor) exists for.
+
+## The whole thing, first
+
+```bash
+# From the repository, with `gh` authenticated.
+stella --budget 5.00 monitor feature/payments-refactor
+```
+
+That is the guide. The rest of this page is what that command is doing, how to
+tell whether it worked, and what to do when it doesn't.
+
+<Callout type="warn">
+The `target` argument defaults to **`main`**. `monitor` commits and pushes its
+fixes to the branch it is watching, so a bare `stella monitor` pushes commits
+directly to `main`. Name your branch or PR explicitly — `feature/…`, or `"#128"`
+for a pull request.
+</Callout>
+
+## Before you start
+
+<CardGrid size="md">
+  <OptionCard name="gh, installed and authenticated">
+    `monitor` reads CI state through the `ci_status` tool, which shells out to
+    GitHub's `gh` CLI. `gh auth status` should be clean. Without it, the run fails at
+    the first status check rather than silently doing nothing.
+  </OptionCard>
+  <OptionCard name="A branch you are willing to have pushed to">
+    Fixes are committed and pushed between checks — that is how the next CI run gets
+    triggered at all. There is no dry-run mode; the feedback loop *is* the remote.
+  </OptionCard>
+  <OptionCard name="A budget, realistically">
+    Reading failure logs is input-token-heavy. `--budget` is a
+    [global flag](/docs/commands#global-flags), so it goes before the subcommand.
+  </OptionCard>
+</CardGrid>
+
+## What each round actually does
+
+`monitor` is not a bespoke CI robot. It is [goal mode](/docs/agent-modes#outcome-driven-goal-mode)
+with one fixed objective compiled in:
+
+> Drive CI for `<target>` to fully green. Watch the latest runs, read the failure
+> logs, fix each root cause in the code, commit and push the fix, then re-check.
+> The goal is met only when the latest CI run has completed with every check
+> successful.
+
+Which means it inherits goal mode's machinery wholesale, and that machinery is
+the interesting part:
+
+1. **Watch.** `ci_status` with `wait: true` blocks until the latest run for the
+   target finishes, then returns its conclusion and the failing jobs' logs.
+2. **Diagnose and fix.** A working round runs the full
+   [staged pipeline](/docs/inference-pipeline) — triage, plan, witness, execute,
+   verify. It is not a raw step loop: `monitor` always runs pipelined, and unlike
+   `stella goal` it exposes no `--no-pipeline` escape hatch.
+3. **Commit and push.** The remote is the only thing that can produce the next
+   round's evidence.
+4. **Judge.** A separate judge model — by preference from a
+   [different family](/docs/inference-pipeline#per-role-model-routing) than the
+   worker — assesses whether the objective is met. It can call `ci_status`
+   itself, so it is checking the run rather than reading the worker's account of
+   the run.
+5. **Repeat**, up to a hard cap of **8** judged rounds.
+
+## "Fixed" means something specific here
+
+This is where `monitor` differs from a script that retries until the exit code
+is zero, and it is worth being precise about, because it is the whole reason to
+use it.
+
+**Inside each round**, verification runs the deterministic
+[evidence ladder](/docs/inference-pipeline#6-verify--the-deterministic-ladder)
+before any model is asked for an opinion. The load-bearing rung is the **flip
+oracle**: the relevant test must have *failed before* the change and *passed
+after* it. A suite that was already green proves nothing about the fix, so it
+cannot be used to claim one. That structurally excludes the failure mode you
+actually fear — a change that makes the red go away without making the bug go
+away.
+
+The same discipline is available to the agent directly as the **`verify_done`**
+tool, which replays a new test against the previous code in a shadow worktree at
+`git HEAD`. The test must fail there and pass on the change to earn a
+**WITNESS CONFIRMED**.
+
+**Across rounds**, the outer goal judge only ends the loop when the *latest CI
+run for the target has completed with every check successful*. Not "the tests I
+ran locally passed". Not "I believe this is fixed". A run on the remote, green,
+that you can open in a browser.
+
+<Callout type="info">
+Pipelined goal rounds mean **double verification**: the pipeline's own judge
+checks each round's work, and the outer goal judge checks the objective. A fix
+that passes locally but doesn't turn CI green gets caught by the second one.
+</Callout>
+
+## When the fix doesn't hold
+
+The interesting cases are the ones where it doesn't just work.
+
+### The next run is red for a different reason
+
+This is the normal case and needs nothing from you. The round ends "not met",
+the new failure logs come back through `ci_status`, and the next round works on
+the new root cause. That is what the round loop is for.
+
+### The same failure comes back
+
+A revision that has already deterministically failed triggers **distress
+guidance**: Stella spends one judge call producing a course-correction note that
+rides along with the next revision prompt, rather than letting the worker keep
+digging in the same direction. You will see the same-failure case resolve or
+change shape rather than repeat identically.
+
+### It hits the round cap
+
+At 8 judged rounds `monitor` **stops and reports the goal as not met**, even
+with CI still red. It is not a daemon and it will not sit on your branch
+overnight. Re-run it to continue — the branch state carries over, so a second
+invocation resumes from the work the first one landed.
+
+That cap exists because the failure it protects against is expensive: an agent
+looping on an infrastructure problem it cannot fix from the code. If two
+`monitor` invocations in a row end at the cap, the constraint is usually not in
+the diff — read on.
+
+### It cannot be fixed from the code
+
+Some red CI is not a code problem: an expired token, a billing cap, a runner
+that no longer exists, a required check whose workflow file never starts. Stella
+will keep proposing code changes because code changes are what it can make. The
+tell is a `ci_status` conclusion that never reaches the test step at all — a job
+that fails in setup, or a run whose conclusion is `startup_failure`.
+
+Read the raw job yourself at that point:
+
+```bash
+gh run list --branch feature/payments-refactor --limit 5
+gh run view <run-id> --log-failed
+```
+
+### The budget aborts it
+
+`--budget` is a hard cap, checked **between** steps and stages — never
+mid-tool-call, so you are never left with a half-applied edit. An aborted run
+leaves its already-pushed commits in place; nothing is rolled back. Raise the
+cap and re-run, or see [Work within a budget](/docs/guides/budget).
+
+## Confirming it, afterwards
+
+`monitor` renders human-readable text and does **not** honor
+`--output-format` — it is an interactive mode. So the confirmation is the same
+one anybody else on your team would use:
+
+```bash
+gh pr checks 128
+```
+
+Then read what it cost you:
+
+```bash
+stella stats --format table
+```
+
+<Callout type="info">
+Want a machine-readable verdict instead? Drive the objective through
+[`stella run`](/docs/commands/run) with `--output-format json` and your own test
+command, and gate on `verdict.deterministic` — the
+[scripting guide](/docs/scripting) has the full pattern for CI-side automation.
+</Callout>
+
+## Running it *from* CI instead of *at* CI
+
+`monitor` watches a remote pipeline from your machine. The other arrangement —
+Stella running headlessly *inside* a CI job — is a different setup with
+different requirements (a non-TTY surface, JSON output, an explicit scope-review
+bypass):
+
+```bash
+stella --output-format json --budget 2.00 \
+  run --test-command "cargo test --workspace" "fix the failing tests" \
+  | jq -e '.status == "completed" and .verdict.deterministic == true'
+```
+
+Headless runs must opt in to bypassing the
+[scope-review gate](/docs/inference-pipeline#3-scope-review) explicitly with
+`agent_engine_config.headless_scope_bypass: "on"` — without it, a plan over the
+thresholds ends the run rather than silently auto-approving itself. See
+[Scripting](/docs/scripting).
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="stella monitor" href="/docs/commands/monitor">
+    The reference: synopsis, flags, exit behavior.
+  </SpecCard>
+  <SpecCard title="Goal mode" href="/docs/agent-modes#outcome-driven-goal-mode">
+    The round loop `monitor` is built on, and how the judge is chosen.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    Where the abort lands, and how to make the money go further.
+  </SpecCard>
+  <SpecCard title="stella fleet" href="/docs/commands/fleet">
+    Several red branches at once — `--watch` reconciles each one's CI and PR status.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -1,0 +1,91 @@
+---
+title: Guides
+description: Task-shaped walkthroughs — fix a red CI run, land a change in a codebase you have never read, find out what a run cost, and hold a hard budget. Each one carried to a finished, verified result.
+---
+
+The rest of the documentation is organized around Stella's parts: a page per
+command, a page per subsystem. This section is organized around **your
+afternoon**. Each guide is one real task carried from the symptom to a verified
+result, in the order you would actually type the commands.
+
+Nothing here restates the reference. Every step links down into it, so you can
+stop and read the whole flag surface at the moment you need it and not before.
+
+## Start here
+
+<CardGrid size="md">
+  <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
+    The pipeline is red on a branch you own. `stella monitor` watches it, fixes root
+    causes, pushes, and re-checks — and stops only on a green run somebody else can
+    see. Includes what to do when the fix doesn't hold.
+  </SpecCard>
+  <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
+    A repository you have never read, and a change that has to land in it. `stella
+    init` builds the code graph, `stella graph` answers the blast-radius question
+    before you commit to an approach, and the change ships verified.
+  </SpecCard>
+  <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
+    A run cost more than you expected. Follow it from the dollar figure down to the
+    exact bytes of the model call that produced it — `stats`, `observe`, `inspect`.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    A hard ceiling in dollars, and what Stella does as it approaches one: where the
+    abort lands, what compaction costs, and how to spend the money on the task
+    instead of on the transcript.
+  </SpecCard>
+  <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
+    Config that isn't applying, a key that won't resolve, a hook that never fires, a
+    graph that answers about code you deleted. The four checks in the order that
+    finds it fastest.
+  </SpecCard>
+</CardGrid>
+
+## What these assume
+
+Every guide assumes you have [installed Stella](/docs/getting-started/installation)
+and that one provider key resolves — `stella config` prints a provider, a model,
+and a redacted key preview rather than an error. If that is not yet true,
+[Getting started](/docs/getting-started) is thirty seconds long and this section
+will still be here.
+
+Nothing else is assumed. Where a guide needs `gh`, a git remote, or an
+initialized code graph, it says so at the point of need and tells you what
+happens if you don't have it.
+
+## The idea the guides share
+
+Stella's distinguishing behavior is not any single command — it is that **work
+ends on evidence rather than on the worker's own claim**. A test that failed
+before the change and passes after it. A diff that exists. A CI run whose latest
+attempt is green. A judge from a different model family than the worker, reading
+the diff and not the narration.
+
+That is worth knowing before the first guide, because it explains a shape you
+will see in all of them: the fastest, cheapest path is usually the one that hands
+Stella something deterministic to check.
+
+```bash
+# The strongest flag on the CLI. It arms the fail→pass flip oracle, which
+# lets most runs finish on deterministic evidence and skip the judge entirely.
+stella run --test-command "cargo test -p api" "add cursor pagination to /orders"
+```
+
+The [inference pipeline](/docs/inference-pipeline) is the full account of how
+that works. You do not need it to follow any guide here.
+
+## Related reading
+
+<CardGrid size="sm">
+  <SpecCard title="Examples & recipes" href="/docs/examples">
+    The configuration half — complete `settings.json` files for a given set of keys
+    and a given budget. Answers *how do I set Stella up*, where the guides answer
+    *how do I get this done*.
+  </SpecCard>
+  <SpecCard title="Agent modes" href="/docs/agent-modes">
+    Deck, run, goal, monitor, fleet — which surface to reach for, and why.
+  </SpecCard>
+  <SpecCard title="Commands" href="/docs/commands">
+    The reference every guide links into: each subcommand's synopsis, flags, and
+    exit codes.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Guides",
+  "pages": [
+    "index",
+    "fix-failing-ci",
+    "unfamiliar-codebase",
+    "what-a-run-cost",
+    "budget",
+    "troubleshooting"
+  ]
+}

--- a/website/content/docs/guides/troubleshooting.mdx
+++ b/website/content/docs/guides/troubleshooting.mdx
@@ -1,0 +1,329 @@
+---
+title: When something isn't working
+description: Config that isn't applying, a key that won't resolve, hooks that never fire, a run that ends without doing anything — the checks in the order that finds it fastest.
+---
+
+Most Stella problems are one of a small number of things, and nearly all of them
+are answerable locally in a few seconds. This page is organized by **symptom**,
+and each section is ordered so the cheapest check that could explain it comes
+first.
+
+## The three commands that answer most of it
+
+```bash
+stella config     # what actually resolved: provider, model, key source, workspace
+stella models     # every provider, its key status, and which source supplied it
+stella doctor     # is the local state Stella owns sound?
+```
+
+Run these before forming a theory. `stella config` in particular resolves every
+source — flags, environment, all three `settings.json` scopes, `credentials.toml`
+— and prints the **effective** result, which is the single most common way a
+config mystery ends.
+
+## "My `settings.json` isn't applying"
+
+Four checks, in this order.
+
+### 1. Is Stella reading the file you are editing?
+
+There are three scopes, and they are merged rather than chosen:
+
+| Scope | Path | Preference |
+| --- | --- | --- |
+| project | `<workspace>/.stella/settings.json` | highest |
+| org-managed | `STELLA_MANAGED_SETTINGS`, else `/Library/Application Support/stella/settings.json` (macOS) or `/etc/stella/settings.json` | middle |
+| user | `~/.stella/settings.json` | lowest |
+
+A missing file at any scope is fine — it is skipped. A file that is **present but
+malformed** is reported as a named error rather than silently dropping your
+configuration, so if you are not seeing an error, the file parsed.
+
+### 2. Is a higher scope overriding it?
+
+Ordinary fields merge project over org-managed over user, and `stella config`
+shows the merged result. If your user-scope value is losing, something more
+specific set it too. On a machine with MDM you may have an org-managed file you
+did not know about — check the platform path above.
+
+### 3. Is the field one that merges the way you assumed?
+
+This is the check people skip, and the merge rules genuinely differ per field:
+
+<CardGrid size="md">
+  <OptionCard name="providers, agent_engine_config">
+    Merge **per field** — even `agents.<role>.params` composes per knob.
+  </OptionCard>
+  <OptionCard name="allowed_models">
+    **Replaces wholesale.** Whichever scope sets it owns the entire list. A project
+    file listing one model does not *add* to your user list; it replaces it.
+  </OptionCard>
+  <OptionCard name="hooks">
+    **Concatenate.** Org, repo, and personal hooks all fire, and no scope can remove
+    another's.
+  </OptionCard>
+  <OptionCard name="tools, mcp">
+    **Last scope wins per key** — and an org-managed `off` is a *ceiling* no lower
+    scope can grant back.
+  </OptionCard>
+</CardGrid>
+
+### 4. Is something outranking `settings.json` entirely?
+
+Command-line flags and some environment variables sit **above** settings:
+
+- **API key** — `--api-key` > provider env var > `settings.json` `api_key` >
+  `credentials.toml` > interactive prompt.
+- **Base URL** — `--base-url` > the `ZAI_GLM_CODING_PLAN=1` toggle (Z.ai only) >
+  `settings.json` `base_url` > the built-in default.
+
+An exported shell variable beats the file almost every time, which is the
+resolution to most "but I set it in settings.json" reports.
+
+<Callout type="info">
+Preview a change without starting a run — global flags first:
+
+```bash
+stella --model anthropic/claude-fable-5 config
+```
+</Callout>
+
+## "My API key isn't resolving"
+
+```bash
+stella models         # every provider, key status, and the source that supplied it
+stella auth list      # what credentials.toml holds, redacted, with resolution source
+```
+
+The chain is **first hit wins**, and nothing below the first hit is ever read:
+
+1. `--api-key` (requires an explicit `--model provider/…`)
+2. the provider's environment variable
+3. `settings.json` → `providers.<id>.api_key`
+4. `~/.stella/credentials.toml`
+5. an interactive prompt, on a TTY, when you named a provider
+
+Three specific traps:
+
+<CardGrid size="md">
+  <SpecCard title="The key is only in a .env file your shell never loads">
+    Project dotenv files are loaded into the environment before step 2, so a repo's
+    `.env.local` does reach Stella — but an **exported shell value always wins**, and a
+    dotenv loaded by an interactive-shell hook is not loaded for a non-interactive
+    invocation. `stella auth set <provider>` is the durable fix.
+  </SpecCard>
+  <SpecCard title="api_key_env renamed the variable">
+    A `providers.<id>.api_key_env` in settings **renames the primary variable** — the
+    named one is checked first, and the provider's original env var demotes to an
+    alias. If a teammate committed that, your usual variable is now the fallback.
+  </SpecCard>
+  <SpecCard title="An empty string is not unset">
+    `providers.<id>.api_key: ""` is treated as unset — but a value that is whitespace,
+    or a stale key, resolves and then fails at the provider. A 401 means the chain
+    worked and the key is wrong.
+  </SpecCard>
+</CardGrid>
+
+### A 401 that names the wrong provider
+
+If `settings.json` pins a `base_url` for one provider and you run without
+`--model`, auto-detection can pick a *different* provider whose key then gets
+sent to the pinned URL. The error names the key's provider while the request
+went somewhere else. Pin the model explicitly and the ambiguity disappears:
+
+```bash
+stella --model zai/glm-5.2 config
+```
+
+### Auto-detection picked a provider you did not expect
+
+With no `--model`, Stella takes the first provider with a resolvable credential,
+in this order:
+
+```text
+zai, anthropic, openai, xai, deepseek, gemini, openrouter, then vertex, and bedrock LAST
+```
+
+Vertex and Bedrock sit last so generic AWS or Google credentials present for
+other reasons never hijack selection. Any leftover key earlier in that list wins
+over the one you meant — `unset` it, or pin `--model`.
+
+## "Hooks, MCP servers, or custom tools never load"
+
+This is almost always the **project trust boundary**, working as designed.
+
+A fresh clone's `hooks`, `providers.*.base_url` / `api_key` / `api_key_env`,
+`mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
+`.stella/mcp.toml` are held back until you opt in — otherwise any repository you
+cloned could run commands on your machine or route your keys through its server.
+
+A stderr notice names everything that was skipped. To grant it:
+
+```bash
+export STELLA_TRUST_PROJECT=1   # scope it per-repo with direnv or a shell guard
+```
+
+`STELLA_PROJECT_HOOKS=1` is the narrower legacy form — it trusts hooks, MCP, and
+context providers but leaves credential routing gated.
+
+<Callout type="warn">
+An **org-managed denial is a ceiling**: `tools: { "web": "off" }` or
+`authority.project_custom_tools: "off"` in the managed scope cannot be granted
+back by a project file, or by `STELLA_TRUST_PROJECT=1`. If a capability stays
+off after trusting the project, look at the managed file.
+</Callout>
+
+## "The model I configured isn't the one that ran"
+
+<CardGrid size="md">
+  <SpecCard title="Check allowed_models first">
+    It **replaces wholesale** across scopes. A model absent from the effective list is
+    not selectable, however it was configured.
+  </SpecCard>
+  <SpecCard title="A role fell back">
+    A configured role model whose provider has no credential **falls back to the
+    worker with a notice** rather than erroring. Configuration can never turn a
+    runnable pipeline into an error — so read the notice.
+  </SpecCard>
+  <SpecCard title="A circuit breaker opened">
+    Three consecutive transport failures open a provider's breaker; routing skips it
+    and reports the fallback visibly. After a cooldown, one trial call decides whether
+    it closes.
+  </SpecCard>
+  <SpecCard title="Cross-family judging moved the judge">
+    The judge prefers a healthy provider whose model *family* differs from the
+    worker's. With one family configured it degrades to the same family — with a
+    caveat, never an error.
+  </SpecCard>
+</CardGrid>
+
+## "`effort` or `reasoning` seems to be ignored"
+
+Two separate causes, and they are easy to confuse:
+
+1. **The provider drops it on the wire.** Z.ai, DeepSeek, and local endpoints do
+   not carry `effort` at all. The setting records intent and changes nothing.
+   Differentiate those roles with a strict `prompt` and `params.max_tokens`
+   instead.
+2. **An auto is overriding you.** `effort_auto` and `reasoning_auto` *override*
+   per-agent `effort` and `reasoning`. If you want per-agent values to apply,
+   the corresponding auto has to be `"off"`.
+
+That second one is why the [balanced profile](/docs/examples#balanced) carries no
+`agents` block at all and the [maximum-quality profile](/docs/examples#maximum-quality)
+turns both autos off.
+
+## "The agent answered about code that isn't there"
+
+The code graph re-indexes on every query, so a stale answer usually means the
+catch-up pass **failed** rather than that it was never run. That failure is
+non-fatal and reported rather than hidden:
+
+```text
+warning: the code graph index pass failed — answering from what the index already
+holds, which may be stale
+```
+
+If you see that, rebuild explicitly:
+
+```bash
+stella init
+stella graph definitions the_symbol_you_expected
+```
+
+A symbol that legitimately has two definitions is listed rather than silently
+resolved — that is not a bug, and it is usually the more interesting finding.
+
+## "A session won't open, or a command mentions `store.db`"
+
+```bash
+stella doctor            # read-only diagnosis, always safe
+stella doctor --repair   # quarantine a store SQLite judged corrupt
+```
+
+`--repair` **renames, never deletes** — the database and both sidecars move
+aside under one timestamp, whatever is still readable is copied to a separate
+salvaged database, and your next session starts fresh. Every quarantine is
+undoable with `mv`.
+
+`doctor` runs before configuration loads, on purpose: a workspace whose store is
+corrupt has to stay diagnosable without a working model config. One consequence
+is that `--output-format` does not apply to it.
+
+## "The run ended without doing anything"
+
+<CardGrid size="md">
+  <SpecCard title="The scope gate stopped it">
+    A plan over `max_steps` (5), `max_files` (8), or `max_cost_usd` (1.00) pauses for
+    review — and headless, without
+    `agent_engine_config.headless_scope_bypass: "on"`, it **ends the run** rather than
+    auto-approving. Deliberate: a gate that approves itself in CI is not a gate.
+  </SpecCard>
+  <SpecCard title="The budget tripped">
+    `--budget` aborts cleanly between steps. Exit code `1`; already-committed work
+    stays. Read `cost_usd` from `--output-format json` to confirm.
+  </SpecCard>
+  <SpecCard title="Verification found nothing to verify">
+    The zero-diff guard means a run that changed nothing can never claim success. If a
+    task was already done, that is the correct outcome.
+  </SpecCard>
+  <SpecCard title="It was interrupted">
+    Exit `130` is `SIGINT`, `143` is `SIGTERM` — distinguishable from a failure
+    exactly so a wrapping script can treat them differently.
+  </SpecCard>
+</CardGrid>
+
+## "Runs cost more than they should"
+
+Start with the cache columns — they explain most surprises:
+
+```bash
+stella stats --format json |
+  jq '.[] | select(.cache_hit_rate < 0.2) | {provider, model, cache_hit_rate, cache_expired_rewrites}'
+```
+
+Then find what changed between turns, which is the usual culprit behind a cold
+prefix:
+
+```bash
+stella inspect <EXEC> --step 0 --diff --only system
+```
+
+[Understand what a run cost](/docs/guides/what-a-run-cost) walks that whole chain.
+
+## Working entirely offline
+
+If you are diagnosing on a plane or inside an air gap, this much needs no
+network and no key: `stella config`, `stella doctor`, `stella models` (listing),
+`stella graph`, `stella scripts`, `stella storage`, `stella commands`,
+`stella stats`, `stella usage`, `stella inspect`, `stella context`,
+`stella proposals`, `stella memory`, and `stella observe`.
+
+The one remaining automatic outbound call is the model-catalog refresh, at most
+once per 24 hours:
+
+```bash
+export STELLA_CATALOG_AUTO_REFRESH=0
+```
+
+## Still stuck
+
+Collect the three outputs at the top of this page plus the failing command, and
+open an issue. `stella config` redacts the key to a preview, so its output is
+safe to paste; `stella inspect` output is **not** — it contains your prompts and
+source excerpts, and receipts never leave your machine unless you move them.
+
+<CardGrid size="sm">
+  <SpecCard title="Settings reference" href="/docs/configuration/settings">
+    Every field, the scope hierarchy, and the trust boundary in full.
+  </SpecCard>
+  <SpecCard title="Credentials" href="/docs/configuration/credentials">
+    The credential chain, `credentials.toml`, and cloud-provider extras.
+  </SpecCard>
+  <SpecCard title="stella doctor" href="/docs/commands/doctor">
+    What each verdict means, and exactly what `--repair` does to your disk.
+  </SpecCard>
+  <SpecCard title="API providers" href="/docs/api-providers">
+    Per-provider dialects, base URLs, and what each one drops on the wire.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/unfamiliar-codebase.mdx
+++ b/website/content/docs/guides/unfamiliar-codebase.mdx
@@ -1,0 +1,220 @@
+---
+title: Make a change in an unfamiliar codebase
+description: A repository you have never read, and a change that has to land in it. Orient with the code graph, find the blast radius before committing to an approach, and ship the change verified.
+---
+
+You have been handed a repository you did not write. The change itself is
+probably small. The expensive part is finding out *where* it goes and *what
+else* it breaks — and that is exactly the part an agent does badly when its only
+instrument is `grep`.
+
+This guide is about doing that part with the code graph instead.
+
+## The whole thing, first
+
+```bash
+cd the-repo
+stella init                                         # index the codebase
+stella graph importers src/db/schema.ts             # what am I about to break?
+stella run --test-command "pnpm test orders" \
+  "add a nullable `archived_at` column to orders and thread it through the API"
+```
+
+## 1. Index the repository
+
+```bash
+stella init
+```
+
+`stella init` does three things worth knowing here: it infers a **domain
+taxonomy** into `.stella/domains.toml` (the tagging vocabulary memories and
+graph nodes use), it builds the **code-graph index** at
+`.stella/private/codegraph.db`, and it adopts any commands, skills, and agents
+already sitting in `.claude/` or `.agents/` directories as symlinks.
+
+It works **offline** through a heuristic fallback, so it succeeds even with no
+provider credential resolved — useful on a machine where you have not set up
+keys yet.
+
+<Callout type="info">
+`init` is a head start, not a prerequisite. Both `stella graph` and the agent's
+`graph_query` tool **bootstrap the index on first use** if it isn't there, and
+each query runs a catch-up pass over changed files. Running `init` up front just
+means the first query isn't the one that pays for the full index build — and you
+get the domain taxonomy, which querying alone does not produce.
+</Callout>
+
+## 2. Ask the questions you would otherwise guess at
+
+This is the step people skip, and it is the one that pays. Before deciding *how*
+to make a change, find out what depends on the thing you are about to touch.
+
+```bash
+# Where is this defined — and is it defined exactly once?
+stella graph definitions resolveOrderTotal
+
+# Who calls it? This is the review surface for a signature change.
+stella graph references resolveOrderTotal
+
+# Blast radius: who imports the file I am about to edit?
+stella graph importers src/db/schema.ts
+
+# What does this file depend on — what do I need to understand first?
+stella graph imports src/api/orders.ts
+
+# The neighborhood, both directions at once.
+stella graph neighbors src/api/orders.ts
+```
+
+Every one of these is **offline and instant**. It reads the local index, makes
+no model calls, and needs no API key — so it costs nothing and you can afford to
+be thorough. Ask five questions before you write a prompt.
+
+Two of them are worth calling out as habits:
+
+<CardGrid size="md">
+  <SpecCard title="definitions, before a rename">
+    A symbol with two definitions is a rename that silently half-lands. `stella graph
+    definitions` lists every site rather than picking one, so you find that out
+    before the edit and not during review.
+  </SpecCard>
+  <SpecCard title="importers, before an edit">
+    The honest answer to "is this change small?" Twelve importers of a schema file
+    means the change is a migration, whatever the diff size suggests.
+  </SpecCard>
+</CardGrid>
+
+## 3. Let the agent use the same index
+
+The graph is not just a CLI convenience — the agent queries it as the
+`graph_query` tool, and that is the point. Where an agent without one greps for
+a symbol name, gets 200 textual hits, and reads a dozen files to disambiguate
+them, an agent with a graph asks for definitions and gets the answer with a
+citation.
+
+Two related tools ride on the same index:
+
+<CardGrid size="md">
+  <OptionCard name="graph_query">
+    Definitions, references, imports, importers, neighborhood — structural questions,
+    answered structurally.
+  </OptionCard>
+  <OptionCard name="read_symbol">
+    Reads a named symbol's exact source span, resolved through the graph rather than
+    by guessing line offsets. Multiple definitions are listed, never silently chosen.
+  </OptionCard>
+  <OptionCard name="project_overview">
+    One read-only pass for languages, entry points, and layout — the orientation call.
+  </OptionCard>
+  <OptionCard name="gather_context">
+    One deterministic sweep combining greps, globs, symbol lookups, and bounded
+    excerpts, saved as a reusable context pack.
+  </OptionCard>
+</CardGrid>
+
+You do not invoke these yourself. They exist so that the cheapest correct
+answer is also the one the model reaches for first, which is what keeps a run in
+an unfamiliar repository from turning into forty file reads.
+
+## 4. Make the change, with an oracle
+
+Now the actual work. In an unfamiliar codebase the single highest-value thing
+you can supply is the **test command**, because it converts "I think this is
+right" into deterministic evidence:
+
+```bash
+stella run --test-command "pnpm test orders" \
+  "add a nullable archived_at column to orders and thread it through the API"
+```
+
+`--test-command` arms the **flip oracle**: the command must *fail before* the
+change and *pass after* it. A suite that was already green cannot be used as
+proof, which is what makes the flip meaningful rather than decorative.
+
+Don't know the test command in a repo you have never read? Ask the repo:
+
+```bash
+stella scripts list          # canonical verbs — install/build/check/test/lint/format
+```
+
+`stella scripts` detects them statically from the manifests (cargo, npm, uv, go,
+make, just, …). It is offline and needs no API key.
+
+### If you can't express "done" as a test
+
+Then don't pass `--test-command`, and Stella supplies the oracle itself. An
+independent model — the **witness author**, never the worker — writes a minimal
+*failing* test pinning the intended behavior, and that test arms the flip oracle
+instead. Witness files are watched for tampering: a worker that edits the
+witness doesn't get credit for passing it.
+
+The witness is scaffolding, not an inheritance. It encodes a moment ("this code
+doesn't do X yet") rather than an invariant, so it lives and dies inside the
+candidate workspace — you never find an unreviewed, already-satisfied test
+sitting in your test directory afterwards. When it turns out to be worth keeping:
+
+```bash
+stella run --keep-witness "make Plan::validate reject a self-dependency by name"
+```
+
+## 5. Review what actually changed
+
+```bash
+stella graph importers src/db/schema.ts   # re-ask: did the blast radius move?
+git diff
+```
+
+In the [Command Deck](/docs/commands/chat), `/diff` and `/files` are the same
+review from inside the session.
+
+<Callout type="warn">
+Cloning an unfamiliar repository means running unfamiliar configuration. A fresh
+clone's `hooks`, `providers.*.base_url` / `api_key` / `api_key_env`,
+`mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
+`.stella/mcp.toml` are **held back until you opt in** — otherwise any repo you
+cloned could run commands on your machine or route your keys through its server.
+A stderr notice names anything skipped.
+
+```bash
+export STELLA_TRUST_PROJECT=1   # scope it per-repo with direnv or a shell guard
+```
+
+See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+</Callout>
+
+## When the repository already documents itself
+
+Most repositories you inherit already contain the instructions an agent needs —
+`AGENTS.md`, `CLAUDE.md`, a `CONTRIBUTING.md`, architecture notes. They are just
+written for people, scattered, and partly out of date.
+
+```bash
+stella ingest                    # what steering does this repo already contain?
+stella ingest AGENTS.md          # extract it into reviewable claims
+stella context review            # read what was proposed, and its probe verdict
+stella context keep a1b2c3       # publish the ones that are actually true
+```
+
+[`stella ingest`](/docs/commands/ingest) mines that prose into atomic claims,
+each carrying its provenance and each **probed against the tree for staleness**
+— which is the part that matters in an inherited repository, where the README
+confidently describes a build system that was replaced two years ago. Nothing
+steers anything until you keep it. [`stella context`](/docs/commands/context) is
+the review surface.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="stella graph" href="/docs/commands/graph">
+    The five operations and what each `target` means.
+  </SpecCard>
+  <SpecCard title="Context engine" href="/docs/context-engine">
+    How the graph, memories, and rules become recall — and why it stays cheap.
+  </SpecCard>
+  <SpecCard title="stella init" href="/docs/commands/init">
+    Exactly which files initialization generates.
+  </SpecCard>
+  <SpecCard title="Agent tools" href="/docs/agent-tools">
+    The full toolbelt, the read-only partition, and the permission model.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/what-a-run-cost.mdx
+++ b/website/content/docs/guides/what-a-run-cost.mdx
@@ -1,0 +1,275 @@
+---
+title: Understand what a run cost, and why
+description: Follow one expensive run from the dollar figure all the way down to the exact bytes the model was sent — stats, the Observatory, and stella inspect. Entirely local, no API key.
+---
+
+A run cost more than you expected. Most tools can tell you *that*. Stella can
+tell you **which model call**, **what it was sent**, and **what changed between
+that call and the one before it** — from local records, with no network access
+and no API key.
+
+This guide walks that chain top to bottom. Each step narrows the question.
+
+## The chain
+
+```bash
+stella stats                              # 1. which model, and how much
+stella observe --open                     # 2. which run, and where the time went
+stella inspect                            # 3. which call inside that run
+stella inspect 42 --step 3                # 4. what that call was actually sent
+stella inspect 42 --step 3 --diff --only system   # 5. what changed since last time
+```
+
+Everything below reads `<workspace>/.stella/private/store.db` and never writes.
+
+## 1. Which model, and how much — `stella stats`
+
+```bash
+stella stats
+```
+
+Aggregates the local store per provider and model: total tokens, total cost,
+resolve rate, and a `TOTAL` row. It is the "where is the money going" view.
+
+The three columns people miss are the cache-economics ones, and they are usually
+where a surprising bill is explained:
+
+<CardGrid size="md">
+  <OptionCard name="HIT%">
+    Cache-read tokens over total input tokens. Prompt caching is 4–10× cheaper than
+    fresh input, so this number is most of your bill's variance.
+  </OptionCard>
+  <OptionCard name="SAVED ($)">
+    Estimated dollars saved by caching, at today's catalog rates. **Signed** — a
+    negative value means the provider's cache-write premium outran the reads it
+    bought, which is a real incident and not a rounding artifact.
+  </OptionCard>
+  <OptionCard name="TTL REWRITES">
+    Calls whose cached prefix went cold because the gap since the session's previous
+    call exceeded the provider's cache TTL, and got rewritten instead of read back.
+    A session parked between turns pays the write premium again for nothing.
+  </OptionCard>
+</CardGrid>
+
+Two diagnoses worth knowing by heart:
+
+- **`HIT%` near 0 with `CACHE WR` also 0**, on an opt-in provider (Anthropic,
+  Bedrock, Claude-via-OpenRouter) — the cache marker probably never reached the
+  wire. Check the adapter config before concluding the model isn't cacheable.
+- **`CACHE WR` nonzero but `HIT%` low** — the prefix is being *rewritten*
+  between turns instead of reused. Something upstream of the cache breakpoint is
+  changing per turn. Step 5 finds out what.
+
+```bash
+# Everything with a suspiciously cold cache, as JSON.
+stella stats --format json |
+  jq '.[] | select(.cache_hit_rate < 0.2) | {provider, model, cache_hit_rate, cache_expired_rewrites}'
+```
+
+<Callout type="info">
+`stella stats` is **this workspace**. For the same numbers across every project on
+this machine, [`stella usage report`](/docs/commands/usage#stella-usage-report)
+reads the local hub at `~/.stella/usage.db`. Local-only — nothing is uploaded.
+</Callout>
+
+## 2. Which run — the Observatory
+
+```bash
+stella observe --open
+```
+
+A local web dashboard over the same stores, served on `127.0.0.1` only, embedded
+in the binary — no install and no build step. Its executions tab gives you
+per-run drill-down, which is how you get from "this month cost $40" to "this
+*run* cost $4".
+
+Take the **execution id** from the run you care about; the rest of this guide
+uses it.
+
+<Callout type="info">
+The Observatory opens the stores strictly read-only and never exports anything.
+See [the dashboard tour](/docs/telemetry/dashboard) for what each tab shows.
+</Callout>
+
+## 3. Which call inside the run — `stella inspect`
+
+```bash
+stella inspect          # executions that have receipts
+stella inspect 42       # that execution's model calls, with roles and seq numbers
+```
+
+Every model call records a **receipt**: the ordered list of context blocks it
+sent, plus the bytes of the blocks the event journal cannot otherwise resolve.
+`stella inspect 42` lists them, so you rarely have to guess.
+
+A single step can hold several calls, and the numbering is fixed:
+
+<CardGrid size="md">
+  <OptionCard name="--call-seq 0" defaultValue="default">
+    The engine's own worker call. Always `0`.
+  </OptionCard>
+  <OptionCard name="--call-seq 1">
+    The overflow summarizer that may run during that step's compaction.
+  </OptionCard>
+  <OptionCard name="--call-seq 2+">
+    The pipeline's management roles — triage, judge, plan, guidance, conversational.
+  </OptionCard>
+</CardGrid>
+
+Those auxiliary calls assemble prompts that exist nowhere else, so their receipt
+is the only record of what they sent. If a run's cost is concentrated in
+something other than seq `0`, that is itself the finding.
+
+## 4. What the call was sent
+
+```bash
+stella inspect 42 --step 3            # role-delimited transcript
+stella inspect 42 --step 3 --full     # …with nothing elided
+```
+
+This reconstructs the exact `Vec<CompletionMessage>` the model received — system
+prompt included — and re-checks it against the digests taken at emission. The
+banner reports the verdict, and the two failure modes are kept separate because
+they mean very different things:
+
+<CardGrid size="md">
+  <OptionCard name="! N block(s) could not be resolved">
+    A documented coverage gap — budget-abort synthetic tool results, discarded
+    speculation, attachments. The rest of the transcript is still faithful.
+  </OptionCard>
+  <OptionCard name="!! N block(s) did NOT re-hash">
+    The journal is torn or was altered. Treat the reconstruction as untrustworthy.
+  </OptionCard>
+</CardGrid>
+
+## 5. What changed since the previous call — `--diff`
+
+This is the step that actually explains a cache regression, and it is the one
+capability here with no real equivalent elsewhere.
+
+A transcript shows the **sum**. It never shows the **delta**. A system prompt is
+hundreds of stable lines, and finding the paragraph that moved by reading two of
+them side by side is not something a person does reliably.
+
+```bash
+stella inspect 42 --step 0 --diff --only system
+```
+
+```text
+--- execution 41 · turn 0 · step 12 · seq 0 (worker)
++++ turn 0 · step 0 · seq 0 (worker)
++1 added, -0 removed  (system messages)
+@@ -14,3 +14,4 @@
+ - Always read a file before editing it — never edit blind.
++- Prefer `apply_edits` for a change touching several files.
+ - Make minimal, surgical edits.
+```
+
+That single added line is a plausible cause of a cold cache: anything that
+changes above the cache breakpoint invalidates the prefix for the whole turn.
+
+Three baselines, all **same-role** (diffing a worker prompt against a judge
+prompt produces noise, not a delta):
+
+<CardGrid size="md">
+  <OptionCard name="prev" defaultValue="default">
+    Whatever ran immediately before in the same role — the previous step, or the last
+    call of the previous turn when this is a turn's first call. Searches the whole
+    session, because a system prompt is byte-stable *within* an execution by design,
+    so drift can only appear across turns.
+  </OptionCard>
+  <OptionCard name="first">
+    The first call of this role in the session.
+  </OptionCard>
+  <OptionCard name="prompt">
+    Your prompt exactly as you submitted it, before any context was added.
+  </OptionCard>
+</CardGrid>
+
+### Why `prompt` is a baseline at all
+
+The words you type are all you *know* exist when you submit them. The system
+prefix, recalled memories, rules, and skills are added afterwards, and no other
+view shows that mutation.
+
+```bash
+stella inspect 42 --step 0 --diff
+```
+
+```text
+--- prompt as submitted
++++ turn 0 · step 0 · seq 0 (worker)
++8729 added, -0 removed  (all messages)
+```
+
+Three words in, 8,730 lines out. That ratio is the honest answer to "why did a
+one-sentence prompt cost that much".
+
+<Callout type="info">
+"no change" is a **result**, not a failure. `--only system` reporting the prompt
+byte-identical to the previous turn is a direct confirmation that the
+prompt-cache stability invariant is holding — which is exactly what you want to
+see when `HIT%` is healthy.
+</Callout>
+
+## Making it a check instead of an investigation
+
+Everything above has a JSON form, so the forensics can run unattended:
+
+```bash
+# Did the system prompt drift between turns? `base` reports which baseline
+# actually resolved, since `prev` becomes `prompt` when nothing preceded the call.
+stella inspect 42 --step 0 --diff --only system --format json |
+  jq '{base, changed, added, removed}'
+
+# Is the reconstruction trustworthy at all?
+stella inspect 42 --step 3 --format json |
+  jq '{verified, unresolved, digest_mismatches}'
+```
+
+## The other cost question: was it worth it?
+
+Dollars are half the story. `stella scoreboard` answers the other half without
+letting a model grade its own homework — model calls, characters a human had to
+type, follow-ups, and a verdict read from a pull request somebody actually
+merged or closed. An open PR is deliberately **not** a verdict.
+
+```bash
+stella scoreboard
+```
+
+The number worth steering on is **$/resolved**, not sticker price: a cheap model
+that needs three attempts is not cheap. See
+[Examples & recipes](/docs/examples) for the profiles that trade those off.
+
+## Keeping the store from growing forever
+
+`store.db` grows monotonically — every run appends executions, events, tool
+calls, context blocks, and receipts.
+
+```bash
+stella stats prune --older-than 90d --dry-run   # look first; deletion cascades
+stella stats prune --older-than 90d --vacuum    # then keep a quarter of history
+```
+
+Prune is **replication-safe by default**: an execution whose telemetry has not
+yet reached the usage hub is never dropped, so pruning before a sync cannot
+silently destroy cost data you are still billing against. `--force` overrides
+that and is irreversible.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="stella inspect" href="/docs/commands/inspect">
+    Every flag, the verification banner, and what receipts deliberately cannot show.
+  </SpecCard>
+  <SpecCard title="stella stats" href="/docs/commands/stats">
+    The cache columns and the prune surface in full.
+  </SpecCard>
+  <SpecCard title="Telemetry & budget" href="/docs/telemetry">
+    What the store holds, how to query it yourself, and the two egress paths.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    Spending less next time, rather than accounting for it afterwards.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -42,11 +42,41 @@ code-graph context engine. In [goal mode](/docs/agent-modes#outcome-driven-goal-
 second model judges the result from evidence, so the loop ends on a verified outcome
 rather than the worker's own say-so.
 
+## Start with the thing you came here to do
+
+Each of these is one real task carried to a finished, verified result. They link
+down into the reference rather than replacing it, so you can read a whole flag
+surface at the moment you need it and not before.
+
+<CardGrid size="md">
+  <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
+    Watch a red branch, fix root causes, push, re-check — and stop only on a green run
+    somebody else can see.
+  </SpecCard>
+  <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
+    Find the blast radius with the code graph before committing to an approach, then
+    ship the change verified.
+  </SpecCard>
+  <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
+    From the dollar figure down to the exact bytes one model call was sent — all of it
+    local.
+  </SpecCard>
+  <SpecCard title="Work within a budget" href="/docs/guides/budget">
+    A hard ceiling, where the abort lands, and what compaction does when the transcript
+    outgrows the window.
+  </SpecCard>
+</CardGrid>
+
+Never run it before? **[Get started](/docs/getting-started)** is thirty seconds —
+install, one key, `stella init`, first verified change. Something not working?
+**[Troubleshooting](/docs/guides/troubleshooting)** is organized by symptom.
+
 ## Where to go
 
 | Section | Read it for |
 | --- | --- |
 | **[Get started](/docs/getting-started)** | Install, configure a provider key, initialize a repo, make a first verified change. |
+| **[Guides](/docs/guides)** | Task-shaped walkthroughs: red CI, an unfamiliar repo, cost forensics, budgets, and troubleshooting. |
 | **Concepts** | How the [pipeline](/docs/inference-pipeline) proves work, how the [context engine](/docs/context-engine) makes recall cheap, and the [modes](/docs/agent-modes) and [fleets](/docs/agent-fleets) you drive it with. |
 | **Configure** | [`settings.json`](/docs/configuration), [providers](/docs/api-providers), [tools and permissions](/docs/agent-tools), [telemetry](/docs/telemetry), and ready-made [recipes](/docs/examples). |
 | **Reference** | Every [command and flag](/docs/commands), [headless scripting](/docs/scripting), the [event bus](/docs/extensions), and [release notes](/docs/release-notes). |

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -130,17 +130,53 @@ testing — with the full [toolbelt](/docs/agent-tools) and its
 
 ### 6. Verify — the deterministic ladder
 
-Verification prefers evidence over opinion, in strict order:
+Verification prefers evidence over opinion. Three deterministic signals are
+gathered first:
 
 - **The flip oracle.** The test command (yours or the witness's) must **fail
   before** the change and **pass after** it. A suite that was already green
   proves nothing; the fail→pass flip is what proves the change did the work.
+  The oracle is a state machine keyed on a normalized command string: it locks
+  onto the first command it sees *fail*, and only a later *pass of that same
+  command* moves it to flipped — which structurally excludes the "it passed,
+  ship it" false positive.
 - **The zero-diff guard.** A run that changed nothing (including untracked
   files) can never claim success.
 - **The diff budget.** A small diff (≤ 400 changed lines by default) backed by
   deterministic evidence can submit without any model judge at all.
-- **Escalation to the judge** happens only when deterministic evidence is
-  unavailable or inconclusive.
+
+From those, the ladder picks one of **four** outcomes — before any model judge
+runs, and in this order:
+
+<CardGrid size="md">
+  <OptionCard name="1 · Revise">
+    Touched tests are **red**. That is already a deterministic failure, so the evidence
+    goes straight back into a revision turn. No judge call is spent confirming a
+    failure that is not in doubt.
+  </OptionCard>
+  <OptionCard name="2 · Unverifiable">
+    **Every** channel was blind — no flip, no test result, an unreadable working tree,
+    and no recorded file touch. The ladder **abstains**: no judge call, and the run is
+    scored as *unverified* rather than passed or failed.
+  </OptionCard>
+  <OptionCard name="3 · Submit fast">
+    Flip achieved, touched tests green, diff within budget. The full deterministic
+    pass — the model judge is **skipped** entirely.
+  </OptionCard>
+  <OptionCard name="4 · Model judge">
+    Genuinely inconclusive — no flip, or a diff over budget, or tests that could not
+    run — but at least one channel could still see something. Only here is a judge
+    asked.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="info">
+The abstain rung is what keeps the ladder honest about its own reach. Before it
+existed, a turn nothing could observe fell through to the judge, which was handed
+an empty record and answered with a confident `FAIL` naming a file that existed.
+Buying a model call to guess from no evidence is worse than saying *I could not
+tell* — so now it says that.
+</Callout>
 
 The same discipline is available to the agent as a tool:
 **`verify_done`** replays a new test against the *previous* code in a shadow

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -4,6 +4,8 @@
     "index",
     "---Get started---",
     "getting-started",
+    "---Guides---",
+    "guides",
     "---Concepts---",
     "inference-pipeline",
     "context-engine",


### PR DESCRIPTION
Closes #929.

## The problem

Every docs page was either a command reference or a subsystem concept. Nothing said *here is how you actually fix a failing CI run, end to end* — so the capabilities that only make sense **in composition** were discoverable only by someone who already knew to look for them: `monitor` together with the witness discipline, `graph` before an edit, `inspect --diff` when a cache goes cold.

## New: a Guides section

Five task-shaped pages, sitting between **Get started** and **Concepts**, each carrying one real task to a finished verified result and linking *down into* the reference rather than restating it.

| Page | The task |
| --- | --- |
| `guides/fix-failing-ci` | A red branch → green. `monitor`'s round loop, what "fixed" means when the flip oracle is the gate, and each distinct way a fix fails to hold (new failure / same failure / round cap / not-a-code-problem / budget). |
| `guides/unfamiliar-codebase` | A repo you have never read. `init` → blast-radius questions → a verified edit. Where the code graph earns its place. |
| `guides/what-a-run-cost` | `stats` → `observe` → `inspect` → `--diff`. The cost-forensics chain, narrowing at each step. |
| `guides/budget` | Where the abort lands, the scope gate that fires *before* any spend, the multipliers, and what compaction actually does. |
| `guides/troubleshooting` | By symptom, cheapest check first — including the "config isn't applying, check these four things in this order" the issue asked for. |

The landing page and Getting Started now **lead with those tasks**, which is the issue's acceptance criterion: a first-time reader reaches a completed, verified change without reading a reference page end to end.

## Also: four true-ups, each verified against source

Not against the surrounding prose — these were found by reading the implementation.

1. **`stella context` had zero mentions anywhere in the docs.** Epic #897 shipped a full 8-subcommand surface (`review`/`keep`/`edit`/`ignore`/`list`/`validate`/`explain`/`propose`) and it was completely undocumented. Now a reference page covering the force/enforcement/truth-basis vocabulary and the deliberate two-substrate split against `stella proposals`. `ingest.mdx` also stopped telling people to review proposals by hand-editing TOML.

2. **`stella completions` was undocumented.** Now a page.

3. **The verification ladder grew a fourth rung and the docs never learned.** `LadderDecision::Unverifiable` abstains when every evidence channel is blind, rather than buying a judge call to guess from an empty record. The documented *order* was also wrong — red touched tests short-circuit to `Revise` before anything else. Corrected to the real four outcomes.

4. **`graph.mdx` said the opposite of what the code does.** It told readers "the graph is only as current as the last `init` — re-run `init` to rebuild". In fact `stella graph` → `run_query` → `open_or_build` bootstraps the index on first use and runs an `index_all` catch-up pass **per query**. That is backwards for the tool's main use, so it is fixed, with the real failure mode (a failed catch-up pass, which reports itself) documented instead.

## Verification

- `pnpm build` green — 86 routes, TypeScript clean.
- Wrote a link checker over the whole docs tree: **every `/docs` link and heading anchor across all 75 pages resolves**, including the pre-existing ones.
- `make doc-citations` passes.

Docs-only: **zero Rust files** in the diff. The local pre-push `file-size` gate fails on pre-existing ceiling drift on `main` (`pipeline.rs` +131, `registry.rs` +43, and four others), unrelated to this branch, so the push used `SKIP_GATE=1`.

## Summary by Sourcery

Introduce a task-focused Guides section to the documentation, update landing/getting-started pages to lead with real workflows, and correct/extend docs for verification behavior, context/proposals, graph indexing, and completions.

New Features:
- Add a Guides docs section with task-oriented walkthroughs for fixing failing CI, changing an unfamiliar codebase, understanding run cost, working within a budget, and troubleshooting.
- Document the new stella context command as the review/publish surface for ingest-generated proposals, including its subcommands and relationship to stella proposals.
- Add documentation for the stella completions command and how to install shell completion scripts across supported shells.

Enhancements:
- Revise the inference pipeline verification section to describe the four-outcome deterministic ladder, including the new Unverifiable rung and the correct outcome ordering.
- Update the main docs index, getting started flow, and examples page to highlight guides as the next step and clarify how reference vs. guides are used.
- Clarify graph command documentation to match actual behavior around index bootstrapping, per-query catch-up, and the real stale-index failure mode.

Documentation:
- Create new guide pages for fixing failing CI, working within a budget, making changes in an unfamiliar codebase, understanding run cost, and troubleshooting common issues.
- Add a Guides index page that explains the intent of task-shaped docs and how they relate to commands, modes, and examples.