### PR TITLE
feat(website): llms.txt/llms-full.txt for AI crawlers, trim 27 oversized meta descriptions

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -36,7 +36,7 @@
 1569 stella-tools/src/media.rs
 3565 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
-1793 stella-tui/src/deck_render.rs
+1808 stella-tui/src/deck_render.rs
 3888 stella-tui/src/deck_ui.rs
 1665 stella-tui/src/views/engine.rs
 1533 stella-tui/src/views/session.rs

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Engine Paths
-description: Every entry point into Stella's agent engine — one-shot runs, the REPL, the Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — and when to use each.
+description: Every entry point into Stella's agent engine — one-shot runs, REPL, Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — when to use each.
 ---
 
 Stella has **one agent engine and many doors into it**. Whether you type into

--- a/website/content/docs/agent-fleets.mdx
+++ b/website/content/docs/agent-fleets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Fleets
-description: Fan a dependency-ordered task DAG out to parallel workers in one shared tree, coordinated by cooperative file claims — with per-task worktree isolation as the opt-in.
+description: Fan a dependency-ordered task DAG out to parallel workers in one shared tree, coordinated by file claims — with per-task worktree isolation as the opt-in.
 ---
 
 `stella fleet` runs **many tasks at once** — each task handled by a full

--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Modes
-description: The ways to drive Stella — interactive Command Deck chat, one-shot pipeline runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
+description: The ways to drive Stella — Command Deck chat, one-shot pipeline runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
 ---
 
 Stella has one engine and several ways to drive it. Pick the mode by how much

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Reusable capabilities in SKILL.md files — project and user scopes, versioning and pinning, the public registry, and how skills reach the model through recall.
+description: Reusable capabilities in SKILL.md files — project and user scopes, versioning, the public registry, and how skills reach the model through recall.
 ---
 
 A **skill** is a reusable capability described in Markdown — a checklist, a

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella arena
-description: The arena-bench harness adapter — run one benchmark episode from a task directory while recording the contextgraph-trace journal the arena runner judges with the protocol's replay oracles.
+description: The arena-bench harness adapter — run one benchmark episode from a task directory, recording the trace journal judged against replay oracles.
 ---
 
 `stella arena` is Stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.

--- a/website/content/docs/commands/context.mdx
+++ b/website/content/docs/commands/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella context
-description: Review, publish, and explain context records — the reviewable steering stella ingest extracts from documents you already wrote. Offline; local files only, no API key.
+description: Review, publish, and explain context records — the reviewable steering stella ingest extracts from documents you already wrote. Offline, local files only.
 ---
 
 `stella ingest` writes proposals. `stella context` is what acts on them.

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella doctor
-description: Check the local state stella owns, report each named check's verdict, and exit non-zero if any fails — with an opt-in repair that moves a corrupt session store aside without ever deleting it.
+description: Check the local state stella owns, report each check's verdict, exit non-zero on failure — with opt-in repair for a corrupt session store, not deletion.
 ---
 
 Answer "is my local state sound?" before you go looking for a bug that isn't yours. `stella doctor` runs each check it knows how to run, prints a verdict per check, and exits non-zero if any failed — so it can gate a script. It reads local state only: no provider, no API key, no network.

--- a/website/content/docs/commands/proposals.mdx
+++ b/website/content/docs/commands/proposals.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella proposals
-description: Review what the adaptive-context loop wants to make durable before it lands — the proposals it induced, the evidence behind each, and Keep/Edit/Ignore as immutable events.
+description: Review what the adaptive-context loop wants to make durable — the induced proposals, the evidence behind each, and Keep/Edit/Ignore as events.
 ---
 
 `stella proposals` is the review surface for the adaptive-context loop. As you work, the loop reflects on turns and induces proposals: things it believes are worth making durable. This command shows you what is pending, the evidence behind each one, and lets you accept it, reword it, or decline it — **before** it steers anything.

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella run
-description: Send a single one-shot prompt to Stella non-interactively.
+description: Send a one-shot prompt through the staged pipeline and let stella work to completion, no back-and-forth — built for scripts, CI jobs, and git hooks.
 ---
 
 Send a one-shot prompt and let the agent work to completion without any interactive back-and-forth. This is the command to reach for in scripts, CI jobs, and Git hooks.

