### PR TITLE
feat(website): hide home nav until scroll, enlarge hero lockup, pair install with docs CTA

### DIFF
--- a/website/src/app/(home)/layout.tsx
+++ b/website/src/app/(home)/layout.tsx
@@ -1,11 +1,6 @@
-import { HomeLayout } from "fumadocs-ui/layouts/home";
 import type { ReactNode } from "react";
-import { baseOptions } from "@/lib/layout.shared";
+import { HomeChrome } from "@/components/home-chrome";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return (
-    <HomeLayout {...baseOptions()}>
-      {children}
-    </HomeLayout>
-  );
+  return <HomeChrome>{children}</HomeChrome>;
 }

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -59,6 +59,11 @@ export default function HomePage() {
       {/* ── What it is ─────────────────────────────────────────────────── */}
       <section className="lp-hero">
         <div className="mx-auto w-full max-w-3xl px-4 py-20 sm:py-28">
+          {/* The home page hides the standard nav bar until the reader
+              scrolls (see components/home-chrome.tsx), so the lockup takes
+              the corner the nav's own logo would otherwise own — large,
+              top-left, first thing assembled. */}
+          <AnimatedLockup className="mb-10 h-20 w-auto text-fd-foreground sm:h-28" />
           <h1 className="lp-h1">
             <span className="lp-brand-face">stella</span> is a terminal coding
             agent that proves its work finished.
@@ -70,25 +75,24 @@ export default function HomePage() {
             and telemetry never leaves your disk.
           </p>
 
-          {/* The lockup assembles once, front and center, and hands the eye
-              straight down to the one action this page wants: install. The
-              hero's old static lockup above the h1 is gone — one mark, where
-              it points at something. */}
+          {/* Install and "read the docs" are the same decision — try it now,
+              or read first — so they sit side by side instead of stacked. */}
           <div className="mt-12">
-            <div className="mb-8 flex justify-center">
-              <AnimatedLockup className="h-16 w-auto text-fd-foreground sm:h-20" />
-            </div>
             <p className="mb-2 text-sm text-fd-muted-foreground">Install it:</p>
-            <InstallBlock command={INSTALL} />
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-stretch">
+              <div className="min-w-0 flex-1">
+                <InstallBlock command={INSTALL} />
+              </div>
+              <Link
+                href="/docs"
+                className="lp-cta flex shrink-0 items-center justify-center rounded-md px-6 text-sm"
+              >
+                Read the docs
+              </Link>
+            </div>
           </div>
 
-          <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3">
-            <Link
-              href="/docs"
-              className="lp-cta inline-flex items-center rounded-md px-4 py-2 text-sm"
-            >
-              Read the docs
-            </Link>
+          <div className="mt-6">
             <a
               href="https://github.com/macanderson/stella"
               className="text-sm text-fd-muted-foreground underline underline-offset-4 hover:text-fd-foreground"

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -611,6 +611,28 @@
   color: var(--color-fd-foreground);
 }
 
+/* The home page's top bar (#nd-nav, unique to fumadocs' HomeLayout header —
+ * docs pages never render an element with this id) fades in once the reader
+ * scrolls; see components/home-chrome.tsx for the attribute it toggles. No
+ * attribute at all — no JS, or any non-home page — means the default: shown.
+ * Opacity/transform only, never `display` or height, so the bar keeps its
+ * sticky flow space reserved and nothing jumps when it appears. */
+#nd-nav {
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+html[data-home-nav="hidden"] #nd-nav {
+  opacity: 0;
+  transform: translateY(-0.5rem);
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  #nd-nav {
+    transition: none;
+  }
+}
+
 /* The brand name set in running text — always lowercase, always mono. */
 .lp-brand-face {
   font-family: var(--font-mono);

--- a/website/src/components/home-chrome.tsx
+++ b/website/src/components/home-chrome.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useLayoutEffect, type ReactNode } from "react";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import { baseOptions } from "@/lib/layout.shared";
+
+/** Matches fumadocs' own `useIsScrollTop` threshold, so "scrolled" means the
+ * same thing here as it does inside the library's transparent-nav mode. */
+const SCROLL_THRESHOLD = 10;
+
+/**
+ * The home page's own chrome. Every other route mounts the standard fumadocs
+ * top bar from first paint; the home page doesn't need it there — the hero
+ * carries its own large, animated lockup in the corner a nav's logo would
+ * otherwise occupy (see AnimatedLockup), so the real bar would just be a
+ * second, smaller lockup competing with it. The bar fades in the moment the
+ * reader leaves the top of the page.
+ *
+ * Implemented as a `data-home-nav` attribute on <html> rather than React
+ * state so scrolling doesn't drive a re-render on every tick, and the nav's
+ * `id="nd-nav"` — unique to the home layout's header, fumadocs never reuses
+ * it on docs pages — is the only CSS selector this needs, in global.css.
+ * useLayoutEffect (not useEffect) so the attribute is set before the
+ * browser's first paint, avoiding a flash of the bar before it hides.
+ */
+export function HomeChrome({ children }: { children: ReactNode }) {
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    const onScroll = () => {
+      root.setAttribute(
+        "data-home-nav",
+        window.scrollY >= SCROLL_THRESHOLD ? "visible" : "hidden",
+      );
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      root.removeAttribute("data-home-nav");
+    };
+  }, []);
+
+  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+}


