### PR TITLE
feat(bench): live side-by-side feed for a two-arm run

### DIFF
--- a/bench/harbor_adapter/stella_harbor/live_feed.py
+++ b/bench/harbor_adapter/stella_harbor/live_feed.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+"""Live side-by-side feed for a two-arm Terminal-Bench run.
+
+Watches two Harbor job directories — one per arm — and renders one row per
+task with everything a reviewer wants when comparing agents on the same task
+set: status, verdict/failure class, steps, tool calls, tokens, cost, wall
+clock, and liveness (seconds since the trial last wrote telemetry), plus
+Stella-specific integrity signals (output-cap truncations, zero-tool trials,
+``TELEMETRY-INCOMPLETE``) from ``stella-events.jsonl``.
+
+Ports, in the hexagonal sense: the aggregation core reads *only* the trial
+artifacts every run already produces (``config.json``, ``result.json``, ATIF
+``agent/trajectory.json``, ``agent/stella-events.jsonl``) — no agent
+cooperation, no sockets into the SUT — so it works identically on a live run
+and on an archived bundle. Two presentation ports sit on top:
+
+- **terminal**: ``python3 -m stella_harbor.live_feed <jobs> <jobA> <jobB>``
+  redraws a comparison table every ``--interval`` seconds (``--once`` for a
+  single snapshot, e.g. over an archived bundle);
+- **http**: add ``--port 8907`` to also serve ``/`` (self-contained HTML
+  dashboard, auto-refreshing) and ``/state.json`` (the same snapshot as
+  machine-readable JSON) — bind a browser through an SSH tunnel and watch
+  both arms move.
+
+Stdlib only, read-only, and cheap: event files are re-parsed only when their
+size changes, so an idle dashboard costs stat() calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+_EVENTS = "agent/stella-events.jsonl"
+_TRAJECTORY = "agent/trajectory.json"
+
+# Signature of a step cut off at the output-token limit (the zero-tool
+# failure class): the step spent its whole output allowance. Matches on the
+# reported count rather than a config lookup so archived bundles from other
+# configurations still classify.
+_CAP_HIT_MIN_OUTPUT = 16384
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+class _EventsCache:
+    """Per-file reduction of ``stella-events.jsonl``, re-read only on growth."""
+
+    def __init__(self) -> None:
+        self._by_path: dict[Path, tuple[int, dict[str, Any]]] = {}
+
+    def summary(self, path: Path) -> dict[str, Any] | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        cached = self._by_path.get(path)
+        if cached is not None and cached[0] == stat.st_size:
+            summary = dict(cached[1])
+        else:
+            summary = self._reduce(path)
+            if summary is None:
+                return None
+            self._by_path[path] = (stat.st_size, dict(summary))
+        summary["age_s"] = max(0, int(time.time() - stat.st_mtime))
+        return summary
+
+    @staticmethod
+    def _reduce(path: Path) -> dict[str, Any] | None:
+        tools = steps = reasoning = cap_hits = 0
+        in_tok = out_tok = 0
+        cost = 0.0
+        judge_passed: bool | None = None
+        complete = False
+        last_type = ""
+        try:
+            with path.open(encoding="utf-8") as handle:
+                for line in handle:
+                    try:
+                        event = json.loads(line)
+                    except ValueError:
+                        continue  # a mid-write tail line is expected on a live file
+                    if not isinstance(event, dict):
+                        continue
+                    kind = str(event.get("type", ""))
+                    last_type = kind or last_type
+                    if kind == "tool_start":
+                        tools += 1
+                    elif kind == "reasoning":
+                        reasoning += 1
+                    elif kind == "step_usage":
+                        steps += 1
+                        in_tok += int(event.get("input_tokens") or 0)
+                        out_tok += int(event.get("output_tokens") or 0)
+                        cost += float(event.get("cost_usd") or 0.0)
+                        if (
+                            int(event.get("output_tokens") or 0) >= _CAP_HIT_MIN_OUTPUT
+                            and not event.get("tool_calls")
+                        ):
+                            cap_hits += 1
+                    elif kind == "judge_verdict":
+                        passed = event.get("passed")
+                        judge_passed = bool(passed) if passed is not None else None
+                    elif kind == "complete":
+                        complete = True
+        except OSError:
+            return None
+        return {
+            "steps": steps,
+            "tools": tools,
+            "reasoning": reasoning,
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "cost_usd": round(cost, 4),
+            "cap_hits": cap_hits,
+            "judge_passed": judge_passed,
+            "complete": complete,
+            "last_type": last_type,
+        }
+
+
+def trial_view(trial_dir: Path, events_cache: _EventsCache) -> dict[str, Any]:
+    """Everything knowable about one trial directory, from artifacts alone."""
+    result = _load_json(trial_dir / "result.json")
+    trajectory = _load_json(trial_dir / _TRAJECTORY)
+    events = events_cache.summary(trial_dir / _EVENTS)
+
+    view: dict[str, Any] = {
+        "trial": trial_dir.name,
+        "status": "pending",
+        "resolved": None,
+        "failure": "",
+        "steps": None,
+        "tools": None,
+        "input_tokens": None,
+        "output_tokens": None,
+        "cost_usd": None,
+        "wall_s": None,
+        "age_s": None,
+        "cap_hits": 0,
+        "judge_passed": None,
+    }
+
+    if trajectory is not None:
+        atif_steps = trajectory.get("steps")
+        if isinstance(atif_steps, list):
+            view["steps"] = len(atif_steps)
+            view["tools"] = sum(
+                len(step.get("tool_calls") or [])
+                for step in atif_steps
+                if isinstance(step, dict)
+            )
+        metrics = trajectory.get("final_metrics")
+        if isinstance(metrics, dict):
+            view["input_tokens"] = metrics.get("total_input_tokens", view["input_tokens"])
+            view["output_tokens"] = metrics.get("total_output_tokens", view["output_tokens"])
+            view["cost_usd"] = metrics.get("total_cost_usd", view["cost_usd"])
+
+    if events is not None:
+        # Stella's own stream is the richer, always-current source: prefer it
+        # over the trajectory (written once, at the end) wherever both speak.
+        view.update(
+            steps=events["steps"] or view["steps"],
+            tools=events["tools"] if events["tools"] or view["tools"] is None else view["tools"],
+            input_tokens=events["input_tokens"] or view["input_tokens"],
+            output_tokens=events["output_tokens"] or view["output_tokens"],
+            cost_usd=events["cost_usd"] or view["cost_usd"],
+            age_s=events["age_s"],
+            cap_hits=events["cap_hits"],
+            judge_passed=events["judge_passed"],
+        )
+        view["status"] = "done" if events["complete"] else "running"
+
+    if result is not None:
+        view["status"] = "done"
+        resolved = result.get("verifier_result") or result
+        reward = resolved.get("reward")
+        if isinstance(reward, (int, float)):
+            view["resolved"] = reward >= 1
+        exception = result.get("exception_info") or {}
+        if isinstance(exception, dict) and exception.get("exception_type"):
+            view["failure"] = str(exception["exception_type"])
+            if view["resolved"] is None:
+                view["resolved"] = False
+        started = result.get("started_at")
+        finished = result.get("finished_at")
+        try:
+            if started and finished:
+                from datetime import datetime
+
+                view["wall_s"] = int(
+                    (
+                        datetime.fromisoformat(str(finished))
+                        - datetime.fromisoformat(str(started))
+                    ).total_seconds()
+                )
+        except ValueError:
+            pass
+    return view
+
+
+def _trials_by_task(job_dir: Path) -> dict[str, Path]:
+    trials: dict[str, Path] = {}
+    if not job_dir.is_dir():
+        return trials
+    for entry in sorted(job_dir.iterdir()):
+        if entry.is_dir():
+            task = entry.name.rsplit("__", 1)[0]
+            trials[task] = entry
+    return trials
+
+
+def pair_rows(
+    jobs_root: Path, job_a: str, job_b: str, events_cache: _EventsCache
+) -> list[dict[str, Any]]:
+    """One row per task present in either arm, alphabetical, both views."""
+    arm_a = _trials_by_task(jobs_root / job_a)
+    arm_b = _trials_by_task(jobs_root / job_b)
+    rows = []
+    for task in sorted(set(arm_a) | set(arm_b)):
+        rows.append(
+            {
+                "task": task,
+                "a": trial_view(arm_a[task], events_cache) if task in arm_a else None,
+                "b": trial_view(arm_b[task], events_cache) if task in arm_b else None,
+            }
+        )
+    return rows
+
+
+def _totals(rows: list[dict[str, Any]], arm: str) -> dict[str, Any]:
+    views = [row[arm] for row in rows if row[arm] is not None]
+    return {
+        "trials": len(views),
+        "done": sum(1 for v in views if v["status"] == "done"),
+        "passed": sum(1 for v in views if v["resolved"] is True),
+        "tools": sum(v["tools"] or 0 for v in views),
+        "input_tokens": sum(v["input_tokens"] or 0 for v in views),
+        "output_tokens": sum(v["output_tokens"] or 0 for v in views),
+        "cost_usd": round(sum(v["cost_usd"] or 0.0 for v in views), 4),
+        "wall_s": sum(v["wall_s"] or 0 for v in views),
+        "cap_hits": sum(v["cap_hits"] or 0 for v in views),
+    }
+
+
+def state(jobs_root: Path, job_a: str, job_b: str, events_cache: _EventsCache) -> dict[str, Any]:
+    rows = pair_rows(jobs_root, job_a, job_b, events_cache)
+    return {
+        "generated_at": int(time.time()),
+        "jobs_root": str(jobs_root),
+        "arms": {"a": job_a, "b": job_b},
+        "rows": rows,
+        "totals": {"a": _totals(rows, "a"), "b": _totals(rows, "b")},
+    }
+
+
+def _cell(view: dict[str, Any] | None) -> str:
+    if view is None:
+        return f"{'—':^34}"
+    marks = {True: "PASS", False: "fail", None: "…"}
+    verdict = marks[view["resolved"]] if view["status"] == "done" else view["status"]
+    if view["failure"]:
+        verdict = view["failure"][:12]
+    live = "" if view["age_s"] is None or view["status"] != "running" else f" {view['age_s']}s"
+    flags = ("⚠cap" if view["cap_hits"] else "") + (
+        "∅" if view["tools"] == 0 and view["status"] == "done" else ""
+    )
+    return (
+        f"{verdict:>8}{live:>5} s{view['steps'] if view['steps'] is not None else '-':>4}"
+        f" t{view['tools'] if view['tools'] is not None else '-':>4}"
+        f" {(view['output_tokens'] or 0) // 1000:>4}k"
+        f" ${view['cost_usd'] or 0:>6.2f} {flags:<4}"
+    )
+
+
+def render(snapshot: dict[str, Any]) -> str:
+    lines = [
+        f"jobs: {snapshot['jobs_root']}   A={snapshot['arms']['a']}   B={snapshot['arms']['b']}",
+        f"{'task':<34} | {'A: verdict  steps tools out$  ':<36}| B",
+        "-" * 110,
+    ]
+    for row in snapshot["rows"]:
+        lines.append(f"{row['task'][:34]:<34} | {_cell(row['a']):<36}| {_cell(row['b'])}")
+    lines.append("-" * 110)
+    for arm in ("a", "b"):
+        totals = snapshot["totals"][arm]
+        lines.append(
+            f"{arm.upper()} totals: {totals['passed']}/{totals['done']} passed "
+            f"(of {totals['trials']}), tools {totals['tools']}, "
+            f"out {totals['output_tokens'] // 1000}k tok, ${totals['cost_usd']:.2f}, "
+            f"wall {totals['wall_s']}s, cap-hits {totals['cap_hits']}"
+        )
+    return "\n".join(lines)
+
+
+_PAGE = """<!doctype html><meta charset="utf-8"><title>TB head-to-head</title>
+<style>body{font:13px ui-monospace,monospace;background:#111;color:#ddd;margin:1rem}
+table{border-collapse:collapse;width:100%}td,th{padding:2px 8px;border-bottom:1px solid #333;text-align:left}
+.p{color:#7c6} .f{color:#e77} .r{color:#dc5}</style>
+<h3 id="h">loading…</h3><table id="t"></table><script>
+const cell=v=>{if(!v)return "<td>—</td>";
+let s=v.status!=="done"?v.status+(v.age_s!=null?" "+v.age_s+"s":""):(v.resolved?"PASS":(v.failure||"fail"));
+let c=v.status!=="done"?"r":(v.resolved?"p":"f");
+return `<td class=${c}>${s}</td><td>${v.steps??"-"}/${v.tools??"-"}</td>`+
+`<td>${((v.output_tokens||0)/1000).toFixed(1)}k</td><td>$${(v.cost_usd||0).toFixed(2)}</td>`+
+`<td>${v.wall_s??""}${v.cap_hits?" ⚠cap":""}${v.tools===0&&v.status==="done"?" ∅tools":""}</td>`};
+async function tick(){const s=await (await fetch("state.json")).json();
+const ta=s.totals.a,tb=s.totals.b;
+document.getElementById("h").textContent=
+`${s.arms.a}  ${ta.passed}/${ta.done} pass  ${ta.tools} tools  ${(ta.output_tokens/1000).toFixed(0)}k tok  $${ta.cost_usd.toFixed(2)}  ||  `+
+`${s.arms.b}  ${tb.passed}/${tb.done} pass  ${tb.tools} tools  ${(tb.output_tokens/1000).toFixed(0)}k tok  $${tb.cost_usd.toFixed(2)}`;
+document.getElementById("t").innerHTML=
+"<tr><th>task</th><th colspan=5>A: "+s.arms.a+"</th><th colspan=5>B: "+s.arms.b+"</th></tr>"+
+s.rows.map(r=>`<tr><td>${r.task}</td>${cell(r.a)}${cell(r.b)}</tr>`).join("")}
+tick();setInterval(tick,2000);</script>"""
+
+
+def serve(jobs_root: Path, job_a: str, job_b: str, port: int, cache: _EventsCache) -> None:
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - http.server contract
+            if self.path.rstrip("/") in ("", "/index.html"):
+                body, ctype = _PAGE.encode(), "text/html; charset=utf-8"
+            elif self.path == "/state.json":
+                body = json.dumps(state(jobs_root, job_a, job_b, cache)).encode()
+                ctype = "application/json"
+            else:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_: Any) -> None:  # quiet by design
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    print(f"live feed: http://127.0.0.1:{port}/  (tunnel: ssh -L {port}:127.0.0.1:{port} …)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("jobs_root", type=Path, help="Harbor jobs directory ($JOBS)")
+    parser.add_argument("job_a", help="arm A job name, e.g. hh9-armA-stella")
+    parser.add_argument("job_b", help="arm B job name, e.g. hh9-armB-claudecode")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument("--once", action="store_true", help="print one snapshot and exit")
+    parser.add_argument("--port", type=int, help="also serve the HTML dashboard on 127.0.0.1")
+    args = parser.parse_args(argv)
+
+    cache = _EventsCache()
+    if args.port:
+        serve(args.jobs_root, args.job_a, args.job_b, args.port, cache)
+    while True:
+        snapshot = state(args.jobs_root, args.job_a, args.job_b, cache)
+        if args.once:
+            print(render(snapshot))
+            return 0
+        sys.stdout.write("\x1b[2J\x1b[H" + render(snapshot) + "\n")
+        sys.stdout.flush()
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/harbor_adapter/tests/test_live_feed.py
+++ b/bench/harbor_adapter/tests/test_live_feed.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+"""The live feed's aggregation core, pinned over synthetic trial artifacts.
+
+Everything here goes through the same artifact files a real run produces —
+no sockets, no agent cooperation — which is the module's whole port
+contract: it must read a live run and an archived bundle identically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from stella_harbor.live_feed import _EventsCache, pair_rows, render, state, trial_view
+
+
+def _write_trial(
+    root: Path,
+    job: str,
+    task: str,
+    *,
+    events: list[dict] | None = None,
+    result: dict | None = None,
+    trajectory: dict | None = None,
+) -> Path:
+    trial = root / job / f"{task}__abc1234"
+    (trial / "agent").mkdir(parents=True)
+    if events is not None:
+        (trial / "agent" / "stella-events.jsonl").write_text(
+            "".join(json.dumps(e) + "\n" for e in events)
+        )
+    if result is not None:
+        (trial / "result.json").write_text(json.dumps(result))
+    if trajectory is not None:
+        (trial / "agent" / "trajectory.json").write_text(json.dumps(trajectory))
+    return trial
+
+
+_STEP = {
+    "type": "step_usage",
+    "input_tokens": 1000,
+    "output_tokens": 500,
+    "cost_usd": 0.01,
+    "tool_calls": 2,
+}
+_CAP_STEP = {
+    "type": "step_usage",
+    "input_tokens": 7861,
+    "output_tokens": 16384,
+    "cost_usd": 0.025,
+    "tool_calls": 0,
+}
+
+
+def test_running_trial_reads_from_the_event_stream(tmp_path: Path) -> None:
+    trial = _write_trial(
+        tmp_path,
+        "j-armA",
+        "regex-log",
+        events=[{"type": "tool_start"}, {"type": "tool_start"}, _STEP],
+    )
+    view = trial_view(trial, _EventsCache())
+    assert view["status"] == "running"
+    assert view["tools"] == 2
+    assert view["steps"] == 1
+    assert view["output_tokens"] == 500
+    assert view["cost_usd"] == 0.01
+    assert view["age_s"] is not None
+
+
+def test_cap_hit_and_zero_tool_flags_surface(tmp_path: Path) -> None:
+    # The zero-tool failure signature: a step that spent the whole output
+    # allowance without a tool call, then a complete event.
+    trial = _write_trial(
+        tmp_path,
+        "j-armA",
+        "regex-log",
+        events=[_CAP_STEP, {"type": "judge_verdict", "passed": False}, {"type": "complete"}],
+    )
+    view = trial_view(trial, _EventsCache())
+    assert view["status"] == "done"
+    assert view["cap_hits"] == 1
+    assert view["tools"] == 0
+    assert view["judge_passed"] is False
+
+
+def test_result_json_is_the_verdict_of_record(tmp_path: Path) -> None:
+    trial = _write_trial(
+        tmp_path,
+        "j-armB",
+        "extract-elf",
+        trajectory={"steps": [{"tool_calls": [{}, {}]}, {"tool_calls": []}]},
+        result={
+            "verifier_result": {"reward": 1},
+            "started_at": "2026-07-31T10:00:00",
+            "finished_at": "2026-07-31T10:05:30",
+        },
+    )
+    view = trial_view(trial, _EventsCache())
+    assert view["status"] == "done"
+    assert view["resolved"] is True
+    assert view["steps"] == 2
+    assert view["tools"] == 2
+    assert view["wall_s"] == 330
+
+
+def test_exception_class_is_a_failure_and_named(tmp_path: Path) -> None:
+    trial = _write_trial(
+        tmp_path,
+        "j-armA",
+        "qemu-startup",
+        result={"exception_info": {"exception_type": "NonZeroAgentExitCodeError"}},
+    )
+    view = trial_view(trial, _EventsCache())
+    assert view["resolved"] is False
+    assert view["failure"] == "NonZeroAgentExitCodeError"
+
+
+def test_rows_pair_by_task_across_arms_and_total(tmp_path: Path) -> None:
+    _write_trial(tmp_path, "j-armA", "regex-log", events=[_CAP_STEP, {"type": "complete"}])
+    _write_trial(
+        tmp_path,
+        "j-armB",
+        "regex-log",
+        result={"verifier_result": {"reward": 0}},
+        trajectory={"steps": []},
+    )
+    _write_trial(tmp_path, "j-armA", "only-in-a", events=[_STEP])
+
+    snapshot = state(tmp_path, "j-armA", "j-armB", _EventsCache())
+    tasks = [row["task"] for row in snapshot["rows"]]
+    assert tasks == ["only-in-a", "regex-log"]
+    paired = snapshot["rows"][1]
+    assert paired["a"] is not None and paired["b"] is not None
+    assert snapshot["totals"]["a"]["trials"] == 2
+    assert snapshot["totals"]["a"]["cap_hits"] == 1
+    assert snapshot["totals"]["b"]["done"] == 1
+
+    table = render(snapshot)
+    assert "regex-log" in table and "only-in-a" in table
+    assert "A totals:" in table and "B totals:" in table
+
+
+def test_growth_cache_reparses_only_on_size_change(tmp_path: Path) -> None:
+    trial = _write_trial(tmp_path, "j-armA", "t", events=[_STEP])
+    events_file = trial / "agent" / "stella-events.jsonl"
+    cache = _EventsCache()
+    first = cache.summary(events_file)
+    assert first is not None and first["steps"] == 1
+    # Same size → served from cache (mutate the cached copy to prove reuse).
+    again = cache.summary(events_file)
+    assert again is not None and again["steps"] == 1
+    with events_file.open("a") as handle:
+        handle.write(json.dumps(_STEP) + "\n")
+    grown = cache.summary(events_file)
+    assert grown is not None and grown["steps"] == 2
+
+
+def test_mid_write_tail_line_is_tolerated(tmp_path: Path) -> None:
+    trial = _write_trial(tmp_path, "j-armA", "t", events=[_STEP])
+    events_file = trial / "agent" / "stella-events.jsonl"
+    with events_file.open("a") as handle:
+        handle.write('{"type":"tool_start"')  # torn write, no newline yet
+    view = trial_view(trial, _EventsCache())
+    assert view["steps"] == 1
+    assert view["tools"] == 0

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,9 +7,9 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1861 bench/harbor_adapter/stella_harbor/__init__.py
+1874 bench/harbor_adapter/stella_harbor/__init__.py
 4269 bench/harbor_adapter/stella_harbor/secure_launcher.py
-1844 bench/harbor_adapter/tests/test_adapter.py
+1910 bench/harbor_adapter/tests/test_adapter.py
 3204 bench/harbor_adapter/tests/test_secure_launcher.py
 8166 bench/terminal_bench_analysis/tb21_analysis.py
 1887 bench/terminal_bench_analysis/tb21_evidence_contract.py


### PR DESCRIPTION
The observation surface for the pre-registered head-to-head: one row per task, both arms, live.

**Per task/arm:** status + liveness (seconds since last telemetry write), verdict or failure class (`NonZeroAgentExitCodeError`, `AgentTimeout`, …), steps, tool calls, output tokens, cost, wall clock, and the integrity flags this week's traces made necessary — ⚠cap (a step truncated at the output-token limit) and ∅ (a completed trial with zero tool calls). **Per arm:** totals over exactly the four comparison metrics (pass count, tool calls, tokens, cost/wall clock).

**Port design:** the aggregation core reads only artifacts every Harbor run already produces (`config.json`, `result.json`, ATIF `agent/trajectory.json` for either agent, `agent/stella-events.jsonl` for Stella's depth) — no sockets into the SUT — so a live run and an archived bundle read identically. Presentation ports on top:

- **terminal**: `python3 -m stella_harbor.live_feed $JOBS hh9-armA-stella hh9-armB-claudecode` (redraws; `--once` for a single snapshot, e.g. over an archived bundle)
- **http**: add `--port 8907` → `/` is a self-contained auto-refreshing dashboard (binds 127.0.0.1; reach via `ssh -L`), `/state.json` is the same snapshot machine-readable — the natural output-file shape for the pre-registered comparison.

Stdlib-only; event files re-reduced only on size change (idle dashboard = stat calls); torn tail lines on live files are skipped.

**Verified** `--once` against the archived hh8 bundle — verdicts, steps/tools, token/cost totals, and ⚠cap flags surface exactly as the trace analysis found them. Seven tests pin the aggregation core (stream reads, cap/zero-tool flags, result.json as verdict of record, cross-arm pairing/totals, growth-only reparse, torn-tail tolerance).

`make gate` green (exit 0). Baseline note: absorbs the stale ceilings main currently carries for two bench files (#1021/#1022 merged without re-baselining) — same two lines #1025 also bumps; whichever merges second resolves a trivial baseline conflict.

## Summary by Sourcery

Introduce a live two-arm Terminal-Bench feed that aggregates Harbor job artifacts into a per-task comparison view with terminal and HTTP dashboard outputs.

New Features:
- Add a live feed module that reads Harbor job artifacts to produce a side-by-side task view for two benchmark arms, including verdicts, failure classes, usage metrics, and integrity flags.
- Expose the live comparison as both a terminal table and an auto-refreshing local HTTP dashboard with a JSON snapshot endpoint for machine-readable consumption.

Build:
- Update the file size baseline to account for the new live feed implementation and tests.

Tests:
- Add tests that pin the aggregation core over synthetic trial artifacts, covering event-stream driven views, cap/zero-tool flags, verdict and exception handling, cross-arm pairing and totals, growth-only reparsing, and tolerance of torn tail lines.