### PR TITLE
fix(bench): register the portability constants env.sh exports

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -174,6 +174,19 @@ _HOST_ONLY_STELLA_ENV = frozenset(
         "STELLA_MODEL",
         "STELLA_BASE_URL",
         _WITNESS_AUTHOR_ENV,
+        # The portability target triple and glibc floor (#1018). `env.sh` exports
+        # both so `build_sut.sh` builds to the same floor `preflight` asserts
+        # against — keeping them apart is what let a glibc-2.35 binary reach five
+        # trials. But every script in `bench/evidence/run/` sources `env.sh`
+        # *before* invoking Harbor, so both are ambient in the adapter's process
+        # and the fail-closed ambient check rejected the run outright.
+        #
+        # Registered host-only rather than added to `_CLAIM_CONTAINER_ENV`: they
+        # describe how the binary was built and verified *on the host*, and mean
+        # nothing inside a task container. Host-only is the honest bucket, and it
+        # keeps the container environment exactly as narrow as it was.
+        "STELLA_TARGET_TRIPLE",
+        "STELLA_GLIBC_FLOOR",
     }
 )
 

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -367,6 +367,72 @@ class TestBuildCommand:
             agent._build_command("Fix it")
 
 
+class TestRunScriptEnvironmentIsRegistered:
+    """Every ``STELLA_*`` the run scripts export must be a knob the adapter knows.
+
+    ``_forwarded_env`` fails **closed** on any ambient ``STELLA_*`` it does not
+    recognise, which is correct — an unregistered knob is an undisclosed change
+    to the SUT. But every script in ``bench/evidence/run/`` sources ``env.sh``
+    before invoking Harbor, so whatever ``env.sh`` exports is ambient in the
+    adapter's own process.
+
+    That makes the two files halves of one contract, and #1018 moved one half:
+    it added ``STELLA_TARGET_TRIPLE`` and ``STELLA_GLIBC_FLOOR`` to ``env.sh``
+    without registering them, so the sanctioned run path aborted before the
+    first trial. Pinning the two names would only catch the defect already
+    found; this asserts the invariant, so the *next* export to ``env.sh`` fails
+    here rather than in front of a benchmark run.
+    """
+
+    @staticmethod
+    def _exported_stella_names() -> set[str]:
+        import re
+
+        repo_root = Path(__file__).resolve().parents[3]
+        env_sh = repo_root / "bench" / "evidence" / "run" / "env.sh"
+        assert env_sh.is_file(), env_sh
+        return set(re.findall(r"export\s+(STELLA_[A-Z0-9_]+)=", env_sh.read_text()))
+
+    def test_every_stella_export_in_env_sh_is_a_registered_knob(self) -> None:
+        exported = self._exported_stella_names()
+        # Guard the guard: a rename that empties this set would pass vacuously.
+        assert "STELLA_BINARY" in exported
+        assert "STELLA_GLIBC_FLOOR" in exported
+
+        registered = (
+            adapter_module._CLAIM_CONTAINER_ENV | adapter_module._HOST_ONLY_STELLA_ENV
+        )
+        assert exported <= registered, (
+            "env.sh exports STELLA_* knobs the adapter fails closed on: "
+            f"{sorted(exported - registered)}"
+        )
+
+    def test_build_only_constants_never_reach_the_task_container(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recognised, but host-only: they describe the build, not the run."""
+        monkeypatch.setenv("STELLA_TARGET_TRIPLE", "x86_64-unknown-linux-gnu")
+        monkeypatch.setenv("STELLA_GLIBC_FLOOR", "2.17")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        forwarded = agent._forwarded_env()  # must not raise
+
+        assert "STELLA_TARGET_TRIPLE" not in forwarded
+        assert "STELLA_GLIBC_FLOOR" not in forwarded
+
+    def test_a_genuinely_unregistered_knob_still_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The registration widened by exactly two names, not in principle."""
+        monkeypatch.setenv("STELLA_SOMETHING_INVENTED", "1")
+        agent = _bare_agent()
+        agent.model_name = "openrouter/z-ai/glm-5.2"
+
+        with pytest.raises(RuntimeError, match="unregistered STELLA_"):
+            agent._forwarded_env()
+
+
 class TestForwardedEnv:
     def test_canonical_engine_posture_has_one_inherited_model_and_fixed_effort(
         self,

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,9 +7,9 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1821 bench/harbor_adapter/stella_harbor/__init__.py
+1834 bench/harbor_adapter/stella_harbor/__init__.py
 4269 bench/harbor_adapter/stella_harbor/secure_launcher.py
-1704 bench/harbor_adapter/tests/test_adapter.py
+1770 bench/harbor_adapter/tests/test_adapter.py
 3204 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py


### PR DESCRIPTION
## The defect

#1018 made `bench/evidence/run/env.sh` export the portability constants:

```bash
export STELLA_TARGET_TRIPLE="x86_64-unknown-linux-gnu"
export STELLA_GLIBC_FLOOR="2.17"
```

so that `build_sut.sh` builds to the same floor `preflight` asserts against. Keeping those two apart is precisely what let a glibc-2.35 binary reach five trials wearing the portable build's filename, so pinning them in one place is right.

But `_forwarded_env` fails **closed** on any ambient `STELLA_*` it does not recognise, and *every* script in `bench/evidence/run/` sources `env.sh` before invoking Harbor. Both new exports are therefore ambient in the adapter's own process:

```
RuntimeError: claim benchmark environment contains unregistered STELLA_* knobs:
  STELLA_GLIBC_FLOOR, STELLA_TARGET_TRIPLE
```

**The sanctioned run path aborts before the first trial.**

## How it was found

Running `docs/stella-bench-handoff/PROMPT-3` (the 20-task head-to-head). `race.sh` sets its environment inline and never sources `env.sh` — that is the only reason the run itself was unaffected, and it is luck rather than design. Anything going through `primary.sh` hits this.

## The fix

The ambient check is correct and is **not weakened**. The two constants are registered in `_HOST_ONLY_STELLA_ENV` rather than `_CLAIM_CONTAINER_ENV`: they describe how the binary was built and verified *on the host*, and mean nothing inside a task container. The container environment stays exactly as narrow as it was.

## Test

`test_every_stella_export_in_env_sh_is_a_registered_knob` parses `env.sh` for `export STELLA_*=` and asserts that set is a subset of what the adapter registers.

This asserts **the invariant, not the two names** — `env.sh` and the adapter's allowlist are two halves of one contract, and this defect is what happens when one half moves. The next export added to `env.sh` now fails in CI rather than in front of a benchmark run. The test guards against passing vacuously if the parse ever returns an empty set.

Two supporting tests: the constants are recognised *without* reaching the container, and a genuinely unregistered knob still raises.

`harbor_adapter`: **290 passed, 1 skipped (exit 0)**. `ruff check` + `ruff format --check` clean. File-size baseline updated.

## Summary by Sourcery

Register new STELLA portability constants with the Harbor adapter and enforce alignment between env.sh exports and the adapter’s allowed environment knobs.

Bug Fixes:
- Allow runs that source env.sh to proceed by registering STELLA_TARGET_TRIPLE and STELLA_GLIBC_FLOOR as recognised host-only environment knobs while keeping them out of the task container environment.

Tests:
- Add tests to ensure every STELLA_* exported from bench/evidence/run/env.sh is registered with the adapter, that the new build-only constants never reach the task container, and that unregistered knobs still cause a fail-closed error.

Chores:
- Update the file-size baseline to reflect the new code and tests.