### PR TITLE
fix(engine): a length-truncated step with no tool call continues the turn instead of completing it

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,8 +20,8 @@
 1576 stella-cli/src/candidate_ws.rs
 4388 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2116 stella-core/src/driver.rs
-2821 stella-core/src/driver/tests.rs
+2195 stella-core/src/driver.rs
+2965 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1609 stella-model/src/anthropic/tests.rs
 1784 stella-model/src/bedrock.rs

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -368,6 +368,33 @@ const SPECULATION_DISCARD_HARVEST_MISMATCH: &str = "harvest_mismatch";
 /// could harvest it, so it is discarded on the abort unwind instead (#460).
 const SPECULATION_DISCARD_BUDGET_ABORT: &str = "budget_abort";
 
+/// How many times one turn may continue past a step that ended at the
+/// output-token limit having called no tool (`FinishReason::Length`,
+/// `tool_calls` empty). Two, not one, because the observed failure is a
+/// reasoning model spending a whole output budget on chain-of-thought: the
+/// first continuation often finishes the thinking, and the second lands the
+/// action. Bounded because each continuation is a paid call, and a model
+/// that truncates a third time is not going to stop on its own — the turn
+/// falls through to the existing truncation warning and the verification
+/// ladder's no-op rung takes it from there.
+const MAX_LENGTH_CONTINUATIONS: u32 = 2;
+
+/// The user message a length-truncated, tool-less step is continued with.
+///
+/// Written for the two shapes the trigger cannot distinguish and does not
+/// need to: chain-of-thought promoted to text by an adapter's reasoning-only
+/// fallback (the Terminal-Bench zero-tool trials — 30 of 30 cap-hit steps in
+/// the 2026-07-31 bundle carried no tool call), and a genuine prose answer
+/// cut off mid-sentence. Both are told the same thing: the turn is not over,
+/// go do the work — with tool calls, not narration. At temperature 0 a bare
+/// retry of the identical request re-truncates identically, which is why
+/// this is a *continuation with new input* rather than a retry.
+const LENGTH_CONTINUATION_NUDGE: &str = "Your previous message hit the output-token limit and \
+     was cut off before any tool call or finished answer. The turn is not over. Continue from \
+     exactly where you stopped: if work remains, emit the tool calls that perform it now — \
+     writing files, running commands, applying edits. Do not restate your reasoning or repeat \
+     text you already produced; describing the work is not doing it.";
+
 /// One committed model call plus the step-scoped context the phases after
 /// it consume: the pre-call raw token estimate (drift feedback + telemetry
 /// — raw, never calibrated, see [`Engine::run_model_call`]) and the
@@ -760,7 +787,13 @@ impl<'a> Engine<'a> {
         }
 
         if let Some(completed) = self