--- a/website/content/docs/commands/scoreboard.mdx
+++ b/website/content/docs/commands/scoreboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella scoreboard
-description: What the work cost, and whether anyone said it was good — calls, characters typed, follow-ups, and the verdict a merged or closed pull request implies. No model judges anything.
+description: What the work cost, and whether anyone said it was good — calls, characters typed, follow-ups, and the verdict a merged or closed PR implies.
 ---
 
 `stella scoreboard` reports four numbers per unit of work: how many times intelligence was invoked, how much a person had to type, how many times they came back, and what they thought of the result. Three are counted from rows the store already writes. The fourth is read from a pull request somebody merged or closed.

--- a/website/content/docs/commands/storage.mdx
+++ b/website/content/docs/commands/storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella storage
-description: Inspect the storage map — every storage layer, namespace, relation, and field, with intent and boundaries from stella.storage.toml — and bound the session store's growth.
+description: Inspect the storage map — every layer, namespace, relation, and field, with intent and boundaries from stella.storage.toml — and bound the store's growth.
 ---
 
 `stella storage` inspects the **storage map**: every storage layer, namespace, relation, and field in your workspace, annotated with intent and boundaries from `stella.storage.toml`. It reads the local index built by [`stella init`](/docs/commands/init) (`.stella/private/codegraph.db`) plus the manifest, so it is fully offline and needs no API key. One verb — `prune` — also does the store's retention housekeeping.

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella tools
-description: List every tool available to the agent this session.
+description: List every tool available to the agent this session — built-in tools, custom tools from .stella/tools/ manifests, and a --validate check for both.
 ---
 
 List every tool available to the agent for the current session — built-in tools, developer custom tools, and manifest diagnostics.

--- a/website/content/docs/commands/tune.mdx
+++ b/website/content/docs/commands/tune.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella tune
-description: Eval-driven self-tuning of Stella's own policy — A/B one knob over two loop-bench runs, promote the winner only when it confidently wins, and roll it back on the record.
+description: Eval-driven self-tuning of Stella's own policy — A/B one knob over two loop-bench runs, promote the winner only when it confidently wins, or roll it back.
 ---
 
 `stella tune` is how Stella's own policy gets tuned by evidence instead of taste. It A/B tests one knob over two [loop-bench](https://github.com/macanderson/stella/tree/main/bench/loop-bench) runs, scores each arm from the per-trial rewards, and promotes the candidate **only** when it confidently beats the baseline — with a reversible rollback record either way.

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella usage
-description: Report, replicate, and prune the cross-project telemetry hub at ~/.stella/usage.db — the same cost numbers as stella stats, across every project on this machine.
+description: Report, replicate, and prune the cross-project telemetry hub at ~/.stella/usage.db — the same cost numbers as stella stats, across every project.
 ---
 
 `stella stats` answers "what did *this* workspace cost." `stella usage` answers the same question across every project on this machine, by reading the **usage hub** — one SQLite database per developer at `~/.stella/usage.db`. It needs no provider and no API key, and nothing it does sends anything anywhere.

--- a/website/content/docs/donate.mdx
+++ b/website/content/docs/donate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Donate
-description: Stella is free, BYOK, zero-telemetry-egress by default, and vendor-agnostic — built and funded by one person. If it saves you time or money, consider sponsoring.
+description: Stella is free, BYOK, zero-telemetry-egress, and vendor-agnostic — built and funded by one person. If it saves you time or money, consider sponsoring.
 ---
 
 Stella is free software. Community/default use has no account or subscription and zero

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -1,6 +1,6 @@
 ---
 title: Event stream compatibility
-description: The versioning contract behind Stella's event stream — what stays stable, what may change, and what a client in any language must do to keep working across upgrades.
+description: The versioning contract behind Stella's event stream — what stays stable, what may change, and what a client must do to keep working across upgrades.
 ---
 
 Every machine-readable surface Stella exposes carries the same event objects:

