### PR TITLE
fix(bench): effort `max`, matching the comparator the protocol designates (#1007)

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -124,10 +124,10 @@ every other digest is an external dataset/comparator/fixture value, unchanged).
 
    | model | frozen (stale) | recomputed 0.5.1 |
    |---|---|---|
-   | deepseek-v4-pro | `fb18233a…` | `1740fa2f3f1bea66c348c7ffca151f526019ef0278829d23acb391e7b2f07159` |
-   | z-ai/glm-5.2 | `de2a3109…` | `9b94f231d91e66c9793e2f61dd8c6edbb4472ea38e431681b5e854d9d22191ea` |
-   | x-ai/grok-4.5 | `f43d8a25…` | `3c7d61553b7a4665ed974e6b32a7a20c1f8c59acaae2bcab3848eec2a39ca8dc` |
-   | z-ai/glm-5.1 (primary) | — (manifest-generated at freeze) | `55fdf3421ae4c8625ab8bdedb11a59867b6d81a20ad378a2080e7e944229f4bd` |
+   | deepseek-v4-pro | `fb18233a…` | `0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2` |
+   | z-ai/glm-5.2 | `de2a3109…` | `a0ab8a753a4ffaf7eff5a4ec051f2e6ba3daef38bfb7455af07a634ebde7a407` |
+   | x-ai/grok-4.5 | `f43d8a25…` | `ff61cb0609f4649df922fb19715bea826121c6eeaad72be9a0f4db20a4a1ea0e` |
+   | z-ai/glm-5.1 (primary) | — (manifest-generated at freeze) | `f15536e5d532d981cf16606c026bca65c3ce60ee08b2a0402b6660e0468cecf4` |
 
    Updated in: protocol calibration table, protocol posture prose,
    `terminal_bench_analysis/README.md` example, and the adapter test assertion.
@@ -302,6 +302,33 @@ the relaunch is a fresh job name rather than a resume. The fix is to pre-pull al
 89 task images with retries first, making image availability a **precondition**
 of the run instead of a term in the measurement. Any future runner on a
 consumer network should do the same.
