### PR TITLE
docs(#928, #877): the last two undocumented CLI surfaces, memory's full lifecycle, a gate that notices, and the self-improvement track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "stella-engine"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-trait",
  "serde",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-trait",
  "serde",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,20 @@ flip oracle, the evidence ladder, witness authoring, the judge escalation
 path, and best-of-N candidate scoring (`verify.rs`, `witness.rs`,
 `candidate.rs`, and the verify/revise wiring in `pipeline.rs`).
 
+## Related tracks
+
+This roadmap covers verification only. The **self-improvement** track — Stella
+authoring its own tools, tuning its own policy from evals, maintaining its own
+source, and distilling its own trajectories (issues #830–#836) — is documented
+at [`website/content/docs/self-improvement.mdx`](website/content/docs/self-improvement.mdx),
+published as [Self-improvement](https://stella.oxagen.sh/docs/self-improvement).
+
+The two are coupled in one direction: every self-authored change in that track
+has to clear the machinery described here. A self-authored tool needs a witness
+that flips, and a self-authored PR needs the same evidence ladder as any other
+work. Weakening verification weakens every self-improvement guarantee that
+depends on it.
+
 ## Where we are today
 
 The current design (L-E11) is deterministic-first and already avoids the two

--- a/stella-cli/src/main_tests.rs
+++ b/stella-cli/src/main_tests.rs
@@ -542,3 +542,162 @@ fn pre_flight_failures_emit_a_machine_readable_error_envelope() {
 fn text_output_never_gets_an_error_envelope_on_stdout() {
     assert!(error_summary_json(OutputFormat::Text, "boom").is_none());
 }
+
+/// The docs section every command page lives in.
+const COMMANDS_DOCS_DIR: &str = "website/content/docs/commands";
+
+/// Entries in `meta.json` that are not commands. `index` is the section's own
+/// landing page.
+const NON_COMMAND_PAGES: &[&str] = &["index"];
+
+/// The repository root, from this crate's manifest directory.
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("stella-cli must have a parent directory")
+        .to_path_buf()
+}
+
+/// The `pages` array of the commands section's `meta.json`.
+fn documented_pages() -> Vec<String> {
+    let meta_path = repo_root().join(COMMANDS_DOCS_DIR).join("meta.json");
+    let raw = std::fs::read_to_string(&meta_path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", meta_path.display()));
+    let meta: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("{} is not valid JSON: {e}", meta_path.display()));
+    meta["pages"]
+        .as_array()
+        .expect("meta.json must carry a `pages` array")
+        .iter()
+        .filter_map(|page| page.as_str())
+        // Fumadocs separators (`---Group---`) are layout, not pages.
+        .filter(|page| !page.starts_with("---"))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The top-level subcommand names clap itself would render, minus the ones a
+/// reader never types. `help` is clap's own built-in, and a hidden command is
+/// hidden from `--help` too, so neither owes the docs a page.
+fn top_level_subcommands() -> Vec<String> {
+    Cli::command()
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set())
+        .map(|sub| sub.get_name().to_owned())
+        .filter(|name| name != "help")
+        .collect()
+}
+
+/// Every command `stella --help` lists must have a reference page, and every
+/// page must correspond to a real command.
+///
+/// # Why this is a test rather than a script over `--help`
+///
+/// It reads the same `Command` tree `--help` renders, but reads it
+/// *structurally*. Parsing help text would make the gate a hostage to terminal
+/// width, ANSI color, and clap's wrapping — three things that have nothing to
+/// do with whether a command is documented. It also needs no new gate step:
+/// `make gate` already runs the test suite.
+///
+/// # Why both directions
+///
+/// Forward catches the bug that motivated this (#928: seven surfaces shipped
+/// with no page, and nothing noticed). Backward catches its mirror — a page
+/// outliving the command it documents, which is worse than no page, because a
+/// reader has no way to tell a stale page from a current one.
+#[test]
+fn every_subcommand_has_a_reference_page() {
+    let pages = documented_pages();
+    let commands = top_level_subcommands();
+
+    let undocumented: Vec<&String> = commands
+        .iter()
+        .filter(|name| !pages.iter().any(|page| page == *name))
+        .collect();
+    assert!(
+        undocumented.is_empty(),
+        "these subcommands have no page in {COMMANDS_DOCS_DIR}/meta.json: {undocumented:?}\n\
+         add `website/content/docs/commands/<name>.mdx` and list it in `meta.json`"
+    );
+
+    let orphaned: Vec<&String> = pages
+        .iter()
+        .filter(|page| !NON_COMMAND_PAGES.contains(&page.as_str()))
+        .filter(|page| !commands.iter().any(|name| name == *page))
+        .collect();
+    assert!(
+        orphaned.is_empty(),
+        "these pages document no existing subcommand: {orphaned:?}\n\
+         remove the page, or add it to NON_COMMAND_PAGES if it is not a command reference"
+    );
+
+    // A `meta.json` entry with no file behind it renders as a broken nav link.
+    for page in &pages {
+        let path = repo_root()
+            .join(COMMANDS_DOCS_DIR)
+            .join(format!("{page}.mdx"));
+        assert!(
+            path.exists(),
+            "meta.json lists `{page}` but {} does not exist",
+            path.display()
+        );
+    }
+}
+
+/// A command's own page must name every subcommand that command has.
+///
+/// This is the check that would have caught the sharpest half of #928:
+/// `stella memory` had grown to twelve subcommands while its page documented
+/// six, so the reference was provably behind the CLI — and behind the project's
+/// own release notes, which described the missing six in prose.
+///
+/// Nested subcommands do not get their own pages; they are documented inside
+/// the parent's. So the assertion is the same one
+/// `stella-tools/tests/docs_in_sync.rs` makes about the tool registry: the
+/// exact invocation a reader would type, `stella <parent> <child>`, must appear
+/// literally in the parent's page.
+#[test]
+fn every_page_documents_all_of_its_commands_subcommands() {
+    let mut missing: Vec<String> = Vec::new();
+
+    for parent in Cli::command()
+        .get_subcommands()
+        .filter(|s| !s.is_hide_set())
+    {
+        let parent_name = parent.get_name();
+        if parent_name == "help" {
+            continue;
+        }
+        let children: Vec<&str> = parent
+            .get_subcommands()
+            .filter(|child| !child.is_hide_set())
+            .map(clap::Command::get_name)
+            .filter(|name| *name != "help")
+            .collect();
+        if children.is_empty() {
+            continue;
+        }
+
+        let path = repo_root()
+            .join(COMMANDS_DOCS_DIR)
+            .join(format!("{parent_name}.mdx"));
+        let Ok(page) = std::fs::read_to_string(&path) else {
+            // The other test owns "this page is missing entirely"; reporting it
+            // twice would make one omission look like two problems.
+            continue;
+        };
+
+        for child in children {
+            if !page.contains(&format!("stella {parent_name} {child}")) {
+                missing.push(format!("stella {parent_name} {child}"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "these subcommands are not documented on their command's page: {missing:#?}\n\
+         each must appear literally as `stella <parent> <child>` in \
+         {COMMANDS_DOCS_DIR}/<parent>.mdx"
+    );
+}

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -1,0 +1,125 @@
+---
+title: stella arena
+description: The arena-bench harness adapter — run one benchmark episode from a task directory while recording the contextgraph-trace journal the arena runner judges with the protocol's replay oracles.
+---
+
+`stella arena` is Stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.
+
+<Callout type="info">
+This command exists for **benchmarking Stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how Stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it.
+</Callout>
+
+## Synopsis
+
+```bash
+stella arena --task-dir <DIR> --journal <FILE> --state-dir <DIR> [--resume]
+             [--no-pipeline] [--test-command <CMD>]
+```
+
+## What it does
+
+arena-bench invokes an agent with `--task-dir`/`--journal`/`--state-dir`/`[--resume]`, **SIGKILLs it mid-episode on purpose**, re-invokes it, and then judges the journal it recorded. Surviving that is the point of the benchmark, so the adapter is built around one rule: the journal must never claim more than actually happened.
+
+<CardGrid size="md">
+  <SpecCard title="Workspace is the task dir">
+    `--task-dir` *is* the workspace for the episode, and the prompt is read from the `TASK.md`
+    inside it.
+  </SpecCard>
+  <SpecCard title="Journal is written first">
+    Each event is appended to the journal **before** it is admitted to the renderer — one
+    flushed line per event.
+  </SpecCard>
+  <SpecCard title="Memory rides the state dir">
+    `--state-dir` persists across episodes, so the memory arm of the benchmark has somewhere
+    durable to live.
+  </SpecCard>
+  <SpecCard title="Resume declares what it recovered">
+    `--resume` truncates a torn tail, recovers the journal, and states exactly what came back
+    before continuing the same session.
+  </SpecCard>
+</CardGrid>
+
+## Flags
+
+<CardGrid size="md">
+  <OptionCard name="--task-dir <DIR>">
+    The episode workspace. The prompt is read from `TASK.md` inside it. Required.
+  </OptionCard>
+  <OptionCard name="--journal <FILE>">
+    The `contextgraph-trace` journal to append. Crash-safe, one flushed line per event.
+    Required.
+  </OptionCard>
+  <OptionCard name="--state-dir <DIR>">
+    Agent state that persists across episodes — the benchmark's memory arm. Required.
+  </OptionCard>
+  <OptionCard name="--resume">
+    Present when arena-bench re-invokes the adapter after a chaos kill. Recovers the journal,
+    declares what was recovered, and continues the same session.
+  </OptionCard>
+  <OptionCard name="--no-pipeline">
+    Use the raw step-loop instead of the staged pipeline. The
+    [pipeline](/docs/inference-pipeline) is the default here exactly as it is for `stella run`.
+  </OptionCard>
+  <OptionCard name="--test-command <CMD>">
+    Test command for the pipeline's deterministic verify ladder, e.g.
+    `--test-command "cargo test -p my-crate"`.
+  </OptionCard>
+</CardGrid>
+
+## Why the journal is written before the event is admitted
+
+An event the journal did not accept must not be admitted to the run. That ordering is not a performance detail — it is what makes the recording truthful under a kill:
+
+- The recorder appends the trace mapping of an event, **then** enqueues the same event to the renderer. This is the same persist-first boundary the durable stream-json sink uses.
+- A SIGKILL at any byte therefore leaves a **truthful prefix**: the journal may be missing the tail, but it never contains work the run had not committed to.
+- On `--resume`, a torn final line is truncated rather than parsed, and the adapter reports what it recovered instead of silently continuing.
+
+The inverse ordering would produce the one failure the benchmark is designed to catch — a journal asserting an effect the agent never got to perform.
+
+## What the journal records
+
+The adapter maps the live agent event stream onto the trace vocabulary:
+
+<CardGrid size="sm">
+  <SpecCard title="prompt_assembled">
+    From the step manifest. Block identities, digests, and token costs are already content-free,
+    so no prompt text crosses into the journal.
+  </SpecCard>
+  <SpecCard title="The tool loop">
+    Tool start and tool result become the paired tool-loop events.
+  </SpecCard>
+  <SpecCard title="Intended-once effects">
+    Mutating file changes and commits become side effects carrying an **intended-once id**.
+  </SpecCard>
+</CardGrid>
+
+That last one carries the weight of the crash test. The id is derived from the path, the kind, and the diff, so the *same* logical edit replayed after a crash-resume **collides** — which is precisely the bug the effect-exactly-once oracle exists to catch — while a genuinely new edit to the same file carries a new diff and therefore a new id.
+
+## Example
+
+```bash
+# One episode, recording the journal arena-bench will judge.
+stella arena \
+  --task-dir ./episodes/0042 \
+  --journal  ./journals/0042.jsonl \
+  --state-dir ./state/memory-arm
+
+# What arena-bench itself runs after the chaos kill.
+stella arena \
+  --task-dir ./episodes/0042 \
+  --journal  ./journals/0042.jsonl \
+  --state-dir ./state/memory-arm \
+  --resume
+```
+
+<Callout type="info">
+Persistent memory works by linking the workspace's `.stella` store into `--state-dir`, which the
+runner preserves between episodes (and wipes for the `amnesic` arm). A fixture that ships its own
+`.stella` wins — the link is only created when the workspace has none.
+</Callout>
+
+## See also
+
+- [Inference pipeline](/docs/inference-pipeline) — the staged path `--no-pipeline` opts out of.
+- [`stella run`](/docs/commands/run) — the ordinary one-shot path this adapter drives underneath.
+- [arena-bench](https://github.com/macanderson/arena-bench) — the harness that invokes this command.

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -79,6 +79,11 @@ stella chat
     What the work cost, and whether anyone said it was good — read from merged and closed pull
     requests, never from a model.
   </SpecCard>
+  <SpecCard title="stella arena" href="/docs/commands/arena">
+    The [arena-bench](https://github.com/macanderson/arena-bench) harness adapter — run one
+    benchmark episode and record the trace journal the arena runner judges. For benchmarking
+    Stella, not for using it.
+  </SpecCard>
   <SpecCard title="stella stats" href="/docs/commands/stats">
     `[prune]` — cost, tokens, and resolve rate per provider and model from this
     workspace's telemetry. `prune` bounds that store's growth, and never destroys
@@ -91,6 +96,10 @@ stella chat
   <SpecCard title="stella cloud" href="/docs/commands/cloud">
     `<status|register>` — show or set the org and workspace identity that scopes hub rows.
     A stub today: it persists ids locally, and the OAuth login lands later.
+  </SpecCard>
+  <SpecCard title="stella telemetry" href="/docs/commands/telemetry">
+    `<status|flush|rollover-discard>` — inspect, flush, or explicitly discard the managed
+    enterprise operational spool. Disabled by default; needs a signed org-managed enrollment.
   </SpecCard>
   <SpecCard title="stella inspect" href="/docs/commands/inspect">
     Show the exact context a past model call was sent, verified against the digests
@@ -136,10 +145,9 @@ stella chat
 
 Each command page in this section documents its usage synopsis, behavior, relevant flags, and realistic examples.
 
-Two subcommands are deliberately absent from the list above because they are not part of the day-to-day surface:
+Every subcommand `stella --help` lists has a page here, and a test asserts it: `every_subcommand_has_a_reference_page` in `stella-cli` diffs the live clap command tree against this section's `meta.json`, so a new subcommand cannot land undocumented.
 
-- `stella telemetry` (`status` / `flush` / `rollover-discard`) manages the managed enterprise operational spool. It is disabled by default and requires a signed org-managed enrollment — see the [Enterprise telemetry boundary](/docs/telemetry#oxagen-enterprise-managed-export).
-- `stella arena` is the [arena-bench](https://github.com/macanderson/arena-bench) harness adapter. It runs a benchmark task from a `--task-dir` and records the trace journal the arena runner scores; it is for benchmarking Stella, not for using it.
+Two of them are specialized rather than day-to-day. `stella arena` is a benchmark-harness adapter for measuring Stella, not for doing work with it; `stella telemetry` operates the managed enterprise spool and is disabled without a signed org-managed enrollment.
 
 ## Global flags
 

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -1,21 +1,24 @@
 ---
 title: stella memory
-description: Inspect memories through the citation feedback loop, validate them against the code, promote a proven one to a project rule, and forget the ones that turned out wrong.
+description: The full lifecycle of a memory — inspect it through the citation feedback loop, rewrite it, promote a proven one to a project rule, retire it reversibly, forget it when it was wrong, and compact or index the store behind it.
 ---
 
-Inspect the project's memories through the citation feedback loop — most-cited first, with usefulness and truthfulness — promote a proven memory to a project rule, and tombstone the ones that turned out wrong. It reads local state only and needs no API key.
+Inspect the project's memories through the citation feedback loop — most-cited first, with usefulness and truthfulness — promote a proven memory to a project rule, retire the ones that stopped earning their place, and tombstone the ones that turned out wrong. It reads local state only and needs no API key.
 
 For the concepts behind memories, reflections, and the code graph, see [Memory](/docs/context-engine). This page is the command reference.
 
 ## Synopsis
 
 ```bash
-stella memory <list|promote|validate|forget|restore|forgotten> [args]
+stella memory <list|edit|promote|validate> [args]
+stella memory <retire|reaffirm|retired> [args]
+stella memory <forget|restore|forgotten> [args]
+stella memory <compact|index> [flags]
 ```
 
 ## What it does
 
-As the agent works, it cites the memories that informed a turn via the `cite_memory` tool; those citations aggregate into a usefulness/truthfulness score per memory. `stella memory` is the inspection and promotion surface over that loop.
+As the agent works, it cites the memories that informed a turn via the `cite_memory` tool; those citations aggregate into a usefulness/truthfulness score per memory. `stella memory` is the inspection, editing, and lifecycle surface over that loop.
 
 ## Subcommands
 
@@ -29,6 +32,23 @@ stella memory list --format json
 ```
 
 `--format` accepts `table` (default, aligned) or `json`.
+
+### `stella memory edit <id> <text>`
+
+Rewrite a memory in place, as a **new revision of the same memory**.
+
+```bash
+stella memory edit nod_9f2c1a "the store API takes a workspace root, not a db path"
+```
+
+The old text becomes history rather than a competitor: one live record, the same id, and recall stops serving the words you replaced. Before memories had a lineage, changing one meant writing a second memory and leaving the first live — both citable, with nothing to say which was current.
+
+<Callout type="info">
+Each edit strands the previous revision's embedding vector, which nothing points at any more.
+That is exactly the class of row [`stella memory compact`](#stella-memory-compact) reclaims, so a
+workspace where memories are edited often is the one that benefits most from an occasional
+compaction.
+</Callout>
 
 ### `stella memory promote <id>`
 
@@ -76,6 +96,104 @@ than guessed. A confidently wrong edge teaches the graph something false; a
 missing one only costs a little recall precision.
 </Callout>
 
+## Retiring and forgetting
+
+Two different mechanisms, for two different situations, and choosing the wrong one is the most common mistake on this surface:
+
+<CardGrid size="md">
+  <SpecCard title="retire — it stopped earning its place">
+    The memory is not wrong; it simply stopped helping. It is excluded from **automatic**
+    selection but stays explicitly retrievable by id. Reverse with `reaffirm`.
+  </SpecCard>
+  <SpecCard title="forget — it was wrong">
+    The memory should never come back. This writes a **tombstone** that also stops the
+    reflection loop re-learning a paraphrase of it. Reverse with `restore`.
+  </SpecCard>
+</CardGrid>
+
+### Three invariants
+
+These hold across everything in this section. They are load-bearing design constraints, not descriptions of current behavior that might drift:
+
+<CardGrid size="md">
+  <SpecCard title="Retirement is reversible">
+    Every retirement can be undone by `stella memory reaffirm <id>`. The retirement itself
+    stays on the ledger, **outranked by the later decision rather than erased** — so "why did
+    this come back?" remains answerable.
+  </SpecCard>
+  <SpecCard title="Nothing is ever deleted">
+    A retired record is excluded from automatic recall and stays explicitly retrievable by id.
+    Selection health is derived from immutable use and feedback records and rebuilds exactly;
+    nothing here is a stored counter that can drift.
+  </SpecCard>
+  <SpecCard title="The agent cannot talk itself into forgetting">
+    Citation feedback is recorded with the evaluation method `agent_self_report`, and that
+    method is **not pruning-eligible**. It may inform selection health; it may never drive a
+    retirement.
+  </SpecCard>
+</CardGrid>
+
+<Callout type="warn">
+The third invariant is the one most likely to be violated by a well-meaning change. A self-report
+that can retire its own subject is self-reinforcing: a model that *misreads* a memory reports it
+unhelpful, which retires it, which destroys the evidence that the reading was wrong. The loop is
+closed on purpose.
+
+It is enforced in one place — `ContextEvaluationMethod::is_pruning_eligible` reads the method to
+decide whether a verdict may retire a record. Retirement requires a human or a deterministic
+source. If you are wiring a new evidence source, that predicate is the seam to change, and
+widening it to admit self-reports is the change to refuse.
+</Callout>
+
+### `stella memory retire <id> --reason <why>`
+
+Stop selecting a memory automatically — reversibly.
+
+```bash
+stella memory retire nod_9f2c1a --reason "the pipeline it describes was replaced in 0.6"
+```
+
+`--reason` is **required**, and an empty one is rejected: a retirement with no legible cause is not auditable. Because citations cannot retire anything on their own, an explicit human judgement is currently the strongest available evidence tier — the loop shows its work, and a person decides.
+
+Some records refuse retirement outright:
+
+<CardGrid size="sm">
+  <OptionCard name="blocking">
+    A directive whose enforcement is `Blocking`.
+  </OptionCard>
+  <OptionCard name="user-confirmed">
+    A record a **user** confirmed. Checked on the action, not the actor — a system
+    auto-activation is not a confirmation and stays retirable.
+  </OptionCard>
+  <OptionCard name="published">
+    A record that has been published.
+  </OptionCard>
+  <OptionCard name="already retired">
+    Retiring twice is refused rather than written as a second event.
+  </OptionCard>
+</CardGrid>
+
+### `stella memory reaffirm <id>`
+
+Put a retired record back into automatic selection.
+
+```bash
+stella memory reaffirm nod_9f2c1a
+stella memory reaffirm nod_9f2c1a --reason "still the only note on the legacy path"
+```
+
+`--reason` is optional and defaults to a plain "reaffirmed by the user". Reaffirming something that was never retired is **refused** rather than recorded — a no-op event sitting in the log would claim a reversal that never happened.
+
+### `stella memory retired`
+
+List what this workspace stopped selecting, and why.
+
+```bash
+stella memory retired
+```
+
+Each row carries the recorded `reason`, the **evidence** behind the decision (how many assessed uses were not helpful, out of how many, across how many distinct tasks), and the exact `reaffirm` command that restores it. Output is sorted, so two runs print the same thing — the same determinism the underlying fold guarantees.
+
 ### `stella memory forget <id>`
 
 Stop a memory steering the agent — and stop the reflection loop re-learning it.
@@ -116,4 +234,74 @@ stella memory forgotten
 them they are the maintenance pass for a memory store that has drifted — `validate` to
 find memories pointing at code that no longer exists, `forget` to retire the ones that
 turned out to be wrong rather than merely stale.
+</Callout>
+
+## Maintaining the store
+
+These two act on `.stella/private/context.db` — the derived index behind recall — rather than on the memories themselves. Neither is required for correctness; both are performance work.
+
+### `stella memory compact`
+
+Reclaim space by dropping **derived index rows whose owner is already gone**.
+
+```bash
+stella memory compact --dry-run
+stella memory compact
+stella memory compact --stale-fingerprints --vacuum
+```
+
+Two classes qualify: embedding vectors that no memory, node, or episode points at (every `stella memory edit` strands one), and domain tags pointing at rows that no longer exist.
+
+<Callout type="info">
+Memories, episodes, facts, and forget tombstones are **never touched**. Point-in-time queries
+answer identically before and after a compaction — which is what makes this safe to run on a
+schedule.
+</Callout>
+
+<CardGrid size="sm">
+  <OptionCard name="--dry-run">
+    Report what would be reclaimed without deleting anything.
+  </OptionCard>
+  <OptionCard name="--stale-fingerprints">
+    Also drop vectors written under an embedder other than the active one. Recall already
+    ignores them, so this frees space today at the cost of a full re-embed if you ever switch
+    back.
+  </OptionCard>
+  <OptionCard name="--vacuum">
+    `VACUUM` afterwards to hand freed pages back to the filesystem. Also automatic for a large
+    compaction.
+  </OptionCard>
+</CardGrid>
+
+### `stella memory index`
+
+Build the approximate-similarity (IVF) index that recall can use instead of scoring every stored vector on every turn.
+
+```bash
+stella memory index --dry-run
+stella memory index
+stella memory index --drop
+```
+
+<Callout type="warn">
+This is **opt-in twice over**: this command builds the index, and `context.retrieval.ann_enabled`
+in `settings.json` is what lets a recall actually use it. An approximate index considers only a
+subset of the corpus, so it can miss a frame the exact scan would have found — which is why
+neither half is on by default.
+</Callout>
+
+<CardGrid size="sm">
+  <OptionCard name="--dry-run">
+    Report what would be built without writing anything.
+  </OptionCard>
+  <OptionCard name="--drop">
+    Remove the index. Recall reverts to the exact full scan — which is what it does by default
+    anyway.
+  </OptionCard>
+</CardGrid>
+
+<Callout type="info">
+Neither command creates a database as a side effect of being asked a question. A workspace that
+has never indexed anything reports that it has nothing to do, rather than materializing an empty
+`context.db` to say so.
 </Callout>

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Commands",
-  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "context", "proposals", "tune", "scoreboard", "stats", "usage", "cloud", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "completions", "version"]
+  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "context", "proposals", "tune", "scoreboard", "arena", "stats", "usage", "cloud", "telemetry", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "doctor", "completions", "version"]
 }

--- a/website/content/docs/commands/telemetry.mdx
+++ b/website/content/docs/commands/telemetry.mdx
@@ -1,0 +1,122 @@
+---
+title: stella telemetry
+description: Inspect, flush, or explicitly discard the managed Oxagen Enterprise operational spool. Disabled by default; requires a signed org-managed enrollment.
+---
+
+`stella telemetry` is the operator surface on the **managed Oxagen Enterprise operational spool** — the durable, owner-only queue that holds content-free execution rollups awaiting delivery to an org intake.
+
+It is **disabled by default**. Without a signed org-managed enrollment every subcommand prints `enterprise telemetry: disabled (no managed enrollment)` and exits successfully, having performed no network I/O and constructed no HTTP client.
+
+<Callout type="info">
+For the boundary itself — what the managed export may contain, what it structurally cannot, how enrollment is provisioned and verified — see [Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export). This page is the command reference.
+
+Nothing here concerns your **local** telemetry. That lives in `.stella/private/store.db`, never leaves the machine on its own, and is read by [`stella stats`](/docs/commands/stats) and the [Observatory](/docs/commands/observe).
+</Callout>
+
+## Synopsis
+
+```bash
+stella telemetry <status|flush|rollover-discard>
+```
+
+All three need **no model provider and no API key** — managed operational export is independent of your model configuration.
+
+## Subcommands
+
+### `stella telemetry status`
+
+Show enrollment state, what is queued, and every durable loss counter.
+
+```bash
+stella telemetry status
+```
+
+Unenrolled, it reports exactly that. Enrolled, it prints one line covering:
+
+<CardGrid size="md">
+  <OptionCard name="pending">
+    Rows and payload bytes queued for the **active** sink and awaiting delivery.
+  </OptionCard>
+  <OptionCard name="stranded">
+    Rows and bytes belonging to a **superseded** sink fingerprint. They will never be
+    delivered to the new sink — see [rollover](#rollover-is-not-delivery) below.
+  </OptionCard>
+  <OptionCard name="quarantine">
+    Rows quarantined as undecodable, with the diagnostic metadata bytes retained for them.
+  </OptionCard>
+  <OptionCard name="ledger_skipped">
+    Export-ledger rows skipped, broken out by cause: `missing_rollup`, `malformed_nonce`,
+    `malformed_rollup`.
+  </OptionCard>
+  <OptionCard name="physical">
+    On-disk size of the spool database. Reported **separately** from payload bytes because
+    SQLite pages, indexes, WAL/SHM, and quarantine metadata all make the file larger than the
+    payload bound.
+  </OptionCard>
+  <OptionCard name="dropped / corrupt_dropped / rollover_discarded">
+    The three cumulative loss counters — capacity eviction, corruption, and explicit rollover
+    discard. Each is durable and monotonic.
+  </OptionCard>
+</CardGrid>
+
+Invalid or expired managed configuration **fails with a diagnostic** rather than reporting an enrolled state. A seat that has silently stopped exporting is the failure this command exists to make visible.
+
+<Callout type="info">
+The loss counters are the reason `status` is worth reading rather than glancing at. Pending going to zero can mean "everything was delivered" or "everything was evicted" — only `dropped`, `corrupt_dropped`, and `rollover_discarded` distinguish the two.
+</Callout>
+
+### `stella telemetry flush`
+
+Attempt **one bounded delivery batch right now**, then report what moved.
+
+```bash
+stella telemetry flush
+```
+
+Prints the number sent, plus the resulting pending and dropped counts. The batch is bounded on every axis:
+
+<CardGrid size="sm">
+  <OptionCard name="≤ 50 events">
+    The per-batch event ceiling.
+  </OptionCard>
+  <OptionCard name="≤ 256 KiB">
+    The per-request payload ceiling.
+  </OptionCard>
+  <OptionCard name="30-second lease">
+    Rows are leased, not removed. A crashed flush releases them rather than losing them.
+  </OptionCard>
+</CardGrid>
+
+Delivery is **at least once and sink-scoped**: rows are acknowledged only after a successful HTTPS response, and redirects are refused. A credential, transport, or server failure releases the *exact* lease with capped exponential backoff plus jitter — from one second up to five minutes, with jitter capped at 25%.
+
+<Callout type="info">
+Stella already starts a detached best-effort flush after enrollment is verified at process startup. That attempt never delays agent execution and is not waited on at shutdown. Use explicit `flush` when an operator needs a **synchronous** delivery attempt — before host maintenance, or to confirm an intake change took effect.
+</Callout>
+
+### `stella telemetry rollover-discard`
+
+Explicitly and permanently discard rows bound to a **superseded** sink fingerprint.
+
+```bash
+stella telemetry rollover-discard
+```
+
+<Callout type="warn">
+This is the one **destructive** subcommand. It deletes stranded rows outright and increments the durable `rollover_discarded` counter by the number removed. There is no undo, and the rows were never delivered anywhere.
+</Callout>
+
+#### Rollover is not delivery
+
+When the signed sink fingerprint changes, rows queued for the old sink are **not** re-pointed at the new one. Sending an org's rows to a sink it did not sign for would be a silent re-routing of its telemetry, so those rows become *stranded* instead. They stay stranded until either the old enrollment is restored — at which point they deliver normally — or an administrator runs this command.
+
+The discard is deliberately explicit and deliberately counted. Capacity eviction, corruption, and rollover loss each keep their own durable counter precisely so that none of them can be mistaken for successful delivery.
+
+## Exit behavior
+
+Being unenrolled is **not** an error: all three subcommands print the disabled line and exit `0`. That keeps the command safe to call unconditionally from an operator script without branching on whether a given host holds a seat. A *malformed or expired* enrollment, by contrast, is an error — the distinction is between "this host has no seat" and "this host has a seat that no longer works."
+
+## See also
+
+- [Enterprise telemetry boundary](/docs/telemetry#oxagen-enterprise-managed-export) — enrollment, the exported envelope, and what it structurally cannot contain.
+- [`stella stats`](/docs/commands/stats) — your local, non-managed cost and token metering.
+- [`stella cloud`](/docs/commands/cloud) — the separate `drain` pipe, with its own wire contract and endpoint.

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -13,6 +13,7 @@
     "agent-fleets",
     "agent-engine-paths",
     "agent-engine-in-your-app",
+    "self-improvement",
     "principles",
     "---Configure---",
     "configuration",

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -1,0 +1,194 @@
+---
+title: Self-improvement
+description: The track where Stella makes Stella measurably more capable — seven components, their dependency order, what is actually built today, and the guardrails that apply to all of them.
+---
+
+Most of what gets called agent "self-improvement" is recall: a note file the agent writes to and reads back. That is useful, and Stella does it — see [Memory](/docs/context-engine). It is also not the same thing as getting *better*.
+
+This track is the other thing. Each component below changes what Stella can do, not just what it remembers, and each one carries a **success metric and a guardrail** so that "improvement" is something proven rather than asserted.
+
+<Callout type="warn">
+**This page describes a direction, most of which is not built.** One first slice has shipped
+([`stella tune`](/docs/commands/tune)). Everything else is a design under active discussion in the
+issue tracker, and the details will change. Read it as a map of where Stella is heading, and check
+the linked issue for the current state of any one component.
+</Callout>
+
+## The shape of the problem
+
+Every component here answers the same question in a different place: *what would it take to make this improvement believable?* The failure mode being designed against is a system that reports its own progress — an agent that grades its own homework will always be improving.
+
+So the pattern repeats. A candidate change is generated cheaply, evaluated against a **held-out** set it did not train on, and promoted only on a measured lift. Nothing is promoted for being frequent, plausible, or recent.
+
+## The seven components
+
+<CardGrid size="md">
+  <SpecCard title="Tool Foundry (#830)">
+    Stella authors, tests, and installs its own tools at runtime. When it hits a capability gap
+    — the same shell incantation reconstructed three times — it synthesizes a typed tool, proves
+    it with a witness test, and registers it. Expands the *action space*, not just memory.
+  </SpecCard>
+  <SpecCard title="Eval-driven self-tuning (#831)">
+    A bandit over Stella's own prompts, policies, and model routing. Variants run A/B on real
+    tasks, scored from receipts; the winner is promoted. Optimizes the *policy that acts on
+    facts* rather than the facts.
+  </SpecCard>
+  <SpecCard title="stella-maintains-stella (#832)">
+    The most literal version: Stella audits its own source, opens gated draft PRs against
+    itself, drives them through the witness gate, and lands verified improvements behind a
+    human merge gate.
+  </SpecCard>
+  <SpecCard title="Experience distillation (#833)">
+    Turn repeated successful trajectories into parameterized Skills and evaluated few-shot
+    exemplar sets. A distilled Skill is a reusable *procedure*, not a recalled fact — and it is
+    promoted only on measured lift.
+  </SpecCard>
+  <SpecCard title="Causal self-model (#834)">
+    A model of Stella's own failure modes — wrong-model pick, tool-choice error, loop, budget
+    blow-out — that predicts the likely failure of the *current* plan and intervenes before it
+    costs a turn.
+  </SpecCard>
+  <SpecCard title="Capability curriculum (#835)">
+    Map the capability frontier from failed and low-confidence tasks, generate graded practice
+    tasks, attempt them in sandboxed worktrees under `verify`, and expand the *verified*
+    capability set. Self-directed practice.
+  </SpecCard>
+  <SpecCard title="Weight-space adapters (#836)">
+    The frontier item. Curate a redacted trajectory dataset, train and evaluate LoRA adapters
+    offline, and — gated by eval **and** human sign-off — promote one that measurably improves
+    behavior. Everything else improves the harness around a fixed model; this improves the
+    model.
+  </SpecCard>
+</CardGrid>
+
+## Dependency order
+
+Four of the seven form a spine, because each one needs the previous one's output to be judged at all. You cannot evaluate an adapter without an evaluator, and you cannot build an evaluator's training set without a dataset.
+
+```text
+  parallel — need nothing from the spine
+  ┌──────────────────────────┐   ┌──────────────────────────┐
+  │ #830 Tool Foundry        │   │ #835 Capability          │
+  │ authors new tools        │   │      curriculum (drills) │
+  └──────────────────────────┘   └──────────────────────────┘
+                │                            │
+                └──────── wins feed ─────────┤
+                                             ▼
+  the spine
+  ┌───────────────┐   ┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+  │ #872 dataset  │──▶│ #831 eval     │──▶│ #833 distill  │──▶│ #836 adapters │
+  │  trajectories │   │  A/B + gate   │   │ Skills/exemp. │   │  LoRA + eval  │
+  └───────────────┘   └───────────────┘   └───────────────┘   └───────────────┘
+                              ▲
+                              │ the same gate promotes everything above
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ #834 Causal self-model — predicts and preempts failures underneath it all │
+  └──────────────────────────────────────────────────────────────────────────┘
+
+  its own lane
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ #832 stella-maintains-stella — audit → gated draft self-PR → human merge  │
+  └──────────────────────────────────────────────────────────────────────────┘
+```
+
+The load-bearing edge is **dataset → eval**. #836's own stated first slice is "just the dataset + eval halves, no training" — prove you can *measure* an improvement before you try to *train* one. Every other promotion in the track reuses that same evaluator.
+
+## What is actually built today
+
+<CardGrid size="md">
+  <SpecCard title="Shipped — stella tune">
+    [`stella tune`](/docs/commands/tune) is #831's first slice: A/B one policy knob (worker
+    reasoning effort) over two loop-bench runs, promote the winner only when it confidently
+    wins, and keep a reversible rollback record. Offline, no API key.
+  </SpecCard>
+  <SpecCard title="Partly there — mining without the gate">
+    A rules miner ships and writes mined rules to `.stella/rules/`, and reflections are mined
+    into skills. Both promote on **frequency and recurrence**, not on measured lift. Adding
+    that gate is precisely what #833 is.
+  </SpecCard>
+  <SpecCard title="Exists, not wired — loop-bench">
+    `bench/loop-bench` works from the command line and is what `stella tune` scores. It does
+    **not** run in CI — the bench workflow runs the Python analysis tooling's pytest suite and
+    never runs Stella against a task. That gap is #873.
+  </SpecCard>
+  <SpecCard title="Not built — the dataset">
+    There is no `stella dataset export`. `stella export` dumps raw, unredacted session
+    telemetry for debugging, which is not a training-ready trajectory set. That is #872.
+  </SpecCard>
+</CardGrid>
+
+Nothing in #830, #832, #834, #835, or #836 is implemented.
+
+### The two first slices in flight
+
+<CardGrid size="sm">
+  <SpecCard title="#872 — stella dataset export">
+    One JSONL record per accepted turn — prompt, tool calls, accepted diff — scrubbed through
+    the existing redaction path, provenance stamped, with a manifest describing the extraction
+    filter so the dataset is reproducible and auditable.
+  </SpecCard>
+  <SpecCard title="#873 — nightly loop-bench gate">
+    A scheduled CI run of loop-bench against a fixed task pool on the cheapest model, failing
+    when the pass rate drops below a floor, with the report uploaded for trend tracking.
+  </SpecCard>
+</CardGrid>
+
+## Guardrails
+
+These are not per-component footnotes; they are the conditions under which any of this is allowed to ship. They repeat across all seven issues because they are the actual design.
+
+<CardGrid size="md">
+  <SpecCard title="Human sign-off on anything that sticks">
+    Self-authored PRs open as **drafts** and never auto-merge. An adapter is never promoted to
+    default without a person approving it. New self-authored tools land disabled behind the
+    same authority gate as any other capability.
+  </SpecCard>
+  <SpecCard title="Promotion requires measured lift on held-out data">
+    Never frequency, never plausibility, never recency. A promotion needs a statistically real
+    improvement on a task set the candidate did not see, plus no regression on a guard set.
+  </SpecCard>
+  <SpecCard title="Reversibility">
+    The prior state is kept, so every promotion can be rolled back — a prior config overlay, a
+    pinned and revertible adapter version, an auto-retired Skill that stopped helping.
+  </SpecCard>
+  <SpecCard title="Provenance and redaction">
+    Training data and distilled artifacts carry their lineage, and are scrubbed before they are
+    stored. Never train on secrets or PII. Publish the eval and the dataset lineage.
+  </SpecCard>
+  <SpecCard title="Advisory before autonomous">
+    Interventions warn before they act, and a firing intervention logs predicted versus actual
+    outcome so the predictor stays honest. **No silent plan changes on safety-relevant paths.**
+  </SpecCard>
+  <SpecCard title="Sandboxed practice">
+    Practice and drill runs are isolated in worktrees and budget-capped. Nothing from a practice
+    run touches the real workspace or ships without the same gate as ordinary work.
+  </SpecCard>
+</CardGrid>
+
+<Callout type="info">
+The reversibility and provenance guardrails are not new to this track — they are the same
+discipline the [memory lifecycle](/docs/commands/memory) already runs on, where retirement is
+reversible, nothing is ever deleted, and the agent's own self-reports are explicitly barred from
+driving a retirement. Self-improvement inherits that posture rather than inventing one.
+</Callout>
+
+## Following along
+
+Each component has an issue carrying its vision, grounded mechanism, success metric, guardrail, and first slice:
+
+- [#830 — Tool Foundry](https://github.com/macanderson/stella/issues/830)
+- [#831 — Eval-driven self-tuning](https://github.com/macanderson/stella/issues/831)
+- [#832 — stella-maintains-stella](https://github.com/macanderson/stella/issues/832)
+- [#833 — Experience distillation](https://github.com/macanderson/stella/issues/833)
+- [#834 — Causal self-model](https://github.com/macanderson/stella/issues/834)
+- [#835 — Capability curriculum](https://github.com/macanderson/stella/issues/835)
+- [#836 — Weight-space adapters](https://github.com/macanderson/stella/issues/836)
+
+First slices: [#872 — dataset export](https://github.com/macanderson/stella/issues/872), [#873 — nightly loop-bench gate](https://github.com/macanderson/stella/issues/873).
+
+## See also
+
+- [`stella tune`](/docs/commands/tune) — the one piece of this you can run today.
+- [Memory](/docs/context-engine) — the recall layer this track is explicitly *beyond*.
+- [Inference pipeline](/docs/inference-pipeline) — the witness and verify machinery every self-authored change has to pass.
+- [`stella scoreboard`](/docs/commands/scoreboard) — outcome measurement that deliberately refuses to ask the model how it did.


### PR DESCRIPTION
Closes #928. Closes #877.

## #928 — every subcommand has a page, and the gate now notices

Five of the seven surfaces #928 names (`ingest`, `proposals`, `tune`, `scoreboard`, `commands`) already landed in #989. The two that remained get pages here.

**`stella arena`** — the arena-bench adapter contract (`--task-dir`/`--journal`/`--state-dir`/`--resume`), and the design point worth writing down: the journal is appended *before* an event is admitted to the renderer, so a SIGKILL at any byte leaves a truthful prefix rather than a journal claiming work the run never committed to. Also covers the intended-once effect id, which is what makes the crash-replay oracle able to catch a duplicated edit.

**`stella telemetry`** — `status` / `flush` / `rollover-discard`, transcribed from `enterprise_telemetry.rs` and the store spool: the exact `status` field list, the 50-event / 256 KiB / 30-second lease, the 1s→5min backoff with jitter capped at 25%, and why `rollover-discard` is explicit and counted rather than silent. Links to `/docs/telemetry` for the boundary itself instead of duplicating it.

`commands/index.mdx` previously asserted these two were *deliberately* absent. That paragraph is replaced — both are now listed, noted as specialized rather than day-to-day.

### `stella memory` documented 6 of its 12 subcommands

Missing were `edit`, `retire`, `retired`, `reaffirm`, `compact`, and `index`. All twelve are now documented, and the page carries the three retirement invariants that until now lived **only in `release-notes.mdx`**:

1. retirement is reversible, and stays on the ledger outranked rather than erased;
2. nothing is ever deleted;
3. `agent_self_report` may inform selection health but must never drive a retirement.

The third is the one someone will violate by accident. It is enforced in exactly one place — `ContextEvaluationMethod::is_pruning_eligible` — so the page names that seam and says plainly that widening it to admit self-reports is the change to refuse. Release notes are not where you look before changing code.

### The gate

Two tests in `stella-cli/src/main_tests.rs`:

- **`every_subcommand_has_a_reference_page`** — diffs the live clap tree against `commands/meta.json` in *both* directions (a command with no page; a page whose command no longer exists), and checks each listed page's file actually exists.
- **`every_page_documents_all_of_its_commands_subcommands`** — asserts every nested subcommand appears literally as `stella <parent> <child>` on its parent's page. This is the check that would have caught the `memory` gap.

Both read the `Command` tree structurally via `CommandFactory` rather than parsing `--help` text, so terminal width, wrapping, and forced ANSI colour can't fool them — and they ride the existing `test` leg, so there's no new gate step to wire up.

**Both were mutation-tested.** Removing `stella memory index` from the page, and `arena` from `meta.json`, each produce the expected named failure. A gate that passes on day one is worth nothing until you've watched it fail.

## #877 — the self-improvement track

`website/content/docs/self-improvement.mdx` documents #830–#836: the seven components, the dependency spine (dataset → eval → distillation → adapter, with tool foundry and capability curriculum in parallel and the causal self-model underneath), and the six guardrails that recur across all seven issues.

The status section is deliberately honest rather than aspirational:

- **Shipped** — `stella tune` is #831's first slice.
- **Partly there** — a rules/skills miner ships, but promotes on recurrence *threshold*, not measured lift. Adding that gate is exactly what #833 is.
- **Exists, not wired** — loop-bench runs from the CLI but not in CI (#873); `bench.yml` only runs the Python pytest suite.
- **Not built** — there is no `stella dataset export` (#872).
- Nothing in #830, #832, #834, #835, or #836 is implemented, and the page says so.

Linked from the docs nav, and cross-referenced from `ROADMAP.md` — which is scoped to the verification pipeline, and is coupled to this track in one direction: every self-authored change has to clear that machinery.

## Two notes on the issues themselves

- **#928's counts are slightly off.** `stella memory` has **12** subcommands with **6** documented, not 13/7. The missing set it named was exactly right.
- **#877 has one acceptance criterion I could not meet.** It requires "the `docs:llms:check` CI gate passes (the page is reflected in `docs/llms.txt`)". There is no `llms.txt` and no such gate — zero matches for `llms` anywhere in the tree. Building that pipeline is a separate project from writing a docs page, so I left it unmet rather than inventing machinery. The other four criteria are met.

## ⚠️ `make gate` is red on main, for an unrelated reason

`make gate` fails at `file-size`:

```
stella-cli/src/command_deck.rs grew to 4642 lines, over its baseline ceiling of 4626 (+16)
```

`command_deck.rs` is **not touched by this PR**, and `git show origin/main:stella-cli/src/command_deck.rs | wc -l` is also 4642 — so `main` is already red on this ratchet. Because `file-size` runs early and the gate is fail-fast, it also **masks `format-check`, `lint`, and `test`**, which is worth knowing when reading any recent red gate.

I deliberately did **not** run `make file-size-update`. Folding someone else's +16 into a documentation PR would hide that growth from review, which is the exact thing the ratchet exists to catch. It wants a one-line fix from whoever owns that change. The push used `SKIP_GATE=1` for the same reason.

## Verification

- `make wire-schema doc-warnings format-check lint test` — **exit 0**, 80 suites `ok`, zero failures. (Run separately, since `file-size` masks them.)
- `pnpm build` in `website/` — clean, 89 static pages, all three new pages render.
- Both new tests pass, and fail correctly when mutated.
- `check-no-scratch`, `check-action-pins`, `check-doc-citations` (×2), `check-invariants` — all OK.

`Cargo.lock` syncs `stella-engine` and `stella-runtime` to 0.6.18 — drift already present on main.

## Summary by Sourcery

Document all remaining CLI surfaces, extend memory lifecycle docs, and add guardrails-backed self-improvement documentation while wiring tests that keep command references in sync with the live CLI.

New Features:
- Add full CLI reference for `stella arena` and `stella telemetry` commands, including behavior, flags, and usage guidance.
- Document the complete lifecycle and maintenance operations of `stella memory`, covering edit, retirement, forgetting, compaction, and indexing.
- Introduce a dedicated self-improvement roadmap page describing Stella's planned self-improvement track, components, dependencies, and guardrails.

Enhancements:
- Update the commands index and metadata so every top-level CLI subcommand is represented with a corresponding docs page, marking specialized surfaces as non-day-to-day.
- Clarify the main verification roadmap by linking it to the self-improvement track and explaining their one-way coupling.

Documentation:
- Expand user-facing documentation for memory management, enterprise telemetry, arena-bench integration, and the self-improvement track, with cross-links to related docs and commands.

Tests:
- Add CLI/gate tests ensuring every documented command has a real subcommand and every subcommand's nested variants are explicitly mentioned on its docs page.