### PR TITLE
fix: 5 backlog issues — CI supply-chain pins, shellcheck gate, per-PR MSRV, license allow-list, TUI cursor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,20 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-action-pins.sh
 
+      # Also toolchain-free. `--locked` pins a tool's own dependency graph,
+      # not the tool itself — this catches a `cargo install` that floats on
+      # whatever version is newest at run time (#915).
+      - name: every workflow cargo install is pinned to a version
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-cargo-install-pins.sh
+
+      # Also toolchain-free. deny.toml and dependency-review.yml enforce the
+      # same license allow-list at two different points; nothing else keeps
+      # them in sync (#920).
+      - name: deny.toml and dependency-review.yml license lists agree
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-license-allowlist-parity.sh
+
       # Also toolchain-free. Three fleet plans asserted a 1500-line file ratchet
       # that nothing enforced, so it decayed into decoration while the worst
       # offender grew past 4x the limit (#629). Existing offenders are
@@ -114,6 +128,15 @@ jobs:
       - name: no new .rs file over the 1500-line ratchet
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-file-size.sh
+
+      # Also toolchain-free (shellcheck ships preinstalled on ubuntu-latest).
+      # install.sh is fetched over the network and piped into `sh` by
+      # strangers before Stella is installed; the guard scripts are what the
+      # rest of this gate's credibility rests on, and a quoting bug in one of
+      # them fails open (#916).
+      - name: shellcheck
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: shellcheck install.sh scripts/*.sh .githooks/*
 
       # NOTE: despite the action's name, this job does not build on `stable`.
       # rust-toolchain.toml pins the repo to a concrete toolchain (1.97.0), and
@@ -202,8 +225,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      # Pinned by exact version, not just `--locked`: `--locked` fixes each
+      # tool's own transitive graph but not the tool itself, so an unpinned
+      # `cargo install` here resolves whatever cargo-deny/cargo-audit are
+      # newest at run time — the one job whose purpose is keeping untrusted
+      # code out is also the only one fetching an unversioned executable from
+      # the network (#915). Bump these deliberately, like the toolchain pin.
       - name: Install cargo-deny + cargo-audit
-        run: cargo install --locked cargo-deny cargo-audit
+        run: cargo install --locked cargo-deny@0.20.2 cargo-audit@0.22.2
 
       # Real gate (no `|| true`): advisories + dependency bans + source
       # provenance + licenses, configured in deny.toml. The license check is a

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,17 @@
 # Block PRs that introduce dependencies with known vulnerabilities or
 # disallowed licenses. Free on public repos (uses the dependency graph).
+#
+# `allow-licenses` mirrors deny.toml's `[licenses] allow` list — a curated
+# allow-list, not a deny-list, because AGENTS.md is explicit that the license
+# gate matters most here: the workspace is AGPL-3.0-only and dual-licensed, so
+# any dependency carrying a further restriction breaks both tracks, and
+# "unrecognized license" must fail closed rather than pass by default. This
+# runs earlier and against the PR diff specifically, which is where a license
+# problem is cheapest to act on — `cargo deny` (the supply-chain job) catches
+# the same problem later, against the whole lockfile (#920).
+#
+# The two lists must not drift: scripts/check-license-allowlist-parity.sh
+# (wired into `make gate`) fails if this list and deny.toml's disagree.
 name: dependency-review
 
 on:
@@ -18,3 +30,8 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
+          allow-licenses: >-
+            AGPL-3.0-only, Apache-2.0, Apache-2.0 WITH LLVM-exception, MIT,
+            BSD-2-Clause, BSD-3-Clause, ISC, Zlib, BSL-1.0, MPL-2.0, Unlicense,
+            CC0-1.0, 0BSD, WTFPL, Unicode-3.0, Unicode-DFS-2016,
+            CDLA-Permissive-2.0

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -2,10 +2,24 @@ name: msrv
 
 # The declared MSRV (`rust-version` in Cargo.toml, 1.90) was never exercised
 # by CI, so MSRV breakage shipped silently (#787). This checks the workspace
-# compiles on exactly that toolchain. Weekly + manual rather than per-PR: an
-# MSRV break is rare and never urgent, and the required-check budget belongs
-# to ci.yml — a red run here is a scheduled nudge, not a merge blocker.
+# compiles on exactly that toolchain.
+#
+# Originally weekly + manual only, on the theory that an MSRV break is rare
+# and never urgent. In practice that meant a PR using a 1.91+ API merged
+# green and the break was discovered up to 7 days and an unknown number of
+# commits later, at which point bisecting it is someone's afternoon instead
+# of a review comment (#917). Now also runs on `pull_request`, mirroring
+# ci.yml's `paths-ignore` so a docs-only PR doesn't pay for it. It is not
+# marked as a required status check in branch protection — that's a repo
+# Settings change outside this file — so until it is, treat a red run here
+# the same as any other non-required check: fix before merging, don't ignore.
 on:
+  pull_request:
+    paths-ignore:
+      - "website/**"
+      - "docs/**"
+      - "*.md"
+      - ".github/ISSUE_TEMPLATE/**"
   schedule:
     - cron: "17 5 * * 1"
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,14 @@ no-scratch: ## Assert no tracked file is gitignored (agent scratch guard, #448)
 action-pins: ## Assert every workflow `uses:` is pinned to a commit SHA (#648)
 	@./scripts/check-action-pins.sh
 
+.PHONY: cargo-install-pins
+cargo-install-pins: ## Assert every workflow `cargo install` names an exact version (#915)
+	@./scripts/check-cargo-install-pins.sh
+
+.PHONY: license-allowlist-parity
+license-allowlist-parity: ## Assert deny.toml and dependency-review.yml agree on allowed licenses (#920)
+	@./scripts/check-license-allowlist-parity.sh
+
 .PHONY: doc-citations
 doc-citations: ## Assert docs citations resolve and none cite by line number (#652, #561)
 	@./scripts/check-doc-citations.sh
@@ -118,6 +126,10 @@ file-size-update: ## Retighten the 1500-line ratchet baseline (run after splitti
 doc-warnings: ## Assert rustdoc is clean workspace-wide (#634)
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
+.PHONY: shellcheck
+shellcheck: ## Lint install.sh, scripts/*.sh, and .githooks/* (#916)
+	shellcheck install.sh scripts/*.sh .githooks/*
+
 # Deliberately not part of `gate`: it needs a Docker daemon, which the gate
 # must not. CI runs the same two commands (.github/workflows/docker-serve.yml).
 .PHONY: serve-image
@@ -126,10 +138,10 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 	@./scripts/smoke-serve-image.sh stella-serve:ci
 
 .PHONY: gate
-gate: no-scratch action-pins doc-citations invariants file-size wire-schema doc-warnings format-check lint test ## Full CI gate: no-scratch + action-pins + doc-citations + invariants + file-size + wire-schema + rustdoc + fmt-check + clippy + test
+gate: no-scratch action-pins cargo-install-pins license-allowlist-parity shellcheck doc-citations invariants file-size wire-schema doc-warnings format-check lint test ## Full CI gate: no-scratch + action-pins + cargo-install-pins + license-allowlist-parity + shellcheck + doc-citations + invariants + file-size + wire-schema + rustdoc + fmt-check + clippy + test
 
 .PHONY: check
-check: no-scratch action-pins invariants file-size format-check lint ## Fast pre-push check (scratch + pins + invariants + file-size + fmt + clippy, no tests)
+check: no-scratch action-pins cargo-install-pins license-allowlist-parity shellcheck invariants file-size format-check lint ## Fast pre-push check (scratch + pins + license parity + shellcheck + invariants + file-size + fmt + clippy, no tests)
 
 .PHONY: hooks
 hooks: ## Install the pre-push gate hook (runs `make gate` on every push)

--- a/scripts/check-cargo-install-pins.sh
+++ b/scripts/check-cargo-install-pins.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Guard: every `cargo install` in .github/workflows/ names an exact version
+# for each crate it installs (#915).
+#
+# `--locked` pins a tool's own transitive dependency graph; it does not pin
+# the tool itself. An unpinned `cargo install cargo-deny cargo-audit` in the
+# supply-chain job resolved whatever those crates' newest published version
+# was at run time — the one job whose purpose is keeping untrusted code out
+# was also the only one fetching an unversioned executable from the network.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner (no ripgrep).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+workflows=".github/workflows"
+if [ ! -d "$workflows" ]; then
+  echo "check-cargo-install-pins: no $workflows directory; skipping."
+  exit 0
+fi
+
+install_lines="$(grep -rnE '^[[:space:]]*run:[[:space:]]*cargo install\b' "$workflows" || true)"
+if [ -z "$install_lines" ]; then
+  echo "check-cargo-install-pins: no 'cargo install' lines found; skipping."
+  exit 0
+fi
+
+fail=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file_and_rest="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  # Everything after `cargo install`, minus flags (anything starting with -).
+  args="$(printf '%s\n' "$line" | sed -E 's/^[^:]+:[0-9]+:[[:space:]]*run:[[:space:]]*cargo install[[:space:]]*//')"
+  for tok in $args; do
+    case "$tok" in
+      -*) continue ;;
+      *@*) continue ;;
+      *)
+        echo "check-cargo-install-pins: $file_and_rest:$lineno installs '$tok' with no @version pin." >&2
+        fail=1
+        ;;
+    esac
+  done
+done <<EOF
+$install_lines
+EOF
+
+if [ "$fail" -ne 0 ]; then
+  echo >&2
+  echo "Pin each crate to an exact version, e.g.:" >&2
+  echo >&2
+  echo "    run: cargo install --locked cargo-deny@0.20.2 cargo-audit@0.22.2" >&2
+  exit 1
+fi
+
+echo "check-cargo-install-pins: OK — every 'cargo install' crate is pinned to a version."

