### PR TITLE
fix(tui): release a stuck routing card when its turn ends

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -37,6 +37,6 @@
 3565 stella-tools/src/registry.rs
 1839 stella-tools/src/scripts.rs
 1808 stella-tui/src/deck_render.rs
-3888 stella-tui/src/deck_ui.rs
+3889 stella-tui/src/deck_ui.rs
 1665 stella-tui/src/views/engine.rs
 1533 stella-tui/src/views/session.rs

--- a/stella-tui/src/deck_ui.rs
+++ b/stella-tui/src/deck_ui.rs
@@ -1319,6 +1319,7 @@ pub fn ingest_inbound(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut De
             }
             _ => {}
         }
+        dispatch::release_if_settled(ui, agent, event);
     }
     model.apply_inbound(inbound);
     clamp(model, ui);

--- a/stella-tui/src/deck_ui/dispatch.rs
+++ b/stella-tui/src/deck_ui/dispatch.rs
@@ -23,6 +23,10 @@ pub struct PendingDispatch {
     /// The lane a sidecar would get (`req:2`), so the card can name it rather
     /// than describing it. Purely cosmetic — the driver assigns the real one.
     pub next_lane: String,
+    /// The agent whose `Running` status raised this card, so the deck can
+    /// tell when that turn ends out from under it (see
+    /// `deck_ui::ingest_inbound`'s auto-release of a stale card).
+    pub agent_id: String,
 }
 
 /// The routes the card offers. Each maps onto a `WorkspaceInput` the driver
@@ -74,10 +78,8 @@ fn carries_its_own_intent(text: &str) -> bool {
 /// (`SteeringTap::is_settling`), which is what keeps the two layers agreeing
 /// about what "still running" means.
 pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<WorkspaceInput> {
-    let running = model
-        .agents
-        .get(ui.focused)
-        .is_some_and(|a| a.status == crate::AgentStatus::Running);
+    let focused = model.agents.get(ui.focused);
+    let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
     if !running || carries_its_own_intent(&text) || ui.ask_before_spawn.not_asking() {
         return Some(WorkspaceInput::Enqueue { text });
     }
@@ -89,6 +91,8 @@ pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<Wo
     ui.pending_dispatch = Some(PendingDispatch {
         text,
         next_lane: format!("req:{}", live + 1),
+        // `running` is only true when `focused` is `Some`.
+        agent_id: focused.expect("running agent is present").meta.id.clone(),
     });
     None
 }
@@ -122,6 +126,46 @@ pub fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
     let text = pending.text.clone();
     ui.pending_dispatch = None;
     Some(DeckAction::Send(route.input(text)))
+}
+
+/// Release a card raised against `agent` if `event` just ended that agent's
+/// turn — a `Complete`, a hard (non-retryable) `Error`, or a fresh
+/// `AskUser`/`ScopeReview` gate, the same set the model fold's own
+/// `status_from_event` maps away from [`crate::AgentStatus::Running`]. A
+/// no-op unless the card is up and belongs to this agent.
+///
+/// Without this the card is sticky forever once raised: it owns every key
+/// ahead of the composer ([`handle_key`], checked first in
+/// `deck_ui::handle_deck_key`), and only `s`/`n`/`p`/Esc clear it. If the
+/// turn it was asking about finishes before the user answers, every further
+/// keystroke — Enter, Backspace, anything typed — dies silently at the
+/// catch-all, and the deck reads as though it stopped accepting input.
+/// Released exactly like Esc: the text goes back to the composer, nothing is
+/// sent, and the very next keystroke reaches it instead of the card.
+pub fn release_if_settled(ui: &mut DeckUi, agent: &str, event: &stella_protocol::AgentEvent) {
+    use stella_protocol::AgentEvent;
+    let vacates_running = matches!(
+        event,
+        AgentEvent::Complete { .. }
+            | AgentEvent::Error {
+                retryable: false,
+                ..
+            }
+            | AgentEvent::AskUser { .. }
+            | AgentEvent::ScopeReview { .. }
+    );
+    if !vacates_running {
+        return;
+    }
+    let Some(pending) = ui.pending_dispatch.as_ref() else {
+        return;
+    };
+    if pending.agent_id != agent {
+        return;
+    }
+    let text = pending.text.clone();
+    ui.pending_dispatch = None;
+    ui.composer.load(text);
 }
 
 /// Whether the deck asks before forking a turn into a sidecar.

--- a/stella-tui/src/deck_ui/tests.rs
+++ b/stella-tui/src/deck_ui/tests.rs
@@ -1231,6 +1231,100 @@ fn ask_user_answer_latches_until_a_fresh_question_rearms() {
     );
 }
 
