### PR TITLE
feat(serve): /v1/sessions and mid-turn steer/pause/resume (#931, #932)

### DIFF
--- a/docs/design/serve-surface.md
+++ b/docs/design/serve-surface.md
@@ -5,11 +5,12 @@
 Option B, the Rust sidecar. It builds its own binary and nothing in
 `stella-cli` links it, so a change here never reaches a `stella` user.
 **This document describes the target surface, not all of it is built:** the
-code today serves one turn per registered id, with no sessions-over-turns, no
-steering, no pause, no approval gate, no `Host`-header guard, and no SIGTERM
-drain. Turn cancellation, a reverse-request deadline, and — as of #971 phase 2
-— **resumable SSE streams** (`seq`, retained history, `?after=` /
-`Last-Event-ID`) *have* shipped. Sections below flag the gaps individually;
+code today has no approval gate, no `Host`-header guard, and no SIGTERM
+drain. Turn cancellation, a reverse-request deadline, — as of #971 phase 2 —
+**resumable SSE streams** (`seq`, retained history, `?after=` /
+`Last-Event-ID`), — as of #932 — **mid-turn steering and pause/resume**, and —
+as of #931 — **server-owned sessions** (`/v1/sessions`, retained history,
+per-session budget) *have* shipped. Sections below flag the gaps individually;
 treat `stella-serve/src/` as the state and this doc as the destination.
 
 **The two crates this document assumed did not exist now do (#971):**
@@ -34,9 +35,10 @@ Oxagen ADR. That repository is private to Oxagen; this document is the
 
 **Read this table before writing a client.** Everything after it describes the
 *destination*; this is the surface a request actually reaches, verified end to
-end against a running binary by Oxagen's sidecar smoke test (oxagen #1132).
-Every other path in this document — including the whole `/v1/sessions/...`
-family in the diagram below — is a 404.
+end against a running binary by Oxagen's sidecar smoke test (oxagen #1132) —
+the `/v1/sessions` and steer/pause rows landed after that smoke test and are
+verified by `stella-serve/tests/sessions.rs` and `tests/control.rs`. Any path
+not in this table is a 404.
 
 | Method | Path | Notes |
 |---|---|---|
@@ -46,14 +48,32 @@ family in the diagram below — is a 404.
 | `GET` | `/v1/turns/{id}/events` | SSE `id: <seq>` + `data: <ServerFrame>`. Resumable via `?after=<seq>` or `Last-Event-ID`. One concurrent subscriber; a second gets 409 |
 | `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |
 | `POST` | `/v1/turns/{id}/tool-result` | Answers a `tool_request` |
-| `POST` | `/v1/turns/{id}/cancel` | The only teardown. There is no `DELETE` |
+| `POST` | `/v1/turns/{id}/cancel` | Hard teardown: drops the turn and its transcript. There is no `DELETE` |
+| `POST` | `/v1/turns/{id}/steer` | `{"message": "…"}` — injected at the next step boundary, echoed as a `steered` event (#932) |
+| `POST` | `/v1/turns/{id}/pause` | Hold at the next step boundary. Idempotent; never mid-tool (#932) |
+| `POST` | `/v1/turns/{id}/resume` | Release a held turn. Idempotent (#932) |
+| `POST` | `/v1/sessions` | `{"system_prompt": "…", "budget": …}` → `{"session_id":"session-<32 hex>"}` (#931) |
+| `GET` | `/v1/sessions/{id}` | History, cost to date, live turn id. Always answers from the last settled state |
+| `POST` | `/v1/sessions/{id}/turns` | `TurnRequest` minus `messages`/`budget`, plus `input` (this turn's new messages). Returns `{"turn_id", "session_id"}`; the turn is then an ordinary `/v1/turns/{id}` member. One live turn per session (else 409) |
+| `DELETE` | `/v1/sessions/{id}` | Ends the session and cancels its live turn |
+
+Session semantics a client must know: the transcript lives on the server and
+the host sends only `input` per turn; the system prompt is minted once at
+session create and held byte-identical across turns (the prompt-cache
+contract); an **aborted turn does not write back** — the session history stays
+as it was, while the aborted turn's spend still joins `cost_usd`; sessions are
+capped (64) and one idle past `ServeConfig::session_idle_ttl` (default 1 h)
+may be reclaimed under pressure, so a long-lived host should expect `404` on a
+session it abandoned and `429` when it hoards.
 
 Corrections to prose further down that reads as present tense but describes the
 destination, and which a client written from it gets wrong:
 
-- **The resource is a turn, not a session.** One `POST /v1/turns` drives exactly
-  one turn; no conversation state is retained between turns and there is no
-  session id. `/readyz` does not exist. `/v1/metrics` **does**.
+- **The turn resource remains first-class.** A stateless `POST /v1/turns`
+  drives exactly one turn with host-supplied messages and retains nothing.
+  Sessions are additive (#931), not a replacement — and note the shape is
+  `POST /v1/sessions/{id}/turns` (plural), not the singular `/turn` some
+  diagrams below sketch. `/readyz` does not exist. `/v1/metrics` **does**.
 - **Reverse RPC is keyed by `request_id` on its own frame types**, not by a
   `call_id` on a `tool_start` / `scope_review` / `ask_user` `AgentEvent`. The
   engine emits dedicated `tool_request` / `provider_request` `ServerFrame`

--- a/stella-serve/src/controls.rs
+++ b/stella-serve/src/controls.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-turn controls: the pause gate and the steering tap, as `Send` handles.
+//!
+//! The engine already models both — `stella_core::ports::TurnGate` parks a turn
+//! at its next step boundary, `TurnSteering` injects queued user messages there
+//! — but until #932 neither port was reachable over HTTP: a served turn ran to
+//! completion or was cancelled outright. This module is the bridge. It follows
+//! the [`crate::pending::Pending`] pattern exactly: the session (turn) object is
+//! exclusively owned by whichever `/events` stream is running, so anything a
+//! POST handler needs to reach mid-turn must be a cloneable, `Send` handle held
+//! by the registry entry instead.
+//!
+//! [`Controls::new`] returns the two halves. [`Controls`] (the sender half)
+//! lives on the registry `Entry` and answers `POST /v1/turns/{id}/pause`,
+//! `/resume` and `/steer`. [`ControlPorts`] (the receiver half) crosses onto the
+//! session thread, where `run_session` lends the port impls to the engine.
+//!
+//! # Cancel must release the gate
+//!
+//! `Engine::run_step` checks cancellation before parking on the gate and again
+//! immediately after it releases — but nothing *inside* `wait_if_paused` looks
+//! at the cancel latch. A turn that is paused when its cancel arrives therefore
+//! stays parked until something flips the gate, holding its OS thread for a
+//! resume that is never coming. Two mechanisms close that, and both are load-
+//! bearing:
+//!
+//! - Every cancel path also calls [`Controls::resume`] (see `Session::cancel`,
+//!   `Drop for Session`, and `routes::handle_cancel`).
+//! - [`PauseGate`] treats a dropped sender as *resumed*, so a turn whose entry
+//!   was torn down without an explicit resume still unparks, observes the
+//!   cancel latch, and unwinds. This is why [`ControlPorts`] must never carry a
+//!   sender clone onto the session thread: a thread that holds its own gate's
+//!   sender can park on it forever.
+
+use std::sync::{Arc, Mutex};
+
+use stella_core::ports::{TurnGate, TurnSteering};
+use tokio::sync::watch;
+
+/// The sender half: pause/resume and steering, cloneable and `Send`, held by
+/// the turn's registry entry alongside its [`crate::pending::Pending`].
+#[derive(Clone)]
+pub(crate) struct Controls {
+    /// `true` while the turn is asked to hold at its next step boundary.
+    ///
+    /// A `watch` channel rather than an `AtomicBool` because pause is not a
+    /// flag the engine polls — it *parks* on it, and the release has to wake
+    /// the parked future. `watch` is runtime-agnostic, so the flip crosses
+    /// from the server runtime to the session thread's current-thread runtime
+    /// the same way the `Pending` one-shots do.
+    pause: Arc<watch::Sender<bool>>,
+    steering: Arc<SteerQueue>,
+}
+
+/// The receiver half, moved onto the session thread exactly once.
+///
+/// Deliberately *not* `Clone` and deliberately without a `watch::Sender`: see
+/// the module docs — the session thread holding its own gate's sender would
+/// defeat the dropped-sender-means-resumed release path.
+pub(crate) struct ControlPorts {
+    gate: PauseGate,
+    steering: Arc<SteerQueue>,
+}
+
+impl Controls {
+    /// A fresh control pair for one turn.
+    pub(crate) fn new() -> (Controls, ControlPorts) {
+        let (pause_tx, pause_rx) = watch::channel(false);
+        let steering = Arc::new(SteerQueue::default());
+        (
+            Controls {
+                pause: Arc::new(pause_tx),
+                steering: Arc::clone(&steering),
+            },
+            ControlPorts {
+                gate: PauseGate(pause_rx),
+                steering,
+            },
+        )
+    }
+
+    /// Hold the turn at its next step boundary. Idempotent — pausing a paused
+    /// turn is a no-op, not an error.
+    pub(crate) fn pause(&self) {
+        self.pause.send_replace(true);
+    }
+
+    /// Let a held turn proceed. Idempotent, and also the release every cancel
+    /// path must perform — see the module docs.
+    pub(crate) fn resume(&self) {
+        self.pause.send_replace(false);
+    }
+
+    /// Queue a user message for injection at the turn's next step boundary.
+    ///
+    /// The engine drains the queue oldest-first, pushes each message into the
+    /// transcript, and emits `AgentEvent::Steered` per message — so the host
+    /// sees its own steer echoed on the event stream.
+    pub(crate) fn steer(&self, text: String) {
+        self.steering.push(text);
+    }
+}
+
+impl ControlPorts {
+    /// Split into the two port impls `run_session` lends to the engine.
+    pub(crate) fn into_ports(self) -> (PauseGate, Arc<SteerQueue>) {
+        (self.gate, self.steering)
+    }
+}
+
+/// `TurnGate` over the watch receiver: parks while the sender holds `true`.
+///
+/// A dropped sender reads as *resumed* — the same posture as the CLI's worker
+/// gate, and here it is a correctness requirement, not merely politeness: the
+/// entry (and with it the sender) can be dropped while the turn is parked, and
+/// the turn must then observe its cancel latch rather than sleep forever.
+pub(crate) struct PauseGate(watch::Receiver<bool>);
+
+#[async_trait::async_trait]
+impl TurnGate for PauseGate {
+    async fn wait_if_paused(&self) {
+        let mut rx = self.0.clone();
+        while *rx.borrow() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+/// `TurnSteering` over a shared queue. The drain is destructive by the trait's
+/// contract — whatever it returns *will* be injected.
+///
+/// `soft_stop_requested` is a hard `false`: the HTTP surface deliberately does
+/// not expose the soft stop (issue #932 scopes the wire to steer, pause and
+/// resume), so no state exists that could request one.
+#[derive(Default)]
+pub(crate) struct SteerQueue {
+    queue: Mutex<Vec<String>>,
+}
+
+impl SteerQueue {
+    fn push(&self, text: String) {
+        self.queue
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(text);
+    }
+}
+
+impl TurnSteering for SteerQueue {
+    fn drain_steering(&self) -> Vec<String> {
+        std::mem::take(&mut *self.queue.lock().unwrap_or_else(|p| p.into_inner()))
+    }
+
+    fn soft_stop_requested(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gate must not park an unpaused turn — `wait_if_paused` on a fresh
+    /// pair returns immediately or the engine would stall on every step.
+    #[tokio::test]
+    async fn an_unpaused_gate_does_not_park() {
+        let (_controls, ports) = Controls::new();
+        let (gate, _) = ports.into_ports();
+        gate.wait_if_paused().await;
+    }
+
+    /// Pause parks; resume releases the parked future. This is the wake path
+    /// `POST /v1/turns/{id}/resume` rides.
+    #[tokio::test]
+    async fn resume_wakes_a_parked_gate() {
+        let (controls, ports) = Controls::new();
+        let (gate, _) = ports.into_ports();
+        controls.pause();
+
+        let parked = tokio::spawn(async move {
+            gate.wait_if_paused().await;
+        });
+        // The parked future must still be pending after the pause…
+        tokio::task::yield_now().await;
+        assert!(!parked.is_finished(), "a paused gate must park");
+
+        controls.resume();
+        tokio::time::timeout(std::time::Duration::from_secs(5), parked)
+            .await
+            .expect("resume must wake the parked gate")
+            .unwrap();
+    }
+
+    /// Dropping the sender half releases a parked gate. This is what stops a
+    /// paused turn whose entry was torn down from holding its OS thread
+    /// forever — see the module docs.
+    #[tokio::test]
+    async fn a_dropped_sender_reads_as_resumed() {
+        let (controls, ports) = Controls::new();
+        let (gate, _) = ports.into_ports();
+        controls.pause();
+
+        let parked = tokio::spawn(async move {
+            gate.wait_if_paused().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!parked.is_finished());
+
+        drop(controls);
+        tokio::time::timeout(std::time::Duration::from_secs(5), parked)
+            .await
+            .expect("a dropped sender must release the gate")
+            .unwrap();
+    }
+
+    /// Steered messages drain oldest-first, and the drain empties the queue —
+    /// the injection order is the order the host posted.
+    #[test]
+    fn steering_drains_in_post_order_and_empties() {
+        let (controls, ports) = Controls::new();
+        let (_, steering) = ports.into_ports();
+        controls.steer("first".to_string());
+        controls.steer("second".to_string());
+        assert_eq!(steering.drain_steering(), vec!["first", "second"]);
+        assert!(steering.drain_steering().is_empty());
+    }
+}

--- a/stella-serve/src/lib.rs
+++ b/stella-serve/src/lib.rs
@@ -53,6 +53,7 @@
 //! (the route table, and why `cancel` is a path segment rather than a `DELETE`).
 
 mod accept;
+mod controls;
 mod error;
 mod frame;
 mod history;
@@ -65,6 +66,7 @@ mod routes;
 pub mod schema_export;
 mod server;
 mod session;
+mod sessions;
 
 pub use error::ServeError;
 pub use frame::{
@@ -73,5 +75,7 @@ pub use frame::{
 };
 pub use observe::{Metrics, Observer, ServeEvent, SharedObserver};
 pub use pending::Pending;
-pub use server::{DEFAULT_RESUME_GRACE, MAX_RESUME_GRACE, ServeConfig, serve};
-pub use session::{Session, SessionSpec};
+pub use server::{
+    DEFAULT_RESUME_GRACE, DEFAULT_SESSION_IDLE_TTL, MAX_RESUME_GRACE, ServeConfig, serve,
+};
+pub use session::{Session, SessionSpec, SettleHook, TurnSettlement};

--- a/stella-serve/src/observe/event.rs
+++ b/stella-serve/src/observe/event.rs
@@ -104,6 +104,20 @@ pub enum Route {
     TurnProviderResult,
     #[serde(rename = "/v1/turns/{id}/cancel")]
     TurnCancel,
+    #[serde(rename = "/v1/turns/{id}/steer")]
+    TurnSteer,
+    #[serde(rename = "/v1/turns/{id}/pause")]
+    TurnPause,
+    #[serde(rename = "/v1/turns/{id}/resume")]
+    TurnResume,
+    #[serde(rename = "/v1/sessions")]
+    SessionsCreate,
+    /// `GET` (read) and `DELETE` (end) share the member path — one resource,
+    /// two verbs, one template in the records.
+    #[serde(rename = "/v1/sessions/{id}")]
+    Session,
+    #[serde(rename = "/v1/sessions/{id}/turns")]
+    SessionTurns,
     /// A path that matched no route. The path itself is deliberately dropped:
     /// a 404 probe is attacker-controlled text, and this is a log.
     #[serde(rename = "<unrouted>")]
@@ -122,6 +136,12 @@ impl Route {
             Self::TurnToolResult => "/v1/turns/{id}/tool-result",
             Self::TurnProviderResult => "/v1/turns/{id}/provider-result",
             Self::TurnCancel => "/v1/turns/{id}/cancel",
+            Self::TurnSteer => "/v1/turns/{id}/steer",
+            Self::TurnPause => "/v1/turns/{id}/pause",
+            Self::TurnResume => "/v1/turns/{id}/resume",
+            Self::SessionsCreate => "/v1/sessions",
+            Self::Session => "/v1/sessions/{id}",
+            Self::SessionTurns => "/v1/sessions/{id}/turns",
             Self::Unrouted => "<unrouted>",
         }
     }
@@ -151,6 +171,29 @@ impl TurnRef {
 }
 
 impl std::fmt::Display for TurnRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// A session id as it appears in a record: truncated, never whole.
+///
+/// Same reasoning as [`TurnRef`] — a session id is a second factor (it names a
+/// retained conversation, and `DELETE` destroys one), minted from the same 128
+/// random bits, so a record carries enough to correlate and not enough to act.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionRef(String);
+
+impl SessionRef {
+    /// Truncate a full session id (`session-<32 hex>`) for recording.
+    #[must_use]
+    pub fn new(session_id: &str) -> Self {
+        let hex = session_id.strip_prefix("session-").unwrap_or(session_id);
+        Self(hex.chars().take(TURN_REF_CHARS).collect())
+    }
+}
+
+impl std::fmt::Display for SessionRef {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(&self.0)
     }
@@ -448,6 +491,28 @@ pub enum ServeEvent {
         reason: StreamEndReason,
     },
 
+    // ---- session registry (#931) ----
+    SessionCreated {
+        session: SessionRef,
+        live_sessions: usize,
+    },
+    /// The registry is at `MAX_SESSIONS` and nothing idle had aged out.
+    SessionRefused {
+        live_sessions: usize,
+    },
+    SessionDeleted {
+        session: SessionRef,
+        live_sessions: usize,
+    },
+    /// An idle-expired session evicted to admit a new one. Lossy — the
+    /// conversation is gone and its id answers `404` — which is why it is
+    /// only done under pressure and only past the idle deadline, and why it
+    /// is reported here rather than being a silent `remove`.
+    SessionReclaimed {
+        session: SessionRef,
+        idle_ms: u64,
+    },
+
     // ---- reverse RPC: the wedge axis ----
     ReverseDispatched {
         turn: TurnRef,
@@ -524,7 +589,9 @@ impl ServeEvent {
             | Self::RequestCompleted { .. }
             | Self::TurnCreated { .. }
             | Self::TurnSettled { .. }
-            | Self::StreamEnded { .. } => Level::Info,
+            | Self::StreamEnded { .. }
+            | Self::SessionCreated { .. }
+            | Self::SessionDeleted { .. } => Level::Info,
 
             // Per model/tool call — a few dozen a turn, so off by default.
             Self::ReverseDispatched { .. } | Self::ReverseAnswered { .. } => Level::Debug,
@@ -535,6 +602,8 @@ impl ServeEvent {
             Self::Unauthorized { .. }
             | Self::TurnRefused { .. }
             | Self::TurnReclaimed { .. }
+            | Self::SessionRefused { .. }
+            | Self::SessionReclaimed { .. }
             | Self::ReverseMisrouted { .. }
             | Self::ReverseAbandoned { .. }
             | Self::AcceptBackoff { .. } => Level::Warn,
@@ -684,16 +753,32 @@ mod tests {
             Route::TurnToolResult,
             Route::TurnProviderResult,
             Route::TurnCancel,
+            Route::TurnSteer,
+            Route::TurnPause,
+            Route::TurnResume,
+            Route::SessionsCreate,
+            Route::Session,
+            Route::SessionTurns,
             Route::Unrouted,
         ] {
             let json = serde_json::to_string(&route).expect("serialize");
             assert_eq!(json, format!("\"{}\"", route.template()));
             assert!(
-                !route.template().contains("turn-"),
-                "{} embeds a concrete turn id",
+                !route.template().contains("turn-") && !route.template().contains("session-"),
+                "{} embeds a concrete id",
                 route.template()
             );
         }
+    }
+
+    /// Same second-factor posture as a turn id: a record correlates a
+    /// session, it cannot address one.
+    #[test]
+    fn a_session_ref_is_truncated_not_whole() {
+        let full = "session-0123456789abcdef0123456789abcdef";
+        let reference = SessionRef::new(full);
+        assert_eq!(reference.to_string(), "01234567");
+        assert_eq!(reference.to_string().len(), TURN_REF_CHARS);
     }
 
     /// Log forging: a header that could split or bloat a record is refused

--- a/stella-serve/src/observe/metrics.rs
+++ b/stella-serve/src/observe/metrics.rs
@@ -52,6 +52,12 @@ pub struct Metrics {
     turns_reclaimed_total: AtomicU64,
     turns_live: AtomicI64,
 
+    sessions_created_total: AtomicU64,
+    sessions_refused_total: AtomicU64,
+    sessions_deleted_total: AtomicU64,
+    sessions_reclaimed_total: AtomicU64,
+    sessions_live: AtomicI64,
+
     turn_duration_ms_total: AtomicU64,
     model_calls_total: AtomicU64,
     model_retries_total: AtomicU64,
@@ -104,6 +110,12 @@ pub struct Snapshot {
     pub turns_aborted_total: u64,
     pub turns_reclaimed_total: u64,
     pub turns_live: u64,
+
+    pub sessions_created_total: u64,
+    pub sessions_refused_total: u64,
+    pub sessions_deleted_total: u64,
+    pub sessions_reclaimed_total: u64,
+    pub sessions_live: u64,
 
     pub turn_duration_ms_total: u64,
     pub model_calls_total: u64,
@@ -163,6 +175,12 @@ impl Metrics {
             turns_aborted_total: self.turns_aborted_total.load(ORDER),
             turns_reclaimed_total: self.turns_reclaimed_total.load(ORDER),
             turns_live: gauge(&self.turns_live),
+
+            sessions_created_total: self.sessions_created_total.load(ORDER),
+            sessions_refused_total: self.sessions_refused_total.load(ORDER),
+            sessions_deleted_total: self.sessions_deleted_total.load(ORDER),
+            sessions_reclaimed_total: self.sessions_reclaimed_total.load(ORDER),
+            sessions_live: gauge(&self.sessions_live),
 
             turn_duration_ms_total: self.turn_duration_ms_total.load(ORDER),
             model_calls_total: self.model_calls_total.load(ORDER),
@@ -271,6 +289,22 @@ impl Observer for Metrics {
             }
             ServeEvent::TurnReclaimed { .. } => {
                 self.turns_reclaimed_total.fetch_add(1, ORDER);
+            }
+
+            ServeEvent::SessionCreated { live_sessions, .. } => {
+                self.sessions_created_total.fetch_add(1, ORDER);
+                self.sessions_live.store(as_i64(*live_sessions), ORDER);
+            }
+            ServeEvent::SessionRefused { live_sessions } => {
+                self.sessions_refused_total.fetch_add(1, ORDER);
+                self.sessions_live.store(as_i64(*live_sessions), ORDER);
+            }
+            ServeEvent::SessionDeleted { live_sessions, .. } => {
+                self.sessions_deleted_total.fetch_add(1, ORDER);
+                self.sessions_live.store(as_i64(*live_sessions), ORDER);
+            }
+            ServeEvent::SessionReclaimed { .. } => {
+                self.sessions_reclaimed_total.fetch_add(1, ORDER);
             }
 
             ServeEvent::ReverseDispatched { kind, .. } => {

--- a/stella-serve/src/routes.rs
+++ b/stella-serve/src/routes.rs
@@ -219,6 +219,7 @@ pub(crate) async fn handle_create(
             reverse_request_timeout,
             turn: TurnRef::new(turn_id),
             observer,
+            on_settled: None,
         })
     });
     let Some(id) = registered else {
@@ -597,12 +598,397 @@ pub(crate) async fn handle_cancel(
         return res.json("404 Not Found", &error_body("unknown turn")).await;
     };
     entry.pending.cancel();
+    // A paused turn is parked on its gate, not on a reverse request, so the
+    // cancel alone cannot wake it — and while a stream holds this entry alive,
+    // neither can the sender-drop fallback. The release is what lets a
+    // paused-then-cancelled turn observe the latch and unwind (`crate::controls`).
+    entry.controls.resume();
     // Dropping our `Arc` here is what reclaims a turn whose stream never opened:
     // the registry no longer holds it, so this may be the last handle, and
     // `Drop for Session` releases the engine thread. A turn that *is* streaming
     // keeps its own handle and unwinds through `handle_events` as usual.
     drop(entry);
     res.json("200 OK", br#"{"status":"cancelled"}"#).await
+}
+
+/// Whether this turn is known to have finished — its session is parked in the
+/// entry and its thread is done. `false` when the turn is live *or* currently
+/// being streamed (the session is checked out, so there is nothing to ask);
+/// a control request in that window is accepted and simply arrives too late
+/// to matter, which is inherent to steering a running turn.
+fn known_finished(entry: &crate::server::Entry) -> bool {
+    match entry.session.try_lock() {
+        Ok(slot) => slot.as_ref().is_some_and(Session::is_finished),
+        Err(std::sync::TryLockError::WouldBlock) => false,
+        Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned
+            .into_inner()
+            .as_ref()
+            .is_some_and(Session::is_finished),
+    }
+}
+
+/// Body of `POST /v1/turns/{id}/steer`.
+#[derive(Debug, Deserialize)]
+struct SteerIn {
+    /// The user message to inject at the turn's next step boundary.
+    message: String,
+}
+
+/// `POST /v1/turns/{id}/steer` — queue a mid-turn user message (#932).
+///
+/// The engine injects it at the next step boundary and echoes it on the event
+/// stream as `AgentEvent::Steered`, so a streaming host sees exactly when its
+/// message landed. Best-effort by nature: a turn that completes before its
+/// next boundary never observes the message — the same race the CLI's `>`
+/// steer has, and one the wire cannot close.
+pub(crate) async fn handle_steer(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    let steer: SteerIn = match serde_json::from_slice(body) {
+        Ok(steer) => steer,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid steer request: {err}")),
+                )
+                .await;
+        }
+    };
+    if steer.message.is_empty() {
+        return res
+            .json("400 Bad Request", &error_body("message must not be empty"))
+            .await;
+    }
+    if known_finished(&entry) {
+        return res
+            .json("409 Conflict", &error_body("turn already finished"))
+            .await;
+    }
+    entry.controls.steer(steer.message);
+    res.json("200 OK", br#"{"status":"queued"}"#).await
+}
+
+/// `POST /v1/turns/{id}/pause` — hold the turn at its next step boundary
+/// (#932). Idempotent. Step granularity, never mid-tool: a step already in
+/// flight (a parked reverse request included) finishes first.
+pub(crate) async fn handle_pause(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    if known_finished(&entry) {
+        return res
+            .json("409 Conflict", &error_body("turn already finished"))
+            .await;
+    }
+    entry.controls.pause();
+    res.json("200 OK", br#"{"status":"paused"}"#).await
+}
+
+/// `POST /v1/turns/{id}/resume` — release a held turn (#932). Idempotent:
+/// resuming a turn that was never paused is a no-op, not an error.
+pub(crate) async fn handle_resume(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    if known_finished(&entry) {
+        return res
+            .json("409 Conflict", &error_body("turn already finished"))
+            .await;
+    }
+    entry.controls.resume();
+    res.json("200 OK", br#"{"status":"resumed"}"#).await
+}
+
+// ── /v1/sessions: server-owned conversations (#931) ──────────────────────────
+//
+// The handlers are the thin part; the state machine (checkout, settle-back,
+// retention) lives in `crate::sessions` where it is unit-tested without a
+// socket. What belongs *here* is the wire shape and the status codes.
+
+/// Body of `POST /v1/sessions`.
+#[derive(Debug, Deserialize)]
+struct SessionCreateRequest {
+    /// Message index 0 for every turn of this session — minted once, held
+    /// byte-identical thereafter. That is the prompt-cache stability contract:
+    /// the engine never touches index 0, so every turn reopens the same cached
+    /// prefix. (The CLI re-mints the system prompt on `stella resume` because
+    /// a new process has a cold cache anyway; a hot server session must not.)
+    system_prompt: String,
+    /// Spend policy for the whole session. `session_limit_usd` finally binds
+    /// across turns here — the session owns one guard and threads it through
+    /// every turn, unlike the stateless route's fresh-guard-per-turn.
+    #[serde(default)]
+    budget: BudgetSpec,
+}
+
+/// Response to `POST /v1/sessions`.
+#[derive(Debug, Serialize)]
+struct SessionCreated<'a> {
+    session_id: &'a str,
+}
+
+/// Body of `POST /v1/sessions/{id}/turns` — the stateless `TurnRequest`,
+/// minus `messages` (the session owns the history) and minus `budget` (the
+/// session owns the guard).
+#[derive(Debug, Deserialize)]
+struct SessionTurnRequest {
+    provider_id: String,
+    #[serde(default)]
+    tools: Vec<ToolSchema>,
+    /// This turn's new input, appended to the session history before the turn
+    /// runs — typically one user message.
+    input: Vec<CompletionMessage>,
+    #[serde(default)]
+    max_steps: Option<usize>,
+    #[serde(default)]
+    reverse_request_timeout_ms: Option<u64>,
+}
+
+/// Response to `POST /v1/sessions/{id}/turns`. The turn is an ordinary member
+/// of `/v1/turns/{id}/...` — events, results, cancel, steer and pause all
+/// address it by `turn_id` exactly as they would a stateless turn.
+#[derive(Debug, Serialize)]
+struct SessionTurnCreated<'a> {
+    turn_id: &'a str,
+    session_id: &'a str,
+}
+
+/// Response to `GET /v1/sessions/{id}` — the last settled state, served even
+/// while a turn is running (see `crate::sessions` on checkout semantics).
+#[derive(Debug, Serialize)]
+struct SessionInfo<'a> {
+    session_id: &'a str,
+    turns_completed: u64,
+    turns_aborted: u64,
+    /// Session-axis spend to date, aborted turns included.
+    cost_usd: f64,
+    /// The id of the turn currently running in this session, if any — the
+    /// handle a reconnecting host needs to rejoin its event stream.
+    live_turn: Option<String>,
+    /// The retained conversation, compaction rewrites included.
+    messages: Vec<CompletionMessage>,
+}
+
+/// `POST /v1/sessions` — open a server-owned conversation.
+pub(crate) async fn handle_session_create(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let request: SessionCreateRequest = match serde_json::from_slice(body) {
+        Ok(request) => request,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid session request: {err}")),
+                )
+                .await;
+        }
+    };
+    let history = vec![CompletionMessage::system(request.system_prompt)];
+    let budget = BudgetGuard::new(
+        request.budget.mode,
+        request.budget.turn_limit_usd,
+        request.budget.session_limit_usd,
+    );
+    let registered =
+        state
+            .sessions()
+            .register(history, budget, state.session_idle_ttl(), state.observer());
+    let Some(id) = registered else {
+        return res
+            .json_with_headers(
+                "429 Too Many Requests",
+                &[("Retry-After", RETRY_AFTER_SECS)],
+                &error_body("too many sessions; delete sessions you are done with"),
+            )
+            .await;
+    };
+    let body = serde_json::to_vec(&SessionCreated { session_id: &id }).unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
+/// `POST /v1/sessions/{id}/turns` — run the next turn of a session.
+///
+/// The reservation-token choreography (reserve → snapshot → register → bind,
+/// with release/settle racing all of it) is documented in `crate::sessions`.
+/// What matters here: no session lock is held across `register_turn`, and the
+/// turn itself is a first-class member of the turn registry, so the live-turn
+/// cap applies and every `/v1/turns/{id}/...` verb works on it.
+pub(crate) async fn handle_session_turn(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(sess) = state.sessions().lookup(id) else {
+        return res
+            .json("404 Not Found", &error_body("unknown session"))
+            .await;
+    };
+    let request: SessionTurnRequest = match serde_json::from_slice(body) {
+        Ok(request) => request,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid turn request: {err}")),
+                )
+                .await;
+        }
+    };
+    if request.input.is_empty() {
+        return res
+            .json(
+                "400 Bad Request",
+                &error_body("input must carry at least one message"),
+            )
+            .await;
+    }
+    let mut config = EngineConfig::default();
+    if let Some(max_steps) = request.max_steps {
+        let Some(effective) = validate_max_steps(max_steps) else {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body("max_steps must be at least 1"),
+                )
+                .await;
+        };
+        config.max_steps = effective;
+    }
+    let mut reverse_request_timeout = SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT;
+    if let Some(requested_ms) = request.reverse_request_timeout_ms {
+        let Some(effective) = validate_reverse_request_timeout(requested_ms) else {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body("reverse_request_timeout_ms must be at least 1"),
+                )
+                .await;
+        };
+        reverse_request_timeout = effective;
+    }
+
+    let Some(token) = sess.reserve() else {
+        return res
+            .json(
+                "409 Conflict",
+                &error_body("a turn is already running in this session"),
+            )
+            .await;
+    };
+    let (mut messages, budget) = sess.snapshot();
+    messages.extend(request.input);
+
+    let observer = state.observer().clone();
+    // The settle hook is minted *inside* the closure, not before the
+    // `register_turn` call: a capacity-refused registration drops the closure
+    // uncalled, and a hook minted early would fire its died-without-settling
+    // path for a turn that never existed — miscounting an abort and racing
+    // the `release` below.
+    let hook_sess = Arc::clone(&sess);
+    let registered = state.register_turn(move |turn_id| {
+        Session::start(SessionSpec {
+            provider_id: request.provider_id,
+            tools: request.tools,
+            messages,
+            config,
+            budget,
+            reverse_request_timeout,
+            turn: TurnRef::new(turn_id),
+            observer,
+            on_settled: Some(hook_sess.settle_hook(token)),
+        })
+    });
+    let Some(turn_id) = registered else {
+        // The turn registry is full — the reservation ends without a turn
+        // ever having existed, so the session is immediately usable again.
+        sess.release(token);
+        return res
+            .json_with_headers(
+                "429 Too Many Requests",
+                &[("Retry-After", RETRY_AFTER_SECS)],
+                &error_body("too many live turns; retry after in-flight turns finish"),
+            )
+            .await;
+    };
+    sess.bind_turn(token, &turn_id);
+    let body = serde_json::to_vec(&SessionTurnCreated {
+        turn_id: &turn_id,
+        session_id: id,
+    })
+    .unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
+/// `GET /v1/sessions/{id}` — history, cost to date, and the live turn if any.
+pub(crate) async fn handle_session_get(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(sess) = state.sessions().lookup(id) else {
+        return res
+            .json("404 Not Found", &error_body("unknown session"))
+            .await;
+    };
+    let view = sess.view();
+    let body = serde_json::to_vec(&SessionInfo {
+        session_id: id,
+        turns_completed: view.turns_completed,
+        turns_aborted: view.turns_aborted,
+        cost_usd: view.cost_usd,
+        live_turn: view.live_turn,
+        messages: view.history,
+    })
+    .unwrap_or_default();
+    res.json("200 OK", &body).await
+}
+
+/// `DELETE /v1/sessions/{id}` — end a session, cancelling its live turn.
+///
+/// The removal happens first, so a concurrent `POST .../turns` racing this
+/// delete loses cleanly (its lookup finds nothing and answers `404`). A turn
+/// already registered keeps running only long enough to unwind: it is
+/// cancelled here exactly the way `POST /v1/turns/{id}/cancel` would, and its
+/// settlement lands on the detached entry, harmlessly.
+pub(crate) async fn handle_session_delete(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+) -> std::io::Result<()> {
+    let Some(sess) = state.sessions().remove(id, state.observer()) else {
+        return res
+            .json("404 Not Found", &error_body("unknown session"))
+            .await;
+    };
+    if let Some(turn_id) = sess.live_turn_id() {
+        // Scoped so the registry guard drops before the awaits below; the
+        // session's own locks are not held here (`live_turn_id` returned).
+        let removed = { state.turns().remove(&turn_id) };
+        if let Some(entry) = removed {
+            entry.pending.cancel();
+            entry.controls.resume();
+        }
+    }
+    res.json("200 OK", br#"{"status":"deleted"}"#).await
 }
 
 pub(crate) fn error_body(message: &str) -> Vec<u8> {

--- a/stella-serve/src/server.rs
+++ b/stella-serve/src/server.rs
@@ -14,6 +14,13 @@
 //! | `POST /v1/turns/{id}/tool-result` | answer a `tool_request` (`ToolResultIn`) |
 //! | `POST /v1/turns/{id}/provider-result` | answer a `provider_request` (`ProviderResultIn`) |
 //! | `POST /v1/turns/{id}/cancel` | end an in-flight turn → `{ "status": "cancelled" }` |
+//! | `POST /v1/turns/{id}/steer` | inject a mid-turn user message (#932) |
+//! | `POST /v1/turns/{id}/pause` | hold the turn at its next step boundary (#932) |
+//! | `POST /v1/turns/{id}/resume` | release a held turn (#932) |
+//! | `POST /v1/sessions` | open a server-owned conversation (#931) → `{ "session_id": … }` |
+//! | `GET /v1/sessions/{id}` | history, cost to date, live turn |
+//! | `POST /v1/sessions/{id}/turns` | run the next turn (turn semantics minus `messages`) |
+//! | `DELETE /v1/sessions/{id}` | end the session, cancelling its live turn |
 //!
 //! Any other method on one of those paths is a `405` carrying `Allow`; any
 //! other path is a `404`. The handlers themselves live in `src/routes.rs`; this
@@ -139,6 +146,16 @@ pub struct ServeConfig {
     /// not a bound, and this one exists to stop an abandoned turn holding
     /// resources forever. See [`ServeConfig::resume_grace`].
     pub resume_grace: Duration,
+    /// How long a session must sit idle (no turn started or settled) before
+    /// the registry may reclaim it to admit a new one.
+    ///
+    /// This is *not* an expiry clock — an idle session inside the cap is kept
+    /// indefinitely. It only decides who is evictable when `POST /v1/sessions`
+    /// finds the registry full: idle past this window → reclaimable, longest
+    /// idle first; otherwise the create is refused with `429`. Memory is
+    /// bounded by the session cap either way, which is why this dial has no
+    /// ceiling: raising it trades `429`s for retention, never boundedness.
+    pub session_idle_ttl: Duration,
 }
 
 /// The default [`ServeConfig::resume_grace`]: thirty seconds.
@@ -156,6 +173,13 @@ pub const DEFAULT_RESUME_GRACE: Duration = Duration::from_secs(30);
 /// infinity could remove it.
 pub const MAX_RESUME_GRACE: Duration = Duration::from_secs(300);
 
+/// The default [`ServeConfig::session_idle_ttl`]: one hour.
+///
+/// Long enough that a conversation paced by a human — minutes between turns —
+/// is never the one evicted; short enough that a host leaking sessions finds
+/// the registry self-healing under pressure rather than permanently full.
+pub const DEFAULT_SESSION_IDLE_TTL: Duration = Duration::from_secs(3600);
+
 impl ServeConfig {
     /// The production wiring: bind, token, and the standard observability stack.
     #[must_use]
@@ -167,6 +191,7 @@ impl ServeConfig {
             observer,
             metrics,
             resume_grace: DEFAULT_RESUME_GRACE,
+            session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
         }
     }
 
@@ -180,6 +205,15 @@ impl ServeConfig {
     #[must_use]
     pub fn with_resume_grace(mut self, grace: Duration) -> Self {
         self.resume_grace = grace.min(MAX_RESUME_GRACE);
+        self
+    }
+
+    /// Set how long a session must sit idle before it is reclaimable under
+    /// pressure — see [`ServeConfig::session_idle_ttl`] for what this does
+    /// and does not bound.
+    #[must_use]
+    pub fn with_session_idle_ttl(mut self, ttl: Duration) -> Self {
+        self.session_idle_ttl = ttl;
         self
     }
 }
@@ -216,6 +250,10 @@ pub(crate) struct Entry {
     /// that includes age. This counter is internal and never leaves the process.
     seq: u64,
     pub(crate) pending: Pending,
+    /// Mid-turn controls (pause/resume/steer) — like `pending`, the shared,
+    /// always-available handle: the session itself is exclusively owned by
+    /// whichever stream is running, so control POSTs go through this instead.
+    pub(crate) controls: crate::controls::Controls,
     pub(crate) session: Mutex<Option<Session>>,
     /// This turn's retained frame tail, shared with the [`Session`].
     ///
@@ -248,11 +286,25 @@ pub(crate) struct ServerState {
     /// See [`ServeConfig::resume_grace`]. `Duration::ZERO` means a disconnect
     /// cancels the turn at once, with no resume window.
     resume_grace: Duration,
+    /// The server-owned conversations (`/v1/sessions`, #931). A separate
+    /// registry from `turns` on purpose: a session is retained state, a turn
+    /// is live work, and they are capped, reclaimed and locked independently.
+    sessions: crate::sessions::SessionRegistry,
+    /// See [`ServeConfig::session_idle_ttl`].
+    session_idle_ttl: Duration,
 }
 
 impl ServerState {
     pub(crate) fn turns(&self) -> MutexGuard<'_, HashMap<String, Arc<Entry>>> {
         self.turns.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    pub(crate) fn sessions(&self) -> &crate::sessions::SessionRegistry {
+        &self.sessions
+    }
+
+    pub(crate) fn session_idle_ttl(&self) -> Duration {
+        self.session_idle_ttl
     }
 
     pub(crate) fn lookup(&self, id: &str) -> Option<Arc<Entry>> {
@@ -314,6 +366,7 @@ impl ServerState {
                         slot.insert(Arc::new(Entry {
                             seq: self.counter.fetch_add(1, Ordering::Relaxed),
                             pending: session.pending(),
+                            controls: session.controls(),
                             history: session.history(),
                             stream_generation: AtomicU64::new(0),
                             session: Mutex::new(Some(session)),
@@ -628,6 +681,8 @@ pub async fn serve(config: ServeConfig, on_ready: impl FnOnce(SocketAddr)) -> st
         observer: config.observer,
         metrics: config.metrics,
         resume_grace: config.resume_grace.min(MAX_RESUME_GRACE),
+        sessions: crate::sessions::SessionRegistry::new(),
+        session_idle_ttl: config.session_idle_ttl,
     });
     state.observer.emit(&ServeEvent::Listening {
         addr: bound.to_string(),
@@ -811,10 +866,14 @@ async fn route(
         None => (req.path.clone(), String::new()),
     };
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-    let (route, turn_id) = classify(&segs);
+    let (route, member_id) = classify(&segs);
     record.set_route(route);
-    let turn_id = turn_id.map(str::to_string);
-    if let Some(id) = turn_id.as_deref() {
+    let member_id = member_id.map(str::to_string);
+    // The member id is a turn id on `/v1/turns/...` and a session id on
+    // `/v1/sessions/...`; only the former belongs in the record's turn slot.
+    if let Some(id) = member_id.as_deref()
+        && route_addresses_a_turn(route)
+    {
         record.set_turn(id);
     }
 
@@ -869,17 +928,54 @@ async fn route(
                 res,
                 record,
                 state,
-                turn_id.as_deref().unwrap_or_default(),
+                member_id.as_deref().unwrap_or_default(),
                 resume_point(&query, &req),
             )
             .await;
         }
         ("POST", Route::TurnCancel) => {
             discard_body(res.stream_mut(), &mut req).await;
-            return routes::handle_cancel(res, state, turn_id.as_deref().unwrap_or_default()).await;
+            return routes::handle_cancel(res, state, member_id.as_deref().unwrap_or_default())
+                .await;
+        }
+        ("POST", Route::TurnPause) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_pause(res, state, member_id.as_deref().unwrap_or_default())
+                .await;
+        }
+        ("POST", Route::TurnResume) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_resume(res, state, member_id.as_deref().unwrap_or_default())
+                .await;
+        }
+        ("GET", Route::Session) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_session_get(
+                res,
+                state,
+                member_id.as_deref().unwrap_or_default(),
+            )
+            .await;
+        }
+        ("DELETE", Route::Session) => {
+            discard_body(res.stream_mut(), &mut req).await;
+            return routes::handle_session_delete(
+                res,
+                state,
+                member_id.as_deref().unwrap_or_default(),
+            )
+            .await;
         }
         // The body-bearing routes fall through to the read below.
-        ("POST", Route::TurnsCreate | Route::TurnToolResult | Route::TurnProviderResult) => {}
+        (
+            "POST",
+            Route::TurnsCreate
+            | Route::TurnToolResult
+            | Route::TurnProviderResult
+            | Route::TurnSteer
+            | Route::SessionsCreate
+            | Route::SessionTurns,
+        ) => {}
         (_, Route::Unrouted) => {
             discard_body(res.stream_mut(), &mut req).await;
             return res.json("404 Not Found", br#"{"error":"not found"}"#).await;
@@ -901,18 +997,36 @@ async fn route(
     }
     record.set_bytes_in(req.body.len() as u64);
 
-    let id = turn_id.as_deref().unwrap_or_default();
+    let id = member_id.as_deref().unwrap_or_default();
     match route {
         Route::TurnsCreate => routes::handle_create(res, state, &req.body).await,
         Route::TurnToolResult => routes::handle_tool_result(res, state, id, &req.body).await,
         Route::TurnProviderResult => {
             routes::handle_provider_result(res, state, id, &req.body).await
         }
-        // Unreachable: the match above admits exactly the three body-bearing
+        Route::TurnSteer => routes::handle_steer(res, state, id, &req.body).await,
+        Route::SessionsCreate => routes::handle_session_create(res, state, &req.body).await,
+        Route::SessionTurns => routes::handle_session_turn(res, state, id, &req.body).await,
+        // Unreachable: the match above admits exactly the body-bearing
         // routes. Answering rather than panicking keeps a future edit that
         // widens that match from taking down a request thread.
         _ => res.json("404 Not Found", br#"{"error":"not found"}"#).await,
     }
+}
+
+/// Whether this route's member id names a turn (as opposed to a session) —
+/// what decides if it belongs in a record's turn slot.
+fn route_addresses_a_turn(route: Route) -> bool {
+    matches!(
+        route,
+        Route::TurnEvents
+            | Route::TurnToolResult
+            | Route::TurnProviderResult
+            | Route::TurnCancel
+            | Route::TurnSteer
+            | Route::TurnPause
+            | Route::TurnResume
+    )
 }
 
 /// Map a path to its route template and, where it has one, the turn id.
@@ -930,6 +1044,12 @@ fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
         ["v1", "turns", id, "tool-result"] => (Route::TurnToolResult, Some(id)),
         ["v1", "turns", id, "provider-result"] => (Route::TurnProviderResult, Some(id)),
         ["v1", "turns", id, "cancel"] => (Route::TurnCancel, Some(id)),
+        ["v1", "turns", id, "steer"] => (Route::TurnSteer, Some(id)),
+        ["v1", "turns", id, "pause"] => (Route::TurnPause, Some(id)),
+        ["v1", "turns", id, "resume"] => (Route::TurnResume, Some(id)),
+        ["v1", "sessions"] => (Route::SessionsCreate, None),
+        ["v1", "sessions", id] => (Route::Session, Some(id)),
+        ["v1", "sessions", id, "turns"] => (Route::SessionTurns, Some(id)),
         _ => (Route::Unrouted, None),
     }
 }
@@ -974,7 +1094,13 @@ fn allowed(route: Route) -> &'static str {
         Route::TurnsCreate
         | Route::TurnToolResult
         | Route::TurnProviderResult
-        | Route::TurnCancel => "POST",
+        | Route::TurnCancel
+        | Route::TurnSteer
+        | Route::TurnPause
+        | Route::TurnResume
+        | Route::SessionsCreate
+        | Route::SessionTurns => "POST",
+        Route::Session => "GET, DELETE",
         // Never reached: `Unrouted` is answered as a 404 before this is called.
         Route::Unrouted => "",
     }
@@ -1076,6 +1202,8 @@ mod tests {
             observer: capture.clone(),
             metrics: Arc::new(Metrics::new()),
             resume_grace: DEFAULT_RESUME_GRACE,
+            sessions: crate::sessions::SessionRegistry::new(),
+            session_idle_ttl: DEFAULT_SESSION_IDLE_TTL,
         };
         (state, capture)
     }
@@ -1090,6 +1218,7 @@ mod tests {
             reverse_request_timeout: SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT,
             turn: TurnRef::new(turn_id),
             observer: crate::observe::null_observer(),
+            on_settled: None,
         }
     }
 

--- a/stella-serve/src/session.rs
+++ b/stella-serve/src/session.rs
@@ -24,6 +24,7 @@ use stella_protocol::{
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
+use crate::controls::{ControlPorts, Controls};
 use crate::error::ServeError;
 use crate::frame::{ServerFrame, TurnOutcomeWire};
 use crate::history::{Encoded, FrameHistory, encode_seq_frame};
@@ -65,6 +66,35 @@ pub struct SessionSpec {
     /// Where this session's boundary events go. `observe::null_observer()` for
     /// callers using [`Session`] as a library type without a sink.
     pub observer: SharedObserver,
+    /// Called exactly once when the turn settles, with the final transcript
+    /// and spend — before the terminal frame is emitted, so a host that sees
+    /// `turn_complete` and immediately reads its session observes the
+    /// write-back. `None` for a stateless turn (the pre-#931 behavior: the
+    /// mutated transcript is simply dropped).
+    ///
+    /// If the hook is never *called* — the session thread could not be spawned
+    /// — it is still *dropped*, and the owner's drop-side bookkeeping runs; a
+    /// session-owned turn uses that to release its live-turn slot rather than
+    /// wedge the session forever (see `crate::sessions`).
+    pub on_settled: Option<SettleHook>,
+}
+
+/// The settlement callback a session owner installs on a turn — see
+/// [`SessionSpec::on_settled`].
+pub type SettleHook = Box<dyn FnOnce(TurnSettlement) + Send>;
+
+/// What a settled turn hands back to its owner: the transcript as the engine
+/// left it, and the budget guard carrying the turn's true spend.
+pub struct TurnSettlement {
+    /// `true` for [`TurnOutcomeWire::Completed`]. An aborted turn still
+    /// settles — its spend is real even though its transcript may not be
+    /// worth keeping (a hard cancel can leave a dangling `tool_use` that
+    /// would poison the next model call).
+    pub completed: bool,
+    /// The conversation as the engine left it, compaction rewrites included.
+    pub messages: Vec<CompletionMessage>,
+    /// The guard the turn ran under; `session_spent_usd` is the running total.
+    pub budget: BudgetGuard,
 }
 
 impl SessionSpec {
@@ -79,6 +109,11 @@ impl SessionSpec {
 pub struct Session {
     frames: mpsc::UnboundedReceiver<ServerFrame>,
     pending: Pending,
+    /// The sender half of this turn's mid-turn controls (pause/steer). Shared
+    /// with the registry entry the same way [`Pending`] is, and for the same
+    /// reason: the session object itself is exclusively owned by whichever
+    /// stream is running, so control POSTs need a handle that is not it.
+    controls: Controls,
     thread: Option<JoinHandle<()>>,
     /// This turn's sequenced, bounded frame tail.
     ///
@@ -99,6 +134,7 @@ impl Session {
     pub fn start(spec: SessionSpec) -> Session {
         let (frame_tx, frame_rx) = mpsc::unbounded_channel::<ServerFrame>();
         let pending = Pending::new(spec.observer.clone(), spec.turn.clone());
+        let (controls, control_ports) = Controls::new();
         // Fallible spawn on purpose: a host that opens more turns than the OS
         // will grant threads must see a cleanly aborted turn on the wire, not
         // the panic bare `std::thread::spawn` raises when creation fails.
@@ -108,7 +144,8 @@ impl Session {
         let abort_turn = spec.turn.clone();
         let thread_pending = pending.clone();
         let builder = std::thread::Builder::new().name("stella-serve-session".to_string());
-        let spawned = builder.spawn(move || run_session(spec, frame_tx, thread_pending));
+        let spawned =
+            builder.spawn(move || run_session(spec, frame_tx, thread_pending, control_ports));
         let thread = match spawned {
             Ok(thread) => Some(thread),
             Err(err) => {
@@ -133,6 +170,7 @@ impl Session {
         Session {
             frames: frame_rx,
             pending,
+            controls,
             thread,
             history: Arc::new(FrameHistory::new()),
         }
@@ -189,6 +227,12 @@ impl Session {
         self.pending.clone()
     }
 
+    /// A handle to this turn's mid-turn controls, cloneable and `Send` — same
+    /// contract as [`Session::pending`], for the pause/steer POST handlers.
+    pub(crate) fn controls(&self) -> Controls {
+        self.controls.clone()
+    }
+
     /// Answer a [`ServerFrame::ToolRequest`] with the host-run tool output.
     pub fn resolve_tool(&self, request_id: &str, output: ToolOutput) -> Result<(), ServeError> {
         self.pending.resolve_tool(request_id, output)
@@ -217,8 +261,14 @@ impl Session {
     /// thread is mid-turn — [`Pending`] is the shared handle both sides hold. It
     /// does **not** kill the thread outright: the turn is allowed to unwind so
     /// the terminal frame still reaches a host that is streaming events.
+    ///
+    /// Also releases the pause gate: the engine only re-checks its cancel
+    /// latch once `wait_if_paused` returns, so a cancel that leaves a paused
+    /// turn parked would hold its OS thread for a resume that is never coming
+    /// (see `crate::controls`).
     pub fn cancel(&self) {
         self.pending.cancel();
+        self.controls.resume();
     }
 
     /// Whether the session thread has finished — i.e. the turn has produced
@@ -254,15 +304,25 @@ impl Drop for Session {
         // not join (a still-running turn could take arbitrarily long) — the
         // thread detaches and drains itself.
         self.pending.cancel();
+        // A paused turn is parked on the gate, not on a reverse request, so the
+        // cancel above cannot wake it — the release here is what lets the
+        // detached thread observe the latch and unwind (see `crate::controls`).
+        self.controls.resume();
         drop(self.thread.take());
     }
 }
 
 /// The body of the session thread: build a current-thread runtime, construct the
 /// remoted ports, and drive one turn to its outcome.
-fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, pending: Pending) {
+fn run_session(
+    mut spec: SessionSpec,
+    frame_tx: mpsc::UnboundedSender<ServerFrame>,
+    pending: Pending,
+    control_ports: ControlPorts,
+) {
     let observer = spec.observer.clone();
     let turn = spec.turn.clone();
+    let on_settled = spec.on_settled.take();
     let started = Instant::now();
     let runtime = match Builder::new_current_thread().enable_time().build() {
         Ok(runtime) => runtime,
@@ -297,7 +357,14 @@ fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, 
             spec.reverse_request_timeout,
         );
         let sleeper = TokioSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, spec.config, &sleeper);
+        // The controls' receiver half is lent to the engine for the turn: the
+        // gate parks each step while `POST /pause` holds, and the steering tap
+        // drains `POST /steer` messages into the transcript at the same
+        // boundary. The sender half stays on the registry entry.
+        let (gate, steering) = control_ports.into_ports();
+        let engine = Engine::with_sleeper(&provider, &tools, spec.config, &sleeper)
+            .with_gate(&gate)
+            .with_steering(&*steering);
 
         // The engine emits `AgentEvent`s; wrap each as a frame for the host. The
         // reverse-RPC request frames bypass this and go straight to `frame_tx`
@@ -339,6 +406,17 @@ fn run_session(spec: SessionSpec, frame_tx: mpsc::UnboundedSender<ServerFrame>, 
             TurnOutcomeWire::Completed { .. } => SettledOutcome::Completed,
             TurnOutcomeWire::Aborted { .. } => SettledOutcome::Aborted,
         };
+        // Settle the owning session BEFORE the terminal frame goes out: the
+        // frame is the host's cue that the turn is over, and a `GET` on the
+        // session issued the moment it arrives must read the written-back
+        // history, not the previous turn's.
+        if let Some(on_settled) = on_settled {
+            on_settled(TurnSettlement {
+                completed: matches!(settled, SettledOutcome::Completed),
+                messages,
+                budget,
+            });
+        }
         let _ = frame_tx.send(ServerFrame::TurnComplete { outcome: wire });
         observer.emit(&ServeEvent::TurnSettled {
             turn,

--- a/stella-serve/src/sessions.rs
+++ b/stella-serve/src/sessions.rs
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Server-owned conversations: the `/v1/sessions` resource (#931).
+//!
+//! Without this, `stella-serve`'s only resource is a single turn, so a host
+//! running a multi-turn interaction re-sends the entire message history on
+//! every create — which makes prompt-cache stability the host's problem,
+//! makes the engine's compaction unreachable, and fragments cost accounting
+//! into unrelated turns. A session moves the transcript to the server side:
+//! the host sends only each turn's new input, and the server threads the one
+//! `Vec<CompletionMessage>` through every turn.
+//!
+//! # What a session is
+//!
+//! A [`SessionEntry`] owns three things between turns:
+//!
+//! - **The history.** Message index 0 is the system prompt, minted once at
+//!   `POST /v1/sessions` and never rewritten — that is the byte-stable prefix
+//!   every provider's cache breakpoint sits behind, and the whole reason a
+//!   server-owned transcript earns the cache discount an API consumer cannot
+//!   get by re-sending messages itself. Compaction needs nothing extra: it
+//!   runs inside `Engine::run_turn`, so threading the same vec through each
+//!   turn is sufficient.
+//! - **The budget guard.** One [`BudgetGuard`] per session, `begin_turn()` at
+//!   each turn, so `session_limit_usd` and `session_spent_usd` finally mean
+//!   what they say — the stateless turn route builds a fresh guard per turn,
+//!   which reduces the session axis to a second turn limit.
+//! - **The counts.** Turns completed and aborted, for `GET /v1/sessions/{id}`.
+//!
+//! A turn *inside* a session is an ordinary turn in the turn registry: it
+//! counts against `MAX_LIVE_TURNS`, streams over `/v1/turns/{id}/events`, and
+//! answers to cancel/steer/pause like any other. The session only decides what
+//! the turn starts from and what happens to what it produced.
+//!
+//! # Checkout, not sharing
+//!
+//! A turn runs on a **clone** of the history and a **copy** of the guard, and
+//! only a `Completed` outcome writes the transcript back. That one decision
+//! carries three properties:
+//!
+//! - `GET` always answers, from the last settled state, even mid-turn — no
+//!   reader ever waits on a running engine.
+//! - An aborted turn leaves the session exactly as it was. This is not just
+//!   tidiness: a hard-cancelled turn can leave a dangling `tool_use` with no
+//!   `tool_result`, and a transcript retaining that pair-break makes the
+//!   *next* model call fail. Discarding the aborted clone is the same posture
+//!   as the CLI's truncate-on-cancel.
+//! - Spend still lands. The settled guard comes back on **every** outcome —
+//!   an aborted turn's tokens were paid for, so its cost joins the session
+//!   total even though its transcript does not.
+//!
+//! # The live-turn token
+//!
+//! One turn at a time per session, enforced by a reservation token rather
+//! than a boolean, because the settle signal can race the reservation: a turn
+//! whose thread could not even be spawned settles (by dropping its hook)
+//! *inside* `register_turn`, before the creating request has resumed. A bare
+//! flag cleared by that early settle would then be re-set by the creator and
+//! wedge the session forever. The token makes every clear conditional on
+//! naming the reservation it ends.
+//!
+//! # Retention
+//!
+//! [`MAX_SESSIONS`] bounds the count, and reclamation is driven by that cap —
+//! the same shape as the turn registry (`server.rs`), for the same reason: a
+//! separate retention ceiling could never bind before the admission cap does.
+//! The difference is what eviction costs. A reclaimed *turn* had already
+//! finished; a reclaimed *session* is a conversation destroyed, its id an
+//! honest `404`. So a session is only evicted under pressure **and** past the
+//! idle deadline ([`crate::server::ServeConfig::session_idle_ttl`]), oldest
+//! idle first, and every eviction is reported. When nothing qualifies, the
+//! create is refused instead — `429` tells the host to `DELETE` what it is
+//! done with, which is recoverable in a way a destroyed transcript is not.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant};
+
+use rand::Rng as _;
+use stella_core::BudgetGuard;
+use stella_protocol::CompletionMessage;
+
+use crate::observe::SharedObserver;
+use crate::observe::event::{ServeEvent, SessionRef};
+use crate::session::{SettleHook, TurnSettlement};
+
+/// Ceiling on retained sessions.
+///
+/// Each one holds a full transcript in memory, so the cap bounds the *count*
+/// of transcripts an authenticated caller can pin (their individual size is
+/// bounded by the engine's own compaction). A `const` rather than a config
+/// field for the same reason as `MAX_LIVE_TURNS`: a host that could raise the
+/// cap could remove it. 64 is twice the live-turn cap — a session is idle
+/// most of its life, so more of them coexist than turns do.
+const MAX_SESSIONS: usize = 64;
+
+/// The session registry: id → retained conversation.
+///
+/// Lock order, where both are ever taken: **sessions map → entry locks**, and
+/// entry locks are only ever taken one at a time (`live` and `core` are
+/// sequential, never nested). The turn registry's lock is never taken while
+/// any of these are held — `routes::handle_session_turn` releases every
+/// session lock before it registers the turn, and `handle_session_delete`
+/// reads the live turn id in its own scope before touching the turn registry.
+pub(crate) struct SessionRegistry {
+    sessions: Mutex<HashMap<String, Arc<SessionEntry>>>,
+    /// Registration order for [`SessionEntry::seq`] — diagnostics only.
+    counter: AtomicU64,
+}
+
+impl SessionRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    fn sessions(&self) -> MutexGuard<'_, HashMap<String, Arc<SessionEntry>>> {
+        self.sessions.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Admit a session and hand back its id, or `None` when the registry is
+    /// full and nothing idle had aged past `idle_ttl`.
+    ///
+    /// Admission, reclamation and insertion happen under one lock hold, the
+    /// same discipline as `ServerState::register_turn` and for the same race.
+    /// Events are emitted after the lock is released — an observer may do I/O.
+    pub(crate) fn register(
+        &self,
+        history: Vec<CompletionMessage>,
+        budget: BudgetGuard,
+        idle_ttl: Duration,
+        observer: &SharedObserver,
+    ) -> Option<String> {
+        let (outcome, reclaimed, live_sessions) = {
+            let mut sessions = self.sessions();
+            let reclaimed = reclaim_idle_expired(&mut sessions, MAX_SESSIONS, idle_ttl);
+            let outcome = if sessions.len() >= MAX_SESSIONS {
+                None
+            } else {
+                let id = new_session_id();
+                let entry = Arc::new(SessionEntry {
+                    seq: self.counter.fetch_add(1, Ordering::Relaxed),
+                    idle_since: Mutex::new(Instant::now()),
+                    live: Mutex::new(None),
+                    next_token: AtomicU64::new(0),
+                    core: Mutex::new(SessionCore {
+                        history,
+                        budget,
+                        turns_completed: 0,
+                        turns_aborted: 0,
+                    }),
+                });
+                sessions.insert(id.clone(), entry);
+                Some(id)
+            };
+            (outcome, reclaimed, sessions.len())
+        };
+        for (id, idle_ms) in reclaimed {
+            observer.emit(&ServeEvent::SessionReclaimed {
+                session: SessionRef::new(&id),
+                idle_ms,
+            });
+        }
+        match &outcome {
+            Some(id) => observer.emit(&ServeEvent::SessionCreated {
+                session: SessionRef::new(id),
+                live_sessions,
+            }),
+            None => observer.emit(&ServeEvent::SessionRefused { live_sessions }),
+        }
+        outcome
+    }
+
+    pub(crate) fn lookup(&self, id: &str) -> Option<Arc<SessionEntry>> {
+        self.sessions().get(id).cloned()
+    }
+
+    /// Remove a session, reporting the deletion. `None` when the id is
+    /// unknown — already deleted, reclaimed, or never real.
+    pub(crate) fn remove(&self, id: &str, observer: &SharedObserver) -> Option<Arc<SessionEntry>> {
+        let (removed, live_sessions) = {
+            let mut sessions = self.sessions();
+            let removed = sessions.remove(id);
+            (removed, sessions.len())
+        };
+        if removed.is_some() {
+            observer.emit(&ServeEvent::SessionDeleted {
+                session: SessionRef::new(id),
+                live_sessions,
+            });
+        }
+        removed
+    }
+}
+
+/// Evict idle-expired sessions, longest idle first, until the registry is
+/// below `target` — or until nothing left qualifies. Returns what was evicted,
+/// for the caller to report outside the lock.
+///
+/// A session qualifies only when no turn is live in it *and* it has sat idle
+/// past `ttl`. Entry locks are taken with `try_lock` because this runs under
+/// the map lock: a contended lock means the session is being used right now,
+/// which is exactly a reason not to reclaim it.
+fn reclaim_idle_expired(
+    sessions: &mut HashMap<String, Arc<SessionEntry>>,
+    target: usize,
+    ttl: Duration,
+) -> Vec<(String, u64)> {
+    if sessions.len() < target {
+        return Vec::new();
+    }
+    let now = Instant::now();
+    let mut expired: Vec<(Duration, String)> = sessions
+        .iter()
+        .filter_map(|(id, entry)| entry.idle_for(now, ttl).map(|idle| (idle, id.clone())))
+        .collect();
+    // Longest idle first: the sessions most plausibly abandoned go first, and
+    // a recently-used one is only taken when nothing older can make room.
+    expired.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    let excess = sessions.len() - target + 1;
+    expired
+        .into_iter()
+        .take(excess)
+        .map(|(idle, id)| {
+            sessions.remove(&id);
+            (id, crate::observe::event::millis(idle))
+        })
+        .collect()
+}
+
+/// One retained conversation.
+pub(crate) struct SessionEntry {
+    /// Registration order. Diagnostics only — eviction is by idle time.
+    #[allow(dead_code)]
+    seq: u64,
+    /// When this session last started or settled a turn. Reads (`GET`) do not
+    /// touch it: observation must not extend a lease, or a dashboard polling
+    /// its sessions would make every one of them immortal.
+    idle_since: Mutex<Instant>,
+    /// The live-turn reservation — see the module docs for why a token.
+    live: Mutex<Option<LiveTurn>>,
+    next_token: AtomicU64,
+    core: Mutex<SessionCore>,
+}
+
+/// The state a session carries between turns.
+struct SessionCore {
+    history: Vec<CompletionMessage>,
+    budget: BudgetGuard,
+    turns_completed: u64,
+    turns_aborted: u64,
+}
+
+struct LiveTurn {
+    token: u64,
+    /// `None` between the reservation and `bind_turn` — the moment where the
+    /// turn id has not been minted yet.
+    turn_id: Option<String>,
+}
+
+/// A read of a session for `GET /v1/sessions/{id}`: always the last settled
+/// state, never blocked on a running turn.
+pub(crate) struct SessionView {
+    pub history: Vec<CompletionMessage>,
+    pub cost_usd: f64,
+    pub turns_completed: u64,
+    pub turns_aborted: u64,
+    pub live_turn: Option<String>,
+}
+
+impl SessionEntry {
+    /// How long this session has been idle beyond `ttl`, or `None` when it is
+    /// live, recently used, or momentarily contended.
+    fn idle_for(&self, now: Instant, ttl: Duration) -> Option<Duration> {
+        let live = match self.live.try_lock() {
+            Ok(live) => live,
+            Err(TryLockError::WouldBlock) => return None,
+            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+        };
+        if live.is_some() {
+            return None;
+        }
+        let idle_since = match self.idle_since.try_lock() {
+            Ok(idle_since) => *idle_since,
+            Err(TryLockError::WouldBlock) => return None,
+            Err(TryLockError::Poisoned(poisoned)) => *poisoned.into_inner(),
+        };
+        let idle = now.saturating_duration_since(idle_since);
+        (idle >= ttl).then_some(idle)
+    }
+
+    fn touch(&self) {
+        *self.idle_since.lock().unwrap_or_else(|p| p.into_inner()) = Instant::now();
+    }
+
+    fn live_lock(&self) -> MutexGuard<'_, Option<LiveTurn>> {
+        self.live.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn core_lock(&self) -> MutexGuard<'_, SessionCore> {
+        self.core.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Reserve the session's one live-turn slot. `None` when a turn is
+    /// already running — the caller answers `409`.
+    pub(crate) fn reserve(&self) -> Option<u64> {
+        let mut live = self.live_lock();
+        if live.is_some() {
+            return None;
+        }
+        let token = self.next_token.fetch_add(1, Ordering::Relaxed);
+        *live = Some(LiveTurn {
+            token,
+            turn_id: None,
+        });
+        self.touch();
+        Some(token)
+    }
+
+    /// The starting state for a reserved turn: the history cloned, and the
+    /// session's guard with its turn axis reset.
+    pub(crate) fn snapshot(&self) -> (Vec<CompletionMessage>, BudgetGuard) {
+        let core = self.core_lock();
+        let mut budget = core.budget;
+        budget.begin_turn();
+        (core.history.clone(), budget)
+    }
+
+    /// Record which turn id the reservation became — unless the turn already
+    /// settled (a spawn failure settles inside `register_turn`, before the
+    /// creator gets here), in which case there is nothing left to name.
+    pub(crate) fn bind_turn(&self, token: u64, turn_id: &str) {
+        let mut live = self.live_lock();
+        if let Some(reserved) = live.as_mut()
+            && reserved.token == token
+        {
+            reserved.turn_id = Some(turn_id.to_string());
+        }
+    }
+
+    /// Give a reservation back without a turn ever existing — registration
+    /// was refused (the turn registry is at capacity).
+    pub(crate) fn release(&self, token: u64) {
+        let mut live = self.live_lock();
+        if live.as_ref().is_some_and(|l| l.token == token) {
+            *live = None;
+        }
+    }
+
+    /// The id of the turn currently running in this session, if any.
+    pub(crate) fn live_turn_id(&self) -> Option<String> {
+        self.live_lock().as_ref().and_then(|l| l.turn_id.clone())
+    }
+
+    /// Read the last settled state — see [`SessionView`].
+    pub(crate) fn view(&self) -> SessionView {
+        let (history, cost_usd, turns_completed, turns_aborted) = {
+            let core = self.core_lock();
+            (
+                core.history.clone(),
+                core.budget.session_spent_usd(),
+                core.turns_completed,
+                core.turns_aborted,
+            )
+        };
+        SessionView {
+            history,
+            cost_usd,
+            turns_completed,
+            turns_aborted,
+            live_turn: self.live_turn_id(),
+        }
+    }
+
+    /// The settlement hook to install on this session's turn
+    /// ([`crate::session::SessionSpec::on_settled`]).
+    ///
+    /// Called → the turn's transcript and spend are folded in. Merely dropped
+    /// (the session thread never ran) → the reservation is released and the
+    /// turn counted aborted, so a spawn failure cannot wedge the session.
+    pub(crate) fn settle_hook(self: &Arc<Self>, token: u64) -> SettleHook {
+        let mut ticket = Ticket {
+            entry: Some(Arc::clone(self)),
+            token,
+        };
+        Box::new(move |settlement| {
+            if let Some(entry) = ticket.entry.take() {
+                entry.settle(ticket.token, settlement);
+            }
+        })
+    }
+
+    /// Fold a settled turn into the session. The guard comes back on every
+    /// outcome (spend is real either way); the transcript only on completion
+    /// (an aborted clone may hold a dangling `tool_use` — see module docs).
+    ///
+    /// The core is written **before** the live slot clears, and the ordering
+    /// is load-bearing: clearing first opens a window where a concurrent
+    /// `POST .../turns` can reserve the freed slot and snapshot the *previous*
+    /// turn's history — losing this one from the next turn's transcript. With
+    /// the core written first, whoever wins the freed slot reads settled
+    /// state. (A host that waits for `turn_complete` never races this — the
+    /// settle also runs before that frame is emitted — but the wire cannot
+    /// make hosts wait.)
+    fn settle(&self, token: u64, settlement: TurnSettlement) {
+        {
+            let mut core = self.core_lock();
+            core.budget = settlement.budget;
+            if settlement.completed {
+                core.history = settlement.messages;
+                core.turns_completed += 1;
+            } else {
+                core.turns_aborted += 1;
+            }
+        }
+        let mut live = self.live_lock();
+        if live.as_ref().is_some_and(|l| l.token == token) {
+            *live = None;
+        }
+        drop(live);
+        self.touch();
+    }
+
+    /// A turn that died without settling — its hook was dropped uncalled.
+    /// Same core-before-live ordering as [`SessionEntry::settle`].
+    fn settle_died(&self, token: u64) {
+        self.core_lock().turns_aborted += 1;
+        let mut live = self.live_lock();
+        if live.as_ref().is_some_and(|l| l.token == token) {
+            *live = None;
+        }
+        drop(live);
+        self.touch();
+    }
+}
+
+/// The drop half of [`SessionEntry::settle_hook`]: if the closure is torn
+/// down without being called, the reservation still ends.
+struct Ticket {
+    entry: Option<Arc<SessionEntry>>,
+    token: u64,
+}
+
+impl Drop for Ticket {
+    fn drop(&mut self) {
+        if let Some(entry) = self.entry.take() {
+            entry.settle_died(self.token);
+        }
+    }
+}
+
+/// Mint a session id that cannot be guessed from another's — same construction
+/// and same reasoning as `new_turn_id` in `server.rs`. Deliberately *not* the
+/// CLI registry's `ses-<ms>-<pid>` format: those ids never leave the machine
+/// and are guessable by design; these are a capability presented over a wire.
+fn new_session_id() -> String {
+    let mut bytes = [0_u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    let mut id = String::with_capacity(8 + 32);
+    id.push_str("session-");
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(id, "{byte:02x}");
+    }
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observe::null_observer;
+    use stella_protocol::BudgetMode;
+
+    fn registry_with_one(idle_ttl: Duration) -> (SessionRegistry, String) {
+        let registry = SessionRegistry::new();
+        let id = registry
+            .register(
+                vec![CompletionMessage::system("sys")],
+                BudgetGuard::new(BudgetMode::Off, None, None),
+                idle_ttl,
+                &null_observer(),
+            )
+            .expect("register");
+        (registry, id)
+    }
+
+    fn settled(completed: bool, messages: Vec<CompletionMessage>) -> TurnSettlement {
+        TurnSettlement {
+            completed,
+            messages,
+            budget: BudgetGuard::new(BudgetMode::Off, None, None),
+        }
+    }
+
+    /// One turn at a time: a second reserve while the first is outstanding is
+    /// refused, and settling frees the slot.
+    #[test]
+    fn a_session_admits_one_live_turn_at_a_time() {
+        let (registry, id) = registry_with_one(Duration::from_secs(3600));
+        let entry = registry.lookup(&id).expect("lookup");
+        let token = entry.reserve().expect("first reserve");
+        assert!(entry.reserve().is_none(), "the slot is single-occupancy");
+        entry.settle(token, settled(true, vec![CompletionMessage::system("sys")]));
+        assert!(entry.reserve().is_some(), "settling frees the slot");
+    }
+
+    /// Only a completed turn rewrites history; an aborted one leaves it — but
+    /// its spend still lands via the returned guard.
+    #[test]
+    fn an_aborted_turn_keeps_the_history_and_the_spend() {
+        let (registry, id) = registry_with_one(Duration::from_secs(3600));
+        let entry = registry.lookup(&id).expect("lookup");
+
+        let token = entry.reserve().expect("reserve");
+        let mut spent = BudgetGuard::new(BudgetMode::Off, None, None);
+        let _ = spent.record_spend(0.25);
+        entry.settle(
+            token,
+            TurnSettlement {
+                completed: false,
+                messages: vec![
+                    CompletionMessage::system("sys"),
+                    CompletionMessage::user("half-finished"),
+                ],
+                budget: spent,
+            },
+        );
+
+        let view = entry.view();
+        assert_eq!(view.history.len(), 1, "an aborted turn writes nothing back");
+        assert_eq!(view.turns_aborted, 1);
+        assert_eq!(view.turns_completed, 0);
+        assert!(
+            (view.cost_usd - 0.25).abs() < f64::EPSILON,
+            "aborted spend is still spend"
+        );
+    }
+
+    /// A hook dropped uncalled — the session thread never ran — must free the
+    /// reservation rather than wedge the session forever.
+    #[test]
+    fn a_dropped_hook_frees_the_reservation() {
+        let (registry, id) = registry_with_one(Duration::from_secs(3600));
+        let entry = registry.lookup(&id).expect("lookup");
+        let token = entry.reserve().expect("reserve");
+        drop(entry.settle_hook(token));
+        assert!(
+            entry.reserve().is_some(),
+            "the reservation must not outlive its dropped hook"
+        );
+        assert_eq!(entry.view().turns_aborted, 1);
+    }
+
+    /// An early settle (before `bind_turn`) must not be resurrected by the
+    /// creator's late bind — the token protocol from the module docs.
+    #[test]
+    fn a_late_bind_after_settle_does_not_wedge_the_session() {
+        let (registry, id) = registry_with_one(Duration::from_secs(3600));
+        let entry = registry.lookup(&id).expect("lookup");
+        let token = entry.reserve().expect("reserve");
+        entry.settle(token, settled(true, vec![CompletionMessage::system("sys")]));
+        entry.bind_turn(token, "turn-dead");
+        assert!(
+            entry.reserve().is_some(),
+            "a bind after settle must find nothing to name"
+        );
+    }
+
+    /// At the cap, an idle-expired session is evicted (longest idle first) —
+    /// and when nothing qualifies, the create is refused instead of taking a
+    /// conversation someone is still using.
+    #[test]
+    fn the_cap_evicts_expired_idle_sessions_and_otherwise_refuses() {
+        let registry = SessionRegistry::new();
+        let observer = null_observer();
+        let budget = || BudgetGuard::new(BudgetMode::Off, None, None);
+        // Fill to the cap with a TTL of zero: everything idle is instantly
+        // expired, so each create past the cap evicts the longest-idle one.
+        for _ in 0..MAX_SESSIONS {
+            assert!(
+                registry
+                    .register(Vec::new(), budget(), Duration::ZERO, &observer)
+                    .is_some()
+            );
+        }
+        assert!(
+            registry
+                .register(Vec::new(), budget(), Duration::ZERO, &observer)
+                .is_some(),
+            "an expired-idle session makes room"
+        );
+        // With an infinite TTL nothing qualifies, so the cap refuses.
+        assert!(
+            registry
+                .register(Vec::new(), budget(), Duration::MAX, &observer)
+                .is_none(),
+            "no eviction of sessions inside their idle window"
+        );
+    }
+
+    /// A session with a live turn is never reclaimed, whatever its age.
+    #[test]
+    fn a_live_session_is_never_reclaimed() {
+        let registry = SessionRegistry::new();
+        let observer = null_observer();
+        let budget = || BudgetGuard::new(BudgetMode::Off, None, None);
+        let mut ids = Vec::new();
+        for _ in 0..MAX_SESSIONS {
+            ids.push(
+                registry
+                    .register(Vec::new(), budget(), Duration::ZERO, &observer)
+                    .expect("register"),
+            );
+        }
+        // Every session holds a live reservation: all expired by TTL, none
+        // reclaimable.
+        let entries: Vec<_> = ids
+            .iter()
+            .map(|id| registry.lookup(id).expect("lookup"))
+            .collect();
+        for entry in &entries {
+            entry.reserve().expect("reserve");
+        }
+        assert!(
+            registry
+                .register(Vec::new(), budget(), Duration::ZERO, &observer)
+                .is_none(),
+            "a running conversation must never be evicted"
+        );
+    }
+}

--- a/stella-serve/tests/bridge.rs
+++ b/stella-serve/tests/bridge.rs
@@ -68,6 +68,7 @@ fn spec_for(prompt: &str) -> SessionSpec {
         reverse_request_timeout: SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT,
         turn: TurnRef::new("turn-bridgetest0"),
         observer: stella_serve::observe::null_observer(),
+        on_settled: None,
     }
 }
 

--- a/stella-serve/tests/common/mod.rs
+++ b/stella-serve/tests/common/mod.rs
@@ -81,6 +81,7 @@ pub async fn start_observed_server_with(resume_grace: Duration) -> (SocketAddr, 
             observer: fanout,
             metrics,
             resume_grace,
+            session_idle_ttl: stella_serve::DEFAULT_SESSION_IDLE_TTL,
         };
         let _ = serve(config, move |addr| {
             let _ = tx.send(addr);

--- a/stella-serve/tests/control.rs
+++ b/stella-serve/tests/control.rs
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-turn controls over the wire (#932): steer, pause, resume.
+//!
+//! The engine has modeled all three since the CLI grew them; these tests pin
+//! that the HTTP surface actually reaches them — and, most importantly, that
+//! the combinations that used to be able to wedge an OS thread (paused +
+//! cancelled) unwind instead. Every await that would hang on a regression is
+//! bounded by an explicit timeout so a failure reads as an assertion, not as
+//! a stuck suite.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{
+    TOKEN, create_turn, model_result, model_wants_echo, next_event, open_sse, post_json,
+    start_observed_server_with, start_server,
+};
+use serde_json::json;
+use stella_serve::observe::ServeEvent;
+
+/// Answer the parked provider request `request_id` with `result`.
+async fn answer_provider(
+    addr: std::net::SocketAddr,
+    turn_id: &str,
+    request_id: &str,
+    result: serde_json::Value,
+) {
+    let body = json!({ "request_id": request_id, "status": "ok", "result": result }).to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &body,
+    )
+    .await;
+    assert!(status.contains("200"), "provider-result: {status} {body}");
+}
+
+/// Answer the parked tool request `request_id` with a canned success.
+async fn answer_tool(addr: std::net::SocketAddr, turn_id: &str, request_id: &str) {
+    let body = json!({
+        "request_id": request_id,
+        "output": { "ok": { "content": "echoed" } },
+    })
+    .to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/tool-result"),
+        Some(TOKEN),
+        &body,
+    )
+    .await;
+    assert!(status.contains("200"), "tool-result: {status} {body}");
+}
+
+/// Read frames until the next `provider_request`, returning it.
+async fn next_provider_request(
+    reader: &mut tokio::io::BufReader<tokio::net::TcpStream>,
+) -> serde_json::Value {
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(reader))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end while a provider_request is owed");
+        if frame["type"] == "provider_request" {
+            return frame;
+        }
+    }
+}
+
+/// A turn with a tool, so it runs at least two steps and therefore crosses at
+/// least one step boundary — the place steer and pause act.
+async fn create_tool_turn(addr: std::net::SocketAddr) -> String {
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [common::echo_tool()],
+        "messages": [{ "role": "user", "content": "hi" }],
+        "reverse_request_timeout_ms": 20_000,
+    })
+    .to_string();
+    let (status, body) = post_json(addr, "/v1/turns", Some(TOKEN), &create).await;
+    assert!(status.contains("200"), "create: {status} {body}");
+    serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// The acceptance line of #932's steering half: a message POSTed mid-turn is
+/// injected at the next step boundary — it reaches the model's next request
+/// and is echoed on the event stream as `steered` — without the turn being
+/// cancelled or the transcript lost.
+#[tokio::test]
+async fn a_steer_lands_in_the_next_model_request_and_echoes_on_the_stream() {
+    let addr = start_server().await;
+    let turn_id = create_tool_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    // Step 1 is parked on its model call. Steer now: the queue drains at the
+    // *next* boundary, i.e. before step 2's model call.
+    let first = next_provider_request(&mut sse).await;
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/steer"),
+        Some(TOKEN),
+        &json!({ "message": "actually, skip the migration" }).to_string(),
+    )
+    .await;
+    assert!(status.contains("200"), "steer: {status} {body}");
+
+    // Finish step 1 with a tool call so a step 2 exists.
+    answer_provider(
+        addr,
+        &turn_id,
+        first["request_id"].as_str().unwrap(),
+        model_wants_echo(),
+    )
+    .await;
+    let tool = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a tool_request must arrive")
+            .expect("stream must not end before the tool_request");
+        if frame["type"] == "tool_request" {
+            break frame;
+        }
+    };
+    answer_tool(addr, &turn_id, tool["request_id"].as_str().unwrap()).await;
+
+    // Step 2's model call must see the steered message in its transcript.
+    let second = next_provider_request(&mut sse).await;
+    let messages = second["request"]["messages"].as_array().unwrap();
+    assert!(
+        messages
+            .iter()
+            .any(|m| { m["role"] == "user" && m["content"] == "actually, skip the migration" }),
+        "the steered message must reach the next model request: {messages:?}"
+    );
+
+    // Let the turn finish, collecting the remaining frames: the `steered`
+    // echo must be among the events the stream delivered.
+    answer_provider(
+        addr,
+        &turn_id,
+        second["request_id"].as_str().unwrap(),
+        model_result("done"),
+    )
+    .await;
+    let mut saw_steered = false;
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the stream must reach its terminal frame");
+        let Some(frame) = frame else { break };
+        if frame["type"] == "event" && frame["event"]["type"] == "steered" {
+            assert_eq!(frame["event"]["text"], "actually, skip the migration");
+            saw_steered = true;
+        }
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "completed");
+            break;
+        }
+    }
+    assert!(
+        saw_steered,
+        "the host must see its steer echoed as an event"
+    );
+}
+
+/// Pause holds the turn at its next step boundary — no further model call is
+/// dispatched — and resume releases exactly the same turn.
+#[tokio::test]
+async fn a_paused_turn_holds_at_the_boundary_until_resumed() {
+    let addr = start_server().await;
+    let turn_id = create_tool_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let first = next_provider_request(&mut sse).await;
+    let (status, _) = post_json(addr, &format!("/v1/turns/{turn_id}/pause"), Some(TOKEN), "").await;
+    assert!(status.contains("200"), "pause: {status}");
+
+    // Finish step 1; step 2 must then park on the gate instead of asking for
+    // its model call.
+    answer_provider(
+        addr,
+        &turn_id,
+        first["request_id"].as_str().unwrap(),
+        model_wants_echo(),
+    )
+    .await;
+    let tool = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a tool_request must arrive")
+            .expect("stream must not end before the tool_request");
+        if frame["type"] == "tool_request" {
+            break frame;
+        }
+    };
+    answer_tool(addr, &turn_id, tool["request_id"].as_str().unwrap()).await;
+
+    // While paused, whatever else the stream delivers (step events from the
+    // settled step), no provider_request may appear.
+    let held_until = tokio::time::Instant::now() + Duration::from_millis(300);
+    loop {
+        let remaining = held_until.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, next_event(&mut sse)).await {
+            Err(_) => break, // quiet — exactly what paused should look like
+            Ok(Some(frame)) => assert_ne!(
+                frame["type"], "provider_request",
+                "a paused turn must not dispatch a model call"
+            ),
+            Ok(None) => panic!("the stream must not end while the turn is paused"),
+        }
+    }
+
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/resume"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("200"), "resume: {status}");
+
+    // The released turn continues: step 2's model call arrives, and the turn
+    // can complete normally.
+    let second = next_provider_request(&mut sse).await;
+    answer_provider(
+        addr,
+        &turn_id,
+        second["request_id"].as_str().unwrap(),
+        model_result("done"),
+    )
+    .await;
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the stream must reach its terminal frame")
+            .expect("the terminal frame must arrive");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "completed");
+            break;
+        }
+    }
+}
+
+/// The liveness invariant from `stella-serve/src/controls.rs`: a cancel must
+/// release the pause gate, or a paused-then-cancelled turn parks its OS
+/// thread forever. This test hangs (and fails on its timeouts) if that
+/// release is ever lost.
+#[tokio::test]
+async fn a_paused_turn_can_still_be_cancelled() {
+    let addr = start_server().await;
+    let turn_id = create_tool_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    let first = next_provider_request(&mut sse).await;
+    let (status, _) = post_json(addr, &format!("/v1/turns/{turn_id}/pause"), Some(TOKEN), "").await;
+    assert!(status.contains("200"), "pause: {status}");
+
+    // Drive the turn to the boundary so it is genuinely parked on the gate,
+    // not on a reverse request.
+    answer_provider(
+        addr,
+        &turn_id,
+        first["request_id"].as_str().unwrap(),
+        model_wants_echo(),
+    )
+    .await;
+    let tool = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a tool_request must arrive")
+            .expect("stream must not end before the tool_request");
+        if frame["type"] == "tool_request" {
+            break frame;
+        }
+    };
+    answer_tool(addr, &turn_id, tool["request_id"].as_str().unwrap()).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/cancel"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("200"), "cancel: {status}");
+
+    // The cancelled turn must unwind to its terminal frame despite the pause.
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a paused turn must still unwind after cancel — the gate was not released")
+            .expect("the terminal frame must arrive");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "aborted");
+            break;
+        }
+    }
+}
+
+/// The control endpoints answer honestly at the edges: unknown turns are 404,
+/// an empty steer is 400, and pause/resume are idempotent.
+#[tokio::test]
+async fn control_endpoints_answer_honestly_at_the_edges() {
+    let addr = start_server().await;
+
+    for path in ["steer", "pause", "resume"] {
+        let (status, _) = post_json(
+            addr,
+            &format!("/v1/turns/turn-doesnotexist/{path}"),
+            Some(TOKEN),
+            &json!({ "message": "x" }).to_string(),
+        )
+        .await;
+        assert!(status.contains("404"), "{path} on unknown turn: {status}");
+    }
+
+    let turn_id = create_turn(addr).await;
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/steer"),
+        Some(TOKEN),
+        &json!({ "message": "" }).to_string(),
+    )
+    .await;
+    assert!(status.contains("400"), "empty steer: {status}");
+
+    for _ in 0..2 {
+        let (status, _) =
+            post_json(addr, &format!("/v1/turns/{turn_id}/pause"), Some(TOKEN), "").await;
+        assert!(status.contains("200"), "pause is idempotent: {status}");
+    }
+    for _ in 0..2 {
+        let (status, _) = post_json(
+            addr,
+            &format!("/v1/turns/{turn_id}/resume"),
+            Some(TOKEN),
+            "",
+        )
+        .await;
+        assert!(status.contains("200"), "resume is idempotent: {status}");
+    }
+
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/cancel"),
+        Some(TOKEN),
+        "",
+    )
+    .await;
+    assert!(status.contains("200"), "cleanup cancel: {status}");
+}
+
+/// A turn that already finished refuses controls with `409` rather than
+/// accepting a steer that can never be drained — silence is the failure mode
+/// this crate keeps being fixed for.
+#[tokio::test]
+async fn steering_a_finished_turn_is_a_conflict_not_a_silent_no_op() {
+    // A wide resume window keeps the finished session parked in its entry
+    // (rather than reaped) while the assertions below run.
+    let (addr, capture) = start_observed_server_with(Duration::from_secs(30)).await;
+    let turn_id = create_turn(addr).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let first = next_provider_request(&mut sse).await;
+
+    // Disconnect, then finish the turn while nobody is streaming: the session
+    // settles and is parked back into its entry, finished.
+    drop(sse);
+    common::await_parked_after_disconnect(&capture).await;
+    answer_provider(
+        addr,
+        &turn_id,
+        first["request_id"].as_str().unwrap(),
+        model_result("done"),
+    )
+    .await;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while capture
+        .find(|e| matches!(e, ServeEvent::TurnSettled { .. }))
+        .is_none()
+    {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the answered turn must settle"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    for (path, body) in [
+        ("steer", json!({ "message": "too late" }).to_string()),
+        ("pause", String::new()),
+        ("resume", String::new()),
+    ] {
+        let (status, body) = post_json(
+            addr,
+            &format!("/v1/turns/{turn_id}/{path}"),
+            Some(TOKEN),
+            &body,
+        )
+        .await;
+        assert!(
+            status.contains("409"),
+            "{path} on a finished turn: {status} {body}"
+        );
+    }
+}

--- a/stella-serve/tests/sessions.rs
+++ b/stella-serve/tests/sessions.rs
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Server-owned conversations over the wire (#931).
+//!
+//! The acceptance line of the issue, verbatim: a host can run a multi-turn
+//! conversation without re-sending history, gets the prompt-cache discount the
+//! CLI gets (pinned here as a byte-identical system prefix across turns), and
+//! sees one aggregated cost for the session. Plus the composition that makes
+//! #932 worth having: a turn inside a session answers to steer like any other
+//! turn, and what the steer injected is *retained* in the session history.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{TOKEN, model_result, model_wants_echo, next_event, open_sse, post_json};
+use serde_json::json;
+
+async fn create_session(addr: std::net::SocketAddr, system_prompt: &str) -> String {
+    let (status, body) = post_json(
+        addr,
+        "/v1/sessions",
+        Some(TOKEN),
+        &json!({ "system_prompt": system_prompt }).to_string(),
+    )
+    .await;
+    assert!(status.contains("200"), "create session: {status} {body}");
+    serde_json::from_str::<serde_json::Value>(&body).unwrap()["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Start the next turn of a session with one user message, returning its
+/// turn id.
+async fn create_session_turn(
+    addr: std::net::SocketAddr,
+    session_id: &str,
+    prompt: &str,
+    tools: bool,
+) -> String {
+    let tools = if tools {
+        json!([common::echo_tool()])
+    } else {
+        json!([])
+    };
+    let create = json!({
+        "provider_id": "mock",
+        "tools": tools,
+        "input": [{ "role": "user", "content": prompt }],
+        "reverse_request_timeout_ms": 20_000,
+    })
+    .to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/sessions/{session_id}/turns"),
+        Some(TOKEN),
+        &create,
+    )
+    .await;
+    assert!(status.contains("200"), "create turn: {status} {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(created["session_id"], session_id);
+    created["turn_id"].as_str().unwrap().to_string()
+}
+
+async fn get_session(addr: std::net::SocketAddr, session_id: &str) -> serde_json::Value {
+    let (status, body) =
+        common::get_json_authed(addr, &format!("/v1/sessions/{session_id}"), TOKEN).await;
+    assert!(status.contains("200"), "get session: {status} {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+/// Stream a session turn to completion, answering its single model call with
+/// `result`. Returns the messages array of the model request — the transcript
+/// the engine actually sent — and asserts the turn completed.
+async fn run_turn_to_completion(
+    addr: std::net::SocketAddr,
+    turn_id: &str,
+    result: serde_json::Value,
+) -> Vec<serde_json::Value> {
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let request = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end before the provider_request");
+        if frame["type"] == "provider_request" {
+            break frame;
+        }
+    };
+    let messages = request["request"]["messages"].as_array().unwrap().clone();
+    let body = json!({
+        "request_id": request["request_id"],
+        "status": "ok",
+        "result": result,
+    })
+    .to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &body,
+    )
+    .await;
+    assert!(status.contains("200"), "provider-result: {status} {body}");
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the terminal frame must arrive")
+            .expect("the stream must reach turn_complete");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "completed");
+            break;
+        }
+    }
+    messages
+}
+
+/// Issue #931's acceptance, end to end: two turns, no history re-sent, the
+/// system prefix byte-identical across both model calls, and the session
+/// aggregating cost across turns.
+#[tokio::test]
+async fn a_session_threads_history_across_turns_on_a_stable_prefix() {
+    let addr = common::start_server().await;
+    let session_id = create_session(addr, "You are stella.").await;
+
+    let turn1 = create_session_turn(addr, &session_id, "hi", false).await;
+    let result = json!({
+        "text": "hello!",
+        "usage": { "input_tokens": 0, "output_tokens": 0 },
+        "model": "mock",
+        "cost_usd": 0.25,
+    });
+    let messages1 = run_turn_to_completion(addr, &turn1, result.clone()).await;
+    assert_eq!(
+        messages1
+            .first()
+            .map(|m| (m["role"].clone(), m["content"].clone())),
+        Some((json!("system"), json!("You are stella."))),
+        "the session's system prompt heads the first turn"
+    );
+
+    // The second turn sends only its new input; the server supplies the rest.
+    let turn2 = create_session_turn(addr, &session_id, "and again", false).await;
+    let messages2 = run_turn_to_completion(addr, &turn2, result).await;
+
+    assert_eq!(
+        serde_json::to_string(&messages1[0]).unwrap(),
+        serde_json::to_string(&messages2[0]).unwrap(),
+        "the system prefix must be byte-identical across turns — that is the \
+         prompt-cache contract the session exists to keep"
+    );
+    let flat: Vec<(String, String)> = messages2
+        .iter()
+        .map(|m| {
+            (
+                m["role"].as_str().unwrap_or_default().to_string(),
+                m["content"].as_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        flat,
+        vec![
+            ("system".into(), "You are stella.".into()),
+            ("user".into(), "hi".into()),
+            ("assistant".into(), "hello!".into()),
+            ("user".into(), "and again".into()),
+        ],
+        "turn 2 must start from turn 1's full settled transcript plus its own input"
+    );
+
+    let session = get_session(addr, &session_id).await;
+    assert_eq!(session["turns_completed"], 2);
+    assert_eq!(session["turns_aborted"], 0);
+    assert!(
+        (session["cost_usd"].as_f64().unwrap() - 0.5).abs() < 1e-9,
+        "two 0.25 turns must aggregate to one 0.50 session: {}",
+        session["cost_usd"]
+    );
+    assert!(session["live_turn"].is_null());
+    assert_eq!(
+        session["messages"].as_array().unwrap().len(),
+        5,
+        "system + (user, assistant) x2"
+    );
+}
+
+/// An aborted turn must leave the session history exactly as it was — a
+/// cancelled turn can hold a dangling `tool_use` that would poison the next
+/// model call — while its spend still joins the session total.
+#[tokio::test]
+async fn an_aborted_turn_leaves_the_history_untouched() {
+    let addr = common::start_server().await;
+    let session_id = create_session(addr, "sys").await;
+
+    let turn1 = create_session_turn(addr, &session_id, "hi", false).await;
+    run_turn_to_completion(addr, &turn1, model_result("ok")).await;
+    let settled = get_session(addr, &session_id).await;
+    let settled_len = settled["messages"].as_array().unwrap().len();
+
+    // Turn 2: park on its model call, then cancel it mid-flight.
+    let turn2 = create_session_turn(addr, &session_id, "risky", false).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn2}/events"), TOKEN).await;
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "provider_request" {
+            break;
+        }
+    }
+    let (status, _) = post_json(addr, &format!("/v1/turns/{turn2}/cancel"), Some(TOKEN), "").await;
+    assert!(status.contains("200"), "cancel: {status}");
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the aborted terminal frame must arrive")
+            .expect("the stream must reach turn_complete");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "aborted");
+            break;
+        }
+    }
+
+    let after = get_session(addr, &session_id).await;
+    assert_eq!(after["turns_completed"], 1);
+    assert_eq!(after["turns_aborted"], 1);
+    assert_eq!(
+        after["messages"].as_array().unwrap().len(),
+        settled_len,
+        "an aborted turn must not write back a transcript"
+    );
+    assert!(
+        after["live_turn"].is_null(),
+        "the aborted turn must release the session's live slot"
+    );
+}
+
+/// One live turn per session: a concurrent second turn is `409`, and the slot
+/// frees once the first settles.
+#[tokio::test]
+async fn a_session_admits_one_turn_at_a_time_over_the_wire() {
+    let addr = common::start_server().await;
+    let session_id = create_session(addr, "sys").await;
+
+    let turn1 = create_session_turn(addr, &session_id, "hi", false).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn1}/events"), TOKEN).await;
+    let request = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "provider_request" {
+            break frame;
+        }
+    };
+
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/sessions/{session_id}/turns"),
+        Some(TOKEN),
+        &json!({
+            "provider_id": "mock",
+            "input": [{ "role": "user", "content": "impatient" }],
+        })
+        .to_string(),
+    )
+    .await;
+    assert!(status.contains("409"), "concurrent turn: {status} {body}");
+
+    // The session reports its live turn — the handle a reconnecting host
+    // needs to rejoin the stream.
+    let session = get_session(addr, &session_id).await;
+    assert_eq!(session["live_turn"], turn1.as_str());
+
+    // Settle turn 1; the slot must free.
+    let answer = json!({
+        "request_id": request["request_id"],
+        "status": "ok",
+        "result": model_result("done"),
+    })
+    .to_string();
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn1}/provider-result"),
+        Some(TOKEN),
+        &answer,
+    )
+    .await;
+    assert!(status.contains("200"));
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the terminal frame must arrive")
+            .expect("the stream must reach turn_complete");
+        if frame["type"] == "turn_complete" {
+            break;
+        }
+    }
+    let turn2 = create_session_turn(addr, &session_id, "next", false).await;
+    assert_ne!(turn1, turn2);
+    let (status, _) = post_json(addr, &format!("/v1/turns/{turn2}/cancel"), Some(TOKEN), "").await;
+    assert!(status.contains("200"), "cleanup cancel: {status}");
+}
+
+/// The resource behaves like one: unknown ids are 404, deletion is terminal,
+/// empty input is refused, and deleting a session cancels its live turn.
+#[tokio::test]
+async fn sessions_are_resources_with_honest_edges() {
+    let addr = common::start_server().await;
+
+    let (status, _) = common::get_json_authed(addr, "/v1/sessions/session-nope", TOKEN).await;
+    assert!(status.contains("404"), "get unknown: {status}");
+
+    let session_id = create_session(addr, "sys").await;
+
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/sessions/{session_id}/turns"),
+        Some(TOKEN),
+        &json!({ "provider_id": "mock", "input": [] }).to_string(),
+    )
+    .await;
+    assert!(status.contains("400"), "empty input: {status} {body}");
+
+    // A live turn, then DELETE: the session vanishes and the turn is
+    // cancelled exactly as `POST /v1/turns/{id}/cancel` would.
+    let turn_id = create_session_turn(addr, &session_id, "hi", false).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "provider_request" {
+            break;
+        }
+    }
+
+    let mut delete = tokio::net::TcpStream::connect(addr).await.unwrap();
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let request = format!(
+        "DELETE /v1/sessions/{session_id} HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nConnection: close\r\n\r\n"
+    );
+    delete.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    delete.read_to_string(&mut response).await.unwrap();
+    assert!(response.contains("200"), "delete: {response}");
+
+    // The cancelled turn unwinds to its aborted terminal frame.
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the aborted terminal frame must arrive")
+            .expect("the stream must reach turn_complete");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "aborted");
+            break;
+        }
+    }
+
+    let (status, _) =
+        common::get_json_authed(addr, &format!("/v1/sessions/{session_id}"), TOKEN).await;
+    assert!(status.contains("404"), "get after delete: {status}");
+}
+
+/// `/v1/sessions/{id}` is the API's first two-verb resource: a wrong method
+/// must name *both* verbs in `Allow`, per RFC 9110 §15.5.6.
+#[tokio::test]
+async fn the_session_member_route_names_both_its_verbs_on_405() {
+    let addr = common::start_server().await;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let request = format!(
+        "POST /v1/sessions/session-abc HTTP/1.1\r\nHost: engine\r\nAuthorization: Bearer {TOKEN}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    assert!(response.contains("405"), "wrong method: {response}");
+    let head = response.split("\r\n\r\n").next().unwrap_or_default();
+    assert!(
+        head.to_ascii_lowercase().contains("allow: get, delete"),
+        "a two-verb resource must name both (RFC 9110 §15.5.6): {head}"
+    );
+}
+
+/// #931 and #932 compose: a steer posted against a session's turn is not only
+/// injected into the running turn — it is *retained*, because the settled
+/// transcript the session keeps is the one the steer landed in.
+#[tokio::test]
+async fn a_steered_session_turn_retains_the_injected_message() {
+    let addr = common::start_server().await;
+    let session_id = create_session(addr, "sys").await;
+    let turn_id = create_session_turn(addr, &session_id, "start", true).await;
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+
+    // Park on step 1's model call, steer, then answer with a tool call so a
+    // second step exists for the steer to land in.
+    let first = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a provider_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "provider_request" {
+            break frame;
+        }
+    };
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/steer"),
+        Some(TOKEN),
+        &json!({ "message": "actually, skip the migration" }).to_string(),
+    )
+    .await;
+    assert!(status.contains("200"), "steer: {status}");
+    let answer = json!({
+        "request_id": first["request_id"],
+        "status": "ok",
+        "result": model_wants_echo(),
+    })
+    .to_string();
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &answer,
+    )
+    .await;
+    assert!(status.contains("200"));
+
+    let tool = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("a tool_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "tool_request" {
+            break frame;
+        }
+    };
+    let answer = json!({
+        "request_id": tool["request_id"],
+        "output": { "ok": { "content": "echoed" } },
+    })
+    .to_string();
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/tool-result"),
+        Some(TOKEN),
+        &answer,
+    )
+    .await;
+    assert!(status.contains("200"));
+
+    let second = loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("step 2's provider_request must arrive")
+            .expect("stream must not end early");
+        if frame["type"] == "provider_request" {
+            break frame;
+        }
+    };
+    let answer = json!({
+        "request_id": second["request_id"],
+        "status": "ok",
+        "result": model_result("done"),
+    })
+    .to_string();
+    let (status, _) = post_json(
+        addr,
+        &format!("/v1/turns/{turn_id}/provider-result"),
+        Some(TOKEN),
+        &answer,
+    )
+    .await;
+    assert!(status.contains("200"));
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the terminal frame must arrive")
+            .expect("the stream must reach turn_complete");
+        if frame["type"] == "turn_complete" {
+            assert_eq!(frame["outcome"]["status"], "completed");
+            break;
+        }
+    }
+
+    let session = get_session(addr, &session_id).await;
+    assert!(
+        session["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|m| { m["role"] == "user" && m["content"] == "actually, skip the migration" }),
+        "the steered message must be retained in the session history: {}",
+        session["messages"]
+    );
+}


### PR DESCRIPTION
Builds #931 and the steer/pause halves of #932 in one branch, in the order the issues themselves suggested: sessions first, controls on top.

## `/v1/sessions` — server-owned conversations (#931)

The whole gap was one dropped variable: `run_session` ran each turn on a `Vec<CompletionMessage>` and threw the mutated vec away. A session keeps it.

- `POST /v1/sessions` (`{system_prompt, budget}`) → `{"session_id":"session-<32 hex>"}`. The system prompt is minted **once** here and held byte-identical for every turn — the prompt-cache stability contract. (The CLI's `restore_messages` re-mints index 0 on resume; that is deliberately *not* imitated, since a hot server session must not break its own prefix.)
- `POST /v1/sessions/{id}/turns` — the stateless turn semantics minus `messages` (the session owns history) and minus `budget` (the session owns one `BudgetGuard`, `begin_turn()` per turn, so `session_limit_usd`/`session_spent_usd` finally bind across turns). The host sends only `input`. The turn it returns is an **ordinary member of `/v1/turns/{id}`** — events, results, cancel, steer, pause all work on it, and `MAX_LIVE_TURNS` stays on turns.
- `GET /v1/sessions/{id}` — history, aggregated cost (aborted turns included), turn counts, live turn id. Always answers from the last settled state, never blocked on a running engine.
- `DELETE /v1/sessions/{id}` — ends the session and cancels its live turn.

**Checkout, not sharing:** a turn runs on a clone of the history and only a `Completed` outcome writes back. An aborted turn leaves the session exactly as it was — the same posture as the CLI's truncate-on-cancel, and what keeps a hard-cancelled turn's dangling `tool_use` from poisoning the next model call — while its spend still lands via the returned guard. One turn at a time per session, enforced with a reservation token rather than a boolean because a spawn-failed turn settles *inside* `register_turn`, before the creating request resumes; a bare flag would be re-set by the creator and wedge the session forever.

**Retention** follows the turn registry's model: a hard cap (`MAX_SESSIONS = 64`), reclamation driven by that cap, every eviction reported. The difference: evicting a session destroys a conversation, so it only happens under pressure *and* past `ServeConfig::session_idle_ttl` (default 1 h), longest-idle first; otherwise the create is refused with `429` — recoverable in a way a destroyed transcript is not.

Compaction needed nothing: it runs inside `Engine::run_turn`, so threading the same vec through each turn is sufficient.

## Steer / pause / resume (#932)

`TurnGate` and `TurnSteering` (which live in `stella-core::ports`, not `stella-pipeline` as the issue guessed) were simply never injected by serve. The `Session` object is exclusively owned by whichever SSE stream is running, so the controls follow the `Pending` pattern: a cloneable `Send` handle on the registry `Entry` (`src/controls.rs`), with the receiver half crossing onto the engine thread.

- `POST /v1/turns/{id}/steer` (`{"message": …}`) — injected at the next step boundary, echoed on the stream as a `steered` event. `409` on a turn known to have finished, rather than a silently-undrainable queue.
- `POST /v1/turns/{id}/pause` / `/resume` — hold/release at step granularity, never mid-tool. Idempotent.

One liveness invariant does the heavy lifting: **every cancel path also releases the gate.** The engine re-checks its cancel latch only after `wait_if_paused` returns, so a paused-then-cancelled turn would otherwise park its OS thread forever. `handle_cancel`, `Session::cancel`, and `Drop for Session` all release explicitly, and `PauseGate` reads a dropped sender as *resumed* (which is also why the engine thread must never hold its own gate's sender). `tests/control.rs::a_paused_turn_can_still_be_cancelled` hangs on its timeouts if this is ever lost.

Because session turns are ordinary turns, the two features compose: `tests/sessions.rs::a_steered_session_turn_retains_the_injected_message` pins that a steer against a session turn is *retained* in the session history.

## The approval gate (#932's third piece) is deliberately not here

`ScopeReviewRequiredHeadless` / `ApprovalGate` live in `stella-pipeline`, which `stella-serve` neither links nor drives — serve runs the bare `stella_core::Engine`, and **no HTTP code path can raise a scope review today**. An `/approve` endpoint would be a dead surface. Making it real means serve driving a pipeline-shaped session (its own increment, on top of the sessions this PR adds — which is where a disconnect-surviving approval boundary would durably live). Written up on #932.

## Wire & docs

- No `ServerFrame` changes — `steered` rides the existing `event` frame, so `docs/wire/` is untouched and `make wire-schema` passes as-is.
- New `Route` variants, `ServeEvent::Session{Created,Refused,Deleted,Reclaimed}`, session counters in `/v1/metrics` (fold-derived, per the observability design).
- `docs/design/serve-surface.md`'s "as built" table updated; the `/v1/sessions` family is no longer aspirational.

## Tests

- `tests/sessions.rs` (6): the issue's acceptance end-to-end — two turns, no history re-sent, **byte-identical system prefix across turns**, aggregated cost; abort-leaves-history-untouched; one-turn-at-a-time; resource edges incl. the API's first two-verb `Allow` header; steer-retention composition.
- `tests/control.rs` (5): steer reaches the next model request and echoes as `steered`; pause holds at the boundary until resume; **paused turns can still be cancelled**; edge codes; finished turns refuse controls with `409`.
- Unit tests in `src/sessions.rs` (token protocol, retention) and `src/controls.rs` (gate park/release, dropped-sender-means-resumed).

Closes #931. Closes the steering and pause halves of #932 (approval boundary written up there, not closed).

## Summary by Sourcery

Add server-owned session support and mid-turn control endpoints to the serve HTTP surface, including steering, pause/resume, and observability for sessions.

New Features:
- Introduce `/v1/sessions` APIs for creating, running turns in, inspecting, and deleting server-owned conversations with retained history and per-session budgeting.
- Expose mid-turn control endpoints `/v1/turns/{id}/steer`, `/pause`, and `/resume` to inject messages and pause/resume running turns.

Enhancements:
- Integrate session lifecycle, retention, and live-turn coordination into the server state with configurable idle TTL and metrics for session activity.
- Wire mid-turn controls into the engine via a new controls bridge so paused turns can be safely cancelled and steering is reflected in transcripts and events.
- Extend observability routes, events, and metrics to track new session and control routes and ensure finished turns reject further controls.

Documentation:
- Update serve surface design documentation to describe the new sessions resource, mid-turn steering/pause/resume behavior, and clarify current built surface.

Tests:
- Add end-to-end tests for session behavior over HTTP, including history threading, cost aggregation, abort semantics, one-turn-at-a-time, and composition with steering.
- Add control tests to validate steer injection timing, pause/resume behavior, cancel-on-pause liveness invariants, edge responses, and conflicts on finished turns.