### PR TITLE
fix(config): `migrate config` must not write a secret into the committed file

### DIFF
--- a/docs/design/config-system/DESIGN.md
+++ b/docs/design/config-system/DESIGN.md
@@ -415,10 +415,20 @@ predates the field is version 1 by definition.
 It is tolerable in `.stella/settings.json`. It is not tolerable in a file
 sitting next to `README.md`.
 
-**Decision:** `api_key` at **project scope** becomes a load-time error naming
+**Decision:** `api_key` at **project scope** becomes an error naming
 `credentials.toml` and `api_key_env` as the two right answers. At user and
 managed scope it keeps working unchanged. Credentials never merge into
 `stella.toml` at any scope.
+
+The rule is enforced on **every path that reads or writes** a project
+`stella.toml`, from one definition (`TomlConfig::validate_project_secrets`) —
+not on load alone. Specifying it as load-only is what let the first
+implementation ship a hole: `stella migrate config` serializes `providers`
+verbatim, so with the check only in the loader it copied a key out of
+`.stella/settings.json` into the committed file *and* produced a config the
+loader then refused to read. A refusal that only fires after the secret is
+already written is not a refusal. Any future writer of this file consults the
+same method, before the write.
 
 ### 6.3 Retire bare root scalars
 
@@ -542,7 +552,7 @@ more code, for a shape that reads worse. Keyed tables throughout.
 | **Comment loss on save** silently deletes the migration's whole value | `toml_edit` + a round-trip test asserting comments and key order survive; build this first (§3.1) |
 | **Trust model quietly weakened** by "simplifying" the scope chain | Port `merge_captured_scopes` unchanged; the existing trust tests must pass against TOML fixtures with no assertion edits |
 | **Two config files both present**, silently composing | Never merge; warn once naming both paths (§6.1) |
-| **Secrets committed** now that the file is at the repo root | `api_key` is a load error at project scope (§6.2) |
+| **Secrets committed** now that the file is at the repo root | `api_key` is an error at project scope on both the load and the migration path, from one shared check (§6.2) |
 | **Per-agent tool scope grants rather than narrows** | `ToolPolicy::intersect` + a property test that the result is never more permissive than either input (§4.4) |
 | **Fallback corrupts cost attribution** | Record resolved provider + model id per call, not the configured intent (§4.2) |
 | **Opened agent set turns silent-ignore into silent-orphan** | Flag agent names no `task` call or pipeline stage references (§4.1) |

--- a/stella-cli/src/settings/migrate.rs
+++ b/stella-cli/src/settings/migrate.rs
@@ -27,6 +27,7 @@ use super::toml_config::{self, CURRENT_SCHEMA_VERSION, ConfigScope};
 use super::{Settings, toml_io};
 
 /// One scope's migration outcome, for the report.
