### PR TITLE
fix(verify): attribute shell writes, and stop the judge passing on its own word

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -34,7 +34,7 @@
 2234 stella-store/src/tests.rs
 1892 stella-store/src/usage.rs
 1569 stella-tools/src/media.rs
-3434 stella-tools/src/registry.rs
+3565 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1745 stella-tui/src/deck_render.rs
 3888 stella-tui/src/deck_ui.rs

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,7 +27,7 @@
 1785 stella-model/src/bedrock.rs
 1955 stella-model/src/openai.rs
 1723 stella-model/src/zai/tests.rs
-3146 stella-pipeline/src/pipeline.rs
+3173 stella-pipeline/src/pipeline.rs
 2392 stella-pipeline/src/pipeline/tests.rs
 2752 stella-protocol/src/event.rs
 2074 stella-store/src/lib.rs

--- a/stella-pipeline/src/pipeline.rs
+++ b/stella-pipeline/src/pipeline.rs
@@ -2399,6 +2399,33 @@ impl<'a> Pipeline<'a> {
                         evidence: evidence.clone(),
                     });
                     if verdict.passed {
+                        // Asymmetric trust (#871). "Not yet" from a judge is
+                        // cheap to be wrong about — it buys one more revision.
+                        // "Done" ends the run, so it has to be corroborated by
+                        // something that is not another model's opinion.
+                        //
+                        // Unsupported, the pass is recorded as UNVERIFIED, not
+                        // as a failure. The distinction is load-bearing: a
+                        // Terminal-Bench trial that solved its task through
+                        // shell redirects and scored 1.0 against its own
+                        // verifier reaches exactly this state, and failing it
+                        // closed would report a correct run as broken. The
+                        // `Unverified` score keeps it from tying a genuinely
+                        // verified sibling in best-of-N.
+                        if inputs.judge_pass_stands_alone() {
+                            let mut abstained = evidence.clone();
+                            abstained.summary = format!(
+                                "UNVERIFIED: judge passed with no deterministic \
+                                 corroboration (no flip, no green test) — {}",
+                                abstained.summary
+                            );
+                            self.unverifiable(&abstained.summary);
+                            return state.into_verified(
+                                true,
+                                &abstained,
+                                score_from_verification(false, None),
+                            );
+                        }
                         return state.into_verified(
                             true,
                             &evidence,

--- a/stella-pipeline/src/verify.rs
+++ b/stella-pipeline/src/verify.rs
@@ -441,6 +441,33 @@ impl LadderInputs {
             && self.file_change_events == 0
     }
 
+    /// Whether a model judge's `passed` would be the *only* thing standing
+    /// behind the claim — no flip, and no test that ran green.
+    ///
+    /// Deliberately narrow. A recorded touch or a readable diff proves the
+    /// tree **changed**; neither says the change is **correct**, and only the
+    /// second claim is the one a pass makes. So they are excluded here even
+    /// though they are real evidence elsewhere on the ladder.
+    ///
+    /// This exists because the judge's authority was measured and found
+    /// wanting. Across an 89-task Terminal-Bench run the authored-witness
+    /// rung never fired — the posture pins one model for every role, and
+    /// Stella will not let the worker write the test that proves the worker,
+    /// so the judge was reasoning from a diff and its own opinion. It agreed
+    /// with the benchmark's grader 46% of the time, and 17 of its false
+    /// passes cost 5 tasks outright.
+    ///
+    /// The response is asymmetric trust rather than removal. A judge that
+    /// says "not yet" is still useful with weak evidence — being wrong costs
+    /// one more revision. A judge that says "done" on the same evidence ends
+    /// the run, so that direction has to be earned. When it is not, the turn
+    /// is scored **unverified**, never failed: a run is not broken by the
+    /// absence of a way to check it, and a Terminal-Bench trial that scored
+    /// 1.0 against its own verifier has taken exactly this path.
+    pub fn judge_pass_stands_alone(&self) -> bool {
+        !self.flip_achieved && self.touched_tests_passed != Some(true)
+    }
+
     /// Whether this turn provably did nothing: it dispatched no call that
     /// could change the workspace, and no channel that *did* report saw any
     /// change.

--- a/stella-pipeline/src/verify/tests.rs
+++ b/stella-pipeline/src/verify/tests.rs
@@ -1028,3 +1028,57 @@ fn a_tautological_witness_blocks_the_fast_submit() {
         "a witness that constrains nothing may not buy a deterministic pass"
     );
 }
+
+/// Asymmetric trust (#871). A judge that says "done" with nothing but its own
+/// opinion behind it ends the run on the strength of a model's guess — the
+/// shape that put 17 false passes into an 89-task Terminal-Bench run.
+#[test]
+fn a_judge_pass_with_no_flip_and_no_green_test_stands_alone() {
+    // The benchmark's real state: work happened and was seen to happen, but
+    // nothing test-shaped ever ran.
+    let inputs = LadderInputs {
+        flip_achieved: false,
+        touched_tests_passed: None,
+        diff_available: true,
+        diff_lines: 40,
+        diff_budget: 400,
+        file_change_events: 12,
+        mutating_actions: 30,
+        ..Default::default()
+    };
+    assert!(
+        inputs.judge_pass_stands_alone(),
+        "a visible diff proves the tree changed, never that the change is right"
+    );
+}
+
+/// Either test-shaped signal is enough to corroborate a pass.
+#[test]
+fn a_flip_or_a_green_test_corroborates_a_judge_pass() {
+    let flipped = LadderInputs {
+        flip_achieved: true,
+        ..Default::default()
+    };
+    assert!(!flipped.judge_pass_stands_alone(), "a flip corroborates");
+
+    let green = LadderInputs {
+        touched_tests_passed: Some(true),
+        ..Default::default()
+    };
+    assert!(
+        !green.judge_pass_stands_alone(),
+        "a green test corroborates"
+    );
+}
+
+/// A *red* test is not corroboration — it points the other way. Reading
+/// `Some(false)` as support would be the exact inversion the ladder exists to
+/// prevent.
+#[test]
+fn a_red_test_does_not_corroborate_a_judge_pass() {
+    let red = LadderInputs {
+        touched_tests_passed: Some(false),
+        ..Default::default()
+    };
+    assert!(red.judge_pass_stands_alone());
+}

--- a/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.jsonl
+++ b/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.jsonl
@@ -19,6 +19,8 @@
 {"type":"step_manifest","turn_instance":0,"step":0,"call_seq":3,"role":"judge","provider":"scripted","model":"scripted","blocks":[{"block_id":"blk_fbf39dd366f72e6ff4f6e453","cache_zone":"volatile","token_cost":218,"resident_since_step":0,"message_index":0}],"effective_budget_tokens":0,"calibration_factor":1.0,"estimated_input_tokens":222}
 {"type":"step_usage","step":0,"role":"judge","provider":"scripted","output_text":"PASS looks right","model":"scripted","input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"cache_write_tokens":0,"estimated_input_tokens":0,"cost_usd":0.0001,"duration_ms":0,"retries":0,"tool_calls":0,"complete":true}
 {"type":"budget_tick","spent_usd":0.00030000000000000003,"limit_usd":null,"mode":"off","session_spent_usd":0.00030000000000000003,"session_limit_usd":null}
-{"type":"judge_verdict","passed":true,"evidence":{"summary":"PASS looks right","deterministic":false}}
+{"type":"judge_verdict","passed":true,"evidence":{"summary":"PASS looks right","deterministic":false,"ladder":{"flip_achieved":false,"unstable_flip":false,"flip_refused_different_failure":false,"diff_lines":2,"diff_budget":400,"diff_available":true,"file_change_events":0,"mutating_actions":0,"new_diag_errors":0,"new_diag_warnings":0}}}
+{"type":"error","message":"verification could not be performed: UNVERIFIED: judge passed with no deterministic corroboration (no flip, no green test) — PASS looks right","retryable":true}
+{"type":"proof","step":{"kind":"verification_unavailable","reason":"UNVERIFIED: judge passed with no deterministic corroboration (no flip, no green test) — PASS looks right"}}
 {"type":"stage","name":"complete"}
 {"type":"complete","model":"scripted/worker","cost_usd":0.00030000000000000003}

--- a/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.manifest.json
+++ b/stella-pipeline/tests/fixtures/golden/judge_escalation_without_a_test_command.manifest.json
@@ -5,5 +5,5 @@
     "kind": "rust_stack",
     "recorded_by": "stella-pipeline::pipeline::tests::golden::judge_escalation_without_a_test_command"
   },
-  "event_count": 24
+  "event_count": 26
 }

