### PR TITLE
fix(bench): reject a non-portable SUT binary on the host, before a run starts

### DIFF
--- a/bench/evidence/run/README.md
+++ b/bench/evidence/run/README.md
@@ -49,6 +49,84 @@ bench/evidence/run/primary.sh A "<job-name>-phaseA"
 bench/evidence/run/finalize.sh "<run-id>" "<job-name>"
 ```
 
+## The SUT binary must be the portable build
+
+`build_sut.sh` cross-compiles against `x86_64-unknown-linux-gnu.2.17` via
+`cargo-zigbuild`. That glibc floor is what lets one binary run in every task
+container. **Do not** substitute a plain host build:
+
+```bash
+# This is the mistake. It produces a host-glibc binary wearing the portable
+# build's filename, in the exact path env.sh exports as STELLA_BINARY.
+cargo build --release --locked -p stella-cli --bin stella
+cp target/release/stella target/x86_64-unknown-linux-gnu/release/stella
+```
+
+On 2026-07-31 a run provisioned that way lost five trials before the agent ever
+started. Every integrity check still passed, because they all answer a different
+question: the host/container SHA-256 comparison confirms *the file arrived
+intact* — and it did, it was the same file on both sides. Nothing answered *can
+this file run here*. The first thing to touch the dynamic loader was
+`stella --version`, inside the container, per trial:
+
+```
+/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6:
+    version `GLIBC_2.34' not found (required by /usr/local/bin/stella)
+```
+
+Harbor recorded `NonZeroAgentExitCodeError` and scored each trial 0.0 —
+indistinguishable, under a fixed denominator, from Stella failing those tasks.
+
+`preflight` now refuses to start a run whose `STELLA_BINARY` requires a glibc
+symbol above the floor, on the host, before any container is created. The floor
+and the target triple are exported once from `env.sh` and consumed by both
+`build_sut.sh` and the check, so the build and the assertion cannot drift apart.
+To inspect a binary directly:
+
+```bash
+python3 bench/harbor_adapter/stella_harbor/portability.py "$STELLA_BINARY" --json
+```
+
+### Is a musl build needed as well? No.
+
+glibc 2.17 fixes containers with *older glibc*. It does nothing for a container
+with no glibc at all, so the question had to be settled against the dataset
+rather than assumed. Every base image across all 89 Terminal-Bench 2.1 tasks:
+
+| base image | tasks | libc |
+|---|---|---|
+| `python:3.13-slim-bookworm` | 41 | glibc |
+| `ubuntu:24.04` | 39 | glibc |
+| `python:3.11-slim` | 2 | glibc |
+| `python:3.10-slim-bookworm` | 2 | glibc |
+| `debian:bullseye-slim` | 2 | glibc **2.31 — the oldest in the set** |
+| `debian:13.0-slim` | 2 | glibc |
+| `python:3.11` | 1 | glibc |
+
+No task image is musl-based, so **no `x86_64-unknown-linux-musl` target is
+added**. An unused second build path is a liability: it doubles what a release
+has to prove and rots silently between the runs that would exercise it.
+
+The name `qemu-alpine-ssh` is the trap here — it is one of the two
+`debian:bullseye-slim` tasks. Alpine appears as an ISO the *agent* downloads and
+boots inside QEMU; it is the guest OS, never the container Stella runs in. The
+loader error confirms this independently: it names
+`/lib/x86_64-linux-gnu/libc.so.6`, a path that exists only where glibc does.
+
+Two independent methods agree on that container's glibc. Statically, its
+Dockerfile says bullseye (glibc 2.31). At runtime, the loader reported
+`GLIBC_2.32`, `2.33` and `2.34` missing while saying nothing about the
+`GLIBC_2.18` … `2.30` the same binary also required — so it provides at least
+2.30 and lacks 2.32, which is 2.31 exactly.
+
+This answer is a property of the pinned dataset, not of Docker. If `TB_DATASET`
+is ever repinned, re-run the tally over the new task set before trusting it:
+
+```bash
+rg --no-filename -N -i -m1 '^\s*FROM\s+(\S+)' -o -r '$1' \
+  "$DATASET_DIR"/*/*/environment/Dockerfile | sort | uniq -c | sort -rn
+```
+
 ## Why the pre-pull is not optional
 
 The first attempt at this run lost four trials in its opening minutes to

--- a/bench/evidence/run/build_sut.sh
+++ b/bench/evidence/run/build_sut.sh
@@ -19,14 +19,18 @@ echo "SUT=$SUT ($(git describe --tags "$SUT" 2>/dev/null || echo no-tag))"
 
 ZC="$(mktemp -d "${TMPDIR:-/tmp}/stella-zig.XXXXXX")"
 mkdir -p "$ZC/global" "$ZC/local"
-rustup target add x86_64-unknown-linux-gnu >/dev/null
+rustup target add "$STELLA_TARGET_TRIPLE" >/dev/null
 RUSTC="$(rustup which rustc)" \
 ZIG_GLOBAL_CACHE_DIR="$ZC/global" ZIG_LOCAL_CACHE_DIR="$ZC/local" \
 STELLA_BUILD_GIT_SHA="$SUT" \
 "$(rustup which cargo)" zigbuild --release --locked \
-  --target x86_64-unknown-linux-gnu.2.17 --package stella-cli --bin stella
+  --target "$STELLA_TARGET_TRIPLE.$STELLA_GLIBC_FLOOR" --package stella-cli --bin stella
 
 test -x "$STELLA_BINARY"
+# Verify the artifact, not that the right command was typed. Building through
+# this script and building through anything else are then distinguishable by
+# inspecting the output, which is the only evidence a later run actually has.
+assert_portable_binary
 file "$STELLA_BINARY"
 shasum -a 256 "$STELLA_BINARY" | awk '{print $1}' > "$TB_ROOT/binary_sha256.txt"
 echo "binary_sha256=$(cat "$TB_ROOT/binary_sha256.txt")"

--- a/bench/evidence/run/env.sh
+++ b/bench/evidence/run/env.sh
@@ -12,7 +12,16 @@ export VENV="$TB_REPO/bench/harbor_adapter/.venv"
 export PATH="$VENV/bin:$PATH"
 export PYTHONPATH="$TB_REPO/bench/harbor_adapter"
 
-export STELLA_BINARY="$TB_REPO/target/x86_64-unknown-linux-gnu/release/stella"
+# The SUT is cross-compiled against an old glibc so it runs in every task image,
+# including the two on `debian:bullseye-slim` (glibc 2.31). Both halves of that
+# contract are pinned here — `build_sut.sh` builds to this floor and `preflight`
+# refuses to start a run with a binary that exceeds it — because keeping them
+# apart is how a glibc-2.35 binary reached five trials on 2026-07-31 wearing the
+# portable build's filename. Constants, not overridable defaults: an operator
+# able to raise the floor to silence the error is the failure being prevented.
+export STELLA_TARGET_TRIPLE="x86_64-unknown-linux-gnu"
+export STELLA_GLIBC_FLOOR="2.17"
+export STELLA_BINARY="$TB_REPO/target/$STELLA_TARGET_TRIPLE/release/stella"
 export STELLA_BUDGET="${STELLA_BUDGET:-0.60}"
 export STELLA_DISABLE_REFLECTION=1
 
@@ -45,9 +54,34 @@ mkdir -p "$JOBS"
 
 [ -f "$TB_ROOT/sut_commit.txt" ] && export STELLA_SOURCE_COMMIT="$(cat "$TB_ROOT/sut_commit.txt")"
 