+/// The routing card owns every key ahead of the composer once raised — but
+/// it used to have no way out if the turn it was asking about finished (or
+/// errored, or itself started asking a question) before the user answered
+/// `s`/`n`/`p`/Esc: every further keystroke, including Enter and Backspace,
+/// died silently at the card's catch-all. This is the "can't clear or submit
+/// anything after a turn completes" bug — the fix releases the card the same
+/// way Esc does the moment its agent stops being `Running`.
+#[test]
+fn a_finished_turn_releases_a_routing_card_stuck_on_its_prompt() {
+    let mut model = model_with(&["lead"]);
+    model.apply_inbound(&Inbound::Status {
+        agent: "lead".into(),
+        status: crate::AgentStatus::Running,
+    });
+    let mut ui = ready_ui();
+
+    for c in "and now the tests".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Handled,
+        "an ambiguous mid-turn prompt raises the card instead of sending"
+    );
+    assert!(ui.pending_dispatch.is_some(), "the card is up");
+
+    ingest_inbound(
+        &Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Complete {
+                model: "test-model".into(),
+                cost_usd: 0.0,
+            },
+        },
+        &mut model,
+        &mut ui,
+    );
+
+    assert!(
+        ui.pending_dispatch.is_none(),
+        "a finished turn releases the card rather than leaving it stuck"
+    );
+    assert_eq!(
+        ui.composer.buffer(),
+        "and now the tests",
+        "the held prompt returns to the composer, same as Esc"
+    );
+
+    // The keyboard is unstuck: the same text submits normally now, since
+    // `dispatch::route`'s own `running` check is false for an idle agent.
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Enqueue {
+            text: "and now the tests".into()
+        })
+    );
+}
+
+/// The release is scoped to the agent the card was raised against — another
+/// agent finishing its own turn must not discard a card still legitimately
+/// waiting on the user.
+#[test]
+fn a_finished_turn_on_another_agent_does_not_release_someone_elses_card() {
+    let mut model = model_with(&["lead"]);
+    model.apply_inbound(&Inbound::Status {
+        agent: "lead".into(),
+        status: crate::AgentStatus::Running,
+    });
+    let mut ui = ready_ui();
+
+    for c in "keep me".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert!(ui.pending_dispatch.is_some());
+
+    ingest_inbound(
+        &Inbound::Event {
+            agent: "req:2".into(),
+            event: AgentEvent::Complete {
+                model: "test-model".into(),
+                cost_usd: 0.0,
+            },
+        },
+        &mut model,
+        &mut ui,
+    );
+
+    assert!(
+        ui.pending_dispatch.is_some(),
+        "a different agent's completion must not release this card"
+    );
+}
+
 #[test]
 fn tab_and_backtab_walk_the_tab_bar() {
     let model = model_with(&["lead"]);

--- a/stella-tui/src/views/dispatch_card.rs
+++ b/stella-tui/src/views/dispatch_card.rs
@@ -70,6 +70,7 @@ mod tests {
         let pending = PendingDispatch {
             text: text.to_string(),
             next_lane: "req:2".into(),
+            agent_id: "lead".into(),
         };
         let area = Rect::new(0, 0, width, 7);
         let mut buf = Buffer::empty(area);


### PR DESCRIPTION
## What & why

Reported live: "I can't clear or submit anything after a turn completes in stella's TUI."

The mid-turn routing card (`pending_dispatch`, added in #986) is raised when a follow-up prompt is submitted while the focused agent is still `Running` and the text doesn't already say where it goes (no `>`/`/`/`!` prefix). Once up, it owns every key ahead of the composer — `dispatch::handle_key` is checked first in `handle_deck_key`, before Ctrl-C, before everything — and only `s`/`n`/`p`/Esc resolve it. Every other key, including Enter and Backspace, is swallowed by its catch-all.

Nothing ever released the card if the turn it was asking about finished (or hard-errored, or itself raised an `AskUser`/`ScopeReview` gate) before the user answered. From that point every keystroke silently no-ops, which reads exactly like "the TUI stopped accepting input" — because it did.

## The fix

`PendingDispatch` now records the `agent_id` whose `Running` status raised it. `dispatch::release_if_settled` is called from `deck_ui::ingest_inbound` on every inbound event; when an event leaves that same agent no longer `Running` (`Complete`, a non-retryable `Error`, `AskUser`, or `ScopeReview`), the card releases exactly like Esc would — the held text goes back to the composer, nothing is sent, and the very next keystroke reaches the composer instead of the card's catch-all.

Scoped to the agent the card belongs to: another agent's turn finishing must not discard a card still legitimately waiting on the user (covered by a test).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_finished_turn_releases_a_routing_card_stuck_on_its_prompt` reproduces the bug end-to-end (raise the card via a real keystroke sequence → ingest a `Complete` event → assert the card is gone, the text is back in the composer, and the composer now accepts the same Enter as a normal submit) and `a_finished_turn_on_another_agent_does_not_release_someone_elses_card` pins the scoping.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (`make gate` green)

## Anything reviewers should know?

Unrelated to this fix: `main`'s `deck_render.rs` file-size baseline was stale (1808 lines vs. a recorded 1793 ceiling, from #1088 growing it without re-baselining) and blocked `make gate` on this branch too. That was fixed independently on `main` by #1094 while this branch was in flight; rebasing picked it up and dropped my now-redundant local fixup commit automatically.

## Summary by Sourcery

Ensure routing cards in the TUI are automatically released when their associated agent’s turn stops running, preventing the interface from getting stuck and restoring the held text to the composer.

Bug Fixes:
- Fix a stuck routing card that continued to capture all keyboard input after its agent’s turn completed or errored, by releasing it and returning the prompt to the composer.
- Scope routing card auto-release to the originating agent so that other agents finishing their turns do not clear an active card.

Tests:
- Add end-to-end tests verifying that a completed turn releases a routing card and that another agent’s completion does not release someone else’s card.