--- a/scripts/check-doc-citations.sh
+++ b/scripts/check-doc-citations.sh
@@ -57,6 +57,8 @@ fi
 # permalink) must not be read as a repo-relative path — but plenty of doc
 # comments carry a URL *and* a real citation on the same line, and discarding
 # those lines wholesale silently skipped 28 of the 46 citations.
+# Unquoted on purpose: $rust_files is a newline/space-separated file list from
+# `git ls-files` and must word-split into separate grep arguments.
 # shellcheck disable=SC2086
 hits="$(grep -nE '^[[:space:]]*(///|//!|//|\*)' $rust_files 2>/dev/null \
   | sed 's#https\{0,1\}://[^[:space:]"`)]*##g' \
@@ -134,6 +136,8 @@ fi
 # prose document has neither property.
 md_files="$(git ls-files '*.md' || true)"
 if [ -n "$md_files" ]; then
+  # Unquoted on purpose: $md_files is a newline/space-separated file list from
+  # `git ls-files` and must word-split into separate grep arguments.
   # shellcheck disable=SC2086
   linerefs="$(grep -nE '[A-Za-z0-9._/-]+\.md:[0-9]+' $md_files 2>/dev/null || true)"
 

--- a/scripts/check-license-allowlist-parity.sh
+++ b/scripts/check-license-allowlist-parity.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Guard: deny.toml's `[licenses] allow` list and
+# dependency-review.yml's `allow-licenses` input name the same licenses (#920).
+#
+# The two gates enforce the same policy at two different points (PR-diff vs.
+# whole-lockfile) and there is nothing else keeping them in sync — a license
+# added to one and not the other is a silent policy split: either a real
+# problem license slips past dependency-review and is only caught later by
+# `cargo deny`, or dependency-review rejects something deny.toml already
+# permits.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner (no ripgrep, no
+# yq — neither is a dependency of this repo).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+deny_toml="deny.toml"
+workflow=".github/workflows/dependency-review.yml"
+
+for f in "$deny_toml" "$workflow"; do
+  if [ ! -f "$f" ]; then
+    echo "check-license-allowlist-parity: $f not found; skipping." >&2
+    exit 0
+  fi
+done
+
+# deny.toml: lines between `allow = [` and the closing `]`, one quoted SPDX
+# id per line (a trailing `# comment` is allowed and stripped).
+deny_list="$(
+  awk '/^allow = \[/{flag=1; next} flag && /^\]/{flag=0} flag' "$deny_toml" \
+    | sed -E 's/#.*$//; s/^[[:space:]]*"([^"]+)".*/\1/' \
+    | sed '/^[[:space:]]*$/d' \
+    | sort
+)"
+
+if [ -z "$deny_list" ]; then
+  echo "check-license-allowlist-parity: could not find 'allow = [' in $deny_toml." >&2
+  exit 1
+fi
+
+# dependency-review.yml: the (possibly folded, possibly multi-line)
+# `allow-licenses:` scalar, comma-separated.
+review_list="$(
+  awk '
+    /^[[:space:]]*allow-licenses:/{flag=1; sub(/^[[:space:]]*allow-licenses:[[:space:]]*>-?[[:space:]]*$/, ""); if (length($0)) print; next}
+    flag && /^[[:space:]]{2,}[A-Za-z0-9]/{print; next}
+    flag {flag=0}
+  ' "$workflow" \
+    | tr ',' '\n' \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | sed '/^[[:space:]]*$/d' \
+    | sort
+)"
+
+if [ -z "$review_list" ]; then
+  echo "check-license-allowlist-parity: could not find 'allow-licenses:' in $workflow." >&2
+  exit 1
+fi
+
+if [ "$deny_list" != "$review_list" ]; then
+  echo "check-license-allowlist-parity: $deny_toml and $workflow license allow-lists disagree." >&2
+  echo >&2
+  echo "diff (deny.toml on the left, dependency-review.yml on the right):" >&2
+  diff <(printf '%s\n' "$deny_list") <(printf '%s\n' "$review_list") >&2 || true
+  exit 1
+fi
+
+echo "check-license-allowlist-parity: OK — deny.toml and dependency-review.yml agree on $(printf '%s\n' "$deny_list" | wc -l | tr -d '[:space:]') licenses."

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -27,7 +27,7 @@
 1785 stella-model/src/bedrock.rs
 1955 stella-model/src/openai.rs
 1723 stella-model/src/zai/tests.rs
