### PR TITLE
fix(ci): unbreak main — openpty wants a raw pointer, not &mut, on *const-winsize platforms

### DIFF
--- a/stella-tui/tests/deck_pty_smoke.rs
+++ b/stella-tui/tests/deck_pty_smoke.rs
@@ -126,7 +126,11 @@ impl DeckPty {
                 &mut slave,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
-                &mut ws,
+                // A raw pointer, not `&mut`: libc's openpty takes `*const
+                // winsize` on Linux but `*mut winsize` on macOS, and `*mut`
+                // coerces to both — `&mut` trips clippy's
+                // unnecessary_mut_passed on the `*const` platforms.
+                &raw mut ws,
             )
         };
         assert_eq!(rc, 0, "openpty: {}", std::io::Error::last_os_error());


### PR DESCRIPTION
Main's `ci` has been red since 18257f54 (#1072): `deck_pty_smoke.rs` passes `&mut ws` to `libc::openpty`, whose `winp` parameter is `*const winsize` on Linux but `*mut winsize` on macOS. The `&mut` coerces to both raw-pointer types (so it compiles everywhere and the macOS pre-push gate was green), but clippy's `unnecessary_mut_passed` fires on the `*const` platforms — Linux CI red, every PR's required check red with it, and **auto-tag cannot cut a release** until this lands.

One line: `&raw mut ws` produces `*mut winsize`, which satisfies macOS's signature verbatim and coerces implicitly to `*const` on Linux, and gives clippy no reference to lint (MSRV is 1.90, `&raw` needs 1.82).

Full `make gate` (fmt, clippy -D warnings, tests) green locally on this exact commit. Marked draft per convention — this is merge-ready and unblocks #1076's required check plus the release pipeline.

## Summary by Sourcery

Adjust test PTY winsize pointer usage to resolve clippy warnings and unblock CI.

CI:
- Unblock Linux CI by fixing clippy unnecessary_mut_passed warning in test code.

Tests:
- Update deck_pty_smoke test to pass a raw winsize pointer to openpty instead of a mutable reference to satisfy platform-specific pointer signatures.