### PR TITLE
fix(engine): the model deadline bounds idle time, not how long an answer takes

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -20,8 +20,8 @@
 1576 stella-cli/src/candidate_ws.rs
 4388 stella-cli/src/command_deck.rs
 2095 stella-core/src/bus.rs
-2195 stella-core/src/driver.rs
-2965 stella-core/src/driver/tests.rs
+2212 stella-core/src/driver.rs
+3047 stella-core/src/driver/tests.rs
 1849 stella-fleet/src/fleet.rs
 1609 stella-model/src/anthropic/tests.rs
 1784 stella-model/src/bedrock.rs

--- a/stella-core/src/driver.rs
+++ b/stella-core/src/driver.rs
@@ -94,7 +94,7 @@ use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, retry_with_backoff_observ
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::step::{
     BorrowedTurn, CancelUsageGuard, CompactionPass, SpeculationDropGuard, StepOutcome,
-    SummarizerHealth, TurnState, bounded_generation,
+    StreamProgress, SummarizerHealth, TurnState, bounded_generation,
 };
 // The latch count itself is only ever named by the test that pins it against
 // the number of failures the summarizer is actually allowed (`audit_fixes`);
@@ -1310,6 +1310,14 @@ impl<'a> Engine<'a> {
         // with no reset marker — the eventual `Text` event is authoritative
         // and consumers replace the preview with it (protocol docs).
         let delta_events = events.clone();
+        // What separates a wedged provider from a slow one, for the model
+        // deadline: every event the gate forwards is a fragment that arrived,
+        // so tapping the same sender the gate already writes to costs one
+        // relaxed increment and needs no new plumbing through the adapter.
+        // Per-attempt, like the pool it sits beside — a retry starts its own
+        // idle clock rather than inheriting the previous attempt's silence.
+        let stream_progress = StreamProgress::default();
+        let attempt_progress = stream_progress.clone();
         // The pump reports its discarded read-only work (a failed attempt's
         // pool, or a hard cancel mid-drain) as `SpeculationDiscarded` events
         // so I/O that actually ran is never silently lost (#370).
@@ -1326,7 +1334,16 @@ impl<'a> Engine<'a> {
         let attempt: RetryAttemptFn = Box::new(move || {
             let read_only = speculation_read_only.clone();
             let gated = speculation_hook_gated.clone();
-            let delta_tx = delta_events.clone();
+            let progress = attempt_progress.clone();
+            let ticked = progress.clone();
+            let forwarded = delta_events.clone();
+            // Every fragment the gate forwards bumps the idle clock on its way
+            // through, so "did anything arrive" is answered by the same events
+            // the consumer already sees — no second channel to keep in sync.
+            let delta_tx = EventSender::from_fn(move |event| {
+                ticked.record();
+                forwarded.send(event)
+            });
             let pump_tx = pump_events.clone();
             Box::pin(async move {
                 let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1351,7 +1368,7 @@ impl<'a> Engine<'a> {
                     // invariant 5 (no panics on runtime data) outranks
                     // asserting a structural claim (#618 item 17).
                     biased;
-                    result = bounded_generation(self.config.model_timeout, &mut complete) => result,
+                    result = bounded_generation(self.config.model_timeout, &progress, &mut complete) => result,
                     _ = &mut pump => Err(ProviderError::Terminal(
                         "speculation pump ended before the model call that feeds it; \
                          the speculation gate holds the channel open for the whole call, \

--- a/stella-core/src/driver/tests.rs
+++ b/stella-core/src/driver/tests.rs
@@ -2963,3 +2963,85 @@ mod compute_passes;
 mod steer_midturn;
 mod usage_completeness;
 mod zero_copy_request;
+
+/// A provider that streams a fragment every `interval` forever: answering the
+/// whole time, never finishing. The shape a reasoning model at high effort
+/// presents on a hard task, where a single call can legitimately stream for
+/// far longer than any fixed wall-clock bound.
+struct SlowStreamingProvider {
+    interval: Duration,
+    calls: Arc<AtomicU32>,
+}
+#[async_trait]
+impl Provider for SlowStreamingProvider {
+    fn id(&self) -> &str {
+        "slow-streaming"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        unreachable!("the engine always takes the observed path")
+    }
+    async fn complete_observed_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+        observer: &dyn stella_protocol::provider::ToolCallObserver,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        loop {
+            tokio::time::sleep(self.interval).await;
+            observer.text_delta("thinking…");
+        }
+    }
+}
+
+/// The distinction the deadline is supposed to draw. This provider streams a
+/// fragment every 20ms against a 50ms deadline: under a wall-clock bound the
+/// call dies the moment total duration passes 50ms, even though something
+/// arrived 20ms ago. Under an idle bound it runs indefinitely, which is
+/// correct — it is answering.
+///
+/// Asserted by *not* aborting within a window many multiples of the deadline:
+/// the turn is still running when the timeout fires, so the future is dropped
+/// with the call still in flight.
+#[tokio::test]
+async fn a_streaming_generation_outlives_the_deadline_because_it_is_not_stalled() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let provider = SlowStreamingProvider {
+        interval: Duration::from_millis(20),
+        calls: calls.clone(),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        model_timeout: Some(Duration::from_millis(50)),
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(600),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "a provider that keeps streaming must not trip the deadline: {outcome:?}"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the streaming call is never re-issued"
+    );
+    drain_events(&mut rx);
+}

--- a/stella-core/src/step.rs
+++ b/stella-core/src/step.rs
@@ -44,7 +44,7 @@
 
 use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -698,7 +698,41 @@ pub(crate) struct CompactionPass {
 // billed model call, one for speculative tool work that already ran real I/O.
 // Neither guard can prevent the loss; both make it visible.
 
-/// Bound one provider dispatch by [`EngineConfig::model_timeout`].
+/// Monotonic count of stream fragments a provider dispatch has delivered.
+///
+/// The one signal that separates "wedged" from "working": a provider still
+/// emitting fragments is answering, however slowly. Cloned into the gate's
+/// delta path and read by [`bounded_generation`]; `Relaxed` because the only
+/// question asked of it is "did this change since I last looked", which no
+/// ordering with other memory affects.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StreamProgress(Arc<AtomicU64>);
+
+impl StreamProgress {
+    pub(crate) fn record(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn count(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Bound one provider dispatch by [`EngineConfig::model_timeout`], measured as
+/// **idle time** — time since the last streamed fragment — rather than total
+/// call duration.
+///
+/// The deadline exists to close an unbounded wait on a provider that is not
+/// answering. Total duration cannot express that: it also fires on a provider
+/// that is answering *the whole time*, just slowly. That distinction stopped
+/// being academic when reasoning models arrived — a single hard-task call at
+/// high effort can legitimately stream for well past ten minutes, and a
+/// wall-clock bound kills it mid-answer and reports it as a provider fault.
+/// Idle time asks the question the deadline actually means: has anything
+/// arrived recently?
+///
+/// A provider that streams nothing at all is bounded exactly as before, since
+/// with no fragments the idle clock and the wall clock are the same clock.
 ///
 /// The trip is [`ProviderError::Terminal`] on purpose. `Transport` is
 /// retryable, so classifying it that way would hand a provider that is simply
@@ -712,6 +746,7 @@ pub(crate) struct CompactionPass {
 /// attempt already spent.
 pub(crate) async fn bounded_generation<F>(
     limit: Option<Duration>,
+    progress: &StreamProgress,
     call: F,
 ) -> Result<CompletionResult, ProviderError>
 where
@@ -720,12 +755,26 @@ where
     let Some(limit) = limit else {
         return call.await;
     };
-    match tokio::time::timeout(limit, call).await {
-        Ok(result) => result,
-        Err(_) => Err(ProviderError::Terminal(format!(
-            "generation exceeded the {}s model deadline",
-            limit.as_secs()
-        ))),
+    let mut call = std::pin::pin!(call);
+    let mut seen = progress.count();
+    loop {
+        match tokio::time::timeout(limit, &mut call).await {
+            Ok(result) => return result,
+            Err(_) => {
+                // The window elapsed. Whether that is a fault depends on what
+                // arrived during it: any fragment at all means the provider is
+                // answering, so re-arm and keep waiting. Only a window that
+                // passed in complete silence is the wedge this bound is for.
+                let now = progress.count();
+                if now == seen {
+                    return Err(ProviderError::Terminal(format!(
+                        "generation stalled: no stream fragment for {}s (model deadline)",
+                        limit.as_secs()
+                    )));
+                }
+                seen = now;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## The problem

`bounded_generation` wrapped the provider dispatch in a total-duration timeout. That bound can't express what the deadline is actually for: it fires on a provider that has said nothing for ten minutes (correct) **and** on one that has been streaming the whole time and is still going at minute eleven (wrong).

The second case stopped being hypothetical when reasoning models arrived. A single hard-task call at high effort can legitimately stream well past ten minutes — Anthropic documents multi-minute single requests as normal on Fable-tier models. Under a wall-clock bound that call gets killed mid-answer and reported as a **provider fault**, for a provider that was working perfectly.

## The fix

The deadline now measures **time since the last streamed fragment**. `StreamProgress` is a relaxed counter bumped by every event the speculation gate forwards — so the signal rides the events the consumer already sees, rather than a second channel that could drift out of sync. `bounded_generation` re-arms while fragments arrive and trips only on a window that passed in silence.

A provider that streams nothing is bounded exactly as before: with no fragments, the idle clock *is* the wall clock. The trip stays `Terminal` for the original reason — a retryable classification would hand a wedged provider the same unbounded wait once per attempt. The counter is per-attempt, like the speculation pool beside it.

## Why now

This is the last blocker for running a Fable-tier worker at high effort. Without it, the harness kills its own best calls and blames the model.

## Tests

- `a_streaming_generation_outlives_the_deadline_because_it_is_not_stalled` — streams every 20ms against a 50ms deadline, survives many multiples of it, issued exactly once. **Aborted at 50ms under the old bound.**
- `a_wedged_generation_trips_the_deadline_once_instead_of_burning_the_retry_budget` — unchanged, still green: silence still trips, still exactly once.

`make gate` green (exit 0).

## Summary by Sourcery

Treat model timeout as an idle-time bound instead of total call duration so long-running streaming generations are not incorrectly aborted.

Bug Fixes:
- Ensure the model deadline only trips when a provider has been silent for the entire timeout window, not while it is actively streaming.
- Preserve the existing behavior for truly wedged providers by still terminating calls that produce no fragments within the timeout and avoiding unnecessary retries.

Tests:
- Add a streaming provider test that verifies a continuously streaming generation outlives the configured deadline and is not retried.