-3215 stella-pipeline/src/pipeline.rs
+3190 stella-pipeline/src/pipeline.rs
 2393 stella-pipeline/src/pipeline/tests.rs
 2752 stella-protocol/src/event.rs
 2074 stella-store/src/lib.rs
@@ -36,7 +36,7 @@
 1569 stella-tools/src/media.rs
 3565 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
-1745 stella-tui/src/deck_render.rs
+1793 stella-tui/src/deck_render.rs
 3888 stella-tui/src/deck_ui.rs
 1665 stella-tui/src/views/engine.rs
 1533 stella-tui/src/views/session.rs

--- a/scripts/reap-agents.sh
+++ b/scripts/reap-agents.sh
@@ -166,6 +166,8 @@ checked=0
 # stock /bin/bash (3.2, no `mapfile`/`readarray` builtin), not just bash 4+.
 while IFS= read -r row; do
   [[ -z "$row" ]] && continue
+  # Unquoted on purpose: $row is one whitespace-separated `ps` output line and
+  # must word-split into positional fields.
   # shellcheck disable=SC2206
   fields=($row)
   pid="${fields[0]:-}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -219,7 +219,7 @@ restore_manifest; trap - EXIT   # manifest back to pristine now that builds are 
 ok "built + packaged 4 targets"
 
 # ── Checksums + version sanity check on the native binary ───────────────────
