### PR TITLE
fix(serve): a failed write is a disconnect, not a dead turn

### DIFF
--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -291,6 +291,32 @@ pub enum StreamEndReason {
     SessionEnded,
 }
 
+impl StreamEndReason {
+    /// Whether this ending means *the subscriber* went away while the turn
+    /// itself is still worth keeping — the condition for parking it rather than
+    /// cancelling it outright.
+    ///
+    /// Two reasons qualify, and they are two names for one event. A stream
+    /// reads the peer's half while it writes frames, so a subscriber that hangs
+    /// up is discovered by whichever of the two notices first: the read, as EOF
+    /// ([`Self::PeerDisconnected`]), or the next write, as a broken pipe
+    /// ([`Self::WriteFailed`]). Those races are decided by `tokio::select!`,
+    /// which polls its branches in a deliberately randomized order — so without
+    /// this, a coin flip inside the runtime decided whether a host that dropped
+    /// its connection could resume the turn it had already paid a model call
+    /// for, or got `404 unknown turn` on reconnect. The distinction is still
+    /// worth *recording* (a failed write says the socket died mid-frame, an EOF
+    /// says it closed cleanly); it is not worth a different lifecycle.
+    ///
+    /// Everything else is final. [`Self::StrayBytes`] is a peer that is very
+    /// much still there and speaking the protocol wrongly; the rest describe
+    /// the *turn* ending, and a finished turn has nothing left to resume.
+    #[must_use]
+    pub fn leaves_the_turn_resumable(self) -> bool {
+        matches!(self, Self::PeerDisconnected | Self::WriteFailed)
+    }
+}
+
 /// Which port raised a reverse request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -587,6 +613,49 @@ mod tests {
             assert_eq!(event, back, "round trip changed the value: {json}");
             let again = serde_json::to_string(&back).expect("re-serialize");
             assert_eq!(json, again, "round trip is not byte-stable");