--- a/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.jsonl
+++ b/stella-pipeline/tests/fixtures/golden/single_task_deterministic_flip.jsonl
@@ -17,6 +17,6 @@
 {"type":"stage","name":"verify"}
 {"type":"proof","step":{"kind":"oracle","command":"cargo test -p x","passed":true,"tree":"candidate"}}
 {"type":"proof","step":{"kind":"oracle","command":"cargo test -p x","passed":true,"tree":"candidate"}}
-{"type":"judge_verdict","passed":true,"evidence":{"summary":"flip oracle: fail→pass of `cargo test -p x`; touched tests green; diff 2 lines within budget","deterministic":true}}
+{"type":"judge_verdict","passed":true,"evidence":{"summary":"flip oracle: fail→pass of `cargo test -p x`; touched tests green; diff 2 lines within budget","deterministic":true,"ladder":{"tracked_command":"cargo test -p x","oracle_trace":[{"tree":"baseline","passed":false},{"tree":"candidate","passed":true},{"tree":"candidate","passed":true}],"flip_achieved":true,"unstable_flip":false,"flip_refused_different_failure":false,"touched_tests_passed":true,"diff_lines":2,"diff_budget":400,"diff_available":true,"file_change_events":0,"mutating_actions":0,"new_diag_errors":0,"new_diag_warnings":0}}}
 {"type":"stage","name":"complete"}
 {"type":"complete","model":"scripted/worker","cost_usd":0.0002}

