### PR TITLE
feat(verify): judge calibration telemetry — measured false-positive rate vs CI ground truth (#871)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -30,8 +30,8 @@
 3064 stella-pipeline/src/pipeline.rs
 2360 stella-pipeline/src/pipeline/tests.rs
 2744 stella-protocol/src/event.rs
-2055 stella-store/src/lib.rs
-2204 stella-store/src/tests.rs
+2073 stella-store/src/lib.rs
+2234 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1566 stella-tools/src/media.rs
 3422 stella-tools/src/registry.rs

--- a/stella-cli/src/cli.rs
+++ b/stella-cli/src/cli.rs
@@ -468,6 +468,20 @@ pub(crate) enum Command {
         only: inspect::RoleFilter,
     },
 
+    /// Judge calibration: false-positive rate vs CI ground truth
+    ///
+    /// Fold every recorded session's pass verdicts against the CI verdicts
+    /// observed after them (#871): how often did a model-judge PASS — and,
+    /// as the comparison cohort, a deterministic ladder pass — later fail
+    /// CI? Rates are reported as unmeasured until CI ground truth exists.
+    /// Reads .stella/private/store.db only; needs no API key and never
+    /// writes.
+    Calibration {
+        /// Output format
+        #[arg(long, value_enum, default_value = "text")]
+        format: inspect::InspectFormat,
+    },
+
     /// Cost, tokens, and resolve rate per provider and model
     ///
     /// Summarize cost, tokens, and resolve rate per provider/model from

--- a/stella-cli/src/cli/help.rs
+++ b/stella-cli/src/cli/help.rs
@@ -45,7 +45,15 @@ const GROUPS: &[(&str, &[&str])] = &[
     ),
     (
         "What it cost, what happened",
-        &["stats", "scoreboard", "observe", "inspect", "usage", "tune"],
+        &[
+            "stats",
+            "scoreboard",
+            "observe",
+            "inspect",
+            "calibration",
+            "usage",
+            "tune",
+        ],
     ),
     (
         "Set up",

--- a/stella-cli/src/inspect.rs
+++ b/stella-cli/src/inspect.rs
@@ -184,6 +184,46 @@ pub(crate) fn run_inspect(args: &InspectArgs) -> Result<(), String> {
     }
 }
 
+/// `stella calibration` (#871): fold every recorded session's pass verdicts
+/// against the CI verdicts observed after them and report the judge's
+/// measured false-positive rate beside the deterministic cohort's. A pure
+/// reading of the event journal the store already keeps — no new write
+/// path, no daemon.
+pub(crate) fn run_calibration(format: InspectFormat) -> Result<(), String> {
+    let store = open_readonly_store()?;
+    let sessions = store
+        .event_session_ids()
+        .map_err(|e| format!("cannot enumerate recorded sessions: {e}"))?;
+    let mut total = stella_pipeline::replay::CalibrationReport::default();
+    for session_id in &sessions {
+        let journal = store
+            .session_events(session_id)
+            .map_err(|e| format!("cannot read session {session_id}: {e}"))?;
+        let events: Vec<stella_protocol::AgentEvent> =
+            journal.events.into_iter().map(|r| r.event).collect();
+        total = total.merge(stella_pipeline::replay::calibration(&events));
+    }
+    if matches!(format, InspectFormat::Json) {
+        return print_json(&serde_json::json!({
+            "sessions": sessions.len(),
+            "judge_passes": total.judge_passes,
+            "judge_reconciled": total.judge_reconciled,
+            "judge_false_positives": total.judge_false_positives,
+            "judge_false_positive_rate": total.judge_false_positive_rate(),
+            "deterministic_passes": total.deterministic_passes,
+            "deterministic_reconciled": total.deterministic_reconciled,
+            "deterministic_false_positives": total.deterministic_false_positives,
+            "deterministic_false_positive_rate": total.deterministic_false_positive_rate(),
+        }));
+    }
+    println!(
+        "{} session(s) with recorded events\n{}",
+        sessions.len(),
+        stella_pipeline::replay::render_calibration(&total)
+    );
+    Ok(())
+}
+
 /// Open the workspace store without creating it. Mirrors `stella stats`: a
 /// question about recorded history must never write.
 fn open_readonly_store() -> Result<Store, String> {

--- a/stella-cli/src/main.rs
+++ b/stella-cli/src/main.rs
@@ -439,6 +439,10 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         Some(Command::Tune { cmd }) => {
             return tune_cmd::run_tune(cmd);
         }
+        Some(Command::Calibration { format }) => {
+            // Reads the local event journal only — no provider, no API key.
+            return inspect::run_calibration(*format);
+        }
         Some(Command::Inspect {
             execution_id,
             turn,
@@ -799,6 +803,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), String> {
         | Command::Storage { .. }
         | Command::Commands { .. }
         | Command::Inspect { .. }
+        | Command::Calibration { .. }
         // Phase 3 (#714)
         | Command::Proposals { .. }
         // Epic #897

--- a/stella-pipeline/src/replay.rs
+++ b/stella-pipeline/src/replay.rs
@@ -43,6 +43,145 @@ pub mod reference_adapter;
 
 use stella_protocol::{AgentEvent, JudgeEvidence, OracleObservation, ProofTree, StageKind};
 
+/// Judge-calibration tallies folded from recorded event streams (#871).
+///
+/// The event store already persists every verdict (with its ladder snapshot,
+/// #865) and every PR/CI observation — so calibration is a *reading* of what
+/// exists, not a new write path. A `JudgeVerdict` with `deterministic: false,
+/// passed: true` is a model judge's PASS; the next **terminal** CI verdict in
+/// the same stream (`Pr { ci: Some(Passing | Failing) }`) reconciles every
+/// unreconciled pass before it. Deterministic passes are tallied identically,
+/// because a false-positive *rate* means nothing without the cohort it should
+/// be compared against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CalibrationReport {
+    /// Model-judge PASS verdicts observed.
+    pub judge_passes: u32,
+    /// …of which a later terminal CI verdict reconciled.
+    pub judge_reconciled: u32,
+    /// …reconciled as CI-FAILING: the judge approved work CI rejected.
+    pub judge_false_positives: u32,
+    /// Deterministic (ladder) passes observed — the comparison cohort.
+    pub deterministic_passes: u32,
+    pub deterministic_reconciled: u32,
+    pub deterministic_false_positives: u32,
+}
+
+impl CalibrationReport {
+    /// Combine per-session reports into a workspace total.
+    pub fn merge(mut self, other: Self) -> Self {
+        self.judge_passes += other.judge_passes;
+        self.judge_reconciled += other.judge_reconciled;
+        self.judge_false_positives += other.judge_false_positives;
+        self.deterministic_passes += other.deterministic_passes;
+        self.deterministic_reconciled += other.deterministic_reconciled;
+        self.deterministic_false_positives += other.deterministic_false_positives;
+        self
+    }
+
+    /// The measured false-positive rate over RECONCILED judge passes, or
+    /// `None` when nothing was reconciled — an unmeasured rate is reported
+    /// as unmeasured, never as zero.
+    pub fn judge_false_positive_rate(&self) -> Option<f64> {
+        (self.judge_reconciled > 0)
+            .then(|| f64::from(self.judge_false_positives) / f64::from(self.judge_reconciled))
+    }
+
+    /// Same rate for the deterministic cohort.
+    pub fn deterministic_false_positive_rate(&self) -> Option<f64> {
+        (self.deterministic_reconciled > 0).then(|| {
+            f64::from(self.deterministic_false_positives) / f64::from(self.deterministic_reconciled)
+        })
+    }
+}
+
+/// Render a [`CalibrationReport`] for a human — the `stella calibration`
+/// body. States unmeasured rates as unmeasured and names the cohort sizes,
+/// so a rate is never read without its denominator.
+pub fn render_calibration(report: &CalibrationReport) -> String {
+    fn cohort(label: &str, passes: u32, reconciled: u32, false_positives: u32) -> String {
+        let rate = if reconciled > 0 {
+            format!(
+                "{:.0}% false-positive rate",
+                100.0 * f64::from(false_positives) / f64::from(reconciled)
+            )
+        } else {
+            "rate unmeasured (no CI ground truth recorded yet)".to_string()
+        };
+        format!(
+            "{label}: {passes} pass(es), {reconciled} reconciled against CI, \
+             {false_positives} CI-failed — {rate}"
+        )
+    }
+    format!(
+        "judge calibration (#871) — passes reconciled against later CI verdicts\n\
+         {}\n{}\n\
+         note: reconciliation is stream-local; passes after a session's last\n\
+         terminal CI verdict stay unreconciled, and reverts are not yet a\n\
+         ground-truth source.",
+        cohort(
+            "  model judge  ",
+            report.judge_passes,
+            report.judge_reconciled,
+            report.judge_false_positives
+        ),
+        cohort(
+            "  deterministic",
+            report.deterministic_passes,
+            report.deterministic_reconciled,
+            report.deterministic_false_positives
+        ),
+    )
+}
+
+/// Fold one event stream into a [`CalibrationReport`] (#871).
+///
+/// Reconciliation is stream-local and forward-only: a terminal CI verdict
+/// covers the passes that PRECEDED it (the PR carries the session's adopted
+/// work), and passes after the last terminal CI observation stay
+/// unreconciled. `Pending`/`Running` reconcile nothing — absence of a
+/// verdict is not a verdict.
+pub fn calibration(events: &[AgentEvent]) -> CalibrationReport {
+    use stella_protocol::CiStatus;
+    let mut report = CalibrationReport::default();
+    // (judge?, still unreconciled) verdicts awaiting a terminal CI result.
+    let mut pending: Vec<bool> = Vec::new();
+    for event in events {
+        match event {
+            AgentEvent::JudgeVerdict {
+                passed: true,
+                evidence,
+            } => {
+                if evidence.deterministic {
+                    report.deterministic_passes += 1;
+                    pending.push(false);
+                } else {
+                    report.judge_passes += 1;
+                    pending.push(true);
+                }
+            }
+            AgentEvent::Pr { ci: Some(ci), .. } => {
+                let failing = match ci {
+                    CiStatus::Passing => false,
+                    CiStatus::Failing => true,
+                    CiStatus::Pending | CiStatus::Running => continue,
+                };
+                for is_judge in pending.drain(..) {
+                    if is_judge {
+                        report.judge_reconciled += 1;
+                        report.judge_false_positives += u32::from(failing);
+                    } else {
+                        report.deterministic_reconciled += 1;
+                        report.deterministic_false_positives += u32::from(failing);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    report
+}
+
 /// Render an oracle trace compactly — `baseline:fail → candidate:pass` —
 /// the canonical rendering shared by the judge prompt (#864) and verdict
 /// provenance (#865). A trailing candidate entry after a flip is the
@@ -890,5 +1029,93 @@ mod tests {
         );
         let parsed = parse_jsonl(&jsonl).unwrap();
         assert_eq!(parsed.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod calibration_tests {
+    use super::*;
+    use stella_protocol::{CiStatus, JudgeEvidence, PrStatus};
+
+    fn verdict(passed: bool, deterministic: bool) -> AgentEvent {
+        AgentEvent::JudgeVerdict {
+            passed,
+            evidence: JudgeEvidence {
+                summary: String::new(),
+                deterministic,
+                evidence_refs: vec![],
+                ladder: None,
+            },
+        }
+    }
+
+    fn ci(status: CiStatus) -> AgentEvent {
+        AgentEvent::Pr {
+            url: "https://example.test/pr/1".into(),
+            status: PrStatus::Open,
+            number: Some(1),
+            ci: Some(status),
+        }
+    }
+
+    /// The #871 acceptance: a JudgePass that later fails CI is recorded as a
+    /// false positive; the deterministic cohort reconciles beside it.
+    #[test]
+    fn a_judge_pass_that_fails_ci_is_a_false_positive() {
+        let events = vec![
+            verdict(true, false), // judge PASS
+            verdict(true, true),  // deterministic pass
+            ci(CiStatus::Failing),
+        ];
+        let report = calibration(&events);
+        assert_eq!(report.judge_passes, 1);
+        assert_eq!(report.judge_reconciled, 1);
+        assert_eq!(report.judge_false_positives, 1);
+        assert_eq!(report.judge_false_positive_rate(), Some(1.0));
+        assert_eq!(report.deterministic_false_positives, 1);
+    }
+
+    /// Pending/Running reconcile nothing, and passes after the last terminal
+    /// CI verdict stay unreconciled — an unmeasured rate reads None.
+    #[test]
+    fn non_terminal_ci_and_trailing_passes_stay_unreconciled() {
+        let events = vec![
+            verdict(true, false),
+            ci(CiStatus::Running),
+            ci(CiStatus::Passing),
+            verdict(true, false), // after the last terminal verdict
+        ];
+        let report = calibration(&events);
+        assert_eq!(report.judge_passes, 2);
+        assert_eq!(report.judge_reconciled, 1);
+        assert_eq!(report.judge_false_positives, 0);
+        assert_eq!(report.judge_false_positive_rate(), Some(0.0));
+
+        let unmeasured = calibration(&[verdict(true, false)]);
+        assert_eq!(unmeasured.judge_false_positive_rate(), None);
+    }
+
+    /// Failed verdicts and revise-loop reds never enter the tallies — the
+    /// question is the false-POSITIVE rate of passes.
+    #[test]
+    fn failed_verdicts_are_not_tallied() {
+        let events = vec![
+            verdict(false, true),
+            verdict(false, false),
+            ci(CiStatus::Passing),
+        ];
+        let report = calibration(&events);
+        assert_eq!(report.judge_passes, 0);
+        assert_eq!(report.deterministic_passes, 0);
+    }
+
+    #[test]
+    fn merge_adds_componentwise() {
+        let a = calibration(&[verdict(true, false), ci(CiStatus::Failing)]);
+        let b = calibration(&[verdict(true, false), ci(CiStatus::Passing)]);
+        let merged = a.merge(b);
+        assert_eq!(merged.judge_passes, 2);
+        assert_eq!(merged.judge_reconciled, 2);
+        assert_eq!(merged.judge_false_positives, 1);
     }
 }

--- a/stella-store/src/lib.rs
+++ b/stella-store/src/lib.rs
@@ -1485,6 +1485,24 @@ impl Store {
         Ok(out)
     }
 
+    /// Session ids with at least one persisted event, newest execution
+    /// first — the enumeration `stella calibration` folds over (#871).
+    pub fn event_session_ids(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT x.session_id, MAX(x.id) AS latest FROM executions x \
+             JOIN events e ON e.execution_id = x.id \
+             WHERE x.session_id IS NOT NULL \
+             GROUP BY x.session_id ORDER BY latest DESC",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// The replay reader: a session's COMPLETE event journal, reassembled
     /// across every execution stamped with `session_id`
     /// ([`Store::set_execution_session`]), ordered by (execution_id, seq) —

--- a/stella-store/src/tests.rs
+++ b/stella-store/src/tests.rs
@@ -2202,3 +2202,33 @@ fn a_failing_file_touch_row_rolls_its_whole_batch_back() {
         "the row written before the failure must roll back with it"
     );
 }
+
+/// #871: the calibration enumeration — sessions with events, newest first,
+/// sessionless executions excluded.
+#[test]
+fn event_session_ids_lists_sessions_with_events_newest_first() {
+    let store = Store::in_memory().unwrap();
+    let older = store.begin_execution("run", "a", "zai", "glm-5.2").unwrap();
+    store.set_execution_session(older, "ses-old").unwrap();
+    store
+        .record_event(older, 0, &AgentEvent::Text { delta: "a".into() })
+        .unwrap();
+    let newer = store.begin_execution("run", "b", "zai", "glm-5.2").unwrap();
+    store.set_execution_session(newer, "ses-new").unwrap();
+    store
+        .record_event(newer, 0, &AgentEvent::Text { delta: "b".into() })
+        .unwrap();
+    // An execution with events but NO session id must not appear.
+    let orphan = store.begin_execution("run", "c", "zai", "glm-5.2").unwrap();
+    store
+        .record_event(orphan, 0, &AgentEvent::Text { delta: "c".into() })
+        .unwrap();
+    // A session with an execution but no events must not appear either.
+    let silent = store.begin_execution("run", "d", "zai", "glm-5.2").unwrap();
+    store.set_execution_session(silent, "ses-silent").unwrap();
+
+    assert_eq!(
+        store.event_session_ids().unwrap(),
+        vec!["ses-new".to_string(), "ses-old".to_string()]
+    );
+}

--- a/website/content/docs/commands/calibration.mdx
+++ b/website/content/docs/commands/calibration.mdx
@@ -1,0 +1,33 @@
+---
+title: stella calibration
+description: The judge's measured false-positive rate — every recorded pass verdict reconciled against the CI results observed after it.
+---
+
+Answer "how often does the judge approve work that CI later rejects?" from what the workspace has already recorded. Every verification verdict is persisted in the local event journal with the ladder snapshot it was decided from, and every PR/CI observation lands in the same stream — so calibration is a *reading*, not a new telemetry pipe. Entirely local; no API key, no network, and it never writes.
+
+## Synopsis
+
+```bash
+stella calibration                # human-readable report
+stella calibration --format json  # machine-readable tallies
+```
+
+## What it reports
+
+Two cohorts, deliberately side by side — a false-positive rate means nothing without the cohort it should be compared against:
+
+- **model judge** — `JudgeVerdict` events with `passed: true` from a model judge (the ladder escalated on inconclusive evidence).
+- **deterministic** — passes the ladder credited itself (fail→pass flip, green tests, budget, and every pre-submit audit).
+
+For each: how many passes were recorded, how many were **reconciled** — a terminal CI verdict (`Passing`/`Failing`) was observed later in the same session's stream — and how many of those reconciled passes failed CI. The rate is printed only over reconciled passes; with no CI ground truth yet, it is reported as **unmeasured**, never as zero.
+
+## Honest limits
+
+- Reconciliation is stream-local and forward-only: a session's terminal CI verdict covers the passes recorded before it, and passes after the last CI observation stay unreconciled.
+- `Pending`/`Running` CI states reconcile nothing — absence of a verdict is not a verdict.
+- Reverts and rollbacks are not yet a ground-truth source; the report says so rather than approximating.
+
+## See also
+
+- [`stella inspect`](/docs/commands/inspect) — the exact context any past call was sent
+- [`stella stats`](/docs/commands/stats) — cost and resolve-rate per provider/model

--- a/website/content/docs/commands/meta.json
+++ b/website/content/docs/commands/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Commands",
-  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "context", "proposals", "tune", "scoreboard", "arena", "stats", "usage", "cloud", "telemetry", "inspect", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "migrate", "doctor", "completions", "version"]
+  "pages": ["index", "run", "chat", "resume", "goal", "monitor", "init", "fleet", "graph", "storage", "scripts", "commands", "models", "ingest", "context", "proposals", "tune", "scoreboard", "arena", "stats", "usage", "cloud", "telemetry", "inspect", "calibration", "observe", "memory", "mcp", "connect", "auth", "tools", "config", "migrate", "doctor", "completions", "version"]
 }


### PR DESCRIPTION
The final Phase 4 item of epic #858. One commit: `960c6d23`.

## The design choice
The issue asked to *persist* JudgePass verdicts alongside ground truth. Everything needed was already persisted: every `JudgeVerdict` rides the event journal with its ladder snapshot (#865), and every PR/CI observation lands in the same stream. So calibration is a **reading of what exists** — no new write path, no daemon, no schema change (the less-is-more durability rule).

## What it does
`replay::calibration` folds one event stream: a model-judge PASS — and, as the comparison cohort, every deterministic pass, because a false-positive *rate* means nothing without its baseline — is reconciled by the next **terminal** CI verdict (`Passing`/`Failing`) in the same session's stream. `Pending`/`Running` reconcile nothing; passes after the last terminal verdict stay unreconciled; a rate with zero reconciled passes reports **unmeasured**, never 0%.

`stella calibration` (text/JSON) surfaces the workspace total: `Store::event_session_ids` enumerates, `session_events` replays, the fold merges. Reads `.stella/private/store.db` only. The honest limits print with the number — stream-local reconciliation, reverts not yet a ground-truth source.

## Acceptance vs the issue
- ✅ JudgePass verdicts persisted with their ladder snapshot (already true since #1035; asserted by the fold's use of them)
- ✅ CI ground truth reconciles verdicts (`a_judge_pass_that_fails_ci_is_a_false_positive`)
- ✅ A command reports the measured false-positive rate (`stella calibration`, with reference page + help-index entry)
- ◻ Auto-tuning the escalate-vs-revise threshold from the measured rate is future work — it should be driven by real measured data once some exists.

## Verified
Full pre-push gate green (the CLI's own self-checks caught and drove the help-index entry, 80-column about line, and reference page). New: 4 fold unit tests + a store enumeration test.

## Summary by Sourcery

Add judge calibration telemetry that computes model and deterministic false-positive rates by replaying existing event streams and expose it via a new `stella calibration` CLI command and documentation.

New Features:
- Introduce workspace-level judge calibration reporting that measures model-judge and deterministic false-positive rates against CI ground truth.
- Add a `stella calibration` CLI command that reads the local event journal and outputs human- or machine-readable calibration tallies.

Enhancements:
- Support enumerating sessions with recorded events, newest first, to drive calibration over the event store.
- Provide a human-readable renderer for calibration reports that highlights cohort sizes, reconciliation counts, and unmeasured rates.

Documentation:
- Add user-facing documentation for the `stella calibration` command, including synopsis, cohorts explanation, and limitations, and register it in the commands help index.

Tests:
- Add unit tests covering calibration folding semantics, false-positive tallies, unreconciled passes behavior, and report merging.
- Add a store test verifying `event_session_ids` only lists sessions with events, ordered newest first.