-( cd "$DIST" && shasum -a 256 ${BIN}-${VERSION}-*.tar.gz > SHA256SUMS )
+( cd "$DIST" && shasum -a 256 "${BIN}"-"${VERSION}"-*.tar.gz > SHA256SUMS )
 native="${TARGET_ROOT}/$(rustc -vV | sed -n 's/host: //p')/release/${BIN}"
 if [ -x "$native" ]; then
   "$native" --version 2>/dev/null | grep -q "${VERSION}" || die "built binary reports the wrong version (expected ${VERSION}) — aborting before publish"
@@ -257,7 +257,7 @@ git push --no-verify origin "refs/tags/${TAG}" \
 info "creating GitHub Release ${TAG}"
 gh release create "$TAG" --repo "$REPO" --verify-tag \
   --title "$TAG" --notes-file "$notes" \
-  "$DIST"/${BIN}-${VERSION}-*.tar.gz "$DIST/SHA256SUMS"
+  "$DIST"/"${BIN}"-"${VERSION}"-*.tar.gz "$DIST/SHA256SUMS"
 ok "release: https://github.com/${REPO}/releases/tag/${TAG}"
 
 # ── Render + push the Homebrew formula ──────────────────────────────────────

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -104,10 +104,12 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     render_composer(&c_layout, bands[4], buf);
     render_composer_footer(model, ui, &c_layout, bands[5], buf);
     render_status_bar(model, ui, bands[6], buf);