-            .dispatch_completion(committed, state.total_cost_usd, &mut state.messages, events)
+            .dispatch_completion(
+                committed,
+                state.total_cost_usd,
+                &mut state.messages,
+                &mut state.length_continuations,
+                events,
+            )
             .await
         {
             return completed.into();
@@ -1676,11 +1709,20 @@ impl<'a> Engine<'a> {
     /// assistant message, execute its tool calls, record their results,
     /// and return `None` so the loop takes another step. Consumes the
     /// step: the result's text moves into the `Completed` outcome.
+    ///
+    /// A tool-less step that ended at the output-token limit is the one
+    /// no-tool shape that does NOT finish the turn (up to
+    /// [`MAX_LENGTH_CONTINUATIONS`] times): the model was cut off, not done,
+    /// so the step is recorded and the turn continues with
+    /// [`LENGTH_CONTINUATION_NUDGE`]. `length_continuations` is the turn's
+    /// running count ([`TurnState`]'s, threaded rather than owned so the
+    /// bound survives across steps).
     async fn dispatch_completion(
         &self,
         committed: CommittedStep,
         total_cost_usd: f64,
         messages: &mut Vec<CompletionMessage>,
+        length_continuations: &mut u32,
         events: &EventSender,
     ) -> Option<TurnOutcome> {
         let CommittedStep {
@@ -1740,9 +1782,46 @@ impl<'a> Engine<'a> {
                     cost_usd: total_cost_usd,
                 });
             }
-            // A non-empty answer that was still truncated at the limit: keep the
-            // partial answer (already emitted above) but tell the user it was
-            // cut off, so a mid-thought stop is never mistaken for a full one.
+            // A non-empty response cut off at the output limit with no tool
+            // call is not a finished turn — it is a step that ran out of room,
+            // and on the Chat Completions dialects it is usually
+            // chain-of-thought promoted to text by the adapter's
+            // reasoning-only fallback. Completing here is the defect that
+            // shipped the zero-tool Terminal-Bench trials: the turn ends,
+            // verification finds nothing observable, and the run reports a
+            // task it never touched (30 of 30 cap-hit steps in the 2026-07-31
+            // bundle carried no tool call). Continue the turn instead: record
+            // the partial, tell the model to act, take another step. A
+            // continuation rather than a retry because at temperature 0 the
+            // identical request re-truncates identically — the nudge is what
+            // changes the outcome.
+            if result.finish_reason == Some(FinishReason::Length)
+                && *length_continuations < MAX_LENGTH_CONTINUATIONS
+            {
+                *length_continuations += 1;
+                let _ = events.send(AgentEvent::Text {
+                    delta: format!(
+                        "\n\n⚠ Output-token limit reached ({} tokens) before any tool call; \
+                         continuing ({}/{}).",
+                        result.usage.output_tokens, *length_continuations, MAX_LENGTH_CONTINUATIONS
+                    ),
+                });
+                messages.push(CompletionMessage {
+                    role: MessageRole::Assistant,
+                    content: result.text.clone(),
+                    tool_calls: Vec::new(),
+                    tool_results: Vec::new(),
+                    attachments: Vec::new(),
+                });
+                messages.push(CompletionMessage::user(LENGTH_CONTINUATION_NUDGE));
+                return None;
+            }
+            // A non-empty answer truncated with the continuation allowance
+            // spent: keep the partial answer (already emitted above) but tell
+            // the user it was cut off, so a mid-thought stop is never
+            // mistaken for a full one. The verification ladder's no-op rung
+            // is what stops a turn that still did nothing from reporting
+            // success past this point.
             if result.finish_reason == Some(FinishReason::Length) {
                 let _ = events.send(AgentEvent::Text {
                     delta: format!(

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -1212,6 +1212,150 @@ async fn empty_completion_aborts_with_a_visible_message_not_a_silent_success() {
     );
 }
 
+/// A `finish_reason: length` result that still carries text — the shape the
+/// zai adapter produces when a reasoning model spends its whole output budget
+/// on chain-of-thought and the reasoning-only fallback promotes it to text.
+/// `output_tokens` matches the default cap because that is the real trace
+/// shape (30/30 cap-hit steps in the 2026-07-31 Terminal-Bench bundle).
+fn length_text_result(text: &str) -> CompletionResultAlias {
+    CompletionResultAlias {
+        text: text.into(),
+        tool_calls: vec![],
+        usage: CompletionUsage {
+            reported: true,
+            input_tokens: 100,
+            output_tokens: 16384,
+            cached_input_tokens: 0,
+            cache_write_tokens: 0,
+        },
+        model: "scripted".into(),
+        cost_usd: 0.001,
+        finish_reason: Some(FinishReason::Length),
+    }
+}
+
+#[tokio::test]
+async fn a_length_truncated_tool_less_step_continues_the_turn_instead_of_completing() {
+    // Step 0 is cut off at the output limit mid-"reasoning" with no tool
+    // call. That is not a finished turn: the engine must record the partial,
+    // nudge the model to act, and take another step — in which the scripted
+    // model does the work and then completes. Regression for the zero-tool
+    // Terminal-Bench trials, where this shape completed instantly and
+    // reported success on tasks the model never touched.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(length_text_result("…half-finished chain of thought")),
+            Ok(tool_call_result("call_1", "bash")),
+            Ok(text_result("done")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tool_calls = Arc::new(AtomicU32::new(0));
+    let tools = CountingTools {
+        calls: tool_calls.clone(),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("build the feature"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    match outcome {
+        TurnOutcome::Completed { text, .. } => {
+            assert_eq!(
+                text, "done",
+                "the turn's answer is the post-continuation one"
+            );
+        }
+        other => panic!("a continued turn must still complete: {other:?}"),
+    }
+    assert_eq!(
+        tool_calls.load(Ordering::SeqCst),
+        1,
+        "the continuation step's tool call actually ran"
+    );
+    let nudges = messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User && m.content == LENGTH_CONTINUATION_NUDGE)
+        .count();
+    assert_eq!(nudges, 1, "exactly one continuation nudge in history");
+    assert!(
+        messages.iter().any(|m| {
+            m.role == MessageRole::Assistant && m.content.contains("half-finished chain of thought")
+        }),
+        "the truncated partial stays in history so the model can continue from it"
+    );
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, AgentEvent::Error { .. })),
+        "a continued-and-recovered turn is not an error"
+    );
+    assert_tool_pairing(&messages);
+}
+
+#[tokio::test]
+async fn length_continuations_are_bounded_per_turn() {
+    // The model truncates tool-less on EVERY step (the scripted provider
+    // loops its last entry). The engine spends its whole continuation
+    // allowance, then falls through to the pre-existing behaviour: complete
+    // with the truncation warning rather than loop paid calls forever. The
+    // verification ladder's no-op rung is the layer that then stops this
+    // turn from reporting success.
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(length_text_result("still thinking…"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("build the feature"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "after the allowance is spent the turn completes (the ladder holds the line): {outcome:?}"
+    );
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        1 + MAX_LENGTH_CONTINUATIONS,
+        "one initial step plus exactly the bounded continuations"
+    );
+    let nudges = messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User && m.content == LENGTH_CONTINUATION_NUDGE)
+        .count();
+    assert_eq!(nudges, MAX_LENGTH_CONTINUATIONS as usize);
+    let events = drain_events(&mut rx);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::Complete { .. }))
+            .count(),
+        1,
+        "exactly one Complete, from the final fall-through step"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Text { delta } if delta.contains("Response was truncated")
+        )),
+        "the exhausted turn still carries the truncation warning"
+    );
+}
+
 #[tokio::test]
 async fn tool_calls_execute_and_feed_back_into_history() {
     let provider = ScriptedProvider {

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -242,6 +242,12 @@ pub struct TurnState {
     pub(crate) step: usize,
     /// The per-turn memos a checkpoint deliberately drops (module docs).
     pub(crate) memos: TurnMemos,
+    /// In-turn continuations already spent on steps that ended at the
+    /// output-token limit with no tool call (`Engine::dispatch_completion`).
+    /// Bounded per turn so a model that keeps truncating cannot loop the
+    /// spend; deliberately NOT checkpointed — a resumed turn starts the
+    /// allowance over, which only re-permits a bounded amount of work.
+    pub(crate) length_continuations: u32,
     /// The host's stop signal, checked at the top of every step.
     pub(crate) cancel: CancelToken,
 }
@@ -266,6 +272,7 @@ impl TurnState {
             transcript_rewrites: 0,
             step: 0,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),
+            length_continuations: 0,
             cancel: CancelToken::new(),
         }
     }
