### PR TITLE
fix(bench): telemetry writes that cry wolf, and a task instruction that parses as a flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,8 @@ docs/brand/__pycache__/
 
 # Terminal recordings (scripts/record-demo.sh)
 /recordings/
+
+# Benchmark evidence handoffs: raw trial traces (100s of MB) plus rig
+# credentials (*.pem). Never committed — a bare `git add .` must not be able
+# to publish an SSH key.
+/docs/stella-bench-handoff/

--- a/bench/evidence/run/primary.sh
+++ b/bench/evidence/run/primary.sh
@@ -10,14 +10,17 @@ JOB="${2:?usage: primary.sh <A|B> <job-name>}"
 test ! -e "$JOBS/$JOB" || { echo "FATAL: $JOBS/$JOB exists — a run never resumes"; exit 1; }
 
 case "$PHASE" in
-  A) KEY=phaseA; CONC="${TB_CONCURRENCY_A:-3}" ;;
-  B) KEY=phaseB; CONC=1 ;;
-  *) echo "FATAL: phase must be A or B"; exit 1 ;;
+  A)   KEY=phaseA; CONC="${TB_CONCURRENCY_A:-3}" ;;
+  B)   KEY=phaseB; CONC=1 ;;
+  ALL) KEY=all;    CONC="${TB_CONCURRENCY:-3}" ;;
+  *)   echo "FATAL: phase must be A, B or ALL"; exit 1 ;;
 esac
 
 python3 -c "
 import json,sys
-print('\n'.join(json.load(open('$TB_ROOT/phases.json'))['$KEY']))
+p=json.load(open('$TB_ROOT/phases.json'))
+names = p['phaseA'] + p['phaseB'] if '$KEY'=='all' else p['$KEY']
+print('\n'.join(sorted(names)))
 " > "$TB_ROOT/$KEY.tasks"
 N=$(grep -c . "$TB_ROOT/$KEY.tasks")
 test "$N" -gt 0 || { echo "FATAL: no tasks for phase $PHASE"; exit 1; }

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -111,6 +111,14 @@ _STREAM_EVENTS_NAME = "stella-events.jsonl"
 _STREAM_EVENTS_PATH = f"/logs/agent/{_STREAM_EVENTS_NAME}"
 _TRAJECTORY_NAME = "trajectory.json"
 
+# The one log line that means telemetry was actually lost: a host-side
+# artifact write failed AND no copy of the artifact exists on disk. Grep for
+# this token during run validation (PROMPT-3 step 5). It is deliberately NOT
+# the old "could not write" wording — that line also fired when a complete
+# container copy was already present (11 false alarms in one 2026-07-31 run,
+# zero bytes lost), which trained readers to ignore it.
+_TELEMETRY_INCOMPLETE = "stella-adapter: TELEMETRY-INCOMPLETE"
+
 # Defaults when neither Harbor nor the environment specify a value.
 _DEFAULT_MODEL = "anthropic/claude-fable-5"
 _DEFAULT_BUDGET = "5.0"
@@ -1429,7 +1437,12 @@ class StellaAgent(BaseInstalledAgent):
         if base_url:
             base_url = _validated_public_base_url(base_url)
             parts += ["--base-url", base_url]
-        parts += ["run", instruction]
+        # `--` ends option parsing so a task instruction that begins with a
+        # dash (a markdown list, a CLI transcript) binds to the positional
+        # instead of parsing as a flag. Without it, `stella run '- foo'`
+        # exits 2 before the agent starts — one 2026-07-31 trial
+        # (pytorch-model-recovery) died exactly this way and scored 0.
+        parts += ["run", "--", instruction]
         return parts
 
     def _selected_provider_credential(self) -> tuple[str, str]:
@@ -1839,8 +1852,10 @@ class StellaAgent(BaseInstalledAgent):
                 ),
             )
         except Exception as exc:  # noqa: BLE001 - metadata must not fail a trial
+            # Serialization failures only: `_write_log` handles (and honestly
+            # classifies) filesystem failures itself and does not raise.
             print(
-                f"stella-adapter: could not write {_TRAJECTORY_NAME}: {exc}",
+                f"stella-adapter: could not build {_TRAJECTORY_NAME}: {exc}",
                 file=sys.stderr,
             )
 
@@ -1853,6 +1868,22 @@ class StellaAgent(BaseInstalledAgent):
         return Path(logs_dir) / name
 
     def _write_log(self, name: str, content: str | None) -> None:
+        """Persist ``content`` under ``logs_dir`` without clobbering — or
+        false-alarming about — a copy that is already there.
+
+        The events file arrives by two racing paths: Stella's in-container
+        sink (downloaded by Harbor, often root-owned) and this host-side
+        write. Whichever lost the race used to hit the other's file and print
+        "could not write" — eleven times in one run, with zero bytes lost,
+        and the error anti-correlated with actual loss. Now: an existing
+        file is left alone (whatever is there is the container's own artifact
+        or an earlier successful write — both authoritative over a host-side
+        reconstruction); a failed write re-checks the filesystem and stays
+        silent when a non-empty copy exists (the race was lost, nothing was);
+        and only "nothing exists and nothing could be written" is loud, with
+        the greppable ``TELEMETRY-INCOMPLETE`` marker run validation looks
+        for.
+        """
         if not content:
             return
         path = self._log_path(name)
@@ -1860,9 +1891,32 @@ class StellaAgent(BaseInstalledAgent):
             return
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
+            if path.exists():
+                # Non-destructive by design; never replace an existing
+                # artifact with a reconstruction.
+                return
             path.write_text(content, encoding="utf-8")
         except OSError as exc:
-            print(f"stella-adapter: could not write {name}: {exc}", file=sys.stderr)
+            if self._artifact_present(path):
+                # Lost the race to the container download: the artifact is
+                # present and non-empty, so nothing was lost and nothing is
+                # printed.
+                return
+            print(
+                f"{_TELEMETRY_INCOMPLETE} {name}: no copy exists and the host "
+                f"write failed: {exc}",
+                file=sys.stderr,
+            )
+
+    @staticmethod
+    def _artifact_present(path: Path) -> bool:
+        """Whether a non-empty file exists at ``path``. Checked *after* a
+        failed write, so a lost race reads as presence rather than loss; a
+        root-owned unreadable file still counts (stat needs only the parent)."""
+        try:
+            return path.stat().st_size > 0
+        except OSError:
+            return False
 
     def _read_log(self, name: str) -> str | None:
         path = self._log_path(name)

--- a/bench/harbor_adapter/tests/test_adapter.py
+++ b/bench/harbor_adapter/tests/test_adapter.py
@@ -291,7 +291,7 @@ class TestBuildCommand:
         ]
         assert cmd[cmd.index("--output-format") + 1] == "stream-json"
         assert cmd[cmd.index("--budget") + 1] == "5.0"  # default budget
-        assert cmd[-2:] == ["run", "Fix the bug"]
+        assert cmd[-3:] == ["run", "--", "Fix the bug"]
         assert "--base-url" not in cmd  # not set
 
     def test_env_overrides_and_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -352,7 +352,7 @@ class TestBuildCommand:
         agent.model_name = "anthropic/claude-fable-5"
         instruction = "rm -rf / ; echo $HOME && $(touch /tmp/owned)"
         cmd = agent._build_command(instruction)