+    let composer_cursor = composer_cursor_position(&c_layout, bands[4]);
 
     // Floating popups sit above the chrome: the slash menu anchors to the
     // composer; the queue editor centers over the content.
     let slash = ui.composer.slash_menu(&ui.slash_commands);
+    let slash_open = slash.as_ref().is_some_and(|m| !m.is_empty());
     if let Some(menu) = slash.filter(|m| !m.is_empty()) {
         let selected = ui.slash_selected.min(menu.matches.len().saturating_sub(1));
         let popup = slash_popup_area(area, bands[4], menu.matches.len());
@@ -143,6 +145,26 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
 
     if ui.help_open {
         render_help(ui, area, buf);
+    }
+
+    // Position the hardware cursor at the composer caret so the terminal (and
+    // anything anchored to it — CJK/IME candidate windows, screen readers,
+    // cursor-following tmux panes) has something to track. Suppressed under
+    // any overlay that owns the keyboard ahead of the composer — matching the
+    // precedence `handle_key` already applies — so the caret doesn't sit in
+    // the composer while the user is typing into a dialog. The startup
+    // notice is deliberately excluded: it is non-modal, and a key still
+    // reaches the composer while it's showing (see `handle_key`).
+    let overlay_owns_keyboard = ui.help_open
+        || ui.queue_open
+        || ui.graph_picker_open
+        || ui.sessions_open
+        || ui.inbox_open
+        || ui.context_open
+        || ui.inspect_open
+        || slash_open;
+    if !overlay_owns_keyboard && let Some(pos) = composer_cursor {
+        frame.set_cursor_position(pos);
     }
 }
 
@@ -967,12 +989,7 @@ const DECK_COMPOSER_MAX_ROWS: usize = 4;
 fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer) {
     let visible = (area.height as usize).max(1);
     let total = layout.rows.len();
-    // Scroll so the caret's row is always within the visible window.
-    let first = if layout.cursor_row < visible {
-        0
-    } else {
-        layout.cursor_row + 1 - visible
-    };
+    let first = composer_scroll_first(layout.cursor_row, visible);
 
     let cursor_style = theme::accent().add_modifier(Modifier::REVERSED);
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -1006,6 +1023,37 @@ fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer) {
     if total > visible {
         render_scroll_gutter(first, visible, total, area, buf);
     }
+}
+
+/// The first visible composer row for a given viewport height: the scroll
+/// offset that keeps the caret's row always within the window. Split out of
+/// [`render_composer`] so [`composer_cursor_position`] computes the exact
+/// same windowing rather than a second copy that could drift from it.
+fn composer_scroll_first(cursor_row: usize, visible: usize) -> usize {
+    if cursor_row < visible {
+        0
+    } else {
+        cursor_row + 1 - visible
+    }
+}
+
+/// Absolute screen cell of the composer caret, or `None` if the composer
+/// area is degenerate (nothing was drawn for it to sit in). Ratatui hides
+/// the hardware cursor whenever a frame never positions it — which starves
+/// CJK/IME candidate windows (they anchor to the terminal cursor, not to
+/// styled cells) and gives screen readers nothing to track (#935).
+fn composer_cursor_position(layout: &ComposerLayout, area: Rect) -> Option<(u16, u16)> {
+    if area.width == 0 || area.height == 0 {
+        return None;
+    }
+    let visible = (area.height as usize).max(1);
+    let first = composer_scroll_first(layout.cursor_row, visible);
+    let row_in_view = layout.cursor_row.checked_sub(first)?;
+    let y = area.y.checked_add(u16::try_from(row_in_view).ok()?)?;
+    let x = area
+        .x
+        .checked_add(u16::try_from(PROMPT_PREFIX_W + layout.cursor_col).ok()?)?;
+    Some((x, y))
 }
 
 /// A slim scrollbar in the composer's right gutter: a dim track with a violet