@@ -284,6 +291,7 @@ impl TurnState {
             transcript_rewrites: checkpoint.transcript_rewrites,
             step: checkpoint.step,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),
+            length_continuations: 0,
             cancel: CancelToken::new(),
         }
     }


### PR DESCRIPTION
## What this fixes

The zero-tool Terminal-Bench trials' root cause. Thirty steps across 22 trials in the 2026-07-31 bundle ended at exactly `max_output_tokens` (16384); **30 of 30 carried zero tool calls**. On think-heavy tasks glm-5.2 spends its whole output budget in the reasoning channel and is cut off before emitting any content or tool call — and the turn then **completed** as if finished.

Two fixes for the same historical "turn ends with no feedback" defect composed into this one:

1. the zai adapter's reasoning-only fallback promotes chain-of-thought into `text` when no `content` arrived ("visible instead of blank");
2. the driver's empty-completion abort — whose message literally names the "budget was likely spent on reasoning" case — checks `text.trim().is_empty()`, which the promotion guarantees is false whenever any reasoning streamed.

So the truncated, tool-less step took the "non-empty text + Length → warn and complete" branch. On a headless run "ask to continue" is addressed to nobody; 51KB of chain-of-thought became the final answer, verification found nothing observable, and (pre-#1017) the run reported success on a task it never touched.

## The fix

`dispatch_completion`: `finish_reason: Length` with no tool call no longer finishes the turn. The partial is recorded as the assistant message and the turn continues with a nudge — the turn is not over; describing the work is not doing it — so the next step acts with the model's own partial reasoning in context.

A **continuation, not a retry**: at temperature 0 the identical request re-truncates identically; the changed input is what changes the outcome.

Bounded by `MAX_LENGTH_CONTINUATIONS = 2` per turn (`TurnState`, not checkpointed — a resume restarts the allowance, which only re-permits a bounded amount). On exhaustion the turn falls through to the existing truncation warning, and the verification ladder's no-op rung (#1017) holds the line. The empty-text abort path is unchanged; Length with dispatched tool calls is unchanged.

## Why this matters for the head-to-head

#1017 made the zero-tool trials fail *honestly*; this PR is the layer that makes them *recoverable*. In the canonical trace (`regex-log`) the model had essentially solved the task in-head when cut off — a continuation converts that from a wasted 16k-token spend into a completed task. Expected effect: the entire zero/low-tool cohort (8 zero-tool + 7 ≤2-tool trials in the bundle) gets a real attempt.

## Tests

- `a_length_truncated_tool_less_step_continues_the_turn_instead_of_completing` — the trace shape end-to-end: truncated CoT step → nudge → tool call → completion; partial stays in history, nudge appears exactly once, tool ran, no Error emitted.
- `length_continuations_are_bounded_per_turn` — a model that truncates every step spends 1 + 2 calls, gets exactly 2 nudges, one Complete, and the truncation warning.
- `empty_completion_aborts_with_a_visible_message_not_a_silent_success` — unchanged, still green.

`make gate` green (exit 0). File-size baseline updated for the two files that grew.

## Summary by Sourcery

Handle length-truncated, tool-less model steps as continuations instead of completed turns, with a bounded continuation budget per turn and updated tests and size baselines.

Bug Fixes:
- Prevent turns from incorrectly completing when a model response is truncated at the output-token limit without any tool calls by continuing the turn with the partial response in context.

Enhancements:
- Introduce a per-turn limit on length-based continuations to avoid unbounded paid calls and emit user-facing warnings when the truncation allowance is exhausted.

Tests:
- Add coverage for length-truncated, tool-less steps continuing the turn and invoking tools, and for enforcing the per-turn continuation limit.
- Keep the existing empty-completion abort behavior covered and adjust file-size baselines for the expanded test and driver code.

Chores:
- Update file-size baselines to account for driver and test file growth.