--- a/stella-tools/src/lib.rs
+++ b/stella-tools/src/lib.rs
@@ -46,6 +46,7 @@ pub mod sandbox;
 pub mod schema_gate;
 pub mod screenshot;
 pub mod scripts;
+pub mod shell_touch;
 pub mod staleness;
 pub mod subagent;
 /// Shared environment policy for every subprocess that can execute model- or

--- a/stella-tools/src/registry.rs
+++ b/stella-tools/src/registry.rs
@@ -910,6 +910,18 @@ impl ToolRegistry {
             );
         }
 
+        // Opaque calls get a before-image. A tool whose input named no file
+        // op but which is allowed to mutate is precisely `bash` and its
+        // relatives: the schema cannot say what they will touch, so the tree
+        // is asked instead (see [`crate::shell_touch`]). Read-only tools are
+        // skipped, and an *unknown* tool counts as mutating for the same
+        // reason the ladder counts it so — on Terminal-Bench the shell is how
+        // nearly all real work lands, and a name we fail to recognize must
+        // never be the reason a change goes unattributed.
+        let shell_probe = (pending_ops.is_empty()
+            && !tool.as_ref().map(|t| t.schema().read_only).unwrap_or(false))
+        .then(|| crate::shell_touch::WorkspaceProbe::capture(&self.root));
+
         let mut output = match tool {
             Some(tool) => tool.execute(input, &self.root).await,
             None => ToolOutput::Error {
@@ -953,6 +965,41 @@ impl ToolRegistry {
                         );
                     }
                 }
