### PR TITLE
fix(verify): a turn that called no tool cannot report success

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,8 +27,8 @@
 1784 stella-model/src/bedrock.rs
 1952 stella-model/src/openai.rs
 1685 stella-model/src/zai/tests.rs
-2757 stella-pipeline/src/pipeline.rs
-2234 stella-pipeline/src/pipeline/tests.rs
+2886 stella-pipeline/src/pipeline.rs
+2277 stella-pipeline/src/pipeline/tests.rs
 2603 stella-protocol/src/event.rs
 2055 stella-store/src/lib.rs
 2204 stella-store/src/tests.rs

--- a/stella-pipeline/proptest-regressions/verify.txt
+++ b/stella-pipeline/proptest-regressions/verify.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c8983ed63aa560fd65dd25f89fb8a5dc878e301aa803c0aea6c36674313c7821 # shrinks to diff_available = false, diff_budget = 0

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -40,7 +40,7 @@
 //! need `&mut Router`). That feedback is the responsibility of the glue that
 //! owns the `Router` — documented here so the boundary is explicit.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use std::sync::Arc;
@@ -81,8 +81,8 @@ use crate::triage::{
 use crate::verify::{
     FlipOracle, JudgeVerdict as ModelJudgeVerdict, LadderDecision, LadderInputs,
     deterministic_fail_evidence, deterministic_pass_evidence, guidance_prompt, heuristic_fallback,
-    judge_prompt, ladder_decision, model_verdict_evidence, parse_judge_response,
-    unverifiable_evidence,
+    judge_prompt, ladder_decision, model_verdict_evidence, nothing_attempted_evidence,
+    parse_judge_response, unverifiable_evidence,
 };
 use crate::witness::airlock::{
     DisclosureGrain, FailureFingerprint, SealedFailure, grain_for_repeats, redact, scrub,
@@ -158,6 +158,24 @@ const DIFF_PROBE_FAILED: &str = "[the diff probe failed; the working tree could 
 const DIFF_PROBE_NOT_A_REPO: &str = "[the working tree is not a git repository, so the diff probe cannot read it at all. This is \
      a permanent property of this workspace, NOT evidence that nothing changed — verify the \
      result on its own merits.]";
+
+/// What a [`LadderDecision::NothingAttempted`] revision turn is told.
+///
+/// Says only what was observed and what is required, and deliberately offers no
+/// theory about *why* the turn stopped — the pipeline does not know, and a
+/// wrong guess ("you seem to have thought the task was complete") is an
+/// invitation to argue with the premise instead of acting on it. The observed
+/// fact is the whole message: no tool ran, so nothing changed.
+///
+/// The last clause matters more than it looks. The turns this fires on ended
+/// with the model narrating a finished solution it never wrote down — on
+/// Terminal-Bench, 123 reasoning events and zero tool calls — so the one thing
+/// worth saying is that describing the work is not doing it.
+const NOTHING_ATTEMPTED_NUDGE: &str = "This turn ended without calling a single tool, so the \
+     workspace is exactly as it was. Nothing has been written yet, whatever the answer above \
+     describes. Carry out the task now with tool calls that change the workspace — writing the \
+     file, running the command, applying the edit. Reasoning about a solution, or stating one in \
+     prose, does not perform it.";
 
 /// One observation of the working tree by [`Pipeline::gather_diff`].
 ///
@@ -496,6 +514,12 @@ struct CandidateState {
     /// `FileChange` events observed across this candidate's engine turns —
     /// one half of the zero-diff guard's "touched files" signal (L-E2).
     file_changes: u32,
+    /// Tool calls this candidate dispatched whose tool is not advertised
+    /// `read_only` — the ladder's only evidence-of-absence channel
+    /// ([`crate::verify::LadderInputs::mutating_actions`]). Counted off the
+    /// engine's own `ToolStart` stream rather than probed for, which is what
+    /// lets `0` mean "never tried" instead of "could not tell".
+    mutating_actions: u32,
     oracle: FlipOracle,
     /// Untracked-file fingerprints snapshotted before the first turn, so
     /// every diff gather can exclude pre-existing dirty state.
@@ -1641,6 +1665,7 @@ impl<'a> Pipeline<'a> {
             messages: base_messages.to_vec(),
             final_text: String::new(),
             file_changes: 0,
+            mutating_actions: 0,
             oracle,
             untracked_before,
             diff_lines: 0,
@@ -1732,7 +1757,13 @@ impl<'a> Pipeline<'a> {
         let steps: &[PlanStep] = plan.unwrap_or_default();
         if steps.is_empty() {
             match self
-                .run_engine_turn(engine, &mut state.messages, budget, &mut state.file_changes)
+                .run_engine_turn(
+                    engine,
+                    &mut state.messages,
+                    budget,
+                    &mut state.file_changes,
+                    &mut state.mutating_actions,
+                )
                 .await
             {
                 TurnOutcome::Completed { text, cost_usd } => {
@@ -1754,7 +1785,13 @@ impl<'a> Pipeline<'a> {
                     step.description
                 )));
                 match self
-                    .run_engine_turn(engine, &mut state.messages, budget, &mut state.file_changes)
+                    .run_engine_turn(
+                        engine,
+                        &mut state.messages,
+                        budget,
+                        &mut state.file_changes,
+                        &mut state.mutating_actions,
+                    )
                     .await
                 {
                     TurnOutcome::Completed { text, cost_usd } => {
@@ -1851,6 +1888,7 @@ impl<'a> Pipeline<'a> {
                 diff_budget: self.config.diff_budget_lines,
                 diff_available: state.diff_available,
                 file_change_events: state.file_changes,
+                mutating_actions: state.mutating_actions,
             };
 
             // Everything the verification side knows about this round's
@@ -1881,6 +1919,44 @@ impl<'a> Pipeline<'a> {
                         score_from_verification(true, None),
                     );
                 }
+                LadderDecision::NothingAttempted => {
+                    // The turn ended without dispatching one call that could
+                    // write anything. Unlike the arm below, no probe failed
+                    // here and no evidence is missing — the pipeline is
+                    // reporting its own dispatch record — so this reports a
+                    // plain `passed: false` and pushes the worker to act.
+                    //
+                    // Before this arm existed the state fell through to
+                    // `Unverifiable`, whose four dark channels it satisfies,
+                    // and abstaining reported `passed: true`: eleven
+                    // Terminal-Bench trials completed "successfully" having
+                    // never touched the task, and Harbor scored every one 0.0.
+                    let evidence = nothing_attempted_evidence(&inputs);
+                    self.emit(AgentEvent::JudgeVerdict {
+                        passed: false,
+                        evidence: evidence.clone(),
+                    });
+                    if state.revisions >= self.config.max_revisions {
+                        return state.into_verified(
+                            false,
+                            &evidence,
+                            score_from_verification(false, Some(false)),
+                        );
+                    }
+                    if let Err(reason) = self
+                        .revise_candidate(
+                            engine,
+                            surface,
+                            budget,
+                            NOTHING_ATTEMPTED_NUDGE,
+                            total,
+                            &mut state,
+                        )
+                        .await
+                    {
+                        return CandidateResult::aborted(state.messages, reason);
+                    }
+                }
                 LadderDecision::Unverifiable => {
                     // Every channel was blind. The judge is not asked, because
                     // the only thing it could do is guess from an empty record
@@ -1895,6 +1971,17 @@ impl<'a> Pipeline<'a> {
                     // in its first word, and the score is `Unverified`, so this
                     // candidate can never tie a genuinely verified sibling in
                     // best-of-N and then win the smaller-diff tiebreak.
+                    //
+                    // The arm above is what makes this defensible. Reaching
+                    // here now means the turn *did* dispatch mutating calls and
+                    // no channel could see their effect — the state the abstain
+                    // rung was built for, and a real one: a Terminal-Bench
+                    // trial that wrote its answer through shell redirects
+                    // recorded no touch, could not be diffed, landed here, and
+                    // scored 1.0 against its verifier. Failing that closed
+                    // would report a correct run as broken, and no revision
+                    // could ever clear it, because nothing about that workspace
+                    // will ever become observable.
                     let evidence = unverifiable_evidence(&inputs);
                     self.unverifiable(&evidence.summary);
                     self.emit(AgentEvent::JudgeVerdict {
@@ -2138,6 +2225,7 @@ impl<'a> Pipeline<'a> {
                 budget,
                 reason,
                 &mut state.file_changes,
+                &mut state.mutating_actions,
                 &mut state.final_text,
                 total,
                 &state.untracked_before,
@@ -2161,6 +2249,7 @@ impl<'a> Pipeline<'a> {
         budget: &mut BudgetGuard,
         reason: &str,
         file_changes: &mut u32,
+        mutating_actions: &mut u32,
         final_text: &mut String,
         total: &mut f64,
         untracked_before: &HashMap<String, String>,
@@ -2170,7 +2259,7 @@ impl<'a> Pipeline<'a> {
             name: StageKind::Execute,
         });
         match self
-            .run_engine_turn(engine, messages, budget, file_changes)
+            .run_engine_turn(engine, messages, budget, file_changes, mutating_actions)
             .await
         {
             TurnOutcome::Completed { text, cost_usd } => {
@@ -2318,13 +2407,21 @@ impl<'a> Pipeline<'a> {
     /// run tool loops for minutes, and buffering froze the renderer for the
     /// whole turn) **except** the engine's `Stage`/`Complete` (the pipeline
     /// owns those), tallying `FileChange`s into `file_changes` for the
-    /// zero-diff guard.
+    /// zero-diff guard and mutating-capable `ToolStart`s into
+    /// `mutating_actions` for the ladder's no-op rung.
+    ///
+    /// The two tallies are deliberately independent. `file_changes` answers
+    /// "did the recorder see the tree change", which a shell redirect defeats;
+    /// `mutating_actions` answers "was anything even asked to change", which
+    /// nothing can defeat, because it is counted off the calls this pipeline
+    /// dispatched rather than off any look at the world.
     async fn run_engine_turn(
         &self,
         engine: &Engine<'_>,
         messages: &mut Vec<CompletionMessage>,
         budget: &mut BudgetGuard,
         file_changes: &mut u32,
+        mutating_actions: &mut u32,
     ) -> TurnOutcome {
         // The filtered sender is SYNCHRONOUS on purpose: when the outer
         // sender carries a durability boundary, a paid StepUsage cannot
@@ -2333,6 +2430,9 @@ impl<'a> Pipeline<'a> {
         // another paid call before the previous one's metering row is durable.
         let seen_file_changes = Arc::new(AtomicU32::new(0));
         let count = seen_file_changes.clone();
+        let seen_mutating = Arc::new(AtomicU32::new(0));
+        let mutating = seen_mutating.clone();
+        let read_only = self.read_only_tool_names();
         let consumer = self.events.clone();
         let filtered = EventSender::from_fn(move |event| {
             match &event {
@@ -2349,6 +2449,16 @@ impl<'a> Pipeline<'a> {
                     }
                     consumer.send(event)
                 }
+                AgentEvent::ToolStart { call } => {
+                    // Counted at dispatch, not at result: a call that errored
+                    // or timed out still means the turn *tried* to act, and
+                    // the no-op rung is about the attempt. Only a name the
+                    // registry positively advertises as read-only is excluded.
+                    if !read_only.contains(&call.name) {
+                        mutating.fetch_add(1, Ordering::Relaxed);
+                    }
+                    consumer.send(event)
+                }
                 _ => consumer.send(event),
             }
         });
@@ -2356,7 +2466,26 @@ impl<'a> Pipeline<'a> {
             .run_turn_with_sender(messages, budget, &filtered)
             .await;
         *file_changes += seen_file_changes.load(Ordering::Relaxed);
+        *mutating_actions += seen_mutating.load(Ordering::Relaxed);
         outcome
+    }
+
+    /// Tool names the registry advertises as `read_only` — the calls that
+    /// structurally cannot have changed the workspace.
+    ///
+    /// Membership is the *only* thing that lets a call be discounted, so the
+    /// direction of every uncertainty is fixed: a name this set has never
+    /// heard of (an MCP server attached mid-run, a host's own extension, a
+    /// tool added since) counts as mutating, and the ladder declines to call
+    /// the turn a no-op. Getting that backwards would let an unrecognized
+    /// tool's real work be reported as nothing attempted.
+    fn read_only_tool_names(&self) -> HashSet<String> {
+        self.tools
+            .schemas()
+            .into_iter()
+            .filter(|schema| schema.read_only)
+            .map(|schema| schema.name)
+            .collect()
     }
 
     /// The real added-line count of an untracked file, via a no-index diff

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -17,7 +17,7 @@ use stella_core::{Clock, ToolExecutor};
 use stella_protocol::event::BudgetMode;
 use stella_protocol::{
     CompletionRequestRef, CompletionResult, CompletionUsage, FileChangeKind, MessageRole,
-    ProviderError, ScopeProposal, ToolOutput, ToolSchema,
+    ProviderError, ScopeProposal, ToolCall, ToolOutput, ToolSchema,
 };
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
@@ -620,6 +620,49 @@ struct FixedGate(ScopeDecision);
 impl ApprovalGate for FixedGate {
     async fn review(&self, _proposal: &ScopeProposal) -> ScopeDecision {
         self.0.clone()
+    }
+}
+
+/// A completion that calls one mutating tool — a turn that *acted*, whatever
+/// a probe can afterwards see of it.
+///
+/// The distinction [`text_result`] cannot express, and the one the ladder's
+/// no-op rung turns on: a turn with no tool calls could not have changed
+/// anything, so its dark channels mean "nothing happened"; a turn with this
+/// one could have, so the same dark channels mean "nobody can tell".
+fn writing_tool_result(text: &str) -> CompletionResult {
+    CompletionResult {
+        tool_calls: vec![ToolCall {
+            call_id: "call-1".into(),
+            name: WRITING_TOOL.into(),
+            input: serde_json::json!({}),
+        }],
+        ..text_result(text)
+    }
+}
+
+/// The one tool [`OneWritingTool`] advertises.
+const WRITING_TOOL: &str = "write_file";
+
+/// A registry with a single mutating tool, for fixtures that need a turn to
+/// have dispatched something. Its `execute` reports success and touches
+/// nothing real — which is exactly the state under test: the call happened,
+/// and no evidence channel can show what it did.
+struct OneWritingTool;
+#[async_trait]
+impl ToolExecutor for OneWritingTool {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: WRITING_TOOL.into(),
+            description: "write a file".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: "written".into(),
+        }
     }
 }
 

--- a/stella-pipeline/src/pipeline/tests/warrant.rs
+++ b/stella-pipeline/src/pipeline/tests/warrant.rs
@@ -107,14 +107,25 @@ async fn a_docs_only_change_completes_without_buying_a_judge_call() {
 /// the ladder with nothing at all to reason over, and a judge handed an empty
 /// record does not produce a better answer — it produced `FAIL … the file
 /// likely does not exist` about a file that was in the container (#973). So the
-/// ladder abstains, and the fixture size is again the assertion: exactly two
-/// provider calls, because a third would mean a judge was bought to guess.
+/// ladder abstains, and the fixture size is again the assertion: exactly three
+/// provider calls, because a fourth would mean a judge was bought to guess.
+///
+/// The worker must *dispatch a mutating tool call* for this to be the abstain
+/// case at all. A turn that calls nothing has the same four dark channels but
+/// a different truth — it could not have changed anything — and now resolves
+/// as `NothingAttempted` instead (see the two no-op tests at the end of this
+/// module). Handing this fixture `EmptyTools` would quietly retarget it at
+/// that rung and stop it testing abstention.
 #[tokio::test]
 async fn a_blind_diff_probe_never_completes_as_nothing_changed() {
-    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        writing_tool_result("writing the fix"),
+        text_result("done"),
+    ]);
     let resolver = OneProvider(&provider);
     let runner = ScriptedRunner::new(vec![], DOCS_DIFF).with_blind_diff();
-    let tools = EmptyTools;
+    let tools = OneWritingTool;
     let recall = NoContextRecall;
     let repo = NoRepoStructure;
     let repo_status = NoRepoStatus;
@@ -336,5 +347,193 @@ async fn a_non_repository_says_so_rather_than_reporting_a_generic_failure() {
         probe.text.contains("NOT evidence that nothing changed"),
         "and must refuse the inversion outright: {}",
         probe.text
+    );
+}
+
+/// The `regex-log` Terminal-Bench 2.1 trial, end to end: the worker answers in
+/// prose, calls no tool, and the workspace is a plain directory the diff probe
+/// can never read. Harbor scored the real trial 0.0; Stella reported success.
+///
+/// [`crate::verify`]'s ladder tests pin the *decision*; this pins what the
+/// pipeline does with it, which is where the defect was actually visible. The
+/// ladder emitted its abstention correctly the whole time — it was the
+/// `passed: true` beside it, and the `Complete` stage after it, that told
+/// every reader downstream the task was done.
+///
+/// `max_revisions: 0` so the turn is terminal here rather than looping; the
+/// revision behaviour is the next test.
+#[tokio::test]
+async fn a_turn_that_called_no_tool_does_not_report_success() {
+    // triage → single; worker → a confident claim it never acted on. The
+    // scripted provider serves exactly two calls: a judge call would exhaust
+    // it and error the run, so the fixture size asserts none is bought.
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: yes"),
+        text_result("I've written the regex to /app/regex.txt. The task is complete."),
+    ]);
+    let resolver = OneProvider(&provider);
+    // No test results and no readable tree: on Terminal-Bench every channel
+    // except the dispatch count is structurally dark.
+    let runner = ScriptedRunner::new(vec![], "").with_not_a_repository();
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            test_command: None,
+            max_revisions: 0,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run(
+            "Write a regex to /app/regex.txt",
+            &mut messages,
+            &mut budget,
+        )
+        .await
+        .expect("run completes");
+
+    let verdict = outcome
+        .verdict
+        .expect("a no-op turn still reports a verdict");
+    assert!(
+        !verdict.passed,
+        "a turn that dispatched no tool must not report success: {}",
+        verdict.summary
+    );
+    assert!(
+        verdict.summary.contains("NO WORK ATTEMPTED"),
+        "and must say plainly what happened: {}",
+        verdict.summary
+    );
+    assert!(
+        !verdict.summary.contains("UNVERIFIABLE"),
+        "this is a determinate finding, not a missing one: {}",
+        verdict.summary
+    );
+
+    let events = drain(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::JudgeVerdict {
+                passed: false,
+                evidence
+            } if evidence.summary.contains("NO WORK ATTEMPTED")
+        )),
+        "the emitted verdict — the field every downstream reader keys on — must be false"
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Judge),
+        "nothing was attempted, so there is nothing for a judge to weigh"
+    );
+}
+
+/// The recovery half: given a revision to spend, a no-op turn is pushed to act
+/// rather than ending the run. This is the behaviour that would have changed
+/// the eleven trials' outcomes — each stopped at 2–3 steps with revisions
+/// still on the table.
+#[tokio::test]
+async fn a_no_op_turn_is_sent_back_to_do_the_work() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("CLASS: single\nWITNESS: no\nJUDGE: yes"),
+        text_result("I've written the regex to /app/regex.txt. The task is complete."),
+        // The revision turn. Still no tools — the second no-op is terminal,
+        // which keeps this test about the push-back and not about recovery
+        // the fixture cannot actually stage.
+        text_result("Confirmed, the file is written."),
+    ]);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "").with_not_a_repository();
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            test_command: None,
+            max_revisions: 1,
+            ..PipelineConfig::default()
+        },
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run(
+            "Write a regex to /app/regex.txt",
+            &mut messages,
+            &mut budget,
+        )
+        .await
+        .expect("run completes");
+
+    let revision = provider
+        .prompts()
+        .into_iter()
+        .find(|p| p.contains("without calling a single tool"))
+        .expect("the worker was sent back with the no-op told plainly");
+    assert!(
+        revision.contains("does not perform it"),
+        "and told that describing the work is not doing it: {revision}"
+    );
+    assert_eq!(
+        outcome.revisions, 1,
+        "exactly the one revision the config allowed was spent"
+    );
+    assert!(
+        !outcome.verdict.expect("a verdict").passed,
+        "a second no-op exhausts the revisions and still must not report success"
     );
 }

--- a/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/stella-pipeline/src/pipeline/witness_stage.rs
@@ -179,9 +179,21 @@ impl<'a> Pipeline<'a> {
             CompletionMessage::system(WITNESS_SYSTEM_PROMPT),
             CompletionMessage::user(witness_prompt(goal, frames, &structure)),
         ];
+        // Both tallies are local and discarded, on the same reasoning: they
+        // measure the *witness author*, and the ladder's channels are about
+        // what the worker did toward the goal. A test file written here is not
+        // the change under verification, and counting it as a mutating action
+        // would let an authored witness disguise a worker that never acted.
         let mut file_changes = 0u32;
+        let mut mutating_actions = 0u32;
         let text = match self
-            .run_engine_turn(&engine, &mut messages, budget, &mut file_changes)
+            .run_engine_turn(
+                &engine,
+                &mut messages,
+                budget,
+                &mut file_changes,
+                &mut mutating_actions,
+            )
             .await
         {
             TurnOutcome::Completed { text, cost_usd } => {
@@ -219,7 +231,13 @@ impl<'a> Pipeline<'a> {
             )
             .with_call_role(stella_protocol::ModelCallRole::WitnessRepair);
             let repaired = match self
-                .run_engine_turn(&repair_engine, &mut messages, budget, &mut file_changes)
+                .run_engine_turn(
+                    &repair_engine,
+                    &mut messages,
+                    budget,
+                    &mut file_changes,
+                    &mut mutating_actions,
+                )
                 .await
             {
                 TurnOutcome::Completed { text, cost_usd } => {

--- a/stella-pipeline/src/verify.rs
+++ b/stella-pipeline/src/verify.rs
@@ -21,7 +21,8 @@
 //! decides — *before any model judge runs*:
 //! - **submit fast** (judge skipped) when flip + touched-tests-green + diff
 //!   within budget all hold;
-//! - **revise** on a clear failure (touched tests red);
+//! - **revise** on a clear failure (touched tests red), or on a turn that
+//!   never attempted anything (`NothingAttempted`);
 //! - **abstain** (`Unverifiable`) when every channel was blind — no flip, no
 //!   test result, an unreadable working tree, and no recorded file touch;
 //! - **escalate to the model judge** only on genuinely inconclusive evidence.
@@ -32,6 +33,28 @@
 //! file that was on disk (#973). "I cannot see the tree" and "the file is not
 //! there" are opposite claims; a ladder that emits the second when it means the
 //! first is worse than one that says nothing.
+//!
+//! # Abstaining is not a place to hide a no-op
+//!
+//! The abstain rung has one failure mode of its own, and it is the mirror of
+//! the one it fixed: a turn that did *nothing* looks exactly like a turn whose
+//! work nothing could see. Both show no flip, no test result, an unreadable
+//! tree and a zero touch count — so both abstained, and abstaining reported a
+//! pass. Eleven Terminal-Bench 2.1 trials ended that way: `glm-5.2` reasoned
+//! for a while, called no tool at all, and the run declared success on a task
+//! it had not touched. Every one scored 0.0.
+//!
+//! [`LadderInputs::mutating_actions`] separates them, and it is the one input
+//! here that can never be blind. Every other channel is a *probe into the
+//! world* that can fail to see; the dispatch count is the pipeline's record of
+//! **what it itself ran**. Zero mutating calls is not "I could not tell whether
+//! anything changed", it is "nothing was ever asked to change" — evidence of
+//! absence, which the ladder is otherwise built never to infer. So it gets its
+//! own rung ([`LadderDecision::NothingAttempted`]) above the blind check, and
+//! that rung fails closed while abstain keeps failing open, because the case
+//! abstain exists for is real: one of those eleven trials' siblings did the
+//! work entirely through shell redirects, recorded no touch, could not be
+//! diffed — and passed its Harbor verifier.
 //!
 //! Linters and typecheckers are deliberately **excluded** from the flip
 //! oracle (L-E11): only a real test command's fail→pass counts. The pipeline
@@ -180,6 +203,11 @@ pub enum LadderDecision {
     /// Clear failure (touched tests are red): feed the evidence back into a
     /// revision turn. No judge call — the failure is already deterministic.
     Revise,
+    /// The turn dispatched nothing that could change the workspace, and no
+    /// channel saw anything change — see [`LadderInputs::nothing_was_attempted`].
+    /// A determinate finding, not an abstention: revise, and report `passed:
+    /// false` if the revisions run out.
+    NothingAttempted,
     /// **Every** evidence channel was unavailable — see
     /// [`LadderInputs::evidence_is_blind`]. The ladder abstains: no judge call,
     /// and the run is scored as unverified rather than passed or failed.
@@ -215,6 +243,21 @@ pub struct LadderInputs {
     /// that emitted the `FileChange` events (`FileTouchPort`). Non-zero is
     /// positive proof the tree changed even when nothing can render *how*.
     pub file_change_events: u32,
+    /// Tool calls this turn that were *capable* of changing the workspace:
+    /// every dispatched call except those whose tool the registry advertises
+    /// as `read_only`.
+    ///
+    /// Unlike every other field here this is not a probe into the world, so it
+    /// cannot come back blind — it is the pipeline's tally of the calls it
+    /// itself dispatched. That is what makes `0` mean "nothing was attempted"
+    /// rather than "nothing was seen", and it is the only input the ladder is
+    /// willing to read as evidence of *absence*.
+    ///
+    /// A call whose tool is unknown counts as mutating. Shell tools are the
+    /// reason: `bash` is not `read_only`, and on Terminal-Bench it is how
+    /// nearly all real work lands — so an unrecognized name must never be the
+    /// reason a turn is written off as a no-op.
+    pub mutating_actions: u32,
 }
 
 impl LadderInputs {
@@ -238,6 +281,30 @@ impl LadderInputs {
             && !self.diff_available
             && self.file_change_events == 0
     }
+
+    /// Whether this turn provably did nothing: it dispatched no call that
+    /// could change the workspace, and no channel that *did* report saw any
+    /// change.
+    ///
+    /// Deliberately says nothing about [`Self::diff_available`]. Every other
+    /// rung has to care whether the probe could look; this one does not,
+    /// because it does not rest on looking. If the model never asked for a
+    /// mutating action, the workspace cannot have changed, and an unreadable
+    /// tree is not a reason to doubt that — which is exactly why this must be
+    /// checked *before* [`Self::evidence_is_blind`], whose four dark channels
+    /// this state would otherwise satisfy on the way to reporting a pass.
+    ///
+    /// The remaining conjuncts are there so a single positive observation
+    /// always wins. A flip, a test result, a recorded touch or a non-empty
+    /// diff each mean *something* happened, whoever caused it — and a turn
+    /// with something to explain deserves a verdict, not this shortcut.
+    pub fn nothing_was_attempted(&self) -> bool {
+        self.mutating_actions == 0
+            && self.file_change_events == 0
+            && self.diff_lines == 0
+            && !self.flip_achieved
+            && self.touched_tests_passed.is_none()
+    }
 }
 
 /// The evidence ladder (L-E11). Decides submit/revise/abstain/escalate from
@@ -245,11 +312,15 @@ impl LadderInputs {
 ///
 /// 1. **Touched tests red → `Revise`.** A red test is a clear, deterministic
 ///    failure; never spend a judge call to "confirm" it.
-/// 2. **Every channel blind → `Unverifiable`.** Nothing could observe this
+/// 2. **Nothing attempted → `NothingAttempted`.** The turn dispatched no
+///    mutating call and nothing observed a change. Checked *above* the blind
+///    rung, which it would otherwise satisfy — and does not fall through to
+///    it, because "no action was taken" is knowledge, not an absence of it.
+/// 3. **Every channel blind → `Unverifiable`.** Nothing could observe this
 ///    turn, so nothing may be claimed about it — in particular not a failure.
-/// 3. **Flip + green + within budget → `SubmitFast`.** The full deterministic
+/// 4. **Flip + green + within budget → `SubmitFast`.** The full deterministic
 ///    pass: judge skipped.
-/// 4. **Otherwise → `ModelJudge`.** Genuinely inconclusive: no flip, or the
+/// 5. **Otherwise → `ModelJudge`.** Genuinely inconclusive: no flip, or the
 ///    diff is over budget (large change deserves a second opinion even with
 ///    green tests), or tests couldn't be run — but something could still see.
 pub fn ladder_decision(inputs: &LadderInputs) -> LadderDecision {
@@ -257,20 +328,27 @@ pub fn ladder_decision(inputs: &LadderInputs) -> LadderDecision {
     if inputs.touched_tests_passed == Some(false) {
         return LadderDecision::Revise;
     }
-    // 2. Nothing could observe the turn. Buying a judge call here spends money
+    // 2. The turn never acted. Ordered above the blind rung on purpose: this
+    //    state satisfies all four of its dark channels, so abstaining would
+    //    absorb it and report the pass that shipped eleven untouched
+    //    Terminal-Bench tasks as successes.
+    if inputs.nothing_was_attempted() {
+        return LadderDecision::NothingAttempted;
+    }
+    // 3. Nothing could observe the turn. Buying a judge call here spends money
     //    to ask a model to guess from an empty record, and the answer it
     //    produced in the wild was a confident FAIL naming a file that existed.
     if inputs.evidence_is_blind() {
         return LadderDecision::Unverifiable;
     }
-    // 3. Full deterministic pass — submit fast, judge skipped.
+    // 4. Full deterministic pass — submit fast, judge skipped.
     if inputs.flip_achieved
         && inputs.touched_tests_passed == Some(true)
         && inputs.diff_lines <= inputs.diff_budget
     {
         return LadderDecision::SubmitFast;
     }
-    // 4. Inconclusive — escalate to the model judge.
+    // 5. Inconclusive — escalate to the model judge.
     LadderDecision::ModelJudge
 }
 
@@ -312,6 +390,31 @@ pub fn unverifiable_evidence(inputs: &LadderInputs) -> JudgeEvidence {
             inputs.file_change_events
         ),
         deterministic: false,
+        evidence_refs: Vec::new(),
+    }
+}
+
+/// Build the `JudgeEvidence` for a [`LadderDecision::NothingAttempted`] turn.
+///
+/// `deterministic: true`, and the contrast with [`unverifiable_evidence`] is
+/// the entire point: that one is marked `false` because it reports the absence
+/// of a result, while this one *is* a result. The pipeline counted the calls it
+/// dispatched and none of them could write anything — no probe was consulted
+/// and none could have changed the answer.
+///
+/// The summary leads with what was and was not done rather than with a channel
+/// list, because unlike the blind case there is nothing here to diagnose: no
+/// instrument failed, and re-running the probes would report the same nothing.
+pub fn nothing_attempted_evidence(inputs: &LadderInputs) -> JudgeEvidence {
+    JudgeEvidence {
+        summary: format!(
+            "NO WORK ATTEMPTED — the turn ended without dispatching a single tool call that \
+             could change the workspace ({} mutating call(s), {} file-change event(s), {} \
+             diff line(s)). This is not an unverifiable result: nothing was asked to change, \
+             so nothing did, whatever the other channels could or could not see.",
+            inputs.mutating_actions, inputs.file_change_events, inputs.diff_lines
+        ),
+        deterministic: true,
         evidence_refs: Vec::new(),
     }
 }
@@ -554,6 +657,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert_eq!(decision, LadderDecision::Revise);
     }
@@ -567,6 +671,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert_eq!(decision, LadderDecision::SubmitFast);
     }
@@ -585,6 +690,7 @@ mod tests {
             diff_budget: 100,
             diff_available: false,
             file_change_events: 0,
+            mutating_actions: 1,
         };
         assert!(inputs.evidence_is_blind());
         assert_eq!(
@@ -613,6 +719,7 @@ mod tests {
             diff_budget: 100,
             diff_available: false,
             file_change_events: 6,
+            mutating_actions: 1,
         };
         assert!(
             !inputs.evidence_is_blind(),
@@ -633,6 +740,7 @@ mod tests {
             diff_budget: 100,
             diff_available: false,
             file_change_events: 0,
+            mutating_actions: 1,
         };
         assert!(!inputs.evidence_is_blind());
         assert_eq!(ladder_decision(&inputs), LadderDecision::Revise);
@@ -650,9 +758,154 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         };
         assert!(!inputs.evidence_is_blind());
         assert_eq!(ladder_decision(&inputs), LadderDecision::ModelJudge);
+    }
+
+    /// The `regex-log` Terminal-Bench 2.1 trial, reconstructed as ladder
+    /// inputs: `glm-5.2` emitted 123 reasoning events, called no tool at all,
+    /// and the run reported success on a task it never touched (Harbor scored
+    /// it 0.0). Every input below is read off that trial's own event stream.
+    ///
+    /// The assertion that matters is the second one. This turn *is* blind by
+    /// [`LadderInputs::evidence_is_blind`] — all four channels are dark, and
+    /// they were dark before the fix too — so the bug was never a wrong
+    /// blindness check. It was that blindness was asked first, and abstaining
+    /// answered `passed: true`. Ordering is the entire fix, which is why this
+    /// test pins both facts at once.
+    #[test]
+    fn a_turn_that_called_no_tool_is_a_no_op_not_an_abstention() {
+        let inputs = LadderInputs {
+            flip_achieved: false,
+            touched_tests_passed: None,
+            diff_lines: 0,
+            diff_budget: 400,
+            // Not a git repository, so the probe is permanently dark here.
+            diff_available: false,
+            file_change_events: 0,
+            mutating_actions: 0,
+        };
+        assert!(inputs.nothing_was_attempted());
+        assert!(
+            inputs.evidence_is_blind(),
+            "the no-op state satisfies the blind check too — the rung order is what separates them"
+        );
+        assert_eq!(
+            ladder_decision(&inputs),
+            LadderDecision::NothingAttempted,
+            "a turn that dispatched nothing must never reach the abstain rung and be passed"
+        );
+    }
+
+    /// The evidence a no-op turn carries, and the one word it must not borrow.
+    /// `UNVERIFIABLE` is a claim about the *instruments*; this turn's
+    /// instruments were fine and reported a determinate nothing, so it is
+    /// marked `deterministic: true` — the opposite of
+    /// [`unverifiable_evidence`], which is `false` precisely because it has no
+    /// result to report.
+    #[test]
+    fn a_no_op_verdict_is_a_result_not_a_missing_one() {
+        let inputs = LadderInputs {
+            flip_achieved: false,
+            touched_tests_passed: None,
+            diff_lines: 0,
+            diff_budget: 400,
+            diff_available: false,
+            file_change_events: 0,
+            mutating_actions: 0,
+        };
+        let evidence = nothing_attempted_evidence(&inputs);
+        assert!(evidence.summary.contains("NO WORK ATTEMPTED"));
+        assert!(
+            !evidence.summary.contains("UNVERIFIABLE"),
+            "a determinate no-op must not describe itself as unobservable"
+        );
+        assert!(
+            evidence.deterministic,
+            "the pipeline counted its own dispatches; no probe could have said otherwise"
+        );
+    }
+
+    /// The case the abstain rung exists for, and the reason the fix above is a
+    /// new rung rather than a flipped boolean: `log-summary-date-ranges` ran
+    /// eight tool calls, wrote its answer through shell redirects (so the
+    /// recorder logged no touch), could not be diffed — and scored **1.0**
+    /// against its Harbor verifier. Identical dark channels, opposite truth.
+    /// Only `mutating_actions` tells it apart from the trial above.
+    #[test]
+    fn a_blind_turn_that_did_act_still_abstains() {
+        let inputs = LadderInputs {
+            flip_achieved: false,
+            touched_tests_passed: None,
+            diff_lines: 0,
+            diff_budget: 400,
+            diff_available: false,
+            file_change_events: 0,
+            mutating_actions: 8,
+        };
+        assert!(inputs.evidence_is_blind());
+        assert!(
+            !inputs.nothing_was_attempted(),
+            "eight dispatched mutating calls are not an absence of work"
+        );
+        assert_eq!(
+            ladder_decision(&inputs),
+            LadderDecision::Unverifiable,
+            "work nothing could observe must still abstain — failing it closed would report a \
+             correct run as broken, and no revision could ever clear it"
+        );
+    }
+
+    /// Any single positive observation outranks the no-op rung, whatever the
+    /// dispatch count says. Something changed; something changed is a thing to
+    /// explain, and this shortcut does not get to skip explaining it.
+    #[test]
+    fn one_positive_observation_defeats_the_no_op_rung() {
+        let base = LadderInputs {
+            flip_achieved: false,
+            touched_tests_passed: None,
+            diff_lines: 0,
+            diff_budget: 400,
+            diff_available: false,
+            file_change_events: 0,
+            mutating_actions: 0,
+        };
+        assert!(base.nothing_was_attempted());
+
+        let recorded_touch = LadderInputs {
+            file_change_events: 1,
+            ..base
+        };
+        let visible_diff = LadderInputs {
+            diff_lines: 12,
+            ..base
+        };
+        let flipped = LadderInputs {
+            flip_achieved: true,
+            ..base
+        };
+        let tests_ran = LadderInputs {
+            touched_tests_passed: Some(true),
+            ..base
+        };
+        for (label, inputs) in [
+            ("a recorded file touch", recorded_touch),
+            ("a non-empty diff", visible_diff),
+            ("a flip", flipped),
+            ("a test result", tests_ran),
+        ] {
+            assert!(
+                !inputs.nothing_was_attempted(),
+                "{label} is a positive observation; the turn is not a no-op"
+            );
+            assert_ne!(
+                ladder_decision(&inputs),
+                LadderDecision::NothingAttempted,
+                "{label} must route somewhere that reasons about it"
+            );
+        }
     }
 
     /// The judge is only ever asked when something could see — but when it is
@@ -685,6 +938,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert_eq!(
             decision,
@@ -703,6 +957,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert_eq!(decision, LadderDecision::ModelJudge);
     }
@@ -716,6 +971,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert_eq!(decision, LadderDecision::ModelJudge);
     }
@@ -764,6 +1020,7 @@ mod tests {
             diff_budget: 100,
             diff_available: true,
             file_change_events: 0,
+            mutating_actions: 1,
         });
         assert!(green.passed);
 
@@ -775,6 +1032,7 @@ mod tests {
                 diff_budget: 100,
                 diff_available: true,
                 file_change_events: 0,
+                mutating_actions: 1,
             });
             assert!(!v.passed, "unconfirmed tests must fall back to FAIL");
         }
@@ -897,6 +1155,69 @@ mod tests {
             let mut oracle = FlipOracle::new();
             oracle.observe("cargo test", passed);
             prop_assert_ne!(oracle.state(), FlipState::Flipped);
+        }
+
+        /// The binding invariant of the no-op rung: **no ladder input that
+        /// dispatched nothing and observed nothing can resolve to a rung that
+        /// reports a pass.**
+        ///
+        /// Stated over the whole input space rather than the eleven trials,
+        /// because the defect was never about a particular trial's numbers —
+        /// it was that one reachable combination fell into `Unverifiable`,
+        /// which answers `passed: true`. A ranged sweep is what proves no such
+        /// combination is left, including ones nobody has produced yet.
+        ///
+        /// `diff_available` is swept and deliberately unconstrained: whether
+        /// the probe could look must make no difference to a turn that never
+        /// gave it anything to look at.
+        #[test]
+        fn a_turn_that_dispatched_nothing_never_reaches_a_passing_rung(
+            diff_available in any::<bool>(),
+            diff_budget in 0u32..1000,
+        ) {
+            let inputs = LadderInputs {
+                flip_achieved: false,
+                touched_tests_passed: None,
+                diff_lines: 0,
+                diff_budget,
+                diff_available,
+                file_change_events: 0,
+                mutating_actions: 0,
+            };
+            prop_assert!(inputs.nothing_was_attempted());
+            let decision = ladder_decision(&inputs);
+            prop_assert_eq!(decision, LadderDecision::NothingAttempted);
+            // The two rungs that answer `passed: true` in the pipeline. Named
+            // individually so a future rung that also passes has to be
+            // considered here rather than silently inheriting a green test.
+            prop_assert_ne!(decision, LadderDecision::SubmitFast);
+            prop_assert_ne!(decision, LadderDecision::Unverifiable);
+        }
+
+        /// The converse, and the guard on the fix's blast radius: any turn
+        /// that *did* dispatch a mutating call keeps the decision it had
+        /// before this rung existed. The no-op rung may only ever claim the
+        /// zero-dispatch corner.
+        #[test]
+        fn dispatching_anything_leaves_every_other_rung_untouched(
+            mutating_actions in 1u32..50,
+            flip_achieved in any::<bool>(),
+            touched in prop::option::of(any::<bool>()),
+            diff_lines in 0u32..800,
+            diff_available in any::<bool>(),
+            file_change_events in 0u32..50,
+        ) {
+            let inputs = LadderInputs {
+                flip_achieved,
+                touched_tests_passed: touched,
+                diff_lines,
+                diff_budget: 400,
+                diff_available,
+                file_change_events,
+                mutating_actions,
+            };
+            prop_assert!(!inputs.nothing_was_attempted());
+            prop_assert_ne!(ladder_decision(&inputs), LadderDecision::NothingAttempted);
         }
     }
 }


