### PR TITLE
feat(config): stella.toml — phase 1 (loads, writes, migrates) + design docs + filesystem map

### DIFF
--- a/docs/design/config-system/DESIGN.md
+++ b/docs/design/config-system/DESIGN.md
@@ -1,4 +1,4 @@
-# Design: `stella.toml` — one config file, and the four features it unlocks
+# Design: `stella.toml` — one config file, and the five features it unlocks
 
 **Status:** Nothing built. This is a proposal. ·
 **Date:** 2026-07-30
@@ -34,8 +34,10 @@ so it should be made deliberately rather than inherited from this doc.
    to serde, and the only defense is a warning printed by a hand-maintained
    key list (`settings/unknown.rs`). A `schema_version` turns forward
    compatibility from a convention into a mechanism.
-3. **Make four capabilities configurable that currently are not**: pipeline
-   stages, per-agent tool scope, named agents, and declarative integrations.
+3. **Make five capabilities configurable that currently are not**: pipeline
+   stages (§4.5), per-agent tool scope and named agents (§4.1, §4.4), model
+   policy over the catalog (§7.2), provider fallback (§4.2), and declarative
+   integrations with multi-backend tools (§5).
 
 **Non-goal: consolidating everything.** Four of the current files should stay
 separate, and §7.1 says why for each. "One config file" means one file for