+            }
+        }
+        // Attribute what the opaque call actually did. Deliberately OUTSIDE
+        // the success gate below: a shell command that exits non-zero has
+        // very often still written something (a build that failed halfway, a
+        // patch that applied two hunks of three), and the ledger's job is to
+        // describe the tree as it is, not as the exit code implies.
+        if let Some(before) = shell_probe {
+            let after = crate::shell_touch::WorkspaceProbe::capture(&self.root);
+            for touch in before.diff(&after) {
+                let Some(full) = crate::resolve_within_root(&self.root, &touch.path) else {
+                    continue;
+                };
+                // An unmeasurable update carries its own post-image as the
+                // pre-image, yielding 0/0. The alternative — an empty
+                // pre-image — would render a same-file rewrite as a
+                // whole-file insertion, which is a louder lie than silence.
+                let pre_content = match (touch.counts_measurable, touch.op) {
+                    (true, _) => touch.pre_content,
+                    (false, FileOp::Update | FileOp::Delete) => std::fs::read(&full)
+                        .ok()
+                        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned()),
+                    (false, _) => None,
+                };
+                self.record_touch(
+                    PendingTouch {
+                        path: touch.path,
+                        full,
+                        op: touch.op,
+                    },
+                    pre_content,
+                    name,
+                    &serde_json::json!({ "reason": format!("attributed to `{name}`") }),
+                    bus.as_ref(),
+                );
             }
         }
         if !output.is_error() {
@@ -1507,10 +1554,21 @@ impl ToolRegistry {
         let (lines_added, lines_removed, diff) = match pending.op {
             FileOp::Read => (0, 0, None),
             FileOp::Create => {
-                let content = input
-                    .get("content")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
+                // `write_file` carries the new content in its input. A file
+                // created by an opaque call (a shell redirect, a compiler
+                // output) carries it only on disk, so fall back to reading
+                // it — otherwise every shell-created file would be recorded
+                // as zero lines long, understating exactly the work this
+                // attribution path exists to see.
+                let from_input = input.get("content").and_then(|v| v.as_str());
+                let from_disk = from_input.is_none().then(|| {
+                    std::fs::read(&pending.full)
+                        .ok()
+                        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                        .unwrap_or_default()
+                });
+                let content =
+                    from_input.unwrap_or_else(|| from_disk.as_deref().unwrap_or_default());
                 (
                     count_lines(content),
                     0,
@@ -1883,6 +1941,79 @@ mod tests {
         let (_root, reg) = bare_registry(None);
         let result = reg.execute("nonexistent", &Value::Null).await;
         assert!(result.is_error());
+    }
+
+    /// The measured defect: over a 20-task Terminal-Bench run, 757 of 1,063
+    /// tool calls were `bash` and the ledger recorded none of them, because
+    /// `classify_file_op` can only read a tool's *input* and a shell command
+    /// is an opaque string. With the diff probe dark on a non-git task
+    /// directory, `file_change_events` is the only channel left that can
+    /// prove the tree changed — so a blind ledger there is a blind ladder.
+    #[tokio::test]
+    async fn a_file_written_by_the_shell_reaches_the_ledger() {
+        let (root, reg) = bare_registry(None);
+        assert_eq!(reg.mutations_recorded(), 0, "clean before");
+
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({"command": "printf 'a\\nb\\n' > made_by_shell.txt"}),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert!(root.path().join("made_by_shell.txt").exists());
+
+        let touched = reg.files_touched();
+        assert!(
+            touched
+                .iter()
+                .any(|(path, ops)| path == "made_by_shell.txt" && ops.contains('C')),
+            "shell-created file missing from the ledger: {touched:?}"
+        );
+        // The count the verification ladder reads.
+        assert!(reg.mutations_recorded() >= 1, "no mutation recorded");
+    }
+
+    /// A shell command that fails can still have written something, so
+    /// attribution must not hang off the exit code.
+    #[tokio::test]
+    async fn a_failing_shell_command_still_reports_what_it_wrote() {
+        let (root, reg) = bare_registry(None);
+
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({"command": "echo partial > half_done.txt; exit 3"}),
+            )
+            .await;
+        // Whatever the tool reports, the tree changed and the ledger says so.
+        let _ = out;
+        assert!(root.path().join("half_done.txt").exists());
+        assert!(
+            reg.files_touched()
+                .iter()
+                .any(|(path, _)| path == "half_done.txt"),
+            "a non-zero exit erased the attribution"
+        );
+    }
+
+    /// Reads must not be inflated into mutations: a shell command that only
+    /// looks at the tree leaves the ledger where it found it.
+    #[tokio::test]
+    async fn a_read_only_shell_command_records_no_mutation() {
+        let (root, reg) = bare_registry(None);
+        std::fs::write(root.path().join("existing.txt"), "unchanged\n").unwrap();
+
+        let out = reg
+            .execute("bash", &serde_json::json!({"command": "cat existing.txt"}))
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert_eq!(
+            reg.mutations_recorded(),
+            0,
+            "inspecting the tree is not changing it: {:?}",
+            reg.files_touched()
+        );
     }
 
     #[tokio::test]

--- a/stella-tools/src/shell_touch.rs
+++ b/stella-tools/src/shell_touch.rs
@@ -1,7 +1,7 @@
 //! Attributing workspace mutations that no tool schema can describe.
 //!
-//! The file ledger ([`crate::registry::ToolRegistry::record_touch`]) is fed by
-//! [`crate::registry::ToolRegistry::classify_file_op`], which reads a tool's
+//! The file ledger (`ToolRegistry::record_touch`) is fed by
+//! `ToolRegistry::classify_file_op`, which reads a tool's
 //! *input* to decide what it is about to do. That works for the CRUD tools —
 //! `write_file` names its path, `edit_file` names its path — and it cannot work
 //! for `bash`. A shell command is an opaque string: `make`, `python build.py`,

--- a/stella-tools/src/shell_touch.rs
+++ b/stella-tools/src/shell_touch.rs
@@ -1,0 +1,327 @@
+//! Attributing workspace mutations that no tool schema can describe.
+//!
+//! The file ledger ([`crate::registry::ToolRegistry::record_touch`]) is fed by
+//! [`crate::registry::ToolRegistry::classify_file_op`], which reads a tool's
+//! *input* to decide what it is about to do. That works for the CRUD tools —
+//! `write_file` names its path, `edit_file` names its path — and it cannot work
+//! for `bash`. A shell command is an opaque string: `make`, `python build.py`,
+//! `patch < fix.diff` and `echo x > f` all change the tree, and none of them
+//! say so in a form a schema can read.
+//!
+//! The consequence was measured rather than assumed. Over a 20-task
+//! Terminal-Bench run, 757 of 1,063 tool calls were `bash` and the ledger
+//! recorded 131 events — one per CRUD-tool call, none from the shell. 71% of
+//! the agent's activity left no trace in the ledger, in the Files tab, or in
+//! the `file_change_events` channel the verification ladder reads.
+//!
+//! That last one is why this matters beyond cosmetics. On Terminal-Bench the
+//! task directory is not a git repository, so the diff probe can only ever
+//! answer "I could not look" (`LadderInputs::diff_available == false`). With
+//! the diff channel dark, `file_change_events` is the *only* channel that can
+//! positively prove the tree changed — and it was blind to the exact tool
+//! doing nearly all of the changing.
+//!
+//! So this module answers the question the schema cannot: fingerprint the
+//! workspace either side of an opaque call and attribute the difference. The
+//! probe never guesses. Every bound it hits is recorded as a bound
+//! ([`WorkspaceProbe::saturated`]) rather than shrinking the answer, because
+//! the distinction between "I looked and saw nothing" and "I could not finish
+//! looking" is the one whose collapse caused #973.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::file_touch::{FileOp, normalize_workspace_path};
+
+/// Directories that cannot themselves be the point of a task and would
+/// otherwise dominate the walk. Deliberately short: build outputs (`target`,
+/// `dist`, `build`) are **not** here, because producing one is frequently the
+/// whole job and a probe that hides it would recreate the blindness this
+/// module exists to remove.
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+];
+
+/// Entry ceiling for one walk. Past this the probe stops and says so.
+const MAX_ENTRIES: usize = 20_000;
+/// Depth ceiling, so a symlink cycle or a pathological tree cannot hang a turn.
+const MAX_DEPTH: usize = 24;
+/// Largest single file whose content is held for a line diff.
+const MAX_CONTENT_BYTES: u64 = 256 * 1024;
+/// Total content budget across one snapshot.
+const MAX_TOTAL_CONTENT: u64 = 16 * 1024 * 1024;
+
+/// What one snapshot recorded about one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Fingerprint {
+    len: u64,
+    /// Modification time in nanoseconds since the epoch, when the platform
+    /// offers one. `None` collapses the comparison onto length alone — a
+    /// same-length in-place rewrite then reads as unchanged, which is a miss
+    /// rather than a false report.
+    mtime_nanos: Option<u128>,
+    /// Pre-call content, when the file was small enough to hold within budget.
+    /// `None` means the line counts for this path are not measurable, and is
+    /// reported as such rather than being rendered as a whole-file rewrite.
+    content: Option<String>,
+}
+
+/// A mutation the probe attributed to an opaque call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellTouch {
+    /// Workspace-normalized path, the same key the ledger uses.
+    pub path: String,
+    pub op: FileOp,
+    /// Pre-call content for a line diff, when it was captured within budget.
+    pub pre_content: Option<String>,
+    /// Whether line counts for this touch can be computed honestly. `false`
+    /// when the file was too large (or arrived too late) to hold a
+    /// pre-image — the touch still records *that* the file changed.
+    pub counts_measurable: bool,
+}
+
+/// A bounded fingerprint of the workspace, taken either side of a call whose
+/// effects cannot be read from its input.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceProbe {
+    entries: BTreeMap<String, Fingerprint>,
+    /// The walk hit [`MAX_ENTRIES`] or [`MAX_DEPTH`]. The snapshot is a lower
+    /// bound on the tree, so a path's *absence* from it proves nothing.
+    saturated: bool,
+}
+
+impl WorkspaceProbe {
+    /// Fingerprint `root`, holding content for files within budget.
+    ///
+    /// Errors are absences, not failures: an unreadable directory is simply
+    /// not described. A probe that refused to return on a permission error
+    /// would turn a partially-visible workspace into no workspace at all.
+    pub fn capture(root: &Path) -> Self {
+        let mut probe = Self::default();
+        let mut budget = MAX_TOTAL_CONTENT;
+        let mut stack = vec![(root.to_path_buf(), 0usize)];
+        while let Some((dir, depth)) = stack.pop() {
+            if depth > MAX_DEPTH {
+                probe.saturated = true;
+                continue;
+            }
+            let Ok(reader) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in reader.flatten() {
+                if probe.entries.len() >= MAX_ENTRIES {
+                    probe.saturated = true;
+                    return probe;
+                }
+                let path = entry.path();
+                let Ok(meta) = entry.metadata() else { continue };
+                if meta.is_dir() {
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    if SKIP_DIRS.contains(&name.as_ref()) {
+                        continue;
+                    }
+                    stack.push((path, depth + 1));
+                    continue;
+                }
+                // Symlinks are not followed: the target is either inside the
+                // root (and walked on its own) or outside it (and not ours).
+                if !meta.is_file() {
+                    continue;
+                }
+                let Some(normalized) = path
+                    .to_str()
+                    .and_then(|raw| normalize_workspace_path(root, raw))
+                else {
+                    continue;
+                };
+                let len = meta.len();
+                let content = if len <= MAX_CONTENT_BYTES && len <= budget {
+                    match std::fs::read(&path) {
+                        // Lossy so a binary still yields a deterministic
+                        // (if approximate) line count, matching how the
+                        // CRUD path reads pre-images.
+                        Ok(bytes) => {
+                            budget = budget.saturating_sub(len);
+                            Some(String::from_utf8_lossy(&bytes).into_owned())
+                        }
+                        Err(_) => None,
+                    }
+                } else {
+                    None
+                };
+                probe.entries.insert(
+                    normalized,
+                    Fingerprint {
+                        len,
+                        mtime_nanos: meta.modified().ok().and_then(|t| {
+                            t.duration_since(std::time::UNIX_EPOCH)
+                                .ok()
+                                .map(|d| d.as_nanos())
+                        }),
+                        content,
+                    },
+                );
+            }
+        }
+        probe
+    }
+
+    /// Whether this snapshot is a lower bound on the tree rather than a
+    /// complete description of it.
+    pub fn saturated(&self) -> bool {
+        self.saturated
+    }
+
+    /// Attribute the difference between this (pre) snapshot and `post`.
+    ///
+    /// Deletions are reported **only** when both snapshots are complete. If
+    /// either walk saturated, a path missing from `post` may simply be a path
+    /// the second walk never reached, and reporting that as a deletion would
+    /// invent a mutation that never happened — the failure mode this module
+    /// exists to avoid, pointed the other way.
+    pub fn diff(&self, post: &Self) -> Vec<ShellTouch> {
+        let mut touches = Vec::new();
+        for (path, after) in &post.entries {
+            match self.entries.get(path) {
+                None => touches.push(ShellTouch {
+                    path: path.clone(),
+                    op: FileOp::Create,
+                    pre_content: None,
+                    counts_measurable: true,
+                }),
+                Some(before)
+                    if before.len != after.len || before.mtime_nanos != after.mtime_nanos =>
+                {
+                    touches.push(ShellTouch {
+                        path: path.clone(),
+                        op: FileOp::Update,
+                        pre_content: before.content.clone(),
+                        counts_measurable: before.content.is_some(),
+                    })
+                }
+                Some(_) => {}
+            }
+        }
+        if !self.saturated && !post.saturated {
+            for (path, before) in &self.entries {
+                if !post.entries.contains_key(path) {
+                    touches.push(ShellTouch {
+                        path: path.clone(),
+                        op: FileOp::Delete,
+                        pre_content: before.content.clone(),
+                        counts_measurable: before.content.is_some(),
+                    });
+                }
+            }
+        }
+        touches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, rel: &str, body: &str) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// The defect this module was built for: a shell redirect is attributed.
+    #[test]
+    fn a_file_created_outside_any_crud_tool_is_attributed() {
+        let dir = tempfile::tempdir().unwrap();
+        let pre = WorkspaceProbe::capture(dir.path());
+        write(dir.path(), "solution.py", "print(1)\n");
+        let post = WorkspaceProbe::capture(dir.path());
+
+        let touches = pre.diff(&post);
+        assert_eq!(touches.len(), 1, "{touches:?}");
+        assert_eq!(touches[0].path, "solution.py");
+        assert_eq!(touches[0].op, FileOp::Create);
+    }
+
+    #[test]
+    fn an_in_place_rewrite_is_an_update_and_carries_its_pre_image() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "main.c", "int main(){return 1;}\n");
+        let pre = WorkspaceProbe::capture(dir.path());
+        // Length differs, so this is caught even where mtime has coarse
+        // resolution.
+        write(dir.path(), "main.c", "int main(){return 0;}\n// fixed\n");
+        let post = WorkspaceProbe::capture(dir.path());
+
+        let touches = pre.diff(&post);
+        assert_eq!(touches.len(), 1, "{touches:?}");
+        assert_eq!(touches[0].op, FileOp::Update);
+        assert!(touches[0].counts_measurable);
+        assert_eq!(
+            touches[0].pre_content.as_deref(),
+            Some("int main(){return 1;}\n")
+        );
+    }
+
+    #[test]
+    fn a_removed_file_is_a_delete_when_both_walks_were_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "stale.txt", "gone\n");
+        let pre = WorkspaceProbe::capture(dir.path());
+        std::fs::remove_file(dir.path().join("stale.txt")).unwrap();
+        let post = WorkspaceProbe::capture(dir.path());
+
+        let touches = pre.diff(&post);
+        assert_eq!(touches.len(), 1, "{touches:?}");
+        assert_eq!(touches[0].op, FileOp::Delete);
+    }
+
+    /// A saturated walk is a lower bound, so absence proves nothing and must
+    /// not be rendered as a deletion.
+    #[test]
+    fn a_saturated_walk_never_invents_a_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "kept.txt", "x\n");
+        let pre = WorkspaceProbe::capture(dir.path());
+        let mut post = WorkspaceProbe::capture(dir.path());
+        post.entries.clear();
+        post.saturated = true;
+
+        assert!(pre.diff(&post).is_empty(), "saturation must not delete");
+    }
+
+    #[test]
+    fn an_untouched_tree_reports_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.txt", "a\n");
+        write(dir.path(), "nested/b.txt", "b\n");
+        let pre = WorkspaceProbe::capture(dir.path());
+        let post = WorkspaceProbe::capture(dir.path());
+
+        assert!(pre.diff(&post).is_empty());
+    }
+
+    /// Skipping `.git` is what keeps the probe affordable; skipping a build
+    /// directory would hide the point of many tasks, so `target/` is walked.
+    #[test]
+    fn vcs_metadata_is_skipped_but_build_output_is_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let pre = WorkspaceProbe::capture(dir.path());
+        write(dir.path(), ".git/objects/ab/cdef", "blob\n");
+        write(dir.path(), "target/release/app", "binary\n");
+        let post = WorkspaceProbe::capture(dir.path());
+
+        let paths: Vec<_> = pre.diff(&post).into_iter().map(|t| t.path).collect();
+        assert_eq!(paths, vec!["target/release/app".to_string()]);
+    }
+}