--- a/website/content/docs/extensions.mdx
+++ b/website/content/docs/extensions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extension hooks
-description: A typed, in-process event bus that lets extensions observe Stella's activity and gate policy-sensitive actions with allow, modify, deny, or require-approval decisions.
+description: A typed, in-process event bus that lets extensions observe Stella's activity and gate sensitive actions with allow, modify, deny, or require-approval.
 ---
 
 Stella's engine (`stella-core`) exposes a typed **event bus** that extensions and embedders

--- a/website/content/docs/guides/fix-failing-ci.mdx
+++ b/website/content/docs/guides/fix-failing-ci.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fix a failing CI run
-description: A branch is red. Walk it to green with stella monitor — what it does each round, what happens when a fix doesn't hold, and why "green" here means a run somebody else can see.
+description: A branch is red. Walk it to green with stella monitor — what it does each round, what happens when a fix doesn't hold, and what "green" means here.
 ---
 
 You pushed a branch and CI went red. You want it green, you would rather not

--- a/website/content/docs/guides/troubleshooting.mdx
+++ b/website/content/docs/guides/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: When something isn't working
-description: Config that isn't applying, a key that won't resolve, hooks that never fire, a run that ends without doing anything — the checks in the order that finds it fastest.
+description: Config that isn't applying, a key that won't resolve, hooks that never fire, a run that does nothing — the checks in the order that finds it fastest.
 ---
 
 Most Stella problems are one of a small number of things, and nearly all of them

--- a/website/content/docs/guides/unfamiliar-codebase.mdx
+++ b/website/content/docs/guides/unfamiliar-codebase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Make a change in an unfamiliar codebase
-description: A repository you have never read, and a change that has to land in it. Orient with the code graph, find the blast radius before committing to an approach, and ship the change verified.
+description: A repository you have never read, and a change that has to land in it. Orient with the code graph, find the blast radius, and ship the change verified.
 ---
 
 You have been handed a repository you did not write. The change itself is

--- a/website/content/docs/guides/what-a-run-cost.mdx
+++ b/website/content/docs/guides/what-a-run-cost.mdx
@@ -1,6 +1,6 @@
 ---
 title: Understand what a run cost, and why
-description: Follow one expensive run from the dollar figure all the way down to the exact bytes the model was sent — stats, the Observatory, and stella inspect. Entirely local, no API key.
+description: Follow one expensive run from the dollar figure down to the exact bytes the model was sent — stats, the Observatory, stella inspect. Entirely local.
 ---
 
 A run cost more than you expected. Most tools can tell you *that*. Stella can

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when the work is done.
+description: Stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when done.
 ---
 
 Stella is a model-agnostic coding agent that runs in your terminal. It is

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -1,6 +1,6 @@
 ---
 title: Inference Pipeline
-description: How Stella turns a prompt into verified work — the agent step loop, the staged pipeline from triage to judge, deterministic verification, and per-role routing.
+description: How Stella turns a prompt into verified work — the step loop, the staged pipeline from triage to judge, deterministic verification, and per-role routing.
 ---
 
 Stella's answer to "did the agent actually do the work?" is structural, not

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -1,6 +1,6 @@
 ---
 title: Determinism over intelligence
-description: Why Stella is a deterministic single-thread engine rather than a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and what follows from both.
+description: Why Stella is a deterministic single-thread engine, not a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and what follows from both.
 ---
 
 The dominant trend in agent architecture is the swarm: a navigator agent, a

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -1,6 +1,6 @@
 ---
 title: Self-improvement
-description: The track where Stella makes Stella measurably more capable — seven components, their dependency order, what is actually built today, and the guardrails that apply to all of them.
+description: The track where Stella makes Stella measurably more capable — seven components, their dependency order, what's built today, and the guardrails on each.
 ---
 
 Most of what gets called agent "self-improvement" is recall: a note file the agent writes to and reads back. That is useful, and Stella does it — see [Memory](/docs/context-engine). It is also not the same thing as getting *better*.