### PR DESCRIPTION
Eleven Terminal-Bench 2.1 trials ended `stage complete` reporting success on tasks they had not touched. Harbor scored every one **0.0**. `regex-log` produced 123 `reasoning` events and **zero tool calls** before completing.

## The defect

The ladder's abstain rung (`Unverifiable`, #973/#981) fires when all four evidence channels are dark and answers `JudgeVerdict { passed: true }` — a run is not failed by the absence of a way to check it.

A turn that did *nothing* presents identically: no flip, no test result, an unreadable tree, no recorded touch, because it never acted. It fell into that rung, and abstaining reported a pass.

```
stage verify -> proof {kind: warrant, required: true, diff_lines: 0}
             -> proof {kind: verification_unavailable, reason: "UNVERIFIABLE ..."}
judge_verdict -> {"passed": true}          <-- here
stage complete
```

The ladder emitted its abstention correctly the whole time. It was the `passed: true` beside it — the field every downstream reader keys on — that lied.

## The fix

`LadderInputs::mutating_actions`: dispatched tool calls whose tool is not advertised `read_only`, counted off the engine's own `ToolStart` stream. It is the one ladder input that is **not a probe into the world**, so it cannot come back blind — it is the pipeline's record of what it itself ran. Zero means "nothing was asked to change", not "nothing could be seen".