### PR DESCRIPTION
Two instrumentation defects, both measured on the 20-task OpenRouter-vs-OpenRouter
head-to-head rather than inferred, and both blocking a credible 89-task run.

## 1. The file ledger was blind to the shell

`classify_file_op` reads a tool's **input** to decide what it will touch. That
works for the CRUD tools and cannot work for `bash`: a shell command is an
opaque string, so `make`, `patch` and `echo > f` changed the tree without
leaving a trace in the ledger, the Files tab, or the `file_change_events`
channel the verification ladder reads.

Measured over 20 tasks: **757 of 1,063 tool calls were `bash`**, and the ledger
recorded 131 events — one per CRUD-tool call, none from the shell. 71% of the
agent's activity was invisible.

That matters beyond cosmetics. On a task directory that is not a git
repository the diff probe can only answer "I could not look", which leaves
`file_change_events` as the only channel that can positively prove the tree
changed.

So ask the tree instead of the schema: fingerprint the workspace either side of
a call whose input named no file op and whose tool may mutate, and attribute
the difference through `record_touch`, preserving the single-emitter
invariant.

The probe is deliberately conservative about its own limits:

- bounds it hits are **recorded** (`saturated`), never used to shrink the answer
- a saturated walk **never reports a deletion** — an absence it cannot vouch for is not evidence
- it runs **outside the success gate**, because a shell command that exits non-zero has often still written something
- build output (`target/`, `dist/`) is walked; producing one is frequently the whole job

