### PR TITLE
fix(tui): strip ANSI escapes from tool output at transcript fold time

### DIFF
--- a/stella-cli/src/command_deck/skills.rs
+++ b/stella-cli/src/command_deck/skills.rs
@@ -1,6 +1,7 @@
 //! SKILLS-tab helper cluster: the deck's skill vocabulary, npx-skills
 //! registry parsing, and install/preview/authoring ops.
 use super::*;
+use stella_tui::strip_ansi;
 
 /// The deck's slash vocabulary: the productized commands (🔒) followed by
 /// every custom command/skill (⚡) currently on disk. Rebuilt after `/init`
@@ -78,29 +79,6 @@ pub(super) fn parse_skill_hits(out: &str) -> Vec<SkillSearchHit> {
         }
     }
     hits
-}
-
-/// Strip ANSI/CSI escape sequences (`ESC [ … final`) from a line, leaving the
-/// visible text. Robust to the SGR color codes `npx skills` emits.
-fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\u{1b}' {
-            // A CSI sequence: '[' then params/intermediates, then a final byte
-            // in 0x40..=0x7e. Consume through the final byte.
-            if chars.next() == Some('[') {
-                for n in chars.by_ref() {
-                    if ('\u{40}'..='\u{7e}').contains(&n) {
-                        break;
-                    }
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
 }
 
 /// If a (de-ANSI'd) line is a URL continuation (`└ https://skills.sh/…`),
@@ -198,7 +176,7 @@ async fn fetch_skill_markdown(registry: &SkillRegistry, id: &str) -> (String, Op
 /// back to the text after a leading preamble (from the first `---` frontmatter
 /// or `#` heading), never a blank preview.
 pub(super) fn extract_skill_md_from_use(out: &str) -> String {
-    let out = strip_ansi(out);
+    let out: &str = &strip_ansi(out);
     if let Some(start) = out.find("<SKILL.md>") {
         let after = &out[start + "<SKILL.md>".len()..];
         let body = match after.find("</SKILL.md>") {

--- a/stella-cli/src/init_fx.rs
+++ b/stella-cli/src/init_fx.rs
@@ -348,27 +348,8 @@ fn terminal_width() -> usize {
 mod tests {
     use super::*;
 
-    /// Drop ANSI SGR/cursor sequences so tests compare visible content.
-    fn strip_ansi(s: &str) -> String {
-        let mut out = String::new();
-        let mut chars = s.chars().peekable();
-        while let Some(c) = chars.next() {
-            if c == '\x1b' {
-                if chars.peek() == Some(&'[') {
-                    chars.next();
-                    // Consume to the final byte of the CSI sequence.
-                    for t in chars.by_ref() {
-                        if t.is_ascii_alphabetic() {
-                            break;
-                        }
-                    }
-                }
-                continue;
-            }
-            out.push(c);
-        }
-        out
-    }
+    // Drops ANSI SGR/cursor sequences so tests compare visible content.
+    use stella_tui::strip_ansi;
 
     #[test]
     fn frames_are_deterministic() {

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -563,24 +563,9 @@ mod tests {
 
     // ── shared event lines ─────────────────────────────────────────────────
 
-    /// Drop ANSI SGR sequences so assertions pin visible text regardless of
-    /// whether `colored` detects a tty in the test harness.
-    fn strip_ansi(s: &str) -> String {
-        let mut out = String::with_capacity(s.len());
-        let mut chars = s.chars();
-        while let Some(c) = chars.next() {
-            if c == '\u{1b}' {
-                for e in chars.by_ref() {
-                    if e == 'm' {
-                        break;
-                    }
-                }
-            } else {
-                out.push(c);
-            }
-        }
-        out
-    }
+    // Strips ANSI so assertions pin visible text regardless of whether
+    // `colored` detects a tty in the test harness.
+    use stella_tui::strip_ansi;
 
     #[test]
     fn styled_event_line_composes_glyph_body_detail_with_single_spaces() {

--- a/stella-tui/src/ansi.rs
+++ b/stella-tui/src/ansi.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The one shared ANSI escape-sequence stripper (#934).
+//!
+//! Tool output reaches the transcript verbatim, and any child process that
+//! detects a TTY colourises it. `ratatui`'s `styled_graphemes` drops the ESC
+//! control byte but renders the rest of the sequence (`[0;32m`) literally, so
+//! unstripped output turns into visible garbage that eats the reader's line
+//! budget. The strip is applied **once, where output folds into the
+//! transcript** — never per frame, because the fold cache would retain the
+//! escapes and re-stripping every paint would be wasted work.
+//!
+//! This module exists so callers stop growing private copies (three grew in
+//! `stella-cli` alone before it was extracted).
+
+use std::borrow::Cow;
+
+/// Remove ANSI escape sequences, leaving the visible text.
+///
+/// Handles the three shapes that occur in practice: CSI (`ESC [` through a
+/// final byte in `@..=~`, which covers all SGR colour codes), OSC (`ESC ]`
+/// through BEL or ST, as emitted for hyperlinks and titles), and the residual
+/// two-byte `ESC x` escapes (charset selects, keypad modes). Text without an
+/// ESC byte — the common case — is returned borrowed, unmodified. In
+/// particular a bare `[` that is not preceded by ESC is legitimate content
+/// and always survives.
+pub fn strip_ansi(s: &str) -> Cow<'_, str> {
+    if !s.contains('\u{1b}') {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            // CSI: params/intermediates, then a final byte in `@..=~`.
+            Some('[') => {
+                for n in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&n) {
+                        break;
+                    }
+                }
+            }
+            // OSC: terminated by BEL or ST (`ESC \`).
+            Some(']') => {
+                while let Some(n) = chars.next() {
+                    if n == '\u{7}' {
+                        break;
+                    }
+                    if n == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            // nF escapes (charset selects): intermediates in `0x20..=0x2f`,
+            // then one final byte. Everything else is a two-byte escape
+            // (keypad modes, `ESC 7`/`ESC 8`) whose second byte was just
+            // consumed by the match.
+            Some(c2) if ('\u{20}'..='\u{2f}').contains(&c2) => {
+                for n in chars.by_ref() {
+                    if !('\u{20}'..='\u{2f}').contains(&n) {
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colourised_cargo_build_line_renders_clean() {
+        let line = "\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[32m    Finished\u{1b}[0m \
+                    `dev` profile [unoptimized + debuginfo] target(s) in 2.41s";
+        assert_eq!(
+            strip_ansi(line),
+            "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.41s"
+        );
+    }
+
+    #[test]
+    fn bare_brackets_without_esc_survive_unmodified() {
+        // Over-eager stripping of legitimate bracket text would be a worse
+        // bug than the escape residue this module removes.
+        let line = "error[E0308]: mismatched types in [u8; 4] at src/lib.rs:1";
+        assert!(matches!(strip_ansi(line), Cow::Borrowed(s) if s == line));
+    }
+
+    #[test]
+    fn osc_hyperlink_and_bel_title_sequences_are_removed() {
+        let bel = "\u{1b}]0;window title\u{7}visible";
+        assert_eq!(strip_ansi(bel), "visible");
+        let st = "\u{1b}]8;;https://example.com\u{1b}\\link text\u{1b}]8;;\u{1b}\\ after";
+        assert_eq!(strip_ansi(st), "link text after");
+    }
+
+    #[test]
+    fn two_byte_escapes_and_truncated_sequences_do_not_leak() {
+        // A charset select is ESC + intermediate + final: all three go.
+        assert_eq!(strip_ansi("a\u{1b}(Bb"), "ab");
+        // A sequence cut off mid-stream (capped output) swallows to the end
+        // rather than leaking a partial `[1;3` into the transcript.
+        assert_eq!(strip_ansi("done\u{1b}[1;3"), "done");
+        // A trailing lone ESC is dropped.
+        assert_eq!(strip_ansi("done\u{1b}"), "done");
+    }
+}

--- a/stella-tui/src/lib.rs
+++ b/stella-tui/src/lib.rs
@@ -29,6 +29,7 @@
 //! (L-T6), the panel panic boundary (L-T7, [`mod@render`]), and the debug channel
 //! (L-T8, [`DebugLog`]).
 
+pub mod ansi;
 pub mod attach;
 pub mod clipboard;
 pub mod composer;
@@ -66,6 +67,7 @@ pub mod theme;
 pub mod transcript_nav;
 pub mod views;
 
+pub use ansi::strip_ansi;
 pub use attach::probe_path_attachment;
 pub use clipboard::{ClipboardPaste, default_attachments_dir};
 pub use composer::{

--- a/stella-tui/src/model.rs
+++ b/stella-tui/src/model.rs
@@ -17,6 +17,7 @@
 //! function of the model. Determinism therefore extends all the way to the
 //! backing cell buffer (the replay-determinism test in [`mod@crate::render`]).
 
+use crate::ansi::strip_ansi;
 use stella_protocol::{
     AgentEvent, BudgetMode, CiStatus, FileChangeKind, MediaJobState, MediaKind, PrStatus,
     ScopeProposal, StageKind, SubAgentPhase, SubAgentStatus, TaskItem, TaskStatus, ToolOutput,
@@ -431,15 +432,27 @@ impl SessionModel {
                 duration_ms,
                 speculated,
             } => {
+                // ANSI escapes are stripped here, at fold time, and nowhere
+                // else: the fold cache would retain them if the renderer
+                // stripped per frame, and ratatui renders everything after
+                // the ESC byte literally (#934).
                 let (ok, summary, full) = match output {
                     ToolOutput::Ok { content } => {
-                        (true, summarize(content), cap_middle(content, OUTPUT_BUDGET))
+                        let content = strip_ansi(content);
+                        (
+                            true,
+                            summarize(&content),
+                            cap_middle(&content, OUTPUT_BUDGET),
+                        )
                     }
-                    ToolOutput::Error { message } => (
-                        false,
-                        summarize(message),
-                        cap_middle(message, OUTPUT_BUDGET),
-                    ),
+                    ToolOutput::Error { message } => {
+                        let message = strip_ansi(message);
+                        (
+                            false,
+                            summarize(&message),
+                            cap_middle(&message, OUTPUT_BUDGET),
+                        )
+                    }
                 };
                 // Resolve the tool's name from its start entry (results only
                 // carry the call id on the wire).

--- a/stella-tui/src/model/tests.rs
+++ b/stella-tui/src/model/tests.rs
@@ -401,6 +401,33 @@ fn tool_result_summary_is_middle_out_truncated() {
 }
 
 #[test]
+fn colourised_tool_output_folds_to_clean_text() {
+    // A `cargo build` failure as a colour-detecting child process emits it.
+    // The escapes must be gone from BOTH the summary and the expanded full
+    // text — the fold cache means anything kept here is kept forever (#934).
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::ToolResult {
+        call_id: "c1".into(),
+        output: ToolOutput::Error {
+            message: "\u{1b}[0m\u{1b}[1m\u{1b}[38;5;9merror[E0308]\u{1b}[0m\u{1b}[1m: \
+                      mismatched types in [u8; 4]\u{1b}[0m"
+                .into(),
+        },
+        duration_ms: 5,
+        speculated: false,
+    });
+    match model.transcript.last() {
+        Some(TranscriptEntry::ToolResult { summary, full, .. }) => {
+            // The escape residue is gone, but legitimate bracket text — the
+            // error code and the array type — survives untouched.
+            assert_eq!(summary, "error[E0308]: mismatched types in [u8; 4]");
+            assert_eq!(full, "error[E0308]: mismatched types in [u8; 4]");
+        }
+        other => panic!("expected a tool result entry, got {other:?}"),
+    }
+}
+
+#[test]
 fn oversized_tool_args_stay_valid_pretty_printable_json() {
     let mut model = SessionModel::new();
     let big = "x".repeat(INPUT_BUDGET * 2);


### PR DESCRIPTION
Fixes #934.

## What

Tool output from any colour-detecting child process reached the transcript verbatim. `ratatui`'s `styled_graphemes` drops the ESC control byte but renders the rest of the sequence (`[0;32m`) literally, so a colourised `cargo build` failure arrived as rows of escape residue that silently ate the reader's line budget.

## How

- **New `stella_tui::ansi::strip_ansi`** (re-exported at the crate root): handles CSI (all SGR colour codes), OSC (hyperlinks/titles, terminated by BEL or ST), and ECMA-48 nF escapes (charset selects), including sequences truncated mid-stream by output capping. Returns `Cow::Borrowed` when the input has no ESC byte — the common case costs nothing.
- **Applied once, at fold time** in `SessionModel::apply`, where `ToolOutput` folds into `TranscriptEntry` — never per frame, so the fold cache only ever holds clean text (the shape #934 prescribes).
- **The three private copies in `stella-cli`** (`command_deck/skills.rs`, and the test-module helpers in `tui.rs` and `init_fx.rs`) are deleted and now use the shared function. Each had diverged: one only ate through `m`, one stopped at any ASCII letter, one lacked OSC handling.

## Deliberately left

`stella-tools/src/issue_ops.rs` and `stella-pipeline/src/witness/airlock.rs` keep their private copies: `stella-tui` *depends on* `stella-tools`, and `stella-pipeline` sees only `stella-protocol`/`stella-core`, so neither can call into `stella-tui`. Unifying those would mean relocating the helper to a lower-level crate — out of scope for #934.

## Tests

- Fold-level: a colourised `cargo build` error folds to clean `summary` and `full` text.
- Unit: bare `[` that is not part of an escape survives unmodified (asserted to stay `Cow::Borrowed`); OSC BEL/ST termination; truncated sequences don't leak partials.
- Full `make gate` green (ran as the pre-push hook).

## Summary by Sourcery

Ensure tool output in the TUI transcript is stripped of ANSI escape sequences at fold time using a shared ANSI stripper, and consolidate callers onto this shared utility.

New Features:
- Introduce a shared stella_tui::ansi::strip_ansi helper, re-exported at the crate root, to remove ANSI escape sequences from text.

Bug Fixes:
- Prevent colourised tool output from leaking ANSI escape residues into transcript summaries and full text by stripping escapes when folding ToolOutput into TranscriptEntry.
- Align stella-cli skill parsing and test helpers to use the shared ANSI stripper instead of diverging local implementations, avoiding incomplete escape handling.

Enhancements:
- Add a dedicated ansi module in stella-tui for ANSI stripping logic, including handling CSI, OSC, and ECMA-48 escape forms and truncated sequences.
- Refine the tool result folding logic in SessionModel to operate on ANSI-stripped content for summarization and middle-out capping.

Tests:
- Add model-level tests to verify colourised tool error output folds to clean summary and full transcript text with brackets preserved.
- Add unit tests for strip_ansi covering bare bracket preservation, OSC BEL/ST termination, charset-select and truncated sequences, and typical colourised build output.