### PR TITLE
test(pipeline): agent-degradation gate — CI pins verification decisions AND their spend

### DIFF
--- a/docs/verification-gate.md
+++ b/docs/verification-gate.md
@@ -1,0 +1,90 @@
+# The verification gate — how CI says whether a change helps or hurts the agent
+
+Experiments on the agent loop fail in a specific, ugly way: the change ships,
+every unit test stays green, and three weeks later a benchmark run shows the
+agent quietly got worse — or more expensive, which is the same thing arriving
+on a different invoice. This document names the three layers CI uses to catch
+that early, what each one can honestly claim, and what none of them can.
+
+The layers are ordered by cost. Every PR pays for the first two on every
+`cargo test --workspace` (they are ordinary tests — free, deterministic, no
+API key, no Docker). The third is bought deliberately.
+
+## Layer 1 — the degradation gate (blocking, per-PR)
+
+`stella-pipeline/src/pipeline/tests/degradation_gate.rs` drives the **real
+pipeline** — triage, execution, witness plumbing, the verification ladder,
+the judge — over scripted model/test doubles, through a fixed matrix of
+scenarios, and pins three things per scenario:
+
+1. **The decision.** A clean fail→pass flip fast-submits deterministically; a
+   flaky flip escalates; a timed-out baseline never manufactures a flip; a
+   fresh lint error vetoes; a red suite revises without buying a judge.
+2. **The spend.** The exact number of model calls, by role, and the exact
+   number of test-suite invocations. A change that leaves every verdict
+   intact but buys a judge call where the ladder used to decide for free is
+   a **cost regression**, and it fails here with a message naming the extra
+   call.
+3. **The evidence.** Verdicts carry their ladder snapshot (provenance), and
+   the judge prompt carries the oracle trace — degradations in what the
+   judge is told are degradations in judge quality one step removed.
+
+What it proves: **the decision policy and its price did not drift.** What it
+cannot prove: that the policy is *good* — both sides of every assertion are
+this codebase's own logic.
+
+When it fails on your PR, one of two things is true. Either you broke
+something — fix it — or you *intended* the new behavior, in which case the
+scenario's expectation is updated **in the same PR**, where the reviewer
+sees "this change makes flaky flips escalate" stated as a diff line instead
+of discovering it in production. Never widen an expectation to "whatever it
+now does"; the gate's entire value is that intent has to be written down.
+
+## Layer 2 — golden trajectories (blocking, per-PR)
+
+`pipeline/tests/golden.rs` records full `AgentEvent` streams from fixed runs
+and structurally diffs them against committed fixtures. This is a **drift
+baseline**: it catches a stage that stopped being emitted, an event that
+moved, a protocol field that vanished — the wire-contract regressions no
+single-flow assertion notices. Refresh with `make record-golden` and review
+the fixture diff as a contract change. It is not independent evidence; both
+sides are the same code.
+
+The wire schema itself (`docs/wire/agentevent.schema.json`) is committed and
+asserted by `stella-protocol/tests/wire_contract.rs`; regenerate with
+`scripts/export-agentevent-schema.sh`. Protocol changes must be additive —
+old streams must keep parsing (pinned by tests).
+
+## Layer 3 — the benchmark arm (deliberate, expensive, honest by protocol)
+
+Terminal-Bench runs under `bench/` measure the thing the first two layers
+cannot: **capability on real tasks**. They cost real money and hours, so
+they are not per-PR. What keeps them honest is protocol, not frequency:
+
+- **Preregistration.** The comparison, task set, SUT commit, and scoring are
+  filed as an issue *before* the run (e.g. #1002, #1013). No moving the
+  goalposts after seeing the number.
+- **The witness arm.** A frozen control adapter (digest-pinned) runs beside
+  the candidate, so "the harness changed" and "the agent changed" cannot be
+  confused.
+- **Small-N discipline.** A 7-task smoke run distinguishes "obviously
+  broken" from "plausibly fine"; it does not rank models or prove a 3%
+  improvement. Claims must match the N.
+
+## How to read the three layers together
+
+- Layer 1 red → your change altered what the agent *decides* or *spends*.
+  This is the signal the gate exists for; treat an unintended red as a bug
+  in the change, not the gate.
+- Layer 2 red → your change altered what the agent *emits*. Consumers
+  (TUI, serve, store projections) are affected; review the fixture diff.
+- Layers 1–2 green but you touched the loop, prompts, routing, or
+  verification: the change is *safe*, not yet *good*. If it claims to make
+  the agent better, it earns a preregistered Layer 3 run before that claim
+  appears anywhere.
+
+None of this measures model quality drift, provider-side changes, or tasks
+outside the scenario matrix and bench set. When an experiment targets
+something no layer observes, the first commit should extend the matrix with
+a scenario that observes it — a gate that never grows is a gate experiments
+learn to route around.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -28,7 +28,7 @@
 1952 stella-model/src/openai.rs
 1720 stella-model/src/zai/tests.rs
 3039 stella-pipeline/src/pipeline.rs
-2332 stella-pipeline/src/pipeline/tests.rs
+2343 stella-pipeline/src/pipeline/tests.rs
 2736 stella-protocol/src/event.rs
 2055 stella-store/src/lib.rs
 2204 stella-store/src/tests.rs

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -287,6 +287,9 @@ enum TestScript {
 
 struct ScriptedRunner {
     test_results: std::sync::Mutex<VecDeque<TestScript>>,
+    /// Total `run_test` invocations, whatever they returned — the
+    /// degradation gate pins this as the suite-run spend of a scenario.
+    test_runs: std::sync::atomic::AtomicU32,
     diff: String,
     /// Untracked files this workspace reports, as `(path, added_lines)`.
     untracked: Vec<(String, u32)>,
@@ -320,12 +323,17 @@ impl ScriptedRunner {
     fn scripted(test_results: Vec<TestScript>, diff: &str) -> Self {
         Self {
             test_results: std::sync::Mutex::new(test_results.into_iter().collect()),
+            test_runs: std::sync::atomic::AtomicU32::new(0),
             diff: diff.to_string(),
             untracked: Vec::new(),
             failure_tail: "test failed".to_string(),
             diff_exit_code: 0,
             diff_stderr: String::new(),
         }
+    }
+    /// How many times `run_test` was invoked on this runner.
+    fn test_runs(&self) -> u32 {
+        self.test_runs.load(std::sync::atomic::Ordering::SeqCst)
     }
     /// A diff probe that FAILS: no stdout and a non-zero exit, the shape a
     /// candidate whose worktree registration vanished actually produces.
@@ -391,6 +399,8 @@ impl DiagnosticRunner for ScriptedRunner {
 #[async_trait]
 impl TestRunner for ScriptedRunner {
     async fn run_test(&self, _invocation: &TestInvocation) -> CmdOutcome {
+        self.test_runs
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let script = self
             .test_results
             .lock()
@@ -2096,6 +2106,7 @@ mod verification_honesty {
 mod airlock;
 mod best_of_n;
 mod chaos;
+mod degradation_gate;
 /// Golden-trajectory recordings of this pipeline's real event stream — a
 /// child module so it reaches the scripted ports above via `super::*`.
 mod golden;

--- a/stella-pipeline/src/pipeline/tests/degradation_gate.rs
+++ b/stella-pipeline/src/pipeline/tests/degradation_gate.rs
@@ -1,0 +1,305 @@
+//! The agent-degradation gate (`docs/verification-gate.md`, layer 1).
+//!
+//! A fixed matrix of full-pipeline scenarios — real triage, execution,
+//! verification ladder, and judge over scripted doubles — each pinning THREE
+//! things at once:
+//!
+//! 1. **The decision**: the verdict and whether it was deterministic.
+//! 2. **The spend**: the exact model calls, by role and in order, and the
+//!    exact number of test-suite invocations. A change that keeps every
+//!    verdict but buys a judge call where the ladder used to decide for free
+//!    is a cost regression, and it fails HERE, on the PR, with the extra
+//!    call named — not three weeks later on an invoice.
+//! 3. **The escalation shape**: whether the judge stage ran at all.
+//!
+//! Runs on every `cargo test` — deterministic, offline, no API key. When a
+//! scenario fails on an *intended* behavior change, update its expectation
+//! in the same PR so the new decision policy is stated as a reviewable diff
+//! line. Never widen an expectation to "whatever it now does".
+
+use super::verification_hardening::{ScriptedLint, lint_error};
+use super::*;
+
+/// What one scenario pins. `roles` is the full ordered model-call sequence
+/// (from `StepManifest` events) — order matters, because "judge before
+/// worker" and "worker before judge" are different pipelines.
+struct Expect {
+    passed: bool,
+    deterministic: bool,
+    judge_stage: bool,
+    roles: &'static [ModelCallRole],
+    test_runs: u32,
+}
+
+struct Scenario {
+    name: &'static str,
+    goal: &'static str,
+    /// Scripted model responses, in call order (triage, worker, [judge]).
+    provider: Vec<CompletionResult>,
+    /// Scripted suite results, in run order; an exhausted queue passes.
+    tests: Vec<TestScript>,
+    /// The diff the workspace reports.
+    diff: &'static str,
+    /// Scripted lint snapshots (`None` = no probe wired).
+    lint: Option<Vec<Option<Vec<LintRecord>>>>,
+    test_command: Option<&'static str>,
+    max_revisions: u32,
+    expect: Expect,
+}
+
+async fn run_scenario(s: Scenario) {
+    let provider = ScriptedProvider::new(s.provider);
+    let resolver = OneProvider(&provider);
+    let runner = ScriptedRunner::scripted(s.tests, s.diff);
+    let lint = s.lint.map(ScriptedLint::new);
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        test_command: s.test_command.map(str::to_string),
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        max_revisions: s.max_revisions,
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: lint.as_ref().map(|l| l as &dyn LintProbe),
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let outcome = pipeline
+        .run(s.goal, &mut messages, &mut budget)
+        .await
+        .unwrap_or_else(|e| panic!("[{}] run failed: {e:?}", s.name));
+
+    let name = s.name;
+    let verdict = outcome
+        .verdict
+        .unwrap_or_else(|| panic!("[{name}] no verdict was produced"));
+    assert_eq!(
+        verdict.passed, s.expect.passed,
+        "[{name}] verdict.passed changed — the decision policy drifted"
+    );
+    assert_eq!(
+        verdict.deterministic, s.expect.deterministic,
+        "[{name}] verdict.deterministic changed — deterministic credit moved"
+    );
+
+    let events = drain(&mut rx);
+    let judge_ran = stages(&events).contains(&StageKind::Judge);
+    assert_eq!(
+        judge_ran, s.expect.judge_stage,
+        "[{name}] judge stage presence changed — escalation shape drifted"
+    );
+    let roles: Vec<ModelCallRole> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::StepManifest { role, .. } => Some(*role),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        roles, s.expect.roles,
+        "[{name}] the model-call sequence changed — this is SPEND: every \
+         entry is a paid call. If the new sequence is intended, update this \
+         scenario in the same PR."
+    );
+    assert_eq!(
+        runner.test_runs(),
+        s.expect.test_runs,
+        "[{name}] the suite-run count changed — this is COMPUTE spend. If \
+         intended, update this scenario in the same PR."
+    );
+}
+
+use ModelCallRole::{Judge, Triage, Worker};
+
+/// The paved road: a genuine fail→pass flip fast-submits deterministically.
+/// Exactly two paid calls (triage, worker) and three suite runs (baseline,
+/// candidate, the #859 confirmation). The judge is never consulted.
+#[tokio::test]
+async fn gate_clean_flip_fast_submits_with_two_calls_and_three_runs() {
+    run_scenario(Scenario {
+        name: "clean_flip",
+        goal: "Fix the failing test",
+        provider: vec![text_result("single"), text_result("done")],
+        tests: vec![TestScript::Fail, TestScript::Pass, TestScript::Pass],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: None,
+        test_command: Some("cargo test -p x"),
+        max_revisions: 2,
+        expect: Expect {
+            passed: true,
+            deterministic: true,
+            judge_stage: false,
+            roles: &[Triage, Worker],
+            test_runs: 3,
+        },
+    })
+    .await;
+}
+
+/// A flaky flip (#859): the confirmation re-run fails, so the determinism is
+/// withheld and ONE judge call is bought. Still three suite runs — the
+/// confirmation is the third; nothing retries it.
+#[tokio::test]
+async fn gate_flaky_flip_buys_exactly_one_judge_call() {
+    run_scenario(Scenario {
+        name: "flaky_flip",
+        goal: "Fix the failing test",
+        provider: vec![
+            text_result("single"),
+            text_result("done"),
+            text_result("PASS — the fix is right; the test itself is flaky"),
+        ],
+        tests: vec![TestScript::Fail, TestScript::Pass, TestScript::Fail],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: None,
+        test_command: Some("cargo test -p x"),
+        max_revisions: 2,
+        expect: Expect {
+            passed: true,
+            deterministic: false,
+            judge_stage: true,
+            roles: &[Triage, Worker, Judge],
+            test_runs: 3,
+        },
+    })
+    .await;
+}
+
+/// A timed-out baseline (#860) arms nothing: no flip exists, so no
+/// confirmation run is ever bought — two suite runs, one judge call.
+#[tokio::test]
+async fn gate_timed_out_baseline_never_buys_a_confirmation() {
+    run_scenario(Scenario {
+        name: "timeout_baseline",
+        goal: "Fix the failing test",
+        provider: vec![
+            text_result("single"),
+            text_result("done"),
+            text_result("PASS — change is consistent with the goal"),
+        ],
+        tests: vec![TestScript::TimeOut, TestScript::Pass],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: None,
+        test_command: Some("cargo test -p x"),
+        max_revisions: 2,
+        expect: Expect {
+            passed: true,
+            deterministic: false,
+            judge_stage: true,
+            roles: &[Triage, Worker, Judge],
+            test_runs: 2,
+        },
+    })
+    .await;
+}
+
+/// The regression veto (#861) fires BEFORE the confirmation run: a fresh
+/// lint error escalates after only two suite runs — the confirmation's
+/// suite run is never spent on a submit the veto already blocked.
+#[tokio::test]
+async fn gate_lint_veto_skips_the_confirmation_run() {
+    run_scenario(Scenario {
+        name: "lint_veto",
+        goal: "Fix the failing test",
+        provider: vec![
+            text_result("single"),
+            text_result("done"),
+            text_result("PASS — the new error is pre-existing debt"),
+        ],
+        tests: vec![TestScript::Fail, TestScript::Pass],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: Some(vec![
+            Some(Vec::new()),
+            Some(vec![lint_error("src/lib.rs", "mismatched types")]),
+        ]),
+        test_command: Some("cargo test -p x"),
+        max_revisions: 2,
+        expect: Expect {
+            passed: true,
+            deterministic: false,
+            judge_stage: true,
+            roles: &[Triage, Worker, Judge],
+            test_runs: 2,
+        },
+    })
+    .await;
+}
+
+/// A red suite is a deterministic failure: no judge call is ever bought to
+/// "confirm" it (L-E11). With revisions exhausted the run fails on exactly
+/// two paid calls.
+#[tokio::test]
+async fn gate_red_tests_fail_without_buying_a_judge() {
+    run_scenario(Scenario {
+        name: "red_tests",
+        goal: "Fix the failing test",
+        provider: vec![text_result("single"), text_result("done")],
+        tests: vec![TestScript::Fail, TestScript::Fail],
+        diff: "@@ -1 +1 @@\n-old\n+new",
+        lint: None,
+        test_command: Some("cargo test -p x"),
+        max_revisions: 0,
+        expect: Expect {
+            passed: false,
+            deterministic: true,
+            judge_stage: false,
+            roles: &[Triage, Worker],
+            test_runs: 2,
+        },
+    })
+    .await;
+}
+
+/// A turn that dispatched nothing is a deterministic no-op finding
+/// (`NothingAttempted`), never an abstention that reads as a pass — the
+/// eleven 0.0-scored Terminal-Bench trials, pinned as spend: two paid
+/// calls, zero suite runs, no judge.
+#[tokio::test]
+async fn gate_a_no_op_turn_fails_closed_without_spend() {
+    run_scenario(Scenario {
+        name: "no_op_turn",
+        goal: "Fix the failing test",
+        provider: vec![text_result("single"), text_result("done")],
+        tests: vec![],
+        diff: "",
+        lint: None,
+        test_command: None,
+        max_revisions: 0,
+        expect: Expect {
+            passed: false,
+            deterministic: true,
+            judge_stage: false,
+            roles: &[Triage, Worker],
+            test_runs: 0,
+        },
+    })
+    .await;
+}

--- a/stella-pipeline/src/pipeline/tests/verification_hardening.rs
+++ b/stella-pipeline/src/pipeline/tests/verification_hardening.rs
@@ -249,12 +249,12 @@ async fn a_flaky_flip_fails_its_confirmation_and_escalates() {
 
 /// A scripted lint probe (#861): pops one scripted snapshot per call, and
 /// reports a clean tree once the script runs out.
-struct ScriptedLint {
+pub(super) struct ScriptedLint {
     snapshots: std::sync::Mutex<VecDeque<Option<Vec<LintRecord>>>>,
 }
 
 impl ScriptedLint {
-    fn new(snapshots: Vec<Option<Vec<LintRecord>>>) -> Self {
+    pub(super) fn new(snapshots: Vec<Option<Vec<LintRecord>>>) -> Self {
         Self {
             snapshots: std::sync::Mutex::new(snapshots.into_iter().collect()),
         }
@@ -272,7 +272,7 @@ impl LintProbe for ScriptedLint {
     }
 }
 
-fn lint_error(file: &str, message: &str) -> LintRecord {
+pub(super) fn lint_error(file: &str, message: &str) -> LintRecord {
     LintRecord {
         file: file.to_string(),
         error: true,


### PR DESCRIPTION
The cheap, honest CI signal for agent experiments (follows #1033/#1035, rebased onto main after they merged).

## What it is
Six full-pipeline scenarios (real triage / execution / verification ladder / judge over scripted doubles) run inside `cargo test --workspace` — offline, deterministic, no API key, milliseconds each. Every scenario pins **three things**:

1. **The decision** — verdict + determinism.
2. **The spend** — the *ordered* model-call sequence by role (from StepManifest events), and the exact suite-run count. An experiment that keeps every verdict but quietly buys a judge call where the ladder used to decide for free fails CI with the extra call named.
3. **The escalation shape** — whether the judge stage ran.

## The matrix
| scenario | verdict | calls | suite runs |
|---|---|---|---|
| clean flip | pass, deterministic | triage, worker | 3 (incl. #859 confirmation) |
| flaky flip (#859) | pass, model | triage, worker, **judge** | 3 |
| timed-out baseline (#860) | pass, model | triage, worker, judge | 2 (no confirmation bought) |
| lint veto (#861) | pass, model | triage, worker, judge | 2 (**veto fires before the confirmation**) |
| red tests | fail, deterministic | triage, worker | 2 (no judge bought) |
| no-op turn | fail, deterministic | triage, worker | 0 |

## The honesty contract
`docs/verification-gate.md` names the three CI layers — this gate (drift in decisions/spend), the golden trajectories (drift in the event contract), and the preregistered Terminal-Bench arm (real capability, bought deliberately) — what each can honestly claim, and the refresh rule: an intended behavior change updates the scenario **in the same PR** as a reviewable diff line; expectations are never widened to "whatever it now does".

Since `ci.yml` already runs `cargo test --workspace` on PRs, this is blocking from the moment it merges — zero new infrastructure.

## Verified
Pipeline suite green on top of merged main (313 tests incl. the 6 gate scenarios), size gate green, clippy clean.

## Summary by Sourcery

Introduce an agent-degradation gate that exercises the full pipeline over scripted scenarios and pins decision, escalation, and cost (model calls and test runs) as a CI-enforced stability contract.

New Features:
- Add a degradation_gate test module that defines a matrix of full-pipeline scenarios with fixed expected verdicts, escalation behavior, model-call sequences, and test-suite run counts.
- Track total test-suite invocations in the scripted test runner so scenarios can assert on compute spend.
- Document the multi-layer verification gate strategy, including the degradation gate, golden trajectories, and benchmark arm, and how they interact in CI.

Enhancements:
- Expose scripted lint helpers to other test modules so lint-driven scenarios can be reused in the degradation gate.