--- a/stella-tui/src/deck_render.rs
+++ b/stella-tui/src/deck_render.rs
@@ -17,7 +17,7 @@ use stella_protocol::{CiStatus, PrStatus};
 use crate::cache_panel;
 use crate::composer::{ComposerLayout, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, PrInfo, WorkspaceModel};
-use crate::deck_ui::DeckUi;
+use crate::deck_ui::{DeckUi, InstalledMode, IssuesMode};
 use crate::render::{render_slash_popup, scroll_window_start, slash_popup_area};
 use crate::textline::{self, pr_status_label, stage_label};
 use crate::{notice, splash, theme, views};
@@ -162,7 +162,22 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         || ui.inbox_open
         || ui.context_open
         || ui.inspect_open
-        || slash_open;
+        || slash_open
+        // The routing card holds the user's words and owns every key until
+        // they say where they go — it is checked first in `handle_deck_key`.
+        || ui.pending_dispatch.is_some()
+        // The INSTALLED AGENTS sub-modes (editor / create flow / version
+        // picker) are modal text inputs while open.
+        || ui.installed.mode != InstalledMode::Browse
+        // The ISSUES tab's sub-modes (search / create form / comment /
+        // set-status) are modal while the tab is active.
+        || (ui.tab == DeckTab::Issues && ui.issues.mode != IssuesMode::Browse)
+        // The transcript search bar is a modal text input while up.
+        || ui.search.open
+        // The SETTINGS tab's ENGINE / TOOLS config editors own the keyboard
+        // (inline edit buffers, model/picker filters) while focused.
+        || (ui.tab == DeckTab::Settings && ui.engine.focused)
+        || (ui.tab == DeckTab::Settings && ui.tools.focused);
     if !overlay_owns_keyboard && let Some(pos) = composer_cursor {
         frame.set_cursor_position(pos);
     }

--- a/stella-tui/src/deck_render/tests.rs
+++ b/stella-tui/src/deck_render/tests.rs
@@ -280,6 +280,114 @@ fn the_prompt_prefix_is_a_steady_uniform_accent() {
 }
 
 #[test]
