### PR TITLE
Website code blocks

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -31,3 +31,4 @@ next-env.d.ts
 
 # vercel
 .vercel
+.env*

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@upstash/redis": "^1.38.0",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "fumadocs-core": "16.9.3",
     "fumadocs-mdx": "15.0.10",
     "fumadocs-ui": "16.9.3",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       fumadocs-core:
         specifier: 16.9.3
         version: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@0.556.0(react@19.2.6))(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
@@ -1008,6 +1014,61 @@ packages:
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2729,6 +2790,16 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/analytics@2.0.1(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+
+  '@vercel/speed-insights@2.0.0(next@16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.2.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -100,7 +100,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Proof ──────────────────────────────────────────────────────── */}
-      <section className="lp-section">
+      <section className="lp-section lp-band">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">One run, start to finish</h2>
           <HeroTerminal />
@@ -151,7 +151,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Doors into the docs ────────────────────────────────────────── */}
-      <section className="lp-section">
+      <section className="lp-section lp-band">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Start here</h2>
           <ul className="border-t border-fd-border">
@@ -172,7 +172,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <footer className="lp-section">
+      <footer className="lp-section lp-footer">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-10 text-sm text-fd-muted-foreground sm:flex-row sm:items-center sm:justify-between">
           <span className="inline-flex items-center gap-2">
             <Mark className="h-4 w-auto" />

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -128,9 +128,23 @@
   --color-fd-ring: var(--stella-gold);
 }
 
-/* Selection carries the brand: a gold wash under whatever is selected. */
+/* Selection swaps worlds: highlighting in light mode paints the dark mode
+ * (paper text on ink), highlighting in dark mode paints the light mode (ink
+ * text on paper) — each mode carries the other's feel under the cursor.
+ * Always-ink surfaces (terminals, code blocks, the dark footer) take the
+ * paper selection in BOTH modes, because an ink selection on an ink ground
+ * would vanish. */
 ::selection {
-  background: color-mix(in oklab, var(--stella-gold) 32%, transparent);
+  background: var(--stella-ink);
+  color: var(--stella-paper);
+}
+.dark ::selection,
+.term ::selection,
+.term::selection,
+figure.shiki ::selection,
+.lp-footer ::selection {
+  background: var(--stella-paper-bg);
+  color: var(--stella-ink);
 }
 
 /* Skip link — first thing in the tab order on every page, invisible until it
@@ -334,10 +348,17 @@
   border-radius: 0.375rem;
 }
 
+/* The active page is a solid gold pill with ink text — the one gold surface
+ * in the tree, because the current location IS the signal (same law as the
+ * CTA). Identical in both modes: gold on white chrome, gold on ink. */
 #nd-sidebar a[data-active="true"] {
-  color: var(--color-fd-primary);
-  font-weight: 500;
-  background: transparent;
+  background: var(--stella-gold);
+  color: var(--stella-ink);
+  font-weight: 600;
+}
+#nd-sidebar a[data-active="true"]:hover {
+  background: var(--stella-gold-400);
+  color: var(--stella-ink);
 }
 
 #nd-sidebar [data-radix-scroll-area-viewport] {