## 2. The judge could end a run on its own word

Across the 89-task run the authored-witness rung **never fired** — the posture
pins one model for every role, and Stella will not let the worker write the
test that proves the worker. So the judge reasoned from a diff and its own
opinion. It agreed with the benchmark's grader **46%** of the time, and 17 of
its false passes cost 5 tasks.

Asymmetric trust rather than removal. "Not yet" from a judge is cheap to be
wrong about — it buys one revision. "Done" ends the run, so that direction now
has to be corroborated by something that is not another model's opinion: a
flip, or a test that ran green. A recorded touch or a readable diff proves the
tree *changed*, never that the change is *right*, so neither counts.

**Uncorroborated, the turn is scored UNVERIFIED — never failed.** That
distinction is load-bearing: a trial that solved its task through shell
redirects and scored 1.0 against its own verifier reaches exactly this state,
and failing it closed would report a correct run as broken.

## Tests

- 6 unit tests on the probe: create / update-with-pre-image / delete / saturation-never-deletes / no-op / skip-list
- 3 integration tests through the real registry: a shell-written file reaches the ledger; a *failing* shell command still reports what it wrote; a read-only shell command records no mutation
- 3 ladder tests on the corroboration predicate, including that a **red** test is not corroboration

`make gate` green.

Golden refreshed: `judge_escalation_without_a_test_command` now emits the same
abstain pair the `Unverifiable` rung already emits (24 → 26 events).