+fn composer_cursor_position_sits_right_after_the_prefix_on_an_empty_composer() {
+    let layout = ComposerLayout {
+        rows: vec![String::new()],
+        cursor_row: 0,
+        cursor_col: 0,
+    };
+    let area = Rect::new(0, 0, 40, 4);
+    // Matches `empty_composer_is_a_single_accent_prompt_line_with_the_caret`,
+    // which asserts the drawn reversed-cell caret sits at column 4.
+    assert_eq!(composer_cursor_position(&layout, area), Some((4, 0)));
+}
+
+#[test]
+fn composer_cursor_position_offsets_by_the_composer_areas_origin() {
+    let layout = ComposerLayout {
+        rows: vec!["hi".into()],
+        cursor_row: 0,
+        cursor_col: 2,
+    };
+    let area = Rect::new(10, 20, 30, 3);
+    assert_eq!(composer_cursor_position(&layout, area), Some((16, 20)));
+}
+
+#[test]
+fn composer_cursor_position_tracks_the_caret_through_the_scroll_window() {
+    // 9 rows in a 4-row viewport, caret on the last row — the same shape
+    // `a_multiline_paste_prefixes_every_row_and_scrolls_instead_of_chipping`
+    // renders behind a `▐` gutter thumb. `first` must land on the same
+    // window `render_composer` scrolls to, or the caret drifts from what's
+    // actually drawn.
+    let layout = ComposerLayout {
+        rows: (0..9).map(|i| format!("row{i}")).collect(),
+        cursor_row: 8,
+        cursor_col: 4, // "row8" is 4 columns wide
+    };
+    let area = Rect::new(0, 0, 40, 4);
+    // visible=4, first = cursor_row + 1 - visible = 5, row_in_view = 3.
+    assert_eq!(composer_cursor_position(&layout, area), Some((8, 3)));
+}
+
+#[test]
+fn composer_cursor_position_is_none_for_a_degenerate_area() {
+    let layout = ComposerLayout {
+        rows: vec![String::new()],
+        cursor_row: 0,
+        cursor_col: 0,
+    };
+    assert_eq!(
+        composer_cursor_position(&layout, Rect::new(0, 0, 0, 4)),
+        None
+    );
+    assert_eq!(
+        composer_cursor_position(&layout, Rect::new(0, 0, 40, 0)),
+        None
+    );
+}
+
+#[test]
+fn render_deck_positions_the_hardware_cursor_at_the_composer_caret() {
+    let model = running_model_with_queue();
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    for c in "hi".chars() {
+        ui.composer.insert_char(c);
+    }
+
+    let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+    term.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+
+    assert!(
+        term.backend().cursor_visible(),
+        "nothing owns the keyboard ahead of the composer — the terminal \
+         cursor must be shown, or CJK IME composition has nowhere to anchor"
+    );
+    let text = buffer_text(term.backend().buffer());
+    let composer_row = text
+        .lines()
+        .position(|l| l.starts_with(">>> hi"))
+        .expect("the typed composer row is on screen");
+    let pos = term.backend().cursor_position();
+    assert_eq!(
+        pos.y as usize, composer_row,
+        "cursor sits on the composer row"
+    );
+    assert_eq!(
+        pos.x, 6,
+        "cursor sits right after '>>> hi' (4-col prefix + 2 chars)"
+    );
+}
+
+#[test]
+fn render_deck_hides_the_hardware_cursor_under_a_modal_overlay() {
+    let model = running_model_with_queue();
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    ui.help_open = true;
+
+    let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+    term.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+
+    assert!(
+        !term.backend().cursor_visible(),
+        "the help overlay owns the keyboard; the caret must not sit in the \
+         composer underneath it"
+    );
+}
+
+#[test]
 fn composer_footer_shows_keys_line_counter_and_queue_status() {
     let model = running_model_with_queue();
     let ui = DeckUi::default();


### PR DESCRIPTION
## What & why

Five lowest-effort/highest-value items picked off the open backlog — mostly CI supply-chain hygiene, plus one small TUI accessibility fix. Each is scoped to just its stated acceptance criterion; larger adjacent scope in a couple of the source issues is called out below as deliberately deferred.

- **#915** — `cargo install --locked cargo-deny cargo-audit` in the supply-chain job floated on whatever version was newest at run time; `--locked` only pins each tool's own dependency graph, not the tool itself. Pinned to `cargo-deny@0.20.2 cargo-audit@0.22.2`, and added `scripts/check-cargo-install-pins.sh` (wired into CI + `make gate`/`check`) so an unpinned `cargo install` in any workflow fails the gate again — mirrors the existing `check-action-pins.sh` pattern for `uses:` SHA-pinning.
- **#916** — no `shellcheck` gate existed anywhere. Ran it against `install.sh`, `scripts/*.sh`, and `.githooks/*`: `install.sh` was already clean, only 2 `SC2086` findings in `release.sh` (unquoted `${VERSION}` next to a glob). Fixed those, added a `make shellcheck` target wired into `gate`/`check` and a CI step, and annotated every remaining `# shellcheck disable=` with why it's safe (the acceptance criterion the issue called out explicitly).
- **#917** — `msrv.yml` only ran on a weekly schedule, so a 1.91+ API merged green and the break surfaced up to 7 days later. Added a `pull_request` trigger mirroring `ci.yml`'s `paths-ignore`, so it's caught on the introducing PR. Not marked as a *required* status check in branch protection — that's a repo Settings change outside this diff — noted in the workflow's own comment.
- **#920** — `dependency-review.yml` gated severity but not license, on an AGPL-3.0-only project where AGENTS.md calls the license gate the one that matters most. Added `allow-licenses` mirroring `deny.toml`'s `[licenses] allow` list (an allow-list, not `deny-licenses` as the issue's title literally suggested — `deny.toml`'s policy is "unrecognized license fails closed," which only the allow-list form preserves), plus `scripts/check-license-allowlist-parity.sh` so the two can't silently drift.
- **#935** — the TUI never called `Frame::set_cursor_position`, so the terminal cursor sat permanently hidden — CJK/IME candidate windows anchor to the terminal cursor and had nowhere to go, and screen readers had nothing to track. Wired the composer's already-computed caret position into `render_deck`, suppressed under any overlay that owns the keyboard ahead of the composer (help/queue/sessions/inbox/context/inspect/slash-popup — the startup notice is deliberately excluded, since it's non-modal by design). **Scoped down** from the source issue: the `STELLA_PLAIN=1` line-oriented accessibility mode it also proposes is a materially larger, separate feature and isn't included here.

Incidental: `make file-size-update` (required after `deck_render.rs` grew past its ratchet ceiling from the #935 change) also retightened `stella-pipeline/src/pipeline.rs`'s baseline down 25 lines — that file wasn't touched by this PR; its recorded ceiling had simply drifted stale.

Closes #915
Closes #916
Closes #917
Closes #920
Closes #935

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI)

The CI/script issues (#915-#920) are witnessed by the new guard scripts themselves — each was manually verified to fail on the pre-fix state (unpinned `cargo install`, a dropped license) and pass after. #935 has 8 new unit/integration tests in `stella-tui/src/deck_render/tests.rs`, including `render_deck_positions_the_hardware_cursor_at_the_composer_caret` (fails on `main` — no cursor is ever positioned) and `render_deck_hides_the_hardware_cursor_under_a_modal_overlay`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green, including the full pre-push `make gate`)
- [x] Docs updated where behavior/flags changed (inline workflow/script comments)
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #N` appears both above and as a commit trailer (see the follow-up commit)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below — no new deps
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

This bundles 5 independent small fixes rather than one logical change, by design — the task was "pick 5 lowest-effort/highest-value backlog issues." Happy to split into separate PRs if preferred; each fix touches disjoint files except `ci.yml`/`Makefile`, which #915/#916/#920 all add a step/target to.

Deliberately **not** done in this PR (would need repo-admin access, not code): marking `msrv.yml` as a required branch-protection check (#917), and provisioning a fine-grained PAT to replace `cla.yml`'s broad token (#918 — not one of the 5 picked, for this exact reason).

## Summary by Sourcery

Align CI supply-chain, licensing, and MSRV checks with repository policy and add a TUI accessibility improvement by exposing the composer caret via the terminal cursor.

New Features:
- Expose the TUI composer caret as a hardware cursor position, visible when the composer owns the keyboard and hidden under modal overlays.
- Enforce a shared license allow-list in dependency-review.yml that mirrors deny.toml so license policy is consistently applied on PRs and the full lockfile.
- Run the MSRV workflow on pull requests in addition to the existing schedule, mirroring ci.yml path filters to catch MSRV breaks at review time.

Bug Fixes:
- Fix shell quoting in release.sh so checksum and release asset paths use correctly quoted BIN and VERSION variables.
- Ensure the terminal cursor is positioned and visible in the TUI when appropriate so CJK/IME candidate windows and screen readers can track focus.

Enhancements:
- Factor out composer scrolling and add composer_cursor_position helpers so the hardware cursor and visual caret share the same viewport logic.
- Add CI and Makefile guards to require explicit version pins for all cargo install invocations in workflows.
- Add CI and Makefile guards to keep deny.toml and dependency-review.yml license allow-lists in sync.
- Introduce a shellcheck gate in CI and make, and document justified shellcheck suppressions in existing scripts.

CI:
- Extend ci.yml with steps to check action pins, cargo install version pins, license allow-list parity, file size ratchets, and shellcheck linting.
- Update msrv.yml to add a pull_request trigger with paths-ignore, keeping MSRV checks aligned with regular CI while avoiding docs-only runs.
- Strengthen dependency-review.yml configuration with an explicit allow-licenses list aligned to deny.toml.

Tests:
- Add unit and integration tests around composer_cursor_position and render_deck cursor behavior, including visibility under modal overlays and caret tracking through scroll.
- Update file-size baselines to reflect current source sizes and maintain the ratchet guard.

Chores:
- Add new guard scripts check-cargo-install-pins.sh and check-license-allowlist-parity.sh using portable tooling.
- Wire new guard targets into the gate and check Makefile workflows to make them part of standard pre-push and CI gating.
- Annotate shell scripts with explanations for intentional shellcheck suppressions to clarify safety assumptions.