### PR TITLE
fix(website): keep letter counters in their glyphs; count every documented install path

### DIFF
--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -15,7 +15,7 @@ If you would rather paste one block and read afterwards, this is the whole path:
 
 ```bash
 # 1. Install.
-curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
+curl -fsSL https://stella.oxagen.sh/install.sh | sh
 
 # 2. Bring your own key — any one provider will do.
 export ANTHROPIC_API_KEY="sk-ant-..."

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -288,7 +288,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Stella
         run: |
-          curl -fsSL https://raw.githubusercontent.com/macanderson/stella/main/install.sh | sh
+          curl -fsSL https://stella.oxagen.sh/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run the task

--- a/website/src/components/animated-lockup.tsx
+++ b/website/src/components/animated-lockup.tsx
@@ -25,8 +25,14 @@ import {
 /** viewBox of the kit's typing lockup (`spin adap` variant). */
 const VIEW_BOX = "0 0 352 96";
 
-/** One path per letter: s, t, e, l, l, a. */
-const LETTERS = WORDMARK_LETTERS_PATH.split(/(?=M)/).filter(Boolean);
+/**
+ * One path per letter: s, t, e, l, l, a. Split on whitespace before `M` —
+ * letter boundaries in the path string are `"Z M"`, while the counter
+ * subpaths inside `e` and `a` are `"ZM"` with no gap and must stay in their
+ * letter's path (a counter separated into its own path stops punching its
+ * hole, and the extra pieces would fall outside the six animation slots).
+ */
+const LETTERS = WORDMARK_LETTERS_PATH.split(/\s+(?=M)/).filter(Boolean);
 
 export function AnimatedLockup({ className }: { className?: string }) {
   return (


### PR DESCRIPTION
Follow-up to #1074 (merged before the adversarial diff review finished — these are its two confirmed findings):

- **Animated lockup letter split**: the split matched the `M` of the counter subpaths inside `e` and `a` (`ZM`, no gap), yielding 8 pieces instead of 6 — two fell outside the six animation slots and rendered from t=0, and a counter separated from its glyph stops punching its hole, so `e`/`a` would paint as solid blobs once assembled. Letter boundaries in the path string are `Z M` (with whitespace), so the split is now `/\s+(?=M)/` — verified to yield exactly six pieces with both counters kept in their glyphs, matching the kit's lt0–lt5 geometry.
- **Two uncounted install paths**: `getting-started/index.mdx` and `scripting.mdx` still piped the GitHub-raw URL, bypassing `install:hits`. Both now use the counted `https://stella.oxagen.sh/install.sh`. The route's `UPSTREAM` const is the one legitimate raw reference left in `website/`.

Verified: letter-split check (6 pieces, 2 interior counters), `pnpm typecheck`, production build exit 0, and a repo-wide sweep showing no remaining raw install URLs outside the proxy route.

## Summary by Sourcery

Fix animated wordmark letter splitting and route documentation to the counted install script URL.

Bug Fixes:
- Correct animated lockup letter path splitting so counters inside e and a remain part of their glyphs and animation uses exactly six letter paths.

Documentation:
- Update getting-started and scripting docs to use the proxied install.sh URL that participates in install hit counting instead of the raw GitHub URL.