### PR TITLE
fix(model): the OpenRouter adapter picks the same reasoning-aware output ceiling as the Anthropic one

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -26,7 +26,7 @@
 1609 stella-model/src/anthropic/tests.rs
 1784 stella-model/src/bedrock.rs
 1952 stella-model/src/openai.rs
-1685 stella-model/src/zai/tests.rs
+1720 stella-model/src/zai/tests.rs
 2886 stella-pipeline/src/pipeline.rs
 2277 stella-pipeline/src/pipeline/tests.rs
 2603 stella-protocol/src/event.rs

--- a/stella-model/src/zai.rs
+++ b/stella-model/src/zai.rs
@@ -311,6 +311,26 @@ fn map_openrouter_effort(effort: ReasoningEffort) -> &'static str {
     }
 }
 
+/// The output allowance a request gets when the caller pinned none, matching
+/// `anthropic.rs`'s reasoning-aware default so the two adapters cannot
+/// disagree about what an un-capped reasoning turn is allowed to spend.
+///
+/// Reasoning spends from the SAME allowance as the answer. A ceiling sized for
+/// a non-thinking reply truncates a thinking model mid-thought, and on the
+/// Chat Completions dialects that lands as a `finish_reason: length` turn that
+/// carries chain-of-thought and no tool call — the shape that ended 30 of 30
+/// cap-hit steps in the 2026-07-31 Terminal-Bench bundle with zero tool calls.
+///
+/// A caller-set cap is still honored verbatim: this only fills the hole where
+/// the caller expressed no preference, which is exactly where a silent 4k-ish
+/// provider default would otherwise decide the turn's fate.
+fn reasoning_aware_max_tokens(requested: Option<u32>, reasoning: Option<bool>) -> Option<u32> {
+    requested.or(match reasoning {
+        Some(true) => Some(32_000),
+        _ => None,
+    })
+}
+
 /// Whether a terminal provider error says reasoning cannot be turned off.
 /// Matched on the upstream's own wording rather than a status code: the same
 /// 400 covers every other malformed-request cause, and only this one is
@@ -1012,7 +1032,7 @@ impl ZaiProvider {
             model: &self.model,
             messages: to_zai_messages(req.messages, &self.model),
             stream: true,
-            max_tokens: req.max_output_tokens,
+            max_tokens: reasoning_aware_max_tokens(req.max_output_tokens, req.reasoning),
             temperature: req.temperature,
             top_p: params.top_p,
             top_k: params.top_k,

--- a/stella-model/src/zai/tests.rs
+++ b/stella-model/src/zai/tests.rs
@@ -1683,3 +1683,38 @@ fn a_caps_flip_degrades_instead_of_aborting_the_turn() {
         );
     }
 }
+
+/// The output allowance an un-capped reasoning turn gets, and the parity that
+/// makes it correct: `anthropic.rs` picks 32k for a thinking model and this
+/// adapter must not disagree. Reasoning spends from the same allowance as the
+/// answer, so a provider's own non-thinking-sized default truncates the turn
+/// mid-thought — and on this dialect that lands as a `finish_reason: length`
+/// step carrying chain-of-thought and no tool call, the exact shape that ended
+/// 30 of 30 cap-hit steps in the 2026-07-31 Terminal-Bench bundle.
+#[test]
+fn an_uncapped_reasoning_turn_gets_thinking_headroom() {
+    assert_eq!(reasoning_aware_max_tokens(None, Some(true)), Some(32_000));
+}
+
+/// A caller who pinned a cap keeps it verbatim — the default only fills the
+/// hole where no preference was expressed. Overriding an explicit ceiling
+/// would silently spend a caller's money on a budget they declined.
+#[test]
+fn a_pinned_cap_is_honored_whatever_the_reasoning_setting() {
+    for reasoning in [None, Some(false), Some(true)] {
+        assert_eq!(
+            reasoning_aware_max_tokens(Some(8_192), reasoning),
+            Some(8_192),
+            "an explicit cap survives reasoning={reasoning:?}"
+        );
+    }
+}
+
+/// Reasoning off (or unstated) leaves the field absent, so a request without
+/// a cap serializes byte-identical to what this adapter has always sent —
+/// the prompt-cache stability contract the params work established.
+#[test]
+fn a_non_reasoning_turn_still_sends_no_cap() {
+    assert_eq!(reasoning_aware_max_tokens(None, Some(false)), None);
+    assert_eq!(reasoning_aware_max_tokens(None, None), None);
+}


### PR DESCRIPTION
**Adapter parity.** `anthropic.rs` already reasons about this correctly — adaptive thinking spends from the *same* output allowance as the answer, so it picks 32k instead of 4096 when reasoning is on. The shared Chat Completions adapter (OpenRouter, Z.ai, xAI, DeepSeek, local) forwarded `max_output_tokens` verbatim and let the provider's default decide. Two adapters, two answers to the same question, decided by which endpoint served the call.

**Why it matters:** on this dialect a truncated turn doesn't error. It lands as `finish_reason: length` carrying chain-of-thought and no tool call — the exact shape that ended **30 of 30 cap-hit steps** in the 2026-07-31 Terminal-Bench bundle with zero tool calls. #1024 made the engine *continue* such a turn instead of completing it; this stops one class of them from being created in the first place.

**The fix** mirrors the Anthropic default *and its restraint*: a caller-set cap is honored verbatim, and reasoning off (or unstated) still sends no field at all — so a request without a cap serializes byte-identical to what this adapter has always sent (the prompt-cache stability contract).

Tests pin all three arms. `make gate` green (exit 0).

**Follow-up, deliberately not in this PR:** `openai.rs` gates sampling params with an *allowlist* (`is_reasoning_model` → `gpt-5`/`o1`/`o3`/`o4`), the posture `anthropic.rs`'s own comments call out as wrong — "an allowlist would silently 400 the next launch, which is precisely how this bug reached production." Flipping it to a denylist changes behavior for known non-reasoning OpenAI models, so it deserves its own PR and its own test matrix.

## Summary by Sourcery

Align the Z.ai/OpenRouter-style adapter’s default max output tokens for reasoning models with the Anthropic adapter to prevent truncated reasoning turns and ensure consistent behavior across providers when no explicit cap is set.

Bug Fixes:
- Prevent uncapped reasoning turns from using provider defaults that are too small, which previously caused mid-thought truncation and missing tool calls on this dialect.

Enhancements:
- Introduce a reasoning-aware max-tokens helper that honors explicit caller caps while supplying a larger default only for reasoning-enabled requests to match Anthropic behavior.

Tests:
- Add unit tests covering uncapped reasoning defaults, preservation of explicit caps, and unchanged behavior for non-reasoning or unspecified reasoning requests.