+
+### 8.5 Effort was `high` against a `max` comparator (#1007)
+
+The posture froze `effort: high` for default/worker/judge. The comparator this
+benchmark is scored against is *"Claude Code using GLM-5.1 at **max effort**"*
+(protocol §Comparator and thresholds), and the public leaderboard carries
+`high`, `xhigh` and `max` as distinct values — so this was not a naming
+variation, it was **less compute applied to one side only**.
+
+Every Terminal-Bench number published before this change was produced under that
+handicap, including the retracted run on [#1002](https://github.com/macanderson/stella/issues/1002).
+
+Fixed: default/worker/judge now use `max`. `triage` stays `low`/`off` — it emits
+a three-line classification and never edits the workspace, so raising it would
+change what Stella *is* rather than what it was allowed to spend.
+
+The posture digests move as a result, exactly as they did when #322 added
+`headless_scope_bypass`. Recomputed via the adapter's own
+`_benchmark_engine_posture`, so a hand-written value cannot diverge from what
+the launcher emits:
+
+| model | was | now |
+|---|---|---|
+| deepseek-v4-pro | `1740fa2f…` | `0de2116f…` |
+| z-ai/glm-5.2 | `9b94f231…` | `a0ab8a75…` |
+| x-ai/grok-4.5 | `3c7d6155…` | `ff61cb06…` |
+| z-ai/glm-5.1 | `55fdf342…` | `f15536e5…` |
 
 ### 8.4 The measured baseline
 

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -123,10 +123,23 @@ def _benchmark_engine_posture(
         # so scope review has nothing to protect here and nobody to ask. Left
         # off, any plan over the thresholds (more than 5 steps) ends the run.
         "headless_scope_bypass": "on",
+        # `max`, not `high`, for every role the outcome depends on. The
+        # comparator this benchmark is scored against is "Claude Code using
+        # GLM-5.1 at **max effort**" (protocol, §Comparator and thresholds), and
+        # the public leaderboard carries `high`, `xhigh` and `max` as distinct
+        # values — so `high` was not a naming variation on the comparator's
+        # setting, it was less compute applied to one side only. Every
+        # Terminal-Bench number published before this change was produced under
+        # that handicap.
+        #
+        # `triage` deliberately stays low/off, and that is parity rather than an
+        # exception to it: it emits a three-line classification and never edits
+        # the workspace, so raising it would change what Stella *is* rather than
+        # what it was allowed to spend.
         "agents": {
-            "default": {"effort": "high", "reasoning": "on"},
-            "worker": {"effort": "high", "reasoning": "on"},
-            "judge": {"effort": "high", "reasoning": "on"},
+            "default": {"effort": "max", "reasoning": "on"},
+            "worker": {"effort": "max", "reasoning": "on"},
+            "judge": {"effort": "max", "reasoning": "on"},
             "triage": {"effort": "low", "reasoning": "off"},
         },
     }

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -385,7 +385,7 @@ class TestForwardedEnv:
         )
         for role in ("default", "worker", "judge"):
             assert posture["agents"][role] == {
-                "effort": "high",
+                "effort": "max",
                 "reasoning": "on",
             }
         assert posture["agents"]["triage"] == {
@@ -397,7 +397,7 @@ class TestForwardedEnv:
         # #322, after the #301 freeze). See bench/terminal-bench-2.1-protocol.md
         # "Engine posture" prose + calibration table for the recomputed hashes.
         assert digest == (
-            "1740fa2f3f1bea66c348c7ffca151f526019ef0278829d23acb391e7b2f07159"
+            "0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2"
         )
 
     def test_excludes_all_provider_keys_and_selects_only_effective_provider(

--- a/bench/terminal-bench-2.1-protocol.md
+++ b/bench/terminal-bench-2.1-protocol.md
@@ -524,9 +524,9 @@ includes `headless_scope_bypass: on` (see Engine posture above), are:
 
 | Configuration model | Engine-posture SHA-256 |
 |---|---|
-| `openrouter/deepseek/deepseek-v4-pro` | `1740fa2f3f1bea66c348c7ffca151f526019ef0278829d23acb391e7b2f07159` |
-| `openrouter/z-ai/glm-5.2` | `9b94f231d91e66c9793e2f61dd8c6edbb4472ea38e431681b5e854d9d22191ea` |
-| `openrouter/x-ai/grok-4.5` | `3c7d61553b7a4665ed974e6b32a7a20c1f8c59acaae2bcab3848eec2a39ca8dc` |
+| `openrouter/deepseek/deepseek-v4-pro` | `0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2` |
+| `openrouter/z-ai/glm-5.2` | `a0ab8a753a4ffaf7eff5a4ec051f2e6ba3daef38bfb7455af07a634ebde7a407` |
+| `openrouter/x-ai/grok-4.5` | `ff61cb0609f4649df922fb19715bea826121c6eeaad72be9a0f4db20a4a1ea0e` |
 
 Each posture differs only in the inherited selected model and its one-entry
 `allowed_models` list. A repository setting or Harbor extra that attempts to

--- a/bench/terminal_bench_analysis/README.md
+++ b/bench/terminal_bench_analysis/README.md
@@ -208,7 +208,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "1740fa2f3f1bea66c348c7ffca151f526019ef0278829d23acb391e7b2f07159"
+        "sha256": "0de2116f1773a81a1ab5590313efba49120ac119149ee21c0b13271a5f469bb2"
       },
       "openrouter/z-ai/glm-5.2": {
         "version": "stella-tb21-engine-posture-v1",
@@ -224,7 +224,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "9b94f231d91e66c9793e2f61dd8c6edbb4472ea38e431681b5e854d9d22191ea"
+        "sha256": "a0ab8a753a4ffaf7eff5a4ec051f2e6ba3daef38bfb7455af07a634ebde7a407"
       },
       "openrouter/x-ai/grok-4.5": {
         "version": "stella-tb21-engine-posture-v1",
@@ -240,7 +240,7 @@ name and `dataset.ref` carries the same `sha256:` digest separately.
             "triage": {"effort": "low", "reasoning": "off"}
           }
         },
