### PR TITLE
feat(tui): rebrand the command deck to comet kit v1.0 — phosphor gold on ink

### DIFF
--- a/stella-cli/src/command_deck/theme_cmd.rs
+++ b/stella-cli/src/command_deck/theme_cmd.rs
@@ -3,14 +3,12 @@
 //! the already-large `command_deck` dispatcher: the parser, the live switch,
 //! and the settings write live here; `command_deck` only wires them to `say`.
 //!
-//! Two themes ship. `stella-dark` (electric blue on deep space) is the
-//! default; `stella-light` is the same blue on paper. Both were described here
-//! — and to users, through [`blurb`] — in the vocabulary of two retired
-//! identities: a terminal-green dark theme and an ember red-orange light one,
-//! neither of which any surface has rendered for two recolours. The palette's
-//! own spec (BRAND.md) has since been retired in favour of the brand kit at
-//! `docs/brand/BRAND.md`; the terminal has not yet been repainted to it.
-//! The switch itself is a per-frame buffer remap in
+//! Two themes ship. `stella-dark` (Phosphor Gold on Ink — the comet kit at
+//! `docs/brand/BRAND.md`) is the default; `stella-light` is the same gold
+//! darkened onto warm paper. [`blurb`] is the user-visible naming of both,
+//! and it has drifted behind the identity before (it once named a terminal
+//! green and an ember red-orange two recolours dead) — keep it telling the
+//! truth. The switch itself is a per-frame buffer remap in
 //! [`stella_tui::theme`], so it takes effect on the next frame with nothing to
 //! re-lay-out — this module only flips the global and writes `ui.theme`.
 
@@ -57,14 +55,13 @@ fn theme_menu() -> String {
 
 /// A one-line description of what each theme looks like.
 ///
-/// Printed to users by `/theme`, which made it the most visible piece of
-/// retired-identity prose left in the product: it named a terminal green and an
-/// ember red-orange that nothing has rendered since two recolours ago. Both
-/// themes carry the same electric-blue brand hue; the ground is what differs.
+/// Printed to users by `/theme`, which has made it the most visible piece of
+/// retired-identity prose in the product more than once. Both themes carry
+/// the same Phosphor Gold brand hue; the ground is what differs.
 fn blurb(theme: ThemeName) -> &'static str {
     match theme {
-        ThemeName::StellaDark => "electric blue on deep space (default)",
-        ThemeName::StellaLight => "electric blue on paper",
+        ThemeName::StellaDark => "phosphor gold on ink (default)",
+        ThemeName::StellaLight => "phosphor gold on paper",
     }
 }
 

--- a/stella-cli/src/init_fx.rs
+++ b/stella-cli/src/init_fx.rs
@@ -452,11 +452,13 @@ mod tests {
             Some(crate::tui::token_rgb(theme::TEXT_TERTIARY))
         );
         assert_eq!(Ink::Shell.rgb(), Some(crate::tui::token_rgb(theme::VIOLET)));
-        // And the star/flame pair stays cool — blue-dominant — so the cinematic
-        // can never drift back to the retired warm accent while still passing.
+        // And the star/flame pair stays warm — the comet's Phosphor Gold is
+        // r > g > b — so the cinematic can never drift back to the retired
+        // electric blue while still passing. (This clause read "cool, not
+        // warm" under the blue identity; the comet inverts it.)
         for ink in [Ink::Flame, Ink::StarBright] {
             let (r, g, b) = ink.rgb().expect("colored inks carry rgb");
-            assert!(b > r && b > g, "{ink:?} must read cool, not warm");
+            assert!(r > g && g > b, "{ink:?} must read warm gold, not cool");
         }
     }
 