--- a/website/content/docs/showcase.mdx
+++ b/website/content/docs/showcase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Showcase
-description: Teams and projects shipping real software with the Stella CLI, and stella-examples, the open cookbook with a working example for every configurable surface.
+description: Teams and projects shipping real software with Stella, and stella-examples, the open cookbook with a working example for every configurable surface.
 ---
 
 Real teams, shipping real software, with Stella in the loop. Each entry names

--- a/website/content/docs/telemetry/files-touched.mdx
+++ b/website/content/docs/telemetry/files-touched.mdx
@@ -1,6 +1,6 @@
 ---
 title: Files touched
-description: Every file Stella reads, creates, updates, or deletes, as a per-session CRUD ledger with reasons and line deltas — live in the TUI, in JSON, and in the store.
+description: Every file Stella reads, creates, updates, or deletes — a per-session CRUD ledger with reasons and line deltas, live in the TUI, in JSON, and in the store.
 ---
 
 Every time Stella touches a file through one of its file tools, it records the touch in a

--- a/website/src/app/llms-full.txt/route.ts
+++ b/website/src/app/llms-full.txt/route.ts
@@ -1,0 +1,35 @@
+/**
+ * llms-full.txt (https://llmstxt.org) — every docs page's raw MDX source in
+ * one file, sidebar order, frontmatter stripped. Where /llms.txt is a link
+ * index sized to skim, this is the whole corpus for a client that wants to
+ * paste stella's documentation into a model's context in a single fetch.
+ *
+ * Reads source.mdx files directly (see rawMdxBody in @/lib/llms) rather than
+ * rendering page.data.body, which is a compiled React component — dumping
+ * its output would mean HTML, not the markdown a model actually wants.
+ */
+import { SITE_NAME, SITE_URL } from "@/lib/site";
+import { listLlmsPages, rawMdxBody } from "@/lib/llms";
+
+export const dynamic = "force-static";
+
+export async function GET(): Promise<Response> {
+  const pages = listLlmsPages();
+
+  const parts: string[] = [
+    `# ${SITE_NAME} — full documentation`,
+    "",
+    `Generated from ${SITE_URL}/docs. One section per page, in sidebar order.`,
+    "",
+  ];
+
+  for (const page of pages) {
+    const body = rawMdxBody(page.url);
+    if (body === undefined) continue; // a React-route page (e.g. the landing page) has no MDX source
+    parts.push(`# ${page.title}`, "", `Source: ${SITE_URL}${page.url}`, "", body, "", "---", "");
+  }
+
+  return new Response(parts.join("\n").trimEnd() + "\n", {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/website/src/app/llms.txt/route.ts
+++ b/website/src/app/llms.txt/route.ts
@@ -1,0 +1,45 @@
+/**
+ * llms.txt (https://llmstxt.org) — a curated link index for AI crawlers and
+ * answer engines, the same job robots.txt/sitemap.xml do for traditional
+ * search, but sized for a model's context window instead of a spider's
+ * crawl budget: titles and one-line descriptions, not full page bodies. The
+ * full text lives at /llms-full.txt for a client that wants to read
+ * everything in one request.
+ */
+import { SITE_NAME, SITE_URL } from "@/lib/site";
+import { listLlmsPages } from "@/lib/llms";
+
+export const dynamic = "force-static";
+
+export async function GET(): Promise<Response> {
+  const pages = listLlmsPages();
+
+  const sections = new Map<string, typeof pages>();
+  for (const page of pages) {
+    const bucket = sections.get(page.section) ?? [];
+    bucket.push(page);
+    sections.set(page.section, bucket);
+  }
+
+  const lines: string[] = [
+    `# ${SITE_NAME}`,
+    "",
+    "> stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when it's done.",
+    "",
+    `Full documentation, one page per file, is linked below. For the complete text in a single request, fetch ${SITE_URL}/llms-full.txt instead.`,
+    "",
+  ];
+
+  for (const [section, entries] of sections) {
+    lines.push(`## ${section}`, "");
+    for (const entry of entries) {
+      const desc = entry.description ? `: ${entry.description}` : "";
+      lines.push(`- [${entry.title}](${SITE_URL}${entry.url})${desc}`);
+    }
+    lines.push("");
+  }
+
+  return new Response(lines.join("\n").trimEnd() + "\n", {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/website/src/lib/llms.ts
+++ b/website/src/lib/llms.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared page listing for llms.txt / llms-full.txt (the emerging convention
+ * at llmstxt.org for what an AI crawler or answer engine should read first).
+ * Walks the same page tree the sidebar renders from, in the same order,
+ * grouped by the meta.json section separators — one source of truth so the
+ * link index and the full-content dump can never disagree about what pages
+ * exist or what order they come in.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { source } from "@/lib/source";
+
+type TreeNode = (typeof source.pageTree)["children"][number];
+
+export interface LlmsPageEntry {
+  section: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+const UNSECTIONED = "Documentation";
+
+function slugFromUrl(url: string): string[] {
+  return url.replace(/^\/docs\/?/, "").split("/").filter(Boolean);
+}
+
+function pushEntry(url: string, fallbackName: unknown, section: string, out: LlmsPageEntry[]): void {
+  const page = source.getPage(slugFromUrl(url));
+  out.push({
+    section,
+    title: page?.data.title ?? String(fallbackName),
+    description: page?.data.description ?? "",
+    url,
+  });
+}
+
+function walk(nodes: readonly TreeNode[], section: string, out: LlmsPageEntry[]): void {
+  for (const node of nodes) {
+    if (node.type === "separator") {
+      if (typeof node.name === "string") section = node.name;
+    } else if (node.type === "page") {
+      pushEntry(node.url, node.name, section, out);
+    } else if (node.type === "folder") {
+      if (node.index) pushEntry(node.index.url, node.index.name, section, out);
+      walk(node.children, section, out);
+    }
+  }
+}
+
+/** Every docs page, in sidebar order, grouped by its top-level nav section. */
+export function listLlmsPages(): LlmsPageEntry[] {
+  const out: LlmsPageEntry[] = [];
+  walk(source.pageTree.children, UNSECTIONED, out);
+  return out;
+}
+
+const CONTENT_ROOT = path.join(process.cwd(), "content", "docs");
+
+/**
+ * Raw MDX source for a page, frontmatter stripped, or `undefined` if no file
+ * on disk matches the URL. Reads the source directly rather than rendering
+ * `page.data.body` — that's a compiled React component, not markdown, and
+ * dumping compiled output would defeat the point of a plain-text file made
+ * for an LLM to read in one pass.
+ */
+export function rawMdxBody(url: string): string | undefined {
+  const slug = slugFromUrl(url).join("/");
+  const candidates =
+    slug === ""
+      ? [path.join(CONTENT_ROOT, "index.mdx")]
+      : [path.join(CONTENT_ROOT, `${slug}.mdx`), path.join(CONTENT_ROOT, slug, "index.mdx")];
+  const file = candidates.find((p) => fs.existsSync(p));
+  if (!file) return undefined;
+  const text = fs.readFileSync(file, "utf8");
+  if (!text.startsWith("---")) return text.trim();
+  const end = text.indexOf("\n---", 3);
+  return end === -1 ? text.trim() : text.slice(end + 4).trim();
+}


### PR DESCRIPTION
## What & why

Optimizes stella.oxagen.sh for search discovery — traditional and AI-crawler alike. Builds on top of #1091 (merged just before this branch was cut), which already fixed the SEO fundamentals: per-page canonical/OG/JSON-LD, the sitemap lastmod bug, and security headers. This picks up two things that were still open.

**1. 27 meta descriptions trimmed to a real SERP-safe length.** Google typically truncates a snippet around 155-160 characters; 27 of this site's 80 doc pages had `description:` frontmatter running 156-191 characters (two ran under 60, thin enough to leave snippet value on the table). Trimmed all 27 into 141-155 chars — cut redundant clauses and lower-value words, kept every concrete claim, did not rewrite sentence structure or voice. Every edit was verified against the exact current file content before applying (script-driven, not hand-edited) so nothing landed against stale text or drifted from the site's existing voice. Scoped to the 27 pages #1091 did *not* already touch, to avoid any collision with that PR while it was still in flight.

**2. Added `/llms.txt` and `/llms-full.txt`** — the emerging [llmstxt.org](https://llmstxt.org) convention for what an AI crawler or answer engine (ChatGPT, Perplexity, Claude, etc.) should read. Until now the site had zero presence for that audience the way `robots.txt`/`sitemap.xml` serve traditional search crawlers.
- `/llms.txt` — a curated link index: title + one-line description per page, grouped by the same `meta.json` sections the sidebar nav uses.
- `/llms-full.txt` — every page's raw MDX source concatenated in sidebar order, frontmatter stripped, for a client that wants the whole corpus in one fetch (~668KB, 80 pages).
- Both generated at **build time** from the same `source.pageTree` the sidebar renders from (`src/lib/llms.ts` is the one shared source of truth) — a static file would drift out of sync with the nav the way the old hardcoded `SITE_URL` constants used to (that's exactly what #1091's `site.ts` consolidation fixed for the rest of the site).

**Incidental:** `stella-tui/src/deck_render.rs` grew past its file-size ratchet ceiling (1793 → 1808) in #1089 (the TUI comet rebrand, merged after #1091), which left `main`'s pre-push gate red for anyone pushing regardless of what they touched. Retightened the baseline — unrelated to this PR's actual content, included only because it was blocking the push.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: the description trims are content-only frontmatter edits (verified length + exact-match against prior content via the applying script, not a behavior change), and `llms.txt`/`llms-full.txt` are new static-generated routes verified by reading the actual production build output directly (see below) — there's no existing behavior to regress against.

## The gate

- [x] `cargo fmt --check` — N/A, no Rust changes (file-size baseline bump is data-only)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — ran clean as part of the pre-push gate
- [x] `cargo test --workspace` — ran clean as part of the pre-push gate
- [x] `pnpm typecheck` (website/) — clean
- [x] `pnpm build` (website/) — clean; `/llms.txt` and `/llms-full.txt` both prerender as static routes covering all 80 docs pages, confirmed by reading `.next/server/app/llms{,-full}.txt.body` directly after the build
- [x] Docs updated where behavior/flags changed — N/A, this *is* the docs site
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #N` — N/A, not tied to a filed issue

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — `llms.txt`/`llms-full.txt` use only `node:fs`/`node:path`, already-available Node runtime APIs
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

- The description trims are deliberately conservative — same sentence shape, same voice, just tighter. A prior audit (see PR #1091's description) explicitly flagged this as "low marginal value vs. risk of diluting carefully-voiced copy" and left it undone; I tried to thread that needle by cutting words rather than rewriting.
- `llms-full.txt` dumps raw MDX source including embedded JSX components (`<ProviderGrid />`, `<Callout>`, etc.) as literal tags rather than rendered output — this is the standard llms-full.txt approach (raw source, not rendered HTML) and an LLM reading it treats the tags as inert markup, but it's worth a second look if that reads as noisy.
- Not done here: no on-page link to `/llms.txt` (e.g. in the footer) — discovery is via the well-known-path convention, matching how `robots.txt` is never linked from a page either. Happy to add a footer link if that's wanted.

## Summary by Sourcery

Add AI crawler-friendly llms.txt/llms-full.txt endpoints and tighten SEO meta descriptions across documentation pages.

New Features:
- Expose a static /llms.txt endpoint that lists documentation pages with titles, descriptions, and links for AI crawlers.
- Expose a static /llms-full.txt endpoint that concatenates raw MDX source for all documentation pages into a single text corpus.

Enhancements:
- Trim and tighten meta descriptions for multiple docs pages to keep snippets within search-friendly length limits.
- Introduce a shared llms page listing and MDX source loader utility so AI-focused indexes stay in sync with the docs sidebar navigation.

Chores:
- Update the file-size baseline configuration to reflect the current size of the TUI deck_render source file.