-        "sha256": "3c7d61553b7a4665ed974e6b32a7a20c1f8c59acaae2bcab3848eec2a39ca8dc"
+        "sha256": "ff61cb0609f4649df922fb19715bea826121c6eeaad72be9a0f4db20a4a1ea0e"
       }
     },
     "job_name": "stella-tb21-calibration-20260721",


### PR DESCRIPTION
Second half of #1007. **Blocks the matched head-to-head study (#1013)** — that preregistration will not launch until effort parity holds.

## The defect

The benchmark posture froze `effort: high` for default/worker/judge. The comparator every Terminal-Bench number is scored against is, in the protocol's own words:

> The public comparator is the maintainer-audited Terminal-Bench 2.1 Claude Code submission using GLM-5.1 **at max effort** (PR #67).

and the public leaderboard carries `high`, `xhigh` and `max` as distinct values in its Effort column.

So this was never a naming variation. It was **less compute, applied to one side only** — and it silently under-reported every run. The retracted [#1002](https://github.com/macanderson/stella/issues/1002) result was produced at `high` and compared against a `max` baseline.

## The fix

`default`, `worker`, `judge` → `max`.

`triage` stays `low`/`off`, and that is parity rather than an exception to it: it emits a three-line classification and never edits the workspace, so raising it would change what Stella *is* rather than what it was allowed to spend.

## Digests move, and that is the point

The posture digest is part of the registered SUT, so it changes — exactly as it did when #322 added `headless_scope_bypass`. Recomputed through the adapter's own `_benchmark_engine_posture` rather than by hand, so documented values cannot diverge from what the launcher actually emits:

| model | was | now |
|---|---|---|
| deepseek-v4-pro | `1740fa2f…` | `0de2116f…` |
| z-ai/glm-5.2 | `9b94f231…` | `a0ab8a75…` |
| x-ai/grok-4.5 | `3c7d6155…` | `ff61cb06…` |
| z-ai/glm-5.1 | `55fdf342…` | `f15536e5…` |

Updated at every site that records them — the protocol's calibration table, `READINESS.md`, the analyzer README, and the adapter's own assertion. `READINESS.md` §8.5 records what the mismatch was and which published numbers it invalidates.

## Why this kept happening

Both halves of #1007 exist because the posture is frozen and *disclosed* but never *reconciled* against the baseline it will be measured against. A run assembled entirely from in-repo defaults was mismatched by construction, silently, in the direction that under-reports Stella.

#1007 still carries the remaining acceptance criterion: **a check that fails when the posture and the pinned comparator disagree on any scored parameter.** The comparator's parameters are already pinned by SHA in the protocol; nothing reads them and compares. That check is what turns this class of defect from "found by accident after a paid run" into "caught before launch".

## Verified

| | |
|---|---|
| adapter pytest | **237 passed** |
| analyzer pytest | **240 passed** |
| `doc-citations`, `no-scratch`, `invariants` | green |

## Summary by Sourcery

Align benchmark engine posture effort settings with the protocol’s max-effort comparator and update all corresponding posture digests.

Enhancements:
- Set default, worker, and judge agent roles to use max effort while keeping triage at low/off effort to preserve its behavior.
- Recompute and propagate new engine-posture SHA-256 digests for all configured models across protocol docs, analyzer examples, and adapter assertions.

Documentation:
- Document the historical effort mismatch against the max-effort comparator and its impact on previously published Terminal-Bench results in READINESS.md.

Tests:
- Adjust harbor adapter tests to assert max-effort settings for core roles and the updated canonical posture digest.