+        }
+    }
+
+    /// A subscriber hanging up is *one* event with two names, because the
+    /// stream discovers it from whichever of its two halves touches the dead
+    /// socket first — the read, as EOF, or the next write, as a broken pipe.
+    /// Both must keep the turn resumable.
+    ///
+    /// This is the invariant, not a restatement of the implementation: the two
+    /// are raced by a `tokio::select!` that randomizes which branch it polls,
+    /// so when only `PeerDisconnected` parked the turn, a coin flip inside the
+    /// runtime decided whether a host that dropped its connection could resume
+    /// the turn it had already paid a model call for — the other side of the
+    /// flip cancelled it and answered the reconnect `404 unknown turn`.
+    #[test]
+    fn both_spellings_of_a_hang_up_keep_the_turn_resumable() {
+        assert!(StreamEndReason::PeerDisconnected.leaves_the_turn_resumable());
+        assert!(
+            StreamEndReason::WriteFailed.leaves_the_turn_resumable(),
+            "a write that failed because the subscriber is gone is that \
+             subscriber being gone, and must park the turn exactly as an EOF \
+             does — otherwise which of two ready select! branches the runtime \
+             happens to poll decides whether the turn survives"
+        );
+    }
+
+    /// The other half of the same rule: an ending that is *not* the peer going
+    /// away must stay final, or a settled turn would be parked — holding an OS
+    /// thread and a registry slot for a reconnect that has nothing to resume.
+    #[test]
+    fn an_ending_that_is_not_a_hang_up_is_final() {
+        for reason in [
+            StreamEndReason::TurnComplete,
+            StreamEndReason::ResumeWindowExpired,
+            StreamEndReason::SessionEnded,
+            // The peer is emphatically still there — it is talking, just
+            // wrongly. Nothing to wait for.
+            StreamEndReason::StrayBytes,
+        ] {
+            assert!(
+                !reason.leaves_the_turn_resumable(),
+                "{reason:?} does not describe a subscriber going away"
+            );
         }
     }
 

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -317,23 +317,37 @@ pub(crate) async fn handle_events(
     .await;
     res.add_bytes(bytes_out);
     record.set_turn(id);
-    state.observer().emit(&ServeEvent::StreamEnded {
-        turn,
-        frames_sent,
-        reason,
-    });
 
     // A peer that vanished may be back: park the session so a reconnect can
     // resume from its retained tail, and let the grace window — not this
     // connection — decide when the turn is definitively abandoned. Every other
     // ending is final, so the session drops here and `Drop for Session`
     // cancels the turn, releasing its thread now rather than at end of scope.
-    if reason == StreamEndReason::PeerDisconnected {
+    //
+    // Asked of the reason rather than compared against one variant: a hang-up
+    // surfaces as an EOF *or* as the failed write that follows it, whichever
+    // the `select!` in `stream_frames` happens to see first, and both have to
+    // land here. See `StreamEndReason::leaves_the_turn_resumable`.
+    if reason.leaves_the_turn_resumable() {
         state.park_for_resume(id, &entry, session, generation);
     } else {
         drop(session);
         state.turns().remove(id);
     }
+
+    // Announced *after* the turn has been disposed of, not before. The event is
+    // the only signal an observer gets that a subscriber went away, and the
+    // obvious thing to do with it is reconnect — so emitting it first published
+    // a moment in which the turn was neither streamed nor yet parked, and a
+    // reconnect arriving inside that window took the `replay_only` path: it got
+    // the retained tail and an immediately-closed stream, with no live source
+    // behind it. Ordering the emit last makes the event describe a state the
+    // server is already in, which is what makes acting on it deterministic.
+    state.observer().emit(&ServeEvent::StreamEnded {
+        turn,
+        frames_sent,
+        reason,
+    });
     res.stream_mut().shutdown().await
 }
 

--- a/stella-serve/tests/common/mod.rs
+++ b/stella-serve/tests/common/mod.rs
@@ -23,7 +23,9 @@ use std::time::Duration;
 
 use serde_json::json;
 use stella_protocol::{CompletionMessage, ToolSchema};
-use stella_serve::observe::{Capture, Fanout, Metrics, SharedObserver};
+use stella_serve::observe::{
+    Capture, Fanout, Metrics, ServeEvent, SharedObserver, StreamEndReason,
+};
 use stella_serve::{ServeConfig, serve};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -205,6 +207,44 @@ pub fn model_wants_echo() -> serde_json::Value {
 }
 
 // ── resumable streams (#971 phase 2) ──────────────────────────────────────
+
+/// Block until the server has noticed the subscriber went away and parked the
+/// turn, returning the reason it recorded.
+///
+/// Dropping a socket tells the *client* the stream is over; the server learns
+/// it whenever its own read or write next touches the dead connection. Until it
+/// does, the session is still checked out by the previous connection, and a
+/// reconnect is answered from the retained tail alone — a replay with no live
+/// source behind it, which is correct for a genuinely concurrent second
+/// subscriber and useless to a resuming one. Waiting for the server's own
+/// `StreamEnded` removes that race from every resume test: the emit is ordered
+/// after the turn is parked (see `routes::handle_events`), so observing it is a
+/// guarantee the session is back in its entry, not a hint that it soon will be.
+///
+/// The reason is asserted, not merely returned: a disconnect that ended the
+/// turn instead of parking it is exactly the regression these tests exist to
+/// catch, and it would otherwise surface as a puzzling timeout here.
+pub async fn await_parked_after_disconnect(capture: &Capture) -> StreamEndReason {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(ServeEvent::StreamEnded { reason, .. }) =
+            capture.find(|e| matches!(e, ServeEvent::StreamEnded { .. }))
+        {
+            assert!(
+                reason.leaves_the_turn_resumable(),
+                "a subscriber hanging up must leave the turn resumable, but the \
+                 server ended it with {reason:?} — the turn is gone and no \
+                 reconnect can recover it"
+            );
+            return reason;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the server never recorded the subscriber going away"
+        );
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+}
 
 /// Read one SSE event as `(id, payload)`, so a test can assert on the `id:`
 /// line a browser `EventSource` would use to resume.

--- a/stella-serve/tests/resume.rs
+++ b/stella-serve/tests/resume.rs
@@ -59,7 +59,7 @@ async fn every_frame_carries_a_monotonic_seq_in_the_payload_and_the_sse_id() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_reconnect_replays_the_frames_it_missed_and_the_turn_survives() {
     // A window long enough that the reconnect below is comfortably inside it.
-    let (addr, _capture) = start_observed_server_with(Duration::from_secs(10)).await;
+    let (addr, capture) = start_observed_server_with(Duration::from_secs(10)).await;
     let turn_id = create_turn(addr).await;
     let events_path = format!("/v1/turns/{turn_id}/events");
 
@@ -70,6 +70,12 @@ async fn a_reconnect_replays_the_frames_it_missed_and_the_turn_survives() {
         .expect("the turn produces a first frame");
     let resume_from = first_id.expect("every frame carries an id");
     drop(sse);
+
+    // Resuming means picking a *parked* turn back up, so wait for the server to
+    // have parked it. Racing that tests something else entirely — a second
+    // subscriber arriving while the first is still attached, which is answered
+    // from the retained tail with no live stream behind it.
+    await_parked_after_disconnect(&capture).await;
 
     // Reconnect asking for the WHOLE retained stream (`after=0`), not merely
     // what followed the frame already seen.
@@ -141,7 +147,7 @@ async fn a_reconnect_replays_the_frames_it_missed_and_the_turn_survives() {
 /// the web host — the one this server exists for — resume with no client code.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn last_event_id_resumes_the_same_way_the_after_query_does() {
-    let (addr, _capture) = start_observed_server_with(Duration::from_secs(10)).await;
+    let (addr, capture) = start_observed_server_with(Duration::from_secs(10)).await;
     let turn_id = create_turn(addr).await;
     let events_path = format!("/v1/turns/{turn_id}/events");
 
@@ -151,6 +157,7 @@ async fn last_event_id_resumes_the_same_way_the_after_query_does() {
         .expect("the turn produces a first frame");
     let resume_from = first_id.expect("every frame carries an id");
     drop(sse);
+    await_parked_after_disconnect(&capture).await;
 
     let mut sse = open_sse_resuming(addr, &events_path, TOKEN, resume_from).await;
     let (_, event) = next_event_with_id(&mut sse)


### PR DESCRIPTION
## The symptom

`cargo test --workspace` fails on `stella-serve`'s
`a_reconnect_replays_the_frames_it_missed_and_the_turn_survives` roughly one run
in eight on a two-core Linux runner. It took down [#997]'s CI; it is on main now
and will keep taking down other branches' CI at the same rate.

The assertion is the unhelpful kind — the reconnect delivered *no* frames at
all, so the value is `None` rather than a wrong number:

```
assertion `left == right` failed: a resume from 0 must replay the retained
stream from its very first frame, or the client cannot rebuild the turn it lost
  left: None
 right: Some(1)
```

It does not reproduce on macOS. Reproduced in a two-CPU Linux container at
**18/150**, then instrumented to capture what the reconnect actually received:

```
--- raw response ---              --- stream events ---
HTTP/1.1 404 Not Found            StreamEnded(WriteFailed, frames_sent=1)
{"error":"unknown turn"}
```

The turn was gone.

## Why

`stream_frames` watches two things at once: the peer's read half — so a host
that vanishes while a turn is parked on a reverse request is noticed rather
than waited on — and the next frame to write. When a subscriber hangs up with a
frame already queued, **both branches are ready**, and `tokio::select!` polls
its branches in a deliberately randomized order.

- Take the read: EOF, the stream ends `PeerDisconnected`, and the turn is
  parked for the resume window.
- Take the frame: the write lands on a closed socket, the stream ends
  `WriteFailed` — which fell through to the arm that runs
  `state.turns().remove(id)` and drops the session, cancelling the turn.

So a coin flip inside the runtime decided whether a host that dropped its
connection could resume the turn it had already paid a model call for. That is
the precise failure resumable SSE exists to prevent, reachable by a client
doing nothing wrong. The test was catching a real bug, not being flaky.

macOS hides it: on ten cores the queued frame is delivered before the drop, so
the two branches are never ready together.

## The fix

**A hang-up is one event with two names.** The stream discovers it from
whichever half touches the dead socket first — as an EOF, or as the broken pipe
that follows. `StreamEndReason::leaves_the_turn_resumable` says that once, on
the type, so a variant added later has to answer the question rather than
inherit an answer from an `==` against a single variant. The distinction stays
worth *recording* — a failed write says the socket died mid-frame — it is just
not worth a different lifecycle. `StrayBytes` stays final: that peer is very
much still there, speaking the protocol wrongly.

**A second race, which the first fix uncovered.** `handle_events` emitted
`StreamEnded` *before* disposing of the turn, publishing a window in which it
was neither streamed nor yet parked. The obvious thing to do with that event is
reconnect, and a reconnect inside the window takes the `replay_only` path — the
retained tail and an immediately-closed stream, which is correct for a genuinely
concurrent second subscriber and useless to a resuming one. Emitting after the
disposal makes the event describe a state the server is already in, which is
what makes acting on it deterministic. The resume tests then wait for it instead
of racing it, through the `Capture` they were already building and discarding as
`_capture`.

## Measured

Two-core Linux container, 150 runs of the resume binary each time:

| | failures |
|---|---|
| before | **18 / 150** |
| parking fix only | **15 / 150** — the 404 gone, the ordering race left |
| both | **0 / 150** |

Full `stella-serve` suite: **0/25** there, green on macOS, and `make gate` green
locally (it runs on push).

## Tests

Two unit tests pin the rule in both directions — that both spellings of a
hang-up keep the turn resumable, and that an ending which is *not* a hang-up
stays final, so a settled turn is never parked holding an OS thread for a
reconnect with nothing to resume.

[#997]: https://github.com/macanderson/stella/pull/997

## Summary by Sourcery

Treat both peer disconnect and failed writes as resumable stream endings, and ensure stream end events are emitted only after turns are parked or cancelled to remove reconnection races.

Bug Fixes:
- Prevent turns from being incorrectly cancelled when a subscriber disconnects during a write by treating the failure as a resumable hang-up.
- Eliminate a race where reconnects could occur before a disconnected turn was parked, leading to stale replay-only streams.

Enhancements:
- Introduce a `StreamEndReason::leaves_the_turn_resumable` helper to centralize resumability decisions for stream endings.
- Add an await helper for tests to block until the server has recorded a disconnect and parked the turn, making resume behavior deterministic.

Tests:
- Add unit tests validating which stream end reasons leave turns resumable versus final.
- Update resume integration tests to wait for the server to park turns after disconnect before reconnecting.