### PR TITLE
fix(model): add claude-sonnet-5 to the seed catalog, correct claude-fable-5

### DIFF
--- a/stella-cli/src/cache_insight.rs
+++ b/stella-cli/src/cache_insight.rs
@@ -96,11 +96,35 @@ mod tests {
 
     #[test]
     fn matches_the_pricing_witness_from_stella_model() {
-        // Same figures stella-model's own `savings_matches_catalog_pricing_math_by_hand`
-        // witness uses: Claude Fable 5 seed pricing (input $3.00/M, cached
-        // $0.30/M), 400k cached reads and 100k writes on a 1M-input call ->
-        // $1.005 saved net of the 1.25x anthropic write premium.
+        // What this pins is the WIRING — that a `StepUsage` event reaches the
+        // catalog and comes back with that model's real saving. The arithmetic
+        // itself is pinned separately, against a hand-built `Pricing`, by
+        // stella-model's `savings_matches_catalog_pricing_math_by_hand`.
+        //
+        // So the expectation is derived from the catalog rather than copied out
+        // of it. A hardcoded figure here fails the moment a price is corrected
+        // — as it did when `claude-fable-5` was carrying Sonnet's $3/$15
+        // instead of its actual $10/$50 — which frames a fix to real data as a
+        // broken test.
         let event = step_usage("claude-fable-5", 1_000_000, 400_000, 100_000);
+        let pricing = Catalog::current()
+            .resolve_for("anthropic", "claude-fable-5")
+            .expect("the seed catalog carries this model")
+            .pricing;
+        let expected = pricing.cache_savings_usd(
+            &CompletionUsage {
+                reported: true,
+                input_tokens: 1_000_000,
+                output_tokens: 0,
+                cached_input_tokens: 400_000,
+                cache_write_tokens: 100_000,
+            },
+            pricing.input_usd_per_mtok * 0.25,
+        );
+        assert!(
+            expected > 0.0,
+            "the fixture must exercise a model whose cache actually pays"
+        );
         let insight =
             cache_insight_for("anthropic", "lead", &event).expect("StepUsage yields an insight");
         match insight {
@@ -112,8 +136,8 @@ mod tests {
             } => {
                 assert_eq!(agent, "lead");
                 assert!(
-                    (savings_usd_delta - 1.005).abs() < 1e-9,
-                    "got {savings_usd_delta}"
+                    (savings_usd_delta - expected).abs() < 1e-9,
+                    "got {savings_usd_delta}, catalog says {expected}"
                 );
                 // Anthropic's default prompt-cache TTL is 5 minutes.
                 assert_eq!(ttl_secs, 300);

--- a/stella-model/src/catalog.rs
+++ b/stella-model/src/catalog.rs
@@ -203,17 +203,48 @@ impl Catalog {
                     },
                 )
                 .with_reasoning(Some(true)),
+                // Anthropic's mainstream model, and the one a head-to-head is
+                // most likely to be run on. Its absence was not a gap in
+                // coverage so much as a hard stop: the seed is the OFFLINE
+                // floor, `stella models refresh` is the only way to grow the
+                // runtime catalog, and a sandboxed benchmark container runs
+                // with `STELLA_CATALOG_AUTO_REFRESH=0` — so an unlisted model
+                // there is unreachable, not merely unpriced.
                 CatalogEntry::new(
-                    "claude-fable-5",
+                    "claude-sonnet-5",
                     "anthropic",
                     "claude",
-                    200_000,
+                    1_000_000,
                     ToolDialect::AnthropicTools,
+                    // List price. An introductory rate runs to 2026-08-31
+                    // ($2.00/$10.00); the seed carries the durable number, so
+                    // cost telemetry over-states slightly until then. That is
+                    // the safe direction for a spend guard and it corrects
+                    // itself without an edit.
                     Pricing {
                         input_usd_per_mtok: 3.00,
                         output_usd_per_mtok: 15.00,
                         cached_input_usd_per_mtok: 0.30,
                         cache_write_usd_per_mtok: 3.75,
+                    },
+                )
+                .with_reasoning(Some(true)),
+                CatalogEntry::new(
+                    "claude-fable-5",
+                    "anthropic",
+                    "claude",
+                    // Was 200_000 with Sonnet's prices — wrong on both counts.
+                    // A catalog entry is not documentation: `cost_usd` is
+                    // computed from it, so a stale row silently under-reports
+                    // spend by 3.3x on every Fable turn, and the context
+                    // figure decides when compaction fires.
+                    1_000_000,
+                    ToolDialect::AnthropicTools,
+                    Pricing {
+                        input_usd_per_mtok: 10.00,
+                        output_usd_per_mtok: 50.00,
+                        cached_input_usd_per_mtok: 1.00,
+                        cache_write_usd_per_mtok: 12.50,
                     },
                 )
                 .with_reasoning(Some(true)),
@@ -624,11 +655,18 @@ mod tests {
             cached_input_tokens: 0,
             cache_write_tokens: 100_000,
         };
-        // 100_000 / 1e6 * 3.75 = 0.375 — the figure that went unreported.
+        // Derived from the entry's OWN rate rather than a copied constant: a
+        // hardcoded figure re-fails this test every time a price is corrected,
+        // which teaches the reader that the correction was the mistake. The
+        // property under test is that the cache-write counter is READ at all —
+        // before the `cache_write_usd_per_mtok` column, `cost_usd` consulted
+        // three of the four counters and returned exactly zero here.
+        let expected = 100_000.0 / 1e6 * pricing.cache_write_usd_per_mtok;
         let cost = pricing.cost_usd(&write_only);
+        assert!(expected > 0.0, "the fixture must exercise a priced rate");
         assert!(
-            (cost - 0.375).abs() < 1e-12,
-            "expected a 100k-token cache write to cost $0.375, got {cost}"
+            (cost - expected).abs() < 1e-12,
+            "expected a 100k-token cache write to cost ${expected}, got {cost}"
         );
     }
 


### PR DESCRIPTION
Surfaced by trying to run a benchmark on Sonnet 5 and having every trial die
before its first token:

```
⚠ settings: resolved model: `anthropic/claude-sonnet-5` — unknown model
stella: unknown model `anthropic/claude-sonnet-5`
```

The seed catalog carried exactly one Anthropic model, `claude-fable-5`, and its
facts were wrong.

## Sonnet 5 was unreachable, not merely unlisted

The seed is the **offline floor**. Only `stella models refresh` grows the
runtime catalog, and a sandboxed container runs with
`STELLA_CATALOG_AUTO_REFRESH=0` — so an unlisted model there cannot be reached
at all. The binding rule at the top of `catalog.rs` is explicit that an unknown
slug is a hard named error rather than a silent fallback, which is the right
behaviour and is exactly why the omission is fatal rather than cosmetic.

Anthropic's mainstream model is also the one a head-to-head is most likely to
be run on.

## Fable 5's row was Sonnet's

200k context and $3/$15, against an actual 1M and $10/$50.

A catalog entry is not documentation — `cost_usd` is computed from it. Every
Fable turn under-reported spend by **3.3x**, and the context figure decides
when compaction fires, so the row was wrong in the two places it is actually
load-bearing.

Sonnet 5 carries **list** price. An introductory rate runs to 2026-08-31
($2.00/$10.00), so cost telemetry over-states slightly until then — the safe
direction for a spend guard, and it corrects itself with no future edit.

## Two tests stopped copying the catalog

Both pinned prices by hand and failed on a legitimate correction, which frames
fixing real data as breaking a test:

- `cache_write_tokens_are_billed_not_free` now derives its expectation from the
  entry's own `cache_write_usd_per_mtok`. The property under test is that the
  counter is **read at all** — before the column existed, `cost_usd` consulted
  three of four counters and returned exactly zero.
- `matches_the_pricing_witness_from_stella_model` now derives from the catalog
  too. It pins the **wiring** (a `StepUsage` event reaches the catalog and comes
  back with that model's real saving); the arithmetic stays pinned against a
  hand-built `Pricing` in stella-model's own witness, which is unaffected.

`make gate` green.

## Summary by Sourcery

Add Anthropic Claude Sonnet 5 to the seed catalog and correct Claude Fable 5’s catalog entry and related pricing tests to reflect accurate model configuration and costs.

New Features:
- Add a seed catalog entry for anthropic/claude-sonnet-5 with reasoning enabled so the model is reachable in offline and sandboxed environments.

Bug Fixes:
- Fix claude-fable-5 catalog configuration to use its actual 1M context window and $10/$50 pricing instead of Sonnet 5’s values, ensuring accurate cost and cache behavior.
- Update pricing-related tests to derive expectations from the catalog entries rather than hardcoded constants so they remain valid when model prices are corrected.

Enhancements:
- Strengthen cache cost and savings tests by asserting they exercise nonzero priced rates and by validating wiring from StepUsage events through the catalog to computed savings.