## Summary by Sourcery

Track shell-initiated file mutations and require deterministic corroboration for judge passes before treating runs as fully verified.

New Features:
- Introduce a workspace fingerprinting probe to attribute file creations, updates, and deletions performed by opaque tools like bash.
- Add a predicate and scoring path that classify unsupported judge passes as UNVERIFIED instead of failed when no flip or green test exists.

Bug Fixes:
- Ensure shell commands that mutate the workspace are reflected in the file ledger and file_change_events, even when the tool schema cannot describe the operation.
- Prevent a model judge from conclusively passing a run based only on its own opinion without test-shaped corroboration.

Enhancements:
- Improve file creation accounting so shell-created files read content from disk when not provided in tool input, yielding accurate line counts.
- Refine verification ladder logic to treat visible diffs and file-change evidence as proof of change, but not as correctness, tightening pass criteria.

Tests:
- Add unit tests for the workspace probe covering creates, updates with pre-images, deletions, saturation behavior, no-op trees, and skip lists.
- Add integration tests ensuring shell-written files reach the ledger, failing shell commands still report mutations, and read-only shell commands record no mutations.
- Extend verification tests to cover judge pass corroboration via flip or green tests and to confirm red tests do not corroborate a pass.
- Refresh golden fixtures to reflect the new UNVERIFIED abstain behavior in judge escalation scenarios.