### PR DESCRIPTION
## Summary
- Hides the standard top nav bar on the home page only, until the reader scrolls. fumadocs' `HomeLayout` renders it as `<header id="nd-nav">` — an id that's exclusive to the home layout (docs pages never render it, confirmed by grepping the rendered HTML), so a new `data-home-nav` attribute on `<html>`, toggled by a new client wrapper (`home-chrome.tsx`) based on scroll position, scopes cleanly to just this page. The attribute is cleaned up on unmount so it can never leak onto docs pages. The bar fades via opacity/transform only (never `display`/height), so its sticky flow space stays reserved and nothing jumps into place when it appears.
- Moves the hero's existing animated brand lockup (`AnimatedLockup` — the CSS-only comet-assembly animation already in the brand kit) from centered above the install command to the top-left corner a nav's logo would traditionally occupy, and enlarges it (`h-16/h-20` → `h-20/h-28`).
- Moves the "Read the docs" CTA to sit beside the install command instead of in a separate row below it.

## Verification
- `tsc --noEmit` clean
- `next build` succeeds (94 pages)
- curl-based structural checks against a local dev server confirmed: the enlarged lockup markup, the CTA sitting next to the install block, and that docs pages never render `#nd-nav`
- Live browser/visual testing wasn't possible in this environment (no Chrome extension connected in this background job) — worth a manual look once previewed/deployed.

## Test plan
- [ ] Visit `/` and confirm the top nav is absent on load, with the large animated lockup in its place
- [ ] Scroll down and confirm the nav fades in smoothly with no layout jump
- [ ] Confirm docs pages (`/docs/...`) still show the nav immediately, unaffected
- [ ] Confirm "Read the docs" button next to the install command works and installs/copies as expected

## Summary by Sourcery

Delay the home page top navigation bar until the user scrolls, while promoting the hero’s brand lockup and tightening the primary install/docs CTA layout.

New Features:
- Introduce a HomeChrome wrapper for the home route that controls visibility of the fumadocs home header via a data-home-nav attribute on the root html element based on scroll position.
- Animate the home page top bar’s appearance with CSS transitions tied to the data-home-nav state while preserving its layout space.
- Present the hero AnimatedLockup prominently in the top-left corner of the home hero section at a larger size.
- Place the “Read the docs” call-to-action directly beside the install command block in the hero instead of in a separate row.

Enhancements:
- Replace the home route’s direct use of fumadocs HomeLayout with the new HomeChrome component to customize chrome behavior without affecting docs pages.