--- a/docs/design/config-system/DESIGN.md
+++ b/docs/design/config-system/DESIGN.md
@@ -1,0 +1,527 @@
+# Design: `stella.toml` — one config file, and the four features it unlocks
+
+**Status:** Nothing built. This is a proposal. ·
+**Date:** 2026-07-30
+
+**Built today:** none of it. Stella reads `settings.json` (JSON, three
+scopes) plus `.stella/mcp.toml`, `.stella/domains.toml`,
+`.stella/tools/*.toml`, `~/.stella/credentials.toml`,
+`~/.stella/integrations.json`, and project `.env` files.
+
+**Companion files:** [`stella.today.toml`](./stella.today.toml) renders every
+knob Stella reads *today* in the proposed shape (a pure transliteration).
+[`stella.next.toml`](./stella.next.toml) renders the shape *after* the
+features below are built. [`agent_system.toml`](./agent_system.toml) is the
+original sketch this responds to.
+
+**Not yet decided:** whether the project-scope file lives at the repo root
+(`./stella.toml`) or stays under `.stella/`. §3.2 recommends the root and
+says why; it is the one call in here that is genuinely reversible-with-pain,
+so it should be made deliberately rather than inherited from this doc.
+
+---
+
+## 1. Goals, and one non-goal
+
+**Goals.**
+
+1. **One file, in a format that can hold its own documentation.** The
+   semantics of `settings.json` currently live in Rust doc comments the user
+   never sees — why `auto_mode` picks a different model family, why
+   `headless_scope_bypass` defaults off, what `ann_enabled` trades away. JSON
+   cannot carry any of it. That knowledge belongs next to the knob.
+2. **A migration seam.** Today a typo and a future key are indistinguishable
+   to serde, and the only defense is a warning printed by a hand-maintained
+   key list (`settings/unknown.rs`). A `schema_version` turns forward
+   compatibility from a convention into a mechanism.
+3. **Make four capabilities configurable that currently are not**: pipeline
+   stages, per-agent tool scope, named agents, and declarative integrations.
+
+**Non-goal: consolidating everything.** Four of the current files should stay
+separate, and §7.1 says why for each. "One config file" means one file for
+*configuration* — not one file for secrets, generated artifacts, and content.
+
+---
+
+## 2. What exists today, and the three invariants that must survive
+
+The full key inventory is in `stella.today.toml`, verified key-by-key against
+the serde structs. What matters here is that **the file format is not where
+Stella's config safety lives** — three invariants do, and none of them are
+visible in a JSON or TOML document. Any port that breaks one is a security
+regression wearing a refactor's clothes.
+
+### 2.1 Precedence and authority are orthogonal
+
+`Settings::merge_captured_scopes` folds `[user, managed, project]` — so the
+**project scope has the highest ordinary precedence**, not the org.
+
+The org wins by two entirely separate mechanisms:
+
+- **Trust rollback.** When the project is untrusted, specific fields are
+  reset to the `[user, managed]`-only merge: `hooks`, `context_providers`,
+  every provider's `base_url`/`api_key`/`api_key_env`, and
+  `mcp.registry_url`. The project does not lose precedence; it loses *those
+  fields*.
+- **The ceiling.** `managed_tool_ceiling` is computed from the managed
+  snapshot **alone**, so no later fold — including an explicitly trusted
+  project — can raise it. `AuthorityPolicy` reads that captured value rather
+  than re-deriving it, so the two cannot disagree.
+
+A port that "simplifies" this into a single ordered chain (managed last,
+wins everything) would look tidier and would be wrong: it would stop a
+project from overriding a model choice, while doing nothing extra to stop it
+from redirecting a credential.
+
+### 2.2 Not every block merges the same way
+
+Four distinct rules are in play, and the port must preserve each:
+
+| Block | Rule |
+|---|---|
+| `providers`, `agents`, `context_providers` | per-entry, per-field overlay |
+| `context`, `ui` | whole-block last-wins |
+| `allowed_models` | replaces wholesale (one vocabulary; concatenating would stop a project narrowing the user's list) |
+| `hooks` | **concatenates** — any scope may add a gate, none may remove another's |
+
+### 2.3 Some values are privileged regardless of scope
+
+A per-agent replacement `prompt` from an untrusted project is discarded and
+restored from the trusted scopes unless managed `authority.project_prompts`
+permits it. Same for `.stella/tools/*.toml` under `project_custom_tools`.
+These are not tool switches — they are code and instruction injection
+surfaces, gated separately.
+
+---
+
+## 3. Phase 1 — the format port
+
+**Scope:** `settings.json` + `.stella/mcp.toml` → `stella.toml`. Semantics
+frozen. No new keys except `[meta]`. The success criterion is that the
+existing settings test suite passes against TOML fixtures with **no
+assertions changed**.
+
+This is ~60–70% mechanical. The merge logic is format-agnostic — it is
+`overlay()` on typed structs, and `#[derive(Deserialize)]` handles TOML for
+free. Three things are not mechanical.
+
+### 3.1 Hazard: `save_to` will eat every comment
+
+`AgentEngineConfig::save_to`, `ToolsSettings::save_to`, and
+`UiSettings::save_to` all read-modify-write through a `serde_json::Value`
+root, preserving unknown keys so a TUI save never drops `providers` or
+`hooks`. That works because JSON has nothing to preserve *besides* keys.
+
+TOML does. The workspace has `toml = "1.1"` and no `toml_edit`. Re-render a
+parsed `toml::Value` and **every comment in the user's file is gone on the
+first `/theme` change** — which deletes the entire reason for moving to TOML.
+
+**Decision: add `toml_edit`, rewrite the three `save_to` implementations
+against a `DocumentMut`, and gate it with a round-trip test that asserts
+comments and key order survive a write.** This is the single most
+underestimated task in the migration and should be built first, before any
+key is ported.
+
+### 3.2 Where the file lives
+
+Recommended:
+
+| Scope | Path |
+|---|---|
+| user | `~/.stella/stella.toml` |
+| managed | `/Library/Application Support/stella/stella.toml` (macOS), `/etc/stella/stella.toml` (else), `STELLA_MANAGED_SETTINGS` override |
+| project | `./stella.toml` at the workspace root |
+
+The project file moving to the repo root is the one genuinely contentious
+call. In favor: it is a committed, human-edited, reviewable file, and the
+ecosystem convention for exactly that is the root (`Cargo.toml`,
+`pyproject.toml`, `deno.json`). Against: it is one more root-level file, and
+it makes the config *more* visible to a drive-by contributor.
+
+That second point argues **for** the root, not against — the trust boundary
+already assumes project config is attacker-controlled, and a config with real
+authority implications is better reviewed in a PR diff than buried three
+directories deep.
+
+Consequence, and it is a real one: a root `stella.toml` is far more likely to
+be committed than `.stella/settings.json` ever was. See §6.2.
+
+### 3.3 The unknown-key walker needs a TOML twin
+
+`settings/unknown.rs` walks a raw `serde_json::Value` against closed key
+sets, descending into genuinely-open maps (`tools`, `providers`,
+`context_providers`, hook matchers) and flagging the rest. It needs a
+`toml::Value` equivalent.
+
+Do **not** write a second walker. Both formats deserialize to a common shape;
+convert `toml::Value` → `serde_json::Value` at the boundary and keep one
+walker, one key list, one set of tests. The key lists are already shared with
+the strict `STELLA_ENGINE_CONFIG_JSON` gate (`ENGINE_ROOT_FIELDS` and
+friends), and that gate **fails closed** — a drifted second copy is a refused
+benchmark run, not a missing warning.
+
+---
+
+## 4. Phase 2 — the agent plane
+
+### 4.1 Open the agent set
+
+Today `AgentEngineAgents` is a struct with four fields: `default`, `worker`,
+`judge`, `triage`. A misspelled agent key is silently ignored.
+
+Two things already exist that this closed set strands:
+
+- The **`task` tool** (#922 → #976/#983) dispatches to one hard-coded
+  read-only persona. Its input schema has `description` and `prompt` — there
+  is no `agent_type`.
+- **`.stella/agents/*.md`** holds named markdown personas, listed by
+  `/agents`, otherwise advisory. They cannot set a model, an effort, or a
+  tool scope.
+
+Opening the set joins them: `[agents.<name>]` becomes a real engine posture,
+and `task` gains an `agent_type` parameter that selects one.
+
+**Migration:** `AgentEngineAgents` becomes `BTreeMap<String, AgentEngineAgent>`
+with the four built-in names **reserved**. `EngineAgentKind` stays for the
+built-ins (the router tiers on it, and `Role::Plan` rides the worker's
+settings), gaining a `Custom(String)` variant.
+
+**Cost of opening it:** the silent-ignore tolerance becomes a liability — a
+misspelled `[agents.wrker]` currently does nothing loudly, and after this
+change it defines a real but unreachable agent. `settings/unknown.rs` must
+learn to flag an agent name that no `task` call and no pipeline stage
+references.
+
+### 4.2 Provider fallback (`provider_preference`)
+
+An agent gets an ordered list instead of a single `provider`. First
+*enabled* provider that can serve the model wins; a 429/5xx/timeout falls
+through.
+
+Three things must be true or this feature quietly corrupts the receipts:
+
+1. **The resolved provider and model id are recorded per call.** A different
+   provider serving "the same" model is a different tokenizer, a different
+   cache, and different pricing. Cost attribution must follow the actual
+   call, never the configured intent.
+2. **Falling through invalidates the prompt cache.** The new provider has no
+   cached prefix. This is a cost event and should be visible as one, not
+   absorbed silently.
+3. **`on_exhausted` is explicit.** `fail` (default) ends the turn;
+   `degrade` falls back to the default agent's model. `degrade` must be
+   opt-in — a judge silently dropping to a weaker model is worse than a
+   clean failure, because the verdict still looks like a verdict.
+
+### 4.3 `prompt_file`
+
+An ergonomic win over inline prompt strings, and an authority hazard.
+
+The inline `prompt` field is **privileged**: a project scope's is discarded
+unless managed `authority.project_prompts = "on"`. A path indirection must
+not become the way around that check.
+
+**Rules:** `prompt_file` is gated by the **same** authority bit as `prompt`;
+the path resolves inside the workspace root; symlinks are refused (the same
+posture `settings/private.rs::reject_symlink` already takes on write); an
+unreadable path is a named error, never a silent fall-through to the built-in
+prompt — a judge quietly running the default prompt while the config says
+otherwise is exactly the kind of invisible misconfiguration this system is
+supposed to make impossible.
+
+### 4.4 Per-agent tool scope
+
+`[agents.<name>.tools]` uses the **exact same grammar** as the root `[tools]`
+block — name > group > `"*"`. Not a similar grammar. The same
+`ToolPolicy::from_switches` and the same precedence, because a second
+tool-permission language is how permission bugs happen.
+
+Composition, outermost first:
+
+```
+managed ceiling  ⊇  root [tools]  ⊇  [agents.<name>.tools]
+```
+
+An agent can only **narrow**. It can never grant a tool that the root block
+or the ceiling denied. This needs a `ToolPolicy::intersect` and a property
+test asserting the result is never more permissive than either input.
+
+### 4.5 Pipeline stages
+
+Today the staged pipeline (triage → plan → witness → execute → verify →
+judge) is hard-coded in `stella-pipeline`, and `--no-pipeline` is the only
+control — it turns the whole thing off and drops to the raw step-loop.
+
+`[pipeline.stages.<name>]` gives each stage `enabled`, `on_disable`
+(`skip` | `fail`), and where relevant `max_revisions` / `routes_to`.
+
+**One `enabled` flag, not two.** The original sketch had both
+`[agents.*].enabled` and `[pipeline.stages.*].enabled` answering "does this
+run", and noted in its own comment that the pipeline one wins. Two flags for
+one question desynchronize. Keep the pipeline's; `[agents.*]` has no
+`enabled`.
+
+`execute` takes `on_disable = "fail"` — there is no turn without it. That is
+a config-validation error at load, not a runtime surprise.
+
+---
+
+## 5. Phase 3 — tools and integrations
+
+### 5.1 `[integrations.<id>]`
+
+Today `stella connect github|linear` runs an OAuth flow and writes tokens to
+`~/.stella/integrations.json`. That is imperative *state*: there is nowhere
+to declare "this workspace files tickets in THIS Jira project", and no way to
+point a tool at a different backend without changing the tool.
+
+This block holds connection **shape** only — endpoints, project keys, and the
+*name* of an env var. Tokens stay in `integrations.json` and the environment.
+
+Two requirements:
+
+- **Fail fast at load** when an integration is `enabled` and the env var it
+  names is unset. The alternative is discovering it mid-turn, when the tool
+  fires, halfway through a run.
+- **An integration is an egress destination.** A project-scope integration
+  can send workspace content to a host the user never approved. It sits on
+  the same trust boundary as `context_providers`: an untrusted project scope
+  contributes nothing.
+
+### 5.2 Multi-backend tools, and the heterogeneous-`[tools]` problem
+
+Binding `create_follow_up_task` to `["jira-prod", "github-main",
+"linear-ops"]` is the strongest idea in the original sketch. It decouples what
+the agent *wants* from where it *lands*.
+
+It makes `[tools]` heterogeneous: `bash = "off"` is a scalar,
+`[tools.jira_search]` is a table. `ToolsSettings` is a flat
+`BTreeMap<String, Toggle>` today.
+
+**Rejected: `#[serde(untagged)]`.** Its failure message is "data did not
+match any variant", with no indication of which field was wrong. For a config
+whose entire posture is loud errors over silent fallback, that is the wrong
+trade.
+
+**Decision — Cargo's dependency shorthand:**
+
+```
+tool = "<toggle>"   IS EXACTLY   [tools.<tool>] enabled = "<toggle>"
+```
+
+A hand-written `Deserialize` that dispatches on the value *kind* (string vs
+table) and reports the actual problem. The string form is sugar, not a second
+dialect, so a two-line read-only agent stays two lines.
+
+`ToolsSettings::save_to` must preserve table-form entries when the TUI
+rewrites the switch map — the same read-modify-write contract as today, one
+level deeper.
+
+### 5.3 What is deliberately not built
+
+**The registry stays a deny-list, not an enumeration.** The original sketch
+enumerated 30 tools with `category` and `enabled`. Stella's tool set is only
+knowable at runtime: built-ins, plus each connected MCP server's tools (names
+known at connect time), plus every `.stella/tools/*.toml` manifest. An
+enumerated config could not name an MCP tool at all, and would drift from the
+built-ins every release. `category` already exists as the catalog's `group`.
+
+---
+
+## 6. Migration, schema decisions, compatibility
+
+### 6.1 The migration
+
+Read order during the transition:
+
+1. `stella.toml` exists → use it. If `settings.json` also exists, **warn
+   once** naming both paths. Never merge the two; a half-migrated config that
+   silently composes is worse than either file alone.
+2. Only `settings.json` → load it, and print a one-line pointer to
+   `stella migrate config`.
+3. Neither → defaults, exactly as today.
+
+`stella migrate config` reads all three JSON scopes, writes the TOML
+equivalents **with the explanatory comments** from `stella.today.toml`, and
+leaves the JSON in place. It never deletes; the user removes the old file
+once satisfied.
+
+Key moves the migration performs, each warning on the old location for one
+release:
+
+| From | To |
+|---|---|
+| `agent_engine_config.*` | `[agents]` |
+| `agent_engine_config.agents.<n>` | `[agents.<n>]` (flattened — see §6.4) |
+| `agent_engine_config.allowed_models` | `[models].allowed` |
+| `.stella/mcp.toml` `[servers.*]` | `[mcp.servers.*]` |
+| `enable_recap` | `[run].recap` (see §6.3) |
+
+Deprecation window: **two minor releases** reading both, then JSON support is
+removed. `schema_version` is what makes the removal safe — a file that
+predates the field is version 1 by definition.
+
+### 6.2 A root `stella.toml` will get committed
+
+`api_key` (a literal secret) is an accepted field in `providers.<id>` today.
+It is tolerable in `.stella/settings.json`. It is not tolerable in a file
+sitting next to `README.md`.
+
+**Decision:** `api_key` at **project scope** becomes a load-time error naming
+`credentials.toml` and `api_key_env` as the two right answers. At user and
+managed scope it keeps working unchanged. Credentials never merge into
+`stella.toml` at any scope.
+
+### 6.3 Retire bare root scalars
+
+TOML attaches a bare key to whatever `[table]` precedes it. Drafting
+`stella.today.toml`, `enable_recap` was written beside `[ui]` and silently
+landed inside `[authority]`. It was caught only because
+`ManagedAuthoritySettings` is `#[serde(deny_unknown_fields)]` — the one
+strict struct in the whole schema. Anywhere else it would have parsed clean
+and configured nothing.
+
+This is a footgun aimed squarely at hand-edited config, and it is worth
+designing out rather than documenting around.
+
+**Decision: every scalar gets a table home.** `enable_recap` → `[run] recap`.
+No bare keys at the document root, and a load-time lint that rejects them
+with a message naming the table they belong in.
+
+### 6.4 Flattening `agents.agents.<name>`
+
+The JSON nests per-agent config one level below the flat model fields
+(`agent_engine_config.agents.judge`). Rendered literally that is
+`[agents.agents.judge]`, which reads badly.
+
+Flattening to `[agents.judge]` is safe **only while the agent set is closed**
+— four struct fields cannot collide with a root field. §4.1 opens that set.
+
+**Decision:** flatten, and reserve the root field names as illegal agent
+names, enforced at load with a named error. The list is exactly
+`ENGINE_ROOT_FIELDS` minus `agents` (which disappears in the flattening):
+`default_model`, `pipeline_judge_model`, `pipeline_worker_model`,
+`pipeline_triage_model`, `allowed_models`, `auto_mode`, `effort_auto`,
+`reasoning_auto`, `headless_scope_bypass`.
+
+`allowed_models` stays reserved even though §6.1 moves it to
+`[models].allowed` — it remains readable at the old location through the
+deprecation window, and un-reserving a name is a breaking change you only
+get to make once.
+
+Reserve from the existing `ENGINE_ROOT_FIELDS` constant rather than a new
+literal. That constant is already shared with the fail-closed
+`STELLA_ENGINE_CONFIG_JSON` gate; a third hand-maintained copy would drift.
+
+### 6.5 Generate the defaults, never hand-write them
+
+`stella.today.toml` was drafted by hand and **seven of the ten
+`[context.retrieval]` defaults were wrong** — plausible round numbers instead
+of the real constants (`recency_weight` 0.3 vs 0.15, `ann_probes` 8 vs 12,
+`lexical_limit` 20 vs 8, and four more). They were caught only by grepping
+`stella-context/src/retrieval.rs` afterwards.
+
+That is not a drafting failure to be more careful about next time; it is
+evidence about the artifact. A documented-defaults config file is a second
+copy of every default in the system, and second copies drift silently — a
+wrong default in a commented example is worse than no example, because it
+reads as authoritative.
+
+**Decision:** `stella migrate config` and any shipped example emit values
+from `Default::default()` on the real structs, with the doc comments attached
+to the *schema* rather than typed into the file. A test asserts the generated
+example round-trips to `Settings::default()`. Nobody hand-maintains a defaults
+list, ever.
+
+---
+
+## 7. Deferred and rejected
+
+### 7.1 Files that stay separate
+
+| File | Why |
+|---|---|
+| `~/.stella/credentials.toml` | 0600 from birth, redacting `Debug`, zeroized on drop, loose-permission advisory. Merging secrets into the most-committed file in the workspace inverts every one of those properties. |
+| `.stella/tools/<name>.toml` | A tool ships **next to its script**. Inlining fifty manifests into one config breaks that locality and makes a tool un-copyable between repos. |
+| `.stella/domains.toml` | Generated by `stella init`. Merging a generated artifact into a hand-edited file guarantees the generator eventually clobbers a human edit. |
+| `.env` / `.env.local` | An ecosystem format with its own precedence rules (`.env.<mode>.local` → `.env.local` → `.env`, live shell always wins). Not ours to absorb. |
+
+### 7.2 Rejected: `[models]` as a model table
+
+The original sketch's `[models.<name>]` with `family`, `latest_alias`,
+`pinned_version`, and `served_by.<provider>.model_id` duplicates the model
+catalog — a SQLite store of cards, pricing versions, and aliases learned from
+telemetry, refreshed from models.dev on explicit request and from
+provider-native `/models`.
+
+Two authorities for one question is a drift generator. Config holds *policy
+over* the catalog (`allowed`, `pin`, `track_latest`); the catalog holds the
+data.
+
+### 7.3 Rejected: `track_latest` resolved per call
+
+The sketch specifies resolution "at call time (or on a periodic refresh)".
+For Stella that breaks three things simultaneously: prompt-cache prefixes (a
+changed model id invalidates the cached prefix), cost comparability within a
+session, and the benchmark contract that the system under test is frozen for
+a run.
+
+**Resolve once at session start; write the resolved id into the session's
+receipts.** `stella models --resolved` shows what a session would pin now.
+
+### 7.4 Deferred: provider `region` / `project_id` / `auth` / `api_version`
+
+`Dialect::Vertex` and `Dialect::Bedrock` are built-in-only *because* they
+need project/location/region resolution a settings entry cannot express.
+Putting those fields in config means teaching
+`stella_model::factory::build_provider` to construct those adapters from
+config rather than from their env chains. That is its own project with its
+own credential-chain implications; it does not belong in this one.
+
+### 7.5 Rejected: array-of-tables for providers and integrations
+
+`[[providers]]` cannot express the per-id, per-field overlay that lets a
+managed `base_url` and a user `api_key_env` compose into one effective
+provider. Reproducing it means matching on `id` and hand-rolling the merge —
+more code, for a shape that reads worse. Keyed tables throughout.
+
+---
+
+## 8. Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Comment loss on save** silently deletes the migration's whole value | `toml_edit` + a round-trip test asserting comments and key order survive; build this first (§3.1) |
+| **Trust model quietly weakened** by "simplifying" the scope chain | Port `merge_captured_scopes` unchanged; the existing trust tests must pass against TOML fixtures with no assertion edits |
+| **Two config files both present**, silently composing | Never merge; warn once naming both paths (§6.1) |
+| **Secrets committed** now that the file is at the repo root | `api_key` is a load error at project scope (§6.2) |
+| **Per-agent tool scope grants rather than narrows** | `ToolPolicy::intersect` + a property test that the result is never more permissive than either input (§4.4) |
+| **Fallback corrupts cost attribution** | Record resolved provider + model id per call, not the configured intent (§4.2) |
+| **Opened agent set turns silent-ignore into silent-orphan** | Flag agent names no `task` call or pipeline stage references (§4.1) |
+| **`stella.toml` at the root reads as an invitation** to configure things a repo should not | The trust boundary already assumes project config is hostile; §6.2 closes the one field that was tolerable only through obscurity |
+| **Documented defaults drift from real ones** — already happened, 7 of 10 in one block | Generate examples from `Default::default()`; test the round-trip (§6.5) |
+
+---
+
+## 9. Sequencing
+
+Each phase is independently shippable and independently valuable. Phase 1 is
+a prerequisite for nothing except the pleasantness of the rest — the four
+features could technically be built against JSON.
+
+| Phase | Contents | Depends on |
+|---|---|---|
+| **0** | `toml_edit` round-trip harness + comment-preservation test | — |
+| **1** | Format port, `[meta]`, `stella migrate config`, dual-read, unknown-key walker (§3, §6) | 0 |
+| **2** | Pipeline stages (§4.5) | 1 (or JSON) |
+| **3** | Per-agent tool scope (§4.4) + open agent set + `task` `agent_type` (§4.1) | 1 |
+| **4** | `[models]` policy: `allowed` / `pin` / `track_latest` (§7.2–7.3) | 1 |
+| **5** | Provider fallback (§4.2) | 1 |
+| **6** | Integrations + multi-backend tools (§5) | 1 |
+
+Phase 2 first among the features because it is the largest capability gain
+for the least new surface: the stages already exist as code, and the config
+only chooses which of them run.
+
+Phase 6 last because it is the only one that introduces a new *category* of
+config object, and it wants the migration and the trust plumbing settled
+underneath it.

--- a/docs/design/config-system/DESIGN.md
+++ b/docs/design/config-system/DESIGN.md
@@ -263,6 +263,31 @@ one question desynchronize. Keep the pipeline's; `[agents.*]` has no
 `execute` takes `on_disable = "fail"` — there is no turn without it. That is
 a config-validation error at load, not a runtime surprise.
 
+**The stage vocabulary is not the six obvious ones.** `StageKind`
+(`stella-protocol/src/event.rs`) has eleven variants: `Triage`,
+`ContextRecall`, `Plan`, `ScopeReview`, `Witness`, `Execute`, `Verify`,
+`Judge`, `Reflect`, `ContextWrite`, `Complete`. `stella.next.toml` shows six
+for readability; the real block must be built against the enum, not against
+a hand-listed subset, or the two drift the first time a stage is added.
+
+Three of the eleven need a decision rather than a default:
+
+- **`ScopeReview` must not be configurable here.** `headless_scope_bypass`
+  already answers "may an unattended run proceed past scope review". Adding
+  `[pipeline.stages.scope_review].enabled` would be exactly the two-flags-one-
+  question bug this section rejects — and on the highest-consequence flag in
+  the file. Leave it out; `headless_scope_bypass` owns it.
+- **`Complete` is terminal**, not a stage anyone turns off. Reject it at load
+  the way `execute` is rejected.
+- **`ContextRecall` / `ContextWrite` / `Reflect` already have owners** in the
+  `[context]` block (`lifecycle.enabled`, `learning.mode`). Exposing them
+  again under `[pipeline.stages]` creates a third overlapping authority.
+  Either they stay out, or `[context]` delegates to them — not both.
+
+This is the same failure mode as the sketch's double `enabled`, one level up:
+the risk in a stage-configuration block is not that a stage is missing, it is
+that a stage acquires a *second* switch.
+
 ---
 
 ## 5. Phase 3 — tools and integrations

--- a/docs/design/config-system/agent_system.toml
+++ b/docs/design/config-system/agent_system.toml
@@ -1,0 +1,368 @@
+# =============================================================================
+# agent_system.toml
+# Example config for a multi-agent system with:
+#   - per-agent configs (triage / worker / judge)
+#   - a pipeline object controlling which agents are active
+#   - multiple API providers, including providers that serve the same model
+#   - "track latest" model aliasing (e.g. auto-upgrades opus-4.5 -> opus-5)
+#   - local OpenAI-compatible model servers (Ollama, vLLM, LM Studio, etc.)
+#   - a toggleable registry of 30 tools
+# =============================================================================
+
+[meta]
+schema_version = 1
+config_name    = "default"
+
+# -----------------------------------------------------------------------------
+# PROVIDERS
+# Each provider is a place that can serve one or more models. Two providers
+# can serve the *same logical model* (e.g. Claude via Anthropic direct vs.
+# via Bedrock) -- that mapping is resolved down in [models.*.served_by].
+# -----------------------------------------------------------------------------
+
+[[providers]]
+id            = "anthropic"
+kind          = "anthropic"                      # native Anthropic API
+base_url      = "https://api.anthropic.com"
+api_key_env   = "ANTHROPIC_API_KEY"               # name of env var holding the key
+enabled       = true
+# Anthropic publishes rolling aliases (e.g. "claude-opus-4-5-latest") that we
+# can use directly instead of resolving a version ourselves.
+supports_latest_alias = true
+
+[[providers]]
+id            = "anthropic_bedrock"
+kind          = "bedrock"
+region        = "us-east-1"
+auth          = "aws_default_credentials"         # uses standard AWS credential chain
+enabled       = false
+supports_latest_alias = false                     # Bedrock model IDs are pinned; no "-latest" tag
+
+[[providers]]
+id            = "anthropic_vertex"
+kind          = "vertex"
+project_id    = "my-gcp-project"
+region        = "us-central1"
+auth          = "gcloud_default_credentials"
+enabled       = false
+supports_latest_alias = false
+
+[[providers]]
+id            = "openai"
+kind          = "openai"
+base_url      = "https://api.openai.com/v1"
+api_key_env   = "OPENAI_API_KEY"
+enabled       = true
+supports_latest_alias = true                      # OpenAI also ships rolling aliases like "gpt-4o"
+
+[[providers]]
+id            = "azure_openai"
+kind          = "azure_openai"
+base_url      = "https://my-resource.openai.azure.com"
+api_key_env   = "AZURE_OPENAI_API_KEY"
+api_version   = "2024-10-21"
+enabled       = false
+supports_latest_alias = false                     # Azure deployments are pinned to a named deployment
+
+# --- Local / self-hosted models, exposed via an OpenAI-compatible endpoint ---
+
+[[providers]]
+id            = "local_ollama"
+kind          = "openai_compatible"
+base_url      = "http://localhost:11434/v1"
+api_key_env   = ""                                # most local servers ignore the key; leave blank
+enabled       = true
+supports_latest_alias = false
+
+[[providers]]
+id            = "local_vllm"
+kind          = "openai_compatible"
+base_url      = "http://localhost:8000/v1"
+api_key_env   = "LOCAL_VLLM_API_KEY"
+enabled       = false
+supports_latest_alias = false
+
+
+# -----------------------------------------------------------------------------
+# MODELS
+# A "model" here is a logical name agents reference (e.g. "claude-opus").
+# It can be served by multiple providers, each with its own provider-specific
+# model ID string (Anthropic, Bedrock and Vertex all name the same model
+# differently). `track_latest = true` means: don't pin a version, always
+# resolve to whatever the provider currently considers newest in that family
+# at call time (or on a periodic refresh) -- this is the mechanism that lets
+# a "claude-opus" agent silently move from opus-4.5 to opus-5 without a config
+# change. `pinned_version` is the fallback used when track_latest = false, or
+# when a provider doesn't support latest-resolution and needs an explicit ID.
+# -----------------------------------------------------------------------------
+
+[models.claude-opus]
+family         = "opus"
+track_latest   = true
+latest_alias   = "claude-opus-4-5-latest"          # used when provider.supports_latest_alias = true
+pinned_version = "claude-opus-4-5-20250929"        # used as fallback / for pinned providers
+
+  [models.claude-opus.served_by.anthropic]
+  model_id = "claude-opus-4-5-latest"              # provider resolves "-latest" itself
+
+  [models.claude-opus.served_by.anthropic_bedrock]
+  model_id = "anthropic.claude-opus-4-5-20250929-v1:0"  # must be re-pinned manually when a new opus ships
+
+  [models.claude-opus.served_by.anthropic_vertex]
+  model_id = "claude-opus-4-5@20250929"
+
+[models.claude-sonnet]
+family         = "sonnet"
+track_latest   = true
+latest_alias   = "claude-sonnet-4-5-latest"
+pinned_version = "claude-sonnet-4-5-20250929"
+
+  [models.claude-sonnet.served_by.anthropic]
+  model_id = "claude-sonnet-4-5-latest"
+
+  [models.claude-sonnet.served_by.anthropic_bedrock]
+  model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+[models.claude-haiku]
+family         = "haiku"
+track_latest   = false                             # triage wants a stable, cheap, predictable model
+pinned_version = "claude-haiku-4-5-20251001"
+
+  [models.claude-haiku.served_by.anthropic]
+  model_id = "claude-haiku-4-5-20251001"
+
+[models.gpt-4o]
+family         = "gpt-4o"
+track_latest   = true
+latest_alias   = "gpt-4o"                          # OpenAI's bare name floats to newest snapshot
+pinned_version = "gpt-4o-2024-11-20"
+
+  [models.gpt-4o.served_by.openai]
+  model_id = "gpt-4o"
+
+  [models.gpt-4o.served_by.azure_openai]
+  model_id = "my-gpt4o-deployment"                 # Azure deployment name, not the raw model name
+
+[models.local-llama3]
+family         = "llama3"
+track_latest   = false
+pinned_version = "llama3.1:70b"
+
+  [models.local-llama3.served_by.local_ollama]
+  model_id = "llama3.1:70b"
+
+  [models.local-llama3.served_by.local_vllm]
+  model_id = "meta-llama/Meta-Llama-3.1-70B-Instruct"
+
+
+# -----------------------------------------------------------------------------
+# AGENTS
+# Each agent picks a logical model and a provider preference order (first
+# enabled provider in the list that serves that model wins; falls through on
+# error/rate-limit). `tools` is a list of tool ids from [tools.*] the agent is
+# permitted to call -- it's still gated by that tool's own `enabled` flag.
+# -----------------------------------------------------------------------------
+
+[agents.triage]
+enabled             = true
+model               = "claude-haiku"
+provider_preference = ["anthropic"]
+temperature         = 0.0
+max_tokens          = 1024
+system_prompt_file  = "prompts/triage.md"
+tools               = ["web_search", "memory_read"]
+
+[agents.worker]
+enabled             = true
+model               = "claude-sonnet"
+provider_preference = ["anthropic", "anthropic_bedrock", "local_vllm"]
+temperature         = 0.2
+max_tokens          = 8192
+system_prompt_file  = "prompts/worker.md"
+tools               = [
+  "web_search", "web_fetch", "code_execution", "file_read", "file_write",
+  "file_edit", "shell_exec", "python_repl", "sql_query", "calculator",
+  "pdf_extract", "spreadsheet_edit", "memory_read", "memory_write",
+  "browser_automation",
+]
+
+[agents.judge]
+enabled             = true
+model               = "claude-opus"
+provider_preference = ["anthropic", "anthropic_vertex"]
+temperature         = 0.0
+max_tokens          = 4096
+system_prompt_file  = "prompts/judge.md"
+tools               = ["calculator", "memory_read"]
+
+
+# -----------------------------------------------------------------------------
+# PIPELINE
+# Controls which agents actually run and in what order/mode. Disabling an
+# agent here short-circuits it even if the [agents.*] block above is enabled
+# -- e.g. flip judge.enabled = false for a cheap two-stage pipeline without
+# touching the agent's own config.
+# -----------------------------------------------------------------------------
+
+[pipeline]
+mode = "sequential"                # "sequential" | "triage_route" | "single_agent"
+
+  [pipeline.stages.triage]
+  enabled       = true
+  on_disable    = "skip"           # "skip" = go straight to next enabled stage
+  routes_to     = ["worker", "judge"]  # triage_route mode: where it can send a request
+
+  [pipeline.stages.worker]
+  enabled       = true
+  on_disable    = "skip"
+
+  [pipeline.stages.judge]
+  enabled       = true
+  on_disable    = "skip"           # if disabled, worker output is returned unreviewed
+  max_revisions = 2                # judge can bounce work back to worker up to N times
+
+
+# -----------------------------------------------------------------------------
+# INTEGRATIONS
+# "Providers" above are LLM backends; "integrations" are the external
+# services *tools* call out to (Jira, GitHub, Linear, Slack, email, a search
+# API, ...). Same shape and same rule as providers: config holds connection
+# details plus the NAME of an env var (`*_env` suffix), never the secret
+# itself. The actual secret lives only in the process environment (a
+# git-ignored .env file locally, a real env var / secrets manager in
+# deployment) -- so this file is safe to commit.
+#
+# A config loader should fail fast at startup if an integration is enabled
+# but the env var named in its `*_env` field isn't actually set.
+# -----------------------------------------------------------------------------
+
+[[integrations]]
+id             = "jira_prod"
+kind           = "jira"
+base_url       = "https://oxagen.atlassian.net"
+project_key    = "OPS"
+user_email_env = "JIRA_USER_EMAIL"        # Jira Cloud uses basic auth: email + API token
+api_key_env    = "JIRA_API_TOKEN"
+enabled        = true
+
+[[integrations]]
+id           = "github_main"
+kind         = "github"
+owner        = "oxagen"
+repo         = "backend"
+api_key_env  = "GITHUB_TOKEN"
+enabled      = true
+
+[[integrations]]
+id           = "linear_ops"
+kind         = "linear"
+team_id      = "OXA"
+api_key_env  = "LINEAR_API_KEY"
+enabled      = false
+
+[[integrations]]
+id              = "slack_workspace"
+kind            = "slack"
+default_channel = "#ops-alerts"
+api_key_env     = "SLACK_BOT_TOKEN"
+enabled         = false
+
+[[integrations]]
+id            = "sendgrid"
+kind          = "smtp"
+from_address  = "ops@oxagen.sh"
+api_key_env   = "SENDGRID_API_KEY"
+enabled       = false
+
+[[integrations]]
+id           = "brave_search"
+kind         = "search_api"
+api_key_env  = "BRAVE_SEARCH_API_KEY"
+enabled      = true
+
+
+# -----------------------------------------------------------------------------
+# TOOLS
+# Full registry of 30 tools, each independently toggleable. An agent can only
+# use a tool if it's both (a) enabled here and (b) listed in its own `tools`.
+#
+# A plain tool is a one-liner: `[tools.<name>] category = "..." enabled = ...`
+#
+# A tool that needs credentials points at an `integration` id above instead
+# of embedding a key -- e.g. web_search -> brave_search. Nothing secret is
+# ever written directly under [tools.*].
+#
+# A tool that can act through *multiple* interchangeable backends (this is
+# the "create_follow_up_task -> Jira | GitHub Issue | Linear" case) lists
+# every eligible integration in `backends`, names a `default_backend`, and
+# gets its own `[tools.<name>.config]` sub-table for behavior that isn't a
+# credential -- e.g. whether the calling agent is allowed to pick the backend
+# per call, or whether a human must confirm before it fires. The same
+# `[tools.<name>.config]` pattern works for any tool that needs extra,
+# non-secret settings (e.g. slack_post.config.allow_dm).
+# -----------------------------------------------------------------------------
+
+# NOTE ON SYNTAX: TOML doesn't allow a table header and its key/values to
+# share a line, so the one-line-per-tool style below needs an explicit
+# `[tools]` header first, then each entry as `name = { ... }` (an inline
+# table) *without* repeating the `tools.` prefix -- we're already inside
+# that table. Tools that need their own nested sub-table (create_follow_up_
+# task, slack_post) switch to the full `[tools.name]` header form further
+# down instead, one field per line.
+
+[tools]
+web_search        = { category = "research",   enabled = true,  integration = "brave_search" }
+web_fetch          = { category = "research",   enabled = true }
+browser_automation = { category = "research",   enabled = false }
+translation        = { category = "research",   enabled = true }
+summarization       = { category = "research",  enabled = true }
+
+code_execution     = { category = "code",       enabled = true }
+python_repl        = { category = "code",       enabled = true }
+shell_exec         = { category = "code",       enabled = false }
+sql_query          = { category = "code",       enabled = true }
+github_read_repo   = { category = "code",       enabled = true,  integration = "github_main" }
+github_create_pr   = { category = "code",       enabled = false, integration = "github_main" }
+
+file_read          = { category = "filesystem", enabled = true }
+file_write         = { category = "filesystem", enabled = true }
+file_edit          = { category = "filesystem", enabled = true }
+pdf_extract        = { category = "filesystem", enabled = true }
+spreadsheet_edit   = { category = "filesystem", enabled = true }
+image_generation   = { category = "filesystem", enabled = false }
+image_analysis     = { category = "filesystem", enabled = true }
+
+calculator         = { category = "utility",    enabled = true }
+calendar_read      = { category = "utility",    enabled = true }
+calendar_write     = { category = "utility",    enabled = false }
+vector_search      = { category = "utility",    enabled = true }
+
+memory_read        = { category = "memory",     enabled = true }
+memory_write       = { category = "memory",     enabled = true }
+
+email_send         = { category = "comms",      enabled = false, integration = "sendgrid" }
+email_read         = { category = "comms",      enabled = true }
+slack_read         = { category = "comms",      enabled = true }
+jira_search        = { category = "tracking",   enabled = true,  integration = "jira_prod" }
+
+# --- Tools with their own nested config sub-table use bracket headers -----
+# (these become sub-tables of [tools], declared here now that [tools] exists)
+
+[tools.create_follow_up_task]
+category        = "tracking"
+enabled         = true
+backends        = ["jira_prod", "github_main", "linear_ops"]  # integrations this tool may target
+default_backend = "jira_prod"  # used when not specified
+
+  [tools.create_follow_up_task.config]
+  agent_may_choose_backend = true  # let the calling agent pick a backend via a tool-call arg
+  require_confirmation     = true  # judge/human must confirm before the ticket is actually filed
+  default_labels           = ["from-agent"]
+
+[tools.slack_post]
+category    = "comms"
+enabled     = false
+integration = "slack_workspace"
+
+  [tools.slack_post.config]
+  allow_dm = false  # restrict to channels, no direct messages

--- a/docs/design/config-system/stella.next.toml
+++ b/docs/design/config-system/stella.next.toml
@@ -226,6 +226,17 @@ prompt_file = ".stella/prompts/security-reviewer.md"
 # acknowledged in its own comment that the pipeline one wins. Two flags for
 # one question desynchronize; this design keeps only the pipeline's.
 
+# NOTE — the six stages below are the READABLE subset, not the vocabulary.
+# `StageKind` (stella-protocol/src/event.rs) has eleven variants: Triage,
+# ContextRecall, Plan, ScopeReview, Witness, Execute, Verify, Judge, Reflect,
+# ContextWrite, Complete. The real block is built against the enum.
+#
+# Three are deliberately NOT configurable here, because each already has an
+# owner and a second switch is how these blocks rot — see DESIGN.md §4.5:
+#   ScopeReview  -> owned by agents.headless_scope_bypass
+#   Complete     -> terminal, not a stage
+#   ContextRecall / ContextWrite / Reflect -> owned by [context]
+
 [pipeline]
 mode = "sequential"   # sequential | triage_route | single_agent
 

--- a/docs/design/config-system/stella.next.toml
+++ b/docs/design/config-system/stella.next.toml
@@ -1,0 +1,382 @@
+# =============================================================================
+# stella.next.toml
+#
+# The config shape AFTER the five features in DESIGN.md are built. This is a
+# TARGET, not a plan of record — every block marked NEW needs the
+# corresponding phase in DESIGN.md before it does anything.
+#
+# This file shows the DELTA. Blocks that survive the port unchanged
+# (`[context]`, `[context_providers]`, `[hooks]`, `[authority]`, `[ui]`,
+# `[mcp.servers]`) are shown in `stella.today.toml` and are not repeated here —
+# assume they carry over verbatim.
+#
+# Marker legend:
+#   NEW        does not exist in any form today
+#   EXTENDED   exists, gains fields
+#   RESHAPED   exists, changes shape (needs a migration)
+#   UNCHANGED  ported as-is (see stella.today.toml)
+# =============================================================================
+
+# Root scalars first — see stella.today.toml's ROOT SCALARS note for why.
+# DESIGN.md §6.3 proposes retiring bare root keys entirely; under that
+# proposal this line becomes `[run] recap = "on"` and the footgun disappears.
+enable_recap = "off"
+
+
+# ── UNCHANGED ────────────────────────────────────────────────────────────────
+[meta]
+schema_version = 2      # bumped: §6.1 migration runs 1 -> 2
+scope          = "project"
+
+
+# =============================================================================
+# PROVIDERS  ── EXTENDED
+# =============================================================================
+# Still a table keyed by id, still merged per-id/per-field, still gated by the
+# project trust boundary. Two additions:
+#
+#   enabled     — a provider can be defined and switched off without deleting
+#                 its block. Today the only way to "disable" a provider is to
+#                 remove its credential, which is not a config action.
+#
+#   weight      — overrides the hard-coded auto-detection preference order in
+#                 `PROVIDERS` (openrouter, zai, anthropic, openai, xai,
+#                 deepseek, gemini, vertex, bedrock). Lower runs first.
+#                 Absent = the built-in order.
+#
+# Note what is NOT here: the first example's `region` / `project_id` /
+# `auth` / `api_version` fields. Vertex and Bedrock resolve those from their
+# own env chains inside the adapter, and `Dialect::{Vertex,Bedrock}` are
+# built-in-only precisely because a settings entry cannot express them.
+# Adding them to config means teaching the factory to build those adapters
+# from config, which is its own project — see DESIGN.md §7 (deferred).
+
+[providers.anthropic]
+enabled       = true
+weight        = 10
+api_key_env   = "ANTHROPIC_API_KEY"
+default_model = "claude-fable-5"
+
+[providers.openrouter]
+enabled     = true
+weight      = 20
+api_key_env = "OPENROUTER_API_KEY"
+
+[providers.local-ollama]
+enabled       = true
+weight        = 90            # last resort
+base_url      = "http://localhost:11434/v1"
+dialect       = "openai-compatible"
+default_model = "llama3.1:70b"
+# Most local servers ignore auth entirely. Omitting api_key_env is fine:
+# the `local` dialect defaults to a placeholder key.
+
+
+# =============================================================================
+# MODELS  ── NEW, and deliberately NOT the first example's `[models]`
+# =============================================================================
+# The original example proposed a full model table in config: `family`,
+# `latest_alias`, `pinned_version`, and a `served_by.<provider>.model_id` map
+# per model. That duplicates a live system.
+#
+# Stella already HAS a model catalog: a SQLite store of model cards, pricing
+# versions, and aliases learned from telemetry, refreshed from models.dev on
+# explicit request and from provider-native /models endpoints. A hand-written
+# table in config would rot the week a model ships and would fight the
+# catalog for authority over the same question.
+#
+# So the split is:
+#     catalog = DATA    (the DB — what models exist, what they cost)
+#     config  = POLICY  (this block — which of them this workspace may use)
+
+[models]
+# Which catalog entries this workspace may select. Empty/absent = no
+# restriction. This is `agent_engine_config.allowed_models` promoted out of
+# the agents block, because it is a statement about models, not about agents.
+# Still REPLACES wholesale across scopes rather than concatenating.
+allowed = [
+  "anthropic/claude-fable-5",
+  "anthropic/claude-opus-5",
+  "zai/glm-5.2",
+]
+
+# Resolve a floating family to its newest catalog entry.
+#
+# CRITICAL SEMANTIC, and the one place this design diverges hardest from the
+# original example, which specified resolution "at call time (or on a periodic
+# refresh)":
+#
+#   Resolution happens ONCE, at session start, and the resolved id is written
+#   into the session's receipts.
+#
+# Per-call resolution would break three things at once: prompt-cache prefixes
+# (a changed model id invalidates the cached prefix), cost comparability
+# across turns in one session, and the benchmark contract that the system
+# under test is frozen for the duration of a run. A model that silently moves
+# opus-4.5 -> opus-5 mid-session makes a run un-reproducible and its cost
+# numbers un-addable.
+#
+# `stella models --resolved` prints what a session would pin right now.
+track_latest = ["anthropic/claude-opus"]
+
+# Hard pins. Beat `track_latest` and beat `allowed` (a pin is an explicit
+# statement; refusing it because a vocabulary list is stale would be
+# obstructive). A pinned id absent from the catalog is a named error, not a
+# silent fallback.
+[models.pin]
+"anthropic/claude-opus" = "claude-opus-5-20260514"
+
+
+# =============================================================================
+# AGENTS  ── RESHAPED (closed set -> open set) + EXTENDED
+# =============================================================================
+# Today the agent set is CLOSED: four struct fields — default, worker, judge,
+# triage. A misspelled agent key in JSON is silently ignored.
+#
+# Opening it is what makes the `task` tool configurable. That tool exists and
+# is merged (#922 -> #976/#983), but it dispatches to ONE hard-coded read-only
+# persona with no `agent_type` parameter. Meanwhile `.stella/agents/*.md`
+# holds named markdown personas that are listed by `/agents` and otherwise
+# advisory — they cannot set a model, an effort, or a tool scope.
+#
+# Opening the set joins those two halves: a named agent here is selectable by
+# `task`, and gets a real engine posture.
+#
+# The four built-in names keep their meaning and stay reserved.
+
+[agents]
+default_model         = "anthropic/claude-fable-5"
+pipeline_worker_model = "zai/glm-5.2"
+pipeline_judge_model  = "anthropic/claude-opus-5"
+pipeline_triage_model = "deepseek/deepseek-chat"
+auto_mode             = "off"
+effort_auto           = "on"
+reasoning_auto        = "on"
+headless_scope_bypass = "off"
+# `allowed_models` MOVED to [models].allowed. §6.1 migrates it and warns on
+# the old location for one release.
+
+# ── EXTENDED: a built-in agent gains provider fallback and a tool scope ──
+[agents.judge]
+model  = "anthropic/claude-opus-5"
+effort = "high"
+
+# NEW — provider_preference. First ENABLED provider in the list that can
+# serve this model wins; on a 429/5xx/timeout the request falls through to the
+# next. Today an agent has exactly one `provider` and a rate limit is a failed
+# turn.
+#
+# Fallback is NOT free and the config must not pretend otherwise:
+#   - a different provider serving "the same" model is a different tokenizer,
+#     a different cache, and different pricing
+#   - the fallback provider's resolved model id is recorded per call, so cost
+#     attribution and receipts stay honest across a switch
+#   - `on_exhausted` decides what happens when every provider fails
+provider_preference = ["anthropic", "openrouter"]
+on_exhausted        = "fail"   # fail | degrade  (degrade = fall back to the
+                               # default agent's model rather than ending the
+                               # turn; opt-in, because a silent capability
+                               # drop in a judge is worse than a clean failure)
+
+# NEW — per-agent tool scope. Uses the EXACT SAME grammar as the root
+# [tools] block (name > group > "*"), because a second tool-permission
+# language is how permission bugs happen.
+#
+# Composition: root [tools] is the workspace floor, this narrows it further,
+# and the managed authority ceiling clamps both. An agent can never GRANT a
+# tool the root block or the ceiling denied — narrowing only.
+[agents.judge.tools]
+"*"       = "off"
+read_file = "on"
+grep      = "on"
+glob      = "on"
+
+# ── NEW: a custom named agent, selectable by the `task` tool ──
+[agents.security-reviewer]
+description = "Adversarial security review of a diff — OWASP, injection, secrets"
+model       = "anthropic/claude-opus-5"
+effort      = "xhigh"
+reasoning   = "on"
+# NEW — prompt from a file instead of an inline string.
+#
+# AUTHORITY NOTE: the inline `prompt` field is privileged (a project scope's
+# is discarded unless managed `authority.project_prompts = "on"`). A path
+# indirection must not become a way around that check — `prompt_file` is
+# gated by the SAME authority bit, and the path is resolved inside the
+# workspace root with symlinks refused. See DESIGN.md §4.3.
+prompt_file = ".stella/prompts/security-reviewer.md"
+
+  [agents.security-reviewer.tools]
+  "*"    = "off"
+  file   = "on"    # a whole group
+  search = "on"
+
+
+# =============================================================================
+# PIPELINE  ── NEW
+# =============================================================================
+# Today the staged pipeline (triage -> plan -> witness -> execute -> verify ->
+# judge) is hard-coded in `stella-pipeline`, and the only control is
+# `--no-pipeline`, which turns the entire thing off and drops to the raw
+# step-loop. There is no way to say "skip the judge" or "allow three revision
+# rounds".
+#
+# ONE `enabled` FLAG, NOT TWO. The original example had `[agents.*].enabled`
+# and `[pipeline.stages.*].enabled` both answering "does this run", and
+# acknowledged in its own comment that the pipeline one wins. Two flags for
+# one question desynchronize; this design keeps only the pipeline's.
+
+[pipeline]
+mode = "sequential"   # sequential | triage_route | single_agent
+
+[pipeline.stages.triage]
+enabled   = true
+# What happens to the turn when this stage is off.
+#   skip  — go straight to the next enabled stage
+#   fail  — refuse to run a pipeline that is missing this stage
+on_disable = "skip"
+# `triage_route` mode only: where this stage may dispatch.
+routes_to  = ["worker", "judge"]
+
+[pipeline.stages.plan]
+enabled    = true
+on_disable = "skip"
+
+[pipeline.stages.witness]
+enabled    = true
+on_disable = "skip"
+
+[pipeline.stages.execute]
+enabled    = true
+# Execute is not optional — there is no turn without it.
+on_disable = "fail"
+
+[pipeline.stages.verify]
+enabled    = true
+on_disable = "skip"
+
+[pipeline.stages.judge]
+enabled    = true
+on_disable = "skip"     # worker output is returned unreviewed
+# How many times the judge may bounce work back to the worker.
+max_revisions = 2
+
+
+# =============================================================================
+# INTEGRATIONS  ── NEW
+# =============================================================================
+# The strongest idea in the original example, and the least built.
+#
+# Today: `stella connect github|linear` runs an OAuth flow and writes tokens
+# to `~/.stella/integrations.json`. That is imperative STATE — there is no
+# declarative statement anywhere of "this workspace talks to THIS Jira
+# project", and no way for a tool to be pointed at a different backend
+# without changing the tool.
+#
+# This block is the declarative half. It holds connection SHAPE only:
+# endpoints, project keys, and the NAME of an env var. Never a secret. Tokens
+# stay in integrations.json / the environment exactly as they are now.
+#
+# A loader must FAIL FAST at startup when an integration is enabled and the
+# env var it names is not set — the alternative is discovering it mid-turn,
+# at the moment the tool fires.
+#
+# TRUST: an integration is an egress destination. A project-scope integration
+# can send workspace content to a host the user never approved, so it sits on
+# the same boundary as `context_providers` — untrusted project scope
+# contributes nothing.
+
+[integrations.jira-prod]
+kind           = "jira"
+base_url       = "https://oxagen.atlassian.net"
+project_key    = "OPS"
+user_email_env = "JIRA_USER_EMAIL"     # Jira Cloud: basic auth = email + token
+api_key_env    = "JIRA_API_TOKEN"
+enabled        = true
+
+[integrations.github-main]
+kind        = "github"
+owner       = "macanderson"
+repo        = "stella"
+api_key_env = "GITHUB_TOKEN"
+enabled     = true
+
+[integrations.linear-ops]
+kind        = "linear"
+team_id     = "OXA"
+api_key_env = "LINEAR_API_KEY"
+enabled     = false
+
+
+# =============================================================================
+# TOOLS  ── EXTENDED (the deny-list is UNCHANGED; multi-backend binding is NEW)
+# =============================================================================
+# The root switch map keeps its exact current semantics: an open map, a
+# deny-list, absent = ON, precedence name > group > "*".
+#
+# It is deliberately NOT turned into an enumerated registry. Stella's tool set
+# is only knowable at runtime — built-ins, plus each connected MCP server's
+# tools, plus every .stella/tools/*.toml manifest — so an enumerated config
+# could never name an MCP tool and would drift from the built-ins on every
+# release.
+
+# SCHEMA NOTE — this section is now HETEROGENEOUS: `bash = "off"` is a
+# scalar, `[tools.jira_search]` is a table. Today `ToolsSettings` is a flat
+# `BTreeMap<String, Toggle>`, so this needs a value type of "toggle OR table".
+#
+# The rule, borrowed from Cargo's dependency shorthand (`serde = "1.0"` vs
+# `serde = { version = "1.0", features = [...] }`):
+#
+#     tool = "<toggle>"   IS EXACTLY   [tools.<tool>] enabled = "<toggle>"
+#
+# The string form is sugar, not a second dialect. That keeps a two-line
+# read-only agent two lines while letting one tool carry a backend binding.
+# See DESIGN.md §5.2 — a bare `#[serde(untagged)]` is rejected there because
+# its "data did not match any variant" error is exactly the silent-typo
+# failure this config's loud-error posture exists to prevent.
+
+[tools]
+bash    = "off"
+process = "off"
+
+# ── NEW: binding a tool to an integration ──
+# A tool that needs credentials names an integration instead of embedding a
+# key. This is what makes the integration block load-bearing rather than
+# decorative.
+[tools.jira_search]
+integration = "jira-prod"
+
+# ── NEW: a tool with interchangeable backends ──
+# The "file a follow-up ticket" case: same intent, three possible systems.
+# Listing them here decouples what the agent WANTS from where it LANDS.
+[tools.create_follow_up_task]
+backends        = ["jira-prod", "github-main", "linear-ops"]
+default_backend = "jira-prod"
+
+  [tools.create_follow_up_task.config]
+  # May the calling agent pick a backend via a tool-call argument, or is it
+  # always `default_backend`?
+  agent_may_choose_backend = true
+  # Route through the existing approval gate before the ticket is actually
+  # filed. This is NOT a new confirmation mechanism — it marks the tool as
+  # gated so the deck's existing PreToolUse/approval path handles it.
+  require_confirmation     = true
+  default_labels           = ["from-agent"]
+
+
+# =============================================================================
+# CARRIED OVER VERBATIM — see stella.today.toml
+# =============================================================================
+#   [hooks.*]              concatenate across scopes, project-trust gated
+#   [mcp] / [mcp.servers]  registry_url + the whole of .stella/mcp.toml
+#   [context.*]            7 sub-blocks; retrieval is live, the rest gated on
+#                          context.lifecycle.enabled
+#   [context_providers.*]  CGP sources, project-trust gated
+#   [authority]            managed scope ONLY, deny_unknown_fields, a ceiling
+#   [ui]                   theme
+#
+# STILL SEPARATE FILES, deliberately:
+#   ~/.stella/credentials.toml    secrets, 0600, zeroized — never merged
+#   .stella/tools/<name>.toml     a tool ships next to its script
+#   .stella/domains.toml          generated by `stella init`
+#   .env / .env.local             project dotenv, live shell always wins

--- a/docs/design/config-system/stella.today.toml
+++ b/docs/design/config-system/stella.today.toml
@@ -1,0 +1,542 @@
+# =============================================================================
+# stella.today.toml
+#
+# Every knob Stella ACTUALLY READS as of 2026-07, rendered in the proposed
+# single-file TOML shape. This is the migration target for phase 1: a pure
+# transliteration, no new semantics, no invented keys.
+#
+#   *** THIS FILE DOES NOT LOAD YET. ***
+#
+# Stella reads `settings.json` (JSON) + `.stella/mcp.toml` today. Nothing
+# parses this file. It exists so the port can be reviewed key-by-key against
+# the running code before any of it is built. Every key below was verified
+# against a serde struct or a `const &[&str]` in the workspace; the source is
+# named in the comment above each block.
+#
+# What this file deliberately does NOT contain:
+#   - `[[integrations]]`, `[models]`, `[pipeline]`, per-agent `tools`,
+#     `provider_preference` — none of those exist. They are in
+#     `stella.next.toml`, with the build plan in `DESIGN.md`.
+#   - credentials. `~/.stella/credentials.toml` stays a separate file, 0600,
+#     zeroized on drop. It is never merged into this one.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# ROOT SCALARS  ── settings.json `enable_recap`
+#
+# THESE MUST COME FIRST, BEFORE ANY TABLE HEADER. This is the sharpest TOML
+# footgun in the whole port: a bare key written *after* a `[table]` silently
+# becomes a key OF that table. Drafting this file, `enable_recap` was placed
+# down beside `[ui]` and silently landed inside `[authority]` instead.
+#
+# It survived only because `ManagedAuthoritySettings` is
+# `#[serde(deny_unknown_fields)]` — the one strict struct in the schema — so
+# it would have been a loud error. Anywhere else in this file it would have
+# parsed clean and configured nothing.
+#
+# DESIGN.md §6.3 proposes fixing this properly by giving every root scalar a
+# table home (`[run] recap = "on"`) so the shape has no bare keys at all.
+#
+# on = print an end-of-run recap in text mode: a deterministic synthesis of
+# the outcome (completed/verified/failed/aborted) and what changed, beside the
+# file and cost panels. No model call. Default off.
+# -----------------------------------------------------------------------------
+
+enable_recap = "off"
+
+
+# -----------------------------------------------------------------------------
+# META  ── NEW IN THE PORT (nothing equivalent exists today)
+#
+# settings.json has no version field. Forward-compat is handled by tolerating
+# unknown keys and warning about them (`settings/unknown.rs`), which cannot
+# tell a typo from a future key. `schema_version` is the one addition phase 1
+# makes, because a migration seam is exactly what the current design lacks.
+#
+# `scope` is a self-declaration checked against the file's LOCATION. It does
+# not choose the scope — the path does. A mismatch is a loud error, because a
+# project file claiming `scope = "managed"` is either a mistake or an attack.
+# -----------------------------------------------------------------------------
+
+[meta]
+schema_version = 1
+scope          = "project"   # "user" | "managed" | "project"
+
+
+# -----------------------------------------------------------------------------
+# PROVIDERS  ── settings.json `providers.<id>`
+# Source: stella-cli/src/settings.rs `ProviderSettings`
+#         stella-cli/src/settings/unknown.rs `PROVIDER_FIELDS`
+#
+# A TABLE keyed by provider id, NOT an array-of-tables. This matters: scopes
+# merge per-id AND per-field (`ProviderSettings::overlay`), so a managed
+# `base_url` and a user `api_key_env` compose into one effective provider.
+# An array-of-tables cannot express that without hand-rolling id-matching.
+#
+# An id matching a built-in OVERRIDES that built-in's defaults. A new id
+# DEFINES a provider, and then `base_url` is required.
+#
+# Built-in ids, in auto-detection preference order
+# (stella-cli/src/config/providers.rs `PROVIDERS`):
+#   openrouter, zai, anthropic, openai, xai, deepseek, gemini, vertex, bedrock
+#   plus the `local` pseudo-provider (never auto-detected).
+#
+# TRUST: `base_url`, `api_key`, and `api_key_env` are credential-routing
+# fields. In an UNTRUSTED project scope all three are discarded and restored
+# from the user/managed merge — a cloned repo cannot redirect where your key
+# is sent. Set STELLA_TRUST_PROJECT=1 to allow it.
+# -----------------------------------------------------------------------------
+
+# Override a built-in: only the fields you want changed.
+[providers.anthropic]
+api_key_env   = "ANTHROPIC_API_KEY"
+default_model = "claude-fable-5"
+
+# Define a new provider. `base_url` required; `dialect` picks the wire adapter.
+# dialect ∈ openai-compatible | openai-responses | anthropic | gemini
+#           | vertex | bedrock              (kebab-case — serde rename_all)
+# `vertex` and `bedrock` are built-in-only: they need project/region
+# resolution a settings entry has no way to express.
+# Source: stella-model/src/factory.rs `Dialect`
+[providers.my-vllm]
+name          = "Internal vLLM"
+base_url      = "http://vllm.internal:8000/v1"
+api_key_env   = "INTERNAL_VLLM_KEY"
+default_model = "meta-llama/Meta-Llama-3.1-70B-Instruct"
+dialect       = "openai-compatible"
+# `id` may restate the key. When present it MUST match, so copy-pasting an
+# entry under a new key cannot silently configure the wrong provider.
+id            = "my-vllm"
+
+# `api_key` (a literal secret) is also accepted here, ranking below env vars
+# and above the interactive prompt. It is omitted from this example on
+# purpose — see DESIGN.md §6, which proposes demoting it at project scope.
+
+
+# -----------------------------------------------------------------------------
+# AGENTS  ── settings.json `agent_engine_config`
+# Source: stella-cli/src/settings.rs `AgentEngineConfig`, `AgentEngineAgent`,
+#         `AgentEngineParams`; unknown.rs ENGINE_{ROOT,AGENT,PARAM}_FIELDS
+#
+# EXACTLY FOUR agents exist, and the set is closed (`AgentEngineAgents` is a
+# struct with four fields, not a map): default, worker, judge, triage.
+# `default` is the interactive/step-loop agent; the other three are the staged
+# pipeline's roles. `Role::Plan` rides the worker's settings.
+#
+# Model precedence per agent:
+#   agents.<a>.model  >  <flat per-role field>  >  default_model  >  provider default
+# -----------------------------------------------------------------------------
+
+[agents]
+# The default agent's model, and the base for every role with no more
+# specific setting. A model string is either `provider/slug`, or a bare slug
+# sent verbatim to THAT provider when the agent's `provider` field is set.
+default_model         = "anthropic/claude-fable-5"
+pipeline_worker_model = "zai/glm-5.2"
+pipeline_judge_model  = "openrouter/openai/gpt-5.5"
+pipeline_triage_model = "deepseek/deepseek-chat"
+
+# The model vocabulary the TUI pickers offer and `auto_mode` selects from.
+# REPLACES wholesale across scopes rather than concatenating — it is one
+# vocabulary, and concatenating would make it impossible for a project to
+# narrow the user's list.
+allowed_models = [
+  "anthropic/claude-fable-5",
+  "zai/glm-5.2",
+  "openrouter/openai/gpt-5.5",
+]
+
+# on/off toggles. A dedicated enum, not a bool: a typo must be a loud parse
+# error, never a silently-false setting.
+auto_mode      = "off"  # on = pick the judge model automatically from
+                        # allowed_models, preferring a different family than
+                        # the worker and ranking by catalog list price
+effort_auto    = "on"   # on = judge high, worker medium, triage low,
+                        # default medium — overrides any per-agent `effort`
+reasoning_auto = "on"   # on = thinking on for judge/worker/default, off for
+                        # triage — overrides any per-agent `reasoning`
+
+# on = a headless run proceeds past scope review instead of stopping at
+# ScopeReviewRequiredHeadless. OFF by default and deliberately so: scope
+# review is what keeps a large blast radius from landing unattended, and a
+# headless surface has nobody to ask. Turn it on only where the tree is
+# disposable and the budget cap is the real guard.
+headless_scope_bypass = "off"
+
+# ---- per-agent overrides. Every field optional = "no opinion" ---------------
+#
+# The JSON nests these one level deeper (`agent_engine_config.agents.judge`).
+# Flattened here to `[agents.judge]` because the agent set is CLOSED — the
+# four names are struct fields, not map keys — so a per-agent table can never
+# collide with a root field. If that set ever opens, this must go back to
+# `[agents.agents.<name>]`.
+
+[agents.judge]
+provider  = "openrouter"      # gateway id; when set, `model` is sent
+model     = "openai/gpt-5.5"  # verbatim as the slug to THIS provider
+effort    = "high"            # low|medium|high|xhigh|max (snake_case)
+reasoning = "on"
+# Replacement system prompt. Workspace memories/rules still append to it —
+# they are additive context, not part of the base instruction set.
+#
+# PRIVILEGED: a project scope's prompt is discarded and restored from the
+# trusted scopes unless managed `authority.project_prompts = "on"`.
+prompt    = "You are a strict code-review judge. Reject on any unproven claim."
+
+  # "Include checkbox" semantics: a present value goes on the wire where the
+  # dialect supports it; absent leaves the provider default untouched.
+  # temperature/max_tokens land on CompletionRequest directly; the rest ride
+  # CompletionRequest::params. An adapter silently drops what its dialect
+  # cannot express — a param must never fail a request.
+  [agents.judge.params]
+  temperature        = 0.2
+  top_p              = 0.9
+  top_k              = 40
+  frequency_penalty  = 0.0
+  presence_penalty   = 0.0
+  repetition_penalty = 1.0
+  max_tokens         = 4096
+  seed               = 42
+  verbosity          = "low"       # low | medium | high
+  service_tier       = "priority"  # auto | default | flex | priority
+
+[agents.worker]
+effort = "medium"
+
+[agents.triage]
+reasoning = "off"
+
+[agents.default]
+effort = "medium"
+
+
+# -----------------------------------------------------------------------------
+# TOOLS  ── settings.json `tools`
+# Source: stella-cli/src/settings.rs `ToolsSettings`
+#         stella-tools/src/policy.rs `ToolPolicy`
+#
+# An OPEN MAP and a DENY-LIST. Absent means ON — Stella ships with every tool
+# available. This is not a registry: it is an overlay on a registry that is
+# only known at runtime (built-ins + each connected MCP server's tools +
+# every `.stella/tools/*.toml` manifest).
+#
+# Precedence, most specific first:
+#   1. exact tool name
+#   2. its group
+#   3. "*"
+# So `{"*" = "off", "read_file" = "on"}` is a read-only agent in two lines.
+#
+# Groups (stella-tools/src/catalog.rs, plus "mcp" and "custom" for tools the
+# catalog does not know):
+#   bash  build  ci  context  file  issue  media  process  repo  scripts
+#   search  session  task  web  |  mcp  custom
+#
+# CEILING: a tool the managed scope denies is denied for good. Neither user
+# nor project can grant it back, and the settings editor renders it LOCKED
+# rather than as a switch that silently does nothing.
+# -----------------------------------------------------------------------------
+
+[tools]
+bash    = "off"   # one tool
+process = "off"   # one whole group
+"*"     = "on"    # the wildcard (quoted — bare * is not a TOML key)
+
+
+# -----------------------------------------------------------------------------
+# HOOKS  ── settings.json `hooks`
+# Source: stella-core/src/hooks.rs `Hooks`, `HookMatcher`, `HookAction`
+#
+# NOTE THE MERGE RULE: hooks CONCATENATE across scopes. They do not overlay.
+# Any scope can add a gate; no scope can remove another's. This is the one
+# block in the file that does not follow the per-field last-wins rule, and
+# the TOML port must preserve it.
+#
+# Event keys are PascalCase (serde rename): SessionStart, PreToolUse,
+# PostToolUse. `matcher` is a glob over the tool name for the two ToolUse
+# events; SessionStart ignores it and runs every action.
+#
+# `timeoutMs` is camelCase (serde rename). Default 60_000, hard cap 600_000.
+# The command receives the event payload as JSON on stdin.
+#
+# TRUST: project-scope hooks are NOT loaded unless STELLA_PROJECT_HOOKS=1 or
+# STELLA_TRUST_PROJECT=1. A hook is arbitrary code execution on `git clone`.
+# -----------------------------------------------------------------------------
+
+[[hooks.SessionStart]]
+  [[hooks.SessionStart.hooks]]
+  type    = "command"
+  command = "./scripts/session-context.sh"
+
+[[hooks.PreToolUse]]
+matcher = "bash"
+  [[hooks.PreToolUse.hooks]]
+  type      = "command"
+  command   = "./scripts/audit-bash.sh"
+  timeoutMs = 5000
+
+[[hooks.PostToolUse]]
+matcher = "write_file"
+  [[hooks.PostToolUse.hooks]]
+  type    = "command"
+  command = "./scripts/fmt-on-write.sh"
+
+
+# -----------------------------------------------------------------------------
+# MCP  ── settings.json `mcp` + the WHOLE of `.stella/mcp.toml`
+# Source: stella-cli/src/settings.rs `McpSettings`
+#         stella-mcp/src/config.rs `McpConfig`, `McpServerEntry`, `McpTransport`
+#
+# `.stella/mcp.toml` is already TOML with a `[servers.<name>]` table, so it
+# folds in verbatim as `[mcp.servers.<name>]`. This is the cheapest
+# consolidation in the whole migration — a prefix, nothing more.
+#
+# TRUST: MCP servers sit on the same code-execution boundary as hooks. A
+# stdio server spawns a process; project scope needs STELLA_TRUST_PROJECT=1.
+#
+# CREDENTIAL SCRUB: a stdio child inherits NO ambient environment except the
+# keys listed in its own `env` table, plus `PATH` (the one deliberate
+# exception, without which `npx`/`uvx`/`docker` could not resolve). An
+# ANTHROPIC_API_KEY in the parent shell can never reach an MCP subprocess.
+# -----------------------------------------------------------------------------
+
+[mcp]
+# Base URL of an MCP Server Registry API (the frozen GET /v0.1/servers
+# contract). Unset = the official registry. Credential-routing-adjacent:
+# discarded from an untrusted project scope.
+registry_url = "https://registry.modelcontextprotocol.io"
+
+[mcp.servers.filesystem]
+transport = "stdio"
+cmd       = "mcp-server-filesystem"
+args      = ["--root", "/workspace"]
+env       = { LOG_LEVEL = "info" }
+# Explicit opt-in for Best-of-N candidate sharing. NEVER inferred from the
+# server's own `read_only_hint`, which is untrusted and cannot distinguish
+# "reads an external system" (safe across candidates) from "reads the local
+# tree" (would read stale bytes from an isolated snapshot).
+candidate_safe = false
+
+[mcp.servers.github]
+transport = "http"
+url       = "https://mcp.example.com/mcp"
+headers   = { Authorization = "Bearer ${GITHUB_MCP_TOKEN}" }
+
+
+# -----------------------------------------------------------------------------
+# CONTEXT  ── settings.json `context`
+# Source: stella-cli/src/settings/context.rs `ContextSettings`
+#
+# Seven sub-blocks. Whole-block last-wins across scopes (not per-field).
+#
+# Two dimensions are deliberately SEPARATE and must not be collapsed:
+#   learning.mode    — how much of the learning loop runs
+#   governance.mode  — who governs promotions
+#
+# Enums here are "loud": an unrecognized value is a hard parse error.
+# Every value below is the shipping default.
+# -----------------------------------------------------------------------------
+
+[context.lifecycle]
+# Ships ON. Setting it false restores every pre-adaptive-context behavior:
+# the recall block is not decomposed, no frame identity is recorded, and the
+# learning loop runs its lexical path. Every other block here except
+# `retrieval` is ignored while this is off.
+enabled = true
+
+[context.learning]
+# off | record_only | advisory
+#   off         — no mining, no proposal induction, no efficacy learning
+#   record_only — capture observations/proposals/uses/outcomes, but never
+#                 select or promote inferred records
+#   advisory    — governed inferred *advisory* use
+mode = "off"
+
+[context.governance]
+mode = "solo"   # solo | team | regulated
+
+[context.promotion.inferred_directive]
+min_observations            = 3
+min_distinct_tasks          = 3
+auto_activate_at_confidence = 85         # 0..=100
+# An inferred directive can never START blocking.
+initial_enforcement         = "advisory" # advisory | blocking
+
+[context.promotion.blocking_directive]
+# A blocking directive always requires explicit human confirmation.
+# Do not turn this off lightly.
+requires_explicit_confirmation = true
+
+[context.efficacy]
+min_attributable_uses                       = 5
+not_helpful_ratio_threshold                 = 0.8  # 0.0..=1.0
+min_attribution_confidence                  = 80   # 0..=100
+receipt_display_min_attribution_confidence  = 80   # 0..=100
+
+[context.retention]
+raw_observation_days           = 30
+proposal_days                  = 30
+inferred_directive_review_days = 180
+
+# UNLIKE the rest of this block, retrieval is LIVE — and live regardless of
+# `lifecycle.enabled`. It configures the retrieval plane that already runs for
+# every user, not the adaptive loop. Every default is exactly the value that
+# shipped hard-coded, so a workspace configuring nothing behaves identically.
+#
+# Out-of-range values are CLAMPED (`RecallTuning::sanitized`), not rejected:
+# this is a file a person edits, and failing a turn over a typo in a tuning
+# knob is a worse answer than ignoring it.
+# Values below are the real constants from stella-context/src/retrieval.rs
+# (DEFAULT_RRF_K and friends), not plausible-looking numbers. Verified.
+[context.retrieval]
+max_frames             = 5      # DEFAULT_RECALL_MAX_FRAMES
+max_tokens             = 1200   # DEFAULT_RECALL_MAX_TOKENS
+rrf_k                  = 60.0   # higher flattens the ranking
+# Weight of recency relative to vector similarity. Damped ON PURPOSE: at
+# parity the newest rows occupy every slot no matter what was asked.
+recency_weight         = 0.15
+mmr_lambda             = 0.7    # 0.0..=1.0, higher favors relevance
+# Mean top-k cosine below which recall falls back to labeled lexical search
+# rather than dressing weak hits up as grounding.
+min_coverage           = 0.15
+coverage_topk          = 5      # how many top hits define that estimate
+max_vector_seeds       = 8      # graph-expansion seeds from strongest hits
+lexical_limit          = 8      # cap on lexical-fallback frames
+# Shortlist size as a multiple of max_frames — what the budget chooses
+# between, and the denominator of the drop report.
+mmr_candidate_multiple = 4
+# The ONE knob here that changes WHICH memories a turn can recall rather than
+# how they are ordered: an approximate index considers a subset of the corpus,
+# so a frame the exact scan would find can be missed. Off by default; every
+# recall it serves says so on `RecallResult::used_ann_index`. Does nothing
+# until `stella memory index` has built one — there is no implicit build,
+# because building is a whole-corpus pass the per-turn path must never pay.
+ann_enabled            = false
+# How many centroid posting lists an enabled probe reads. Higher is more exact
+# and slower; the probe widens past this on its own when the ranking's depth
+# requirements demand it, so this is a FLOOR, not a cap.
+ann_probes             = 12
+
+
+# -----------------------------------------------------------------------------
+# CONTEXT PROVIDERS  ── settings.json `context_providers`
+# Source: stella-cli/src/settings/context_providers.rs
+#
+# Third-party CGP context sources reached over stdio/HTTP. Merged per-entry
+# across scopes like `providers`, so a project may enable a provider the user
+# scope declared without restating its transport.
+#
+# Empty (the shipping default) registers nothing and leaves recall exactly as
+# it is today.
+#
+# TRUST: same code-execution boundary as hooks and MCP. An enabled stdio entry
+# spawns its command at admission time — the conformance suite runs on its own
+# connection first, so the process starts before anything has vetted it. An
+# http entry is no safer: the same untrusted file supplies the
+# `egress_consent` that lets a query payload carrying workspace content leave
+# the machine. An untrusted project scope contributes nothing here.
+# -----------------------------------------------------------------------------
+
+[context_providers.acme-docs]
+transport = "stdio"          # stdio | http
+command   = "acme-context-server"
+args      = ["--index", "./docs"]
+enabled   = true
+
+[context_providers.corp-kb]
+transport       = "http"
+url             = "https://kb.corp.example/cgp"
+enabled         = false
+# Hosts this provider may send workspace content to. Empty = no egress.
+egress_consent  = ["kb.corp.example"]
+consent_grantor = "security@corp.example"
+
+
+# -----------------------------------------------------------------------------
+# AUTHORITY  ── settings.json `authority`   ***MANAGED SCOPE ONLY***
+# Source: stella-cli/src/settings/authority.rs `ManagedAuthoritySettings`
+#
+# Honored ONLY from the org-managed settings file. Present in a user or
+# project file, it is ignored — the containing file IS the policy source.
+#
+# This is the block that makes the whole scope model safe, and it is
+# `#[serde(deny_unknown_fields)]` — the ONE strict object in the schema. A
+# misspelled ceiling must fail loudly rather than silently not apply.
+#
+# It is a CEILING, not a default: it is computed from the managed snapshot
+# alone, so no later fold — including an explicitly trusted project — can
+# raise it.
+#
+# Managed file location:
+#   macOS  /Library/Application Support/stella/settings.json
+#   else   /etc/stella/settings.json
+#   override with STELLA_MANAGED_SETTINGS (also how tests point at a fixture)
+# -----------------------------------------------------------------------------
+
+[authority]
+project_prompts             = "off"  # may a repo replace an agent's system prompt?
+project_custom_tools        = "off"  # may a repo's .stella/tools/*.toml load?
+bash                        = "off"  # hard deny, unraisable
+web                         = "on"
+media_requires_host_approval = "on"
+
+
+# -----------------------------------------------------------------------------
+# UI  ── settings.json `ui`
+# Source: stella-cli/src/settings.rs `UiSettings`
+#
+# Whole-block last-wins across scopes; carries no authority.
+# (`enable_recap`, the other misc root, is hoisted to the top of this file —
+#  see the ROOT SCALARS note for why it cannot live here.)
+# -----------------------------------------------------------------------------
+
+[ui]
+theme = "stella-dark"   # stella-dark | stella-light
+
+
+# -----------------------------------------------------------------------------
+# ENTERPRISE TELEMETRY  ── settings.json `enterprise_telemetry`
+#
+# Captured from MANAGED scope only, parsed as raw JSON and validated fail-open
+# by its own adapter. Shape is deliberately not pinned by the settings schema.
+# Shown here only for completeness of the key inventory.
+# -----------------------------------------------------------------------------
+
+# [enterprise_telemetry]
+# ... adapter-defined ...
+
+
+# =============================================================================
+# FILES THAT STAY SEPARATE  (and why)
+# =============================================================================
+#
+# ~/.stella/credentials.toml    `[credentials] <provider> = "sk-..."`
+#     Stays separate, permanently. Created 0600 from birth, hand-written
+#     redacting Debug, zeroized on drop, loose-permission advisory on read.
+#     A stella.toml at the repo root is far more likely to be committed than
+#     `.stella/settings.json` ever was — merging secrets into it would make
+#     the most-committed file in the workspace the most dangerous one.
+#
+# .stella/tools/<name>.toml     one custom script tool per file
+#     name / description / command (argv, spawned directly, never a shell) /
+#     timeout_ms / [env] / [input_schema] (JSON Schema written as TOML).
+#     Stays per-file: a tool ships NEXT TO its script, and inlining fifty of
+#     them into one config would break that locality. Gated by managed
+#     `authority.project_custom_tools`.
+#
+# .stella/domains.toml          version / inferred_by / [[domain]]
+#     GENERATED by `stella init`, not hand-written. Merging a generated
+#     artifact into a hand-edited file guarantees the generator eventually
+#     clobbers a human edit.
+#
+# ~/.stella/integrations.json   `stella connect` OAuth tokens
+#     STATE, not config. Becomes config in `stella.next.toml` §integrations —
+#     but the tokens themselves stay out of the config file.
+#
+# .env / .env.local             project dotenv
+#     Loaded most-specific-first: .env.<mode>.local, .env.local, .env.
+#     NEVER loaded: .env.example / .sample / .dist, and any non-.local
+#     .env.<mode>. The live shell always wins over a file.
+#
+# .stella/{rules,skills,commands,agents,memories}/
+#     Markdown-with-frontmatter CONTENT, not configuration. Out of scope.


### PR DESCRIPTION
Design docs **plus a working Phase 1**: `stella.toml` now loads, writes, and migrates.

## What ships

**Phase 0 — comment-preserving writes** (`settings/toml_io.rs`). Built first because it gates everything. `toml_edit` replaces re-rendering a parsed `toml::Value`, which would discard every comment in the user's file on the first `/theme` save — deleting the one advantage the format was adopted for, on a write nobody thinks is destructive. The round-trip test is the contract.

**Phase 1 — the format port.**

- `settings/toml_config.rs` owns the document shape and lowers it into the existing `Settings`, so the merge/trust/authority chain consumes the result unchanged. The JSON loader is untouched — zero regression risk for anyone who hasn't migrated.
- Three scopes: `<repo>/stella.toml` (**repo root**, decided), `~/.stella/stella.toml`, and the managed file. TOML wins whole where both exist and the shadowed JSON is announced — never merged.
- `[meta]` with `schema_version` and a `scope` checked against the file's actual location.
- A separate TOML unknown-key vocabulary. `agents` is a valid root in TOML and a typo in JSON; one shared list would bless keys that configure nothing.
- `stella migrate config [--dry-run]`.

## Three things the port had to get right rather than inherit

- **The managed TOML read reuses the hardened `O_NOFOLLOW` + ownership/mode reader.** That check is what makes the authority ceiling trustworthy; a TOML path around it would let any local user raise the org's ceiling by dropping a file.
- **`STELLA_MANAGED_SETTINGS` names ONE file** and its extension picks the reader. Probing for a sibling would let a second, unnamed file supply the ceiling.
- **`api_key` is a load error at project scope**, naming both alternatives and never echoing the secret. A file next to `README.md` gets committed far more readily than `.stella/settings.json` ever did.

## Deferred, and said out loud

`[mcp.servers]` parses but is **not consumed yet** — it warns loudly instead of dropping servers on the floor. Folding it crosses `agent::load_mcp_plan`'s code-execution trust gate; getting that wrong re-opens the `git clone && stella` RCE the gate closes, so it's its own change.

## Three defects the generated output exposed

Fixed at the writer layer, so hand-saves get them too:

- `temperature` rendered as `0.20000000298023224` — an f32 widened by the serializer. Same number, but it reads as corruption in a file a person edits. Narrowed only when the round-trip is exactly lossless; the trailing `.0` is mandatory or `60.0` renders as `60` and parses back as an integer.
- serde emits every nested struct as an inline table, collapsing the config onto a few enormous lines. Now real headered tables and `[[arrays.of.tables]]`.
- A table holding only sub-tables emitted a bare `[providers]` / `[context]` header. Noise — and it invites the next person to add a key under the empty header where it silently belongs to the wrong table.

## Two bugs found by running it, not by reading it

- **`stella migrate config` was unreachable when you needed it most.** It ran after `Config::load`, so a `settings.json` naming a model whose provider no longer exists made the fix-it command fail. Moved before provider resolution, beside `doctor`.
- **The reference config had drifted from the implementation.** Pointing the built binary at `stella.today.toml` showed it still used `enable_recap` (bare root scalar) and `agents.allowed_models` after the port moved them to `[run].recap` and `[models].allowed`. Both parsed clean and configured nothing. The unknown-key pass caught it; there's now a test that loads the shipped reference and asserts zero unrecognized keys — a reference config documenting keys the loader ignores is a wrong answer with the authority of an example.

## Also in here

- **`docs/filesystem-layout.md`** — an ASCII map of every path stella reads or writes, across all three tiers, with what's safe to commit, what each env override relocates, and what you lose by deleting each thing.
- **`docs/design/config-system/`** — `stella.today.toml` (the full annotated reference, now load-tested), `stella.next.toml` (the shape after Phases 2–6), and `DESIGN.md` (status header updated to what's actually built).

## Verification

- 34 new TOML tests; **956 pass** in `stella-cli`; the 83 existing settings tests pass **unedited**, which was the stated safety criterion.
- `cargo clippy --workspace --all-targets` clean; `cargo fmt` applied.
- Migration smoke-tested end-to-end on a real workspace, including a config too broken to start.
- The shipped reference config loads with zero unrecognized keys.
- `check-file-size.sh` findings on `main` are pre-existing (unrelated Rust files, drifted baseline). New files: 567 / 402 / 231 lines, all under the 1500 ratchet.

## Note

Includes the `agent_system.toml` commit, currently **unpushed on local `main`**, so the doc references resolve. It will dedupe on rebase when that commit is pushed.