--- a/stella-cli/src/settings.rs
+++ b/stella-cli/src/settings.rs
@@ -791,8 +791,8 @@ impl ToolsSettings {
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct UiSettings {
     /// The TUI colour theme slug (`stella-dark` | `stella-light`). Unset — or
-    /// unrecognised — falls back to the default (`stella-dark`, electric blue
-    /// on deep space; the brand kit has since moved to `docs/brand/BRAND.md`).
+    /// unrecognised — falls back to the default (`stella-dark`, Phosphor Gold
+    /// on Ink; the comet brand kit at `docs/brand/BRAND.md`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<String>,
 }

--- a/stella-cli/src/tui.rs
+++ b/stella-cli/src/tui.rs
@@ -49,19 +49,19 @@ fn truncate_with_ellipsis(s: &str, max: usize) -> String {
 // only — `/color` exists so several terminal windows running stella can be told
 // apart at a glance, which needs hues that are *distinct* rather than on-brand.
 // `colored`'s named ANSI colors are the portable stand-ins, and the nearest one
-// to the brand's electric blue (`theme::ACCENT`, `#5AA0FF`) is bright-blue.
+// to the brand's Phosphor Gold (`theme::ACCENT`, `#FFB000`) is bright-yellow.
 //
-// It used to be bright-CYAN, from back when the identity was the pale "sky"
-// blue: the default accent stayed a cyan through two recolours while every
-// other surface moved to electric blue. The slug is deliberately NOT renamed —
-// `sky` is a name a user types at `/color`, not a brand token, and retiring it
-// would break muscle memory and any saved habit for no benefit. What was wrong
-// was the hue behind it, and that is what changed.
+// The default used to be bright-blue (and bright-cyan before that): the
+// accent trailed the identity through recolour after recolour because
+// nothing asserted which hue the default resolves to. The comet kit ends
+// that — the brand slot is `gold` now, and the test below pins it.
 //
-// `sky` and `azure` therefore land on the same ANSI code, exactly as `sky` and
-// `cyan` used to: the named set holds no second distinct blue. Both are kept so
-// an existing `/color azure` still resolves.
-const PALETTE: [(&str, Color); 6] = [
+// The old slugs are all kept as personalisation: `sky` and `azure` still
+// land on bright-blue (the named set holds no second distinct blue), and
+// `/color sky` keeps working for anyone whose muscle memory types it — it
+// just no longer claims to be the brand.
+const PALETTE: [(&str, Color); 7] = [
+    ("gold", Color::BrightYellow),
     ("sky", Color::BrightBlue),
     ("cyan", Color::BrightCyan),
     ("azure", Color::BrightBlue),
@@ -72,7 +72,7 @@ const PALETTE: [(&str, Color); 6] = [
 
 static ACCENT: AtomicUsize = AtomicUsize::new(0);
 
-/// The session accent color (defaults to the brand sky, `PALETTE[0]`).
+/// The session accent color (defaults to the brand gold, `PALETTE[0]`).
 pub fn accent() -> Color {
     PALETTE[ACCENT.load(Ordering::Relaxed) % PALETTE.len()].1
 }
@@ -636,21 +636,25 @@ mod tests {
         );
     }
 
-    /// Sky is the brand, so it is the default accent -- `/color` with no
+    /// Gold is the brand, so it is the default accent -- `/color` with no
     /// argument, and a fresh session, must land on it.
     #[test]
-    fn default_accent_is_sky() {
-        assert_eq!(PALETTE[0].0, "sky");
+    fn default_accent_is_gold() {
+        assert_eq!(PALETTE[0].0, "gold");
         assert_eq!(ACCENT.load(Ordering::Relaxed) % PALETTE.len(), 0);
+        // …and it must be the BRAND hue, not merely first in the list. The
+        // default trailed the identity through recolour after recolour
+        // because nothing asserted which colour the default slug actually
+        // resolves to. Bright-yellow is the nearest named ANSI stand-in for
+        // `theme::ACCENT` (Phosphor Gold `#FFB000`).
+        assert_eq!(PALETTE[0].1, Color::BrightYellow);
+        assert_eq!(accent(), Color::BrightYellow);
+        // The old brand slug survives as personalisation, then the process
+        // global returns to the brand default for any test that reads it.
         assert!(set_accent("sky"));
         assert_eq!(PALETTE[ACCENT.load(Ordering::Relaxed)].0, "sky");
-        // …and it must be the BRAND hue, not merely first in the list. The
-        // default sat on bright-cyan through two recolours because nothing
-        // asserted which colour the default slug actually resolves to — only
-        // that it was called `sky`. Bright-blue is the nearest named ANSI
-        // stand-in for `theme::ACCENT` (`#5AA0FF`).
-        assert_eq!(PALETTE[0].1, Color::BrightBlue);
-        assert_eq!(accent(), Color::BrightBlue);
+        assert!(set_accent("gold"));
+        assert_eq!(accent(), Color::BrightYellow);
     }
 
     #[test]

--- a/stella-tui/src/markdown.rs
+++ b/stella-tui/src/markdown.rs
@@ -373,16 +373,18 @@ fn strip_numbered(lead: &str) -> Option<(&str, &str)> {
 
 /// Build a heading line with level-appropriate styling.
 ///
-/// The hierarchy is sky → sky → white, all bold:
-/// * **H1** is a filled brand-sky pill — near-black [`theme::GROUND`] text on
-///   an [`theme::ACCENT`] background, with a space of padding each side so
-///   it reads as a solid title bar. This is the deliberate high-contrast
-///   replacement for the old washed-out heading.
-/// * **H2** is bold brand-sky text (no fill).
+/// The hierarchy is gold → gold → paper, all bold:
+/// * **H1** is a filled gold pill — ink-dark [`theme::GROUND`] text on an
+///   [`theme::ACCENT`] background, with a space of padding each side so it
+///   reads as a solid title bar. This is the kit's one sanctioned gold
+///   *fill* (the website's sidebar pill and CTA do the same), and the text
+///   on it must stay ink: ink-on-gold is 10.74:1 where white-on-gold is
+///   1.83:1.
+/// * **H2** is bold gold text (no fill).
 /// * **H3+** is bold primary-ink text.
 fn heading_line(content: &str, level: usize) -> Line<'static> {
     if level == 1 {
-        // One span so the sky fill is a single unbroken pill behind the text.
+        // One span so the gold fill is a single unbroken pill behind the text.
         let pill = Style::new()
             .bg(theme::ACCENT)
             .fg(theme::GROUND)
@@ -615,14 +617,15 @@ mod tests {
     }
 
     #[test]
-    fn h1_is_a_high_contrast_sky_pill() {
+    fn h1_is_a_high_contrast_gold_pill() {
         // The exact fix the user asked for: the H1 must be a bold, filled,
-        // high-contrast bar — near-black ink on brand sky — never washed-out
-        // or a light-text-on-pale-background combination.
+        // high-contrast bar — ink on Phosphor Gold — never washed-out or a
+        // light-text-on-pale-background combination (white on gold is
+        // 1.83:1; ink on gold is 10.74:1).
         let lines = render("# Rust Async Patterns");
         let span = &lines[0].spans[0];
-        assert_eq!(span.style.bg, Some(theme::ACCENT), "sky fill");
-        assert_eq!(span.style.fg, Some(theme::GROUND), "near-black text");
+        assert_eq!(span.style.bg, Some(theme::ACCENT), "gold fill");
+        assert_eq!(span.style.fg, Some(theme::GROUND), "ink text");
         assert!(span.style.add_modifier.contains(Modifier::BOLD), "bold");
     }
 

--- a/stella-tui/src/palette.rs
+++ b/stella-tui/src/palette.rs
@@ -1,208 +1,260 @@
 //! Raw palette values -- the single normative colour source for the terminal.
-//! Cut from the since-retired BRAND.md; the brand kit now lives at
-//! `docs/brand/BRAND.md`, and the terminal has not yet been repainted to it.
+//! Cut from the brand kit v1.0 ("the comet") at `docs/brand/` -- read
+//! `css/tokens.css` and `brand-guidelines.html` before touching a value here.
 //! Nothing here is semantic: for role names
 //! (accent, ink, rule, status) see [`crate::theme`], which is the only module
 //! that should reference these directly.
 //!
-//! The identity is **electric blue and gold on deep space**. Blue is the
-//! interactive signal (active/running, focus, links); gold is the mark (the
-//! logo cursor block, splash rules, section markers) and never carries status.
-//! The paper theme (`stella-light`) swaps both for their ink counterparts.
+//! The identity is **Phosphor Gold on Ink**: one colour, owned. Gold
+//! `#FFB000` is the signal -- the mark, the prompt, active/selected, focus --
+//! and never the surface; Ink `#0B0B0C` is the ground; text is warm Paper
+//! with the kit's warm neutral ramp beneath it. The old electric-blue/gold
+//! split is gone: brand and gold are one family now, so `BRAND` and `GOLD`
+//! deliberately share values. The paper theme (`stella-light`) swaps the
+//! ground for warm paper and the gold for its deep ramp stops.
 //!
-//! Token names are hue-neutral on purpose (`BRAND`, not `SKY`): the brand hue
-//! has been recoloured before (aurora → gold → sky → green → ember → blue) and
-//! the name must outlive the value. Add a *value* here; name a *role* in
-//! `theme`.
+//! Token names are hue-neutral on purpose (`BRAND`, not `GOLD_ACCENT`): the
+//! brand hue has been recoloured before (aurora → gold → sky → green → ember →
+//! blue → gold) and the name must outlive the value. Add a *value* here; name
+//! a *role* in `theme`.
 //!
-//! Mirrored by `docs/brand/tokens/*`, `website/src/app/tokens.css` and the
-//! observatory's inlined `:root` block; all of them must be edited together.
+//! Mirrored by `docs/brand/css/tokens.css`, `website/src/app/tokens.css` and
+//! the observatory's inlined `:root` block; all of them must be edited
+//! together. (The observatory's dark block is the closest sibling: same
+//! ground ramp, same text ramp, same status trio, same data marks.)
 
 use ratatui::style::Color;
 
 // ── Ground (dark) ───────────────────────────────────────────────
 //
-// Deep space: a near-black with a blue cast rather than true black. Pure black
-// makes an accent scream; a tinted ground lets it speak, and it is what the
-// marketing site already renders. `surface` and `raised` step up for cards and
-// popovers; the two hairlines are the seam.
+// Ink: the terminal, not pure black. The kit's dark ground is a warm-neutral
+// near-black -- no blue cast, no cool grays anywhere on the dark side. Pure
+// black makes an accent scream; ink lets it speak, and it is what the
+// marketing site and the observatory already render. `surface` and `raised`
+// step up for cards and popovers; the two hairlines are the seam.
 
-/// Deepest ground -- full-bleed backdrops, the splash, OG art.
-pub const VOID: Color = Color::Rgb(0x05, 0x07, 0x0C);
+/// Deepest ground -- full-bleed backdrops, the splash, OG art. The
+/// observatory's `--void`.
+pub const VOID: Color = Color::Rgb(0x05, 0x05, 0x06);
 
-/// App background. The default dark canvas.
-pub const GROUND: Color = Color::Rgb(0x08, 0x0A, 0x0F);
+/// App background. Ink `#0B0B0C` -- THE brand ground, painted as a real frame
+/// fill by the deck, so every contrast figure below is measured against it.
+pub const GROUND: Color = Color::Rgb(0x0B, 0x0B, 0x0C);
 
-/// Card / panel surface, one step above ground.
-pub const SURFACE: Color = Color::Rgb(0x0B, 0x0F, 0x17);
+/// Card / panel surface, one step above ground (the kit's dark `--surface`).
+pub const SURFACE: Color = Color::Rgb(0x13, 0x13, 0x15);
 
 /// Raised surface -- popovers, selected rows, hovered cells.
-pub const RAISED: Color = Color::Rgb(0x10, 0x16, 0x23);
+pub const RAISED: Color = Color::Rgb(0x1B, 0x1B, 0x1E);
 
-/// Seam / rule. Deliberately low-contrast on ground (1.2:1): decorative only,
-/// never the sole carrier of structure.
-pub const HAIRLINE: Color = Color::Rgb(0x18, 0x20, 0x31);
+/// Seam / rule (the kit's dark `--border`). Deliberately low-contrast on
+/// ground (1.26:1): decorative only, never the sole carrier of structure.
+pub const HAIRLINE: Color = Color::Rgb(0x23, 0x23, 0x27);
 
 /// Seam where a boundary must actually read -- panel edges, focused borders.
-/// Still below 3:1 on ground (1.4:1), so it is a *stronger* decoration, not a
-/// substitute for a glyph or a gap.
-pub const HAIRLINE_STRONG: Color = Color::Rgb(0x23, 0x2D, 0x42);
+/// Still below 3:1 on ground (1.57:1), so it is a *stronger* decoration, not
+/// a substitute for a glyph or a gap.
+pub const HAIRLINE_STRONG: Color = Color::Rgb(0x33, 0x33, 0x38);
 
-// ── Brand (dark: electric blue) ─────────────────────────────────
+// ── Brand (dark: Phosphor Gold) ─────────────────────────────────
 //
-// The interactive signal: active/running, focus, links, primary action.
-// Reserved -- never a general-purpose highlight. `BRAND` is 5.1:1 on ground,
-// which clears AA for body text but leaves no headroom on `surface`/`raised`,
-// so anything that paints *text* or a one-cell rule takes `BRAND_BRIGHT`
-// (7.4:1) and only larger flat fills take `BRAND`.
+// The one owned colour. Brand marks, the prompt, active/running, focus,
+// selection, primary action -- and nothing else: gold is the signal, never
+// the surface. Reserved exactly as the blue before it was, but unlike the
+// blue it needs no separate text tone: `#FFB000` measures 10.74:1 on ground,
+// so the same value is safe on a glyph, a one-cell rule, and a fill. A gold
+// fill (a pill, a selected tab) always carries INK text -- white on gold is
+// 1.83:1 and illegible.
 
-/// The brand hue on dark ground -- electric blue. Fills, not small text.
-pub const BRAND: Color = Color::Rgb(0x2E, 0x7B, 0xFF);
+/// Phosphor Gold `#FFB000` -- CRT amber, the gold star. 10.74:1 on ground.
+/// This is the exact kit value; it may not drift.
+pub const BRAND: Color = Color::Rgb(0xFF, 0xB0, 0x00);
 
-/// The text- and stroke-safe brand tone. 7.4:1 on ground; use this wherever
-/// the brand hue lands on a glyph or a 1-cell rule.
-pub const BRAND_BRIGHT: Color = Color::Rgb(0x5A, 0xA0, 0xFF);
+/// The bright stop of the brand sweep (kit `gold-400`, the observatory's
+/// `--gold-bright`). 12.12:1 on ground. Gradients and hover lifts only --
+/// resting chrome stays on [`BRAND`].
+pub const BRAND_BRIGHT: Color = Color::Rgb(0xFD, 0xC1, 0x54);
 
-/// Pressed / gradient-deep stop, and the leading stop of the progress fill.
-pub const BRAND_DEEP: Color = Color::Rgb(0x1A, 0x5F, 0xE0);
+/// Pressed / gradient-deep stop, and the leading stop of the progress fill
+/// (kit `gold-600`). 7.24:1 on ground, so even the fill's tail clears AA.
+pub const BRAND_DEEP: Color = Color::Rgb(0xD0, 0x91, 0x00);
 
-// ── Brand (light: blue on paper) ────────────────────────────────
+// ── Brand (light: gold on paper) ────────────────────────────────
 //
-// The `stella-light` primary. Same hue family, darkened until it clears AA on
-// white (7.0:1). Applied by the per-frame theme remap in [`crate::theme`],
-// truecolor only.
+// The `stella-light` primary. Gold cannot hold a text edge on paper at full
+// strength, so the light accent walks down the kit's own gold ramp until it
+// clears AA on [`PAPER`]. Applied by the per-frame theme remap in
+// [`crate::theme`], truecolor only.
 
-/// The light-theme brand hue -- 7.0:1 on [`PAPER`].
+/// The light-theme brand hue (kit `gold-800`) -- 6.04:1 on [`PAPER`].
 ///
-/// This *was* [`BRAND_DEEP`]'s value too, on the theory that the dark theme's
-/// pressed stop is the light theme's resting tone. It isn't: the same colour
-/// that reads at 7.0:1 on paper measures 2.84:1 on ground, under the 3:1 floor
-/// for a graphical element -- and `BRAND_DEEP` leads the progress fill, so the
-/// left end of a running bar sat below the floor. The two are separate values
-/// now; only the golds still hold that relationship.
-pub const BRAND_INK: Color = Color::Rgb(0x15, 0x50, 0xC8);
+/// Deliberately one step *below* the kit's `gold-deep` `#A37200`: that tone
+/// is the web kit's light-ground gold for UI-sized text and measures 3.79:1
+/// on the painted paper ground -- fine for chrome, under the 4.5:1 floor for
+/// terminal-cell text. `gold-deep` stays in the family as [`GOLD_INK`], the
+/// light theme's *chrome* gold.
+pub const BRAND_INK: Color = Color::Rgb(0x79, 0x55, 0x00);
 
-/// Pressed stop / leading progress stop on paper.
-pub const BRAND_INK_DEEP: Color = Color::Rgb(0x0F, 0x3A, 0x94);
+/// Pressed stop / leading progress stop on paper (kit `gold-900`, 9.67:1).
+pub const BRAND_INK_DEEP: Color = Color::Rgb(0x52, 0x39, 0x00);
 
 // ── Gold ────────────────────────────────────────────────────────
 //
-// The identity accent: the logo's block cursor, splash rules, section markers.
+// Identity chrome: the logo's block cursor, splash rules, section markers.
+// Under the comet kit, gold IS the brand, so [`GOLD`] and [`BRAND`] share a
+// value on purpose -- the split only survives as *names* so the identity
+// sweep ([`GOLD_DEEP`] → [`GOLD_BRIGHT`]) can run wider and quieter than the
+// progress fill's.
 //
-// Gold NEVER carries status. It sits close enough to [`WARNING`] in hue that a
-// reader must never have to tell the two apart in the same row -- status is
-// amber and always glyph-paired; gold is identity and appears only on brand
-// chrome. `theme::gold_is_never_a_status_colour` enforces this.
+// Gold NEVER carries a verdict. It sits 4.0° from [`WARNING`] in hue, so a
+// reader must never be asked to tell an outcome from chrome by hue alone --
+// status is always glyph-paired (`theme::gold_never_carries_a_verdict`
+// enforces this). Activity is the one status gold does carry: active/running
+// IS the accent, by kit rule.
 
-/// The mark's gold -- 11.9:1 on ground.
-pub const GOLD: Color = Color::Rgb(0xF5, 0xC1, 0x45);
+/// The mark's gold -- the same Phosphor Gold as [`BRAND`].
+pub const GOLD: Color = Color::Rgb(0xFF, 0xB0, 0x00);
 
-/// Headline gradient stop -- the bright end of the gold sweep.
-pub const GOLD_BRIGHT: Color = Color::Rgb(0xFF, 0xD8, 0x73);
+/// Headline gradient stop -- the bright end of the gold sweep (== kit
+/// `gold-400`, [`BRAND_BRIGHT`]).
+pub const GOLD_BRIGHT: Color = Color::Rgb(0xFD, 0xC1, 0x54);
 
-/// Trailing stop of the gold fill.
-pub const GOLD_DEEP: Color = Color::Rgb(0xC9, 0x94, 0x20);
+/// Trailing stop of the identity sweep (kit `gold-700`, the web kit's
+/// `gold-deep`). 4.65:1 on ground -- clears AA body text and the 3:1
+/// graphical floor, but the *progress* fill leads with the stronger
+/// [`BRAND_DEEP`] instead.
+pub const GOLD_DEEP: Color = Color::Rgb(0xA3, 0x72, 0x00);
 
-/// Gold on a light ground -- 5.5:1 on [`PAPER`]. One gold cannot hold its edge
-/// against both white and deep space.
-pub const GOLD_INK: Color = Color::Rgb(0x8A, 0x61, 0x18);
+/// Gold chrome on a light ground (kit `gold-700` again -- `gold-deep` is the
+/// kit's one light-ground gold). 3.79:1 on [`PAPER`]: a *graphical* tone
+/// (splash rules, the identity sweep), while light-ground gold TEXT takes
+/// [`BRAND_INK`].
+pub const GOLD_INK: Color = Color::Rgb(0xA3, 0x72, 0x00);
 
 // ── Text (dark ground) ──────────────────────────────────────────
 //
-// Cool neutrals for the dark canvas. Prose is white: the accent earns its
-// meaning by being rare, which only works if the default voice is uncoloured.
+// Warm Paper over the kit's warm neutral ramp -- no cool grays. Prose is
+// paper-white: the accent earns its meaning by being rare, which only works
+// if the default voice is uncoloured.
 
-/// Primary text. The transcript's default voice. 18.1:1 on [`GROUND`].
-pub const TEXT_PRIMARY: Color = Color::Rgb(0xF2, 0xF5, 0xFA);
+/// Primary text. Warm Paper -- the transcript's default voice. 17.44:1 on
+/// [`GROUND`].
+pub const TEXT_PRIMARY: Color = Color::Rgb(0xF4, 0xF1, 0xEA);
 
-/// Secondary text. The safe small-text tone on every dark ground (6.7:1).
-pub const TEXT_SECONDARY: Color = Color::Rgb(0x8E, 0x97, 0xA8);
+/// Secondary text (the observatory's `--text-2`, the kit's dark
+/// `--muted-fg`). The safe small-text tone on every dark ground (6.83:1).
+pub const TEXT_SECONDARY: Color = Color::Rgb(0x9B, 0x98, 0x90);
 
-/// Labels and captions. AA body on void/ground/surface (4.8:1 / 4.6:1); on
-/// [`RAISED`] it drops to 4.4:1 and is a large-text / UI tone only.
-pub const TEXT_TERTIARY: Color = Color::Rgb(0x73, 0x7D, 0x92);
+/// Labels and captions (kit `neutral-500`, the observatory's `--text-3`).
+/// AA body on void/ground/surface (5.71:1 / 5.38:1); on [`RAISED`] it drops
+/// to 4.98:1 -- still AA, but treat it as the floor.
+pub const TEXT_TERTIARY: Color = Color::Rgb(0x8D, 0x8A, 0x82);
 
 // ── Status ──────────────────────────────────────────────────────
 //
-// Always paired with a glyph. Hue alone never carries meaning.
+// Functional, not brand: always paired with a glyph. Hue alone never carries
+// meaning -- which matters doubly now that warning is a hue-neighbour of the
+// gold accent (4.0° apart).
 
-/// Success / done / added. Also the settled cost of a finished turn -- money
-/// spent is a fact, and a fact reads green.
+/// Success / done / added (11.29:1 on ground). Also the settled cost of a
+/// finished turn -- money spent is a fact, and a fact reads green.
 pub const SUCCESS: Color = Color::Rgb(0x4A, 0xDE, 0x80);
 
-/// Warning / needs-input. Amber-yellow -- caution, deliberately clear of the
-/// retired warning orange and never sharing a row with [`GOLD`].
+/// Warning / needs-input. Amber (10.26:1) -- 4.0° from the gold accent in
+/// hue, which is exactly why the glyph, never the hue, is the status
+/// carrier.
 pub const WARNING: Color = Color::Rgb(0xEA, 0xB3, 0x08);
 
-/// Error / failed / removed.
+/// Error / failed / removed (6.62:1 on ground).
 pub const DANGER: Color = Color::Rgb(0xFF, 0x5C, 0x7A);
 
 // ── Status (light ground) ───────────────────────────────────────
 //
 // The same three meanings, darkened along their own hue until they clear AA
-// on paper. The dark-ground status tones are light colours -- `success` is
-// 1.72:1 on white -- so a light surface needs its own set for the same
-// reason the brand hue does.
+// on the painted paper ground. The dark-ground status tones are light
+// colours -- `success` is well under 2:1 on paper -- so a light surface
+// needs its own set for the same reason the brand hue does.
 
-/// Success on a light ground -- 5.76:1 on paper.
+/// Success on a light ground -- 5.16:1 on [`PAPER`].
 pub const SUCCESS_INK: Color = Color::Rgb(0x16, 0x74, 0x4F);
 
-/// Warning on a light ground -- amber-brown, 4.92:1 on paper.
-pub const WARNING_INK: Color = Color::Rgb(0xA1, 0x62, 0x07);
+/// Warning on a light ground -- amber-brown, 5.61:1 on [`PAPER`].
+///
+/// One step darker than the web kit's `warning-ink` `#A16207`, which was
+/// tuned for white and measures 4.41:1 on the warm paper the deck actually
+/// paints -- under the 4.5:1 floor. Same hue, more ink.
+pub const WARNING_INK: Color = Color::Rgb(0x8A, 0x54, 0x05);
 
-/// Error on a light ground -- 5.66:1 on paper.
+/// Error on a light ground -- 5.06:1 on [`PAPER`].
 pub const DANGER_INK: Color = Color::Rgb(0xC8, 0x1E, 0x3E);
 
 // ── Ground (light) ──────────────────────────────────────────────
 //
-// The paper mode. Accent here is [`BRAND_INK`], text is [`INK`].
+// The paper mode: the kit's warm paper, not white. Accent here is
+// [`BRAND_INK`], text is [`INK`].
 
-/// Light background.
-pub const PAPER: Color = Color::Rgb(0xFF, 0xFF, 0xFF);
+/// Light background -- the kit's `paper-bg`, a warm off-white.
+pub const PAPER: Color = Color::Rgb(0xF6, 0xF2, 0xE9);
 
-/// Light surface, one step in from paper.
-pub const SNOW: Color = Color::Rgb(0xF5, 0xF7, 0xFA);
+/// Light surface (the kit's light `--surface`). Lifts *lighter* than paper,
+/// as the dark surface lifts lighter than ink.
+pub const SNOW: Color = Color::Rgb(0xFC, 0xFA, 0xF4);
 
-/// Light raised surface -- popovers, selected rows on paper.
-pub const PAPER_RAISED: Color = Color::Rgb(0xE7, 0xEB, 0xF2);
+/// Light raised surface -- popovers, selected rows on paper (kit
+/// `neutral-100`).
+pub const PAPER_RAISED: Color = Color::Rgb(0xE4, 0xE2, 0xDC);
 
-/// Light seam / rule -- the paper counterpart of [`HAIRLINE`].
-pub const PAPER_HAIRLINE: Color = Color::Rgb(0xD3, 0xDA, 0xE6);
+/// Light seam / rule (the kit's light `--border`) -- the paper counterpart
+/// of [`HAIRLINE`].
+pub const PAPER_HAIRLINE: Color = Color::Rgb(0xE4, 0xDE, 0xCF);
 
-/// Primary text on paper -- 19.2:1.
-pub const INK: Color = Color::Rgb(0x0A, 0x0F, 0x1A);
+/// Primary text on paper -- Ink itself, 17.61:1. (The same value as
+/// [`GROUND`]: the kit's one black serves as both the dark ground and the
+/// light text, which is the point of an identity this small.)
+pub const INK: Color = Color::Rgb(0x0B, 0x0B, 0x0C);
 
-/// Secondary text on paper -- 6.7:1.
-pub const MUTED: Color = Color::Rgb(0x52, 0x5C, 0x6E);
+/// Secondary text on paper (the kit's light `--muted-fg`) -- 4.83:1.
+pub const MUTED: Color = Color::Rgb(0x6E, 0x6A, 0x5F);
 
-/// Tertiary text on paper -- the paper counterpart of [`TEXT_TERTIARY`].
-/// 4.69:1 on [`PAPER`], so it clears AA body; on [`SNOW`] (4.37:1) and
-/// [`PAPER_RAISED`] (3.92:1) it is a large-text / UI tone only, exactly as
-/// [`TEXT_TERTIARY`] is on [`RAISED`].
-pub const INK_DIM: Color = Color::Rgb(0x6B, 0x74, 0x88);
+/// Tertiary text on paper (kit `neutral-600`) -- the paper counterpart of
+/// [`TEXT_TERTIARY`]. 4.61:1 on [`PAPER`], so it clears AA body; on [`SNOW`]
+/// (4.94:1) it holds, and on [`PAPER_RAISED`] (3.98:1) it is a large-text /
+/// UI tone only, exactly as [`TEXT_TERTIARY`] is treated on [`RAISED`].
+pub const INK_DIM: Color = Color::Rgb(0x73, 0x6C, 0x68);
 
 // ── Data marks ──────────────────────────────────────────────────
 //
-// The categorical series palette, shared with the observatory. Deliberately
-// *not* the brand hue -- a data mark must not read as "active" -- and
-// deliberately not a status hue either. [`DATA_1`] and [`GOLD`] must never
-// appear in the same chart; they are the same brass at a glance.
+// The categorical series palette, shared verbatim with the observatory
+// (its `--c1..--c4`). Deliberately *not* the brand hue -- a data mark must
+// not read as "active" -- and deliberately not a status hue either. All are
+// complements of gold that stay warm/rich on ink: a muted violet, a warm
+// rose, a deep teal.
+//
+// [`DATA_1`] and [`GOLD`] are hue 42° and 41° -- 1.06:1 against each other,
+// nothing distinguishes them but size. The observatory stands the amber mark
+// down from every plotted surface for exactly this reason; in the deck it
+// survives ONLY as the syntax-keyword tone inside code bodies, where gold
+// chrome never reaches (see `theme::SYNTAX_KEYWORD`). Never put it on a
+// chip, a node, or an agent.
 
-/// Categorical 1 -- amber.
+/// Categorical 1 -- amber. 10.11:1 on ground; see the stand-down note above.
 pub const DATA_1: Color = Color::Rgb(0xE3, 0xB3, 0x41);
-/// Categorical 2 -- violet.
+/// Categorical 2 -- muted violet, hue 256° (215° from gold). 5.29:1 on
+/// ground.
 pub const DATA_2: Color = Color::Rgb(0x8F, 0x70, 0xE8);
-/// Categorical 3 -- magenta.
+/// Categorical 3 -- warm rose, hue 331° (70° from gold). 5.09:1 on ground;
+/// 1.30:1 against [`DANGER`], so it never carries an error meaning and never
+/// appears without a label or glyph.
 pub const DATA_3: Color = Color::Rgb(0xE4, 0x40, 0x8F);
-/// Categorical 4 -- teal.
+/// Categorical 4 -- deep teal, hue 175° (134° from gold). 10.54:1 on ground.
 pub const DATA_4: Color = Color::Rgb(0x2F, 0xD3, 0xC6);
 
 /// Every palette colour, paired with its token name.
 ///
 /// Lets a test walk the whole palette -- see theme.rs's
 /// `every_dark_palette_value_has_a_fallback` -- without a hand-maintained
-/// second list. Names match the token column of the retired BRAND.md (the
-/// current kit lives at `docs/brand/BRAND.md`).
+/// second list. Names match the kit's token vocabulary at
+/// `docs/brand/css/tokens.css`.
 pub const ALL: [(&str, Color); 35] = [
     ("void", VOID),
     ("ground", GROUND),

--- a/stella-tui/src/progress.rs
+++ b/stella-tui/src/progress.rs
@@ -18,9 +18,9 @@
 //!   the **pulsing head** are the *only* indeterminate cues, and they signal
 //!   liveness (`AgentStatus::Running`) — never progress. They ride *on top of*
 //!   the determinate fill and never advance it.
-//! - The fill rides the brand **sky** gradient (deep sky → sky)
-//!   — the deck's one deliberately warm run, so its sole activity indicator
-//!   is unmistakable against the cool aurora chrome everywhere else.
+//! - The fill rides the brand **gold** gradient (deep gold → Phosphor Gold)
+//!   — activity is the accent, so the deck's sole activity indicator is
+//!   unmistakable against the quiet warm-neutral chrome everywhere else.
 //! - **tok/s** is the focused agent's *live turn* rate — output tokens since
 //!   the turn began over the turn's own elapsed; it is omitted (not guessed)
 //!   whenever there's nothing real to divide, including a running lane with
@@ -233,7 +233,7 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
 }
 
 /// The label chunk (`✓ plan · ▸ execute · verify`) as styled spans, plus its
-/// display width. Done = success green, Active = sky (matches the fill),
+/// display width. Done = success green, Active = gold (matches the fill),
 /// Pending = dim.
 fn label_line(state: &ProgressState) -> (Vec<Span<'static>>, usize) {
     let mut spans = Vec::new();

--- a/stella-tui/src/render/entry.rs
+++ b/stella-tui/src/render/entry.rs
@@ -245,9 +245,9 @@ fn entry_body(
             let total_lines = text.lines().count().max(1);
             let show_all = expand_thinking || expanded;
             let chevron = if show_all { "⏶" } else { "⏵" };
-            // Dim, not tinted. Reasoning is the agent talking to itself; it is
-            // the *least* load-bearing text on screen, and the glacier blue it
-            // used to wear now reads as the brand accent.
+            // Dim, not tinted. Reasoning is the agent talking to itself; it
+            // is the *least* load-bearing text on screen, so it wears the
+            // quiet warm neutral, never a hue.
             let header_style = quiet();
             let reasoning_style = Style::new()
                 .fg(theme::TEXT_TERTIARY)

--- a/stella-tui/src/splash.rs
+++ b/stella-tui/src/splash.rs
@@ -10,12 +10,11 @@
 //! done — even mid-fade. If there is no init to cover, it is gone in well
 //! under a second.
 //!
-//! What it draws is the previous identity's lockup (see `docs/brand/BRAND.md`
-//! for the current kit, which the terminal has not yet adopted): the chevron, the
-//! `stella` wordmark, and the block cursor — plus the build version and the
-//! resolved model once one is known. Colours come from [`crate::theme`]'s
-//! semantic roles, never from raw palette constants, so the mark follows the
-//! identity rather than pinning a copy of it.
+//! What it draws is the comet identity's lockup (`docs/brand/BRAND.md`): the
+//! chevron, the `stella` wordmark, and the gold block cursor — plus the build
+//! version and the resolved model once one is known. Colours come from
+//! [`crate::theme`]'s semantic roles, never from raw palette constants, so
+//! the mark follows the identity rather than pinning a copy of it.
 //!
 //! The one presentational concession is a **single** fade step: for the first
 //! [`REVEAL`] the mark renders muted, then in its real colours. One step, not

--- a/stella-tui/src/theme.rs
+++ b/stella-tui/src/theme.rs
@@ -1,6 +1,6 @@
 //! The one place the deck's look is defined — colors, semantic styles, and
 //! glyphs. Every view pulls from here so the deck reads as one system in both
-//! the Stella brand palette and its status semantics. No view hard-codes a
+//! the stella brand palette and its status semantics. No view hard-codes a
 //! color; that is what keeps a 12-panel TUI feeling designed rather than
 //! assembled.
 
@@ -10,26 +10,31 @@ use crate::deck::TraceKind;
 use crate::envelope::AgentStatus;
 use crate::palette;
 
-// ── Stella palette — "electric blue and gold on deep space" ─────────────────
+// ── stella palette — "Phosphor Gold on Ink" (brand kit v1.0, the comet) ─────
 //
-// A star chart, not a product launch. The ground is a blue-cast near-black;
-// the electric blue is the interactive signal — reserved for brand,
-// active/running, and focus, and for nothing else. If everything is blue,
-// nothing is: a general-purpose highlight is exactly what this hue must not
-// become. (Blue is the *default* accent; `stella-light` swaps it for the same
-// hue darkened onto paper — see [`apply_theme`].)
+// One colour, owned. The ground is Ink, a warm-neutral near-black; Phosphor
+// Gold is the signal — reserved for brand, the prompt, active/running,
+// selection and focus, and for nothing else. Gold is the signal, never the
+// surface: if everything is gold, nothing is, so a general-purpose highlight
+// is exactly what this hue must not become. The one sanctioned gold *fill*
+// is a pill that owns attention (the H1 title bar, a selected tab), and a
+// gold fill always carries INK text — white on gold is 1.83:1. (Gold is the
+// *default* accent; `stella-light` swaps it for the deep gold ramp on warm
+// paper — see [`apply_theme`].)
 //
-// Gold is the second half of the identity: the logo's block cursor, splash
-// rules, section markers. **Gold never carries status.** It is the same brass
-// as [`WARNING`] at a glance, so the two may never share a row — status is
-// amber and always glyph-paired, gold is chrome. Enforced by
-// `gold_is_never_a_status_colour`.
+// The old blue/gold split is collapsed: the identity chrome (the logo's
+// block cursor, splash rules, section markers) and the interactive accent
+// are the same gold now. What survives of the old law: **gold never carries
+// a verdict.** Warning amber sits 4.0° from gold in hue, so an outcome may
+// never be told from chrome by hue alone — status is always glyph-paired,
+// and activity (running) is the only status that takes the accent. Enforced
+// by `gold_never_carries_a_verdict`.
 //
-// The corollary the transcript actually depends on: **prose is white.** The
+// The corollary the transcript actually depends on: **prose is paper.** The
 // accent buys attention, so it may only be spent where attention is owed — on
 // the deck that means the tool being called, the active tab, and the progress
-// fill. Everything else is [`INK`] (white) or [`MUTED`], and a row that wants
-// to be scannable does it with a glyph and a column, not with a hue.
+// fill. Everything else is [`INK`] (warm paper) or [`MUTED`], and a row that
+// wants to be scannable does it with a glyph and a column, not with a hue.
 //
 // Status always pairs colour with a glyph (see [`status_glyph`]) so hue never
 // carries meaning alone — active ▶ vs done ✓ — which is also what keeps the
@@ -48,27 +53,28 @@ use crate::palette;
 // Grounds (dark → light lift).
 /// Deepest ground — full-bleed backdrops and the splash.
 pub const VOID: Color = palette::VOID;
-/// App background — deep space, a near-black with a blue cast. Applied as a
-/// real frame fill by `render_deck`, not just assumed from the terminal.
+/// App background — Ink, the terminal's warm-neutral near-black. Applied as
+/// a real frame fill by `render_deck`, not just assumed from the terminal.
 pub const GROUND: Color = palette::GROUND;
 /// Card / panel surface.
 pub const SURFACE: Color = palette::SURFACE;
 /// Raised panel (one step above surface).
 pub const RAISED: Color = palette::RAISED;
-/// Hairline border / rule — a cool slate seam. Deliberately below 3.0
-/// contrast (1.2:1): it may never be the only thing conveying structure.
+/// Hairline border / rule — a warm charcoal seam. Deliberately below 3.0
+/// contrast (1.26:1): it may never be the only thing conveying structure.
 pub const HAIRLINE: Color = palette::HAIRLINE;
-/// The louder seam, for a boundary that must actually read (1.4:1). Still
+/// The louder seam, for a boundary that must actually read (1.57:1). Still
 /// decoration — a stronger rule, not a substitute for a glyph or a gap.
 pub const HAIRLINE_STRONG: Color = palette::HAIRLINE_STRONG;
 
-// Text tiers (primary → dim) — cool, blue-leaning neutrals.
+// Text tiers (primary → dim) — warm paper over the kit's warm neutral ramp;
+// no cool grays anywhere on the dark side.
 /// Primary text.
 pub const TEXT_PRIMARY: Color = palette::TEXT_PRIMARY;
 /// Secondary text. The safe small-text tone on every ground.
 pub const TEXT_SECONDARY: Color = palette::TEXT_SECONDARY;
-/// Tertiary text (labels, captions). Clears AA body text on [`GROUND`]
-/// (4.59:1); on [`SURFACE`]/[`RAISED`] it is a large-text / UI tone only.
+/// Tertiary text (labels, captions). AA body on [`GROUND`]/[`SURFACE`]
+/// (5.71:1 / 5.38:1); on [`RAISED`] (4.98:1) it sits right at the floor.
 pub const TEXT_TERTIARY: Color = palette::TEXT_TERTIARY;
 /// Dim text (the quietest legible tier) — the same tone as [`TEXT_TERTIARY`].
 /// Kept as a distinct role name for the progress track and other chrome that
@@ -81,8 +87,9 @@ pub const TEXT_DIM: Color = palette::TEXT_TERTIARY;
 pub const SUCCESS: Color = palette::SUCCESS;
 /// Success (bright — text / completed fills).
 pub const SUCCESS_BRIGHT: Color = palette::SUCCESS;
-/// Warning (base). Amber-yellow — distinct from both the brand blue and danger.
-/// Never on the same surface as [`GOLD`], which is the same brass at a glance.
+/// Warning (base). Amber — a hue-neighbour of the gold accent (4.0° apart),
+/// which is exactly why a warning never appears without its glyph: the
+/// glyph, not the hue, is the status carrier.
 pub const WARNING: Color = palette::WARNING;
 /// Warning (bright — text).
 pub const WARNING_BRIGHT: Color = palette::WARNING;
@@ -93,69 +100,78 @@ pub const DANGER_BRIGHT: Color = palette::DANGER;
 
 // ── Categorical hues (deliberately NOT brand) ───────────────────────────────
 //
-// A few surfaces need more mutually-distinguishable colours than a two-hue
+// A few surfaces need more mutually-distinguishable colours than a one-hue
 // brand palette provides: syntax tokens, graph node kinds, and one colour per
 // concurrent agent. Making those the brand hue would violate the reservation
 // above, so they are a categorical set — the *same four values* the
 // observatory paints its data marks with, so a series in a chart and a chip in
-// the deck agree. They carry no brand meaning and must never be used for
-// brand, status, or "active".
+// the deck agree. All are complements of gold that stay warm/rich on ink —
+// muted violet (215° from gold), deep teal (134°), warm rose (70°) — and every
+// one clears AA body (5.09:1 or better) on [`GROUND`]. They carry no brand
+// meaning and must never be used for brand, status, or "active".
 
 /// Violet — process/structural events (links, diff hunk headers, graph
 /// relations, trace stages, the user's own prompt). Categorical, not the brand
-/// accent. `data-2`.
+/// accent. `data-2`, 5.29:1 on ground.
 pub const VIOLET: Color = palette::DATA_2;
-/// Amber — the second categorical hue: syntax keywords, file/module graph
-/// nodes. `data-1`. A categorical set is only useful to the extent its members
-/// cannot be mistaken for one another or for the accent. (Distinct from the
-/// amber-yellow [`WARNING`] status, which lives in a different context — a
-/// syntax token is never a caution. It is *not* distinct from [`GOLD`], which
-/// is why gold stays on chrome and never enters a chart or a chip row.)
+/// Amber — the stood-down categorical hue. `data-1` measures 1.06:1 against
+/// the gold accent — the same brass at a glance — so with gold as THE accent
+/// it may no longer colour a chip, a node, or an agent (the observatory
+/// stands the same mark down from every plotted surface). It survives in one
+/// context only: syntax keywords inside code bodies, where gold chrome never
+/// reaches and the neighbouring tones are the diff washes and the other
+/// syntax hues. 10.11:1 on ground.
 pub const AMBER: Color = palette::DATA_1;
-/// Teal — the third categorical hue: media traces and one slot of the
-/// per-agent palette. `data-4`. Blue-green, so it reads apart from both the
-/// brand blue and the success green. It replaces a glacier blue (`AGENT_ICE`)
-/// and then a lilac, each of which drifted within confusable range of the
-/// accent.
+/// Teal — media traces and one slot of the per-agent palette. `data-4`,
+/// 10.54:1 on ground. Deep blue-green: 134° from the gold accent and far
+/// from the success green, and emphatically not the retired ice blue — it
+/// replaced a glacier blue (`AGENT_ICE`) that drifted confusable with the
+/// old accent, and it reads rich, not icy, on ink.
 pub const TEAL: Color = palette::DATA_4;
-/// Magenta — the fourth categorical hue. `data-3`. Held for series four and
-/// for surfaces that need a fourth chip; deliberately far from [`DANGER`]'s
-/// red-pink in context because it never appears without a neutral label.
+/// Warm rose — file artifacts (trace chips, graph file/module nodes) and the
+/// fourth chart series. `data-3`, 5.09:1 on ground. 70° from gold; 1.30:1
+/// against [`DANGER`]'s red-pink, so it never carries an error meaning and
+/// never appears without a neutral label or glyph beside it.
 pub const MAGENTA: Color = palette::DATA_3;
 
 // ── Role aliases (what the rest of the crate references) ─────────────────────
 // Role names remap onto the palette so call sites read as intent (accent,
 // ink, rule) rather than as a hue that a future recolor would falsify.
 
-/// Stella brand accent — electric blue, in the tone that is safe on text and
-/// on a one-cell rule (`brand-bright`, 7.4:1 on [`GROUND`]). Brand,
-/// active/running, focus, and progress only. In the transcript, the tool name
-/// and nothing else. The active theme's actual hue is applied per-frame by
-/// [`apply_theme`]; this is the canonical dark value every call site renders.
+/// stella's brand accent — Phosphor Gold `#FFB000`, the kit value exactly
+/// (10.74:1 on [`GROUND`]). Brand, active/running, focus, selection, and
+/// progress only. In the transcript, the tool name and nothing else. The
+/// active theme's actual hue is applied per-frame by [`apply_theme`]; this is
+/// the canonical dark value every call site renders.
 ///
-/// This is deliberately the *bright* brand tone, not `palette::BRAND`: almost
-/// every call site in the crate paints a glyph or a border with it, and plain
-/// `brand` only reaches 5.1:1 on ground (4.9:1 on [`SURFACE`]). Reach for
-/// [`ACCENT_FILL`] when the colour covers an area rather than a stroke.
-pub const ACCENT: Color = palette::BRAND_BRIGHT;
-/// The brand hue for *fills* — a block, a bar body, a selected-row wash. Large
-/// area, so 5.1:1 on ground is enough and the deeper, more saturated blue reads
-/// better than the bright one at size. Never use it for text or a 1-cell rule.
+/// Unlike the blue it replaced, gold needs no separate text tone: the same
+/// value clears AA on a glyph, a one-cell rule, and a fill on every dark
+/// ground. When it is a *fill*, the text on it must be [`GROUND`]-dark —
+/// ink on gold is 10.74:1 where white on gold is 1.83:1.
+pub const ACCENT: Color = palette::BRAND;
+/// The brand hue for *fills* — a pill, a bar body, a selected-tab wash. The
+/// same Phosphor Gold: one owned colour means the stroke and the fill agree,
+/// and the fill's legibility comes from pairing it with ink text, never from
+/// a second hue.
 pub const ACCENT_FILL: Color = palette::BRAND;
-/// A deeper accent (gradient / pressed).
+/// A deeper accent (gradient / pressed) — kit `gold-600`, the leading stop of
+/// the progress fill (7.24:1 on ground, so the fill's tail clears AA).
 pub const ACCENT_DEEP: Color = palette::BRAND_DEEP;
 
-/// The identity gold — the logo's block cursor, splash rules, section markers,
-/// and brand chrome generally. **Never a status**: it is the same brass as
-/// [`WARN`] at a glance, and `gold_is_never_a_status_colour` proves no status
-/// mapping can return it.
+/// The identity gold — the logo's block cursor, splash rules, section
+/// markers, and brand chrome generally. The same Phosphor Gold as [`ACCENT`]:
+/// under the comet kit, chrome and accent are one colour. **Never a
+/// verdict**: it sits 4.0° from [`WARN`] in hue, and
+/// `gold_never_carries_a_verdict` proves no outcome mapping can return it —
+/// activity (running/active) is the one status that takes gold, by kit rule.
 pub const GOLD: Color = palette::GOLD;
 /// The bright stop of the gold sweep (headlines, the splash rule's leading
-/// edge).
+/// edge). Kit `gold-400`.
 pub const GOLD_BRIGHT: Color = palette::GOLD_BRIGHT;
-/// The trailing stop of the gold sweep.
+/// The trailing stop of the gold sweep. Kit `gold-700` — the identity sweep
+/// runs wider and quieter than the progress fill's ([`ACCENT_DEEP`]).
 pub const GOLD_DEEP: Color = palette::GOLD_DEEP;
-/// Near-white primary text.
+/// Warm-paper primary text.
 pub const INK: Color = TEXT_PRIMARY;
 /// Dimmed secondary text.
 pub const MUTED: Color = TEXT_SECONDARY;
@@ -163,7 +179,10 @@ pub const MUTED: Color = TEXT_SECONDARY;
 pub const RULE: Color = HAIRLINE;
 
 /// Background tint for the transcript entry selected with the arrow keys —
-/// a barely-there slate lift so the highlight reads without shouting.
+/// a barely-there warm lift so the highlight reads without shouting. A full
+/// gold wash would make the selection a surface, which gold may not be; the
+/// gold *pill* treatment is reserved for single-line attention (the H1 bar,
+/// an active tab), where ink-on-gold text keeps it legible.
 pub const SELECT_BG: Color = palette::RAISED;
 
 /// Success / positive / added lines.
@@ -183,7 +202,7 @@ pub const HELD: Color = VIOLET;
 // ── Runtime theme (the `/theme` switch) ──────────────────────────────────────
 //
 // Colours above are compile-time constants: the canonical **dark** palette
-// (electric blue and gold on deep space), which is what every view renders and
+// (Phosphor Gold on Ink), which is what every view renders and
 // what ships as the default. A theme switch is applied *after* the widgets draw, as a
 // per-frame value→value remap over the finished buffer ([`apply_theme`]) —
 // the exact mechanism [`degrade_buffer`] already uses for colour-depth. That
@@ -194,16 +213,16 @@ pub const HELD: Color = VIOLET;
 // whose interpolated cells are never equal to a token; so its source
 // ([`brand_gradient`] via [`primary_stops`]) is theme-aware directly.
 
-/// The shipped themes. `stella-dark` (electric blue on deep space) is the
-/// default; `stella-light` (the same blue darkened onto paper) is its
-/// complement. The names match the `/theme` argument and the `ui.theme`
-/// settings value verbatim.
+/// The shipped themes. `stella-dark` (Phosphor Gold on Ink) is the default;
+/// `stella-light` (the deep gold ramp on warm paper) is its complement. The
+/// names match the `/theme` argument and the `ui.theme` settings value
+/// verbatim.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ThemeName {
-    /// Electric blue and gold on deep space. Default.
+    /// Phosphor Gold on Ink. Default.
     #[default]
     StellaDark,
-    /// The same blue and gold darkened onto paper white.
+    /// The same gold darkened onto warm paper.
     StellaLight,
 }
 
@@ -260,31 +279,34 @@ pub fn set_active_theme(theme: ThemeName) {
 }
 
 /// The active theme's brand gradient stops, deep → bright: `brand-deep` →
-/// `brand-bright` on `stella-dark`, `brand-ink-deep` → `brand-ink` on
-/// `stella-light`. Feeds [`brand_gradient`] so the progress fill and wordmark
-/// sweep recolour with the theme.
+/// `brand` (Phosphor Gold) on `stella-dark`, `brand-ink-deep` → `brand-ink`
+/// on `stella-light`. Feeds [`brand_gradient`] so the progress fill and
+/// wordmark sweep recolour with the theme.
 ///
-/// The bright end is [`ACCENT`] (`brand-bright`), not `palette::BRAND`, so that
-/// the truecolor gradient lands on the same value a degraded terminal falls
-/// back to — `crate::progress` paints a solid [`ACCENT`] when
-/// [`ColorMode::is_truecolor`] is false, and a fill whose colour jumped between
-/// depths would be a downgrade-path bug.
+/// The bright end is [`ACCENT`] (the gold itself, not `brand-bright`), so
+/// that the truecolor gradient lands on the same value a degraded terminal
+/// falls back to — `crate::progress` paints a solid [`ACCENT`] when
+/// [`ColorMode::is_truecolor`] is false, and a fill whose colour jumped
+/// between depths would be a downgrade-path bug. (`brand-bright` belongs to
+/// the identity sweep's high end, [`gold_stops`].)
 pub fn primary_stops() -> [Color; 2] {
     match active_theme() {
-        ThemeName::StellaDark => [palette::BRAND_DEEP, palette::BRAND_BRIGHT],
+        ThemeName::StellaDark => [palette::BRAND_DEEP, palette::BRAND],
         ThemeName::StellaLight => [palette::BRAND_INK_DEEP, palette::BRAND_INK],
     }
 }
 
 /// The active theme's gold gradient stops, deep → bright. Gold is identity
-/// chrome: the splash rule, section markers, the wordmark's cursor block. It is
-/// never a status and never a data mark, so nothing that resolves a *meaning*
-/// may call this.
+/// chrome: the splash rule, section markers, the wordmark's cursor block. It
+/// is never a verdict and never a data mark, so nothing that resolves an
+/// *outcome* may call this.
 pub fn gold_stops() -> [Color; 2] {
     match active_theme() {
         ThemeName::StellaDark => [palette::GOLD_DEEP, palette::GOLD_BRIGHT],
-        // One gold on paper: `gold-ink` is the only value in the family that
-        // holds an edge against white, so the light sweep is flat by design.
+        // One gold on paper: `gold-ink` (the kit's `gold-deep`, its one
+        // light-ground gold) holds the 3:1 graphical floor on paper, so the
+        // light sweep is flat by design. Gold *text* on paper is darker
+        // still — the flat-token remap sends it to `brand-ink`.
         ThemeName::StellaLight => [palette::GOLD_INK, palette::GOLD_INK],
     }
 }
@@ -337,9 +359,11 @@ pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(102, 34, 42);
 // `crate::diff`), while a recognized token overrides only the foreground.
 // Every color is chosen to read on all three diff backdrops (add green, del
 // red, and the plain panel), and every one is *categorical*: syntax is not
-// brand, not status, and not activity, so none of these is the brand hue. Keyword
-// takes [`AMBER`], strings a soft spring green, numbers the [`VIOLET`]
-// anchor, and comments dim toward [`MUTED`].
+// brand, not status, and not activity. Keyword takes [`AMBER`] — the one
+// surviving home of the amber mark, legitimate here because gold chrome
+// never enters a code body, so nothing nearby can be confused for "active" —
+// strings a soft spring green, numbers the [`VIOLET`] anchor, and comments
+// dim toward the caption tier.
 
 /// Language keyword (`fn`/`let`/`def`/`import`/`return`…).
 pub const SYNTAX_KEYWORD: Color = AMBER;
@@ -347,16 +371,19 @@ pub const SYNTAX_KEYWORD: Color = AMBER;
 pub const SYNTAX_STRING: Color = Color::Rgb(126, 231, 135);
 /// Numeric literal — violet, the counterpoint to the amber keyword stop.
 pub const SYNTAX_NUMBER: Color = VIOLET;
-/// Line comment (rendered dimmed + italic).
-pub const SYNTAX_COMMENT: Color = Color::Rgb(118, 124, 134);
+/// Line comment (rendered dimmed + italic). The same warm neutral as
+/// [`TEXT_TERTIARY`] — "comments dim toward the caption tier" made literal,
+/// and the cool gray it replaces is banned from the dark side outright.
+pub const SYNTAX_COMMENT: Color = palette::TEXT_TERTIARY;
 
 /// Inline code spans and fenced-code plain runs (`crate::markdown`). A calm
 /// sage green — quiet enough that a backticked word reads as *technical*
-/// rather than as emphasis, and 72° of hue away from [`ACCENT`] so it never
-/// reads as *active*. This replaces the warning-orange the transcript used to
-/// paint every `identifier` with: code is not a warning, and an alarm hue on
-/// every backticked word was the single loudest thing on the deck. Not a brand
-/// value — it is TUI-only and has no entry in `palette`.
+/// rather than as emphasis, and 105° of hue away from [`ACCENT`] so it never
+/// reads as *active* (8.94:1 on ground). This replaces the warning-orange the
+/// transcript used to paint every `identifier` with: code is not a warning,
+/// and an alarm hue on every backticked word was the single loudest thing on
+/// the deck. Not a brand value — it is TUI-only and has no entry in
+/// `palette`.
 pub const CODE: Color = Color::Rgb(0x6F, 0xBF, 0x92);
 
 // ── Brand gradient (the wordmark sweep and the progress-bar fill) ───────────
@@ -365,15 +392,16 @@ pub const CODE: Color = Color::Rgb(0x6F, 0xBF, 0x92);
 // earlier generation ran two separate gradients — one for brand chrome and a
 // second for the progress bar — which is precisely the split this palette
 // collapses. Progress *is* activity, activity is the brand hue, so one
-// gradient serves both. The stops track the ACTIVE theme (blue on deep space,
-// the same blue darkened on paper) via [`primary_stops`]: the progress fill
+// gradient serves both. The stops track the ACTIVE theme (gold on ink, the
+// deep gold ramp on paper) via [`primary_stops`]: the progress fill
 // interpolates non-token cells the per-frame [`apply_theme`] remap can't see,
 // so its source has to be theme-aware directly.
 //
-// Gold has its own two-stop sweep ([`gold_stops`] / [`gold_gradient`]) for
-// identity chrome — the splash rule and section markers. It is a separate
-// gradient precisely because it must never end up somewhere a status could,
-// and because the progress bar's degraded fallback is a solid [`ACCENT`].
+// The identity chrome keeps its own wider two-stop sweep ([`gold_stops`] /
+// [`gold_gradient`]) — the splash rule and section markers. Same family now
+// (gold-700 → gold-400 around the same hue), but a separate gradient: chrome
+// may sweep quiet-to-bright while the progress fill's tail must hold AA on
+// its own, and the progress bar's degraded fallback is a solid [`ACCENT`].
 
 /// The brand gradient's stops for the *default* (dark) theme, deep → bright.
 /// [`primary_stops`] returns these for `stella-dark` and the paper pair for
@@ -541,23 +569,28 @@ const FALLBACKS: &[(Color, u8, u8)] = &[
     (HAIRLINE, 235, 8),
     (HAIRLINE_STRONG, 236, 8),
     (TEXT_PRIMARY, 255, 15),
-    (TEXT_SECONDARY, 103, 7),
-    (TEXT_TERTIARY, 244, 8),
-    // Accent, fill and deep accent take *different* 256 indices (75/33/26) and
-    // the deep one drops to plain blue at 16 colours, so the progress fill
-    // keeps a readable head-to-tail ramp even where the gradient collapses.
-    (ACCENT, 75, 12),
-    (ACCENT_FILL, 33, 12),
-    (ACCENT_DEEP, 26, 4),
-    // Gold stays on the *bright yellow* side at both depths. The nearest cube
-    // entry to `gold` by RGB distance is 215 (255,175,95) — an orange — and an
-    // orange is the one thing this identity may not render, so 221/222 (the
-    // next-nearest, 1.15× the distance) are used instead. At 16 colours the
-    // whole family takes bright yellow so it never collapses onto `warning`'s
-    // plain yellow: gold is chrome, warning is a status, and the two may not
-    // become the same cell.
-    (GOLD, 221, 11),
-    (GOLD_BRIGHT, 222, 11),
+    (TEXT_SECONDARY, 246, 7),
+    (TEXT_TERTIARY, 245, 8),
+    // Phosphor Gold `#FFB000` sits one unit from cube entry 214 (255,175,0) —
+    // for once the terminal cube holds the brand almost exactly. The family
+    // stays on the *yellow* side everywhere: the nearest entry to
+    // `gold-bright` is 215 (255,175,95), an orange, and orange is the one
+    // thing this identity may not render, so it takes 221 (255,215,95)
+    // instead; `gold-deep` likewise skips orange 130 for 136 (175,135,0).
+    // The progress ramp's deep stop takes 178 rather than nearest-entry 172
+    // (215,135,0, again orange) — it shares that dark yellow with `warning`,
+    // which is acceptable because a degraded terminal never paints the
+    // gradient at all (`crate::progress` collapses to solid ACCENT), while
+    // ACCENT vs ACCENT_DEEP staying distinct keeps the head-to-tail ramp
+    // honest. At 16 colours the accent family takes bright yellow (11) and
+    // the deep stop plain yellow's darker sibling is unavailable, so it
+    // shares 3 with warning under the same never-painted reasoning; GOLD
+    // family values stay on 11 so chrome never collapses onto `warning`'s
+    // plain yellow — gold is chrome, warning is a verdict, and the two may
+    // not become the same cell.
+    (ACCENT, 214, 11), // also ACCENT_FILL and GOLD (one value, one entry)
+    (GOLD_BRIGHT, 221, 11),
+    (ACCENT_DEEP, 178, 3),
     (GOLD_DEEP, 136, 11),
     (SUCCESS, 78, 10),
     (WARNING, 178, 3),
@@ -573,7 +606,6 @@ const FALLBACKS: &[(Color, u8, u8)] = &[
     (DIFF_DEL_BG_EMPH, 88, 1),
     (MATCH_BG, 58, 3),
     (SYNTAX_STRING, 114, 10),
-    (SYNTAX_COMMENT, 244, 8),
 ];
 
 /// Resolve one color for the mode actually in use. Truecolor passes through;
@@ -637,46 +669,45 @@ pub fn degrade_buffer(buf: &mut ratatui::buffer::Buffer, mode: ColorMode) {
 
 /// `stella-light`: every canonical (dark) token value → its paper counterpart.
 const LIGHT_REMAP: &[(Color, Color)] = &[
-    // Grounds → paper. VOID and GROUND are distinct values now (they were both
-    // true black under the retired identity), so each needs its own entry.
+    // Grounds → paper.
     (VOID, palette::PAPER),
     (GROUND, palette::PAPER),
     (SURFACE, palette::SNOW),
     (RAISED, palette::PAPER_RAISED),            // also SELECT_BG
     (HAIRLINE, palette::PAPER_HAIRLINE),        // also RULE
     (HAIRLINE_STRONG, palette::PAPER_HAIRLINE), // one paper seam serves both
-    // Text → ink (INK==TEXT_PRIMARY, MUTED==TEXT_SECONDARY, DIM==TERTIARY).
+    // Text → ink (INK==TEXT_PRIMARY, MUTED==TEXT_SECONDARY, DIM==TERTIARY;
+    // SYNTAX_COMMENT rides the tertiary entry too).
     (TEXT_PRIMARY, palette::INK),
     (TEXT_SECONDARY, palette::MUTED),
     (TEXT_TERTIARY, palette::INK_DIM),
-    // Brand → the paper blue. ACCENT is `brand-bright`, ACCENT_FILL is `brand`;
-    // both land on `brand-ink`, which is the tone that clears AA on white.
-    // ACCENT_DEEP shares its value with `brand-ink`, so its entry has to sit
-    // *after* the two above and map on to `brand-ink-deep` — first match wins
-    // per cell, and these are distinct keys, so ordering is documentation
-    // rather than load-bearing.
+    // Brand → the deep gold ramp. ACCENT, ACCENT_FILL and GOLD are one
+    // Phosphor Gold value, so one entry sends every flat gold cell to
+    // `brand-ink` (kit gold-800, 6.04:1 on paper) — the kit's `gold-deep`
+    // is reserved for *graphical* chrome via `gold_stops`, because at
+    // 3.79:1 it cannot carry terminal-cell text on paper.
     (ACCENT, palette::BRAND_INK),
-    (ACCENT_FILL, palette::BRAND_INK),
-    (ACCENT_DEEP, palette::BRAND_INK_DEEP),
-    // Gold → the one gold that holds an edge on white.
-    (GOLD, palette::GOLD_INK),
     (GOLD_BRIGHT, palette::GOLD_INK),
+    (ACCENT_DEEP, palette::BRAND_INK_DEEP),
+    // `gold-deep` already IS the kit's light-ground gold; its entry is the
+    // identity so the sweep's trailing stop needs no second value.
     (GOLD_DEEP, palette::GOLD_INK),
     // Status → ink variants (OK/BRIGHT share the base value).
     (SUCCESS, palette::SUCCESS_INK),
     (WARNING, palette::WARNING_INK),
     (DANGER, palette::DANGER_INK),
-    // Inline code — a darker sage, legible on paper.
-    (CODE, Color::Rgb(0x2F, 0x7D, 0x55)),
-    // Categorical hues, darkened for AA on paper (RUN/HELD/NUMBER==VIOLET,
-    // KEYWORD==AMBER).
+    // Inline code — a darker sage, 5.26:1 on paper.
+    (CODE, Color::Rgb(0x2A, 0x71, 0x50)),
+    // Categorical hues, darkened for AA on the warm paper (RUN/HELD/NUMBER==
+    // VIOLET, KEYWORD==AMBER). Teal drops to teal-700: the old teal-600
+    // measured 3.35:1 on the kit's paper, under the 4.5:1 text floor.
     (VIOLET, Color::Rgb(0x6D, 0x28, 0xD9)),
     (AMBER, Color::Rgb(0x92, 0x40, 0x0E)),
-    (TEAL, Color::Rgb(0x0D, 0x94, 0x88)),
+    (TEAL, Color::Rgb(0x0F, 0x76, 0x6E)),
     (MAGENTA, Color::Rgb(0xA6, 0x18, 0x5C)),
-    // Syntax bodies.
-    (SYNTAX_STRING, Color::Rgb(0x15, 0x80, 0x3D)),
-    (SYNTAX_COMMENT, Color::Rgb(0x6B, 0x72, 0x80)),
+    // Syntax bodies. Strings take green-800 (6.38:1 — green-700 sat at
+    // 4.49:1 on the warm paper).
+    (SYNTAX_STRING, Color::Rgb(0x16, 0x65, 0x34)),
     // Diff tints → light washes.
     (DIFF_ADD_BG, Color::Rgb(0xDC, 0xFC, 0xE7)),
     (DIFF_DEL_BG, Color::Rgb(0xFE, 0xE2, 0xE2)),
@@ -768,14 +799,16 @@ pub fn status_glyph(status: AgentStatus) -> &'static str {
 
 /// Color a [`crate::graph::GraphNode`] by its `kind`, so the Graph tab's node
 /// list, detail panel, and node-edge sketch all agree on one palette:
-/// function/method violet, struct/enum/trait green, file/module amber —
-/// three distinct categorical hues, none of them the reserved brand accent.
-/// A node kind is a category, not an activity.
+/// function/method violet, struct/enum/trait green, file/module warm rose —
+/// three distinct categorical hues, none of them the reserved brand accent
+/// (the rose replaces an amber that became indistinguishable from the gold
+/// accent, and it matches the Traces tab's file chip so "file" is one colour
+/// everywhere). A node kind is a category, not an activity.
 pub fn graph_kind_color(kind: &str) -> Color {
     match kind {
         "function" | "method" => RUN,
         "struct" | "enum" | "trait" => OK,
-        "file" | "module" => AMBER,
+        "file" | "module" => MAGENTA,
         _ => MUTED,
     }
 }
@@ -818,11 +851,13 @@ pub fn spark_glyph(intensity: u8) -> char {
 /// A small rotating palette an agent id is hashed into. The point is
 /// stability, not per-color meaning: the same id always lands on the same
 /// slot, so an agent reads as one consistent color everywhere it appears.
-/// Five distinct categorical hues — violet, amber, green, teal, secondary — none
-/// of them the reserved brand hue (an agent is not "the brand") and none of
-/// them danger (which reads as failure elsewhere, so it never brands a healthy
-/// agent).
-const AGENT_PALETTE: [Color; 5] = [HELD, AMBER, OK, TEXT_SECONDARY, TEAL];
+/// Five distinct categorical hues — violet, rose, green, teal, secondary —
+/// none of them the reserved brand hue (an agent is not "the brand"; the
+/// amber slot the rose replaces was 1.06:1 against the gold accent, and a
+/// chip that can be mistaken for "running" is worse than no chip) and none
+/// of them danger (which reads as failure elsewhere, so it never brands a
+/// healthy agent).
+const AGENT_PALETTE: [Color; 5] = [HELD, MAGENTA, OK, TEXT_SECONDARY, TEAL];
 
 /// A deterministic (not randomized — stable across processes and test runs)
 /// color for one agent id, picked from `AGENT_PALETTE` by hashing the id.
@@ -848,19 +883,20 @@ fn fnv1a(s: &str) -> u64 {
 
 /// A color per [`TraceKind`], for the Traces tab's kind chip. Grouped by
 /// meaning: `RUN` (violet) for process/action events (stage, tool, vcs),
-/// `AMBER`/`TEAL` for produced artifacts (file, media) — categorical, so
-/// an artifact never reads as "running" — a dim neutral for quiet
-/// memory/context events, and the shared
-/// `OK`/`WARN`/`BAD` semantics for verdicts, spend, and errors. Memory drops
-/// to `TEXT_TERTIARY` rather than reuse violet — the process group already
-/// owns that anchor.
+/// `MAGENTA`/`TEAL` for produced artifacts (file, media) — categorical, so
+/// an artifact never reads as "running"; the file chip's warm rose sits
+/// 1.30:1 from [`BAD`], which is tolerable exactly because a chip is always
+/// a coloured *word* and an error is always glyph-paired — a dim neutral for
+/// quiet memory/context events, and the shared `OK`/`WARN`/`BAD` semantics
+/// for verdicts, spend, and errors. Memory drops to `TEXT_TERTIARY` rather
+/// than reuse violet — the process group already owns that anchor.
 pub fn trace_kind_color(kind: TraceKind) -> Color {
     match kind {
         TraceKind::Stage => RUN,
         TraceKind::Text => INK,
         TraceKind::Reasoning => MUTED,
         TraceKind::Tool => RUN,
-        TraceKind::File => AMBER,
+        TraceKind::File => MAGENTA,
         TraceKind::Budget => WARN,
         TraceKind::Context => TEXT_TERTIARY,
         TraceKind::Verdict => OK,

--- a/stella-tui/src/theme/tests.rs
+++ b/stella-tui/src/theme/tests.rs
@@ -42,7 +42,9 @@ fn trace_kind_color_covers_every_variant_without_panic() {
 /// derived) so this and [`every_named_token_has_a_fallback`] fail loudly the
 /// moment a new truecolor token lands without a [`FALLBACKS`] entry. Role
 /// aliases (`INK`, `OK`, `DANGER`, …) share a value with a palette token, so
-/// they are intentionally not re-listed.
+/// they are intentionally not re-listed — under the comet kit that includes
+/// `ACCENT_FILL` and `GOLD` (one Phosphor Gold with `ACCENT`) and
+/// `SYNTAX_COMMENT` (the caption tier, `TEXT_TERTIARY`).
 const ALL_RGB_TOKENS: &[Color] = &[
     VOID,
     GROUND,
@@ -54,10 +56,8 @@ const ALL_RGB_TOKENS: &[Color] = &[
     TEXT_SECONDARY,
     TEXT_TERTIARY,
     ACCENT,
-    ACCENT_FILL,
-    ACCENT_DEEP,
-    GOLD,
     GOLD_BRIGHT,
+    ACCENT_DEEP,
     GOLD_DEEP,
     SUCCESS,
     WARNING,
@@ -73,7 +73,6 @@ const ALL_RGB_TOKENS: &[Color] = &[
     DIFF_DEL_BG_EMPH,
     MATCH_BG,
     SYNTAX_STRING,
-    SYNTAX_COMMENT,
 ];
 
 /// Palette values that only ever reach a cell through [`apply_theme`]'s
@@ -154,14 +153,20 @@ fn every_named_token_has_a_fallback() {
 #[test]
 fn role_aliases_track_their_palette_token() {
     // Brand roles resolve to the generated palette, not to a local literal.
-    // ACCENT is the *bright* brand tone: it is what paints text and rules,
-    // and plain `brand` does not clear AA body on surface/raised.
-    assert_eq!(ACCENT, palette::BRAND_BRIGHT);
-    assert_eq!(ACCENT_FILL, palette::BRAND);
+    // Under the comet kit the accent IS the gold: one Phosphor Gold serves
+    // text, rules and fills (10.74:1 on ground), so ACCENT, ACCENT_FILL and
+    // GOLD are one value on purpose.
+    assert_eq!(ACCENT, palette::BRAND);
+    assert_eq!(ACCENT_FILL, ACCENT);
+    assert_eq!(GOLD, ACCENT);
+    assert_eq!(palette::BRAND, palette::GOLD);
+    assert_eq!(palette::BRAND_BRIGHT, palette::GOLD_BRIGHT);
     assert_eq!(ACCENT_DEEP, palette::BRAND_DEEP);
-    assert_eq!(GOLD, palette::GOLD);
     assert_eq!(GOLD_BRIGHT, palette::GOLD_BRIGHT);
     assert_eq!(GOLD_DEEP, palette::GOLD_DEEP);
+    // The identity sweep and the progress fill lead with different deep
+    // stops on purpose: chrome may run quiet, the fill's tail must hold AA.
+    assert_ne!(GOLD_DEEP, ACCENT_DEEP);
     assert_eq!(VOID, palette::VOID);
     assert_eq!(HAIRLINE_STRONG, palette::HAIRLINE_STRONG);
     assert_eq!(GROUND, palette::GROUND);
@@ -176,6 +181,7 @@ fn role_aliases_track_their_palette_token() {
     // Syntax and process hues are categorical -- never the brand accent.
     assert_eq!(SYNTAX_NUMBER, VIOLET);
     assert_eq!(SYNTAX_KEYWORD, AMBER);
+    assert_eq!(SYNTAX_COMMENT, TEXT_TERTIARY);
     // The categorical set is the observatory's data-mark palette verbatim,
     // so a series in a chart and a chip in the deck are the same colour.
     assert_eq!(AMBER, palette::DATA_1);
@@ -184,13 +190,19 @@ fn role_aliases_track_their_palette_token() {
     assert_eq!(TEAL, palette::DATA_4);
 }
 
-/// BRAND.md's one hard prohibition: **gold never carries status.** Gold and
-/// [`WARNING`] are the same brass at a glance (42.3° vs 45.4° hue), so a
-/// reader must never be asked to tell them apart — gold is identity chrome
-/// and status is glyph-paired amber. This is the test that would fail if
-/// someone reached for the prettier colour in a status mapping.
+/// The kit's one hard prohibition, restated for a gold accent: **gold never
+/// carries a verdict.** Gold and [`WARNING`] are 4.0° apart in hue — the
+/// same brass at a glance — so a reader must never be asked to tell an
+/// *outcome* (ok / warn / bad, done / failed) from chrome by hue. The one
+/// status gold does carry is activity: active/running IS the accent, by kit
+/// rule ("gold is the signal"), and that pairing is asserted here so it
+/// cannot silently regress to a lesser hue either. This is the test that
+/// would fail if someone reached for the prettier colour in a verdict
+/// mapping.
 #[test]
-fn gold_is_never_a_status_colour() {
+fn gold_never_carries_a_verdict() {
+    // Activity is gold — the one permitted (required, even) status use.
+    assert_eq!(status_color(AgentStatus::Running), ACCENT);
     for gold in [GOLD, GOLD_BRIGHT, GOLD_DEEP] {
         for (status, name) in [
             (OK, "OK"),
@@ -203,7 +215,6 @@ fn gold_is_never_a_status_colour() {
         }
         for status in [
             AgentStatus::Queued,
-            AgentStatus::Running,
             AgentStatus::Paused,
             AgentStatus::WaitingInput,
             AgentStatus::Done,
@@ -294,80 +305,116 @@ fn hue_separation(a: Color, b: Color) -> f64 {
 
 /// The palette law, in the form a future edit would actually break.
 ///
-/// The guard has outlived four recolours now (aurora → gold → sky → green →
-/// blue), which is the point: each time, the *shape* of the law survived
-/// and only the hue it names changed. Keep rewriting it rather than deleting
-/// it.
+/// The guard has outlived five recolours now (aurora → gold → sky → green →
+/// blue → gold again), which is the point: each time, the *shape* of the law
+/// survived and only the hue it names changed. Keep rewriting it rather than
+/// deleting it.
 ///
-/// The blue recolour changed the law in two real ways. First, the ground is
-/// no longer neutral: deep space is a blue-cast near-black on purpose, so
-/// the old "the canvas may not carry a cast" clause inverts into "the canvas
-/// must carry the *right* cast". Second, the green brand had one permitted
-/// neighbour (success, also green, told apart by ▶ vs ✓). A blue brand has
-/// none: success, warning and danger are all far from blue, so the
-/// reservation is absolute again — which is the stronger law.
+/// The comet recolour changed the law in three real ways. First, the exact
+/// values are load-bearing: Phosphor Gold `#FFB000` and Ink `#0B0B0C` are
+/// the brand, so clause 1 pins the hex rather than merely the dominance.
+/// Second, the ground lost its cast: ink is a warm-neutral near-black, so
+/// the old "the canvas must carry the blue cast" clause inverts back into
+/// "the canvas may carry (almost) no cast" — and the same warmth law now
+/// covers the text ramp, because the owner banned cool grays outright.
+/// Third, the reservation has *named neighbours* again: a gold accent lives
+/// 4.0° from warning amber and 0.8° from the amber data mark, so instead of
+/// "no exceptions" the law says exactly which two hues may sit close and
+/// what confines each of them.
 ///
 /// What must hold now:
-///   1. The accent is the generated brand blue — not a local literal that
-///      drifted, not one of the retired hues, and actually blue. It is the
-///      *bright* tone, because almost every call site paints text with it.
-///   2. The ground is deep space: blue-cast, and never true black, or the
-///      accent screams instead of speaking.
-///   3. Warning ramps warm (r > g > b — amber, not the retired orange),
-///      success ramps green, danger ramps red.
-///   4. The brand blue is reserved. Every chromatic role must sit at least
-///      30° of hue away from it, with no exceptions.
-///   5. Gold is identity, not status: it stays clear of the brand blue *and*
-///      is never a status value (see `gold_is_never_a_status_colour`).
+///   1. The accent is the kit's Phosphor Gold, exactly; the ground is Ink,
+///      exactly. Brand and gold are one family (the collapse IS the
+///      rebrand).
+///   2. Every retired hue is gone — the whole electric-blue family, the old
+///      warm-tinted gold, and the cool gray text ramp with them.
+///   3. Grounds are near-neutral and never true black; text is warm.
+///   4. Warning ramps warm, success ramps green, danger ramps red.
+///   5. Gold is reserved. Every chromatic role sits ≥ 30° of hue away,
+///      except the two named neighbours: WARN (always glyph-paired) and
+///      AMBER (confined to syntax keywords in code bodies).
 #[test]
-fn palette_law_blue_is_the_brand() {
+fn palette_law_gold_is_the_brand() {
     const RETIRED_AURORA_CYAN: Color = Color::Rgb(0x3F, 0xE0, 0xFF);
     const RETIRED_EMBER_FLAME: Color = Color::Rgb(0xFF, 0x7E, 0x5F);
     const RETIRED_EMBER_CRIMSON: Color = Color::Rgb(0xC2, 0x18, 0x5B);
     const RETIRED_GOLD: Color = Color::Rgb(0xFF, 0xDD, 0x00);
     const RETIRED_GOLD_DEEP: Color = Color::Rgb(0xE0, 0xB8, 0x00);
     /// The old glacier blue, retired *because* it collided with the sky
-    /// accent — the exact failure this test's clause 4 still prevents.
+    /// accent — and doubly banned now: the owner hates ice blue.
     const RETIRED_AGENT_ICE: Color = Color::Rgb(0xA8, 0xC7, 0xF0);
-    /// The sky blue of two recolours ago. The brand is blue again but a
-    /// *different* blue; no token may drift back to the old pair.
+    /// The sky blue of three recolours ago.
     const RETIRED_SKY: Color = Color::Rgb(0x7D, 0xD3, 0xFC);
     const RETIRED_SKY_DEEP: Color = Color::Rgb(0x38, 0xBD, 0xF8);
     /// The warning orange the "get rid of the orange" pass removed; warning
     /// is amber-yellow now and must not slide back to it.
     const RETIRED_WARNING_ORANGE: Color = Color::Rgb(0xFF, 0x8A, 0x1F);
-    /// The terminal green this recolour retired, and its deep stop.
+    /// The terminal green of two identities ago, and its deep stop.
     const RETIRED_PHOSPHOR_GREEN: Color = Color::Rgb(0x00, 0xE6, 0x76);
     const RETIRED_PHOSPHOR_GREEN_DEEP: Color = Color::Rgb(0x00, 0xB2, 0x5A);
     /// The vermilion light-theme brand ("ember") and its deep stop.
     const RETIRED_EMBER: Color = Color::Rgb(0xFF, 0x3D, 0x1F);
     const RETIRED_EMBER_DEEP: Color = Color::Rgb(0xD6, 0x2E, 0x0E);
+    /// The electric blue this recolour retired: brand, bright, deep, and the
+    /// two paper blues. The comet kit has no blue anywhere.
+    const RETIRED_ELECTRIC_BLUE: Color = Color::Rgb(0x2E, 0x7B, 0xFF);
+    const RETIRED_ELECTRIC_BLUE_BRIGHT: Color = Color::Rgb(0x5A, 0xA0, 0xFF);
+    const RETIRED_ELECTRIC_BLUE_DEEP: Color = Color::Rgb(0x1A, 0x5F, 0xE0);
+    const RETIRED_BLUE_INK: Color = Color::Rgb(0x15, 0x50, 0xC8);
+    const RETIRED_BLUE_INK_DEEP: Color = Color::Rgb(0x0F, 0x3A, 0x94);
+    /// The warm-tinted gold that shipped beside the blue (`#F5C145` family).
+    /// The comet gold is `#FFB000` exactly; the old tint may not resurface.
+    const RETIRED_WARM_GOLD: Color = Color::Rgb(0xF5, 0xC1, 0x45);
+    const RETIRED_WARM_GOLD_BRIGHT: Color = Color::Rgb(0xFF, 0xD8, 0x73);
+    const RETIRED_WARM_GOLD_DEEP: Color = Color::Rgb(0xC9, 0x94, 0x20);
+    /// The cool, blue-leaning gray text ramp — the "cool grays" the comet
+    /// kit's warm neutral ramp replaces.
+    const RETIRED_COOL_TEXT: Color = Color::Rgb(0xF2, 0xF5, 0xFA);
+    const RETIRED_COOL_TEXT_2: Color = Color::Rgb(0x8E, 0x97, 0xA8);
+    const RETIRED_COOL_TEXT_3: Color = Color::Rgb(0x73, 0x7D, 0x92);
+    /// The blue-cast "deep space" ground the ink ramp replaces.
+    const RETIRED_DEEP_SPACE: Color = Color::Rgb(0x08, 0x0A, 0x0F);
 
-    // 1. The accent comes from the palette, not a drifted local literal, it
-    //    is the text-safe bright tone, and it is blue (b dominant).
+    // 1. The accent is Phosphor Gold and the ground is Ink — the exact kit
+    //    values, pinned by hex so the brand cannot silently drift. This is
+    //    the one clause that names numbers: `#FFB000` on `#0B0B0C` is the
+    //    identity.
     assert_eq!(
         ACCENT,
-        palette::BRAND_BRIGHT,
-        "the accent must be the bright brand blue"
+        Color::Rgb(0xFF, 0xB0, 0x00),
+        "the accent must be Phosphor Gold #FFB000, exactly"
     );
-    for (blue, name) in [(ACCENT, "ACCENT"), (ACCENT_FILL, "ACCENT_FILL")] {
-        let Color::Rgb(r, g, b) = blue else {
+    assert_eq!(
+        GROUND,
+        Color::Rgb(0x0B, 0x0B, 0x0C),
+        "the ground must be Ink #0B0B0C, exactly"
+    );
+    assert_eq!(ACCENT, palette::BRAND, "the accent comes from the palette");
+    assert_eq!(
+        GOLD, ACCENT,
+        "brand and gold are one family under the comet"
+    );
+    for (gold, name) in [(ACCENT, "ACCENT"), (ACCENT_FILL, "ACCENT_FILL")] {
+        let Color::Rgb(r, g, b) = gold else {
             panic!("{name} must be a truecolor token");
         };
-        assert!(b > r && b > g, "{name} must be blue-dominant");
+        assert!(r > g && g > b, "{name} must be warm-dominant (r > g > b)");
     }
 
-    // The retired hues are gone from every token and alias.
+    // 2. The retired hues are gone from every token and alias.
     let mut all: Vec<Color> = ALL_RGB_TOKENS.to_vec();
     all.extend([
         RUN,
         SYNTAX_NUMBER,
         SYNTAX_KEYWORD,
+        SYNTAX_COMMENT,
         HELD,
         ACCENT,
+        ACCENT_FILL,
         OK,
         ACCENT_DEEP,
         CODE,
+        GOLD,
     ]);
     all.extend(BRAND_STOPS);
     all.extend(LIGHT_REMAP.iter().map(|(_, to)| *to));
@@ -386,30 +433,61 @@ fn palette_law_blue_is_the_brand() {
             (RETIRED_PHOSPHOR_GREEN_DEEP, "deep phosphor green"),
             (RETIRED_EMBER, "ember vermilion"),
             (RETIRED_EMBER_DEEP, "deep ember vermilion"),
+            (RETIRED_ELECTRIC_BLUE, "electric blue"),
+            (RETIRED_ELECTRIC_BLUE_BRIGHT, "bright electric blue"),
+            (RETIRED_ELECTRIC_BLUE_DEEP, "deep electric blue"),
+            (RETIRED_BLUE_INK, "the paper blue"),
+            (RETIRED_BLUE_INK_DEEP, "the deep paper blue"),
+            (RETIRED_WARM_GOLD, "the warm-tinted gold"),
+            (RETIRED_WARM_GOLD_BRIGHT, "the warm-tinted bright gold"),
+            (RETIRED_WARM_GOLD_DEEP, "the warm-tinted deep gold"),
+            (RETIRED_COOL_TEXT, "the cool primary gray"),
+            (RETIRED_COOL_TEXT_2, "the cool secondary gray"),
+            (RETIRED_COOL_TEXT_3, "the cool tertiary gray"),
+            (RETIRED_DEEP_SPACE, "the deep-space ground"),
         ] {
             assert_ne!(*token, retired, "a token still holds {name}");
         }
     }
 
-    // 2. The ground is deep space: a blue cast, and never true black. Pure
-    //    black makes the accent scream; the cast is what lets it speak.
+    // 3. The ground is ink: near-neutral (a whisper of cast at most, in
+    //    either temperature), and never true black — pure black makes the
+    //    accent scream; ink lets it speak. The text ramp is warm: the owner
+    //    banned cool grays, so no text tier may lean blue.
     for (ground, name) in [
         (VOID, "VOID"),
         (GROUND, "GROUND"),
         (SURFACE, "SURFACE"),
         (RAISED, "RAISED"),
+        (HAIRLINE, "HAIRLINE"),
+        (HAIRLINE_STRONG, "HAIRLINE_STRONG"),
     ] {
         let Color::Rgb(r, g, b) = ground else {
             panic!("{name} must be a truecolor token");
         };
+        let (max, min) = (r.max(g).max(b), r.min(g).min(b));
         assert!(
-            b > r && b >= g,
-            "{name} ({ground:?}) must carry the deep-space blue cast"
+            max - min <= 5,
+            "{name} ({ground:?}) must be near-neutral ink, not a cast"
         );
         assert_ne!(ground, Color::Rgb(0, 0, 0), "{name} must not be true black");
     }
+    for (text, name) in [
+        (TEXT_PRIMARY, "TEXT_PRIMARY"),
+        (TEXT_SECONDARY, "TEXT_SECONDARY"),
+        (TEXT_TERTIARY, "TEXT_TERTIARY"),
+    ] {
+        let Color::Rgb(r, g, b) = text else {
+            panic!("{name} must be a truecolor token");
+        };
+        assert!(
+            r >= g && g >= b,
+            "{name} ({text:?}) must be a warm neutral (r ≥ g ≥ b) — cool \
+             grays are banned"
+        );
+    }
 
-    // 3. Warning ramps warm (r > g > b — amber, no longer the orange that
+    // 4. Warning ramps warm (r > g > b — amber, no longer the orange that
     //    dominated the transcript), success ramps green, danger ramps red.
     let Color::Rgb(wr, wg, wb) = WARNING else {
         panic!("WARNING must be a truecolor token");
@@ -424,42 +502,85 @@ fn palette_law_blue_is_the_brand() {
     };
     assert!(dr > dg && dr > db, "danger must be red-dominant");
 
-    // 4. The brand blue is reserved for brand / active / focus / progress.
-    //    No chromatic role may sit within 30° of it — which is how
-    //    `AGENT_ICE` died, and the clause has no exceptions now that success
-    //    is no longer a neighbour of the brand hue.
+    // 5. Gold is reserved for brand / active / focus / selection / progress.
+    //    Every chromatic role sits ≥ 30° of hue away — which is how
+    //    `AGENT_ICE` died — except the two *named* neighbours below.
     for (role, name) in [
-        (WARN, "WARN"),
         (BAD, "BAD"),
         (OK, "OK"),
         (RUN, "RUN"),
         (HELD, "HELD"),
         (VIOLET, "VIOLET"),
-        (AMBER, "AMBER"),
         (TEAL, "TEAL"),
         (MAGENTA, "MAGENTA"),
-        (GOLD, "GOLD"),
-        (GOLD_BRIGHT, "GOLD_BRIGHT"),
-        (GOLD_DEEP, "GOLD_DEEP"),
         (CODE, "CODE"),
-        (SYNTAX_KEYWORD, "SYNTAX_KEYWORD"),
         (SYNTAX_STRING, "SYNTAX_STRING"),
         (SYNTAX_NUMBER, "SYNTAX_NUMBER"),
     ] {
-        assert_ne!(role, ACCENT, "{name} must not be the reserved brand blue");
-        assert_ne!(role, ACCENT_FILL, "{name} must not be the brand fill");
+        assert_ne!(role, ACCENT, "{name} must not be the reserved gold");
         let sep = hue_separation(role, ACCENT);
         assert!(
             sep >= 30.0,
-            "{name} ({role:?}) is {sep:.1}° from the brand accent; \
+            "{name} ({role:?}) is {sep:.1}° from the gold accent; \
              30° is the floor for two hues to be told apart in a cell"
         );
     }
+    // The named neighbours. WARN sits 4.0° from gold: permitted because a
+    // status never appears without its glyph (`status_glyph`), so the hue is
+    // never the only carrier. AMBER sits 0.8° away: permitted because it
+    // paints syntax keywords inside code bodies and nothing else — the
+    // observatory stands the same mark down from every plotted surface, and
+    // the deck stands it down from every chip, node and agent.
+    for (neighbour, name) in [(WARN, "WARN"), (AMBER, "AMBER")] {
+        assert_ne!(neighbour, ACCENT, "{name} may neighbour gold, not BE it");
+        let sep = hue_separation(neighbour, ACCENT);
+        assert!(
+            sep < 30.0,
+            "{name} is a *named* hue-neighbour of gold ({sep:.1}°); if it \
+             has moved ≥ 30° away, promote it to the reserved list above"
+        );
+    }
+    assert!(
+        !AGENT_PALETTE.contains(&AMBER),
+        "the amber mark is stood down: no agent chip may wear it"
+    );
+    for kind in [
+        "function", "method", "struct", "enum", "trait", "file", "module", "?",
+    ] {
+        assert_ne!(
+            graph_kind_color(kind),
+            AMBER,
+            "the amber mark is stood down: no graph node may wear it"
+        );
+    }
+    for kind in [
+        TraceKind::Stage,
+        TraceKind::Text,
+        TraceKind::Reasoning,
+        TraceKind::Tool,
+        TraceKind::File,
+        TraceKind::Budget,
+        TraceKind::Context,
+        TraceKind::Verdict,
+        TraceKind::Media,
+        TraceKind::Vcs,
+        TraceKind::Error,
+        TraceKind::Complete,
+        TraceKind::Other,
+    ] {
+        assert_ne!(
+            trace_kind_color(kind),
+            AMBER,
+            "the amber mark is stood down: no trace chip may wear it"
+        );
+    }
 
-    // 5. The brand's own tones are the only things allowed near it, and the
-    //    bright/fill pair really is one hue family.
-    assert!(hue_separation(ACCENT_FILL, ACCENT) < 10.0);
+    // 6. The brand's own tones are the only things allowed near it, and the
+    //    accent/fill pair really is one value now.
+    assert_eq!(ACCENT_FILL, ACCENT);
     assert!(hue_separation(ACCENT_DEEP, ACCENT) < 10.0);
+    assert!(hue_separation(GOLD_DEEP, ACCENT) < 10.0);
+    assert!(hue_separation(GOLD_BRIGHT, ACCENT) < 10.0);
 }
 
 #[test]
@@ -568,10 +689,10 @@ fn degrade_buffer_is_noop_when_truecolor() {
 #[test]
 fn degrade_buffer_resolves_every_cell_when_degraded() {
     let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
-    buf.content[0].fg = ACCENT; // → 75 (256) / 12 (16)
+    buf.content[0].fg = ACCENT; // → 214 (256) / 11 (16)
     buf.content[0].bg = VIOLET; // → 98 (256) / 13 (16)
     degrade_buffer(&mut buf, ColorMode::Ansi256);
-    assert_eq!(buf.content[0].fg, Color::Indexed(75));
+    assert_eq!(buf.content[0].fg, Color::Indexed(214));
     assert_eq!(buf.content[0].bg, Color::Indexed(98));
 }
 
@@ -636,7 +757,11 @@ fn apply_theme_is_identity_for_dark_and_remaps_for_light() {
         remap_theme(ACCENT_DEEP, LIGHT_REMAP),
         palette::BRAND_INK_DEEP
     );
-    assert_eq!(remap_theme(GOLD, LIGHT_REMAP), palette::GOLD_INK);
+    // Flat gold cells are accent cells now, so they take the accent's paper
+    // text tone; the kit's own light-ground gold (`gold-ink`) survives in the
+    // graphical `gold_stops` sweep only.
+    assert_eq!(remap_theme(GOLD, LIGHT_REMAP), palette::BRAND_INK);
+    assert_eq!(remap_theme(GOLD_DEEP, LIGHT_REMAP), palette::GOLD_INK);
     assert_eq!(remap_theme(VOID, LIGHT_REMAP), palette::PAPER);
     assert_eq!(remap_theme(GROUND, LIGHT_REMAP), palette::PAPER);
     assert_eq!(remap_theme(TEXT_PRIMARY, LIGHT_REMAP), palette::INK);
@@ -695,8 +820,8 @@ fn degrade_buffer_strips_color_under_no_color() {
 
 #[test]
 fn brand_gradient_spans_deep_to_bright_accent() {
-    // The default theme is `stella-dark`, so the stops are the blue accent
-    // pair; `primary_stops` swaps them for the paper blues under
+    // The default theme is `stella-dark`, so the stops are the gold accent
+    // pair; `primary_stops` swaps them for the deep paper golds under
     // `stella-light`.
     assert_eq!(brand_gradient(0.0), ACCENT_DEEP);
     assert_eq!(brand_gradient(1.0), ACCENT);


### PR DESCRIPTION
Repaints the command deck (stella-tui) and the CLI's brand surfaces to brand kit v1.0 — "the comet": Phosphor Gold `#FFB000` on Ink `#0B0B0C`, warm Paper text, warm neutral ramp. The electric-blue/deep-space identity is gone from every token, every fallback table, every doc comment, and both user-visible `/theme` blurbs. Normative sources: `docs/brand/css/tokens.css` + `brand-guidelines.html`; sibling mappings mirrored from the observatory's dark `:root` block (PR #1078, merged) and `website/src/app/tokens.css`.

Architecture unchanged and respected: `palette.rs` stays the raw value layer, `theme.rs` the semantic layer (roles, fallbacks, light remap); no view hard-codes a color. Contrast figures below are WCAG, measured against the ground the deck actually paints (dark: ink `#0B0B0C`; light: paper `#F6F2E9`).

## Dark theme (canonical) — old → new

| token | old | new | encodes | contrast on ink |
|---|---|---|---|---|
| brand / accent | `#2E7BFF` blue | `#FFB000` Phosphor Gold | THE accent: brand, prompt, active/running, focus, selection, progress | 10.74:1 |
| brand-bright | `#5AA0FF` | `#FDC154` (gold-400) | bright stop of the identity sweep, hover lift | 12.12:1 |
| brand-deep | `#1A5FE0` | `#D09100` (gold-600) | progress-fill leading stop, pressed | 7.24:1 |
| gold | `#F5C145` | `#FFB000` | identity chrome — collapsed onto the accent (the collapse IS the rebrand) | 10.74:1 |
| gold-bright | `#FFD873` | `#FDC154` | gold sweep bright stop | 12.12:1 |
| gold-deep | `#C99420` | `#A37200` (gold-700, kit gold-deep) | gold sweep trailing stop (graphical) | 4.65:1 (≥3:1 floor) |
| void | `#05070C` | `#050506` | deepest ground (splash) | — |
| ground | `#080A0F` | `#0B0B0C` Ink | painted app background | — |
| surface | `#0B0F17` | `#131315` | cards / panels | — |
| raised / select-bg | `#101623` | `#1B1B1E` | popovers, selected rows | — |
| hairline | `#182031` | `#232327` | decorative seam | 1.26:1 (intentional) |
| hairline-strong | `#232D42` | `#333338` | louder seam | 1.57:1 (intentional) |
| text-primary | `#F2F5FA` cool | `#F4F1EA` warm Paper | prose | 17.44:1 |
| text-secondary | `#8E97A8` cool | `#9B9890` warm | secondary text | 6.83:1 |
| text-tertiary | `#737D92` cool | `#8D8A82` (neutral-500) | captions, labels | 5.71:1 |
| success | `#4ADE80` | `#4ADE80` (kept, kit value) | success / done / added — glyph-paired | 11.29:1 |
| warning | `#EAB308` | `#EAB308` (kept, kit value) | warning / needs-input — 4.0° from gold, glyph is the carrier | 10.26:1 |
| danger | `#FF5C7A` | `#FF5C7A` (kept, kit value) | error / failed / removed | 6.62:1 |
| data-2 / violet | `#8F70E8` | `#8F70E8` (kept) | process events, agent slot, syntax numbers — muted violet, 215° from gold | 5.29:1 |
| data-3 / warm rose | `#E4408F` | `#E4408F` (kept; now also file artifacts) | file trace chips, graph file/module nodes, series 4 | 5.09:1 |
| data-4 / teal | `#2FD3C6` | `#2FD3C6` (kept) | media traces, agent slot — deep teal, 134° from gold | 10.54:1 |
| data-1 / amber | `#E3B341` chips+syntax | `#E3B341` syntax keywords ONLY | 1.06:1 against gold — stood down from chips/nodes/agents (observatory precedent) | 10.11:1 |
| syntax-comment | `#767C86` cool gray | `#8D8A82` (== text-tertiary) | code comments | 5.71:1 |
| code / syntax-string / diff washes / match-bg | unchanged | unchanged | sage `#6FBF92` (105° from gold), spring green, green/red tints, dark-gold match wash | 8.94 / 12.80 / — |

## Light theme (`stella-light`) — old → new (contrast on paper `#F6F2E9`)

| token | old | new | note |
|---|---|---|---|
| paper (ground) | `#FFFFFF` | `#F6F2E9` | the kit's warm paper-bg |
| snow (surface) | `#F5F7FA` | `#FCFAF4` | lifts lighter, like dark surfaces lift lighter |
| paper-raised | `#E7EBF2` | `#E4E2DC` | neutral-100 |
| paper-hairline | `#D3DAE6` | `#E4DECF` | kit light border |
| ink (text) | `#0A0F1A` | `#0B0B0C` | the kit's one black |
| muted | `#525C6E` cool | `#6E6A5F` warm | 4.83:1 |
| ink-dim | `#6B7488` cool | `#736C68` (neutral-600) | 4.61:1 |
| brand-ink (accent text) | `#1550C8` blue | `#795500` (gold-800) | 6.04:1 — kit's gold-deep `#A37200` is only 3.79:1 on this ground, so it stays *chrome* (`gold_stops`) |
| brand-ink-deep | `#0F3A94` | `#523900` (gold-900) | 9.67:1 |
| gold-ink | `#8A6118` | `#A37200` (kit gold-deep) | graphical chrome, ≥3:1 |
| warning-ink | `#A16207` | `#8A5405` | kit value measures 4.41:1 on the warm paper (it was tuned for white) — darkened one step along the hue to 5.61:1 |
| success-ink / danger-ink | `#16744F` / `#C81E3E` | kept | 5.16:1 / 5.06:1 |
| teal (light) | `#0D9488` | `#0F766E` | 3.35 → 4.90:1 |
| code (light) | `#2F7D55` | `#2A7150` | 4.49 → 5.26:1 |
| syntax-string (light) | `#15803D` | `#166534` | 4.49 → 6.38:1 |
| violet / amber / magenta (light) | kept | `#6D28D9` / `#92400E` / `#A6185C` | 6.36 / 6.35 / 6.47:1 |

## How the non-gold hues were chosen

The categorical marks are the observatory's `--c1..--c4` verbatim (PR #1078), so a chip in the deck and a series in a chart stay one system — and they already are the requested complements of gold: muted violet (hue 256°), warm rose (331°), deep teal (175°), all ≥5:1 on ink, none in the ice-blue family. What changed is *where* they may appear: the amber mark (1.06:1 against gold — the same brass) is stood down from every chip/node/agent surface exactly as the observatory stands it down from every chart, surviving only as the syntax-keyword tone inside code bodies where gold chrome never reaches. File artifacts moved from amber to the warm rose (documented: 1.30:1 from danger's red-pink, mitigated by word+glyph chips and the ✗ pairing on errors).

## Invariants rewritten, not deleted

- `palette_law_blue_is_the_brand` → `palette_law_gold_is_the_brand`: pins the exact hexes `#FFB000` / `#0B0B0C` (the drift-guard the task asked for), bans the whole retired electric-blue family + the warm-tinted old gold + the cool gray ramp + the blue-cast ground, requires near-neutral ink grounds and warm (r ≥ g ≥ b) text, keeps warning-warm/success-green/danger-red ramps, and reserves gold at ≥30° hue separation with two *named* neighbours (warning: always glyph-paired; amber: code bodies only).
- `gold_is_never_a_status_colour` → `gold_never_carries_a_verdict`: running/active IS the accent now (asserted, so it can't regress), and no verdict (ok/warn/bad, done/failed/killed, gauge, trace, agent, graph) may ever be gold.
- Progress-fill degrade invariant kept: the truecolor gradient's bright end is exactly `ACCENT`, which is what non-truecolor terminals paint solid.
- 256/16-colour fallbacks re-derived by nearest cube entry with the existing yellow-over-orange rule: gold → 214 (one RGB unit from exact!), gold-bright → 221 (nearest was orange 215), gold-deep → 136, brand-deep → 178 (nearest was orange 172; shares WARNING's index only where the gradient never actually paints on degraded terminals). Gold vs warning stay distinct cells at every depth (tested).

## The markdown H1 pill became the brand pattern for free

`heading_line` already painted `bg(ACCENT) + fg(GROUND)` — under gold that is precisely the website's gold-pill-with-ink-text (sidebar active pill / CTA). Ink on gold: 10.74:1; the comments and test (`h1_is_a_high_contrast_gold_pill`) now document why white-on-gold (1.83:1) is forbidden.

## stella-cli (the surfaces that read the theme)

- The splash lockup, wordmark banner gradient (`STELLAR_STOPS`) and init cinematic all read live `theme::` tokens, so they recolored themselves; the cinematic's temperature clause inverted (cool-dominant → warm-dominant) so it now *prevents* a slide back to blue.
- `/theme` blurbs: "electric blue on deep space" → "phosphor gold on ink" / "phosphor gold on paper" (user-visible, lowercase).
- `/color` default is now `gold` (BrightYellow, the nearest named-ANSI stand-in for `#FFB000`), pinned by test; `sky`/`azure`/`cyan` survive as personalisation so muscle memory keeps working.

## Verification

- `cargo test -p stella-tui` — 745 tests green, including `tests/deck_pty_smoke.rs` (real PTY, space-stripped probes) and the deck snapshot / progress-brand-fill / render-robustness suites.
- `cargo test -p stella-cli` — 1002 tests green (one deliberate invariant flip in `init_fx`, above).
- `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `cargo check --workspace` clean.
- `./scripts/check-file-size.sh` and `./scripts/check-invariants.sh` green.
- Straggler sweep: no old-palette hex/RGB triple survives outside the retired-constant guards in tests (`rg` over `0x2E,0x7B`, `0x5A,0xA0`, `0xF5,0xC1`, cool-gray triples, etc.).

## Summary by Sourcery

Rebrand the TUI and CLI visual identity from the former electric-blue palette to the comet kit "Phosphor Gold on Ink," updating semantic theme definitions, raw palette tokens, and brand invariants while preserving architecture.

New Features:
- Introduce Phosphor Gold on Ink as the canonical stella-dark brand theme and its warm-paper complement for stella-light.
- Set the CLI accent color default to a gold ANSI stand-in and expose a new `gold` slug in the `/color` palette.

Enhancements:
- Refresh palette and theme documentation comments to align with brand kit v1.0, including explicit contrast and usage rules for gold, ink, and text tiers.
- Adjust categorical data hues, syntax colors, and agent/graph/trace mappings so they complement gold, stand down amber from chips/nodes/agents, and avoid brand/status confusion.
- Refine markdown heading styling so H1 renders as a high-contrast gold pill with ink text, matching the updated brand pattern.
- Recalculate light-theme remaps and ANSI fallbacks to respect the new warm paper ground, WCAG contrast floors, and gold’s reserved roles.
- Update splash, progress, cinematic, and settings text to describe and enforce the new gold-centric identity without changing layout or behavior.

Tests:
- Extend and rewrite theme and palette tests to codify the new brand law (gold is the accent, never a verdict), ensure removal of retired blue/gold/gray hues, and verify fallbacks, remaps, and defaults for both TUI and CLI.