@@ -547,6 +568,24 @@
 
 .lp-section {
   border-top: 1px solid var(--color-fd-border);
+}
+
+/* Alternating band: sections that carry evidence (the run, the doors) sit on
+ * the muted ground so the page reads as panels rather than one long scroll —
+ * warm cream on paper, lifted surface on ink. */
+.lp-band {
+  background: var(--color-fd-muted);
+}
+
+/* The footer ships dark in BOTH modes: a shade below the dark ground, the
+ * page bottoming out into the terminal. The fd text tokens are re-scoped so
+ * the light mode's ink text doesn't land on a near-black ground. */
+.lp-footer {
+  background: #070708;
+  border-top-color: #232327;
+  --color-fd-foreground: var(--stella-paper);
+  --color-fd-muted-foreground: #9b9890;
+  color: var(--stella-paper);
 }
 
 /* The hero carries the kit's terminal-grid texture: faint grid lines at the
@@ -1032,6 +1071,132 @@
   }
   .lp-lk-cur {
     opacity: 0;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Docs code blocks — terminals, in both modes.
+ *
+ * The docs' fenced blocks take the home page's `.term` treatment: the ground
+ * is ALWAYS ink, because the product lives in a dark terminal and a code
+ * block is a window into it, not a panel of the page. That means the dark
+ * shiki theme renders in light mode too — the `--shiki-dark` override below
+ * beats fumadocs' light-mode rule by source order (same selector, later
+ * import). Inline code is untouched: it sits in running prose and stays
+ * theme-aware.
+ *
+ * The fd tokens are re-scoped inside the figure so line numbers, highlighted
+ * lines, and focus rings resolve against ink in both modes.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.shiki:not(.not-fumadocs-codeblock *) code span {
+  color: var(--shiki-dark);
+  font-style: var(--shiki-dark-font-style);
+}
+
+figure.shiki {
+  background: var(--stella-ink);
+  border-color: #232327;
+  border-radius: 0.5rem;
+  box-shadow: var(--stella-shadow-card);
+  color: var(--stella-paper);
+  cursor: copy;
+  --color-fd-primary: var(--stella-gold);
+  --color-fd-muted-foreground: #9b9890;
+  --color-fd-ring: var(--stella-gold);
+}
+
+/* The title bar, when a block has one — the `.term-head` look. */
+figure.shiki > div:has(figcaption) {
+  border-bottom-color: #232327;
+  color: #9b9890;
+}
+
+/* The floating copy chip — bottom-right, over the code, anchored to the
+ * figure so it does not scroll away with long blocks. Idle it whispers
+ * "copy"; on success it pops ("copied!" with the check drawing in) on the
+ * kit's pop easing, then settles back. */
+.lp-code-copy {
+  position: absolute;
+  bottom: 0.6rem;
+  inset-inline-end: 0.6rem;
+  z-index: 2;
+  border: 1px solid #232327;
+  border-radius: 0.375rem;
+  background: #1a1a1d;
+  color: #9b9890;
+  font-family: var(--font-mono);
+  font-size: var(--stella-type-2xs);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  transition:
+    color var(--stella-duration-base) var(--stella-ease-arrive),
+    border-color var(--stella-duration-base) var(--stella-ease-arrive),
+    background-color var(--stella-duration-base) var(--stella-ease-arrive);
+}
+.lp-code-copy:hover {
+  color: var(--stella-paper);
+  border-color: var(--stella-neutral-600);
+}
+.lp-code-copy:focus-visible {
+  outline: 2px solid var(--stella-gold);
+  outline-offset: 2px;
+}
+.lp-code-copy[data-copied] {
+  color: var(--stella-success); /* 11.4:1 on ink; word + glyph carry it */
+  border-color: color-mix(in oklab, var(--stella-success) 40%, #232327);
+}
+
+.lp-code-copy-face {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  animation: lp-code-pop var(--stella-duration-slow) var(--stella-ease-pop);
+}
+
+@keyframes lp-code-pop {
+  0% {
+    transform: scale(0.9);
+  }
+  60% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.lp-code-copy-check {
+  width: 0.85em;
+  height: 0.85em;
+}
+.lp-code-copy-check path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 12;
+  stroke-dashoffset: 12;
+  animation: lp-code-check 240ms var(--stella-ease-arrive) 80ms forwards;
+}
+
+@keyframes lp-code-check {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-code-copy-face {
+    animation: none;
+  }
+  .lp-code-copy-check path {
+    animation: none;
+    stroke-dashoffset: 0;
   }
 }
 

--- a/website/src/app/install.sh/route.ts
+++ b/website/src/app/install.sh/route.ts
@@ -25,7 +25,15 @@ export async function GET(): Promise<Response> {
     const upstream = await fetch(UPSTREAM, { next: { revalidate: 300 } });
     if (!upstream.ok) throw new Error(`upstream ${upstream.status}`);
     script = await upstream.text();
-  } catch {
+  } catch (error) {
+    // The redirect path still installs (the one-liner uses -L); the log line
+    // is what tells us the proxy is degraded before anyone notices.
+    console.error(
+      JSON.stringify({
+        event: "install-sh-fallback",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
     return Response.redirect(UPSTREAM, 302);
   }
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -3,6 +3,8 @@ import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import localFont from "next/font/local";
 import { RootProvider } from "fumadocs-ui/provider/next";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 /**
  * One face: JetBrains Mono, self-hosted from the brand kit's own woff2 files
@@ -77,6 +79,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           Skip to content
         </a>
         <RootProvider>{children}</RootProvider>
+        {/* Vercel Web Analytics + Core Web Vitals. Both are cookie-less,
+            no-op outside Vercel deployments, and served same-origin from
+            /_vercel/* — nothing third-party enters the page. */}
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/website/src/components/docs-code-block.tsx
+++ b/website/src/components/docs-code-block.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  CodeBlock,
+  Pre,
+} from "fumadocs-ui/components/codeblock";
+import { type ComponentProps, useRef, useState } from "react";
+
+/**
+ * The docs' code block — a terminal, handled like the home page's install
+ * block: the whole surface is the copy control (a click anywhere copies;
+ * a drag-selection does not), and the success state is a floating "✓ copied!"
+ * chip over the code in the bottom-right corner. The chip is also a real
+ * button, so keyboard users have a focusable control and clicks on it don't
+ * depend on the figure-level handler.
+ *
+ * Fumadocs' CodeBlock keeps everything else — titles, tabs, line numbers,
+ * diff/highlight marks, the scroll viewport — with its own copy button
+ * disabled and the chip mounted through the `Actions` slot, which anchors to
+ * the figure, not the scroll area, so the chip floats over long code instead
+ * of scrolling away with it.
+ *
+ * The copy text is cloned the way fumadocs' own button does it (drop
+ * `.nd-copy-ignore`, take textContent) so what lands in the clipboard is
+ * identical to upstream behavior.
+ */
+export function DocsCodeBlock({
+  children,
+  ...props
+}: ComponentProps<typeof CodeBlock>) {
+  const figureRef = useRef<HTMLElement>(null);
+  const timer = useRef<number | undefined>(undefined);
+  const [copied, setCopied] = useState(false);
+  // Remounts the chip's inner span so the pop/draw animation replays on
+  // every copy, without remounting the button (which would drop focus).
+  const [pulse, setPulse] = useState(0);
+
+  async function copy() {
+    const pre = figureRef.current?.querySelector("pre");
+    if (!pre) return;
+    const clone = pre.cloneNode(true) as HTMLElement;
+    clone
+      .querySelectorAll(".nd-copy-ignore")
+      .forEach((node) => node.replaceWith("\n"));
+    try {
+      await navigator.clipboard.writeText(clone.textContent ?? "");
+    } catch {
+      // Clipboard denied (permissions, insecure context). Claim nothing.
+      return;
+    }
+    setCopied(true);
+    setPulse((p) => p + 1);
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <CodeBlock
+      {...props}
+      ref={figureRef}
+      allowCopy={false}
+      onClick={() => {
+        // A mouseup that ends a text selection also fires click; copying
+        // over someone's selection would be hostile, so only a plain click
+        // (collapsed selection) copies.
+        const selection = window.getSelection();
+        if (selection && !selection.isCollapsed) return;
+        void copy();
+      }}
+      Actions={() => (
+        <>
+          <button
+            type="button"
+            className="lp-code-copy"
+            data-copied={copied || undefined}
+            aria-label="Copy code"
+            onClick={(event) => {
+              event.stopPropagation();
+              void copy();
+            }}
+          >
+            <span key={pulse} className="lp-code-copy-face">
+              {copied ? (
+                <>
+                  <svg
+                    viewBox="0 0 12 12"
+                    className="lp-code-copy-check"
+                    aria-hidden="true"
+                  >
+                    <path d="M2.5 6.5 5 9l4.5-5.5" />
+                  </svg>
+                  copied!
+                </>
+              ) : (
+                "copy"
+              )}
+            </span>
+          </button>
+          <span className="sr-only" aria-live="polite">
+            {copied ? "Code copied" : ""}
+          </span>
+        </>
+      )}
+    >
+      <Pre>{children}</Pre>
+    </CodeBlock>
+  );
+}

--- a/website/src/lib/counters.ts
+++ b/website/src/lib/counters.ts
@@ -30,12 +30,32 @@ function client(): Redis | null {
   return Redis.fromEnv();
 }
 
-/** Add one to a counter. Fire-and-forget semantics; never throws. */
+/**
+ * Add one to a counter. Fire-and-forget semantics; never throws. Each bump
+ * (and each failure) emits one structured line so Vercel's function logs
+ * carry the funnel too — searchable as `install-funnel` in the dashboard.
+ */
 export async function bump(counter: InstallCounter): Promise<void> {
+  const redis = client();
   try {
-    await client()?.incr(`install:${counter}`);
-  } catch {
-    // Counting is best-effort by design.
+    const total = await redis?.incr(`install:${counter}`);
+    console.log(
+      JSON.stringify({
+        event: "install-funnel",
+        counter,
+        total: total ?? null,
+        stored: redis !== null,
+      }),
+    );
+  } catch (error) {
+    // Counting is best-effort by design — log it, never surface it.
+    console.error(
+      JSON.stringify({
+        event: "install-funnel-error",
+        counter,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
   }
 }
 

--- a/website/src/lib/counters.ts
+++ b/website/src/lib/counters.ts
@@ -20,14 +20,15 @@ export type InstallCounter = "hits" | "copies";
 
 function client(): Redis | null {
   // Checked per call rather than at module top level so `next build` (which
-  // evaluates module scope) never requires the env to exist.
-  if (
-    !process.env.UPSTASH_REDIS_REST_URL ||
-    !process.env.UPSTASH_REDIS_REST_TOKEN
-  ) {
-    return null;
-  }
-  return Redis.fromEnv();
+  // evaluates module scope) never requires the env to exist. The Vercel
+  // Marketplace integration (store: upstash-kv-carmine-notebook) injects
+  // KV_REST_API_*; the UPSTASH_REDIS_REST_* pair is the SDK's own default
+  // naming, kept as a fallback for a hand-configured environment.
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token =
+    process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
 }
 
 /**

--- a/website/src/mdx-components.tsx
+++ b/website/src/mdx-components.tsx
@@ -2,6 +2,7 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 
 import { Badge, CardGrid, OptionCard, SpecCard, ToolCard } from "@/components/cards";
+import { DocsCodeBlock } from "@/components/docs-code-block";
 import {
   CredentialChainDiagram,
   FleetFanoutDiagram,
@@ -28,6 +29,9 @@ import { ProviderLogo, ProviderMark } from "@/components/provider-logos";
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    // Code blocks are terminals: always-ink, click-anywhere copy, floating
+    // "copied!" chip — the home page's install-block handling, docs-wide.
+    pre: (props) => <DocsCodeBlock {...props} />,
     // Diagrams
     HeroFlowDiagram,
     PipelineFlowDiagram,


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

<!-- What does this PR do, and what problem does it solve? -->

<!--
  Replace the N below with the issue number, or delete the line if there is no
  issue. A number in the PR *title* does NOT close anything — GitHub only reads
  closing keywords from this description and from commit messages.
  Use `Refs #N` instead if this PR advances the issue without finishing it.
-->

Closes #N

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

<!-- If the witness is impractical (e.g. TUI rendering), say how you verified instead. -->

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

## Ground-rule check

<!-- Delete lines that don't apply. -->

- [ ] No I/O added to `stella-core`; no new deps without justification below
- [ ] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

<!-- Risky areas, follow-ups deferred, alternative approaches you rejected. -->

## Summary by Sourcery

Unify docs code blocks with the terminal-style treatment, enhance install funnel observability and reliability, and integrate Vercel analytics while refining layout theming.

New Features:
- Introduce a dedicated DocsCodeBlock component that turns fenced MDX code blocks into terminal-style, always-dark code blocks with click-anywhere copy and a floating copied notification chip.
- Wire MDX <pre> elements to use the new DocsCodeBlock so docs-wide code blocks share consistent behavior and styling.
- Add Vercel Web Analytics and Speed Insights to the site layout for cookie-less usage and performance tracking.

Bug Fixes:
- Update Redis client configuration to support Vercel KV environment variables in addition to the legacy Upstash names, avoiding misconfiguration in Marketplace setups.
- Emit structured logs from install counter bumps and from install.sh proxy failures so issues in the install funnel can be detected from Vercel logs without affecting users.

Enhancements:
- Adjust global selection styling so light and dark modes invert each other, with terminals, code blocks, and the footer using a paper-style selection for contrast in both modes.
- Restyle the active sidebar navigation item as a gold pill with ink text for clearer current-page highlighting.
- Introduce lp-band sections to visually band key homepage areas and convert the footer into a consistently dark, terminal-like section with updated text colors.
- Refine shiki-based docs code block styling to always use an ink background, dark theme colors, and re-scoped fumadocs tokens for consistent appearance across modes.

Build:
- Add @vercel/analytics and @vercel/speed-insights dependencies to the website package.