+#[derive(Debug)]
 pub enum Outcome {
     /// No `settings.json` at this scope — nothing to do.
     NothingToDo,
@@ -155,6 +156,28 @@ pub fn migrate_scope(
     // with their working config already shadowed by the broken one.
     let reparsed = toml_config::TomlConfig::parse(&rendered, toml_path)?;
     reparsed.validate_meta(toml_path, scope)?;
+    // A project-scope `stella.toml` lives at the repo root and is committed, so
+    // the loader refuses an inline `api_key` there. Apply the SAME rule before
+    // writing: `render` serializes `providers` verbatim, so without this a key
+    // sitting in `.stella/settings.json` would be copied into the committed
+    // file — leaking it — and produce a config stella then refuses to load.
+    //
+    // The refusal happens BEFORE `write_settings`, so the secret never reaches
+    // disk. The loader's message names `toml_path`, which does not exist yet at
+    // this point, so name the file the secret is actually in — that is the one
+    // the user has to edit. Scoped to THIS file rather than "nothing was
+    // written", because `run` migrates the user scope first and has already
+    // printed what it wrote by the time the project scope is refused.
+    reparsed
+        .validate_project_secrets(toml_path, scope)
+        .map_err(|err| {
+            format!(
+                "{err}\nThe key is in {} — move it out of that file, then re-run \
+                 `stella migrate config`. {} was not written.",
+                json_path.display(),
+                toml_path.display()
+            )
+        })?;
 
     if !dry_run {
         let user_private = scope == ConfigScope::User;

--- a/stella-cli/src/settings/toml_config.rs
+++ b/stella-cli/src/settings/toml_config.rs
@@ -261,6 +261,37 @@ impl TomlConfig {
         Ok(())
     }
 
+    /// Refuse an inline `providers.<id>.api_key` at the project scope.
+    ///
+    /// `<repo>/stella.toml` lives at the repository root and is meant to be
+    /// committed and reviewed like source, so a literal secret in it leaks into
+    /// version control. The rule is enforced on BOTH the load path and the
+    /// migration path from one definition here — when only the loader had it,
+    /// `stella migrate config` would happily copy a key out of
+    /// `.stella/settings.json` into the committed file and then produce a
+    /// config stella refuses to read on the next launch.
+    ///
+    /// The offending value is never echoed: the message names the provider and
+    /// the file, so it stays safe to paste into an issue.
+    pub fn validate_project_secrets(&self, path: &Path, scope: ConfigScope) -> Result<(), String> {
+        if scope != ConfigScope::Project {
+            return Ok(());
+        }
+        for (id, entry) in &self.providers {
+            if entry.api_key.is_some() {
+                return Err(format!(
+                    "config file {}: providers.{id}.api_key is a literal secret in a \
+                     file that belongs in version control. Use `api_key_env = \"...\"` \
+                     to name an environment variable, or run \
+                     `stella auth set {id}` to store the key in \
+                     ~/.stella/credentials.toml (owner-only).",
+                    path.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Lower this document into the [`Settings`] the merge chain consumes, plus
     /// the MCP servers it declared (empty when the document has no
     /// `[mcp.servers]`, which is how a workspace keeps using `.stella/mcp.toml`
@@ -369,21 +400,9 @@ pub fn load_toml_scope(
     // ever was, so the one field that was tolerable purely through obscurity
     // stops being tolerable. Env-var indirection and the 0600 credentials file
     // both already exist; this is a refusal with two named alternatives, not a
-    // capability being removed.
-    if scope == ConfigScope::Project {
-        for (id, entry) in &parsed.providers {
-            if entry.api_key.is_some() {
-                return Err(format!(
-                    "config file {}: providers.{id}.api_key is a literal secret in a \
-                     file that belongs in version control. Use `api_key_env = \"...\"` \
-                     to name an environment variable, or run \
-                     `stella auth set {id}` to store the key in \
-                     ~/.stella/credentials.toml (owner-only).",
-                    path.display()
-                ));
-            }
-        }
-    }
+    // capability being removed. `stella migrate config` applies the same rule
+    // before it writes, so the two paths cannot disagree about what is legal.
+    parsed.validate_project_secrets(path, scope)?;
 
     let mut warnings = Vec::new();
     let server_count = parsed

--- a/stella-cli/src/settings/toml_tests.rs
+++ b/stella-cli/src/settings/toml_tests.rs
@@ -721,6 +721,118 @@ fn a_migrated_file_round_trips_through_a_section_save() {
     );
 }
 
+/// A project `settings.json` holding an inline `api_key`.
+const PROJECT_SETTINGS_WITH_SECRET: &str = r#"{
+  "providers": {
+    "anthropic": {"api_key": "sk-secret", "default_model": "claude-fable-5"}
+  }
+}"#;
+
+/// The security regression. `render` serializes `providers` verbatim and the
+/// loader refuses an inline `api_key` at the project scope, so a migration that
+/// skipped that rule would write the secret into the committed repo-root file
+/// AND produce a config stella then refuses to load. Both halves are asserted:
+/// the refusal, and that nothing reached disk.
+#[test]
+fn migrating_an_inline_api_key_to_project_scope_is_refused_and_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = write(dir.path(), "settings.json", PROJECT_SETTINGS_WITH_SECRET);
+    let toml_path = dir.path().join("stella.toml");
+
+    let err = super::migrate::migrate_scope(&json, &toml_path, ConfigScope::Project, false)
+        .expect_err("a committed file must not receive a literal secret");
+
+    // The secret never reaches the filesystem — not even partially written.
+    assert!(
+        !toml_path.exists(),
+        "refusal must leave no file behind: {}",
+        toml_path.display()
+    );
+    // Same two alternatives the loader names, so the advice cannot diverge.
+    assert!(err.contains("api_key_env"), "{err}");
+    assert!(err.contains("credentials.toml"), "{err}");
+    // And the file the user has to actually edit, which is the JSON — the
+    // stella.toml the loader's message names does not exist yet.
+    assert!(err.contains("settings.json"), "names the source: {err}");
+    // The secret itself is never echoed, so the error stays safe to paste.
+    assert!(!err.contains("sk-secret"), "the key is not echoed: {err}");
+}
+
+/// Why the check above is load-bearing rather than defensive: `render` is a
+/// pure serializer with no opinion about secrets, and `api_key` is
+/// `skip_serializing_if = "Option::is_none"`, so a key that is present IS
+/// written. This pins that — if `render` ever stopped emitting it, the guard
+/// would silently become untested rather than unnecessary.
+#[test]
+fn render_itself_would_write_the_secret_if_nothing_stopped_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = write(dir.path(), "settings.json", PROJECT_SETTINGS_WITH_SECRET);
+    let settings = Settings::load_scope(&json).unwrap();
+
+    let rendered = super::migrate::render(&settings, ConfigScope::Project).unwrap();
+
+    assert!(
+        rendered.contains("sk-secret"),
+        "render emits the key verbatim; only the guard keeps it off disk:\n{rendered}"
+    );
+}
+
+/// `--dry-run` reports what a real run WOULD do, so it has to fail here too. A
+/// dry run that printed "would write" for a config the real run refuses would
+/// be the one output the user trusts before committing.
+#[test]
+fn a_dry_run_refuses_the_same_project_scope_secret() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = write(dir.path(), "settings.json", PROJECT_SETTINGS_WITH_SECRET);
+    let toml_path = dir.path().join("stella.toml");
+
+    assert!(super::migrate::migrate_scope(&json, &toml_path, ConfigScope::Project, true).is_err());
+    assert!(!toml_path.exists());
+}
+
+/// The rule is scoped to the committed file, not to secrets in general.
+/// `~/.stella/stella.toml` is private and 0600, and the loader accepts an
+/// inline key there — so migration must keep working, or users with a
+/// perfectly legal user-scope key could never migrate at all.
+#[test]
+fn migrating_an_inline_api_key_to_user_scope_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = write(dir.path(), "settings.json", PROJECT_SETTINGS_WITH_SECRET);
+    let toml_path = dir.path().join("stella.toml");
+
+    super::migrate::migrate_scope(&json, &toml_path, ConfigScope::User, false).unwrap();
+
+    let settings = load_toml(&toml_path, ConfigScope::User).unwrap();
+    assert_eq!(
+        settings.providers["anthropic"].api_key.as_deref(),
+        Some("sk-secret")
+    );
+}
+
+/// The general invariant the specific tests above are instances of: whatever
+/// migration writes, the loader can read back at the same scope.
+#[test]
+fn a_migration_that_succeeds_always_produces_a_loadable_file() {
+    for (scope, body) in [
+        (ConfigScope::User, PROJECT_SETTINGS_WITH_SECRET),
+        (ConfigScope::Project, PROJECT_SETTINGS_WITH_SECRET),
+        (ConfigScope::User, RICH_SETTINGS),
+        (ConfigScope::Project, RICH_SETTINGS),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let json = write(dir.path(), "settings.json", body);
+        let toml_path = dir.path().join("stella.toml");
+
+        if super::migrate::migrate_scope(&json, &toml_path, scope, false).is_err() {
+            // A refusal is a valid outcome; it just must not have written.
+            assert!(!toml_path.exists(), "{scope:?} refused but wrote a file");
+            continue;
+        }
+        load_toml(&toml_path, scope)
+            .unwrap_or_else(|e| panic!("{scope:?} migrated to an unloadable file: {e}"));
+    }
+}
+
 /// The engine config splits across two sections, so clearing it has to remove
 /// both — a stale `[models]` left behind would keep narrowing the vocabulary
 /// after the user cleared the setting that created it.


### PR DESCRIPTION
## What & why

`stella migrate config` wrote a live credential into a file that is meant to be
committed, and then produced a config the loader refuses to read.

`<repo>/stella.toml` lives at the repository root and is reviewed like source, so
`load_toml_scope` has always rejected an inline `providers.<id>.api_key` at project
scope. That rule lived in exactly one place — the **read** path. The **write** path
never had it:

- `render()` serializes `settings.providers` verbatim via `toml_io::item_for`, and
  `ProviderSettings::api_key` is `#[serde(skip_serializing_if = "Option::is_none")]`,
  so a key that is present *is* written.
- `migrate_scope` ran only `TomlConfig::parse` + `validate_meta`. Neither looks at
  secrets.

**Concrete trigger.** A user whose `.stella/settings.json` contains
`{"providers": {"anthropic": {"api_key": "sk-…"}}}` runs `stella migrate config`.
`run()` migrates the project scope into `workspace_root.join("stella.toml")`:

1. Migration reports success and writes the plaintext key into the repo-root file —
   a credential leaked into version control.
2. On the next launch `load_scope_dual` prefers the TOML, `load_toml_scope` rejects
   the inline project-scope `api_key`, and stella will not start.

The user is left with a committed secret *and* a CLI that won't run.

## The fix

Extract the check as `TomlConfig::validate_project_secrets(path, scope)` and call it
from **both** paths. `load_toml_scope`'s behavior is unchanged — same logic, same
error string, now shared rather than inlined.

Migration applies it after rendering and **before** `write_settings`, so a refusal
leaves nothing on disk: the file is never created, rather than created-then-rejected.

Details worth a reviewer's eye:

- **`--dry-run` refuses too.** The check sits above the `if !dry_run` block. A dry run
  that printed "would write" for a config the real run refuses is precisely the output
  a user trusts before committing.
- **The error names the source JSON.** The loader's message names the `stella.toml`,
  which does not exist yet at migration time — so on its own it would send the user to
  a nonexistent file. The migration wraps it with the `settings.json` the key is
  actually in.
- **Scoped wording.** It says "`<path>` was not written", not "nothing was written",
  because `run()` migrates the user scope first and has already printed what it wrote
  by the time the project scope is refused.
- **The secret is never echoed**, so the error stays safe to paste into an issue.
- **User scope is untouched.** `~/.stella/stella.toml` is private and 0600 and the
  loader accepts an inline key there, so migration must keep working — otherwise users
  with a perfectly legal user-scope key could never migrate at all.

`migrate.rs:69` is the only place in the tree that serializes `providers` into a TOML
document (checked against every `item_for`/`save_sections` call site), so this closes
the whole gap rather than one instance.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`migrating_an_inline_api_key_to_project_scope_is_refused_and_writes_nothing` — on
`main`, `migrate_scope` returns `Ok` and the `expect_err` panics; the assertion that no
file was left behind fails too, because the secret is on disk.

Six tests in `stella-cli/src/settings/toml_tests.rs`:

| Test | Pins |
| --- | --- |
| `migrating_an_inline_api_key_to_project_scope_is_refused_and_writes_nothing` | the refusal, that no file is left behind, that both alternatives and the source are named, and that the key is not echoed |
| `render_itself_would_write_the_secret_if_nothing_stopped_it` | that `render` *does* emit the key — so the guard cannot silently become untested if that ever changes |
| `a_dry_run_refuses_the_same_project_scope_secret` | `--dry-run` agrees with the real run |
| `migrating_an_inline_api_key_to_user_scope_still_works` | the rule is scoped to the committed file, not to secrets in general |
| `a_migration_that_succeeds_always_produces_a_loadable_file` | the general invariant: whatever migration writes, the loader reads back at the same scope |
| (existing) `an_inline_api_key_is_refused_at_project_scope_with_both_alternatives_named` | the loader's behavior is unchanged by the extraction |

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — `make gate` exit 0, 80 test binaries, 0 failures
- [x] Docs updated where behavior changed

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The design doc is where the bug came from.** `docs/design/config-system/DESIGN.md`
§6.2 specified this as a "**load-time** error", and the risk table said "`api_key` is a
load error at project scope". An implementer reading that has no reason to touch the
writer. §6.2 now specifies every path that reads *or writes* the file, from one
definition, and says why — so the same hole is harder to reintroduce.

`#[derive(Debug)]` on `migrate::Outcome` is incidental: `expect_err` requires it.

Deliberately not changed: a project-scope refusal still aborts the whole
`stella migrate config` via `?` after the user scope has already been written and
printed. That is pre-existing control flow, it is loud rather than silent, and the
error now names exactly which file was skipped — narrowing it to a per-scope
report felt like a separate change.

## Summary by Sourcery

Prevent project-scope config migration from writing inline API keys into committed TOML and align migration with loader secret validation.

Bug Fixes:
- Ensure project-scope config migration refuses inline provider API keys before writing, preventing secrets from being committed and avoiding creation of configs the loader will not accept.

Enhancements:
- Share project-scope secret validation between loader and migration paths via TomlConfig::validate_project_secrets, and improve error messaging to point back to the JSON source and clarify which files were or were not written.

Documentation:
- Update config-system design documentation to specify that project-scope api_key is rejected on both load and migration paths from a single shared check.

Tests:
- Add regression tests covering refusal to migrate inline project-scope API keys without touching disk, dry-run behavior, continued support for user-scope inline keys, and the invariant that successful migrations always produce loadable TOML files.