### PR TITLE
fix(pipeline): reject a renamed witness test file as tampering

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -28,7 +28,7 @@
 1955 stella-model/src/openai.rs
 1723 stella-model/src/zai/tests.rs
 3173 stella-pipeline/src/pipeline.rs
-2392 stella-pipeline/src/pipeline/tests.rs
+2393 stella-pipeline/src/pipeline/tests.rs
 2752 stella-protocol/src/event.rs
 2074 stella-store/src/lib.rs
 2234 stella-store/src/tests.rs

--- a/stella-cli/src/agent/tools.rs
+++ b/stella-cli/src/agent/tools.rs
@@ -179,7 +179,7 @@ impl RepoStatusPort for GitRepoStatus {
     }
 
     async fn artifact_identity(&self, path: &str) -> Option<stella_pipeline::ArtifactIdentity> {
-        fs_artifact_identity(&self.root.join(path))
+        fs_artifact_identity(&self.root, path)
     }
 }
 
@@ -188,13 +188,47 @@ impl RepoStatusPort for GitRepoStatus {
 /// restored after a same-length edit and would incorrectly credit a tampered
 /// witness. One definition is shared with candidate snapshots.
 pub(crate) fn fs_fingerprint(path: &std::path::Path) -> Option<String> {
-    fs_artifact_identity(path).map(|identity| identity.fingerprint)
+    Some(
+        OpenedWitnessArtifact::open(path)?
+            .identity_for_path(path)?
+            .fingerprint,
+    )
 }
 
+/// Identity for the workspace-relative `rel` under `root`, attesting the
+/// location the artifact was actually observed at: `path` carries the opened
+/// file's canonical position relative to the canonical root. A witness that
+/// was renamed and is still reachable through an aliased lookup (a
+/// case-folding filesystem, a symlinked parent directory) therefore reports
+/// its real location, which the pipeline's pinned-path equality rejects as
+/// tampering. A file whose canonical position cannot be stated inside `root`
+/// has no identity at all — fail closed, exactly like a symlink.
 pub(crate) fn fs_artifact_identity(
-    path: &std::path::Path,
+    root: &std::path::Path,
+    rel: &str,
 ) -> Option<stella_pipeline::ArtifactIdentity> {
-    OpenedWitnessArtifact::open(path)?.identity_for_path(path)
+    let full = root.join(rel);
+    let identity = OpenedWitnessArtifact::open(&full)?.identity_for_path(&full)?;
+    Some(ArtifactIdentity {
+        path: observed_relative_path(root, &full)?,
+        ..identity
+    })
+}
+
+/// The canonical position of `full` relative to the canonical `root`, in the
+/// repo-relative `/`-separated form the pipeline pins witness paths in.
+fn observed_relative_path(root: &std::path::Path, full: &std::path::Path) -> Option<String> {
+    let canonical_root = std::fs::canonicalize(root).ok()?;
+    let observed = std::fs::canonicalize(full).ok()?;
+    let rel = observed.strip_prefix(&canonical_root).ok()?;
+    let mut out = String::new();
+    for component in rel.components() {
+        if !out.is_empty() {
+            out.push('/');
+        }
+        out.push_str(component.as_os_str().to_str()?);
+    }
+    (!out.is_empty()).then_some(out)
 }
 
 struct OpenedWitnessArtifact {
@@ -255,6 +289,10 @@ impl OpenedWitnessArtifact {
             write!(&mut fingerprint, "{byte:02x}").ok()?;
         }
         Some(ArtifactIdentity {
+            // The observed location is attested by `fs_artifact_identity`,
+            // which knows the workspace root. Left empty here, a bare content
+            // identity can never satisfy the pipeline's pinned-path equality.
+            path: String::new(),
             fingerprint,
             kind: ArtifactKind::Regular,
             mode,
@@ -811,19 +849,23 @@ mod tests {
         let symlink = dir.path().join("symlink.rs");
         std::fs::write(&file, "test bytes\n").unwrap();
 
-        let before = fs_artifact_identity(&file).unwrap();
+        let before = fs_artifact_identity(dir.path(), "witness.rs").unwrap();
         assert_eq!(before.kind, ArtifactKind::Regular);
         assert!(before.is_regular_single_link());
+        assert_eq!(
+            before.path, "witness.rs",
+            "the identity attests the location it was observed at"
+        );
 
         std::fs::hard_link(&file, &hardlink).unwrap();
         assert!(
-            fs_artifact_identity(&file).is_none(),
+            fs_artifact_identity(dir.path(), "witness.rs").is_none(),
             "multi-link files fail closed at the identity boundary"
         );
 
         std::os::unix::fs::symlink(&file, &symlink).unwrap();
         assert!(
-            fs_artifact_identity(&symlink).is_none(),
+            fs_artifact_identity(dir.path(), "symlink.rs").is_none(),
             "no-follow identity must never open a symlink target"
         );
 
@@ -831,7 +873,7 @@ mod tests {
         let mut permissions = std::fs::metadata(&file).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&file, permissions).unwrap();
-        let executable = fs_artifact_identity(&file).unwrap();
+        let executable = fs_artifact_identity(dir.path(), "witness.rs").unwrap();
         assert_ne!(before.fingerprint, executable.fingerprint);
     }
 
@@ -853,12 +895,42 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn witness_identity_attests_the_observed_location_through_an_aliased_lookup() {
+        // A renamed witness can stay reachable at its pinned path when the
+        // lookup is aliased — here a symlinked parent directory, the same
+        // shape a case-folding filesystem produces. The identity must report
+        // where the bytes actually live, so the pipeline's pinned-path
+        // equality rejects the move as tampering.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("moved")).unwrap();
+        std::fs::write(dir.path().join("moved/witness.rs"), "test bytes\n").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("moved"), dir.path().join("tests")).unwrap();
+
+        let identity = fs_artifact_identity(dir.path(), "tests/witness.rs")
+            .expect("the aliased lookup still opens a regular file");
+        assert_eq!(
+            identity.path, "moved/witness.rs",
+            "the attested path is the canonical location, not the asked-for one"
+        );
+        assert!(
+            !stella_pipeline::witness_identity_matches(
+                &stella_pipeline::ArtifactIdentity {
+                    path: "tests/witness.rs".into(),
+                    ..identity.clone()
+                },
+                Some(&identity)
+            ),
+            "an identity pinned at the asked-for path must reject the moved artifact"
+        );
+    }
+
     #[test]
     fn witness_identity_requires_established_platform_link_count() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("witness.rs");
-        std::fs::write(&path, "test bytes\n").unwrap();
-        let identity = fs_artifact_identity(&path);
+        std::fs::write(dir.path().join("witness.rs"), "test bytes\n").unwrap();
+        let identity = fs_artifact_identity(dir.path(), "witness.rs");
         #[cfg(unix)]
         assert!(
             identity.is_some(),

--- a/stella-cli/src/candidate_ws.rs
+++ b/stella-cli/src/candidate_ws.rs
@@ -569,7 +569,7 @@ impl RepoStatusPort for SnapshotRepoStatus {
     }
 
     async fn artifact_identity(&self, path: &str) -> Option<stella_pipeline::ArtifactIdentity> {
-        fs_artifact_identity(&self.ws_root.join(path))
+        fs_artifact_identity(&self.ws_root, path)
     }
 }
 

--- a/stella-pipeline/src/pipeline/tests.rs
+++ b/stella-pipeline/src/pipeline/tests.rs
@@ -194,6 +194,7 @@ impl RepoStatusPort for SeqRepoStatus {
                 .unwrap()
                 .get(path)
                 .map(|fingerprint| ArtifactIdentity {
+                    path: path.to_string(),
                     fingerprint: fingerprint.clone(),
                     kind: ArtifactKind::Regular,
                     mode: 0o100644,

--- a/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -988,6 +988,89 @@ async fn a_tampered_witness_file_hard_fails_before_judge_evaluation() {
     );
 }
 
+/// Tamper exclusion: the worker RENAMED the witness test file after it was
+/// authored. A rename keeps every content facet — bytes, mode, link count —
+/// and an aliased lookup (a case-folding filesystem, a symlinked parent
+/// directory) can still resolve the pinned path to those bytes, so the
+/// observation arrives identical in everything but the location it was
+/// actually made at. The location is part of the pinned identity: the
+/// candidate hard-fails without judge override, exactly like an edit.
+#[tokio::test]
+async fn a_renamed_witness_file_hard_fails_before_judge_evaluation() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("done"), // worker
+        text_result("TEST_COMMAND: cargo test --test witness witness -- --exact"),
+        text_result("PASS override attempt"), // must remain unused
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // The candidate's own repo status. `artifact_identity` is asked twice:
+    // once right after the graft, where the artifact sits at its accepted
+    // path (w1 at tests/witness.rs), and once at the tamper check — where the
+    // worker has since moved the file (the untracked delta shows the move):
+    // the very same bytes, observed at tests/renamed_witness.rs.
+    let candidate_status = SeqRepoStatus::new(vec![
+        vec![],
+        vec![("tests/witness.rs", "w1")],
+        vec![("tests/renamed_witness.rs", "w1")],
+    ])
+    .with_artifact_identities(vec![
+        Some(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        }),
+        Some(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        }),
+    ]);
+    // The authoring snapshot: the artifact appears (w1) and is accepted there.
+    let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
+        .with_artifact_identity(ArtifactIdentity {
+            fingerprint: "w1".into(),
+            kind: ArtifactKind::Regular,
+            mode: 0o100644,
+            link_count: 1,
+        });
+    // The post-execute observation PASSES — the renamed file still collects
+    // under the flip command on this run — so the ladder would submit fast.
+    // The rename must override that.
+    let candidate = FakeWorkspace::new(0, vec![true], Ok(vec![]), log.clone())
+        .with_repo_status(candidate_status);
+    let baseline = FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone())
+        .with_repo_status(baseline_status);
+    let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
+    let (outcome, events, _) = run_isolated(
+        &provider,
+        &port,
+        PipelineConfig {
+            max_revisions: 0,
+            ..PipelineConfig::default()
+        },
+        "Fix the retry bug",
+    )
+    .await;
+    let outcome = outcome.expect("a renamed witness is a truthful candidate failure");
+
+    assert_aborted_because(
+        &outcome.status,
+        "witness artifact changed after its accepted baseline: tests/witness.rs",
+    );
+    assert!(
+        !stages(&events).contains(&StageKind::Judge),
+        "a renamed witness is not eligible for judge override"
+    );
+    let log = log.lock().unwrap().clone();
+    assert!(
+        !log.iter().any(|entry| entry.starts_with("adopt:")),
+        "a moved witness must never reach adoption: {log:?}"
+    );
+}
+
 /// The grafted witness is scaffolding, not the worker's work, so it must never
 /// be attributed to the turn's diff.
 ///

--- a/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -382,6 +382,7 @@ async fn sealed_witness_identity_survives_git_reclassification_out_of_untracked_
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let identity = ArtifactIdentity {
+        path: "tests/authority_witness.rs".into(),
         fingerprint: "sha256:test".into(),
         kind: ArtifactKind::Regular,
         mode: 0o100644,
@@ -629,6 +630,7 @@ async fn symlink_witness_artifact_aborts_after_worker_execution() {
         vec![("tests/authority_witness.rs", "sha256:symlink")],
     ])
     .with_artifact_identity(ArtifactIdentity {
+        path: "tests/authority_witness.rs".into(),
         fingerprint: "sha256:symlink".into(),
         kind: ArtifactKind::Symlink,
         mode: 0o120777,
@@ -678,12 +680,14 @@ async fn post_baseline_witness_tamper_is_hard_failure_even_if_judge_would_pass()
     ])
     .with_artifact_identities(vec![
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
             link_count: 1,
         }),
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w2".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -692,6 +696,7 @@ async fn post_baseline_witness_tamper_is_hard_failure_even_if_judge_would_pass()
     ]);
     let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
         .with_artifact_identity(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -940,12 +945,14 @@ async fn a_tampered_witness_file_hard_fails_before_judge_evaluation() {
     ])
     .with_artifact_identities(vec![
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
             link_count: 1,
         }),
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w2".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -955,6 +962,7 @@ async fn a_tampered_witness_file_hard_fails_before_judge_evaluation() {
     // The authoring snapshot: the artifact appears (w1) and is accepted there.
     let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
         .with_artifact_identity(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -1016,12 +1024,14 @@ async fn a_renamed_witness_file_hard_fails_before_judge_evaluation() {
     ])
     .with_artifact_identities(vec![
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
             link_count: 1,
         }),
         Some(ArtifactIdentity {
+            path: "tests/renamed_witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -1031,6 +1041,7 @@ async fn a_renamed_witness_file_hard_fails_before_judge_evaluation() {
     // The authoring snapshot: the artifact appears (w1) and is accepted there.
     let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
         .with_artifact_identity(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -1096,6 +1107,7 @@ async fn a_grafted_witness_is_not_billed_to_the_workers_diff() {
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));
     let identity = ArtifactIdentity {
+        path: "tests/authority_witness.rs".into(),
         fingerprint: "sha256:test".into(),
         kind: ArtifactKind::Regular,
         mode: 0o100644,
@@ -1186,18 +1198,21 @@ async fn a_revise_turn_that_edits_the_witness_hard_fails_at_the_next_check() {
     ])
     .with_artifact_identities(vec![
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
             link_count: 1,
         }),
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
             link_count: 1,
         }),
         Some(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w2".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,
@@ -1206,6 +1221,7 @@ async fn a_revise_turn_that_edits_the_witness_hard_fails_at_the_next_check() {
     ]);
     let baseline_status = SeqRepoStatus::new(vec![vec![], vec![("tests/witness.rs", "w1")]])
         .with_artifact_identity(ArtifactIdentity {
+            path: "tests/witness.rs".into(),
             fingerprint: "w1".into(),
             kind: ArtifactKind::Regular,
             mode: 0o100644,

--- a/stella-pipeline/src/ports.rs
+++ b/stella-pipeline/src/ports.rs
@@ -308,9 +308,19 @@ pub enum ArtifactKind {
 
 /// Complete witness artifact identity. Accepted identities are regular,
 /// single-link files whose fingerprint commits to bytes, type, mode, and link
-/// count from one no-follow file handle.
+/// count from one no-follow file handle — plus the workspace-relative path the
+/// observation was actually made at, so a renamed artifact can never equal its
+/// accepted baseline.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtifactIdentity {
+    /// The workspace-relative location the artifact was actually observed at,
+    /// not the path the caller asked about. The two differ exactly when the
+    /// lookup was aliased — a case-folding filesystem or a symlinked parent
+    /// directory resolving a pinned path to a file that has since been moved —
+    /// which is a rename, and a rename is tampering. Adapters that cannot
+    /// attest a location must leave this empty: an empty path can never match
+    /// an accepted one, so the identity fails closed.
+    pub path: String,
     pub fingerprint: String,
     pub kind: ArtifactKind,
     pub mode: u32,

--- a/stella-pipeline/src/witness.rs
+++ b/stella-pipeline/src/witness.rs
@@ -482,7 +482,10 @@ fn dotnet_invocation_is_exact(path: &str, args: &[String]) -> bool {
     })
 }
 
-/// Pin the accepted delta entry to a no-follow filesystem identity.
+/// Pin the accepted delta entry to a no-follow filesystem identity. The
+/// identity must have been observed at the accepted path itself — an
+/// observation the adapter attests was resolved elsewhere (or could not
+/// locate at all) is not the accepted artifact.
 pub fn validate_witness_identity(
     path: &str,
     expected_fingerprint: &str,
@@ -491,6 +494,7 @@ pub fn validate_witness_identity(
     match identity {
         Some(identity)
             if identity.is_regular_single_link()
+                && identity.path == path
                 && identity.fingerprint == expected_fingerprint =>
         {
             Ok(())
@@ -558,7 +562,10 @@ pub struct Witness {
 }
 
 /// Whether the current no-follow filesystem observation is exactly the
-/// regular, single-link artifact accepted at witness authoring time.
+/// regular, single-link artifact accepted at witness authoring time —
+/// including the location the observation was made at, so a witness that was
+/// renamed to a different path never matches even when an aliased lookup
+/// still resolves the pinned path to its unchanged bytes.
 pub fn witness_identity_matches(
     expected: &ArtifactIdentity,
     current: Option<&ArtifactIdentity>,
@@ -1027,6 +1034,7 @@ mod tests {
 
     fn identity(fingerprint: &str) -> ArtifactIdentity {
         ArtifactIdentity {
+            path: "tests/authority_witness.rs".to_string(),
             fingerprint: fingerprint.to_string(),
             kind: ArtifactKind::Regular,
             mode: 0o100_644,
@@ -1052,6 +1060,50 @@ mod tests {
         assert!(
             !witness_identity_matches(&expected, None),
             "an artifact that no longer exists can never match"
+        );
+    }
+
+    #[test]
+    fn a_witness_artifact_renamed_to_a_different_path_is_tampered() {
+        // A rename keeps every content facet — bytes, mode, link count — and
+        // an aliased lookup (a case-folding filesystem, a symlinked parent
+        // directory) can still resolve the pinned path to the moved bytes.
+        // The location the observation was made at is part of the identity,
+        // so the moved artifact must not match.
+        let expected = identity("w1");
+        let renamed = ArtifactIdentity {
+            path: "tests/renamed_witness.rs".to_string(),
+            ..identity("w1")
+        };
+        assert!(
+            !witness_identity_matches(&expected, Some(&renamed)),
+            "the path is part of the identity — a content comparison misses a rename"
+        );
+    }
+
+    #[test]
+    fn witness_acceptance_requires_the_identity_observed_at_the_accepted_path() {
+        let observed_at_accepted_path = identity("w1");
+        assert!(
+            validate_witness_identity(
+                "tests/authority_witness.rs",
+                "w1",
+                Some(&observed_at_accepted_path)
+            )
+            .is_ok()
+        );
+        let observed_elsewhere = ArtifactIdentity {
+            path: "tests/renamed_witness.rs".to_string(),
+            ..identity("w1")
+        };
+        assert!(
+            validate_witness_identity(
+                "tests/authority_witness.rs",
+                "w1",
+                Some(&observed_elsewhere)
+            )
+            .is_err(),
+            "an identity the adapter attests was resolved elsewhere is not the accepted artifact"
         );
     }
 


### PR DESCRIPTION
## The gap

The witness tamper check (`Pipeline::verify_candidate`, `stella-pipeline/src/pipeline.rs`) re-observes each pinned witness path and compares the result to the identity accepted at authoring via `witness_identity_matches`. The module docs (`witness.rs`) promise the pinned identity covers "bytes, type, mode, link count, **and path**" and that a worker who "edits, replaces, links, **renames**, or deletes" the witness hard-fails — but `ArtifactIdentity` carried no path, so the check could only compare content facets.

A rename keeps every content facet intact, and the pinned-path lookup can keep resolving to the moved bytes: the production adapter opens `root.join(path)` with `O_NOFOLLOW`, which guards only the final component — a case-folding filesystem (macOS default) or a symlinked parent directory still resolves the old path after the file has moved. In that shape the renamed witness sailed through the tamper check and the run completed with a deterministic pass and adoption.

## The fix

- `stella-pipeline/src/ports.rs` — `ArtifactIdentity` gains `path`: the workspace-relative location the observation was **actually made at**. Adapters that cannot attest a location leave it empty, which can never match an accepted path (fail closed).
- `stella-pipeline/src/witness.rs` — `validate_witness_identity` now requires `identity.path == path` at acceptance and at the graft re-pin; `witness_identity_matches`' strict equality then rejects a renamed witness at every verify-loop tamper check, exactly like an edit. Same abort surface and message: `witness artifact changed after its accepted baseline: <path>`.
- `stella-cli/src/agent/tools.rs` — `fs_artifact_identity(root, rel)` attests the opened file's canonical position relative to the canonical root (`observed_relative_path`), so aliased lookups report the real location; a file whose canonical position cannot be stated inside the root has no identity at all.

## Fail→pass evidence

The first commit adds `pipeline::tests::witness_isolation::a_renamed_witness_file_hard_fails_before_judge_evaluation` (worker moves the witness after the graft; the pinned-path observation still returns the unchanged bytes). On that commit:

```
thread '...a_renamed_witness_file_hard_fails_before_judge_evaluation' panicked:
expected an aborted run, got Completed
```

On the second commit the same scenario aborts with `witness artifact changed after its accepted baseline: tests/witness.rs`, the judge is never consulted, and nothing is adopted. New unit pins: `a_witness_artifact_renamed_to_a_different_path_is_tampered`, `witness_acceptance_requires_the_identity_observed_at_the_accepted_path` (stella-pipeline), and `witness_identity_attests_the_observed_location_through_an_aliased_lookup` (stella-cli, real symlinked-directory alias on disk).

## Gates

- `cargo test -p stella-pipeline` — green (exit 0, 348 lib tests + integration suites)
- `cargo test -p stella-cli witness` — green (16 tests incl. the new attestation test and the seal/adopt identity round-trips)
- `cargo fmt --check` clean on touched crates; `cargo clippy -p stella-pipeline --all-targets -- -D warnings` and `-p stella-cli` clean; `cargo check --workspace --all-targets` green
- file-size gate: `pipeline/tests.rs` grew by the one line the shared fake needed for the new field; baseline updated via `make file-size-update`

## Summary by Sourcery

Ensure witness tamper detection treats path changes as tampering and rejects renamed witness artifacts even when content is unchanged.

New Features:
- Record workspace-relative path in witness artifact identities and propagate it through pipeline and CLI adapters to support path-based tamper detection.

Bug Fixes:
- Reject witness artifacts that have been renamed or resolved through aliased lookups at a different path from their accepted baseline, preventing them from passing tamper checks.
- Require witness acceptance to use identities observed at the accepted path, failing closed when the adapter cannot attest a location or when the artifact has moved.

Enhancements:
- Refine filesystem identity helpers in the CLI to attest canonical artifact locations under the workspace root and update unit tests to cover aliased lookups, renames, and path-aware matching behavior.

Tests:
- Add pipeline and CLI tests that simulate renamed witness files, aliased directory lookups, and path-aware identity validation to guard against regressions in tamper detection behavior.