### PR TITLE
fix(bench): an empty STELLA_BUDGET means no cap, not a malformed number

### DIFF
--- a/bench/evidence/run/env.sh
+++ b/bench/evidence/run/env.sh
@@ -22,7 +22,12 @@ export PYTHONPATH="$TB_REPO/bench/harbor_adapter"
 export STELLA_TARGET_TRIPLE="x86_64-unknown-linux-gnu"
 export STELLA_GLIBC_FLOOR="2.17"
 export STELLA_BINARY="$TB_REPO/target/$STELLA_TARGET_TRIPLE/release/stella"
-export STELLA_BUDGET="${STELLA_BUDGET:-0.60}"
+# `-` and not `:-`: unset still takes the development default, but an
+# explicitly empty value stays empty and means *no per-trial cap*, which a
+# head-to-head against a comparator with no spend ceiling has to be able to
+# say. With `:-` that posture is unreachable — the empty string is substituted
+# away here, and every run silently carries a cap the other side does not.
+export STELLA_BUDGET="${STELLA_BUDGET-0.60}"
 export STELLA_DISABLE_REFLECTION=1
 
 # The frozen dataset, pinned by digest. An unversioned name is not a freeze.

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -114,6 +114,12 @@ _TRAJECTORY_NAME = "trajectory.json"
 # Defaults when neither Harbor nor the environment specify a value.
 _DEFAULT_MODEL = "anthropic/claude-fable-5"
 _DEFAULT_BUDGET = "5.0"
+# What a run with no per-trial spend cap discloses as its cap. A word rather
+# than an omission, because the metadata dict drops `None` values entirely and
+# a published manifest would then spell "no cap" and "this adapter never
+# recorded one" the same way. Deliberately not numeric: nothing downstream
+# should be able to read it as a ceiling that was in force.
+_NO_BUDGET_CAP = "unbounded"
 _DEFAULT_DISABLE_REFLECTION = "1"
 _DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _ADAPTER_VERSION = "0.6.0"
@@ -1060,7 +1066,9 @@ class StellaAgent(BaseInstalledAgent):
     _base_url: str | None
     _provider_route_policy: str | None
     _disable_reflection: str
-    _budget_usd: str
+    # `None` is "no per-trial cap", which is a real posture and not a missing
+    # value — see `_configured_budget`.
+    _budget_usd: str | None
     _credential_handoff_mode: str
     _host_credential_source: str
     _host_credential_name: str | None
@@ -1243,9 +1251,7 @@ class StellaAgent(BaseInstalledAgent):
         configured_model = self._effective_model()
         env = self._forwarded_env()
         self._disable_reflection = env["STELLA_DISABLE_REFLECTION"]
-        self._budget_usd = (
-            self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET) or _DEFAULT_BUDGET
-        )
+        self._budget_usd = self._configured_budget()
         witness_author = self._witness_author_model()
         self._witness_author_model_value = witness_author
         (
@@ -1394,14 +1400,16 @@ class StellaAgent(BaseInstalledAgent):
         the instruction as one literal argument without shell quoting/parsing.
         """
         model = model or self._effective_model()
-        budget = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)
+        budget = self._configured_budget()
         base_url = base_url or self._effective_base_url(model)
         parts = [
             _INSTALL_PATH,
             "--model",
             model,
-            "--budget",
-            budget,
+            # Omitted entirely when there is no cap. `--budget ""` is not "no
+            # budget" to clap, it is a malformed number, and it exits 2 before
+            # the turn starts.
+            *(["--budget", budget] if budget is not None else []),
             "--output-format",
             "stream-json",
         ]
@@ -1490,6 +1498,33 @@ class StellaAgent(BaseInstalledAgent):
                 value = str(extra[key])
         return value
 
+    def _configured_budget(self) -> str | None:
+        """Resolve the per-trial spend cap, where **empty means no cap**.
+
+        ``--budget`` is ``Option<f64>`` in the CLI and is documented as "omit to
+        meter spend for the cost summary without ever blocking", so "no cap" is
+        a state the contract already has — reachable only by *omitting* the
+        flag. ``_configured_value`` cannot express it: ``os.environ.get`` treats
+        an exported empty string as a present value, so ``_DEFAULT_BUDGET``
+        never fires and the empty string is forwarded as though it were a
+        number. It then reaches clap's ``parse_budget``, which rejects it
+        (```` is not a number``) and exits 2 **before the turn starts** — a
+        failure Harbor can only record as ``NonZeroAgentExitCodeError``, which
+        is arithmetically indistinguishable from the agent failing the task.
+
+        A head-to-head against a comparator that has no spend ceiling has to be
+        able to say "no ceiling" on this side too, or the cap is a difference
+        between the agents that is not the one being measured. Empty resolves to
+        ``None`` and every caller omits: the flag, the forwarded variable, and
+        the recorded value alike. ``None`` in the manifest reads as "no cap",
+        which is the truth; ``_DEFAULT_BUDGET`` there would be a number no run
+        ever enforced.
+        """
+        budget = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)
+        if budget is None or not str(budget).strip():
+            return None
+        return budget
+
     def _forwarded_env(self) -> dict[str, str]:
         """Build the registered minimal claim environment.
 
@@ -1546,7 +1581,10 @@ class StellaAgent(BaseInstalledAgent):
                         + ", ".join(unexpected_extra)
                     )
 