+# Assert the SUT binary can actually execute inside a task container.
+#
+# Every other integrity check answers "did the file arrive intact" — the
+# host/container SHA-256 comparison passes because it is the same file on both
+# sides. Nothing answered "can this file run here", and the first thing to touch
+# the dynamic linker was `stella --version`, inside the container, per trial,
+# after the run had already started. Harbor recorded the loader's rejection as
+# NonZeroAgentExitCodeError and the trial scored 0.0, indistinguishable from the
+# agent failing the task. This check runs on the host before any container is
+# created, so a substituted binary costs one message instead of a run.
+assert_portable_binary() {
+  local binary="${1:-$STELLA_BINARY}"
+  local checker="$TB_REPO/bench/harbor_adapter/stella_harbor/portability.py"
+  command -v python3 >/dev/null 2>&1 || {
+    echo "FATAL: python3 is required to verify SUT binary portability"; return 1; }
+  test -f "$checker" || { echo "FATAL: portability checker missing at $checker"; return 1; }
+  python3 "$checker" "$binary" --max-glibc "$STELLA_GLIBC_FLOOR" || {
+    echo "FATAL: $binary cannot execute in a Terminal-Bench task container."
+    echo "       Rebuild with bench/evidence/run/build_sut.sh — do not substitute"
+    echo "       a plain \`cargo build --release\` artifact into the target/ path."
+    return 1
+  }
+}
+
 preflight() {
   test -n "${OPENROUTER_API_KEY:-}" || { echo "FATAL: OPENROUTER_API_KEY unset"; return 1; }
   test -x "$STELLA_BINARY" || { echo "FATAL: no SUT binary at $STELLA_BINARY (run build_sut.sh)"; return 1; }
+  assert_portable_binary || return 1
   test "${#STELLA_SOURCE_COMMIT}" = 40 || { echo "FATAL: STELLA_SOURCE_COMMIT is not a full SHA"; return 1; }
   test "$(command -v harbor)" = "$VENV/bin/harbor" || { echo "FATAL: wrong harbor on PATH"; return 1; }
   test "$(harbor --version)" = "0.6.1" || { echo "FATAL: harbor $(harbor --version) != 0.6.1 (audited constant)"; return 1; }

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -75,6 +75,7 @@ from .credential_bundle import (
     HOST_CREDENTIAL_SOURCE,
     read_bundle_from_environment,
 )
+from .portability import raise_for_loader_failure
 from .posture import (
     _ASSURANCE_TIERS_VERSION,
     _ENGINE_POSTURE_VERSION,
@@ -1122,16 +1123,24 @@ class StellaAgent(BaseInstalledAgent):
         self._harbor_sha256 = _harbor_content_sha256()
 
         await environment.upload_file(str(binary_path), _REMOTE_TMP)
-        install_result = await self.exec_as_root(
-            environment,
-            command=(
-                f"sha256sum {_REMOTE_TMP} && "
-                f"cp {_REMOTE_TMP} {_INSTALL_PATH} && "
-                f"chmod +x {_INSTALL_PATH} && "
-                f"{_INSTALL_PATH} --version"
-            ),
-            timeout_sec=120,
-        )
+        # `--version` is the first command that touches the container's dynamic
+        # loader, so a binary that cannot run here dies at this exec and Harbor
+        # attributes the raw nonzero exit to the agent. Classify the loader's
+        # own diagnostic before that happens.
+        try:
+            install_result = await self.exec_as_root(
+                environment,
+                command=(
+                    f"sha256sum {_REMOTE_TMP} && "
+                    f"cp {_REMOTE_TMP} {_INSTALL_PATH} && "
+                    f"chmod +x {_INSTALL_PATH} && "
+                    f"{_INSTALL_PATH} --version"
+                ),
+                timeout_sec=120,
+            )
+        except NonZeroAgentExitCodeError as error:
+            raise_for_loader_failure(error, binary_path)
+            raise
         installed_stdout = getattr(install_result, "stdout", None) or ""
         remote_digest_match = re.search(r"(?m)^([0-9a-f]{64})\s+", installed_stdout)
         remote_digest = remote_digest_match.group(1) if remote_digest_match else None

--- a/bench/harbor_adapter/stella_harbor/portability.py
+++ b/bench/harbor_adapter/stella_harbor/portability.py
@@ -397,9 +397,9 @@ def _read_version_requirements(
 def read_libc_profile(path: Path | str) -> LibcProfile:
     """Read a binary's C-library requirements from disk.
 
-    ``mmap`` rather than ``read_bytes`` because the SUT is ~32 MiB and the
-    adapter may profile it on concurrent trials; only the pages actually
-    touched are ever resident.
+    ``mmap`` rather than ``read_bytes`` because the SUT is ~32 MiB and several
+    trials can be diagnosing a failure at once; only the pages actually touched
+    — the headers and two small sections — are ever resident.
     """
     binary = Path(path)
     with binary.open("rb") as handle:

--- a/bench/harbor_adapter/stella_harbor/portability.py
+++ b/bench/harbor_adapter/stella_harbor/portability.py
@@ -1,0 +1,665 @@
+"""Prove a host-built SUT binary can execute inside a task container.
+
+Why this exists
+---------------
+Every integrity check the benchmark already runs answers *"did the file arrive
+intact"* — the SHA-256 the container computes is compared against the host's,
+and it matches because it is the same file on both sides. Nothing answered
+*"can this file run here"*. On 2026-07-31 a run was provisioned by a script
+that bypassed ``bench/evidence/run/build_sut.sh``::
+
+    cargo build --release --locked -p stella-cli --bin stella
+    cp target/release/stella target/x86_64-unknown-linux-gnu/release/stella
+
+That produced a glibc-2.35 binary (Ubuntu 22.04 build host) wearing the
+portable build's filename, in the exact path ``env.sh`` exports as
+``STELLA_BINARY``. Every digest check passed. The first thing to touch the
+dynamic loader was ``stella --version`` — inside the container, per trial,
+after the run had started — and it died::
+
+    /usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6:
+        version `GLIBC_2.34' not found (required by /usr/local/bin/stella)
+
+Harbor recorded ``NonZeroAgentExitCodeError`` and the trial scored 0.0,
+indistinguishable in the results from the agent failing the task.
+
+What this module checks
+-----------------------
+The requirement a binary places on its C library is recorded in the ELF
+``.gnu.version_r`` section: one ``Verneed`` per needed library, each carrying
+``Vernaux`` entries naming the symbol versions (``GLIBC_2.34``) the binary
+demands. That table *is* what the loader walks at ``exec`` time to decide
+whether to abort. Reading it on the host runs the loader's check ahead of time,
+before any container exists.
+
+Parsing is done here rather than by shelling out to ``readelf``/``objdump``
+because those are absent from a macOS development host — a guard that silently
+no-ops on the machine most likely to hold a wrong-architecture build is not a
+guard. Pure stdlib also keeps the regression test hermetic: no binutils, no
+Docker, no cross-compiler.
+
+The floor
+---------
+``build_sut.sh`` cross-compiles against ``x86_64-unknown-linux-gnu.2.17``.
+glibc 2.17 is RHEL 7 era (2012) and runs essentially anywhere. The oldest base
+image in Terminal-Bench 2.1 is ``debian:bullseye-slim`` (glibc 2.31), so the
+2.17 floor clears the whole dataset with fourteen years of margin. Both the
+floor and the target triple are exported by ``env.sh`` so the build and this
+check can never disagree about what "portable" means.
+
+Run standalone::
+
+    python3 stella_harbor/portability.py /path/to/stella --max-glibc 2.17
+
+Exit status is ``0`` portable, ``1`` not portable, ``2`` could not be
+determined. Preflight treats every nonzero status as fatal: a binary whose
+portability cannot be established has not been shown to be portable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mmap
+import re
+import struct
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "DEFAULT_GLIBC_FLOOR",
+    "DEFAULT_MACHINE",
+    "BinaryIncompatibleWithContainerError",
+    "BinaryPortabilityError",
+    "LibcProfile",
+    "LoaderFailure",
+    "MalformedElfError",
+    "NotAnElfError",
+    "classify_loader_failure",
+    "check_portability",
+    "format_version",
+    "libc_profile_from_bytes",
+    "parse_glibc_floor",
+    "probe_libc_profile",
+    "raise_for_loader_failure",
+    "read_libc_profile",
+]
+
+# The glibc floor `build_sut.sh` targets. Kept in sync by `env.sh`, which
+# exports STELLA_GLIBC_FLOOR to both the build and this check.
+DEFAULT_GLIBC_FLOOR = (2, 17)
+
+# Task images publish linux/amd64 only, and `env.sh` pins
+# DOCKER_DEFAULT_PLATFORM to match. An arm64 binary is unrunnable there for the
+# same class of reason a too-new glibc is, and fails just as late.
+DEFAULT_MACHINE = "x86-64"
+
+_ELF_MAGIC = b"\x7fELF"
+_EI_NIDENT = 16
+_ELFCLASS32 = 1
+_ELFCLASS64 = 2
+_ELFDATA2LSB = 1
+_ELFDATA2MSB = 2
+_PT_INTERP = 3
+_SHT_GNU_VERNEED = 0x6FFFFFFE
+
+_MACHINE_NAMES = {
+    3: "x86",
+    8: "mips",
+    40: "arm",
+    62: "x86-64",
+    183: "aarch64",
+    243: "riscv",
+}
+
+# `GLIBC_2.34`, `GLIBC_2.2.5`. Deliberately anchored: a `GLIBC_*` token that is
+# not a dotted version (`GLIBC_ABI_DT_RELR`, emitted by glibc 2.36+ toolchains)
+# cannot be shown satisfiable by an older libc, so it is reported rather than
+# silently dropped.
+_GLIBC_VERSION_TOKEN = re.compile(r"^GLIBC_(\d+(?:\.\d+)*)$")
+
+_MUSL_INTERPRETER = re.compile(r"ld-musl", re.IGNORECASE)
+
+
+class BinaryPortabilityError(RuntimeError):
+    """The binary's runtime requirements could not be established."""
+
+
+class NotAnElfError(BinaryPortabilityError):
+    """The file is not an ELF object — e.g. a Mach-O or a shell script."""
+
+
+class MalformedElfError(BinaryPortabilityError):
+    """The file claims to be ELF but its headers do not parse."""
+
+
+class BinaryIncompatibleWithContainerError(RuntimeError):
+    """The uploaded SUT binary could not execute in the task container.
+
+    Deliberately not a ``NonZeroAgentExitCodeError``. The install probe
+    (``stella --version``) is the first command to touch the container's
+    dynamic loader, so a mis-provisioned binary fails there — before the agent
+    has been asked to do anything. Harbor writes the exception class into
+    ``result.json``, and on 2026-07-31 five trials carrying this failure were
+    recorded under the same class as a genuine nonzero agent exit and scored
+    0.0, arithmetically indistinguishable from Stella failing those tasks.
+
+    Raising a distinct class keeps a provisioning defect attributable as one.
+    """
+
+
+@dataclass(frozen=True)
+class LibcProfile:
+    """What a binary demands of the C library where it will be executed."""
+
+    name: str
+    machine: str
+    bits: int
+    interpreter: str | None
+    libc_flavor: str
+    # Every `GLIBC_*` token in `.gnu.version_r`, in file order.
+    glibc_tokens: tuple[str, ...] = ()
+    # The parsed subset, highest last.
+    glibc_versions: tuple[tuple[int, ...], ...] = ()
+    # `GLIBC_*` tokens that are not dotted versions.
+    unparsed_glibc_tokens: tuple[str, ...] = ()
+    needed_versioned_libraries: tuple[str, ...] = ()
+
+    @property
+    def max_glibc(self) -> tuple[int, ...] | None:
+        """The highest glibc version this binary cannot run without."""
+        return max(self.glibc_versions) if self.glibc_versions else None
+
+    def describe(self) -> str:
+        """One human-readable line naming the properties that decide the verdict."""
+        parts = [f"{self.machine}/{self.bits}-bit", self.libc_flavor]
+        highest = self.max_glibc
+        if highest is not None:
+            parts.append(f"max GLIBC_{format_version(highest)}")
+        elif self.libc_flavor == "glibc":
+            parts.append("no versioned glibc symbols")
+        if self.interpreter:
+            parts.append(f"interp {self.interpreter}")
+        return ", ".join(parts)
+
+
+@dataclass(frozen=True)
+class LoaderFailure:
+    """A container-side execution failure attributed to the binary, not the agent."""
+
+    kind: str
+    summary: str
+    details: tuple[str, ...] = field(default=())
+
+
+def format_version(version: tuple[int, ...]) -> str:
+    """Render a parsed version tuple back to its dotted form."""
+    return ".".join(str(part) for part in version)
+
+
+def parse_glibc_floor(text: str) -> tuple[int, ...]:
+    """Parse a dotted glibc floor such as ``2.17``."""
+    stripped = text.strip()
+    if not re.fullmatch(r"\d+(?:\.\d+)*", stripped):
+        raise ValueError(f"not a dotted glibc version: {text!r}")
+    return tuple(int(part) for part in stripped.split("."))
+
+
+def _cstring(data: memoryview | bytes, start: int, limit: int) -> str:
+    """Read a NUL-terminated string, refusing to run past ``limit``."""
+    if start < 0 or start >= limit:
+        raise MalformedElfError("string table offset is outside the section")
+    end = start
+    while end < limit and data[end] != 0:
+        end += 1
+    return bytes(data[start:end]).decode("utf-8", "replace")
+
+
+def _unpack(fmt: str, data: memoryview | bytes, offset: int) -> tuple[int, ...]:
+    """`struct.unpack_from` that reports a malformed ELF instead of a struct error."""
+    try:
+        return struct.unpack_from(fmt, data, offset)
+    except struct.error as error:
+        raise MalformedElfError(
+            f"truncated ELF structure at offset {offset}"
+        ) from error
+
+
+def libc_profile_from_bytes(data: bytes | memoryview, *, name: str) -> LibcProfile:
+    """Read the C-library requirements recorded in an ELF image."""
+    if len(data) < _EI_NIDENT or bytes(data[:4]) != _ELF_MAGIC:
+        raise NotAnElfError(
+            f"{name} is not an ELF binary (no \\x7fELF magic) — a Linux task "
+            "container cannot execute it whatever else is true of it"
+        )
+
+    ei_class = data[4]
+    ei_data = data[5]
+    if ei_class == _ELFCLASS64:
+        bits, header_fmt, phdr_fmt, shdr_fmt = 64, "HHIQQQIHHHHHH", "IIQQQQ", "IIQQQQII"
+    elif ei_class == _ELFCLASS32:
+        bits, header_fmt, phdr_fmt, shdr_fmt = 32, "HHIIIIIHHHHHH", "IIIII", "IIIIIIII"
+    else:
+        raise MalformedElfError(f"{name}: unknown ELF class {ei_class}")
+
+    if ei_data == _ELFDATA2LSB:
+        endian = "<"
+    elif ei_data == _ELFDATA2MSB:
+        endian = ">"
+    else:
+        raise MalformedElfError(f"{name}: unknown ELF endianness {ei_data}")
+
+    (
+        _e_type,
+        e_machine,
+        _e_version,
+        _e_entry,
+        e_phoff,
+        e_shoff,
+        _e_flags,
+        _e_ehsize,
+        e_phentsize,
+        e_phnum,
+        e_shentsize,
+        e_shnum,
+        _e_shstrndx,
+    ) = _unpack(endian + header_fmt, data, _EI_NIDENT)
+
+    machine = _MACHINE_NAMES.get(e_machine, f"unknown({e_machine})")
+    interpreter = _read_interpreter(
+        data, endian + phdr_fmt, e_phoff, e_phentsize, e_phnum, bits
+    )
+    tokens, libraries = _read_version_requirements(
+        data, endian + shdr_fmt, e_shoff, e_shentsize, e_shnum, endian
+    )
+
+    glibc_tokens = tuple(token for token in tokens if token.startswith("GLIBC_"))
+    versions: list[tuple[int, ...]] = []
+    unparsed: list[str] = []
+    for token in glibc_tokens:
+        match = _GLIBC_VERSION_TOKEN.match(token)
+        if match is None:
+            unparsed.append(token)
+        else:
+            versions.append(tuple(int(part) for part in match.group(1).split(".")))
+
+    if interpreter and _MUSL_INTERPRETER.search(interpreter):
+        flavor = "musl"
+    elif glibc_tokens or (interpreter and "ld-linux" in interpreter):
+        flavor = "glibc"
+    elif interpreter is None:
+        flavor = "static"
+    else:
+        flavor = "unknown"
+
+    return LibcProfile(
+        name=name,
+        machine=machine,
+        bits=bits,
+        interpreter=interpreter,
+        libc_flavor=flavor,
+        glibc_tokens=glibc_tokens,
+        glibc_versions=tuple(sorted(set(versions))),
+        unparsed_glibc_tokens=tuple(dict.fromkeys(unparsed)),
+        needed_versioned_libraries=libraries,
+    )
+
+
+def _read_interpreter(
+    data: bytes | memoryview,
+    fmt: str,
+    phoff: int,
+    phentsize: int,
+    phnum: int,
+    bits: int,
+) -> str | None:
+    """Return the ``PT_INTERP`` path — the loader this binary asks for by name."""
+    if phoff == 0 or phnum == 0:
+        return None
+    for index in range(phnum):
+        fields = _unpack(fmt, data, phoff + index * phentsize)
+        if bits == 64:
+            p_type, _p_flags, p_offset, _p_vaddr, _p_paddr, p_filesz = fields
+        else:
+            p_type, p_offset, _p_vaddr, _p_paddr, p_filesz = fields
+        if p_type != _PT_INTERP:
+            continue
+        if p_offset + p_filesz > len(data):
+            raise MalformedElfError("PT_INTERP segment runs past end of file")
+        raw = bytes(data[p_offset : p_offset + p_filesz])
+        return raw.split(b"\0", 1)[0].decode("utf-8", "replace")
+    return None
+
+
+def _read_version_requirements(
+    data: bytes | memoryview,
+    fmt: str,
+    shoff: int,
+    shentsize: int,
+    shnum: int,
+    endian: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Collect every symbol version named in ``.gnu.version_r``.
+
+    Returns the version tokens (``GLIBC_2.34``) and the libraries requiring
+    them (``libc.so.6``). A statically linked binary has no such section and
+    correctly yields nothing.
+    """
+    if shoff == 0 or shnum == 0:
+        return (), ()
+
+    sections = []
+    for index in range(shnum):
+        fields = _unpack(fmt, data, shoff + index * shentsize)
+        # sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size, sh_link, sh_info
+        sections.append((fields[1], fields[4], fields[5], fields[6], fields[7]))
+
+    tokens: list[str] = []
+    libraries: list[str] = []
+    for sh_type, sh_offset, sh_size, sh_link, sh_info in sections:
+        if sh_type != _SHT_GNU_VERNEED:
+            continue
+        if sh_link >= len(sections):
+            raise MalformedElfError(".gnu.version_r links to a missing string table")
+        _, str_offset, str_size, _, _ = sections[sh_link]
+        str_limit = str_offset + str_size
+        if str_limit > len(data) or sh_offset + sh_size > len(data):
+            raise MalformedElfError(".gnu.version_r section runs past end of file")
+
+        position = sh_offset
+        section_end = sh_offset + sh_size
+        for _ in range(sh_info):
+            if position + 16 > section_end:
+                raise MalformedElfError("Verneed entry runs past its section")
+            _vn_version, vn_cnt, vn_file, vn_aux, vn_next = _unpack(
+                endian + "HHIII", data, position
+            )
+            libraries.append(_cstring(data, str_offset + vn_file, str_limit))
+            aux = position + vn_aux
+            for _ in range(vn_cnt):
+                if aux + 16 > section_end:
+                    raise MalformedElfError("Vernaux entry runs past its section")
+                _hash, _flags, _other, vna_name, vna_next = _unpack(
+                    endian + "IHHII", data, aux
+                )
+                tokens.append(_cstring(data, str_offset + vna_name, str_limit))
+                if vna_next == 0:
+                    break
+                aux += vna_next
+            if vn_next == 0:
+                break
+            position += vn_next
+
+    return tuple(tokens), tuple(dict.fromkeys(libraries))
+
+
+def read_libc_profile(path: Path | str) -> LibcProfile:
+    """Read a binary's C-library requirements from disk.
+
+    ``mmap`` rather than ``read_bytes`` because the SUT is ~32 MiB and the
+    adapter may profile it on concurrent trials; only the pages actually
+    touched are ever resident.
+    """
+    binary = Path(path)
+    with binary.open("rb") as handle:
+        try:
+            data = mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ)
+        except ValueError as error:  # mmap of an empty file
+            raise NotAnElfError(f"{binary} is empty") from error
+        # Release the view before closing the map. A live memoryview makes
+        # `mmap.close()` raise BufferError, which on the error path would
+        # replace the diagnosis with an unrelated exception and defeat the
+        # fail-closed exit status.
+        view = memoryview(data)
+        try:
+            return libc_profile_from_bytes(view, name=str(binary))
+        finally:
+            view.release()
+            data.close()
+
+
+def check_portability(
+    profile: LibcProfile,
+    *,
+    max_glibc: tuple[int, ...] = DEFAULT_GLIBC_FLOOR,
+    machine: str | None = DEFAULT_MACHINE,
+) -> list[str]:
+    """Return every reason this binary would fail to execute in a task container.
+
+    An empty list means the binary satisfies the floor. musl and fully static
+    builds satisfy it trivially — they carry no glibc requirement at all — and
+    are reported as such rather than treated as suspicious.
+    """
+    violations: list[str] = []
+
+    if machine is not None and profile.machine != machine:
+        violations.append(
+            f"built for {profile.machine}, but task containers run {machine} "
+            "(DOCKER_DEFAULT_PLATFORM=linux/amd64); it would die with "
+            "'Exec format error'"
+        )
+
+    highest = profile.max_glibc
+    if highest is not None and highest > max_glibc:
+        offenders = sorted(
+            (version for version in profile.glibc_versions if version > max_glibc),
+            reverse=True,
+        )
+        named = ", ".join(f"GLIBC_{format_version(item)}" for item in offenders)
+        violations.append(
+            f"requires {named}, above the GLIBC_{format_version(max_glibc)} floor "
+            "build_sut.sh targets — this is a host-glibc build, not the portable one"
+        )
+
+    if profile.unparsed_glibc_tokens:
+        named = ", ".join(profile.unparsed_glibc_tokens)
+        violations.append(
+            f"requires the non-versioned glibc marker(s) {named}, which no glibc "
+            f"at the GLIBC_{format_version(max_glibc)} floor provides"
+        )
+
+    return violations
+
+
+def classify_loader_failure(text: str) -> LoaderFailure | None:
+    """Recognise a dynamic-loader rejection in container output.
+
+    The loader's own diagnostics are the only evidence available once the
+    binary is already in the container, and each maps to a distinct provisioning
+    mistake. Returning a typed failure lets the caller raise something that can
+    never be tallied as the agent failing its task.
+    """
+    if not text:
+        return None
+
+    missing_versions = re.findall(
+        r"version [`'\"]([A-Za-z0-9_.]+)['\"] not found", text
+    )
+    if missing_versions:
+        unique = tuple(dict.fromkeys(missing_versions))
+        return LoaderFailure(
+            kind="glibc-too-old-for-binary",
+            summary=(
+                "the uploaded binary requires newer glibc symbol versions than "
+                "the task container provides"
+            ),
+            details=unique,
+        )
+
+    if re.search(r"cannot execute binary file: Exec format error", text):
+        return LoaderFailure(
+            kind="wrong-architecture",
+            summary="the uploaded binary was built for a different CPU architecture",
+        )
+
+    missing_libraries = re.findall(
+        r"error while loading shared libraries: ([^:]+): cannot open shared object",
+        text,
+    )
+    if missing_libraries:
+        return LoaderFailure(
+            kind="missing-shared-library",
+            summary=(
+                "the task container lacks a shared library the binary links against"
+            ),
+            details=tuple(dict.fromkeys(missing_libraries)),
+        )
+
+    if re.search(
+        r"(?:not found|No such file or directory)\s*$", text.strip()
+    ) and re.search(r"ld-(?:linux|musl)|/usr/local/bin/stella", text):
+        return LoaderFailure(
+            kind="loader-absent",
+            summary=(
+                "the task container has no dynamic loader for this binary "
+                "(a glibc build on a musl image reports exactly this)"
+            ),
+        )
+
+    return None
+
+
+def probe_libc_profile(path: Path | str) -> LibcProfile | None:
+    """Profile a binary for diagnosis, returning ``None`` if it cannot be read.
+
+    The *blocking* check belongs on the host before a run starts
+    (``assert_portable_binary`` in ``bench/evidence/run/env.sh``), where one
+    message replaces an entire wasted run; a check that only fires per-trial has
+    already cost what it was meant to save. This exists so that when a container
+    does reject the binary, the error can report what was actually uploaded, and
+    so it must tolerate anything it is handed — development builds, a Mach-O
+    binary from a macOS tree, the short byte strings the adapter's tests use.
+    """
+    try:
+        return read_libc_profile(path)
+    except Exception:  # noqa: BLE001 - diagnostic aid, never fatal
+        return None
+
+
+def raise_for_loader_failure(error: Exception, binary: Path | str) -> None:
+    """Re-raise a dynamic-loader rejection under its own class, or return.
+
+    A genuine nonzero exit from the install probe (a full disk, a read-only
+    ``/usr/local/bin``) is left alone to propagate unchanged. Only output
+    carrying a loader diagnostic is reclassified, so this can never mask an
+    unrelated failure as a packaging one. The host binary is profiled here
+    rather than at install time because it is read only to compose this
+    message — on a healthy run nothing ever parses it.
+    """
+    failure = classify_loader_failure(str(error))
+    if failure is None:
+        return
+    detail = f" ({', '.join(failure.details)})" if failure.details else ""
+    profile = probe_libc_profile(binary)
+    uploaded = (
+        f" The host binary that was uploaded is: {profile.describe()}."
+        if profile
+        else ""
+    )
+    raise BinaryIncompatibleWithContainerError(
+        f"[{failure.kind}] {failure.summary}{detail}.{uploaded} This is a "
+        "provisioning failure, not the agent failing the task — the install "
+        "probe never returned, so Stella was never asked to do any work and "
+        "this trial carries no signal about it. Rebuild the SUT with "
+        "bench/evidence/run/build_sut.sh, which cross-compiles against the "
+        "pinned glibc floor; a plain `cargo build --release` artifact copied "
+        "into the target/ path reproduces exactly this while passing every "
+        "digest check."
+    ) from error
+
+
+def _render_report(profile: LibcProfile, violations: list[str]) -> str:
+    lines = [f"binary: {profile.name}", f"profile: {profile.describe()}"]
+    if profile.needed_versioned_libraries:
+        lines.append(f"versioned deps: {', '.join(profile.needed_versioned_libraries)}")
+    if violations:
+        lines.append("NOT PORTABLE:")
+        lines.extend(f"  - {item}" for item in violations)
+        lines.append(
+            "Rebuild with `bench/evidence/run/build_sut.sh`, which cross-compiles "
+            "against the pinned glibc floor via cargo-zigbuild. Do not "
+            "`cargo build --release` and copy the result into the target/ path — "
+            "that is the substitution this check exists to catch."
+        )
+    else:
+        lines.append(
+            "portable: satisfies the floor for every Terminal-Bench task image"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. 0 portable, 1 not portable, 2 undeterminable."""
+    parser = argparse.ArgumentParser(
+        prog="portability",
+        description=(
+            "Assert a SUT binary can execute in a Terminal-Bench task container "
+            "before any container is created."
+        ),
+    )
+    parser.add_argument("binary", help="path to the binary to inspect")
+    parser.add_argument(
+        "--max-glibc",
+        default=format_version(DEFAULT_GLIBC_FLOOR),
+        help="highest glibc version the binary may require (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--machine",
+        default=DEFAULT_MACHINE,
+        help="expected ELF machine, or 'any' to skip (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit the profile and verdict as JSON"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        floor = parse_glibc_floor(args.max_glibc)
+    except ValueError as error:
+        print(f"FATAL: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        profile = read_libc_profile(args.binary)
+    except (BinaryPortabilityError, OSError) as error:
+        # Fail closed: a binary whose requirements cannot be read has not been
+        # shown to be runnable, and this check exists precisely because
+        # "it looked fine" was how the bad binary got through.
+        print(f"FATAL: cannot establish portability: {error}", file=sys.stderr)
+        return 2
+
+    machine = None if args.machine.lower() == "any" else args.machine
+    violations = check_portability(profile, max_glibc=floor, machine=machine)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "binary": profile.name,
+                    "machine": profile.machine,
+                    "bits": profile.bits,
+                    "libc_flavor": profile.libc_flavor,
+                    "interpreter": profile.interpreter,
+                    "glibc_tokens": list(profile.glibc_tokens),
+                    "max_glibc": (
+                        format_version(profile.max_glibc)
+                        if profile.max_glibc is not None
+                        else None
+                    ),
+                    "max_glibc_allowed": format_version(floor),
+                    "violations": violations,
+                    "portable": not violations,
+                },
+                indent=2,
+            )
+        )
+    else:
+        stream = sys.stderr if violations else sys.stdout
+        print(_render_report(profile, violations), file=stream)
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess in tests
+    raise SystemExit(main())

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -75,6 +75,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/atif.py",
     "bench/harbor_adapter/stella_harbor/credential_bundle.py",
     "bench/harbor_adapter/stella_harbor/host_attestation.py",
+    "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",
 )

--- a/bench/harbor_adapter/tests/test_install_classification.py
+++ b/bench/harbor_adapter/tests/test_install_classification.py
@@ -1,0 +1,182 @@
+"""A container rejecting the SUT binary must not be scored as an agent failure.
+
+Harbor records the exception class raised during agent setup into the trial's
+``result.json``. On 2026-07-31 five trials whose binary could not execute were
+recorded as ``NonZeroAgentExitCodeError`` — the same class a genuine nonzero
+agent exit carries — and scored 0.0. Under a fixed denominator that is
+arithmetically indistinguishable from Stella failing those tasks.
+
+These tests pin the two halves of the fix: a loader diagnostic is reclassified,
+and anything else keeps the class it already had. Both matter — reclassifying
+every install failure would hide real ones just as thoroughly as the bug being
+fixed here.
+
+Kept out of ``test_adapter.py`` so the ELF-level tests in ``test_portability``
+stay runnable without Harbor, and so this feature's tests live together.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from harbor.agents.installed.base import NonZeroAgentExitCodeError  # noqa: E402
+
+from stella_harbor import StellaAgent, _sha256_file  # noqa: E402
+from stella_harbor.portability import (  # noqa: E402
+    BinaryIncompatibleWithContainerError,
+)
+from tests.test_portability import build_elf  # noqa: E402
+
+# Verbatim from
+# rig-runs/jobs/dev2-armA-stella/qemu-alpine-ssh__Q2td85H/exception.txt.
+_GLIBC_REJECTION = (
+    "Command failed (exit 1): sha256sum /tmp/stella-upload && cp "
+    "/tmp/stella-upload /usr/local/bin/stella && chmod +x "
+    "/usr/local/bin/stella && /usr/local/bin/stella --version\n"
+    "stdout: 852f8cfd308ee063e3ad46b556483ae1fd9c591cfc89a0d9d2defbe51eef3687  "
+    "/tmp/stella-upload\n"
+    "/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6: version "
+    "`GLIBC_2.34' not found (required by /usr/local/bin/stella)"
+)
+
+
+class _Environment:
+    """Enough of a Harbor environment for ``install`` to reach its assertions."""
+
+    task_env_config = SimpleNamespace(workdir="/workspace")
+
+    async def upload_file(self, source: str, destination: str) -> None:
+        return None
+
+
+def _agent() -> StellaAgent:
+    """A StellaAgent bypassing Harbor's base ``__init__``, as test_adapter does."""
+    agent = StellaAgent.__new__(StellaAgent)
+    agent._extra_env = {}
+    return agent
+
+
+def _install_raising(message: str):
+    async def _exec_as_root(
+        environment: object, *, command: str, timeout_sec: int
+    ) -> SimpleNamespace:
+        raise NonZeroAgentExitCodeError(message)
+
+    return _exec_as_root
+
+
+class TestLoaderRejectionIsNotAnAgentFailure:
+    def test_glibc_rejection_raises_its_own_class(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        agent = _agent()
+        agent.exec_as_root = _install_raising(_GLIBC_REJECTION)
+
+        with pytest.raises(BinaryIncompatibleWithContainerError) as caught:
+            asyncio.run(agent.install(_Environment()))
+
+        error = caught.value
+        assert not isinstance(error, NonZeroAgentExitCodeError), (
+            "the point is that Harbor records a different class for this trial"
+        )
+        message = str(error)
+        assert "GLIBC_2.34" in message
+        assert "not the agent failing the task" in message
+        assert "build_sut.sh" in message
+        # The host-side profile of what was actually uploaded is what turns a
+        # container-side mystery into an actionable operator message.
+        assert "max GLIBC_2.34" in message
+
+    def test_wrong_architecture_is_also_classified(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(machine=183, requirements={"libc.so.6": []}))
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        agent = _agent()
+        agent.exec_as_root = _install_raising(
+            "Command failed (exit 126): /usr/local/bin/stella: cannot execute "
+            "binary file: Exec format error"
+        )
+        with pytest.raises(BinaryIncompatibleWithContainerError) as caught:
+            asyncio.run(agent.install(_Environment()))
+        assert "aarch64" in str(caught.value)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Command failed (exit 1): cp: cannot create regular file "
+            "'/usr/local/bin/stella': Read-only file system",
+            "Command failed (exit 1): sha256sum: /tmp/stella-upload: "
+            "No space left on device",
+        ],
+    )
+    def test_unrelated_install_failures_keep_their_class(
+        self, message: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.17"]}))
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        agent = _agent()
+        agent.exec_as_root = _install_raising(message)
+        with pytest.raises(NonZeroAgentExitCodeError):
+            asyncio.run(agent.install(_Environment()))
+
+
+class TestProfilingNeverBreaksInstall:
+    def test_a_non_elf_binary_installs_exactly_as_before(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The blocking check lives in env.sh; nothing here may become fatal.
+
+        A development binary, a Mach-O build from a macOS tree, or the short
+        byte strings the adapter's other tests write must all install unchanged.
+        """
+        binary = tmp_path / "stella"
+        binary.write_bytes(b"\xcf\xfa\xed\xfe not an elf")
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        agent = _agent()
+
+        async def _exec_as_root(
+            environment: object, *, command: str, timeout_sec: int
+        ) -> SimpleNamespace:
+            return SimpleNamespace(
+                return_code=0,
+                stdout=f"{_sha256_file(binary)}  /tmp/stella-upload\nstella 0.6.24",
+            )
+
+        agent.exec_as_root = _exec_as_root
+        asyncio.run(agent.install(_Environment()))
+        assert agent._binary_sha256_verified is True
+
+    def test_an_unreadable_binary_does_not_mask_the_loader_diagnosis(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even with no profile to report, the failure is still reclassified."""
+        binary = tmp_path / "stella"
+        binary.write_bytes(b"not an elf")
+        binary.chmod(0o755)
+        monkeypatch.setenv("STELLA_BINARY", str(binary))
+
+        agent = _agent()
+        agent.exec_as_root = _install_raising(_GLIBC_REJECTION)
+        with pytest.raises(BinaryIncompatibleWithContainerError) as caught:
+            asyncio.run(agent.install(_Environment()))
+        assert "GLIBC_2.34" in str(caught.value)

--- a/bench/harbor_adapter/tests/test_portability.py
+++ b/bench/harbor_adapter/tests/test_portability.py
@@ -1,0 +1,579 @@
+"""Regression tests for the SUT binary portability guard.
+
+These would have caught the 2026-07-31 substitution. A run was provisioned with
+``cargo build --release`` output copied into the path ``env.sh`` exports as
+``STELLA_BINARY``; the resulting glibc-2.35 binary passed every existing check
+(the host/container SHA-256 matched — it was the same file) and died in the
+container on ``stella --version`` with ``GLIBC_2.34 not found``. Harbor scored
+those trials 0.0, indistinguishable from the agent failing the task.
+
+Every assertion here is on the *artifact*: an ELF image is synthesized with a
+chosen set of glibc requirements and the guard's verdict is checked. Nothing
+asserts that a particular build command was typed, because the failure was
+precisely that the right command was not typed and everything downstream still
+agreed. Synthesizing ELF bytes keeps the suite hermetic — no binutils, no
+Docker, no cross-compiler — so it runs identically on a macOS laptop and in CI.
+
+The parser is additionally validated against both real artifacts: the exact
+binary that broke the run (rejected, max ``GLIBC_2.34``) and a genuine
+``cargo zigbuild --target x86_64-unknown-linux-gnu.2.17`` build (accepted, max
+``GLIBC_2.17``). Those cannot be committed — one is 32 MiB — so they are
+exercised through the opt-in fixture test at the bottom.
+"""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from stella_harbor.portability import (
+    DEFAULT_GLIBC_FLOOR,
+    LibcProfile,
+    MalformedElfError,
+    NotAnElfError,
+    check_portability,
+    classify_loader_failure,
+    libc_profile_from_bytes,
+    parse_glibc_floor,
+    read_libc_profile,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CHECKER = _REPO_ROOT / "bench" / "harbor_adapter" / "stella_harbor" / "portability.py"
+_ENV_SH = _REPO_ROOT / "bench" / "evidence" / "run" / "env.sh"
+
+_EM_X86_64 = 62
+_EM_AARCH64 = 183
+_SHT_STRTAB = 3
+_SHT_GNU_VERNEED = 0x6FFFFFFE
+_PT_INTERP = 3
+
+_GLIBC_LOADER = "/lib64/ld-linux-x86-64.so.2"
+_MUSL_LOADER = "/lib/ld-musl-x86_64.so.1"
+
+# The literal container output from
+# rig-runs/jobs/dev2-armA-stella/qemu-alpine-ssh__Q2td85H/exception.txt.
+_OBSERVED_LOADER_REJECTION = (
+    "Command failed (exit 1): sha256sum /tmp/stella-upload && cp "
+    "/tmp/stella-upload /usr/local/bin/stella && chmod +x /usr/local/bin/stella "
+    "&& /usr/local/bin/stella --version\n"
+    "stdout: 852f8cfd308ee063e3ad46b556483ae1fd9c591cfc89a0d9d2defbe51eef3687  "
+    "/tmp/stella-upload\n"
+    "/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6: version "
+    "`GLIBC_2.32' not found (required by /usr/local/bin/stella)\n"
+    "/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6: version "
+    "`GLIBC_2.33' not found (required by /usr/local/bin/stella)\n"
+    "/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6: version "
+    "`GLIBC_2.34' not found (required by /usr/local/bin/stella)\n\n"
+    "stderr: None"
+)
+
+
+def build_elf(
+    *,
+    machine: int = _EM_X86_64,
+    interpreter: str | None = _GLIBC_LOADER,
+    requirements: dict[str, list[str]] | None = None,
+    endian: str = "<",
+) -> bytes:
+    """Assemble a minimal but structurally valid ELF64 image.
+
+    Carries only what decides the verdict: the machine, the ``PT_INTERP``
+    loader path, and a ``.gnu.version_r`` table naming the symbol versions each
+    shared library must provide. That is the same table the dynamic loader
+    consults at ``exec``, so a binary built here fails or passes the guard for
+    exactly the reason a real one would.
+    """
+    ehsize, phentsize, shentsize = 64, 56, 64
+
+    dynstr = bytearray(b"\0")
+    offsets: dict[str, int] = {}
+
+    def intern(text: str) -> int:
+        if text not in offsets:
+            offsets[text] = len(dynstr)
+            dynstr.extend(text.encode() + b"\0")
+        return offsets[text]
+
+    entries = list((requirements or {}).items())
+    for library, versions in entries:
+        intern(library)
+        for version in versions:
+            intern(version)
+
+    verneed = bytearray()
+    for index, (library, versions) in enumerate(entries):
+        last_library = index == len(entries) - 1
+        verneed += struct.pack(
+            endian + "HHIII",
+            1,  # vn_version
+            len(versions),  # vn_cnt
+            intern(library),  # vn_file
+            16,  # vn_aux — first Vernaux follows immediately
+            0 if last_library else 16 + 16 * len(versions),  # vn_next
+        )
+        for position, version in enumerate(versions):
+            last_version = position == len(versions) - 1
+            verneed += struct.pack(
+                endian + "IHHII",
+                0,  # vna_hash
+                0,  # vna_flags
+                position + 2,  # vna_other
+                intern(version),  # vna_name
+                0 if last_version else 16,  # vna_next
+            )
+
+    phnum = 1 if interpreter else 0
+    cursor = ehsize + phentsize * phnum
+    interp_offset = cursor
+    interp_bytes = interpreter.encode() + b"\0" if interpreter else b""
+    cursor += len(interp_bytes)
+    dynstr_offset = cursor
+    cursor += len(dynstr)
+    verneed_offset = cursor
+    cursor += len(verneed)
+    padding = (-cursor) % 8
+    cursor += padding
+    shoff = cursor
+    shnum = 3 if entries else 2
+
+    image = bytearray()
+    image += b"\x7fELF" + bytes([2, 1 if endian == "<" else 2, 1, 0, 0]) + b"\0" * 7
+    image += struct.pack(
+        endian + "HHIQQQIHHHHHH",
+        3,  # e_type = ET_DYN
+        machine,
+        1,  # e_version
+        0,  # e_entry
+        ehsize if phnum else 0,  # e_phoff
+        shoff,
+        0,  # e_flags
+        ehsize,
+        phentsize,
+        phnum,
+        shentsize,
+        shnum,
+        0,  # e_shstrndx — sections are found by type, never by name
+    )
+    if phnum:
+        image += struct.pack(
+            endian + "IIQQQQQQ",
+            _PT_INTERP,
+            4,  # p_flags = PF_R
+            interp_offset,
+            0,
+            0,
+            len(interp_bytes),
+            len(interp_bytes),
+            1,
+        )
+    image += interp_bytes
+    image += dynstr
+    image += verneed
+    image += b"\0" * padding
+
+    def section(
+        sh_type: int, offset: int, size: int, link: int = 0, info: int = 0
+    ) -> bytes:
+        return struct.pack(
+            endian + "IIQQQQIIQQ", 0, sh_type, 0, 0, offset, size, link, info, 1, 0
+        )
+
+    image += section(0, 0, 0)
+    image += section(_SHT_STRTAB, dynstr_offset, len(dynstr))
+    if entries:
+        image += section(
+            _SHT_GNU_VERNEED, verneed_offset, len(verneed), link=1, info=len(entries)
+        )
+    return bytes(image)
+
+
+def profile_of(**kwargs: object) -> LibcProfile:
+    """Synthesize an ELF and read back its libc requirements."""
+    return libc_profile_from_bytes(build_elf(**kwargs), name="synthetic")  # type: ignore[arg-type]
+
+
+class TestTheSubstitutedBinary:
+    """The exact defect: a host-glibc build wearing the portable build's name."""
+
+    def test_host_glibc_build_is_rejected_with_the_offending_symbols_named(
+        self,
+    ) -> None:
+        profile = profile_of(
+            requirements={
+                "libc.so.6": [
+                    "GLIBC_2.2.5",
+                    "GLIBC_2.14",
+                    "GLIBC_2.32",
+                    "GLIBC_2.33",
+                    "GLIBC_2.34",
+                ]
+            }
+        )
+        assert profile.max_glibc == (2, 34)
+
+        violations = check_portability(profile)
+        assert violations, "a glibc-2.34 binary must not pass the 2.17 floor"
+        message = " ".join(violations)
+        # The message has to name the symbol so an operator can act on it.
+        assert "GLIBC_2.34" in message
+        assert "GLIBC_2.17" in message
+        assert "GLIBC_2.14" not in message, "symbols under the floor are not offenders"
+
+    def test_portable_build_at_the_floor_is_accepted(self) -> None:
+        # A real `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` build
+        # requires exactly up to GLIBC_2.17, so the comparison must be
+        # inclusive. An exclusive bound would reject every correct build.
+        profile = profile_of(
+            requirements={
+                "libc.so.6": ["GLIBC_2.2.5", "GLIBC_2.14", "GLIBC_2.16", "GLIBC_2.17"]
+            }
+        )
+        assert profile.max_glibc == DEFAULT_GLIBC_FLOOR
+        assert check_portability(profile) == []
+
+    def test_versions_are_ordered_numerically_not_lexically(self) -> None:
+        # "2.9" sorts above "2.17" as text. A string comparison here would
+        # reject a correct build and, worse, could accept a bad one.
+        profile = profile_of(requirements={"libc.so.6": ["GLIBC_2.9", "GLIBC_2.2.5"]})
+        assert profile.max_glibc == (2, 9)
+        assert check_portability(profile) == []
+
+    def test_dotted_patch_versions_parse(self) -> None:
+        profile = profile_of(requirements={"libc.so.6": ["GLIBC_2.3.4"]})
+        assert profile.max_glibc == (2, 3, 4)
+        assert check_portability(profile) == []
+
+    def test_multiple_versioned_libraries_are_all_considered(self) -> None:
+        profile = profile_of(
+            requirements={
+                "libc.so.6": ["GLIBC_2.17"],
+                "libm.so.6": ["GLIBC_2.29"],
+                "libgcc_s.so.1": ["GCC_3.0"],
+            }
+        )
+        assert profile.needed_versioned_libraries == (
+            "libc.so.6",
+            "libm.so.6",
+            "libgcc_s.so.1",
+        )
+        # Non-glibc version tokens are irrelevant to the floor and ignored.
+        assert "GCC_3.0" not in profile.glibc_tokens
+        assert profile.max_glibc == (2, 29)
+        assert check_portability(profile)
+
+
+class TestOtherWaysABinaryCannotRunThere:
+    def test_wrong_architecture_is_rejected(self) -> None:
+        # env.sh pins DOCKER_DEFAULT_PLATFORM=linux/amd64 so a multi-arch base
+        # cannot build arm64 and then fail to exec it. That intent is only
+        # enforceable by looking at the artifact.
+        profile = profile_of(machine=_EM_AARCH64, requirements={"libc.so.6": []})
+        assert profile.machine == "aarch64"
+        violations = check_portability(profile)
+        assert any("aarch64" in item for item in violations)
+
+    def test_architecture_check_can_be_waived(self) -> None:
+        profile = profile_of(machine=_EM_AARCH64, requirements={"libc.so.6": []})
+        assert check_portability(profile, machine=None) == []
+
+    def test_non_elf_file_is_rejected(self) -> None:
+        # A macOS development build in STELLA_BINARY is Mach-O; the old
+        # `test -x` preflight accepted it and the failure surfaced per-trial.
+        with pytest.raises(NotAnElfError):
+            libc_profile_from_bytes(b"\xcf\xfa\xed\xfe" + b"\0" * 60, name="mach-o")
+
+    def test_shell_script_is_rejected(self) -> None:
+        with pytest.raises(NotAnElfError):
+            libc_profile_from_bytes(b'#!/bin/sh\nexec stella "$@"\n', name="wrapper")
+
+    def test_truncated_elf_is_rejected_rather_than_assumed_fine(self) -> None:
+        image = build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]})
+        with pytest.raises((MalformedElfError, NotAnElfError)):
+            libc_profile_from_bytes(image[:80], name="truncated")
+
+    def test_unknown_elf_class_is_rejected(self) -> None:
+        broken = bytearray(build_elf(requirements={"libc.so.6": ["GLIBC_2.17"]}))
+        broken[4] = 7  # neither ELFCLASS32 nor ELFCLASS64
+        with pytest.raises(MalformedElfError):
+            libc_profile_from_bytes(bytes(broken), name="bad-class")
+
+    def test_non_versioned_glibc_marker_is_reported(self) -> None:
+        # glibc 2.36+ toolchains can emit GLIBC_ABI_DT_RELR, which is not a
+        # dotted version and cannot be shown satisfiable by an older libc.
+        # Fail closed and name it rather than silently dropping the token.
+        profile = profile_of(
+            requirements={"libc.so.6": ["GLIBC_2.17", "GLIBC_ABI_DT_RELR"]}
+        )
+        assert profile.unparsed_glibc_tokens == ("GLIBC_ABI_DT_RELR",)
+        violations = check_portability(profile)
+        assert any("GLIBC_ABI_DT_RELR" in item for item in violations)
+
+
+class TestBuildsWithNoGlibcRequirement:
+    """musl and static builds clear the floor trivially — they carry no glibc."""
+
+    def test_static_binary_is_portable(self) -> None:
+        profile = profile_of(interpreter=None, requirements=None)
+        assert profile.libc_flavor == "static"
+        assert profile.max_glibc is None
+        assert check_portability(profile) == []
+
+    def test_musl_binary_is_portable(self) -> None:
+        profile = profile_of(interpreter=_MUSL_LOADER, requirements=None)
+        assert profile.libc_flavor == "musl"
+        assert check_portability(profile) == []
+
+    def test_glibc_flavor_is_detected_from_the_loader(self) -> None:
+        profile = profile_of(requirements={"libc.so.6": ["GLIBC_2.17"]})
+        assert profile.libc_flavor == "glibc"
+        assert profile.interpreter == _GLIBC_LOADER
+
+
+class TestLoaderFailureClassification:
+    def test_the_observed_container_output_is_classified(self) -> None:
+        failure = classify_loader_failure(_OBSERVED_LOADER_REJECTION)
+        assert failure is not None
+        assert failure.kind == "glibc-too-old-for-binary"
+        assert failure.details == ("GLIBC_2.32", "GLIBC_2.33", "GLIBC_2.34")
+
+    def test_exec_format_error_is_classified(self) -> None:
+        failure = classify_loader_failure(
+            "/usr/local/bin/stella: cannot execute binary file: Exec format error"
+        )
+        assert failure is not None
+        assert failure.kind == "wrong-architecture"
+
+    def test_missing_shared_library_is_classified(self) -> None:
+        failure = classify_loader_failure(
+            "/usr/local/bin/stella: error while loading shared libraries: "
+            "libssl.so.3: cannot open shared object file: No such file or directory"
+        )
+        assert failure is not None
+        assert failure.kind == "missing-shared-library"
+        assert failure.details == ("libssl.so.3",)
+
+    def test_absent_loader_is_classified(self) -> None:
+        # A glibc binary on a musl image reports exactly this from the shell.
+        failure = classify_loader_failure("/usr/local/bin/stella: not found")
+        assert failure is not None
+        assert failure.kind == "loader-absent"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "cp: cannot create regular file '/usr/local/bin/stella': "
+            "Read-only file system",
+            "sha256sum: /tmp/stella-upload: No space left on device",
+            "stella 0.6.24",
+        ],
+    )
+    def test_unrelated_failures_are_not_reclassified(self, text: str) -> None:
+        # Reclassifying a genuine install failure as a packaging one would hide
+        # it just as thoroughly as the bug being fixed.
+        assert classify_loader_failure(text) is None
+
+
+class TestFloorParsing:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [("2.17", (2, 17)), ("2", (2,)), ("2.3.4", (2, 3, 4)), (" 2.17 ", (2, 17))],
+    )
+    def test_valid_floors(self, text: str, expected: tuple[int, ...]) -> None:
+        assert parse_glibc_floor(text) == expected
+
+    @pytest.mark.parametrize("text", ["", "2.x", "GLIBC_2.17", "2..17", "latest"])
+    def test_invalid_floors_are_rejected(self, text: str) -> None:
+        with pytest.raises(ValueError):
+            parse_glibc_floor(text)
+
+
+class TestCommandLine:
+    """The CLI is what `env.sh` actually invokes, so its contract is tested."""
+
+    @staticmethod
+    def _run(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(_CHECKER), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_exits_nonzero_and_names_the_symbol_for_a_bad_binary(
+        self, tmp_path: Path
+    ) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        result = self._run(str(binary))
+        assert result.returncode == 1
+        combined = result.stdout + result.stderr
+        assert "GLIBC_2.34" in combined
+        assert "build_sut.sh" in combined
+
+    def test_exits_zero_for_a_portable_binary(self, tmp_path: Path) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.17"]}))
+        assert self._run(str(binary)).returncode == 0
+
+    def test_undeterminable_binary_exits_two_rather_than_zero(
+        self, tmp_path: Path
+    ) -> None:
+        # Fail closed: "could not be established" is not "portable".
+        binary = tmp_path / "stella"
+        binary.write_bytes(b"not an elf at all")
+        assert self._run(str(binary)).returncode == 2
+
+    def test_empty_file_exits_two(self, tmp_path: Path) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(b"")
+        assert self._run(str(binary)).returncode == 2
+
+    def test_missing_file_exits_two(self, tmp_path: Path) -> None:
+        assert self._run(str(tmp_path / "absent")).returncode == 2
+
+    def test_invalid_floor_exits_two(self, tmp_path: Path) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.17"]}))
+        assert self._run(str(binary), "--max-glibc", "nonsense").returncode == 2
+
+    def test_json_report_is_machine_readable(self, tmp_path: Path) -> None:
+        import json
+
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        result = self._run(str(binary), "--json")
+        payload = json.loads(result.stdout)
+        assert payload["portable"] is False
+        assert payload["max_glibc"] == "2.34"
+        assert payload["max_glibc_allowed"] == "2.17"
+        assert payload["machine"] == "x86-64"
+
+    def test_runs_without_importing_the_adapter_package(self, tmp_path: Path) -> None:
+        # `env.sh` invokes the checker by file path, deliberately: importing
+        # `stella_harbor` pulls in Harbor, which need not be installed on a host
+        # that is only building the SUT. Run it with the package unimportable.
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        result = subprocess.run(
+            [sys.executable, "-S", str(_CHECKER), str(binary)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env={"PATH": "/usr/bin:/bin", "PYTHONPATH": ""},
+            check=False,
+        )
+        assert result.returncode == 1
+
+
+class TestPreflightWiring:
+    """The guard must be *called*, not merely present in the tree.
+
+    A check nobody invokes is exactly as protective as no check. These tests
+    fail if `assert_portable_binary` is removed from `env.sh`, or if `preflight`
+    stops calling it.
+    """
+
+    @staticmethod
+    def _bash(script: str, tb_root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+                "TB_REPO": str(_REPO_ROOT),
+                "TB_ROOT": str(tb_root),
+                "HOME": str(tb_root),
+            },
+        )
+
+    def test_env_sh_rejects_a_non_portable_binary(self, tmp_path: Path) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        binary.chmod(0o755)
+        result = self._bash(
+            f'source "$TB_REPO/bench/evidence/run/env.sh"; '
+            f'assert_portable_binary "{binary}"',
+            tmp_path,
+        )
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "GLIBC_2.34" in combined
+        assert "build_sut.sh" in combined
+
+    def test_env_sh_accepts_a_portable_binary(self, tmp_path: Path) -> None:
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.17"]}))
+        binary.chmod(0o755)
+        result = self._bash(
+            f'source "$TB_REPO/bench/evidence/run/env.sh"; '
+            f'assert_portable_binary "{binary}"',
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_preflight_calls_the_guard_before_it_can_reach_docker(
+        self, tmp_path: Path
+    ) -> None:
+        # preflight's later checks need Harbor and Docker. Asserting the run
+        # dies on the binary proves the guard runs early enough to be reached
+        # on a host where those are unavailable, and that it is wired in at all.
+        binary = tmp_path / "stella"
+        binary.write_bytes(build_elf(requirements={"libc.so.6": ["GLIBC_2.34"]}))
+        binary.chmod(0o755)
+        result = self._bash(
+            'source "$TB_REPO/bench/evidence/run/env.sh"; '
+            f'export STELLA_BINARY="{binary}"; '
+            "export OPENROUTER_API_KEY=test-key; "
+            f'export STELLA_SOURCE_COMMIT="{"a" * 40}"; '
+            "preflight",
+            tmp_path,
+        )
+        assert result.returncode != 0
+        assert "GLIBC_2.34" in result.stdout + result.stderr
+
+    def test_the_floor_is_shared_by_the_build_and_the_check(self) -> None:
+        # build_sut.sh must cross-compile against the same floor the guard
+        # enforces. Two literals that can drift apart is the class of mistake
+        # this whole change is about.
+        env_text = _ENV_SH.read_text()
+        build_text = (_REPO_ROOT / "bench/evidence/run/build_sut.sh").read_text()
+        assert 'STELLA_GLIBC_FLOOR="2.17"' in env_text
+        assert "$STELLA_TARGET_TRIPLE.$STELLA_GLIBC_FLOOR" in build_text
+        assert "2.17" not in build_text, "the floor must not be duplicated as a literal"
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/exe").exists() and sys.platform != "darwin",
+    reason="fixture test is opt-in on any platform",
+)
+class TestRealArtifacts:
+    """Opt-in checks against binaries too large to commit.
+
+    Point ``STELLA_PORTABILITY_FIXTURE`` at a real build to verify the parser
+    against it. Used during development against the 32 MiB binary from the
+    failed run (rejected, ``GLIBC_2.34``) and a genuine zigbuild-2.17 artifact
+    (accepted, ``GLIBC_2.17``).
+    """
+
+    def test_real_binary_if_provided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import os
+
+        fixture = os.environ.get("STELLA_PORTABILITY_FIXTURE")
+        if not fixture:
+            pytest.skip("set STELLA_PORTABILITY_FIXTURE to a real Linux binary")
+        profile = read_libc_profile(fixture)
+        assert profile.machine == "x86-64"
+        expected = os.environ.get("STELLA_PORTABILITY_EXPECT", "portable")
+        violations = check_portability(profile)
+        if expected == "portable":
+            assert violations == [], profile.describe()
+        else:
+            assert violations, profile.describe()

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1812 bench/harbor_adapter/stella_harbor/__init__.py
-4268 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1821 bench/harbor_adapter/stella_harbor/__init__.py
+4269 bench/harbor_adapter/stella_harbor/secure_launcher.py
 1704 bench/harbor_adapter/tests/test_adapter.py
 3204 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
## What happened

The 2026-07-31 Terminal-Bench 2.1 head-to-head lost five trials before the agent
ever started:

```
/usr/local/bin/stella: /lib/x86_64-linux-gnu/libc.so.6:
    version `GLIBC_2.32' not found (required by /usr/local/bin/stella)
    version `GLIBC_2.33' not found (required by /usr/local/bin/stella)
    version `GLIBC_2.34' not found (required by /usr/local/bin/stella)
```

Harbor recorded `NonZeroAgentExitCodeError` and scored each trial 0.0. Under a
fixed denominator that is arithmetically indistinguishable from Stella failing
the task, and Claude Code was immune to it (it installs in-container), so it was
also an unfair asymmetry in the comparison.

**This was caused by a provisioning script that bypassed `build_sut.sh` — it is
not a change to how the shipped binary is built.** `build_sut.sh` already
cross-compiles correctly against `x86_64-unknown-linux-gnu.2.17`. The run in
question was provisioned by hand with:

```bash
cargo build --release --locked -p stella-cli --bin stella
cp target/release/stella target/x86_64-unknown-linux-gnu/release/stella   # the bug
```

That put a glibc-2.35 binary (Ubuntu 22.04 build host) at the exact path
`env.sh` exports as `STELLA_BINARY`. Every integrity check still passed, because
they all answer a different question: the host/container SHA-256 comparison
confirms *the file arrived intact* — and it did, it is the same file on both
sides. Nothing answered *can this file run here*. The first thing to exercise
the dynamic loader was `stella --version`, inside the container, per trial,
after the run had already started.

So the fix is a guard against that class of mistake, not a build change.

## What this adds

**1. A host-side preflight guard.** `preflight` in `bench/evidence/run/env.sh`
now refuses to start a run whose `STELLA_BINARY` requires a glibc symbol above
the floor — on the host, before any container is created, because a check that
only fires per-trial has already wasted the run. It fails closed and names the
offending symbol:

```
NOT PORTABLE:
  - requires GLIBC_2.34, GLIBC_2.33, GLIBC_2.32, …, above the GLIBC_2.17 floor
    build_sut.sh targets — this is a host-glibc build, not the portable one
FATAL: … cannot execute in a Terminal-Bench task container.
       Rebuild with bench/evidence/run/build_sut.sh — do not substitute
       a plain `cargo build --release` artifact into the target/ path.
```

The floor and the target triple become constants in `env.sh` that
**`build_sut.sh` now consumes**, so the thing that is built and the thing that
is asserted cannot drift apart. `build_sut.sh` also runs the assertion on the
artifact it just produced.

**2. `stella_harbor/portability.py`** reads the binary's requirements out of the
ELF `.gnu.version_r` section — the same table the dynamic loader walks at `exec`
to decide whether to abort. Parsing it in pure stdlib rather than shelling out to
`readelf`/`objdump` matters twice: those are absent on a macOS development host,
where a guard that silently no-ops is worse than none; and it keeps the
regression tests hermetic (no binutils, no Docker, no cross-compiler).

It also checks the ELF machine, which makes the intent behind
`DOCKER_DEFAULT_PLATFORM=linux/amd64` checkable on the artifact instead of just
hoped for — an arm64 build fails the same way, just as late.

Usable directly:

```bash
python3 bench/harbor_adapter/stella_harbor/portability.py "$STELLA_BINARY" --json
```

**3. Adapter-side error quality.** A loader rejection during install now raises
`BinaryIncompatibleWithContainerError` rather than surfacing as a generic
`NonZeroAgentExitCodeError`. Harbor writes the exception class into
`result.json`, so this is what makes a packaging defect attributable as one
instead of being tallied as the agent failing its task. The message names the
symbol, reports what was actually uploaded, and says plainly that the agent was
never asked to do any work.

Unrelated install failures (read-only `/usr/local/bin`, a full disk) keep their
original class — reclassifying everything would hide real failures just as well
as the bug being fixed. The host binary is profiled only on the failure path, so
a healthy run never parses it.

**4. The musl question: no musl target, and here is why.**

glibc 2.17 fixes containers with *older glibc*; it does nothing for a container
with no glibc at all, so this was settled against the dataset rather than
assumed. Every base image across all 89 Terminal-Bench 2.1 tasks:

| base image | tasks | libc |
|---|---|---|
| `python:3.13-slim-bookworm` | 41 | glibc |
| `ubuntu:24.04` | 39 | glibc |
| `python:3.11-slim` | 2 | glibc |
| `python:3.10-slim-bookworm` | 2 | glibc |
| `debian:bullseye-slim` | 2 | glibc **2.31 — oldest in the set** |
| `debian:13.0-slim` | 2 | glibc |
| `python:3.11` | 1 | glibc |

**No task image is musl-based**, so no `x86_64-unknown-linux-musl` target is
added. An unused second build path is a liability — it doubles what a release
must prove and rots between the runs that would exercise it.

`qemu-alpine-ssh` is the trap in the name: it is one of the two
`debian:bullseye-slim` tasks. Alpine appears as an ISO the *agent* downloads and
boots inside QEMU — the guest OS, never the container Stella runs in. The loader
error confirms it independently by naming `/lib/x86_64-linux-gnu/libc.so.6`, a
path that exists only where glibc does.

Two independent methods agree on that container's glibc: statically its
Dockerfile says bullseye (2.31); at runtime the loader reported 2.32/2.33/2.34
missing while saying nothing about the `GLIBC_2.18`…`2.30` the same binary also
required — so it provides ≥2.30 and lacks 2.32, which is 2.31 exactly.

This is a property of the pinned dataset, not of Docker. The run README carries
the reasoning and a one-line command to re-derive the table if `TB_DATASET` is
ever repinned.

## Tests

`tests/test_portability.py` (44 tests) asserts on the **artifact**, never on a
build command having been typed — the failure was precisely that the right
command was not typed and everything downstream still agreed. ELF images are
synthesized with chosen glibc requirements, so the suite is hermetic and runs
identically on a laptop and in CI. Covered: the substituted host-glibc build,
the inclusive floor boundary, numeric-vs-lexical version ordering (`2.9` sorts
above `2.17` as text), wrong architecture, non-ELF and truncated files, musl and
static builds, non-versioned `GLIBC_ABI_DT_RELR` markers, every CLI exit code,
and that the checker runs without importing the adapter package.

`TestPreflightWiring` runs the real `env.sh` function against a synthesized bad
binary, so the guard being *deleted or unwired* fails the suite — a check nobody
calls is exactly as protective as no check. One test asserts the floor is not
duplicated as a literal in `build_sut.sh`.

`tests/test_install_classification.py` pins both halves of the adapter change.

Both real artifacts were used during development and both behave correctly: the
binary that broke the run (sha256 `852f8cfd…`, the digest recorded in the failing
trial's `result.json`) is **rejected** at max `GLIBC_2.34`, and a genuine
`cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` build is **accepted** at
max `GLIBC_2.17` — exercising the inclusive bound, since a correct build sits
exactly on the floor. They are 32 MiB and 196 MiB so they are not committed;
`STELLA_PORTABILITY_FIXTURE` runs the check against any real binary.

## Notes for review

- The SHA-256 host/container check is untouched. It is correct; it just answers
  "did the file arrive intact", which is a different question from the one that
  failed here.
- No change to the benchmark posture or to scoring.
- `portability.py` is added to `_FIXED_ADAPTER_SOURCE_PATHS`. That list is
  enumerated rather than globbed on purpose — the audited-claim path byte-compares
  every adapter source against the published commit, so an undeclared module would
  execute without ever being compared. This necessarily changes the adapter source
  hash, as any adapter change does.
- `scripts/file-size-baseline.txt` rises by 9 lines for `__init__.py` (a
  `try`/`except` around the install exec, plus one import) and 1 for
  `secure_launcher.py` (the path declaration above). Both are irreducible; the
  rest of the new code lives in its own modules, so `test_adapter.py` is
  unchanged. Recorded via `make file-size-update` as the guard's own message
  directs.

## Summary by Sourcery

Add a host-side portability guard and Harbor adapter support to ensure the SUT binary can execute in all Terminal-Bench task containers and classify loader failures separately from agent failures.

Bug Fixes:
- Prevent mis-provisioned host-glibc SUT binaries from silently passing integrity checks and then failing at runtime inside task containers.

Enhancements:
- Introduce an ELF-based portability checker that enforces a shared glibc floor and architecture for the SUT binary, and wire it into the build and preflight pipeline.
- Improve Harbor adapter install error handling to distinguish binary incompatibility with the container from generic nonzero agent exits.

Documentation:
- Document the requirement to use the cross-compiled portable SUT build, explain why a musl target is not needed, and provide guidance and commands to verify dataset libc versions and binary portability.

Tests:
- Add comprehensive unit and integration tests for ELF portability analysis, CLI behavior, preflight wiring, and install-time error classification to prevent regressions in SUT binary portability and error reporting.