`LadderDecision::NothingAttempted` sits **above** the blind check, reports `passed: false`, and spends a revision telling the worker that describing the work is not doing it.

### Why abstain still fails open

`log-summary-date-ranges` took the identical `UNVERIFIABLE → passed: true` path and **scored 1.0**: eight tool calls, answer written through shell redirects so the recorder logged no touch, workspace not a git repo so no diff. Its channels are dark for the honest reason, and no revision could ever clear it — on Terminal-Bench nothing about that workspace ever becomes observable. Flipping abstain wholesale would report correct runs as broken. Only the dispatch count separates the two cases, which is why this is a new rung rather than a changed boolean.

Unknown tool names count as mutating, matching `ToolSchema::read_only`'s own documented default. The witness author's turns are excluded — a test file it writes is not the change under verification.

## Tests

- `a_turn_that_called_no_tool_is_a_no_op_not_an_abstention` — the `regex-log` trial at the ladder seam, asserting it **is** blind *and* resolves to `NothingAttempted`. Rung order is the entire fix; inverting the two checks fails this and the property below.
- `a_blind_turn_that_did_act_still_abstains` — the reward-1.0 shape, unchanged.
- `a_turn_that_dispatched_nothing_never_reaches_a_passing_rung` / `dispatching_anything_leaves_every_other_rung_untouched` — properties bounding the new rung to exactly the zero-dispatch corner.
- `a_turn_that_called_no_tool_does_not_report_success` / `a_no_op_turn_is_sent_back_to_do_the_work` — pipeline end-to-end, on the emitted verdict.

