### PR TITLE
fix(tui): a cache read proves the cache engaged; unblock main's file-size gate

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -36,7 +36,7 @@
 1569 stella-tools/src/media.rs
 3565 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
-1793 stella-tui/src/deck_render.rs
+1808 stella-tui/src/deck_render.rs
 3888 stella-tui/src/deck_ui.rs
 1665 stella-tui/src/views/engine.rs
 1533 stella-tui/src/views/session.rs

--- a/stella-tui/src/cache_panel.rs
+++ b/stella-tui/src/cache_panel.rs
@@ -67,7 +67,22 @@ impl AgentEntry {
         if hit_rate >= threshold {
             return None;
         }
-        if self.cache_is_opt_in_provider && self.cache_write_tokens == 0 {
+        // A READ is proof the cache engaged: nothing can be read that was
+        // never written. Writes and reads land on different turns — once a
+        // prefix is cached, every later turn reads it and writes nothing — so
+        // `cache_write_tokens == 0` is the NORMAL shape of a warm cache, not
+        // evidence of a missing marker.
+        //
+        // Diagnosing off writes alone put "opt-in never engaged — likely a
+        // bug" on a statline that was simultaneously reporting 9.6K read
+        // tokens and real savings. A warning that contradicts the number
+        // printed beside it is worse than silence: it sends the reader
+        // hunting for a defect that is not there, and teaches them to
+        // disregard the next one.
+        if self.cache_is_opt_in_provider
+            && self.cache_write_tokens == 0
+            && self.cache_read_tokens == 0
+        {
             return Some(CacheCause::OptInNeverEngaged);
         }
         Some(CacheCause::PrefixInstability)
@@ -275,6 +290,18 @@ mod tests {
         assert_eq!(
             entry(30_000, 0, 0, 5, false).cache_diagnosis(0.20),
             Some(CacheCause::PrefixInstability)
+        );
+        // Reported from a live session: 9.6K read against 0 written, and the
+        // statline said "opt-in never engaged — likely a bug" beside its own
+        // evidence that the cache was working. A read cannot come from a
+        // cache that was never written; writes and reads simply land on
+        // different turns, so zero writes is the ordinary shape of a warm
+        // prefix. Low-but-nonzero hits are instability, never an absent
+        // marker.
+        assert_eq!(
+            entry(96_000, 9_600, 0, 5, true).cache_diagnosis(0.20),
+            Some(CacheCause::PrefixInstability),
+            "a cache read is proof the cache engaged"
         );
     }
 


### PR DESCRIPTION
Two small things, one of which is blocking every branch cut from main.

## 1. main is red on its own file-size gate

`stella-tui/src/deck_render.rs` is **1808 lines against a 1793 ceiling**. #1088
grew it by 15 without re-baselining, so `make gate` fails on main itself and on
anything branched from it. Re-baselined here.

Worth noting the mechanism, because it will recur: each PR's CI runs against
its own base, never against the merged result. Two PRs that are individually
green can land a red main, and `scripts/file-size-baseline.txt` is unusually
exposed to it — one file that unrelated PRs all touch.

## 2. "cache opt-in never engaged" fired on a working cache

Reported from a live session. The statline said:

> ⚠ cache opt-in never engaged — this provider needs an explicit cache marker
> and none was sent (likely a bug)

while the CACHE cell **on the same line** read `10% (9.6K rd · 0 wr)` with
$0.03 saved.

`cache_diagnosis` inferred a missing marker from zero **writes** alone. But
writes and reads land on different turns: once a prefix is cached, every later
turn reads it and writes nothing, so `writes == 0, reads > 0` is the ordinary
shape of a warm cache rather than evidence of anything wrong.

Nothing can be read from a cache that was never written, so **a read is proof
of engagement**. `OptInNeverEngaged` now requires zero reads too; low-but-
nonzero hits are prefix instability, which is what that session actually had.

A warning that contradicts the number printed beside it is worse than silence:
it sends the reader hunting for a defect that is not there, and teaches them to
disregard the next one.

Test pins the reported shape (9.6K read, 0 written) → `PrefixInstability`.

`make gate` green.

## Summary by Sourcery

Adjust cache diagnostics to treat any cache reads as proof of engagement and re-baseline the file-size gate so main passes CI.

Bug Fixes:
- Prevent false "opt-in never engaged" warnings when a cache shows reads but no writes by requiring zero reads before raising this diagnosis.

Enhancements:
- Classify low-but-nonzero cache hits with zero writes as prefix instability to better reflect warm cache behavior.

Build:
- Update the file-size baseline configuration so the deck_render.rs size gate passes on main.

Tests:
- Add a cache diagnosis test case for the reported 9.6K reads and 0 writes scenario to pin it as prefix instability.