-        budget = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)
+        # Not forwarded at all when there is no cap: the CLI declares `--budget`
+        # with `env = "STELLA_BUDGET"`, so an empty value in the container's
+        # environment fails the same parse the omitted flag was avoiding.
+        budget = self._configured_budget()
         if budget is not None:
             forwarded["STELLA_BUDGET"] = budget
         reflection = self._configured_value(
@@ -1622,7 +1660,9 @@ class StellaAgent(BaseInstalledAgent):
             )
         budget_usd = getattr(self, "_budget_usd", None)
         if budget_usd is None:
-            budget_usd = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)
+            budget_usd = self._configured_budget()
+        if budget_usd is None:
+            budget_usd = _NO_BUDGET_CAP
         credential_handoff_mode = getattr(
             self, "_credential_handoff_mode", _HANDOFF_MODE
         )

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -367,6 +367,146 @@ class TestBuildCommand:
             agent._build_command("Fix it")
 
 
+class TestNoBudgetCap:
+    """An empty ``STELLA_BUDGET`` means *no cap*, and must reach nothing.
+
+    The head-to-head protocol permits exactly one difference between the arms —
+    the endpoint. Claude Code has no per-trial spend ceiling, so Stella must be
+    able to run without one too. ``race.sh`` says that with ``STELLA_BUDGET=""``.
+
+    Before this, the empty string was forwarded verbatim as ``--budget ""``.
+    Clap's ``parse_budget`` rejects it and exits 2 *before the turn starts*, so
+    Harbor records ``NonZeroAgentExitCodeError`` and scores 0.0 — the same
+    shape, and the same silence, as the substituted-binary failure #1018 was
+    written to make loud. Every trial in the arm, not a sample of them.
+    """
+
+    def test_empty_budget_omits_the_flag_instead_of_passing_an_unparseable_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STELLA_BUDGET", "")
+        monkeypatch.delenv("STELLA_BASE_URL", raising=False)
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--budget" not in cmd
+        # The failure mode was an empty argv element, not just a stray flag.
+        assert "" not in cmd
+        assert cmd[-2:] == ["run", "Fix the bug"]
+
+    def test_whitespace_budget_is_treated_as_no_cap_not_as_a_number(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STELLA_BUDGET", "   ")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        assert "--budget" not in agent._build_command("Fix the bug")
+
+    def test_unset_budget_still_takes_the_development_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No cap must be *opt-in*. Unset keeps the cap it always had."""
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        cmd = agent._build_command("Fix the bug")
+
+        assert cmd[cmd.index("--budget") + 1] == "5.0"
+
+    def test_empty_budget_is_not_forwarded_into_the_container(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Omitting the flag is not enough: the CLI also reads the env var.
+
+        ``--budget`` is declared ``env = "STELLA_BUDGET"``, so forwarding an
+        empty value into the container fails the identical parse the omitted
+        flag was avoiding — just one layer further in, where it is harder to see.
+        """
+        monkeypatch.setenv("STELLA_BUDGET", "")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        assert "STELLA_BUDGET" not in agent._forwarded_env()
+
+    def test_a_cap_that_is_set_is_still_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STELLA_BUDGET", "0.17")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        assert agent._forwarded_env()["STELLA_BUDGET"] == "0.17"
+        cmd = agent._build_command("Fix the bug")
+        assert cmd[cmd.index("--budget") + 1] == "0.17"
+
+    def test_no_cap_is_recorded_as_no_cap_rather_than_as_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manifest must not name a ceiling the run never enforced.
+
+        The recording site used ``... or _DEFAULT_BUDGET``, so an uncapped run
+        would have been published as capped at ``5.0`` — a disclosed
+        measurement parameter that was never true of the run disclosing it.
+
+        Nor may it simply vanish: the metadata dict drops ``None`` values, and
+        an absent key reads identically to an adapter too old to record one.
+        """
+        monkeypatch.setenv("STELLA_BUDGET", "")
+        monkeypatch.delenv("STELLA_DISABLE_REFLECTION", raising=False)
+        agent = _bare_agent()
+        agent._metrics = {"status": "completed", "steps": 1}
+        agent._return_code = 0
+
+        class _Ctx:
+            cost_usd = None
+            n_input_tokens = None
+            n_output_tokens = None
+            n_cache_tokens = None
+            metadata = None
+
+        ctx = _Ctx()
+        agent.populate_context_post_run(ctx)
+
+        assert ctx.metadata["stella_budget_usd"] == "unbounded"
+        # Never a number: nothing downstream may read it as a ceiling in force.
+        with pytest.raises(ValueError):
+            float(ctx.metadata["stella_budget_usd"])
+
+    def test_env_sh_lets_an_explicit_empty_value_survive(self) -> None:
+        """``-`` and not ``:-``, asserted on the artifact rather than the diff.
+
+        ``${STELLA_BUDGET:-0.60}`` substitutes on *empty as well as unset*, so
+        the no-cap posture is unreachable through the sanctioned entry point no
+        matter what the adapter does.
+        """
+        import subprocess
+
+        repo_root = Path(__file__).resolve().parents[3]
+        env_sh = repo_root / "bench" / "evidence" / "run" / "env.sh"
+        assert env_sh.is_file()
+
+        def _budget_after_sourcing(preset: str | None) -> str:
+            setter = "export STELLA_BUDGET=''" if preset == "" else "true"
+            script = (
+                f'export TB_REPO="{repo_root}"; '
+                f'export TB_ROOT="$(mktemp -d)"; '
+                f"{setter}; "
+                f'source "{env_sh}" >/dev/null 2>&1; '
+                f'printf "%s" "${{STELLA_BUDGET-<unset>}}"'
+            )
+            done = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, check=False
+            )
+            return done.stdout
+
+        assert _budget_after_sourcing("") == ""
+        assert _budget_after_sourcing(None) == "0.60"
+
+
 class TestForwardedEnv:
     def test_canonical_engine_posture_has_one_inherited_model_and_fixed_effort(
         self,

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,9 +7,9 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1821 bench/harbor_adapter/stella_harbor/__init__.py
+1861 bench/harbor_adapter/stella_harbor/__init__.py
 4269 bench/harbor_adapter/stella_harbor/secure_launcher.py
-1704 bench/harbor_adapter/tests/test_adapter.py
+1844 bench/harbor_adapter/tests/test_adapter.py
 3204 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py


### PR DESCRIPTION
## The defect

`bench/evidence/run/race.sh` — the standing Stella-vs-Claude-Code head-to-head — exports:

```bash
export STELLA_BUDGET=""            # empty => adapter omits --budget entirely
```

The adapter never did that. `_configured_value` resolves through `os.environ.get(key, default)`, and **an exported empty string is a present value, not a missing one** — so `_DEFAULT_BUDGET` never fires and `""` is forwarded verbatim:

```python
budget = self._configured_value("STELLA_BUDGET", _DEFAULT_BUDGET)   # -> ""
parts = [_INSTALL_PATH, "--model", model, "--budget", budget, ...]  # -> --budget ""
```

`stella-cli/src/cli.rs:126` declares `budget: Option<f64>` with `value_parser = parse_budget`, and `parse_budget("")` returns ``"`` is not a number"``. **Clap exits 2 before the turn starts.**

Harbor can only record that as `NonZeroAgentExitCodeError` and score the trial 0.0 — the same shape, and the same silence, as the substituted-binary failure #1018 was written to make loud. Except #1018's failure hit five trials; this one hits **every trial in the arm**, and the run still reports a clean per-task table full of zeros.

## Why "no cap" has to be expressible

The head-to-head protocol permits exactly one difference between the arms — the endpoint. Claude Code has no per-trial spend ceiling. If Stella cannot say "no ceiling", the cap becomes a second difference between the agents, applied to one side only, in the direction that truncates it.

## The fix

`_configured_budget()` is the single seam: empty or whitespace resolves to `None`, and every consumer omits rather than forwarding a value the contract cannot parse. Four sites went through the old resolution and each leaked differently:

| site | old behaviour |
|---|---|
| argv builder | `--budget ""` → clap exit 2 |
| `_forwarded_env` | `STELLA_BUDGET=""` into the container, where `env = "STELLA_BUDGET"` fails the identical parse one layer further in |
| `_budget_usd` | `... or _DEFAULT_BUDGET` — an uncapped run **published as capped at 5.0** |
| metadata recorder | pre-existing `if v is not None` filter drops the key, spelling "no cap" and "this adapter never recorded one" identically |

The last two are the ones that still matter once the crash is gone. A manifest naming a ceiling that was never in force is worse than a loud failure, because nothing about it looks wrong. No-cap now discloses as `_NO_BUDGET_CAP = "unbounded"` — deliberately not numeric, so nothing downstream can read it as a limit that applied.

`env.sh` moves `${STELLA_BUDGET:-0.60}` → `${STELLA_BUDGET-0.60}`. `:-` substitutes on **empty as well as unset**, so the no-cap posture was unreachable through the sanctioned entry point no matter what the adapter did. Unset still takes the `0.60` development default — no cap stays opt-in, and no existing run changes behaviour.

**Not touched:** `secure_launcher.py`, which requires the exact frozen `_CANONICAL_BUDGET` for claim runs. That check is correct and answers a different question.

## Tests

`TestNoBudgetCap` in `bench/harbor_adapter/tests/test_adapter.py`:

- flag omitted entirely, and no empty argv element survives
- whitespace treated as no-cap, not as a number
- **unset still takes `5.0`** — the default must not regress
- nothing forwarded into the container env
- a cap that *is* set is still forwarded both ways
- the manifest discloses `unbounded`, and `float()` on it raises
- `env.sh` sourced in a subshell, asserting `-` vs `:-` on the artifact rather than on the diff

`harbor_adapter`: **294 passed, 1 skipped (exit 0)**. `ruff check` + `ruff format --check`: clean (exit 0). File-size baseline updated for the two files that grew.

## Provenance

Found while executing `docs/stella-bench-handoff/PROMPT-3` (the 20-task head-to-head), which is gated on #1017 and #1018 having merged. Both had. This is the third thing standing between that runbook and a trustworthy number, and it was invisible from the runbook itself — `race.sh` documents the behaviour it wanted in a comment, and the comment was wrong.

## Summary by Sourcery

Allow Stella bench runs to explicitly opt into "no per-trial budget cap" without crashing or misreporting the cap, and ensure that state is correctly surfaced across CLI, container env, and run metadata.

Bug Fixes:
- Treat empty or whitespace STELLA_BUDGET as no cap instead of forwarding it as an invalid numeric budget that causes the Stella CLI to exit before runs start.
- Prevent uncapped runs from being recorded in manifests as if they were capped at the default budget value.

Enhancements:
- Introduce a dedicated configured-budget resolver that normalizes budget inputs and represents "no cap" as a distinct manifest value.
- Adjust the adapter to omit budget flags and environment variables entirely when no cap is requested, while preserving behavior when a cap is set.

Tests:
- Add a focused test suite verifying no-cap behavior for STELLA_BUDGET across command construction, forwarded environment, manifest recording, and the bench env.sh entrypoint.