### PR TITLE
feat(website): white sidebar, hero install focus, counted installs

### DIFF
--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -29,7 +29,7 @@ back to `cargo install` on platforms without a prebuilt binary (unsupported targ
 musl-libc Linux even on supported architectures):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
+curl -fsSL https://stella.oxagen.sh/install.sh | sh
 stella --version
 ```
 
@@ -50,7 +50,7 @@ script says so and prints the `export` line to add. Two env vars tune it:
 
 ```bash
 STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.6.10 \
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh)"
+  sh -c "$(curl -fsSL https://stella.oxagen.sh/install.sh)"
 ```
 
 Pick the tag from the

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@upstash/redis": "^1.38.0",
     "fumadocs-core": "16.9.3",
     "fumadocs-mdx": "15.0.10",
     "fumadocs-ui": "16.9.3",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       fumadocs-core:
         specifier: 16.9.3
         version: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@0.556.0(react@19.2.6))(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
@@ -1003,6 +1006,9 @@ packages:
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1865,6 +1871,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -2716,6 +2725,10 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -3945,6 +3958,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.24.6: {}
 

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { HeroTerminal } from "@/components/command-deck";
-import { Mark, Wordmark } from "@/components/brand";
+import { AnimatedLockup } from "@/components/animated-lockup";
+import { Mark } from "@/components/brand";
+import { InstallBlock } from "@/components/install-block";
 import { PROVIDER_CATALOG } from "@/components/provider-cards";
 
 /**
@@ -20,9 +22,12 @@ import { PROVIDER_CATALOG } from "@/components/provider-cards";
  * Copied from content/docs/getting-started/installation.mdx. If that page's
  * command changes, this one has to change with it — a landing page that
  * installs a different thing than the docs say is worse than no landing page.
+ *
+ * The URL is the site's own /install.sh, which serves the canonical script
+ * from the repo (src/app/install.sh/route.ts) and counts the download — the
+ * copy beacon in InstallBlock counts the other half of the funnel.
  */
-const INSTALL =
-  "curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh";
+const INSTALL = "curl -fsSL https://stella.oxagen.sh/install.sh | sh";
 
 /** The four entry points, in the order a new reader needs them. */
 const DOORS = [
@@ -54,10 +59,6 @@ export default function HomePage() {
       {/* ── What it is ─────────────────────────────────────────────────── */}
       <section className="lp-hero">
         <div className="mx-auto w-full max-w-3xl px-4 py-20 sm:py-28">
-          <span className="mb-10 inline-flex items-center gap-3">
-            <Mark className="h-10 w-auto" label="stella" />
-            <Wordmark className="h-8 w-auto text-fd-foreground" />
-          </span>
           <h1 className="lp-h1">
             <span className="lp-brand-face">stella</span> is a terminal coding
             agent that proves its work finished.
@@ -69,14 +70,16 @@ export default function HomePage() {
             and telemetry never leaves your disk.
           </p>
 
-          <div className="mt-10">
-            <p className="mb-2 text-sm text-fd-muted-foreground">Install it:</p>
-            <div className="term">
-              <pre className="term-body">
-                <span className="term-prompt">$ </span>
-                {INSTALL}
-              </pre>
+          {/* The lockup assembles once, front and center, and hands the eye
+              straight down to the one action this page wants: install. The
+              hero's old static lockup above the h1 is gone — one mark, where
+              it points at something. */}
+          <div className="mt-12">
+            <div className="mb-8 flex justify-center">
+              <AnimatedLockup className="h-16 w-auto text-fd-foreground sm:h-20" />
             </div>
+            <p className="mb-2 text-sm text-fd-muted-foreground">Install it:</p>
+            <InstallBlock command={INSTALL} />
           </div>
 
           <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3">

--- a/website/src/app/api/hit/route.ts
+++ b/website/src/app/api/hit/route.ts
@@ -1,0 +1,21 @@
+import { bump, readCounters } from "@/lib/counters";
+
+/**
+ * The copy side of the install funnel. POST (the landing page's
+ * `sendBeacon` on every successful copy) bumps `install:copies`; GET returns
+ * both counters as JSON so the numbers are one curl away:
+ *
+ *     curl -s https://stella.oxagen.sh/api/hit
+ *     {"configured":true,"hits":123,"copies":456}
+ */
+
+export async function POST(): Promise<Response> {
+  await bump("copies");
+  return new Response(null, { status: 204 });
+}
+
+export async function GET(): Promise<Response> {
+  return Response.json(await readCounters(), {
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -297,14 +297,35 @@
 /* ═══════════════════════════════════════════════════════════════════════════
  * Page chrome — recede
  *
- * The sidebar and header exist to be ignored until wanted. No fills, no
- * borders on items, no bold. The active page is the only thing in the tree
- * that takes colour, and it takes the ground-aware gold because it is the
- * signal.
+ * The sidebar and header exist to be ignored until wanted. No borders on
+ * items, no bold. The active page is the only thing in the tree that takes
+ * colour, and it takes the ground-aware gold because it is the signal.
+ *
+ * The sidebar's ground is WHITE, not the page's warm paper. Fumadocs paints
+ * the aside with `bg-fd-card` (#fcfaf4 here), which sat within 1.02:1 of the
+ * #f6f2e9 page — the two grounds read as one soft warm field with no seam.
+ * Navigation is chrome, not page: it gets the cool white ground so the warm
+ * paper reads as "the document" and the sidebar reads as "the frame". The
+ * fd tokens are re-scoped inside the aside so hover/selected chips stay
+ * neutral on white instead of dropping warm cream blobs on it. Dark mode
+ * needs no override: fd-card (#131315) already lifts off the ink ground.
  * ═════════════════════════════════════════════════════════════════════════ */
 
 #nd-sidebar {
   font-size: var(--stella-type-sm);
+  --color-fd-card: #ffffff;
+  --color-fd-accent: #f0f0ee; /* hover/selected chip — neutral on white */
+  --color-fd-secondary: #f0f0ee;
+  --color-fd-muted: #f6f6f4;
+  background-color: #ffffff;
+}
+
+.dark #nd-sidebar {
+  --color-fd-card: var(--stella-surface);
+  --color-fd-accent: #201d15; /* restore the ink-warmed hover on dark */
+  --color-fd-secondary: #1a1a1d;
+  --color-fd-muted: var(--stella-surface);
+  background-color: var(--stella-surface);
 }
 
 #nd-sidebar a,
@@ -662,6 +683,356 @@
 }
 .term-ok {
   color: var(--stella-success); /* 11.4:1 on ink */
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Install block — the one-liner you copy.
+ *
+ * A real surface, not a sticker: hovering lifts it on a spring (Motion-
+ * generated linear() curve, ~6% overshoot, settles in 350ms — physical, not
+ * cartoon), and a gold sheen sweeps left→right — the comet's direction —
+ * once on arrival and again every 10 seconds for as long as the pointer
+ * stays. The 10s cycle is one keyframe track: the sweep occupies the first
+ * 14% (1.4s), the rest holds off-screen, so `infinite` re-fires it on
+ * exactly the requested period with no JavaScript.
+ *
+ * The wrapper owns overflow (to clip the sweeping pseudo-element) and
+ * therefore must also own the card shadow — a shadow on the inner .term
+ * would be clipped by this very overflow.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.lp-install {
+  position: relative;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: var(--stella-shadow-card);
+  transition: transform 350ms
+    linear(
+      0,
+      0.3667,
+      0.8271,
+      1.0379,
+      1.0652,
+      1.0332,
+      1.006,
+      0.9961,
+      0.996,
+      0.9984,
+      0.9999,
+      1
+    );
+}
+.lp-install .term {
+  box-shadow: none;
+  border-radius: inherit;
+}
+.lp-install:hover,
+.lp-install:focus-within {
+  transform: scale(1.02);
+}
+
+/* The sheen. Ink ground in both themes, so one gold tint serves both. */
+.lp-install::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    transparent 35%,
+    rgb(255 176 0 / 0.05) 45%,
+    rgb(255 216 115 / 0.16) 50%,
+    rgb(255 176 0 / 0.05) 55%,
+    transparent 65%
+  );
+  transform: translateX(-101%);
+}
+.lp-install:hover::after,
+.lp-install:focus-within::after {
+  animation: lp-shimmer 10s var(--stella-ease-arrive) infinite;
+}
+@keyframes lp-shimmer {
+  0% {
+    transform: translateX(-101%);
+  }
+  14% {
+    transform: translateX(101%);
+  }
+  100% {
+    transform: translateX(101%);
+  }
+}
+
+/* The stretched hit target: one control, covering the whole block. */
+.lp-install-hit {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+.lp-install-hit:focus-visible {
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: 2px;
+}
+
+/* Corner chip — visual state only (aria-hidden); clicks fall through. */
+.lp-install-chip {
+  position: absolute;
+  top: 0.55rem;
+  inset-inline-end: 0.6rem;
+  pointer-events: none;
+  font-family: var(--font-mono);
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #9b9890; /* muted on ink, regardless of page theme */
+  background: #1a1a1d;
+  border: 1px solid #232327;
+  border-radius: 0.375rem;
+  padding: 0.15rem 0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-install {
+    transition: none;
+  }
+  .lp-install:hover,
+  .lp-install:focus-within {
+    transform: none;
+  }
+  .lp-install:hover::after,
+  .lp-install:focus-within::after {
+    animation: none;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Animated lockup — the kit's typing lockup, played once.
+ *
+ * Timeline, percentages, and easings are copied from
+ * docs/brand/brand-guidelines.html § motion (the 3.6s variant) — assemble,
+ * don't spin. The kit loops it; here every track runs once and holds its
+ * 100% state (`forwards`), which is each element's resting state, so the
+ * lockup finishes assembled and stays. The cursor's resting state is
+ * hidden — with animation off (reduced motion) it must be hidden explicitly,
+ * because its base style is visible.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.lp-lk-t0 {
+  animation: lp-lk-t0 3.6s linear 1 forwards;
+}
+@keyframes lp-lk-t0 {
+  0%,
+  4.5% {
+    opacity: 0;
+    transform: translateX(-14px);
+    animation-timing-function: var(--stella-ease-arrive);
+  }
+  11.5%,
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.lp-lk-t1 {
+  animation: lp-lk-t1 3.6s linear 1 forwards;
+}
+@keyframes lp-lk-t1 {
+  0%,
+  1% {
+    opacity: 0;
+    transform: translateX(-14px);
+    animation-timing-function: var(--stella-ease-arrive);
+  }
+  8%,
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.lp-lk-t2 {
+  animation: lp-lk-t2 3.6s linear 1 forwards;
+}
+@keyframes lp-lk-t2 {
+  0%,
+  8% {
+    opacity: 0;
+    transform: translateX(-14px);
+    animation-timing-function: var(--stella-ease-arrive);
+  }
+  15%,
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.lp-lk-star {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: lp-lk-star 3.6s linear 1 forwards;
+}
+@keyframes lp-lk-star {
+  0%,
+  16% {
+    opacity: 0;
+    transform: scale(0);
+    animation-timing-function: var(--stella-ease-pop);
+  }
+  26%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* The letters type on; steps(1,end) snaps each one in with no fade. */
+.lp-lk-l0 {
+  animation: lp-lk-l0 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l0 {
+  0% {
+    opacity: 0;
+  }
+  28%,
+  100% {
+    opacity: 1;
+  }
+}
+.lp-lk-l1 {
+  animation: lp-lk-l1 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l1 {
+  0% {
+    opacity: 0;
+  }
+  33%,
+  100% {
+    opacity: 1;
+  }
+}
+.lp-lk-l2 {
+  animation: lp-lk-l2 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l2 {
+  0% {
+    opacity: 0;
+  }
+  38%,
+  100% {
+    opacity: 1;
+  }
+}
+.lp-lk-l3 {
+  animation: lp-lk-l3 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l3 {
+  0% {
+    opacity: 0;
+  }
+  43%,
+  100% {
+    opacity: 1;
+  }
+}
+.lp-lk-l4 {
+  animation: lp-lk-l4 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l4 {
+  0% {
+    opacity: 0;
+  }
+  48%,
+  100% {
+    opacity: 1;
+  }
+}
+.lp-lk-l5 {
+  animation: lp-lk-l5 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-l5 {
+  0% {
+    opacity: 0;
+  }
+  53%,
+  100% {
+    opacity: 1;
+  }
+}
+
+/* The cursor advances a letter-width per typed letter, blinks, and rests
+ * hidden. */
+.lp-lk-cur {
+  animation: lp-lk-cur 3.6s steps(1, end) 1 forwards;
+}
+@keyframes lp-lk-cur {
+  0%,
+  24% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+  28% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  33% {
+    transform: translateX(36px);
+  }
+  38% {
+    transform: translateX(72px);
+  }
+  43% {
+    transform: translateX(108px);
+  }
+  48% {
+    transform: translateX(144px);
+  }
+  53% {
+    transform: translateX(180px);
+  }
+  58% {
+    opacity: 0;
+    transform: translateX(216px);
+  }
+  62.5% {
+    opacity: 1;
+  }
+  67% {
+    opacity: 0;
+  }
+  71.5% {
+    opacity: 1;
+  }
+  76% {
+    opacity: 0;
+  }
+  80.5% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 0;
+  }
+  89.5% {
+    opacity: 1;
+  }
+  90%,
+  100% {
+    opacity: 0;
+    transform: translateX(216px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [class^="lp-lk-"],
+  [class*=" lp-lk-"] {
+    animation: none;
+  }
+  .lp-lk-cur {
+    opacity: 0;
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/website/src/app/install.sh/route.ts
+++ b/website/src/app/install.sh/route.ts
@@ -1,0 +1,38 @@
+import { bump } from "@/lib/counters";
+
+/**
+ * Serves the install script from the site's own domain — `curl -fsSL
+ * https://stella.oxagen.sh/install.sh | sh` — so every real install run is
+ * countable. The script itself stays canonical in the repository; this route
+ * proxies GitHub raw (cached upstream for 5 minutes via the data cache) and
+ * bumps `install:hits` on every request.
+ *
+ * The response is `no-store`: a CDN-cached copy would serve installs the
+ * function never sees, and the count exists to be believed. If the upstream
+ * fetch fails, redirect to GitHub raw instead of failing — the one-liner
+ * uses -L, so a degraded counter must never become a degraded install.
+ */
+
+const UPSTREAM =
+  "https://raw.githubusercontent.com/macanderson/stella/main/install.sh";
+
+export async function GET(): Promise<Response> {
+  // Count first: a hit that ends in the fallback redirect is still a hit.
+  await bump("hits");
+
+  let script: string;
+  try {
+    const upstream = await fetch(UPSTREAM, { next: { revalidate: 300 } });
+    if (!upstream.ok) throw new Error(`upstream ${upstream.status}`);
+    script = await upstream.text();
+  } catch {
+    return Response.redirect(UPSTREAM, 302);
+  }
+
+  return new Response(script, {
+    headers: {
+      "content-type": "text/x-shellscript; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/website/src/components/animated-lockup.tsx
+++ b/website/src/components/animated-lockup.tsx
@@ -1,0 +1,70 @@
+import {
+  GOLD,
+  STAR_PATH,
+  TRAIL_RECTS,
+  WORDMARK_LETTERS_PATH,
+} from "@/components/brand";
+
+/**
+ * The kit's animated lockup (docs/brand/brand-guidelines.html § motion),
+ * played ONCE: the trails arrive left→right, the star pops, the letters type
+ * on behind a gold cursor, the cursor blinks out. Same geometry, same
+ * timeline, same easings as the kit's looping demo — the only difference is
+ * `animation-iteration-count: 1` with `fill-mode: forwards`, which is safe
+ * because every track's 100% keyframe is its resting state.
+ *
+ * Geometry is not duplicated: the six letters are the M-command segments of
+ * WORDMARK_LETTERS_PATH, drawn inside the +100px group the kit uses for its
+ * typing variant. Animation CSS lives in global.css (`lp-lk-*`), following
+ * the diagrams' one-stylesheet convention.
+ *
+ * Server component on purpose — the whole animation is CSS, so it costs no
+ * client JavaScript and starts on first paint.
+ */
+
+/** viewBox of the kit's typing lockup (`spin adap` variant). */
+const VIEW_BOX = "0 0 352 96";
+
+/** One path per letter: s, t, e, l, l, a. */
+const LETTERS = WORDMARK_LETTERS_PATH.split(/(?=M)/).filter(Boolean);
+
+export function AnimatedLockup({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox={VIEW_BOX}
+      className={className}
+      role="img"
+      aria-label="stella"
+    >
+      <g>
+        {TRAIL_RECTS.map((r, i) => (
+          <rect
+            key={r.y}
+            {...r}
+            className={`lp-lk-t${i}`}
+            fill={`var(--stella-gold, ${GOLD})`}
+          />
+        ))}
+        <path
+          d={STAR_PATH}
+          className="lp-lk-star"
+          fill={`var(--stella-gold, ${GOLD})`}
+        />
+        <g transform="translate(100 0)" fill="currentColor">
+          {LETTERS.map((d, i) => (
+            <path key={d.slice(0, 12)} d={d} className={`lp-lk-l${i}`} />
+          ))}
+        </g>
+        <rect
+          className="lp-lk-cur"
+          x="106"
+          y="20.1"
+          width="20"
+          height="55.8"
+          rx="2"
+          fill={`var(--stella-gold, ${GOLD})`}
+        />
+      </g>
+    </svg>
+  );
+}

--- a/website/src/components/install-block.tsx
+++ b/website/src/components/install-block.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+/**
+ * The copyable install one-liner.
+ *
+ * One stretched, invisible button covers the whole block, so a click anywhere
+ * copies the command and keyboard/screen-reader users get exactly one control
+ * ("Copy install command"). The corner chip is purely visual state — it is
+ * aria-hidden, and the announcement rides a polite live region instead.
+ *
+ * Every successful copy fires a beacon at /api/hit. Together with the
+ * download counter behind /install.sh this yields the two numbers worth
+ * having: how many people copied the command, and how many actually ran it.
+ * Counting is fire-and-forget — it must never delay or break the copy.
+ */
+export function InstallBlock({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+    } catch {
+      // Clipboard denied (permissions, insecure context). Claim nothing.
+      return;
+    }
+    setCopied(true);
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => setCopied(false), 2000);
+    try {
+      navigator.sendBeacon("/api/hit");
+    } catch {
+      // Counting is best-effort by design.
+    }
+  }
+
+  return (
+    <div className="lp-install">
+      <div className="term">
+        <pre className="term-body">
+          <span className="term-prompt">$ </span>
+          {command}
+        </pre>
+      </div>
+      <button
+        type="button"
+        className="lp-install-hit"
+        aria-label="Copy install command"
+        onClick={() => void copy()}
+      />
+      <span className="lp-install-chip" aria-hidden="true">
+        {copied ? "✓ copied" : "copy"}
+      </span>
+      <span className="sr-only" aria-live="polite">
+        {copied ? "Install command copied" : ""}
+      </span>
+    </div>
+  );
+}

--- a/website/src/lib/counters.ts
+++ b/website/src/lib/counters.ts
@@ -1,0 +1,59 @@
+import { Redis } from "@upstash/redis";
+
+/**
+ * The install funnel's two counters — script downloads (`install:hits`,
+ * bumped by /install.sh) and command copies (`install:copies`, bumped by the
+ * landing page's beacon at /api/hit).
+ *
+ * Storage is Upstash Redis via the Vercel Marketplace (`vercel integration
+ * add upstash`), which injects UPSTASH_REDIS_REST_URL/TOKEN. `INCR` is
+ * atomic, so concurrent hits never lose counts — the failure mode a
+ * read-modify-write over blob storage would have.
+ *
+ * Everything degrades to a no-op when the store is not provisioned, and
+ * every call swallows its errors: counting is a passenger. It must never
+ * delay, break, or block serving the install script — a lost count is
+ * nothing, a failed install is a lost user.
+ */
+
+export type InstallCounter = "hits" | "copies";
+
+function client(): Redis | null {
+  // Checked per call rather than at module top level so `next build` (which
+  // evaluates module scope) never requires the env to exist.
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return null;
+  }
+  return Redis.fromEnv();
+}
+
+/** Add one to a counter. Fire-and-forget semantics; never throws. */
+export async function bump(counter: InstallCounter): Promise<void> {
+  try {
+    await client()?.incr(`install:${counter}`);
+  } catch {
+    // Counting is best-effort by design.
+  }
+}
+
+/** Both counters. `configured: false` means the store is not provisioned. */
+export async function readCounters(): Promise<{
+  configured: boolean;
+  hits: number;
+  copies: number;
+}> {
+  try {
+    const redis = client();
+    if (!redis) return { configured: false, hits: 0, copies: 0 };
+    const [hits, copies] = await redis.mget<(number | null)[]>(
+      "install:hits",
+      "install:copies",
+    );
+    return { configured: true, hits: hits ?? 0, copies: copies ?? 0 };
+  } catch {
+    return { configured: false, hits: 0, copies: 0 };
+  }
+}

--- a/website/src/lib/layout.shared.tsx
+++ b/website/src/lib/layout.shared.tsx
@@ -8,17 +8,22 @@ import { Mark, Wordmark } from "@/components/brand";
  * Branding: the lockup — gold comet flying left→right into the outlined
  * wordmark — followed by a quiet "docs" qualifier. The wordmark's own sparkle
  * is dropped here because the comet already carries the gold; two stars in a
- * 16px-tall nav is one star too many. Everything renders inline from the same
- * geometry the rest of the site uses, so the letters paint with
+ * nav-sized lockup is one star too many. Everything renders inline from the
+ * same geometry the rest of the site uses, so the letters paint with
  * `currentColor` and invert with the theme.
+ *
+ * Size: the lockup fills the fixed-height header instead of floating in it —
+ * mark 28px, wordmark 24px. The header's own height clamps it, so growing
+ * these numbers never grows the chrome; past ~h-8 the mark starts touching
+ * the header padding, which is the real ceiling.
  */
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
       title: (
-        <span className="inline-flex items-center gap-2">
-          <Mark className="h-5 w-auto" />
-          <Wordmark className="h-4 w-auto text-fd-foreground" sparkle={false} />
+        <span className="inline-flex items-center gap-2.5">
+          <Mark className="h-7 w-auto" />
+          <Wordmark className="h-6 w-auto text-fd-foreground" sparkle={false} />
           <span className="text-sm text-fd-muted-foreground">docs</span>
         </span>
       ),


### PR DESCRIPTION
Five requests from Mac, all against the comet theme (main after #1063/#1070):

## Sidebar contrast
The docs sidebar painted `bg-fd-card` (#fcfaf4) on the #f6f2e9 warm-paper page — a 1.02:1 non-seam that read as one soft brown field. The sidebar is now **white** in light mode, with the `--color-fd-*` tokens re-scoped inside `#nd-sidebar` so Fumadocs' hover/selected chips go neutral on white instead of warm cream. Dark mode already had its lift (#131315 on #0b0b0c) and is untouched.

## Header lockup
Mark 20→28px, wordmark 16→24px, inside the fixed-height header — the chrome cannot get taller, the lockup stops being invisible.

## Install block (the hero's one action)
- **Copyable**: one stretched, invisible button covers the block (single control, `aria-label`, focus ring, polite live-region announcement; the corner `copy / ✓ copied` chip is aria-hidden state).
- **Springy grow**: hover lifts it `scale(1.02)` on a Motion-generated `linear()` spring — 350ms, ~6% overshoot, settles. A surface, not a cartoon.
- **Shimmer**: a gold sheen sweeps left→right (the comet's direction), immediately on hover and again **every 10s while still hovered** — one 10s keyframe track (sweep = first 14%), `infinite`, zero JS.
- Reduced motion disables all of it.

## Animated lockup, drawn once
The brand kit's 3.6s typing lockup (trails arrive → star pops → letters type behind a gold cursor → cursor blinks out) now assembles **once** front-and-center above the install prompt: same timeline, same easings, `iteration-count: 1` + `fill: forwards` (every track's 100% keyframe is its resting state). The letters are split from `WORDMARK_LETTERS_PATH` at its `M` commands inside the kit's `translate(100,0)` group — no geometry duplicated. The hero's old static lockup is removed (one mark, where it points at something). Pure CSS, server-rendered, no client JS.

## Counted install funnel
Two numbers, atomically counted in Upstash Redis via the Vercel Marketplace:
- `install:hits` — **GET /install.sh** now serves the canonical script from the site's own domain (proxies GitHub raw with a 5-min upstream cache; `no-store` response so the CDN can't hide hits; **redirect fallback to GitHub raw if the proxy fetch fails**, so counting can never break an install). Landing page + installation docs now point at `https://stella.oxagen.sh/install.sh`.
- `install:copies` — the copy control fires `sendBeacon('/api/hit')` per successful copy.
- **GET /api/hit** returns both: `{"configured":true,"hits":…,"copies":…}`.

Everything no-ops gracefully until the store exists — **one-time setup: `vercel integration add upstash`** on the site's Vercel project (injects `UPSTASH_REDIS_REST_URL/TOKEN`). Until then the script still serves and `configured:false` says why the numbers are zero.

## Verification
- `pnpm typecheck` and production `next build` clean; 94/94 static pages; `ƒ /install.sh` + `ƒ /api/hit` registered.
- Live smoke on the built server: `/install.sh` → 200 `text/x-shellscript`, 12,947 bytes (byte-size-identical to repo `install.sh`); `/api/hit` GET → `{"configured":false,…}` (graceful no-env path); POST → 204.
- Adversarial model review of the diff is running; findings land as follow-up commits here.

## Summary by Sourcery

Refresh the website hero and navigation chrome, and add an install funnel that counts script downloads and command copies via Upstash-backed endpoints.

New Features:
- Expose an /install.sh route that serves the canonical install script from the site domain while proxying GitHub raw with a fallback redirect.
- Expose an /api/hit endpoint that increments install copy counts and returns both install script hit and copy counters as JSON.
- Add a copyable install block component on the landing page with an accessible, full-surface control and visual feedback.
- Introduce an animated brand lockup in the hero that plays once via CSS animations.

Enhancements:
- Change the docs sidebar to use a white background in light mode with re-scoped Fumadocs color tokens, keeping dark mode behavior intact.
- Increase the mark and wordmark sizes in the header so the branding fills the fixed header height without increasing chrome size.
- Add motion and shimmer styling around the install block, with reduced-motion fallbacks to respect user preferences.

Build:
- Add @upstash/redis as a website dependency to support install funnel counters.