-        assert cmd[-2:] == ["run", instruction]
+        assert cmd[-3:] == ["run", "--", instruction]
 
     def test_secret_bearing_base_url_never_enters_command(
         self, monkeypatch: pytest.MonkeyPatch
@@ -460,7 +460,7 @@ class TestNoBudgetCap:
         assert "--budget" not in cmd
         # The failure mode was an empty argv element, not just a stray flag.
         assert "" not in cmd
-        assert cmd[-2:] == ["run", "Fix the bug"]
+        assert cmd[-3:] == ["run", "--", "Fix the bug"]
 
     def test_whitespace_budget_is_treated_as_no_cap_not_as_a_number(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1223,7 +1223,7 @@ class TestRun:
                 self, *, command: list[str], env: dict[str, str], stdin: bytes
             ):
                 assert command[0] == _INSTALL_PATH
-                assert command[-2:] == ["run", "Fix the task."]
+                assert command[-3:] == ["run", "--", "Fix the task."]
                 assert command[command.index("--base-url") + 1] == (
                     "https://openrouter.ai/api/v1"
                 )

--- a/bench/harbor_adapter/tests/test_log_writes.py
+++ b/bench/harbor_adapter/tests/test_log_writes.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+"""Host-side artifact writes: non-destructive, and honest about loss.
+
+The events file reaches ``logs_dir`` by two racing paths — Stella's
+in-container sink (downloaded by Harbor, often root-owned) and the adapter's
+host-side ``_write_log``. The 2026-07-31 run printed ``could not write
+stella-events.jsonl: [Errno 13]`` eleven times while losing zero bytes: the
+error and actual data loss were *anti-correlated*, which trains a reader to
+ignore the one line that would ever matter.
+
+These tests pin the repaired contract for both race orderings:
+
+- container copy lands first → the host write backs off silently;
+- host write lands first → it succeeds (and a later identical call is a
+  silent no-op, never an overwrite);
+- a write that fails while a copy exists (the race lost mid-flight) is
+  silent;
+- a write that fails with NO copy on disk — the only genuine telemetry loss —
+  is loud and carries the greppable ``TELEMETRY-INCOMPLETE`` marker that run
+  validation (PROMPT-3 step 5) searches for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="harbor 0.6.x is required for adapter tests")
+
+from stella_harbor import (  # noqa: E402 - after importorskip by design
+    _STREAM_EVENTS_NAME,
+    _TELEMETRY_INCOMPLETE,
+    StellaAgent,
+)
+
+
+def _agent_with_logs(tmp_path: Path) -> StellaAgent:
+    agent = StellaAgent.__new__(StellaAgent)
+    agent.logs_dir = tmp_path
+    return agent
+
+
+def test_absent_file_is_written(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    agent = _agent_with_logs(tmp_path)
+    agent._write_log(_STREAM_EVENTS_NAME, '{"type":"complete"}\n')
+    assert (tmp_path / _STREAM_EVENTS_NAME).read_text() == '{"type":"complete"}\n'
+    assert capsys.readouterr().err == ""
+
+
+def test_existing_file_is_never_overwritten_and_never_alarmed(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    # Container copy landed first (ordering 1). The host-side reconstruction
+    # must neither replace it nor print anything scary about it.
+    target = tmp_path / _STREAM_EVENTS_NAME
+    target.write_text("container copy — authoritative\n")
+    agent = _agent_with_logs(tmp_path)
+
+    agent._write_log(_STREAM_EVENTS_NAME, "host reconstruction — different\n")
+
+    assert target.read_text() == "container copy — authoritative\n"
+    assert capsys.readouterr().err == ""
+
+
+def test_lost_race_is_silent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    # Ordering 2, lost mid-flight: the existence check sees nothing, the
+    # container download lands root-owned, and the host write then fails.
+    # The artifact is present — nothing was lost, so nothing is printed.
+    target = tmp_path / _STREAM_EVENTS_NAME
+    real_write_text = Path.write_text
+
+    def download_wins(self: Path, content: str, **kwargs: object) -> int:
+        if self == target:
+            real_write_text(self, "container copy landed mid-race\n")
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_write_text(self, content, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", download_wins)
+    agent = _agent_with_logs(tmp_path)
+
+    agent._write_log(_STREAM_EVENTS_NAME, "host reconstruction\n")
+
+    monkeypatch.undo()
+    assert target.read_text() == "container copy landed mid-race\n"
+    assert capsys.readouterr().err == ""
+
+
+def test_genuine_loss_is_loud_and_greppable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    # The only real telemetry loss: the write fails AND no copy exists.
+    target = tmp_path / _STREAM_EVENTS_NAME
+
+    def always_denied(self: Path, content: str, **kwargs: object) -> int:
+        raise PermissionError(13, "Permission denied", str(self))
+
+    monkeypatch.setattr(Path, "write_text", always_denied)
+    agent = _agent_with_logs(tmp_path)
+
+    agent._write_log(_STREAM_EVENTS_NAME, "events that now exist nowhere\n")
+
+    monkeypatch.undo()
+    assert not target.exists()
+    err = capsys.readouterr().err
+    assert _TELEMETRY_INCOMPLETE in err
+    assert _STREAM_EVENTS_NAME in err
+    # The old cry-wolf wording must not come back: validation greps must be
+    # able to treat any occurrence of the marker as a real loss.
+    assert "could not write" not in err
+
+
+def test_empty_content_writes_nothing(tmp_path: Path) -> None:
+    agent = _agent_with_logs(tmp_path)
+    agent._write_log(_STREAM_EVENTS_NAME, None)
+    agent._write_log(_STREAM_EVENTS_NAME, "")
+    assert not (tmp_path / _STREAM_EVENTS_NAME).exists()
+
+
+def test_run_instruction_binds_after_double_dash(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A task instruction that begins with a dash must reach `stella run` as
+    # the positional, not parse as a flag: one 2026-07-31 trial
+    # (pytorch-model-recovery) exited 2 before the agent started because its
+    # instruction opened with "- ".
+    monkeypatch.delenv("STELLA_BUDGET", raising=False)
+    monkeypatch.delenv("STELLA_MODEL", raising=False)
+    monkeypatch.delenv("STELLA_BASE_URL", raising=False)
+    agent = StellaAgent.__new__(StellaAgent)
+    agent.model_name = "openrouter/z-ai/glm-5.2"
+
+    cmd = agent._build_command("- start with a dash")
+
+    run_at = cmd.index("run")
+    assert cmd[run_at:] == ["run", "--", "- start with a dash"]

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,9 +7,9 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1861 bench/harbor_adapter/stella_harbor/__init__.py
+1928 bench/harbor_adapter/stella_harbor/__init__.py
 4269 bench/harbor_adapter/stella_harbor/secure_launcher.py
-1844 bench/harbor_adapter/tests/test_adapter.py
+1910 bench/harbor_adapter/tests/test_adapter.py
 3204 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py


### PR DESCRIPTION
Completes the outstanding half of the PROMPT-2 deliverable (Part 2 — the events.jsonl false alarm), plus the leading-dash launcher bug found in the trace review, plus the run-harness pieces the 20-task rerun protocol (PROMPT-3) expects to be settled.

## Part 1 — the events.jsonl "Permission denied" was a false alarm that hid real ones

Two racing writers: Harbor's root-owned container download vs the adapter's host-side `_write_log`. The loser hit the other's file → "could not write … [Errno 13]" — **11 times in one run, zero bytes lost** (all 11 errored trials had complete streams; the 9 truncated streams logged no error — alarm and loss were anti-correlated).

`_write_log` is now **non-destructive and honest**:
- an existing file is never replaced (the container's artifact is authoritative over a host reconstruction);
- a failed write re-checks the filesystem and stays **silent when a non-empty copy exists**;
- only "nothing exists and nothing could be written" is **loud**, with a greppable `TELEMETRY-INCOMPLETE` marker — deliberately not the old wording, so run validation (PROMPT-3 step 5) can treat every occurrence as genuine loss.

Same treatment for the `trajectory.json` sibling; its serialization-failure arm now says "could not build" instead of claiming a write failed.

## Part 2 — instructions beginning with "-" never reached the agent

`_build_command` passed the instruction as a bare token after `run`; `pytorch-model-recovery`'s instruction begins with `- `, clap read it as a flag, and the trial died with "unexpected argument '- '" **before the agent started** — scored 0.0 as if the agent failed. Argv is now `run -- <instruction>`.

## Run-harness pieces

- `primary.sh` gains the `ALL` phase from the frozen live-run patch set (phaseA+phaseB in one run — the 89-task shape).
- `docs/stella-bench-handoff/` is gitignored: raw traces + the rig SSH key must never be one `git add .` away from publication.
- (The third frozen patch — empty `STELLA_BUDGET` = no cap — already landed in #1021; not duplicated.)

## Tests

`tests/test_log_writes.py` pins both race orderings and both honesty properties, plus the leading-dash argv shape; existing argv-tail assertions updated for `--`. Full adapter suite 303 passed / 1 skipped; `make gate` green (exit 0). File-size baseline updated (also absorbs a stale ceiling main already carried for `test_adapter.py`).

## Why now

PROMPT-3's validation explicitly assumes this fix: *"grep the run log for `could not write` … After that fix, any occurrence means telemetry was actually lost."* With this merged, the pre-registered head-to-head's telemetry channel is trustworthy in both directions.

## Summary by Sourcery

Clarify and harden harbor adapter telemetry logging, ensure leading-dash task instructions reach the agent correctly, and extend the run harness to support an ALL phase over combined task sets.

Bug Fixes:
- Make host-side log writes non-destructive and only emit a distinct TELEMETRY-INCOMPLETE marker when telemetry artifacts are genuinely missing and unwritable.
- Ensure task instructions beginning with a dash are passed to `stella run` as positional arguments via `--`, preventing them from being misparsed as flags and killing trials before the agent starts.
- Update trajectory artifact error reporting to distinguish serialization failures from filesystem issues.

Enhancements:
- Add an ALL phase to the primary run harness that executes a combined, sorted set of phaseA and phaseB tasks with configurable concurrency.
- Improve artifact presence detection in the harbor adapter to treat existing non-empty, even root-owned, files as authoritative copies rather than loss.

Tests:
- Introduce a dedicated test suite for host-side log writes that locks in race-order behavior, non-overwrite guarantees, and TELEMETRY-INCOMPLETE signaling for genuine telemetry loss.
- Update adapter command-shape tests to assert the presence of `--` before instructions and refresh file-size baselines accordingly.

Chores:
- Gitignore the `docs/stella-bench-handoff/` directory to avoid accidentally committing raw traces or rig SSH keys.