### PR TITLE
fix(ingest): grow the output budget on a cut-off extraction reply

### DIFF
--- a/stella-cli/src/ingest_cmd/extract.rs
+++ b/stella-cli/src/ingest_cmd/extract.rs
@@ -34,7 +34,9 @@ use stella_core::ingest::{
     Proposal, Provenance, Record, RecordKind, Refutation, Steering, Truth, TruthBasis, Verdict,
     gate,
 };
-use stella_protocol::{CompletionMessage, CompletionRequest, ModelCallRole, Provider};
+use stella_protocol::{
+    CompletionMessage, CompletionRequest, FinishReason, ModelCallRole, Provider,
+};
 
 use super::probe;
 
@@ -295,6 +297,16 @@ fn build_defaults(
     }
 }
 
+/// The starting output budget: 16k, not the 4k this used to carry. A document
+/// near the [`MAX_PROMPT_CHARS`] cap can atomize into dozens of records, each
+/// carrying every optional field in the schema — 4k truncated mid-object on
+/// real instruction files (AGENTS.md-sized documents) well before reaching the
+/// closing `]`, which `parse_claims` then reported as a JSON syntax error
+/// rather than what it actually was. 16k matches the ceiling `EngineConfig`
+/// already uses for the same reason, and sits within every seeded catalog
+/// model's output limit.
+const BASE_OUTPUT_TOKENS: u32 = 16_384;
+
 /// Call the model, tolerating prose and one bad reply. Mirrors `infer_domains`:
 /// bounded repair, then give up on this document rather than hammering.
 async fn call_model(
@@ -314,12 +326,13 @@ async fn call_model(
         CompletionMessage::user(&user),
     ];
     let mut total_cost = 0.0;
+    let mut max_output_tokens = BASE_OUTPUT_TOKENS;
     const ATTEMPTS: usize = 2;
 
     for attempt in 0..ATTEMPTS {
         let request = CompletionRequest {
             messages: messages.clone(),
-            max_output_tokens: Some(4096),
+            max_output_tokens: Some(max_output_tokens),
             temperature: Some(0.0),
             effort: None,
             tools: Vec::new(),
@@ -339,11 +352,28 @@ async fn call_model(
         {
             Ok(accounted) => {
                 total_cost += accounted.cost_usd;
+                let cut_off = accounted.result.finish_reason == Some(FinishReason::Length);
                 match parse_claims(&accounted.result.text) {
                     Ok(claims) => return Ok((claims, total_cost)),
                     // Last attempt: no more repairs, report why it failed.
                     Err(err) if attempt + 1 == ATTEMPTS => {
-                        return Err(format!("could not parse the model's records: {err}"));
+                        return Err(if cut_off {
+                            format!(
+                                "the model's reply was cut off at {max_output_tokens} output \
+                                 tokens before finishing the record list — try a smaller or \
+                                 split document"
+                            )
+                        } else {
+                            format!("could not parse the model's records: {err}")
+                        });
+                    }
+                    // Cut off, not malformed: the reply was on track but ran out of
+                    // room. Asking it to "respond with ONLY the JSON array" again
+                    // wouldn't fix a token budget, and at temperature 0 would likely
+                    // just truncate at the same point — give it more room instead
+                    // and repeat the same request rather than re-litigating it.
+                    Err(_) if cut_off => {
+                        max_output_tokens = max_output_tokens.saturating_mul(2);
                     }
                     Err(_) => {
                         // Feed the failure back once.

--- a/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -6,9 +6,13 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use stella_core::context_record::RecordProposalStatus;
 use stella_core::ingest::{ContextFile, ProbeKind, Verdict};
-use stella_protocol::{CompletionRequestRef, CompletionResult, CompletionUsage, ProviderError};
+
+use stella_protocol::{
+    CompletionRequestRef, CompletionResult, CompletionUsage, FinishReason, ProviderError,
+};
 
 use super::*;
 
@@ -238,6 +242,97 @@ impl Provider for CannedProvider {
             finish_reason: None,
         })
     }
+}
+
+/// A provider whose first reply is cut off at the token limit (`finish_reason:
+/// Length`, no closing `]`) and whose second reply is the same records,
+/// complete — the shape a real truncation-then-retry takes. Records the
+/// `max_output_tokens` each call was asked for, so the test can prove the
+/// retry actually grew the budget rather than only asking more politely.
+struct TruncatesOnceProvider {
+    calls: AtomicUsize,
+    requested_budgets: std::sync::Mutex<Vec<Option<u32>>>,
+}
+
+#[async_trait]
+impl Provider for TruncatesOnceProvider {
+    fn id(&self) -> &str {
+        "truncates-once"
+    }
+
+    async fn complete_ref(
+        &self,
+        request: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.requested_budgets
+            .lock()
+            .expect("lock")
+            .push(request.max_output_tokens);
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        let (text, finish_reason) = if call == 0 {
+            // Cut off mid-object: no closing `}` for the record, no closing `]`
+            // for the array — exactly what a token-limit truncation leaves.
+            (
+                "[{\"lineage_suffix\":\"pkg-manager\",\"kind\":\"fact\",\"statement\":\"Th"
+                    .to_string(),
+                Some(FinishReason::Length),
+            )
+        } else {
+            (
+                "[{\"lineage_suffix\":\"pkg-manager\",\"kind\":\"fact\",\
+                 \"statement\":\"This repository uses pnpm.\"}]"
+                    .to_string(),
+                Some(FinishReason::Stop),
+            )
+        };
+        Ok(CompletionResult {
+            text,
+            tool_calls: Vec::new(),
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 20,
+                output_tokens: 8,
+                ..CompletionUsage::default()
+            },
+            model: "canned-model".into(),
+            cost_usd: 0.001,
+            finish_reason,
+        })
+    }
+}
+
+#[test]
+fn a_truncated_reply_is_retried_with_a_larger_budget_instead_of_failing() {
+    let root = temp_root("truncated-retry");
+    let provider = TruncatesOnceProvider {
+        calls: AtomicUsize::new(0),
+        requested_budgets: std::sync::Mutex::new(Vec::new()),
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let (claims, _cost) = runtime
+        .block_on(call_model(
+            &provider,
+            "canned-model",
+            &root,
+            "AGENTS.md",
+            "# Conventions\nThis repository uses pnpm.\n",
+        ))
+        .expect("recovers from the truncated first reply");
+
+    assert_eq!(claims.len(), 1);
+    assert_eq!(claims[0].lineage_suffix, "pkg-manager");
+
+    let budgets = provider.requested_budgets.lock().expect("lock").clone();
+    assert_eq!(
+        budgets,
+        vec![Some(BASE_OUTPUT_TOKENS), Some(BASE_OUTPUT_TOKENS * 2)],
+        "the retry must ask for more room, not repeat the same budget"
+    );
+    let _ = std::fs::remove_dir_all(&root);
 }
 
 #[test]


### PR DESCRIPTION
## What & why

`stella ingest AGENTS.md` failed with:

```
AGENTS.md  could not parse the model's records: EOF while parsing an object at line 417 column 28
```

Root cause: `stella-cli/src/ingest_cmd/extract.rs`'s `call_model` hardcoded `max_output_tokens: Some(4096)`. A sufficiently rich instruction file (AGENTS.md-sized, near the 24k-char prompt cap) atomizes into enough records — each carrying every optional field in the `Claim` schema — that the model's reply gets cut off mid-object well before reaching the closing `]`. `parse_claims` then reported that as a generic JSON syntax error, and the one bounded-repair retry made it worse: it fed the truncated text back and asked the model to "respond with ONLY the JSON array" again, which doesn't fix a token budget and, at `temperature: 0.0`, tends to truncate at the same point on retry.

`stella_protocol::CompletionResult::finish_reason` already exists specifically to distinguish a token-limit cutoff (`FinishReason::Length`) from a natural stop — the doc comment on the type says as much — but nothing in the ingest path was reading it (nor is its sibling `infer_domains` in `domains.rs`, which this function's own comment says it mirrors; left that one alone since it's a separate call site and out of scope for this fix, but it likely wants the same treatment).

Fix, in `stella-cli/src/ingest_cmd/extract.rs`:
- Base output budget raised 4096 → 16384, matching the ceiling `EngineConfig::default()` already uses (`stella-core/src/driver.rs`) for the identical reason — enough room for the answer to land after a reasoning model's chain-of-thought.
- `call_model` now checks `accounted.result.finish_reason == Some(FinishReason::Length)`. On a cut-off first attempt, it doubles the budget and repeats the same request instead of spending the one retry on a message that can't fix the actual problem.
- The final-attempt error message now says what actually happened ("the model's reply was cut off at N output tokens...") instead of surfacing a raw serde_json EOF error when the cause was truncation.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_truncated_reply_is_retried_with_a_larger_budget_instead_of_failing` in `stella-cli/src/ingest_cmd/extract/tests.rs`: a mock provider returns a truncated reply (`finish_reason: Length`, no closing `]`) on the first call and the same record complete on the second, and asserts both that extraction recovers the record *and* that the second call actually requested a larger budget (`vec![Some(BASE_OUTPUT_TOKENS), Some(BASE_OUTPUT_TOKENS * 2)]`) rather than just repeating the same one. Confirmed it fails to compile on `main` (`BASE_OUTPUT_TOKENS` doesn't exist there) and passes with the fix.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — pre-push gate ran green (one unrelated flaky `stella-tools` git-temp-clone test failed on the first push attempt, unrelated to this change, and passed clean on retry)
- [x] Docs updated where behavior/flags changed — N/A, no user-facing flag/behavior surface changed, only the internal retry/budget logic
- [ ] CLA signed — N/A, already signed
- [ ] `Closes #N` — no issue filed; found via direct repro (`stella ingest AGENTS.md`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types touched

## Anything reviewers should know?

`domains.rs::infer_domains` has the identical pattern (hardcoded `max_output_tokens: Some(2048)`, no `finish_reason` check) and is even more likely to truncate given its smaller budget. Left out of this PR to keep it to one logical change, but it's the same bug in the function this one explicitly mirrors and probably deserves the same fix as a fast follow.

## Summary by Sourcery

Handle truncated model replies during ingest by increasing the initial output token budget and retrying with a larger budget when the model stops due to length, and add coverage to verify the new behavior.

Bug Fixes:
- Prevent ingest from failing with JSON parse errors when the model reply is cut off at the output token limit by detecting length-based truncation and retrying with a larger budget.

Enhancements:
- Raise the default output token budget for ingest extraction requests to align with engine configuration and better accommodate large instruction documents.
- Improve the final error message for ingest failures to clearly report when the model reply was truncated at the output token limit.

Tests:
- Add a provider-backed test that simulates a truncated first reply and verifies that ingest retries with an increased output token budget and successfully recovers the record.