`a_blind_diff_probe_never_completes_as_nothing_changed` had `EmptyTools`, so it was silently retargeted at the new rung; its fixture now dispatches a mutating call, which is what made it an abstention case to begin with.

`make gate` green (exit 0). File-size baseline updated for the two files that grew.

## On the triage timeout

9 of the 11 trials also show `usage_incomplete {role: triage, reason: "timeout", duration_ms: ~10001}`. **This is an artifact of the benchmark patch, not a product defect** — no posture change is included here.

The runs patched `triage` from the committed `{effort: low, reasoning: off}` to `{effort: max, reasoning: on}` against a 10s `triage_latency_ceiling`. A reasoning model at max effort does not return a three-line classification inside that. One patch was applied bundle-wide, so all 86 trials ran that way and the bundle carries no control; 42 of 54 Stella trials timed out.

The timeout is also already non-silent and non-fatal: it emits `usage_incomplete` (which is how it was found) and degrades to the deterministic keyword floor, which still verifies unconditionally.

## The defect is not glm-5.2-specific

`bench/evidence/tb21-20260730c/` — **glm-5.1**, unmodified `main`, **committed** posture — reports *"trials with zero tool calls: 7"*, on the same tasks: `regex-log` (0), `distribution-search` (0), `model-extraction-relu-logits` (0), `circuit-fibsqrt` (1), `pytorch-model-recovery` (0), `regex-chess` (0), all reward 0.0. (`qemu-*` are the separate glibc packaging failure.)

Different model, different effort, unpatched posture, same signature. glm-5.2 raises the rate; the completion path that turns it into a reported success is model-independent.

## Summary by Sourcery

Introduce a new verification ladder rung to treat turns that dispatch no mutating tool calls as deterministic failures rather than unverifiable passes, and wire this signal through the pipeline.

Bug Fixes:
- Prevent no-op turns with zero mutating tool calls from being reported as successful by classifying them as `NothingAttempted` and failing them closed.

Enhancements:
- Track mutating tool dispatches in pipeline state and ladder inputs, distinguishing no-op turns from genuinely unobservable work.
- Emit explicit evidence and revision nudges for no-op turns, and ensure revisions are spent pushing the worker to perform actual tool-based work.
- Expand tests and property-based checks to cover the new ladder behaviour, pipeline outcomes, and abstention semantics without changing behaviour for turns that did act.

Tests:
- Add unit, integration, and property-based tests to pin behaviour for no-op vs acting blind turns, ensure no-op turns never reach passing rungs, and verify end-to-end pipeline handling and revision behaviour.